### PR TITLE
Use Java 17 to run the EE extras build steps

### DIFF
--- a/.github/actions/build-ee-extra/action.yml
+++ b/.github/actions/build-ee-extra/action.yml
@@ -4,7 +4,9 @@ description: Build Metabase Enterprise Edition with extra features
 inputs:
   java-version:
     required: true
-    default: '21'
+    # Use Java 17 to run steps like `jar uf`, otherwise the build fails because it tries to verify every file the JAR
+    # and some have 17+ bytecode for whatever reason... see https://metaboat.slack.com/archives/C5XHN8GLW/p1731504670951389
+    default: '17'
   iam-role:
     description: "The IAM role to assume"
     required: true

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -124,9 +124,6 @@ jobs:
       if: ${{ matrix.edition == 'ee-extra' }}
       uses: ./.github/actions/build-ee-extra
       with:
-        # Build with Java 11 so they compiled code doesn't try to use Java >11 classes... see
-        # https://metaboat.slack.com/archives/C5XHN8GLW/p1731517744549619?thread_ts=1731504670.951389&cid=C5XHN8GLW
-        java-version: 11
         iam-role: ${{ secrets.METABASE_EE_EXTRA_IAM_ROLE }}
     - name: Set up Docker Buildx
       id: buildx


### PR DESCRIPTION
In the build process for the ee-extras uberjar we run `jar uf ...` to add partner drivers to the uberjar. This fails with Java 11 because apparently `jar uf` verifies every class file in the uberjar and something in there has version 61 (Java 17) bytecode. Why does it need to do this when it's basically just adding files to a ZIP file? Who knows, but there seems to be no way to disable the verification. 

I'm still investigating who the naughty class is but I'm guessing it's something selectively loaded based on Java version because the JAR does in fact work fine on Java 11.

We were using Java 17 in the first place for this job before I bumped it to 21 in #48854 and then downgraded it to 11 in #49975. So this is reverting those changes back to what they were last week to get things working again.

Note that this is really just kicking the can down the road, if we get a Java 21+ class in a dep in the future then Java 17 is probably going to start failing here too. But that's a problem for another day. 

See Slacc thread https://metaboat.slack.com/archives/C5XHN8GLW/p1731504670951389 for more discussion 