### PR TITLE
fix(sdk): populate the store with initial values from the config

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
@@ -111,7 +111,7 @@ export const MetabaseProvider = memo(function MetabaseProvider(
   // we need a different store for each test or each storybook story
   const storeRef = useRef<Store<SdkStoreState, Action> | undefined>(undefined);
   if (!storeRef.current) {
-    storeRef.current = getSdkStore();
+    storeRef.current = getSdkStore(props.config);
   }
 
   return (

--- a/enterprise/frontend/src/embedding-sdk/store/reducer.ts
+++ b/enterprise/frontend/src/embedding-sdk/store/reducer.ts
@@ -63,7 +63,7 @@ export const setUsageProblem = createAction<SdkUsageProblem | null>(
   SET_USAGE_PROBLEM,
 );
 
-const initialState: SdkState = {
+export const sdkInitialState: SdkState = {
   metabaseInstanceUrl: "",
   token: {
     token: null,
@@ -79,7 +79,7 @@ const initialState: SdkState = {
   fetchRefreshTokenFn: null,
 };
 
-export const sdk = createReducer(initialState, builder => {
+export const sdk = createReducer(sdkInitialState, builder => {
   builder.addCase(refreshTokenAsync.pending, state => {
     state.token = { ...state.token, loading: true };
   });


### PR DESCRIPTION
> [!NOTE]  
> I don't have a strong opinion on this refactor, feel free to suggest to not merge it.



I did this refactor while working on https://github.com/metabase/metabase/pull/50078, thinking it was needed, it turns out it wasn't needed as only the `api.basename` created issues if wrapped on a useEffect.

Since I had the code already ready I thought it was worth opening the pr anyway

The most useful thing of this refactor though is that we don't see the action in the redux log as we see directly the computed initial state