### PR TITLE
Fix relative date time FE i18n issues

### DIFF
--- a/frontend/src/metabase-lib/v1/queries/utils/query-time.js
+++ b/frontend/src/metabase-lib/v1/queries/utils/query-time.js
@@ -1,6 +1,6 @@
 import { assoc } from "icepick";
 import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
-import { msgid, ngettext, t } from "ttag";
+import { t } from "ttag";
 import _ from "underscore";
 
 import { formatDateTimeWithUnit } from "metabase/lib/formatting";
@@ -247,25 +247,9 @@ export function getStartingFrom(mbql) {
   return [num, unit];
 }
 
-export function formatStartingFrom(bucketing, n) {
-  const suffix = n >= 0 ? "from now" : "ago";
-  switch (bucketing) {
-    case "minute":
-      return ngettext(msgid`minute ${suffix}`, `minutes ${suffix}`, n);
-    case "hour":
-      return ngettext(msgid`hour ${suffix}`, `hours ${suffix}`, n);
-    case "day":
-      return ngettext(msgid`day ${suffix}`, `days ${suffix}`, n);
-    case "week":
-      return ngettext(msgid`week ${suffix}`, `weeks ${suffix}`, n);
-    case "month":
-      return ngettext(msgid`month ${suffix}`, `months ${suffix}`, n);
-    case "quarter":
-      return ngettext(msgid`quarter ${suffix}`, `quarters ${suffix}`, n);
-    case "year":
-      return ngettext(msgid`year ${suffix}`, `years ${suffix}`, n);
-  }
-  return "";
+export function formatStartingFrom(unit, n) {
+  const unitText = Lib.describeTemporalUnit(unit, n);
+  return n >= 0 ? t`${unitText} from now` : t`${unitText} ago`;
 }
 
 function getTimeInterval(mbql) {

--- a/frontend/src/metabase-lib/v1/queries/utils/query-time.js
+++ b/frontend/src/metabase-lib/v1/queries/utils/query-time.js
@@ -248,7 +248,7 @@ export function getStartingFrom(mbql) {
 }
 
 export function formatStartingFrom(unit, n) {
-  const unitText = Lib.describeTemporalUnit(unit, n);
+  const unitText = Lib.describeTemporalUnit(unit, n).toLowerCase();
   return n >= 0 ? t`${unitText} from now` : t`${unitText} ago`;
 }
 


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/24624

Fixes FE issues with translating the relative date value in dashboards. The issue is still not fixed because there is a bug in MBQL lib with translating unites. See `Previous` is not translated. But the function is used in all other places so we can fix it once.

<img width="897" alt="Screenshot 2024-10-28 at 10 45 58" src="https://github.com/user-attachments/assets/fc6a903b-c0fa-4dcb-a7e9-13750cb21624">
