### PR TITLE
Search Index recency ranker to use last-viewed-at

### DIFF
--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -672,6 +672,7 @@
                   :database-id    false
                   :last-editor-id :r.user_id
                   :last-edited-at :r.timestamp
+                  :last-viewed-at true
                   :pinned         [:> [:coalesce :collection_position [:inline 0]] [:inline 0]]
                   :view-count     true
                   :created-at     true

--- a/src/metabase/search/postgres/index.clj
+++ b/src/metabase/search/postgres/index.clj
@@ -53,6 +53,7 @@
              [:legacy_input :text :not-null]
              ;; scoring related
              [:dashboardcard_count :int]
+             [:last_viewed_at :timestamp]
              [:model_rank :int :not-null]
              [:official_collection :boolean]
              [:pinned :boolean]

--- a/src/metabase/search/postgres/scoring.clj
+++ b/src/metabase/search/postgres/scoring.clj
@@ -80,7 +80,7 @@
    :view-count (atan-size :view_count search.config/view-count-scaling)
    :pinned     (truthy :pinned)
    :bookmarked bookmark-score-expr
-   :recency    (inverse-duration :model_updated_at [:now] search.config/stale-time-in-days)
+   :recency    (inverse-duration [:coalesce :last_viewed_at :model_updated_at] [:now] search.config/stale-time-in-days)
    :dashboard  (size :dashboardcard_count search.config/dashboard-count-ceiling)
    :model      (idx-rank :model_rank (count search.config/all-models))})
 

--- a/src/metabase/search/spec.clj
+++ b/src/metabase/search/spec.clj
@@ -38,6 +38,7 @@
          :name
          :official-collection
          :dashboardcard-count
+         :last-viewed-at
          :pinned
          :verified                                          ;;  in addition to being a filter, this is also a ranker
          :view-count


### PR DESCRIPTION
The idea here is that we can put more weight on last-viewed time versus any old update (e.g. a migration)

~~I'm not sure how different these times will be in practice.~~

The difference can be quite large in practice!

```sql
select (d.updated_at - d.last_viewed_at) as updated_after from report_dashboard d order by updated_after desc;
```

```
117 days 4 hours 25 mins 26.3969 secs
101 days 0 hours 57 mins 38.19332 secs
97 days 21 hours 20 mins 26.857349 secs
....
-772 days -18 hours -43 mins -35.795375 secs
```

The negative records are surprising, I would expect us to bump updated_at whenever we view it?

In any case, this justifies the ranker change quite well.