### PR TITLE
skip json() -> JSON.stringify and just forward the text

### DIFF
--- a/docs/embedding/sdk/authentication.md
+++ b/docs/embedding/sdk/authentication.md
@@ -52,9 +52,10 @@ async function metabaseAuthHandler(req, res) {
 
   try {
     const response = await fetch(ssoUrl, { method: "GET" });
-    const token = await response.json();
+    const session = await response.text();
 
-    return res.status(200).json(token);
+    console.log("Received session", session);
+    return res.status(200).set("Content-Type", "application/json").end(session);
   } catch (error) {
     if (error instanceof Error) {
       res.status(401).json({


### PR DESCRIPTION
This is helpful to forward possible errors that didn't come as json, closes https://github.com/metabase/metabase/issues/49762
More context on [the product doc](https://www.notion.so/metabase/Make-troubleshooting-SDK-auth-easier-11f69354c90180319a05e4b652adc249#11f69354c90180859197e284a0213f0f)

Similar to https://github.com/metabase/metabase-nodejs-react-sdk-embedding-sample/pull/5 done on the demo app