### PR TITLE
Remove some styled components in Summarize

### DIFF
--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.styled.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.styled.tsx
@@ -1,9 +1,5 @@
 import styled from "@emotion/styled";
 
-export const ColumnPickerContainer = styled.div`
-  min-width: 300px;
-`;
-
 export const ColumnPickerHeaderContainer = styled.div`
   display: flex;
   align-items: center;

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -26,7 +26,6 @@ import * as Lib from "metabase-lib";
 import { QueryColumnPicker } from "../QueryColumnPicker";
 
 import {
-  ColumnPickerContainer,
   ColumnPickerHeaderContainer,
   ColumnPickerHeaderTitle,
   ColumnPickerHeaderTitleContainer,
@@ -329,9 +328,11 @@ export function AggregationPicker({
     const columns = Lib.aggregationOperatorColumns(operator);
     const columnGroups = Lib.groupColumns(columns);
     return (
-      <ColumnPickerContainer
+      <Box
         className={className}
+        mih="18.75rem"
         data-testid="aggregation-column-picker"
+        c="summarize"
       >
         <ColumnPickerHeader onClick={handleResetOperator}>
           {operatorInfo.displayName}
@@ -346,7 +347,7 @@ export function AggregationPicker({
           onSelect={handleColumnSelect}
           onClose={onClose}
         />
-      </ColumnPickerContainer>
+      </Box>
     );
   }
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AddAggregationButton/AddAggregationButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AddAggregationButton/AddAggregationButton.tsx
@@ -2,10 +2,9 @@ import type { ReactNode } from "react";
 import { useState } from "react";
 import { t } from "ttag";
 
+import { AggregationPicker } from "metabase/common/components/AggregationPicker";
 import { Popover, Tooltip } from "metabase/ui";
 import * as Lib from "metabase-lib";
-
-import { AggregationPicker } from "../SummarizeSidebar.styled";
 
 import { AddAggregationButtonRoot } from "./AddAggregationButton.styled";
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AggregationItem/AggregationItem.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AggregationItem/AggregationItem.tsx
@@ -1,9 +1,8 @@
 import { useCallback, useState } from "react";
 
+import { AggregationPicker } from "metabase/common/components/AggregationPicker";
 import { Popover } from "metabase/ui";
 import * as Lib from "metabase-lib";
-
-import { AggregationPicker } from "../SummarizeSidebar.styled";
 
 import { AggregationName, RemoveIcon, Root } from "./AggregationItem.styled";
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeContent/SummarizeBreakoutColumnList.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeContent/SummarizeBreakoutColumnList.tsx
@@ -1,10 +1,9 @@
 import { t } from "ttag";
 
-import { Stack, type StackProps } from "metabase/ui";
+import { Space, Stack, type StackProps, Title } from "metabase/ui";
 import type * as Lib from "metabase-lib";
 
 import { BreakoutColumnList } from "../BreakoutColumnList";
-import { SectionTitle } from "../SummarizeSidebar.styled";
 
 type SummarizeBreakoutColumnListProps = {
   query: Lib.Query;
@@ -33,7 +32,8 @@ export const SummarizeBreakoutColumnList = ({
     spacing="0"
     {...containerProps}
   >
-    <SectionTitle>{t`Group by`}</SectionTitle>
+    <Title order={5} fw={900}>{t`Group by`}</Title>
+    <Space my="sm" />
     <BreakoutColumnList
       query={query}
       stageIndex={stageIndex}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.styled.tsx
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled";
 
-import { AggregationPicker as BaseAggregationPicker } from "metabase/common/components/AggregationPicker";
 import SidebarContent from "metabase/query_builder/components/SidebarContent";
 
 export const SidebarView = styled(SidebarContent)`
@@ -9,28 +8,4 @@ export const SidebarView = styled(SidebarContent)`
   left: 0;
   right: 0;
   bottom: 0;
-`;
-
-const Section = styled.section`
-  padding: 1.5rem;
-`;
-
-export const SectionTitle = styled.h3`
-  font-weight: 900;
-  margin-bottom: 1rem;
-`;
-
-export const AggregationsContainer = styled(Section)`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  padding-top: 0;
-`;
-
-export const AggregationPicker = styled(BaseAggregationPicker)`
-  color: var(--mb-color-summarize);
-`;
-
-export const ColumnListContainer = styled(Section)`
-  border-top: 1px solid var(--mb-color-border);
 `;


### PR DESCRIPTION
Removes some styled components in `Summarize` in favor of mantine components. These were just a few changes that I made when I was working on #49834 and felt that they weren't exactly relevant to that PR. 