### PR TITLE
feat(sdk): small usability improvements for embedding cli

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/cli/constants/config.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/constants/config.ts
@@ -3,6 +3,7 @@ export const CONTAINER_NAME = "metabase-enterprise-embedding";
 export const SITE_NAME = "Metabase Embedding SDK Demo";
 export const SDK_PACKAGE_NAME = "@metabase/embedding-sdk-react";
 export const SDK_NPM_LINK = `https://npm.im/package/${SDK_PACKAGE_NAME}`;
+export const SAMPLE_CREDENTIALS_FILE_NAME = "METABASE_LOGIN.json";
 
 /**
  * Default port for the local Metabase instance.

--- a/enterprise/frontend/src/embedding-sdk/cli/constants/database.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/constants/database.ts
@@ -48,3 +48,5 @@ export const CLI_SHOWN_DB_FIELDS = [
   "conn-uri",
   "authdb",
 ];
+
+export const SAMPLE_DB_ID = 1;

--- a/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
@@ -1,6 +1,10 @@
 import { blue, green, yellow } from "chalk";
 
-import { CONTAINER_NAME, SDK_NPM_LINK } from "./config";
+import {
+  CONTAINER_NAME,
+  SAMPLE_CREDENTIALS_FILE_NAME,
+  SDK_NPM_LINK,
+} from "./config";
 
 export const PACKAGE_JSON_NOT_FOUND_MESSAGE = `
   Could not find a package.json file in the current directory.
@@ -44,8 +48,8 @@ export const getMetabaseInstanceSetupCompleteMessage = (
   `
   Metabase is running at ${blue(instanceUrl)}
 
-  Login with email "${email}" and password "${password}".
-  You can find your login credentials at METABASE_LOGIN.json
+  Login with email "${blue(email)}" and password "${blue(password)}".
+  You can find your login credentials at "${blue(SAMPLE_CREDENTIALS_FILE_NAME)}".
 
   Metabase will phone home some data collected via Snowplow.
   We don’t collect any usernames, emails, server IPs, database details of any kind, or

--- a/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
@@ -35,10 +35,16 @@ export const getEmbeddingFailedMessage = (reason: string) => `
   Reason: ${reason}
 `;
 
-export const getMetabaseInstanceSetupCompleteMessage = (instanceUrl: string) =>
+export const getMetabaseInstanceSetupCompleteMessage = (
+  instanceUrl: string,
+  email: string,
+  password: string,
+) =>
   // eslint-disable-next-line no-unconditional-metabase-links-render -- link for the CLI message
   `
   Metabase is running at ${blue(instanceUrl)}
+
+  Login with email "${email}" and password "${password}".
   You can find your login credentials at METABASE_LOGIN.json
 
   Metabase will phone home some data collected via Snowplow.

--- a/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
@@ -49,7 +49,7 @@ export const getMetabaseInstanceSetupCompleteMessage = (
   Metabase is running at ${blue(instanceUrl)}
 
   Login with email "${blue(email)}" and password "${blue(password)}".
-  You can find your login credentials at "${blue(SAMPLE_CREDENTIALS_FILE_NAME)}".
+  You can also find your login credentials at "${blue(SAMPLE_CREDENTIALS_FILE_NAME)}".
 
   Metabase will phone home some data collected via Snowplow.
   We don’t collect any usernames, emails, server IPs, database details of any kind, or

--- a/enterprise/frontend/src/embedding-sdk/cli/run.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/run.ts
@@ -1,6 +1,7 @@
 import {
   addDatabaseConnectionStep,
   askForTenancyColumns,
+  askIfHasDatabase,
   checkIfReactProject,
   checkIsDockerRunning,
   checkSdkAvailable,
@@ -28,6 +29,7 @@ export const CLI_STEPS: CliStepConfig[] = [
   { id: "checkIfReactProject", executeStep: checkIfReactProject },
   { id: "checkSdkAvailable", executeStep: checkSdkAvailable },
   { id: "checkIsDockerRunning", executeStep: checkIsDockerRunning },
+  { id: "askIfHasDatabase", executeStep: askIfHasDatabase },
   { id: "generateCredentials", executeStep: generateCredentials },
   {
     id: "startLocalMetabaseContainer",

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/add-database-connection.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/add-database-connection.ts
@@ -1,5 +1,4 @@
 import { search } from "@inquirer/prompts";
-import toggle from "inquirer-toggle";
 import ora from "ora";
 
 import type { CliStepMethod } from "embedding-sdk/cli/types/cli";
@@ -15,13 +14,7 @@ export const addDatabaseConnectionStep: CliStepMethod = async state => {
     instanceUrl: state.instanceUrl ?? "",
   });
 
-  const hasDatabase = await toggle({
-    message:
-      "Do you have a database to connect to? This will be used to embed your data.",
-    default: true,
-  });
-
-  if (!hasDatabase || !settings || !settings.engines) {
+  if (!settings || !settings.engines) {
     return [{ type: "error", message: "Aborted." }, state];
   }
 

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/add-database-connection.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/add-database-connection.ts
@@ -4,7 +4,7 @@ import ora from "ora";
 import type { CliStepMethod } from "embedding-sdk/cli/types/cli";
 import type { Settings } from "metabase-types/api/settings";
 
-import { CLI_SHOWN_DB_ENGINES } from "../constants/database";
+import { CLI_SHOWN_DB_ENGINES, SAMPLE_DB_ID } from "../constants/database";
 import { addDatabaseConnection } from "../utils/add-database-connection";
 import { askForDatabaseConnectionInfo } from "../utils/ask-for-db-connection-info";
 import { fetchInstanceSettings } from "../utils/fetch-instance-settings";
@@ -16,6 +16,10 @@ export const addDatabaseConnectionStep: CliStepMethod = async state => {
 
   if (!settings || !settings.engines) {
     return [{ type: "error", message: "Aborted." }, state];
+  }
+
+  if (state.useSampleDatabase) {
+    return [{ type: "success" }, { ...state, databaseId: SAMPLE_DB_ID }];
   }
 
   const engineChoices = getEngineChoices(settings);

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/ask-if-has-database.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/ask-if-has-database.ts
@@ -1,7 +1,7 @@
-import { select } from "@inquirer/prompts";
 import toggle from "inquirer-toggle";
 
 import type { CliStepMethod } from "embedding-sdk/cli/types/cli";
+import { printHelperText } from "embedding-sdk/cli/utils/print";
 
 /**
  * Asks the user first if they have a database to connect to.
@@ -13,28 +13,11 @@ export const askIfHasDatabase: CliStepMethod = async state => {
     default: true,
   });
 
-  if (hasDatabase) {
-    return [{ type: "success" }, state];
+  if (!hasDatabase) {
+    printHelperText(
+      "Sample data will be used to demonstrate embedding features.",
+    );
   }
 
-  const shouldUseSampleDatabase = await select({
-    message:
-      "Do you want to use an example database to try out the Embedding SDK?",
-    choices: [
-      { name: "Use an example database", value: true },
-      { name: "Exit setup", value: false },
-    ],
-  });
-
-  if (shouldUseSampleDatabase) {
-    return [{ type: "success" }, { ...state, shouldUseSampleDatabase: true }];
-  }
-
-  return [
-    {
-      type: "error",
-      message: "Setup cancelled. You can run the setup again later.",
-    },
-    state,
-  ];
+  return [{ type: "success" }, { ...state, useSampleDatabase: !hasDatabase }];
 };

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/ask-if-has-database.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/ask-if-has-database.ts
@@ -1,0 +1,40 @@
+import { select } from "@inquirer/prompts";
+import toggle from "inquirer-toggle";
+
+import type { CliStepMethod } from "embedding-sdk/cli/types/cli";
+
+/**
+ * Asks the user first if they have a database to connect to.
+ */
+export const askIfHasDatabase: CliStepMethod = async state => {
+  const hasDatabase = await toggle({
+    message:
+      "Do you have a database to connect to? This will be used to embed your data.",
+    default: true,
+  });
+
+  if (hasDatabase) {
+    return [{ type: "success" }, state];
+  }
+
+  const shouldUseSampleDatabase = await select({
+    message:
+      "Do you want to use an example database to try out the Embedding SDK?",
+    choices: [
+      { name: "Use an example database", value: true },
+      { name: "Exit setup", value: false },
+    ],
+  });
+
+  if (shouldUseSampleDatabase) {
+    return [{ type: "success" }, { ...state, shouldUseSampleDatabase: true }];
+  }
+
+  return [
+    {
+      type: "error",
+      message: "Setup cancelled. You can run the setup again later.",
+    },
+    state,
+  ];
+};

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/ask-tenancy-columns.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/ask-tenancy-columns.ts
@@ -5,6 +5,11 @@ import type { CliStepMethod } from "../types/cli";
 import { printHelperText } from "../utils/print";
 
 export const askForTenancyColumns: CliStepMethod = async state => {
+  // The sample database does not have tenancy columns.
+  if (state.useSampleDatabase) {
+    return [{ type: "success" }, state];
+  }
+
   printHelperText(
     `e.g. does your table have a customer_id column to isolate tenants?`,
   );

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/ask-tenancy-columns.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/ask-tenancy-columns.ts
@@ -24,9 +24,11 @@ export const askForTenancyColumns: CliStepMethod = async state => {
   }
 
   if (!state.chosenTables) {
-    const message = "You have not selected any tables.";
+    printHelperText(
+      "You have not selected any tables. Continuing without tenancy isolation.",
+    );
 
-    return [{ type: "error", message }, state];
+    return [{ type: "success" }, state];
   }
 
   const tenancyColumnNames: Record<string, string> = {};
@@ -82,9 +84,11 @@ export const askForTenancyColumns: CliStepMethod = async state => {
   }
 
   if (Object.keys(tenancyColumnNames).length === 0) {
-    const message = "Your tables do not have any multi-tenancy column.";
+    printHelperText(
+      "Your tables do not have any multi-tenancy column. Continuing without tenancy isolation.",
+    );
 
-    return [{ type: "error", message }, state];
+    return [{ type: "success" }, state];
   }
 
   return [{ type: "success" }, { ...state, tenancyColumnNames }];

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/ask-tenancy-columns.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/ask-tenancy-columns.ts
@@ -16,7 +16,7 @@ export const askForTenancyColumns: CliStepMethod = async state => {
 
   const hasTenancyIsolation = await toggle({
     message: `Is your tenancy isolation based on a column?`,
-    default: true,
+    default: false,
   });
 
   if (!hasTenancyIsolation) {

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/generate-credentials.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/generate-credentials.ts
@@ -4,6 +4,7 @@ import { input } from "@inquirer/prompts";
 
 import { isEmail } from "metabase/lib/email";
 
+import { SAMPLE_CREDENTIALS_FILE_NAME } from "../constants/config";
 import type { CliStepMethod } from "../types/cli";
 import { addFileToGitIgnore } from "../utils/add-file-to-git-ignore";
 import { generateRandomDemoPassword } from "../utils/generate-password";
@@ -26,13 +27,11 @@ export const generateCredentials: CliStepMethod = async state => {
 
   const password = generateRandomDemoPassword();
 
-  const credentialFile = "METABASE_LOGIN.json";
-
-  await addFileToGitIgnore(credentialFile);
+  await addFileToGitIgnore(SAMPLE_CREDENTIALS_FILE_NAME);
 
   // Store the login credentials to a file.
   await fs.writeFile(
-    `./${credentialFile}`,
+    `./${SAMPLE_CREDENTIALS_FILE_NAME}`,
     JSON.stringify({ email, password }, null, 2),
   );
 

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/index.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/index.ts
@@ -3,6 +3,7 @@ export * from "./create-api-key";
 export * from "./generate-credentials";
 export * from "./poll-metabase-instance";
 export * from "./setup-metabase-instance";
+export * from "./ask-if-has-database";
 export * from "./show-metabase-cli-title";
 export * from "./start-local-metabase-container";
 export * from "./check-if-react-project";

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/show-metabase-cli-title.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/show-metabase-cli-title.ts
@@ -8,10 +8,5 @@ export const showMetabaseCliTitle: CliStepMethod = state => {
   printTitle(`View docs at https://npm.im/${SDK_PACKAGE_NAME}`);
   printEmptyLines();
 
-  return [
-    {
-      type: "success",
-    },
-    state,
-  ];
+  return [{ type: "success" }, state];
 };

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/show-post-setup-steps.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/show-post-setup-steps.ts
@@ -27,6 +27,8 @@ export const showPostSetupSteps: CliStepMethod = async state => {
 
   const STEP_3 = getMetabaseInstanceSetupCompleteMessage(
     state.instanceUrl ?? "",
+    state.email ?? "",
+    state.password ?? "",
   );
 
   const POST_SETUP_STEPS = [];

--- a/enterprise/frontend/src/embedding-sdk/cli/types/cli.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/types/cli.ts
@@ -13,6 +13,9 @@ export type CliState = Partial<{
   token: string;
   databaseId: number;
 
+  /** The user does not have a database yet, so we should use the sample database. */
+  shouldUseSampleDatabase: boolean;
+
   /** Metabase instance settings */
   settings: Settings;
 

--- a/enterprise/frontend/src/embedding-sdk/cli/types/cli.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/types/cli.ts
@@ -13,8 +13,8 @@ export type CliState = Partial<{
   token: string;
   databaseId: number;
 
-  /** The user does not have a database yet, so we should use the sample database. */
-  shouldUseSampleDatabase: boolean;
+  /** User does not have a database, so the sample database is used instead. */
+  useSampleDatabase: boolean;
 
   /** Metabase instance settings */
   settings: Settings;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/49485, https://github.com/metabase/metabase/issues/49486, https://github.com/metabase/metabase/issues/49431

### Description

This PR makes 4 small usability changes to the SDK:

- Prints out the username and password in the console, so they can reference it without checking out the `METABASE_LOGIN.json` file.
- Checks if they have a database at the very first step, so they know what to expect.
- Instead of aborting when they select "no" to the database question, we fallback to the sample database.
- It does not bail out if your tables do not have any multi-tenancy column, and just continues normally without multi-tenancy.

### Demo

![CleanShot 2567-11-06 at 21 31 13@2x](https://github.com/user-attachments/assets/7d30e725-0519-48bb-8e8e-80a5c02e0f68)

![CleanShot 2567-11-06 at 21 35 15@2x](https://github.com/user-attachments/assets/87925bd5-6bf1-4a04-af1d-105bb15709d4)
