### PR TITLE
fix(sdk): put a bandage on the flashing error on static question in strict mode

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-load-static-question.ts
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-load-static-question.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { loadStaticQuestion } from "embedding-sdk/lib/load-static-question";
 import type { GenericErrorResponse } from "metabase/lib/errors";
@@ -17,6 +17,17 @@ export function useLoadStaticQuestion(
   questionId: number | null,
   parameterValues?: Record<string, string | number>,
 ) {
+  // This is a hack around strict mode calling the useEffect twice ->
+  // the first request is being cancelled and we render a error state for a few renders
+  // This needs to start at true, it needs to bypass the double use effect of strict mode
+  // See https://github.com/metabase/metabase/issues/49620 for more details on the issue
+  const isMounted = useRef(true);
+  useEffect(() => {
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
   const [questionState, setQuestionState] = useState<QuestionState>({
     loading: false,
     card: null,
@@ -56,6 +67,10 @@ export function useLoadStaticQuestion(
           error: null,
         });
       } catch (error) {
+        if (!isMounted.current) {
+          return;
+        }
+
         if (typeof error === "object") {
           setQuestionState({
             result: null,


### PR DESCRIPTION
This puts a bandage on  [[SDK] Strict mode causes issues on network calls of static question, causing it to render an error for a brief moment](https://github.com/metabase/metabase/issues/49620): it just hides the error but *doesn't solve the real issue*, so I won't close it.

I Couldn't resist not trying to fix this, as it was extremely annoying a bad first impression to see an error flashing *consistently* on every page load.

# How to reproduce:

- add a console.error on the render of SDKError
- on a vite project with strict mode on, embed a static question
- before this PR: it should render the error for a bit
- with this PR: it should not render/log the from the first step

# Demo
(see the linked issue for a demo of the issue)

https://github.com/user-attachments/assets/9e81b78f-b169-48b9-b38f-573c5dec485e

