### PR TITLE
Fix flaky homepage xrays test

### DIFF
--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -100,6 +100,9 @@ describe("scenarios > home > homepage", () => {
 
       cy.visit("/");
       cy.wait("@getXrayCandidates");
+      cy.findByTestId("home-page")
+        .findByTestId("loading-indicator")
+        .should("not.exist");
 
       repeatAssertion(() =>
         cy

--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -100,6 +100,9 @@ describe("scenarios > home > homepage", () => {
 
       cy.visit("/");
       cy.wait("@getXrayCandidates");
+      // The repeated assertion below uses { timeout: 0 } and sometimes it happens too fast,
+      // even before React finishes re-rendering after @getXrayCandidates completes.
+      // This assertion prevents it.
       cy.findByTestId("home-page")
         .findByTestId("loading-indicator")
         .should("not.exist");


### PR DESCRIPTION
Fixes one of top 10 flaky tests: https://stats.metabase.com/question/18032

### Description

Example failures:
- https://github.com/metabase/metabase/actions/runs/11723704758/job/32656343013?pr=49656
- https://github.com/metabase/metabase/actions/runs/11739955207

### How to verify

Stress test: https://github.com/metabase/metabase/actions/runs/11742366760

Apply this patch and the test should fail:
```patch
diff --git a/frontend/src/metabase/home/components/HomeXraySection/HomeXraySection.tsx b/frontend/src/metabase/home/components/HomeXraySection/HomeXraySection.tsx
index 2c7a957df0..f711f91682 100644
--- a/frontend/src/metabase/home/components/HomeXraySection/HomeXraySection.tsx
+++ b/frontend/src/metabase/home/components/HomeXraySection/HomeXraySection.tsx
@@ -33,7 +33,7 @@ import {
 export const HomeXraySection = () => {
   const {
     data: databasesData,
-    isLoading: databasesLoading,
+    isFetching: databasesLoading,
     error: databasesError,
   } = useListDatabasesQuery();
 ```