### PR TITLE
fix(49482): don't create a new store on each MetabaseProvider render

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
@@ -104,15 +104,12 @@ export const MetabaseProviderInternal = ({
   );
 };
 
-export const MetabaseProvider = memo(function MetabaseProvider({
-  // @ts-expect-error -- we don't want to expose the store prop
-  // eslint-disable-next-line react/prop-types
-  store = undefined,
-  ...props
-}: MetabaseProviderProps) {
+export const MetabaseProvider = memo(function MetabaseProvider(
+  props: MetabaseProviderProps,
+) {
   // This makes the store stable across re-renders, but still not a singleton:
   // we need a different store for each test or each storybook story
-  const storeRef = useRef(store);
+  const storeRef = useRef<Store<SdkStoreState, Action> | undefined>(undefined);
   if (!storeRef.current) {
     storeRef.current = getSdkStore();
   }

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
@@ -1,6 +1,6 @@
 import { Global } from "@emotion/react";
 import type { Action, Store } from "@reduxjs/toolkit";
-import { type JSX, type ReactNode, memo, useEffect } from "react";
+import { type JSX, type ReactNode, memo, useEffect, useRef } from "react";
 import { Provider } from "react-redux";
 
 import { SdkThemeProvider } from "embedding-sdk/components/private/SdkThemeProvider";
@@ -107,12 +107,19 @@ export const MetabaseProviderInternal = ({
 export const MetabaseProvider = memo(function MetabaseProvider({
   // @ts-expect-error -- we don't want to expose the store prop
   // eslint-disable-next-line react/prop-types
-  store = getSdkStore(),
+  store = undefined,
   ...props
 }: MetabaseProviderProps) {
+  // This makes the store stable across re-renders, but still not a singleton:
+  // we need a different store for each test or each storybook story
+  const storeRef = useRef(store);
+  if (!storeRef.current) {
+    storeRef.current = getSdkStore();
+  }
+
   return (
-    <Provider store={store}>
-      <MetabaseProviderInternal store={store} {...props} />
+    <Provider store={storeRef.current}>
+      <MetabaseProviderInternal store={storeRef.current} {...props} />
     </Provider>
   );
 });

--- a/enterprise/frontend/src/embedding-sdk/test/auth-flow.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/test/auth-flow.unit.spec.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import fetchMock from "fetch-mock";
 
 import {
@@ -7,6 +7,7 @@ import {
   setupCurrentUserEndpoint,
   setupPropertiesEndpoints,
 } from "__support__/server-mocks";
+import { waitForLoaderToBeRemoved } from "__support__/ui";
 import { waitForRequest } from "__support__/utils";
 import {
   MetabaseProvider,
@@ -26,7 +27,7 @@ const AUTH_PROVIDER_URL = "http://auth-provider:3000/sso/metabase";
 const MOCK_API_KEY = "mock-api-key";
 const USER_CURRENT_URL = `${METABASE_INSTANCE_URL}/api/user/current`;
 const MOCK_SESSION = {
-  exp: 1729761473,
+  exp: Number.MAX_SAFE_INTEGER,
   iat: 1729760873,
   id: "5e03fb0a-2398-423f-98b3-0c4abaf0c47a",
 };
@@ -70,6 +71,37 @@ describe("SDK auth flow", () => {
 
     setupCardEndpoints(MOCK_CARD);
     setupCardQueryEndpoints(MOCK_CARD, {} as any);
+  });
+
+  it("should initialize the auth flow only once, not on rerenders", async () => {
+    const sdkConfig = defineEmbeddingSdkConfig({
+      metabaseInstanceUrl: METABASE_INSTANCE_URL,
+      jwtProviderUri: AUTH_PROVIDER_URL,
+    });
+
+    const { rerender } = setup(sdkConfig);
+
+    expect(fetchMock.calls(AUTH_PROVIDER_URL)).toHaveLength(1);
+
+    rerender(
+      <MetabaseProvider
+        config={{
+          ...sdkConfig,
+        }}
+      >
+        <StaticQuestion questionId={1} />
+      </MetabaseProvider>,
+    );
+
+    await waitForLoaderToBeRemoved();
+
+    expect(fetchMock.calls(AUTH_PROVIDER_URL)).toHaveLength(1);
+
+    expect(screen.queryByText("Initializing...")).not.toBeInTheDocument();
+    expect(
+      // this is just something we know it's on the screen when everything is ok
+      screen.getByTestId("query-visualization-root"),
+    ).toBeInTheDocument();
   });
 
   describe("when using jwtProvider", () => {


### PR DESCRIPTION
Fixes #49482

Pointing this PR to https://github.com/metabase/metabase/pull/49214 as that PR made the bug surface in a breaking way and it added some tests that I wanted to work on this branch too.


# How to verify:
- all tests should pass (CI is green)
- Shoppy should not be stuck on "Initializating" when changing page
- Storybook should not use a global store across stories:
    - open storybook `IS_EMBEDDING_SDK=true yarn storybook`
    - open the [`No Styles Error` story](http://localhost:6006/?path=/story/embeddingsdk-styles-tests--no-styles-error), it should show the error
    - click on the sidebar on "No Styles Success"
    - it should correctly show the success state (meaning, it wasn't stuck on the error redux state)