### PR TITLE
docs(sdk): fix dead link in sdk quickstart

### DIFF
--- a/docs/embedding/sdk/quickstart.md
+++ b/docs/embedding/sdk/quickstart.md
@@ -198,4 +198,4 @@ In your app, you'll see an embedded `InteractiveQuestion` component.
 
 ![Embedded Metabase components](../images/embedded-components.png)
 
-Try changing some of the `theme` options in the [client app](https://github.com/metabase/metabase-nodejs-react-sdk-embedding-sample/blob/main/client/src/App.js) to style the components.
+Try changing some of the `theme` options in the [client app](https://github.com/metabase/metabase-nodejs-react-sdk-embedding-sample/blob/main/client/src/App.jsx) to style the components.


### PR DESCRIPTION
We have a dead link after merging https://github.com/metabase/metabase-nodejs-react-sdk-embedding-sample/pull/4.

![CleanShot 2567-11-08 at 16 08 25@2x](https://github.com/user-attachments/assets/46558b74-407e-4a2d-94a1-36d12d272c0b)
