### PR TITLE
XLSX Pivot Exports Now Use The Sort Settings from Viz Settings

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -126,6 +126,7 @@
   org.apache.poi/poi-ooxml                  {:mvn/version "5.2.5"
                                              :exclusions  [org.bouncycastle/bcpkix-jdk15on
                                                            org.bouncycastle/bcprov-jdk15on]}
+  org.apache.poi/poi-ooxml-full             {:mvn/version "5.2.5"}
   org.apache.sshd/sshd-core                 {:mvn/version "2.12.1"              ; ssh tunneling and test server
                                              :exclusions  [org.slf4j/slf4j-api
                                                            org.slf4j/jcl-over-slf4j]}

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -614,12 +614,14 @@
     (doseq [idx pivot-measures]
       (.addColumnLabel pivot-table DataConsolidateFunction/SUM #_(get aggregation-functions idx DataConsolidateFunction/SUM) idx))
     (doseq [[idx sort-setting] column-sort-order]
-      (-> pivot-table
-          .getCTPivotTableDefinition
-          .getPivotFields
-          (.getPivotFieldArray idx)
-          (.setSortType (sort-setting {:ascending  STFieldSortType/ASCENDING
-                                       :descending STFieldSortType/DESCENDING}))))
+      (let [setting (sort-setting {:ascending  STFieldSortType/ASCENDING
+                                   :descending STFieldSortType/DESCENDING})]
+        (when setting
+          (-> pivot-table
+              .getCTPivotTableDefinition
+              .getPivotFields
+              (.getPivotFieldArray idx)
+              (.setSortType setting)))))
     (let [swb   (-> (SXSSFWorkbook. ^XSSFWorkbook wb)
                     (doto (.setCompressTempFiles true)))
           sheet (spreadsheet/select-sheet "data" swb)]

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -25,7 +25,8 @@
    (org.apache.poi.ss.usermodel Cell DataConsolidateFunction DataFormat DateUtil Workbook)
    (org.apache.poi.ss.util AreaReference CellRangeAddress CellReference)
    (org.apache.poi.xssf.streaming SXSSFRow SXSSFSheet SXSSFWorkbook)
-   (org.apache.poi.xssf.usermodel XSSFPivotTable XSSFRow XSSFSheet XSSFWorkbook)))
+   (org.apache.poi.xssf.usermodel XSSFPivotTable XSSFRow XSSFSheet XSSFWorkbook)
+   (org.openxmlformats.schemas.spreadsheetml.x2006.main STFieldSortType)))
 
 (set! *warn-on-reflection* true)
 
@@ -576,7 +577,7 @@
 ;; Since we're the ones creating the file, we can lower the ratio to get what we want.
 (ZipSecureFile/setMinInflateRatio 0.001)
 (defn- init-native-pivot
-  [{:keys [pivot-grouping-key] :as pivot-spec}
+  [{:keys [pivot-grouping-key column-sort-order] :as pivot-spec}
    {:keys [ordered-cols col-settings viz-settings format-rows?]}]
   (let [idx-shift                   (fn [indices]
                                       (map (fn [idx]
@@ -612,6 +613,13 @@
       (.addColLabel pivot-table idx))
     (doseq [idx pivot-measures]
       (.addColumnLabel pivot-table DataConsolidateFunction/SUM #_(get aggregation-functions idx DataConsolidateFunction/SUM) idx))
+    (doseq [[idx sort-setting] column-sort-order]
+      (-> pivot-table
+          .getCTPivotTableDefinition
+          .getPivotFields
+          (.getPivotFieldArray idx)
+          (.setSortType (sort-setting {:ascending  STFieldSortType/ASCENDING
+                                       :descending STFieldSortType/DESCENDING}))))
     (let [swb   (-> (SXSSFWorkbook. ^XSSFWorkbook wb)
                     (doto (.setCompressTempFiles true)))
           sheet (spreadsheet/select-sheet "data" swb)]

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -614,8 +614,9 @@
     (doseq [idx pivot-measures]
       (.addColumnLabel pivot-table DataConsolidateFunction/SUM #_(get aggregation-functions idx DataConsolidateFunction/SUM) idx))
     (doseq [[idx sort-setting] column-sort-order]
-      (let [setting (sort-setting {:ascending  STFieldSortType/ASCENDING
-                                   :descending STFieldSortType/DESCENDING})]
+      (let [setting (case sort-setting
+                      :ascending STFieldSortType/ASCENDING
+                      :descending STFieldSortType/DESCENDING)]
         (when setting
           (-> pivot-table
               .getCTPivotTableDefinition


### PR DESCRIPTION
Fixes #49416

Prior to this PR, the xlsx pivot exports worked correctly except for the fact that no sorting (ascending or descending) was applied to the pivot rows or columns. Now, those settings are used when they exist.

NOTE: I cannot create a unit test that inspects the appearance of a Pivot table in the xlsx file since its contents are not calculated. They only get calculated when the file is first opened by Excel or Numbers or Sheets, until then the pivot table is merely a definition.
