### PR TITLE
feat(sdk): deprecate the ModifyQuestion component

### DIFF
--- a/docs/embedding/sdk/questions.md
+++ b/docs/embedding/sdk/questions.md
@@ -13,7 +13,6 @@ There are different ways you can embed questions:
 - [`StaticQuestion`](#embedding-a-static-question). Embeds a chart. Clicking on the chart doesn't do anything.
 - [`InteractiveQuestion`](#embedding-an-interactive-question). Clicking on the chart gives you the drill-through menu.
 - [`CreateQuestion`]()
-- [`ModifyQuestion`](#embedding-an-editable-question). Embeds the interactive question and the query builder.
 
 ## Embedding a static question
 
@@ -238,18 +237,18 @@ export default function App() {
 
 ## Embedding an editable question
 
-With the `ModifyQuestion` component, you can edit an existing question using the query builder by passing the question's ID.
+You can edit an existing question using the query builder by using the `isSaveEnabled` prop on the `InteractiveQuestion` component.
 
 ```tsx
 import React from "react";
-import {MetabaseProvider, ModifyQuestion} from "@metabase/embedding-sdk-react";
+import {MetabaseProvider, InteractiveQuestion} from "@metabase/embedding-sdk-react";
 
 const config = {...}
 
 export default function App() {
     return (
         <MetabaseProvider config={config}>
-            <ModifyQuestion questionId={1}/>
+            <InteractiveQuestion questionId={1} isSaveEnabled />
         </MetabaseProvider>
     );
 }

--- a/enterprise/frontend/src/embedding-sdk/components/public/ModifyQuestion/ModifyQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/ModifyQuestion/ModifyQuestion.tsx
@@ -2,8 +2,7 @@ import { QuestionEditor } from "embedding-sdk/components/private/QuestionEditor"
 
 import type { InteractiveQuestionProps } from "../InteractiveQuestion";
 
-type ModifyQuestionProps = InteractiveQuestionProps;
-
+/** @deprecated Use `InteractiveQuestion` with `isSaveEnabled={true}` instead. */
 export const ModifyQuestion = ({
   questionId,
   plugins,
@@ -12,7 +11,7 @@ export const ModifyQuestion = ({
   entityTypeFilter,
   isSaveEnabled,
   saveToCollectionId,
-}: ModifyQuestionProps = {}) => (
+}: InteractiveQuestionProps = {}) => (
   <QuestionEditor
     questionId={questionId}
     plugins={plugins}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/49716

Deprecates the ModifyQuestion component and removes it from the documentation. We should remove it in later releases.