### PR TITLE
Allow changing the limit using just the html input arrows

### DIFF
--- a/frontend/src/metabase/querying/notebook/components/LimitStep/LimitStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/LimitStep/LimitStep.tsx
@@ -46,6 +46,7 @@ export function LimitStep({
       <LimitInput
         className={CS.mb1}
         type="number"
+        min={1}
         value={value}
         placeholder={t`Enter a limit`}
         small

--- a/frontend/src/metabase/querying/notebook/components/LimitStep/LimitStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/LimitStep/LimitStep.tsx
@@ -9,6 +9,8 @@ import * as Lib from "metabase-lib";
 import type { NotebookStepProps } from "../../types";
 import { NotebookCell } from "../NotebookCell";
 
+import { isLimitValid, parseLimit } from "./util";
+
 export function LimitStep({
   query,
   step,
@@ -20,15 +22,23 @@ export function LimitStep({
   const limit = Lib.currentLimit(query, stageIndex);
   const [value, setValue] = useState(typeof limit === "number" ? limit : "");
 
-  const handleBlur = (event: FocusEvent<HTMLInputElement>) => {
-    const nextLimit = parseInt(event.target.value, 0);
-    if (nextLimit >= 1) {
+  const updateLimit = (nextLimit: number) => {
+    if (isLimitValid(nextLimit)) {
       updateQuery(Lib.limit(query, stageIndex, nextLimit));
     }
   };
 
+  const handleBlur = (event: FocusEvent<HTMLInputElement>) => {
+    updateLimit(parseLimit(event.target.value));
+  };
+
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     setValue(event.target.value);
+
+    const isFocused = event.target === document.activeElement;
+    if (!isFocused) {
+      updateLimit(parseLimit(event.target.value));
+    }
   };
 
   return (

--- a/frontend/src/metabase/querying/notebook/components/LimitStep/LimitStep.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/LimitStep/LimitStep.unit.spec.tsx
@@ -54,13 +54,35 @@ describe("LimitStep", () => {
     expect(Lib.currentLimit(getNextQuery(), 0)).toBe(52);
   });
 
-  it("should update the limit", () => {
+  it("should update the limit only when blurred", () => {
+    const step = createMockNotebookStep({ query: QUERY_WITH_LIMIT });
+    const { getNextQuery, updateQuery } = setup(step);
+
+    const limitInput = screen.getByPlaceholderText("Enter a limit");
+
+    fireEvent.focus(limitInput);
+
+    // HACK: manually set document.activeElement to the input
+    // so the focus check works.
+    Object.defineProperty(document, "activeElement", {
+      value: limitInput,
+      writable: false,
+    });
+
+    fireEvent.change(limitInput, { target: { value: "100" } });
+    fireEvent.change(limitInput, { target: { value: "1000" } });
+    fireEvent.blur(limitInput);
+
+    expect(updateQuery).toHaveBeenCalledTimes(1);
+    expect(Lib.currentLimit(getNextQuery(), 0)).toBe(1000);
+  });
+
+  it("should update the limit when not focused (eg. when clicking the arrows)", () => {
     const step = createMockNotebookStep({ query: QUERY_WITH_LIMIT });
     const { getNextQuery } = setup(step);
 
     const limitInput = screen.getByPlaceholderText("Enter a limit");
     fireEvent.change(limitInput, { target: { value: "1000" } });
-    fireEvent.blur(limitInput);
 
     expect(Lib.currentLimit(getNextQuery(), 0)).toBe(1000);
   });
@@ -81,6 +103,16 @@ describe("LimitStep", () => {
 
     const limitInput = screen.getByPlaceholderText("Enter a limit");
     fireEvent.change(limitInput, { target: { value: "-1" } });
+
+    expect(updateQuery).not.toHaveBeenCalled();
+  });
+
+  it("shouldn't update the limit if its not a valid number", () => {
+    const step = createMockNotebookStep({ query: QUERY_WITH_LIMIT });
+    const { updateQuery } = setup(step);
+
+    const limitInput = screen.getByPlaceholderText("Enter a limit");
+    fireEvent.change(limitInput, { target: { value: "not a number" } });
 
     expect(updateQuery).not.toHaveBeenCalled();
   });

--- a/frontend/src/metabase/querying/notebook/components/LimitStep/LimitStep.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/LimitStep/LimitStep.unit.spec.tsx
@@ -77,7 +77,7 @@ describe("LimitStep", () => {
     expect(Lib.currentLimit(getNextQuery(), 0)).toBe(1000);
   });
 
-  it("should update the limit when not focused (eg. when clicking the arrows)", () => {
+  it("should update the limit when not focused (eg. when clicking the arrows) (metabase#49587)", () => {
     const step = createMockNotebookStep({ query: QUERY_WITH_LIMIT });
     const { getNextQuery } = setup(step);
 

--- a/frontend/src/metabase/querying/notebook/components/LimitStep/util.ts
+++ b/frontend/src/metabase/querying/notebook/components/LimitStep/util.ts
@@ -1,0 +1,7 @@
+export function isLimitValid(number: number) {
+  return !Number.isNaN(number) && number > 0;
+}
+
+export function parseLimit(value: string) {
+  return parseInt(value, 0);
+}

--- a/frontend/src/metabase/querying/notebook/components/LimitStep/util.ts
+++ b/frontend/src/metabase/querying/notebook/components/LimitStep/util.ts
@@ -1,5 +1,5 @@
 export function isLimitValid(number: number) {
-  return !Number.isNaN(number) && number > 0;
+  return !Number.isNaN(number) && Number.isInteger(number) && number > 0;
 }
 
 export function parseLimit(value: string) {

--- a/frontend/src/metabase/querying/notebook/components/LimitStep/util.ts
+++ b/frontend/src/metabase/querying/notebook/components/LimitStep/util.ts
@@ -3,5 +3,5 @@ export function isLimitValid(number: number) {
 }
 
 export function parseLimit(value: string) {
-  return parseInt(value, 0);
+  return parseInt(value, 10);
 }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/49587

### Description

Currently using the arrow buttons in the number input does not work because the input is never focused or blurred.

This PR fixes that by allowing the value to be changed without focusing.

I've also added a `min={1}` prop to the input to keep users from entering zero, or negative values.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Accounts -> Limit
2. Open the `View the SQL` panel
3. Click the arrows in the limit input to change it's value, the limit in the SQL panel should change accordingly
4. Focus the input and change the value, it should only update the SQL panel once blurred

### Demo

https://github.com/user-attachments/assets/4623931c-1d6e-415e-aaaf-182138d0aedf

### Checklist

- [x] Unit test have been updated accordingly
- [ ] There's no way we can specifically click the arrows in the number input in Cypress, so no reproduction was added.