### PR TITLE
add llm-payloads to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ modules/drivers/*/.lsp/*
 
 # swc
 .swc/
+
+# metabot
+llm-payloads


### PR DESCRIPTION
### Description

`llm-payloads` contains sensitive data such instance tokens so it would be great to have it ignored.