### PR TITLE
Fix missing question type for metrics

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/utils.ts
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/utils.ts
@@ -128,5 +128,9 @@ export const getAutocompleteResultMeta = (
     return t`Model in ${collectionName}`;
   }
 
+  if (type === "metric") {
+    return t`Metric in ${collectionName}`;
+  }
+
   throw new Error(`Unknown question.type(): ${type}`);
 };


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/49454

### Description

We aren't handling metrics in the ACE suggestion descriptions (and are throwing errors instead). This is causing the suggestions not show up completely when one of them is a metric.

### How to verify

1. Create any metric and name it `Test Metric 49454`
2. Create any question and name it `Test Question 49454`
3. New -> SQL Query
4. Type `select * from {{ #test`
5. The completions should show up and contain both the test question and the test metric.
