### PR TITLE
Update static embed card copy to avoid confusion

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -67,7 +67,7 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
       cy.findByRole("article", { name: "Static embedding" }).within(() => {
         // FE unit tests are making sure this section doesn't exist when a valid token is provided,
         // so we don't have to do it here using conditional logic
-        assertLinkMatchesUrl("upgrade to a paid plan", upgradeUrl);
+        assertLinkMatchesUrl("upgrade to a specific paid plan", upgradeUrl);
 
         cy.findByRole("link", { name: "Manage" })
           .should("have.attr", "href")

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/common.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/common.embedding.unit.spec.tsx
@@ -62,12 +62,14 @@ describe("[OSS] embedding settings", () => {
           }),
         );
         expect(
-          withinStaticEmbeddingCard.getByText("upgrade to a paid plan"),
+          withinStaticEmbeddingCard.getByText(
+            "upgrade to a specific paid plan",
+          ),
         ).toBeInTheDocument();
 
         expect(
           withinStaticEmbeddingCard.getByRole("link", {
-            name: "upgrade to a paid plan",
+            name: "upgrade to a specific paid plan",
           }),
         ).toHaveProperty(
           "href",
@@ -274,12 +276,14 @@ describe("[OSS] embedding settings", () => {
           }),
         );
         expect(
-          withinStaticEmbeddingCard.getByText("upgrade to a paid plan"),
+          withinStaticEmbeddingCard.getByText(
+            "upgrade to a specific paid plan",
+          ),
         ).toBeInTheDocument();
 
         expect(
           withinStaticEmbeddingCard.getByRole("link", {
-            name: "upgrade to a paid plan",
+            name: "upgrade to a specific paid plan",
           }),
         ).toHaveProperty(
           "href",

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/enterprise.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/enterprise.embedding.unit.spec.tsx
@@ -71,12 +71,14 @@ describe("[EE, no token] embedding settings", () => {
           }),
         );
         expect(
-          withinStaticEmbeddingCard.getByText("upgrade to a paid plan"),
+          withinStaticEmbeddingCard.getByText(
+            "upgrade to a specific paid plan",
+          ),
         ).toBeInTheDocument();
 
         expect(
           withinStaticEmbeddingCard.getByRole("link", {
-            name: "upgrade to a paid plan",
+            name: "upgrade to a specific paid plan",
           }),
         ).toHaveProperty(
           "href",
@@ -281,12 +283,14 @@ describe("[EE, no token] embedding settings", () => {
           }),
         );
         expect(
-          withinStaticEmbeddingCard.getByText("upgrade to a paid plan"),
+          withinStaticEmbeddingCard.getByText(
+            "upgrade to a specific paid plan",
+          ),
         ).toBeInTheDocument();
 
         expect(
           withinStaticEmbeddingCard.getByRole("link", {
-            name: "upgrade to a paid plan",
+            name: "upgrade to a specific paid plan",
           }),
         ).toHaveProperty(
           "href",

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
@@ -72,7 +72,9 @@ describe("[EE, with token] embedding settings", () => {
           }),
         );
         expect(
-          withinStaticEmbeddingCard.queryByText("upgrade to a paid plan"),
+          withinStaticEmbeddingCard.queryByText(
+            "upgrade to a specific paid plan",
+          ),
         ).not.toBeInTheDocument();
       });
 
@@ -301,7 +303,9 @@ describe("[EE, with token] embedding settings", () => {
           }),
         );
         expect(
-          withinStaticEmbeddingCard.queryByText("upgrade to a paid plan"),
+          withinStaticEmbeddingCard.queryByText(
+            "upgrade to a specific paid plan",
+          ),
         ).not.toBeInTheDocument();
       });
 

--- a/frontend/src/metabase/admin/settings/components/widgets/EmbeddingOption/StaticEmbeddingOptionCard/StaticEmbeddingOptionCard.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/EmbeddingOption/StaticEmbeddingOptionCard/StaticEmbeddingOptionCard.tsx
@@ -25,9 +25,9 @@ export const StaticEmbeddingOptionCard = ({
 
   const upgradeText = jt`A "powered by Metabase" banner appears on static embeds. You can ${(
     <ExternalLink key="upgrade-link" href={upgradeUrl}>
-      {t`upgrade to a paid plan`}
+      {t`upgrade to a specific paid plan`}
     </ExternalLink>
-  )} to remove it.`;
+  )} which removes it.`;
 
   return (
     <EmbeddingOption

--- a/frontend/src/metabase/admin/upsells/UpsellMetabaseBanner.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellMetabaseBanner.tsx
@@ -7,12 +7,12 @@ export function UpsellMetabaseBanner() {
     <UpsellCard
       title={t`Removing the banner`}
       buttonLink="https://www.metabase.com/upgrade"
-      buttonText={t`Upgrade to a paid plan`}
+      buttonText={t`Upgrade plan`}
       campaign="remove-mb-branding"
       source="static-embed-settings-look-and-feel"
       fullWidth
     >
-      {t`The “Powered by Metabase” banner appears on all static embeds created with the open source version. You’ll need to upgrade to remove it.`}
+      {t`The “Powered by Metabase” banner appears on all static embeds created with your current version. Upgrade to remove it (and customize a lot more)`}
     </UpsellCard>
   );
 }

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/common.unit.spec.tsx
@@ -496,14 +496,14 @@ describe("Static Embed Setup phase", () => {
 
         expect(
           screen.getByText(
-            "The “Powered by Metabase” banner appears on all static embeds created with the open source version. You’ll need to upgrade to remove it.",
+            "The “Powered by Metabase” banner appears on all static embeds created with your current version. Upgrade to remove it (and customize a lot more)",
           ),
         ).toBeVisible();
 
         const link = within(
           screen.getByLabelText("Removing the banner"),
         ).getByRole("link", {
-          name: "Upgrade to a paid plan",
+          name: "Upgrade plan",
         });
         expect(link).toBeVisible();
         expect(link).toHaveAttribute(

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/enterprise.unit.spec.tsx
@@ -41,7 +41,7 @@ describe("Static Embed Setup phase - EE, no token", () => {
 
         expect(
           screen.getByText(
-            "The “Powered by Metabase” banner appears on all static embeds created with the open source version. You’ll need to upgrade to remove it.",
+            "The “Powered by Metabase” banner appears on all static embeds created with your current version. Upgrade to remove it (and customize a lot more)",
           ),
         ).toBeVisible();
       });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/48925

### Description

This updates the description on the static embedding card in the admin settings page to avoid confusion.

### How to verify

Go to /admin/settings/embedding-in-other-applications and check the static embed card copy.

### Demo
#### Admin settings
![image](https://github.com/user-attachments/assets/999d2c76-5652-4857-9c49-a6f412b239ca)

#### Static embedding sharing modal
![image](https://github.com/user-attachments/assets/d06bc2d3-4fed-427f-b01f-df02f143b180)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
