### PR TITLE
test(sdk): assert abort calls on static question unmount

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/StaticQuestion/StaticQuestion.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/StaticQuestion/StaticQuestion.unit.spec.tsx
@@ -180,14 +180,14 @@ describe("StaticQuestion", () => {
     const abortSpy = jest.spyOn(AbortController.prototype, "abort");
 
     const { unmount } = setup();
-
     await act(async () => unmount());
 
-    expect(abortSpy).toHaveBeenCalled();
-    abortSpy.mockRestore();
-
-    // sanity check that the two requests were made initially
+    // two requests should've been made initially
     expect(fetchMock.calls(`path:/api/card/1`).length).toBe(1);
     expect(fetchMock.calls(`path:/api/card/1/query`).length).toBe(1);
+
+    // consequently, two abort calls should've been made for the two requests
+    expect(abortSpy).toHaveBeenCalledTimes(2);
+    abortSpy.mockRestore();
   });
 });


### PR DESCRIPTION
Asserts that two abort calls are made when unmounting static question unmount, one for `/card/1` and one for `/card/1/query`