### PR TITLE
Don't hardcode Linux/x64 arch in Docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN INTERACTIVE=false CI=true MB_EDITION=$MB_EDITION bin/build.sh :version ${VER
 ## jar from the previous stage rather than the local build
 ## we're not yet there to provide an ARM runner till https://github.com/adoptium/adoptium/issues/96 is ready
 
-FROM --platform=linux/amd64 eclipse-temurin:21-jre-alpine as runner
+FROM eclipse-temurin:21-jre-alpine as runner
 
 ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 

--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 
 ENV FC_LANG=en-US LC_CTYPE=en_US.UTF-8
 


### PR DESCRIPTION
Next step towards having a multiarch image that supports ARM

We need to do this because the Temurin Alpine + Java 21 image isn't happy with hardcoding Linux x64 anymore, it's failing with 

https://docs.docker.com/reference/build-checks/from-platform-flag-const-disallowed/