### PR TITLE
Fix logic for deployment-model in stats ping

### DIFF
--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -517,9 +517,9 @@
 (defn- deployment-model
   []
   (cond
-   (premium-features/is-hosted?) "cloud"
-   (in-docker?)                  "docker"
-   :else                         "jar"))
+    (premium-features/is-hosted?) "cloud"
+    (in-docker?)                  "docker"
+    :else                         "jar"))
 
 (def ^:private activation-days 3)
 

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -516,10 +516,10 @@
 
 (defn- deployment-model
   []
-  (case
+  (cond
    (premium-features/is-hosted?) "cloud"
-   (in-docker?) "docker"
-   :else "jar"))
+   (in-docker?)                  "docker"
+   :else                         "jar"))
 
 (def ^:private activation-days 3)
 

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.analytics.stats-test
   (:require
+   [clojure.java.io :as io]
    [clojure.set :as set]
    [clojure.test :refer :all]
    [java-time.api :as t]
@@ -422,6 +423,23 @@
       (with-redefs [config/current-major-version (constantly nil)
                     config/current-minor-version (constantly nil)]
         (is false? (@#'stats/csv-upload-available?))))))
+
+(deftest deployment-model-test
+  (testing "deployment model correctly reports cloud/docker/jar"
+    (with-redefs [premium-features/is-hosted? (constantly true)]
+      (is (= "cloud" (@#'stats/deployment-model))))
+
+    ;; Lets just mock io/file to always return an existing (temp) file, to validate that we're doing a filesystem check
+    ;; to determine whether we're in a Docker container
+    (mt/with-temp-file [mock-file]
+      (spit mock-file "Temp file!")
+      (with-redefs [premium-features/is-hosted? (constantly false)
+                    io/file                     (constantly (java.io.File. mock-file))]
+        (is (= "docker" (@#'stats/deployment-model)))))
+
+    (with-redefs [premium-features/is-hosted? (constantly false)
+                  stats/in-docker?            (constantly false)]
+      (is (= "jar" (@#'stats/deployment-model))))))
 
 (deftest no-features-enabled-but-not-available-test
   (testing "Ensure that a feature cannot be reported as enabled if it is not also available"


### PR DESCRIPTION
Fixes `deployment-model` function in stats ping to use `cond` instead of case, and adds a unit test. I think this was a case where I had different logic in there originally, then refactored it, and this slipped through the cracks. 🤦 

I've added a basic unit test. Wasn't sure how to mock a Docker environment so I just mocked that the `io/file` call returns a valid file to verify that we're hitting that code...happy to take other suggestions if anyone has them.

Fixes https://github.com/metabase/metabase/issues/49258