### PR TITLE
Clarify cache API permissions and add tests

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
@@ -149,24 +149,24 @@
 
           (mt/with-all-users-data-perms-graph! {db-id {:details :no}}
             (mt/with-non-admin-groups-no-collection-perms collection-id
-             (doseq [[model id] [["question" card-id]
-                                 #_["database" db-id]
-                                 #_["dashboard" dashboard-id]]]
-               (testing (format "\nTesting cache config for %s %d" model id)
-                 (mt/user-http-request :rasta :get 403 "cache/"
-                                       :model model
-                                       :id id)
+              (doseq [[model id] [["question" card-id]
+                                  #_["database" db-id]
+                                  #_["dashboard" dashboard-id]]]
+                (testing (format "\nTesting cache config for %s %d" model id)
+                  (mt/user-http-request :rasta :get 403 "cache/"
+                                        :model model
+                                        :id id)
 
-                 (mt/user-http-request :rasta :put 403 "cache/"
-                                       {:model    model
-                                        :model_id id
-                                        :strategy {:type "nocache" :name "card1"}})
-                 (mt/user-http-request :rasta :post 403 "cache/invalidate"
-                                       (keyword model) [id])
+                  (mt/user-http-request :rasta :put 403 "cache/"
+                                        {:model    model
+                                         :model_id id
+                                         :strategy {:type "nocache" :name "card1"}})
+                  (mt/user-http-request :rasta :post 403 "cache/invalidate"
+                                        (keyword model) [id])
 
-                 (mt/user-http-request :rasta :delete 403 "cache/"
-                                       {:model    model
-                                        :model_id id}))))))))))
+                  (mt/user-http-request :rasta :delete 403 "cache/"
+                                        {:model    model
+                                         :model_id id}))))))))))
 
 (deftest invalidation-test
   (mt/with-model-cleanup [:model/CacheConfig

--- a/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
@@ -27,16 +27,6 @@
                                                     :database_id   (:id db)
                                                     :collection_id (:id col1)}
                        :model/Card          card3  {:name "card3"}]
-
-          (testing "Access from regular users"
-            (testing "No general access"
-              (is (= "You don't have permissions to do that."
-                     (mt/user-http-request :rasta :get 403 "cache/"))))
-            (testing "But have access to a separate (accessible to them) entities"
-              (is (= {:data []}
-                     (mt/user-http-request :rasta :get 200 "cache/"
-                                           :model "question" :id (:id card1))))))
-
           (testing "Can configure root"
             (is (mt/user-http-request :crowberto :put 200 "cache/"
                                       {:model    "root"
@@ -117,6 +107,66 @@
                                        :model_id 0
                                        :strategy {:type     "schedule"
                                                   :schedule "0/2 * * * * ?"}}))))))))
+
+(deftest cache-config-permissions-test
+  (mt/with-model-cleanup [:model/CacheConfig]
+    (mt/with-premium-features #{:cache-granular-controls :audit-app}
+      (mt/with-temp [:model/Database      {db-id :id}         {}
+                     :model/Collection    {collection-id :id} {:name "col1"}
+                     :model/Dashboard     {dashboard-id :id}  {:name          "dash1"
+                                                               :collection_id collection-id}
+                     :model/Card          {card-id :id}       {:name          "card1"
+                                                               :database_id   db-id
+                                                               :collection_id collection-id}]
+        (testing "Non-admins have no general access to cache config"
+          (is (= "You don't have permissions to do that."
+                 (mt/user-http-request :rasta :get 403 "cache/"))))
+
+        (testing "Non-admins can access cache config only if they have write access to the model"
+          (mt/with-all-users-data-perms-graph! {db-id {:details :yes}}
+            (doseq [[model id] [["question" card-id]
+                                ["database" db-id]
+                                ["dashboard" dashboard-id]]]
+              (testing (format "\nTesting cache config for %s %d" model id)
+                (is (= {:data []}
+                       (mt/user-http-request :rasta :get 200 "cache/"
+                                             :model model
+                                             :id id)))
+
+                (is (mt/user-http-request :rasta :put 200 "cache/"
+                                          {:model    model
+                                           :model_id id
+                                           :strategy {:type "nocache" :name "card1"}}))
+
+                (is (=?
+                     {:count 1}
+                     (mt/user-http-request :rasta :post 200 "cache/invalidate"
+                                           (keyword model) [id])))
+
+                (is (nil? (mt/user-http-request :rasta :delete 204 "cache/"
+                                                {:model    model
+                                                 :model_id id}))))))
+
+          (mt/with-all-users-data-perms-graph! {db-id {:details :no}}
+            (mt/with-non-admin-groups-no-collection-perms collection-id
+             (doseq [[model id] [["question" card-id]
+                                 #_["database" db-id]
+                                 #_["dashboard" dashboard-id]]]
+               (testing (format "\nTesting cache config for %s %d" model id)
+                 (mt/user-http-request :rasta :get 403 "cache/"
+                                       :model model
+                                       :id id)
+
+                 (mt/user-http-request :rasta :put 403 "cache/"
+                                       {:model    model
+                                        :model_id id
+                                        :strategy {:type "nocache" :name "card1"}})
+                 (mt/user-http-request :rasta :post 403 "cache/invalidate"
+                                       (keyword model) [id])
+
+                 (mt/user-http-request :rasta :delete 403 "cache/"
+                                       {:model    model
+                                        :model_id id}))))))))))
 
 (deftest invalidation-test
   (mt/with-model-cleanup [:model/CacheConfig

--- a/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
@@ -132,31 +132,27 @@
                        (mt/user-http-request :rasta :get 200 "cache/"
                                              :model model
                                              :id id)))
-
                 (is (mt/user-http-request :rasta :put 200 "cache/"
                                           {:model    model
                                            :model_id id
                                            :strategy {:type "nocache" :name "card1"}}))
-
-                (is (=?
-                     {:count 1}
-                     (mt/user-http-request :rasta :post 200 "cache/invalidate"
-                                           (keyword model) [id])))
-
+                (is (=? {:count 1}
+                        (mt/user-http-request :rasta :post 200 "cache/invalidate"
+                                              (keyword model) [id])))
                 (is (nil? (mt/user-http-request :rasta :delete 204 "cache/"
                                                 {:model    model
-                                                 :model_id id}))))))
+                                                 :model_id id})))))))
 
+        (testing "Non-admins cannot access cache config if they do not have write access to the model"
           (mt/with-all-users-data-perms-graph! {db-id {:details :no}}
             (mt/with-non-admin-groups-no-collection-perms collection-id
               (doseq [[model id] [["question" card-id]
-                                  #_["database" db-id]
-                                  #_["dashboard" dashboard-id]]]
+                                  ["database" db-id]
+                                  ["dashboard" dashboard-id]]]
                 (testing (format "\nTesting cache config for %s %d" model id)
                   (mt/user-http-request :rasta :get 403 "cache/"
                                         :model model
                                         :id id)
-
                   (mt/user-http-request :rasta :put 403 "cache/"
                                         {:model    model
                                          :model_id id


### PR DESCRIPTION
* Updates cache API perms so that any user with write access to a db/dashboard/question can edit the cache settings, per [discussion](https://metaboat.slack.com/archives/C064EB1UE5P/p1731095641995099?thread_ts=1731094735.330919&cid=C064EB1UE5P)
* Adds integration tests