### PR TITLE
Optimize search index updates using delayed batches

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -132,6 +132,7 @@
      metabase.driver.sql-jdbc.execute/execute-prepared-statement!
      metabase.pulse.send/send-pulse!
      metabase.query-processor.store/store-database!
+     metabase.util/run-count!
      next.jdbc/execute!}}
 
   :metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -53,8 +53,8 @@
     (throw (ex-info "Search index is not enabled." {:status-code 501}))
 
     (search/supports-index?)
-    (if (task/job-exists? task.search-index/job-key-full)
-      (do (task/trigger-now! task.search-index/job-key-full) {:message "task triggered"})
+    (if (task/job-exists? task.search-index/reindex-job-key)
+      (do (task/trigger-now! task.search-index/reindex-job-key) {:message "task triggered"})
       (do (search/reindex!) {:message "done"}))
 
     :else

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -53,8 +53,8 @@
     (throw (ex-info "Search index is not enabled." {:status-code 501}))
 
     (search/supports-index?)
-    (if (task/job-exists? task.search-index/job-key)
-      (do (task/trigger-now! task.search-index/job-key) {:message "task triggered"})
+    (if (task/job-exists? task.search-index/job-key-full)
+      (do (task/trigger-now! task.search-index/job-key-full) {:message "task triggered"})
       (do (search/reindex!) {:message "done"}))
 
     :else

--- a/src/metabase/search/postgres/index.clj
+++ b/src/metabase/search/postgres/index.clj
@@ -240,7 +240,8 @@
     (when @initialized?
       (batch-upsert! active-table entries))
     (when @reindexing?
-      (batch-upsert! pending-table entries))))
+      (batch-upsert! pending-table entries))
+    (count entries)))
 
 (defn search-query
   "Query fragment for all models corresponding to a query parameter `:search-term`."

--- a/src/metabase/search/postgres/ingestion.clj
+++ b/src/metabase/search/postgres/ingestion.clj
@@ -7,6 +7,7 @@
    [metabase.search.postgres.index :as search.index]
    [metabase.search.spec :as search.spec]
    [metabase.util :as u]
+   [metabase.util.queue :as queue]
    [toucan2.core :as t2]
    [toucan2.realize :as t2.realize]))
 
@@ -100,25 +101,40 @@
   "Force ingestion to happen immediately, on the same thread."
   false)
 
-(defmacro ^:private run-on-thread [& body]
-  `(if *force-sync*
-     (do ~@body)
-     (doto (Thread. ^Runnable (fn [] ~@body))
-       (.start))))
+;; TODO put item on a delay queue
+;; TODO have a worker (task?) that pull items off the queue, groups them and bulk executes
+
+(defn- bulk-ingest! [updates]
+  (->> (for [[search-model where-clauses] (u/group-by first second updates)]
+         (spec-index-reducible search-model (into [:or (distinct where-clauses)])))
+       ;; init collection is only for clj-kondo, as we know that the list is non-empty
+       (reduce u/rconcat [])
+       (batch-update!)))
+
+(defonce ^:private queue (queue/delay-queue))
+
+(def ^:private delay-ms 100)
+
+(def ^:private batch-max 50)
+
+(defn- ^:private ingest-maybe-async! [updates]
+  (if *force-sync*
+    (bulk-ingest! updates)
+    (do (doseq [update updates]
+          (queue/put-with-delay! queue delay-ms update))
+        ;; TODO create a worker task to do this instead
+        (doto (Thread. ^Runnable (fn []
+                                   ;; add buffer to the queue waiting time
+                                   (let [queued-updates (queue/take-delayed-batch! queue batch-max (+ delay-ms 50))]
+                                     (bulk-ingest! queued-updates))))
+          (.start)))))
 
 (defn update-index!
   "Given a new or updated instance, create or update all the corresponding search entries if needed."
   [instance & [always?]]
   (when-let [updates (seq (search.spec/search-models-to-update instance always?))]
     ;; We need to delay execution to handle deletes, which alert us *before* updating the database.
-    ;; TODO It's dangerous to simply unleash threads on the world, this should use a queue in future.
-    (run-on-thread
-     (Thread/sleep 100)
-     (->> (for [[search-model where-clause] updates]
-            (spec-index-reducible search-model where-clause))
-          ;; init collection is only for clj-kondo, as we know that the list is non-empty
-          (reduce u/rconcat [])
-          (batch-update!)))
+    (ingest-maybe-async! updates)
     nil))
 
 ;; TODO think about how we're going to handle cascading deletes.

--- a/src/metabase/search/postgres/ingestion.clj
+++ b/src/metabase/search/postgres/ingestion.clj
@@ -6,12 +6,19 @@
    [metabase.search.config :as search.config]
    [metabase.search.postgres.index :as search.index]
    [metabase.search.spec :as search.spec]
+   [metabase.task :as task]
    [metabase.util :as u]
    [metabase.util.queue :as queue]
    [toucan2.core :as t2]
    [toucan2.realize :as t2.realize]))
 
 (set! *warn-on-reflection* true)
+
+(defonce ^:private queue (queue/delay-queue))
+
+(def ^:private delay-ms 100)
+
+(def ^:private batch-max 50)
 
 (def ^:private insert-batch-size 150)
 
@@ -90,7 +97,7 @@
          (m/distinct-by (juxt :id :model))
          (map ->entry)
          (partition-all insert-batch-size)))
-       (run! search.index/batch-update!)))
+       (transduce (map search.index/batch-update!) + 0)))
 
 (defn populate-index!
   "Go over all searchable items and populate the index with them."
@@ -103,28 +110,34 @@
 
 (defn- bulk-ingest! [updates]
   (->> (for [[search-model where-clauses] (u/group-by first second updates)]
-         (spec-index-reducible search-model (into [:or (distinct where-clauses)])))
+         (spec-index-reducible search-model (into [:or] (distinct where-clauses))))
        ;; init collection is only for clj-kondo, as we know that the list is non-empty
        (reduce u/rconcat [])
        (batch-update!)))
 
-(defonce ^:private queue (queue/delay-queue))
+(defn process-next-batch
+  "Wait up to 'delay-ms' for a queued batch to become ready, and process the batch if we get one.
+  Returns the number of search index entries that get updated as a result."
+  [first-delay-ms next-delay-ms]
+  (if-let [queued-updates (queue/take-delayed-batch! queue batch-max first-delay-ms next-delay-ms)]
+    (bulk-ingest! queued-updates)
+    0))
 
-(def ^:private delay-ms 100)
+(defn- index-worker-exists? []
+  (task/job-exists? @(requiring-resolve 'metabase.task.search-index/job-key-full))
+  (task/job-exists? @(requiring-resolve 'metabase.task.search-index/job-key-incremental)))
 
-(def ^:private batch-max 50)
-
-(defn- ^:private ingest-maybe-async! [updates]
-  (if *force-sync*
-    (bulk-ingest! updates)
-    (do (doseq [update updates]
-          (queue/put-with-delay! queue delay-ms update))
-        ;; TODO create a worker task to do this instead
-        (doto (Thread. ^Runnable (fn []
-                                   ;; add buffer to the queue waiting time
-                                   (let [queued-updates (queue/take-delayed-batch! queue batch-max (+ delay-ms 50))]
-                                     (bulk-ingest! queued-updates))))
-          (.start)))))
+(defn- ^:private ingest-maybe-async!
+  "Update or create any search index entries related to the given updates.
+  Will be async if the worker exists, otherwise it will be done synchronously on the calling thread.
+  Can also be forced to be run synchronous for testing."
+  ([updates]
+   (ingest-maybe-async! updates (or *force-sync* (not (index-worker-exists?)))))
+  ([updates sync?]
+   (if sync?
+     (bulk-ingest! updates)
+     (doseq [update updates]
+       (queue/put-with-delay! queue delay-ms update)))))
 
 (defn update-index!
   "Given a new or updated instance, create or update all the corresponding search entries if needed."

--- a/src/metabase/search/postgres/ingestion.clj
+++ b/src/metabase/search/postgres/ingestion.clj
@@ -124,8 +124,8 @@
     0))
 
 (defn- index-worker-exists? []
-  (task/job-exists? @(requiring-resolve 'metabase.task.search-index/job-key-full))
-  (task/job-exists? @(requiring-resolve 'metabase.task.search-index/job-key-incremental)))
+  (task/job-exists? @(requiring-resolve 'metabase.task.search-index/reindex-job-key))
+  (task/job-exists? @(requiring-resolve 'metabase.task.search-index/update-job-key)))
 
 (defn- ^:private ingest-maybe-async!
   "Update or create any search index entries related to the given updates.

--- a/src/metabase/search/postgres/ingestion.clj
+++ b/src/metabase/search/postgres/ingestion.clj
@@ -101,9 +101,6 @@
   "Force ingestion to happen immediately, on the same thread."
   false)
 
-;; TODO put item on a delay queue
-;; TODO have a worker (task?) that pull items off the queue, groups them and bulk executes
-
 (defn- bulk-ingest! [updates]
   (->> (for [[search-model where-clauses] (u/group-by first second updates)]
          (spec-index-reducible search-model (into [:or (distinct where-clauses)])))

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -1145,3 +1145,11 @@
          (let [acc1 (reduce f init r1)
                acc2 (reduce f acc1 r2)]
            acc2)))))
+
+(defn run-count!
+  "Runs the supplied procedure (via reduce), for purposes of side effects, on successive items. See [clojure.core/run!]
+   Returns the number of items processed."
+  [proc reducible]
+  (let [cnt (volatile! 0)]
+    (reduce (fn [_ item] (vswap! cnt inc) (proc item)) nil reducible)
+    @cnt))

--- a/test/metabase/util/queue_test.clj
+++ b/test/metabase/util/queue_test.clj
@@ -83,3 +83,20 @@
 
     (testing "The realtime events are processed in order"
       (mt/ordered-subset? realtime-events processed))))
+
+(deftest delay-queue-test
+  (let [q (queue/delay-queue)]
+    (dotimes [_ 5]
+      (queue/put-with-delay! q (+ 100 (* 100 (Math/random))) (System/nanoTime)))
+    (is (empty? (queue/take-delayed-batch! q 3)))
+    (is (nil? (queue/take-delayed-batch! q 3 90)))
+    (is (< 0 (count (queue/take-delayed-batch! q 3 110))))
+    (is (> 4 (count (queue/take-delayed-batch! q 3))))
+    (is (empty? (queue/take-delayed-batch! q 3))))
+
+  ;; TODO
+  ;; add a bunch of stuff, from a bunch of queues
+  ;; check that it isn't all ready immediately
+  ;; check that we don't lose anything
+  ;; check that it matures (roughly) in order
+  )

--- a/test/metabase/util/queue_test.clj
+++ b/test/metabase/util/queue_test.clj
@@ -89,8 +89,8 @@
     (dotimes [_ 5]
       (queue/put-with-delay! q (+ 100 (* 100 (Math/random))) (System/nanoTime)))
     (is (empty? (queue/take-delayed-batch! q 3)))
-    (is (nil? (queue/take-delayed-batch! q 3 90)))
-    (is (< 0 (count (queue/take-delayed-batch! q 3 110))))
+    (is (nil? (queue/take-delayed-batch! q 3 90 0)))
+    (is (< 0 (count (queue/take-delayed-batch! q 3 110 0))))
     (is (> 4 (count (queue/take-delayed-batch! q 3))))
     (is (empty? (queue/take-delayed-batch! q 3))))
 

--- a/test/metabase/util_test.cljc
+++ b/test/metabase/util_test.cljc
@@ -563,3 +563,14 @@
             (eduction (map inc) (range 3))
             (eduction (map dec) (range 10 0 -1)))
            [25])))))
+
+(deftest ^:parallel run-count!-test
+  (testing "counts the things"
+    (is (zero? (u/run-count! inc nil)))
+    (is (zero? (u/run-count! inc [])))
+    (is (= 3 (u/run-count! inc (range 3))))
+    (is (= 3 (u/run-count! inc (eduction (map inc) (range 3))))))
+  (testing "does the stuff"
+    (let [acc (volatile! [])]
+      (u/run-count! #(vswap! acc conj %) (eduction (map inc) (range 3)))
+      (is (= [1 2 3] @acc)))))


### PR DESCRIPTION
The current implementation creates an unbounded number of background threads, each of which executes bulk ingestion queues scoped to a single model instance's downstream dependencies.

With this change, we start using a shared queue to enforce the delay, with a single worker that can ingest larger batches if the queue starts falling behind. The delay is also useful as our app often makes a bunch of updates in sequence to the same entities, and this lets us deduplicate the work.