### PR TITLE
Fix :pivot-measures with column names

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
@@ -1166,7 +1166,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
       visualization_settings: {
         "pivot_table.column_split": {
           rows: ["CATEGORY", "EAN"],
-          columns: ["count"],
+          columns: [],
           values: ["count"],
         },
       },

--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -358,7 +358,7 @@
                                (lib.metadata.jvm/application-database-metadata-provider (:database query)))
         query              (lib/query metadata-provider query)
         returned-columns   (lib/returned-columns query)
-        {:keys [aggregations breakouts]} (group-by :lib/source returned-columns)
+        {:source/keys [aggregations breakouts]} (group-by :lib/source returned-columns)
         column-name->index (into {}
                                  (map-indexed (fn [i column] [(:name column) i]))
                                  (concat breakouts aggregations))

--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -357,13 +357,14 @@
         metadata-provider  (or (:lib/metadata query)
                                (lib.metadata.jvm/application-database-metadata-provider (:database query)))
         query              (lib/query metadata-provider query)
-        index-in-breakouts (into {}
-                                 (comp (filter (comp #{:source/breakouts} :lib/source))
-                                       (map-indexed (fn [i column] [(:name column) i])))
-                                 (lib/returned-columns query))
+        returned-columns   (lib/returned-columns query)
+        column-name->index (into {}
+                                 (map-indexed (fn [i column] [(:name column) i]))
+                                 (concat (filter (comp #{:source/breakouts} :lib/source) returned-columns)
+                                         (filter (comp #{:source/aggregations} :lib/source) returned-columns)))
         process-columns    (fn process-columns [column-names]
                              (when (seq column-names)
-                               (into [] (keep index-in-breakouts) column-names)))
+                               (into [] (keep column-name->index) column-names)))
         pivot-opts         {:pivot-rows     (process-columns rows)
                             :pivot-cols     (process-columns columns)
                             :pivot-measures (process-columns values)}]

--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -358,7 +358,7 @@
                                (lib.metadata.jvm/application-database-metadata-provider (:database query)))
         query              (lib/query metadata-provider query)
         returned-columns   (lib/returned-columns query)
-        {:source/keys [aggregations breakouts]} (group-by :lib/source returned-columns)
+        {:keys [aggregations breakouts]} (group-by :lib/source returned-columns)
         column-name->index (into {}
                                  (map-indexed (fn [i column] [(:name column) i]))
                                  (concat breakouts aggregations))

--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -358,10 +358,10 @@
                                (lib.metadata.jvm/application-database-metadata-provider (:database query)))
         query              (lib/query metadata-provider query)
         returned-columns   (lib/returned-columns query)
+        {:source/keys [aggregations breakouts]} (group-by :lib/source returned-columns)
         column-name->index (into {}
                                  (map-indexed (fn [i column] [(:name column) i]))
-                                 (concat (filter (comp #{:source/breakouts} :lib/source) returned-columns)
-                                         (filter (comp #{:source/aggregations} :lib/source) returned-columns)))
+                                 (concat breakouts aggregations))
         process-columns    (fn process-columns [column-names]
                              (when (seq column-names)
                                (into [] (keep column-name->index) column-names)))

--- a/test/metabase/api/downloads_exports_test.clj
+++ b/test/metabase/api/downloads_exports_test.clj
@@ -1095,11 +1095,9 @@
                                                                                 [:avg [:field (mt/id :products :rating) {:base-type :type/Float}]]]
                                                                  :breakout     [[:field (mt/id :products :category) {:base-type :type/Text}]]}}
                                        :visualization_settings {:pivot_table.column_split
-                                                                {:rows    [[:field (mt/id :products :category) {:base-type :type/Text}]]
+                                                                {:rows    ["CATEGORY"]
                                                                  :columns []
-                                                                 :values  [[:aggregation 1]
-                                                                           [:aggregation 0]
-                                                                           [:aggregation 2]]}
+                                                                 :values  ["sum" "count" "avg"]}
                                                                 :column_settings
                                                                 {"[\"name\",\"count\"]" {:column_title "Count Renamed"}
                                                                  "[\"name\",\"sum\"]"   {:column_title "Sum Renamed"}
@@ -1134,10 +1132,9 @@
                                                                  :breakout     [[:field (mt/id :products :category) {:base-type :type/Text}]
                                                                                 [:field (mt/id :products :created_at) {:base-type :type/DateTime :temporal-unit :year}]]}}
                                        :visualization_settings {:pivot_table.column_split
-                                                                {:rows    [[:field (mt/id :products :created_at) {:base-type :type/DateTime :temporal-unit :year}]
-                                                                           [:field (mt/id :products :category) {:base-type :type/Text}]]
+                                                                {:rows    ["CREATED_AT" "CATEGORY"]
                                                                  :columns []
-                                                                 :values  [[:aggregation 0]]}
+                                                                 :values  ["count"]}
                                                                 :column_settings
                                                                 {"[\"name\",\"count\"]" {:column_title "Count Renamed"}}}}]
         (let [expected-header   ["Created At" "Category" "Count"]


### PR DESCRIPTION
Follow up for https://github.com/metabase/metabase/pull/49414
The PR was merged at the same time as https://github.com/metabase/metabase/pull/49367. New column-name based settings do not take `:pivot-measures` into account. This PR fixes the issue and adjusts the tests to use column names.