### PR TITLE
fix(sdk): sdk version wrapped in quotes

### DIFF
--- a/webpack.embedding-sdk.config.js
+++ b/webpack.embedding-sdk.config.js
@@ -29,9 +29,7 @@ const sdkPackageTemplateJson = fs.readFileSync(
   "utf-8",
 );
 const sdkPackageTemplateJsonContent = JSON.parse(sdkPackageTemplateJson);
-const EMBEDDING_SDK_VERSION = JSON.stringify(
-  sdkPackageTemplateJsonContent.version,
-);
+const EMBEDDING_SDK_VERSION = sdkPackageTemplateJsonContent.version;
 
 // TODO: Reuse babel and css configs from webpack.config.js
 // Babel:


### PR DESCRIPTION
We're currently saving the sdk version in a string that contains the double quotes: eg: `"1.52.2"` instead of just `1.52.5`

<img width="212" alt="image" src="https://github.com/user-attachments/assets/e5280bdd-de0c-40f7-bc6f-be77a2d4287d">
<img width="570" alt="image" src="https://github.com/user-attachments/assets/993eb446-36e9-4ae8-a311-307737a45a76">
This is inconsistent with how we send the other headers and is also confusing.

We should be able to change this without creating issues:
- on the FE this is only logged and we're not doing anything with it besides ending it to the BE
- on the BE as far as I understood we only use it for analytics so the worst that can happen is that we'll need to do some clean up on the data.

# Demo

## Before
<img width="541" alt="image" src="https://github.com/user-attachments/assets/45704e21-523c-40cb-bfac-03b4f2aab900">
<img width="570" alt="image" src="https://github.com/user-attachments/assets/9891b72b-a04a-4869-835e-2324badb6e80">

<img width="212" alt="image" src="https://github.com/user-attachments/assets/e5280bdd-de0c-40f7-bc6f-be77a2d4287d">
<img width="570" alt="image" src="https://github.com/user-attachments/assets/993eb446-36e9-4ae8-a311-307737a45a76">


## After
<img width="556" alt="image" src="https://github.com/user-attachments/assets/d8259b53-3849-4c4f-82d7-58e47a03fcd2">
<img width="267" alt="image" src="https://github.com/user-attachments/assets/70c09382-ec14-4bde-ad3f-9a75ab7dd2e6">
<img width="617" alt="image" src="https://github.com/user-attachments/assets/c2a19c10-0e0d-4751-92fa-e4b5a231a271">



## Query Execution log before/after
![image](https://github.com/user-attachments/assets/3ddebe74-f550-465f-b6c5-2193fd939300)
