### PR TITLE
Items in the audit collection are not cleaned up

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/stale.clj
+++ b/enterprise/backend/src/metabase_enterprise/stale.clj
@@ -37,13 +37,16 @@
                :pulse [:and
                        [:= :pulse_card.pulse_id :pulse.id]
                        [:= :pulse.archived false]]
-               :sandboxes [:= :sandboxes.card_id :report_card.id]]
+               :sandboxes [:= :sandboxes.card_id :report_card.id]
+               :collection [:= :collection.id :report_card.collection_id]]
    :where [:and
            [:= :sandboxes.id nil]
            [:= :pulse.id nil]
            [:= :moderation_review.id nil]
            [:= :report_card.archived false]
            [:<= :report_card.last_used_at (-> args :cutoff-date)]
+           ;; find things only in regular collections, not the `instance-analytics` collection.
+           [:= :collection.type nil]
            (when (embed.settings/some-embedding-enabled?)
              [:= :report_card.enable_embedding false])
            (when (public-settings/enable-public-sharing)
@@ -62,11 +65,14 @@
    :from :report_dashboard
    :left-join [:pulse [:and
                        [:= :pulse.archived false]
-                       [:= :pulse.dashboard_id :report_dashboard.id]]]
+                       [:= :pulse.dashboard_id :report_dashboard.id]]
+               :collection [:= :collection.id :report_dashboard.collection_id]]
    :where [:and
            [:= :pulse.id nil]
            [:= :report_dashboard.archived false]
            [:<= :report_dashboard.last_viewed_at (-> args :cutoff-date)]
+           ;; find things only in regular collections, not the `instance-analytics` collection.
+           [:= :collection.type nil]
            (when (embed.settings/some-embedding-enabled?)
              [:= :report_dashboard.enable_embedding false])
            (when (public-settings/enable-public-sharing)

--- a/enterprise/backend/test/metabase_enterprise/stale_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/stale_test.clj
@@ -244,6 +244,21 @@
              :sort-direction :asc}))
         "should not include verified dashboards or cards")))
 
+(deftest cards-in-non-standard-collection-types-are-excluded
+  (mt/with-temp [:model/Collection {col-id :id} {:type "instance-analytics"}
+                 :model/Card _ (stale-card {:name "A" :collection_id col-id})
+                 :model/Dashboard _ (stale-dashboard {:name "Dash" :collection_id col-id})]
+    (is (= {:rows  []
+            :total 0}
+           (stale/find-candidates
+            {:collection-ids #{col-id}
+             :cutoff-date    (date-months-ago 6)
+             :limit          10
+             :offset         0
+             :sort-column    :name
+             :sort-direction :asc}))
+        "should not include cards or dashboard in non-standard collections")))
+
 (deftest public-and-embedded-content-is-excluded
   (mt/with-temp [:model/Collection {col-id :id} {}
                  :model/Card {card-id1 :id} (stale-card {:name          "Acard"


### PR DESCRIPTION
The audit collection is a bit weird. Users have permissions on the collection but even superusers don't actually have write permissions on the elements within it.

For now, I'm just excluding anything in the audit collection from the "stale" endpoint, so we won't suggest cleaning these up, but I wonder if maybe there's a cleaner way here. It feels weird to fake permissions like this.

Fixes https://github.com/metabase/metabase/issues/49164
