### PR TITLE
enforce key prop on tooltip row in echarts tooltip

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartTooltip/EChartsTooltip/EChartsTooltip.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/EChartsTooltip/EChartsTooltip.tsx
@@ -66,11 +66,12 @@ export const EChartsTooltip = ({
         })}
       >
         <tbody>
-          {paddedRows.map(row => {
+          {paddedRows.map((row, i) => {
+            const key = row.key ?? String(i);
             return !row.isSecondary ? (
-              <TooltipRow {...row} />
+              <TooltipRow {...row} key={key} />
             ) : (
-              <SecondaryRow {...row} />
+              <SecondaryRow {...row} key={key} />
             );
           })}
         </tbody>


### PR DESCRIPTION
Fixes
<img width="1091" alt="image" src="https://github.com/user-attachments/assets/d6dc7c1d-b165-44c7-add2-ce3593e975b0">
that can show up in the console of the devs using the sdk.

It seems that the type of the row has an optional key. I set a default key to make sure we don't have the warning in the console.

