### PR TITLE
Enforce collection perms on native source-card IDs instead of requiring native query perms

### DIFF
--- a/e2e/test/scenarios/permissions/view-data.cy.spec.js
+++ b/e2e/test/scenarios/permissions/view-data.cy.spec.js
@@ -913,7 +913,7 @@ function lackPermissionsView(isQbQuestion, shouldExist) {
     }
   }
 
-  cy.findByText(/You do not have permissions to run this query/).should(
+  cy.findByText(/Blocked: you are not allowed to run queries/).should(
     shouldExist ? "exist" : "not.exist",
   );
 }

--- a/e2e/test/scenarios/permissions/view-data.cy.spec.js
+++ b/e2e/test/scenarios/permissions/view-data.cy.spec.js
@@ -913,7 +913,7 @@ function lackPermissionsView(isQbQuestion, shouldExist) {
     }
   }
 
-  cy.findByText(/Blocked: you are not allowed to run queries/).should(
+  cy.findByText(/You do not have permissions to run this query/).should(
     shouldExist ? "exist" : "not.exist",
   );
 }

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
@@ -8,20 +8,22 @@
    [metabase.util.i18n :refer [tru]]))
 
 (defenterprise check-block-permissions
-  "Assert that block permissions are not in effect for Database for a query that's only allowed to run because of
-  Collection perms; throw an Exception if they are; otherwise return `true`. The query is still allowed to run if the
-  current User has unrestricted data permissions from another Group. See the namespace documentation for
+  "Assert that block permissions are not in effect for Database or Tables for a query that's otherwise allowed to run
+  because of Collection perms; throw an Exception if they are; otherwise return `true`. The query is still allowed to
+  run if the current User has unrestricted data permissions from another Group. See the namespace documentation for
   [[metabase.models.collection]] for more details."
   :feature :advanced-permissions
   [{database-id :database :as query}]
-  (or
-   (not= :blocked (data-perms/full-db-permission-for-user api/*current-user-id* :perms/view-data database-id))
-   (let [table-ids (query-perms/query->source-table-ids query)]
-     (= #{:unrestricted}
-        (set
-         (map (partial data-perms/table-permission-for-user api/*current-user-id* :perms/view-data database-id)
-              table-ids))))
-   (throw (ex-info (tru "Blocked: you are not allowed to run queries against Database {0}." database-id)
-                   {:type               qp.error-type/missing-required-permissions
-                    :actual-permissions @api/*current-user-permissions-set*
-                    :permissions-error? true}))))
+  (let [{:keys [table-ids native?]} (query-perms/query->source-ids query)]
+    (when (or
+           (= :blocked (data-perms/full-db-permission-for-user api/*current-user-id* :perms/view-data database-id))
+           native?
+           (when (seq table-ids)
+             (not= #{:unrestricted}
+                   (set
+                    (map (partial data-perms/table-permission-for-user api/*current-user-id* :perms/view-data database-id)
+                         table-ids)))))
+      (throw (ex-info (tru "You do not have permissions to run this query.")
+                      {:type               qp.error-type/missing-required-permissions
+                       :actual-permissions @api/*current-user-permissions-set*
+                       :permissions-error? true})))))

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
@@ -14,10 +14,9 @@
   [[metabase.models.collection]] for more details."
   :feature :advanced-permissions
   [{database-id :database :as query}]
-  (let [{:keys [table-ids native?]} (query-perms/query->source-ids query)]
+  (let [{:keys [table-ids]} (query-perms/query->source-ids query)]
     (when (or
            (= :blocked (data-perms/full-db-permission-for-user api/*current-user-id* :perms/view-data database-id))
-           native?
            (when (seq table-ids)
              (not= #{:unrestricted}
                    (set

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
@@ -21,7 +21,7 @@
         (set
          (map (partial data-perms/table-permission-for-user api/*current-user-id* :perms/view-data database-id)
               table-ids))))
-   (throw (ex-info (tru "Blocked: you are not allowed to run queries against Database {0}." database-id)
+   (throw (ex-info (tru "You do not have permissions to run this query.")
                    {:type               qp.error-type/missing-required-permissions
                     :actual-permissions @api/*current-user-permissions-set*
                     :permissions-error? true}))))

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
@@ -1,11 +1,20 @@
 (ns metabase-enterprise.advanced-permissions.models.permissions.block-permissions
   (:require
    [metabase.api.common :as api]
+   [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.models.data-permissions :as data-perms]
    [metabase.models.query.permissions :as query-perms]
    [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.query-processor.error-type :as qp.error-type]
+   [metabase.query-processor.store :as qp.store]
    [metabase.util.i18n :refer [tru]]))
+
+(defn- throw-block-permissions-exception
+  []
+  (throw (ex-info (tru "You do not have permissions to run this query.")
+                  {:type               qp.error-type/missing-required-permissions
+                   :actual-permissions @api/*current-user-permissions-set*
+                   :permissions-error? true})))
 
 (defenterprise check-block-permissions
   "Assert that block permissions are not in effect for Database or Tables for a query that's otherwise allowed to run
@@ -14,14 +23,19 @@
   [[metabase.models.collection]] for more details."
   :feature :advanced-permissions
   [{database-id :database :as query}]
-  (or
-   (not= :blocked (data-perms/full-db-permission-for-user api/*current-user-id* :perms/view-data database-id))
-   (let [table-ids (query-perms/query->source-table-ids query)]
-     (= #{:unrestricted}
-        (set
-         (map (partial data-perms/table-permission-for-user api/*current-user-id* :perms/view-data database-id)
-              table-ids))))
-   (throw (ex-info (tru "You do not have permissions to run this query.")
-                   {:type               qp.error-type/missing-required-permissions
-                    :actual-permissions @api/*current-user-permissions-set*
-                    :permissions-error? true}))))
+  (let [{:keys [table-ids card-ids]} (query-perms/query->source-ids query)
+        table-permissions            (map (partial data-perms/table-permission-for-user api/*current-user-id*
+                                                   :perms/view-data database-id)
+                                          table-ids)]
+    ;; Make sure we don't have block permissions for any individual tables in the query
+    (or
+     (not= :blocked (data-perms/full-db-permission-for-user api/*current-user-id* :perms/view-data database-id))
+     (= #{:unrestricted} (set table-permissions))
+     (throw-block-permissions-exception))
+
+    ;; Recursively check block permissions for any Cards referenced by the query
+    (doseq [card-id card-ids]
+      (let [{query :dataset-query} (lib.metadata.protocols/card (qp.store/metadata-provider) card-id)]
+        (check-block-permissions query)))
+
+    true))

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/query_processor/middleware/permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/query_processor/middleware/permissions.clj
@@ -35,14 +35,13 @@
         table-perms (if (or native? (seq card-ids))
                       ;; If we detect any native subqueries/joins, even with source-card IDs, require full native
                       ;; download perms
-                      [(data-perms/native-download-permission-for-user api/*current-user-id* db-id)]
-                      (map (fn [table-id]
-                             (data-perms/table-permission-for-user api/*current-user-id* :perms/download-results db-id table-id))
-                           table-ids))
-        table-perms-set (set table-perms)]
+                      #{(data-perms/native-download-permission-for-user api/*current-user-id* db-id)}
+                      (set (map (fn [table-id]
+                                  (data-perms/table-permission-for-user api/*current-user-id* :perms/download-results db-id table-id))
+                                table-ids)))]
     ;; The download perm level for a query should be equal to the lowest perm level of any table referenced by the query.
-    (or (table-perms-set :no)
-        (table-perms-set :ten-thousand-rows)
+    (or (table-perms :no)
+        (table-perms :ten-thousand-rows)
         :one-million-rows)))
 
 (defenterprise apply-download-limit

--- a/enterprise/backend/src/metabase_enterprise/audit_app/permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/permissions.clj
@@ -44,12 +44,12 @@
   (when (= query-type :native)
     (throw (ex-info (tru "Native queries are not allowed on the audit database")
                     outer-query)))
-  (let [table-ids-or-native-kw (query-perms/query->source-table-ids query)]
+  (let [{:keys [table-ids native?]} (query-perms/query->source-ids query)]
+    (when native?
+      (throw (ex-info (tru "Native queries are not allowed on the audit database")
+                      outer-query)))
     (qp.store/with-metadata-provider database-id
-      (doseq [table-id table-ids-or-native-kw]
-        (when (= table-id ::query-perms/native)
-          (throw (ex-info (tru "Native queries are not allowed on the audit database")
-                          outer-query)))
+      (doseq [table-id table-ids]
         (when-not (audit-db-view-names
                    (u/lower-case-en (:name (lib.metadata/table (qp.store/metadata-provider) table-id))))
           (throw (ex-info (tru "Audit queries are only allowed on audit views")

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
@@ -212,7 +212,7 @@
                 (testing "disallow running the query"
                   (is (thrown-with-msg?
                        clojure.lang.ExceptionInfo
-                       #"You do not have permissions to run this query"
+                       #"Blocked: you are not allowed to run queries against Database \d+"
                        (check-block-perms)))
                   (is (thrown-with-msg?
                        clojure.lang.ExceptionInfo

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
@@ -4,15 +4,11 @@
    [metabase-enterprise.sandbox.models.group-table-access-policy
     :refer [GroupTableAccessPolicy]]
    [metabase.models
-    :refer [Card
-            Collection
-            Database
-            Permissions
-            PermissionsGroup
-            PermissionsGroupMembership
-            User]]
+    :refer [Card Collection Database Permissions PermissionsGroup
+            PermissionsGroupMembership User]]
    [metabase.models.data-permissions :as data-perms]
    [metabase.models.data-permissions.graph :as data-perms.graph]
+   [metabase.models.interface :as mi]
    [metabase.models.permissions :as perms]
    [metabase.models.permissions-group :as perms-group]
    [metabase.query-processor :as qp]
@@ -216,7 +212,7 @@
                        (check-block-perms)))
                   (is (thrown-with-msg?
                        clojure.lang.ExceptionInfo
-                       #"You do not have permissions to run this query"
+                       #"Blocked: you are not allowed to run queries against Database \d+"
                        (run-saved-question))))))))))))
 
 (deftest legacy-no-self-service-test
@@ -246,3 +242,88 @@
               (data-perms/set-table-permission! group-id (mt/id :orders) :perms/view-data :legacy-no-self-service)
               (is (true? (mt/with-current-user user-id
                            (#'qp.perms/check-block-permissions query)))))))))))
+
+(deftest nested-query-permissions-test
+  (mt/with-non-admin-groups-no-root-collection-perms
+    (mt/with-temp [:model/Collection disallowed-collection {}
+                   :model/Card       parent-card           {:dataset_query {:database (mt/id)
+                                                                            :type     :native
+                                                                            :native   {:query "SELECT id FROM venues ORDER BY id ASC LIMIT 2;"}}
+                                                            :database_id   (mt/id)
+                                                            :collection_id (u/the-id disallowed-collection)}
+                   :model/Collection allowed-collection    {}
+                   :model/Card       child-card            {:dataset_query {:database (mt/id)
+                                                                            :type     :query
+                                                                            :query    {:source-table (format "card__%d" (u/the-id parent-card))}}
+                                                            :collection_id (u/the-id allowed-collection)}]
+      (letfn [(rasta-view-data-perm= [perm] (is (= perm
+                                                   (get-in (data-perms/permissions-for-user (mt/user->id :rasta)) [(mt/id) :perms/view-data]))
+                                                "rasta should be blocked for this table."))]
+        (mt/with-no-data-perms-for-all-users!
+          (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :blocked)
+          (perms/grant-collection-read-permissions! (perms-group/all-users) allowed-collection)
+          (letfn [(process-query-for-card [card]
+                    (mt/user-http-request :rasta :post (format "card/%d/query" (u/the-id card))))]
+            (testing "Should be able to run a Card with another Card as its source query with just perms for the former (#15131)"
+              (testing "Should not be able to run the parent Card"
+                (mt/with-test-user :rasta
+                  (is (not (mi/can-read? disallowed-collection)))
+                  (is (not (mi/can-read? parent-card))))
+                (is (= "You don't have permissions to do that."
+                       (process-query-for-card parent-card))))
+              (testing "Should not be able to run the child Card due to Block permissions"
+                (mt/with-test-user :rasta
+                  (is (not (mi/can-read? parent-card)))
+                  (is (mi/can-read? allowed-collection))
+                  (is (mi/can-read? child-card)))
+                (rasta-view-data-perm= :blocked)
+                (testing "Data perms prohibit running queries"
+                  (is (thrown-with-msg?
+                       clojure.lang.ExceptionInfo
+                       #"Blocked: you are not allowed to run queries"
+                       (mt/rows (process-query-for-card child-card)))
+                      "Even if the user has can-write? on a Card, they should not be able to run it because they are blocked on Card's db"))))
+            (testing "view-data = unrestricted is required to allow running the query (#15131)"
+              (mt/with-restored-data-perms!
+                (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
+                (rasta-view-data-perm= :unrestricted)
+                (is (= [[1] [2]] (mt/rows (process-query-for-card child-card)))
+                    "view-data = unrestricted is sufficient to allow running the query")))))))))
+
+(deftest cannot-run-any-native-queries-when-blocked-test
+  (mt/with-non-admin-groups-no-root-collection-perms
+    (mt/with-temp [:model/Collection allowed-collection    {}
+                   :model/Collection disallowed-collection {}
+                   :model/Card       parent-card           {:dataset_query {:database (mt/id)
+                                                                            :type     :native
+                                                                            :native   {:query "SELECT id FROM venues ORDER BY id ASC LIMIT 2;"}}
+                                                            :database_id   (mt/id)
+                                                            :collection_id (u/the-id disallowed-collection)}
+                   :model/Card       child-card            {:dataset_query {:database (mt/id)
+                                                                            :type     :query
+                                                                            :query    {:source-table (format "card__%d" (u/the-id parent-card))}}
+                                                            :collection_id (u/the-id allowed-collection)}]
+      (letfn [(process-query-for-card [card]
+                (mt/user-http-request :rasta :post (format "card/%d/query" (u/the-id card))))]
+        (testing "Cannot run native queries when a single table is unrestricted and the rest are blocked"
+          (mt/with-no-data-perms-for-all-users!
+            (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :blocked)
+            (data-perms/set-table-permission! (perms-group/all-users) (mt/id :venues) :perms/view-data :unrestricted)
+            (perms/grant-collection-read-permissions! (perms-group/all-users) allowed-collection)
+            (is (thrown-with-msg?
+                 clojure.lang.ExceptionInfo
+                 #"Blocked: you are not allowed to run queries"
+                 (mt/rows (process-query-for-card child-card)))
+                "Someone with `:blocked` permissions on ANY table in the database cannot run ANY card with native queries, including as a source for another card.")))
+        ;; update collection perms in place:
+        (perms/revoke-collection-permissions! (perms-group/all-users) allowed-collection)
+        (testing "Cannot run native queries when a single table is blocked and the rest are unrestricted"
+          (mt/with-no-data-perms-for-all-users!
+            (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
+            (data-perms/set-table-permission! (perms-group/all-users) (mt/id :venues) :perms/view-data :blocked)
+            (perms/grant-collection-read-permissions! (perms-group/all-users) allowed-collection)
+            (is (thrown-with-msg?
+                 clojure.lang.ExceptionInfo
+                 #"Blocked: you are not allowed to run queries"
+                 (mt/rows (process-query-for-card child-card)))
+                "Someone with `:blocked` permissions on ANY table in the database cannot run ANY card with native queries, including as a source for another card.")))))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
@@ -244,104 +244,107 @@
                            (#'qp.perms/check-block-permissions query)))))))))))
 
 (deftest nested-query-permissions-test
-  (mt/with-non-admin-groups-no-root-collection-perms
-    (mt/with-temp [:model/Collection disallowed-collection {}
-                   :model/Card       parent-card           {:dataset_query {:database (mt/id)
-                                                                            :type     :native
-                                                                            :native   {:query "SELECT id FROM venues ORDER BY id ASC LIMIT 2;"}}
-                                                            :database_id   (mt/id)
-                                                            :collection_id (u/the-id disallowed-collection)}
-                   :model/Collection allowed-collection    {}
-                   :model/Card       child-card            {:dataset_query {:database (mt/id)
-                                                                            :type     :query
-                                                                            :query    {:source-table (format "card__%d" (u/the-id parent-card))}}
-                                                            :collection_id (u/the-id allowed-collection)}]
-      (letfn [(rasta-view-data-perm= [perm] (is (= perm
-                                                   (get-in (data-perms/permissions-for-user (mt/user->id :rasta)) [(mt/id) :perms/view-data]))
-                                                "rasta should be blocked for this table."))]
-        (mt/with-no-data-perms-for-all-users!
-          (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :blocked)
-          (perms/grant-collection-read-permissions! (perms-group/all-users) allowed-collection)
-          (letfn [(process-query-for-card [card]
-                    (mt/user-http-request :rasta :post (format "card/%d/query" (u/the-id card))))]
-            (testing "Should be able to run a Card with another Card as its source query with just perms for the former (#15131)"
-              (testing "Should not be able to run the parent Card"
-                (mt/with-test-user :rasta
-                  (is (not (mi/can-read? disallowed-collection)))
-                  (is (not (mi/can-read? parent-card))))
-                (is (= "You don't have permissions to do that."
-                       (process-query-for-card parent-card))))
-              (testing "Should not be able to run the child Card due to Block permissions"
-                (mt/with-test-user :rasta
-                  (is (not (mi/can-read? parent-card)))
-                  (is (mi/can-read? allowed-collection))
-                  (is (mi/can-read? child-card)))
-                (rasta-view-data-perm= :blocked)
-                (testing "Data perms prohibit running queries"
-                  (is (thrown-with-msg?
-                       clojure.lang.ExceptionInfo
-                       #"Blocked: you are not allowed to run queries"
-                       (mt/rows (process-query-for-card child-card)))
-                      "Even if the user has can-write? on a Card, they should not be able to run it because they are blocked on Card's db"))))
-            (testing "view-data = unrestricted is required to allow running the query (#15131)"
-              (mt/with-restored-data-perms!
-                (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
-                (rasta-view-data-perm= :unrestricted)
-                (is (= [[1] [2]] (mt/rows (process-query-for-card child-card)))
-                    "view-data = unrestricted is sufficient to allow running the query")))))))))
-
-(deftest cannot-run-any-native-queries-when-blocked-test
-  (mt/with-non-admin-groups-no-root-collection-perms
-    (mt/with-temp [:model/Collection allowed-collection    {}
-                   :model/Collection disallowed-collection {}
-                   :model/Card       parent-card           {:dataset_query {:database (mt/id)
-                                                                            :type     :native
-                                                                            :native   {:query "SELECT id FROM venues ORDER BY id ASC LIMIT 2;"}}
-                                                            :database_id   (mt/id)
-                                                            :collection_id (u/the-id disallowed-collection)}
-                   :model/Card       child-card            {:dataset_query {:database (mt/id)
-                                                                            :type     :query
-                                                                            :query    {:source-table (format "card__%d" (u/the-id parent-card))}}
-                                                            :collection_id (u/the-id allowed-collection)}]
-      (letfn [(process-query-for-card [card]
-                (mt/user-http-request :rasta :post (format "card/%d/query" (u/the-id card))))]
-        (testing "Cannot run native queries when a single table is unrestricted and the rest are blocked"
+  (mt/with-premium-features #{:advanced-permissions}
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp [:model/Collection disallowed-collection {}
+                     :model/Card       parent-card           {:dataset_query {:database (mt/id)
+                                                                              :type     :native
+                                                                              :native   {:query "SELECT id FROM venues ORDER BY id ASC LIMIT 2;"}}
+                                                              :database_id   (mt/id)
+                                                              :collection_id (u/the-id disallowed-collection)}
+                     :model/Collection allowed-collection    {}
+                     :model/Card       child-card            {:dataset_query {:database (mt/id)
+                                                                              :type     :query
+                                                                              :query    {:source-table (format "card__%d" (u/the-id parent-card))}}
+                                                              :collection_id (u/the-id allowed-collection)}]
+        (letfn [(rasta-view-data-perm= [perm] (is (= perm
+                                                     (get-in (data-perms/permissions-for-user (mt/user->id :rasta)) [(mt/id) :perms/view-data]))
+                                                  "rasta should be blocked for this table."))]
           (mt/with-no-data-perms-for-all-users!
             (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :blocked)
-            (data-perms/set-table-permission! (perms-group/all-users) (mt/id :venues) :perms/view-data :unrestricted)
             (perms/grant-collection-read-permissions! (perms-group/all-users) allowed-collection)
-            (is (thrown-with-msg?
-                 clojure.lang.ExceptionInfo
-                 #"Blocked: you are not allowed to run queries"
-                 (mt/rows (process-query-for-card child-card)))
-                "Someone with `:blocked` permissions on ANY table in the database cannot run ANY card with native queries, including as a source for another card.")))
-        ;; update collection perms in place:
-        (perms/revoke-collection-permissions! (perms-group/all-users) allowed-collection)
-        (testing "Cannot run native queries when a single table is blocked and the rest are unrestricted"
-          (mt/with-no-data-perms-for-all-users!
-            (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
-            (data-perms/set-table-permission! (perms-group/all-users) (mt/id :venues) :perms/view-data :blocked)
-            (perms/grant-collection-read-permissions! (perms-group/all-users) allowed-collection)
-            (is (thrown-with-msg?
-                 clojure.lang.ExceptionInfo
-                 #"Blocked: you are not allowed to run queries"
-                 (mt/rows (process-query-for-card child-card)))
-                "Someone with `:blocked` permissions on ANY table in the database cannot run ANY card with native queries, including as a source for another card.")))))))
+            (letfn [(process-query-for-card [card]
+                      (mt/user-http-request :rasta :post (format "card/%d/query" (u/the-id card))))]
+              (testing "Should be able to run a Card with another Card as its source query with just perms for the former (#15131)"
+                (testing "Should not be able to run the parent Card"
+                  (mt/with-test-user :rasta
+                    (is (not (mi/can-read? disallowed-collection)))
+                    (is (not (mi/can-read? parent-card))))
+                  (is (= "You don't have permissions to do that."
+                         (process-query-for-card parent-card))))
+                (testing "Should not be able to run the child Card due to Block permissions"
+                  (mt/with-test-user :rasta
+                    (is (not (mi/can-read? parent-card)))
+                    (is (mi/can-read? allowed-collection))
+                    (is (mi/can-read? child-card)))
+                  (rasta-view-data-perm= :blocked)
+                  (testing "Data perms prohibit running queries"
+                    (is (thrown-with-msg?
+                         clojure.lang.ExceptionInfo
+                         #"Blocked: you are not allowed to run queries"
+                         (mt/rows (process-query-for-card child-card)))
+                        "Even if the user has can-write? on a Card, they should not be able to run it because they are blocked on Card's db"))))
+              (testing "view-data = unrestricted is required to allow running the query (#15131)"
+                (mt/with-restored-data-perms!
+                  (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
+                  (rasta-view-data-perm= :unrestricted)
+                  (is (= [[1] [2]] (mt/rows (process-query-for-card child-card)))
+                      "view-data = unrestricted is sufficient to allow running the query"))))))))))
+
+(deftest cannot-run-any-native-queries-when-blocked-test
+  (mt/with-premium-features #{:advanced-permissions}
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp [:model/Collection allowed-collection    {}
+                     :model/Collection disallowed-collection {}
+                     :model/Card       parent-card           {:dataset_query {:database (mt/id)
+                                                                              :type     :native
+                                                                              :native   {:query "SELECT id FROM venues ORDER BY id ASC LIMIT 2;"}}
+                                                              :database_id   (mt/id)
+                                                              :collection_id (u/the-id disallowed-collection)}
+                     :model/Card       child-card            {:dataset_query {:database (mt/id)
+                                                                              :type     :query
+                                                                              :query    {:source-table (format "card__%d" (u/the-id parent-card))}}
+                                                              :collection_id (u/the-id allowed-collection)}]
+        (letfn [(process-query-for-card [card]
+                  (mt/user-http-request :rasta :post (format "card/%d/query" (u/the-id card))))]
+          (testing "Cannot run native queries when a single table is unrestricted and the rest are blocked"
+            (mt/with-no-data-perms-for-all-users!
+              (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :blocked)
+              (data-perms/set-table-permission! (perms-group/all-users) (mt/id :venues) :perms/view-data :unrestricted)
+              (perms/grant-collection-read-permissions! (perms-group/all-users) allowed-collection)
+              (is (thrown-with-msg?
+                   clojure.lang.ExceptionInfo
+                   #"Blocked: you are not allowed to run queries"
+                   (mt/rows (process-query-for-card child-card)))
+                  "Someone with `:blocked` permissions on ANY table in the database cannot run ANY card with native queries, including as a source for another card.")))
+          ;; update collection perms in place:
+          (perms/revoke-collection-permissions! (perms-group/all-users) allowed-collection)
+          (testing "Cannot run native queries when a single table is blocked and the rest are unrestricted"
+            (mt/with-no-data-perms-for-all-users!
+              (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
+              (data-perms/set-table-permission! (perms-group/all-users) (mt/id :venues) :perms/view-data :blocked)
+              (perms/grant-collection-read-permissions! (perms-group/all-users) allowed-collection)
+              (is (thrown-with-msg?
+                   clojure.lang.ExceptionInfo
+                   #"Blocked: you are not allowed to run queries"
+                   (mt/rows (process-query-for-card child-card)))
+                  "Someone with `:blocked` permissions on ANY table in the database cannot run ANY card with native queries, including as a source for another card."))))))))
 
 (deftest native-queries-against-db-with-some-blocked-table-is-illegal-test
-  (mt/with-temp [:model/Card {card-id :id {db-id :database} :dataset_query} {:dataset_query (mt/native-query {:query "select 1"})}]
-    (mt/with-no-data-perms-for-all-users!
-      (data-perms/set-database-permission! (perms-group/all-users) db-id :perms/create-queries (data-perms/most-permissive-value :perms/create-queries))
-      (data-perms/set-database-permission! (perms-group/all-users) db-id :perms/view-data (data-perms/most-permissive-value :perms/view-data))
-      ;; rasta has access to the database:
-      (is (= [[1]]
-             (mt/rows (mt/user-http-request :rasta :post 202 (format "card/%d/query" card-id)))))
+  (mt/with-premium-features #{:advanced-permissions}
+    (mt/with-temp [:model/Card {card-id :id {db-id :database} :dataset_query} {:dataset_query (mt/native-query {:query "select 1"})}]
+      (mt/with-no-data-perms-for-all-users!
+        (data-perms/set-database-permission! (perms-group/all-users) db-id :perms/create-queries (data-perms/most-permissive-value :perms/create-queries))
+        (data-perms/set-database-permission! (perms-group/all-users) db-id :perms/view-data (data-perms/most-permissive-value :perms/view-data))
+        ;; rasta has access to the database:
+        (is (= [[1]]
+               (mt/rows (mt/user-http-request :rasta :post 202 (format "card/%d/query" card-id)))))
 
-      ;; block a single table on the db:
-      (let [tables-in-db (map :id (:tables (t2/hydrate (t2/select-one :model/Database db-id) :tables)))
-            table-id (rand-nth tables-in-db)]
-        (data-perms/set-table-permissions! (perms-group/all-users) :perms/view-data {table-id :blocked}))
-      (is (thrown-with-msg?
-           clojure.lang.ExceptionInfo
-           #"Blocked: you are not allowed to run queries"
-           (mt/rows (mt/user-http-request :rasta :post (format "card/%d/query" card-id))))))))
+        ;; block a single table on the db:
+        (let [tables-in-db (map :id (:tables (t2/hydrate (t2/select-one :model/Database db-id) :tables)))
+              table-id (rand-nth tables-in-db)]
+          (data-perms/set-table-permissions! (perms-group/all-users) :perms/view-data {table-id :blocked}))
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"Blocked: you are not allowed to run queries"
+             (mt/rows (mt/user-http-request :rasta :post (format "card/%d/query" card-id)))))))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
@@ -212,7 +212,7 @@
                 (testing "disallow running the query"
                   (is (thrown-with-msg?
                        clojure.lang.ExceptionInfo
-                       #"Blocked: you are not allowed to run queries against Database \d+"
+                       #"You do not have permissions to run this query"
                        (check-block-perms)))
                   (is (thrown-with-msg?
                        clojure.lang.ExceptionInfo

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
@@ -208,11 +208,11 @@
                 (testing "disallow running the query"
                   (is (thrown-with-msg?
                        clojure.lang.ExceptionInfo
-                       #"Blocked: you are not allowed to run queries against Database \d+"
+                       #"You do not have permissions to run this query"
                        (check-block-perms)))
                   (is (thrown-with-msg?
                        clojure.lang.ExceptionInfo
-                       #"Blocked: you are not allowed to run queries against Database \d+"
+                       #"You do not have permissions to run this query"
                        (run-saved-question))))))))))))
 
 (deftest legacy-no-self-service-test
@@ -233,7 +233,7 @@
               (data-perms/set-database-permission! group-id (mt/id) :perms/create-queries :no)
               (is (thrown-with-msg?
                    clojure.lang.ExceptionInfo
-                   #"Blocked: you are not allowed to run queries against Database \d+"
+                   #"You do not have permissions to run this query"
                    (mt/with-current-user user-id
                      (#'qp.perms/check-block-permissions query)))))
 
@@ -281,7 +281,7 @@
                   (testing "Data perms prohibit running queries"
                     (is (thrown-with-msg?
                          clojure.lang.ExceptionInfo
-                         #"Blocked: you are not allowed to run queries"
+                         #"You do not have permissions to run this query"
                          (mt/rows (process-query-for-card child-card)))
                         "Even if the user has can-write? on a Card, they should not be able to run it because they are blocked on Card's db"))))
               (testing "view-data = unrestricted is required to allow running the query (#15131)"
@@ -314,7 +314,7 @@
               (perms/grant-collection-read-permissions! (perms-group/all-users) allowed-collection)
               (is (thrown-with-msg?
                    clojure.lang.ExceptionInfo
-                   #"Blocked: you are not allowed to run queries"
+                   #"You do not have permissions to run this query"
                    (mt/rows (process-query-for-card child-card)))
                   "Someone with `:blocked` permissions on ANY table in the database cannot run ANY card with native queries, including as a source for another card.")))
           ;; update collection perms in place:
@@ -326,7 +326,7 @@
               (perms/grant-collection-read-permissions! (perms-group/all-users) allowed-collection)
               (is (thrown-with-msg?
                    clojure.lang.ExceptionInfo
-                   #"Blocked: you are not allowed to run queries"
+                   #"You do not have permissions to run this query"
                    (mt/rows (process-query-for-card child-card)))
                   "Someone with `:blocked` permissions on ANY table in the database cannot run ANY card with native queries, including as a source for another card."))))))))
 
@@ -346,5 +346,5 @@
           (data-perms/set-table-permissions! (perms-group/all-users) :perms/view-data {table-id :blocked}))
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
-             #"Blocked: you are not allowed to run queries"
+             #"You do not have permissions to run this query"
              (mt/rows (mt/user-http-request :rasta :post (format "card/%d/query" card-id)))))))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
@@ -317,11 +317,11 @@
               (mt/with-test-user :rasta
                 (rasta-view-data-perm= :blocked)
                 (testing "Should not be able to run the parent Card due to Block permissions"
-                    (is (mi/can-read? parent-card))
-                    (is (thrown-with-msg?
-                         clojure.lang.ExceptionInfo
-                         #"You do not have permissions to run this query"
-                         (mt/rows (process-query-for-card child-card)))))
+                  (is (mi/can-read? parent-card))
+                  (is (thrown-with-msg?
+                       clojure.lang.ExceptionInfo
+                       #"You do not have permissions to run this query"
+                       (mt/rows (process-query-for-card child-card)))))
 
                 (testing "Should not be able to run the child Card due to Block permissions"
                   (mt/with-test-user :rasta

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/card_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/card_test.clj
@@ -109,12 +109,13 @@
                                                                   :group_id (u/the-id group)}
                  :model/Card                       card          {:name "Some Name" :dataset_query {:database (mt/id),
                                                                                                     :type :query,
-                                                                                                    :query {:source-table (mt/id :venues)}}}]
-    (let [cases [[:unrestricted           :query-builder-and-native "Request Permitted"]
-                 [:unrestricted           :query-builder            "Request Permitted"]
-                 [:unrestricted           :no                       "Request Permitted"]
-                 [:legacy-no-self-service :no                       "You do not have permissions to run this query."]
-                 [:blocked                :no                       "You do not have permissions to run this query."]]
+                                                                                                    :query {:source-table (mt/id :venues)
+                                                                                                            :limit 1}}}]
+    (let [cases [[:unrestricted           :query-builder-and-native true]
+                 [:unrestricted           :query-builder            true]
+                 [:unrestricted           :no                       true]
+                 [:legacy-no-self-service :no                       false]
+                 [:blocked                :no                       false]]
           ;; These are invalid permission combinations, so we don't test them:
           invalid-cases [[:legacy-no-self-service :query-builder-and-native]
                          [:legacy-no-self-service :query-builder]
@@ -126,12 +127,14 @@
                 (count invalid-cases)))
           "Please test these permissions settings behaviors exhaustively: if you add perms, add the tests for them.")
       (mt/with-no-data-perms-for-all-users!
-        (doseq [[view-perm create-perm expected] cases]
+        (doseq [[view-perm create-perm should-succeed?] cases]
           (data-perms/set-table-permission! group (mt/id :venues) :perms/view-data view-perm)
           (data-perms/set-table-permission! group (mt/id :venues) :perms/create-queries create-perm)
           (testing (str "view-data: " view-perm ", create-queries: " create-perm)
-            (is (= expected (:error (mt/user-http-request user-id :post 202 (str "card/" (u/the-id card) "/query"))
-                                    "Request Permitted")))))))))
+            (let [response (mt/user-http-request user-id :post 202 (str "card/" (u/the-id card) "/query"))]
+              (if should-succeed?
+                (is (= 1 (count (mt/rows response))))
+                (is (thrown? clojure.lang.ExceptionInfo (mt/rows response)))))))))))
 
 (deftest sandbox-join-permissions-test
   (testing "Sandboxed query can't be saved when sandboxed table is joined to a table that the current user doesn't have access to"

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -432,9 +432,9 @@
 
 ;;; -------------------------------------------------- Saving Cards --------------------------------------------------
 
-(defn check-data-permissions-for-query
-  "Make sure the Current User has the appropriate *data* permissions to run `query`. We don't want Users saving Cards
-  with queries they wouldn't be allowed to run!"
+(defn check-permissions-for-query
+  "Make sure the Current User has the appropriate permissions to run `query`. We don't want Users saving Cards with
+  queries they wouldn't be allowed to run!"
   [query]
   {:pre [(map? query)]}
   (when-not (query-perms/can-run-query? query)
@@ -484,7 +484,7 @@
    cache_ttl              [:maybe ms/PositiveInt]}
   (check-if-card-can-be-saved dataset_query type)
   ;; check that we have permissions to run the query that we're trying to save
-  (check-data-permissions-for-query dataset_query)
+  (check-permissions-for-query dataset_query)
   ;; check that we have permissions for the collection we're trying to save this card to, if applicable
   (collection/check-write-perms-for-collection collection_id)
   (let [body (cond-> body
@@ -511,7 +511,7 @@
   [card-before-updates card-updates]
   (let [card-updates (m/update-existing card-updates :dataset_query compatibility/normalize-dataset-query)]
     (when (api/column-will-change? :dataset_query card-before-updates card-updates)
-      (check-data-permissions-for-query (:dataset_query card-updates)))))
+      (check-permissions-for-query (:dataset_query card-updates)))))
 
 (defn- check-allowed-to-change-embedding
   "You must be a superuser to change the value of `enable_embedding` or `embedding_params`. Embedding must be

--- a/src/metabase/api/revision.clj
+++ b/src/metabase/api/revision.clj
@@ -36,7 +36,7 @@
         revision         (api/check-404 (t2/select-one Revision :model (name model), :model_id id, :id revision_id))]
     ;; if reverting a Card, make sure we have *data* permissions to run the query we're reverting to
     (when (= model :model/Card)
-      (api.card/check-data-permissions-for-query (get-in revision [:object :dataset_query])))
+      (api.card/check-permissions-for-query (get-in revision [:object :dataset_query])))
     ;; ok, we're g2g
     (revision/revert!
      {:entity      model

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -368,9 +368,9 @@
                     {perm-type (Permissions perm-type)})))
   (if (is-superuser? user-id)
     (most-permissive-value perm-type)
-    ;; The DB-level permission is the most-restrictive table-level permission within a DB schema. So for each group,
-    ;; select the most-restrictive table-level permission. Then use normal coalesce logic to select the *least*
-    ;; restrictive group permission.
+    ;; The DB-level permission is the most-restrictive table-level permission within a DB. So for each group, select the
+    ;; most-restrictive table-level permission. Then use normal coalesce logic to select the *least* restrictive group
+    ;; permission.
     (let [perm-values (most-restrictive-per-group
                        perm-type
                        (->> (get-permissions user-id perm-type database-id)

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -368,7 +368,7 @@
                     {perm-type (Permissions perm-type)})))
   (if (is-superuser? user-id)
     (most-permissive-value perm-type)
-    ;; The schema-level permission is the most-restrictive table-level permission within a schema. So for each group,
+    ;; The DB-level permission is the most-restrictive table-level permission within a DB schema. So for each group,
     ;; select the most-restrictive table-level permission. Then use normal coalesce logic to select the *least*
     ;; restrictive group permission.
     (let [perm-values (most-restrictive-per-group

--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -85,7 +85,7 @@
        {:native? true})
 
      (m :guard (every-pred map? #(pos-int? (:source-table %))))
-     (apply merge-witl merge-source-ids
+     (apply merge-with merge-source-ids
       {:table-ids #{(:source-table m)}}
       (query->source-ids (dissoc m :source-table))))))
 

--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -76,18 +76,18 @@
   indicating a native query or subquery. Intended to be used in the context of permissions enforcement."
   [query :- :map]
   (apply merge-with merge-source-ids
-         (lib.util.match/match query
-           ;; If we come across a native query, replace it with a card ID if it came from a source card, so we can check
-           ;; permissions on the card and not necessarily require full native query access to the DB
-           (m :guard (every-pred map? :native))
-           (if-let [source-card-id (:qp/stage-is-from-source-card m)]
-             {:card-ids #{source-card-id}}
-             {:native? true})
+   (lib.util.match/match query
+     ;; If we come across a native query, replace it with a card ID if it came from a source card, so we can check
+     ;; permissions on the card and not necessarily require full native query access to the DB
+     (m :guard (every-pred map? :native))
+     (if-let [source-card-id (:qp/stage-is-from-source-card m)]
+       {:card-ids #{source-card-id}}
+       {:native? true})
 
-           (m :guard (every-pred map? #(pos-int? (:source-table %))))
-           (merge-source-ids
-            {:table-ids (:source-table m)}
-            (query->source-ids (dissoc m :source-table))))))
+     (m :guard (every-pred map? #(pos-int? (:source-table %))))
+     (apply merge-witl merge-source-ids
+      {:table-ids #{(:source-table m)}}
+      (query->source-ids (dissoc m :source-table))))))
 
 (mu/defn query->source-table-ids
   "Returns a sequence of all :source-table IDs referenced by a query. Convenience wrapper around `query->source-ids` if

--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -76,18 +76,18 @@
   indicating a native query or subquery. Intended to be used in the context of permissions enforcement."
   [query :- :map]
   (apply merge-with merge-source-ids
-   (lib.util.match/match query
+         (lib.util.match/match query
      ;; If we come across a native query, replace it with a card ID if it came from a source card, so we can check
      ;; permissions on the card and not necessarily require full native query access to the DB
-     (m :guard (every-pred map? :native))
-     (if-let [source-card-id (:qp/stage-is-from-source-card m)]
-       {:card-ids #{source-card-id}}
-       {:native? true})
+           (m :guard (every-pred map? :native))
+           (if-let [source-card-id (:qp/stage-is-from-source-card m)]
+             {:card-ids #{source-card-id}}
+             {:native? true})
 
-     (m :guard (every-pred map? #(pos-int? (:source-table %))))
-     (merge-with merge-source-ids
-                 {:table-ids #{(:source-table m)}}
-                 (query->source-ids (dissoc m :source-table))))))
+           (m :guard (every-pred map? #(pos-int? (:source-table %))))
+           (merge-with merge-source-ids
+                       {:table-ids #{(:source-table m)}}
+                       (query->source-ids (dissoc m :source-table))))))
 
 (mu/defn query->source-table-ids
   "Returns a sequence of all :source-table IDs referenced by a query. Convenience wrapper around `query->source-ids` if

--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -94,11 +94,13 @@
              {:native? true})
 
            (m :guard (every-pred map? #(pos-int? (:source-table %))))
-           (if-let [source-card-id (:qp/stage-is-from-source-card m)]
-             {:card-ids #{source-card-id}}
-             (merge-with merge-source-ids
-                         {:table-ids #{(:source-table m)}}
-                         (query->source-ids (dissoc m :source-table)))))))
+           (merge-with merge-source-ids
+                       {:table-ids #{(:source-table m)}}
+                       ;; If there's a source card associated with a table ID, include it so that we can ensure that
+                       ;; ad-hoc queries don't access cards with no collection perms
+                       (when-let [source-card-id (:qp/stage-is-from-source-card m)]
+                         {:card-ids #{source-card-id}})
+                       (query->source-ids (dissoc m :source-table))))))
 
 (mu/defn query->source-table-ids
   "Returns a sequence of all :source-table IDs referenced by a query. Convenience wrapper around `query->source-ids` if

--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -85,9 +85,9 @@
        {:native? true})
 
      (m :guard (every-pred map? #(pos-int? (:source-table %))))
-     (apply merge-with merge-source-ids
-      {:table-ids #{(:source-table m)}}
-      (query->source-ids (dissoc m :source-table))))))
+     (merge-with merge-source-ids
+                 {:table-ids #{(:source-table m)}}
+                 (query->source-ids (dissoc m :source-table))))))
 
 (mu/defn query->source-table-ids
   "Returns a sequence of all :source-table IDs referenced by a query. Convenience wrapper around `query->source-ids` if

--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -276,6 +276,7 @@
   "Checks whether the current user has sufficient view data and query permissions to run `query`. Returns `true` if the
   user has perms for the query, and throws an exception otherwise (exceptions can be disabled by setting
   `throw-exceptions?` to `false`).
+
   If the [:gtap ::perms] path is present in the query, these perms are implicitly granted to the current user."
   [{{gtap-perms :gtaps} ::perms, :as query} required-perms & {:keys [throw-exceptions?]
                                                               :or   {throw-exceptions? true}}]

--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -161,7 +161,8 @@
                       (not already-preprocessed?) preprocess-query)
               {:keys [table-ids card-ids native?]} (query->source-ids query)]
           (merge
-           {:card-ids card-ids}
+           (when (seq card-ids)
+             {:card-ids card-ids})
            (when (seq table-ids)
              {:perms/create-queries (zipmap table-ids (repeat :query-builder))
               :perms/view-data      (zipmap table-ids (repeat :unrestricted))})
@@ -190,7 +191,7 @@
 
 (defn required-perms-for-query
   "Returns a map representing the permissions requried to run `query`. The map has the optional keys
-  :paths (containing legacy permission paths), :perms/view-data, and :perms/create-queries."
+  :paths (containing legacy permission paths), :card-ids, :perms/view-data, and :perms/create-queries."
   [query & {:as perms-opts}]
   (if (empty? query)
     {}

--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -61,7 +61,7 @@
 ;;
 
 (defn- merge-source-ids
-  "Combine sets of table or card IDs if there are multiple references"
+  "Merge function which takes the union of two sets of IDs, if they are both sets"
   [val1 val2]
   (if (and (set? val1) (set? val2))
     (set/union val1 val2)
@@ -77,8 +77,8 @@
   [query :- :map]
   (apply merge-with merge-source-ids
          (lib.util.match/match query
-     ;; If we come across a native query, replace it with a card ID if it came from a source card, so we can check
-     ;; permissions on the card and not necessarily require full native query access to the DB
+           ;; If we come across a native query, replace it with a card ID if it came from a source card, so we can check
+           ;; permissions on the card and not necessarily require full native query access to the DB
            (m :guard (every-pred map? :native))
            (if-let [source-card-id (:qp/stage-is-from-source-card m)]
              {:card-ids #{source-card-id}}

--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -54,7 +54,8 @@
     (letfn [(update-stages [stages]
               (let [stages        (fix-mongodb-first-stage stages)
                     stages        (for [stage stages]
-                                    ;; this is for detecting circular refs below.
+                                    ;; This is for detecting circular refs below, and is later used as part of
+                                    ;; permissions enforcement
                                     (assoc stage :qp/stage-is-from-source-card card-id))
                     card-metadata (into [] (remove :remapped-from)
                                         (lib.card/card-metadata-columns metadata-providerable card))

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -100,8 +100,7 @@
         card-id
         (do
           (query-perms/check-card-read-perms database-id card-id)
-          (when-not (query-perms/has-perm-for-query? outer-query :perms/view-data required-perms)
-            (throw (query-perms/perms-exception required-perms))))
+          (check-block-permissions outer-query))
 
         ;; set when querying for field values of dashboard filters, which only require
         ;; collection perms for the dashboard and not ad-hoc query perms

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -17,6 +17,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]))
+
 (def ^:dynamic *card-id*
   "ID of the Card currently being executed, if there is one. Bind this in a Card-execution so we will use
   Card [Collection] perms checking rather than ad-hoc perms checking."

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -61,7 +61,7 @@
   needing to cache permissions for inactive tables."
   [{database-id :database, :as outer-query}]
   (qp.store/with-metadata-provider database-id
-    (let [table-ids (filter int? (query-perms/query->source-table-ids outer-query))]
+    (let [table-ids (query-perms/query->source-table-ids outer-query)]
       (doseq [table-id table-ids]
         (let [table (lib.metadata.protocols/table (qp.store/metadata-provider) table-id)]
           (when-not (:active table)

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -99,8 +99,9 @@
       (cond
         card-id
         (do
-          (check-block-permissions outer-query)
-          (query-perms/check-card-read-perms database-id card-id))
+          (query-perms/check-card-read-perms database-id card-id)
+          (when-not (query-perms/has-perm-for-query? outer-query :perms/view-data required-perms)
+            (throw (query-perms/perms-exception required-perms))))
 
         ;; set when querying for field values of dashboard filters, which only require
         ;; collection perms for the dashboard and not ad-hoc query perms

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -87,7 +87,7 @@
   (dissoc query ::query-perms/perms))
 
 (defn remove-source-card-keys
-  "Pre-processing middlewre. Removes any instances of the `:qp/stage-is-from-source-card` key which is added by the
+  "Pre-processing middleware. Removes any instances of the `:qp/stage-is-from-source-card` key which is added by the
   fetch-source-query middleware when source cards are resolved in a query. Since we rely on this for permission enforcement,
   we want to disallow users from passing it in themselves (like `remove-permissions-key` above)."
   [query]
@@ -112,12 +112,7 @@
         card-id
         (do
           (query-perms/check-card-read-perms database-id card-id)
-          (check-block-permissions outer-query)
-          ;; Recursively check *data* permissions for any source Cards. We're not binding *card-id* here since read
-          ;; permissions to the top-level Card are sufficient.
-          (doseq [card-id source-card-ids]
-            (let [{query :dataset-query} (lib.metadata.protocols/card (qp.store/metadata-provider) card-id)]
-              (check-query-permissions* query))))
+          (check-block-permissions outer-query))
 
         ;; set when querying for field values of dashboard filters, which only require
         ;; collection perms for the dashboard and not ad-hoc query perms

--- a/src/metabase/query_processor/preprocess.clj
+++ b/src/metabase/query_processor/preprocess.clj
@@ -104,6 +104,7 @@
   #_{:clj-kondo/ignore [:deprecated-var]}
   [#'normalize/normalize-preprocessing-middleware
    (ensure-pmbql #'qp.perms/remove-permissions-key)
+   (ensure-pmbql #'qp.perms/remove-source-card-keys)
    (ensure-pmbql #'qp.constraints/maybe-add-default-userland-constraints)
    (ensure-pmbql #'validate/validate-query)
    (ensure-pmbql #'fetch-source-query/resolve-source-cards)

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2657,7 +2657,7 @@
           (update-card card {:description "a new description"})
           (is (empty? (reviews card)))))
       (testing "Does not add nil moderation reviews when there are reviews but not verified"
-        ;; testing that we aren't just adding a nil moderation each time we update a card
+       ;; testing that we aren't just adding a nil moderation each time we update a card
         (with-card :verified
           (is (verified? card))
           (moderation-review/create-review! {:moderated_item_id   (u/the-id card)
@@ -3742,18 +3742,19 @@
                   (is (not (mi/can-read? parent-card))))
                 (is (= "You don't have permissions to do that."
                        (process-query-for-card parent-card))))
-              (testing "Should be able to run the child Card (#15131)"
+              (testing "Should not be able to run the child Card due to Block permissions"
                 (mt/with-test-user :rasta
                   (is (not (mi/can-read? parent-card)))
                   (is (mi/can-read? allowed-collection))
                   (is (mi/can-read? child-card)))
+                (rasta-view-data-perm= :blocked)
                 (testing "Data perms prohibit running queries"
                   (is (thrown-with-msg?
                        clojure.lang.ExceptionInfo
                        #"You do not have permissions to run this query."
                        (mt/rows (process-query-for-card child-card)))
                       "Even if the user has can-write? on a Card, they should not be able to run it because they are blocked on Card's db"))))
-            (testing "view-data = unrestricted is required to allow running the query"
+            (testing "view-data = unrestricted is required to allow running the query (#15131)"
               (mt/with-restored-data-perms!
                 (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
                 (rasta-view-data-perm= :unrestricted)

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2657,7 +2657,7 @@
           (update-card card {:description "a new description"})
           (is (empty? (reviews card)))))
       (testing "Does not add nil moderation reviews when there are reviews but not verified"
-       ;; testing that we aren't just adding a nil moderation each time we update a card
+     ;; testing that we aren't just adding a nil moderation each time we update a card
         (with-card :verified
           (is (verified? card))
           (moderation-review/create-review! {:moderated_item_id   (u/the-id card)
@@ -3662,7 +3662,7 @@
               (mt/user-http-request :rasta :post (format "card/%d/query" (u/the-id card))))
             (blocked? [response] (or
                                   (= "You don't have permissions to do that." response)
-                                  (re-matches #"Blocked: you are not allowed to run queries against Database \d+."
+                                  (re-matches #"You do not have permissions to run this query"
                                               (:error response))))]
       ;;    | Data perms | Collection perms | outcome
       ;;    ------------ | ---------------- | --------
@@ -3703,8 +3703,7 @@
 
       ;; delete these in place so we can reset them below, you cannot set them twice in a row
       (perms/revoke-collection-permissions! (perms-group/all-users) collection)
-
-      (testing "should NOT be able to run the parent Card when data-perms and valid collection perms"
+      (testing "should NOT be able to run the parent Card with data-perms and valid collection perms"
         (mt/with-no-data-perms-for-all-users!
           (mt/with-non-admin-groups-no-collection-perms collection
             (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2602,72 +2602,72 @@
                                      :status              "verified"
                                      :text                "lookin good"}]))
          ~@body))]
-   (letfn [(verified? [card]
-             (-> card (t2/hydrate [:moderation_reviews :moderator_details])
-                 :moderation_reviews first :status #{"verified"} boolean))
-           (reviews [card]
-             (t2/select ModerationReview
-                        :moderated_item_type "card"
-                        :moderated_item_id (u/the-id card)
-                        {:order-by [[:id :desc]]}))
-           (update-card [card diff]
-             (mt/user-http-request :crowberto :put 200 (str "card/" (u/the-id card)) (merge card diff)))]
-     (testing "Changing core attributes un-verifies the card"
-       (with-card :verified
-         (is (verified? card))
-         (update-card card (update-in card [:dataset_query :query :source-table] inc))
-         (is (not (verified? card)))
-         (testing "The unverification edit has explanatory text"
-           (is (= "Unverified due to edit"
-                  (-> (reviews card) first :text))))))
-     (testing "Changing some attributes does not unverify"
-       (tools.macro/macrolet [(remains-verified [& body]
-                                `(~'with-card :verified
-                                              (is (~'verified? ~'card) "Not verified initially")
-                                              ~@body
-                                              (is (~'verified? ~'card) "Not verified after action")))]
-         (testing "changing collection"
-           (remains-verified
-            (update-card card {:collection_id (u/the-id collection2)})))
-         (testing "pinning"
-           (remains-verified
-            (update-card card {:collection_position 1})))
-         (testing "making public"
-           (remains-verified
-            (update-card card {:made_public_by_id (mt/user->id :rasta)
-                               :public_uuid (random-uuid)})))
-         (testing "Changing description"
-           (remains-verified
-            (update-card card {:description "foo"})))
-         (testing "Changing name"
-           (remains-verified
-            (update-card card {:name "foo"})))
-         (testing "Changing archived"
-           (remains-verified
-            (update-card card {:archived true})))
-         (testing "Changing display"
-           (remains-verified
-            (update-card card {:display :line})))
-         (testing "Changing visualization settings"
-           (remains-verified
-            (update-card card {:visualization_settings {:table.cell_column "FOO"}})))))
-     (testing "Does not add a new nil moderation review when not verified"
-       (with-card :not-verified
-         (is (empty? (reviews card)))
-         (update-card card {:description "a new description"})
-         (is (empty? (reviews card)))))
-     (testing "Does not add nil moderation reviews when there are reviews but not verified"
+    (letfn [(verified? [card]
+              (-> card (t2/hydrate [:moderation_reviews :moderator_details])
+                  :moderation_reviews first :status #{"verified"} boolean))
+            (reviews [card]
+              (t2/select ModerationReview
+                         :moderated_item_type "card"
+                         :moderated_item_id (u/the-id card)
+                         {:order-by [[:id :desc]]}))
+            (update-card [card diff]
+              (mt/user-http-request :crowberto :put 200 (str "card/" (u/the-id card)) (merge card diff)))]
+      (testing "Changing core attributes un-verifies the card"
+        (with-card :verified
+          (is (verified? card))
+          (update-card card (update-in card [:dataset_query :query :source-table] inc))
+          (is (not (verified? card)))
+          (testing "The unverification edit has explanatory text"
+            (is (= "Unverified due to edit"
+                   (-> (reviews card) first :text))))))
+      (testing "Changing some attributes does not unverify"
+        (tools.macro/macrolet [(remains-verified [& body]
+                                 `(~'with-card :verified
+                                               (is (~'verified? ~'card) "Not verified initially")
+                                               ~@body
+                                               (is (~'verified? ~'card) "Not verified after action")))]
+          (testing "changing collection"
+            (remains-verified
+             (update-card card {:collection_id (u/the-id collection2)})))
+          (testing "pinning"
+            (remains-verified
+             (update-card card {:collection_position 1})))
+          (testing "making public"
+            (remains-verified
+             (update-card card {:made_public_by_id (mt/user->id :rasta)
+                                :public_uuid (random-uuid)})))
+          (testing "Changing description"
+            (remains-verified
+             (update-card card {:description "foo"})))
+          (testing "Changing name"
+            (remains-verified
+             (update-card card {:name "foo"})))
+          (testing "Changing archived"
+            (remains-verified
+             (update-card card {:archived true})))
+          (testing "Changing display"
+            (remains-verified
+             (update-card card {:display :line})))
+          (testing "Changing visualization settings"
+            (remains-verified
+             (update-card card {:visualization_settings {:table.cell_column "FOO"}})))))
+      (testing "Does not add a new nil moderation review when not verified"
+        (with-card :not-verified
+          (is (empty? (reviews card)))
+          (update-card card {:description "a new description"})
+          (is (empty? (reviews card)))))
+      (testing "Does not add nil moderation reviews when there are reviews but not verified"
        ;; testing that we aren't just adding a nil moderation each time we update a card
-       (with-card :verified
-         (is (verified? card))
-         (moderation-review/create-review! {:moderated_item_id   (u/the-id card)
-                                            :moderated_item_type "card"
-                                            :moderator_id        (mt/user->id :rasta)
-                                            :status              nil})
-         (is (not (verified? card)))
-         (is (= 2 (count (reviews card))))
-         (update-card card {:description "a new description"})
-         (is (= 2 (count (reviews card)))))))))
+        (with-card :verified
+          (is (verified? card))
+          (moderation-review/create-review! {:moderated_item_id   (u/the-id card)
+                                             :moderated_item_type "card"
+                                             :moderator_id        (mt/user->id :rasta)
+                                             :status              nil})
+          (is (not (verified? card)))
+          (is (= 2 (count (reviews card))))
+          (update-card card {:description "a new description"})
+          (is (= 2 (count (reviews card)))))))))
 
 (deftest test-that-we-can-bulk-move-some-cards-with-no-collection-into-a-collection
   (mt/with-temp [Collection  collection {:name "Pog Collection"}

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2602,72 +2602,72 @@
                                      :status              "verified"
                                      :text                "lookin good"}]))
          ~@body))]
-    (letfn [(verified? [card]
-              (-> card (t2/hydrate [:moderation_reviews :moderator_details])
-                  :moderation_reviews first :status #{"verified"} boolean))
-            (reviews [card]
-              (t2/select ModerationReview
-                         :moderated_item_type "card"
-                         :moderated_item_id (u/the-id card)
-                         {:order-by [[:id :desc]]}))
-            (update-card [card diff]
-              (mt/user-http-request :crowberto :put 200 (str "card/" (u/the-id card)) (merge card diff)))]
-      (testing "Changing core attributes un-verifies the card"
-        (with-card :verified
-          (is (verified? card))
-          (update-card card (update-in card [:dataset_query :query :source-table] inc))
-          (is (not (verified? card)))
-          (testing "The unverification edit has explanatory text"
-            (is (= "Unverified due to edit"
-                   (-> (reviews card) first :text))))))
-      (testing "Changing some attributes does not unverify"
-        (tools.macro/macrolet [(remains-verified [& body]
-                                 `(~'with-card :verified
-                                               (is (~'verified? ~'card) "Not verified initially")
-                                               ~@body
-                                               (is (~'verified? ~'card) "Not verified after action")))]
-          (testing "changing collection"
-            (remains-verified
-             (update-card card {:collection_id (u/the-id collection2)})))
-          (testing "pinning"
-            (remains-verified
-             (update-card card {:collection_position 1})))
-          (testing "making public"
-            (remains-verified
-             (update-card card {:made_public_by_id (mt/user->id :rasta)
-                                :public_uuid (random-uuid)})))
-          (testing "Changing description"
-            (remains-verified
-             (update-card card {:description "foo"})))
-          (testing "Changing name"
-            (remains-verified
-             (update-card card {:name "foo"})))
-          (testing "Changing archived"
-            (remains-verified
-             (update-card card {:archived true})))
-          (testing "Changing display"
-            (remains-verified
-             (update-card card {:display :line})))
-          (testing "Changing visualization settings"
-            (remains-verified
-             (update-card card {:visualization_settings {:table.cell_column "FOO"}})))))
-      (testing "Does not add a new nil moderation review when not verified"
-        (with-card :not-verified
-          (is (empty? (reviews card)))
-          (update-card card {:description "a new description"})
-          (is (empty? (reviews card)))))
-      (testing "Does not add nil moderation reviews when there are reviews but not verified"
-      ;; testing that we aren't just adding a nil moderation each time we update a card
-        (with-card :verified
-          (is (verified? card))
-          (moderation-review/create-review! {:moderated_item_id   (u/the-id card)
-                                             :moderated_item_type "card"
-                                             :moderator_id        (mt/user->id :rasta)
-                                             :status              nil})
-          (is (not (verified? card)))
-          (is (= 2 (count (reviews card))))
-          (update-card card {:description "a new description"})
-          (is (= 2 (count (reviews card)))))))))
+   (letfn [(verified? [card]
+             (-> card (t2/hydrate [:moderation_reviews :moderator_details])
+                 :moderation_reviews first :status #{"verified"} boolean))
+           (reviews [card]
+             (t2/select ModerationReview
+                        :moderated_item_type "card"
+                        :moderated_item_id (u/the-id card)
+                        {:order-by [[:id :desc]]}))
+           (update-card [card diff]
+             (mt/user-http-request :crowberto :put 200 (str "card/" (u/the-id card)) (merge card diff)))]
+     (testing "Changing core attributes un-verifies the card"
+       (with-card :verified
+         (is (verified? card))
+         (update-card card (update-in card [:dataset_query :query :source-table] inc))
+         (is (not (verified? card)))
+         (testing "The unverification edit has explanatory text"
+           (is (= "Unverified due to edit"
+                  (-> (reviews card) first :text))))))
+     (testing "Changing some attributes does not unverify"
+       (tools.macro/macrolet [(remains-verified [& body]
+                                `(~'with-card :verified
+                                              (is (~'verified? ~'card) "Not verified initially")
+                                              ~@body
+                                              (is (~'verified? ~'card) "Not verified after action")))]
+         (testing "changing collection"
+           (remains-verified
+            (update-card card {:collection_id (u/the-id collection2)})))
+         (testing "pinning"
+           (remains-verified
+            (update-card card {:collection_position 1})))
+         (testing "making public"
+           (remains-verified
+            (update-card card {:made_public_by_id (mt/user->id :rasta)
+                               :public_uuid (random-uuid)})))
+         (testing "Changing description"
+           (remains-verified
+            (update-card card {:description "foo"})))
+         (testing "Changing name"
+           (remains-verified
+            (update-card card {:name "foo"})))
+         (testing "Changing archived"
+           (remains-verified
+            (update-card card {:archived true})))
+         (testing "Changing display"
+           (remains-verified
+            (update-card card {:display :line})))
+         (testing "Changing visualization settings"
+           (remains-verified
+            (update-card card {:visualization_settings {:table.cell_column "FOO"}})))))
+     (testing "Does not add a new nil moderation review when not verified"
+       (with-card :not-verified
+         (is (empty? (reviews card)))
+         (update-card card {:description "a new description"})
+         (is (empty? (reviews card)))))
+     (testing "Does not add nil moderation reviews when there are reviews but not verified"
+     ;; testing that we aren't just adding a nil moderation each time we update a card
+       (with-card :verified
+         (is (verified? card))
+         (moderation-review/create-review! {:moderated_item_id   (u/the-id card)
+                                            :moderated_item_type "card"
+                                            :moderator_id        (mt/user->id :rasta)
+                                            :status              nil})
+         (is (not (verified? card)))
+         (is (= 2 (count (reviews card))))
+         (update-card card {:description "a new description"})
+         (is (= 2 (count (reviews card)))))))))
 
 (deftest test-that-we-can-bulk-move-some-cards-with-no-collection-into-a-collection
   (mt/with-temp [Collection  collection {:name "Pog Collection"}
@@ -3782,7 +3782,7 @@
             (perms/grant-collection-read-permissions! (perms-group/all-users) allowed-collection)
             (is (thrown-with-msg?
                  clojure.lang.ExceptionInfo
-                 #"You do not have permissions to run this query."
+                 #"Blocked: you are not allowed to run queries"
                  (mt/rows (process-query-for-card child-card)))
                 "Someone with `:blocked` permissions on ANY table in the database cannot run ANY card with native queries, including as a source for another card.")))
         ;; update collection perms in place:
@@ -3794,7 +3794,7 @@
             (perms/grant-collection-read-permissions! (perms-group/all-users) allowed-collection)
             (is (thrown-with-msg?
                  clojure.lang.ExceptionInfo
-                 #"You do not have permissions to run this query."
+                 #"Blocked: you are not allowed to run queries"
                  (mt/rows (process-query-for-card child-card)))
                 "Someone with `:blocked` permissions on ANY table in the database cannot run ANY card with native queries, including as a source for another card.")))))))
 

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2657,7 +2657,7 @@
           (update-card card {:description "a new description"})
           (is (empty? (reviews card)))))
       (testing "Does not add nil moderation reviews when there are reviews but not verified"
-     ;; testing that we aren't just adding a nil moderation each time we update a card
+    ;; testing that we aren't just adding a nil moderation each time we update a card
         (with-card :verified
           (is (verified? card))
           (moderation-review/create-review! {:moderated_item_id   (u/the-id card)

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2602,72 +2602,72 @@
                                      :status              "verified"
                                      :text                "lookin good"}]))
          ~@body))]
-    (letfn [(verified? [card]
-              (-> card (t2/hydrate [:moderation_reviews :moderator_details])
-                  :moderation_reviews first :status #{"verified"} boolean))
-            (reviews [card]
-              (t2/select ModerationReview
-                         :moderated_item_type "card"
-                         :moderated_item_id (u/the-id card)
-                         {:order-by [[:id :desc]]}))
-            (update-card [card diff]
-              (mt/user-http-request :crowberto :put 200 (str "card/" (u/the-id card)) (merge card diff)))]
-      (testing "Changing core attributes un-verifies the card"
-        (with-card :verified
-          (is (verified? card))
-          (update-card card (update-in card [:dataset_query :query :source-table] inc))
-          (is (not (verified? card)))
-          (testing "The unverification edit has explanatory text"
-            (is (= "Unverified due to edit"
-                   (-> (reviews card) first :text))))))
-      (testing "Changing some attributes does not unverify"
-        (tools.macro/macrolet [(remains-verified [& body]
-                                 `(~'with-card :verified
-                                               (is (~'verified? ~'card) "Not verified initially")
-                                               ~@body
-                                               (is (~'verified? ~'card) "Not verified after action")))]
-          (testing "changing collection"
-            (remains-verified
-             (update-card card {:collection_id (u/the-id collection2)})))
-          (testing "pinning"
-            (remains-verified
-             (update-card card {:collection_position 1})))
-          (testing "making public"
-            (remains-verified
-             (update-card card {:made_public_by_id (mt/user->id :rasta)
-                                :public_uuid (random-uuid)})))
-          (testing "Changing description"
-            (remains-verified
-             (update-card card {:description "foo"})))
-          (testing "Changing name"
-            (remains-verified
-             (update-card card {:name "foo"})))
-          (testing "Changing archived"
-            (remains-verified
-             (update-card card {:archived true})))
-          (testing "Changing display"
-            (remains-verified
-             (update-card card {:display :line})))
-          (testing "Changing visualization settings"
-            (remains-verified
-             (update-card card {:visualization_settings {:table.cell_column "FOO"}})))))
-      (testing "Does not add a new nil moderation review when not verified"
-        (with-card :not-verified
-          (is (empty? (reviews card)))
-          (update-card card {:description "a new description"})
-          (is (empty? (reviews card)))))
-      (testing "Does not add nil moderation reviews when there are reviews but not verified"
-    ;; testing that we aren't just adding a nil moderation each time we update a card
-        (with-card :verified
-          (is (verified? card))
-          (moderation-review/create-review! {:moderated_item_id   (u/the-id card)
-                                             :moderated_item_type "card"
-                                             :moderator_id        (mt/user->id :rasta)
-                                             :status              nil})
-          (is (not (verified? card)))
-          (is (= 2 (count (reviews card))))
-          (update-card card {:description "a new description"})
-          (is (= 2 (count (reviews card)))))))))
+   (letfn [(verified? [card]
+             (-> card (t2/hydrate [:moderation_reviews :moderator_details])
+                 :moderation_reviews first :status #{"verified"} boolean))
+           (reviews [card]
+             (t2/select ModerationReview
+                        :moderated_item_type "card"
+                        :moderated_item_id (u/the-id card)
+                        {:order-by [[:id :desc]]}))
+           (update-card [card diff]
+             (mt/user-http-request :crowberto :put 200 (str "card/" (u/the-id card)) (merge card diff)))]
+     (testing "Changing core attributes un-verifies the card"
+       (with-card :verified
+         (is (verified? card))
+         (update-card card (update-in card [:dataset_query :query :source-table] inc))
+         (is (not (verified? card)))
+         (testing "The unverification edit has explanatory text"
+           (is (= "Unverified due to edit"
+                  (-> (reviews card) first :text))))))
+     (testing "Changing some attributes does not unverify"
+       (tools.macro/macrolet [(remains-verified [& body]
+                                `(~'with-card :verified
+                                              (is (~'verified? ~'card) "Not verified initially")
+                                              ~@body
+                                              (is (~'verified? ~'card) "Not verified after action")))]
+         (testing "changing collection"
+           (remains-verified
+            (update-card card {:collection_id (u/the-id collection2)})))
+         (testing "pinning"
+           (remains-verified
+            (update-card card {:collection_position 1})))
+         (testing "making public"
+           (remains-verified
+            (update-card card {:made_public_by_id (mt/user->id :rasta)
+                               :public_uuid (random-uuid)})))
+         (testing "Changing description"
+           (remains-verified
+            (update-card card {:description "foo"})))
+         (testing "Changing name"
+           (remains-verified
+            (update-card card {:name "foo"})))
+         (testing "Changing archived"
+           (remains-verified
+            (update-card card {:archived true})))
+         (testing "Changing display"
+           (remains-verified
+            (update-card card {:display :line})))
+         (testing "Changing visualization settings"
+           (remains-verified
+            (update-card card {:visualization_settings {:table.cell_column "FOO"}})))))
+     (testing "Does not add a new nil moderation review when not verified"
+       (with-card :not-verified
+         (is (empty? (reviews card)))
+         (update-card card {:description "a new description"})
+         (is (empty? (reviews card)))))
+     (testing "Does not add nil moderation reviews when there are reviews but not verified"
+       ;; testing that we aren't just adding a nil moderation each time we update a card
+       (with-card :verified
+         (is (verified? card))
+         (moderation-review/create-review! {:moderated_item_id   (u/the-id card)
+                                            :moderated_item_type "card"
+                                            :moderator_id        (mt/user->id :rasta)
+                                            :status              nil})
+         (is (not (verified? card)))
+         (is (= 2 (count (reviews card))))
+         (update-card card {:description "a new description"})
+         (is (= 2 (count (reviews card)))))))))
 
 (deftest test-that-we-can-bulk-move-some-cards-with-no-collection-into-a-collection
   (mt/with-temp [Collection  collection {:name "Pog Collection"}

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2657,7 +2657,7 @@
           (update-card card {:description "a new description"})
           (is (empty? (reviews card)))))
       (testing "Does not add nil moderation reviews when there are reviews but not verified"
-     ;; testing that we aren't just adding a nil moderation each time we update a card
+       ;; testing that we aren't just adding a nil moderation each time we update a card
         (with-card :verified
           (is (verified? card))
           (moderation-review/create-review! {:moderated_item_id   (u/the-id card)

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2602,72 +2602,72 @@
                                      :status              "verified"
                                      :text                "lookin good"}]))
          ~@body))]
-   (letfn [(verified? [card]
-             (-> card (t2/hydrate [:moderation_reviews :moderator_details])
-                 :moderation_reviews first :status #{"verified"} boolean))
-           (reviews [card]
-             (t2/select ModerationReview
-                        :moderated_item_type "card"
-                        :moderated_item_id (u/the-id card)
-                        {:order-by [[:id :desc]]}))
-           (update-card [card diff]
-             (mt/user-http-request :crowberto :put 200 (str "card/" (u/the-id card)) (merge card diff)))]
-     (testing "Changing core attributes un-verifies the card"
-       (with-card :verified
-         (is (verified? card))
-         (update-card card (update-in card [:dataset_query :query :source-table] inc))
-         (is (not (verified? card)))
-         (testing "The unverification edit has explanatory text"
-           (is (= "Unverified due to edit"
-                  (-> (reviews card) first :text))))))
-     (testing "Changing some attributes does not unverify"
-       (tools.macro/macrolet [(remains-verified [& body]
-                                `(~'with-card :verified
-                                              (is (~'verified? ~'card) "Not verified initially")
-                                              ~@body
-                                              (is (~'verified? ~'card) "Not verified after action")))]
-         (testing "changing collection"
-           (remains-verified
-            (update-card card {:collection_id (u/the-id collection2)})))
-         (testing "pinning"
-           (remains-verified
-            (update-card card {:collection_position 1})))
-         (testing "making public"
-           (remains-verified
-            (update-card card {:made_public_by_id (mt/user->id :rasta)
-                               :public_uuid (random-uuid)})))
-         (testing "Changing description"
-           (remains-verified
-            (update-card card {:description "foo"})))
-         (testing "Changing name"
-           (remains-verified
-            (update-card card {:name "foo"})))
-         (testing "Changing archived"
-           (remains-verified
-            (update-card card {:archived true})))
-         (testing "Changing display"
-           (remains-verified
-            (update-card card {:display :line})))
-         (testing "Changing visualization settings"
-           (remains-verified
-            (update-card card {:visualization_settings {:table.cell_column "FOO"}})))))
-     (testing "Does not add a new nil moderation review when not verified"
-       (with-card :not-verified
-         (is (empty? (reviews card)))
-         (update-card card {:description "a new description"})
-         (is (empty? (reviews card)))))
-     (testing "Does not add nil moderation reviews when there are reviews but not verified"
-     ;; testing that we aren't just adding a nil moderation each time we update a card
-       (with-card :verified
-         (is (verified? card))
-         (moderation-review/create-review! {:moderated_item_id   (u/the-id card)
-                                            :moderated_item_type "card"
-                                            :moderator_id        (mt/user->id :rasta)
-                                            :status              nil})
-         (is (not (verified? card)))
-         (is (= 2 (count (reviews card))))
-         (update-card card {:description "a new description"})
-         (is (= 2 (count (reviews card)))))))))
+    (letfn [(verified? [card]
+              (-> card (t2/hydrate [:moderation_reviews :moderator_details])
+                  :moderation_reviews first :status #{"verified"} boolean))
+            (reviews [card]
+              (t2/select ModerationReview
+                         :moderated_item_type "card"
+                         :moderated_item_id (u/the-id card)
+                         {:order-by [[:id :desc]]}))
+            (update-card [card diff]
+              (mt/user-http-request :crowberto :put 200 (str "card/" (u/the-id card)) (merge card diff)))]
+      (testing "Changing core attributes un-verifies the card"
+        (with-card :verified
+          (is (verified? card))
+          (update-card card (update-in card [:dataset_query :query :source-table] inc))
+          (is (not (verified? card)))
+          (testing "The unverification edit has explanatory text"
+            (is (= "Unverified due to edit"
+                   (-> (reviews card) first :text))))))
+      (testing "Changing some attributes does not unverify"
+        (tools.macro/macrolet [(remains-verified [& body]
+                                 `(~'with-card :verified
+                                               (is (~'verified? ~'card) "Not verified initially")
+                                               ~@body
+                                               (is (~'verified? ~'card) "Not verified after action")))]
+          (testing "changing collection"
+            (remains-verified
+             (update-card card {:collection_id (u/the-id collection2)})))
+          (testing "pinning"
+            (remains-verified
+             (update-card card {:collection_position 1})))
+          (testing "making public"
+            (remains-verified
+             (update-card card {:made_public_by_id (mt/user->id :rasta)
+                                :public_uuid (random-uuid)})))
+          (testing "Changing description"
+            (remains-verified
+             (update-card card {:description "foo"})))
+          (testing "Changing name"
+            (remains-verified
+             (update-card card {:name "foo"})))
+          (testing "Changing archived"
+            (remains-verified
+             (update-card card {:archived true})))
+          (testing "Changing display"
+            (remains-verified
+             (update-card card {:display :line})))
+          (testing "Changing visualization settings"
+            (remains-verified
+             (update-card card {:visualization_settings {:table.cell_column "FOO"}})))))
+      (testing "Does not add a new nil moderation review when not verified"
+        (with-card :not-verified
+          (is (empty? (reviews card)))
+          (update-card card {:description "a new description"})
+          (is (empty? (reviews card)))))
+      (testing "Does not add nil moderation reviews when there are reviews but not verified"
+       ;; testing that we aren't just adding a nil moderation each time we update a card
+        (with-card :verified
+          (is (verified? card))
+          (moderation-review/create-review! {:moderated_item_id   (u/the-id card)
+                                             :moderated_item_type "card"
+                                             :moderator_id        (mt/user->id :rasta)
+                                             :status              nil})
+          (is (not (verified? card)))
+          (is (= 2 (count (reviews card))))
+          (update-card card {:description "a new description"})
+          (is (= 2 (count (reviews card)))))))))
 
 (deftest test-that-we-can-bulk-move-some-cards-with-no-collection-into-a-collection
   (mt/with-temp [Collection  collection {:name "Pog Collection"}

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2657,7 +2657,7 @@
           (update-card card {:description "a new description"})
           (is (empty? (reviews card)))))
       (testing "Does not add nil moderation reviews when there are reviews but not verified"
-      ;; testing that we aren't just adding a nil moderation each time we update a card
+     ;; testing that we aren't just adding a nil moderation each time we update a card
         (with-card :verified
           (is (verified? card))
           (moderation-review/create-review! {:moderated_item_id   (u/the-id card)
@@ -3712,91 +3712,6 @@
               (is (mi/can-read? collection))
               (is (mi/can-read? card)))
             (is (= [[1] [2]] (mt/rows (process-query))))))))))
-
-(deftest nested-query-permissions-test
-  (mt/with-non-admin-groups-no-root-collection-perms
-    (mt/with-temp [:model/Collection disallowed-collection {}
-                   :model/Card       parent-card           {:dataset_query {:database (mt/id)
-                                                                            :type     :native
-                                                                            :native   {:query "SELECT id FROM venues ORDER BY id ASC LIMIT 2;"}}
-                                                            :database_id   (mt/id)
-                                                            :collection_id (u/the-id disallowed-collection)}
-                   :model/Collection allowed-collection    {}
-                   :model/Card       child-card            {:dataset_query {:database (mt/id)
-                                                                            :type     :query
-                                                                            :query    {:source-table (format "card__%d" (u/the-id parent-card))}}
-                                                            :collection_id (u/the-id allowed-collection)}]
-      (letfn [(rasta-view-data-perm= [perm] (is (= perm
-                                                   (get-in (data-perms/permissions-for-user (mt/user->id :rasta)) [(mt/id) :perms/view-data]))
-                                                "rasta should be blocked for this table."))]
-        (mt/with-no-data-perms-for-all-users!
-          (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :blocked)
-          (perms/grant-collection-read-permissions! (perms-group/all-users) allowed-collection)
-          (letfn [(process-query-for-card [card]
-                    (mt/user-http-request :rasta :post (format "card/%d/query" (u/the-id card))))]
-            (testing "Should be able to run a Card with another Card as its source query with just perms for the former (#15131)"
-              (testing "Should not be able to run the parent Card"
-                (mt/with-test-user :rasta
-                  (is (not (mi/can-read? disallowed-collection)))
-                  (is (not (mi/can-read? parent-card))))
-                (is (= "You don't have permissions to do that."
-                       (process-query-for-card parent-card))))
-              (testing "Should not be able to run the child Card due to Block permissions"
-                (mt/with-test-user :rasta
-                  (is (not (mi/can-read? parent-card)))
-                  (is (mi/can-read? allowed-collection))
-                  (is (mi/can-read? child-card)))
-                (rasta-view-data-perm= :blocked)
-                (testing "Data perms prohibit running queries"
-                  (is (thrown-with-msg?
-                       clojure.lang.ExceptionInfo
-                       #"Blocked: you are not allowed to run queries"
-                       (mt/rows (process-query-for-card child-card)))
-                      "Even if the user has can-write? on a Card, they should not be able to run it because they are blocked on Card's db"))))
-            (testing "view-data = unrestricted is required to allow running the query (#15131)"
-              (mt/with-restored-data-perms!
-                (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
-                (rasta-view-data-perm= :unrestricted)
-                (is (= [[1] [2]] (mt/rows (process-query-for-card child-card)))
-                    "view-data = unrestricted is sufficient to allow running the query")))))))))
-
-(deftest cannot-run-any-native-queries-when-blocked-test
-  (mt/with-non-admin-groups-no-root-collection-perms
-    (mt/with-temp [:model/Collection allowed-collection    {}
-                   :model/Collection disallowed-collection {}
-                   :model/Card       parent-card           {:dataset_query {:database (mt/id)
-                                                                            :type     :native
-                                                                            :native   {:query "SELECT id FROM venues ORDER BY id ASC LIMIT 2;"}}
-                                                            :database_id   (mt/id)
-                                                            :collection_id (u/the-id disallowed-collection)}
-                   :model/Card       child-card            {:dataset_query {:database (mt/id)
-                                                                            :type     :query
-                                                                            :query    {:source-table (format "card__%d" (u/the-id parent-card))}}
-                                                            :collection_id (u/the-id allowed-collection)}]
-      (letfn [(process-query-for-card [card]
-                (mt/user-http-request :rasta :post (format "card/%d/query" (u/the-id card))))]
-        (testing "Cannot run native queries when a single table is unrestricted and the rest are blocked"
-          (mt/with-no-data-perms-for-all-users!
-            (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :blocked)
-            (data-perms/set-table-permission! (perms-group/all-users) (mt/id :venues) :perms/view-data :unrestricted)
-            (perms/grant-collection-read-permissions! (perms-group/all-users) allowed-collection)
-            (is (thrown-with-msg?
-                 clojure.lang.ExceptionInfo
-                 #"Blocked: you are not allowed to run queries"
-                 (mt/rows (process-query-for-card child-card)))
-                "Someone with `:blocked` permissions on ANY table in the database cannot run ANY card with native queries, including as a source for another card.")))
-        ;; update collection perms in place:
-        (perms/revoke-collection-permissions! (perms-group/all-users) allowed-collection)
-        (testing "Cannot run native queries when a single table is blocked and the rest are unrestricted"
-          (mt/with-no-data-perms-for-all-users!
-            (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
-            (data-perms/set-table-permission! (perms-group/all-users) (mt/id :venues) :perms/view-data :blocked)
-            (perms/grant-collection-read-permissions! (perms-group/all-users) allowed-collection)
-            (is (thrown-with-msg?
-                 clojure.lang.ExceptionInfo
-                 #"Blocked: you are not allowed to run queries"
-                 (mt/rows (process-query-for-card child-card)))
-                "Someone with `:blocked` permissions on ANY table in the database cannot run ANY card with native queries, including as a source for another card.")))))))
 
 (deftest query-metadata-test
   (mt/with-temp

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2657,7 +2657,7 @@
           (update-card card {:description "a new description"})
           (is (empty? (reviews card)))))
       (testing "Does not add nil moderation reviews when there are reviews but not verified"
-       ;; testing that we aren't just adding a nil moderation each time we update a card
+      ;; testing that we aren't just adding a nil moderation each time we update a card
         (with-card :verified
           (is (verified? card))
           (moderation-review/create-review! {:moderated_item_id   (u/the-id card)

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2657,7 +2657,7 @@
           (update-card card {:description "a new description"})
           (is (empty? (reviews card)))))
       (testing "Does not add nil moderation reviews when there are reviews but not verified"
-       ;; testing that we aren't just adding a nil moderation each time we update a card
+      ;; testing that we aren't just adding a nil moderation each time we update a card
         (with-card :verified
           (is (verified? card))
           (moderation-review/create-review! {:moderated_item_id   (u/the-id card)
@@ -3750,7 +3750,7 @@
                 (testing "Data perms prohibit running queries"
                   (is (thrown-with-msg?
                        clojure.lang.ExceptionInfo
-                       #"You do not have permissions to run this query."
+                       #"Blocked: you are not allowed to run queries"
                        (mt/rows (process-query-for-card child-card)))
                       "Even if the user has can-write? on a Card, they should not be able to run it because they are blocked on Card's db"))))
             (testing "view-data = unrestricted is required to allow running the query (#15131)"

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2657,7 +2657,7 @@
           (update-card card {:description "a new description"})
           (is (empty? (reviews card)))))
       (testing "Does not add nil moderation reviews when there are reviews but not verified"
-       ;; testing that we aren't just adding a nil moderation each time we update a card
+      ;; testing that we aren't just adding a nil moderation each time we update a card
         (with-card :verified
           (is (verified? card))
           (moderation-review/create-review! {:moderated_item_id   (u/the-id card)
@@ -3660,10 +3660,7 @@
                                                 :collection_id (u/the-id collection)}]
     (letfn [(process-query []
               (mt/user-http-request :rasta :post (format "card/%d/query" (u/the-id card))))
-            (blocked? [response] (or
-                                  (= "You don't have permissions to do that." response)
-                                  (re-matches #"You do not have permissions to run this query"
-                                              (:error response))))]
+            (blocked? [response] (= "You don't have permissions to do that." response))]
       ;;    | Data perms | Collection perms | outcome
       ;;    ------------ | ---------------- | --------
       ;;    | no         | no               | blocked
@@ -3703,7 +3700,8 @@
 
       ;; delete these in place so we can reset them below, you cannot set them twice in a row
       (perms/revoke-collection-permissions! (perms-group/all-users) collection)
-      (testing "should NOT be able to run the parent Card with data-perms and valid collection perms"
+
+      (testing "should NOT be able to run the parent Card when data-perms and valid collection perms"
         (mt/with-no-data-perms-for-all-users!
           (mt/with-non-admin-groups-no-collection-perms collection
             (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1042,7 +1042,7 @@
   (testing "Check that moving a dashboard to another collection will fixup both collections"
     (mt/with-non-admin-groups-no-root-collection-perms
       (mt/with-temp [Collection collection-1 {}
-                     Collection collection-2] {}
+                     Collection collection-2 {}]
         (api.card-test/with-ordered-items collection-1 [Dashboard a
                                                         Card      b
                                                         Card      c

--- a/test/metabase/models/data_permissions_test.clj
+++ b/test/metabase/models/data_permissions_test.clj
@@ -144,7 +144,7 @@
             table-id (rand-nth tables-in-db)]
         (data-perms/set-table-permissions! (perms-group/all-users) :perms/view-data {table-id :blocked}))
 
-      (is (= "You do not have permissions to run this query."
+      (is (= (str "Blocked: you are not allowed to run queries against Database " db-id ".")
              (:error (mt/user-http-request :rasta :post 202 (format "card/%d/query" card-id))))))))
 
 (deftest database-permission-for-user-test

--- a/test/metabase/models/query/permissions_test.clj
+++ b/test/metabase/models/query/permissions_test.clj
@@ -223,7 +223,8 @@
                                                  (mt/mbql-query checkins
                                                    {:aggregation [[:sum $id]]
                                                     :breakout    [$user_id]}))]
-      (is (= {:perms/view-data      {(mt/id :users) :unrestricted
+      (is (= {:card-ids             #{card-id}
+              :perms/view-data      {(mt/id :users) :unrestricted
                                      (mt/id :checkins) :unrestricted}
               :perms/create-queries {(mt/id :users) :query-builder
                                      (mt/id :checkins) :query-builder}}
@@ -237,6 +238,7 @@
                                          [:field "USER_ID" {:base-type :type/Integer, :join-alias "__alias__"}]]}]
                  :limit 10})
               :throw-exceptions? true)))
+
       (is (= {:perms/view-data      {(mt/id :users) :unrestricted
                                      (mt/id :checkins) :unrestricted}
               :perms/create-queries {(mt/id :users) :query-builder

--- a/test/metabase/models/query/permissions_test.clj
+++ b/test/metabase/models/query/permissions_test.clj
@@ -307,15 +307,17 @@
 
 (deftest ^:parallel native-query-source-card-id-join-permissions-test
   (testing "MBQL query with native source card (#30077)"
-    (mt/with-temp [:model/Card {card-id :id} {:dataset_query {:query (mt/native-query "SELECT * FROM orders")}}]
+    (mt/with-temp [:model/Card {card-id :id} {:dataset_query {:database (mt/id)
+                                                              :type :native
+                                                              :native {:query "SELECT * FROM orders"}}}]
       (let [query {:database (mt/id)
                    :type     :query
                    :query    {:source-table (mt/id :products)
                               :joins        [{:alias "Join Alias"
+                                              :condition [:= true false]
                                               :source-query
                                               {:qp/stage-is-from-source-card card-id
-                                               :native "SELECT * FROM orders"}
-                                              :condition [:= true false]}]}}]
+                                               :native "SELECT * FROM orders"}}]}}]
         ;; The source card of the joined native query is detected, and we don't require full native perms
         (is (= {:card-ids             #{card-id}
                 :perms/create-queries {(mt/id :products) :query-builder}

--- a/test/metabase/query_processor/middleware/permissions_test.clj
+++ b/test/metabase/query_processor/middleware/permissions_test.clj
@@ -370,23 +370,23 @@
             ;; Grant read permissions for Collection 2 but not Collection 1
             (perms/grant-collection-read-permissions! (perms-group/all-users) collection-2-id)
             (doseq [[card-1-query-type card-1-query] {"MBQL"   (mt/mbql-query venues
-                                                                              {:order-by [[:asc $id]], :limit 2})
+                                                                 {:order-by [[:asc $id]], :limit 2})
                                                       "native" (mt/native-query
-                                                                {:query (str "SELECT id, name, category_id, latitude, longitude, price "
-                                                                             "FROM venues "
-                                                                             "ORDER BY id ASC "
-                                                                             "LIMIT 2")})}]
+                                                                 {:query (str "SELECT id, name, category_id, latitude, longitude, price "
+                                                                              "FROM venues "
+                                                                              "ORDER BY id ASC "
+                                                                              "LIMIT 2")})}]
               (testing (format "\nCard 1 is a %s query" card-1-query-type)
                 (t2.with-temp/with-temp [:model/Card {card-1-id :id, :as card-1} {:collection_id collection-1-id
                                                                                   :dataset_query card-1-query}]
                   (doseq [[card-2-query-type card-2-query] {"MBQL"   (mt/mbql-query nil
-                                                                                    {:source-table (format "card__%d" card-1-id)})
+                                                                       {:source-table (format "card__%d" card-1-id)})
                                                             "native" (mt/native-query
-                                                                      {:query         "SELECT * FROM {{card}}"
-                                                                       :template-tags {"card" {:name         "card"
-                                                                                               :display-name "card"
-                                                                                               :type         :card
-                                                                                               :card-id      card-1-id}}})}]
+                                                                       {:query         "SELECT * FROM {{card}}"
+                                                                        :template-tags {"card" {:name         "card"
+                                                                                                :display-name "card"
+                                                                                                :type         :card
+                                                                                                :card-id      card-1-id}}})}]
                     (testing (format "\nCard 2 is a %s query" card-2-query-type)
                       (t2.with-temp/with-temp [:model/Card card-2 {:collection_id collection-2-id
                                                                    :dataset_query card-2-query}]
@@ -413,7 +413,7 @@
                                    #"You do not have permissions to view Card"
                                    (mt/rows
                                     (qp/process-query (mt/mbql-query nil
-                                                                     {:source-table (format "card__%d" card-1-id)}))))))
+                                                        {:source-table (format "card__%d" card-1-id)}))))))
 
                             (testing "Should be able to run ad-hoc query with Card 2 as source query [Ad-hoc -> Card 2 -> Card 1 -> Source Query]"
                               (is (= expected
@@ -421,7 +421,7 @@
                                       (qp/process-query
                                        (qp/userland-query
                                         (mt/mbql-query nil
-                                                       {:source-table (format "card__%d" (u/the-id card-2))})))))))))))))))))))))
+                                          {:source-table (format "card__%d" (u/the-id card-2))})))))))))))))))))))))
 
 (deftest e2e-ignore-user-supplied-card-ids-test
   (testing "You shouldn't be able to bypass security restrictions by passing `[:info :card-id]` in the query."

--- a/test/metabase/query_processor/middleware/permissions_test.clj
+++ b/test/metabase/query_processor/middleware/permissions_test.clj
@@ -445,7 +445,7 @@
                                    :alias        "v"
                                    :source-query {:native "SELECT * from orders"}
                                    :condition    [:= true true]
-                                                ;; Make sure we can't just pass in this key and join to arbitrary SQL!
+                                   ;; Make sure we can't just pass in this key and join to arbitrary SQL!
                                    :qp/stage-is-from-source-card card-id}]
                        :order-by [[:asc $id]]
                        :limit    2})]

--- a/test/metabase/query_processor/middleware/permissions_test.clj
+++ b/test/metabase/query_processor/middleware/permissions_test.clj
@@ -296,14 +296,15 @@
                :type     :query
                :query    {:source-table (u/the-id table)}})))))))
 
-(deftest e2e-nested-source-card-test
-  (testing "Make sure permissions are calculated for Card -> Card -> Source Query (#12354)"
+(deftest e2e-nested-source-card-full-permissions-test
+  (testing "Make sure permissions are calculated correctly for Card 1 -> Card 2 -> Source Query when there are full
+           Collection permissions to both Cards (#12354)"
     (mt/with-non-admin-groups-no-root-collection-perms
       (mt/with-temp-copy-of-db
         (mt/with-no-data-perms-for-all-users!
           (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
           (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :no)
-          (t2.with-temp/with-temp [Collection collection]
+          (t2.with-temp/with-temp [:model/Collection collection]
             (perms/grant-collection-read-permissions! (perms-group/all-users) collection)
             (doseq [[card-1-query-type card-1-query] {"MBQL"   (mt/mbql-query venues
                                                                  {:order-by [[:asc $id]], :limit 2})
@@ -313,8 +314,8 @@
                                                                               "ORDER BY id ASC "
                                                                               "LIMIT 2")})}]
               (testing (format "\nCard 1 is a %s query" card-1-query-type)
-                (t2.with-temp/with-temp [Card {card-1-id :id, :as card-1} {:collection_id (u/the-id collection)
-                                                                           :dataset_query card-1-query}]
+                (t2.with-temp/with-temp [:model/Card {card-1-id :id, :as card-1} {:collection_id (u/the-id collection)
+                                                                                  :dataset_query card-1-query}]
                   (doseq [[card-2-query-type card-2-query] {"MBQL"   (mt/mbql-query nil
                                                                        {:source-table (format "card__%d" card-1-id)})
                                                             "native" (mt/native-query
@@ -324,8 +325,8 @@
                                                                                                 :type         :card
                                                                                                 :card-id      card-1-id}}})}]
                     (testing (format "\nCard 2 is a %s query" card-2-query-type)
-                      (t2.with-temp/with-temp [Card card-2 {:collection_id (u/the-id collection)
-                                                            :dataset_query card-2-query}]
+                      (t2.with-temp/with-temp [:model/Card card-2 {:collection_id (u/the-id collection)
+                                                                   :dataset_query card-2-query}]
                         (testing "\nshould be able to read nested-nested Card if we have Collection permissions\n"
                           (mt/with-test-user :rasta
                             (let [expected [[1 "Red Medicine"           4 10.0646 -165.374 3]
@@ -355,6 +356,72 @@
                                          (qp/userland-query
                                           (mt/mbql-query nil
                                             {:source-table (format "card__%d" (u/the-id card-2))}))))))))))))))))))))))
+
+(deftest e2e-nested-source-card-no-permissions-test
+  (testing "Make sure permissions are calculated correctly for Card 2 -> Card 1 -> Source Query when a user has access to Card 2,
+           but not Card 1."
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp-copy-of-db
+        (mt/with-no-data-perms-for-all-users!
+          (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
+          (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :no)
+          (mt/with-temp [Collection {collection-1-id :id} {}
+                         Collection {collection-2-id :id} {}]
+            ;; Grant read permissions for Collection 2 but not Collection 1
+            (perms/grant-collection-read-permissions! (perms-group/all-users) collection-2-id)
+            (doseq [[card-1-query-type card-1-query] {"MBQL"   (mt/mbql-query venues
+                                                                              {:order-by [[:asc $id]], :limit 2})
+                                                      "native" (mt/native-query
+                                                                {:query (str "SELECT id, name, category_id, latitude, longitude, price "
+                                                                             "FROM venues "
+                                                                             "ORDER BY id ASC "
+                                                                             "LIMIT 2")})}]
+              (testing (format "\nCard 1 is a %s query" card-1-query-type)
+                (t2.with-temp/with-temp [:model/Card {card-1-id :id, :as card-1} {:collection_id collection-1-id
+                                                                                  :dataset_query card-1-query}]
+                  (doseq [[card-2-query-type card-2-query] {"MBQL"   (mt/mbql-query nil
+                                                                                    {:source-table (format "card__%d" card-1-id)})
+                                                            "native" (mt/native-query
+                                                                      {:query         "SELECT * FROM {{card}}"
+                                                                       :template-tags {"card" {:name         "card"
+                                                                                               :display-name "card"
+                                                                                               :type         :card
+                                                                                               :card-id      card-1-id}}})}]
+                    (testing (format "\nCard 2 is a %s query" card-2-query-type)
+                      (t2.with-temp/with-temp [:model/Card card-2 {:collection_id collection-2-id
+                                                                   :dataset_query card-2-query}]
+                        (mt/with-test-user :rasta
+                          (let [expected [[1 "Red Medicine"           4 10.0646 -165.374 3]
+                                          [2 "Stout Burgers & Beers" 11 34.0996 -118.329 2]]]
+                            (testing "Should not be able to run Card 1 directly"
+                              (binding [qp.perms/*card-id* (u/the-id card-1)]
+                                (is (thrown-with-msg?
+                                     ExceptionInfo
+                                     #"You do not have permissions to view Card"
+                                     (mt/rows
+                                      (qp/process-query (:dataset_query card-1)))))))
+
+                            (testing "Should be able to run Card 2 directly [Card 2 -> Card 1 -> Source Query]"
+                              (binding [qp.perms/*card-id* (u/the-id card-2)]
+                                (is (= expected
+                                       (mt/rows
+                                        (qp/process-query (:dataset_query card-2)))))))
+
+                            (testing "Should not be able to run ad-hoc query with Card 1 as source query [Ad-hoc -> Card 1 -> Source Query]"
+                              (is (thrown-with-msg?
+                                   ExceptionInfo
+                                   #"You do not have permissions to view Card"
+                                   (mt/rows
+                                    (qp/process-query (mt/mbql-query nil
+                                                                     {:source-table (format "card__%d" card-1-id)}))))))
+
+                            (testing "Should be able to run ad-hoc query with Card 2 as source query [Ad-hoc -> Card 2 -> Card 1 -> Source Query]"
+                              (is (= expected
+                                     (mt/rows
+                                      (qp/process-query
+                                       (qp/userland-query
+                                        (mt/mbql-query nil
+                                                       {:source-table (format "card__%d" (u/the-id card-2))})))))))))))))))))))))
 
 (deftest e2e-ignore-user-supplied-card-ids-test
   (testing "You shouldn't be able to bypass security restrictions by passing `[:info :card-id]` in the query."


### PR DESCRIPTION
* Changes the `query->source-table-ids` to be `query-perms/query->source-ids` which returns a map with this structure: `{:table-ids #{} :card-ids #{} :native? false}`. `query->source-table-ids` is preserved as a wrapper for callers who only need table IDs.
* `:card-ids` returns any card IDs associated with the `:qp/stage-is-from-source-card` key, indicating that a native subquery originally came from a saved card. `:native?` will only be `true` if there are any `:native` keys in the query which don't have a `:qp/stage-is-from-source-card`.
* When computing permissions required to execute a query, we check read perms for any card IDs returned from `query->source-ids`. Previously, we would require full ad-hoc native perms in this case, which led to unexpected permission errors in certain cases.

Other changes:
* I've moved block permission enforcement back to being EE-only. This shouldn't have a major impact, other than for instances that had set block on EE and then downgraded to OSS (but I've confirmed that this is the expected behavior from product)
* I've moved around some code and tests

Resolves https://github.com/metabase/metabase/issues/30077