### PR TITLE
hide admin links when dealing with non admins

### DIFF
--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -165,6 +165,23 @@ describe("command palette", () => {
     cy.location("hash").should("contain", "#start-of-week");
   });
 
+  it("settings pages should not be present if you don't have access to those pages", () => {
+    cy.signInAsNormalUser();
+    cy.visit("/");
+    cy.findByRole("button", { name: /Search/ }).click();
+
+    commandPalette().within(() => {
+      commandPaletteInput().type("Settings");
+      cy.findByRole("option", { name: "No results for “Settings”" }).should(
+        "exist",
+      );
+      commandPaletteInput().clear().type("Performance");
+      cy.findByRole("option", {
+        name: "No results for “Performance”",
+      }).should("exist");
+    });
+  });
+
   it("should not be accessible when doing full app embedding", () => {
     visitFullAppEmbeddingUrl({
       url: "/",

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -24,6 +24,7 @@ import {
   getDocsUrl,
   getSettings,
 } from "metabase/selectors/settings";
+import { getUserIsAdmin } from "metabase/selectors/user";
 import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
 import { Icon, type IconName } from "metabase/ui";
 import {
@@ -44,6 +45,7 @@ export const useCommandPalette = ({
   const docsUrl = useSelector(state => getDocsUrl(state, {}));
   const showMetabaseLinks = useSelector(getShowMetabaseLinks);
   const isSearchTypeaheadEnabled = useSetting("search-typeahead-enabled");
+  const isAdmin = useSelector(getUserIsAdmin);
 
   // Used for finding actions within the list
   const { searchQuery } = useKBar(state => ({
@@ -258,9 +260,9 @@ export const useCommandPalette = ({
   const adminActions = useMemo<PaletteAction[]>(() => {
     // Subpaths - i.e. paths to items within the main Admin tabs - are needed
     // in the command palette but are not part of the main list of admin paths
-    const adminSubpaths = getPerformanceAdminPaths(
-      PLUGIN_CACHING.getTabMetadata(),
-    );
+    const adminSubpaths = isAdmin
+      ? getPerformanceAdminPaths(PLUGIN_CACHING.getTabMetadata())
+      : [];
     const paths = [...adminPaths, ...adminSubpaths];
     return paths.map(adminPath => ({
       id: `admin-page-${adminPath.key}`,
@@ -269,25 +271,31 @@ export const useCommandPalette = ({
       perform: () => dispatch(push(adminPath.path)),
       section: "admin",
     }));
-  }, [adminPaths, dispatch]);
+  }, [adminPaths, dispatch, isAdmin]);
 
   const adminSettingsActions = useMemo<PaletteAction[]>(() => {
-    return Object.entries(settingsSections)
-      .filter(([slug, section]) => {
-        if (section.getHidden?.(settingValues)) {
-          return false;
-        }
+    const hasSettingsPath = adminPaths.find(path => path.key === "settings");
 
-        return !slug.includes("/");
-      })
-      .map(([slug, section]) => ({
-        id: `admin-settings-${slug}`,
-        name: `${t`Settings`} - ${section.name}`,
-        icon: "gear",
-        perform: () => dispatch(push(`/admin/settings/${slug}`)),
-        section: "admin",
-      }));
-  }, [settingsSections, settingValues, dispatch]);
+    if (hasSettingsPath) {
+      return Object.entries(settingsSections)
+        .filter(([slug, section]) => {
+          if (section.getHidden?.(settingValues)) {
+            return false;
+          }
+
+          return !slug.includes("/");
+        })
+        .map(([slug, section]) => ({
+          id: `admin-settings-${slug}`,
+          name: `${t`Settings`} - ${section.name}`,
+          icon: "gear",
+          perform: () => dispatch(push(`/admin/settings/${slug}`)),
+          section: "admin",
+        }));
+    } else {
+      return [];
+    }
+  }, [settingsSections, settingValues, adminPaths, dispatch]);
 
   useRegisterActions(
     hasQuery ? [...adminActions, ...adminSettingsActions] : [],


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/49729

### Description
Ensures that users have access to the settings page before adding settings links to the command palette

### How to verify

1. Log in as a non-admin
2. Open the command palette
3. Type accessing a settings link (search for Email, or Site Name)
4. It should not show any settings links

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
