### PR TITLE
[MBQL lib] Relax schema to avoid spammy normalization warnings

### DIFF
--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -1634,16 +1634,15 @@
 (mr/def ::check-keys-for-query-type
   [:and
    [:fn
-    {:error/message "Query must specify either `:native` or `:query`, but not both."}
-    (every-pred
-     (some-fn :native :query)
-     (complement (every-pred :native :query)))]
+    {:error/message "Query must specify at most one of `:native` or `:query`, but not both."}
+    (complement (every-pred :native :query))]
    [:fn
-    {:error/message "Native queries must specify `:native`; MBQL queries must specify `:query`."}
+    {:error/message "Native queries must not specify `:query`; MBQL queries must not specify `:native`."}
     (fn [{native :native, mbql :query, query-type :type}]
       (core/case query-type
-        :native native
-        :query  mbql))]])
+        :native (core/not mbql)
+        :query  (core/not native)
+        false))]])
 
 (mr/def ::check-query-does-not-have-source-metadata
   "`:source-metadata` is added to queries when `card__id` source queries are resolved. It contains info about the
@@ -1666,7 +1665,7 @@
 (mr/def ::Query
   [:and
    [:map
-    [:database ::DatabaseID]
+    [:database   {:optional true} ::DatabaseID]
 
     [:type
      [:enum

--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -585,8 +585,9 @@
                         :native
                         :query)]
       (merge (dissoc base :stages :parameters :lib.convert/converted?)
-             (cond-> {:type query-type query-type inner-query}
-               (seq parameters) (assoc :parameters parameters))))
+             (cond-> {:type query-type}
+               (seq inner-query) (assoc query-type inner-query)
+               (seq parameters)  (assoc :parameters parameters))))
     (catch #?(:clj Throwable :cljs :default) e
       (throw (ex-info (lib.util/format "Error converting MLv2 query to legacy query: %s" (ex-message e))
                       {:query query}

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -88,6 +88,7 @@
    card-type :- ::lib.schema.metadata/card.type]
   (and (binding [lib.schema.expression/*suppress-expression-type-check?* true]
          (mr/validate ::lib.schema/query query))
+       (:database query)
        (boolean (can-run-method query card-type))))
 
 (defmulti can-save-method

--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -45,8 +45,9 @@
     {:decode/normalize common/normalize-map}
     [:lib/type [:= {:decode/normalize common/normalize-keyword} :mbql.stage/native]]
     ;; the actual native query, depends on the underlying database. Could be a raw SQL string or something like that.
-    ;; Only restriction is that it is non-nil.
-    [:native some?]
+    ;; Only restriction is that, if present, it is non-nil.
+    ;; It is valid to have a blank query like `{:type :native}` in legacy.
+    [:native {:optional true} some?]
     ;; any parameters that should be passed in along with the query to the underlying query engine, e.g. for JDBC these
     ;; are the parameters we pass in for a `PreparedStatement` for `?` placeholders. These can be anything, including
     ;; nil.
@@ -224,9 +225,7 @@
   [:multi {:dispatch      lib-type
            :error/message "Invalid stage :lib/type: expected :mbql.stage/native or :mbql.stage/mbql"}
    [:mbql.stage/native :map]
-   [:mbql.stage/mbql   [:fn
-                        {:error/message "An initial MBQL stage of a query must have :source-table or :source-card"}
-                        (some-fn :source-table :source-card)]]])
+   [:mbql.stage/mbql   :map]])
 
 (mr/def ::stage.additional
   [:multi {:dispatch      lib-type
@@ -338,9 +337,9 @@
     [:lib/type [:=
                 {:decode/normalize common/normalize-keyword}
                 :mbql/query]]
-    [:database [:multi {:dispatch (partial = id/saved-questions-virtual-database-id)}
-                [true  ::id/saved-questions-virtual-database]
-                [false ::id/database]]]
+    [:database {:optional true} [:multi {:dispatch (partial = id/saved-questions-virtual-database-id)}
+                                 [true  ::id/saved-questions-virtual-database]
+                                 [false ::id/database]]]
     [:stages   [:ref ::stages]]
     [:parameters {:optional true} [:maybe [:ref ::parameter/parameters]]]
     ;;

--- a/test/metabase/actions_test.clj
+++ b/test/metabase/actions_test.clj
@@ -169,8 +169,10 @@
       (testing (str action " without :query")
         (is (thrown-with-msg?
              Exception
-             #"\QMBQL queries must specify `:query`.\E"
-             (actions/perform-action! action (dissoc request-body :query))))))))
+             #"\QNative queries must not specify `:query`; MBQL queries must not specify `:native`.\E"
+             (actions/perform-action! action (-> request-body
+                                                 (dissoc :query)
+                                                 (assoc :native {:query "Not really a SQL query"})))))))))
 
 (deftest row-update-action-gives-400-when-matching-more-than-one
   (mt/test-drivers (mt/normal-drivers-with-feature :actions)

--- a/test/metabase/lib/schema/join_test.cljc
+++ b/test/metabase/lib/schema/join_test.cljc
@@ -13,9 +13,13 @@
   (is (=? {:stages ["should have at least 1 elements" ["end of input"]]}
           (mu.humanize/humanize (mc/explain ::lib.schema.join/join {:stages []}))))
   ;; not sure why these errors are repeated.
-  (is (=? {:stages [[{:joins [{:stages [[{:lib/type "missing required key"}
-                                         "Invalid stage :lib/type: expected :mbql.stage/native or :mbql.stage/mbql"]]}]}
-                     "An initial MBQL stage of a query must have :source-table or :source-card"]]}
+  (is (=? {:lib/type "missing required key"
+           :stages [{:joins [{:stages [[{:lib/type "missing required key"}
+                                        "Invalid stage :lib/type: expected :mbql.stage/native or :mbql.stage/mbql"]]
+                              :lib/options "missing required key"
+                              :conditions  "should have at least 1 elements"}]}]}
           (mu.humanize/humanize (mc/explain ::lib.schema/query {:stages [{:lib/type :mbql.stage/mbql
                                                                           :joins    [{:lib/type :mbql/join
-                                                                                      :stages   [{}]}]}]})))))
+                                                                                      :stages   [{}]
+                                                                                      :conditions []
+                                                                                      :alias      "join alias"}]}]})))))

--- a/test/metabase/lib/schema_test.cljc
+++ b/test/metabase/lib/schema_test.cljc
@@ -63,6 +63,12 @@
       (is (=? {:stages [{:order-by [#"^Duplicate values ignoring uuids in.*"]}]}
               (me/humanize (mc/explain ::lib.schema/query query-with-duplicate-order-bys)))))))
 
+(deftest ^:parallel allow-blank-database-test
+  (testing ":database field can be missing"
+    (is (not (mc/explain ::lib.schema/query {:lib/type :mbql/query
+                                             :stages   [{:lib/type :mbql.stage/native
+                                                         :native   "SELECT 1"}]})))))
+
 (def ^:private valid-ag-1
   [:count {:lib/uuid (str (random-uuid))}])
 


### PR DESCRIPTION
Part of #43400.

### Description

In particular, this allows for a nearly-blank query without its
`:database` set, and without inner `:query` or `:native` (legacy)
or anything in the stage but the `:lib/type` (pMBQL).

### How to verify

1. Click around with the JS console open
2. Observe no `metabase.lib.normalize` warnings anymore

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
