### PR TITLE
Fix search query issue with trailing quotation mark

### DIFF
--- a/src/metabase/search/postgres/index.clj
+++ b/src/metabase/search/postgres/index.clj
@@ -179,6 +179,8 @@
 (defn- process-phrase [word-or-phrase]
   ;; a phrase is quoted even if the closing quotation mark has not been typed yet
   (cond
+    ;; trailing quotation mark
+    (= word-or-phrase "\"") nil
     ;; quoted phrases must be matched sequentially
     (str/starts-with? word-or-phrase "\"")
     (as-> word-or-phrase <>
@@ -206,6 +208,7 @@
   (->> words-and-phrases
        (remove #{"and"})
        (map process-phrase)
+       (remove str/blank?)
        (str/join " & ")))
 
 (defn- complete-last-word

--- a/test/metabase/search/postgres/index_test.clj
+++ b/test/metabase/search/postgres/index_test.clj
@@ -190,7 +190,9 @@
 
   (testing "unbalanced quotes"
     (is (= "'big' <-> 'data' & 'big' <-> 'mistake':*"
-           (search-expr "\"Big Data\" \"Big Mistake"))))
+           (search-expr "\"Big Data\" \"Big Mistake")))
+    (is (= "'something'"
+           (search-expr "something \""))))
 
   (is (= "'partial' <-> 'quoted' <-> 'and' <-> 'or' <-> '-split':*"
          (search-expr "\"partial quoted AND OR -split")))


### PR DESCRIPTION
Without this change we'd try to look for the empty string[^1], which is an illegal expression in ts_query.

[^1]: The query string would be. `'something' & ''`