### PR TITLE
Fix auto-release artifact name collision

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Upload Metabase ${{ matrix.edition }} JAR as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: metabase-${{ matrix.edition }}-uberjar
+          name: metabase-test-${{ matrix.edition }}-uberjar
           path: |
             ./metabase.jar
             ./COMMIT-ID
@@ -112,7 +112,7 @@ jobs:
       - uses: actions/download-artifact@v4
         name: Retrieve uberjar artifact
         with:
-          name: metabase-${{ matrix.edition }}-uberjar
+          name: metabase-test-${{ matrix.edition }}-uberjar
       - name: Launch uberjar (and keep it running)
         run: java -jar ./metabase.jar &
       - name: Wait for Metabase to start
@@ -162,7 +162,7 @@ jobs:
       - uses: actions/download-artifact@v4
         name: Retrieve uberjar artifact for ${{ matrix.edition }}
         with:
-          name: metabase-${{ matrix.edition }}-uberjar
+          name: metabase-test-${{ matrix.edition }}-uberjar
       - name: Get the version info
         run: |
           jar xf metabase.jar version.properties
@@ -214,7 +214,7 @@ jobs:
       - uses: actions/download-artifact@v4
         name: Retrieve uberjar artifact
         with:
-          name: metabase-${{ matrix.edition }}-uberjar
+          name: metabase-test-${{ matrix.edition }}-uberjar
       - name: Move the Uberjar to the context dir
         run: mv metabase.jar bin/docker/.
       - name: Set up Docker Buildx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,6 +199,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: metabase-${{ matrix.edition }}-uberjar
+        overwrite: true
         path: |
           ./metabase.jar
           ./COMMIT-ID


### PR DESCRIPTION
Changing the auto-release workflow so that the publish and test jobs were called directly by the build job created a name collision on the `metabase-{edition}-uberjar` artifact. 


See errors: [one](https://github.com/metabase/metabase/actions/runs/11675211312/job/32509636197#step:7:19) [two](https://github.com/metabase/metabase/actions/runs/11694910511/job/32569718123#step:7:19)

This changes the pre-release workflow to use a different artifact name, and allows the publish job to overwrite any artifact name collisions


