### PR TITLE
Do not pollute SDK users `window` object

### DIFF
--- a/frontend/src/metabase/lib/i18n.js
+++ b/frontend/src/metabase/lib/i18n.js
@@ -2,6 +2,7 @@ import dayjs from "dayjs";
 import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
 import { addLocale, useLocale } from "ttag";
 
+import { isEmbeddingSdk } from "metabase/env";
 import api from "metabase/lib/api";
 import { DAY_OF_WEEK_OPTIONS } from "metabase/lib/date-time";
 import MetabaseSettings from "metabase/lib/settings";
@@ -202,5 +203,7 @@ if (window.MetabaseUserLocalization) {
  * @param {object} translationsObject A translated object with the same structure as the one produced in `loadLocalization` function.
  */
 export function setUserLocale(translationsObject) {
-  window.MetabaseUserLocalization = translationsObject;
+  if (!isEmbeddingSdk) {
+    window.MetabaseUserLocalization = translationsObject;
+  }
 }


### PR DESCRIPTION
Relate to #8490

### Description

This PR applies the same fix I added in #49751, to not pollute SDK users' `window` object. This doesn't change any behavior at all. It just makes the SDK more user friendly.

### How to verify

1. Set the instance locale to something not English to see the problem more clearly.
1. Go to the only dashboard in the example collection and add a text card. Set the value as 
    ```
    {{ param }}
    ```
    And link it to any dashboard filter.
1. Embed that dashboard using the SDK.
1. pass `locale` of your choice to `MetabaseProvider`
1. See that the smartscalar should be translated properly.
1. Open the devtool and see that `window.MetabaseUserLocalization` is undefined. If you test this on `master` you should see a value.

### Demo

#### Before
![Screenshot 2024-11-08 at 8 52 52 PM](https://github.com/user-attachments/assets/bee6cf52-6c40-4ddd-bedb-17fb1238b5e3)


#### After
![Screenshot 2024-11-08 at 8 52 30 PM](https://github.com/user-attachments/assets/f78b0614-1cda-40e9-be06-79706e0c14fd)

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
