### PR TITLE
docs - note on databricks legacy catalogs

### DIFF
--- a/docs/databases/connections/databricks.md
+++ b/docs/databases/connections/databricks.md
@@ -28,9 +28,9 @@ See [Personal Access Token (PAT)](https://docs.databricks.com/en/dev-tools/auth/
 
 ## Catalog
 
-For now, you can only select one catalog. Metabase doesn't support multi-catalog connections.
+For now, you can only select one catalog. Metabase doesn't support multi-catalog connections. If you want to use more than one catalog in Metabase, you can set up multiple connections, each selecting a different catalog.
 
-You also can't sync Databricks's legacy catalogs, including the `samples` or `hive_metastore` catalogs.
+You can't sync Databricks's legacy catalogs, however, including the `samples` or `hive_metastore` catalogs.
 
 ## Schemas
 

--- a/docs/databases/connections/databricks.md
+++ b/docs/databases/connections/databricks.md
@@ -60,4 +60,3 @@ Note that only the `*` wildcard is supported; you can't use other special charac
 You can append options to the connection string that Metabase uses to connect to your database. E.g., `IgnoreTransactions=0`.
 
 See [Compute settings for the Databricks JDBC Driver](https://docs.databricks.com/en/integrations/jdbc/compute.html).
-

--- a/docs/databases/connections/databricks.md
+++ b/docs/databases/connections/databricks.md
@@ -61,4 +61,5 @@ See [Compute settings for the Databricks JDBC Driver](https://docs.databricks.co
 
 ## Limitations
 
-Currently, you can't sync Databricks's `samples` catalog.
+- You can only sync one catalog.
+- You can't sync Databricks's legacy catalogs, including the `samples` or `hive_metastore` catalogs.

--- a/docs/databases/connections/databricks.md
+++ b/docs/databases/connections/databricks.md
@@ -30,6 +30,8 @@ See [Personal Access Token (PAT)](https://docs.databricks.com/en/dev-tools/auth/
 
 For now, you can only select one catalog. Metabase doesn't support multi-catalog connections.
 
+You also can't sync Databricks's legacy catalogs, including the `samples` or `hive_metastore` catalogs.
+
 ## Schemas
 
 You can specify which schemas you want to sync and scan. Options are:
@@ -59,7 +61,3 @@ You can append options to the connection string that Metabase uses to connect to
 
 See [Compute settings for the Databricks JDBC Driver](https://docs.databricks.com/en/integrations/jdbc/compute.html).
 
-## Limitations
-
-- You can only sync one catalog.
-- You can't sync Databricks's legacy catalogs, including the `samples` or `hive_metastore` catalogs.


### PR DESCRIPTION
Folds limitations into the relevant catalog section on the Databricks driver page. Adds note about multiple connections.