### PR TITLE
Adjust dependent dashboard cards

### DIFF
--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -780,13 +780,16 @@
           breakout-clause))
 
 (defn- action-for-identifier+refs
-  "TBD"
+  "TBD!!!!!!!!!!!!!!"
   [after--identifier->refs identifier before--refs]
-  (let [after--refs (get after--identifier->refs identifier)]
+  (let [after--refs (get after--identifier->refs identifier #{})]
     (cond
-      ;; Ignore delete for now. It's prone to nuke what could be usable.
-      #_#_(delete? before--indexed-refs after--indexed-refs)
-        [:delete]
+      (or (and (< 1 (count before--refs) (count after--refs))
+               (not= before--refs after--refs))
+          (and (= 1 (count before--refs))
+               (not= 1 (count after--refs))
+               (not (contains? after--refs (first before--refs)))))
+      [:delete]
 
       (and (= 1 (count before--refs) (count after--refs))
            (not= before--refs after--refs))

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -805,15 +805,15 @@
 (defn- update-mapping
   "Return modifed mapping, or nil, according to action."
   [identifier->action mapping]
-  (if-not (and (= :dimension (get-in mapping [:target 0]))
-               (#{:field :expression} (get-in mapping [:target 1 0])))
-    mapping
-    (let [dimension (get-in mapping [:target 1])
-          identifier (subvec dimension 0 2)
-          [action arg] (get identifier->action identifier)]
-      (case action
-        :update (assoc-in mapping [:target 1] arg)
-        mapping))))
+  (let [[dim [ref-kind id-or-name :as ref]] (:target mapping)]
+    (if-not (and (= dim :dimension)
+                 (#{:field :expression} ref-kind))
+      mapping
+      (let [identifier (subvec ref 0 2)
+            [action arg] (get identifier->action identifier)]
+        (case action
+          :update (assoc-in mapping [:target 1] arg)
+          mapping))))
 
 (defn- updates-for-dashcards
   [identifier->action dashcards]

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -848,6 +848,7 @@
   [identifier->action dashcards]
   (not-empty (keep (partial update-for-dashcard identifier->action) dashcards)))
 
+;; ! :delete action is shut down until I find reasonable condition for deletion.
 (defn- update-associated-parameters!
   "Update _parameter mappings_ of _dashcards_ that target modified _card_, to reflect the modification.
 

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -821,7 +821,7 @@
                    :let [updated (into [] (keep #(update-mapping identifier->action %))
                                        parameter_mappings)]
                    :when (not= parameter_mappings updated)]
-             [id {:parameter_mappings updated}])))
+               [id {:parameter_mappings updated}])))
 
 (defn- update-associated-parameters!
   "Update _parameter mappings_ of _dashcards_ that target modified _card_, to reflect the modification.

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -866,6 +866,8 @@
     (when-some [identifier->action (breakouts-->identifier->action breakout-before breakout-after)]
       (let [dashcards          (t2/select :model/DashboardCard :card_id (some :id [card-after card-before]))
             updates            (updates-for-dashcards identifier->action dashcards)]
+        ;; Beware. This can have negative impact on card update performance as queries are fired in sequence. I'm not
+        ;; aware of more reasonable way.
         (doseq [[id update] updates]
           (t2/update! :model/DashboardCard :id id update))))))
 

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -771,12 +771,9 @@
   "Generate mapping of of _ref identifier_ -> #{_ref..._}.
 
   _ref identifier_ is a vector of first 2 elements of ref, eg. [:expression \"xix\"] or [:field 10]"
-  [breakout-clause]
-  (reduce (fn [acc breakout]
-            (update acc (subvec breakout 0 2)
-                    #(conj (set %1) breakout)))
-          {}
-          breakout-clause))
+  [breakouts]
+  (-> (group-by #(subvec % 0 2) breakouts)
+      (update-vals set)))
 
 (defn- action-for-identifier+refs
   "Generate _action_ for combination of args.

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -788,7 +788,8 @@
   [after--identifier->refs identifier before--refs]
   (let [after--refs (get after--identifier->refs identifier #{})]
     (cond
-      (or
+      #_#_(or
+       ;; If before is subset we should not do anything
        ;; If there was more than 1 ref to a field in orig breakout and there is a difference
        (and (< 1 (count before--refs))
             (not= before--refs after--refs))

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -873,7 +873,13 @@
                                                :enable_embedding :type :parameters :parameter_mappings :embedding_params
                                                :result_metadata :collection_preview :verified-result-metadata?}))
     ;; ok, now update dependent parameters
-    (update-associated-parameters! card-before-update card-updates))
+    (try
+      (update-associated-parameters! card-before-update card-updates)
+      (catch Throwable e
+        (log/error "Update of dependent card parameters failed!")
+        (log/debug e
+                   "`card-before-update`:" (pr-str card-before-update)
+                   "`card-updates`:" (pr-str card-updates)))))
   ;; Fetch the updated Card from the DB
   (let [card (t2/select-one Card :id (:id card-before-update))]
     (delete-alerts-if-needed! :old-card card-before-update, :new-card card, :actor actor)

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -854,8 +854,9 @@
             updates            (updates-for-dashcards identifier->action dashcards)]
         ;; Beware. This can have negative impact on card update performance as queries are fired in sequence. I'm not
         ;; aware of more reasonable way.
-        (doseq [[id update] updates]
-          (t2/update! :model/DashboardCard :id id update))))))
+        (t2/with-transaction [_conn]
+          (doseq [[id update] updates]
+            (t2/update! :model/DashboardCard :id id update)))))))
 
 (defn update-card!
   "Update a Card. Metadata is fetched asynchronously. If it is ready before [[metadata-sync-wait-ms]] elapses it will be

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -784,27 +784,12 @@
   _Action_ is to be performed on _parameter mapping_ of a _dashcard_. For more info see
   the [[update-associated-parameters!]]'s docstring.
 
-  _Action_ has a form of [<action> & args]. Currently :delete, :update, :noop are implemented."
+  _Action_ has a form of [<action> & args]. Currently :update, :noop are implemented."
   [after--identifier->refs identifier before--refs]
   (let [after--refs (get after--identifier->refs identifier #{})]
-    (cond
-      #_#_(or
-       ;; If before is subset we should not do anything
-       ;; If there was more than 1 ref to a field in orig breakout and there is a difference
-       (and (< 1 (count before--refs))
-            (not= before--refs after--refs))
-       ;; If there was 1 ref to a field in orig breakout and if not present in modified breakout
-       (and (= 1 (count before--refs))
-            (not= 1 (count after--refs))
-            (not (contains? after--refs (first before--refs)))))
-      [:delete]
-
-      ;; If there was 1 ref in orig and modfied breakout that's different
-      (and (= 1 (count before--refs) (count after--refs))
-           (not= before--refs after--refs))
+    (if (and (= 1 (count before--refs) (count after--refs))
+             (not= before--refs after--refs))
       [:update (first after--refs)]
-
-      :else
       [:noop])))
 
 (defn- breakouts-->identifier->action
@@ -831,8 +816,7 @@
           [action arg] (get identifier->action identifier [:noop])]
       (case action
         :update (assoc-in mapping [:target 1] arg)
-        :noop   mapping
-        :delete nil))))
+        :noop   mapping))))
 
 (defn- update-for-dashcard
   "Return nil for no-op updates or [<dashcard-id> <update>]. <update> is a map of `:parameter_mappings` only as only

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -827,7 +827,11 @@
 
 (defn- updates-for-dashcards
   [identifier->action dashcards]
-  (not-empty (keep (partial update-for-dashcard identifier->action) dashcards)))
+  (not-empty (for [{:keys [id parameter_mappings]} dashcards
+                   :let [updated (into [] (keep #(update-mapping identifier->action %))
+                                          parameter_mappings]
+                   :when (not= parameter_mappings updated)]
+             [id {:parameter_mappings updated}]))
 
 (defn- update-associated-parameters!
   "Update _parameter mappings_ of _dashcards_ that target modified _card_, to reflect the modification.

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -768,10 +768,9 @@
     :dataset_query})
 
 (defn- breakout-->identifier->refs
-  "~~Generate mapping of _ref identifier_ -> [_breakout index_ _ref_] from breakout clause, ie. vector of refs.~~
-  Generate mapping of of _ref identifier_ -> [_refs_].
+  "Generate mapping of of _ref identifier_ -> #{_ref..._}.
 
-  _ref identifier_ is a vector of first 2 elements of ref."
+  _ref identifier_ is a vector of first 2 elements of ref, eg. [:expression \"xix\"] or [:field 10]"
   [breakout-clause]
   (reduce (fn [acc breakout]
             (update acc (subvec breakout 0 2)

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -832,7 +832,6 @@
   [identifier->action dashcards]
   (not-empty (keep (partial update-for-dashcard identifier->action) dashcards)))
 
-;; ! :delete action is shut down until I find reasonable condition for deletion.
 (defn- update-associated-parameters!
   "Update _parameter mappings_ of _dashcards_ that target modified _card_, to reflect the modification.
 

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -789,7 +789,7 @@
   (let [after--refs (get after--identifier->refs identifier #{})]
     (cond
       (or
-       ;; If there were more than 1 ref to a field in orig breakout and there is a difference
+       ;; If there was more than 1 ref to a field in orig breakout and there is a difference
        (and (< 1 (count before--refs))
             (not= before--refs after--refs))
        ;; If there was 1 ref to a field in orig breakout and if not present in modified breakout

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -828,7 +828,7 @@
     mapping
     (let [dimension (get-in mapping [:target 1])
           identifier (subvec dimension 0 2)
-          [action arg] (get identifier->action identifier)]
+          [action arg] (get identifier->action identifier [:noop])]
       (case action
         :update (assoc-in mapping [:target 1] arg)
         :noop   mapping
@@ -846,7 +846,7 @@
 
 (defn- updates-for-dashcards
   [identifier->action dashcards]
-  (keep (partial update-for-dashcard identifier->action) dashcards))
+  (not-empty (keep (partial update-for-dashcard identifier->action) dashcards)))
 
 (defn- update-associated-parameters!
   "Update _parameter mappings_ of _dashcards_ that target modified _card_, to reflect the modification.

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -850,9 +850,10 @@
             updates            (updates-for-dashcards identifier->action dashcards)]
         ;; Beware. This can have negative impact on card update performance as queries are fired in sequence. I'm not
         ;; aware of more reasonable way.
-        (t2/with-transaction [_conn]
-          (doseq [[id update] updates]
-            (t2/update! :model/DashboardCard :id id update)))))))
+        (when (seq updates)
+          (t2/with-transaction [_conn]
+            (doseq [[id update] updates]
+              (t2/update! :model/DashboardCard :id id update)))))))
 
 (defn update-card!
   "Update a Card. Metadata is fetched asynchronously. If it is ready before [[metadata-sync-wait-ms]] elapses it will be

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -809,7 +809,9 @@
 
 (defn- update-mapping
   [identifier->action mapping]
-  (when (= :dimension (get-in mapping [:target 0]))
+  (if-not (and (= :dimension (get-in mapping [:target 0]))
+               (#{:field :expression} (get-in mapping [:target 1 0])))
+    mapping
     (let [dimension (get-in mapping [:target 1])
           identifier (subvec dimension 0 2)
           [action arg] (get identifier->action identifier)]

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4869,52 +4869,50 @@
 ;; of tested functionality.
 ;; TODO: Address the exception!
 (deftest dependent-dashcard-parameters-test
-  (mt/test-driver
-    :postgres
-    (mt/with-temp [:model/Card {card-id :id} {:name "c1"
-                                              :dataset_query (mt/mbql-query
-                                                               orders
-                                                               {:aggregation [[:count]]
-                                                                :breakout
-                                                                [!day.$created_at]})}
-                   :model/Dashboard {dashboard-id :id} {:name "d1"
-                                                        :parameters []}
-                   :model/DashboardCard {dashcard-id :id} {:card_id card-id
-                                                           :dashboard_id dashboard-id
-                                                           :parameter_mappings []}]
-      (t2/update! :model/Dashboard :id dashboard-id {:parameters [{:name "TIME Gr"
-                                                                   :slug "tgr"
-                                                                   :id "30d7efb0"
-                                                                   :type :temporal-unit
-                                                                   :sectionId "temporal-unit"}]})
-      (t2/update! :model/DashboardCard :id dashcard-id {:parameter_mappings [{:parameter_id "30d7efb0"
-                                                                              :type :temporal-unit
-                                                                              :card_id card-id
-                                                                              :target [:dimension
-                                                                                       (mt/$ids orders !day.$created_at)]}]})
-      (testing "Baseline"
-        (is (=? [["2016-04-01T00:00:00Z" 1]
-                 ["2016-05-01T00:00:00Z" 19]]
-                (->> (mt/user-http-request
-                      :crowberto :post 202
-                      (format "dashboard/%d/dashcard/%d/card/%d/query" dashboard-id dashcard-id card-id)
-                      {:parameters [{:id "30d7efb0"
-                                     :type "temporal-unit"
-                                     :value "month"
-                                     :target
-                                     [:dimension
-                                      (mt/$ids orders !day.$created_at)]}]})
-                     mt/rows
-                     (take 2)))))
-      (mt/user-http-request
-       :crowberto :put 200
-       (format "card/%d" card-id)
-       {:dataset_query (mt/mbql-query
-                         orders
-                         {:aggregation [[:count]]
-                          :breakout
-                          [!year.$created_at]})})
-      (testing "Mapping is adjusted to new target (#49202)"
-        (is (= (mt/$ids orders !year.$created_at)
-               (t2/select-one-fn #(get-in % [:parameter_mappings 0 :target 1])
-                                 :model/DashboardCard :id dashcard-id)))))))
+  (mt/with-temp [:model/Card {card-id :id} {:name "c1"
+                                            :dataset_query (mt/mbql-query
+                                                             orders
+                                                             {:aggregation [[:count]]
+                                                              :breakout
+                                                              [!day.$created_at]})}
+                 :model/Dashboard {dashboard-id :id} {:name "d1"
+                                                      :parameters []}
+                 :model/DashboardCard {dashcard-id :id} {:card_id card-id
+                                                         :dashboard_id dashboard-id
+                                                         :parameter_mappings []}]
+    (t2/update! :model/Dashboard :id dashboard-id {:parameters [{:name "TIME Gr"
+                                                                 :slug "tgr"
+                                                                 :id "30d7efb0"
+                                                                 :type :temporal-unit
+                                                                 :sectionId "temporal-unit"}]})
+    (t2/update! :model/DashboardCard :id dashcard-id {:parameter_mappings [{:parameter_id "30d7efb0"
+                                                                            :type :temporal-unit
+                                                                            :card_id card-id
+                                                                            :target [:dimension
+                                                                                     (mt/$ids orders !day.$created_at)]}]})
+    (testing "Baseline"
+      (is (=? [["2016-04-01T00:00:00Z" 1]
+               ["2016-05-01T00:00:00Z" 19]]
+              (->> (mt/user-http-request
+                    :crowberto :post 202
+                    (format "dashboard/%d/dashcard/%d/card/%d/query" dashboard-id dashcard-id card-id)
+                    {:parameters [{:id "30d7efb0"
+                                   :type "temporal-unit"
+                                   :value "month"
+                                   :target
+                                   [:dimension
+                                    (mt/$ids orders !day.$created_at)]}]})
+                   mt/rows
+                   (take 2)))))
+    (mt/user-http-request
+     :crowberto :put 200
+     (format "card/%d" card-id)
+     {:dataset_query (mt/mbql-query
+                       orders
+                       {:aggregation [[:count]]
+                        :breakout
+                        [!year.$created_at]})})
+    (testing "Mapping is adjusted to new target (#49202)"
+      (is (= (mt/$ids orders !year.$created_at)
+             (t2/select-one-fn #(get-in % [:parameter_mappings 0 :target 1])
+                               :model/DashboardCard :id dashcard-id))))))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4864,3 +4864,54 @@
             ;; dashcards and parameters for each dashcard, linked to a single card. Following is the proof
             ;; of things working as described.
             (is (= 1 @call-count))))))))
+
+(deftest dependent-dashcard-parameters-test
+  (mt/test-driver
+   :postgres
+   (mt/with-temp [:model/Card {card-id :id} {:name "c1"
+                                             :dataset_query (mt/mbql-query
+                                                             orders
+                                                             {:aggregation [[:count]]
+                                                              :breakout
+                                                              [!day.$created_at]})}
+                  :model/Dashboard {dashboard-id :id} {:name "d1"
+                                                       :parameters []}
+                  :model/DashboardCard {dashcard-id :id} {:card_id card-id
+                                                          :dashboard_id dashboard-id
+                                                          :parameter_mappings []}]
+     (t2/update! :model/Dashboard :id dashboard-id {:parameters [{:name "TIME Gr"
+                                                                  :slug "tgr"
+                                                                  :id "30d7efb0"
+                                                                  :type :temporal-unit
+                                                                  :sectionId "temporal-unit"}]})
+     (t2/update! :model/DashboardCard :id dashcard-id {:parameter_mappings [{:parameter_id "30d7efb0"
+                                                                             :type :temporal-unit
+                                                                             :card_id card-id
+                                                                             :target [:dimension
+                                                                                      (mt/$ids orders !day.$created_at)]}]})
+     ;; baseline
+     (is (=? [["2016-04-01T00:00:00Z" 1]
+              ["2016-05-01T00:00:00Z" 19]]
+             (->> (mt/user-http-request
+                   :crowberto :post 202
+                   (format "dashboard/%d/dashcard/%d/card/%d/query" dashboard-id dashcard-id card-id)
+                   {:parameters [{:id "30d7efb0"
+                                  :type "temporal-unit"
+                                  :value "month"
+                                  :target
+                                  [:dimension
+                                   (mt/$ids orders !day.$created_at)]}]})
+                  mt/rows
+                  (take 2))))
+     (mt/user-http-request
+      :crowberto :put 200
+      (format "card/%d" card-id)
+      {:dataset_query (mt/mbql-query
+                       orders
+                       {:aggregation [[:count]]
+                        :breakout
+                        [!year.$created_at]})})
+     (testing "Mapping is adjusted to new target"
+       (is (= (mt/$ids orders !year.$created_at)
+              (t2/select-one-fn #(get-in % [:parameter_mappings 0 :target 1])
+                                :model/DashboardCard :id dashcard-id)))))))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4865,53 +4865,56 @@
             ;; of things working as described.
             (is (= 1 @call-count))))))))
 
+;; Exception during scheduled (grouper) update of UserParameterValue is thrown. It is not relevant in context
+;; of tested functionality.
+;; TODO: Address the exception!
 (deftest dependent-dashcard-parameters-test
   (mt/test-driver
-   :postgres
-   (mt/with-temp [:model/Card {card-id :id} {:name "c1"
-                                             :dataset_query (mt/mbql-query
-                                                             orders
-                                                             {:aggregation [[:count]]
-                                                              :breakout
-                                                              [!day.$created_at]})}
-                  :model/Dashboard {dashboard-id :id} {:name "d1"
-                                                       :parameters []}
-                  :model/DashboardCard {dashcard-id :id} {:card_id card-id
-                                                          :dashboard_id dashboard-id
-                                                          :parameter_mappings []}]
-     (t2/update! :model/Dashboard :id dashboard-id {:parameters [{:name "TIME Gr"
-                                                                  :slug "tgr"
-                                                                  :id "30d7efb0"
-                                                                  :type :temporal-unit
-                                                                  :sectionId "temporal-unit"}]})
-     (t2/update! :model/DashboardCard :id dashcard-id {:parameter_mappings [{:parameter_id "30d7efb0"
-                                                                             :type :temporal-unit
-                                                                             :card_id card-id
-                                                                             :target [:dimension
-                                                                                      (mt/$ids orders !day.$created_at)]}]})
-     ;; baseline
-     (is (=? [["2016-04-01T00:00:00Z" 1]
-              ["2016-05-01T00:00:00Z" 19]]
-             (->> (mt/user-http-request
-                   :crowberto :post 202
-                   (format "dashboard/%d/dashcard/%d/card/%d/query" dashboard-id dashcard-id card-id)
-                   {:parameters [{:id "30d7efb0"
-                                  :type "temporal-unit"
-                                  :value "month"
-                                  :target
-                                  [:dimension
-                                   (mt/$ids orders !day.$created_at)]}]})
-                  mt/rows
-                  (take 2))))
-     (mt/user-http-request
-      :crowberto :put 200
-      (format "card/%d" card-id)
-      {:dataset_query (mt/mbql-query
-                       orders
-                       {:aggregation [[:count]]
-                        :breakout
-                        [!year.$created_at]})})
-     (testing "Mapping is adjusted to new target"
-       (is (= (mt/$ids orders !year.$created_at)
-              (t2/select-one-fn #(get-in % [:parameter_mappings 0 :target 1])
-                                :model/DashboardCard :id dashcard-id)))))))
+    :postgres
+    (mt/with-temp [:model/Card {card-id :id} {:name "c1"
+                                              :dataset_query (mt/mbql-query
+                                                               orders
+                                                               {:aggregation [[:count]]
+                                                                :breakout
+                                                                [!day.$created_at]})}
+                   :model/Dashboard {dashboard-id :id} {:name "d1"
+                                                        :parameters []}
+                   :model/DashboardCard {dashcard-id :id} {:card_id card-id
+                                                           :dashboard_id dashboard-id
+                                                           :parameter_mappings []}]
+      (t2/update! :model/Dashboard :id dashboard-id {:parameters [{:name "TIME Gr"
+                                                                   :slug "tgr"
+                                                                   :id "30d7efb0"
+                                                                   :type :temporal-unit
+                                                                   :sectionId "temporal-unit"}]})
+      (t2/update! :model/DashboardCard :id dashcard-id {:parameter_mappings [{:parameter_id "30d7efb0"
+                                                                              :type :temporal-unit
+                                                                              :card_id card-id
+                                                                              :target [:dimension
+                                                                                       (mt/$ids orders !day.$created_at)]}]})
+      (testing "Baseline"
+        (is (=? [["2016-04-01T00:00:00Z" 1]
+                 ["2016-05-01T00:00:00Z" 19]]
+                (->> (mt/user-http-request
+                      :crowberto :post 202
+                      (format "dashboard/%d/dashcard/%d/card/%d/query" dashboard-id dashcard-id card-id)
+                      {:parameters [{:id "30d7efb0"
+                                     :type "temporal-unit"
+                                     :value "month"
+                                     :target
+                                     [:dimension
+                                      (mt/$ids orders !day.$created_at)]}]})
+                     mt/rows
+                     (take 2)))))
+      (mt/user-http-request
+       :crowberto :put 200
+       (format "card/%d" card-id)
+       {:dataset_query (mt/mbql-query
+                         orders
+                         {:aggregation [[:count]]
+                          :breakout
+                          [!year.$created_at]})})
+      (testing "Mapping is adjusted to new target (#49202)"
+        (is (= (mt/$ids orders !year.$created_at)
+               (t2/select-one-fn #(get-in % [:parameter_mappings 0 :target 1])
+                                 :model/DashboardCard :id dashcard-id)))))))


### PR DESCRIPTION
Closes #49202

### Description

Card can have multiple multiple breakout elements referencing same field or expression, having different  _temporal unit_. Those refs can be targeted by dashboard _temporal unit parameter_. If refs change, and card is saved, _parameter mappings_ have to be updated to target new, modified refs. This PR implements that for the case, where it is certain which ref was modified how.

First mappings of _identifier_ -> _action_ are generated (described in docstrings). Then, dashcards are fetched, updates are generated and executed.

### Tests

Run newly added tests or follow the reproduction steps.
