### PR TITLE
fix: make cards the same height in the share modal

### DIFF
--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.tsx
@@ -116,7 +116,6 @@ export function SelectEmbedTypePane({
           to={interactiveEmbeddingCta.url}
           target={interactiveEmbeddingCta.target}
           rel="noreferrer"
-          style={{ height: "100%" }}
         >
           <SharingPaneButton
             title={t`Interactive embedding`}
@@ -133,12 +132,7 @@ export function SelectEmbedTypePane({
         </Link>
 
         {/* REACT SDK */}
-        <a
-          href={sdkUrl}
-          style={{ height: "100%" }}
-          target="_blank"
-          rel="noreferrer"
-        >
+        <a href={sdkUrl} target="_blank" rel="noreferrer">
           <SharingPaneButton
             title={t`Embedded analytics SDK`}
             badge={

--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SharingPaneButton/SharingPaneButton.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SharingPaneButton/SharingPaneButton.tsx
@@ -30,7 +30,7 @@ export const SharingPaneButton = ({
     withBorder
     data-testid={dataTestId}
     onClick={onClick}
-    h="100%"
+    mih="100%"
     pos="relative"
     w={"22rem"}
   >


### PR DESCRIPTION
As reported [here](https://metaboat.slack.com/archives/C01MS7DQKR6/p1730219381577259)

Firefox apparently doesn't support align:stretch on children that have a "set" height, even if it's "100%".
We still need it for when the card is wrapped in <a>, so I changed it to "min-height" and that makes it work

Demo/after:
Firefox:
<img width="1204" alt="image" src="https://github.com/user-attachments/assets/b07d737b-1975-4348-8251-0a588f458283">
Chrome:
<img width="1514" alt="image" src="https://github.com/user-attachments/assets/12785a5f-9a8d-43a1-b8c8-73f761a671dd">
