### PR TITLE
Command Palette Search result order

### DIFF
--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -188,7 +188,7 @@ export const useCommandPalette = ({
               icon: icon.name,
               section: "search",
               keywords: debouncedSearchText,
-              priority: Priority.NORMAL,
+              priority: Priority.NORMAL - index,
               perform: () => {
                 trackSearchClick("item", index, "command-palette");
               },


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/49766

### Description
With how the command palette is set up, when you perform a search it has it's own way of matching a query to an action. This can cause the order to change from what the API has returned, to what the Command Palette library thinks is a better order. This PR links the priority of the search results to their index, making the results returned in the `Search Results` section mirror what the API returned

### How to verify

1. Open the Command Palette
2. Enter a search query, and click "View All Results"
3. Open the command palette again and re-enter the query, you should see the results in the search app are the same as what's in the palette

### Demo
![image](https://github.com/user-attachments/assets/9a480bc8-c6ff-4c18-be27-a8fb9feb0f79)
![image](https://github.com/user-attachments/assets/b151189c-1a50-4a67-af70-a4ebb7b7d52c)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
