### PR TITLE
Fix - Values from the returned rows not present in the visualization are interpolable in the URL but don't have values

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
@@ -6,6 +6,7 @@ import {
   assertDescendantNotOverflowsContainer,
   assertIsEllipsified,
   assertIsNotEllipsified,
+  createNativeQuestionAndDashboard,
   createQuestion,
   cypressWaitAll,
   echartsContainer,
@@ -1871,4 +1872,82 @@ describe("issue 48878", () => {
     });
     cy.wait("@fetchCard");
   }
+});
+
+describe("issue 46318", () => {
+  const query = `SELECT 'group_1' AS main_group, 'sub_group_1' AS sub_group, 111 AS value_sum, 'group_1__sub_group_1' AS group_name
+UNION ALL
+SELECT 'group_1', 'sub_group_2', 68, 'group_1__sub_group_2'
+UNION ALL
+SELECT 'group_2', 'sub_group_1', 79, 'group_2__sub_group_1'
+UNION ALL
+SELECT 'group_2', 'sub_group_2', 52, 'group_2__sub_group_2';
+`;
+
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("passes values from unused columns of row visualization to click behavior (metabase#46318)", () => {
+    createNativeQuestionAndDashboard({
+      questionDetails: {
+        name: "46318",
+        native: { query },
+        display: "row",
+        visualization_settings: {
+          "graph.dimensions": ["MAIN_GROUP", "SUB_GROUP"],
+          "graph.series_order_dimension": null,
+          "graph.series_order": null,
+          "graph.metrics": ["VALUE_SUM"],
+        },
+      },
+    }).then(response => {
+      visitDashboard(response.body.dashboard_id);
+    });
+
+    editDashboard();
+    getDashboardCard().realHover().icon("click").click();
+    cy.get("aside").within(() => {
+      cy.findByText("Go to a custom destination").click();
+      cy.findByText("URL").click();
+    });
+    modal().within(() => {
+      cy.findByPlaceholderText("e.g. http://acme.com/id/{{user_id}}").type(
+        "http://localhost:4000/?q={{group_name}}",
+        { parseSpecialCharSequences: false },
+      );
+      cy.button("Done").click();
+    });
+    saveDashboard();
+
+    cy.findAllByRole("graphics-symbol").eq(0).click();
+    cy.location("href").should(
+      "eq",
+      "http://localhost:4000/?q=group_1__sub_group_1",
+    );
+
+    cy.go("back");
+
+    cy.findAllByRole("graphics-symbol").eq(2).click(); // intentionally eq(2), not eq(1) - that's how row viz works
+    cy.location("href").should(
+      "eq",
+      "http://localhost:4000/?q=group_1__sub_group_2",
+    );
+
+    cy.go("back");
+
+    cy.findAllByRole("graphics-symbol").eq(1).click(); // intentionally eq(1), not eq(2) - that's how row viz works
+    cy.location("href").should(
+      "eq",
+      "http://localhost:4000/?q=group_2__sub_group_1",
+    );
+    cy.go("back");
+
+    cy.findAllByRole("graphics-symbol").eq(3).click();
+    cy.location("href").should(
+      "eq",
+      "http://localhost:4000/?q=group_2__sub_group_2",
+    );
+  });
 });

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
@@ -1887,9 +1887,7 @@ SELECT 'group_2', 'sub_group_2', 52, 'group_2__sub_group_2';
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-  });
 
-  it("passes values from unused columns of row visualization to click behavior (metabase#46318)", () => {
     createNativeQuestionAndDashboard({
       questionDetails: {
         name: "46318",
@@ -1920,7 +1918,9 @@ SELECT 'group_2', 'sub_group_2', 52, 'group_2__sub_group_2';
       cy.button("Done").click();
     });
     saveDashboard();
+  });
 
+  it("passes values from unused columns of row visualization to click behavior (metabase#46318)", () => {
     cy.findAllByRole("graphics-symbol").eq(0).click();
     cy.location("href").should(
       "eq",

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.ts
@@ -51,7 +51,11 @@ const getMetricColumnData = (
   });
 };
 
-const getColumnData = (columns: ColumnDescriptor[], datum: GroupedDatum) => {
+const getColumnData = (
+  columns: ColumnDescriptor[],
+  datum: GroupedDatum,
+  seriesIndex: number,
+) => {
   return columns
     .map(columnDescriptor => {
       const { column, index } = columnDescriptor;
@@ -66,8 +70,7 @@ const getColumnData = (columns: ColumnDescriptor[], datum: GroupedDatum) => {
 
         value = formatNullable(metricSum);
       } else {
-        const distinctValues = new Set(datum.rawRows.map(row => row[index]));
-        value = distinctValues.size === 1 ? datum.rawRows[0][index] : null;
+        value = datum.rawRows[seriesIndex][index];
       }
 
       return value != null
@@ -84,6 +87,7 @@ const getColumnData = (columns: ColumnDescriptor[], datum: GroupedDatum) => {
 const getColumnsData = (
   chartColumns: CartesianChartColumns,
   series: Series<GroupedDatum, unknown>,
+  seriesIndex: number,
   datum: GroupedDatum,
   datasetColumns: DatasetColumn[],
   visualizationSettings: VisualizationSettings,
@@ -121,7 +125,7 @@ const getColumnsData = (
     datasetColumns,
   );
 
-  data.push(...getColumnData(otherColumnsDescriptiors, datum));
+  data.push(...getColumnData(otherColumnsDescriptiors, datum, seriesIndex));
   return data;
 };
 
@@ -131,10 +135,11 @@ export const getClickData = (
   chartColumns: CartesianChartColumns,
   datasetColumns: DatasetColumn[],
 ): ClickObject => {
-  const { series, datum } = bar;
+  const { series, seriesIndex, datum } = bar;
   const data = getColumnsData(
     chartColumns,
     series,
+    seriesIndex,
     datum,
     datasetColumns,
     visualizationSettings,
@@ -299,6 +304,7 @@ export const getHoverData = (
     const data = getColumnsData(
       chartColumns,
       bar.series,
+      bar.seriesIndex,
       bar.datum,
       datasetColumns,
       settings,


### PR DESCRIPTION
Fixes #46318

### How to verify

1. New > SQL query
2. Paste this: `SELECT 'group_1' AS main_group, 'sub_group_1' AS sub_group, 111 AS value_sum, 'group_1__sub_group_1' AS group_name
UNION ALL
SELECT 'group_1', 'sub_group_2', 68, 'group_1__sub_group_2'
UNION ALL
SELECT 'group_2', 'sub_group_1', 79, 'group_2__sub_group_1'
UNION ALL
SELECT 'group_2', 'sub_group_2', 52, 'group_2__sub_group_2';
`
3. Run query
4. Change viz type to "Row"
5. Open viz settings
6. Set Y-Axis to "main_group"
7. Set X-Axis to "value_sum"
8. Click "Add series breakout" and select "sub_group"
    - if you do this step before step 7 you'll hit #49529
10. Save question and add it to dashboard
11. Configure click behavior for this dashcard: custom URL: `https://example.com/?{{group_name}}`
12. Save dashboard
13. Try out click behavior

URL should contain value after `?`.

Related PR: #26547 