### PR TITLE
redshift defines "text" as varchar(255) and we want it to be way longer

### DIFF
--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -463,7 +463,7 @@
   [_driver upload-type]
   (case upload-type
     ::upload/varchar-255              [[:varchar 255]]
-    ::upload/text                     [:text]
+    ::upload/text                     [[:varchar 65535]]
     ::upload/int                      [:bigint]
     ;; identity(1, 1) defines an auto-increment column starting from 1
     ::upload/auto-incrementing-int-pk [:bigint [:identity 1 1]]


### PR DESCRIPTION
Subject says it all. One thing I'm not sure about: this test has different type predefined, but I think it's fine if I change it? It seems like there were no e2e tests checking uploads of `text` type.

Fixes #49147