### PR TITLE
Remove sandboxes tests from flaky jail

### DIFF
--- a/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
@@ -596,7 +596,7 @@ describeEE("formatting > sandboxes", () => {
        *
        * Related issues: metabase#10474, metabase#14629
        */
-      ["normal", "workaround"].forEach(test => {
+      ["normal" /* , "workaround" */].forEach(test => {
         it(
           `${test.toUpperCase()} version:\n advanced sandboxing should not ignore data model features like object detail of FK (metabase-enterprise#520)`,
           { tags: "@quarantine" },

--- a/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
@@ -596,10 +596,10 @@ describeEE("formatting > sandboxes", () => {
        *
        * Related issues: metabase#10474, metabase#14629
        */
-      ["normal" /* , "workaround" */].forEach(test => {
+      ["normal", "workaround"].forEach(test => {
         it(
           `${test.toUpperCase()} version:\n advanced sandboxing should not ignore data model features like object detail of FK (metabase-enterprise#520)`,
-          { tags: "@quarantine" },
+          { tags: test === "normal" ? "@quarantine" : [] },
           () => {
             cy.intercept("POST", "/api/card/*/query").as("cardQuery");
             cy.intercept("PUT", "/api/card/*").as("questionUpdate");

--- a/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
@@ -505,257 +505,253 @@ describeEE("formatting > sandboxes", () => {
       });
     });
 
-    describe(
-      "with display values remapped to use a foreign key",
-      { tags: "@flaky" },
-      () => {
-        beforeEach(() => {
-          cy.intercept("POST", "/api/dataset").as("datasetQuery");
-          cy.log("Remap Product ID's display value to `title`");
-          remapDisplayValueToFK({
-            display_value: ORDERS.PRODUCT_ID,
-            name: "Product ID",
-            fk: PRODUCTS.TITLE,
-          });
+    describe("with display values remapped to use a foreign key", () => {
+      beforeEach(() => {
+        cy.intercept("POST", "/api/dataset").as("datasetQuery");
+        cy.log("Remap Product ID's display value to `title`");
+        remapDisplayValueToFK({
+          display_value: ORDERS.PRODUCT_ID,
+          name: "Product ID",
+          fk: PRODUCTS.TITLE,
         });
+      });
 
-        /**
-         * There isn't an exact issue that this test reproduces, but it is basically a version of (metabase-enterprise#520)
-         * that uses a query builder instead of SQL based questions.
-         */
-        it("should be able to sandbox using query builder saved questions", () => {
-          cy.log("Create 'Orders'-based question using QB");
-          cy.createQuestion({
-            name: "520_Orders",
-            query: {
-              "source-table": ORDERS_ID,
-              filter: [">", ["field", ORDERS.TOTAL, null], 10],
-            },
-          }).then(({ body: { id: CARD_ID } }) => {
-            cy.sandboxTable({
-              table_id: ORDERS_ID,
-              card_id: CARD_ID,
-              attribute_remappings: {
-                attr_uid: ["dimension", ["field", ORDERS.USER_ID, null]],
-              },
-            });
-          });
-
-          cy.log("Create 'Products'-based question using QB");
-          cy.createQuestion({
-            name: "520_Products",
-            query: {
-              "source-table": PRODUCTS_ID,
-              filter: [">", ["field", PRODUCTS.PRICE, null], 10],
-            },
-          }).then(({ body: { id: CARD_ID } }) => {
-            cy.sandboxTable({
-              table_id: PRODUCTS_ID,
-              card_id: CARD_ID,
-              attribute_remappings: {
-                attr_cat: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
-              },
-            });
-          });
-
-          cy.signOut();
-          cy.signInAsSandboxedUser();
-
-          openOrdersTable({
-            callback: xhr => expect(xhr.response.body.error).not.to.exist,
-          });
-
-          cy.wait("@datasetQuery");
-
-          assertQueryBuilderRowCount(11); // test that user is sandboxed - normal users has over 2000 rows
-          assertDatasetReqIsSandboxed({
-            requestAlias: "@datasetQuery",
-            columnId: ORDERS.USER_ID,
-            columnAssertion: USERS.sandboxed.login_attributes.attr_uid,
-          });
-
-          cy.findByTestId("TableInteractive-root")
-            .findByText("Awesome Concrete Shoes")
-            .click();
-          popover()
-            .findByText(/View details/i)
-            .click();
-
-          cy.log(
-            "It should show object details instead of filtering by this Product ID",
-          );
-          cy.findByTestId("object-detail");
-          cy.findAllByText("McClure-Lockman");
-        });
-
-        /**
-         * This issue (metabase-enterprise#520) has a peculiar quirk:
-         *  - It works ONLY if SQL question is first run (`result_metadata` builds), and then the question is saved.
-         *  - In a real-world scenario it is quite possible for an admin to save that SQL question without running it first. This fails!
-         *  (more info: https://github.com/metabase/metabase-enterprise/issues/520#issuecomment-772528159)
-         *
-         * That's why this test has 2 versions that reflect both scenarios. We'll call them "normal" and "workaround".
-         * Until the underlying issue is fixed, "normal" scenario will be skipped.
-         *
-         * Related issues: metabase#10474, metabase#14629
-         */
-
-        // skipping the workaround test because the function `runAndSaveQuestion`
-        // relies on the existence of a save button on a saved question that is not dirty
-        // which is a bug fixed in issue metabase#14302
-        ["normal" /* , "workaround" */].forEach(test => {
-          it(
-            `${test.toUpperCase()} version:\n advanced sandboxing should not ignore data model features like object detail of FK (metabase-enterprise#520)`,
-            { tags: "@quarantine" },
-            () => {
-              cy.intercept("POST", "/api/card/*/query").as("cardQuery");
-              cy.intercept("PUT", "/api/card/*").as("questionUpdate");
-
-              cy.createNativeQuestion({
-                name: "EE_520_Q1",
-                native: {
-                  query:
-                    "SELECT * FROM ORDERS WHERE USER_ID={{sandbox}} AND TOTAL > 10",
-                  "template-tags": {
-                    sandbox: {
-                      "display-name": "Sandbox",
-                      id: "1115dc4f-6b9d-812e-7f72-b87ab885c88a",
-                      name: "sandbox",
-                      type: "number",
-                    },
-                  },
-                },
-              }).then(({ body: { id: CARD_ID } }) => {
-                test === "workaround"
-                  ? runAndSaveQuestion({ question: CARD_ID, sandboxValue: "1" })
-                  : null;
-
-                cy.sandboxTable({
-                  table_id: ORDERS_ID,
-                  card_id: CARD_ID,
-                  attribute_remappings: {
-                    attr_uid: ["variable", ["template-tag", "sandbox"]],
-                  },
-                });
-              });
-
-              cy.createNativeQuestion({
-                name: "EE_520_Q2",
-                native: {
-                  query:
-                    "SELECT * FROM PRODUCTS WHERE CATEGORY={{sandbox}} AND PRICE > 10",
-                  "template-tags": {
-                    sandbox: {
-                      "display-name": "Sandbox",
-                      id: "3d69ba99-7076-2252-30bd-0bb8810ba895",
-                      name: "sandbox",
-                      type: "text",
-                    },
-                  },
-                },
-              }).then(({ body: { id: CARD_ID } }) => {
-                test === "workaround"
-                  ? runAndSaveQuestion({
-                      question: CARD_ID,
-                      sandboxValue: "Widget",
-                    })
-                  : null;
-
-                cy.sandboxTable({
-                  table_id: PRODUCTS_ID,
-                  card_id: CARD_ID,
-                  attribute_remappings: {
-                    attr_cat: ["variable", ["template-tag", "sandbox"]],
-                  },
-                });
-              });
-
-              cy.signOut();
-              cy.signInAsSandboxedUser();
-
-              openOrdersTable();
-
-              cy.log("Reported failing on v1.36.x");
-
-              cy.log(
-                "It should show remapped Display Values instead of Product ID",
-              );
-              cy.get("[data-testid=cell-data]")
-                .contains("Awesome Concrete Shoes")
-                .click();
-              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-              cy.findByText(/View details/i).click();
-
-              cy.log(
-                "It should show object details instead of filtering by this Product ID",
-              );
-              // The name of this Vendor is visible in "details" only
-              cy.findByTestId("object-detail");
-              cy.findAllByText("McClure-Lockman");
-
-              /**
-               * Helper function related to this test only!
-               */
-              function runAndSaveQuestion({ question, sandboxValue } = {}) {
-                // Run the question
-                cy.visit(`/question/${question}?sandbox=${sandboxValue}`);
-                // Wait for results
-                cy.wait("@cardQuery");
-                // Save the question
-                cy.findByText("Save").click();
-                modal().within(() => {
-                  cy.button("Save").click();
-                });
-                // Wait for an update so the other queries don't accidentally cancel it
-                cy.wait("@questionUpdate");
-              }
-            },
-          );
-        });
-
-        it("simple sandboxing should work (metabase#14629)", () => {
-          cy.updatePermissionsGraph({
-            [COLLECTION_GROUP]: {
-              [SAMPLE_DB_ID]: {
-                "view-data": {
-                  PUBLIC: {
-                    [PRODUCTS_ID]: "unrestricted",
-                  },
-                },
-              },
-            },
-          });
-
+      /**
+       * There isn't an exact issue that this test reproduces, but it is basically a version of (metabase-enterprise#520)
+       * that uses a query builder instead of SQL based questions.
+       */
+      it("should be able to sandbox using query builder saved questions", () => {
+        cy.log("Create 'Orders'-based question using QB");
+        cy.createQuestion({
+          name: "520_Orders",
+          query: {
+            "source-table": ORDERS_ID,
+            filter: [">", ["field", ORDERS.TOTAL, null], 10],
+          },
+        }).then(({ body: { id: CARD_ID } }) => {
           cy.sandboxTable({
             table_id: ORDERS_ID,
+            card_id: CARD_ID,
             attribute_remappings: {
               attr_uid: ["dimension", ["field", ORDERS.USER_ID, null]],
             },
           });
-
-          cy.signOut();
-          cy.signInAsSandboxedUser();
-          openOrdersTable({
-            callback: xhr => expect(xhr.response.body.error).not.to.exist,
-          });
-          assertQueryBuilderRowCount(11); // test that user is sandboxed - normal users has over 2000 rows
-          assertDatasetReqIsSandboxed({
-            columnId: ORDERS.USER_ID,
-            columnAssertion: USERS.sandboxed.login_attributes.attr_uid,
-          });
-
-          // Title of the first order for User ID = 1
-          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-          cy.findByText("Awesome Concrete Shoes");
-
-          cy.signOut();
-          cy.signInAsAdmin();
-          cy.visit(
-            "/admin/permissions/data/group/3/database/1/schema/PUBLIC/5/segmented",
-          );
         });
-      },
-    );
+
+        cy.log("Create 'Products'-based question using QB");
+        cy.createQuestion({
+          name: "520_Products",
+          query: {
+            "source-table": PRODUCTS_ID,
+            filter: [">", ["field", PRODUCTS.PRICE, null], 10],
+          },
+        }).then(({ body: { id: CARD_ID } }) => {
+          cy.sandboxTable({
+            table_id: PRODUCTS_ID,
+            card_id: CARD_ID,
+            attribute_remappings: {
+              attr_cat: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
+            },
+          });
+        });
+
+        cy.signOut();
+        cy.signInAsSandboxedUser();
+
+        openOrdersTable({
+          callback: xhr => expect(xhr.response.body.error).not.to.exist,
+        });
+
+        cy.wait("@datasetQuery");
+
+        assertQueryBuilderRowCount(11); // test that user is sandboxed - normal users has over 2000 rows
+        assertDatasetReqIsSandboxed({
+          requestAlias: "@datasetQuery",
+          columnId: ORDERS.USER_ID,
+          columnAssertion: USERS.sandboxed.login_attributes.attr_uid,
+        });
+
+        cy.findByTestId("TableInteractive-root")
+          .findByText("Awesome Concrete Shoes")
+          .click();
+        popover()
+          .findByText(/View details/i)
+          .click();
+
+        cy.log(
+          "It should show object details instead of filtering by this Product ID",
+        );
+        cy.findByTestId("object-detail");
+        cy.findAllByText("McClure-Lockman");
+      });
+
+      /**
+       * This issue (metabase-enterprise#520) has a peculiar quirk:
+       *  - It works ONLY if SQL question is first run (`result_metadata` builds), and then the question is saved.
+       *  - In a real-world scenario it is quite possible for an admin to save that SQL question without running it first. This fails!
+       *  (more info: https://github.com/metabase/metabase-enterprise/issues/520#issuecomment-772528159)
+       *
+       * That's why this test has 2 versions that reflect both scenarios. We'll call them "normal" and "workaround".
+       * Until the underlying issue is fixed, "normal" scenario will be skipped.
+       *
+       * Related issues: metabase#10474, metabase#14629
+       */
+
+      // skipping the workaround test because the function `runAndSaveQuestion`
+      // relies on the existence of a save button on a saved question that is not dirty
+      // which is a bug fixed in issue metabase#14302
+      ["normal" /* , "workaround" */].forEach(test => {
+        it(
+          `${test.toUpperCase()} version:\n advanced sandboxing should not ignore data model features like object detail of FK (metabase-enterprise#520)`,
+          { tags: "@quarantine" },
+          () => {
+            cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+            cy.intercept("PUT", "/api/card/*").as("questionUpdate");
+
+            cy.createNativeQuestion({
+              name: "EE_520_Q1",
+              native: {
+                query:
+                  "SELECT * FROM ORDERS WHERE USER_ID={{sandbox}} AND TOTAL > 10",
+                "template-tags": {
+                  sandbox: {
+                    "display-name": "Sandbox",
+                    id: "1115dc4f-6b9d-812e-7f72-b87ab885c88a",
+                    name: "sandbox",
+                    type: "number",
+                  },
+                },
+              },
+            }).then(({ body: { id: CARD_ID } }) => {
+              test === "workaround"
+                ? runAndSaveQuestion({ question: CARD_ID, sandboxValue: "1" })
+                : null;
+
+              cy.sandboxTable({
+                table_id: ORDERS_ID,
+                card_id: CARD_ID,
+                attribute_remappings: {
+                  attr_uid: ["variable", ["template-tag", "sandbox"]],
+                },
+              });
+            });
+
+            cy.createNativeQuestion({
+              name: "EE_520_Q2",
+              native: {
+                query:
+                  "SELECT * FROM PRODUCTS WHERE CATEGORY={{sandbox}} AND PRICE > 10",
+                "template-tags": {
+                  sandbox: {
+                    "display-name": "Sandbox",
+                    id: "3d69ba99-7076-2252-30bd-0bb8810ba895",
+                    name: "sandbox",
+                    type: "text",
+                  },
+                },
+              },
+            }).then(({ body: { id: CARD_ID } }) => {
+              test === "workaround"
+                ? runAndSaveQuestion({
+                    question: CARD_ID,
+                    sandboxValue: "Widget",
+                  })
+                : null;
+
+              cy.sandboxTable({
+                table_id: PRODUCTS_ID,
+                card_id: CARD_ID,
+                attribute_remappings: {
+                  attr_cat: ["variable", ["template-tag", "sandbox"]],
+                },
+              });
+            });
+
+            cy.signOut();
+            cy.signInAsSandboxedUser();
+
+            openOrdersTable();
+
+            cy.log("Reported failing on v1.36.x");
+
+            cy.log(
+              "It should show remapped Display Values instead of Product ID",
+            );
+            cy.get("[data-testid=cell-data]")
+              .contains("Awesome Concrete Shoes")
+              .click();
+            // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+            cy.findByText(/View details/i).click();
+
+            cy.log(
+              "It should show object details instead of filtering by this Product ID",
+            );
+            // The name of this Vendor is visible in "details" only
+            cy.findByTestId("object-detail");
+            cy.findAllByText("McClure-Lockman");
+
+            /**
+             * Helper function related to this test only!
+             */
+            function runAndSaveQuestion({ question, sandboxValue } = {}) {
+              // Run the question
+              cy.visit(`/question/${question}?sandbox=${sandboxValue}`);
+              // Wait for results
+              cy.wait("@cardQuery");
+              // Save the question
+              cy.findByText("Save").click();
+              modal().within(() => {
+                cy.button("Save").click();
+              });
+              // Wait for an update so the other queries don't accidentally cancel it
+              cy.wait("@questionUpdate");
+            }
+          },
+        );
+      });
+
+      it("simple sandboxing should work (metabase#14629)", () => {
+        cy.updatePermissionsGraph({
+          [COLLECTION_GROUP]: {
+            [SAMPLE_DB_ID]: {
+              "view-data": {
+                PUBLIC: {
+                  [PRODUCTS_ID]: "unrestricted",
+                },
+              },
+            },
+          },
+        });
+
+        cy.sandboxTable({
+          table_id: ORDERS_ID,
+          attribute_remappings: {
+            attr_uid: ["dimension", ["field", ORDERS.USER_ID, null]],
+          },
+        });
+
+        cy.signOut();
+        cy.signInAsSandboxedUser();
+        openOrdersTable({
+          callback: xhr => expect(xhr.response.body.error).not.to.exist,
+        });
+        assertQueryBuilderRowCount(11); // test that user is sandboxed - normal users has over 2000 rows
+        assertDatasetReqIsSandboxed({
+          columnId: ORDERS.USER_ID,
+          columnAssertion: USERS.sandboxed.login_attributes.attr_uid,
+        });
+
+        // Title of the first order for User ID = 1
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+        cy.findByText("Awesome Concrete Shoes");
+
+        cy.signOut();
+        cy.signInAsAdmin();
+        cy.visit(
+          "/admin/permissions/data/group/3/database/1/schema/PUBLIC/5/segmented",
+        );
+      });
+    });
 
     ["remapped", "default"].forEach(test => {
       it(`${test.toUpperCase()} version:\n should work on questions with joins, with sandboxed target table, where target fields cannot be filtered (metabase#13642)`, () => {

--- a/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
@@ -599,7 +599,7 @@ describeEE("formatting > sandboxes", () => {
       ["normal", "workaround"].forEach(test => {
         it(
           `${test.toUpperCase()} version:\n advanced sandboxing should not ignore data model features like object detail of FK (metabase-enterprise#520)`,
-          { tags: test === "normal" ? "@quarantine" : [] },
+          { tags: "@quarantine" },
           () => {
             cy.intercept("POST", "/api/card/*/query").as("cardQuery");
             cy.intercept("PUT", "/api/card/*").as("questionUpdate");

--- a/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
@@ -596,11 +596,7 @@ describeEE("formatting > sandboxes", () => {
        *
        * Related issues: metabase#10474, metabase#14629
        */
-
-      // skipping the workaround test because the function `runAndSaveQuestion`
-      // relies on the existence of a save button on a saved question that is not dirty
-      // which is a bug fixed in issue metabase#14302
-      ["normal" /* , "workaround" */].forEach(test => {
+      ["normal", "workaround"].forEach(test => {
         it(
           `${test.toUpperCase()} version:\n advanced sandboxing should not ignore data model features like object detail of FK (metabase-enterprise#520)`,
           { tags: "@quarantine" },
@@ -624,7 +620,7 @@ describeEE("formatting > sandboxes", () => {
               },
             }).then(({ body: { id: CARD_ID } }) => {
               test === "workaround"
-                ? runAndSaveQuestion({ question: CARD_ID, sandboxValue: "1" })
+                ? runQuestion({ question: CARD_ID, sandboxValue: "1" })
                 : null;
 
               cy.sandboxTable({
@@ -652,7 +648,7 @@ describeEE("formatting > sandboxes", () => {
               },
             }).then(({ body: { id: CARD_ID } }) => {
               test === "workaround"
-                ? runAndSaveQuestion({
+                ? runQuestion({
                     question: CARD_ID,
                     sandboxValue: "Widget",
                   })
@@ -693,18 +689,11 @@ describeEE("formatting > sandboxes", () => {
             /**
              * Helper function related to this test only!
              */
-            function runAndSaveQuestion({ question, sandboxValue } = {}) {
+            function runQuestion({ question, sandboxValue } = {}) {
               // Run the question
               cy.visit(`/question/${question}?sandbox=${sandboxValue}`);
               // Wait for results
               cy.wait("@cardQuery");
-              // Save the question
-              cy.findByText("Save").click();
-              modal().within(() => {
-                cy.button("Save").click();
-              });
-              // Wait for an update so the other queries don't accidentally cancel it
-              cy.wait("@questionUpdate");
             }
           },
         );

--- a/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
@@ -596,10 +596,10 @@ describeEE("formatting > sandboxes", () => {
        *
        * Related issues: metabase#10474, metabase#14629
        */
-      [/* "normal",  */ "workaround"].forEach(test => {
+      ["normal", "workaround"].forEach(test => {
         it(
           `${test.toUpperCase()} version:\n advanced sandboxing should not ignore data model features like object detail of FK (metabase-enterprise#520)`,
-          { tags: "@quarantine" },
+          { tags: test === "normal" ? "@quarantine" : [] },
           () => {
             cy.intercept("POST", "/api/card/*/query").as("cardQuery");
             cy.intercept("PUT", "/api/card/*").as("questionUpdate");

--- a/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
@@ -595,6 +595,10 @@ describeEE("formatting > sandboxes", () => {
        * Until the underlying issue is fixed, "normal" scenario will be skipped.
        *
        * Related issues: metabase#10474, metabase#14629
+       *
+       * Update 2024/11/07:
+       * It's expected that this test fails - the issue is still there.
+       * See https://github.com/metabase/metabase/issues/49671 for a proposed fix.
        */
       ["normal", "workaround"].forEach(test => {
         it(

--- a/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
@@ -596,10 +596,10 @@ describeEE("formatting > sandboxes", () => {
        *
        * Related issues: metabase#10474, metabase#14629
        */
-      ["normal", "workaround"].forEach(test => {
+      [/* "normal",  */ "workaround"].forEach(test => {
         it(
           `${test.toUpperCase()} version:\n advanced sandboxing should not ignore data model features like object detail of FK (metabase-enterprise#520)`,
-          { tags: test === "normal" ? "@quarantine" : [] },
+          { tags: "@quarantine" },
           () => {
             cy.intercept("POST", "/api/card/*/query").as("cardQuery");
             cy.intercept("PUT", "/api/card/*").as("questionUpdate");


### PR DESCRIPTION
### Description

Use "hide whitespace" option for review.


### How to verify

- `simple sandboxing should work (metabase#14629)`
    - Stress test: https://github.com/metabase/metabase/actions/runs/11722205274 (100/100)
    - Last time it flaked: May 9, 2024
- `should be able to sandbox using query builder saved questions`
    - Stress test: https://github.com/metabase/metabase/actions/runs/11722198013 (100/100)
    - Last time it flaked: May 9, 2024
- `WORKAROUND version: advanced sandboxing should not ignore data model features like object detail of FK (metabase-enterprise#520)`
    - Stress test: https://github.com/metabase/metabase/actions/runs/11723164294/job/32654242720 (100/100)
    - Last time it flaked: May 9, 2024
    - This test is still in `@quarantine`
