### PR TITLE
Update Macaw to 0.2.24 and set its run mode

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -79,7 +79,7 @@
   io.github.eerohele/pp                     {:git/tag "2024-01-04.60"           ; super fast pretty-printing library
                                              :git/sha "a428751"
                                              :git/url "https://github.com/eerohele/pp"}
-  io.github.metabase/macaw                  {:mvn/version "0.2.20"}             ; Parse native SQL queries
+  io.github.metabase/macaw                  {:mvn/version "0.2.23"}             ; Parse native SQL queries
   ;; The 2.X line of Resilience4j requires Java 17, so we cannot upgrade this dependency until that is our minimum JVM version
   io.github.resilience4j/resilience4j-retry {:mvn/version "1.7.1" #_"must be 1.7.1"} ; Support for retrying operations
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector
@@ -262,6 +262,7 @@
    :jvm-opts    ["-Dmb.run.mode=dev"
                  "-Dmb.field.filter.operators.enabled=true"
                  "-Dmb.test.env.setting=ABCDEFG"
+                 "-Dmacaw.run.mode=dev"
                  "-Duser.timezone=UTC"
                  "-Dfile.encoding=UTF-8"
                  "-Duser.language=en"
@@ -292,6 +293,7 @@
   {:extra-paths ["test_config"]
    :exec-fn     metabase.test-runner/find-and-run-tests-cli
    :jvm-opts    ["-Dmb.run.mode=test"
+                 "-Dmacaw.run.mode=test"
                  "-Dmb.db.in.memory=true"
                  "-Dmb.jetty.join=false"
                  "-Dmb.field.filter.operators.enabled=true"
@@ -307,6 +309,7 @@
   :run
   {:main-opts ["-m" "metabase.bootstrap"]
    :jvm-opts  ["-Dmb.run.mode=dev"
+               "-Dmacaw.run.mode=dev"
                "-Djava.awt.headless=true"]}                   ; prevent Java icon from randomly popping up in macOS dock
 
   ;; alias for CI-specific options.

--- a/deps.edn
+++ b/deps.edn
@@ -79,7 +79,7 @@
   io.github.eerohele/pp                     {:git/tag "2024-01-04.60"           ; super fast pretty-printing library
                                              :git/sha "a428751"
                                              :git/url "https://github.com/eerohele/pp"}
-  io.github.metabase/macaw                  {:mvn/version "0.2.23"}             ; Parse native SQL queries
+  io.github.metabase/macaw                  {:mvn/version "0.2.24"}             ; Parse native SQL queries
   ;; The 2.X line of Resilience4j requires Java 17, so we cannot upgrade this dependency until that is our minimum JVM version
   io.github.resilience4j/resilience4j-retry {:mvn/version "1.7.1" #_"must be 1.7.1"} ; Support for retrying operations
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector

--- a/src/metabase/query_analysis/native_query_analyzer/impl.cljc
+++ b/src/metabase/query_analysis/native_query_analyzer/impl.cljc
@@ -51,7 +51,7 @@
      :quotes-preserve-case? (not (contains? #{:mysql :sqlserver} driver))
      :features              {:postgres-syntax        (isa? driver/hierarchy driver :postgres)
                              :square-bracket-quotes  (= :sqlserver driver)
-                             :unsupported-statements true
+                             :unsupported-statements false
                              :backslash-escape-char  true
                              ;; This will slow things down, but until we measure the difference, opt for correctness.
                              :complex-parsing        true}


### PR DESCRIPTION
Bumps Macaw to 0.2.23 and synchronises its run mode with Metabase.

This should have two consequences:

- Remove the large stacktrace from CI
- Type errors if NQA is passed data in the wrong shape