### PR TITLE
ci(sdk): [master] Prevent SDK from being upgraded unintentionally

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -7,9 +7,9 @@ on:
         description: "Branch we want to release the SDK from"
         type: choice
         required: true
-        default: "49881-prevent-sdk-from-being-upgraded-unintentionally"
+        default: "master"
         options:
-          - 49881-prevent-sdk-from-being-upgraded-unintentionally
+          - master
           - release-x.51.x
 
 concurrency:
@@ -254,7 +254,7 @@ jobs:
         run: |
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
           # Please keep the value in sync with `inputs.branch`'s release branch
-          npm publish --dry-run --tag ${{fromJson('{"49881-prevent-sdk-from-being-upgraded-unintentionally": "nightly", "release-x.51.x": "51-stable"}')[inputs.branch]}}
+          npm publish --dry-run --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable"}')[inputs.branch]}}
 
       - name: Add `latest` tag to the latest release branch (`release-x.51.x`) deployment
         if: ${{ inputs.branch == 'release-x.51.x' }}

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -237,11 +237,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable Pull request auto-merge (using GitHub Metabase Automation account)
-        run: |
-          gh pr merge --auto --squash
-        env:
-          GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+      # - name: Enable Pull request auto-merge (using GitHub Metabase Automation account)
+      #   run: |
+      #     gh pr merge --auto --squash
+      #   env:
+      #     GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
       - name: Retrieve build SDK package artifact
         uses: actions/download-artifact@v4
@@ -254,13 +254,14 @@ jobs:
         run: |
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
           # Please keep the value in sync with `inputs.branch`'s release branch
-          npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable"}')[inputs.branch]}}
+          npm publish --dry-run --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable"}')[inputs.branch]}}
 
       - name: Add `latest` tag to the latest release branch (`release-x.51.x`) deployment
         if: ${{ inputs.branch == 'release-x.51.x' }}
         working-directory: sdk
         run: |
-          npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
+          # npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
+          echo set latest tag to @metabase/embedding-sdk-react@${{ env.sdk_version }}
 
   git-tag:
     needs: [publish-npm, determine-version]
@@ -277,9 +278,10 @@ jobs:
       # Lightweight tags don't need committer name and email
       - name: Create a new git tag
         run: |
-          git tag ${{ env.tag }}
+          echo ${{ env.tag }}
+          # git tag ${{ env.tag }}
 
-      - name: Push the new tag
-        id: push-tag
-        run: |
-          git push origin ${{ env.tag }}
+      # - name: Push the new tag
+      #   id: push-tag
+      #   run: |
+      #     git push origin ${{ env.tag }}

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -59,11 +59,16 @@ jobs:
           result-encoding: string
           script: |
             const currentVersion = "${{ steps.current-sdk-version.outputs.sdk_current_version }}";
-            const versionParts = currentVersion.split(".");
+            const [currentVersionWithoutSuffix, suffix] = currentVersion.split("-");
+            const versionParts = currentVersionWithoutSuffix.split(".");
             versionParts[versionParts.length - 1] = parseInt(versionParts.at(-1)) + 1;
             const newVersion = versionParts.join(".");
 
-            return newVersion
+            if (!suffix) {
+              return newVersion;
+            }
+
+            return `${newVersion}-${suffix}`
 
       - name: Append workflow summary
         run: |
@@ -249,7 +254,7 @@ jobs:
         run: |
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
           # Please keep the value in sync with `inputs.branch`'s release branch
-          npm publish --tag ${{fromJson('{"master": "canary", "release-x.51.x": "51-stable"}')[inputs.branch]}}
+          npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable"}')[inputs.branch]}}
 
       - name: Add `latest` tag to the latest release branch (`release-x.51.x`) deployment
         if: ${{ inputs.branch == 'release-x.51.x' }}

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -7,9 +7,9 @@ on:
         description: "Branch we want to release the SDK from"
         type: choice
         required: true
-        default: "master"
+        default: "49881-prevent-sdk-from-being-upgraded-unintentionally"
         options:
-          - master
+          - 49881-prevent-sdk-from-being-upgraded-unintentionally
           - release-x.51.x
 
 concurrency:
@@ -254,7 +254,7 @@ jobs:
         run: |
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
           # Please keep the value in sync with `inputs.branch`'s release branch
-          npm publish --dry-run --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable"}')[inputs.branch]}}
+          npm publish --dry-run --tag ${{fromJson('{"49881-prevent-sdk-from-being-upgraded-unintentionally": "nightly", "release-x.51.x": "51-stable"}')[inputs.branch]}}
 
       - name: Add `latest` tag to the latest release branch (`release-x.51.x`) deployment
         if: ${{ inputs.branch == 'release-x.51.x' }}

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -227,7 +227,7 @@ jobs:
 
       - name: Edit PR adding useful information (using Metabase bot app)
         run: |
-          gh pr edit --add-reviewer @metabase/embedding --add-label no-backport
+          gh pr edit --add-reviewer @metabase/embedding,albertoperdomo --add-label no-backport
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -237,11 +237,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Enable Pull request auto-merge (using GitHub Metabase Automation account)
-      #   run: |
-      #     gh pr merge --auto --squash
-      #   env:
-      #     GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+      - name: Enable Pull request auto-merge (using GitHub Metabase Automation account)
+        run: |
+          gh pr merge --auto --squash
+        env:
+          GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
       - name: Retrieve build SDK package artifact
         uses: actions/download-artifact@v4
@@ -254,14 +254,13 @@ jobs:
         run: |
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
           # Please keep the value in sync with `inputs.branch`'s release branch
-          npm publish --dry-run --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable"}')[inputs.branch]}}
+          npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable"}')[inputs.branch]}}
 
       - name: Add `latest` tag to the latest release branch (`release-x.51.x`) deployment
         if: ${{ inputs.branch == 'release-x.51.x' }}
         working-directory: sdk
         run: |
-          # npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
-          echo set latest tag to @metabase/embedding-sdk-react@${{ env.sdk_version }}
+          npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
 
   git-tag:
     needs: [publish-npm, determine-version]
@@ -278,10 +277,9 @@ jobs:
       # Lightweight tags don't need committer name and email
       - name: Create a new git tag
         run: |
-          echo ${{ env.tag }}
-          # git tag ${{ env.tag }}
+          git tag ${{ env.tag }}
 
-      # - name: Push the new tag
-      #   id: push-tag
-      #   run: |
-      #     git push origin ${{ env.tag }}
+      - name: Push the new tag
+        id: push-tag
+        run: |
+          git push origin ${{ env.tag }}

--- a/enterprise/frontend/src/embedding-sdk/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk/package.template.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabase/embedding-sdk-react",
-  "version": "1.52.1",
+  "version": "0.52.1-nightly",
   "description": "Metabase Embedding SDK for React",
   "bin": "./dist/cli.js",
   "repository": {


### PR DESCRIPTION
This is a part of https://github.com/metabase/metabase/issues/49881

### Description

- Use version `0.x.y` instead to avoid version being bumped unintentionally in users' lock files.
- For nightly (builds from `master`), we will also append the suffix `-nightly` to the version, so it stands out that this isn't the stable version.

### How to verify


### Demo

- [Master mock workflow run](https://github.com/metabase/metabase/actions/runs/11799780623) with commit 7d5d8bf802e1698278f2e466944eb61074c70f8c
  - [Docs PR](https://github.com/metabase/metabase/pull/49884):
    - The [tag link](https://github.com/metabase/metabase/compare/embedding-sdk-1.52.1...embedding-sdk-0.52.2-nightly) looks correct.
    - [New] [Added Alberto as the reviewer](https://metaboat.slack.com/archives/C063Q3F1HPF/p1724665116620199?thread_ts=1724509353.669699&cid=C063Q3F1HPF), so he sees the notification when the new version is deployed.
  - [New git tag](https://github.com/metabase/metabase/actions/runs/11799780623/job/32869868296#step:3:8) looks correct.
### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~ Tests are shown above.
