### PR TITLE
Check only :stages of the result of metric resolution in the QP

### DIFF
--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -263,7 +263,7 @@
                          (update stage-or-join :stages #(adjust-metric-stages query path %)))))]
           (u/prog1
             (update query :stages #(adjust-metric-stages query nil %))
-            (when-let [metric (find-first-metric <>)]
+            (when-let [metric (find-first-metric (:stages <>))]
               (throw (ex-info "Failed to replace metric" {:metric metric})))))
         (catch Throwable e
           (prometheus/inc! :metabase-query-processor/metrics-adjust-errors)

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -251,7 +251,7 @@
    2. Metric source cards can reference themselves.
       A query built from a `:source-card` of `:type :metric` can reference itself."
   [query]
-  (if-not (find-first-metric query)
+  (if-not (find-first-metric (:stages query))
     query
     (do
       (prometheus/inc! :metabase-query-processor/metrics-adjust)

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -59,8 +59,13 @@
               (lib.tu/mock-metadata-provider
                {:cards [metric]}))])))
 
-(def adjust
-  (comp #'metrics/adjust #'fetch-source-query/resolve-source-cards))
+(defn- adjust
+  [query]
+  (-> query
+      (assoc-in [:info :pivot/original-query] query)
+      (#'fetch-source-query/resolve-source-cards)
+      (#'metrics/adjust)
+      (dissoc :info)))
 
 (defn- check-prometheus-metrics!
   [& {expected-metrics-count  :metabase-query-processor/metrics-adjust


### PR DESCRIPTION
### Description

The query can contain all kinds of things, in particular the whole original query in the case of pivot questions, so we should check only the part that actually gets resolved by the middleware.

The issue was [reported](https://metaboat.slack.com/archives/C079BJHAH2T/p1730743638094299) in the `#ext-sailamx-metabase` Slack channel.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR (even though it's a bit stupid)
