### PR TITLE
WIP Fix flake in native subquery tests

### DIFF
--- a/e2e/test/scenarios/native/native_subquery.cy.spec.js
+++ b/e2e/test/scenarios/native/native_subquery.cy.spec.js
@@ -86,15 +86,12 @@ describe("scenarios > question > native subquery", () => {
 
         openNativeEditor();
         cy.reload(); // Refresh the state, so previously created questions need to be loaded again.
-        cy.get(".ace_editor")
-          .should("be.visible")
-          .type(" ")
-          .realType("{{#people");
+        cy.get(".ace_editor").should("be.visible").type(" ").type("{{#people");
 
         // Wait until another explicit autocomplete is triggered
         // (slightly longer than AUTOCOMPLETE_DEBOUNCE_DURATION)
         // See https://github.com/metabase/metabase/pull/20970
-        cy.wait(1000);
+        cy.wait(2000);
         cy.get(".ace_autocomplete")
           .should("be.visible")
           .findByText(`${questionId2}-a-`);


### PR DESCRIPTION
Fix a flake introduced by https://github.com/metabase/metabase/pull/45136

[Stress test](https://github.com/metabase/metabase/actions/runs/11610394558/job/32329613951)