### PR TITLE
Ensure no duplicates in search index

### DIFF
--- a/test/metabase/search/postgres/index_test.clj
+++ b/test/metabase/search/postgres/index_test.clj
@@ -40,10 +40,10 @@
 
 (deftest idempotent-test
   (with-index
-   (let [count-rows  (fn [] (t2/count @#'search.index/active-table))
-         rows-before (count-rows)]
-     (search.ingestion/populate-index!)
-     (is (= rows-before (count-rows))))))
+    (let [count-rows  (fn [] (t2/count @#'search.index/active-table))
+          rows-before (count-rows)]
+      (search.ingestion/populate-index!)
+      (is (= rows-before (count-rows))))))
 
 (deftest consistent-subset-test
   (with-index

--- a/test/metabase/search/postgres/index_test.clj
+++ b/test/metabase/search/postgres/index_test.clj
@@ -38,6 +38,13 @@
          (search.ingestion/populate-index!)
          ~@body))))
 
+(deftest idempotent-test
+  (with-index
+   (let [count-rows  (fn [] (t2/count @#'search.index/active-table))
+         rows-before (count-rows)]
+     (search.ingestion/populate-index!)
+     (is (= rows-before (count-rows))))))
+
 (deftest consistent-subset-test
   (with-index
     (testing "It's consistent with in-place search on various full words"


### PR DESCRIPTION
Refs https://github.com/metabase/metabase/issues/40964

Uses a constraint + upserts to ensure we don't return duplicate results.