### PR TITLE
Add MB_NOT_BEHIND_PROXY env var to explicitly skip using X-Forwarded-For header

### DIFF
--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -794,8 +794,8 @@ See [fonts](../configuring-metabase/fonts.md).")
 
 (defsetting not-behind-proxy
   (deferred-tru
-    (str "Indicates whether Metabase is running behind a proxy that sets the source-address-header for incoming "
-         "requests. Defaults to false, but can be set to true via environment variable."))
+   (str "Indicates whether Metabase is running behind a proxy that sets the source-address-header for incoming "
+        "requests. Defaults to false, but can be set to true via environment variable."))
   :type       :boolean
   :setter     :none
   :visibility :internal

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -792,6 +792,16 @@ See [fonts](../configuring-metabase/fonts.md).")
   :getter  (fn [] (some-> (setting/get-value-of-type :string :source-address-header)
                           u/lower-case-en)))
 
+(defsetting not-behind-proxy
+  (deferred-tru
+    (str "Indicates whether Metabase is running behind a proxy that sets the source-address-header for incoming "
+         "requests. Defaults to false, but can be set to true via environment variable."))
+  :type       :boolean
+  :setter     :none
+  :visibility :internal
+  :default    false
+  :export?    false)
+
 (defn remove-public-uuid-if-public-sharing-is-disabled
   "If public sharing is *disabled* and `object` has a `:public_uuid`, remove it so people don't try to use it (since it
   won't work). Intended for use as part of a `post-select` implementation for Cards and Dashboards."

--- a/src/metabase/server/request/util.clj
+++ b/src/metabase/server/request/util.clj
@@ -79,16 +79,21 @@
 
 (defn ip-address
   "The IP address a Ring `request` came from. Looks at the `public-settings/source-address-header` header (by default
-  `X-Forwarded-For`, or the `(:remote-addr request)` if not set."
+  `X-Forwarded-For`, or the `(:remote-addr request)` if not set, or if disabled via MB_NOT_BEHIND_PROXY=true."
   [{:keys [headers remote-addr]}]
-  (some-> (or (some->> (public-settings/source-address-header) (get headers))
-              remote-addr)
-          ;; first IP (if there are multiple) is the actual client -- see
-          ;; https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
-          (str/split #"\s*,\s*")
-          first
-          ;; strip out non-ip-address characters like square brackets which we get sometimes
-          (str/replace #"[^0-9a-fA-F.:]" "")))
+  (let [header-ip-address (some->> (public-settings/source-address-header)
+                                   (get headers))
+        source-address    (if (or (public-settings/not-behind-proxy)
+                                  (not header-ip-address))
+                            remote-addr
+                            header-ip-address)]
+    (some-> source-address
+            ;; first IP (if there are multiple) is the actual client -- see
+            ;; https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
+            (str/split #"\s*,\s*")
+            first
+            ;; strip out non-ip-address characters like square brackets which we get sometimes
+            (str/replace #"[^0-9a-fA-F.:]" ""))))
 
 (def DeviceInfo
   "Schema for the device info returned by `device-info`."

--- a/test/metabase/server/request/util_test.clj
+++ b/test/metabase/server/request/util_test.clj
@@ -58,6 +58,7 @@
     (testing "request with no forwarding"
       (is (= "127.0.0.1"
              (req.util/ip-address request))))
+
     (testing "request with forwarding"
       (let [mock-request (-> (ring.mock/request :get "api/session")
                              (ring.mock/header "X-Forwarded-For" "5.6.7.8"))]
@@ -73,7 +74,14 @@
           (let [mock-request (-> (ring.mock/request :get "api/session")
                                  (ring.mock/header "x-proxyuser-ip" "1.2.3.4"))]
             (is (= "1.2.3.4"
-                   (req.util/ip-address mock-request)))))))))
+                   (req.util/ip-address mock-request)))))))
+
+    (testing "forwarding explicitly disabled via MB_NOT_BEHIND_PROXY=true"
+      (mt/with-temp-env-var-value! [mb-not-behind-proxy "true"]
+        (let [mock-request (-> (ring.mock/request :get "api/session")
+                               (ring.mock/header "X-Forwarded-For" "5.6.7.8"))]
+          (is (= "127.0.0.1"
+                 (req.util/ip-address mock-request))))))))
 
 (deftest ^:parallel geocode-ip-addresses-test
   (are [ip-addresses expected] (malli= [:maybe expected]


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase-private/issues/47

Adds an environment variable that allows instances to explicitly disable looking at the `X-Forwarded-For` header for the source IP address of a request, if it's not being set by a reverse proxy.