### PR TITLE
Merge login_attributes when updating existing users via config file

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file/users_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file/users_test.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.advanced-config.file :as advanced-config.file]
-   [metabase.models :refer [User]]
    [metabase.setup :as setup]
    [metabase.test :as mt]
    [metabase.util.password :as u.password]
@@ -18,36 +17,43 @@
 (deftest init-from-config-file-test
   (try
     (binding [advanced-config.file/*config* {:version 1
-                                             :config  {:users [{:first_name "Cam"
-                                                                :last_name  "Era"
-                                                                :email      "cam+config-file-test@metabase.com"
-                                                                :password   "2cans"}]}}]
+                                             :config  {:users [{:first_name       "Cam"
+                                                                :last_name        "Era"
+                                                                :email            "cam+config-file-test@metabase.com"
+                                                                :password         "2cans"
+                                                                :login_attributes {"a" 1}}]}}]
       (testing "Create a User if it does not already exist"
         (is (= :ok
                (advanced-config.file/initialize!)))
-        (is (partial= {:first_name "Cam"
-                       :last_name  "Era"
-                       :email      "cam+config-file-test@metabase.com"}
-                      (t2/select-one User :email "cam+config-file-test@metabase.com")))
+        (is (partial= {:first_name       "Cam"
+                       :last_name        "Era"
+                       :email            "cam+config-file-test@metabase.com"
+                       :login_attributes {"a" 1}}
+                      (t2/select-one [:model/User :first_name :last_name :email :login_attributes]
+                                     :email "cam+config-file-test@metabase.com")))
         (is (= 1
-               (t2/count User :email "cam+config-file-test@metabase.com"))))
-      (testing "upsert if User already exists"
-        (let [hashed-password          (fn [] (t2/select-one-fn :password User :email "cam+config-file-test@metabase.com"))
-              salt                     (fn [] (t2/select-one-fn :password_salt User :email "cam+config-file-test@metabase.com"))
+               (t2/count :model/User :email "cam+config-file-test@metabase.com"))))
+
+      (testing "upsert if User already exists, with merged login attributes"
+        (let [hashed-password          (fn [] (t2/select-one-fn :password :model/User :email "cam+config-file-test@metabase.com"))
+              salt                     (fn [] (t2/select-one-fn :password_salt :model/User :email "cam+config-file-test@metabase.com"))
               original-hashed-password (hashed-password)]
           (binding [advanced-config.file/*config* {:version 1
-                                                   :config  {:users [{:first_name "Cam"
-                                                                      :last_name  "Saul"
-                                                                      :email      "cam+config-file-test@metabase.com"
-                                                                      :password   "2cans"}]}}]
+                                                   :config  {:users [{:first_name       "Cam"
+                                                                      :last_name        "Saul"
+                                                                      :email            "cam+config-file-test@metabase.com"
+                                                                      :password         "2cans"
+                                                                      :login_attributes {"b" 2}}]}}]
             (is (= :ok
                    (advanced-config.file/initialize!)))
             (is (= 1
-                   (t2/count User :email "cam+config-file-test@metabase.com")))
-            (is (partial= {:first_name "Cam"
-                           :last_name  "Saul"
-                           :email      "cam+config-file-test@metabase.com"}
-                          (t2/select-one User :email "cam+config-file-test@metabase.com")))
+                   (t2/count :model/User :email "cam+config-file-test@metabase.com")))
+            (is (partial= {:first_name       "Cam"
+                           :last_name        "Saul"
+                           :email            "cam+config-file-test@metabase.com"
+                           :login_attributes {"a" 1 "b" 2}}
+                          (t2/select-one [:model/User :first_name :last_name :email :login_attributes]
+                                         :email "cam+config-file-test@metabase.com")))
             (testing "Password should be hashed, but it should be a NEW HASH"
               (let [new-hashed-password (hashed-password)]
                 (is (not= original-hashed-password
@@ -58,7 +64,7 @@
                 (testing "Password should work correctly"
                   (is (u.password/verify-password "2cans" (salt) new-hashed-password)))))))))
     (finally
-      (t2/delete! User :email "cam+config-file-test@metabase.com"))))
+      (t2/delete! :model/User :email "cam+config-file-test@metabase.com"))))
 
 (deftest init-from-config-file-force-admin-for-first-user-test
   (testing "If this is the first user being created, always make the user a superuser regardless of what is specified"
@@ -77,9 +83,9 @@
                            :last_name    "Era"
                            :email        "cam+config-file-admin-test@metabase.com"
                            :is_superuser true}
-                          (t2/select-one User :email "cam+config-file-admin-test@metabase.com")))
+                          (t2/select-one :model/User :email "cam+config-file-admin-test@metabase.com")))
             (is (= 1
-                   (t2/count User :email "cam+config-file-admin-test@metabase.com"))))))
+                   (t2/count :model/User :email "cam+config-file-admin-test@metabase.com"))))))
       (testing "Create the another User, DO NOT force them to be an admin"
         (binding [advanced-config.file/*config* {:version 1
                                                  :config  {:users [{:first_name   "Cam"
@@ -93,11 +99,11 @@
                          :last_name    "Saul"
                          :email        "cam+config-file-admin-test-2@metabase.com"
                          :is_superuser false}
-                        (t2/select-one User :email "cam+config-file-admin-test-2@metabase.com")))
+                        (t2/select-one :model/User :email "cam+config-file-admin-test-2@metabase.com")))
           (is (= 1
-                 (t2/count User :email "cam+config-file-admin-test-2@metabase.com")))))
-      (finally (t2/delete! User :email [:in #{"cam+config-file-admin-test@metabase.com"
-                                              "cam+config-file-admin-test-2@metabase.com"}])))))
+                 (t2/count :model/User :email "cam+config-file-admin-test-2@metabase.com")))))
+      (finally (t2/delete! :model/User :email [:in #{"cam+config-file-admin-test@metabase.com"
+                                                     "cam+config-file-admin-test-2@metabase.com"}])))))
 
 (deftest init-from-config-file-env-var-for-password-test
   (testing "Ensure that we can set User password using {{env ...}} templates"
@@ -111,7 +117,7 @@
         (testing "Create a User if it does not already exist"
           (is (= :ok
                  (advanced-config.file/initialize!)))
-          (let [user (t2/select-one [User :first_name :last_name :email :password_salt :password]
+          (let [user (t2/select-one [:model/User :first_name :last_name :email :password_salt :password]
                                     :email "cam+config-file-password-test@metabase.com")]
             (is (partial= {:first_name "Cam"
                            :last_name  "Era"
@@ -119,7 +125,7 @@
                           user))
             (is (u.password/verify-password "1234cans" (:password_salt user) (:password user))))))
       (finally
-        (t2/delete! User :email "cam+config-file-password-test@metabase.com")))))
+        (t2/delete! :model/User :email "cam+config-file-password-test@metabase.com")))))
 
 (deftest init-from-config-file-validation-test
   (are [user error-pattern] (thrown-with-msg?


### PR DESCRIPTION
If we're updating an existing user on startup via the config file, merge `login_attributes` instead of entirely overwriting them.

Slack thread: https://metaboat.slack.com/archives/C01LQQ2UW03/p1731546332879779?thread_ts=1731533299.724969&cid=C01LQQ2UW03