### PR TITLE
[testing] Add order-by to the generative testing for queries

### DIFF
--- a/test/metabase/lib/test_util/generators/util.cljc
+++ b/test/metabase/lib/test_util/generators/util.cljc
@@ -7,3 +7,31 @@
   [xs]
   (when-not (empty? xs)
     (rand-nth xs)))
+
+(defn weighted-choice
+  "Given a map of `{x weight}`, randomly choose among the choices, based on their weights.
+
+  The weights are unitless positive integers.
+
+  Returns the selected `x`."
+  [choices]
+  (let [;; Returns a pair of the total weight, and a list of [max-roll choice] pairs, in ascending order of max-roll.
+        [total ascending]    (reduce (fn [[cumulative pairs] [choice weight]]
+                                       (let [new-cum (+ cumulative weight)]
+                                         [new-cum (conj pairs [new-cum choice])]))
+                                     [0 []]
+                                     choices)
+        roll                 (rand-int total)
+        [[_weight selected]] (drop-while (fn [[max-roll _choice]]
+                                           (<= max-roll roll))
+                                         ascending)]
+    selected))
+
+(comment
+  ;; Human testing that [[weighted-choice]] is sampling properly.
+  ;; Should be something like {:a 100000, :b 10000, :c 1000}.
+  (->> (for [_ (range 111000)]
+         (weighted-choice {:a 100
+                           :b 10
+                           :c 1}))
+       frequencies))


### PR DESCRIPTION
### Description

Add `:order-by` to the query generators.

This introduces a reusable `weighted-choice` function and a "weight"
system for the various steps. `:order-by` should be more rare than
filters, etc., `:limit` and `:append-stage` should be more rare still.


### How to verify

- Generate queries at the REPL; they contain `:order-by` clauses now.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
