### PR TITLE
Tag released Metabase version with an additional short Docker tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,6 +310,21 @@ jobs:
           console.log("The canonical version of this Metabase", edition, "edition is", canonical_version);
 
           return canonical_version;
+    - name: Determine the docker short version tag
+      uses: actions/github-script@v7
+      id: short_canonical_version
+      with:
+        result-encoding: string
+        script: |
+          const edition = '${{ matrix.edition }}';
+
+          const canonical_version = "${{ steps.canonical_version.outputs.result }}";
+          const versionParts = canonical_version.split("."); // ["v1", "51", "1", "3"]
+          const shortCanonicalVersion = versionParts.slice(0, 2).join("."); // "v1.51"
+
+          console.log("The short canonical version of this Metabase", edition, "edition is", shortCanonicalVersion);
+
+          return shortCanonicalVersion;
     - uses: actions/download-artifact@v4
       name: Retrieve previously downloaded Uberjar
       with:
@@ -358,6 +373,10 @@ jobs:
         echo "Pushing ${{ steps.canonical_version.outputs.result }} to ${{ env.DOCKERHUB_REPO }} ..."
         docker tag localhost:5000/local-metabase:${{ steps.canonical_version.outputs.result }} ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }}
         docker push ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }}
+
+        echo "Pushing ${{ steps.short_canonical_version.outputs.result }} to ${{ env.DOCKERHUB_REPO }} ..."
+        docker tag localhost:5000/local-metabase:${{ steps.canonical_version.outputs.result }} ${{ env.DOCKERHUB_REPO }}:${{ steps.short_canonical_version.outputs.result }}
+        docker push ${{ env.DOCKERHUB_REPO }}:${{ steps.short_canonical_version.outputs.result }}
         echo "Finished!"
 
   verify-docker-pull:


### PR DESCRIPTION
> [!note]
> We should not merge this PR until https://github.com/metabase/metabase/pull/48910 lands because that one touches the same part of the code this PR modifies.

This is a part of the cleanup of #48727

Tag released metabase Docker image with additional shortened tags e.g. tag v1.51.2 as v1.51, v0.50.2.1 as v0.50.

This allows us to use the same tag for a given major Metabase version without having to specify the latest point version. This is needed since our SDK readme will point to the shorter Docker tag. Now [it's using the exact docker version tag](https://github.com/metabase/metabase/blob/cf30638e4077f6edee07fb1f71ccf378d504f46a/enterprise/frontend/src/embedding-sdk/README.md?plain=1#L86).

I'm not sure how to test this 😓 
