### PR TITLE
feat(sdk): Add `isOpen` prop to control CreateDashboardModal

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.stories.tsx
@@ -1,6 +1,10 @@
 import { action } from "@storybook/addon-actions";
 import type { StoryFn } from "@storybook/react";
-import { type JSXElementConstructor, useState } from "react";
+import {
+  type ComponentProps,
+  type JSXElementConstructor,
+  useState,
+} from "react";
 
 import { EditableDashboard } from "embedding-sdk/components/public";
 import { CommonSdkStoryWrapper } from "embedding-sdk/test/CommonSdkStoryWrapper";
@@ -19,15 +23,20 @@ export default {
   decorators: [CommonSdkStoryWrapper],
 };
 
-const Template: StoryFn<typeof CreateDashboardModal> = () => (
+const Template: StoryFn<ComponentProps<typeof CreateDashboardModal>> = args => (
   <CreateDashboardModal
     onClose={action("onClose")}
     onCreate={action("onCreate")}
+    {...args}
   />
 );
 
 export const Default = {
   render: Template,
+
+  args: {
+    isOpen: true,
+  },
 };
 
 const HookTemplate: StoryFn<

--- a/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.tsx
@@ -9,15 +9,19 @@ import type { State } from "metabase-types/store";
 
 export interface CreateDashboardModalProps {
   initialCollectionId?: CollectionId | null;
+  isOpen?: boolean;
   onCreate: (dashboard: Dashboard) => void;
   onClose?: () => void;
 }
 
-const CreateDashboardModalInner = (props: CreateDashboardModalProps) => {
-  const { initialCollectionId, onCreate, onClose } = props;
-
+const CreateDashboardModalInner = ({
+  initialCollectionId,
+  isOpen = true,
+  onCreate,
+  onClose,
+}: CreateDashboardModalProps) => {
   return (
-    <Modal onClose={onClose}>
+    <Modal isOpen={isOpen} onClose={onClose}>
       <CreateDashboardModalConnected
         onCreate={onCreate}
         onClose={onClose}

--- a/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.unit.spec.tsx
@@ -104,12 +104,26 @@ describe("CreateDashboardModal", () => {
     expect(onCreate).toHaveBeenCalledTimes(1);
     expect(onCreate).toHaveBeenLastCalledWith(mockResponseDashboard);
   });
+
+  it('should support "isOpen" prop', () => {
+    const { rerender } = setup({
+      props: {
+        isOpen: false,
+      },
+    });
+
+    expect(screen.queryByText("New dashboard")).not.toBeInTheDocument();
+
+    rerender(<CreateDashboardModal isOpen />);
+
+    expect(screen.getByText("New dashboard")).toBeInTheDocument();
+  });
 });
 
 function setup({ props }: { props?: Partial<CreateDashboardModalProps> } = {}) {
   setupCollectionByIdEndpoint({ collections: COLLECTIONS });
 
-  renderWithProviders(<CreateDashboardModal {...props} />, {
+  return renderWithProviders(<CreateDashboardModal {...props} />, {
     mode: "sdk",
     sdkProviderProps: {
       config: createMockJwtConfig(),


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/49325

### Description

Add isOpen prop to control CreateDashboardModal visibility

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Run SDK storybook
2. Check CreateDashboardModal > Default story

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
