### PR TITLE
Fix dirty yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10813,7 +10813,7 @@ element-resize-detector@^1.2.2:
   dependencies:
     batch-processor "1.0.0"
 
-elliptic@^6.5.3, elliptic@^6.5.4:
+elliptic@^6.5.3, elliptic@^6.5.4, elliptic@^6.6.0:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.0.tgz#5919ec723286c1edf28685aa89261d4761afa210"
   integrity sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==


### PR DESCRIPTION
Redo of https://github.com/metabase/metabase/pull/49424, which was overwritten by another PR.