### PR TITLE
Implement enterprise search rankers in the database

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/search/scoring.clj
+++ b/enterprise/backend/src/metabase_enterprise/search/scoring.clj
@@ -10,20 +10,20 @@
   {:official-collection (fulltext.scoring/truthy :official_collection)
    :verified            (fulltext.scoring/truthy :verified)})
 
-(defn- additional-scorers []
-  (cond-> (list)
-    (premium-features/has-feature? :official-collections)
-    (conj :official-collection)
+(def ^:private scorers-enabled
+  {:official-collection #(premium-features/has-feature? :official-collection)
+   :verified            #(premium-features/has-feature? :content-verification)})
 
-    (premium-features/has-feature? :content-verification)
-    (conj :verified)))
+(defn- additional-scorers
+  "Which additional scorers are active?"
+  []
+  (into [] (comp (filter (fn [[_ pred]] (pred))) (map first)) scorers-enabled))
 
 (defenterprise scorers
   "Return the select-item expressions used to calculate the score for each search result."
   :feature :none
   []
-  (merge fulltext.scoring/base-scorers
-         (select-keys enterprise-scorers (additional-scorers))))
+  (merge fulltext.scoring/base-scorers (select-keys enterprise-scorers (additional-scorers))))
 
 ;; ------------ LEGACY ----------
 

--- a/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
@@ -108,7 +108,7 @@
   {:pre [(> 10 (count values))]}
   (mapv vec (mapcat math.combo/permutations (math.combo/subsets values))))
 
-(defn test-corups [words]
+(defn test-corpus [words]
   (let [corpus (->> words
                     all-permutations-all-orders
                     (mapv #(str/join " " %))
@@ -126,9 +126,9 @@
                  :name))))))
 
 (deftest identical-results-result-in-identical-hits
-  (test-corups ["foo" "bar"])
-  (test-corups ["foo" "bar" "baz"])
-  (test-corups ["foo" "bar" "baz" "quux"]))
+  (test-corpus ["foo" "bar"])
+  (test-corpus ["foo" "bar" "baz"])
+  (test-corpus ["foo" "bar" "baz" "quux"]))
 
 (deftest score-result-test
   (let [score-result-names (fn [] (set (map :name (scoring/score-result {}))))]

--- a/src/metabase/models/action.clj
+++ b/src/metabase/models/action.clj
@@ -405,16 +405,16 @@
    :attrs        {:archived       true
                   :collection-id  :model.collection_id
                   :creator-id     true
-                  :database-id    :query_action.database_id
                   :native-query   :query_action.dataset_query
                   ;; workaround for actions not having revisions (yet)
                   :last-edited-at :updated_at
-                  :table-id       false
                   :created-at     true
                   :updated-at     true}
    :search-terms [:name :description]
    :render-terms {:model-id   :model.id
-                  :model-name :model.name}
+                  :model-name :model.name
+                  :database-id    :query_action.database_id
+                  :table-id       false}
    :where        [:= :collection.namespace nil]
    :joins        {:model        [:model/Card [:= :model.id :this.model_id]]
                   :query_action [:model/QueryAction [:= :query_action.action_id :this.id]]

--- a/src/metabase/models/action.clj
+++ b/src/metabase/models/action.clj
@@ -405,6 +405,7 @@
    :attrs        {:archived       true
                   :collection-id  :model.collection_id
                   :creator-id     true
+                  :database-id    :query_action.database_id
                   :native-query   :query_action.dataset_query
                   ;; workaround for actions not having revisions (yet)
                   :last-edited-at :updated_at
@@ -412,9 +413,7 @@
                   :updated-at     true}
    :search-terms [:name :description]
    :render-terms {:model-id   :model.id
-                  :model-name :model.name
-                  :database-id    :query_action.database_id
-                  :table-id       false}
+                  :model-name :model.name}
    :where        [:= :collection.namespace nil]
    :joins        {:model        [:model/Card [:= :model.id :this.model_id]]
                   :query_action [:model/QueryAction [:= :query_action.action_id :this.id]]

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -1033,7 +1033,6 @@
                   ;; This is used for legacy ranking, in future it will be replaced by :pinned
                   :collection-position        true
                   :collection-type            :collection.type
-                  :database-id                false
                   ;; This field can become stale, unless we change to calculate it just-in-time.
                   :display                    true
                   :moderated-status           :mr.status

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -1014,12 +1014,11 @@
    :attrs        {:archived            true
                   :collection-id       :collection_id
                   :creator-id          true
-                  :database-id         false
-                  :native-query        [:case [:= "native" :query_type] :dataset_query]
                   :dashboardcard-count {:select [:%count.*]
                                         :from   [:report_dashboardcard]
                                         :where  [:= :report_dashboardcard.card_id :this.id]}
-                  :table-id            false
+                  :native-query        [:case [:= "native" :query_type] :dataset_query]
+                  :official-collection [:= "official" :collection.authority_level]
                   :last-edited-at      :r.timestamp
                   :last-editor-id      :r.user_id
                   :pinned              [:> [:coalesce :collection_position [:inline 0]] [:inline 0]]
@@ -1029,15 +1028,16 @@
                   :updated-at          true}
    :search-terms [:name :description]
    :render-terms {:archived-directly          true
-                  :collection-authority_level :collection.authority_level
                   :collection-location        :collection.location
                   :collection-name            :collection.name
                   ;; This is used for legacy ranking, in future it will be replaced by :pinned
                   :collection-position        true
                   :collection-type            :collection.type
+                  :database-id                false
                   ;; This field can become stale, unless we change to calculate it just-in-time.
                   :display                    true
-                  :moderated-status           :mr.status}
+                  :moderated-status           :mr.status
+                  :table-id                   false}
    :bookmark     [:model/CardBookmark [:and
                                        [:= :bookmark.card_id :this.id]
                                        [:= :bookmark.user_id :current_user/id]]]
@@ -1054,7 +1054,7 @@
                                                         [:= :mr.moderated_item_id :this.id]
                                                         [:= :mr.most_recent true]]]
                   ;; workaround for dataflow :((((((
-                  :dashcard [:model/DashboardCard [:= :dashcard.card_id :this.id]]}})
+                  :dashcard   [:model/DashboardCard [:= :dashcard.card_id :this.id]]}})
 
 (search/define-spec "card"
   (-> base-search-spec (sql.helpers/where [:= :this.type "question"])))

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -1028,6 +1028,7 @@
                   :updated-at          true}
    :search-terms [:name :description]
    :render-terms {:archived-directly          true
+                  :collection-authority_level :collection.authority_level
                   :collection-location        :collection.location
                   :collection-name            :collection.name
                   ;; This is used for legacy ranking, in future it will be replaced by :pinned

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -1036,8 +1036,7 @@
                   :collection-type            :collection.type
                   ;; This field can become stale, unless we change to calculate it just-in-time.
                   :display                    true
-                  :moderated-status           :mr.status
-                  :table-id                   false}
+                  :moderated-status           :mr.status}
    :bookmark     [:model/CardBookmark [:and
                                        [:= :bookmark.card_id :this.id]
                                        [:= :bookmark.user_id :current_user/id]]]

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -1740,7 +1740,6 @@
    :attrs        {:collection-id :id
                   :creator-id    false
                   :database-id   false
-                  :table-id      false
                   :archived      true
                   :created-at    true
                   ;; intentionally not tracked

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -669,6 +669,7 @@
    :attrs        {:archived       true
                   :collection-id  true
                   :creator-id     true
+                  :database-id    false
                   :last-editor-id :r.user_id
                   :last-edited-at :r.timestamp
                   :pinned         [:> [:coalesce :collection_position [:inline 0]] [:inline 0]]
@@ -681,9 +682,7 @@
                   :collection-name            :collection.name
                   ;; This is used for legacy ranking, in future it will be replaced by :pinned
                   :collection-position        true
-                  :collection-type            :collection.type
-                  :database-id                false
-                  :table-id                   false}
+                  :collection-type            :collection.type}
    :where        []
    :bookmark     [:model/DashboardBookmark [:and
                                             [:= :bookmark.dashboard_id :this.id]

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -669,25 +669,25 @@
    :attrs        {:archived       true
                   :collection-id  true
                   :creator-id     true
-                  :database-id    false
                   :last-editor-id :r.user_id
                   :last-edited-at :r.timestamp
                   :pinned         [:> [:coalesce :collection_position [:inline 0]] [:inline 0]]
-                  :table-id       false
                   :view-count     true
                   :created-at     true
                   :updated-at     true}
    :search-terms [:name :description]
-   :render-terms {:collection-name            :collection.name
-                  :collection-type            :collection.type
+   :render-terms {:archived-directly          true
                   :collection-authority_level :collection.authority_level
-                  :archived-directly          true
+                  :collection-name            :collection.name
                   ;; This is used for legacy ranking, in future it will be replaced by :pinned
-                  :collection-position        true}
+                  :collection-position        true
+                  :collection-type            :collection.type
+                  :database-id                false
+                  :table-id                   false}
    :where        []
    :bookmark     [:model/DashboardBookmark [:and
                                             [:= :bookmark.dashboard_id :this.id]
-                                             ;; a magical alias, or perhaps this clause can be implicit
+                                            ;; a magical alias, or perhaps this clause can be implicit
                                             [:= :bookmark.user_id :current_user/id]]]
    :joins        {:collection [:model/Collection [:= :collection.id :this.collection_id]]
                   :r          [:model/Revision [:and

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -509,7 +509,6 @@
                   :creator-id    false
                   ;; not sure if this is another bug
                   :database-id   false
-                  :table-id      false
                   :created-at    true
                   :updated-at    true}
    :search-terms [:name :description]

--- a/src/metabase/models/model_index.clj
+++ b/src/metabase/models/model_index.clj
@@ -188,8 +188,6 @@
    :attrs        {:id            :model_pk
                   :collection-id :collection.id
                   :creator-id    false
-                  :database-id   :model.database_id
-                  :table-id      false
                   ;; this seems wrong, I'd expect it to track whether the model is archived.
                   :archived      false
                   :created-at    false
@@ -197,6 +195,8 @@
    :search-terms [:name]
    :render-terms {:collection-name :collection.name
                   :collection-type :collection.type
+                  :database-id   :model.database_id
+                  :table-id      false
                   :model-id        :model.id
                   :model-name      :model.name
                   :pk-ref          :model_index.pk_ref

--- a/src/metabase/models/model_index.clj
+++ b/src/metabase/models/model_index.clj
@@ -190,13 +190,12 @@
                   :creator-id    false
                   ;; this seems wrong, I'd expect it to track whether the model is archived.
                   :archived      false
+                  :database-id   :model.database_id
                   :created-at    false
                   :updated-at    false}
    :search-terms [:name]
    :render-terms {:collection-name :collection.name
                   :collection-type :collection.type
-                  :database-id   :model.database_id
-                  :table-id      false
                   :model-id        :model.id
                   :model-name      :model.name
                   :pk-ref          :model_index.pk_ref

--- a/src/metabase/models/segment.clj
+++ b/src/metabase/models/segment.clj
@@ -193,14 +193,14 @@
   {:model        :model/Segment
    :attrs        {:collection-id :id
                   :creator-id    false
-                  :database-id   :table.db_id
-                  :table-id      :table_id
                   :archived      true
                   ;; Matching legacy behavior, where this cannot be filtered on.
                   ;:created-at    true
                   :updated-at    true}
    :search-terms [:name :description]
-   :render-terms {:table_description :table.description
+   :render-terms {:database-id   :table.db_id
+                  :table-id      :table_id
+                  :table_description :table.description
                   :table_name        :table.name
                   :table_schema      :table.schema}
    :joins        {:table [:model/Table [:= :table.id :this.table_id]]}})

--- a/src/metabase/models/segment.clj
+++ b/src/metabase/models/segment.clj
@@ -191,15 +191,15 @@
 
 (search/define-spec "segment"
   {:model        :model/Segment
-   :attrs        {:collection-id :id
+   :attrs        {:archived      true
+                  :collection-id :id
                   :creator-id    false
-                  :archived      true
+                  :database-id   :table.db_id
                   ;; Matching legacy behavior, where this cannot be filtered on.
                   ;:created-at    true
                   :updated-at    true}
    :search-terms [:name :description]
-   :render-terms {:database-id   :table.db_id
-                  :table-id      :table_id
+   :render-terms {:table-id          :table_id
                   :table_description :table.description
                   :table_name        :table.name
                   :table_schema      :table.schema}

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -302,18 +302,18 @@
 
 (search/define-spec "table"
   {:model        :model/Table
-   :attrs        {:collection-id false
-                  :creator-id    false
-                  ;; legacy search uses :active for this, but then has a rule to only ever show active tables
+   :attrs        {;; legacy search uses :active for this, but then has a rule to only ever show active tables
                   ;; so we moved that to the where clause
                   :archived      false
+                  :collection-id false
+                  :creator-id    false
+                  :database-id   :db_id
                   :view-count    true
                   :created-at    true
                   :updated-at    true}
    :search-terms [:name :description :display_name]
-   :render-terms {:database-id   :db_id
-                  :initial-sync-status true
-                  :table-id      :id
+   :render-terms {:initial-sync-status true
+                  :table-id            :id
                   :table-description   :description
                   :table-name          :name
                   :table-schema        :schema

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -304,8 +304,6 @@
   {:model        :model/Table
    :attrs        {:collection-id false
                   :creator-id    false
-                  :database-id   :db_id
-                  :table-id      :id
                   ;; legacy search uses :active for this, but then has a rule to only ever show active tables
                   ;; so we moved that to the where clause
                   :archived      false
@@ -313,7 +311,9 @@
                   :created-at    true
                   :updated-at    true}
    :search-terms [:name :description :display_name]
-   :render-terms {:initial-sync-status true
+   :render-terms {:database-id   :db_id
+                  :initial-sync-status true
+                  :table-id      :id
                   :table-description   :description
                   :table-name          :name
                   :table-schema        :schema

--- a/src/metabase/search/postgres/index.clj
+++ b/src/metabase/search/postgres/index.clj
@@ -54,6 +54,7 @@
              ;; scoring related
              [:dashboardcard_count :int]
              [:model_rank :int :not-null]
+             [:official_collection :boolean]
              [:pinned :boolean]
              [:verified :boolean]
              [:view_count :int]

--- a/src/metabase/search/postgres/index.clj
+++ b/src/metabase/search/postgres/index.clj
@@ -60,8 +60,6 @@
              [:view_count :int]
              ;; permission related entities
              [:collection_id :int]
-             [:database_id :int]
-             [:table_id :int]
              ;; filter related
              [:archived :boolean :not-null [:default false]]
              [:creator_id :int]

--- a/src/metabase/search/postgres/index.clj
+++ b/src/metabase/search/postgres/index.clj
@@ -60,6 +60,7 @@
              [:view_count :int]
              ;; permission related entities
              [:collection_id :int]
+             [:database_id :int]
              ;; filter related
              [:archived :boolean :not-null [:default false]]
              [:creator_id :int]

--- a/src/metabase/search/spec.clj
+++ b/src/metabase/search/spec.clj
@@ -33,6 +33,7 @@
    :name
    :created-at
    :creator-id
+   :database-id
    :native-query
    :official-collection
    :dashboardcard-count

--- a/src/metabase/search/spec.clj
+++ b/src/metabase/search/spec.clj
@@ -25,9 +25,7 @@
 (def ^:private explicit-attrs
   "These attributes must be explicitly defined, omitting them could be a source of bugs."
   [:archived
-   :collection-id
-   :database-id
-   :table-id])
+   :collection-id])
 
 (def ^:private optional-attrs
   "These attributes may be omitted (for now) in the interest of brevity in the definitions."
@@ -36,6 +34,7 @@
    :created-at
    :creator-id
    :native-query
+   :official-collection
    :dashboardcard-count
    :last-edited-at
    :last-editor-id


### PR DESCRIPTION
I got somewhat stumped on how to unit test this, as its purely declarative stuff which is used elsewhere to generate SQL.

As far as behavior goes, they're also not very interesting without applying the weights in opposition to the regular rankers, and we still need to pick these weights.

I came to the conclusion that we should leave testing for when we add concrete "use case" example tests.