### PR TITLE
docs(sdk): remove extra duplicated line

### DIFF
--- a/docs/embedding/sdk/questions.md
+++ b/docs/embedding/sdk/questions.md
@@ -65,7 +65,6 @@ export default function App() {
         </MetabaseProvider>
     );
 }
-const questionId = 1; // This is the question ID you want to embed
 ```
 
 ## Question props


### PR DESCRIPTION
That was probably a merge conflict gone wrong

@jeff-bruemmer can you confirm this needs to be backported?
I'm not familiar with how the docs are deployed but it seems like the md file is present on `release-x.51.x`