### PR TITLE
[redshift] Disable legacy parsing implementation for Redshift driver

### DIFF
--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -32,7 +32,7 @@
 
 (set! *warn-on-reflection* true)
 
-(driver/register! :redshift, :parent #{:postgres ::sql-jdbc.legacy/use-legacy-classes-for-read-and-set})
+(driver/register! :redshift, :parent #{:postgres})
 
 (doseq [[feature supported?] {:connection-impersonation  true
                               :describe-fields           true

--- a/test/metabase/query_processor_test/alternative_date_test.clj
+++ b/test/metabase/query_processor_test/alternative_date_test.clj
@@ -490,9 +490,9 @@
 
 (defmethod yyyymmddhhmmss-dates-expected-rows :redshift
   [_driver]
-  [[1 "foo" #t "2019-04-21T16:43Z[UTC]"]
-   [2 "bar" #t "2020-04-21T16:43Z[UTC]"]
-   [3 "baz" #t "2021-04-21T16:43Z[UTC]"]])
+  [[1 "foo" (OffsetDateTime/from #t "2019-04-21T16:43Z[UTC]")]
+   [2 "bar" (OffsetDateTime/from #t "2020-04-21T16:43Z[UTC]")]
+   [3 "baz" (OffsetDateTime/from #t "2021-04-21T16:43Z[UTC]")]])
 
 (doseq [driver [:h2 :postgres]]
   (defmethod yyyymmddhhmmss-dates-expected-rows driver


### PR DESCRIPTION
IIUC, Redshift JDBC driver used to not be compliant with JDBC 4.2 spec and didn't handle TIMESTAMP -> java.sql.Timestamp conversions correctly. That's why it is marked with additional flag to use manual timestamp parsing in the client code. This parsing is less efficient than the native one.

Nowadays, this page claims Redshift to be compatible with JDBC 4.2: https://docs.aws.amazon.com/redshift/latest/mgmt/jdbc20-download-driver.html. If this is true, then we can perhaps turn off legacy parsing for Redshift.

Obviously, I'll need some input/confirmation from somebody who is familiar with Redshift.