### PR TITLE
Update fullscreen dashboard filter on dark theme

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.tsx
@@ -133,6 +133,18 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)<{
           ? "var(--mb-color-border)"
           : getDashboardBodyBgColor(isNightMode)};
     `}
+
+    ${({ isNightMode }) =>
+    isNightMode &&
+    css`
+      --mb-color-text-secondary: color-mix(
+        in srgb,
+        var(--mb-color-text-white) 65%,
+        transparent
+      );
+      --mb-color-border: var(--mb-color-text-medium);
+      --mb-color-background: var(--mb-color-bg-black);
+    `}
 `;
 
 export const ParametersAndCardsContainer = styled.div<{

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.tsx
@@ -139,10 +139,10 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)<{
     css`
       --mb-color-text-secondary: color-mix(
         in srgb,
-        var(--mb-color-text-white) 65%,
+        var(--mb-base-color-white) 65%,
         transparent
       );
-      --mb-color-border: var(--mb-color-text-medium);
+      --mb-color-border: var(--mb-base-color-orion-60);
       --mb-color-background: var(--mb-color-bg-black);
     `}
 `;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/49332

### Description

Since fullscreen dashboard dark theme and static embedded dashboard dark theme are implemented differently, we need to add necessary styles to the fullscreen dashboard dark theme to make the filters look the same.

Please note that this doesn't fix the popover style since the style is identical to v50

And you can see this comment for more details why this happens https://github.com/metabase/metabase/issues/49332#issuecomment-2447258341

### How to verify

1. Create a dashboard if not exist.
1. Add a question, and a filter, and link it to the card.
1. Click the 3-dot button and select "Enter fullscreen"
1. Click the crescent moon icon to switch to dark mode

### Demo

#### V50 for reference
![Screenshot 2024-10-30 at 8 51 26 PM](https://github.com/user-attachments/assets/188dc9c3-d757-4278-a200-b85154758906)

#### Before
![Screenshot 2024-10-30 at 9 43 09 PM](https://github.com/user-attachments/assets/543ce31f-2166-47f3-a565-82f5a6a36117)

#### After
![Screenshot 2024-10-30 at 9 36 14 PM](https://github.com/user-attachments/assets/392c3ad6-fd6c-4910-9971-5af07d53d8f9)


### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~ No tests since it's purely visual
