### PR TITLE
Translate more strings on static embed with `#locale`

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -1098,7 +1098,25 @@ describe("issue 8490", () => {
             ],
           },
           display: "smartscalar",
-          enable_embedding: true,
+        },
+        {
+          name: "Pie chart",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [["count"]],
+            breakout: [
+              [
+                "field",
+                PRODUCTS.VENDOR,
+                { "base-type": "type/Text", "source-field": ORDERS.PRODUCT_ID },
+              ],
+            ],
+            limit: 5,
+          },
+          visualization_settings: {
+            "pie.slice_threshold": 20,
+          },
+          display: "pie",
         },
       ],
       cards: [{}, { col: 11 }],
@@ -1125,21 +1143,34 @@ describe("issue 8490", () => {
     });
 
     cy.findByTestId("embed-frame").within(() => {
-      cy.log("assert the line chart");
-      // X-axis labels: Jan 2023
-      cy.findByText("1월 2023").should("be.visible");
       // PDF export
       cy.findByText("PDF로 내보내기").should("be.visible");
       // Powered by
       cy.findByText("제공:").should("be.visible");
-      // Aggregation "count"
-      cy.findByText("카운트").should("be.visible");
+
+      cy.log("assert the line chart");
+      getDashboardCard(0).within(() => {
+        // X-axis labels: Jan 2023
+        cy.findByText("1월 2023").should("be.visible");
+        // Aggregation "count"
+        cy.findByText("카운트").should("be.visible");
+      });
 
       cy.log("assert the trend chart");
-      // N/A
-      cy.findByText("해당 없음").should("be.visible");
-      // (No data)
-      cy.findByText("(데이터 없음)").should("be.visible");
+      getDashboardCard(2).within(() => {
+        // N/A
+        cy.findByText("해당 없음").should("be.visible");
+        // (No data)
+        cy.findByText("(데이터 없음)").should("be.visible");
+      });
+
+      cy.log("assert the pie chart");
+      getDashboardCard(1).within(() => {
+        // Total
+        cy.findByText("합계").should("be.visible");
+        // Other
+        cy.findByTestId("chart-legend").findByText("기타").should("be.visible");
+      });
     });
 
     cy.log("test a static embedded question");

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -1,6 +1,7 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   addOrUpdateDashboardCard,
+  assertEChartsTooltip,
   createDashboardWithQuestions,
   createNativeQuestion,
   createQuestionAndDashboard,
@@ -10,6 +11,7 @@ import {
   getIframeBody,
   modal,
   openStaticEmbeddingModal,
+  otherSeriesChartPaths,
   popover,
   queryBuilderMain,
   restore,
@@ -1050,10 +1052,19 @@ describe("issue 8490", () => {
                 { "base-type": "type/DateTime", "temporal-unit": "month" },
               ],
             ],
+            filter: [
+              "time-interval",
+              ["field", PRODUCTS.CREATED_AT, { "base-type": "type/DateTime" }],
+              -12,
+              "month",
+            ],
           },
+          limit: 100,
           visualization_settings: {
             "graph.dimensions": ["CREATED_AT", "CATEGORY"],
             "graph.metrics": ["count"],
+            "graph.max_categories_enabled": true,
+            "graph.max_categories": 2,
           },
           display: "bar",
           enable_embedding: true,
@@ -1150,12 +1161,33 @@ describe("issue 8490", () => {
 
       cy.log("assert the line chart");
       getDashboardCard(0).within(() => {
-        // X-axis labels: Jan 2023
-        cy.findByText("1월 2023").should("be.visible");
+        // X-axis labels: Jan 2024
+        cy.findByText("1월 2024").should("be.visible");
         // Aggregation "count"
         cy.findByText("카운트").should("be.visible");
+        // "Other" bar tooltip
+        otherSeriesChartPaths().first().realHover();
       });
+    });
 
+    assertEChartsTooltip({
+      rows: [
+        {
+          name: "Gizmo",
+          value: "4",
+        },
+        {
+          name: "Widget",
+          value: "2",
+        },
+        {
+          name: "합계",
+          value: "6",
+        },
+      ],
+    });
+
+    cy.findByTestId("embed-frame").within(() => {
       cy.log("assert the trend chart");
       getDashboardCard(2).within(() => {
         // N/A
@@ -1192,7 +1224,7 @@ describe("issue 8490", () => {
 
     cy.findByTestId("embed-frame").within(() => {
       // X-axis labels: Jan 2023
-      cy.findByText("4월 2022").should("be.visible");
+      cy.findByText("11월 2023").should("be.visible");
       // Powered by
       cy.findByText("제공:").should("be.visible");
       // Aggregation "count"

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -25,7 +25,7 @@ import {
   withDatabase,
 } from "e2e/support/helpers";
 
-const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+const { PRODUCTS, PRODUCTS_ID, ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
 describe.skip("issue 15860", () => {
   const q1IdFilter = {
@@ -1058,10 +1058,53 @@ describe("issue 8490", () => {
           display: "bar",
           enable_embedding: true,
         },
+        {
+          name: "Order quantity trend",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [
+              [
+                "sum",
+                ["field", ORDERS.QUANTITY, { "base-type": "type/Integer" }],
+              ],
+            ],
+            breakout: [
+              [
+                "field",
+                ORDERS.CREATED_AT,
+                { "base-type": "type/DateTime", "temporal-unit": "month" },
+              ],
+            ],
+            filter: [
+              "and",
+              [
+                "time-interval",
+                ["field", ORDERS.CREATED_AT, { "base-type": "type/DateTime" }],
+                -2,
+                "month",
+              ],
+              [
+                "=",
+                [
+                  "field",
+                  PRODUCTS.VENDOR,
+                  {
+                    "base-type": "type/Text",
+                    "source-field": ORDERS.PRODUCT_ID,
+                  },
+                ],
+                "Alfreda Konopelski II Group",
+              ],
+            ],
+          },
+          display: "smartscalar",
+          enable_embedding: true,
+        },
       ],
-    }).then(({ dashboard, questions: [question] }) => {
+      cards: [{}, { col: 11 }],
+    }).then(({ dashboard, questions: [lineChartQuestion] }) => {
       cy.wrap(dashboard.id).as("dashboardId");
-      cy.wrap(question.id).as("questionId");
+      cy.wrap(lineChartQuestion.id).as("lineChartQuestionId");
     });
   });
 
@@ -1082,24 +1125,30 @@ describe("issue 8490", () => {
     });
 
     cy.findByTestId("embed-frame").within(() => {
+      cy.log("assert the line chart");
       // X-axis labels: Jan 2023
       cy.findByText("1월 2023").should("be.visible");
-
       // PDF export
       cy.findByText("PDF로 내보내기").should("be.visible");
-
       // Powered by
       cy.findByText("제공:").should("be.visible");
-
       // Aggregation "count"
       cy.findByText("카운트").should("be.visible");
+
+      cy.log("assert the trend chart");
+      // N/A
+      cy.findByText("해당 없음").should("be.visible");
+      // (No data)
+      cy.findByText("(데이터 없음)").should("be.visible");
     });
 
     cy.log("test a static embedded question");
-    cy.get("@questionId").then(questionId => {
+
+    cy.log("assert the line chart");
+    cy.get("@lineChartQuestionId").then(lineChartQuestionId => {
       visitEmbeddedPage(
         {
-          resource: { question: questionId },
+          resource: { question: lineChartQuestionId },
           params: {},
         },
         {
@@ -1113,10 +1162,8 @@ describe("issue 8490", () => {
     cy.findByTestId("embed-frame").within(() => {
       // X-axis labels: Jan 2023
       cy.findByText("4월 2022").should("be.visible");
-
       // Powered by
       cy.findByText("제공:").should("be.visible");
-
       // Aggregation "count"
       cy.findByText("카운트").should("be.visible");
     });

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/other-series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/other-series.ts
@@ -100,55 +100,75 @@ const AGGREGATION_FN_MAP: Record<
   AggregationType,
   { fn: (values: number[]) => number; label: string }
 > = {
-  count: {
-    label: t`Total`,
-    fn: sum,
+  get count() {
+    return {
+      label: t`Total`,
+      fn: sum,
+    };
   },
-  sum: {
-    label: t`Total`,
-    fn: sum,
+  get sum() {
+    return {
+      label: t`Total`,
+      fn: sum,
+    };
   },
-  "cum-sum": {
-    label: t`Total`,
-    fn: sum,
+  get "cum-sum"() {
+    return {
+      label: t`Total`,
+      fn: sum,
+    };
   },
-  "cum-count": {
-    label: t`Total`,
-    fn: sum,
+  get "cum-count"() {
+    return {
+      label: t`Total`,
+      fn: sum,
+    };
   },
-  avg: {
-    label: t`Average`,
-    fn: values => sum(values) / values.length,
+  get avg() {
+    return {
+      label: t`Average`,
+      fn: (values: number[]) => sum(values) / values.length,
+    };
   },
-  distinct: {
-    label: t`Distinct values`,
-    fn: values => new Set(values).size,
+  get distinct() {
+    return {
+      label: t`Distinct values`,
+      fn: (values: number[]) => new Set(values).size,
+    };
   },
-  min: {
-    label: t`Min`,
-    fn: values => Math.min(...values),
+  get min() {
+    return {
+      label: t`Min`,
+      fn: (values: number[]) => Math.min(...values),
+    };
   },
-  max: {
-    label: t`Max`,
-    fn: values => Math.max(...values),
+  get max() {
+    return {
+      label: t`Max`,
+      fn: (values: number[]) => Math.max(...values),
+    };
   },
-  median: {
-    label: t`Median`,
-    fn: values => {
-      const sortedValues = values.sort((a, b) => a - b);
-      const middleIndex = Math.floor(sortedValues.length / 2);
-      return sortedValues.length % 2
-        ? sortedValues[middleIndex]
-        : (sortedValues[middleIndex - 1] + sortedValues[middleIndex]) / 2;
-    },
+  get median() {
+    return {
+      label: t`Median`,
+      fn: (values: number[]) => {
+        const sortedValues = values.sort((a, b) => a - b);
+        const middleIndex = Math.floor(sortedValues.length / 2);
+        return sortedValues.length % 2
+          ? sortedValues[middleIndex]
+          : (sortedValues[middleIndex - 1] + sortedValues[middleIndex]) / 2;
+      },
+    };
   },
-  stddev: {
-    label: t`Standard deviation`,
-    fn: values => {
-      const mean = sum(values) / values.length;
-      const squaredDifferences = values.map(v => (v - mean) ** 2);
-      const variance = sum(squaredDifferences) / values.length;
-      return Math.sqrt(variance);
-    },
+  get stddev() {
+    return {
+      label: t`Standard deviation`,
+      fn: (values: number[]) => {
+        const mean = sum(values) / values.length;
+        const squaredDifferences = values.map(v => (v - mean) ** 2);
+        const variance = sum(squaredDifferences) / values.length;
+        return Math.sqrt(variance);
+      },
+    };
   },
 };

--- a/frontend/src/metabase/visualizations/echarts/pie/constants.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/constants.ts
@@ -36,8 +36,8 @@ export const OTHER_SLICE_MIN_PERCENTAGE = 0.005;
 
 export const OTHER_SLICE_KEY = `${NULL_CHAR}___OTHER___`;
 
-export const OTHER_SLICE_NAME = t`Other`;
+export const getSliceName = () => t`Other`;
 
-export const TOTAL_TEXT = t`Total`.toUpperCase();
+export const getTotalText = () => t`Total`.toUpperCase();
 
 export const OPTION_NAME_SEPERATOR = `–${NULL_CHAR}–`;

--- a/frontend/src/metabase/visualizations/echarts/pie/constants.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/constants.ts
@@ -36,7 +36,7 @@ export const OTHER_SLICE_MIN_PERCENTAGE = 0.005;
 
 export const OTHER_SLICE_KEY = `${NULL_CHAR}___OTHER___`;
 
-export const getSliceName = () => t`Other`;
+export const getOtherSliceName = () => t`Other`;
 
 export const getTotalText = () => t`Total`.toUpperCase();
 

--- a/frontend/src/metabase/visualizations/echarts/pie/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/model/index.ts
@@ -24,7 +24,7 @@ import type { ShowWarning } from "../../types";
 import {
   OTHER_SLICE_KEY,
   OTHER_SLICE_MIN_PERCENTAGE,
-  OTHER_SLICE_NAME,
+  getSliceName,
 } from "../constants";
 import { getDimensionFormatter } from "../format";
 import { getArrayFromMapValues } from "../util";
@@ -188,7 +188,7 @@ function aggregateChildrenSlices(
 
     node.children.set(OTHER_SLICE_KEY, {
       key: OTHER_SLICE_KEY,
-      name: OTHER_SLICE_NAME,
+      name: getSliceName(),
       value: otherTotal,
       displayValue: otherTotal,
       normalizedPercentage: otherTotal / node.value,
@@ -471,7 +471,7 @@ export function getPieChartModel(
 
     sliceTree.set(OTHER_SLICE_KEY, {
       key: OTHER_SLICE_KEY,
-      name: OTHER_SLICE_NAME,
+      name: getSliceName(),
       value: otherTotal,
       displayValue: otherTotal,
       normalizedPercentage: visible ? otherTotal / total : 0,
@@ -509,7 +509,7 @@ export function getPieChartModel(
   if (sliceTree.size === 0) {
     sliceTree.set(OTHER_SLICE_KEY, {
       key: OTHER_SLICE_KEY,
-      name: OTHER_SLICE_NAME,
+      name: getSliceName(),
       value: 1,
       displayValue: 0,
       normalizedPercentage: 0,

--- a/frontend/src/metabase/visualizations/echarts/pie/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/model/index.ts
@@ -24,7 +24,7 @@ import type { ShowWarning } from "../../types";
 import {
   OTHER_SLICE_KEY,
   OTHER_SLICE_MIN_PERCENTAGE,
-  getSliceName,
+  getOtherSliceName,
 } from "../constants";
 import { getDimensionFormatter } from "../format";
 import { getArrayFromMapValues } from "../util";
@@ -188,7 +188,7 @@ function aggregateChildrenSlices(
 
     node.children.set(OTHER_SLICE_KEY, {
       key: OTHER_SLICE_KEY,
-      name: getSliceName(),
+      name: getOtherSliceName(),
       value: otherTotal,
       displayValue: otherTotal,
       normalizedPercentage: otherTotal / node.value,
@@ -471,7 +471,7 @@ export function getPieChartModel(
 
     sliceTree.set(OTHER_SLICE_KEY, {
       key: OTHER_SLICE_KEY,
-      name: getSliceName(),
+      name: getOtherSliceName(),
       value: otherTotal,
       displayValue: otherTotal,
       normalizedPercentage: visible ? otherTotal / total : 0,
@@ -509,7 +509,7 @@ export function getPieChartModel(
   if (sliceTree.size === 0) {
     sliceTree.set(OTHER_SLICE_KEY, {
       key: OTHER_SLICE_KEY,
-      name: getSliceName(),
+      name: getOtherSliceName(),
       value: 1,
       displayValue: 0,
       normalizedPercentage: 0,

--- a/frontend/src/metabase/visualizations/echarts/pie/option.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/option.ts
@@ -9,7 +9,7 @@ import type {
   RenderingContext,
 } from "metabase/visualizations/types";
 
-import { DIMENSIONS, OPTION_NAME_SEPERATOR, TOTAL_TEXT } from "./constants";
+import { DIMENSIONS, OPTION_NAME_SEPERATOR, getTotalText } from "./constants";
 import type { PieChartFormatters } from "./format";
 import type { PieChartModel, SliceTreeNode } from "./model/types";
 import { getArrayFromMapValues, getSliceTreeNodesFromPath } from "./util";
@@ -42,7 +42,7 @@ function getTotalGraphicOption(
   let labelText = "";
 
   const defaultLabelWillOverflow =
-    renderingContext.measureText(TOTAL_TEXT, fontStyle) >= innerRadius * 2;
+    renderingContext.measureText(getTotalText(), fontStyle) >= innerRadius * 2;
 
   if (settings["pie.show_total"] && !defaultLabelWillOverflow) {
     let sliceValueOrTotal = 0;
@@ -65,7 +65,7 @@ function getTotalGraphicOption(
       labelText = slice.name.toUpperCase();
     } else {
       sliceValueOrTotal = chartModel.total;
-      labelText = TOTAL_TEXT;
+      labelText = getTotalText();
     }
 
     const valueWillOverflow =

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.js
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.js
@@ -526,18 +526,24 @@ function formatDateStr({ date, dateUnitSettings, options }) {
 }
 
 export const CHANGE_TYPE_OPTIONS = {
-  MISSING: {
-    CHANGE_TYPE: "PREVIOUS_VALUE_MISSING",
-    PERCENT_CHANGE_STR: t`N/A`,
-    COMPARISON_VALUE_STR: t`(No data)`,
+  get MISSING() {
+    return {
+      CHANGE_TYPE: "PREVIOUS_VALUE_MISSING",
+      PERCENT_CHANGE_STR: t`N/A`,
+      COMPARISON_VALUE_STR: t`(No data)`,
+    };
   },
-  SAME: {
-    CHANGE_TYPE: "PREVIOUS_VALUE_SAME",
-    PERCENT_CHANGE_STR: t`No change`,
-    COMPARISON_VALUE_STR: "",
+  get SAME() {
+    return {
+      CHANGE_TYPE: "PREVIOUS_VALUE_SAME",
+      PERCENT_CHANGE_STR: t`No change`,
+      COMPARISON_VALUE_STR: "",
+    };
   },
-  CHANGED: {
-    CHANGE_TYPE: "PREVIOUS_VALUE_CHANGED",
+  get CHANGED() {
+    return {
+      CHANGE_TYPE: "PREVIOUS_VALUE_CHANGED",
+    };
   },
 };
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/49864

### Description

This PR translates the 3 places mentioned in the issue in static embeddings/public links.

### How to verify
Follow the repro from https://github.com/metabase/metabase/issues/49864

Just to make sure, you can also revert all the code except the E2E test and run the test, and all new assertions should fail.

### Demo
1. Pie chart - Other
     ![Screenshot 2024-11-12 at 3 01 53 PM](https://github.com/user-attachments/assets/8e05a821-06bd-4341-9a73-52d4416f9f36)

1. Trend chart - No data
     ![Screenshot 2024-11-12 at 2 37 29 PM](https://github.com/user-attachments/assets/c40fec73-a0ee-42bb-bd8c-c2893f19b4e3)

1. Line chart - Tooltip aggregation name
     ![Screenshot 2024-11-12 at 3 01 01 PM](https://github.com/user-attachments/assets/4bedd01a-ecbc-460d-8982-c94f483aecdd)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
