### PR TITLE
Fix dirty yarn.lock by resolving elliptic

### DIFF
--- a/package.json
+++ b/package.json
@@ -326,6 +326,7 @@
     "ansi-regex": "5.0.1",
     "cookie": "^0.7.0",
     "d3-color": "^3.1.0",
+    "elliptic": "^6.6.0",
     "debug": "^4.3.4",
     "follow-redirects": "^1.15.5",
     "jsdom": "^22.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13651,7 +13651,7 @@ http-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
-http-proxy-middleware@^2.0.3, http-proxy-middleware@^2.0.6, http-proxy-middleware@^2.0.7:
+http-proxy-middleware@^2.0.3, http-proxy-middleware@^2.0.6:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz#915f236d92ae98ef48278a95dedf17e991936ec6"
   integrity sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==
@@ -16397,7 +16397,7 @@ markdown-table@^2.0.0:
   dependencies:
     repeat-string "^1.0.0"
 
-markdown-to-jsx@^7.1.8, markdown-to-jsx@^7.4.0:
+markdown-to-jsx@^7.1.8:
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.5.0.tgz#42ece0c71e842560a7d8bd9f81e7a34515c72150"
   integrity sha512-RrBNcMHiFPcz/iqIj0n3wclzHXjwS7mzjBNWecKKVhNTIxQepIix6Il/wZCn2Cg5Y1ow2Qi84+eJrryFRWBEWw==


### PR DESCRIPTION
It looks like I was a bit to hasty when merging https://github.com/metabase/metabase/pull/49371 today.

Running `yarn` locally on master makes `yarn.lock` currently.

This PR fixes that by adding `elliptic` to the `resolutions` in `package.json`.