### PR TITLE
temporary disable csp in cypress

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -181,7 +181,6 @@ const mainConfig = {
         },
       }
     : {}),
-  experimentalCspAllowList: ["frame-src"],
   projectId: "ywjy9z",
   numTestsKeptInMemory: process.env["CI"] ? 1 : 50,
   reporter: "cypress-multi-reporters",

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -989,7 +989,8 @@ describe("issue 40660", () => {
   });
 });
 
-describe("issue 49142", () => {
+// Skipped since it does not make sense when CSP is disabled
+describe.skip("issue 49142", () => {
   const questionDetails = {
     name: "Products",
     query: { "source-table": PRODUCTS_ID, limit: 2 },


### PR DESCRIPTION
### Description

[Slack convo](https://metaboat.slack.com/archives/C505ZNNH4/p1729882659997879)
Cypress by default strips all CSP headers. Previously, I enabled CSP headers only for `frame-src` to verify iframes behavior but it seems to be enabling other CSP headers which prevents some styles from loading. Temporary removing the setting until I find the right solution.