### PR TITLE
Remove @flaky tag from no longer flaking tests

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-text-category.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-text-category.cy.spec.js
@@ -37,36 +37,32 @@ describe("scenarios > dashboard > filters > SQL > text/category", () => {
     editDashboard();
   });
 
-  it(
-    "should work when set through the filter widget",
-    { tags: "@flaky" },
-    () => {
-      Object.entries(DASHBOARD_SQL_TEXT_FILTERS).forEach(([filter]) => {
-        cy.log(`Make sure we can connect ${filter} filter`);
-        setFilter("Text or Category", filter);
+  it("should work when set through the filter widget", () => {
+    Object.entries(DASHBOARD_SQL_TEXT_FILTERS).forEach(([filter]) => {
+      cy.log(`Make sure we can connect ${filter} filter`);
+      setFilter("Text or Category", filter);
 
-        cy.findByText("Select…").click();
-        popover().contains(filter).click();
-      });
+      cy.findByText("Select…").click();
+      popover().contains(filter).click();
+    });
 
-      saveDashboard();
+    saveDashboard();
 
-      Object.entries(DASHBOARD_SQL_TEXT_FILTERS).forEach(
-        ([filter, { value, representativeResult }], index) => {
-          filterWidget().eq(index).click();
-          applyFilterByType(filter, value);
+    Object.entries(DASHBOARD_SQL_TEXT_FILTERS).forEach(
+      ([filter, { value, representativeResult }], index) => {
+        filterWidget().eq(index).click();
+        applyFilterByType(filter, value);
 
-          cy.log(`Make sure ${filter} filter returns correct result`);
-          cy.findByTestId("dashcard").within(() => {
-            cy.contains(representativeResult);
-          });
+        cy.log(`Make sure ${filter} filter returns correct result`);
+        cy.findByTestId("dashcard").within(() => {
+          cy.contains(representativeResult);
+        });
 
-          clearFilterWidget(index);
-          cy.wait("@dashcardQuery");
-        },
-      );
-    },
-  );
+        clearFilterWidget(index);
+        cy.wait("@dashcardQuery");
+      },
+    );
+  });
 
   it("should work when set as the default filter and when that filter is removed (metabase#20493)", () => {
     setFilter("Text or Category", "Is");

--- a/e2e/test/scenarios/metrics/metrics-collection.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-collection.cy.spec.js
@@ -69,7 +69,7 @@ describe("scenarios > metrics > collection", () => {
     cy.signInAsNormalUser();
   });
 
-  it("should show metrics in collections", { tags: "@flaky" }, () => {
+  it("should show metrics in collections", () => {
     createQuestion(ORDERS_SCALAR_METRIC);
     createQuestion(ORDERS_TIMESERIES_METRIC);
     cy.visit("/collection/root");

--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -233,64 +233,59 @@ describe("scenarios > models metadata", () => {
     cy.findByLabelText("Display name").should("have.value", "TOTAL");
   });
 
-  it.skip(
-    // disabled for cypress 13 compatibility
-    "should allow reverting to a specific metadata revision",
-    { tags: "@flaky" },
-    () => {
-      cy.intercept("POST", "/api/revision/revert").as("revert");
+  it("should allow reverting to a specific metadata revision", () => {
+    cy.intercept("POST", "/api/revision/revert").as("revert");
 
-      cy.createNativeQuestion({
-        name: "Native Model",
-        type: "model",
-        native: {
-          query: "SELECT * FROM ORDERS LIMIT 5",
-        },
-      }).then(({ body: { id: nativeModelId } }) => {
-        cy.visit(`/model/${nativeModelId}/metadata`);
-        cy.wait("@cardQuery");
-      });
+    cy.createNativeQuestion({
+      name: "Native Model",
+      type: "model",
+      native: {
+        query: "SELECT * FROM ORDERS LIMIT 5",
+      },
+    }).then(({ body: { id: nativeModelId } }) => {
+      cy.visit(`/model/${nativeModelId}/metadata`);
+      cy.wait("@cardQuery");
+    });
 
-      openColumnOptions("SUBTOTAL");
-      mapColumnTo({ table: "Orders", column: "Subtotal" });
-      setColumnType("No special type", "Cost");
-      saveMetadataChanges();
+    openColumnOptions("SUBTOTAL");
+    mapColumnTo({ table: "Orders", column: "Subtotal" });
+    setColumnType("No special type", "Cost");
+    saveMetadataChanges();
 
-      cy.log("Revision 1");
-      cy.findByTestId("TableInteractive-root").within(() => {
-        cy.findByText("Subtotal ($)").should("be.visible");
-        cy.findByText("SUBTOTAL").should("not.exist");
-      });
+    cy.log("Revision 1");
+    cy.findByTestId("TableInteractive-root").within(() => {
+      cy.findByText("Subtotal ($)").should("be.visible");
+      cy.findByText("SUBTOTAL").should("not.exist");
+    });
 
-      openQuestionActions();
-      popover().findByTextEnsureVisible("Edit metadata").click();
+    openQuestionActions();
+    popover().findByTextEnsureVisible("Edit metadata").click();
 
-      cy.log("Revision 2");
-      openColumnOptions("TAX");
-      mapColumnTo({ table: "Orders", column: "Tax" });
-      setColumnType("No special type", "Cost");
-      saveMetadataChanges();
+    cy.log("Revision 2");
+    openColumnOptions("TAX");
+    mapColumnTo({ table: "Orders", column: "Tax" });
+    setColumnType("No special type", "Cost");
+    saveMetadataChanges();
 
-      cy.findAllByTestId("header-cell")
-        .should("contain", "Subtotal ($)")
-        .and("contain", "Tax ($)")
-        .and("not.contain", "TAX");
+    cy.findAllByTestId("header-cell")
+      .should("contain", "Subtotal ($)")
+      .and("contain", "Tax ($)")
+      .and("not.contain", "TAX");
 
-      cy.reload();
-      questionInfoButton().click();
+    cy.reload();
+    questionInfoButton().click();
 
-      cy.findByTestId("sidesheet").within(() => {
-        cy.findByRole("tab", { name: "History" }).click();
-        cy.findAllByTestId("question-revert-button").first().click();
-      });
+    cy.findByTestId("sidesheet").within(() => {
+      cy.findByRole("tab", { name: "History" }).click();
+      cy.findAllByTestId("question-revert-button").first().click();
+    });
 
-      cy.wait("@revert");
-      cy.findAllByTestId("header-cell")
-        .should("contain", "Subtotal ($)")
-        .and("not.contain", "Tax ($)")
-        .and("contain", "TAX");
-    },
-  );
+    cy.wait("@revert");
+    cy.findAllByTestId("header-cell")
+      .should("contain", "Subtotal ($)")
+      .and("not.contain", "Tax ($)")
+      .and("contain", "TAX");
+  });
 
   describe("native models metadata overwrites", { viewportWidth: 1400 }, () => {
     beforeEach(() => {

--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -101,33 +101,27 @@ describe("scenarios > models metadata", () => {
         .and("not.contain", "Pre-tax");
     });
 
-    it(
-      "clears custom metadata when a model is turned back into a question",
-      { tags: "@flaky" },
-      () => {
-        openQuestionActions();
-        popover().findByTextEnsureVisible("Edit metadata").click();
+    it("clears custom metadata when a model is turned back into a question", () => {
+      openQuestionActions();
+      popover().findByTextEnsureVisible("Edit metadata").click();
 
-        openColumnOptions("Subtotal");
-        renameColumn("Subtotal", "Pre-tax");
-        setColumnType("No special type", "Cost");
-        saveMetadataChanges();
+      openColumnOptions("Subtotal");
+      renameColumn("Subtotal", "Pre-tax");
+      setColumnType("No special type", "Cost");
+      saveMetadataChanges();
 
-        cy.findAllByTestId("header-cell")
-          .should("contain", "Pre-tax ($)")
-          .and("not.contain", "Subtotal");
+      cy.findAllByTestId("header-cell")
+        .should("contain", "Pre-tax ($)")
+        .and("not.contain", "Subtotal");
 
-        openQuestionActions();
-        popover()
-          .findByTextEnsureVisible("Turn back to saved question")
-          .click();
-        cy.wait("@cardQuery");
+      openQuestionActions();
+      popover().findByTextEnsureVisible("Turn back to saved question").click();
+      cy.wait("@cardQuery");
 
-        cy.findAllByTestId("header-cell")
-          .should("contain", "Subtotal")
-          .and("not.contain", "Pre-tax ($)");
-      },
-    );
+      cy.findAllByTestId("header-cell")
+        .should("contain", "Subtotal")
+        .and("not.contain", "Pre-tax ($)");
+    });
   });
 
   it("should edit native model metadata", () => {

--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -101,27 +101,33 @@ describe("scenarios > models metadata", () => {
         .and("not.contain", "Pre-tax");
     });
 
-    it("clears custom metadata when a model is turned back into a question", () => {
-      openQuestionActions();
-      popover().findByTextEnsureVisible("Edit metadata").click();
+    it(
+      "clears custom metadata when a model is turned back into a question",
+      { tags: "@flaky" },
+      () => {
+        openQuestionActions();
+        popover().findByTextEnsureVisible("Edit metadata").click();
 
-      openColumnOptions("Subtotal");
-      renameColumn("Subtotal", "Pre-tax");
-      setColumnType("No special type", "Cost");
-      saveMetadataChanges();
+        openColumnOptions("Subtotal");
+        renameColumn("Subtotal", "Pre-tax");
+        setColumnType("No special type", "Cost");
+        saveMetadataChanges();
 
-      cy.findAllByTestId("header-cell")
-        .should("contain", "Pre-tax ($)")
-        .and("not.contain", "Subtotal");
+        cy.findAllByTestId("header-cell")
+          .should("contain", "Pre-tax ($)")
+          .and("not.contain", "Subtotal");
 
-      openQuestionActions();
-      popover().findByTextEnsureVisible("Turn back to saved question").click();
-      cy.wait("@cardQuery");
+        openQuestionActions();
+        popover()
+          .findByTextEnsureVisible("Turn back to saved question")
+          .click();
+        cy.wait("@cardQuery");
 
-      cy.findAllByTestId("header-cell")
-        .should("contain", "Subtotal")
-        .and("not.contain", "Pre-tax ($)");
-    });
+        cy.findAllByTestId("header-cell")
+          .should("contain", "Subtotal")
+          .and("not.contain", "Pre-tax ($)");
+      },
+    );
   });
 
   it("should edit native model metadata", () => {


### PR DESCRIPTION
Closes #44040

### Description

Turns out some tests do not flake anymore, unclear why.
I also used https://stats.metabase.com/model/14828 to see the last time they flaked.

Use "hide whitespace" option for review.

### How to verify

- `metrics-collection.cy.spec.js`
    - `should show metrics in collections`
        - Stress test `#1`: https://github.com/metabase/metabase/actions/runs/11705816850 (100/100)
        - Stress test `#2`: https://github.com/metabase/metabase/actions/runs/11719677456 (100/100)
        - Last time it flaked: unknown
- `dashboard-filters-sql-text-category.cy.spec.js`
    - `should work when set through the filter widget`
        - Stress test `#1`: https://github.com/metabase/metabase/actions/runs/11705799155 (85/100 - timed out due to 1h limit)
        - Stress test `#2`: https://github.com/metabase/metabase/actions/runs/11719681840 (82/100 - timed out due to 1h limit)
        - Last time it flaked: August 23, 2024
- `models-metadata.cy.spec.js`
    - `clears custom metadata when a model is turned back into a question`
        - Stress test `#1`: https://github.com/metabase/metabase/actions/runs/11705828362 (100/100)
        - Stress test `#2`: https://github.com/metabase/metabase/actions/runs/11719685827 (100/100)
        - Last time it flaked: July 26, 2024
