### PR TITLE
Triage bugs when the bug tags get added

### DIFF
--- a/.github/workflows/bugs-triage-slack-notification.yml
+++ b/.github/workflows/bugs-triage-slack-notification.yml
@@ -4,6 +4,7 @@ on:
   issues:
     types:
       - opened
+      - labeled
 jobs:
   on-issue-opened:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Currently, our bug triage > slack message workflow only triggers on newly created issues - this also will trigger when any bug issue gets labeled

This has the potential to get spammy - e.g. if an untriaged bug issue gets other tags added, it will trigger again.