### PR TITLE
Update slack settings urls

### DIFF
--- a/frontend/src/metabase/admin/app/components/DeprecationNotice/DeprecationNotice.tsx
+++ b/frontend/src/metabase/admin/app/components/DeprecationNotice/DeprecationNotice.tsx
@@ -42,7 +42,7 @@ const getBannerContent = (
   hasDeprecatedDatabase: boolean,
 ) => {
   const databaseListUrl = "/admin/databases";
-  const slackSettingsUrl = "/admin/settings/slack";
+  const slackSettingsUrl = "/admin/settings/notifications/slack";
 
   if (hasSlackBot && hasDeprecatedDatabase) {
     return jt`You’re using a ${(

--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -221,7 +221,7 @@
    {:title       (tru "Set Slack credentials")
     :group       (tru "Get connected")
     :description (tru "Does your team use Slack? If so, you can send automated updates via dashboard subscriptions.")
-    :link        "/admin/settings/slack"
+    :link        "/admin/settings/notifications/slack"
     :completed   (configured :slack)
     :triggered   :always}
    {:title       (tru "Setup embedding")

--- a/src/metabase/email/slack_token_error.hbs
+++ b/src/metabase/email/slack_token_error.hbs
@@ -7,6 +7,6 @@
       <h2 style="font-weight: normal; color: #4C545B; line-height: 34px;">Your Slack connection stopped working</h2>
       <p style="line-height: 22px; margin-bottom: 40px">This may affect existing dashboard subscriptions. Follow the steps in settings to reconnect Slack and get things up and running again.</p>
     </div>
-    <a style="{{context.style.button}}" href="{{context.site_url}}/admin/settings/slack">Go to settings</a>
+    <a style="{{context.style.button}}" href="{{context.site_url}}/admin/settings/notifications/slack">Go to settings</a>
   </div>
 {{> metabase/email/_footer.hbs }}

--- a/test/metabase/notification/payload/impl/system_event_test.clj
+++ b/test/metabase/notification/payload/impl/system_event_test.clj
@@ -201,7 +201,7 @@
         admin-emails (t2/select-fn-set :email :model/User :is_superuser true)]
     (testing "send to admins with a link to setting page"
       (check admin-emails [#"Your Slack connection stopped working"
-                           #"<a[^>]*href=\"https?://metabase\.com/admin/settings/slack\"[^>]*>Go to settings</a>"]))
+                           #"<a[^>]*href=\"https?://metabase\.com/admin/settings/notifications/slack\"[^>]*>Go to settings</a>"]))
 
     (mt/with-temporary-setting-values
       [admin-email "it@metabase.com"]


### PR DESCRIPTION

### Description

We changed the url of slack settings from `/admin/settings/slack` to `/admin/settings/notifications/slack` but failed to update a few links, which led to broken links

![Screen Shot 2024-11-14 at 7 56 51 AM](https://github.com/user-attachments/assets/cde4d667-3fd8-4d65-8f2a-2af4537fd5a6)

![Screen Shot 2024-11-14 at 7 33 14 AM](https://github.com/user-attachments/assets/8f7904c4-00fa-4c5b-962c-61465dc3c7b8)

