### PR TITLE
fix: respect click behavior on public dashboards

### DIFF
--- a/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
@@ -2,10 +2,12 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   assertDashboardFixedWidth,
   assertDashboardFullWidth,
+  createDashboardWithQuestions,
   createPublicDashboardLink,
   dashboardParametersContainer,
   describeEE,
   filterWidget,
+  getDashboardCard,
   goToTab,
   openNewPublicLinkDropdown,
   openSharingMenu,
@@ -17,7 +19,7 @@ import {
   visitPublicDashboard,
 } from "e2e/support/helpers";
 
-const { PRODUCTS } = SAMPLE_DATABASE;
+const { PRODUCTS, ORDERS_ID } = SAMPLE_DATABASE;
 
 const questionDetails = {
   name: "sql param",
@@ -285,6 +287,54 @@ describe("scenarios > public > dashboard", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- we don't care where the text is
     cy.findByText("Registerkarte als PDF exportieren").should("be.visible");
     cy.url().should("include", "locale=de");
+  });
+
+  it("should respect click behavior", () => {
+    createDashboardWithQuestions({
+      dashboardName: "test click behavior",
+      questions: [
+        {
+          name: "orders",
+          query: {
+            "source-table": ORDERS_ID,
+            limit: 5,
+          },
+        },
+      ],
+      cards: [
+        {
+          visualization_settings: {
+            column_settings: {
+              '["name","TOTAL"]': {
+                click_behavior: {
+                  type: "link",
+                  linkType: "url",
+                  linkTemplate: "https://metabase.com",
+                },
+              },
+            },
+          },
+        },
+      ],
+    }).then(({ dashboard }) => {
+      visitPublicDashboard(dashboard.id);
+    });
+
+    // This is a hacky way to intercept the link click we create an a element
+    // with href on fly and remove it afterwards in lib/dom.js
+    cy.window().then(win => {
+      cy.spy(win.document.body, "appendChild").as("appendChild");
+    });
+
+    getDashboardCard().findByText("39.72").click();
+
+    cy.get("@appendChild").then(appendChild => {
+      // last call is a link
+      const element = appendChild.lastCall.args[0];
+
+      expect(element.tagName).to.eq("A");
+      expect(element.href).to.eq("https://metabase.com/");
+    });
   });
 });
 

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -139,7 +139,7 @@ type OwnProps = {
   mode?: QueryClickActionsMode | Mode;
   // public dashboard passes it explicitly
   width?: number;
-  // public dashboard passes it as noop
+  // public or embedded dashboard passes it as noop
   navigateToNewCardFromDashboard?: (
     opts: NavigateToNewCardFromDashboardOpts,
   ) => void;

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage.tsx
@@ -12,8 +12,6 @@ import { useSelector } from "metabase/lib/redux";
 import { PublicOrEmbeddedDashboard } from "./PublicOrEmbeddedDashboard";
 import { usePublicDashboardEndpoints } from "./WithPublicDashboardEndpoints";
 
-const noop = () => {};
-
 export const PublicOrEmbeddedDashboardPage = (props: WithRouterProps) => {
   const { location, router } = props;
   const parameterQueryParams = props.location.query;
@@ -71,7 +69,6 @@ export const PublicOrEmbeddedDashboardPage = (props: WithRouterProps) => {
         parameterQueryParams={parameterQueryParams}
         cardTitled={true}
         locale={locale}
-        navigateToNewCardFromDashboard={noop}
       />
     </>
   );

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage.tsx
@@ -12,6 +12,8 @@ import { useSelector } from "metabase/lib/redux";
 import { PublicOrEmbeddedDashboard } from "./PublicOrEmbeddedDashboard";
 import { usePublicDashboardEndpoints } from "./WithPublicDashboardEndpoints";
 
+const noop = () => {};
+
 export const PublicOrEmbeddedDashboardPage = (props: WithRouterProps) => {
   const { location, router } = props;
   const parameterQueryParams = props.location.query;
@@ -69,6 +71,7 @@ export const PublicOrEmbeddedDashboardPage = (props: WithRouterProps) => {
         parameterQueryParams={parameterQueryParams}
         cardTitled={true}
         locale={locale}
+        navigateToNewCardFromDashboard={noop}
       />
     </>
   );

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -245,10 +245,6 @@ class Visualization extends PureComponent {
   }
 
   visualizationIsClickable = clicked => {
-    const { onChangeCardAndRun } = this.props;
-    if (!onChangeCardAndRun) {
-      return false;
-    }
     try {
       return this.getClickActions(clicked).length > 0;
     } catch (e) {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/49776
closes https://github.com/metabase/metabase/issues/50086

### Description

~public or embedded dashboards do not allow drills so we removed the top level prop to allow drilling, at the same time this prop is used to calculate if the visualization clickable or not, so instead of huge and error-prone refactoring we decided to pass `noop` from top level as it's been done before.~

Later on we found some tests failing because of the metabase-lib which doesn't expect an empty query. So instead we decided to remove an unnecessary check 

### How to verify

follow steps from the issue

### Demo


https://github.com/user-attachments/assets/d2857b4b-21f8-4221-af87-ef2125f802e5



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] [stress test](https://github.com/metabase/metabase/actions/runs/11863480424/job/33065013747)
