### PR TITLE
Make sure metrics migration populates all permissions fields

### DIFF
--- a/src/metabase/db/custom_migrations/metrics_v2.clj
+++ b/src/metabase/db/custom_migrations/metrics_v2.clj
@@ -23,8 +23,11 @@
                                 :collection
                                 {:name coll-name, :slug slug, :description desc})]
              (let [all-users-group-id (t2/select-one-fn :id :permissions_group :name "All Users")]
-               (t2/insert! :permissions {:object   (format "/collection/%s/read/" collection-id)
-                                         :group_id all-users-group-id}))
+               (t2/insert! :permissions {:object        (format "/collection/%s/read/" collection-id)
+                                         :group_id      all-users-group-id
+                                         :perm_type     "perms/collection-access"
+                                         :perm_value    "read"
+                                         :collection_id collection-id}))
              collection-id))))))
 
 (defn- add-metric-id

--- a/test/metabase/db/custom_migrations/metrics_v2_test.clj
+++ b/test/metabase/db/custom_migrations/metrics_v2_test.clj
@@ -233,8 +233,11 @@
               rewritten-query (-> rewritten-card :dataset_query normalized-query)]
           (is (= 1 (count metric-cards)))
           (is (int? card-id))
-          (is (=? [{:object (str "/collection/" (:id migration-coll) "/read/")
-                    :group_id 1}]
+          (is (=? [{:object        (str "/collection/" (:id migration-coll) "/read/")
+                    :group_id      1
+                    :collection_id (:id migration-coll)
+                    :perm_type     "perms/collection-access"
+                    :perm_value    "read"}]
                   coll-permissions))
           (is (= original-query (:dataset_query_metrics_v2_migration_backup rewritten-card)))
           (is (query-validator rewritten-query))


### PR DESCRIPTION
Identical root cause to https://github.com/metabase/metabase/pull/48746

We're relying on the presence of the new `collection_id`, `perm_type` and `perm_value` fields on the `permissions` table when listing collections for a user, but these weren't being populated by the metrics migration, probably because they're not (yet) required fields on the table.

Fixes https://github.com/metabase/metabase/issues/49357