### PR TITLE
Skip model persistence for users using connection impersonation

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/api/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/api/util.clj
@@ -1,11 +1,26 @@
 (ns metabase-enterprise.advanced-permissions.api.util
   (:require
+   [metabase-enterprise.advanced-permissions.driver.impersonation :as advanced-perms.driver.impersonation]
    [metabase.api.common :refer [*current-user-id* *is-superuser?*]]
    [metabase.models.permissions-group-membership
     :refer [PermissionsGroupMembership]]
    [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.util.i18n :refer [tru]]
    [toucan2.core :as t2]))
+
+(defenterprise impersonation-enforced-for-db?
+  "Returns a boolean if the current user has a connection impersonation policy which should be enforced for the provided
+  database. Will throw an error if [[api/*current-user-id*]] is not bound."
+  :feature :advanced-permissions
+  [db-or-id]
+  (boolean
+   (when-not *is-superuser?*
+     (if *current-user-id*
+       (seq (advanced-perms.driver.impersonation/enforced-impersonations-for-db db-or-id))
+       ;; If no *current-user-id* is bound we can't check for impersonations, so we should throw in this case to avoid
+       ;; returning `false` for users who should actually be using impersonation.
+       (throw (ex-info (str (tru "No current user found"))
+                       {:status-code 403}))))))
 
 ;; TODO: this function should only return true if an impersonation policy is enforced for the user
 (defenterprise impersonated-user?

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
@@ -48,19 +48,31 @@
    (when (and db-or-id (premium-features/enable-advanced-permissions?))
      (t2/exists? :model/ConnectionImpersonation :db_id (u/id db-or-id)))))
 
+(defn enforced-impersonations-for-db
+  "Returns the connection impersonation policies which should be enforced for the provided DB for the current user, if one
+  exists. Returns `nil` if no policies exist, or none should be enforced for the current user.
+
+  Note: this returns a list of policies. Typically a user should only be in one group with an impersonation policy at a time,
+  but there may be policies in multiple groups if they use the same user attribute."
+  [db-or-id]
+  (let [group-ids           (t2/select-fn-set :group_id PermissionsGroupMembership :user_id api/*current-user-id*)
+        conn-impersonations (when (seq group-ids)
+                              (t2/select :model/ConnectionImpersonation
+                                         :group_id [:in group-ids]
+                                         :db_id (u/the-id db-or-id)))]
+    (when (and (seq conn-impersonations)
+               (enforce-impersonations? db-or-id conn-impersonations group-ids))
+      conn-impersonations)))
+
 (defn connection-impersonation-role
   "Fetches the database role that should be used for the current user, if connection impersonation is in effect.
   Returns `nil` if connection impersonation should not be used for the current user. Throws an exception if multiple
   conflicting connection impersonation policies are found, or the role is not a single string."
   [database-or-id]
   (when (and database-or-id (not api/*is-superuser?*))
-    (let [group-ids           (t2/select-fn-set :group_id PermissionsGroupMembership :user_id api/*current-user-id*)
-          conn-impersonations (when (seq group-ids)
-                                (t2/select :model/ConnectionImpersonation
-                                           :group_id [:in group-ids]
-                                           :db_id (u/the-id database-or-id)))
+    (let [conn-impersonations (enforced-impersonations-for-db database-or-id)
           role-attributes     (set (map :attribute conn-impersonations))]
-      (when (enforce-impersonations? database-or-id conn-impersonations group-ids)
+      (when conn-impersonations
         (when (> (count role-attributes) 1)
           (throw (ex-info (tru "Multiple conflicting connection impersonation policies found for current user")
                           {:user-id api/*current-user-id*

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
@@ -214,15 +214,16 @@
                                         :database (mt/id)}]
                     (let [admin-result        (mt/as-admin (qp/process-query query))
                           impersonated-result (mt/with-test-user :rasta (qp/process-query query))]
-                      (testing "Query from admin hits the model cache"
-                        (is (str/includes? (-> admin-result :data :native_form :query)
-                                           (:table_name persisted-info))
-                            "Did not use the persisted model cache"))
-
                       (testing "Impersonated user (rasta) does not hit the model cache"
                         (is (not (str/includes? (-> impersonated-result :data :native_form :query)
                                                 (:table_name persisted-info)))
-                            "Erroneously used the persisted model cache"))))
+                            "Erroneously used the persisted model cache"))
+
+                      ;; Make sure we run admin query second to reset the DB role on the connection for other tests!
+                      (testing "Query from admin hits the model cache"
+                        (is (str/includes? (-> admin-result :data :native_form :query)
+                                           (:table_name persisted-info))
+                            "Did not use the persisted model cache"))))
                   (finally
                     (doseq [statement ["REVOKE ALL PRIVILEGES ON TABLE \"products\" FROM \"impersonation_role\";"
                                        "DROP ROLE IF EXISTS \"impersonation_role\";"]]

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
@@ -212,18 +212,19 @@
                                         :query    {:aggregation  [:count]
                                                    :source-table (str "card__" (:id model))}
                                         :database (mt/id)}]
-                    (let [admin-result        (mt/as-admin (qp/process-query query))
-                          impersonated-result (mt/with-test-user :rasta (qp/process-query query))]
+                    (let [impersonated-result (mt/with-test-user :rasta (qp/process-query query))
+                          ;; Make sure we run admin query second to reset the DB role on the connection for other tests!
+                          admin-result        (mt/as-admin (qp/process-query query))]
                       (testing "Impersonated user (rasta) does not hit the model cache"
                         (is (not (str/includes? (-> impersonated-result :data :native_form :query)
                                                 (:table_name persisted-info)))
                             "Erroneously used the persisted model cache"))
 
-                      ;; Make sure we run admin query second to reset the DB role on the connection for other tests!
                       (testing "Query from admin hits the model cache"
                         (is (str/includes? (-> admin-result :data :native_form :query)
                                            (:table_name persisted-info))
                             "Did not use the persisted model cache"))))
+
                   (finally
                     (doseq [statement ["REVOKE ALL PRIVILEGES ON TABLE \"products\" FROM \"impersonation_role\";"
                                        "DROP ROLE IF EXISTS \"impersonation_role\";"]]

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
@@ -1,6 +1,7 @@
 (ns ^:mb/driver-tests metabase-enterprise.advanced-permissions.driver.impersonation-test
   (:require
    [clojure.java.jdbc :as jdbc]
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase-enterprise.advanced-permissions.api.util-test
     :as advanced-perms.api.tu]
@@ -9,6 +10,7 @@
    [metabase.driver.postgres-test :as postgres-test]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.models.database :refer [Database]]
+   [metabase.query-processor :as qp]
    [metabase.server.middleware.session :as mw.session]
    [metabase.sync :as sync]
    [metabase.test :as mt]
@@ -183,3 +185,48 @@
                       {:aggregation [[:count]]})))))
           (finally
             (t2/update! :model/Database :id (mt/id) (update (mt/db) :details dissoc :role))))))))
+
+(deftest persistence-disabled-when-impersonated-test
+  ;; Test explicitly with postgres since it supports persistence and impersonation
+  (mt/test-drivers #{:postgres}
+    (mt/with-premium-features #{:advanced-permissions}
+      (mt/dataset test-data
+        (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                     :attributes     {"impersonation_attr" "impersonation_role"}}
+          ;; Create impersonation_role on test DB
+          (let [details (t2/select-one-fn :details :model/Database (mt/id))
+                spec    (sql-jdbc.conn/connection-details->spec :postgres details)]
+            (doseq [statement ["DROP ROLE IF EXISTS \"impersonation_role\";"
+                               "CREATE ROLE \"impersonation_role\";"
+                               "GRANT ALL PRIVILEGES ON TABLE \"products\" to \"impersonation_role\";"]]
+              (jdbc/execute! spec [statement]))
+            (try
+              (mt/with-persistence-enabled! [persist-models!]
+                (mt/with-temp [:model/Card model {:type          :model
+                                                  :dataset_query (mt/mbql-query products)}]
+                  ;; persist model as admin
+                  (mt/with-test-user :crowberto
+                    (persist-models!))
+                  (let [persisted-info      (t2/select-one :model/PersistedInfo
+                                                           :database_id (mt/id)
+                                                           :card_id (:id model))
+                        query               {:type     :query
+                                             :query    {:aggregation  [:count]
+                                                        :source-table (str "card__" (:id model))}
+                                             :database (mt/id)}
+                        admin-result        (mt/with-test-user :crowberto
+                                              (qp/process-query query))
+                        impersonated-result (mt/with-test-user :rasta
+                                              (qp/process-query query))]
+                    (testing "Query from admin hits the model cache"
+                      (is (str/includes? (-> admin-result :data :native_form :query)
+                                         (:table_name persisted-info))
+                          "Did not use the persisted model cache"))
+                    (testing "Impersonated user (rasta) does not hit the model cache"
+                      (is (not (str/includes? (-> impersonated-result :data :native_form :query)
+                                              (:table_name persisted-info)))
+                          "Erroneously used the persisted model cache")))))
+              (finally
+                (doseq [statement ["REVOKE ALL PRIVILEGES ON TABLE \"products\" FROM \"impersonation_role\";"
+                                   "DROP ROLE IF EXISTS \"impersonation_role\";"]]
+                  (jdbc/execute! spec [statement]))))))))))

--- a/enterprise/backend/test/metabase_enterprise/cache/config_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/config_test.clj
@@ -147,7 +147,10 @@
                                    (swap! called-on conj (u/the-id persisted-info))))
                 queued-for-deletion (into #{} (map :id) (#'task.persist-refresh/deletable-models))]
             (testing "Query finds deletabable, and off persisted infos"
-              (is (= (set (map u/the-id deletable-persisted-infos)) queued-for-deletion)))
+              ;; use superset, because orphaned PersistedInfo records from other tests might also be deletable
+              (is (set/superset?
+                   (set (map u/the-id deletable-persisted-infos))
+                   queued-for-deletion)))
               ;; we manually pass in the deleteable ones to not catch others in a running instance
             (testing "Both deletables are pruned by prune-deletables!"
               (#'task.persist-refresh/prune-deletables! test-refresher deletable-persisted-infos)

--- a/enterprise/backend/test/metabase_enterprise/cache/config_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/config_test.clj
@@ -148,9 +148,7 @@
                 queued-for-deletion (into #{} (map :id) (#'task.persist-refresh/deletable-models))]
             (testing "Query finds deletabable, and off persisted infos"
               ;; use superset, because orphaned PersistedInfo records from other tests might also be deletable
-              (is (set/superset?
-                   (set (map u/the-id deletable-persisted-infos))
-                   queued-for-deletion)))
+              (is (set/superset? queued-for-deletion (set (map u/the-id deletable-persisted-infos)))))
               ;; we manually pass in the deleteable ones to not catch others in a running instance
             (testing "Both deletables are pruned by prune-deletables!"
               (#'task.persist-refresh/prune-deletables! test-refresher deletable-persisted-infos)

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
@@ -1087,7 +1087,7 @@
             (is (= {:cached? false, :num-rows 5}
                    (run-query)))))))))
 
-(deftest persistence-disabled-when-sandboxed
+(deftest persistence-disabled-when-sandboxed-test
   (mt/test-drivers (mt/normal-drivers-with-feature :persist-models)
     (mt/dataset test-data
       ;; with-gtaps! creates a new copy of the database. So make sure to do that before anything else. Gets really
@@ -1107,7 +1107,7 @@
             ;; persist model (as admin, so sandboxing is not applied to the persisted query)
             (mt/with-test-user :crowberto
               (persist-models!))
-            (let [persisted-info (t2/select-one 'PersistedInfo
+            (let [persisted-info (t2/select-one :model/PersistedInfo
                                                 :database_id (mt/id)
                                                 :card_id (:id model))]
               (is (= "persisted" (:state persisted-info))

--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -770,6 +770,20 @@
   ;; ee version becomes available
   false)
 
+(defenterprise impersonation-enforced-for-db?
+  "Returns a boolean if the current user has an enforced connection impersonation policy for a provided database. In OSS
+  this is always false. Will throw an error if [[api/*current-user-id*]] is not bound."
+  metabase-enterprise.advanced-permissions.api.util
+  [_db-or-id]
+  (when-not api/*current-user-id*
+    ;; If no *current-user-id* is bound we can't check for impersonations, so we should throw in this case to avoid
+    ;; returning `false` for users who should actually be using impersonations.
+    (throw (ex-info (str (tru "No current user found"))
+                    {:status-code 403})))
+  ;; oss doesn't have connection impersonation. But we throw if no current-user-id so the behavior doesn't change when
+  ;; ee version becomes available
+  false)
+
 (defn sandboxed-or-impersonated-user?
   "Returns a boolean if the current user uses sandboxing or connection impersonation for any database. In OSS is always
   false. Will throw an error if [[api/*current-user-id*]] is not bound."

--- a/src/metabase/query_processor/middleware/persistence.clj
+++ b/src/metabase/query_processor/middleware/persistence.clj
@@ -1,17 +1,21 @@
 (ns metabase.query-processor.middleware.persistence
   (:require
    [metabase.lib.util.match :as lib.util.match]
-   [metabase.models.query.permissions :as query-perms]))
+   [metabase.models.query.permissions :as query-perms]
+   [metabase.public-settings.premium-features :as premium-features]))
 
 (defn substitute-persisted-query
-  "Removes persisted information if user is sandboxed.
-   `:persisted-info/native` is set in [[metabase.query-processor.middleware.fetch-source-query]].
+  "Removes persisted information if user is sandboxed or uses connection impersonation. `:persisted-info/native` is set
+  in [[metabase.query-processor.middleware.fetch-source-query]].
 
-   If permissions are applied to the query (sandboxing) then do not use the cached query.
-   It may be be possible to use the persistence cache with sandboxing at a later date with further work."
-  [{::query-perms/keys [perms] :as  query}]
-  (if perms
+  Sandboxing is detected by the presence of the ::query-perms/perms key added by row-level-restrictions middleware.
+
+  It may be be possible to use the persistence cache with sandboxing and/or impersonation at a later date with further
+  work, but for now we skip the cache in these cases."
+  [{::query-perms/keys [perms] :as query}]
+  (if (or perms ;; sandboxed?
+          (premium-features/impersonation-enforced-for-db? (:database query)))
     (lib.util.match/replace query
-      (x :guard (every-pred map? :persisted-info/native))
-      (dissoc x :persisted-info/native))
+                            (x :guard (every-pred map? :persisted-info/native))
+                            (dissoc x :persisted-info/native))
     query))

--- a/src/metabase/query_processor/middleware/persistence.clj
+++ b/src/metabase/query_processor/middleware/persistence.clj
@@ -1,5 +1,6 @@
 (ns metabase.query-processor.middleware.persistence
   (:require
+   [metabase.api.common :as api]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.models.query.permissions :as query-perms]
    [metabase.public-settings.premium-features :as premium-features]))
@@ -13,9 +14,10 @@
   It may be be possible to use the persistence cache with sandboxing and/or impersonation at a later date with further
   work, but for now we skip the cache in these cases."
   [{::query-perms/keys [perms] :as query}]
-  (if (or perms ;; sandboxed?
-          (premium-features/impersonation-enforced-for-db? (:database query)))
+  (if (and api/*current-user-id*
+           (or perms ;; sandboxed?
+               (premium-features/impersonation-enforced-for-db? (:database query))))
     (lib.util.match/replace query
-                            (x :guard (every-pred map? :persisted-info/native))
-                            (dissoc x :persisted-info/native))
+      (x :guard (every-pred map? :persisted-info/native))
+      (dissoc x :persisted-info/native))
     query))

--- a/test/metabase/query_processor/persistence_test.clj
+++ b/test/metabase/query_processor/persistence_test.clj
@@ -93,6 +93,7 @@
                   (is (= [[num-rows-query]] (mt/rows (qp/process-query query-on-top)))))))))))))
 
 ;; sandbox tests in metabase-enterprise.sandbox.query-processor.middleware.row-level-restrictions-test
+;; impersonation tests in metabase-enterprise.advanced-permissions.driver.impersonation-test
 
 (defn- populate-metadata [{query :dataset_query id :id :as _model}]
   (let [updater (a/thread


### PR DESCRIPTION
Skips using the model persistence cache for queries by users who have a connection impersonation policy in place for the DB being queried. Only applicable to postgres at the moment since no other driver supports both features.

Resolves https://github.com/metabase/metabase/issues/49172