### PR TITLE
fix(sdk): remove `Cannot update a component XX` error

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-init-data.ts
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-init-data.ts
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import { useMount } from "react-use";
 import _ from "underscore";
 
@@ -37,9 +37,13 @@ export const useInitData = ({ config }: InitDataLoaderParameters) => {
   if (api.basename !== config.metabaseInstanceUrl) {
     api.basename = config.metabaseInstanceUrl;
   }
-  if (config.fetchRequestToken !== fetchRefreshTokenFnFromStore) {
-    dispatch(setFetchRefreshTokenFn(config.fetchRequestToken ?? null));
-  }
+
+  useEffect(() => {
+    if (config.fetchRequestToken !== fetchRefreshTokenFnFromStore) {
+      // This needs to be a useEffect to avoid the `Cannot update a component XX while rendering a different component` error
+      dispatch(setFetchRefreshTokenFn(config.fetchRequestToken ?? null));
+    }
+  }, [config.fetchRequestToken, fetchRefreshTokenFnFromStore, dispatch]);
 
   useMount(() => {
     if (hasBeenInitialized.current) {


### PR DESCRIPTION
different component` error

This PR removes this error that shows up just by rendering the provider.

The issue is solved by adding back a useEffect I previously removed, but since doing something similar on the lines above introduces a bug (which is the reason I removed the useEffects) I added a test for that specific case

<img width="1382" alt="image" src="https://github.com/user-attachments/assets/043c83cb-8854-45bb-9790-d54ffe7b93bb">

# Demo
<img width="698" alt="image" src="https://github.com/user-attachments/assets/9ce76d2d-0469-443c-a3d2-673b657a5604">
