### PR TITLE
Add grey color accent

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
@@ -348,7 +348,7 @@ describe("scenarios > visualizations > bar chart", () => {
   });
 
   it("supports gray series colors", () => {
-    const greyColor = "#D7DCDF";
+    const grayColor = "#F3F3F4";
 
     visitQuestionAdhoc({
       ...breakoutBarChart,
@@ -358,18 +358,18 @@ describe("scenarios > visualizations > bar chart", () => {
       },
     });
 
-    // Ensure the grey color did not get assigned to series
-    chartPathWithFillColor(greyColor).should("not.exist");
+    // Ensure the gray color did not get assigned to series
+    chartPathWithFillColor(grayColor).should("not.exist");
 
     cy.findByTestId("viz-settings-button").click();
 
     // Open color picker for the first series
     cy.findByLabelText("#88BF4D").click();
 
-    // Assign grey color to the first series
-    cy.findByLabelText(greyColor).click();
+    // Assign gray color to the first series
+    cy.findByLabelText(grayColor).click();
 
-    chartPathWithFillColor(greyColor).should("be.visible");
+    chartPathWithFillColor(grayColor).should("be.visible");
   });
 
   it("supports up to 100 series (metabase#28796)", () => {

--- a/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
@@ -27,6 +27,22 @@ import {
 
 const { ORDERS, ORDERS_ID, PEOPLE, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
+const breakoutBarChart = {
+  display: "bar",
+  dataset_query: {
+    type: "query",
+    query: {
+      "source-table": ORDERS_ID,
+      aggregation: [["count"]],
+      breakout: [
+        ["field", PEOPLE.SOURCE, { "source-field": ORDERS.USER_ID }],
+        ["field", PRODUCTS.CATEGORY, { "source-field": ORDERS.PRODUCT_ID }],
+      ],
+    },
+    database: SAMPLE_DB_ID,
+  },
+};
+
 describe("scenarios > visualizations > bar chart", () => {
   beforeEach(() => {
     restore();
@@ -135,25 +151,7 @@ describe("scenarios > visualizations > bar chart", () => {
 
   describe("with x-axis series", () => {
     beforeEach(() => {
-      visitQuestionAdhoc({
-        display: "bar",
-        dataset_query: {
-          type: "query",
-          query: {
-            "source-table": ORDERS_ID,
-            aggregation: [["count"]],
-            breakout: [
-              ["field", PEOPLE.SOURCE, { "source-field": ORDERS.USER_ID }],
-              [
-                "field",
-                PRODUCTS.CATEGORY,
-                { "source-field": ORDERS.PRODUCT_ID },
-              ],
-            ],
-          },
-          database: SAMPLE_DB_ID,
-        },
-      });
+      visitQuestionAdhoc(breakoutBarChart);
 
       cy.findByTestId("viz-settings-button").click();
       sidebar().findByText("Data").click();
@@ -347,6 +345,31 @@ describe("scenarios > visualizations > bar chart", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Category is Doohickey").should("be.visible");
     });
+  });
+
+  it("supports gray series colors", () => {
+    const greyColor = "#D7DCDF";
+
+    visitQuestionAdhoc({
+      ...breakoutBarChart,
+      visualization_settings: {
+        "graph.dimensions": ["CATEGORY", "SOURCE"],
+        "graph.metrics": ["count"],
+      },
+    });
+
+    // Ensure the grey color did not get assigned to series
+    chartPathWithFillColor(greyColor).should("not.exist");
+
+    cy.findByTestId("viz-settings-button").click();
+
+    // Open color picker for the first series
+    cy.findByLabelText("#88BF4D").click();
+
+    // Assign grey color to the first series
+    cy.findByLabelText(greyColor).click();
+
+    chartPathWithFillColor(greyColor).should("be.visible");
   });
 
   it("supports up to 100 series (metabase#28796)", () => {

--- a/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangePopover.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangePopover.styled.tsx
@@ -2,7 +2,6 @@ import styled from "@emotion/styled";
 
 export const PopoverRoot = styled.div`
   padding: 0.75rem;
-  width: 19.25rem;
 `;
 
 export const PopoverColorList = styled.div`

--- a/frontend/src/metabase/core/components/ColorSelector/ColorSelectorPopover.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorSelector/ColorSelectorPopover.styled.tsx
@@ -5,5 +5,5 @@ export const PopoverRoot = styled.div`
   flex-wrap: wrap;
   gap: 0.25rem;
   padding: 0.75rem;
-  max-width: 19.25rem;
+  max-width: 22rem;
 `;

--- a/frontend/src/metabase/css/core/colors.module.css
+++ b/frontend/src/metabase/css/core/colors.module.css
@@ -144,7 +144,7 @@
   --mb-base-color-blue-10: #eef6fd; /* baby blue */
   --mb-base-color-blue-5: #f8fbfe;
 
-  /* Orion (Grey) */
+  /* Gray */
   --mb-base-color-gray-100: #121619; /* bg-black */
   --mb-base-color-gray-90: #20272b;
   --mb-base-color-gray-80: #313b42;
@@ -153,9 +153,22 @@
   --mb-base-color-gray-50: #808991;
   --mb-base-color-gray-40: #929aa1;
   --mb-base-color-gray-30: #b4bcc3;
-  --mb-base-color-gray-20: #dbdfe3; /* accent-grey-dark */
-  --mb-base-color-gray-10: #f3f5f7; /* accent-grey */
-  --mb-base-color-gray-5: #fafbfc; /* accent-grey-light */
+  --mb-base-color-gray-20: #dbdfe3;
+  --mb-base-color-gray-10: #f3f5f7;
+  --mb-base-color-gray-5: #fafbfc;
+
+  /* Orion */
+  --mb-base-color-orion-100: #071722;
+  --mb-base-color-orion-90: #182731;
+  --mb-base-color-orion-80: #2f3c45;
+  --mb-base-color-orion-70: #47535b;
+  --mb-base-color-orion-60: #656f76;
+  --mb-base-color-orion-50: #81898e;
+  --mb-base-color-orion-40: #92999e;
+  --mb-base-color-orion-30: #b7bcbf;
+  --mb-base-color-orion-20: #dcdfe0; /* accent-grey-dark */
+  --mb-base-color-orion-10: #f3f3f4; /* accent-grey */
+  --mb-base-color-orion-5: #fafafb; /* accent-grey-light */
 }
 
 .textDefault {

--- a/frontend/src/metabase/css/core/colors.module.css
+++ b/frontend/src/metabase/css/core/colors.module.css
@@ -144,9 +144,8 @@
   --mb-base-color-blue-10: #eef6fd; /* baby blue */
   --mb-base-color-blue-5: #f8fbfe;
 
-  /* Gray */
-  /*   bg-black */
-  --mb-base-color-gray-100: #121619;
+  /* Orion (Grey) */
+  --mb-base-color-gray-100: #121619; /* bg-black */
   --mb-base-color-gray-90: #20272b;
   --mb-base-color-gray-80: #313b42;
   --mb-base-color-gray-70: #47545e;
@@ -154,9 +153,9 @@
   --mb-base-color-gray-50: #808991;
   --mb-base-color-gray-40: #929aa1;
   --mb-base-color-gray-30: #b4bcc3;
-  --mb-base-color-gray-20: #dbdfe3;
-  --mb-base-color-gray-10: #f3f5f7;
-  --mb-base-color-gray-5: #fafbfc;
+  --mb-base-color-gray-20: #dbdfe3; /* accent-grey-dark */
+  --mb-base-color-gray-10: #f3f5f7; /* accent-grey */
+  --mb-base-color-gray-5: #fafbfc; /* accent-grey-light */
 }
 
 .textDefault {

--- a/frontend/src/metabase/css/core/colors.module.css
+++ b/frontend/src/metabase/css/core/colors.module.css
@@ -166,9 +166,9 @@
   --mb-base-color-orion-50: #81898e;
   --mb-base-color-orion-40: #92999e;
   --mb-base-color-orion-30: #b7bcbf;
-  --mb-base-color-orion-20: #dcdfe0; /* accent-grey-dark */
-  --mb-base-color-orion-10: #f3f3f4; /* accent-grey */
-  --mb-base-color-orion-5: #fafafb; /* accent-grey-light */
+  --mb-base-color-orion-20: #dcdfe0; /* accent-gray-dark */
+  --mb-base-color-orion-10: #f3f3f4; /* accent-gray */
+  --mb-base-color-orion-5: #fafafb; /* accent-gray-light */
 }
 
 .textDefault {

--- a/frontend/src/metabase/lib/colors/charts.ts
+++ b/frontend/src/metabase/lib/colors/charts.ts
@@ -10,7 +10,7 @@ export const getColorsForValues = (
   if (keys.length <= ACCENT_COUNT) {
     return getHashBasedMapping(
       keys,
-      getAccentColors({ light: false, dark: false }, palette),
+      getAccentColors({ light: false, dark: false, grey: false }, palette),
       existingMapping,
       (color: string) => getPreferredColor(color, palette),
     );
@@ -18,7 +18,7 @@ export const getColorsForValues = (
     return getOrderBasedMapping(
       keys,
       getAccentColors(
-        { light: keys.length > ACCENT_COUNT * 2, harmony: true },
+        { light: keys.length > ACCENT_COUNT * 2, harmony: true, grey: false },
         palette,
       ),
       existingMapping,

--- a/frontend/src/metabase/lib/colors/charts.ts
+++ b/frontend/src/metabase/lib/colors/charts.ts
@@ -10,7 +10,7 @@ export const getColorsForValues = (
   if (keys.length <= ACCENT_COUNT) {
     return getHashBasedMapping(
       keys,
-      getAccentColors({ light: false, dark: false, grey: false }, palette),
+      getAccentColors({ light: false, dark: false, gray: false }, palette),
       existingMapping,
       (color: string) => getPreferredColor(color, palette),
     );
@@ -18,7 +18,7 @@ export const getColorsForValues = (
     return getOrderBasedMapping(
       keys,
       getAccentColors(
-        { light: keys.length > ACCENT_COUNT * 2, harmony: true, grey: false },
+        { light: keys.length > ACCENT_COUNT * 2, harmony: true, gray: false },
         palette,
       ),
       existingMapping,

--- a/frontend/src/metabase/lib/colors/groups.ts
+++ b/frontend/src/metabase/lib/colors/groups.ts
@@ -9,27 +9,50 @@ export const getAccentColors = (
     light = true,
     dark = true,
     harmony = false,
+    grey = true,
   }: AccentColorOptions = {},
   palette?: ColorPalette,
 ) => {
   const ranges = [];
-  main && ranges.push(getMainAccentColors(palette));
-  light && ranges.push(getLightAccentColors(palette));
-  dark && ranges.push(getDarkAccentColors(palette));
+  main && ranges.push(getMainAccentColors(palette, grey));
+  light && ranges.push(getLightAccentColors(palette, grey));
+  dark && ranges.push(getDarkAccentColors(palette, grey));
 
   return harmony ? _.unzip(ranges).flat() : ranges.flat();
 };
 
-export const getMainAccentColors = (palette?: ColorPalette) => {
-  return _.times(ACCENT_COUNT, i => color(`accent${i}`, palette));
+const getBaseAccentsNames = (withGrey = false) => {
+  const accents = _.times(ACCENT_COUNT, i => `accent${i}`);
+  if (withGrey) {
+    accents.push("accent-grey");
+  }
+
+  return accents;
 };
 
-export const getLightAccentColors = (palette?: ColorPalette) => {
-  return _.times(ACCENT_COUNT, i => color(`accent${i}-light`, palette));
+export const getMainAccentColors = (
+  palette?: ColorPalette,
+  withGrey = false,
+) => {
+  return getBaseAccentsNames(withGrey).map(accent => color(accent, palette));
 };
 
-export const getDarkAccentColors = (palette?: ColorPalette) => {
-  return _.times(ACCENT_COUNT, i => color(`accent${i}-dark`, palette));
+export const getLightAccentColors = (
+  palette?: ColorPalette,
+  withGrey = false,
+) => {
+  return getBaseAccentsNames(withGrey).map(accent =>
+    color(`${accent}-light`, palette),
+  );
+};
+
+export const getDarkAccentColors = (
+  palette?: ColorPalette,
+  withGrey = false,
+) => {
+  return getBaseAccentsNames(withGrey).map(accent =>
+    color(`${accent}-dark`, palette),
+  );
 };
 
 export const getStatusColorRanges = () => {

--- a/frontend/src/metabase/lib/colors/groups.ts
+++ b/frontend/src/metabase/lib/colors/groups.ts
@@ -9,22 +9,22 @@ export const getAccentColors = (
     light = true,
     dark = true,
     harmony = false,
-    grey = true,
+    gray = true,
   }: AccentColorOptions = {},
   palette?: ColorPalette,
 ) => {
   const ranges = [];
-  main && ranges.push(getMainAccentColors(palette, grey));
-  light && ranges.push(getLightAccentColors(palette, grey));
-  dark && ranges.push(getDarkAccentColors(palette, grey));
+  main && ranges.push(getMainAccentColors(palette, gray));
+  light && ranges.push(getLightAccentColors(palette, gray));
+  dark && ranges.push(getDarkAccentColors(palette, gray));
 
   return harmony ? _.unzip(ranges).flat() : ranges.flat();
 };
 
-const getBaseAccentsNames = (withGrey = false) => {
+const getBaseAccentsNames = (withGray = false) => {
   const accents = _.times(ACCENT_COUNT, i => `accent${i}`);
-  if (withGrey) {
-    accents.push("accent-grey");
+  if (withGray) {
+    accents.push("accent-gray");
   }
 
   return accents;
@@ -32,25 +32,25 @@ const getBaseAccentsNames = (withGrey = false) => {
 
 export const getMainAccentColors = (
   palette?: ColorPalette,
-  withGrey = false,
+  withGray = false,
 ) => {
-  return getBaseAccentsNames(withGrey).map(accent => color(accent, palette));
+  return getBaseAccentsNames(withGray).map(accent => color(accent, palette));
 };
 
 export const getLightAccentColors = (
   palette?: ColorPalette,
-  withGrey = false,
+  withGray = false,
 ) => {
-  return getBaseAccentsNames(withGrey).map(accent =>
+  return getBaseAccentsNames(withGray).map(accent =>
     color(`${accent}-light`, palette),
   );
 };
 
 export const getDarkAccentColors = (
   palette?: ColorPalette,
-  withGrey = false,
+  withGray = false,
 ) => {
-  return getBaseAccentsNames(withGrey).map(accent =>
+  return getBaseAccentsNames(withGray).map(accent =>
     color(`${accent}-dark`, palette),
   );
 };

--- a/frontend/src/metabase/lib/colors/groups.unit.spec.ts
+++ b/frontend/src/metabase/lib/colors/groups.unit.spec.ts
@@ -1,0 +1,20 @@
+import { getAccentColors } from "./groups";
+import { color } from "./palette";
+
+describe("groups", () => {
+  describe("getAccentColors", () => {
+    it("should return main accent colors without grey by default", () => {
+      const colors = getAccentColors({ grey: false });
+      expect(colors).not.toContain(color("accent-grey"));
+      expect(colors).not.toContain(color("accent-grey-light"));
+      expect(colors).not.toContain(color("accent-grey-dark"));
+    });
+
+    it("should include grey when specified", () => {
+      const colors = getAccentColors();
+      expect(colors).toContain(color("accent-grey"));
+      expect(colors).toContain(color("accent-grey-light"));
+      expect(colors).toContain(color("accent-grey-dark"));
+    });
+  });
+});

--- a/frontend/src/metabase/lib/colors/groups.unit.spec.ts
+++ b/frontend/src/metabase/lib/colors/groups.unit.spec.ts
@@ -3,18 +3,18 @@ import { color } from "./palette";
 
 describe("groups", () => {
   describe("getAccentColors", () => {
-    it("should return main accent colors without grey by default", () => {
-      const colors = getAccentColors({ grey: false });
-      expect(colors).not.toContain(color("accent-grey"));
-      expect(colors).not.toContain(color("accent-grey-light"));
-      expect(colors).not.toContain(color("accent-grey-dark"));
+    it("should return main accent colors without gray by default", () => {
+      const colors = getAccentColors({ gray: false });
+      expect(colors).not.toContain(color("accent-gray"));
+      expect(colors).not.toContain(color("accent-gray-light"));
+      expect(colors).not.toContain(color("accent-gray-dark"));
     });
 
-    it("should include grey when specified", () => {
+    it("should include gray when specified", () => {
       const colors = getAccentColors();
-      expect(colors).toContain(color("accent-grey"));
-      expect(colors).toContain(color("accent-grey-light"));
-      expect(colors).toContain(color("accent-grey-dark"));
+      expect(colors).toContain(color("accent-gray"));
+      expect(colors).toContain(color("accent-gray-light"));
+      expect(colors).toContain(color("accent-gray-dark"));
     });
   });
 });

--- a/frontend/src/metabase/lib/colors/palette.ts
+++ b/frontend/src/metabase/lib/colors/palette.ts
@@ -23,9 +23,9 @@ export const colors = {
   accent5: "#F2A86F",
   accent6: "#98D9D9",
   accent7: "#7172AD",
-  "accent-grey": "#B4BCC3",
-  "accent-grey-light": "#F3F5F7",
-  "accent-grey-dark": "#808991",
+  "accent-grey": "#F3F5F7", // Orion 10 (--mb-base-color-gray-10)
+  "accent-grey-light": "#FAFBFC", // Orion 5 (--mb-base-color-gray-5)
+  "accent-grey-dark": "#DBDFE3", // Orion 20 (--mb-base-color-gray-20)
   "admin-navbar": "#7172AD",
   white: "#FFFFFF",
   success: "#84BB4C",

--- a/frontend/src/metabase/lib/colors/palette.ts
+++ b/frontend/src/metabase/lib/colors/palette.ts
@@ -23,6 +23,7 @@ export const colors = {
   accent5: "#F2A86F",
   accent6: "#98D9D9",
   accent7: "#7172AD",
+  "accent-grey": "#B4BCC3",
   "admin-navbar": "#7172AD",
   white: "#FFFFFF",
   success: "#84BB4C",
@@ -74,6 +75,7 @@ export const aliases: Record<string, (palette: ColorPalette) => string> = {
   "accent5-light": palette => tint(color(`accent5`, palette)),
   "accent6-light": palette => tint(color(`accent6`, palette)),
   "accent7-light": palette => tint(color(`accent7`, palette)),
+  "accent-grey-light": palette => tint(color(`accent-grey`, palette)),
 
   "accent0-dark": palette => shade(color(`accent0`, palette)),
   "accent1-dark": palette => shade(color(`accent1`, palette)),
@@ -83,6 +85,7 @@ export const aliases: Record<string, (palette: ColorPalette) => string> = {
   "accent5-dark": palette => shade(color(`accent5`, palette)),
   "accent6-dark": palette => shade(color(`accent6`, palette)),
   "accent7-dark": palette => shade(color(`accent7`, palette)),
+  "accent-grey-dark": palette => shade(color(`accent-grey`, palette)),
 };
 
 /**

--- a/frontend/src/metabase/lib/colors/palette.ts
+++ b/frontend/src/metabase/lib/colors/palette.ts
@@ -24,6 +24,8 @@ export const colors = {
   accent6: "#98D9D9",
   accent7: "#7172AD",
   "accent-grey": "#B4BCC3",
+  "accent-grey-light": "#F3F5F7",
+  "accent-grey-dark": "#808991",
   "admin-navbar": "#7172AD",
   white: "#FFFFFF",
   success: "#84BB4C",
@@ -75,7 +77,6 @@ export const aliases: Record<string, (palette: ColorPalette) => string> = {
   "accent5-light": palette => tint(color(`accent5`, palette)),
   "accent6-light": palette => tint(color(`accent6`, palette)),
   "accent7-light": palette => tint(color(`accent7`, palette)),
-  "accent-grey-light": palette => tint(color(`accent-grey`, palette)),
 
   "accent0-dark": palette => shade(color(`accent0`, palette)),
   "accent1-dark": palette => shade(color(`accent1`, palette)),
@@ -85,7 +86,6 @@ export const aliases: Record<string, (palette: ColorPalette) => string> = {
   "accent5-dark": palette => shade(color(`accent5`, palette)),
   "accent6-dark": palette => shade(color(`accent6`, palette)),
   "accent7-dark": palette => shade(color(`accent7`, palette)),
-  "accent-grey-dark": palette => shade(color(`accent-grey`, palette)),
 };
 
 /**

--- a/frontend/src/metabase/lib/colors/palette.ts
+++ b/frontend/src/metabase/lib/colors/palette.ts
@@ -23,9 +23,9 @@ export const colors = {
   accent5: "#F2A86F",
   accent6: "#98D9D9",
   accent7: "#7172AD",
-  "accent-grey": "#F3F3F4", // Orion 10 (--mb-base-color-orion-10)
-  "accent-grey-light": "#FAFAFB", // Orion 5 (--mb-base-color-orion-5)
-  "accent-grey-dark": "#DCDFE0", // Orion 20 (--mb-base-color-orion-20)
+  "accent-gray": "#F3F3F4", // Orion 10 (--mb-base-color-orion-10)
+  "accent-gray-light": "#FAFAFB", // Orion 5 (--mb-base-color-orion-5)
+  "accent-gray-dark": "#DCDFE0", // Orion 20 (--mb-base-color-orion-20)
   "admin-navbar": "#7172AD",
   white: "#FFFFFF",
   success: "#84BB4C",

--- a/frontend/src/metabase/lib/colors/palette.ts
+++ b/frontend/src/metabase/lib/colors/palette.ts
@@ -23,9 +23,9 @@ export const colors = {
   accent5: "#F2A86F",
   accent6: "#98D9D9",
   accent7: "#7172AD",
-  "accent-grey": "#F3F5F7", // Orion 10 (--mb-base-color-gray-10)
-  "accent-grey-light": "#FAFBFC", // Orion 5 (--mb-base-color-gray-5)
-  "accent-grey-dark": "#DBDFE3", // Orion 20 (--mb-base-color-gray-20)
+  "accent-grey": "#F3F3F4", // Orion 10 (--mb-base-color-orion-10)
+  "accent-grey-light": "#FAFAFB", // Orion 5 (--mb-base-color-orion-5)
+  "accent-grey-dark": "#DCDFE0", // Orion 20 (--mb-base-color-orion-20)
   "admin-navbar": "#7172AD",
   white: "#FFFFFF",
   success: "#84BB4C",

--- a/frontend/src/metabase/lib/colors/types.ts
+++ b/frontend/src/metabase/lib/colors/types.ts
@@ -9,5 +9,5 @@ export interface AccentColorOptions {
   light?: boolean;
   dark?: boolean;
   harmony?: boolean;
-  grey?: boolean;
+  gray?: boolean;
 }

--- a/frontend/src/metabase/lib/colors/types.ts
+++ b/frontend/src/metabase/lib/colors/types.ts
@@ -9,4 +9,5 @@ export interface AccentColorOptions {
   light?: boolean;
   dark?: boolean;
   harmony?: boolean;
+  grey?: boolean;
 }

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingColorPicker/ChartSettingColorPicker.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingColorPicker/ChartSettingColorPicker.tsx
@@ -26,7 +26,7 @@ export const ChartSettingColorPicker = ({
     light: true,
     dark: true,
     harmony: false,
-    grey: true,
+    gray: true,
   },
 }: ChartSettingColorPickerProps) => {
   return (

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingColorPicker/ChartSettingColorPicker.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingColorPicker/ChartSettingColorPicker.tsx
@@ -21,7 +21,13 @@ export const ChartSettingColorPicker = ({
   title,
   pillSize,
   onChange,
-  accentColorOptions = { main: true, light: true, dark: true, harmony: false },
+  accentColorOptions = {
+    main: true,
+    light: true,
+    dark: true,
+    harmony: false,
+    grey: true,
+  },
 }: ChartSettingColorPickerProps) => {
   return (
     <div className={cx(CS.flex, CS.alignCenter, className)}>

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSeriesOrder.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSeriesOrder.tsx
@@ -186,12 +186,7 @@ export const ChartSettingSeriesOrder = ({
             <Group p={4} spacing="sm">
               <ColorSelector
                 value={otherColor ?? color("text-light")}
-                colors={[
-                  ...getAccentColors(),
-                  color("text-light"),
-                  color("text-medium"),
-                  color("text-dark"),
-                ]}
+                colors={getAccentColors()}
                 onChange={onOtherColorChange}
                 pillSize="small"
               />

--- a/frontend/src/metabase/visualizations/echarts/pie/util/colors.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/util/colors.ts
@@ -1,4 +1,7 @@
+import { match } from "ts-pattern";
+
 import { aliases, colors } from "metabase/lib/colors";
+import { isEmpty } from "metabase/lib/validate";
 
 const ACCENT_KEY_PREFIX = "accent";
 
@@ -8,7 +11,9 @@ const isAccentColorKey = (key: string) => key.startsWith(ACCENT_KEY_PREFIX);
 
 const extractAccentKey = (input: string): AccentKey => {
   const withoutPrefix = input.slice(ACCENT_KEY_PREFIX.length);
-  return withoutPrefix.split("-")[0] ?? null;
+  return (
+    withoutPrefix.split("-").filter(segment => !isEmpty(segment))[0] ?? null
+  );
 };
 
 export function createHexToAccentNumberMap() {
@@ -42,16 +47,31 @@ export function getRingColorAlias(
   accentKey: AccentKey,
   ring: "inner" | "middle" | "outer",
 ) {
-  let suffix = "";
-  if (ring === "inner") {
-    suffix = "-dark";
-  } else if (ring === "outer") {
-    suffix = "-light";
-  }
+  const variant = match(ring)
+    .with("inner", () => "dark")
+    .with("outer", () => "light")
+    .otherwise(() => null);
 
-  return `${ACCENT_KEY_PREFIX}${accentKey}${suffix}`;
+  return getColorName(accentKey, variant);
 }
 
 export function getPickerColorAlias(accentKey: AccentKey) {
-  return `${ACCENT_KEY_PREFIX}${accentKey}-dark`;
+  return getColorName(accentKey, "dark");
+}
+
+function getColorName(accentKey: AccentKey, variant: string | null) {
+  let colorName = ACCENT_KEY_PREFIX;
+
+  const isNumericKey = Number.isFinite(parseInt(accentKey));
+  if (isNumericKey) {
+    colorName += accentKey;
+  } else {
+    colorName += `-${accentKey}`;
+  }
+
+  if (variant != null) {
+    colorName += `-${variant}`;
+  }
+
+  return colorName;
 }

--- a/frontend/src/metabase/visualizations/echarts/pie/util/colors.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/util/colors.unit.spec.ts
@@ -3,17 +3,17 @@ import { getPickerColorAlias, getRingColorAlias } from "./colors";
 describe("getRingColorAlias", () => {
   it("should return the correct color alias for inner ring", () => {
     expect(getRingColorAlias("1", "inner")).toBe("accent1-dark");
-    expect(getRingColorAlias("grey", "inner")).toBe("accent-grey-dark");
+    expect(getRingColorAlias("gray", "inner")).toBe("accent-gray-dark");
   });
 
   it("should return the correct color alias for middle ring", () => {
     expect(getRingColorAlias("1", "middle")).toBe("accent1");
-    expect(getRingColorAlias("grey", "middle")).toBe("accent-grey");
+    expect(getRingColorAlias("gray", "middle")).toBe("accent-gray");
   });
 
   it("should return the correct color alias for outer ring", () => {
     expect(getRingColorAlias("1", "outer")).toBe("accent1-light");
-    expect(getRingColorAlias("grey", "outer")).toBe("accent-grey-light");
+    expect(getRingColorAlias("gray", "outer")).toBe("accent-gray-light");
   });
 });
 
@@ -24,7 +24,7 @@ describe("getPickerColorAlias", () => {
   });
 
   it("should return the correct color alias for non-numeric accent keys", () => {
-    expect(getPickerColorAlias("grey")).toBe("accent-grey-dark");
+    expect(getPickerColorAlias("gray")).toBe("accent-gray-dark");
     expect(getPickerColorAlias("something")).toBe("accent-something-dark");
   });
 });

--- a/frontend/src/metabase/visualizations/echarts/pie/util/colors.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/util/colors.unit.spec.ts
@@ -1,0 +1,30 @@
+import { getPickerColorAlias, getRingColorAlias } from "./colors";
+
+describe("getRingColorAlias", () => {
+  it("should return the correct color alias for inner ring", () => {
+    expect(getRingColorAlias("1", "inner")).toBe("accent1-dark");
+    expect(getRingColorAlias("grey", "inner")).toBe("accent-grey-dark");
+  });
+
+  it("should return the correct color alias for middle ring", () => {
+    expect(getRingColorAlias("1", "middle")).toBe("accent1");
+    expect(getRingColorAlias("grey", "middle")).toBe("accent-grey");
+  });
+
+  it("should return the correct color alias for outer ring", () => {
+    expect(getRingColorAlias("1", "outer")).toBe("accent1-light");
+    expect(getRingColorAlias("grey", "outer")).toBe("accent-grey-light");
+  });
+});
+
+describe("getPickerColorAlias", () => {
+  it("should return the correct color alias for numeric accent keys", () => {
+    expect(getPickerColorAlias("1")).toBe("accent1-dark");
+    expect(getPickerColorAlias("10")).toBe("accent10-dark");
+  });
+
+  it("should return the correct color alias for non-numeric accent keys", () => {
+    expect(getPickerColorAlias("grey")).toBe("accent-grey-dark");
+    expect(getPickerColorAlias("something")).toBe("accent-something-dark");
+  });
+});


### PR DESCRIPTION
[Slack convo](https://metaboat.slack.com/archives/C01LQQ2UW03/p1729747765162769)

### Description

Adds grey color accent to series color settings. It is not assigned to series by default compared to other color accents and instead it should be explicitly selected in series settings.

### How to verify

- Create a new line/area/bar/gauge/map chart
- Ensure you can select grey series colors
- Ensure grey color is not assigned automatically even on large number of series. Existing `frontend/src/metabase/lib/colors/charts.unit.spec.ts` specs verify that without changes.

### Demo

<img width="1717" alt="Screenshot 2024-10-24 at 3 48 52 PM" src="https://github.com/user-attachments/assets/86596943-4551-40f0-b30d-3e86a0d8b446">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
