### PR TITLE
test(sdk): remove setupEnterprisePlugins from test setup as we don't

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/test/server-mocks/sdk-init.ts
+++ b/enterprise/frontend/src/embedding-sdk/test/server-mocks/sdk-init.ts
@@ -1,4 +1,3 @@
-import { setupEnterprisePlugins } from "__support__/enterprise";
 import {
   setupCurrentUserEndpoint,
   setupPropertiesEndpoints,
@@ -44,7 +43,6 @@ export const setupSdkState = ({
     "token-features": tokenFeatures,
   };
 
-  setupEnterprisePlugins();
   setupCurrentUserEndpoint(currentUser);
   setupSettingsEndpoints(settingDefinitions);
   setupPropertiesEndpoints(settingValuesWithToken);


### PR DESCRIPTION
have them in the real codebase + to remove warnings from test output


# Description
This removes the "unknown token feature ..." log from the test output, plus we actually don't have the plugins on the sdk code as of now so it makes sense to remove this call from the test setup too.