### PR TITLE
fix broken css rule, remove description from field table

### DIFF
--- a/frontend/src/metabase/components/List/List.module.css
+++ b/frontend/src/metabase/components/List/List.module.css
@@ -53,7 +53,8 @@
 }
 
 .itemBody {
-  display: flex 1 1 auto;
+  display: flex;
+  flex: 1 1 auto;
   overflow: hidden;
 }
 

--- a/frontend/src/metabase/components/ListItem/ListItem.jsx
+++ b/frontend/src/metabase/components/ListItem/ListItem.jsx
@@ -30,7 +30,7 @@ const ListItem = ({
         <div className={S.itemIcons}>
           {icon && <Icon className={S.chartIcon} name={icon} size={16} />}
         </div>
-        <div className={S.itemBody}>
+        <div className={cx(S.itemBody, CS.flexColumn)}>
           <div className={S.itemTitle}>
             <Ellipsified tooltip={name}>{name}</Ellipsified>
           </div>

--- a/frontend/src/metabase/reference/components/Field.jsx
+++ b/frontend/src/metabase/reference/components/Field.jsx
@@ -16,9 +16,9 @@ import { isTypeFK } from "metabase-lib/v1/types/utils/isa";
 import F from "./Field.module.css";
 
 const Field = ({ field, foreignKeys, url, icon, isEditing, formField }) => (
-  <div className={cx(S.item, CS.pt1, CS.borderTop)}>
+  <div className={cx(S.item, CS.py1, CS.borderTop)}>
     <div className={S.itemBody} style={{ maxWidth: "100%", borderTop: "none" }}>
-      <div className={F.field}>
+      <div className={F.field} style={{ flexGrow: "1" }}>
         <div className={cx(S.itemTitle, F.fieldName)}>
           {isEditing ? (
             <input
@@ -59,7 +59,7 @@ const Field = ({ field, foreignKeys, url, icon, isEditing, formField }) => (
               optionSectionFn={o => o.section}
             />
           ) : (
-            <div className={CS.flex}>
+            <div className={cx(CS.flex, CS.alignCenter)}>
               <div className={S.leftIcons}>
                 {icon && <Icon className={S.chartIcon} name={icon} size={20} />}
               </div>
@@ -109,11 +109,6 @@ const Field = ({ field, foreignKeys, url, icon, isEditing, formField }) => (
         </div>
         <div className={F.fieldOther} />
       </div>
-      {field.description && (
-        <div className={cx(S.itemSubtitle, CS.mb2, { [CS.mt1]: isEditing })}>
-          {field.description}
-        </div>
-      )}
     </div>
   </div>
 );

--- a/frontend/src/metabase/reference/components/Field.jsx
+++ b/frontend/src/metabase/reference/components/Field.jsx
@@ -17,7 +17,10 @@ import F from "./Field.module.css";
 
 const Field = ({ field, foreignKeys, url, icon, isEditing, formField }) => (
   <div className={cx(S.item, CS.py1, CS.borderTop)}>
-    <div className={S.itemBody} style={{ maxWidth: "100%", borderTop: "none" }}>
+    <div
+      className={cx(S.itemBody, CS.flexColumn)}
+      style={{ maxWidth: "100%", borderTop: "none" }}
+    >
       <div className={F.field} style={{ flexGrow: "1" }}>
         <div className={cx(S.itemTitle, F.fieldName)}>
           {isEditing ? (
@@ -83,7 +86,7 @@ const Field = ({ field, foreignKeys, url, icon, isEditing, formField }) => (
         </div>
         <div className={F.fieldDataType}>{field.base_type}</div>
       </div>
-      <div className={cx(S.itemSubtitle, F.fieldSecondary, { [CS.mt1]: true })}>
+      <div className={cx(S.itemSubtitle, { [CS.mt1]: true })}>
         <div className={F.fieldForeignKey}>
           {isEditing
             ? (isTypeFK(formField.semantic_type.value) ||
@@ -107,7 +110,11 @@ const Field = ({ field, foreignKeys, url, icon, isEditing, formField }) => (
                 </span>
               )}
         </div>
-        <div className={F.fieldOther} />
+        {field.description && (
+          <div className={cx(S.itemSubtitle, CS.mb2, { [CS.mt1]: isEditing })}>
+            {field.description}
+          </div>
+        )}
       </div>
     </div>
   </div>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/49257

### Description
Not a perfect solution, but fixes the broken CSS rule (while trying not to break anything else), and removes Field descriptions from the field list tables (in the table and segment sections). You can still squish the table to the point that it's ugly, but I do think it's an improvement over what's currently there

### How to verify
1. Go to Browse -> Databases -> learn about our data
2. Sample Database -> Tables -> Orders -> Fields in this table
3. The table should be formatted in a sorta sane way


### Demo
When Viewing:
![image](https://github.com/user-attachments/assets/254e83bd-9582-4ac3-ab98-0fe6a188c4c6)

When Editing:
![image](https://github.com/user-attachments/assets/14bae5e2-5bf3-4af9-ac3d-c910d82087af)


### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
