### PR TITLE
Make release log updates smarter

### DIFF
--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -1,10 +1,12 @@
 name: Update Release Log
-run-name: Update Release Log ${{ inputs.version }}
+run-name: Update Release Log ${{ inputs.version || github.ref_name }}
 
 on:
   push:
     branches:
       - release-x.*
+    tags:
+      - v*
   workflow_dispatch:
     inputs:
       version:
@@ -22,10 +24,8 @@ jobs:
   update-release-log:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # don't run this workflow automatically for forks
+    # don't run this workflow for forks
     if: ${{ github.event_name != 'push' || github.repository == 'metabase/metabase' }}
-    env:
-      VERSION: ${{ inputs.version || vars.CURRENT_VERSION }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -40,8 +40,7 @@ jobs:
         run: yarn --cwd release --frozen-lockfile && npm i -g tsx
       - name: Build release scripts
         run: yarn --cwd release build
-      - name: Get version number from branch name
-        if: ${{ github.event_name == 'push' }}
+      - name: Get version number
         uses: actions/github-script@v7
         with:
           script: | # js
@@ -50,14 +49,20 @@ jobs:
               getMajorVersion,
             } = require('${{ github.workspace }}/release/dist/index.cjs');
 
-            const version = getVersionFromReleaseBranch({
-              branch: context.ref,
-            });
+            console.log({ context });
 
+            // if the version is explicitly set, use that
+            if (context.payload?.inputs?.version) {
+              core.exportVariable('VERSION', context.payload.inputs.version);
+              return;
+            }
+
+            // otherwise, get the version from the release branch name
+            const branch = context.payload.ref;
+            const version = getVersionFromReleaseBranch(branch);
             const majorVersion = getMajorVersion(version);
 
-            console.log({ ref: context.ref, version, majorVersion });
-
+            console.log({ branch, version, majorVersion });
             core.exportVariable('VERSION', majorVersion);
 
       - name: generate release Log

--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -2,14 +2,15 @@ name: Update Release Log
 run-name: Update Release Log ${{ inputs.version }}
 
 on:
+  push:
+    branches:
+      - release-x.*
   workflow_dispatch:
     inputs:
       version:
         description: 'Major Metabase version (e.g. 45, 52, 68)'
         type: number
         required: true
-  schedule:
-    - cron: '45 * * * *' # hourly
   workflow_call:
     inputs:
       version:
@@ -21,11 +22,10 @@ jobs:
   update-release-log:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # don't run this workflow on a cron for forks
-    if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
+    # don't run this workflow automatically for forks
+    if: ${{ github.event_name != 'push' || github.repository == 'metabase/metabase' }}
     env:
-      VERSION: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call')
-        && inputs.version || vars.CURRENT_VERSION }}
+      VERSION: ${{ inputs.version || vars.CURRENT_VERSION }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -38,6 +38,28 @@ jobs:
           fetch-depth: 0 # we want all branches and tags
       - name: Install Dependencies
         run: yarn --cwd release --frozen-lockfile && npm i -g tsx
+      - name: Build release scripts
+        run: yarn --cwd release build
+      - name: Get version number from branch name
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/github-script@v7
+        with:
+          script: | # js
+            const {
+              getVersionFromReleaseBranch,
+              getMajorVersion,
+            } = require('${{ github.workspace }}/release/dist/index.cjs');
+
+            const version = getVersionFromReleaseBranch({
+              branch: context.ref,
+            });
+
+            const majorVersion = getMajorVersion(version);
+
+            console.log({ ref: context.ref, version, majorVersion });
+
+            core.exportVariable('VERSION', majorVersion);
+
       - name: generate release Log
         run: cd release && tsx ./src/release-log-run.ts $VERSION > v$VERSION.html
       - name: generate release channel log

--- a/release/src/release-log.ts
+++ b/release/src/release-log.ts
@@ -14,8 +14,8 @@ type CommitInfo = {
 const tablePageTemplate = fs.readFileSync('./src/tablePageTemplate.html', 'utf8');
 
 export async function gitLog(majorVersion: number) {
-  const { stdout: baseCommit } = await $`git merge-base origin/release-x.${majorVersion}.x master`;
-  const { stdout } = await $`git log origin/release-x.${majorVersion}.x ..${baseCommit.trim()} --pretty='format:%(decorate:prefix=,suffix=)||%s||%H||%ah'`;
+  const { stdout: baseCommit } = await $`git merge-base origin/release-x.${majorVersion}.x origin/master`;
+  const { stdout } = await $`git log origin/release-x.${majorVersion}.x..${baseCommit.trim()} --pretty='format:%(decorate:prefix=,suffix=)||%s||%H||%ah'`;
   const processedCommits = stdout.split('\n').map(processCommit);
   return buildTable(processedCommits, majorVersion);
 }
@@ -34,9 +34,9 @@ export function processCommit(commitLine: string): CommitInfo {
 const issueLink = (issueNumber: string) => `https://github.com/metabase/metabase/issues/${issueNumber}`;
 
 function linkifyIssueNumbers(message: string) {
-  return message.replace(issueNumberRegex, (_, issueNumber) => {
+  return message?.replace(issueNumberRegex, (_, issueNumber) => {
     return `<a href="${issueLink(issueNumber)}" target="_blank">(#${issueNumber})</a>`;
-  });
+  }) ?? message ?? '';
 }
 
 function tableRow(commit: CommitInfo) {


### PR DESCRIPTION
### Description

Instead of updating the release log hourly for the latest release branch, this updates the release log for any release branch on push to that release branch, or push of a new release tag

### Checklist

- [x] [tested in my fork](https://github.com/iethree/metabase/actions/runs/12284039170/job/34278903495)
