### PR TITLE
[util] Add `u.time/local-date`, `local-time` and `local-date-time`

### DIFF
--- a/src/metabase/util/time.cljc
+++ b/src/metabase/util/time.cljc
@@ -30,7 +30,10 @@
   unit-diff
   truncate
   add
-  format-for-base-type])
+  format-for-base-type
+  local-date
+  local-date-time
+  local-time])
 
 (defn- prep-options [options]
   (merge internal/default-options (u/normalize-map options)))

--- a/src/metabase/util/time/impl.clj
+++ b/src/metabase/util/time/impl.clj
@@ -222,6 +222,52 @@
   [value]
   (t/local-time value))
 
+;;; ----------------------------------------------- constructors -----------------------------------------------------
+(defn local-time
+  "Constructs a platform time value (eg. Moment, LocalTime) for the given hour and minute, plus optional seconds and
+  milliseconds.
+
+  If called with no arguments, returns the current time."
+  ([]
+   (t/local-time))
+  ([hours minutes]
+   (local-time hours minutes 0 0))
+  ([hours minutes seconds]
+   (local-time hours minutes seconds 0))
+  ([hours minutes seconds millis]
+   (t/local-time hours minutes seconds (* 1000000 millis))))
+
+(defn local-date
+  "Constructs a platform date value (eg. Moment, LocalDate) for the given year, month and day.
+
+  Day is 1-31. January = 1, or you can specify keywords like `:jan`, `:jun`.
+
+  If called with no arguments, returns the current date."
+  ([]
+   (t/local-date))
+  ([year month day]
+   (t/local-date year
+                 (or (common/month-keywords month) month)
+                 day)))
+
+(defn local-date-time
+  "Constructs a platform datetime (eg. Moment, LocalDateTime).
+
+  Accepts either:
+  - no arguments (returns the current datetime)
+  - a local date and local time (see [[local-date]] and [[local-time]]); or
+  - year, month, day, hour, and minute, plus optional seconds and millis."
+  ([]
+   (t/local-date-time))
+  ([a-date a-time]
+   (t/local-date-time a-date a-time))
+  ([year month day hours minutes]
+   (local-date-time (local-date year month day) (local-time hours minutes)))
+  ([year month day hours minutes seconds]
+   (local-date-time (local-date year month day) (local-time hours minutes seconds)))
+  ([year month day hours minutes seconds millis]
+   (local-date-time (local-date year month day) (local-time hours minutes seconds millis))))
+
 ;;; ------------------------------------------------ arithmetic ------------------------------------------------------
 
 (defn unit-diff

--- a/src/metabase/util/time/impl_common.cljc
+++ b/src/metabase/util/time/impl_common.cljc
@@ -111,3 +111,20 @@
   [time-str]
   (or (second (re-matches (re-pattern (str "(.*?)" (optional offset-part) \$)) time-str))
       time-str))
+
+(def ^:const month-keywords
+  "Mapping of human-friendly keywords to literal month numbers.
+
+  1 = January."
+  {:jan 1
+   :feb 2
+   :mar 3
+   :apr 4
+   :may 5
+   :jun 6
+   :jul 7
+   :aug 8
+   :sep 9
+   :oct 10
+   :nov 11
+   :dec 12})


### PR DESCRIPTION
### Description

These are helpful for creating literal dates and times in a
cross-platform way. Useful for generating queries, in particular for
expression and filter values.

### How to verify

See the unit tests. They're working nicely in the generative testing branches.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
