### PR TITLE
feat(sdk): deprecate CreateQuestion and migrate cli and docs to use InteractiveQuestion

### DIFF
--- a/docs/embedding/sdk/questions.md
+++ b/docs/embedding/sdk/questions.md
@@ -238,7 +238,7 @@ export default function App() {
 
 ## Embedding the query builder
 
-With the `CreateQuestion` component, you can embed the query builder without a pre-defined question.
+You can embed the query builder without a pre-defined question by using the `InteractiveQuestion` component without the `questionId`.
 
 ```tsx
 import React from "react";
@@ -247,10 +247,68 @@ import {MetabaseProvider, CreateQuestion} from "@metabase/embedding-sdk-react";
 const config = {...}
 
 export default function App() {
+    // The questionId is undefined at first.
+    // Once the question is saved, we set the questionId to the saved question's id.
+    const [questionId, setQuestionId] = useState(undefined)
+
+    const [isVisualizationView, setIsVisualizationView] = useState(false)
+    const [isSaveModalOpen, setSaveModalOpen] = useState(false)
+
     return (
         <MetabaseProvider config={config}>
-            <CreateQuestion/>
+            <InteractiveQuestion
+                questionId={questionId}
+                onSave={(question) => {
+                    setQuestionId(question.id())
+                    setSaveModalOpen(false)
+                }}
+                isSaveEnabled
+            >
+                <div>
+                    <div
+                        style={{
+                            display: "flex",
+                            justifyContent: "space-between",
+                            width: "100%",
+                        }}
+                    >
+                        <div style={{ display: "flex" }}>
+                            <InteractiveQuestion.Title />
+                        </div>
+
+                        <div style={{ display: "flex" }}>
+                            <button
+                                onClick={() => setIsVisualizationView(!isVisualizationView)}
+                            >
+                                Show {isVisualizationView ? "editor" : "visualization"}
+                            </button>
+
+                            <button onClick={() => setSaveModalOpen(true)}>Save</button>
+                        </div>
+                    </div>
+
+                    {isVisualizationView && (
+                        <div style={{ height: "500px" }}>
+                            <InteractiveQuestion.QuestionVisualization />
+                        </div>
+                    )}
+
+                    {!isVisualizationView && (
+                        <InteractiveQuestion.Editor
+                            onApply={() => setIsVisualizationView(true)}
+                        />
+                    )}
+
+                    {isSaveModalOpen && (
+                        <div className="modal">
+                            <InteractiveQuestion.SaveQuestionForm
+                                onClose={() => setSaveModalOpen(false)}
+                            />
+                        </div>
+                    )}
+                </div>
+            </InteractiveQuestion>
         </MetabaseProvider>
-    );
+    )
 }
 ```

--- a/enterprise/frontend/src/embedding-sdk/cli/snippets/analytics-css-snippet.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/snippets/analytics-css-snippet.ts
@@ -5,12 +5,16 @@ export const ANALYTICS_CSS_SNIPPET = `
   cursor: pointer;
 }
 
+.analytics-root {
+  background: var(--analytics-background);
+}
+
 .analytics-root.theme-light {
-  background: #F9FBFC;
+  --analytics-background: #F9FBFC;
 }
 
 .analytics-root.theme-dark {
-  background: #2D353A;
+  --analytics-background: #2D353A;
 }
 
 .analytics-container {
@@ -70,5 +74,49 @@ export const ANALYTICS_CSS_SNIPPET = `
   color: var(--mb-color-text-primary);
   font-size: 24px;
   text-align: center;
+}
+
+.create-question-header {
+  margin-bottom: 20px;
+}
+
+.create-question-button-group {
+  display: flex;
+  gap: 10px;
+}
+
+.create-question-button-group button {
+  color: #509EE3;
+  padding: 10px 15px;
+  border: 1px solid #509EE3;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.create-question-header {
+  display: flex;
+  justify-content: space-between;
+}
+
+.create-question-save-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.create-question-save-modal .modal-inner {
+  background: var(--analytics-background);
+  padding: 30px;
+  width: 100%;
+  max-width: 600px;
+  border-radius: 5px;
 }
 `.trim();

--- a/enterprise/frontend/src/embedding-sdk/cli/snippets/analytics-dashboard-snippet.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/snippets/analytics-dashboard-snippet.ts
@@ -17,8 +17,10 @@ export const getAnalyticsDashboardSnippet = (options: Options) => {
 
   return `
 import { useState, useContext, useReducer } from 'react'
-import { InteractiveDashboard, CreateQuestion } from '${SDK_PACKAGE_NAME}'
+import { InteractiveDashboard } from '${SDK_PACKAGE_NAME}'
+
 import { AnalyticsContext } from "./analytics-provider"
+import { CreateQuestion } from "./create-question"
 
 ${imports}
 

--- a/enterprise/frontend/src/embedding-sdk/cli/snippets/create-question-snippet.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/snippets/create-question-snippet.ts
@@ -1,0 +1,72 @@
+import { SDK_PACKAGE_NAME } from "embedding-sdk/cli/constants/config";
+
+export const CREATE_QUESTION_SNIPPET = `
+import { useState } from 'react'
+import { InteractiveQuestion } from '${SDK_PACKAGE_NAME}'
+
+export const CreateQuestion = () => {
+  // The questionId is undefined at first.
+  // Once the question is saved, we set the questionId to the saved question's id.
+  const [questionId, setQuestionId] = useState(undefined)
+
+  const [isVisualizationView, setIsVisualizationView] = useState(false)
+  const [isSaveModalOpen, setSaveModalOpen] = useState(false)
+  const [isVisualizationReady, setIsVisualizationReady] = useState(false)
+
+  return (
+    <InteractiveQuestion
+      questionId={questionId}
+      onSave={(question) => {
+        setQuestionId(question.id())
+        setSaveModalOpen(false)
+      }}
+      isSaveEnabled
+    >
+      <div className="create-question-container">
+        <div className="create-question-header">
+          <div>
+            <InteractiveQuestion.Title />
+          </div>
+
+          <div className="create-question-button-group">
+            {isVisualizationReady && (
+              <button
+                onClick={() => setIsVisualizationView(!isVisualizationView)}
+              >
+                Show {isVisualizationView ? 'editor' : 'visualization'}
+              </button>
+            )}
+
+            <button onClick={() => setSaveModalOpen(true)}>Save</button>
+          </div>
+        </div>
+
+        {isVisualizationReady && isVisualizationView && (
+          <div style={{height: '500px'}}>
+            <InteractiveQuestion.QuestionVisualization />
+          </div>
+        )}
+
+        {!isVisualizationView && (
+          <InteractiveQuestion.Editor
+            onApply={() => {
+              setIsVisualizationView(true)
+              setIsVisualizationReady(true)
+            }}
+          />
+        )}
+
+        {isSaveModalOpen && (
+          <div className="create-question-save-modal">
+            <div className="modal-inner">
+              <InteractiveQuestion.SaveQuestionForm
+                onClose={() => setSaveModalOpen(false)}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </InteractiveQuestion>
+  )
+}
+`;

--- a/enterprise/frontend/src/embedding-sdk/cli/snippets/index.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/snippets/index.ts
@@ -5,3 +5,4 @@ export * from "./analytics-page-snippet";
 export * from "./theme-switcher-snippet";
 export * from "./user-switcher-snippet";
 export * from "./express-server-snippet";
+export * from "./create-question-snippet";

--- a/enterprise/frontend/src/embedding-sdk/cli/utils/get-component-snippets.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/utils/get-component-snippets.ts
@@ -2,6 +2,7 @@ import {
   ANALYTICS_PAGE_SNIPPET,
   ANALYTICS_PROVIDER_SNIPPET_MINIMAL,
   ANALYTICS_PROVIDER_SNIPPET_WITH_USER_SWITCHER,
+  CREATE_QUESTION_SNIPPET,
   THEME_SWITCHER_SNIPPET,
   getAnalyticsDashboardSnippet,
   getEmbeddingProviderSnippet,
@@ -46,6 +47,10 @@ export function getComponentSnippets(options: Options) {
     {
       name: "analytics-page",
       content: ANALYTICS_PAGE_SNIPPET.trim(),
+    },
+    {
+      name: "create-question",
+      content: CREATE_QUESTION_SNIPPET.trim(),
     },
   ];
 

--- a/enterprise/frontend/src/embedding-sdk/components/public/CreateQuestion/CreateQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CreateQuestion/CreateQuestion.tsx
@@ -4,6 +4,7 @@ import type { InteractiveQuestionProps } from "../InteractiveQuestion";
 
 type CreateQuestionProps = Omit<InteractiveQuestionProps, "questionId">;
 
+/** @deprecated Use `InteractiveQuestion` with `isSaveEnabled={true}` and without specifying `questionId` instead. */
 export const CreateQuestion = ({
   plugins,
   onSave,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/49715

Deprecates the `CreateQuestion` component. Migrates documentation and the Embedding CLI to use `InteractiveQuestion` instead.

# CLI Demo

![CleanShot 2567-11-13 at 04 00 19@2x](https://github.com/user-attachments/assets/930bb959-01a4-4dda-95f2-0ee69a02ea74)

![CleanShot 2567-11-13 at 04 00 34@2x](https://github.com/user-attachments/assets/2150c112-b917-4b64-9392-d5abe59647a5)

![CleanShot 2567-11-13 at 04 00 25@2x](https://github.com/user-attachments/assets/768cd887-d845-4c4f-8709-2dfd1ae5741b)
