### PR TITLE
fix(sdk): Editable dashboard should not overlap content below it

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/README.md
+++ b/enterprise/frontend/src/embedding-sdk/README.md
@@ -652,6 +652,18 @@ component.
   but without its cards - at this stage dashboard title, tabs and cards grid is rendered, but cards content is not yet
   loaded.
 
+By default, this component takes full page height (100vh). You can override this with custom styles passed via `style` or `className` props.
+
+```tsx
+<EditableDashboard
+  style={{
+    height: 800,
+    overflow: "auto",
+  }}
+  dashboardId={dashboardId}
+/>
+```
+
 ### Creating Dashboards
 
 Creating dashboard could be done with `useCreateDashboardApi` hook or `CreateDashboardModal` component.

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/ConnectedDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/ConnectedDashboard.tsx
@@ -35,6 +35,7 @@ import {
 } from "metabase/dashboard/selectors";
 import type {
   DashboardFullscreenControls,
+  DashboardLoaderWrapperProps,
   DashboardRefreshPeriodControls,
 } from "metabase/dashboard/types";
 import { useValidatedEntityId } from "metabase/lib/entity-id/hooks/use-validated-entity-id";
@@ -100,6 +101,7 @@ type ConnectedDashboardProps = {
   className?: string;
 } & DashboardFullscreenControls &
   DashboardRefreshPeriodControls &
+  DashboardLoaderWrapperProps &
   PublicOrEmbeddedDashboardEventHandlersProps;
 
 const ConnectedDashboardInner = ({

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/EditableDashboard.styled.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/EditableDashboard.styled.tsx
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 import { PublicComponentWrapper } from "embedding-sdk/components/private/PublicComponentWrapper";
 
 export const StyledPublicComponentWrapper = styled(PublicComponentWrapper)`
-  height: 100vh;
+  min-height: 100vh;
   background: var(--mb-color-bg-dashboard);
   display: flex;
   flex-direction: column;

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/EditableDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/EditableDashboard.tsx
@@ -91,6 +91,7 @@ export const EditableDashboard = ({
             setRefreshElapsedHook={setRefreshElapsedHook}
             isFullscreen={isFullscreen}
             onFullscreenChange={onFullscreenChange}
+            noLoaderWrapper
             onNavigateToNewCardFromDashboard={onNavigateToNewCardFromDashboard}
             downloadsEnabled={withDownloads}
             onLoad={onLoad}

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.tsx
@@ -44,6 +44,7 @@ export const DashboardLoadingAndErrorWrapper = styled(
 
 export const DashboardStyled = styled.div`
   display: flex;
+  flex: 1 0 auto;
   flex-direction: column;
   min-height: 100%;
   width: 100%;

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -198,6 +198,7 @@ function Dashboard(props: DashboardProps) {
     toggleSidebar,
     parameterQueryParams,
     downloadsEnabled = true,
+    noLoaderWrapper = false,
   } = props;
 
   const dispatch = useDispatch();
@@ -396,6 +397,7 @@ function Dashboard(props: DashboardProps) {
       isNightMode={shouldRenderAsNightMode}
       loading={!dashboard}
       error={error}
+      noWrapper={noLoaderWrapper}
     >
       {() => {
         if (!dashboard) {

--- a/frontend/src/metabase/dashboard/types/display-options.ts
+++ b/frontend/src/metabase/dashboard/types/display-options.ts
@@ -26,7 +26,12 @@ export type DashboardDownloadControls = {
   downloadsEnabled?: boolean;
 };
 
+export type DashboardLoaderWrapperProps = {
+  noLoaderWrapper?: boolean;
+};
+
 export type DashboardDisplayOptionControls = DashboardFullscreenControls &
   DashboardRefreshPeriodControls &
   DashboardNightModeControls &
-  DashboardDownloadControls;
+  DashboardDownloadControls &
+  DashboardLoaderWrapperProps;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/48933

### Description

This fixes `EditableDashboard` to have correct size on a page. 
Minimum - 100vh, Maximum by dashboard content.

### Demo

<table>
<tr>
<th> Before: </th>
<th> After: </th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/dae93fd0-5e36-405f-871f-79727ca67795

</td>
<td>

https://github.com/user-attachments/assets/b9981bbb-a278-4fea-9eb7-5e19282aaf6f

</td>
</tr>
</table>

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
