### PR TITLE
Update release branch 51 SDK readme to use static 51 versions

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/README.md
+++ b/enterprise/frontend/src/embedding-sdk/README.md
@@ -83,12 +83,12 @@ You have the following options:
 Start the Metabase container:
 
 ```bash
-docker run -d -p 3000:3000 --name metabase metabase/metabase-enterprise:v1.51.1
+docker run -d -p 3000:3000 --name metabase metabase/metabase-enterprise:latest
 ```
 
 ### 2. Running the Jar file
 
-1. Download the Jar file from https://downloads.metabase.com/enterprise/v1.51.1/metabase.jar
+1. Download the Jar file from https://downloads.metabase.com/enterprise/latest/metabase.jar
 2. Create a new directory and move the Metabase JAR into it.
 3. Change into your new Metabase directory and run the JAR.
 


### PR DESCRIPTION
Part of #48727

> [!note]
> Currently `latest` tag is pointing to `1.50.31`, but we'll update that for [`1.51.2` when it's deployed](https://metaboat.slack.com/archives/C05MPF0TM3L/p1730139401846979?thread_ts=1730102593.927909&cid=C05MPF0TM3L), so we should wait until the `latest` tag is updated to v51 before merging this PR.


This uploads the SDK document to point to stable Metabase versions so that we don't need to update the readme again every time we release a new minor version.
