### PR TITLE
[Metabot] Auto-close on route change

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
@@ -42,7 +42,9 @@ export const MetabotChat = ({ onClose }: { onClose: () => void }) => {
     onClose();
   }, [resetInput, onClose]);
 
-  useAutoCloseMetabot(!!input);
+  useAutoCloseMetabot({
+    hasUserInput: !!input,
+  });
 
   const [inputExpanded, setInputExpanded] = useState(false);
   const handleMaybeExpandInput = () => {

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/index.tsx
@@ -1,1 +1,2 @@
 export * from "./MetabotChat";
+export { METABOT_AUTO_CLOSE_DURATION_MS } from "./useAutoCloseMetabot";

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/useAutoCloseMetabot.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/useAutoCloseMetabot.tsx
@@ -1,0 +1,42 @@
+import { useEffect } from "react";
+import { useLocation, usePrevious } from "react-use";
+
+import { useMetabotAgent } from "metabase-enterprise/metabot/hooks";
+
+export const METABOT_AUTO_CLOSE_DURATION_MS = 30 * 1000;
+
+export function useAutoCloseMetabot(hasUserInput: boolean) {
+  const { visible, setVisible, isDoingScience } = useMetabotAgent();
+
+  const location = useLocation();
+  const { pathname } = location;
+  const prevPathname = usePrevious(pathname);
+
+  const isUiClosable = visible && !isDoingScience && !hasUserInput;
+  const isRouteChange =
+    pathname !== undefined &&
+    prevPathname !== undefined &&
+    pathname !== prevPathname;
+
+  // auto-close metabot on route change, unless:
+  // - route change happened during metabot processing
+  // - user has some kind of value in the input
+  useEffect(() => {
+    if (isUiClosable && isRouteChange) {
+      setVisible(false);
+    }
+  }, [isUiClosable, isRouteChange, setVisible]);
+
+  // auto-close based when inactive for too long
+  const isInactive = !hasUserInput && !isDoingScience;
+
+  useEffect(() => {
+    if (isInactive) {
+      const timer = setTimeout(
+        () => setVisible(false),
+        METABOT_AUTO_CLOSE_DURATION_MS,
+      );
+      return () => clearTimeout(timer);
+    }
+  }, [isInactive, setVisible]);
+}

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/useAutoCloseMetabot.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/useAutoCloseMetabot.tsx
@@ -5,6 +5,10 @@ import { useMetabotAgent } from "metabase-enterprise/metabot/hooks";
 
 export const METABOT_AUTO_CLOSE_DURATION_MS = 30 * 1000;
 
+function basePathSegment(pathname: string) {
+  return pathname.split("/")?.[1] ?? "";
+}
+
 export function useAutoCloseMetabot(hasUserInput: boolean) {
   const { visible, setVisible, isDoingScience } = useMetabotAgent();
 
@@ -13,19 +17,20 @@ export function useAutoCloseMetabot(hasUserInput: boolean) {
   const prevPathname = usePrevious(pathname);
 
   const isUiClosable = visible && !isDoingScience && !hasUserInput;
-  const isRouteChange =
+  const isClosableRouteChange =
     pathname !== undefined &&
     prevPathname !== undefined &&
-    pathname !== prevPathname;
+    basePathSegment(pathname) !== basePathSegment(prevPathname);
 
   // auto-close metabot on route change, unless:
   // - route change happened during metabot processing
+  // - base segment of the route is the same (prevent hide if /question/1 => /question#ad-hoc-query-has)
   // - user has some kind of value in the input
   useEffect(() => {
-    if (isUiClosable && isRouteChange) {
+    if (isUiClosable && isClosableRouteChange) {
       setVisible(false);
     }
-  }, [isUiClosable, isRouteChange, setVisible]);
+  }, [isUiClosable, isClosableRouteChange, setVisible]);
 
   // auto-close based when inactive for too long
   const isInactive = !hasUserInput && !isDoingScience;

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/useAutoCloseMetabot.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/useAutoCloseMetabot.tsx
@@ -9,7 +9,11 @@ function basePathSegment(pathname: string) {
   return pathname.split("/")?.[1] ?? "";
 }
 
-export function useAutoCloseMetabot(hasUserInput: boolean) {
+export function useAutoCloseMetabot({
+  hasUserInput,
+}: {
+  hasUserInput: boolean;
+}) {
   const { visible, setVisible, isDoingScience } = useMetabotAgent();
 
   const location = useLocation();

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
@@ -34,7 +34,9 @@ export const useMetabotAgent = () => {
   });
 
   return {
-    visible: useSelector(getMetabotVisisble as any),
+    visible: useSelector(getMetabotVisisble as any) as ReturnType<
+      typeof getMetabotVisisble
+    >,
     setVisible: useCallback(
       (isVisible: boolean) => dispatch(setVisible(isVisible)),
       [dispatch],
@@ -48,7 +50,6 @@ export const useMetabotAgent = () => {
       const history = sendMessageReq.data?.history || [];
       await dispatch(submitInput({ message, context, history }));
     },
-    isLoading: sendMessageReq.isLoading,
-    isProcessing,
+    isDoingScience: sendMessageReq.isLoading || isProcessing,
   };
 };

--- a/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
@@ -170,6 +170,31 @@ describe("metabot", () => {
 
       jest.useRealTimers();
     });
+
+    // eslint-disable-next-line jest/expect-expect
+    it("should properly auto-close metabot if route changes", async () => {
+      const { store } = setup();
+
+      // should close on normal route change
+      await assertVisible();
+      act(() => window.history?.pushState(null, "", "/1"));
+      await assertNotVisible();
+
+      // should not close on route change if metabot is processing
+      showMetabot(store.dispatch);
+      act(() => store.dispatch(setIsProcessing(true)));
+      act(() => window.history?.pushState(null, "", "/2"));
+      await assertVisible();
+      act(() => store.dispatch(setIsProcessing(false)));
+      hideMetabot(store.dispatch);
+      await assertNotVisible();
+
+      // should not close if user has value in the input
+      showMetabot(store.dispatch);
+      await userEvent.type(await input(), "Some incomplete user prompt");
+      act(() => window.history?.pushState(null, "", "/3"));
+      await assertVisible();
+    });
   });
 
   describe("message", () => {

--- a/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
@@ -194,6 +194,12 @@ describe("metabot", () => {
       await userEvent.type(await input(), "Some incomplete user prompt");
       act(() => window.history?.pushState(null, "", "/3"));
       await assertVisible();
+
+      // should not close if the user navigates within the base path segment
+      act(() => window.history?.pushState(null, "", "/3/sub-path"));
+      await assertVisible();
+      act(() => window.history?.pushState(null, "", "/3"));
+      await assertVisible();
     });
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
@@ -173,32 +173,47 @@ describe("metabot", () => {
 
     // eslint-disable-next-line jest/expect-expect
     it("should properly auto-close metabot if route changes", async () => {
+      setup();
+
+      await assertVisible();
+      act(() => window.history?.pushState(null, "", "/some-route"));
+      await assertNotVisible();
+    });
+
+    // eslint-disable-next-line jest/expect-expect
+    it("should not close on route change if metabot is processing", async () => {
       const { store } = setup();
 
-      // should close on normal route change
-      await assertVisible();
-      act(() => window.history?.pushState(null, "", "/1"));
-      await assertNotVisible();
-
-      // should not close on route change if metabot is processing
       showMetabot(store.dispatch);
       act(() => store.dispatch(setIsProcessing(true)));
-      act(() => window.history?.pushState(null, "", "/2"));
+      act(() => window.history?.pushState(null, "", "/some-route"));
       await assertVisible();
       act(() => store.dispatch(setIsProcessing(false)));
       hideMetabot(store.dispatch);
       await assertNotVisible();
+    });
+
+    // eslint-disable-next-line jest/expect-expect
+    it("should not close on route change if there is user input", async () => {
+      const { store } = setup();
 
       // should not close if user has value in the input
       showMetabot(store.dispatch);
       await userEvent.type(await input(), "Some incomplete user prompt");
-      act(() => window.history?.pushState(null, "", "/3"));
+      act(() => window.history?.pushState(null, "", "/some-route"));
       await assertVisible();
+    });
 
-      // should not close if the user navigates within the base path segment
-      act(() => window.history?.pushState(null, "", "/3/sub-path"));
+    // eslint-disable-next-line jest/expect-expect
+    it("should not close on route change if new location shares base bath segement", async () => {
+      const { store } = setup();
+
+      act(() => window.history?.pushState(null, "", "/base-path"));
+      showMetabot(store.dispatch);
       await assertVisible();
-      act(() => window.history?.pushState(null, "", "/3"));
+      act(() => window.history?.pushState(null, "", "/base-path/sub-path"));
+      await assertVisible();
+      act(() => window.history?.pushState(null, "", "/base-path"));
       await assertVisible();
     });
   });


### PR DESCRIPTION
### Description

Auto-close Metabot when the route changes unless:
- the user has typed something in the Metabot input
- the route change happened while Metabot is processing
- the base path segment is unchanged in the route change (example: `/question/123` => `/question#ad-hoc-hash` will keep Metabot open)

> [!NOTE]  
> The "is processing" approach works as long as everything in the processing phase is properly awaited. This doesn't happen currently for re-running questions, so I added the restriction that the navigation has have a different base path segment to account for this. I think in practice this is preferred (doing collection things in `/collection/*`, doing admin things in `/admin/*`, etc.). Also it's probably best to err on the side of keeping it open unnecessarily, rather than closed unexpectedly.

### Demo

https://github.com/user-attachments/assets/437252c7-a191-4529-8fb7-29f68382a4ce

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
