### PR TITLE
feat(sdk): use Alert component for SDKError

### DIFF
--- a/e2e/test/scenarios/embedding-sdk/metabase-sdk-styles-tests.cy.spec.ts
+++ b/e2e/test/scenarios/embedding-sdk/metabase-sdk-styles-tests.cy.spec.ts
@@ -112,7 +112,7 @@ describeSDK("scenarios > embedding-sdk > static-dashboard", () => {
           defaultBrowserFonteFamily,
         );
 
-        cy.findByText("Error").should(
+        cy.findByText(/Failed to fetch the user/).should(
           "have.css",
           "font-family",
           "Lato, sans-serif",

--- a/e2e/test/scenarios/embedding-sdk/static-dashboard-cors.cy.spec.js
+++ b/e2e/test/scenarios/embedding-sdk/static-dashboard-cors.cy.spec.js
@@ -90,7 +90,6 @@ describeSDK("scenarios > embedding-sdk > static-dashboard", () => {
     });
 
     cy.get("#metabase-sdk-root").within(() => {
-      cy.findByText("Error").should("be.visible");
       cy.findByText(
         "Failed to fetch the user, the session might be invalid.",
       ).should("be.visible");
@@ -153,7 +152,6 @@ describeSDK("scenarios > embedding-sdk > static-dashboard", () => {
     });
 
     cy.get("#metabase-sdk-root").within(() => {
-      cy.findByText("Error").should("be.visible");
       cy.findByText(
         "Failed to fetch the user, the session might be invalid.",
       ).should("be.visible");

--- a/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentWrapper/SdkError.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentWrapper/SdkError.tsx
@@ -2,6 +2,7 @@ import { useSdkSelector } from "embedding-sdk/store";
 import { getErrorComponent } from "embedding-sdk/store/selectors";
 import type { SdkErrorComponentProps } from "embedding-sdk/store/types";
 import Alert from "metabase/core/components/Alert";
+import { color } from "metabase/lib/colors";
 import { Box, Center } from "metabase/ui";
 
 export const SdkError = ({ message }: SdkErrorComponentProps) => {
@@ -16,8 +17,15 @@ export const SdkError = ({ message }: SdkErrorComponentProps) => {
   );
 };
 
+const FORCE_DARK_TEXT_COLOR = {
+  // The Alert component has a light background, we need to force a dark text
+  // color. The sdk aliases text-dark to the primary color, which in dark themes
+  // is a light color, making the text un-readable
+  "--mb-color-text-dark": color("text-dark"),
+} as React.CSSProperties;
+
 const DefaultErrorMessage = ({ message }: SdkErrorComponentProps) => (
-  <Box p="sm">
+  <Box p="sm" style={FORCE_DARK_TEXT_COLOR}>
     <Alert variant="error" icon="warning">
       {message}
     </Alert>

--- a/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentWrapper/SdkError.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentWrapper/SdkError.tsx
@@ -1,9 +1,8 @@
-import { t } from "ttag";
-
 import { useSdkSelector } from "embedding-sdk/store";
 import { getErrorComponent } from "embedding-sdk/store/selectors";
 import type { SdkErrorComponentProps } from "embedding-sdk/store/types";
-import { Center } from "metabase/ui";
+import Alert from "metabase/core/components/Alert";
+import { Box, Center } from "metabase/ui";
 
 export const SdkError = ({ message }: SdkErrorComponentProps) => {
   const CustomError = useSdkSelector(getErrorComponent);
@@ -18,8 +17,9 @@ export const SdkError = ({ message }: SdkErrorComponentProps) => {
 };
 
 const DefaultErrorMessage = ({ message }: SdkErrorComponentProps) => (
-  <div>
-    <div>{t`Error`}</div>
-    <div>{message}</div>
-  </div>
+  <Box p="sm">
+    <Alert variant="error" icon="warning">
+      {message}
+    </Alert>
+  </Box>
 );

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
@@ -170,7 +170,6 @@ describe("InteractiveQuestion", () => {
 
     await waitForLoaderToBeRemoved();
 
-    expect(screen.getByText("Error")).toBeInTheDocument();
     expect(screen.getByText("Question not found")).toBeInTheDocument();
   });
 });

--- a/enterprise/frontend/src/embedding-sdk/components/public/StaticQuestion/StaticQuestion.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/StaticQuestion/StaticQuestion.unit.spec.tsx
@@ -125,7 +125,6 @@ describe("StaticQuestion", () => {
   it("should render an error if a question isn't found", async () => {
     setup({ isValidCard: false });
     await waitForLoaderToBeRemoved();
-    expect(screen.getByText("Error")).toBeInTheDocument();
     expect(
       screen.getByText("You don't have permissions to do that."),
     ).toBeInTheDocument();


### PR DESCRIPTION
This uses our Alert component to make the errors a bit nicer, as suggested in:
https://metaboat.slack.com/archives/C063Q3F1HPF/p1731348270154669?thread_ts=1731086685.911859&cid=C063Q3F1HPF

The icon doesn't show up in shoppy, but since it shows in my empty project i suspect is some css magic we have on shoppy.
@heypoom if you want to check, I noticed it does show up when I remove the padding from AlertIcon 🤔 

# Demo
## Empty app with two components
<img width="1590" alt="image" src="https://github.com/user-attachments/assets/0e79140d-da5e-477c-9ed4-fe7c5bc8da5f">

## Shoppy
<img width="1596" alt="image" src="https://github.com/user-attachments/assets/6f9c0e6c-3dc9-48c1-ba95-73c43b5ec5ec">
<img width="1583" alt="image" src="https://github.com/user-attachments/assets/25777190-ebb5-47db-b277-1e59a428fec2">
<img width="1585" alt="image" src="https://github.com/user-attachments/assets/e5c53fc3-7685-4c8c-bf73-dacb6e0ca773">
