### PR TITLE
Attempt to fix native editor flakes

### DIFF
--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.js
@@ -4,6 +4,7 @@ import {
   POPOVER_ELEMENT,
   addPostgresDatabase,
   cartesianChartCircle,
+  createNativeQuestion,
   createQuestion,
   focusNativeEditor,
   modal,
@@ -589,18 +590,12 @@ describe("issue 34330", () => {
 
   it("should only call the autocompleter with all text typed (metabase#34330)", () => {
     const editor = openNativeEditor();
+    const query = "USER";
 
-    // can't use cy.type because it does not simulate the bug
-    // Delay needed for React 18. TODO: fix shame
-    editor.type("USER").type("_", { delay: 1000 });
+    editor.type(query);
 
-    cy.wait("@autocomplete").then(({ request }) => {
-      const url = new URL(request.url);
-      expect(url.searchParams.get("substring")).to.equal("USER_");
-    });
-
-    // only one call to the autocompleter should have been made
     cy.get("@autocomplete.all").should("have.length", 1);
+    cy.get("@autocomplete").its("request.url").should("contain", query);
   });
 
   it("should call the autocompleter eventually, even when only 1 character was typed (metabase#34330)", () => {
@@ -619,10 +614,17 @@ describe("issue 34330", () => {
   });
 
   it("should call the autocompleter when backspacing to a 1-character prefix(metabase#34330)", () => {
-    const editor = openNativeEditor();
+    createNativeQuestion(
+      {
+        native: {
+          query: "SE",
+        },
+      },
+      { visitQuestion: true },
+    );
 
-    // can't use cy.type because it does not simulate the bug
-    editor.type("SE{backspace}");
+    cy.findByTestId("visibility-toggler").click();
+    focusNativeEditor().type("{backspace}");
 
     cy.wait("@autocomplete").then(({ request }) => {
       const url = new URL(request.url);

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.js
@@ -590,19 +590,22 @@ describe("issue 34330", () => {
 
   it("should only call the autocompleter with all text typed (metabase#34330)", () => {
     const editor = openNativeEditor();
-    const query = "USER";
+    const query = "USER_ID";
+    editor.realType(query);
 
-    editor.type(query);
+    cy.wait("@autocomplete").then(({ request }) => {
+      const url = new URL(request.url);
+      expect(url.searchParams.get("substring")).to.equal(query);
+    });
 
+    // only one call to the autocompleter should have been made
     cy.get("@autocomplete.all").should("have.length", 1);
-    cy.get("@autocomplete").its("request.url").should("contain", query);
   });
 
   it("should call the autocompleter eventually, even when only 1 character was typed (metabase#34330)", () => {
     const editor = openNativeEditor();
 
-    // can't use cy.type because it does not simulate the bug
-    editor.type("U");
+    editor.realType("U");
 
     cy.wait("@autocomplete").then(({ request }) => {
       const url = new URL(request.url);

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.js
@@ -4,7 +4,6 @@ import {
   POPOVER_ELEMENT,
   addPostgresDatabase,
   cartesianChartCircle,
-  createNativeQuestion,
   createQuestion,
   focusNativeEditor,
   modal,
@@ -590,7 +589,7 @@ describe("issue 34330", () => {
 
   it("should only call the autocompleter with all text typed (metabase#34330)", () => {
     const editor = openNativeEditor();
-    const query = "USER_ID";
+    const query = "USER";
     editor.realType(query);
 
     cy.wait("@autocomplete").then(({ request }) => {
@@ -617,17 +616,7 @@ describe("issue 34330", () => {
   });
 
   it("should call the autocompleter when backspacing to a 1-character prefix(metabase#34330)", () => {
-    createNativeQuestion(
-      {
-        native: {
-          query: "SE",
-        },
-      },
-      { visitQuestion: true },
-    );
-
-    cy.findByTestId("visibility-toggler").click();
-    focusNativeEditor().type("{backspace}");
+    openNativeEditor().realType("SE{backspace}");
 
     cy.wait("@autocomplete").then(({ request }) => {
       const url = new URL(request.url);

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -126,8 +126,16 @@ describe("scenarios > question > native", () => {
   });
 
   it("can save a question with no rows", () => {
-    openNativeEditor().type("select * from people where false");
-    runQuery();
+    visitQuestionAdhoc({
+      dataset_query: {
+        type: "native",
+        database: SAMPLE_DB_ID,
+        native: {
+          query: "select * from people where false",
+        },
+      },
+      visualization_settings: {},
+    });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("No results!");
     cy.icon("contract").click();

--- a/e2e/test/scenarios/native/native_subquery.cy.spec.js
+++ b/e2e/test/scenarios/native/native_subquery.cy.spec.js
@@ -79,16 +79,18 @@ describe("scenarios > question > native subquery", () => {
         openNativeEditor().realType("{{#people");
         cy.get(".ace_autocomplete")
           .should("be.visible")
-          .findByText(`${questionId2}-a-`);
+          .findByText(`${questionId2}-a-`, { timeout: 5000 });
         cy.get(".ace_autocomplete")
           .should("be.visible")
-          .findByText("Model in Bobby Tables's Personal Collection");
+          .findByText("Model in Bobby Tables's Personal Collection", {
+            timeout: 5000,
+          });
         cy.get(".ace_autocomplete")
           .should("be.visible")
-          .findByText(`${questionId1}-a-`);
+          .findByText(`${questionId1}-a-`, { timeout: 5000 });
         cy.get(".ace_autocomplete")
           .should("be.visible")
-          .findByText("Question in Our analytics");
+          .findByText("Question in Our analytics", { timeout: 5000 });
       });
     });
   });

--- a/e2e/test/scenarios/native/native_subquery.cy.spec.js
+++ b/e2e/test/scenarios/native/native_subquery.cy.spec.js
@@ -77,20 +77,22 @@ describe("scenarios > question > native subquery", () => {
         collection_id: ADMIN_PERSONAL_COLLECTION_ID,
       }).then(({ body: { id: questionId2 } }) => {
         openNativeEditor().realType("{{#people");
+        const timeoutOptions = { timeout: 5000 };
         cy.get(".ace_autocomplete")
           .should("be.visible")
-          .findByText(`${questionId2}-a-`, { timeout: 5000 });
+          .findByText(`${questionId2}-a-`, timeoutOptions);
         cy.get(".ace_autocomplete")
           .should("be.visible")
-          .findByText("Model in Bobby Tables's Personal Collection", {
-            timeout: 5000,
-          });
+          .findByText(
+            "Model in Bobby Tables's Personal Collection",
+            timeoutOptions,
+          );
         cy.get(".ace_autocomplete")
           .should("be.visible")
-          .findByText(`${questionId1}-a-`, { timeout: 5000 });
+          .findByText(`${questionId1}-a-`, timeoutOptions);
         cy.get(".ace_autocomplete")
           .should("be.visible")
-          .findByText("Question in Our analytics", { timeout: 5000 });
+          .findByText("Question in Our analytics", timeoutOptions);
       });
     });
   });

--- a/e2e/test/scenarios/native/native_subquery.cy.spec.js
+++ b/e2e/test/scenarios/native/native_subquery.cy.spec.js
@@ -1,11 +1,12 @@
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  ADMIN_PERSONAL_COLLECTION_ID,
+  ORDERS_QUESTION_ID,
+} from "e2e/support/cypress_sample_instance_data";
 import {
   createNativeQuestion,
   createQuestion,
-  entityPickerModal,
   focusNativeEditor,
   openNativeEditor,
-  openQuestionActions,
   restore,
   runNativeQuery,
   startNewNativeQuestion,
@@ -73,28 +74,9 @@ describe("scenarios > question > native subquery", () => {
           query: "SELECT id FROM PEOPLE",
         },
         type: "model",
+        collection_id: ADMIN_PERSONAL_COLLECTION_ID,
       }).then(({ body: { id: questionId2 } }) => {
-        // Move question 2 to personal collection
-        cy.visit(`/question/${questionId2}`);
-        openQuestionActions();
-        cy.findByTestId("move-button").click();
-        entityPickerModal().within(() => {
-          cy.findByRole("tab", { name: /Collections/ }).click();
-          cy.findByText("Bobby Tables's Personal Collection").click();
-          cy.button("Move").click();
-        });
-
-        openNativeEditor();
-        cy.reload(); // Refresh the state, so previously created questions need to be loaded again.
-        cy.get(".ace_editor")
-          .should("be.visible")
-          .type(" ")
-          .realType("{{#people");
-
-        // Wait until another explicit autocomplete is triggered
-        // (slightly longer than AUTOCOMPLETE_DEBOUNCE_DURATION)
-        // See https://github.com/metabase/metabase/pull/20970
-        cy.wait(2000);
+        openNativeEditor().realType("{{#people");
         cy.get(".ace_autocomplete")
           .should("be.visible")
           .findByText(`${questionId2}-a-`);

--- a/e2e/test/scenarios/native/native_subquery.cy.spec.js
+++ b/e2e/test/scenarios/native/native_subquery.cy.spec.js
@@ -94,7 +94,7 @@ describe("scenarios > question > native subquery", () => {
         // Wait until another explicit autocomplete is triggered
         // (slightly longer than AUTOCOMPLETE_DEBOUNCE_DURATION)
         // See https://github.com/metabase/metabase/pull/20970
-        cy.wait(1000);
+        cy.wait(2000);
         cy.get(".ace_autocomplete")
           .should("be.visible")
           .findByText(`${questionId2}-a-`);


### PR DESCRIPTION
- `native_reproductions` (still broken) https://github.com/metabase/metabase/actions/runs/11616723015
- `native` (good) https://github.com/metabase/metabase/actions/runs/11616330964
- `native_subquery` (still broken) https://github.com/metabase/metabase/actions/runs/11616734923