### PR TITLE
Add user type visibility options to new search engine

### DIFF
--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -7,6 +7,7 @@
    [java-time.api :as t]
    [metabase.api.common :as api]
    [metabase.public-settings :as public-settings]
+   [metabase.public-settings.premium-features :as premium-features]
    [metabase.search :as search]
    [metabase.search.config :as search.config]
    [metabase.server.middleware.offset-paging :as mw.offset-paging]
@@ -135,6 +136,8 @@
        :created-at                          created_at
        :created-by                          (set created_by)
        :current-user-id                     api/*current-user-id*
+       :is-impersonated-user?               (premium-features/impersonated-user?)
+       :is-sandboxed-user?                  (premium-features/sandboxed-user?)
        :is-superuser?                       api/*is-superuser?*
        :current-user-perms                  @api/*current-user-permissions-set*
        :filter-items-in-personal-collection filter_items_in_personal_collection

--- a/src/metabase/models/model_index.clj
+++ b/src/metabase/models/model_index.clj
@@ -187,6 +187,7 @@
 
 (search/define-spec "indexed-entity"
   {:model        :model/ModelIndexValue
+   :visibility   :app-user
    :attrs        {:id            :model_pk
                   :collection-id :collection.id
                   :creator-id    false

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -129,8 +129,8 @@
    [:current-user-id    pos-int?]
    [:is-superuser?      :boolean]
    ;; TODO only optional and maybe for tests, clean that up!
-   [:is-impersonated-user? {:optional true } [:maybe :boolean]]
-   [:is-sandboxed-user?    {:optional true } [:maybe :boolean]]
+   [:is-impersonated-user? {:optional true} [:maybe :boolean]]
+   [:is-sandboxed-user?    {:optional true} [:maybe :boolean]]
    [:current-user-perms [:set perms.u/PathSchema]]
 
    [:model-ancestors?   :boolean]

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -128,7 +128,11 @@
    [:archived?          [:maybe :boolean]]
    [:current-user-id    pos-int?]
    [:is-superuser?      :boolean]
+   ;; TODO only optional and maybe for tests, clean that up!
+   [:is-impersonated-user? {:optional true } [:maybe :boolean]]
+   [:is-sandboxed-user?    {:optional true } [:maybe :boolean]]
    [:current-user-perms [:set perms.u/PathSchema]]
+
    [:model-ancestors?   :boolean]
    [:models             [:set SearchableModel]]
    ;; TODO this is optional only for tests, clean those up!

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -248,6 +248,8 @@
    [:search-string                                        [:maybe ms/NonBlankString]]
    [:models                                               [:maybe [:set SearchableModel]]]
    [:current-user-id                                      pos-int?]
+   [:is-impersonated-user?               {:optional true} :boolean]
+   [:is-sandboxed-user?                  {:optional true} :boolean]
    [:is-superuser?                                        :boolean]
    [:current-user-perms                                   [:set perms.u/PathSchema]]
    [:archived                            {:optional true} [:maybe :boolean]]
@@ -276,6 +278,8 @@
            current-user-perms
            filter-items-in-personal-collection
            ids
+           is-impersonated-user?
+           is-sandboxed-user?
            is-superuser?
            last-edited-at
            last-edited-by
@@ -299,6 +303,8 @@
                         :calculate-available-models? (boolean calculate-available-models?)
                         :current-user-id             current-user-id
                         :current-user-perms          current-user-perms
+                        :is-impersonated-user?       is-impersonated-user?
+                        :is-sandboxed-user?          is-sandboxed-user?
                         :is-superuser?               is-superuser?
                         :models                      models
                         :model-ancestors?            (boolean model-ancestors?)
@@ -318,6 +324,7 @@
     (when (and (seq ids)
                (not= (count models) 1))
       (throw (ex-info (tru "Filtering by ids work only when you ask for a single model") {:status-code 400})))
+    ;; TODO this is rather hidden, perhaps better to do it further down the stack
     (assoc ctx :models (search.filter/search-context->applicable-models ctx))))
 
 (defn- to-toucan-instance [row]

--- a/src/metabase/search/in_place/filter.clj
+++ b/src/metabase/search/in_place/filter.clj
@@ -79,7 +79,7 @@
                                  search.util/tokenize
                                  (map search.util/wildcard-match))]
        (cond
-         (and (= model "indexed-entity") (search.permissions/sandboxed-or-impersonated-user?))
+         (and (= model "indexed-entity") (search.permissions/sandboxed-or-impersonated-user? search-context))
          [:= 0 1]
 
          (and (#{"card" "dataset"} model) (= column (search.config/column-with-model-alias model :dataset_query)))

--- a/src/metabase/search/spec.clj
+++ b/src/metabase/search/spec.clj
@@ -76,6 +76,7 @@
 (def ^:private Specification
   [:map {:closed true}
    [:name SearchModel]
+   [:visibility [:enum :all :app-user]]
    [:model :keyword]
    [:attrs Attrs]
    [:search-terms [:sequential {:min 1} :keyword]]
@@ -168,7 +169,7 @@
                (mapcat
                 find-fields-top
                 ;; Remove the keys with special meanings (should probably switch this to an allowlist rather)
-                (vals (dissoc spec :name :native-query :where :joins :bookmark :model)))
+                (vals (dissoc spec :name :visibility :native-query :where :joins :bookmark :model)))
                (find-fields-expr (:where spec)))))
 
 (defn- replace-qualification [expr from to]
@@ -244,6 +245,7 @@
   [search-model spec]
   `(let [spec# (-> ~spec
                    (assoc :name ~search-model)
+                   (update :visibility #(or % :all))
                    (update :attrs #(merge ~default-attrs %)))]
      (validate-spec! spec#)
      (derive (:model spec#) :hook/search-index)

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -735,9 +735,10 @@
                            (search! "rom" :rasta))))))
 
           (testing "Sandboxed users do not see indexed entities in search"
-            (with-redefs [premium-features/sandboxed-or-impersonated-user? (constantly true)]
-              (is (= #{}
-                     (into #{} (comp relevant-1 (map :name)) (search! "fort")))))))))))
+            (with-redefs [premium-features/impersonated-user? (constantly true)]
+              (is (empty? (into #{} (comp relevant-1 (map :name)) (search! "fort")))))
+            (with-redefs [premium-features/sandboxed-user? (constantly true)]
+              (is (empty? (into #{} (comp relevant-1 (map :name)) (search! "fort")))))))))))
 
 (defn- archived-collection [m]
   (assoc m

--- a/test/metabase/search/filter_test.clj
+++ b/test/metabase/search/filter_test.clj
@@ -19,21 +19,31 @@
   ;; We ignore :card-db-id as legacy search implements this filter sneakily inside the models themselves.
   (math.combo/subsets (remove #{:archived? :table-db-id} (filter-keys))))
 
-(defn with-all-models [search-ctx]
+(defn- with-all-models [search-ctx]
   (assoc search-ctx :models search.config/all-models))
+
+(defn- with-all-models-and-regular-user [search-ctx]
+  (with-all-models (assoc search-ctx :is-impersonated-user? false :is-sandboxed-user? false)))
+
+(defn- with-all-models-and-sandboxed-user [search-ctx]
+  (with-all-models (assoc search-ctx :is-impersonated-user? false :is-sandboxed-user? true)))
 
 (deftest search-context->applicable-models-test
   (testing "All models are relevant if we're not looking in the trash"
     (is (= search.config/all-models
-           (search.filter/search-context->applicable-models (with-all-models {:archived? false})))))
+           (search.filter/search-context->applicable-models (with-all-models-and-regular-user {:archived? false})))))
 
   (testing "We only search for certain models in the trash"
     (is (= #{"dashboard" "dataset" "segment" "collection" "action" "metric" "card"}
-           (search.filter/search-context->applicable-models (with-all-models {:archived? true})))))
+           (search.filter/search-context->applicable-models (with-all-models-and-regular-user {:archived? true})))))
+
+  (testing "Indexed entities are not visible for sandboxed users"
+    (is (= (disj search.config/all-models "indexed-entity")
+           (search.filter/search-context->applicable-models (with-all-models-and-sandboxed-user {:archived? false})))))
 
   (doseq [active-filters (active-filter-combinations)]
     (testing (str "Consistent models included when filtering on " (vec active-filters))
-      (let [search-ctx (with-all-models (zipmap active-filters (repeat true)))]
+      (let [search-ctx (with-all-models-and-regular-user (zipmap active-filters (repeat true)))]
         (is (= (search.in-place.filter/search-context->applicable-models search-ctx)
                (search.filter/search-context->applicable-models search-ctx)))))))
 


### PR DESCRIPTION
Refs https://github.com/metabase/metabase/issues/40964

This matches legacy search's logic. I think it's the very last thing!