### PR TITLE
Update `saveDashboard` helper to wait for the GET `/api/dashboard/:id`

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.ts
+++ b/e2e/support/helpers/e2e-dashboard-helpers.ts
@@ -84,11 +84,15 @@ export function saveDashboard({
   waitMs = 1,
   awaitRequest = true,
 } = {}) {
-  cy.intercept("PUT", "/api/dashboard/*").as("saveDashboardCards");
+  cy.intercept("PUT", "/api/dashboard/*").as(
+    "saveDashboard-saveDashboardCards",
+  );
+  cy.intercept("GET", "/api/dashboard/*").as("saveDashboard-getDashboard");
   cy.button(buttonLabel).click();
 
   if (awaitRequest) {
-    cy.wait("@saveDashboardCards");
+    cy.wait("@saveDashboard-saveDashboardCards");
+    cy.wait("@saveDashboard-getDashboard");
   }
 
   cy.findByText(editBarText).should("not.exist");

--- a/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
@@ -693,9 +693,7 @@ describe("scenarios > custom column > boolean functions", () => {
         .findByText(parameterDetails.name)
         .click();
       popover().findByText(expressionName).click();
-      cy.intercept("GET", "/api/dashboard/*").as("getDashboard");
       saveDashboard();
-      cy.wait("@getDashboard");
 
       cy.log("verify click behavior");
       getDashboardCard().within(() => {


### PR DESCRIPTION
### Description

Both `updateDashboard` and `updateDashboardAndCards` actions re-fetch the dashboard, so `saveDashboard` helper should also wait for that - it helped with flakiness in at least 1 case. See https://github.com/metabase/metabase/pull/49476#discussion_r1827980492.

Also updates the aliases used within `saveDashboard` so that they are unique and don't interfere if test uses the same aliases (e.g. result of `cy.get("@alias")` would be affected).

### How to verify

CI is green.