### PR TITLE
Fix having to specify platform when pulling docker from ARM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,6 +199,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: metabase-${{ matrix.edition }}-uberjar
+        overwrite: true
         path: |
           ./metabase.jar
           ./COMMIT-ID

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,6 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: metabase-${{ matrix.edition }}-uberjar
-        overwrite: true
         path: |
           ./metabase.jar
           ./COMMIT-ID
@@ -303,8 +302,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        # checkout the commit that was tagged so we get the right dockerfile
-        ref: ${{ inputs.commit }}
         fetch-depth: 0  # IMPORTANT! to get all the tags
     - name: prepare release scripts
       run: cd release && yarn && yarn build
@@ -324,6 +321,34 @@ jobs:
           console.log("The canonical version of this Metabase", edition, "edition is", canonical_version);
 
           return canonical_version;
+    - uses: actions/download-artifact@v4
+      name: Retrieve previously downloaded Uberjar
+      with:
+        name: metabase-${{ matrix.edition }}-uberjar
+    - name: Move the Uberjar to the context dir
+      run: mv ./metabase.jar bin/docker/.
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        driver-opts: network=host
+    - name: Build ${{ matrix.edition }} container
+      uses: docker/build-push-action@v3
+      with:
+        context: bin/docker/.
+        platforms: linux/amd64
+        network: host
+        tags: localhost:5000/local-metabase:${{ steps.canonical_version.outputs.result }}
+        no-cache: true
+        push: true
+
+    - name: Launch container
+      run: docker run --rm -dp 3000:3000 localhost:5000/local-metabase:${{ steps.canonical_version.outputs.result }}
+      timeout-minutes: 5
+    - name: Wait for Metabase to start
+      run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
+      timeout-minutes: 3
+
     - name: Determine the target Docker Hub repository
       run: |
         if [[ "${{ matrix.edition }}" == "ee" ]]; then
@@ -333,31 +358,18 @@ jobs:
           echo "Metabase OSS: image is going to be pushed to ${{ github.repository_owner }}/metabase"
           echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase" >> $GITHUB_ENV
         fi
-    - uses: actions/download-artifact@v4
-      name: Retrieve previously downloaded Uberjar
-      with:
-        name: metabase-${{ matrix.edition }}-uberjar
-    - name: Move the Uberjar to the context dir
-      run: mv ./metabase.jar bin/docker/.
+
     - name: Login to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
         password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v3
-    - name: Build ${{ matrix.edition }} container
-      uses: docker/build-push-action@v6
-      with:
-        context: bin/docker/.
-        platforms: linux/amd64
-        network: host
-        tags: ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }}
-        no-cache: true
-        push: true
+    - name: Retag and push container image to Docker Hub
+      run: |
+        echo "Pushing ${{ steps.canonical_version.outputs.result }} to ${{ env.DOCKERHUB_REPO }} ..."
+        docker tag localhost:5000/local-metabase:${{ steps.canonical_version.outputs.result }} ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }}
+        docker push ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }}
+        echo "Finished!"
 
   verify-docker-pull:
     runs-on: ubuntu-22.04
@@ -368,7 +380,7 @@ jobs:
         edition: [oss, ee]
     steps:
     - name: Login to Docker Hub # authenticated, to avoid being rate-throttled
-      uses: docker/login-action@v3
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
         password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
@@ -421,6 +433,8 @@ jobs:
     - name: Tag Release
       uses: actions/github-script@v7
       with:
+        # FIXME: there's a perms problem in my fork
+        github-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
         result-encoding: string
         script: | # js
           const { tagRelease } = require('${{ github.workspace }}/release/dist/index.cjs');
@@ -458,7 +472,7 @@ jobs:
         $GITHUB_WORKSPACE/release/reorder-tags.sh ${{ needs.check-version.outputs.ee }} ${{ inputs.commit }}
 
   trigger-docs-update:
-    if: ${{ !inputs.auto }}
+    if: false # FIXME FOR TESTING ${{ !inputs.auto }}
     needs:
       - push-tags
       - check-version
@@ -552,6 +566,7 @@ jobs:
             });
 
   trigger-ee-extra-pr:
+    if: false # FIXME FOR TESTING
     needs: verify-s3-download
     runs-on: ubuntu-22.04
     timeout-minutes: 10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,6 +302,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        # checkout the commit that was tagged so we get the right dockerfile
+        ref: ${{ inputs.commit }}
         fetch-depth: 0  # IMPORTANT! to get all the tags
     - name: prepare release scripts
       run: cd release && yarn && yarn build
@@ -433,8 +435,6 @@ jobs:
     - name: Tag Release
       uses: actions/github-script@v7
       with:
-        # FIXME: there's a perms problem in my fork
-        github-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
         result-encoding: string
         script: | # js
           const { tagRelease } = require('${{ github.workspace }}/release/dist/index.cjs');
@@ -472,7 +472,7 @@ jobs:
         $GITHUB_WORKSPACE/release/reorder-tags.sh ${{ needs.check-version.outputs.ee }} ${{ inputs.commit }}
 
   trigger-docs-update:
-    if: false # FIXME FOR TESTING ${{ !inputs.auto }}
+    if: ${{ !inputs.auto }}
     needs:
       - push-tags
       - check-version
@@ -566,7 +566,6 @@ jobs:
             });
 
   trigger-ee-extra-pr:
-    if: false # FIXME FOR TESTING
     needs: verify-s3-download
     runs-on: ubuntu-22.04
     timeout-minutes: 10


### PR DESCRIPTION


### Description

Pushing with docker's build-and-push action yielded a different manifest, what is better suited to multi-arch builds. Unfortunately, this made default behavior on ARM machines require specifying `linux/amd64` arch, and is likely to disrupt users' workflows:

```
▶ docker pull metabase/metabase:v0.51.3
v0.51.3: Pulling from metabase/metabase
no matching manifest for linux/arm64/v8 in the manifest list entries
```

This reverts most of #48910 until we can provide proper ARM64 builds (probably in v52)


## details

v51.2 manifest (old)
```sh
▶ docker manifest inspect metabase/metabase:v0.51.2
{
	"schemaVersion": 2,
	"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
	"config": {
		"mediaType": "application/vnd.docker.container.image.v1+json",
		"size": 5943,
		"digest": "sha256:5149594173480012c4793001c7699a90308b3f89af1888b9d104d014df050593"
	},
	"layers": [
		{
			"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
			"size": 3623807,
			"digest": "sha256:43c4264eed91be63b206e17d93e75256a6097070ce643c5e8f0379998b44f170"
		},
		{
			"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
			"size": 18307482,
			"digest": "sha256:ddb2831a0384f7139841ad3dbca976f0db0643b819a108b4c1dce7e255309c4b"
		},
		{
			"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
			"size": 43577909,
			"digest": "sha256:6cf742362f936f1af99046582a78334db874b167db3583ca05315acc6ff765ce"
		},
		{
			"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
			"size": 126,
			"digest": "sha256:fe6b4fa47f17ecc1d38143f39a612776415bfca4ce770911d39abb9902c3cadc"
		},
		{
			"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
			"size": 2278,
			"digest": "sha256:0bc8086457f8a9cf1c8dbd7d0182da4f95bbfdfc8f2c59ca55d1624e6cfcd806"
		},
		{
			"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
			"size": 89338109,
			"digest": "sha256:681f8480e075154d995e2021822145cbcdbc437d2394aff2ca3e6d378571e516"
		},
		{
			"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
			"size": 383560600,
			"digest": "sha256:9a3dc8f3ea757429247c37b65c4d90b18d34de74b76ca0708806da1ef3aef833"
		}
	]
}
```


v51.3 manifest (new)
```sh
▶ docker manifest inspect metabase/metabase:v0.51.3
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 1631,
         "digest": "sha256:a6b11b81665571faebae7aeebe4c3f0002bbbcb92a109eff8e32d2b3f841c4b4",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 567,
         "digest": "sha256:265fe1db6957e00d1d61234f8aabfb9c79e45b77cce8db81845d7c0810ed691d",
         "platform": {
            "architecture": "unknown",
            "os": "unknown"
         }
      }
   ]
}
```