### PR TITLE
Fix csp directives for embed previews

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -181,6 +181,7 @@ const mainConfig = {
         },
       }
     : {}),
+  experimentalCspAllowList: ["frame-src"],
   projectId: "ywjy9z",
   numTestsKeptInMemory: process.env["CI"] ? 1 : 50,
   reporter: "cypress-multi-reporters",

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -2,6 +2,7 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   addOrUpdateDashboardCard,
   createNativeQuestion,
+  createQuestionAndDashboard,
   describeEE,
   filterWidget,
   getDashboardCard,
@@ -985,5 +986,40 @@ describe("issue 40660", () => {
         "be.visible",
       );
     });
+  });
+});
+
+describe("issue 49142", () => {
+  const questionDetails = {
+    name: "Products",
+    query: { "source-table": PRODUCTS_ID, limit: 2 },
+  };
+
+  const dashboardDetails = {
+    name: "Embeddable dashboard",
+    enable_embedding: true,
+  };
+
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    createQuestionAndDashboard({
+      questionDetails,
+      dashboardDetails,
+    }).then(({ body: { dashboard_id } }) => {
+      visitDashboard(dashboard_id);
+    });
+  });
+
+  it("embedding preview should be always working", () => {
+    openStaticEmbeddingModal({
+      activeTab: "lookAndFeel",
+      previewMode: "preview",
+    });
+    cy.findByTestId("embed-preview-iframe")
+      .its("0.contentDocument.body")
+      .should("be.visible")
+      .and("contain", "Embeddable dashboard");
   });
 });

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -104,7 +104,7 @@
   (->> (str/split hosts-string #"[ ,\s\r\n]+")
        (remove str/blank?)
        (mapcat add-wildcard-entries)
-       vec))
+       (into ["'self'"])))
 
 (def ^{:doc "Parse the string of allowed iframe hosts, adding wildcard prefixes as needed."}
   parse-allowed-iframe-hosts


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/49142

We set content security directives to allow for iframes on dashboards. This list did not include 'self' so we can't actually host an iframe pointing at our, well, self.

Embed previews work by just embedding an iframe with the dashboard and this breaks if we don't allow iframes from our self.

#### Before
<img width="1356" alt="image" src="https://github.com/user-attachments/assets/e50146d6-a0e9-4fe4-8889-996ecc983b6f">


#### After
<img width="1356" alt="image" src="https://github.com/user-attachments/assets/10c3e968-8d55-4a46-9097-c9a909a69281">
