### PR TITLE
Docs: update custom expressions limitations

### DIFF
--- a/docs/questions/query-builder/expressions-list.md
+++ b/docs/questions/query-builder/expressions-list.md
@@ -147,7 +147,7 @@ Syntax: `Median(column)`.
 
 Example: `Median([Age])` would find the midpoint age where half of the ages are older, and half of the ages are younger.
 
-Databases that don't support `median`: MariaDB, MySQL, SQLite, Vertica, and SQL Server. Presto only provides approximate results.
+Databases that don't support `median`: Druid, MariaDB, MongoDB, MySQL, SQLite, Vertica, and SQL Server. Presto only provides approximate results.
 
 Related: [Min](#min), [Max](#max), [Average](#average).
 
@@ -169,7 +169,7 @@ Syntax: `Percentile(column, percentile-value)`
 
 Example: `Percentile([Score], 0.9)` would return the value at the 90th percentile for all values in that column.
 
-Databases that don't support `percentile`: H2, MariaDB, MySQL, SQL Server, SQLite, Vertica. Presto only provides approximate results.
+Databases that don't support `percentile`: Druid, H2, MariaDB, MySQL, MongoDB, SQL Server, SQLite, Vertica. Presto only provides approximate results.
 
 ### Share
 
@@ -186,6 +186,8 @@ Calculates the standard deviation of the column, which is a measure of the varia
 Syntax: `StandardDeviation(column)`
 
 Example: `StandardDeviation([Population])` would return the SD for the values in the `Population` column.
+
+Databases that don't support `StandardDeviation`: Druid, SQLite.
 
 ### Sum
 
@@ -212,6 +214,8 @@ Syntax: `Variance(column)`
 Example: `Variance([Temperature])` will return a measure of the dispersion from the mean temperature for all temps in that column.
 
 Related: [StandardDeviation](#standarddeviation), [Average](#average).
+
+Databases that don't support `Variance`: Druid, SQLite.
 
 ## Functions
 
@@ -567,6 +571,8 @@ Syntax: `datetimeDiff(datetime1, datetime2, unit)`.
 
 Example: `datetimeDiff("2022-02-01", "2022-03-01", "month")` would return `1`.
 
+See the [database limitations](./expressions/datetimediff.md#limitations) for `datetimediff`.
+
 ### [datetimeSubtract](./expressions/datetimesubtract.md)
 
 Subtracts some unit of time from a date or timestamp value.
@@ -744,7 +750,7 @@ Related: [Sum](#sum) and [SumIf](#sumif).
 
 ### Offset
 
-> ⚠️ The `Offset` function is currently unavailable for MySQL/MariaDB.
+> ⚠️ The `Offset` function is currently unavailable for MySQL/MariaDB, MongoDB, and Druid.
 
 For more info, check out our page on [Offset](./expressions/offset.md).
 
@@ -773,25 +779,31 @@ Example: `Offset(Sum([Total]), -1)` would get the `Sum([Total])` value from the 
 
 Limitations are noted for each aggregation and function above, and here there are in summary:
 
-**H2** (including Metabase Sample Database): `Median`, `Percentile`, `convertTimezone` and `regexextract`
+**H2** (including Metabase Sample Database): `Median`, `Percentile`, `convertTimezone` and `regexextract`.
 
-**Druid**: `regexextract` is only available for the Druid-JDBC driver.
+**Athena**: `convertTimezone`.
 
-**MongoDB**: `regexextract`
+**Databricks**: `convertTimezone`.
+
+**Druid**: `Median`, `Percentile`, `StandardDeviation`, `power`, `log`, `exp`, `sqrt`, `Offset`. Function `regexextract` is only available for the Druid-JDBC driver.
+
+**MongoDB**: `Median`, `Percentile`, `power`, `log`, `exp`, `sqrt`, `Offset`, `regexextract`
 
 **MariaDB**: `Median`, `Percentile`, `Offset`.
 
 **MySQL**: `Median`, `Percentile`, `Offset`.
 
-**Presto**: Only provides _approximate_ results for `Median` and `Percentile`.
+**Presto**: `convertTimezone`. Only provides _approximate_ results for `Median` and `Percentile`.
 
 **Redshift**: `Average` will return [integer results for integer columns](https://docs.aws.amazon.com/redshift/latest/dg/r_AVG.html#r_AVG-data-types).
 
-**SQL Server**: `Median`, `Percentile` and `regexextract`
+**SparkSQL**: `convertTimezone`.
 
-**SQLite**: `log`, `Median`, `Percentile`, `power`, `regexextract`, `StandardDeviation`, `sqrt` and `Variance`
+**SQL Server**: `Median`, `Percentile` and `regexextract`.
 
-**Vertica**: `Median` and `Percentile`
+**SQLite**: `exp`, `log`, `Median`, `Percentile`, `power`, `regexextract`, `StandardDeviation`, `sqrt` and `Variance`.
+
+**Vertica**: `Median` and `Percentile`.
 
 If you're using or maintaining a third-party database driver, please [refer to the wiki](https://github.com/metabase/metabase/wiki/What's-new-in-0.35.0-for-Metabase-driver-authors) to see how your driver might be impacted.
 

--- a/docs/questions/query-builder/expressions/converttimezone.md
+++ b/docs/questions/query-builder/expressions/converttimezone.md
@@ -87,12 +87,12 @@ For more gory details, see [Limitations](#limitations).
 ## Accepted data types
 
 | [Data type](https://www.metabase.com/learn/grow-your-data-skills/data-fundamentals/data-types-overview#examples-of-data-types) | Works with `convertTimezone` |
-| ------------------------------------------------------------------------------------------------ | ---------------------------- |
-| String                                                                                           | ❌                           |
-| Number                                                                                           | ❌                           |
-| Timestamp                                                                                        | ✅                           |
-| Boolean                                                                                          | ❌                           |
-| JSON                                                                                             | ❌                           |
+| ------------------------------------------------------------------------------------------------------------------------------ | ---------------------------- |
+| String                                                                                                                         | ❌                           |
+| Number                                                                                                                         | ❌                           |
+| Timestamp                                                                                                                      | ✅                           |
+| Boolean                                                                                                                        | ❌                           |
+| JSON                                                                                                                           | ❌                           |
 
 We use "timestamp" and "datetime" to talk about any temporal data type that's supported by Metabase.
 
@@ -115,6 +115,7 @@ Note that the first part of the timestamp is in UTC (same thing as GMT). The tim
 `convertTimezone` is currently unavailable for the following databases:
 
 - Amazon Athena
+- Databricks
 - Druid
 - MongoDB
 - Presto

--- a/docs/questions/query-builder/expressions/offset.md
+++ b/docs/questions/query-builder/expressions/offset.md
@@ -4,7 +4,7 @@ title: Offset
 
 # Offset
 
-> ⚠️ The `Offset` function is currently unavailable for MySQL/MariaDB.
+> ⚠️ The `Offset` function is currently unavailable for MySQL/MariaDB, MongoDB, and Druid.
 
 The `Offset` function returns the value of an expression in a different row. `Offset` can only be used in the query builder's Summarize step (you cannot use `Offset` to create a custom column).
 
@@ -25,12 +25,12 @@ Because `Offset` refers to other rows, the order of the breakouts matters (the b
 The `Offset` function returns whatever value is in the offset row.
 
 | [Data type](https://www.metabase.com/learn/grow-your-data-skills/data-fundamentals/data-types-overview#examples-of-data-types) | Returned by `Offset` |
-| ------------------------------------------------------------------------------------------------ | -------------------- |
-| String                                                                                           | ✅                    |
-| Number                                                                                           | ✅                    |
-| Timestamp                                                                                        | ✅                    |
-| Boolean                                                                                          | ✅                    |
-| JSON                                                                                             | ✅                    |
+| ------------------------------------------------------------------------------------------------------------------------------ | -------------------- |
+| String                                                                                                                         | ✅                   |
+| Number                                                                                                                         | ✅                   |
+| Timestamp                                                                                                                      | ✅                   |
+| Boolean                                                                                                                        | ✅                   |
+| JSON                                                                                                                           | ✅                   |
 
 ## Example year-over-year (YoY) time series comparison using `Offset`
 
@@ -85,7 +85,6 @@ The above expression adds up this period's total, plus the totals for the previo
 The `Offset` function compares with SQL's `LAG` and `LEAD` window functions.
 
 For example, if you're trying to create a line chart with two series to compare a) this month's order counts with b) the previous month's order counts, you'd `count` the orders for this month, then use an `offset` expression to count the previous month's orders, like so:
-
 
 ```
 Offset(count, -1)


### PR DESCRIPTION
syncing up limitations with a source of truth is gonna be a whole Project (tm) because the internal Notion DB tier doc seems to be incorrect in multiple places.

While the Project(tm) is shaping up, we should still give correct information to people.

I got this from cross-checking Notion DB Tier doc  with the driver source code.