### PR TITLE
never show the ai section in AG

### DIFF
--- a/frontend/src/metabase/admin/settings/selectors/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors/selectors.js
@@ -501,7 +501,9 @@ export const ADMIN_SETTINGS_SECTIONS = {
   },
   llm: {
     name: t`AI Features`,
-    getHidden: () => !PLUGIN_LLM_AUTODESCRIPTION.isEnabled(),
+    getHidden: settings => {
+      !PLUGIN_LLM_AUTODESCRIPTION.isEnabled() && !settings["airgap-enabled"];
+    },
     order: 131,
     settings: [
       {


### PR DESCRIPTION
- AG instances cannot connect to open ai, so they don't need to ever see that setting.