### PR TITLE
Fix flaky alert tests

### DIFF
--- a/e2e/test/scenarios/sharing/alert/alert-types.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/alert-types.cy.spec.js
@@ -93,6 +93,8 @@ describe("scenarios > alert > types", { tags: "@external" }, () => {
       cy.findByTestId("chart-container").should("contain", "Goal");
 
       openSharingMenu("Create alert");
+      cy.wait("@channel");
+
       cy.findByTestId("alert-create").within(() => {
         cy.findByText("Reaches the goal line").click();
         cy.findByText("The first time").click();
@@ -111,14 +113,17 @@ describe("scenarios > alert > types", { tags: "@external" }, () => {
       cy.createQuestion(multiSeriesQuestionWithGoal, { visitQuestion: true });
 
       openSharingMenu("Create alert");
+      cy.wait("@channel");
 
       // *** The warning below is not showing when we try to make an alert (Issue #???)
       // cy.contains(
       //   "Goal-based alerts aren't yet supported for charts with more than one line",
       // );
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Done").click();
+      modal().within(() => {
+        cy.findByText("Let's set up your alert").should("be.visible");
+        cy.findByText("Done").click();
+      });
 
       // The alert condition should fall back to rows
       cy.wait("@savedAlert").then(({ response: { body } }) => {

--- a/e2e/test/scenarios/sharing/alert/alert-types.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/alert-types.cy.spec.js
@@ -4,6 +4,7 @@ import {
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
 import {
+  modal,
   openSharingMenu,
   restore,
   setupSMTP,
@@ -47,6 +48,7 @@ const rawTestCases = [
 describe("scenarios > alert > types", { tags: "@external" }, () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/alert").as("savedAlert");
+    cy.intercept("GET", "/api/channel").as("channel");
 
     restore();
     cy.signInAsAdmin();
@@ -61,9 +63,12 @@ describe("scenarios > alert > types", { tags: "@external" }, () => {
         visitQuestion(questionId);
 
         openSharingMenu("Create alert");
+        cy.wait("@channel");
 
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.findByText("Done").click();
+        modal().within(() => {
+          cy.findByText("Let's set up your alert").should("be.visible");
+          cy.findByText("Done").click();
+        });
 
         cy.wait("@savedAlert").then(({ response: { body } }) => {
           expect(body.alert_condition).to.equal("rows");


### PR DESCRIPTION
Fixes 3 of top 10 flaky tests: https://stats.metabase.com/question/18032

### Description

Example failures:
- https://github.com/metabase/metabase/actions/runs/11705503386/job/32600831777?pr=49583
- https://github.com/metabase/metabase/actions/runs/11722658161/job/32653038907?pr=49665

### How to verify

- `rows based alerts`
    - Stress test: https://github.com/metabase/metabase/actions/runs/11724145111 (50/50 + 50/50)
- `goal based alerts`
    - `should work for timeseries questions with a set goal`
        - Stress test: https://github.com/metabase/metabase/actions/runs/11724257888 (100/100)
    - `should not be possible to create goal based alert for a multi-series question`
        - Stress test: https://github.com/metabase/metabase/actions/runs/11724267141 (100/100)