### PR TITLE
Enable debugUnreturnedConnectionStackTraces in data-warehouse-connection-pool-properties

### DIFF
--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -1879,6 +1879,20 @@ This variable affects connections that are severed and undetected by Metabase (t
 
 Unless set otherwise, the default production value for `metabase.query-processor.query-timeout-ms` is used which is 1,200,000 ms (i.e. 1,200 seconds or 20 minutes).
 
+### `MB_JDBC_DATA_WAREHOUSE_DEBUG_UNRETURNED_CONNECTION_STACK_TRACES`
+
+Type: boolean<br>
+Default: `false`<br>
+Since: v51.3
+
+If `true`, log a stack trace for any connections killed due to exceeding the timeout specified in [MB_JDBC_DATA_WAREHOUSE_UNRETURNED_CONNECTION_TIMEOUT_SECONDS](#mb_jdbc_data_warehouse_unreturned_connection_timeout_seconds).
+
+Note: In addtion to enabling this variable, you need to update the com.mchange log level to INFO or higher via a custom log4j configuration in order to see the stack traces in the logs.
+
+See the [Metabase log configuration](./log-configuration.md) documentation for how to configure log levels.
+
+See [MB_JDBC_DATA_WAREHOUSE_UNRETURNED_CONNECTION_TIMEOUT_SECONDS](#mb_jdbc_data_warehouse_unreturned_connection_timeout_seconds) for setting the timeout after which connections will be killed.
+
 ### `MB_JETTY_ASYNC_RESPONSE_TIMEOUT`
 
 Type: integer<br>

--- a/src/metabase/cmd/resources/other-env-vars.md
+++ b/src/metabase/cmd/resources/other-env-vars.md
@@ -221,6 +221,20 @@ This variable affects connections that are severed and undetected by Metabase (t
 
 Unless set otherwise, the default production value for `metabase.query-processor.query-timeout-ms` is used which is 1,200,000 ms (i.e. 1,200 seconds or 20 minutes).
 
+### `MB_JDBC_DATA_WAREHOUSE_DEBUG_UNRETURNED_CONNECTION_STACK_TRACES`
+
+Type: boolean<br>
+Default: `false`<br>
+Since: v51.3
+
+If `true`, log a stack trace for any connections killed due to exceeding the timeout specified in [MB_JDBC_DATA_WAREHOUSE_UNRETURNED_CONNECTION_TIMEOUT_SECONDS](#mb_jdbc_data_warehouse_unreturned_connection_timeout_seconds).
+
+Note: In addtion to enabling this variable, you need to update the com.mchange log level to INFO or higher via a custom log4j configuration in order to see the stack traces in the logs.
+
+See the [Metabase log configuration](./log-configuration.md) documentation for how to configure log levels.
+
+See [MB_JDBC_DATA_WAREHOUSE_UNRETURNED_CONNECTION_TIMEOUT_SECONDS](#mb_jdbc_data_warehouse_unreturned_connection_timeout_seconds) for setting the timeout after which connections will be killed.
+
 ### `MB_JETTY_ASYNC_RESPONSE_TIMEOUT`
 
 Type: integer<br>

--- a/src/metabase/cmd/resources/other-env-vars.md
+++ b/src/metabase/cmd/resources/other-env-vars.md
@@ -229,11 +229,9 @@ Since: v51.3
 
 If `true`, log a stack trace for any connections killed due to exceeding the timeout specified in [MB_JDBC_DATA_WAREHOUSE_UNRETURNED_CONNECTION_TIMEOUT_SECONDS](#mb_jdbc_data_warehouse_unreturned_connection_timeout_seconds).
 
-Note: In addtion to enabling this variable, you need to update the com.mchange log level to INFO or higher via a custom log4j configuration in order to see the stack traces in the logs.
+In order to see the stack traces in the logs, you'll also need to update the com.mchange log level to "INFO" or higher via a custom log4j configuration. For configuring log levels, see [Metabase log configuration](./log-configuration.md).
 
-See the [Metabase log configuration](./log-configuration.md) documentation for how to configure log levels.
-
-See [MB_JDBC_DATA_WAREHOUSE_UNRETURNED_CONNECTION_TIMEOUT_SECONDS](#mb_jdbc_data_warehouse_unreturned_connection_timeout_seconds) for setting the timeout after which connections will be killed.
+To set a timeout for how long Metabase should wait before it kills unreturned connections, see [MB_JDBC_DATA_WAREHOUSE_UNRETURNED_CONNECTION_TIMEOUT_SECONDS](#mb_jdbc_data_warehouse_unreturned_connection_timeout_seconds).
 
 ### `MB_JETTY_ASYNC_RESPONSE_TIMEOUT`
 

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -137,9 +137,16 @@ For setting the maximum, see [MB_APPLICATION_DB_MAX_CONNECTION_POOL_SIZE](#mb_ap
    ;;
    ;; Kill idle connections above the minPoolSize after 5 minutes.
    "maxIdleTimeExcessConnections" (* 5 60)
-   ;; kill connections after this amount of time if they haven't been returned -- this should be the same as the query
-   ;; timeout. This theoretically shouldn't happen since the QP should kill things after a certain timeout but it's
-   ;; better to be safe than sorry -- it seems like in practice some connections disappear into the ether
+   ;; [From dox] Seconds. If set, if an application checks out but then fails to check-in [i.e. close()] a Connection
+   ;; within the specified period of time, the pool will unceremoniously destroy() the Connection. This permits
+   ;; applications with occasional Connection leaks to survive, rather than eventually exhausting the Connection
+   ;; pool. And that's a shame. Zero means no timeout, applications are expected to close() their own
+   ;; Connections. Obviously, if a non-zero value is set, it should be to a value longer than any Connection should
+   ;; reasonably be checked-out. Otherwise, the pool will occasionally kill Connections in active use, which is bad.
+   ;;
+   ;; This should be the same as the query timeout. This theoretically shouldn't happen since the QP should kill
+   ;; things after a certain timeout but it's better to be safe than sorry -- it seems like in practice some
+   ;; connections disappear into the ether
    "unreturnedConnectionTimeout"  (jdbc-data-warehouse-unreturned-connection-timeout-seconds)
    ;; Set the data source name so that the c3p0 JMX bean has a useful identifier, which incorporates the DB ID, driver,
    ;; and name from the details

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -109,15 +109,14 @@ For setting the maximum, see [MB_APPLICATION_DB_MAX_CONNECTION_POOL_SIZE](#mb_ap
   "Tell c3p0 to log a stack trace for any connections killed due to exceeding the timeout specified in
   [[jdbc-data-warehouse-unreturned-connection-timeout-seconds]].
 
-  Note: even if this value is set to true, the exceptions are not logged by default because we set the com.mchange log
-  level to ERROR in our log4j2.xml config, and c3p0 logs the exceptions at INFO level. You need to update the
-  com.mchange log level to INFO via a custom log4j config in order to see the stack traces in the logs."
+  Note: You also need to update the com.mchange log level to INFO or higher in the log4j configs in order to see the
+  stack traces in the logs."
   :visibility :internal
   :type       :boolean
   :default    false
   :export?    false
   :setter     :none
-  :doc        false)
+  :doc        false) ; This setting is documented in other-env-vars.md.
 
 (defmethod data-warehouse-connection-pool-properties :default
   [driver database]
@@ -170,10 +169,6 @@ For setting the maximum, see [MB_APPLICATION_DB_MAX_CONNECTION_POOL_SIZE](#mb_ap
    ;; is applications that occasionally fail to return Connections, leading to pool growth, and eventually
    ;; exhaustion (when the pool hits maxPoolSize with all Connections checked-out and lost). This parameter should
    ;; only be set while debugging, as capturing the stack trace will slow down every Connection check-out.
-   ;;
-   ;; N.B. Even if this is set to true, these exceptions are not actually logged by default because we set the
-   ;; com.mchange log level to ERROR in our log4j2.xml config, and c3p0 logs the exceptions at INFO level. Therefore,
-   ;; you need to update the log level to INFO via a custom log4j config in order to see the stack traces in the logs.
    ;;
    ;; As noted in the C3P0 docs, this does add some overhead to create the Exception at Connection checkout.
    ;; criterium/quick-bench indicates this is ~600ns of overhead per Exception created on my laptop, which is small

--- a/src/metabase/logger.clj
+++ b/src/metabase/logger.clj
@@ -82,6 +82,14 @@
     (name (ns-name a-namespace))
     (name a-namespace)))
 
+(defn level-enabled?
+  "Is logging at `level` enabled for `a-namespace`?"
+  (^Boolean [level]
+   (level-enabled? *ns* level))
+  (^Boolean [a-namespace level]
+   (let [^Logger logger (log.impl/get-logger log/*logger-factory* a-namespace)]
+     (.isEnabled logger level))))
+
 (defn effective-ns-logger
   "Get the logger that will be used for the namespace named by `a-namespace`."
   ^LoggerConfig [a-namespace]

--- a/test/metabase/driver/sql_jdbc/connection_test.clj
+++ b/test/metabase/driver/sql_jdbc/connection_test.clj
@@ -242,8 +242,16 @@
 
 (deftest ^:parallel include-debug-unreturned-connection-stack-traces-test
   (testing "We should be setting debugUnreturnedConnectionStackTraces (#47981)"
-    (is (=? {"debugUnreturnedConnectionStackTraces" true}
+    (is (=? {"debugUnreturnedConnectionStackTraces" boolean?}
             (sql-jdbc.conn/data-warehouse-connection-pool-properties :h2 (mt/db))))))
+
+(deftest debug-unreturned-connection-stack-traces-test
+  (testing "We should be able to set jdbc-data-warehouse-debug-unreturned-connection-stack-traces via env var (#47981)"
+    (doseq [setting [true false]]
+      (mt/with-temp-env-var-value! [mb-jdbc-data-warehouse-debug-unreturned-connection-stack-traces (str setting)]
+        (is (= setting
+               (sql-jdbc.conn/jdbc-data-warehouse-debug-unreturned-connection-stack-traces))
+            (str "setting=" setting))))))
 
 (defn- init-h2-tcp-server [port]
   (let [args   ["-tcp" "-tcpPort", (str port), "-tcpAllowOthers" "-tcpDaemon"]

--- a/test/metabase/driver/sql_jdbc/connection_test.clj
+++ b/test/metabase/driver/sql_jdbc/connection_test.clj
@@ -240,6 +240,11 @@
       (is (= 20
              (sql-jdbc.conn/jdbc-data-warehouse-unreturned-connection-timeout-seconds))))))
 
+(deftest ^:parallel include-debug-unreturned-connection-stack-traces-test
+  (testing "We should be setting debugUnreturnedConnectionStackTraces (#47981)"
+    (is (=? {"debugUnreturnedConnectionStackTraces" true}
+            (sql-jdbc.conn/data-warehouse-connection-pool-properties :h2 (mt/db))))))
+
 (defn- init-h2-tcp-server [port]
   (let [args   ["-tcp" "-tcpPort", (str port), "-tcpAllowOthers" "-tcpDaemon"]
         server (Server/createTcpServer (into-array args))]

--- a/test/metabase/driver/sql_jdbc/connection_test.clj
+++ b/test/metabase/driver/sql_jdbc/connection_test.clj
@@ -253,6 +253,29 @@
                (sql-jdbc.conn/jdbc-data-warehouse-debug-unreturned-connection-stack-traces))
             (str "setting=" setting))))))
 
+(deftest debug-unreturned-connection-stack-traces-misconfigured-c3p0-log-warning-test
+  (testing "We should log a warning if debug stack traces are enabled but c3p0 INFO logs are not (#47981)\n"
+    ;; kondo thinks the c3p0-log-level binding is unused
+    #_{:clj-kondo/ignore [:unused-binding]}
+    (letfn [(warning-found? [warnings]
+              (boolean (some #(str/includes?
+                               (:message %)
+                               "You must raise the log level for com.mchange to INFO")
+                             warnings)))
+            (warnings-logged? [c3p0-log-level setting warning-expected?]
+              (mt/with-temp-env-var-value! [mb-jdbc-data-warehouse-debug-unreturned-connection-stack-traces setting]
+                (mt/with-log-level [com.mchange c3p0-log-level]
+                  (mt/with-log-messages-for-level [warnings :warn]
+                    (and (= setting
+                            (get (sql-jdbc.conn/data-warehouse-connection-pool-properties :h2 (mt/db))
+                                 "debugUnreturnedConnectionStackTraces"))
+                         (= warning-expected? (warning-found? (warnings))))))))]
+      (are [c3p0-log-level setting warning-expected?] (warnings-logged? c3p0-log-level setting warning-expected?)
+        :error true  true
+        :error false false
+        :info  true  false
+        :info  false false))))
+
 (defn- init-h2-tcp-server [port]
   (let [args   ["-tcp" "-tcpPort", (str port), "-tcpAllowOthers" "-tcpDaemon"]
         server (Server/createTcpServer (into-array args))]

--- a/test/metabase/logger_test.clj
+++ b/test/metabase/logger_test.clj
@@ -9,6 +9,7 @@
    [metabase.logger :as logger]
    [metabase.test :as mt])
   (:import
+   (org.apache.logging.log4j Level)
    (org.apache.logging.log4j.core Logger)))
 
 (set! *warn-on-reflection* true)
@@ -94,3 +95,37 @@
         (finally
           (when (.exists f)
             (io/delete-file f)))))))
+
+(deftest level-enabled?-test
+  (are [set-level check-level expected-value] (= expected-value
+                                                 (mt/with-log-level [metabase.logger-test set-level]
+                                                   (logger/level-enabled? 'metabase.logger-test check-level)))
+    :error Level/ERROR true
+    :error Level/WARN  false
+    :error Level/INFO  false
+    :error Level/DEBUG false
+    :error Level/TRACE false
+
+    :warn Level/ERROR true
+    :warn Level/WARN  true
+    :warn Level/INFO  false
+    :warn Level/DEBUG false
+    :warn Level/TRACE false
+
+    :info Level/ERROR true
+    :info Level/WARN  true
+    :info Level/INFO  true
+    :info Level/DEBUG false
+    :info Level/TRACE false
+
+    :debug Level/ERROR true
+    :debug Level/WARN  true
+    :debug Level/INFO  true
+    :debug Level/DEBUG true
+    :debug Level/TRACE false
+
+    :trace Level/ERROR true
+    :trace Level/WARN  true
+    :trace Level/INFO  true
+    :trace Level/DEBUG true
+    :trace Level/TRACE true))


### PR DESCRIPTION
Closes #47981

### Description

Add a new `defsetting` for `jdbc-data-warehouse-debug-unreturned-connection-stack-traces` and enable [debugUnreturnedConnectionStackTraces](https://www.mchange.com/projects/c3p0/#debugUnreturnedConnectionStackTraces) in `data-warehouse-connection-pool-properties` when the corresponding setting is enabled.

This causes C3P0 to create and save an `Exception` object on connection checkout, and then log the associated stack trace  when/if it kills a connection due to exceeding the [unreturnedConnectionTimeout](https://www.mchange.com/projects/c3p0/#unreturnedConnectionTimeout).

The motivation is to help with debugging runaway connection pool issues when they occur in the wild.

A couple of things worth pointing out about debugUnreturnedConnectionStackTraces:

1. The stack traces are recorded at the time the connection is *checked out*, which may or may not be enough info to tell us why the connection ultimately got stuck. E.g. the logged stack traces probably won't point us to a smoking gun if the cause is a weird protocol error down in the driver.
2. Stack traces are only logged for connections that C3P0 ultimately decides to kill due to exceeding the unreturnedConnectionTimeout, so if the symptom is that we're seeing connection pool exhaustion issues, logging these stack traces is probably only going to help us if the cause for the connection pool exhaustion is that C3P0 is failing to actually kill/remove the connections (though of course it would still be good to clean these up and ensure we close them ourselves instead).

See also

https://www.mchange.com/projects/c3p0/#configuring_to_debug_and_workaround_broken_clients
 

### How to verify

At the REPL, in this case assuming you've already connected a mysql sample db

```clojure
(in-ns 'dev)
(require '[metabase.driver.sql-jdbc.connection :as sql-jdbc.conn])

(let [db (t2/select-one Database :name "MySQL Sample")]
  (sql-jdbc.conn/invalidate-pool-for-db! db)
  (mt/with-log-level [com.mchange.v2.resourcepool.BasicResourcePool :info]
    (mt/with-temporary-setting-values [jdbc-data-warehouse-unreturned-connection-timeout-seconds 1
                                       jdbc-data-warehouse-debug-unreturned-connection-stack-traces true]
      (mt/with-driver (:engine db)
        (mt/with-db db
          (qp/process-query (mt/native-query {:query "SELECT SLEEP(3)"})))))))
```

When running the application standalone, you need to

1. Set `MB_JDBC_DATA_WAREHOUSE_UNRETURNED_CONNECTION_TIMEOUT_SECONDS=true`
2. Raise the log level for the `com.mchange` namespace to INFO or higher via a [custom log4j config](https://www.metabase.com/docs/latest/configuring-metabase/log-configuration). (For dev purposes, just edit the file `resources/log4j2.xml`).


### Demo

Sample stack trace

```
2024-11-06 01:29:09,070 INFO resourcepool.BasicResourcePool :: A checked-out resource is overdue, and will be destroyed: com.mchange.v2.c3p0.impl.NewPooledConnection@159739c8
2024-11-06 01:29:09,072 INFO resourcepool.BasicResourcePool :: Logging the stack trace by which the overdue resource was checked-out.
java.lang.Exception: DEBUG STACK TRACE: Overdue resource check-out stack trace.
	at com.mchange.v2.resourcepool.BasicResourcePool.checkoutResource(BasicResourcePool.java:588)
	at com.mchange.v2.c3p0.impl.C3P0PooledConnectionPool.checkoutAndMarkConnectionInUse(C3P0PooledConnectionPool.java:758)
	at com.mchange.v2.c3p0.impl.C3P0PooledConnectionPool.checkoutPooledConnection(C3P0PooledConnectionPool.java:685)
	at com.mchange.v2.c3p0.impl.AbstractPoolBackedDataSource.getConnection(AbstractPoolBackedDataSource.java:140)
	at metabase.driver.sql_jdbc.execute$fn__148189$do_with_resolved_connection148188__148190.invoke(execute.clj:337)
	at metabase.driver.sql_jdbc.execute$fn__148189$fn__148193.invoke(execute.clj:321)
	at metabase.driver.sql_jdbc.execute$eval148240$fn__148241.invoke(execute.clj:392)
	at clojure.lang.MultiFn.invoke(MultiFn.java:244)
	at metabase.driver.sql_jdbc.execute$execute_reducible_query.invokeStatic(execute.clj:708)
	at metabase.driver.sql_jdbc.execute$execute_reducible_query.invoke(execute.clj:694)
	at metabase.driver.sql_jdbc.execute$execute_reducible_query.invokeStatic(execute.clj:705)
	at metabase.driver.sql_jdbc.execute$execute_reducible_query.invoke(execute.clj:694)
	at metabase.driver.sql_jdbc$eval150178$fn__150179.invoke(sql_jdbc.clj:79)
	at clojure.lang.MultiFn.invoke(MultiFn.java:244)
	at metabase.query_processor.pipeline$_STAR_execute_STAR_.invokeStatic(pipeline.clj:47)
	at metabase.query_processor.pipeline$_STAR_execute_STAR_.invoke(pipeline.clj:34)
	at metabase.query_processor.pipeline$_STAR_run_STAR_.invokeStatic(pipeline.clj:97)
	at metabase.query_processor.pipeline$_STAR_run_STAR_.invoke(pipeline.clj:90)
	at metabase.query_processor.execute$run.invokeStatic(execute.clj:62)
	at metabase.query_processor.execute$run.invoke(execute.clj:56)
	at metabase.query_processor.middleware.update_used_cards$fn__111720$update_used_cards_BANG_111719__111721$_AMPERSAND_f__111722.invoke(update_used_cards.clj:60)
	at metabase.query_processor.middleware.update_used_cards$fn__111720$update_used_cards_BANG_111719__111721$fn__111732.invoke(update_used_cards.clj:52)
	at metabase.query_processor.execute$add_native_form_to_result_metadata$fn__111744.invoke(execute.clj:25)
	at metabase.query_processor.execute$add_preprocessed_query_to_result_metadata_for_userland_query$fn__111750.invoke(execute.clj:36)
	at metabase.query_processor.middleware.cache$maybe_return_cached_results$maybe_return_cached_results_STAR___111570.invoke(cache.clj:241)
	at metabase.query_processor.middleware.permissions$check_query_permissions$fn__110415.invoke(permissions.clj:147)
	at metabase.query_processor.middleware.enterprise$check_download_permissions_middleware$fn__106535.invoke(enterprise.clj:51)
	at metabase.query_processor.middleware.enterprise$maybe_apply_column_level_perms_check_middleware$fn__106545.invoke(enterprise.clj:64)
	at metabase.query_processor.execute$fn__111784$execute111783__111785$fn__111786.invoke(execute.clj:94)
	at metabase.query_processor.setup$fn__111042$do_with_qp_setup111041__111043.invoke(setup.clj:225)
	at metabase.query_processor.setup$fn__111042$fn__111047.invoke(setup.clj:216)
	at metabase.query_processor.execute$fn__111784$execute111783__111785.invoke(execute.clj:93)
	at metabase.query_processor.execute$fn__111784$fn__111789.invoke(execute.clj:89)
	at metabase.query_processor$process_query_STAR__STAR_.invokeStatic(query_processor.clj:49)
	at metabase.query_processor$process_query_STAR__STAR_.invoke(query_processor.clj:44)
	at metabase.query_processor.middleware.enterprise$eval106562$handle_audit_app_internal_queries__106563$fn__106565.invoke(enterprise.clj:96)
	at metabase.query_processor.middleware.enterprise$handle_audit_app_internal_queries_middleware$fn__106573.invoke(enterprise.clj:103)
	at metabase.query_processor.middleware.process_userland_query$fn__112214$process_userland_query_middleware112213__112215$_AMPERSAND_f__112216.invoke(process_userland_query.clj:191)
	at metabase.query_processor.middleware.process_userland_query$fn__112214$process_userland_query_middleware112213__112215$fn__112222.invoke(process_userland_query.clj:188)
	at metabase.query_processor.middleware.catch_exceptions$fn__111883$catch_exceptions111882__111884$_AMPERSAND_f__111885.invoke(catch_exceptions.clj:125)
	at metabase.query_processor.middleware.catch_exceptions$fn__111883$catch_exceptions111882__111884$fn__111900.invoke(catch_exceptions.clj:122)
	at metabase.query_processor$fn__112558$process_query112557__112559$fn__112560.invoke(query_processor.clj:80)
...
```

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
