### PR TITLE
Analyze tables for compound queries

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -79,7 +79,7 @@
   io.github.eerohele/pp                     {:git/tag "2024-01-04.60"           ; super fast pretty-printing library
                                              :git/sha "a428751"
                                              :git/url "https://github.com/eerohele/pp"}
-  io.github.metabase/macaw                  {:mvn/version "0.2.18"}             ; Parse native SQL queries
+  io.github.metabase/macaw                  {:mvn/version "0.2.20"}             ; Parse native SQL queries
   ;; The 2.X line of Resilience4j requires Java 17, so we cannot upgrade this dependency until that is our minimum JVM version
   io.github.resilience4j/resilience4j-retry {:mvn/version "1.7.1" #_"must be 1.7.1"} ; Support for retrying operations
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector


### PR DESCRIPTION
### Description

This PR updates Macaw to the latest version, which exposes a new analyzer which handles compound queries.

It also finishes the migration to using tagged-union result maps consistently across all the interfaces.

This should also remove the atrociously verbose analysis error messages in CI.