### PR TITLE
fix(sdk): fix sdk reducer types for the mantine v7 upgrade

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/store/reducer.ts
+++ b/enterprise/frontend/src/embedding-sdk/store/reducer.ts
@@ -108,69 +108,52 @@ const initialState: SdkState = {
 };
 
 export const sdk = createReducer(initialState, builder => {
-  builder.addCase(refreshTokenAsync.pending, state => ({
-    ...state,
-    token: { ...state.token, loading: true },
-  }));
+  builder.addCase(refreshTokenAsync.pending, state => {
+    state.token.loading = true;
+  });
 
-  builder.addCase(refreshTokenAsync.fulfilled, (state, action) => ({
-    ...state,
-    token: {
-      ...state.token,
-      token: action.payload,
-      error: null,
-      loading: false,
-    },
-  }));
+  builder.addCase(refreshTokenAsync.fulfilled, (state, action) => {
+    state.token.loading = false;
+    state.token.token = action.payload;
+    state.token.error = null;
+  });
 
-  builder.addCase(refreshTokenAsync.rejected, (state, action) => ({
-    ...state,
-    isLoggedIn: false,
-    token: {
-      ...state.token,
-      token: null,
-      error: action.error,
-      loading: false,
-    },
-  }));
+  builder.addCase(refreshTokenAsync.rejected, (state, action) => {
+    state.token.token = null;
+    state.token.error = action.error;
+    state.token.loading = false;
+  });
 
-  builder.addCase(setLoginStatus, (state, action) => ({
-    ...state,
-    loginStatus: action.payload,
-  }));
+  builder.addCase(setLoginStatus, (state, action) => {
+    state.loginStatus = action.payload;
+  });
 
-  builder.addCase(setLoaderComponent, (state, action) => ({
-    ...state,
-    loaderComponent: action.payload,
-  }));
+  builder.addCase(setLoaderComponent, (state, action) => {
+    state.loaderComponent = action.payload;
+  });
 
   builder.addCase(setPlugins, (state, action) => ({
     ...state,
     plugins: action.payload,
   }));
 
-  builder.addCase(setEventHandlers, (state, action) => ({
-    ...state,
-    eventHandlers: action.payload,
-  }));
+  builder.addCase(setEventHandlers, (state, action) => {
+    state.eventHandlers = action.payload;
+  });
 
-  builder.addCase(setErrorComponent, (state, action) => ({
-    ...state,
-    errorComponent: action.payload,
-  }));
+  builder.addCase(setErrorComponent, (state, action) => {
+    state.errorComponent = action.payload;
+  });
 
-  builder.addCase(setMetabaseClientUrl, (state, action) => ({
-    ...state,
-    metabaseInstanceUrl: action.payload,
-  }));
+  builder.addCase(setMetabaseClientUrl, (state, action) => {
+    state.metabaseInstanceUrl = action.payload;
+  });
 
-  builder.addCase(setFetchRefreshTokenFn, (state, action) => ({
-    ...state,
-    fetchRefreshTokenFn: action.payload,
-  }));
+  builder.addCase(setFetchRefreshTokenFn, (state, action) => {
+    state.fetchRefreshTokenFn = action.payload;
+  });
 
-  builder.addCase(setUsageProblem, (state, action) => ({
-    ...state,
-    usageProblem: action.payload,
-  }));
+  builder.addCase(setUsageProblem, (state, action) => {
+    state.usageProblem = action.payload;
+  });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/49316

Fixes the SDK reducer types for the Mantine v7 upgrade. As we are already using Immer under the hood in our `@reduxjs/toolkit` reducer (notice the `WritableDraft<SdkState>` types, we can safely use Immer's shorthand. This has the added benefit of fixing the reducer type errors in https://github.com/metabase/metabase/issues/49316

### How to verify

- Run `yarn build-embedding-sdk` on the `mantine-v7/main` branch, you will get a type error.
- Run the same command on this branch, and the build succeeds with no type errors.