### PR TITLE
metabot v3: change axes names tool

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/reactions.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/reactions.clj
@@ -164,3 +164,9 @@
                          [:direction [:maybe [:enum "asc" "desc"]]]]]]
    [:limits [:vector [:map
                       [:limit integer?]]]]])
+
+(defreaction :metabot.reaction/change-axes-labels
+  [:map
+   [:type [:= :metabot.reaction/change-axes-labels]]
+   [:x_axis_label [:maybe :string]]
+   [:y_axis_label [:maybe :string]]])

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools.clj
@@ -4,6 +4,7 @@
    [clojure.string :as str]
    [malli.core :as mc]
    [malli.transform :as mtx]
+   [metabase-enterprise.metabot-v3.tools.change-axes-labels]
    [metabase-enterprise.metabot-v3.tools.change-display-type]
    [metabase-enterprise.metabot-v3.tools.change-query]
    [metabase-enterprise.metabot-v3.tools.change-table-visualization-settings]
@@ -25,6 +26,7 @@
   metabase-enterprise.metabot-v3.tools.confirm-invite-user/keep-me
   metabase-enterprise.metabot-v3.tools.change-display-type/keep-me
   metabase-enterprise.metabot-v3.tools.change-query/keep-me
+  metabase-enterprise.metabot-v3.tools.change-axes-labels/keep-me
   metabase-enterprise.metabot-v3.tools.change-table-visualization-settings/keep-me
   metabase-enterprise.metabot-v3.tools.who-is-your-favorite/keep-me)
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/change-axes-labels.json
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/change-axes-labels.json
@@ -1,0 +1,21 @@
+{
+  "name": "change-axes-labels",
+  "description": "Change X and Y axes labels. Make sure that the visualization type is `line`, `bar`, `area`, `combo`, `scatter`, `waterfall`, or `row` before calling this tool.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "x_axis_label": {
+        "type": ["string", "null"],
+        "description": "The new label for the X axis. Set to `null` if should not be changed.",
+        "nullable": true
+      },
+      "y_axis_label": {
+        "type": ["string", "null"],
+        "description": "The new label for the Y axis. Set to `null` if should not be changed.",
+        "nullable": true
+      }
+    },
+    "required": ["x_axis_label", "y_axis_label"],
+    "additionalProperties": false
+  }
+}

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/change_axes_labels.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/change_axes_labels.clj
@@ -1,0 +1,16 @@
+(ns metabase-enterprise.metabot-v3.tools.change-axes-labels
+  (:require
+   [metabase-enterprise.metabot-v3.tools.interface :as metabot-v3.tools.interface]
+   [metabase.util.malli :as mu]))
+
+(mu/defmethod metabot-v3.tools.interface/*tool-applicable?* :metabot.tool/change-axes-labels
+  [_tool-name context]
+  (contains? #{"line" "bar" "area" "combo" "scatter" "waterfall" "row"}
+              (some-> context :current_visualization_settings :current_display_type)))
+
+(mu/defmethod metabot-v3.tools.interface/*invoke-tool* :metabot.tool/change-axes-labels
+  [_tool-name {:keys [x-axis-label y-axis-label], :as _argument-map}]
+  {:reactions [{:type :metabot.reaction/change-axes-labels
+                :x_axis_label x-axis-label
+                :y_axis_label y-axis-label}]
+   :output "success"})

--- a/enterprise/frontend/src/metabase-enterprise/metabot/reactions/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/reactions/index.ts
@@ -6,6 +6,7 @@ import { writeBack } from "./metabot";
 import { changeQuery } from "./queries";
 import type { ReactionHandler } from "./types";
 import {
+  changeAxesLabels,
   changeDisplayType,
   changeTableVisualizationSettings,
 } from "./visualizations";
@@ -19,6 +20,7 @@ type ReactionHandlers = {
 };
 
 export const reactionHandlers: ReactionHandlers = {
+  "metabot.reaction/change-axes-labels": changeAxesLabels,
   "metabot.reaction/change-display-type": changeDisplayType,
   "metabot.reaction/change-table-visualization-settings":
     changeTableVisualizationSettings,

--- a/enterprise/frontend/src/metabase-enterprise/metabot/reactions/visualizations.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/reactions/visualizations.ts
@@ -9,6 +9,7 @@ import { setQuestionDisplayType } from "metabase/query_builder/components/chart-
 import { getQueryResults, getQuestion } from "metabase/query_builder/selectors";
 import * as Lib from "metabase-lib";
 import type {
+  MetabotChangeAxesLabelsReaction,
   MetabotChangeDisplayTypeReaction,
   MetabotChangeVisiualizationSettingsReaction,
 } from "metabase-types/api";
@@ -66,4 +67,20 @@ export const changeDisplayType: ReactionHandler<
       );
       dispatch(setUIControls({ isShowingRawTable: false }));
     }
+  };
+
+export const changeAxesLabels: ReactionHandler<
+  MetabotChangeAxesLabelsReaction
+> =
+  reaction =>
+  async ({ dispatch }) => {
+    const settings: Record<string, string | undefined> = {};
+    if (reaction.x_axis_label) {
+      settings["graph.x_axis.title_text"] = reaction.x_axis_label;
+    }
+    if (reaction.y_axis_label) {
+      settings["graph.y_axis.title_text"] = reaction.y_axis_label;
+    }
+
+    await dispatch(onUpdateVisualizationSettings(settings));
   };

--- a/frontend/src/metabase-types/api/metabot.ts
+++ b/frontend/src/metabase-types/api/metabot.ts
@@ -144,7 +144,14 @@ export type MetabotChangeQueryReaction = {
   limits: MetabotLimitQueryDetails[];
 };
 
+export type MetabotChangeAxesLabelsReaction = {
+  type: "metabot.reaction/change-axes-labels";
+  x_axis_label: string | null;
+  y_axis_label: string | null;
+};
+
 export type MetabotReaction =
+  | MetabotChangeAxesLabelsReaction
   | MetabotMessageReaction
   | MetabotChangeDisplayTypeReaction
   | MetabotChangeVisiualizationSettingsReaction


### PR DESCRIPTION
Sliced out from https://github.com/metabase/metabase/pull/49504

### Description

Adds change axes names tool.

### Demo

<video src="https://github.com/user-attachments/assets/5df62a41-1a6f-4301-a579-8f0a6385a72b" />

