### PR TITLE
Push metabot to stats

### DIFF
--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+      - metabot-v3-second-try
     paths-ignore:
       # config files
       - ".**"
@@ -149,8 +150,15 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - name: Retag and push images if master (ee)
-      if: ${{ (github.ref_name == 'master') && matrix.edition == 'ee' }}
+
+    # FIXME: uncomment this and delete the following block when we're done testing metabot
+
+    # - name: Retag and push images if master (ee)
+    #   if: ${{ (github.ref_name == 'master') && matrix.edition == 'ee' }}
+    #   run: docker tag localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-ee ${{ github.repository_owner }}/metabase-enterprise-head:latest && docker push ${{ github.repository_owner }}/metabase-enterprise-head:latest
+
+    - name: Retag and push images if metabot-v3-second-try (ee)
+      if: ${{ (github.ref_name == 'metabot-v3-second-try') && matrix.edition == 'ee' }}
       run: docker tag localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-ee ${{ github.repository_owner }}/metabase-enterprise-head:latest && docker push ${{ github.repository_owner }}/metabase-enterprise-head:latest
 
     - name: Retag and push images if master (oss)

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -151,15 +151,14 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    # FIXME: uncomment this and delete the following block when we're done testing metabot
+    - name: Retag and push images if master (ee)
+      if: ${{ (github.ref_name == 'master') && matrix.edition == 'ee' }}
+      run: docker tag localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-ee ${{ github.repository_owner }}/metabase-enterprise-head:latest && docker push ${{ github.repository_owner }}/metabase-enterprise-head:latest
 
-    # - name: Retag and push images if master (ee)
-    #   if: ${{ (github.ref_name == 'master') && matrix.edition == 'ee' }}
-    #   run: docker tag localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-ee ${{ github.repository_owner }}/metabase-enterprise-head:latest && docker push ${{ github.repository_owner }}/metabase-enterprise-head:latest
-
+    # TODO: remove when we're done testing metabot
     - name: Retag and push images if metabot-v3-second-try (ee)
       if: ${{ (github.ref_name == 'metabot-v3-second-try') && matrix.edition == 'ee' }}
-      run: docker tag localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-ee ${{ github.repository_owner }}/metabase-enterprise-head:latest && docker push ${{ github.repository_owner }}/metabase-enterprise-head:latest
+      run: docker tag localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-ee ${{ github.repository_owner }}/metabase-enterprise-head:metabot && docker push ${{ github.repository_owner }}/metabase-enterprise-head:metabot
 
     - name: Retag and push images if master (oss)
       if: ${{ (github.ref_name == 'master') && matrix.edition == 'oss' }}


### PR DESCRIPTION
- on any push to the `metabot-v3-second-try` branch, build a new uberjar, containerize it and push to `metabase-enterprise-head:metabot`.
