### PR TITLE
Assume question is dirty when edited from notebook

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -10,6 +10,7 @@ import {
   createNativeQuestion,
   createQuestion,
   echartsContainer,
+  editDashboard,
   enterCustomColumnDetails,
   entityPickerModal,
   entityPickerModalTab,
@@ -37,8 +38,11 @@ import {
   restore,
   resyncDatabase,
   rightSidebar,
+  saveDashboard,
   saveQuestion,
   setModelMetadata,
+  showDashboardCardActions,
+  sidebar,
   sidesheet,
   startNewQuestion,
   summarize,
@@ -2258,3 +2262,98 @@ function expectNoScrollbarContainer(element) {
 
   expect(hasScrollbarContainer).to.be.false;
 }
+
+describe("issue 48829", () => {
+  const questionDetails = {
+    name: "Issue 48829",
+    query: {
+      "source-table": PRODUCTS_ID,
+    },
+  };
+
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should not show the unsaved changes warning when switching back to chill mode from the notebook editor after adding a filter from headers (metabase#48829)", () => {
+    createQuestion(questionDetails, { visitQuestion: true });
+
+    tableHeaderClick("Category");
+    popover().findByText("Filter by this column").click();
+    popover().within(() => {
+      cy.findByText("Doohickey").click();
+      cy.findByText("Add filter").click();
+    });
+
+    queryBuilderHeader().button("Show Editor").click();
+    getNotebookStep("filter")
+      .findAllByTestId("notebook-cell-item")
+      .icon("close")
+      .should("be.visible")
+      .click();
+
+    visualize();
+
+    modal().should("not.exist");
+  });
+
+  it("should not show the unsaved changes warning when switching back to chill mode from the notebook editor after adding a filter via the filter modal (metabase#48829)", () => {
+    createQuestion(questionDetails, { visitQuestion: true });
+
+    queryBuilderHeader().button("Filter").click();
+    modal().within(() => {
+      cy.findByText("Doohickey").click();
+      cy.button("Apply filters").click();
+    });
+
+    queryBuilderHeader().button("Show Editor").click();
+    getNotebookStep("filter")
+      .findAllByTestId("notebook-cell-item")
+      .icon("close")
+      .should("be.visible")
+      .click();
+
+    visualize();
+
+    modal().should("not.exist");
+  });
+
+  it("should not show the unsaved changes warning when switching back to chill mode from the notebook editor after visiting a filtered question from a dashboard click action (metabase#48829)", () => {
+    // Set up dashboard
+    cy.createDashboardWithQuestions({ questions: [questionDetails] }).then(
+      ({ dashboard }) => {
+        visitDashboard(dashboard.id);
+      },
+    );
+
+    showDashboardCardActions();
+    editDashboard();
+    getDashboardCard().findByLabelText("Click behavior").click();
+
+    sidebar().within(() => {
+      cy.findByText("Title").click();
+      cy.findByText("Go to a custom destination").click();
+      cy.findByText("Saved question").click();
+    });
+
+    entityPickerModal().findByText(questionDetails.name).click();
+    sidebar().findByTestId("click-mappings").findByText("Title").click();
+    popover().findByText("Title").click();
+    saveDashboard();
+
+    // Navigate to question using click action in dashboard
+    main().findByText("Rustic Paper Wallet").click();
+
+    queryBuilderHeader().button("Show Editor").click();
+    getNotebookStep("filter")
+      .findAllByTestId("notebook-cell-item")
+      .icon("close")
+      .should("be.visible")
+      .click();
+
+    visualize();
+
+    modal().should("not.exist");
+  });
+});

--- a/frontend/src/metabase/query_builder/actions/navigation.js
+++ b/frontend/src/metabase/query_builder/actions/navigation.js
@@ -15,6 +15,7 @@ import {
   getOriginalQuestion,
   getQueryBuilderMode,
   getQuestion,
+  getUiControls,
   getZoomedObjectId,
 } from "../selectors";
 import { getQueryBuilderModeFromLocation } from "../typed-utils";
@@ -142,6 +143,7 @@ export const updateUrl = createThunkAction(
 
       if (dirty == null) {
         const originalQuestion = getOriginalQuestion(getState());
+        const uiControls = getUiControls(getState());
         const isAdHocModelOrMetric = isAdHocModelOrMetricQuestion(
           question,
           originalQuestion,
@@ -149,7 +151,8 @@ export const updateUrl = createThunkAction(
         dirty =
           !originalQuestion ||
           (!isAdHocModelOrMetric &&
-            question.isDirtyComparedTo(originalQuestion));
+            (question.isDirtyComparedTo(originalQuestion) ||
+              uiControls.isModifiedFromNotebook));
       }
 
       const { isNative } = Lib.queryDisplayInfo(question.query());


### PR DESCRIPTION

Closes https://github.com/metabase/metabase/issues/48829

### Description

There are some cases where editing a question in place can cause the unsaved changes modal to show up unwanted when removing a filter.

### Scenario A: when navigating to a question from a dashboard click action
1. New > Question > Orders > Visualize > Save
2. Add this (or any other) question to dashboard
3. Configure click behavior for this dashcard:
    - choose any source column
    - set saved question from step 1 as target
    - choose any target column
4. Save
5. Try out the click behavior
6. You're now taken to chill mode
7. Click "Show editor"
8. Remove the filter
9. Click "Visualize" or "Show Visualization"

❌ Unsaved changes warning is shown

### Scenario B: when adding a filter via a column header

1. New > Question > Orders > Visualize > Save
2. Navigate to the question
3. Add a filter to the question (by clicking on a header and selecting Filter on this column)
4. Show Editor
5. Remove the filter
6. Visualize

❌ Unsaved changes warning is shown

This PR fixes both these instances.

### How to verify

Execute both scenarios and make sure no unsaved changes warning is shown.
