### PR TITLE
Fix flaky dashboard filter test

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-required-simple-filter.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-required-simple-filter.cy.spec.js
@@ -1,4 +1,5 @@
 import {
+  changeSynchronousBatchUpdateSetting,
   clearFilterWidget,
   editDashboard,
   restore,
@@ -43,6 +44,7 @@ describe("scenarios > dashboard > filters > SQL > simple filter > required ", ()
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
+    changeSynchronousBatchUpdateSetting(true);
 
     cy.createNativeQuestionAndDashboard({
       questionDetails,
@@ -64,6 +66,10 @@ describe("scenarios > dashboard > filters > SQL > simple filter > required ", ()
 
       visitDashboard(dashboard_id);
     });
+  });
+
+  afterEach(() => {
+    changeSynchronousBatchUpdateSetting(false);
   });
 
   it("should respect default filter precedence while properly updating the url for each step of the flow", () => {


### PR DESCRIPTION
### Description

Fixes top flaky test (see https://stats.metabase.com/question/18032 but exclude branches containing `metabot`).
Example failures:
- https://github.com/metabase/metabase/actions/runs/11846659470
- https://github.com/metabase/metabase/actions/runs/11857360075

### How to verify

Stress test: https://github.com/metabase/metabase/actions/runs/11857429381
