### PR TITLE
Introduce `verifyNotebookQuery` e2e util

### DIFF
--- a/e2e/support/helpers/e2e-notebook-helpers.ts
+++ b/e2e/support/helpers/e2e-notebook-helpers.ts
@@ -6,6 +6,7 @@ import {
   popover,
 } from "e2e/support/helpers/e2e-ui-elements-helpers";
 import type { NotebookStepType } from "metabase/query_builder/components/notebook/types";
+import type { IconName } from "metabase/ui";
 
 export function notebookButton() {
   return cy
@@ -222,4 +223,275 @@ export function selectSavedQuestionsToJoin(
 export function selectFilterOperator(operatorName: string) {
   cy.findByLabelText("Filter operator").click();
   cy.findByRole("menu").findByText(operatorName).click();
+}
+
+type JoinType = "left-join" | "right-join" | "inner-join" | "full-join";
+
+type Stage = {
+  joins?: {
+    lhsTable: string;
+    rhsTable: string;
+    type: JoinType;
+    conditions: {
+      operator: "=" | ">" | "<" | ">=" | "<=" | "!=";
+      lhsColumn: string;
+      rhsColumn: string;
+    }[];
+  }[];
+  expressions?: string[];
+  filters?: string[];
+  aggregations?: string[];
+  breakouts?: string[];
+  sort?: {
+    column: string;
+    order: "asc" | "desc";
+  }[];
+  limit?: number;
+};
+
+export function verifyNotebookQuery(dataSource: string, stages: Stage[] = []) {
+  getNotebookStep("data").findByText(dataSource).should("be.visible");
+
+  for (let stageIndex = 0; stageIndex < stages.length; ++stageIndex) {
+    const {
+      joins,
+      expressions,
+      filters,
+      aggregations,
+      breakouts,
+      sort,
+      limit,
+    } = stages[stageIndex];
+
+    verifyNotebookJoins(stageIndex, joins);
+    verifyNotebookExpressions(stageIndex, expressions);
+    verifyNotebookFilters(stageIndex, filters);
+    verifyNotebookAggregations(stageIndex, aggregations, breakouts);
+    verifyNotebookBreakouts(stageIndex, aggregations, breakouts);
+    verifyNotebookSort(stageIndex, sort);
+    verifyNotebookLimit(stageIndex, limit);
+  }
+}
+
+function verifyNotebookJoins(
+  stageIndex: number,
+  joins: Stage["joins"] | undefined,
+) {
+  const joinTypeIcons: Record<JoinType, IconName> = {
+    "left-join": "join_left_outer",
+    "right-join": "join_right_outer",
+    "inner-join": "join_inner",
+    "full-join": "join_full_outer",
+  };
+
+  if (Array.isArray(joins)) {
+    cy.findAllByTestId(new RegExp(`^step-join-${stageIndex}-\\d+$`)).should(
+      "have.length",
+      joins.length,
+    );
+
+    for (let joinIndex = 0; joinIndex < joins.length; ++joinIndex) {
+      const { lhsTable, rhsTable, type, conditions } = joins[joinIndex];
+
+      getJoinItems(stageIndex, joinIndex).eq(0).should("have.text", lhsTable);
+      getJoinItems(stageIndex, joinIndex).eq(1).should("have.text", rhsTable);
+
+      getNotebookStep("join", { stage: stageIndex, index: joinIndex })
+        .icon(joinTypeIcons[type])
+        .should("be.visible");
+
+      getNotebookStep("join", { stage: stageIndex, index: joinIndex })
+        .findAllByTestId(/^join-condition-\d+$/)
+        .should("have.length", conditions.length);
+
+      for (
+        let conditionIndex = 0;
+        conditionIndex < conditions.length;
+        ++conditionIndex
+      ) {
+        const { operator, lhsColumn, rhsColumn } = conditions[conditionIndex];
+        getNotebookStep("join", { stage: stageIndex, index: joinIndex })
+          .findByTestId(`join-condition-${conditionIndex}`)
+          .within(() => {
+            cy.findByLabelText("Left column")
+              .should("contain.text", lhsTable)
+              .and("contain.text", lhsColumn);
+
+            cy.findByLabelText("Right column")
+              .should("contain.text", rhsTable)
+              .and("contain.text", rhsColumn);
+
+            cy.findByLabelText("Change operator").should("have.text", operator);
+          });
+      }
+    }
+  } else {
+    getNotebookStep("join", { stage: stageIndex }).should("not.exist");
+  }
+}
+
+function verifyNotebookExpressions(
+  stageIndex: number,
+  expressions: string[] | undefined,
+) {
+  if (Array.isArray(expressions)) {
+    getExpressionItems(stageIndex).should(
+      "have.length",
+      expressions.length + 1, // +1 because of add button
+    );
+
+    for (let index = 0; index < expressions.length; ++index) {
+      getExpressionItems(stageIndex)
+        .eq(index)
+        .should("have.text", expressions[index]);
+    }
+  } else {
+    getNotebookStep("expression", { stage: stageIndex }).should("not.exist");
+  }
+}
+
+function verifyNotebookFilters(
+  stageIndex: number,
+  filters: string[] | undefined,
+) {
+  if (Array.isArray(filters)) {
+    getFilterItems(stageIndex).should(
+      "have.length",
+      filters.length + 1, // +1 because of add button
+    );
+
+    for (let index = 0; index < filters.length; ++index) {
+      getFilterItems(stageIndex).eq(index).should("have.text", filters[index]);
+    }
+  } else {
+    getNotebookStep("filter", { stage: stageIndex }).should("not.exist");
+  }
+}
+
+function verifyNotebookAggregations(
+  stageIndex: number,
+  aggregations: string[] | undefined,
+  breakouts: string[] | undefined,
+) {
+  if (Array.isArray(aggregations)) {
+    getNotebookStep("summarize", { stage: stageIndex }).scrollIntoView();
+    getSummarizeItems(stageIndex, "aggregate").should(
+      "have.length",
+      aggregations.length + 1, // +1 because of add button
+    );
+
+    for (let index = 0; index < aggregations.length; ++index) {
+      getSummarizeItems(stageIndex, "aggregate")
+        .eq(index)
+        .should("have.text", aggregations[index]);
+    }
+  } else {
+    if (Array.isArray(breakouts)) {
+      getSummarizeItems(stageIndex, "aggregate").should(
+        "have.length",
+        1, // 1 because of add button
+      );
+    } else {
+      getNotebookStep("summarize", { stage: stageIndex }).should("not.exist");
+    }
+  }
+}
+
+function verifyNotebookBreakouts(
+  stageIndex: number,
+  aggregations: string[] | undefined,
+  breakouts: string[] | undefined,
+) {
+  if (Array.isArray(breakouts)) {
+    getSummarizeItems(stageIndex, "breakout").should(
+      "have.length",
+      breakouts.length + 1, // +1 because of add button
+    );
+
+    for (let index = 0; index < breakouts.length; ++index) {
+      getSummarizeItems(stageIndex, "breakout")
+        .eq(index)
+        .should("have.text", breakouts[index]);
+    }
+  } else {
+    if (Array.isArray(aggregations)) {
+      getSummarizeItems(stageIndex, "breakout").should(
+        "have.length",
+        1, // 1 because of add button
+      );
+    } else {
+      getNotebookStep("summarize", { stage: stageIndex }).should("not.exist");
+    }
+  }
+}
+
+function verifyNotebookSort(
+  stageIndex: number,
+  sort:
+    | {
+        column: string;
+        order: "asc" | "desc";
+      }[]
+    | undefined,
+) {
+  if (Array.isArray(sort)) {
+    getSortItems(stageIndex).should(
+      "have.length",
+      sort.length + 1, // +1 because of add button
+    );
+
+    for (let index = 0; index < sort.length; ++index) {
+      const { column, order } = sort[index];
+      getSortItems(stageIndex).eq(index).should("have.text", column);
+      getSortItems(stageIndex)
+        .eq(index)
+        .icon(order === "asc" ? "arrow_up" : "arrow_down")
+        .should("be.visible");
+    }
+  } else {
+    getNotebookStep("sort", { stage: stageIndex }).should("not.exist");
+  }
+}
+
+function verifyNotebookLimit(stageIndex: number, limit: number | undefined) {
+  if (typeof limit === "number") {
+    getNotebookStep("limit", { stage: stageIndex })
+      .findByPlaceholderText("Enter a limit")
+      .should("have.value", String(limit));
+  } else {
+    getNotebookStep("limit", { stage: stageIndex }).should("not.exist");
+  }
+}
+
+function getJoinItems(stageIndex: number, index: number) {
+  return getNotebookStep("join", { stage: stageIndex, index }).findAllByTestId(
+    "notebook-cell-item",
+  );
+}
+
+function getExpressionItems(stageIndex: number) {
+  return getNotebookStep("expression", { stage: stageIndex }).findAllByTestId(
+    "notebook-cell-item",
+  );
+}
+
+function getFilterItems(stageIndex: number) {
+  return getNotebookStep("filter", { stage: stageIndex }).findAllByTestId(
+    "notebook-cell-item",
+  );
+}
+
+function getSummarizeItems(
+  stageIndex: number,
+  stepType: Extract<NotebookStepType, "aggregate" | "breakout">,
+) {
+  return getNotebookStep("summarize", { stage: stageIndex })
+    .findByTestId(stepType === "aggregate" ? "aggregate-step" : "breakout-step")
+    .findAllByTestId("notebook-cell-item");
+}
+
+function getSortItems(stageIndex: number) {
+  return getNotebookStep("sort", { stage: stageIndex }).findAllByTestId(
+    "notebook-cell-item",
+  );
 }

--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -10,6 +10,7 @@ import {
   chartPathWithFillColor,
   createDashboardWithTabs,
   dashboardHeader,
+  describeEE,
   editDashboard,
   entityPickerModal,
   filterWidget,
@@ -172,7 +173,7 @@ const URL_WITH_FILLED_PARAMS = URL_WITH_PARAMS.replace(
   .replace(`{{${CREATED_AT_COLUMN_ID}}}`, POINT_CREATED_AT)
   .replace(`{{${DASHBOARD_FILTER_TEXT.slug}}}`, FILTER_VALUE);
 
-describe("scenarios > dashboard > dashboard cards > click behavior", () => {
+describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -21,6 +21,7 @@ import {
   getTextCardDetails,
   modal,
   multiAutocompleteInput,
+  openNotebook,
   openStaticEmbeddingModal,
   popover,
   queryBuilderHeader,
@@ -30,6 +31,7 @@ import {
   setTokenFeatures,
   updateDashboardCards,
   updateSetting,
+  verifyNotebookQuery,
   visitDashboard,
   visitEmbeddedPage,
   visitIframe,
@@ -943,17 +945,24 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
         "have.text",
         "Created At is Jul 1–31, 2022",
       );
-      cy.location().should(({ hash, pathname }) => {
-        expect(pathname).to.equal("/question");
 
-        const card = deserializeCardFromUrl(hash);
-        expect(card.name).to.deep.equal(TARGET_QUESTION.name);
-        expect(card.display).to.deep.equal(TARGET_QUESTION.display);
-        expect(card.dataset_query.query).to.deep.equal({
-          ...TARGET_QUESTION.query,
-          filter: QUERY_FILTER_CREATED_AT,
-        });
-      });
+      cy.location("pathname").should("equal", "/question");
+      cy.findByTestId("app-bar").should(
+        "contain.text",
+        `Started from ${TARGET_QUESTION.name}`,
+      );
+
+      verifyVizTypeIsLine();
+
+      openNotebook();
+      verifyNotebookQuery("Orders", [
+        {
+          filters: ["Created At is Jul 1–31, 2022"],
+          aggregations: ["Count"],
+          breakouts: ["Created At: Month"],
+          limit: 5,
+        },
+      ]);
 
       cy.go("back");
       testChangingBackToDefaultBehavior();
@@ -2644,3 +2653,11 @@ const createDashboardWithTabsLocal = ({
     });
   });
 };
+
+function verifyVizTypeIsLine() {
+  cy.findByTestId("viz-type-button").click();
+  cy.findByTestId("sidebar-content")
+    .findByTestId("Line-container")
+    .should("have.attr", "aria-selected", "true");
+  cy.findByTestId("viz-type-button").click();
+}

--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -1362,11 +1362,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
         cy.get("aside").findByText("No available targets").should("not.exist");
         addTextParameter();
         addTimeParameter();
-        cy.get("aside")
-          .findByRole("textbox")
-          .type(`Count: {{${COUNT_COLUMN_ID}}}`, {
-            parseSpecialCharSequences: false,
-          });
+        customizeLinkText(`Count: {{${COUNT_COLUMN_ID}}}`);
 
         cy.icon("chevronleft").click();
 
@@ -1386,11 +1382,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
         addSavedQuestionDestination();
         addSavedQuestionCreatedAtParameter();
         addSavedQuestionQuantityParameter();
-        cy.get("aside")
-          .findByRole("textbox")
-          .type(`Created at: {{${CREATED_AT_COLUMN_ID}}}`, {
-            parseSpecialCharSequences: false,
-          });
+        customizeLinkText(`Count: {{${CREATED_AT_COLUMN_ID}}}`);
 
         cy.icon("chevronleft").click();
 
@@ -2641,6 +2633,12 @@ const createDashboardWithTabsLocal = ({
     });
   });
 };
+
+function customizeLinkText(text) {
+  cy.get("aside")
+    .findByRole("textbox")
+    .type(text, { parseSpecialCharSequences: false });
+}
 
 function verifyVizTypeIsLine() {
   cy.findByTestId("viz-type-button").click();

--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -1,4 +1,4 @@
-import { USER_GROUPS } from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_BY_YEAR_QUESTION_ID,
@@ -39,7 +39,6 @@ import {
   createMockActionParameter,
   createMockDashboardCard,
 } from "metabase-types/api/mocks";
-const { PRODUCTS, SAMPLE_DB_ID } = SAMPLE_DATABASE;
 
 const COUNT_COLUMN_ID = "count";
 const COUNT_COLUMN_NAME = "Count";
@@ -71,7 +70,7 @@ const FIRST_TAB = { id: 900, name: "first" };
 const SECOND_TAB = { id: 901, name: "second" };
 const THIRD_TAB = { id: 902, name: "third" };
 
-const { ORDERS_ID, ORDERS, PEOPLE } = SAMPLE_DATABASE;
+const { ORDERS_ID, ORDERS, PEOPLE, PRODUCTS } = SAMPLE_DATABASE;
 
 const TARGET_DASHBOARD = {
   name: "Target dashboard",

--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -1382,7 +1382,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
         addSavedQuestionDestination();
         addSavedQuestionCreatedAtParameter();
         addSavedQuestionQuantityParameter();
-        customizeLinkText(`Count: {{${CREATED_AT_COLUMN_ID}}}`);
+        customizeLinkText(`Created at: {{${CREATED_AT_COLUMN_ID}}}`);
 
         cy.icon("chevronleft").click();
 

--- a/e2e/test/scenarios/filters/filter.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter.cy.spec.js
@@ -23,6 +23,7 @@ import {
   setupBooleanQuery,
   summarize,
   tableHeaderClick,
+  verifyNotebookQuery,
   visitQuestionAdhoc,
   visualize,
 } from "e2e/support/helpers";
@@ -760,20 +761,16 @@ describe("scenarios > question > filter", () => {
     cy.findByTestId("apply-filters").click();
     openNotebook();
 
-    // filter
-    getNotebookStep("filter").should("contain", "Category is Gizmo");
-
-    // summarize 1
-    getNotebookStep("summarize", { stage: 0, index: 0 }).should(
-      "contain",
-      "Created At: Month",
-    );
-
-    // summarize 2
-    getNotebookStep("summarize", { stage: 1, index: 0 }).should(
-      "contain",
-      "Average of Count",
-    );
+    verifyNotebookQuery("Products", [
+      {
+        filters: ["Category is Gizmo"],
+        aggregations: ["Count"],
+        breakouts: ["Created At: Month"],
+      },
+      {
+        aggregations: ["Average of Count"],
+      },
+    ]);
   });
 
   it("user shouldn't need to scroll to add filter (metabase#14307)", () => {


### PR DESCRIPTION
Extracted from postponed #48828

### Description

Adds a `verifyNotebookQuery` util that verifies the shape of a query in the notebook editor and uses that util in 4 places as an example.

`verifyNotebookQuery`:
- supports all types of clauses 
- supports multiple stages
- accounts for both missing and redundant clauses
- respects the order of clauses
- handles "open" and "closed" steps
  - e.g. `filters: []` will mean that filter stage should be open and empty (only have "+" button displayed)
  - e.g. `filters: undefined` will mean that the filter stage should be closed

### How to verify

CI is green.