### PR TITLE
[MBQL lib] Match implicitly joined refs with multiple paths

### DIFF
--- a/src/metabase/lib/equality.cljc
+++ b/src/metabase/lib/equality.cljc
@@ -128,13 +128,11 @@
 (mu/defn- matching-join? :- :boolean
   [[_ref-kind {:keys [join-alias source-field]} _ref-id] :- ::lib.schema.ref/ref
    column                                                :- ::lib.schema.metadata/column]
-  ;; If the ref has a source-field, and it matches the column's :fk-field-id then this is an implicitly joined field.
-  ;; Implicitly joined columns have :source-alias ("PRODUCTS__via__PRODUCT_ID") but the refs don't have any join alias.
-  (or (and source-field
-           (clojure.core/= source-field (:fk-field-id column)))
-      ;; If it's not an implicit join, then either the join aliases must match for an explicit join, or both be nil for
-      ;; an own column.
-      (clojure.core/= (column-join-alias column) join-alias)))
+  (if source-field
+    (clojure.core/= source-field (:fk-field-id column))
+    ;; If it's not an implicit join, then either the join aliases must match for an explicit join, or both be nil for
+    ;; an own column.
+    (clojure.core/= (column-join-alias column) join-alias)))
 
 (mu/defn- plausible-matches-for-name :- [:sequential ::lib.schema.metadata/column]
   [[_ref-kind opts ref-name :as a-ref] :- ::lib.schema.ref/ref

--- a/test/metabase/lib/equality_test.cljc
+++ b/test/metabase/lib/equality_test.cljc
@@ -677,3 +677,16 @@
               (lib.equality/find-matching-ref (first columns) column-refs)))
       (is (=? [:field {} "CREATED_AT_2"]
               (lib.equality/find-matching-ref (second columns) column-refs))))))
+
+(deftest ^:parallel find-matching-column-multiple-implicit-joins-test
+  (testing "when there are multiple implicit joins for the same column, matches correctly"
+    (let [base      (lib/query meta/metadata-provider (meta/table-metadata :ic/reports))
+          columns   (lib.metadata.calculation/visible-columns base)
+          by-id     (group-by :id columns)
+          name-cols (by-id (meta/id :ic/accounts :name))]
+      (is (= 2 (count name-cols)))
+      (doseq [col name-cols
+              :let [query (lib/filter base (lib/= col "foo"))
+                    cols  (lib.metadata.calculation/visible-columns query)
+                    [_op _opts filter-col] (first (lib/filters query))]]
+        (is (=? col (lib.equality/find-matching-column query -1 filter-col cols)))))))


### PR DESCRIPTION
### Description

The ref (usually) contains enough information to unambiguously find the
matching implictly-joined column, even if there are several FKs that
could join the target table.

The remaining ambiguous case is if the *same* FK column exists
multiple times - current MBQL uses raw field IDs for the FK field, so it
can't distinguish between eg. an FK in the main table and the one from a
self-join.


**A second lib bug found by generative testing without actually trying!**

### How to verify

See the unit tests.

To trigger this bug:


1. Create a query on table with multiple FKs to a single target table.
    - There is not such a table in the Sample Database.
2. Implicitly join some column from the target table
3. Try to edit or otherwise interact with that clause.
4. Receive ambiguity errors in the console, and/or odd behaviour like (de)selecting both at once in the `:fields` list.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
