### PR TITLE
[QP] Update breakouts in `:order-by` when setting time granularity

### DIFF
--- a/test/metabase/query_processor/middleware/parameters/mbql_test.clj
+++ b/test/metabase/query_processor/middleware/parameters/mbql_test.clj
@@ -432,3 +432,22 @@
       (testing "Should prefer :value over :default"
         (is (= 59
                (venues-with-price {:default 1, :value 2})))))))
+
+(deftest ^:parallel time-granularity-parameters-test
+  (testing "time granularity parameters should update the matching clause in the breakouts and order-by clauses"
+    (let [by-unit  (fn [unit]
+                     [:field
+                      (mt/id :orders :created_at)
+                      {:base-type :type/DateTimeWithLocalTZ, :temporal-unit unit}])
+          query    {:database (mt/id)
+                    :type     :query
+                    :query    {:source-table (mt/id :orders)
+                               :aggregation  [[:count]]
+                               :breakout     [(by-unit :day)
+                                              (by-unit :month)]
+                               :order-by     [[:asc (by-unit :month)]]}
+                    :parameters [{:type   :temporal-unit
+                                  :target [:dimension (by-unit :month)]
+                                  :value  :week}]}]
+      (is (= ["2016-04-30T00:00:00Z" "2016-04-24T00:00:00Z" 1]
+             (first (mt/rows (mt/process-query query))))))))


### PR DESCRIPTION
Closes #49263.

### Description

Previously the `:order-by` clauses were not updated, which caused invalid SQL to be
generated, since the ORDER BY (time unit not updated) and GROUP BY (time unit updated)
did not line up.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> MBQL -> Sample Database -> Orders
2. COUNT aggregation
3. Break out by Created At by both month and day
4. Explicitly order by Created At: Day, Descending.
5. Add this card to a dashboard
6. Add a time granularity parameter to the dashboard and link it to the Created At: Day column
7. Try to set the time granularity using the dashboard filter.

Originally this caused the query to fail to run because of the SQL error. Now it works correctly.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
