### PR TITLE
Fix static embed card download when param has accentuation

### DIFF
--- a/e2e/support/helpers/api/createDashboardWithQuestions.ts
+++ b/e2e/support/helpers/api/createDashboardWithQuestions.ts
@@ -1,4 +1,4 @@
-import type { Card, Dashboard } from "metabase-types/api";
+import type { Card, Dashboard, DashboardCard } from "metabase-types/api";
 
 import { cypressWaitAll } from "../e2e-misc-helpers";
 
@@ -16,14 +16,11 @@ export const createDashboardWithQuestions = ({
   dashboardName?: string;
   dashboardDetails?: DashboardDetails;
   questions: (NativeQuestionDetails | StructuredQuestionDetails)[];
-  cards?: Partial<Card>[];
-}): Cypress.Chainable<
-  Cypress.Response<{
-    dashboard: Dashboard;
-    questions: Card;
-  }>
-> => {
-  // @ts-expect-error - Cypress typings don't account for what happens in then() here
+  cards?: Partial<DashboardCard>[];
+}): Cypress.Chainable<{
+  dashboard: Dashboard;
+  questions: Card[];
+}> => {
   return createDashboard({ name: dashboardName, ...dashboardDetails }).then(
     ({ body: dashboard }) => {
       return cypressWaitAll(

--- a/e2e/test/scenarios/embedding/embed-resource-downloads.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embed-resource-downloads.cy.spec.ts
@@ -150,7 +150,7 @@ describeWithSnowplowEE(
           createDashboardWithQuestions({
             // Can't figure out the type if I extracted `dashboardDetails` to a variable.
             dashboardDetails: {
-              name: "Dashboard with parameters",
+              name: "Dashboard with a parameter",
               parameters: [CATEGORY_FILTER],
               enable_embedding: true,
               embedding_params: {
@@ -316,7 +316,7 @@ describeWithSnowplowEE(
           // Can't figure out the type if I extracted `questionDetails` to a variable.
           createNativeQuestion(
             {
-              name: "25374",
+              name: "Native question with a parameter",
               native: {
                 "template-tags": {
                   num: {

--- a/e2e/test/scenarios/embedding/embed-resource-downloads.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embed-resource-downloads.cy.spec.ts
@@ -6,6 +6,7 @@ import {
 import {
   addOrUpdateDashboardCard,
   createDashboardWithQuestions,
+  createNativeQuestion,
   describeWithSnowplowEE,
   expectGoodSnowplowEvent,
   expectNoBadSnowplowEvents,
@@ -303,6 +304,92 @@ describeWithSnowplowEE(
           resource_type: "question",
           accessed_via: "static-embed",
           export_type: "csv",
+        });
+      });
+
+      describe("with native question parameters", () => {
+        beforeEach(() => {
+          cy.signInAsAdmin();
+
+          setTokenFeatures("all");
+
+          // Can't figure out the type if I extracted `questionDetails` to a variable.
+          createNativeQuestion(
+            {
+              name: "25374",
+              native: {
+                "template-tags": {
+                  num: {
+                    id: "f7672b4d-1e84-1fa8-bf02-b5e584cd4535",
+                    name: "num",
+                    "display-name": "Num",
+                    type: "number",
+                    default: null,
+                  },
+                },
+                query: "select {{num}}",
+              },
+              parameters: [
+                {
+                  id: "f7672b4d-1e84-1fa8-bf02-b5e584cd4535",
+                  type: "number/=",
+                  target: ["variable", ["template-tag", "num"]],
+                  name: "Num",
+                  slug: "num",
+                  default: null,
+                },
+              ],
+              enable_embedding: true,
+              embedding_params: {
+                num: "enabled",
+              },
+            },
+            {
+              idAlias: "questionId",
+              wrapId: true,
+            },
+          );
+
+          cy.signOut();
+        });
+
+        it("should be able to download a static embedded dashcard as CSV", () => {
+          const value = 9999;
+          cy.get("@questionId").then(questionId => {
+            visitEmbeddedPage(
+              {
+                resource: { question: Number(questionId) },
+                params: {
+                  num: value,
+                },
+              },
+              {
+                pageStyle: {
+                  downloads: true,
+                },
+              },
+            );
+          });
+
+          waitLoading();
+
+          main().findByText(value).should("exist");
+
+          cy.findByTestId("download-button").click();
+
+          popover().within(() => {
+            cy.findByText(".csv").click();
+            cy.findByTestId("download-results-button").click();
+          });
+
+          cy.verifyDownload(".csv", { contains: true });
+
+          expectGoodSnowplowEvent({
+            event: "download_results_clicked",
+            resource_type: "question",
+            accessed_via: "static-embed",
+            export_type: "csv",
+          });
         });
       });
     });

--- a/frontend/src/metabase/redux/downloads.ts
+++ b/frontend/src/metabase/redux/downloads.ts
@@ -164,9 +164,9 @@ const getDatasetParams = ({
 }: DownloadQueryResultsOpts): DownloadQueryResultsParams => {
   const cardId = question.id();
 
-  const exportParams: Record<string, string> = {
-    format_rows: String(enableFormatting),
-    pivot_results: String(enablePivot),
+  const exportParams = {
+    format_rows: enableFormatting,
+    pivot_results: enablePivot,
   };
 
   const { accessedVia, resourceType: resource } = getDownloadedResourceType({
@@ -208,7 +208,7 @@ const getDatasetParams = ({
         url: `/api/embed/dashboard/${token}/dashcard/${dashcardId}/card/${cardId}/${type}`,
         params: new URLSearchParams({
           parameters: JSON.stringify(params),
-          ...exportParams,
+          ..._.mapObject(exportParams, value => String(value)),
         }),
       };
     }
@@ -221,7 +221,7 @@ const getDatasetParams = ({
         url: Urls.embedCard(token, type),
         params: new URLSearchParams({
           parameters: JSON.stringify(Object.fromEntries(params)),
-          ...exportParams,
+          ..._.mapObject(exportParams, value => String(value)),
         }),
       };
     }

--- a/frontend/src/metabase/redux/downloads.ts
+++ b/frontend/src/metabase/redux/downloads.ts
@@ -164,9 +164,9 @@ const getDatasetParams = ({
 }: DownloadQueryResultsOpts): DownloadQueryResultsParams => {
   const cardId = question.id();
 
-  const exportParams = {
-    format_rows: enableFormatting,
-    pivot_results: enablePivot,
+  const exportParams: Record<string, string> = {
+    format_rows: String(enableFormatting),
+    pivot_results: String(enablePivot),
   };
 
   const { accessedVia, resourceType: resource } = getDownloadedResourceType({
@@ -206,20 +206,23 @@ const getDatasetParams = ({
       return {
         method: "GET",
         url: `/api/embed/dashboard/${token}/dashcard/${dashcardId}/card/${cardId}/${type}`,
-        params: Urls.getEncodedUrlSearchParams({ ...params, ...exportParams }),
+        params: new URLSearchParams({
+          parameters: JSON.stringify(params),
+          ...exportParams,
+        }),
       };
     }
 
     if (resource === "question" && token) {
-      // For whatever wacky reason the /api/embed endpoint expect params like ?key=value instead
-      // of like ?params=<json-encoded-params-array> like the other endpoints do.
       const params = new URLSearchParams(window.location.search);
-      params.set("format_rows", String(enableFormatting));
-      params.set("pivot_results", String(enablePivot));
+
       return {
         method: "GET",
         url: Urls.embedCard(token, type),
-        params,
+        params: new URLSearchParams({
+          parameters: JSON.stringify(Object.fromEntries(params)),
+          ...exportParams,
+        }),
       };
     }
   }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/49118

Caused by MS3 of a project #46335, I believe there was a merge conflict when the fix #46250 landed a day before we merged the project PR, so we missed this.

### Description

Restore the fix from #46250 by passing params in `parameters` as a JSON string rather than passing it directly.

I also change question download to use `parameters` like the original fix from #46250, but there's no bug in question downloads as we can't seem to create a parameter with accentuation unlike dashboard parameters.

### How to verify

Follow the repro step from #49118

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
