### PR TITLE
[qp] Convert timestamps to strings as the last post-processing step

### DIFF
--- a/src/metabase/analyze/fingerprint/insights.clj
+++ b/src/metabase/analyze/fingerprint/insights.clj
@@ -242,7 +242,7 @@
         xfn        #(nth % x-position)]
     (fingerprinters/with-error-handling
       ((map (fn [row]
-              ;; Convert string datetime into days-from-epoch early.
+              ;; Convert string datetimes or Instants into into days-from-epoch early.
               (update (vec row) x-position #(some-> %
                                                     fingerprinters/->temporal
                                                     ->millis-from-epoch

--- a/src/metabase/query_processor/postprocess.clj
+++ b/src/metabase/query_processor/postprocess.clj
@@ -28,7 +28,8 @@
   Where `rff` has the form
 
     (f metadata) -> rf"
-  [#'results-metadata/record-and-return-metadata!
+  [#'format-rows/format-rows
+   #'results-metadata/record-and-return-metadata!
    #'limit/limit-result-rows
    #'qp.middleware.enterprise/limit-download-result-rows
    #'qp.add-rows-truncated/add-rows-truncated
@@ -36,7 +37,6 @@
    #'qp.middleware.enterprise/merge-sandboxing-metadata
    #'qp.add-dimension-projections/remap-results
    #'pivot-export/add-data-for-pivot-export
-   #'format-rows/format-rows
    #'large-int-id/convert-id-to-string
    #'viz-settings/update-viz-settings
    #'qp.cumulative-aggregations/sum-cumulative-aggregation-columns


### PR DESCRIPTION
The whole reason that `metabase.analyze.fingerprint.insights` has to parse strings into timestamps (making it the most expensive operation if the table contains a timestamp column) is that this step is run after `format-rows` step. From what I can tell, there is nothing in the post-processing pipeline that requires stringifying timestamps early, so it makes sense to move that step to the end of the pipeline, thus saving on the redundant back-n-forth.