### PR TITLE
[Backport 50] Map Oracle DATE to type/DateTime (#49592)

### DIFF
--- a/modules/drivers/oracle/src/metabase/driver/oracle.clj
+++ b/modules/drivers/oracle/src/metabase/driver/oracle.clj
@@ -61,7 +61,9 @@
     [#"RAW"         :type/*]
     [#"CHAR"        :type/Text]
     [#"CLOB"        :type/OracleCLOB]
-    [#"DATE"        :type/Date]
+    ;; Yes, the DATE is mapped to `:type/DateTime`. Oracle's DATE can store also a time part.
+    ;; See the docs - https://docs.oracle.com/en/database/oracle/oracle-database/19/nlspg/datetime-data-types-and-time-zone-support.html#GUID-3A1B7AC6-2EDB-4DDC-9C9D-223D4C72AC74
+    [#"DATE"        :type/DateTime]
     [#"DOUBLE"      :type/Float]
     ;; Expression filter type
     [#"^EXPRESSION" :type/*]

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -504,3 +504,36 @@
                (mt/with-native-query-testing-context query
                  (is (= (t/zoned-date-time (u.date/parse test-date) report-tz)
                         (ffirst (mt/rows (qp/process-query query))))))))))))))
+
+(mt/defdataset date-cols-with-datetime-values
+  [["dates_with_time" [{:field-name "date_with_time"
+                        :base-type {:native "DATE"}}]
+    [[(t/offset-date-time 2024 11 5 12 12 12)]
+     [(t/offset-date-time 2024 11 6 13 13 13)]]]])
+
+(deftest date-column-filtering-test
+  (mt/test-driver
+    :oracle
+    (mt/dataset
+      date-cols-with-datetime-values
+      (testing "Oracle's DATE columns are mapped to type/DateTime (#49440)"
+        (testing "Synced field is correctly mapped"
+          (let [date-field (t2/select-one :model/Field
+                                          {:where [:and
+                                                   [:= :table_id (t2/select-one-fn :id :model/Table :db_id (mt/id))]
+                                                   [:= :name "date_with_time"]]})]
+            (are [key* expected-type] (= expected-type (key* date-field))
+              :base_type :type/DateTime
+              :database_type "DATE")))
+        (testing "Filtering with day temporal unit returns expected resutls"
+          (is (= [[2M "2024-11-06T13:13:13Z"]]
+                 (mt/rows
+                  (mt/run-mbql-query
+                    dates_with_time
+                    {:filter [:= [:field %date_with_time {:base-type :type/Date :temporal-unit :day}] "2024-11-06"]})))))
+        (testing "Filtering by datetime retuns expected results"
+          (is (= [[1M "2024-11-05T12:12:12Z"]]
+                 (mt/rows
+                  (mt/run-mbql-query
+                    dates_with_time
+                    {:filter [:= [:field %date_with_time {:base-type :type/Date}] "2024-11-05T12:12:12"]})))))))))

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -505,7 +505,7 @@
                  (is (= (t/zoned-date-time (u.date/parse test-date) report-tz)
                         (ffirst (mt/rows (qp/process-query query))))))))))))))
 
-(mt/defdataset date-cols-with-datetime-values
+(mt/defdataset date-cols-with-datetime
   [["dates_with_time" [{:field-name "date_with_time"
                         :base-type {:native "DATE"}}]
     [[(t/offset-date-time 2024 11 5 12 12 12)]
@@ -515,7 +515,7 @@
   (mt/test-driver
     :oracle
     (mt/dataset
-      date-cols-with-datetime-values
+      date-cols-with-datetime
       (testing "Oracle's DATE columns are mapped to type/DateTime (#49440)"
         (testing "Synced field is correctly mapped"
           (let [date-field (t2/select-one :model/Field

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -505,8 +505,9 @@
                  (is (= (t/zoned-date-time (u.date/parse test-date) report-tz)
                         (ffirst (mt/rows (qp/process-query query))))))))))))))
 
-(mt/defdataset date-cols-with-datetime
-  [["dates_with_time" [{:field-name "date_with_time"
+(mt/defdataset d-w-dt
+  ;; date with datetime values
+  [["d_w_dt" [{:field-name "d_w_dt"
                         :base-type {:native "DATE"}}]
     [[(t/offset-date-time 2024 11 5 12 12 12)]
      [(t/offset-date-time 2024 11 6 13 13 13)]]]])
@@ -515,13 +516,13 @@
   (mt/test-driver
     :oracle
     (mt/dataset
-      date-cols-with-datetime
+      d-w-dt
       (testing "Oracle's DATE columns are mapped to type/DateTime (#49440)"
         (testing "Synced field is correctly mapped"
           (let [date-field (t2/select-one :model/Field
                                           {:where [:and
                                                    [:= :table_id (t2/select-one-fn :id :model/Table :db_id (mt/id))]
-                                                   [:= :name "date_with_time"]]})]
+                                                   [:= :name "d_w_dt"]]})]
             (are [key* expected-type] (= expected-type (key* date-field))
               :base_type :type/DateTime
               :database_type "DATE")))
@@ -529,11 +530,11 @@
           (is (= [[2M "2024-11-06T13:13:13Z"]]
                  (mt/rows
                   (mt/run-mbql-query
-                    dates_with_time
-                    {:filter [:= [:field %date_with_time {:base-type :type/Date :temporal-unit :day}] "2024-11-06"]})))))
+                    d_w_dt
+                    {:filter [:= [:field %d_w_dt {:base-type :type/Date :temporal-unit :day}] "2024-11-06"]})))))
         (testing "Filtering by datetime retuns expected results"
           (is (= [[1M "2024-11-05T12:12:12Z"]]
                  (mt/rows
                   (mt/run-mbql-query
-                    dates_with_time
-                    {:filter [:= [:field %date_with_time {:base-type :type/Date}] "2024-11-05T12:12:12"]})))))))))
+                    d_w_dt
+                    {:filter [:= [:field %d_w_dt {:base-type :type/Date}] "2024-11-05T12:12:12"]})))))))))

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -524,7 +524,7 @@
                                                    [:= :table_id (t2/select-one-fn :id :model/Table
                                                                                     {:where [:and
                                                                                              [:= :db_id (mt/id)]
-                                                                                             [:= :name "date_db_dtab"]]})]
+                                                                                             [:= :name "ora_date_db_dtab"]]})]
                                                    [:= :name "dcol"]]})]
             (are [key* expected-type] (= expected-type (key* date-field))
               :base_type :type/DateTime

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -505,10 +505,10 @@
                  (is (= (t/zoned-date-time (u.date/parse test-date) report-tz)
                         (ffirst (mt/rows (qp/process-query query))))))))))))))
 
-(mt/defdataset d-w-dt
+(mt/defdataset ora-date-db
   ;; date with datetime values
-  [["d_w_dt" [{:field-name "d_w_dt"
-                        :base-type {:native "DATE"}}]
+  [["dtab" [{:field-name "dcol"
+             :base-type {:native "DATE"}}]
     [[(t/offset-date-time 2024 11 5 12 12 12)]
      [(t/offset-date-time 2024 11 6 13 13 13)]]]])
 
@@ -516,13 +516,16 @@
   (mt/test-driver
     :oracle
     (mt/dataset
-      d-w-dt
+      ora-date-db
       (testing "Oracle's DATE columns are mapped to type/DateTime (#49440)"
         (testing "Synced field is correctly mapped"
           (let [date-field (t2/select-one :model/Field
                                           {:where [:and
-                                                   [:= :table_id (t2/select-one-fn :id :model/Table :db_id (mt/id))]
-                                                   [:= :name "d_w_dt"]]})]
+                                                   [:= :table_id (t2/select-one-fn :id :model/Table
+                                                                                    {:where [:and
+                                                                                             [:= :db_id (mt/id)]
+                                                                                             [:= :name "date_db_dtab"]]})]
+                                                   [:= :name "dcol"]]})]
             (are [key* expected-type] (= expected-type (key* date-field))
               :base_type :type/DateTime
               :database_type "DATE")))
@@ -530,11 +533,11 @@
           (is (= [[2M "2024-11-06T13:13:13Z"]]
                  (mt/rows
                   (mt/run-mbql-query
-                    d_w_dt
-                    {:filter [:= [:field %d_w_dt {:base-type :type/Date :temporal-unit :day}] "2024-11-06"]})))))
+                    dtab
+                    {:filter [:= [:field %dcol {:base-type :type/Date :temporal-unit :day}] "2024-11-06"]})))))
         (testing "Filtering by datetime retuns expected results"
           (is (= [[1M "2024-11-05T12:12:12Z"]]
                  (mt/rows
                   (mt/run-mbql-query
-                    d_w_dt
-                    {:filter [:= [:field %d_w_dt {:base-type :type/Date}] "2024-11-05T12:12:12"]})))))))))
+                    dtab
+                    {:filter [:= [:field %dcol {:base-type :type/Date}] "2024-11-05T12:12:12"]})))))))))


### PR DESCRIPTION
Backport of https://github.com/metabase/metabase/pull/49592 into `release-x.50.x` as per [discussion on slack](https://metaboat.slack.com/archives/D07HUKCKRE3/p1730967754162549).
