### PR TITLE
metabot v3: provide complete visualization settings to llm

### DIFF
--- a/frontend/src/metabase/metabot-v3/selectors.ts
+++ b/frontend/src/metabase/metabot-v3/selectors.ts
@@ -1,0 +1,64 @@
+import { createSelector } from "@reduxjs/toolkit";
+import _ from "underscore";
+
+import {
+  getRawSeries,
+  getTransformedSeries,
+  getVisualizationSettings,
+} from "metabase/query_builder/selectors";
+import { keyForSingleSeries } from "metabase/visualizations/lib/settings/series";
+import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
+
+/**
+ * This selector hydrates the visualization settings with default values for the series, column, and other settings.
+ * This is used to provide a more accurate context to the LLM when changing settings.
+ */
+export const getVisualizationMetabotContext = createSelector(
+  [getTransformedSeries, getRawSeries, getVisualizationSettings],
+  (transformedSeries, rawSeries, visualizationSettings) => {
+    const hydratedVisualizationSettings: ComputedVisualizationSettings = {
+      ...visualizationSettings,
+    };
+
+    if (typeof hydratedVisualizationSettings.series === "function") {
+      const seriesSettings: ComputedVisualizationSettings["series_settings"] =
+        {};
+      transformedSeries.forEach(series => {
+        seriesSettings[keyForSingleSeries(series)] =
+          hydratedVisualizationSettings.series(series);
+      });
+      hydratedVisualizationSettings.series_settings = seriesSettings;
+    }
+
+    if (typeof hydratedVisualizationSettings.column === "function") {
+      const columnSettings: ComputedVisualizationSettings["column_settings"] = {
+        ...hydratedVisualizationSettings.column_settings,
+      };
+      rawSeries.forEach(series => {
+        series.data.cols.forEach(col => {
+          const columnSetting = hydratedVisualizationSettings.column?.(col);
+
+          if (columnSetting) {
+            // Use column name as key instead of column key because LLMs are bad with stringified json keys like `["name","column_name"]`
+            columnSettings[col.name] = {
+              ...columnSetting,
+              // Remove unnecessary properties from column objects
+              column: _.pick(columnSetting.column, [
+                "name",
+                "display_name",
+                "effective_type",
+                "base_type",
+                "database_type",
+                "semantic_type",
+              ]),
+            };
+          }
+        });
+      });
+
+      hydratedVisualizationSettings.column_settings = columnSettings;
+    }
+
+    return hydratedVisualizationSettings;
+  },
+);

--- a/frontend/src/metabase/query_builder/containers/use-register-metabot-context.tsx
+++ b/frontend/src/metabase/query_builder/containers/use-register-metabot-context.tsx
@@ -1,6 +1,7 @@
 import _ from "underscore";
 
 import { useRegisterMetabotContextProvider } from "metabase/metabot";
+import { getVisualizationMetabotContext } from "metabase/metabot-v3/selectors";
 
 import { getQueryResults, getQuestion } from "../selectors";
 
@@ -15,7 +16,7 @@ export const useRegisterMetabotContext = () => {
       ...(col.description && { description: col.description }),
     }));
 
-    const vizSettings = question?.card()?.visualization_settings || {};
+    const vizSettings = getVisualizationMetabotContext(state);
     const columnSettings = vizSettings["table.columns"] || [];
     const disabledColumnNames = new Set(
       columnSettings.filter(col => !col.enabled).map(c => c.name),
@@ -28,6 +29,7 @@ export const useRegisterMetabotContext = () => {
     return {
       current_question_id: question?.id() || null,
       current_visualization_settings: {
+        ...vizSettings,
         current_display_type: question?.display(),
         ...(visible_columns.length ? { visible_columns } : {}),
         ...(hidden_columns.length ? { hidden_columns } : {}),


### PR DESCRIPTION
### Description

Provide complete visualization settings to LLMs. If we pass only `card.visualization_settings` we received from the server it will not include visualization settings that has not been explicitly changed.

For example, if a user did not change x-axis label manually, the settings will not contain `graph.x_axis.title_text` but it is important to provide the inferred by default value to LLM so it knows what are current axes names.
