### PR TITLE
Disable nice-to-have tests that work locally, but fail in CI

### DIFF
--- a/test/metabase/search/postgres/index_test.clj
+++ b/test/metabase/search/postgres/index_test.clj
@@ -56,35 +56,35 @@
 
 ;; Disabled due to CI issue
 #_(deftest incremental-update-test
-  (with-index
-    (testing "The index is updated when models change"
+    (with-index
+      (testing "The index is updated when models change"
      ;; Has a second entry is "Revenue Project(ions)", when using English dictionary
-      (is (= 1 #_2 (count (search.index/search "Projected Revenue"))))
-      (is (= 0 (count (search.index/search "Protected Avenue"))))
-      (t2/update! :model/Card {:name "Projected Revenue"} {:name "Protected Avenue"})
-      (is (= 0 #_1 (count (search.index/search "Projected Revenue"))))
-      (is (= 1 (count (search.index/search "Protected Avenue"))))
+        (is (= 1 #_2 (count (search.index/search "Projected Revenue"))))
+        (is (= 0 (count (search.index/search "Protected Avenue"))))
+        (t2/update! :model/Card {:name "Projected Revenue"} {:name "Protected Avenue"})
+        (is (= 0 #_1 (count (search.index/search "Projected Revenue"))))
+        (is (= 1 (count (search.index/search "Protected Avenue"))))
      ;; Delete hooks are disabled, for now, over performance concerns.
      ;(t2/delete! :model/Card :name "Protected Avenue")
-      (search.ingestion/delete-model! (t2/select-one :model/Card :name "Protected Avenue"))
-      (is (= 0 #_1 (count (search.index/search "Projected Revenue"))))
-      (is (= 0 (count (search.index/search "Protected Avenue")))))))
+        (search.ingestion/delete-model! (t2/select-one :model/Card :name "Protected Avenue"))
+        (is (= 0 #_1 (count (search.index/search "Projected Revenue"))))
+        (is (= 0 (count (search.index/search "Protected Avenue")))))))
 
 ;; Disabled due to CI issue
 #_(deftest related-update-test
-  (with-index
-    (testing "The index is updated when model dependencies change"
-      (let [index-table    @#'search.index/active-table
-            table-id       (t2/select-one-pk :model/Table :name "Indexed Table")
-            legacy-input   #(-> (t2/select-one [index-table :legacy_input] :model "table" :model_id table-id)
-                                :legacy_input
-                                (json/parse-string true))
-            db-id          (t2/select-one-fn :db_id :model/Table table-id)
-            db-name-fn     (comp :database_name legacy-input)
-            alternate-name (str (random-uuid))]
-        (is (= "Indexed Database" (db-name-fn)))
-        (t2/update! :model/Database db-id {:name alternate-name})
-        (is (= alternate-name (db-name-fn)))))))
+    (with-index
+      (testing "The index is updated when model dependencies change"
+        (let [index-table    @#'search.index/active-table
+              table-id       (t2/select-one-pk :model/Table :name "Indexed Table")
+              legacy-input   #(-> (t2/select-one [index-table :legacy_input] :model "table" :model_id table-id)
+                                  :legacy_input
+                                  (json/parse-string true))
+              db-id          (t2/select-one-fn :db_id :model/Table table-id)
+              db-name-fn     (comp :database_name legacy-input)
+              alternate-name (str (random-uuid))]
+          (is (= "Indexed Database" (db-name-fn)))
+          (t2/update! :model/Database db-id {:name alternate-name})
+          (is (= alternate-name (db-name-fn)))))))
 
 (deftest consistent-subset-test
   (with-index

--- a/test/metabase/search/postgres/index_test.clj
+++ b/test/metabase/search/postgres/index_test.clj
@@ -1,6 +1,6 @@
 (ns metabase.search.postgres.index-test
   (:require
-   [cheshire.core :as json]
+   ;[cheshire.core :as json]
    [clojure.test :refer [deftest is testing]]
    [metabase.db :as mdb]
    [metabase.search.postgres.core :as search.postgres]
@@ -54,7 +54,8 @@
       (search.ingestion/populate-index!)
       (is (= rows-before (count-rows))))))
 
-(deftest incremental-update-test
+;; Disabled due to CI issue
+#_(deftest incremental-update-test
   (with-index
     (testing "The index is updated when models change"
      ;; Has a second entry is "Revenue Project(ions)", when using English dictionary
@@ -69,7 +70,8 @@
       (is (= 0 #_1 (count (search.index/search "Projected Revenue"))))
       (is (= 0 (count (search.index/search "Protected Avenue")))))))
 
-(deftest related-update-test
+;; Disabled due to CI issue
+#_(deftest related-update-test
   (with-index
     (testing "The index is updated when model dependencies change"
       (let [index-table    @#'search.index/active-table


### PR DESCRIPTION
Let's get master green again. I haven't found a way to reproduce these failures locally yet.