### PR TITLE
Add a force parameter to permission graph endpoints to bypass revision number check

### DIFF
--- a/e2e/test/scenarios/native/snippets.cy.spec.js
+++ b/e2e/test/scenarios/native/snippets.cy.spec.js
@@ -368,7 +368,9 @@ describeEE("scenarios > question > snippets (EE)", () => {
     });
 
     it("shouldn't update root permissions when changing permissions on a created folder (metabase#17268)", () => {
-      cy.intercept("PUT", "/api/collection/graph").as("updatePermissions");
+      cy.intercept("PUT", "/api/collection/graph?skip-graph=true").as(
+        "updatePermissions",
+      );
 
       openNativeEditor();
       cy.icon("snippet").click();

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -733,7 +733,9 @@ describe("scenarios > admin > permissions", () => {
         true,
       );
 
-      cy.intercept("PUT", "/api/collection/graph").as("updateGraph");
+      cy.intercept("PUT", "/api/collection/graph?skip-graph=true").as(
+        "updateGraph",
+      );
 
       cy.button("Save changes").click();
       modal().within(() => {
@@ -742,7 +744,6 @@ describe("scenarios > admin > permissions", () => {
 
       cy.wait("@updateGraph").then(interception => {
         cy.log("should skip graph in request and response");
-        expect(interception.request.body.skip_graph).to.equal(true);
         expect(interception.response.body).to.not.haveOwnProperty("groups");
       });
 

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/application_permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/application_permissions.clj
@@ -76,13 +76,14 @@
   "Update the application Permissions graph.
   This works just like [[metabase.models.data-permissions.graph/update-data-perms-graph!]], but for Application permissions;
   refer to that function's extensive documentation to get a sense for how this works."
-  [new-graph :- ApplicationPermissionsGraph]
+  [new-graph :- ApplicationPermissionsGraph
+   force?     :- :boolean]
   (let [old-graph          (graph)
         old-perms          (:groups old-graph)
         new-perms          (:groups new-graph)
         [diff-old changes] (data/diff old-perms new-perms)]
     (perms.u/log-permissions-changes diff-old changes)
-    (perms.u/check-revision-numbers old-graph new-graph)
+    (when-not force? (perms.u/check-revision-numbers old-graph new-graph))
     (when (seq changes)
       (t2/with-transaction [_conn]
         (doseq [[group-id changes] changes]

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/application_permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/application_permissions.clj
@@ -76,16 +76,19 @@
   "Update the application Permissions graph.
   This works just like [[metabase.models.data-permissions.graph/update-data-perms-graph!]], but for Application permissions;
   refer to that function's extensive documentation to get a sense for how this works."
-  [new-graph :- ApplicationPermissionsGraph
-   force?     :- :boolean]
-  (let [old-graph          (graph)
-        old-perms          (:groups old-graph)
-        new-perms          (:groups new-graph)
-        [diff-old changes] (data/diff old-perms new-perms)]
-    (perms.u/log-permissions-changes diff-old changes)
-    (when-not force? (perms.u/check-revision-numbers old-graph new-graph))
-    (when (seq changes)
-      (t2/with-transaction [_conn]
-        (doseq [[group-id changes] changes]
-          (update-application-permissions! group-id changes))
-        (perms.u/save-perms-revision! ApplicationPermissionsRevision (:revision old-graph) (:groups old-graph) changes)))))
+  ([new-graph :- ApplicationPermissionsGraph]
+   (update-graph! new-graph false))
+
+  ([new-graph :- ApplicationPermissionsGraph
+    force?     :- :boolean]
+   (let [old-graph          (graph)
+         old-perms          (:groups old-graph)
+         new-perms          (:groups new-graph)
+         [diff-old changes] (data/diff old-perms new-perms)]
+     (perms.u/log-permissions-changes diff-old changes)
+     (when-not force? (perms.u/check-revision-numbers old-graph new-graph))
+     (when (seq changes)
+       (t2/with-transaction [_conn]
+         (doseq [[group-id changes] changes]
+           (update-application-permissions! group-id changes))
+         (perms.u/save-perms-revision! ApplicationPermissionsRevision (:revision old-graph) (:groups old-graph) changes))))))

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/setup-permission.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/setup-permission.ts
@@ -116,13 +116,12 @@ export const setupPermissions: CliStepMethod = async state => {
     }
 
     // Update the permissions for sandboxed collections
-    res = await fetch(`${instanceUrl}/api/collection/graph`, {
+    res = await fetch(`${instanceUrl}/api/collection/graph?skip-graph=true`, {
       method: "PUT",
       headers: { "content-type": "application/json", cookie },
       body: JSON.stringify({
         groups,
         revision: 0,
-        skip_graph: true,
       }),
     });
 

--- a/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/common.unit.spec.tsx
@@ -104,7 +104,6 @@ describe("Admin > CollectionPermissionsPage", () => {
             3: "read",
           },
         },
-        skip_graph: true,
       });
     });
 
@@ -161,7 +160,6 @@ describe("Admin > CollectionPermissionsPage", () => {
             3: "write",
           },
         },
-        skip_graph: true,
       });
     });
 

--- a/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/enterprise.unit.spec.tsx
@@ -115,7 +115,6 @@ describe("Admin > CollectionPermissionsPage (enterprise)", () => {
             13371337: "none",
           },
         },
-        skip_graph: true,
       });
     });
   });

--- a/frontend/src/metabase/admin/permissions/permissions.js
+++ b/frontend/src/metabase/admin/permissions/permissions.js
@@ -240,7 +240,6 @@ export const saveCollectionPermissions = createThunkAction(
       namespace,
       revision: collectionPermissionsRevision,
       groups: modifiedPermissions,
-      skip_graph: true,
     });
 
     return {

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -206,7 +206,7 @@ export const CollectionsApi = {
   getRoot: GET("/api/collection/root"),
   update: PUT("/api/collection/:id"),
   graph: GET("/api/collection/graph"),
-  updateGraph: PUT("/api/collection/graph"),
+  updateGraph: PUT("/api/collection/graph?skip-graph=true"),
 };
 
 const PIVOT_PUBLIC_PREFIX = "/api/public/pivot/";

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -117,7 +117,7 @@
                              [:= :type collection/trash-collection-type] 1
                              :else 2]] :asc]
                           [:%lower.name :asc]]})
-   exclude-other-user-collections (remove-other-users-personal-subcollections api/*current-user-id*)))
+    exclude-other-user-collections (remove-other-users-personal-subcollections api/*current-user-id*)))
 
 (api/defendpoint GET "/"
   "Fetch a list of all Collections that the current user has read permissions for (`:can_write` is returned as an
@@ -411,8 +411,8 @@
                     [:u.last_name :last_edit_last_name]
                     [:r.timestamp :last_edit_timestamp]
                     [:mr.status :moderated_status]]
-                   (#{:question :model} card-type)
-                   (conj :c.database_id))
+                    (#{:question :model} card-type)
+                    (conj :c.database_id))
        :from      [[:report_card :c]]
        :left-join [[:revision :r] [:and
                                    [:= :r.model_id :c.id]

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -117,7 +117,7 @@
                              [:= :type collection/trash-collection-type] 1
                              :else 2]] :asc]
                           [:%lower.name :asc]]})
-    exclude-other-user-collections (remove-other-users-personal-subcollections api/*current-user-id*)))
+   exclude-other-user-collections (remove-other-users-personal-subcollections api/*current-user-id*)))
 
 (api/defendpoint GET "/"
   "Fetch a list of all Collections that the current user has read permissions for (`:can_write` is returned as an
@@ -411,8 +411,8 @@
                     [:u.last_name :last_edit_last_name]
                     [:r.timestamp :last_edit_timestamp]
                     [:mr.status :moderated_status]]
-                    (#{:question :model} card-type)
-                    (conj :c.database_id))
+                   (#{:question :model} card-type)
+                   (conj :c.database_id))
        :from      [[:report_card :c]]
        :left-join [[:revision :r] [:and
                                    [:= :r.model_id :c.id]
@@ -1228,7 +1228,7 @@
   "Map describing permissions for 1 or more groups.
   Revision # is used for consistency"
   [:map
-   [:revision int?]
+   [:revision {:optional true} [:maybe int?]]
    [:groups [:map-of GroupID GroupPermissionsGraph]]])
 
 (def ^:private graph-decoder
@@ -1241,26 +1241,32 @@
 
 (defn- update-graph!
   "Handles updating the graph for a given namespace."
-  [namespace graph skip_graph]
-  (graph/update-graph! namespace graph)
-  (if skip_graph
+  [namespace graph skip-graph force?]
+  (graph/update-graph! namespace graph force?)
+  (if skip-graph
     {:revision (c-perm-revision/latest-id)}
     (graph/graph namespace)))
 
 (api/defendpoint PUT "/graph"
-  "Do a batch update of Collections Permissions by passing in a modified graph.
-  Will overwrite parts of the graph that are present in the request, and leave the rest unchanged.
+  "Do a batch update of Collections Permissions by passing in a modified graph. Will overwrite parts of the graph that
+  are present in the request, and leave the rest unchanged.
 
-  If the `skip_graph` query parameter is true, it will only return the current revision"
-  [:as {{:keys [namespace revision groups skip_graph]} :body}]
-  {namespace [:maybe ms/NonBlankString]
-   revision  ms/Int
-   groups :map
-   skip_graph [:maybe ms/BooleanValue]}
+  If the `force` query parameter is `true`, a `revision` number is not required. The provided graph will be persisted
+  as-is, and has the potential to clobber other writes that happened since the last read.
+
+  If the `skip_graph` query parameter is `true`, it will only return the current revision, not the entire permissions
+  graph."
+  [:as {{:keys [namespace revision groups]} :body
+        {:keys [skip-graph force]} :params}]
+  {namespace  [:maybe ms/NonBlankString]
+   revision   [:maybe ms/Int]
+   groups     :map
+   force      [:maybe ms/BooleanValue]
+   skip-graph [:maybe ms/BooleanValue]}
   (api/check-superuser)
-  (update-graph!
-   namespace
-   (decode-graph {:revision revision :groups groups})
-   skip_graph))
+  (update-graph! namespace
+                 (decode-graph {:revision revision :groups groups})
+                 skip-graph
+                 force))
 
 (api/define-routes)

--- a/src/metabase/api/permission_graph.clj
+++ b/src/metabase/api/permission_graph.clj
@@ -131,8 +131,9 @@
 (def StrictApiPermissionsGraph
   "Top level strict data graph schema expected over the API. Includes revision ID for avoiding concurrent updates."
   [:map
-   [:groups [:map-of GroupId [:maybe StrictDbGraph]]]
-   [:revision int?]])
+   [:revision {:optional true} [:maybe int?]]
+   [:force {:optional true} [:maybe boolean?]]
+   [:groups [:map-of GroupId [:maybe StrictDbGraph]]]])
 
 ;;; --------------------------------------------- Execution Permissions ----------------------------------------------
 

--- a/src/metabase/api/permissions.clj
+++ b/src/metabase/api/permissions.clj
@@ -127,9 +127,11 @@
 
   If the skip-graph query param is truthy, then the graph will not be returned."
   [:as {body :body
-        {skip-graph :skip-graph} :params}]
+        {skip-graph :skip-graph
+         force      :force} :params}]
   {body :map
-   skip-graph [:maybe :boolean]}
+   skip-graph [:maybe ms/BooleanValue]
+   force      [:maybe ms/BooleanValue]}
   (api/check-superuser)
   (let [new-graph (mc/decode api.permission-graph/StrictApiPermissionsGraph
                              body
@@ -148,7 +150,7 @@
             old       (or old {})
             new       (or new {})]
         (perms.u/log-permissions-changes old new)
-        (perms.u/check-revision-numbers old-graph new-graph)
+        (when-not force (perms.u/check-revision-numbers old-graph new-graph))
         (data-perms.graph/update-data-perms-graph! {:groups new})
         (perms.u/save-perms-revision! :model/PermissionsRevision (:revision old-graph) old new)
         (let [sandbox-updates        (:sandboxes new-graph)

--- a/src/metabase/permissions/util.clj
+++ b/src/metabase/permissions/util.clj
@@ -28,11 +28,12 @@
   make sure people don't submit a new graph based on something out of date, which would otherwise stomp over changes
   made in the interim. Return a 409 (Conflict) if the numbers don't match up."
   [old-graph new-graph]
-  (when (not= (:revision old-graph) (:revision new-graph))
-    (throw (ex-info (tru
-                     (str "Looks like someone else edited the permissions and your data is out of date. "
-                          "Please fetch new data and try again."))
-                    {:status-code 409}))))
+  (when-not (:force new-graph)
+    (when (not= (:revision old-graph) (:revision new-graph))
+      (throw (ex-info (tru
+                       (str "Looks like someone else edited the permissions and your data is out of date. "
+                            "Please fetch new data and try again."))
+                      {:status-code 409})))))
 
 (defn save-perms-revision!
   "Save changes made to permission graph for logging/auditing purposes.

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -624,7 +624,7 @@
              :authority_level nil
              :entity_id       true
              :name            collection-name}
-            personal-collection (assoc :personal_owner_id personal-collection))
+             personal-collection (assoc :personal_owner_id personal-collection))
            extra-keypairs)))
 
 (deftest collection-items-return-cards-test

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -624,7 +624,7 @@
              :authority_level nil
              :entity_id       true
              :name            collection-name}
-             personal-collection (assoc :personal_owner_id personal-collection))
+            personal-collection (assoc :personal_owner_id personal-collection))
            extra-keypairs)))
 
 (deftest collection-items-return-cards-test
@@ -2157,6 +2157,21 @@
               (is (= {"Currency A" "write", "Currency A -> B" "read"}
                      (nice-graph response))))))
 
+        (testing "Should require a `revision` parameter equal to the current graph's revision"
+          (is (= (str "Looks like someone else edited the permissions and your data is out of date. "
+                      "Please fetch new data and try again.")
+                 (mt/user-http-request :crowberto :put 409 "collection/graph"
+                                       (-> (graph/graph)
+                                           (update :revision dec))))))
+
+        (testing "Should be able to override the need for a `revision` parameter by passing `force=true`"
+          (let [response (mt/user-http-request :crowberto :put 200 "collection/graph?force=true"
+                                               (-> (graph/graph)
+                                                   (assoc :groups {group-id {default-ab :read}})
+                                                   (dissoc :revision)))]
+            (is (= {"Default A" "read", "Default A -> B" "read"}
+                   (nice-graph response)))))
+
         (testing "have to be a superuser"
           (is (= "You don't have permissions to do that."
                  (mt/user-http-request :rasta :put 403 "collection/graph"
@@ -2299,8 +2314,7 @@
   (is (malli= [:map {:closed true} [:revision :int]]
               (mt/user-http-request :crowberto
                                     :put 200
-                                    "collection/graph"
+                                    "collection/graph?skip-graph=true"
                                     {:revision (c-perm-revision/latest-id)
-                                     :groups {}
-                                     :skip_graph true}))
+                                     :groups {}}))
       "PUTs with skip_graph should not return the coll permission graph."))

--- a/test/metabase/api/permissions_test.clj
+++ b/test/metabase/api/permissions_test.clj
@@ -237,7 +237,7 @@
               :create-queries :query-builder}
              (get-in (data-perms.graph/api-graph) [:groups (u/the-id group) db-id])))))))
 
-(deftest update-perms-graph-with-skip-graph-skips-graph-test
+(deftest update-perms-graph-with-skip-graph-test
   (testing "PUT /api/permissions/graph"
     (testing "permissions graph is not returned when skip-graph"
       (t2.with-temp/with-temp [:model/PermissionsGroup group       {}
@@ -263,6 +263,19 @@
             (is (not (perm-test-util/validate-graph-api-groups (:groups no-returned-g))))
             (is (mc/validate [:map {:closed true}
                               [:revision pos-int?]] no-returned-g))))))))
+
+(deftest update-perms-graph-force-test
+  (testing "PUT /api/permissions/graph"
+    (testing "permissions graph does not check revision number when force=true"
+      (let [do-perm-put    (fn [url status] (mt/user-http-request
+                                             :crowberto :put status url
+                                             (-> (data-perms.graph/api-graph)
+                                                 (update :revision dec))))]
+        (is (= (str "Looks like someone else edited the permissions and your data is out of date. "
+                    "Please fetch new data and try again.")
+               (do-perm-put "permissions/graph?force=false" 409)))
+
+        (do-perm-put "permissions/graph?force=true" 200)))))
 
 (deftest can-revoke-permsissions-via-graph-test
   (testing "PUT /api/permissions/graph"

--- a/test/metabase/models/collection/graph_test.clj
+++ b/test/metabase/models/collection/graph_test.clj
@@ -307,7 +307,7 @@
   "`graph/update-graph!` updates the before and after values in the graph asyncronously, so we need to wait for them to be written"
   ([new-graph] (update-graph-and-wait! nil new-graph))
   ([namespaze new-graph]
-   (when-let [future (graph/update-graph! namespaze new-graph)]
+   (when-let [future (graph/update-graph! namespaze new-graph false)]
      ;; Block until the entire graph has been `filled-in!`
      @future)))
 
@@ -368,7 +368,7 @@
 
             (testing "Should be able to update the graph for a non-default namespace.\n"
               (let [before (graph/graph :currency)]
-                @(graph/update-graph! :currency (assoc (graph/graph) :groups {group-id {default-a :write, currency-a :write}}))
+                @(graph/update-graph! :currency (assoc (graph/graph) :groups {group-id {default-a :write, currency-a :write}}) false)
                 (is (= {"Currency A" :write, "Currency A -> B" :read, :root :none}
                        (nice-graph (graph/graph :currency))))
 


### PR DESCRIPTION
* Adds a `force` query parameter to permission graph `PUT` endpoints that allows you to skip enforcement of the `revision` number check, which can be set by API users who aren't worried about conflicting writes ([request](https://metaboat.slack.com/archives/C05MPF0TM3L/p1731343498768859))
* Standardizes the `skip-graph` query parameter across the different endpoints ([thread](https://metaboat.slack.com/archives/C064EB1UE5P/p1731352753721429))

Resolves https://github.com/metabase/metabase/issues/49845