### PR TITLE
Basic tsquery escaping

### DIFF
--- a/src/metabase/search/postgres/index.clj
+++ b/src/metabase/search/postgres/index.clj
@@ -155,23 +155,29 @@
     (when @reindexing?
       (t2/delete! pending-table :model_id id :model [:in search-models]))))
 
-(defn- process-negation [term]
-  (if (str/starts-with? term "-")
-    (str "!" (subs term 1))
-    term))
+(defn- quote* [s]
+  (str "'" s "'"))
 
 (defn- process-phrase [word-or-phrase]
   ;; a phrase is quoted even if the closing quotation mark has not been typed yet
-  (if (str/starts-with? word-or-phrase "\"")
+  (cond
     ;; quoted phrases must be matched sequentially
+    (str/starts-with? word-or-phrase "\"")
     (as-> word-or-phrase <>
       ;; remove the quote mark(s)
       (str/replace <> #"^\"|\"$" "")
       (str/trim <>)
       (str/split <> #"\s+")
+      (map quote* <>)
       (str/join " <-> " <>))
+
+    ;; negation
+    (str/starts-with? word-or-phrase "-")
+    (str "!" (quote* (subs word-or-phrase 1)))
+
     ;; just a regular word
-    word-or-phrase))
+    :else
+    (quote* word-or-phrase)))
 
 (defn- split-preserving-quotes
   "Break up the words in the search input, preserving quoted and partially quoted segments."
@@ -181,8 +187,7 @@
 (defn- process-clause [words-and-phrases]
   (->> words-and-phrases
        (remove #{"and"})
-       (map (comp process-phrase
-                  process-negation))
+       (map process-phrase)
        (str/join " & ")))
 
 (defn- complete-last-word
@@ -197,6 +202,7 @@
         complete?      (not (str/ends-with? trimmed "\""))
         ;; TODO also only complete if search-typeahead-enabled and the context is the search palette
         maybe-complete (if complete? complete-last-word identity)]
+    #p
     (->> (split-preserving-quotes trimmed)
          (remove str/blank?)
          (partition-by #{"or"})

--- a/src/metabase/search/postgres/index.clj
+++ b/src/metabase/search/postgres/index.clj
@@ -156,7 +156,7 @@
       (t2/delete! pending-table :model_id id :model [:in search-models]))))
 
 (defn- quote* [s]
-  (str "'" s "'"))
+  (str "'" (str/replace s "'" "''") "'"))
 
 (defn- process-phrase [word-or-phrase]
   ;; a phrase is quoted even if the closing quotation mark has not been typed yet

--- a/src/metabase/search/postgres/index.clj
+++ b/src/metabase/search/postgres/index.clj
@@ -202,7 +202,6 @@
         complete?      (not (str/ends-with? trimmed "\""))
         ;; TODO also only complete if search-typeahead-enabled and the context is the search palette
         maybe-complete (if complete? complete-last-word identity)]
-    #p
     (->> (split-preserving-quotes trimmed)
          (remove str/blank?)
          (partition-by #{"or"})

--- a/test/metabase/search/postgres/index_test.clj
+++ b/test/metabase/search/postgres/index_test.clj
@@ -197,4 +197,8 @@
 
   (testing "dangerous characters"
     (is (= "'you' & '<-' & 'pointing':*"
-           (search-expr "you <- pointing")))))
+           (search-expr "you <- pointing"))))
+
+  (testing "single quotes"
+    (is (= "'you''re':*"
+           (search-expr "you're")))))

--- a/test/metabase/search/postgres/index_test.clj
+++ b/test/metabase/search/postgres/index_test.clj
@@ -193,4 +193,8 @@
            (search-expr "\"Big Data\" \"Big Mistake"))))
 
   (is (= "'partial' <-> 'quoted' <-> 'and' <-> 'or' <-> '-split':*"
-         (search-expr "\"partial quoted AND OR -split"))))
+         (search-expr "\"partial quoted AND OR -split")))
+
+  (testing "dangerous characters"
+    (is (= "'you' & '<-' & 'pointing':*"
+           (search-expr "you <- pointing")))))

--- a/test/metabase/search/postgres/index_test.clj
+++ b/test/metabase/search/postgres/index_test.clj
@@ -164,29 +164,33 @@
 (def search-expr #'search.index/to-tsquery-expr)
 
 (deftest to-tsquery-expr-test
-  (is (= "a & b & c:*"
+  (is (= "'a' & 'b' & 'c':*"
          (search-expr "a b c")))
 
-  (is (= "a & b & c:*"
+  (is (= "'a' & 'b' & 'c':*"
          (search-expr "a AND b AND c")))
 
-  (is (= "a & b & c"
+  (is (= "'a' & 'b' & 'c'"
          (search-expr "a b \"c\"")))
 
-  (is (= "a & b | c:*"
+  (is (= "'a' & 'b' | 'c':*"
          (search-expr "a b or c")))
 
-  (is (= "this & !that:*"
+  (is (= "'this' & !'that':*"
          (search-expr "this -that")))
 
-  (is (= "a & b & c <-> d & e | b & e:*"
+  (is (= "'a' & 'b' & 'c' <-> 'd' & 'e' | 'b' & 'e':*"
          (search-expr "a b \" c d\" e or b e")))
 
-  (is  (= "ab <-> and <-> cde <-> f | !abc & def & ghi | jkl <-> mno <-> or <-> pqr"
+  (is  (= "'ab' <-> 'and' <-> 'cde' <-> 'f' | !'abc' & 'def' & 'ghi' | 'jkl' <-> 'mno' <-> 'or' <-> 'pqr'"
           (search-expr "\"ab and cde f\" or -abc def AND ghi OR \"jkl mno OR pqr\"")))
 
-  (is (= "big & data | business <-> intelligence | data & wrangling:*"
+  (is (= "'big' & 'data' | 'business' <-> 'intelligence' | 'data' & 'wrangling':*"
          (search-expr "Big Data oR \"Business Intelligence\" OR data and wrangling")))
 
-  (is (= "partial <-> quoted <-> and <-> or <-> -split:*"
+  (testing "unbalanced quotes"
+    (is (= "'big' <-> 'data' & 'big' <-> 'mistake':*"
+           (search-expr "\"Big Data\" \"Big Mistake"))))
+
+  (is (= "'partial' <-> 'quoted' <-> 'and' <-> 'or' <-> '-split':*"
          (search-expr "\"partial quoted AND OR -split"))))


### PR DESCRIPTION
We don't want search to fail with syntax errors on weird characters.

At first I thought about stripping non-whitelisted characters, but it turns out its easy to escape phrases and this seems a bit more intuitive.

Expect us to come back to the whole expression language as a whole though.