### PR TITLE
Flake fix: native editor selection range

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -360,6 +360,12 @@ export class NativeQueryEditor extends Component<
     100,
   );
 
+  handleSelectionChange = () => {
+    if (this._editor && this.props.setNativeEditorSelectedRange) {
+      this.props.setNativeEditorSelectedRange(this._editor.getSelectionRange());
+    }
+  };
+
   handleKeyDown = (e: KeyboardEvent) => {
     const { isRunning, cancelQuery, enableRun } = this.props;
 
@@ -421,7 +427,7 @@ export class NativeQueryEditor extends Component<
     // listen to onChange events
     editor.getSession().on("change", this.onChange);
     editor.getSelection().on("changeCursor", this.handleCursorChange);
-    editor.getSelection().on("changeSelection", this.handleCursorChange);
+    editor.getSelection().on("changeSelection", this.handleSelectionChange);
 
     const minLineNumberWidth = 20;
     editor.getSession().gutterRenderer = {


### PR DESCRIPTION
Fixes a [flake](https://github.com/metabase/metabase/actions/runs/11662688937/job/32471342586) introduced by https://github.com/metabase/metabase/pull/49213

Because this PR was impossible to write tests for (see PR description), please test the changes manually:

1. New → Native Question
2. SQL snippets → Create a snippet → SQL: `x = 10`, name: `Test` → `Save` and leave the snippet sidebar open
3. Paste or type the following in the SQL editor:
  ```sql
SELECT * FROM orders WHERE y = 10
AND z = 20
  ```
4. Select the `y = 10` _backwards_ (ie. by dragging the mouse from right to left)
5. Press backspace
6. Click the insert button for the `Test` snippet you just created

The SQL editor should now contain: 
```sql
SELECT * FROM orders WHERE {{snippet: test}}
AND z = 20
```

[stress test 1](https://github.com/metabase/metabase/actions/runs/11673709808/job/32504974042)
[stress test 2](https://github.com/metabase/metabase/actions/runs/11673826822/job/32505306154)