### PR TITLE
ci(sdk): [release-51] Prevent SDK from being upgraded unintentionally

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -10,7 +10,7 @@ on:
         default: "master"
         options:
           - master
-          - 49881-release-51-prevent-sdk-from-being-upgraded-unintentionally
+          - release-x.51.x
 
 concurrency:
   # We want to ensure only one job is running at a time per branch because
@@ -254,10 +254,10 @@ jobs:
         run: |
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
           # Please keep the value in sync with `inputs.branch`'s release branch
-          npm publish --dry-run --tag ${{fromJson('{"master": "nightly", "49881-release-51-prevent-sdk-from-being-upgraded-unintentionally": "51-stable"}')[inputs.branch]}}
+          npm publish --dry-run --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable"}')[inputs.branch]}}
 
-      - name: Add `latest` tag to the latest release branch (`49881-release-51-prevent-sdk-from-being-upgraded-unintentionally`) deployment
-        if: ${{ inputs.branch == '49881-release-51-prevent-sdk-from-being-upgraded-unintentionally' }}
+      - name: Add `latest` tag to the latest release branch (`release-x.51.x`) deployment
+        if: ${{ inputs.branch == 'release-x.51.x' }}
         working-directory: sdk
         run: |
           # npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -10,7 +10,7 @@ on:
         default: "master"
         options:
           - master
-          - release-x.51.x
+          - 49881-release-51-prevent-sdk-from-being-upgraded-unintentionally
 
 concurrency:
   # We want to ensure only one job is running at a time per branch because
@@ -254,10 +254,10 @@ jobs:
         run: |
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
           # Please keep the value in sync with `inputs.branch`'s release branch
-          npm publish --dry-run --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable"}')[inputs.branch]}}
+          npm publish --dry-run --tag ${{fromJson('{"master": "nightly", "49881-release-51-prevent-sdk-from-being-upgraded-unintentionally": "51-stable"}')[inputs.branch]}}
 
-      - name: Add `latest` tag to the latest release branch (`release-x.51.x`) deployment
-        if: ${{ inputs.branch == 'release-x.51.x' }}
+      - name: Add `latest` tag to the latest release branch (`49881-release-51-prevent-sdk-from-being-upgraded-unintentionally`) deployment
+        if: ${{ inputs.branch == '49881-release-51-prevent-sdk-from-being-upgraded-unintentionally' }}
         working-directory: sdk
         run: |
           # npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -237,11 +237,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable Pull request auto-merge (using GitHub Metabase Automation account)
-        run: |
-          gh pr merge --auto --squash
-        env:
-          GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+      # - name: Enable Pull request auto-merge (using GitHub Metabase Automation account)
+      #   run: |
+      #     gh pr merge --auto --squash
+      #   env:
+      #     GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
       - name: Retrieve build SDK package artifact
         uses: actions/download-artifact@v4
@@ -254,13 +254,14 @@ jobs:
         run: |
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
           # Please keep the value in sync with `inputs.branch`'s release branch
-          npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable"}')[inputs.branch]}}
+          npm publish --dry-run --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable"}')[inputs.branch]}}
 
       - name: Add `latest` tag to the latest release branch (`release-x.51.x`) deployment
         if: ${{ inputs.branch == 'release-x.51.x' }}
         working-directory: sdk
         run: |
-          npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
+          # npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
+          echo set latest tag to @metabase/embedding-sdk-react@${{ env.sdk_version }}
 
   git-tag:
     needs: [publish-npm, determine-version]
@@ -277,9 +278,10 @@ jobs:
       # Lightweight tags don't need committer name and email
       - name: Create a new git tag
         run: |
-          git tag ${{ env.tag }}
+          echo ${{ env.tag }}
+          # git tag ${{ env.tag }}
 
-      - name: Push the new tag
-        id: push-tag
-        run: |
-          git push origin ${{ env.tag }}
+      # - name: Push the new tag
+      #   id: push-tag
+      #   run: |
+      #     git push origin ${{ env.tag }}

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -59,11 +59,16 @@ jobs:
           result-encoding: string
           script: |
             const currentVersion = "${{ steps.current-sdk-version.outputs.sdk_current_version }}";
-            const versionParts = currentVersion.split(".");
+            const [currentVersionWithoutSuffix, suffix] = currentVersion.split("-");
+            const versionParts = currentVersionWithoutSuffix.split(".");
             versionParts[versionParts.length - 1] = parseInt(versionParts.at(-1)) + 1;
             const newVersion = versionParts.join(".");
 
-            return newVersion
+            if (!suffix) {
+              return newVersion;
+            }
+
+            return `${newVersion}-${suffix}`
 
       - name: Append workflow summary
         run: |
@@ -249,7 +254,7 @@ jobs:
         run: |
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
           # Please keep the value in sync with `inputs.branch`'s release branch
-          npm publish --tag ${{fromJson('{"master": "canary", "release-x.51.x": "51-stable"}')[inputs.branch]}}
+          npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable"}')[inputs.branch]}}
 
       - name: Add `latest` tag to the latest release branch (`release-x.51.x`) deployment
         if: ${{ inputs.branch == 'release-x.51.x' }}

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -227,7 +227,7 @@ jobs:
 
       - name: Edit PR adding useful information (using Metabase bot app)
         run: |
-          gh pr edit --add-reviewer @metabase/embedding --add-label no-backport
+          gh pr edit --add-reviewer @metabase/embedding,albertoperdomo --add-label no-backport
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -237,11 +237,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Enable Pull request auto-merge (using GitHub Metabase Automation account)
-      #   run: |
-      #     gh pr merge --auto --squash
-      #   env:
-      #     GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+      - name: Enable Pull request auto-merge (using GitHub Metabase Automation account)
+        run: |
+          gh pr merge --auto --squash
+        env:
+          GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
       - name: Retrieve build SDK package artifact
         uses: actions/download-artifact@v4
@@ -254,14 +254,13 @@ jobs:
         run: |
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
           # Please keep the value in sync with `inputs.branch`'s release branch
-          npm publish --dry-run --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable"}')[inputs.branch]}}
+          npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable"}')[inputs.branch]}}
 
       - name: Add `latest` tag to the latest release branch (`release-x.51.x`) deployment
         if: ${{ inputs.branch == 'release-x.51.x' }}
         working-directory: sdk
         run: |
-          # npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
-          echo set latest tag to @metabase/embedding-sdk-react@${{ env.sdk_version }}
+          npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
 
   git-tag:
     needs: [publish-npm, determine-version]
@@ -278,10 +277,9 @@ jobs:
       # Lightweight tags don't need committer name and email
       - name: Create a new git tag
         run: |
-          echo ${{ env.tag }}
-          # git tag ${{ env.tag }}
+          git tag ${{ env.tag }}
 
-      # - name: Push the new tag
-      #   id: push-tag
-      #   run: |
-      #     git push origin ${{ env.tag }}
+      - name: Push the new tag
+        id: push-tag
+        run: |
+          git push origin ${{ env.tag }}

--- a/enterprise/frontend/src/embedding-sdk/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk/package.template.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabase/embedding-sdk-react",
-  "version": "1.51.3",
+  "version": "0.51.3",
   "description": "Metabase Embedding SDK for React",
   "bin": "./dist/cli.js",
   "repository": {


### PR DESCRIPTION
This is a part of https://github.com/metabase/metabase/issues/49881

### Description

- Use version `0.x.y` instead to avoid version being bumped unintentionally in users' lock files.
- For nightly (builds from `master`), we will also append the suffix `-nightly` to the version, so it stands out that this isn't the stable version.

### How to verify


### Demo

- [Release 51 mock workflow run](https://github.com/metabase/metabase/actions/runs/11800347528) with commit a2c21f4d0b976f00c2054e4e3b356ead06f9b385
  - [Docs PR](https://github.com/metabase/metabase/pull/49892):
    - All the entries in the release branch have been included in the [`master` docs version](https://github.com/metabase/metabase/pull/49884/files). Which is correct because the entries in the release branch should be a subset of the master version unless we have a change that targets the release 51 branch directly (we rarely do that anyway)
    - The [tag link](https://github.com/metabase/metabase/compare/embedding-sdk-1.51.3...embedding-sdk-0.51.4) looks correct.
    - [New] [Added Alberto as the reviewer](https://metaboat.slack.com/archives/C063Q3F1HPF/p1724665116620199?thread_ts=1724509353.669699&cid=C063Q3F1HPF), so he sees the notification when the new version is deployed.
  - As this is like the release branch, it [adds the `latest` tag to the npm version](https://github.com/metabase/metabase/actions/runs/11800347528/job/32871880065#step:14:8) correctly.
  - [New git tag](https://github.com/metabase/metabase/actions/runs/11800347528/job/32871923801#step:3:8) looks correct.
### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~ Tests are shown above.

