### PR TITLE
Deprecate scores from search API response

### DIFF
--- a/frontend/src/metabase-types/api/mocks/search.ts
+++ b/frontend/src/metabase-types/api/mocks/search.ts
@@ -1,10 +1,6 @@
 import _ from "underscore";
 
-import type {
-  SearchResponse,
-  SearchResult,
-  SearchScore,
-} from "metabase-types/api";
+import type { SearchResponse, SearchResult } from "metabase-types/api";
 
 import { createMockCollection } from "./collection";
 
@@ -40,7 +36,6 @@ export const createMockSearchResult = (
     initial_sync_status: null,
     dashboard_count: null,
     context: null,
-    scores: [createMockSearchScore()],
     created_at: "2022-01-01T00:00:00.000Z",
     creator_common_name: "Testy Tableton",
     creator_id: 2,
@@ -50,15 +45,6 @@ export const createMockSearchResult = (
     ...options,
   };
 };
-
-export const createMockSearchScore = (
-  options: Partial<SearchScore> = {},
-): SearchScore => ({
-  score: 1,
-  weight: 1,
-  name: "text-total-occurrences",
-  ...options,
-});
 
 export const createMockSearchResults = ({
   items = [createMockSearchResult()],

--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -27,24 +27,6 @@ export type EnabledSearchModel = (typeof ENABLED_SEARCH_MODELS)[number];
 
 export type SearchModel = (typeof SEARCH_MODELS)[number];
 
-export interface SearchScore {
-  weight: number;
-  score: number;
-  name:
-    | "pinned"
-    | "bookmarked"
-    | "recency"
-    | "dashboard"
-    | "model"
-    | "official collection score"
-    | "verified"
-    | "text-consecutivity"
-    | "text-total-occurrences"
-    | "text-fullness";
-  match?: string;
-  column?: string;
-}
-
 interface BaseSearchResult<
   Id extends SearchResultId,
   Model extends SearchModel,
@@ -107,7 +89,6 @@ export interface SearchResult<
   initial_sync_status: InitialSyncStatus | null;
   dashboard_count: number | null;
   context: any; // this might be a dead property
-  scores: SearchScore[];
   last_edited_at: string | null;
   last_editor_id: UserId | null;
   last_editor_common_name: string | null;

--- a/frontend/src/metabase/search/components/SearchResult/components/Score.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/components/Score.tsx
@@ -1,6 +1,0 @@
-import CS from "metabase/css/core/index.css";
-import type { SearchScore } from "metabase-types/api";
-
-export function Score({ scores }: { scores: SearchScore[] }) {
-  return <pre className={CS.hide}>{JSON.stringify(scores, null, 2)}</pre>;
-}

--- a/frontend/src/metabase/search/components/SearchResult/components/index.ts
+++ b/frontend/src/metabase/search/components/SearchResult/components/index.ts
@@ -1,4 +1,3 @@
 export { Context } from "./Context";
 export { ItemIcon } from "./ItemIcon";
-export { Score } from "./Score";
 export * from "./constants";


### PR DESCRIPTION
Search currently returns a detailed list of the scores for each item, which is pretty hefty, and the type is also coupled to the current rankers, which will change in future. 

Removing from the type to start to just validate that nothing uses it.

Best to just not model this. Going to see about just removing it from the BE as well, and put in some other way to debug. Worst case an opt-in query parameter.