### PR TITLE
Realitime search re-indexing infrastructure

### DIFF
--- a/src/metabase/search/postgres/index.clj
+++ b/src/metabase/search/postgres/index.clj
@@ -145,6 +145,16 @@
     (when @reindexing?
       (upsert! pending-table entry))))
 
+(defn delete!
+  "Remove any entries corresponding directly to a given model instance."
+  [id search-models]
+  ;; In practice, we expect this to be 1-1, but the data model does not preclude it.
+  (when (seq search-models)
+    (when @initialized?
+      (t2/delete! active-table :model_id id :model [:in search-models]))
+    (when @reindexing?
+      (t2/delete! pending-table :model_id id :model [:in search-models]))))
+
 (defn- process-negation [term]
   (if (str/starts-with? term "-")
     (str "!" (subs term 1))

--- a/src/metabase/search/postgres/ingestion.clj
+++ b/src/metabase/search/postgres/ingestion.clj
@@ -24,9 +24,8 @@
   (model-rankings model (count model-rankings)))
 
 (defn- searchable-text [m]
-  ;; TODO use spec instead
   ;; For now, we never index the native query content
-  (->> (search.config/searchable-columns (:model m) false)
+  (->> (:search-terms (search.spec/spec (:model m)))
        (map m)
        (str/join " ")))
 

--- a/src/metabase/search/postgres/ingestion.clj
+++ b/src/metabase/search/postgres/ingestion.clj
@@ -128,7 +128,10 @@
          (batch-update!))))
 
 ;; TODO think about how we're going to handle cascading deletes.
-;; One idea is to queue a general purge command.
+;; Ideas:
+;; - Queue full re-index (rather expensive)
+;; - Queue "purge" (empty left join to the model) - needs special case for indexed-entity
+;; - Pre-delete hook using pre-calculated PK-based graph
 (defn delete-model!
   "Given a deleted instance, delete all the corresponding search entries."
   [instance]

--- a/src/metabase/search/postgres/ingestion.clj
+++ b/src/metabase/search/postgres/ingestion.clj
@@ -120,7 +120,7 @@
   (batch-update! (search-items-reducible)))
 
 (defn update-index!
-  "Given a new or updated instance, create or update all the corresponding search entries."
+  "Given a new or updated instance, create or update all the corresponding search entries if needed."
   [instance]
   (when-let [updates (seq (search.spec/search-models-to-update instance))]
     (->> (for [[search-model where-clause] updates]

--- a/src/metabase/search/postgres/ingestion.clj
+++ b/src/metabase/search/postgres/ingestion.clj
@@ -94,7 +94,7 @@
        (sql.helpers/where where-clause))))
 
 (defn- spec-index-reducible [search-model & [where-clause]]
-  (->> (spec-index-query search-model where-clause)
+  (->> (spec-index-query-where search-model where-clause)
        t2/reducible-query
        (eduction (map #(assoc % :model search-model)))))
 

--- a/src/metabase/search/postgres/ingestion.clj
+++ b/src/metabase/search/postgres/ingestion.clj
@@ -94,7 +94,7 @@
        (sql.helpers/where where-clause))))
 
 (defn- spec-index-reducible [search-model & [where-clause]]
-  (->> (spec-index-query-where search-model where-clause)
+  (->> (spec-index-query search-model where-clause)
        t2/reducible-query
        (eduction (map #(assoc % :model search-model)))))
 

--- a/src/metabase/search/postgres/ingestion.clj
+++ b/src/metabase/search/postgres/ingestion.clj
@@ -146,7 +146,7 @@
       (search.index/delete! id search-models))))
 
 (defn- index-model-entries [search-model where-clause]
-  (-> (#'metabase.search.postgres.ingestion/spec-index-query search-model)
+  (-> (spec-index-query search-model)
       (sql.helpers/where where-clause)))
 
 (comment

--- a/src/metabase/search/spec.clj
+++ b/src/metabase/search/spec.clj
@@ -233,7 +233,6 @@
 (defmacro define-spec
   "Define a spec for a search model."
   [search-model spec]
-  ;; TODO validate spec shape, consistency, and completeness
   `(let [spec# (-> ~spec
                    (assoc :name ~search-model)
                    (update :attrs #(merge ~default-attrs %)))]

--- a/test/metabase/search/postgres/index_test.clj
+++ b/test/metabase/search/postgres/index_test.clj
@@ -85,7 +85,7 @@
 
         (t2/update! :model/Database db-id {:name alternate-name})
         ;; TODO wire up an actual hook
-        (search.ingestion/update-index! (t2/select-one :model/Table :id table-id))
+        (search.ingestion/update-index! (t2/select-one :model/Database :id db-id))
 
         (is (= alternate-name (db-name-fn)))))))
 

--- a/test/metabase/search/postgres/index_test.clj
+++ b/test/metabase/search/postgres/index_test.clj
@@ -48,6 +48,20 @@
       (search.ingestion/populate-index!)
       (is (= rows-before (count-rows))))))
 
+(deftest incremental-update-test
+  (with-index
+   (testing "The index is updated when models change"
+     ;; The second entry is "Revenue Project(ions)"
+     (is (= 2 (count (search.index/search "Projected Revenue"))))
+     (is (= 0 (count (search.index/search "Protected Avenue"))))
+
+     (t2/update! :model/Card {:name "Projected Revenue"} {:name "Protected Avenue"})
+     ;; TODO wire up an actual hook
+     (search.ingestion/update-index! (t2/select-one :model/Card :name "Protected Avenue"))
+
+     (is (= 1 (count (search.index/search "Projected Revenue"))))
+     (is (= 1 (count (search.index/search "Protected Avenue")))))))
+
 (deftest consistent-subset-test
   (with-index
     (testing "It's consistent with in-place search on various full words"

--- a/test/metabase/search/postgres/index_test.clj
+++ b/test/metabase/search/postgres/index_test.clj
@@ -75,7 +75,7 @@
   (with-index
     (testing "The index is updated when model dependencies change"
       (let [index-table    @#'search.index/active-table
-            table-id   (t2/select-one-pk :model/Table :name "Indexed Table")
+            table-id       (t2/select-one-pk :model/Table :name "Indexed Table")
             legacy-input   #(-> (t2/select-one [index-table :legacy_input] :model "table" :model_id table-id)
                                 :legacy_input
                                 (json/parse-string true))

--- a/test/metabase/search/postgres/index_test.clj
+++ b/test/metabase/search/postgres/index_test.clj
@@ -60,7 +60,13 @@
      (search.ingestion/update-index! (t2/select-one :model/Card :name "Protected Avenue"))
 
      (is (= 1 (count (search.index/search "Projected Revenue"))))
-     (is (= 1 (count (search.index/search "Protected Avenue")))))))
+     (is (= 1 (count (search.index/search "Protected Avenue"))))
+
+     ;; TODO wire up the actual hook, and actually delete it
+     (search.ingestion/delete-model! (t2/select-one :model/Card :name "Protected Avenue"))
+
+     (is (= 1 (count (search.index/search "Projected Revenue"))))
+     (is (= 0 (count (search.index/search "Protected Avenue")))))))
 
 (deftest consistent-subset-test
   (with-index

--- a/test/metabase/search/postgres/index_test.clj
+++ b/test/metabase/search/postgres/index_test.clj
@@ -68,6 +68,22 @@
      (is (= 1 (count (search.index/search "Projected Revenue"))))
      (is (= 0 (count (search.index/search "Protected Avenue")))))))
 
+(deftest related-update-test
+  (with-index
+   (testing "The index is updated when models change"
+     ;; The second entry is "Revenue Project(ions)"
+     (is (= 2 (count #p (search.index/search "Trash"))))
+
+     (t2/update! :model/Card {:name "Projected Revenue"} {:name "Protected Avenue"})
+     ;; TODO wire up an actual hook
+     (search.ingestion/update-index! (t2/select-one :model/Card :name "Protected Avenue"))
+
+     (is (= 1 (count (search.index/search "Projected Revenue"))))
+     (is (= 1 (count (search.index/search "Protected Avenue"))))
+
+     (is (= 1 (count (search.index/search "Projected Revenue"))))
+     (is (= 0 (count (search.index/search "Protected Avenue")))))))
+
 (deftest consistent-subset-test
   (with-index
     (testing "It's consistent with in-place search on various full words"

--- a/test/metabase/search/spec_test.clj
+++ b/test/metabase/search/spec_test.clj
@@ -58,7 +58,8 @@
   ;; TODO replace real specs with frozen test ones once things have stabilized
 
   (is (= #:model{:Card             #{{:search-model "card",
-                                      :fields       #{:description
+                                      :fields       #{:id
+                                                      :description
                                                       :archived
                                                       :archived_directly
                                                       :collection_position


### PR DESCRIPTION
This PR puts the reverse mapping of `{column changes => related search model instances}` to work.

It does not yet wire this machinery up to the models actual hooks, because:

1. Performance concerns.
2. [Inability to know what change in after-update](https://github.com/camsaul/toucan2/issues/129)
3. A plan to handle cascading deletes.