### PR TITLE
FE - e2e - Add tests verifying that pre-existing dashboards without "stage-number" attribute present work

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -2264,10 +2264,6 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
    */
   describe("click behavior parameter mappings for questions without target stage index", () => {
     beforeEach(() => {
-      cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-        "dashcardQuery",
-      );
-
       createQuestion({
         name: "Target question",
         query: {
@@ -2329,12 +2325,19 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
           cy.wrap(dashboard_id).as("dashboardId");
         });
       });
+
+      cy.intercept("POST", "/api/dataset").as("dataset");
+      cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
+        "dashcardQuery",
+      );
     });
 
     it("click behavior works even when 'stage-number' attribute is missing in target dimension", () => {
       cy.get("@dashboardId").then(dashboardId => visitDashboard(dashboardId));
       cy.wait("@dashcardQuery");
+
       cy.findAllByTestId("cell-data").contains("5").first().click();
+      cy.wait("@dataset");
 
       cy.findByTestId("app-bar").should(
         "contain.text",

--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -2309,7 +2309,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
                             dimension: [
                               "dimension",
                               ["field", PRODUCTS.RATING, null],
-                              /** { "stage-number": 0 } intentionally not provided */
+                              /** { "stage-number": 0 } intentionally omitted */
                             ],
                           },
                           id: [

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
@@ -214,7 +214,7 @@ describe("issue 16334", () => {
 
     const getVisualizationSettings = targetId => ({
       column_settings: {
-        [`["ref",["field",${REVIEWS.RATING},null],{"stage-number":0}]`]: {
+        [`["ref",["field",${REVIEWS.RATING},null]]`]: {
           click_behavior: {
             targetId,
             parameterMapping: {

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
@@ -214,23 +214,32 @@ describe("issue 16334", () => {
 
     const getVisualizationSettings = targetId => ({
       column_settings: {
-        [`["ref",["field",${REVIEWS.RATING},null]]`]: {
+        [`["ref",["field",${REVIEWS.RATING},null],{"stage-number":0}]`]: {
           click_behavior: {
             targetId,
             parameterMapping: {
-              [`["dimension",["field",${PRODUCTS.RATING},null]]`]: {
-                source: {
-                  type: "column",
-                  id: "RATING",
-                  name: "Rating",
+              [`["dimension",["field",${PRODUCTS.RATING},null],{"stage-number":0}]`]:
+                {
+                  source: {
+                    type: "column",
+                    id: "RATING",
+                    name: "Rating",
+                  },
+                  target: {
+                    type: "dimension",
+                    id: [
+                      `["dimension",["field",${PRODUCTS.RATING},null],{"stage-number":0}]`,
+                    ],
+                    dimension: [
+                      "dimension",
+                      ["field", PRODUCTS.RATING, null],
+                      { "stage-number": 0 },
+                    ],
+                  },
+                  id: [
+                    `["dimension",["field",${PRODUCTS.RATING},null],{"stage-number":0}]`,
+                  ],
                 },
-                target: {
-                  type: "dimension",
-                  id: [`["dimension",["field",${PRODUCTS.RATING},null]]`],
-                  dimension: ["dimension", ["field", PRODUCTS.RATING, null]],
-                },
-                id: [`["dimension",["field",${PRODUCTS.RATING},null]]`],
-              },
             },
             linkType: "question",
             type: "link",

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-query-stages.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-query-stages.cy.spec.ts
@@ -2153,13 +2153,9 @@ describe("parameter mappings without target stage index", () => {
     changeSynchronousBatchUpdateSetting(true); // prevent last_used_param_values from breaking test isolation
 
     cy.intercept("POST", "/api/dataset").as("dataset");
-    // cy.intercept("GET", "/api/dashboard/**").as("getDashboard");
-    // cy.intercept("PUT", "/api/dashboard/**").as("updateDashboard");
     cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
       "dashcardQuery",
     );
-
-    // question with 1 stage + aggregations + breakouts, filter on 1st stage without stage-number,
 
     createQuestionAndDashboard({
       questionDetails: {
@@ -2265,12 +2261,14 @@ describe("parameter mappings without target stage index", () => {
       getPopoverItem("Count").click();
     });
     saveDashboard();
+    cy.wait("@dashcardQuery");
 
     filterWidget().eq(1).click();
     popover().within(() => {
       cy.findByPlaceholderText("Enter a number").type("1");
       cy.button("Add filter").click();
     });
+    cy.wait("@dashcardQuery");
 
     getDashboardCard().within(() => {
       cy.findByText("No results!").should("be.visible");

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-query-stages.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-query-stages.cy.spec.ts
@@ -2186,6 +2186,13 @@ describe("parameter mappings without target stage index", () => {
             type: "string/=",
             sectionId: "string",
           },
+          {
+            name: "Number",
+            slug: "number",
+            id: "f5944ad9",
+            type: "number/=",
+            sectionId: "number",
+          },
         ],
       },
     }).then(({ body: { card_id, dashboard_id } }) => {
@@ -2244,6 +2251,43 @@ describe("parameter mappings without target stage index", () => {
         filters: ["Category is Gadget"],
         aggregations: ["Count"],
         breakouts: ["Category"],
+      },
+    ]);
+
+    cy.findByLabelText("Back to Test Dashboard").click();
+
+    cy.log("connect parameter with 'stage-number' attribute present");
+    editDashboard();
+
+    getFilter("Number").click();
+    getDashboardCard(0).findByText("Select…").click();
+    popover().within(() => {
+      getPopoverItem("Count").click();
+    });
+    saveDashboard();
+
+    filterWidget().eq(1).click();
+    popover().within(() => {
+      cy.findByPlaceholderText("Enter a number").type("1");
+      cy.button("Add filter").click();
+    });
+
+    getDashboardCard().within(() => {
+      cy.findByText("No results!").should("be.visible");
+      cy.findByTestId("legend-caption-title").click();
+    });
+
+    cy.wait("@dataset");
+
+    openNotebook();
+    verifyNotebookQuery("Products", [
+      {
+        filters: ["Category is Gadget"],
+        aggregations: ["Count"],
+        breakouts: ["Category"],
+      },
+      {
+        filters: ["Count is equal to 1"],
       },
     ]);
   });

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-query-stages.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-query-stages.cy.spec.ts
@@ -2155,9 +2155,9 @@ describe("parameter mappings without target stage index", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
     // cy.intercept("GET", "/api/dashboard/**").as("getDashboard");
     // cy.intercept("PUT", "/api/dashboard/**").as("updateDashboard");
-    // cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-    //   "dashboardData",
-    // );
+    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
+      "dashcardQuery",
+    );
 
     // question with 1 stage + aggregations + breakouts, filter on 1st stage without stage-number,
 
@@ -2206,7 +2206,7 @@ describe("parameter mappings without target stage index", () => {
                     "base-type": "type/Text",
                   },
                 ],
-                // { "stage-number": 0 }, intentionally omitted
+                // { "stage-number": 0 }, // intentionally omitted
               ],
             },
           ],
@@ -2214,6 +2214,7 @@ describe("parameter mappings without target stage index", () => {
       });
 
       visitDashboard(dashboard_id);
+      cy.wait("@dashcardQuery");
     });
   });
 
@@ -2227,11 +2228,12 @@ describe("parameter mappings without target stage index", () => {
       cy.findByText("Gadget").click();
       cy.button("Add filter").click();
     });
+    cy.wait("@dashcardQuery");
 
     getDashboardCard().within(() => {
       cy.findByText("Gadget").should("be.visible");
       cy.findByText("53").should("be.visible");
-      cy.findByTestId("legend-caption").click();
+      cy.findByTestId("legend-caption-title").click();
     });
 
     cy.wait("@dataset");
@@ -2240,8 +2242,6 @@ describe("parameter mappings without target stage index", () => {
     verifyNotebookQuery("Products", [
       {
         filters: ["Category is Gadget"],
-      },
-      {
         aggregations: ["Count"],
         breakouts: ["Category"],
       },


### PR DESCRIPTION
Closes #49109

### Description

Depends on ##48828

This PR adds tests asserting that pre-existing dashboards (which don't have `stage-number` attribute in target dimension) still work after changes from this epic.

Currently both tests fail as "migrations" are not there yet. But now we have something to test against.