### PR TITLE
Preserve locale when in the `as-admin` macro is used

### DIFF
--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -473,7 +473,8 @@
     (merge
      (with-current-user-fetch-user-for-id ~`api/*current-user-id*)
      {:is-superuser? true
-      :permissions-set #{"/"}})
+      :permissions-set #{"/"}
+      :user-locale i18n/*user-locale*})
     (fn [] ~@body)))
 
 (defmacro with-current-user

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -474,7 +474,13 @@
         (is (= (mt/user->id :rasta) *current-user-id*))
        ;; *is-superuser?* and permissions set are overrided
         (is (true? api/*is-superuser?*))
-        (is (= #{"/"} @api/*current-user-permissions-set*))))))
+        (is (= #{"/"} @api/*current-user-permissions-set*)))))
+  (testing "as-admin preserves any locale settings"
+    (let [original "fr"]
+      (binding [i18n/*user-locale* original]
+        (mw.session/as-admin
+          (is (= original i18n/*user-locale*))
+          (is (= "French" (.getDisplayLanguage (i18n/user-locale)))))))))
 
 ;;; ----------------------------------------------------- Locale -----------------------------------------------------
 


### PR DESCRIPTION
Motivating issue:

```shell
❯ http get 'http://localhost:3000/api/embed/dashboard/eyJhbGciOiJIUzI1NiJ9.eyJyZXNvdXJjZSI6eyJkYXNoYm9hcmQiOjEyfSwicGFyYW1zIjp7fX0.QZ-tEWpgJeSMUuaPfuH6_VQwM2yXNMcuureWCtHsszU/dashcard/162/card/124' x-metabase-locale:fr -pb | jq '.data|.cols|map(.display_name)'
[
  "State",
  "Count"
]
```

I'm running a query that has aggregated columns and it is returning the untranslated. Note that these are computed and dynamically given a display name.

```clojure
(case tag
  :count     (i18n/tru "Count")
  :cum-count (i18n/tru "Cumulative count"))
```

The problem is that we run embedding things as admin. And that gets the current user, which in embed and public spaces is nil, and so binds a nil to user-locale, which defaults to english when translating.

After:

```
❯ http get 'http://localhost:3000/api/embed/dashboard/eyJhbGciOiJIUzI1NiJ9.eyJyZXNvdXJjZSI6eyJkYXNoYm9hcmQiOjEyfSwicGFyYW1zIjp7fX0.QZ-tEWpgJeSMUuaPfuH6_VQwM2yXNMcuureWCtHsszU/dashcard/162/card/124' x-metabase-locale:fr -pb | jq '.data|.cols|map(.display_name)'
[
  "State",
  "Nombre de lignes"
]

❯ http get 'http://localhost:3000/api/embed/dashboard/eyJhbGciOiJIUzI1NiJ9.eyJyZXNvdXJjZSI6eyJkYXNoYm9hcmQiOjEyfSwicGFyYW1zIjp7fX0.QZ-tEWpgJeSMUuaPfuH6_VQwM2yXNMcuureWCtHsszU/dashcard/162/card/124' x-metabase-locale:zh -pb | jq '.data|.cols|map(.display_name)'
[
  "State",
  "行数"
]

❯ http get 'http://localhost:3000/api/embed/dashboard/eyJhbGciOiJIUzI1NiJ9.eyJyZXNvdXJjZSI6eyJkYXNoYm9hcmQiOjEyfSwicGFyYW1zIjp7fX0.QZ-tEWpgJeSMUuaPfuH6_VQwM2yXNMcuureWCtHsszU/dashcard/162/card/124' x-metabase-locale:es -pb | jq '.data|.cols|map(.display_name)'
[
  "State",
  "Contar"
]
```

This is fetching a dashboard's card which is a query of orders grouped by created at month, sum of total.
