### PR TITLE
refactor(sdk): use ignore flag instead of mounted ref

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-load-static-question.ts
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-load-static-question.ts
@@ -34,6 +34,7 @@ export function useLoadStaticQuestion(
 
   useEffect(() => {
     const cancelDeferred = defer();
+    let ignore = false; // flag to ignore the result if the component unmounts: https://react.dev/learn/you-might-not-need-an-effect#fetching-data
 
     async function loadCardData() {
       setQuestionState(state => ({ ...state, loading: true }));
@@ -49,20 +50,24 @@ export function useLoadStaticQuestion(
           cancelDeferred,
         });
 
-        setQuestionState({
-          card,
-          result,
-          loading: false,
-          error: null,
-        });
+        if (!ignore) {
+          setQuestionState({
+            card,
+            result,
+            loading: false,
+            error: null,
+          });
+        }
       } catch (error) {
         if (typeof error === "object") {
-          setQuestionState({
-            result: null,
-            card: null,
-            loading: false,
-            error,
-          });
+          if (!ignore) {
+            setQuestionState({
+              result: null,
+              card: null,
+              loading: false,
+              error,
+            });
+          }
         } else {
           console.error("error loading static question", error);
         }
@@ -74,6 +79,7 @@ export function useLoadStaticQuestion(
     return () => {
       // cancel pending requests upon unmount
       cancelDeferred.resolve();
+      ignore = true;
     };
   }, [questionId, parameterValues]);
 

--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-load-static-question.ts
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-load-static-question.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { loadStaticQuestion } from "embedding-sdk/lib/load-static-question";
 import type { GenericErrorResponse } from "metabase/lib/errors";
@@ -17,17 +17,6 @@ export function useLoadStaticQuestion(
   questionId: number | null,
   parameterValues?: Record<string, string | number>,
 ) {
-  // This is a hack around strict mode calling the useEffect twice ->
-  // the first request is being cancelled and we render a error state for a few renders
-  // This needs to start at true, it needs to bypass the double use effect of strict mode
-  // See https://github.com/metabase/metabase/issues/49620 for more details on the issue
-  const isMounted = useRef(true);
-  useEffect(() => {
-    return () => {
-      isMounted.current = false;
-    };
-  }, []);
-
   const [questionState, setQuestionState] = useState<QuestionState>({
     loading: false,
     card: null,
@@ -67,10 +56,6 @@ export function useLoadStaticQuestion(
           error: null,
         });
       } catch (error) {
-        if (!isMounted.current) {
-          return;
-        }
-
         if (typeof error === "object") {
           setQuestionState({
             result: null,


### PR DESCRIPTION
Better fix than  https://github.com/metabase/metabase/pull/49659

Literally what the docs tells to do: https://react.dev/learn/you-might-not-need-an-effect#fetching-data