### PR TITLE
Make sure block perm enforcement allows native queries if powering a sandbox

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
@@ -23,7 +23,7 @@
   [[metabase.models.collection]] for more details."
   :feature :advanced-permissions
   [{{gtap-perms :gtaps} ::query-perms/perms, database-id :database :as query}]
-  (let [{:keys [table-ids card-ids]} (query-perms/query->source-ids query)
+  (let [{:keys [table-ids card-ids native?]} (query-perms/query->source-ids query)
         table-permissions            (map (partial data-perms/table-permission-for-user api/*current-user-id*
                                                    :perms/view-data database-id)
                                           table-ids)]
@@ -32,7 +32,7 @@
      (not= :blocked (data-perms/full-db-permission-for-user api/*current-user-id* :perms/view-data database-id))
      (= #{:unrestricted} (set table-permissions))
      ;; Don't block a query if we have native access implicitly granted to power a sandbox
-     (= :query-builder-and-native (:perms/create-queries gtap-perms))
+     (and native? (= :query-builder-and-native (:perms/create-queries gtap-perms)))
      (throw-block-permissions-exception))
 
     ;; Recursively check block permissions for any Cards referenced by the query

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
@@ -22,15 +22,17 @@
   run if the current User has unrestricted data permissions from another Group. See the namespace documentation for
   [[metabase.models.collection]] for more details."
   :feature :advanced-permissions
-  [{database-id :database :as query}]
+  [{{gtap-perms :gtaps} ::query-perms/perms, database-id :database :as query}]
   (let [{:keys [table-ids card-ids]} (query-perms/query->source-ids query)
         table-permissions            (map (partial data-perms/table-permission-for-user api/*current-user-id*
                                                    :perms/view-data database-id)
                                           table-ids)]
-    ;; Make sure we don't have block permissions for any individual tables in the query
+    ;; Make sure we don't have block permissions for the entire DB or individual tables referenced by the query.
     (or
      (not= :blocked (data-perms/full-db-permission-for-user api/*current-user-id* :perms/view-data database-id))
      (= #{:unrestricted} (set table-permissions))
+     ;; Don't block a query if we have native access implicitly granted to power a sandbox
+     (= :query-builder-and-native (:perms/create-queries gtap-perms))
      (throw-block-permissions-exception))
 
     ;; Recursively check block permissions for any Cards referenced by the query

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
@@ -1215,3 +1215,10 @@
                                      :people {:remappings {"user_id" [:dimension $people.zip]}}}})
       (data-perms/set-table-permission! &group (mt/id :people) :perms/view-data :unrestricted)
       (is (= 0 (count (mt/rows (qp/process-query (mt/mbql-query orders)))))))))
+
+(deftest native-sandbox-table-level-block-perms-test
+  (testing "A sandbox powered by a native query source card can be used even when other tables have block perms (#49969)"
+    (met/with-gtaps! {:gtaps      {:venues (venues-category-native-gtap-def)}
+                      :attributes {"cat" 50}}
+      (data-perms/set-table-permission! &group (mt/id :people) :perms/view-data :blocked)
+      (is (= 10 (count (mt/rows (qp/process-query (mt/mbql-query venues)))))))))

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -108,11 +108,12 @@
     (let [card-id         (or *card-id* (:qp/source-card-id outer-query))
           required-perms  (query-perms/required-perms-for-query outer-query :already-preprocessed? true)
           source-card-ids (set/difference (:card-ids required-perms) (:card-ids gtap-perms))]
+      ;; On EE, check block permissions up front for all queries. If block perms are in place, reject all native queries
+      ;; (unless overriden by `gtap-perms`) and any queries that touch blocked tables/DBs
+      (check-block-permissions outer-query)
       (cond
         card-id
-        (do
-          (query-perms/check-card-read-perms database-id card-id)
-          (check-block-permissions outer-query))
+        (query-perms/check-card-read-perms database-id card-id)
 
         ;; set when querying for field values of dashboard filters, which only require
         ;; collection perms for the dashboard and not ad-hoc query perms


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/49969

https://github.com/metabase/metabase/pull/49364 moved block permission enforcement explicitly back to EE code in the `check-block-permissions` function, as it was before we introduced table-level block.

However, the `check-block-permissions` did not take into account the `gtap-perms` key in the query, added by sandboxing middleware, which contains permissions which should be implicitly granted to the current user to allow sandboxing to function. I guess this wasn't needed before table-level block, since block and sandboxing couldn't live side-by-side. But now, you can have a native sandbox in one table and block perms in a different table, and we should allow the sandboxed query to execute despite the user not having native query perms for the DB.