### PR TITLE
Backport refactor from #8490 to 51

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
@@ -57,7 +57,7 @@ export const MetabaseProviderInternal = ({
   theme,
   store,
   className,
-  locale,
+  locale = "en",
 }: InternalMetabaseProviderProps): JSX.Element => {
   const { fontFamily } = theme ?? {};
   useInitData({ config });

--- a/frontend/src/metabase/dashboard/types/hash-options.ts
+++ b/frontend/src/metabase/dashboard/types/hash-options.ts
@@ -3,6 +3,9 @@ import type {
   EmbeddingDisplayOptions,
 } from "metabase/public/lib/types";
 
+/**
+ * This is a type that controls some dashboard states.
+ */
 export type DashboardControlsHashOptions = {
   refresh?: number | null;
   fullscreen?: boolean;

--- a/frontend/src/metabase/dashboard/types/hash-options.ts
+++ b/frontend/src/metabase/dashboard/types/hash-options.ts
@@ -1,11 +1,15 @@
-import type { EmbeddingDisplayOptions } from "metabase/public/lib/types";
+import type {
+  AdditionalEmbeddingHashOptions,
+  EmbeddingDisplayOptions,
+} from "metabase/public/lib/types";
 
 export type DashboardControlsHashOptions = {
   refresh?: number | null;
   fullscreen?: boolean;
-  hide_parameters?: string | null;
 };
 
 export type DashboardUrlHashOptions = Partial<
-  EmbeddingDisplayOptions & DashboardControlsHashOptions
+  EmbeddingDisplayOptions &
+    DashboardControlsHashOptions &
+    AdditionalEmbeddingHashOptions
 >;

--- a/frontend/src/metabase/lib/i18n.js
+++ b/frontend/src/metabase/lib/i18n.js
@@ -2,6 +2,7 @@ import dayjs from "dayjs";
 import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
 import { addLocale, useLocale } from "ttag";
 
+import { isEmbeddingSdk } from "metabase/env";
 import api from "metabase/lib/api";
 import { DAY_OF_WEEK_OPTIONS } from "metabase/lib/date-time";
 import MetabaseSettings from "metabase/lib/settings";
@@ -202,5 +203,7 @@ if (window.MetabaseUserLocalization) {
  * @param {object} translationsObject A translated object with the same structure as the one produced in `loadLocalization` function.
  */
 export function setUserLocale(translationsObject) {
-  window.MetabaseUserLocalization = translationsObject;
+  if (!isEmbeddingSdk) {
+    window.MetabaseUserLocalization = translationsObject;
+  }
 }

--- a/frontend/src/metabase/lib/i18n.js
+++ b/frontend/src/metabase/lib/i18n.js
@@ -192,3 +192,15 @@ if (window.MetabaseSiteLocalization) {
 if (window.MetabaseUserLocalization) {
   setLocalization(window.MetabaseUserLocalization);
 }
+
+/**
+ * In static embeddings/public links, there is no user locale, since there is no user in static embeddings/public links.
+ * But we reset the locale to the site locale when `withInstanceLanguage` is called. This breaks static embeddings/public links
+ * since they don't have a user locale. So this function is for them to set the locale from a URL hash as the user locale,
+ * then the translation on some part of FE still works even after `withInstanceLanguage` is called.
+ *
+ * @param {object} translationsObject A translated object with the same structure as the one produced in `loadLocalization` function.
+ */
+export function setUserLocale(translationsObject) {
+  window.MetabaseUserLocalization = translationsObject;
+}

--- a/frontend/src/metabase/lib/i18n.js
+++ b/frontend/src/metabase/lib/i18n.js
@@ -32,6 +32,8 @@ export async function loadLocalization(locale) {
           },
         };
   setLocalization(translationsObject);
+
+  return translationsObject;
 }
 
 // Tell moment.js to use the value of the start-of-week Setting for its current locale

--- a/frontend/src/metabase/public/LocaleProvider.tsx
+++ b/frontend/src/metabase/public/LocaleProvider.tsx
@@ -1,7 +1,7 @@
 import { type PropsWithChildren, useEffect, useState } from "react";
 
 import { setLocaleHeader } from "metabase/lib/api";
-import { loadLocalization } from "metabase/lib/i18n";
+import { loadLocalization, setUserLocale } from "metabase/lib/i18n";
 
 export const LocaleProvider = ({
   children,
@@ -17,7 +17,7 @@ export const LocaleProvider = ({
       setLocaleHeader(locale);
       loadLocalization(locale).then(translatedObject => {
         setIsLoadingLocale(false);
-        window.MetabaseUserLocalization = translatedObject;
+        setUserLocale(translatedObject);
       });
     }
   }, [locale]);

--- a/frontend/src/metabase/public/LocaleProvider.tsx
+++ b/frontend/src/metabase/public/LocaleProvider.tsx
@@ -5,7 +5,7 @@ import { loadLocalization, setUserLocale } from "metabase/lib/i18n";
 
 export const LocaleProvider = ({
   children,
-  locale = "en",
+  locale,
 }: PropsWithChildren<{ locale?: string | null }>) => {
   // The state is not used explicitly, but we need to trigger a re-render when the locale changes
   // as changing the locale in ttag doesn't trigger react components to update

--- a/frontend/src/metabase/public/LocaleProvider.tsx
+++ b/frontend/src/metabase/public/LocaleProvider.tsx
@@ -15,7 +15,10 @@ export const LocaleProvider = ({
     if (locale) {
       setIsLoadingLocale(true);
       setLocaleHeader(locale);
-      loadLocalization(locale).then(() => setIsLoadingLocale(false));
+      loadLocalization(locale).then(translatedObject => {
+        setIsLoadingLocale(false);
+        window.MetabaseUserLocalization = translatedObject;
+      });
     }
   }, [locale]);
 

--- a/frontend/src/metabase/public/hooks/use-embed-frame-options.ts
+++ b/frontend/src/metabase/public/hooks/use-embed-frame-options.ts
@@ -1,11 +1,11 @@
 import type { Location } from "history";
 
-import type { DashboardUrlHashOptions } from "metabase/dashboard/types";
 import { parseHashOptions } from "metabase/lib/browser";
 import { isWithinIframe } from "metabase/lib/dom";
 import { PLUGIN_RESOURCE_DOWNLOADS } from "metabase/plugins";
 
 import { DEFAULT_EMBED_DISPLAY_PARAMS } from "../constants";
+import type { EmbeddingHashOptions } from "../lib/types";
 
 export const useEmbedFrameOptions = ({ location }: { location: Location }) => {
   const {
@@ -16,7 +16,7 @@ export const useEmbedFrameOptions = ({ location }: { location: Location }) => {
     hide_parameters = DEFAULT_EMBED_DISPLAY_PARAMS.hideParameters,
     hide_download_button = null,
     downloads = DEFAULT_EMBED_DISPLAY_PARAMS.downloadsEnabled,
-  } = parseHashOptions(location.hash) as DashboardUrlHashOptions;
+  } = parseHashOptions(location.hash) as EmbeddingHashOptions;
 
   const downloadsEnabled = PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled({
     hide_download_button,

--- a/frontend/src/metabase/public/lib/types.ts
+++ b/frontend/src/metabase/public/lib/types.ts
@@ -25,6 +25,9 @@ export type EmbeddingParameters = Record<string, EmbeddingParameterVisibility>;
 
 export type EmbeddingParametersValues = Record<string, string>;
 
+/**
+ * This is a type for all the display options in static embedding sharing modal's Look and Feel tab.
+ */
 export type EmbeddingDisplayOptions = {
   font: null | string;
   theme: DisplayTheme;
@@ -36,6 +39,11 @@ export type EmbeddingDisplayOptions = {
   downloads: boolean | null;
 };
 
+/**
+ * This is a type that doesn't belong to static embedding sharing modal.
+ * Properties here exists only in the document (just `hide_parameters` since `locale` is a new one),
+ * but not in the UI.
+ */
 export type AdditionalEmbeddingHashOptions = {
   hide_parameters?: string | null;
 };

--- a/frontend/src/metabase/public/lib/types.ts
+++ b/frontend/src/metabase/public/lib/types.ts
@@ -36,6 +36,13 @@ export type EmbeddingDisplayOptions = {
   downloads: boolean | null;
 };
 
+export type AdditionalEmbeddingHashOptions = {
+  hide_parameters?: string | null;
+};
+
+export type EmbeddingHashOptions = EmbeddingDisplayOptions &
+  AdditionalEmbeddingHashOptions;
+
 export type CodeSampleParameters = {
   siteUrl: string;
   secretKey: string;


### PR DESCRIPTION
This is a followed up task from #8490. Since we didn't backport the PR that fixes the issue to 51. We should backport the refactor part of it, so we don't have conflicts in the future. It technically import the behavior change for static embeddings/public links, but it does nothing in the SDK since we don't have a localization object in `window` object on the SDK.

### Description

This PR backports the refactor code from master.

### How to verify

1. Set the instance locale to something not English to see the problem more clearly.
1. Go to the only dashboard in the example collection and add a text card. Set the value as 
    ```
    {{ param }}
    ```
    And link it to any dashboard filter.
1. Embed that dashboard using the SDK.
1. pass `locale` of your choice to `MetabaseProvider`
1. See that the smartscalar should be translated properly.

### Demo

![image](https://github.com/user-attachments/assets/9134595b-a0df-4a9f-bbb0-2bda2488d374)

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~ This PR doesn't change any behavior.
