### PR TITLE
fix: bigquery all parameterized types

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -217,6 +217,9 @@
                         (str/starts-with? raw-data-type "INT") "INTEGER" ;; INT64
                         (str/starts-with? raw-data-type "FLOAT") "FLOAT" ;; FLOAT 64
                         (str/starts-with? raw-data-type "STRING") "STRING" ;; STRING(255)
+                        (str/starts-with? raw-data-type "BYTES") "BYTES" ;; BYTES(255)
+                        (str/starts-with? raw-data-type "NUMERIC") "NUMERIC" ;; NUMERIC(255)
+                        (str/starts-with? raw-data-type "BIGNUMERIC") "BIGNUMERIC" ;; BIGNUMERIC(255)
                         (= raw-data-type "BOOL") "BOOLEAN"
                         :else raw-data-type)]
     [database-type (database-type->base-type database-type)]))

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -227,10 +227,20 @@
                                          " decimal_col DECIMAL, "
                                          " bignumeric_col BIGNUMERIC, "
                                          " bigdecimal_col BIGDECIMAL, "
-                                         " string255_col STRING(255)) "
-                                         "AS SELECT NUMERIC '%s', DECIMAL '%s', BIGNUMERIC '%s', BIGDECIMAL '%s', 'hello'")
+                                         " string255_col STRING(255), "
+                                         " bytes32_col BYTES(32), "
+                                         " numeric29_col NUMERIC(29), "
+                                         " decimal29_col DECIMAL(29), "
+                                         " bignumeric32_col BIGNUMERIC(32), "
+                                         " bigdecimal76_col BIGDECIMAL(76,38))"
+                                         "AS SELECT NUMERIC '%s', DECIMAL '%s', BIGNUMERIC '%s', BIGDECIMAL '%s', 'hello', "
+                                         "  B'mybytes', NUMERIC '%s', DECIMAL '%s', BIGNUMERIC '%s', BIGDECIMAL '%s'")
                                     ~test-db-name
                                     tbl-nm#
+                                    ~numeric-val
+                                    ~decimal-val
+                                    ~bignumeric-val
+                                    ~bigdecimal-val
                                     ~numeric-val
                                     ~decimal-val
                                     ~bignumeric-val
@@ -757,7 +767,42 @@
                :database-type "STRING",
                :base-type :type/Text,
                :database-partitioned false,
-               :database-position 4}]
+               :database-position 4}
+              {:name "bytes32_col",
+               :table-name tbl-nm,
+               :table-schema test-db-name,
+               :database-type "BYTES",
+               :base-type :type/*,
+               :database-partitioned false,
+               :database-position 5}
+              {:name "numeric29_col",
+               :table-name tbl-nm,
+               :table-schema test-db-name,
+               :database-type "NUMERIC",
+               :base-type :type/Decimal,
+               :database-partitioned false,
+               :database-position 6}
+              {:name "decimal29_col",
+               :table-name tbl-nm,
+               :table-schema test-db-name,
+               :database-type "NUMERIC",
+               :base-type :type/Decimal,
+               :database-partitioned false,
+               :database-position 7}
+              {:name "bignumeric32_col",
+               :table-name tbl-nm
+               :table-schema test-db-name
+               :database-type "BIGNUMERIC",
+               :base-type :type/Decimal,
+               :database-partitioned false,
+               :database-position 8}
+              {:name "bigdecimal76_col",
+               :table-name tbl-nm
+               :table-schema test-db-name
+               :database-type "BIGNUMERIC",
+               :base-type :type/Decimal,
+               :database-partitioned false,
+               :database-position 9}]
              (driver/describe-fields :bigquery-cloud-sdk (mt/db) {:table-names [tbl-nm] :schema-names [test-db-name]}))
           "`describe-fields` should see the fields in the table")
       (sync/sync-database! (mt/db) {:scan :schema})


### PR DESCRIPTION
Fixes: #49913

In #49786 we handled parameterized STRING types like `STRING(255)`

Here we add handling for the other other types https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#parameterized_data_types

`BIGDECIMAL` and `DECIMAL` are aliases for `BIGNUMERIC` and `NUMERIC` https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#parameterized_decimal_type
