### PR TITLE
fix type errors that appear on the mantine branch

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/store/reducer.ts
+++ b/enterprise/frontend/src/embedding-sdk/store/reducer.ts
@@ -80,10 +80,9 @@ const initialState: SdkState = {
 };
 
 export const sdk = createReducer(initialState, builder => {
-  builder.addCase(refreshTokenAsync.pending, state => ({
-    ...state,
-    token: { ...state.token, loading: true },
-  }));
+  builder.addCase(refreshTokenAsync.pending, state => {
+    state.token = { ...state.token, loading: true };
+  });
 
   builder.addCase(refreshTokenAsync.fulfilled, (state, action) => {
     state.token = {
@@ -111,38 +110,34 @@ export const sdk = createReducer(initialState, builder => {
     state.loginStatus = { status: "error", error };
   });
 
-  builder.addCase(setLoaderComponent, (state, action) => ({
-    ...state,
-    loaderComponent: action.payload,
-  }));
+  builder.addCase(setLoaderComponent, (state, action) => {
+    state.loaderComponent = action.payload;
+  });
 
-  builder.addCase(setPlugins, (state, action) => ({
-    ...state,
-    plugins: action.payload,
-  }));
+  builder.addCase(setPlugins, (state, action) => {
+    // At the time of writing, doing `this.state.plugins = action.payload` causes
+    // `Type instantiation is excessively deep and possibly infinite.` for
+    // this specific action, but it fixes the others.
+    return { ...state, plugins: action.payload };
+  });
 
-  builder.addCase(setEventHandlers, (state, action) => ({
-    ...state,
-    eventHandlers: action.payload,
-  }));
+  builder.addCase(setEventHandlers, (state, action) => {
+    state.eventHandlers = action.payload;
+  });
 
-  builder.addCase(setErrorComponent, (state, action) => ({
-    ...state,
-    errorComponent: action.payload,
-  }));
+  builder.addCase(setErrorComponent, (state, action) => {
+    state.errorComponent = action.payload;
+  });
 
-  builder.addCase(setMetabaseClientUrl, (state, action) => ({
-    ...state,
-    metabaseInstanceUrl: action.payload,
-  }));
+  builder.addCase(setMetabaseClientUrl, (state, action) => {
+    state.metabaseInstanceUrl = action.payload;
+  });
 
-  builder.addCase(setFetchRefreshTokenFn, (state, action) => ({
-    ...state,
-    fetchRefreshTokenFn: action.payload,
-  }));
+  builder.addCase(setFetchRefreshTokenFn, (state, action) => {
+    state.fetchRefreshTokenFn = action.payload;
+  });
 
-  builder.addCase(setUsageProblem, (state, action) => ({
-    ...state,
-    usageProblem: action.payload,
-  }));
+  builder.addCase(setUsageProblem, (state, action) => {
+    state.usageProblem = action.payload;
+  });
 });


### PR DESCRIPTION
Re-implements https://github.com/metabase/metabase/pull/49352 after [feat(sdk): refactor the auth code to provide better error messages](https://github.com/metabase/metabase/pull/49214) got merged

# How to verify
- CI should be green on this PR
- `tsc` should not error if you rebase the [mantine PR](https://github.com/metabase/metabase/pull/49097) on this PR