### PR TITLE
FE - e2e - Cover public & embedded dashboards with tests 

### DIFF
--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-query-stages.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-query-stages.cy.spec.ts
@@ -1118,6 +1118,8 @@ describe("scenarios > dashboard > filters > query stages", () => {
 
         it("2nd stage breakout", () => {
           setup2ndStageBreakoutFilter();
+          apply2ndStageBreakoutFilter();
+          cy.wait(["@dashboardData", "@dashboardData"]);
 
           verifyDashcardRowsCount({
             dashcardIndex: 0,
@@ -1520,6 +1522,8 @@ describe("scenarios > dashboard > filters > query stages", () => {
 
         it("2nd stage breakout", () => {
           setup2ndStageBreakoutFilter();
+          apply2ndStageBreakoutFilter();
+          cy.wait(["@dashboardData", "@dashboardData"]);
 
           verifyDashcardRowsCount({
             dashcardIndex: 0,
@@ -1534,6 +1538,51 @@ describe("scenarios > dashboard > filters > query stages", () => {
             dashboardCount: "Rows 1-1 of 1077",
             queryBuilderCount: "Showing 1,077 rows",
           });
+
+          cy.log("public dashboard");
+          getDashboardId().then(dashboardId =>
+            visitPublicDashboard(dashboardId),
+          );
+          waitForPublicDashboardData();
+          // TODO: https://github.com/metabase/metabase/issues/49282
+          // We should use apply2ndStageBreakoutFilter() instead of the next 4 lines:
+          filterWidget().eq(0).click();
+          popover().within(() => {
+            cy.findByPlaceholderText("Enter some text").type("Gadget");
+            cy.button("Add filter").click();
+          });
+          waitForPublicDashboardData();
+
+          getDashboardCard(0)
+            .findByText("Rows 1-1 of 1077")
+            .should("be.visible");
+          getDashboardCard(1)
+            .findByText("Rows 1-1 of 1077")
+            .should("be.visible");
+
+          cy.log("embedded dashboard");
+          getDashboardId().then(dashboardId => {
+            visitEmbeddedPage({
+              resource: { dashboard: dashboardId },
+              params: {},
+            });
+          });
+          waitForEmbeddedDashboardData();
+          // TODO: https://github.com/metabase/metabase/issues/49282
+          // We should use apply2ndStageBreakoutFilter() instead of the next 4 lines:
+          filterWidget().eq(0).click();
+          popover().within(() => {
+            cy.findByPlaceholderText("Enter some text").type("Gadget");
+            cy.button("Add filter").click();
+          });
+          waitForEmbeddedDashboardData();
+
+          getDashboardCard(0)
+            .findByText("Rows 1-1 of 1077")
+            .should("be.visible");
+          getDashboardCard(1)
+            .findByText("Rows 1-1 of 1077")
+            .should("be.visible");
         });
       });
     });
@@ -2656,13 +2705,14 @@ function setup2ndStageBreakoutFilter() {
 
   cy.button("Save").click();
   cy.wait("@updateDashboard");
+}
 
+function apply2ndStageBreakoutFilter() {
   filterWidget().eq(0).click();
   popover().within(() => {
     cy.findByLabelText("Gadget").click();
     cy.button("Add filter").click();
   });
-  cy.wait(["@dashboardData", "@dashboardData"]);
 }
 
 function getFilter(name: string) {

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-query-stages.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-query-stages.cy.spec.ts
@@ -847,6 +847,8 @@ describe("scenarios > dashboard > filters > query stages", () => {
 
         it("2nd stage custom column", () => {
           setup2ndStageCustomColumnFilter();
+          apply2nStageCustomColumnFilter();
+          cy.wait(["@dashboardData", "@dashboardData"]);
 
           verifyDashcardCellValues({
             dashcardIndex: 0,
@@ -1096,6 +1098,8 @@ describe("scenarios > dashboard > filters > query stages", () => {
 
         it("2nd stage custom column", () => {
           setup2ndStageCustomColumnFilter();
+          apply2nStageCustomColumnFilter();
+          cy.wait(["@dashboardData", "@dashboardData"]);
 
           verifyDashcardRowsCount({
             dashcardIndex: 0,
@@ -1426,6 +1430,8 @@ describe("scenarios > dashboard > filters > query stages", () => {
 
         it("2nd stage custom column", () => {
           setup2ndStageCustomColumnFilter();
+          apply2nStageCustomColumnFilter();
+          cy.wait(["@dashboardData", "@dashboardData"]);
 
           verifyDashcardRowsCount({
             dashcardIndex: 0,
@@ -1440,6 +1446,31 @@ describe("scenarios > dashboard > filters > query stages", () => {
             dashboardCount: "Rows 1-1 of 31",
             queryBuilderCount: "Showing 31 rows",
           });
+
+          cy.log("public dashboard");
+          getDashboardId().then(dashboardId =>
+            visitPublicDashboard(dashboardId),
+          );
+          waitForPublicDashboardData();
+          apply2nStageCustomColumnFilter();
+          waitForPublicDashboardData();
+
+          getDashboardCard(0).findByText("Rows 1-1 of 31").should("be.visible");
+          getDashboardCard(1).findByText("Rows 1-1 of 31").should("be.visible");
+
+          cy.log("embedded dashboard");
+          getDashboardId().then(dashboardId => {
+            visitEmbeddedPage({
+              resource: { dashboard: dashboardId },
+              params: {},
+            });
+          });
+          waitForEmbeddedDashboardData();
+          apply2nStageCustomColumnFilter();
+          waitForEmbeddedDashboardData();
+
+          getDashboardCard(0).findByText("Rows 1-1 of 31").should("be.visible");
+          getDashboardCard(1).findByText("Rows 1-1 of 31").should("be.visible");
         });
 
         it("2nd stage aggregation", () => {
@@ -1689,6 +1720,8 @@ describe("scenarios > dashboard > filters > query stages", () => {
 
         it("2nd stage custom column", () => {
           setup2ndStageCustomColumnFilter();
+          apply2nStageCustomColumnFilter();
+          cy.wait(["@dashboardData", "@dashboardData"]);
 
           verifyDashcardCellValues({
             dashcardIndex: 0,
@@ -2506,14 +2539,15 @@ function setup2ndStageCustomColumnFilter() {
 
   cy.button("Save").click();
   cy.wait("@updateDashboard");
+}
 
+function apply2nStageCustomColumnFilter() {
   filterWidget().eq(0).click();
   popover().within(() => {
     cy.findAllByPlaceholderText("Enter a number").eq(0).type("0");
     cy.findAllByPlaceholderText("Enter a number").eq(1).type("20");
     cy.button("Add filter").click();
   });
-  cy.wait(["@dashboardData", "@dashboardData"]);
 }
 
 function setup2ndStageAggregationFilter() {

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-query-stages.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-query-stages.cy.spec.ts
@@ -1481,7 +1481,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
           cy.wait(["@dashboardData", "@dashboardData"]);
 
           verifyDashcardRowsCount({
-            dashcardIndex: 1,
+            dashcardIndex: 0,
             dashboardCount: "Rows 1-1 of 6",
             queryBuilderCount: "Showing 6 rows",
           });
@@ -1490,6 +1490,22 @@ describe("scenarios > dashboard > filters > query stages", () => {
 
           verifyDashcardRowsCount({
             dashcardIndex: 1,
+            dashboardCount: "Rows 1-1 of 6",
+            queryBuilderCount: "Showing 6 rows",
+          });
+
+          goBackToDashboard();
+
+          verifyDashcardRowsCount({
+            dashcardIndex: 2,
+            dashboardCount: "Rows 1-1 of 6",
+            queryBuilderCount: "Showing 6 rows",
+          });
+
+          goBackToDashboard();
+
+          verifyDashcardRowsCount({
+            dashcardIndex: 3,
             dashboardCount: "Rows 1-1 of 6",
             queryBuilderCount: "Showing 6 rows",
           });
@@ -1504,6 +1520,8 @@ describe("scenarios > dashboard > filters > query stages", () => {
 
           getDashboardCard(0).findByText("Rows 1-1 of 6").should("be.visible");
           getDashboardCard(1).findByText("Rows 1-1 of 6").should("be.visible");
+          getDashboardCard(2).findByText("Rows 1-1 of 6").should("be.visible");
+          getDashboardCard(3).findByText("Rows 1-1 of 6").should("be.visible");
 
           cy.log("embedded dashboard");
           getDashboardId().then(dashboardId => {
@@ -1518,6 +1536,8 @@ describe("scenarios > dashboard > filters > query stages", () => {
 
           getDashboardCard(0).findByText("Rows 1-1 of 6").should("be.visible");
           getDashboardCard(1).findByText("Rows 1-1 of 6").should("be.visible");
+          getDashboardCard(2).findByText("Rows 1-1 of 6").should("be.visible");
+          getDashboardCard(3).findByText("Rows 1-1 of 6").should("be.visible");
         });
 
         it("2nd stage breakout", () => {
@@ -1539,6 +1559,22 @@ describe("scenarios > dashboard > filters > query stages", () => {
             queryBuilderCount: "Showing 1,077 rows",
           });
 
+          goBackToDashboard();
+
+          verifyDashcardRowsCount({
+            dashcardIndex: 2,
+            dashboardCount: "Rows 1-1 of 1077",
+            queryBuilderCount: "Showing 1,077 rows",
+          });
+
+          goBackToDashboard();
+
+          verifyDashcardRowsCount({
+            dashcardIndex: 3,
+            dashboardCount: "Rows 1-1 of 1077",
+            queryBuilderCount: "Showing 1,077 rows",
+          });
+
           cy.log("public dashboard");
           getDashboardId().then(dashboardId =>
             visitPublicDashboard(dashboardId),
@@ -1557,6 +1593,12 @@ describe("scenarios > dashboard > filters > query stages", () => {
             .findByText("Rows 1-1 of 1077")
             .should("be.visible");
           getDashboardCard(1)
+            .findByText("Rows 1-1 of 1077")
+            .should("be.visible");
+          getDashboardCard(2)
+            .findByText("Rows 1-1 of 1077")
+            .should("be.visible");
+          getDashboardCard(3)
             .findByText("Rows 1-1 of 1077")
             .should("be.visible");
 
@@ -1581,6 +1623,12 @@ describe("scenarios > dashboard > filters > query stages", () => {
             .findByText("Rows 1-1 of 1077")
             .should("be.visible");
           getDashboardCard(1)
+            .findByText("Rows 1-1 of 1077")
+            .should("be.visible");
+          getDashboardCard(2)
+            .findByText("Rows 1-1 of 1077")
+            .should("be.visible");
+          getDashboardCard(3)
             .findByText("Rows 1-1 of 1077")
             .should("be.visible");
         });

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-query-stages.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-query-stages.cy.spec.ts
@@ -2646,6 +2646,7 @@ function getDashboardId(): Cypress.Chainable<number> {
 }
 
 function waitForPublicDashboardData() {
+  // tests with public dashboards always have 4 dashcards
   cy.wait([
     "@publicDashboardData",
     "@publicDashboardData",
@@ -2655,6 +2656,7 @@ function waitForPublicDashboardData() {
 }
 
 function waitForEmbeddedDashboardData() {
+  // tests with embedded dashboards always have 4 dashcards
   cy.wait([
     "@embeddedDashboardData",
     "@embeddedDashboardData",

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-query-stages.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-query-stages.cy.spec.ts
@@ -847,7 +847,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
 
         it("2nd stage custom column", () => {
           setup2ndStageCustomColumnFilter();
-          apply2nStageCustomColumnFilter();
+          apply2ndStageCustomColumnFilter();
           cy.wait(["@dashboardData", "@dashboardData"]);
 
           verifyDashcardCellValues({
@@ -1098,7 +1098,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
 
         it("2nd stage custom column", () => {
           setup2ndStageCustomColumnFilter();
-          apply2nStageCustomColumnFilter();
+          apply2ndStageCustomColumnFilter();
           cy.wait(["@dashboardData", "@dashboardData"]);
 
           verifyDashcardRowsCount({
@@ -1430,7 +1430,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
 
         it("2nd stage custom column", () => {
           setup2ndStageCustomColumnFilter();
-          apply2nStageCustomColumnFilter();
+          apply2ndStageCustomColumnFilter();
           cy.wait(["@dashboardData", "@dashboardData"]);
 
           verifyDashcardRowsCount({
@@ -1452,7 +1452,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
             visitPublicDashboard(dashboardId),
           );
           waitForPublicDashboardData();
-          apply2nStageCustomColumnFilter();
+          apply2ndStageCustomColumnFilter();
           waitForPublicDashboardData();
 
           getDashboardCard(0).findByText("Rows 1-1 of 31").should("be.visible");
@@ -1466,7 +1466,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
             });
           });
           waitForEmbeddedDashboardData();
-          apply2nStageCustomColumnFilter();
+          apply2ndStageCustomColumnFilter();
           waitForEmbeddedDashboardData();
 
           getDashboardCard(0).findByText("Rows 1-1 of 31").should("be.visible");
@@ -1475,6 +1475,8 @@ describe("scenarios > dashboard > filters > query stages", () => {
 
         it("2nd stage aggregation", () => {
           setup2ndStageAggregationFilter();
+          apply2ndStageAggregationFilter();
+          cy.wait(["@dashboardData", "@dashboardData"]);
 
           verifyDashcardRowsCount({
             dashcardIndex: 1,
@@ -1489,6 +1491,31 @@ describe("scenarios > dashboard > filters > query stages", () => {
             dashboardCount: "Rows 1-1 of 6",
             queryBuilderCount: "Showing 6 rows",
           });
+
+          cy.log("public dashboard");
+          getDashboardId().then(dashboardId =>
+            visitPublicDashboard(dashboardId),
+          );
+          waitForPublicDashboardData();
+          apply2ndStageAggregationFilter();
+          waitForPublicDashboardData();
+
+          getDashboardCard(0).findByText("Rows 1-1 of 6").should("be.visible");
+          getDashboardCard(1).findByText("Rows 1-1 of 6").should("be.visible");
+
+          cy.log("embedded dashboard");
+          getDashboardId().then(dashboardId => {
+            visitEmbeddedPage({
+              resource: { dashboard: dashboardId },
+              params: {},
+            });
+          });
+          waitForEmbeddedDashboardData();
+          apply2ndStageAggregationFilter();
+          waitForEmbeddedDashboardData();
+
+          getDashboardCard(0).findByText("Rows 1-1 of 6").should("be.visible");
+          getDashboardCard(1).findByText("Rows 1-1 of 6").should("be.visible");
         });
 
         it("2nd stage breakout", () => {
@@ -1720,7 +1747,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
 
         it("2nd stage custom column", () => {
           setup2ndStageCustomColumnFilter();
-          apply2nStageCustomColumnFilter();
+          apply2ndStageCustomColumnFilter();
           cy.wait(["@dashboardData", "@dashboardData"]);
 
           verifyDashcardCellValues({
@@ -1738,6 +1765,8 @@ describe("scenarios > dashboard > filters > query stages", () => {
 
         it("2nd stage aggregation", () => {
           setup2ndStageAggregationFilter();
+          apply2ndStageAggregationFilter();
+          cy.wait(["@dashboardData", "@dashboardData"]);
 
           verifyDashcardCellValues({
             dashcardIndex: 0,
@@ -2541,7 +2570,7 @@ function setup2ndStageCustomColumnFilter() {
   cy.wait("@updateDashboard");
 }
 
-function apply2nStageCustomColumnFilter() {
+function apply2ndStageCustomColumnFilter() {
   filterWidget().eq(0).click();
   popover().within(() => {
     cy.findAllByPlaceholderText("Enter a number").eq(0).type("0");
@@ -2584,14 +2613,15 @@ function setup2ndStageAggregationFilter() {
 
   cy.button("Save").click();
   cy.wait("@updateDashboard");
+}
 
+function apply2ndStageAggregationFilter() {
   filterWidget().eq(0).click();
   popover().within(() => {
     cy.findAllByPlaceholderText("Enter a number").eq(0).type("0");
     cy.findAllByPlaceholderText("Enter a number").eq(1).type("2");
     cy.button("Add filter").click();
   });
-  cy.wait(["@dashboardData", "@dashboardData"]);
 }
 
 function setup2ndStageBreakoutFilter() {

--- a/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
@@ -14,13 +14,13 @@ import {
   modal,
   popover,
   queryBuilderHeader,
-  queryBuilderMain,
   resetFilterWidgetToDefault,
   restore,
   saveDashboard,
   selectDashboardFilter,
   setFilter,
   sidebar,
+  tableInteractive,
   undoToast,
   undoToastList,
   updateDashboardCards,
@@ -275,7 +275,7 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
         cy.findByText("Created At: Year").should("be.visible");
         cy.findByText(singleBreakoutQuestionDetails.name).click();
       });
-      queryBuilderMain().findByText("Created At: Year").should("be.visible");
+      tableInteractive().findByText("Created At: Year").should("be.visible");
       backToDashboard();
       editDashboard();
       removeQuestion();
@@ -296,7 +296,7 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
         cy.findByText("Q2 2022").should("be.visible");
         cy.findByText(multiBreakoutQuestionDetails.name).click();
       });
-      queryBuilderMain().findByText("Q2 2022").should("be.visible");
+      tableInteractive().findByText("Created At: Quarter").should("be.visible");
       backToDashboard();
       editDashboard();
       removeQuestion();
@@ -313,7 +313,7 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
         cy.findByText("Created At: Quarter").should("be.visible");
         cy.findByText(multiStageQuestionDetails.name).click();
       });
-      queryBuilderMain().findByText("Created At: Quarter").should("be.visible");
+      tableInteractive().findByText("Created At: Quarter").should("be.visible");
       backToDashboard();
       editDashboard();
       removeQuestion();
@@ -337,7 +337,7 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
         cy.findByText("Date: Quarter").should("be.visible");
         cy.findByText(expressionBreakoutQuestionDetails.name).click();
       });
-      queryBuilderMain().findByText("Date: Quarter").should("be.visible");
+      tableInteractive().findByText("Date: Quarter").should("be.visible");
       backToDashboard();
       editDashboard();
       removeQuestion();
@@ -427,10 +427,9 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
       appBar()
         .should("contain.text", "Started from")
         .should("contain.text", multiBreakoutQuestionDetails.name);
-      queryBuilderMain().within(() => {
+      tableInteractive().within(() => {
         cy.findByText("Created At: Year").should("be.visible");
-        cy.findByText("April 24, 2022").should("be.visible");
-        cy.findByText("May 1, 2022").should("be.visible");
+        cy.findByText("Product → Created At: Week").should("be.visible");
       });
     });
 
@@ -462,7 +461,7 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
       appBar()
         .should("contain.text", "Started from")
         .should("contain.text", singleBreakoutQuestionDetails.name);
-      queryBuilderMain().within(() => {
+      tableInteractive().within(() => {
         cy.findByText("Created At: Year").should("be.visible");
         cy.findByText("2022").should("be.visible");
       });


### PR DESCRIPTION
Closes #47234
Closes #46520

### Description

Part of #46520.
Adds tests for applying filter parameters in public & embedded dashboards to a 2-stage query with aggregations and breakouts in the last stage: at 1st stage, 2nd stage, and extra 3rd filter stage.

### How to verify

It's expected that 2 tests are failing in CI:
- `temporal-unit-parameters.cy.spec.js`
    - `should connect a parameter to a question and drill thru`
    - `should connect multiple parameters to a card with multiple breakouts`