### PR TITLE
Mongo objects should download as JSON, not EDN

### DIFF
--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -4,6 +4,7 @@
    [cheshire.core :as json]
    [clojure.test :refer :all]
    [medley.core :as m]
+   [metabase.api.downloads-exports-test :as downloads-test]
    [metabase.db.metadata-queries :as metadata-queries]
    [metabase.driver :as driver]
    [metabase.driver.mongo :as mongo]
@@ -855,3 +856,16 @@
         (is (= {:version "4.0.28-23"
                 :semantic-version [4 0]}
                (driver/dbms-version :mongo (mt/db))))))))
+
+(deftest object-columns-export-as-json
+  (mt/test-driver :mongo
+    (mt/with-db (missing-fields-db)
+      (sync/sync-database! (missing-fields-db))
+      (testing "Objects are formatted correctly as JSON in downloads"
+        (mt/with-temp [:model/Card card {:display       :table
+                                         :dataset_query {:database (mt/id)
+                                                         :type     :query
+                                                         :query   {:source-table (mt/id :coll)}}}]
+          (let [results (downloads-test/all-downloads card {:export-format :csv :format-rows true})]
+            (is (= []
+                   results))))))))

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -865,7 +865,17 @@
         (mt/with-temp [:model/Card card {:display       :table
                                          :dataset_query {:database (mt/id)
                                                          :type     :query
-                                                         :query   {:source-table (mt/id :coll)}}}]
-          (let [results (downloads-test/all-downloads card {:export-format :csv :format-rows true})]
-            (is (= []
+                                                         :query    {:source-table (mt/id :coll)}}}]
+          (let [results (downloads-test/card-download card {:export-format :csv :format-rows true})]
+            (is (= [["ID" "A" "B" "C"]
+                    ["1"
+                     "a string"
+                     "{\"b_c\":\"a string\",\"b_d\":42,\"b_e\":{\"b_e_f\":\"a string\"}}"
+                     ""]
+                    ["2"
+                     "a string"
+                     "{\"b_d\":null,\"b_e\":null,\"b_c\":null}"
+                     ""]
+                    ["3" "a string" "{\"b_e\":{}}" ""]
+                    ["4" "a string" "null" ""]]
                    results))))))))

--- a/src/metabase/formatter.clj
+++ b/src/metabase/formatter.clj
@@ -272,7 +272,7 @@
   When exporting, the map must be encoded as json so that exports match the app's output."
   [value]
   (cond-> value
-    (string? value) json/encode))
+    (not (string? value)) json/encode))
 
 (mu/defn create-formatter
   "Create a formatter for a column based on its timezone, column metadata, and visualization-settings"

--- a/src/metabase/formatter.clj
+++ b/src/metabase/formatter.clj
@@ -266,14 +266,13 @@
              (format "%.8f° %s" (Math/abs v) dir)
              v)))))
 
-(defn dictionary-formatter
+(defn- dictionary-formatter
   "Format dictionaries as json.
   The value if a dictionary is Clojure edn on the backend, but displays as JSON in
   When exporting, the map must be encoded as json so that exports match the app's output."
   [value]
-  (if (string? value)
-    value
-    (json/encode value)))
+  (cond-> value
+    (string? value) json/encode))
 
 (mu/defn create-formatter
   "Create a formatter for a column based on its timezone, column metadata, and visualization-settings"
@@ -296,8 +295,7 @@
      (number-formatter col visualization-settings)
 
      (or (isa? (:semantic_type col) :type/SerializedJSON)
-         (isa? (:base_type col) :type/Dictionary)
-         (isa? (:effective_type col) :type/Dictionary))
+         (isa? ((some-fn :effective_type :base_type) col) :type/Dictionary))
      (partial dictionary-formatter)
 
      :else

--- a/src/metabase/formatter.clj
+++ b/src/metabase/formatter.clj
@@ -294,7 +294,7 @@
           (or (isa? (:effective_type col) :type/Number)
               (isa? (:base_type col) :type/Number)))
      (number-formatter col visualization-settings)
-     #_#_
+
      (or (isa? (:semantic_type col) :type/SerializedJSON)
          (isa? (:base_type col) :type/Dictionary)
          (isa? (:effective_type col) :type/Dictionary))

--- a/src/metabase/formatter.clj
+++ b/src/metabase/formatter.clj
@@ -3,6 +3,7 @@
    column metadata, and visualization-settings are known. These functions can be used for uniform rendering of all
    artifacts such as generated CSV or image files that need consistent formatting across the board."
   (:require
+   [cheshire.core :as json]
    [clojure.pprint :refer [cl-format]]
    [clojure.string :as str]
    [hiccup.util]
@@ -265,22 +266,39 @@
              (format "%.8f° %s" (Math/abs v) dir)
              v)))))
 
+(defn dictionary-formatter
+  "Format dictionaries as json.
+  The value if a dictionary is Clojure edn on the backend, but displays as JSON in
+  When exporting, the map must be encoded as json so that exports match the app's output."
+  [value]
+  (if (string? value)
+    value
+    (json/encode value)))
+
 (mu/defn create-formatter
   "Create a formatter for a column based on its timezone, column metadata, and visualization-settings"
-  [timezone-id :- [:maybe :string] col visualization-settings]
-  (cond
-    ;; for numbers, return a format function that has already computed the differences.
-    ;; todo: do the same for temporal strings
-    (types/temporal-field? col)
-    #(datetime/format-temporal-str timezone-id % col visualization-settings)
+  ([timezone-id :- [:maybe :string] col visualization-settings]
+   (create-formatter timezone-id col visualization-settings true))
+  ([timezone-id :- [:maybe :string] col visualization-settings apply-formatting?]
+   (cond
+     ;; for numbers, return a format function that has already computed the differences.
+     ;; todo: do the same for temporal strings
+     (and apply-formatting? (types/temporal-field? col))
+     #(datetime/format-temporal-str timezone-id % col visualization-settings)
 
-    (isa? (:semantic_type col) :type/Coordinate)
-    (partial format-geographic-coordinates (:semantic_type col))
+     (and apply-formatting? (isa? (:semantic_type col) :type/Coordinate))
+     (partial format-geographic-coordinates (:semantic_type col))
 
-    ;; todo integer columns with a unit
-    (or (isa? (:effective_type col) :type/Number)
-        (isa? (:base_type col) :type/Number))
-    (number-formatter col visualization-settings)
+     ;; todo integer columns with a unit
+     (and apply-formatting?
+          (or (isa? (:effective_type col) :type/Number)
+              (isa? (:base_type col) :type/Number)))
+     (number-formatter col visualization-settings)
 
-    :else
-    str))
+     (or (isa? (:semantic_type col) :type/SerializedJSON)
+         (isa? (:base_type col) :type/Dictionary)
+         (isa? (:effective_type col) :type/Dictionary))
+     (partial dictionary-formatter)
+
+     :else
+     str)))

--- a/src/metabase/formatter.clj
+++ b/src/metabase/formatter.clj
@@ -294,11 +294,11 @@
           (or (isa? (:effective_type col) :type/Number)
               (isa? (:base_type col) :type/Number)))
      (number-formatter col visualization-settings)
-
+     #_#_
      (or (isa? (:semantic_type col) :type/SerializedJSON)
          (isa? (:base_type col) :type/Dictionary)
          (isa? (:effective_type col) :type/Dictionary))
      (partial dictionary-formatter)
 
      :else
-     str)))
+     (if apply-formatting? str identity))))

--- a/src/metabase/query_processor/streaming/csv.clj
+++ b/src/metabase/query_processor/streaming/csv.clj
@@ -98,9 +98,7 @@
             (swap! pivot-data assoc :pivot-grouping pivot-grouping-key))
 
           (vreset! ordered-formatters
-                   (if format-rows?
-                     (mapv #(formatter/create-formatter results_timezone % viz-settings) ordered-cols)
-                     (vec (repeat (count ordered-cols) identity))))
+                   (mapv #(formatter/create-formatter results_timezone % viz-settings format-rows?) ordered-cols))
 
           ;; write the column names for non-pivot tables
           (when col-names

--- a/src/metabase/query_processor/streaming/json.clj
+++ b/src/metabase/query_processor/streaming/json.clj
@@ -50,9 +50,7 @@
                         pivot-grouping (m/remove-nth pivot-grouping))]
             (vreset! col-names names))
           (vreset! ordered-formatters
-                   (if format-rows?
-                     (mapv #(formatter/create-formatter results_timezone % viz-settings) ordered-cols)
-                     (vec (repeat (count ordered-cols) identity))))
+                   (mapv #(formatter/create-formatter results_timezone % viz-settings format-rows?) ordered-cols))
           (.write writer "[\n")))
 
       (write-row! [_ row row-num _ {:keys [output-order]}]

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -365,12 +365,7 @@
 ;; `metabase.server.middleware`.
 (defmethod set-cell! Object
   [^Cell cell value _styles _typed-styles]
-  ;; stick the object in a JSON map and encode it, which will force conversion to a string. Then unparse that JSON and
-  ;; use the resulting value as the cell's new String value.  There might be some more efficient way of doing this but
-  ;; I'm not sure what it is.
-  (.setCellValue cell (str (-> (json/generate-string {:v value})
-                               (json/parse-string keyword)
-                               :v))))
+  (.setCellValue cell (json/generate-string value)))
 
 (defmethod set-cell! nil [^Cell cell _value _styles _typed-styles]
   (.setBlank cell))

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -1,6 +1,7 @@
 (ns metabase.query-processor.streaming.xlsx
   (:require
    [cheshire.core :as json]
+   [cheshire.generate :as json.generate]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [dk.ative.docjure.spreadsheet :as spreadsheet]
@@ -362,10 +363,22 @@
 
 ;; add a generic implementation for the method that writes values to XLSX cells that just piggybacks off the
 ;; implementations we've already defined for encoding things as JSON. These implementations live in
-;; `metabase.server.middleware`.
+;; `metabase.server.middleware.json`.
 (defmethod set-cell! Object
   [^Cell cell value _styles _typed-styles]
-  (.setCellValue cell (json/generate-string value)))
+  ;; Ok, this seems a bit strange, but the reason for generating the string and sometimes parsing it again:
+  ;; An Object can come in without an encoder (custom encoders can be added with `json.generate/add-encoder`)
+  ;; In such cases, we want to just turn that object into a json-encoded string, and be done with it.
+  ;; But in cases where the Object DOES have an encoder, we want the encoder's output directly, not wrapped in
+  ;; another set of quotes, so we read the encoded result back to 'unwrap' it once.
+  ;; And, if we don't encode the value first, we end up with a string of the object's classname, which isn't
+  ;; the expected output.
+  ;; Finally, we wrap the encoded-obj in `str` in case the custom object's encoding is not a string;
+  ;; For simplicity, we'll assume objects are exported as some kind of string, and the value can be parsed
+  ;; by the user later somehow
+  (let [encoded-obj (cond-> (json/encode value)
+                      (contains? (:impls json.generate/JSONable) (type value)) json/parse-string)]
+    (.setCellValue cell (str encoded-obj))))
 
 (defmethod set-cell! nil [^Cell cell _value _styles _typed-styles]
   (.setBlank cell))

--- a/test/metabase/api/downloads_exports_test.clj
+++ b/test/metabase/api/downloads_exports_test.clj
@@ -56,7 +56,9 @@
       :xlsx (read-xlsx pivot results)
       :json (tabulate-maps results))))
 
-(defn- card-download
+(defn card-download
+  "Provides the result of the card download via the card api in `export-format`,
+  formatting rows if `format-rows` is true, and pivoting the results if `pivot` is true."
   [{:keys [id] :as _card} {:keys [export-format format-rows pivot]}]
   (->> (mt/user-http-request :crowberto :post 200
                              (format "card/%d/query/%s" id (name export-format))

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -643,7 +643,7 @@
 (deftest encode-strange-classes-test
   (testing (str "Make sure that we're piggybacking off of the JSON encoding logic when encoding strange values in "
                 "XLSX (#5145, #5220, #5459)")
-    (is (= ["Hello XLSX World!" "{:v \"No Encoder\"}"]
+    (is (= ["\"Hello XLSX World!\"" "{\"v\":\"No Encoder\"}"]
            (second (xlsx-export [{:name "val1"} {:name "val2"}]
                                 {}
                                 [[(SampleNastyClass. "Hello XLSX World!") (AnotherNastyClass. "No Encoder")]]))))))

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -638,15 +638,24 @@
  (fn [obj, ^JsonGenerator json-generator]
    (.writeString json-generator (str (:v obj)))))
 
+(defrecord ^:private SampleNastyClass2 [^Number v])
+
+(json.generate/add-encoder
+ SampleNastyClass2
+ (fn [obj, ^JsonGenerator json-generator]
+   (.writeNumber json-generator (long (:v obj)))))
+
 (defrecord ^:private AnotherNastyClass [^String v])
 
 (deftest encode-strange-classes-test
   (testing (str "Make sure that we're piggybacking off of the JSON encoding logic when encoding strange values in "
                 "XLSX (#5145, #5220, #5459)")
-    (is (= ["\"Hello XLSX World!\"" "{\"v\":\"No Encoder\"}"]
-           (second (xlsx-export [{:name "val1"} {:name "val2"}]
+    (is (= ["Hello XLSX World!" "23" "{\"v\":\"No Encoder\"}"]
+           (second (xlsx-export [{:name "val1"} {:name "val2"} {:name "val3"}]
                                 {}
-                                [[(SampleNastyClass. "Hello XLSX World!") (AnotherNastyClass. "No Encoder")]]))))))
+                                [[(SampleNastyClass. "Hello XLSX World!")
+                                  (SampleNastyClass2. 23)
+                                  (AnotherNastyClass. "No Encoder")]]))))))
 
 (defn- parse-column-widths
   [^org.apache.poi.ss.usermodel.Sheet sheet]


### PR DESCRIPTION
Fixes #48198

Prior to this change, object columns (base or effective type of :type/Dictionary) were just formatted with `(str value)` which results in a csv or json download containing EDN formatted objects.

This is a bug because we present object column values as json in the app, so the expected formatting of the download should match this.

The formatter function now takes this type into account. As well, since this is a type of formatting that should be always applied (even when format_rows is false), the function is modified to unconditionally apply the json/encode formatting to dictionary types when encountered.
