### PR TITLE
is-hosted and ag-mode are mutex

### DIFF
--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -536,7 +536,10 @@
   :visibility :public
   :setter     :none
   :audit      :never
-  :getter     (fn [] (boolean ((*token-features*) "hosting")))
+  :getter     (fn [] (boolean
+                      (and
+                       ((*token-features*) "hosting")
+                       (not (airgap-enabled)))))
   :doc        false)
 
 (defn log-enabled?


### PR DESCRIPTION
This is a stopgap for older tokens that actually have "hosting" in them. we should never respect "hosting" feature in ag-mode.