### PR TITLE
Manual backport of [QP] Fix query caching for pivot queries (#48962)

### DIFF
--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -327,3 +327,10 @@
     (-> a-query
         (update :stages #(vec (take (inc stage-number) %)))
         (update-in [:stages stage-number] preview-stage clause-type clause-index))))
+
+(defn serializable
+  "Given a query, ensure it doesn't have any keys or structures that aren't safe for serialization.
+
+  For example, any Atoms or Delays or should be removed."
+  [a-query]
+  (dissoc a-query :lib/metadata))

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -14,6 +14,7 @@
    [java-time.api :as t]
    [medley.core :as m]
    [metabase.config :as config]
+   [metabase.lib.query :as lib.query]
    [metabase.public-settings :as public-settings]
    [metabase.query-processor.middleware.cache-backend.db :as backend.db]
    [metabase.query-processor.middleware.cache-backend.interface :as i]
@@ -61,7 +62,8 @@
   "Add `object` (e.g. a result row or metadata) to the current cache entry."
   [object]
   (when *in-fn*
-    (*in-fn* object)))
+    (*in-fn* (cond-> object
+               (map? object) (m/update-existing :json_query lib.query/serializable)))))
 
 (def ^:private ^:dynamic *result-fn*
   "The `result-fn` provided by [[impl/do-with-serialization]]."
@@ -141,7 +143,7 @@
          (let [normal-format? (and (map? (unreduced result))
                                    (seq (get-in (unreduced result) [:data :cols])))
                result*        (-> (if normal-format?
-                                    (merge-with merge @final-metadata (unreduced result))
+                                    (m/deep-merge @final-metadata (unreduced result))
                                     (unreduced result))
                                   (assoc :cache/details {:hash query-hash :cached true :updated_at last-ran}))]
            (rf (cond-> result*


### PR DESCRIPTION
This was throwing errors trying to `nippy/freeze!` an Atom.

That was because in certain circumstances a pMBQL query can end up in `(:json_query metadata)` for a query, and those can contain an atom due to `metabase.lib.cache` and both `CachedMetadataProvider` and `InvocationTracker`.

I added `lib.query/serializable` as a single location to strip out anything that isn't serializable, such as atoms. (And the entire `:lib/metadata`, which is a wasted effort to serialize.)