### PR TITLE
Map Oracle DATE to type/DateTime

### DIFF
--- a/modules/drivers/oracle/src/metabase/driver/oracle.clj
+++ b/modules/drivers/oracle/src/metabase/driver/oracle.clj
@@ -58,7 +58,9 @@
     [#"RAW"         :type/*]
     [#"CHAR"        :type/Text]
     [#"CLOB"        :type/OracleCLOB]
-    [#"DATE"        :type/Date]
+    ;; Yes, the DATE is mapped to `:type/DateTime`. Oracle's DATE can store also a time part.
+    ;; See the docs - https://docs.oracle.com/en/database/oracle/oracle-database/19/nlspg/datetime-data-types-and-time-zone-support.html#GUID-3A1B7AC6-2EDB-4DDC-9C9D-223D4C72AC74
+    [#"DATE"        :type/DateTime]
     [#"DOUBLE"      :type/Float]
     ;; Expression filter type
     [#"^EXPRESSION" :type/*]

--- a/test/metabase/query_processor/streaming/csv_test.clj
+++ b/test/metabase/query_processor/streaming/csv_test.clj
@@ -39,6 +39,11 @@
   [_driver _feature _database]
   false)
 
+;; Oracle's DATE has a time part. It is mapped to `:type/DateTime`.
+(defmethod driver/database-supports? [:oracle ::date-columns-should-be-emitted-without-time]
+  [_driver _feature _database]
+  false)
+
 (deftest ^:parallel date-columns-should-be-emitted-without-time
   (mt/test-drivers (mt/normal-drivers-with-feature ::date-columns-should-be-emitted-without-time)
     (is (= [["1" "April 7, 2014"      "5" "12"]


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/49440

### Description

This PR changes the mapping of Oracle's `DATE` from `:type/Date` to `:type/DateTime`. Reason is that database's type is semantically closer to the latter. With regards to the issue's description, now, to achieve _quick filter on_ drill, to filter on a specific date, the time part has to be removed manually. Drill, as is, filters on field's datetime value. Further details on why it was decided for this approach can be found in [this slack thread](https://metaboat.slack.com/archives/C0645JP1W81/p1730847052051819).

### How to verify

New tests were added, the existing ones passing.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
