### PR TITLE
Revert CI uberjar build Java version from 21 to 11

### DIFF
--- a/.github/actions/build-ee-extra/action.yml
+++ b/.github/actions/build-ee-extra/action.yml
@@ -2,6 +2,9 @@ name: Build ee-extra
 description: Build Metabase Enterprise Edition with extra features
 
 inputs:
+  java-version:
+    required: true
+    default: '21'
   iam-role:
     description: "The IAM role to assume"
     required: true
@@ -12,10 +15,10 @@ runs:
     - name: Prepare Java
       uses: actions/setup-java@v3
       with:
-        java-version: '21'
+        java-version: ${{ inputs.java-version }}
         distribution: 'temurin'
     - name: Reveal its original version.properties
-      run: jar xf  ./bin/docker/metabase.jar version.properties && cat version.properties
+      run: jar xf ./bin/docker/metabase.jar version.properties && cat version.properties
       shell: bash
     - name: get major version
       id: major_version

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -42,6 +42,9 @@ jobs:
       uses: ./.github/actions/prepare-backend
       with:
         m2-cache-key: uberjar
+        # Build with Java 11 so they compiled code doesn't try to use Java >11 classes... see
+        # https://metaboat.slack.com/archives/C5XHN8GLW/p1731517744549619?thread_ts=1731504670.951389&cid=C5XHN8GLW
+        java-version: 11
     - name: Build
       run: ./bin/build.sh
     - name: Prepare uberjar artifact
@@ -121,6 +124,9 @@ jobs:
       if: ${{ matrix.edition == 'ee-extra' }}
       uses: ./.github/actions/build-ee-extra
       with:
+        # Build with Java 11 so they compiled code doesn't try to use Java >11 classes... see
+        # https://metaboat.slack.com/archives/C5XHN8GLW/p1731517744549619?thread_ts=1731504670.951389&cid=C5XHN8GLW
+        java-version: 11
         iam-role: ${{ secrets.METABASE_EE_EXTRA_IAM_ROLE }}
     - name: Set up Docker Buildx
       id: buildx


### PR DESCRIPTION
I switched the JVM version we using to build the uberjar in CI from 11 to 21 (#48854). This change is causing something somewhere to generate bytecode at compilation time that references `java.util.SequencedCollection`, which is only in Java 21+.

Since we still want to support running on Java 11 for the time being, I am reverting the changes to the JVM version we use to build the uberjar. 

Note that our Docker image will still run with Java 21, we're only building the uberjar with 11.