### PR TITLE
Split dashboard PDF exports into pages

### DIFF
--- a/frontend/src/metabase/visualizations/components/TableSimple/TableSimple.tsx
+++ b/frontend/src/metabase/visualizations/components/TableSimple/TableSimple.tsx
@@ -187,7 +187,12 @@ function TableSimpleInner({
     (rowIndex: number, index: number) => {
       const ref = index === 0 ? firstRowRef : null;
       return (
-        <tr key={rowIndex} ref={ref} data-testid="table-row">
+        <tr
+          key={rowIndex}
+          ref={ref}
+          data-testid="table-row"
+          data-allow-page-break-after
+        >
           {data.rows[rowIndex].map((value, columnIndex) => (
             <TableCell
               key={`${rowIndex}-${columnIndex}`}

--- a/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
+++ b/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
@@ -132,7 +132,7 @@ const createHeaderElement = (dashboardName: string, marginBottom: number) => {
     font-family: "Lato", sans-serif;
     font-size: 24px;
     font-weight: 700;
-    color: var(--mb-color-text-dark);
+    color: var(--mb-color-text-primary);
     border-bottom: 1px solid var(--mb-color-border);
     padding: 24px 16px 16px 16px;
     margin-bottom: ${marginBottom}px;
@@ -170,6 +170,10 @@ export const saveDashboardPdf = async (
   const contentHeight = node.offsetHeight + headerHeight;
   const width = contentWidth + PAGE_PADDING * 2;
 
+  const backgroundColor = getComputedStyle(document.documentElement)
+    .getPropertyValue("--mb-color-bg-dashboard")
+    .trim();
+
   const { default: html2canvas } = await import("html2canvas-pro");
   const image = await html2canvas(node, {
     height: contentHeight,
@@ -177,6 +181,8 @@ export const saveDashboardPdf = async (
     useCORS: true,
     onclone: (_doc: Document, node: HTMLElement) => {
       node.classList.add(SAVING_DOM_IMAGE_CLASS);
+      node.style.height = `${contentHeight}px`;
+      node.style.backgroundColor = backgroundColor;
       node.insertBefore(pdfHeader, node.firstChild);
     },
   });
@@ -215,6 +221,10 @@ export const saveDashboardPdf = async (
       : Math.max(pageBreaksDiff + PAGE_PADDING * 2, optimalPageHeight);
 
     pdf.addPage([width, pageHeight]);
+
+    // Add background color to the page
+    pdf.setFillColor(backgroundColor);
+    pdf.rect(0, 0, width, pageHeight, "F");
 
     // Calculate the source and destination dimensions for this page slice
     const sourceY = prevBreak;

--- a/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
+++ b/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
@@ -4,6 +4,131 @@ import type { Dashboard } from "metabase-types/api";
 
 import { SAVING_DOM_IMAGE_CLASS } from "./save-chart-image";
 
+const TARGET_ASPECT_RATIO = 22 / 17;
+
+interface DashCardBounds {
+  top: number;
+  bottom: number;
+  height: number;
+}
+
+const getSortedDashCardBounds = (node: HTMLElement): DashCardBounds[] => {
+  const dashCards = Array.from(node.querySelectorAll("[data-dashcard-key]"));
+  const containerRect = node.getBoundingClientRect();
+
+  return dashCards
+    .map(card => {
+      const rect = (card as HTMLElement).getBoundingClientRect();
+      return {
+        top: Math.round(rect.top - containerRect.top),
+        bottom: Math.round(rect.bottom - containerRect.top),
+        height: Math.round(rect.height),
+      };
+    })
+    .sort((a, b) => a.top - b.top);
+};
+
+function findPossiblePageBreaks(
+  sortedCards: DashCardBounds[],
+  optimalPageHeight: number,
+): number[] {
+  if (sortedCards.length === 0) {
+    return [];
+  }
+
+  const maxBottom = Math.max(...sortedCards.map(card => card.bottom));
+
+  const breakCandidates = new Set<number>();
+
+  sortedCards.forEach(card => breakCandidates.add(card.bottom));
+
+  for (let i = 0; i < sortedCards.length - 1; i++) {
+    const currentBottom = Math.max(
+      ...sortedCards.slice(0, i + 1).map(card => card.bottom),
+    );
+    const nextTop = sortedCards[i + 1].top;
+
+    if (nextTop > currentBottom) {
+      breakCandidates.add(currentBottom);
+    }
+  }
+
+  const sortedBreakPoints = Array.from(breakCandidates).sort((a, b) => a - b);
+
+  if (sortedBreakPoints.length === 0) {
+    return [];
+  }
+
+  const result: number[] = [];
+  let currentPosition = 0;
+  let bestNextBreak = sortedBreakPoints[0];
+
+  while (currentPosition < maxBottom) {
+    let bestDiff = Infinity;
+
+    for (const breakPoint of sortedBreakPoints) {
+      if (breakPoint <= currentPosition) {
+        continue;
+      }
+
+      const pageHeight = breakPoint - currentPosition;
+      const diff = Math.abs(pageHeight - optimalPageHeight);
+
+      if (diff < bestDiff) {
+        bestDiff = diff;
+        bestNextBreak = breakPoint;
+      }
+
+      if (pageHeight > optimalPageHeight * 2) {
+        break;
+      }
+    }
+
+    if (bestNextBreak > currentPosition) {
+      result.push(bestNextBreak);
+      currentPosition = bestNextBreak;
+    } else {
+      break;
+    }
+  }
+
+  if (result.length > 0 && result[result.length - 1] === maxBottom) {
+    result.pop();
+  }
+
+  return result;
+}
+
+const canvasToBlob = (canvas: any) => {
+  canvas.toBlob(blob => {
+    if (blob) {
+      const link = document.createElement("a");
+      const url = URL.createObjectURL(blob);
+      link.rel = "noopener";
+      link.download = "test.png";
+      link.href = url;
+      link.click();
+      link.remove();
+      setTimeout(() => URL.revokeObjectURL(url), 60_000);
+    }
+  });
+};
+
+const createHeaderElement = (dashboardName: string) => {
+  const header = document.createElement("div");
+  header.style.cssText = `
+    font-family: "Lato", sans-serif;
+    font-size: 24px;
+    font-weight: 700;
+    color: var(--mb-color-text-dark);
+    border-bottom: 1px solid var(--mb-color-border);
+    padding: 32px 16px 16px 16px;
+    margin-bottom: 16px;
+  `;
+  header.textContent = dashboardName;
+  return header;
+};
+
 export const saveDashboardPdf = async (
   selector: string,
   dashboardName: string,
@@ -14,39 +139,75 @@ export const saveDashboardPdf = async (
     ?.querySelector(".react-grid-layout");
 
   if (!node || !(node instanceof HTMLElement)) {
-    console.warn("No node found for selector", selector);
+    console.warn("No dashboard content found", selector);
     return;
   }
+
+  const originalCardBounds = getSortedDashCardBounds(node);
+
+  // const tempHeader = createHeaderElement(dashboardName);
+  // document.body.appendChild(tempHeader);
+  // const headerHeight = tempHeader.getBoundingClientRect().height;
+  // document.body.removeChild(tempHeader);
+
+  const headerHeight = 0;
+
+  const adjustedCardBounds = originalCardBounds.map(bound => ({
+    ...bound,
+    top: bound.top + headerHeight,
+    bottom: bound.bottom + headerHeight,
+  }));
 
   const { default: html2canvas } = await import("html2canvas-pro");
   const image = await html2canvas(node, {
     useCORS: true,
     onclone: (doc: Document, node: HTMLElement) => {
       node.classList.add(SAVING_DOM_IMAGE_CLASS);
-      const title = doc.createElement("h2") as HTMLElement;
-      title.innerHTML = dashboardName;
-      title.style["borderBottom"] = "1px solid var(--mb-color-border)";
-      title.style["padding"] = "2rem 1rem 1rem 1rem";
-      title.style["marginBottom"] = "1rem";
-      node.insertBefore(title, node.firstChild);
     },
   });
 
-  const imageHeight = parseInt(image.getAttribute("height") ?? "0");
   const imageWidth = parseInt(image.getAttribute("width") ?? "0");
+  const maxBottom = Math.max(...adjustedCardBounds.map(card => card.bottom));
+  const scale = window.devicePixelRatio || 1;
+  const actualWidth = image.width / scale;
 
-  const pdfWidth = imageWidth;
-  const pdfHeight = imageHeight + 80;
-
+  const targetPageHeight = Math.round(imageWidth * TARGET_ASPECT_RATIO);
   const { default: jspdf } = await import("jspdf");
+
+  const pageBreaks = findPossiblePageBreaks(
+    adjustedCardBounds,
+    targetPageHeight,
+  );
+
+  const firstPageHeight = pageBreaks.length > 0 ? pageBreaks[0] : maxBottom;
   const pdf = new jspdf({
     unit: "px",
     hotfixes: ["px_scaling"],
-    format: [pdfWidth, pdfHeight],
-    orientation: pdfWidth > pdfHeight ? "l" : "p",
+    format: [actualWidth, firstPageHeight],
+    orientation: "p",
   });
 
-  pdf.addImage(image, "JPEG", 0, 0, imageWidth, imageHeight, "", "FAST", 0);
+  pdf.addImage(image, "JPEG", 0, 0, actualWidth, maxBottom);
+
+  pageBreaks.forEach((breakPoint, index) => {
+    if (index < pageBreaks.length - 1) {
+      const nextBreak = pageBreaks[index + 1];
+      const pageHeight = nextBreak - breakPoint;
+
+      pdf.addPage([actualWidth, pageHeight]);
+      pdf.addImage(image, "JPEG", 0, -breakPoint, actualWidth, maxBottom);
+    }
+  });
+
+  if (pageBreaks.length > 0) {
+    const lastBreak = pageBreaks[pageBreaks.length - 1];
+    const remainingHeight = maxBottom - lastBreak;
+
+    if (remainingHeight > 0) {
+      pdf.addPage([actualWidth, remainingHeight]);
+      pdf.addImage(image, "JPEG", 0, -lastBreak, actualWidth, maxBottom);
+    }
+  }
 
   pdf.save(fileName);
 };

--- a/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
+++ b/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
@@ -39,7 +39,7 @@ const getSortedDashCardBounds = (node: HTMLElement): DashCardBounds[] => {
     .sort((a, b) => a.top - b.top);
 };
 
-const findPageBreakCandidates = (
+export const findPageBreakCandidates = (
   cards: DashCardBounds[],
   offset = 0,
 ): number[] => {
@@ -71,12 +71,12 @@ const findPageBreakCandidates = (
   return sortedBreaks.map(pageBreak => pageBreak + offset);
 };
 
-function getPageBreaks(
+export const getPageBreaks = (
   sortedCards: DashCardBounds[],
   optimalPageHeight: number,
   totalHeight: number,
   offset = 0,
-): number[] {
+): number[] => {
   if (sortedCards.length === 0) {
     return [];
   }
@@ -124,7 +124,7 @@ function getPageBreaks(
   }
 
   return result;
-}
+};
 
 const createHeaderElement = (dashboardName: string, marginBottom: number) => {
   const header = document.createElement("div");

--- a/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
+++ b/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
@@ -9,7 +9,9 @@ export const saveDashboardPdf = async (
   dashboardName: string,
 ) => {
   const fileName = `${dashboardName}.pdf`;
-  const node = document.querySelector(selector);
+  const node = document
+    .querySelector(selector)
+    ?.querySelector(".react-grid-layout");
 
   if (!node || !(node instanceof HTMLElement)) {
     console.warn("No node found for selector", selector);
@@ -25,6 +27,7 @@ export const saveDashboardPdf = async (
       title.innerHTML = dashboardName;
       title.style["borderBottom"] = "1px solid var(--mb-color-border)";
       title.style["padding"] = "2rem 1rem 1rem 1rem";
+      title.style["marginBottom"] = "1rem";
       node.insertBefore(title, node.firstChild);
     },
   });

--- a/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.unit.spec.ts
@@ -1,0 +1,155 @@
+import { findPageBreakCandidates, getPageBreaks } from "./save-dashboard-pdf";
+
+describe("save-dashboard-pdf", () => {
+  describe("findPageBreakCandidates", () => {
+    it("should find a potential page break between two cards", () => {
+      const cards = [
+        { top: 0, bottom: 99, height: 99, allowedBreaks: new Set<number>() },
+        {
+          top: 100,
+          bottom: 200,
+          height: 100,
+          allowedBreaks: new Set<number>(),
+        },
+      ];
+
+      const breaks = findPageBreakCandidates(cards);
+      expect(breaks).toEqual([99]);
+    });
+
+    it("should include allowed breaks within cards", () => {
+      const cards = [
+        {
+          top: 0,
+          bottom: 300,
+          height: 300,
+          allowedBreaks: new Set<number>([100, 200]),
+        },
+        {
+          top: 300,
+          bottom: 400,
+          height: 100,
+          allowedBreaks: new Set<number>(),
+        },
+      ];
+
+      const breaks = findPageBreakCandidates(cards);
+      expect(breaks).toEqual([100, 200, 300]);
+    });
+
+    it("should respect offset parameter", () => {
+      const cards = [
+        { top: 0, bottom: 100, height: 100, allowedBreaks: new Set<number>() },
+        {
+          top: 100,
+          bottom: 200,
+          height: 100,
+          allowedBreaks: new Set<number>(),
+        },
+      ];
+
+      const breaks = findPageBreakCandidates(cards, 50);
+      expect(breaks).toEqual([150]);
+    });
+
+    it("should not include breaks that would trim any cards", () => {
+      const cards = [
+        {
+          top: 0,
+          bottom: 99,
+          height: 99,
+          allowedBreaks: new Set<number>([
+            20, // the only break that would not trim any of the cards
+            80,
+          ]),
+        },
+        {
+          top: 100,
+          bottom: 200,
+          height: 100,
+          allowedBreaks: new Set<number>(),
+        },
+        {
+          top: 50,
+          bottom: 150,
+          height: 100,
+          allowedBreaks: new Set<number>(),
+        },
+      ];
+
+      const breaks = findPageBreakCandidates(cards);
+      expect(breaks).toEqual([20]);
+    });
+  });
+
+  describe("getPageBreaks", () => {
+    it("should return empty array when all cards fit in one page", () => {
+      const cards = [
+        { top: 0, bottom: 100, height: 100, allowedBreaks: new Set<number>() },
+        {
+          top: 100,
+          bottom: 200,
+          height: 100,
+          allowedBreaks: new Set<number>(),
+        },
+      ];
+
+      const breaks = getPageBreaks(cards, 300, 200);
+      expect(breaks).toEqual([]);
+    });
+
+    it("should choose break points close to optimal page height", () => {
+      const cards = [
+        { top: 0, bottom: 250, height: 250, allowedBreaks: new Set<number>() },
+        { top: 250, bottom: 300, height: 50, allowedBreaks: new Set<number>() },
+        {
+          top: 300,
+          bottom: 500,
+          height: 200,
+          allowedBreaks: new Set<number>(),
+        },
+      ];
+
+      const optimalPageHeight = 270;
+      const breaks = getPageBreaks(cards, optimalPageHeight, 500);
+      expect(breaks).toEqual([250]); // The page break at 250 is the closest to the optimal page height of 270
+    });
+
+    it("should create multiple breaks for very long content", () => {
+      const cards = [
+        { top: 0, bottom: 200, height: 200, allowedBreaks: new Set<number>() },
+        {
+          top: 200,
+          bottom: 400,
+          height: 200,
+          allowedBreaks: new Set<number>(),
+        },
+        {
+          top: 400,
+          bottom: 600,
+          height: 200,
+          allowedBreaks: new Set<number>(),
+        },
+      ];
+
+      const breaks = getPageBreaks(cards, 200, 600);
+      expect(breaks).toEqual([200, 400]);
+    });
+
+    it("should respect minimum page size constraint", () => {
+      const cards = [
+        { top: 0, bottom: 100, height: 100, allowedBreaks: new Set<number>() },
+        {
+          top: 100,
+          bottom: 250,
+          height: 150,
+          allowedBreaks: new Set<number>(),
+        },
+        { top: 250, bottom: 300, height: 50, allowedBreaks: new Set<number>() },
+      ];
+
+      const breaks = getPageBreaks(cards, 200, 300);
+      expect(breaks).toEqual([250]);
+    });
+  });
+});

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
@@ -63,6 +63,7 @@ export function Cell({
 }: CellProps) {
   return (
     <PivotTableCell
+      data-allow-page-break-after
       data-testid="pivot-table-cell"
       isNightMode={isNightMode}
       isBold={isBold}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50584

### Description

Split dashboard PDF exports into pages to make them print-friendly. Since we want to avoid having page breaks in the middle of a card, pages aspect ratio are not constant. 

### How to verify

- Create a very long dashboard with many cards
- If the dashboard layout has places where it can be sliced horizontally without cutting any dashcards ensure its exported PDF includes page breaks
- If the dashboard includes long tables on places of potential page breaks ensure its exported PDF includes page breaks between rows

### Demo

Loom: https://www.loom.com/share/483736b593af44649185d0cfba6aa06b?sid=91a49d7f-9a96-4db8-a2ca-3b7f73c86357

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
