### PR TITLE
Give the command palette a higher z-index

### DIFF
--- a/frontend/src/metabase/palette/components/Palette.tsx
+++ b/frontend/src/metabase/palette/components/Palette.tsx
@@ -44,18 +44,9 @@ const PaletteContainer = () => {
   });
 
   return (
-    <Overlay opacity={0.5}>
+    <Overlay zIndex={500} opacity={0.5}>
       <Center>
-        <Card
-          ref={ref}
-          w="640px"
-          mt="10vh"
-          p="0"
-          style={{
-            zIndex: 100,
-          }}
-          data-testid="command-palette"
-        >
+        <Card ref={ref} w="640px" mt="10vh" p="0" data-testid="command-palette">
           <Box w="100%" p="1.5rem" pb="0">
             <PaletteInput
               defaultPlaceholder={t`Search for anything or jump somewhere…`}


### PR DESCRIPTION
This is a mini-PR that quickly fixes #45469. A more rigorous solution, with tests, is in progress.

On this branch the command palette correctly appears above the data picker
![Kapture 2024-10-31 at 09.51.10.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/2351bd54-0732-4054-8da4-1e159dea9326.gif)

