### PR TITLE
[refs] Ensure all column-creating clauses have idents on read

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/backfill_ids.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/backfill_ids.clj
@@ -8,7 +8,6 @@
    [metabase-enterprise.serialization.v2.models :as serdes.models]
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
-   [metabase.util :as u]
    [metabase.util.log :as log]
    [toucan2.core :as t2]
    [toucan2.model :as t2.model]))
@@ -21,8 +20,7 @@
     (when (seq missing)
       (log/infof "Backfilling entity_id for %s rows of %s" (pr-str (count missing)) (name model))
       (doseq [entity missing
-              :let [hashed (serdes/identity-hash entity)
-                    eid    (u/generate-nano-id hashed)]]
+              :let [eid (serdes/backfill-entity-id entity)]]
         (t2/update! model (get entity pk) {:entity_id eid})))))
 
 (defn has-entity-id?

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -1,6 +1,7 @@
 (ns ^:mb/once metabase-enterprise.serialization.v2.e2e-test
   (:require
    [clojure.java.io :as io]
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [medley.core :as m]
    [metabase-enterprise.serialization.cmd :as cmd]
@@ -914,3 +915,73 @@
                                             {:aggregation [[:metric (:id new-metric)]]
                                              :breakout    [[:field %orders.user_id nil]]})}
                           (t2/select-one :model/Card :name "Metric Consuming Question Card"))))))))))))
+
+(deftest ^:sequential query-idents-stable-across-serdes-test-1-randomized-idents
+  (ts/with-random-dump-dir [dump-dir "serdesv2-"]
+    (ts/with-dbs [source-db dest-db]
+      (ts/with-db source-db
+        (t2.with-temp/with-temp
+          [:model/Collection {coll-id :id}    {:name "Collection"}
+           :model/Card       {card-id :id
+                              eid :entity_id} {:name "The Card"
+                                               :collection_id coll-id
+                                               :dataset_query
+                                               (mt/mbql-query orders
+                                                 {:aggregation [[:count] [:sum $subtotal]]
+                                                  :breakout    [$product_id->products.category $created_at]})}]
+          (let [extraction (serdes/with-cache (into [] (extract/extract {})))]
+            (storage/store! (seq extraction) dump-dir))
+          (let [original (:query (:dataset_query (t2/select-one :model/Card :id card-id)))]
+            (ts/with-db dest-db
+              (is (serdes/with-cache (serdes.load/load-metabase! (ingest/ingest-yaml dump-dir)))
+                  "ingested successfully")
+              (let [imported (:query (:dataset_query (t2/select-one :model/Card :entity_id eid)))]
+                (is (= (select-keys original [:aggregation-idents :breakout-idents])
+                       (select-keys imported [:aggregation-idents :breakout-idents])))))))))))
+
+(deftest ^:sequential query-idents-stable-across-serdes-test-2-preexisting-card
+  (ts/with-random-dump-dir [dump-dir "serdesv2-"]
+    (ts/with-dbs [source-db dest-db]
+      (ts/with-db source-db
+        (let [base (mt/$ids orders
+                     {:database (mt/id)
+                      :type     :query
+                      :query    {:source-table $$orders
+                                 :aggregation  [[:count] [:sum $subtotal]]
+                                 :breakout     [$product_id->products.category $created_at]}})]
+          (t2.with-temp/with-temp
+            [:model/Collection {coll-id :id}    {:name "Collection"}
+             :model/Card       {card-id :id
+                                eid :entity_id} {:name "The Card"
+                                                 :collection_id coll-id
+                                                 :dataset_query base}]
+            ;; When that temp Card got `t2/insert!`-ed, it had randomized idents generated. Strip them off.
+            (t2/update! :model/Card card-id {:dataset_query base})
+            ;; Now serialize this card!
+            (let [extraction (serdes/with-cache (into [] (extract/extract {})))]
+              (storage/store! (seq extraction) dump-dir))
+
+            (let [original (:dataset_query (t2/select-one :model/Card :id card-id))]
+              (ts/with-db dest-db
+                (is (serdes/with-cache (serdes.load/load-metabase! (ingest/ingest-yaml dump-dir)))
+                    "ingested successfully")
+                (let [imported    (t2/select-one :model/Card :entity_id eid)
+                      ;; The card was imported with the (backfilled) idents on it; strip those off too.
+                      ;; This simulates a Card that was serialized prior to the `:ident`s being added.
+                      stripped    (-> imported
+                                      :dataset_query
+                                      (update :query dissoc :aggregation-idents :breakout-idents))
+                      _           (t2/update! :model/Card (:id imported) {:dataset_query stripped})
+                      ;; Now on reading the card again, its idents will be backfilled on the client.
+                      preexisting (:dataset_query (t2/select-one :model/Card :entity_id eid))]
+                  (testing "the dest card has no idents as stored in appdb"
+                    (is (nil? (-> (t2/select-one :report_card :id (:id imported))
+                                  :dataset_query
+                                  (str/index-of "-idents")))))
+                  (testing "reading a preexisting card (without idents) backfills the same idents in each instance"
+                    (is (=? {:query {:aggregation-idents {0 (str "aggregation_" eid "@0__0")}
+                                     :breakout-idents    {0 (str "breakout_" eid "@0__0")}}}
+                            original))
+                    (is (=? {:query {:aggregation-idents {0 (str "aggregation_" eid "@0__0")}
+                                     :breakout-idents    {0 (str "breakout_" eid "@0__0")}}}
+                            preexisting))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -225,14 +225,14 @@
             (reset! serialized (into [] (serdes.extract/extract {})))))
 
         (testing "the serialized form is as desired"
-          (is (= {:type  :query
-                  :query {:source-table ["my-db" nil "customers"]
-                          :filter       [:>= [:field ["my-db" nil "customers" "age"] nil] 18]
-                          :aggregation  [[:count]]}
-                  :database "my-db"}
-                 (->> (by-model @serialized "Card")
-                      first
-                      :dataset_query))))
+          (let [card (first (by-model @serialized "Card"))]
+            (is (=? {:type  :query
+                     :query {:source-table ["my-db" nil "customers"]
+                             :filter       [:>= [:field ["my-db" nil "customers" "age"] nil] 18]
+                             :aggregation  [[:count]]
+                             :aggregation-idents {0 string?}}
+                     :database "my-db"}
+                    (:dataset_query card)))))
 
         (testing "deserializing adjusts the IDs properly"
           (ts/with-db dest-db
@@ -259,12 +259,13 @@
             (is (not= (:dataset_query @card1s)
                       (:dataset_query @card1d)))
             (testing "the Card's query is based on the new Database, Table, and Field IDs"
-              (is (= {:type     :query
-                      :query    {:source-table (:id @table1d)
-                                 :filter       [:>= [:field (:id @field1d) nil] 18]
-                                 :aggregation  [[:count]]}
-                      :database (:id @db1d)}
-                     (:dataset_query @card1d))))))))))
+              (is (=? {:type     :query
+                       :query    {:source-table (:id @table1d)
+                                  :filter       [:>= [:field (:id @field1d) nil] 18]
+                                  :aggregation  [[:count]]
+                                  :aggregation-idents {0 string?}}
+                       :database (:id @db1d)}
+                      (:dataset_query @card1d))))))))))
 
 (deftest segment-test
   ;; Segment.definition is a JSON-encoded MBQL query, which contain database, table, and field IDs - these need to be

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -179,7 +179,8 @@
   "Get metrics based on questions
   TODO characterize by # executions and avg latency"
   []
-  (let [cards (t2/select [:model/Card :query_type :public_uuid :enable_embedding :embedding_params :dataset_query :dashboard_id]
+  (let [cards (t2/select [:model/Card :query_type :public_uuid :enable_embedding :embedding_params :dataset_query
+                          :dashboard_id :entity_id :created_at :collection_id :name]
                          {:where (mi/exclude-internal-content-hsql :model/Card)})]
     {:questions (merge-count-maps (for [card cards]
                                     (let [native? (= (keyword (:query_type card)) :native)

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -484,11 +484,12 @@
 
 (api/defendpoint POST "/"
   "Create a new `Card`. Card `type` can be `question`, `metric`, or `model`."
-  [:as {{:keys [collection_id collection_position dataset_query description display name dashboard_id
-                parameters parameter_mappings result_metadata visualization_settings cache_ttl type], :as body} :body}]
+  [:as {{:keys [collection_id collection_position dashboard_id dataset_query description display entity_id
+                name parameters parameter_mappings result_metadata visualization_settings cache_ttl type], :as body} :body}]
   {name                   ms/NonBlankString
    type                   [:maybe ::card-type]
    dataset_query          ms/Map
+   entity_id              [:maybe ms/NonBlankString] ;; TODO: Make that a NanoID regex schema?
    parameters             [:maybe [:sequential ms/Parameter]]
    parameter_mappings     [:maybe [:sequential ms/ParameterMapping]]
    description            [:maybe ms/NonBlankString]

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -493,7 +493,7 @@
     (let [cards (t2/select :model/Card
                            {:select    [:c.id :c.dataset_query :c.result_metadata :c.name
                                         :c.description :c.collection_id :c.database_id :c.type
-                                        :c.source_card_id
+                                        :c.source_card_id :c.created_at :c.entity_id
                                         [:r.status :moderated_status]]
                             :from      [[:report_card :c]]
                             :left-join [[{:select   [:moderated_item_id :status]

--- a/src/metabase/db/metadata_queries.clj
+++ b/src/metabase/db/metadata_queries.clj
@@ -151,11 +151,13 @@
                              (into {} (for [field text-fields]
                                         [field [(str (gensym "substring"))
                                                 [:substring [:field (u/the-id field) nil]
-                                                 1 truncation-size]]])))]
+                                                 1 truncation-size]]])))
+        expressions        (into {} (vals field->expressions))]
     {:database   (:db_id table)
      :type       :query
      :query      (cond-> {:source-table (u/the-id table)
-                          :expressions  (into {} (vals field->expressions))
+                          :expressions  expressions
+                          :expression-idents (update-vals expressions (fn [_] (u/generate-nano-id)))
                           :fields       (vec (for [field fields]
                                                (if-let [[expression-name _] (get field->expressions field)]
                                                  [:expression expression-name]

--- a/src/metabase/lib/metadata/jvm.clj
+++ b/src/metabase/lib/metadata/jvm.clj
@@ -233,9 +233,11 @@
   (merge
    (next-method query-type model parsed-args honeysql)
    {:select    [:card/collection_id
+                :card/created_at   ; Needed for backfilling :entity_id on demand; see [[metabase.models.card]].
                 :card/database_id
                 :card/dataset_query
                 :card/id
+                :card/entity_id
                 :card/name
                 :card/result_metadata
                 :card/table_id

--- a/src/metabase/lib/remove_replace.cljc
+++ b/src/metabase/lib/remove_replace.cljc
@@ -284,7 +284,10 @@
 (defn- local-replace-expression-references [stage target-ref-id replacement-ref]
   (let [replace-embedded-refs (fn replace-refs [stage]
                                 (lib.util.match/replace stage
-                                  [:expression _ target-ref-id] (fresh-ref replacement-ref)))]
+                                  [:expression _ target-ref-id]
+                                  (-> replacement-ref
+                                      fresh-ref
+                                      (lib.common/preserve-ident-of &match))))]
     (replace-embedded-refs stage)))
 
 (defn- local-replace-expression

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -194,6 +194,15 @@
         (f entity))
       raw-hash))
 
+(defn backfill-entity-id
+  "Given an entity with a (possibly empty) `:entity_id` field:
+  - Return the `:entity_id` if it's set.
+  - Compute the backfill `:entity_id` based on the [[identity-hash]]."
+  [entity]
+  (or (:entity_id entity)
+      (:entity-id entity)
+      (u/generate-nano-id (identity-hash entity))))
+
 (defn identity-hash?
   "Returns true if s is a valid identity hash string."
   [s]

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -267,7 +267,7 @@
   {:pre [(int? card-id) (u/maybe? sequential? parameters)]}
   (let [card       (api/read-check (t2/select-one [:model/Card :id :name :dataset_query :database_id :collection_id
                                                    :type :result_metadata :visualization_settings :display
-                                                   :cache_invalidated_at]
+                                                   :cache_invalidated_at :entity_id :created_at]
                                                   :id card-id))
         dash-viz   (when (and (not= context :question)
                               dashcard-id)

--- a/src/metabase/related.clj
+++ b/src/metabase/related.clj
@@ -5,6 +5,7 @@
    [medley.core :as m]
    [metabase.api.common :as api]
    [metabase.legacy-mbql.normalize :as mbql.normalize]
+   [metabase.legacy-mbql.util :as mbql.u]
    [metabase.models.interface :as mi]
    [metabase.query-processor.util :as qp.util]
    [metabase.util.malli.registry :as mr]
@@ -25,12 +26,17 @@
            qp.util/normalize-token)]]
    [:* :any]])
 
+(defn- strip-idents [clause]
+  (cond-> clause
+    (mbql.u/is-clause? :field clause) (update 2 dissoc :ident)))
+
 (defn- collect-context-bearing-forms
   [form]
   (let [form (mbql.normalize/normalize-fragment [:query :filter] form)]
     (into #{}
           (comp (filter (mr/validator ContextBearingForm))
-                (map #(update % 0 qp.util/normalize-token)))
+                (map #(update % 0 qp.util/normalize-token))
+                (map strip-idents))
           (tree-seq sequential? identity form))))
 
 (defmulti definition

--- a/test/metabase/api/alert_test.clj
+++ b/test/metabase/api/alert_test.clj
@@ -64,7 +64,9 @@
     :details       {}}))
 
 (defn- alert-response [response]
-  (m/dissoc-in response [:creator :last_login]))
+  (-> response
+      (m/dissoc-in [:creator :last_login])
+      (m/dissoc-in [:card :collection])))
 
 (defmacro ^:private with-test-email! [& body]
   `(mt/with-temporary-setting-values [~'site-url "https://metabase.com/testmb"]

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -1,6 +1,8 @@
 (ns metabase.models.card-test
   (:require
+   [clojure.data :as data]
    [clojure.set :as set]
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.audit :as audit]
@@ -9,6 +11,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.jvm :as lib.metadata.jvm]
+   [metabase.lib.test-metadata :as meta]
    [metabase.models.card :as card]
    [metabase.models.interface :as mi]
    [metabase.models.parameter-card :as parameter-card]
@@ -1189,44 +1192,44 @@
         (is (= "Orders, Count"
                (:query_description (t2/select-one :model/Card :id id))))))))
 
-(def ^:private bare-query
-  {:database 1
-   :type     :query
-   :query    {:source-query {:source-table 12
-                             :aggregation [[:count] [:sum [:field 9 nil]]]
-                             :breakout    [[:field 8 nil] [:expression "yo"]]
-                             :expressions {"yo" [:+ [:field 8 nil] 7]}}
-              :joins        [{:alias        "a_join"
-                              :condition    [:= [:field 8 nil] [:field 88 {:join-alias "a_join"}]]
-                              :source-table 21}
-                             {:alias        "another_join"
-                              :condition    [:= [:field 8 nil]
-                                             [:field 88 {:join-alias "another_join"}]]
-                              :source-table 22}]}})
+(defn- bare-query []
+  (mt/$ids orders
+    {:database (mt/id)
+     :type     :query
+     :query    {:source-query {:source-table $$orders
+                               :aggregation  [[:count] [:sum $subtotal]]
+                               :breakout     [$subtotal [:expression "yo"]]
+                               :expressions  {"yo" [:+ $subtotal 7]}}
+                :joins        [{:alias        "a_join"
+                                :condition    [:= $product_id &a_join.products.id]
+                                :source-table $$products}
+                               {:alias        "another_join"
+                                :condition    [:= $user_id &another_join.people.id]
+                                :source-table $$people}]}}))
 
 (defn- bare-query-exp [eid]
-  {:source-query {:source-table       12
-                  :aggregation        [[:count] [:sum [:field 9 nil]]]
-                  :aggregation-idents {0 (str "aggregation_" eid "@0__0")
-                                       1 (str "aggregation_" eid "@0__1")}
-                  :breakout           [[:field 8 nil] [:expression "yo"]]
-                  :breakout-idents    {0 (str "breakout_" eid "@0__0")
-                                       1 (str "breakout_" eid "@0__1")}
-                  :expressions        {"yo" [:+ [:field 8 nil] 7]}
-                  :expression-idents  {"yo" (str "expression_" eid "@0__yo")}}
-   :joins        [{:alias "a_join"
-                   :ident (str "join_" eid "@1__a_join")}
-                  {:alias "another_join"
-                   :ident (str "join_" eid "@1__another_join")}]})
+  (mt/$ids orders
+    {:source-query {:source-table       $$orders
+                    :aggregation        [[:count] [:sum $subtotal]]
+                    :aggregation-idents {0 (str "aggregation_" eid "@0__0")
+                                         1 (str "aggregation_" eid "@0__1")}
+                    :breakout           [$subtotal [:expression "yo"]]
+                    :breakout-idents    {0 (str "breakout_" eid "@0__0")
+                                         1 (str "breakout_" eid "@0__1")}
+                    :expressions        {"yo" [:+ $subtotal 7]}
+                    :expression-idents  {"yo" (str "expression_" eid "@0__yo")}}
+     :joins        [{:alias "a_join"
+                     :ident (str "join_" eid "@1__a_join")}
+                    {:alias "another_join"
+                     :ident (str "join_" eid "@1__another_join")}]}))
 
 (deftest ^:sequential idents-populated-on-insert
   (mt/with-temp [:model/Card {eid   :entity_id
                               query :dataset_query} {:name          "A card"
-                                                     :dataset_query bare-query}]
+                                                     :dataset_query (bare-query)}]
     (testing "on insert, a :dataset_query with missing idents gets them filled in"
       (is (string? eid))
-      (is (=? {:source-query {:source-table 12
-                              :aggregation-idents {0 string?}
+      (is (=? {:source-query {:aggregation-idents {0 string?}
                               :breakout-idents    {0 string?}
                               :expression-idents  {"yo" string?}}
                :joins        [{:alias "a_join"
@@ -1237,9 +1240,9 @@
 
 (deftest ^:sequential entity-id-used-for-idents-if-missing-test
   (mt/with-temp [:model/Card {id :id} {:name          "A card"
-                                       :dataset_query bare-query}]
+                                       :dataset_query (bare-query)}]
     ;; :idents are populated on initial insert; update to remove them. (Update does not populate them like insert.)
-    (t2/update! :model/Card id {:dataset_query bare-query})
+    (t2/update! :model/Card id {:dataset_query (bare-query)})
     ;; Can't use the one from `with-temp` since it came before the above edit.
     (let [{eid   :entity_id
            query :dataset_query} (t2/select-one :model/Card :id id)]
@@ -1251,10 +1254,10 @@
 
 (deftest ^:sequential fall-back-to-hashing-entity-id-test
   (mt/with-temp [:model/Card {id :id} {:name          "A card"
-                                       :dataset_query bare-query}]
+                                       :dataset_query (bare-query)}]
     ;; :idents are populated on initial insert; update to remove them. (Update does not populate them like insert.)
     ;; Also remove the generated :entity_id.
-    (t2/update! :model/Card id {:dataset_query bare-query
+    (t2/update! :model/Card id {:dataset_query (bare-query)
                                 :entity_id     nil})
     ;; Can't use the one from `with-temp` since it came before the above edit.
     (let [{eid   :entity_id
@@ -1265,3 +1268,359 @@
         (is (string? eid))
         (is (=? (bare-query-exp eid)
                 (:query query)))))))
+
+(deftest ^:sequential e2e-entity-id-and-idents-test
+  (mt/with-temp [:model/Card {id :id} {:name          "A card"
+                                       :dataset_query (bare-query)}]
+    ;; :idents are populated on initial insert; update to remove them. (Update does not populate them like insert.)
+    ;; Also remove the generated :entity_id.
+    (t2/update! :model/Card id {:dataset_query (bare-query)
+                                :entity_id     nil})
+    ;; Can't use the one from `with-temp` since it came before the above edit.
+    (let [{eid   :entity_id
+           query :dataset_query} (t2/select-one :model/Card :id id)]
+      (testing "idents should be populated on read"
+        ;; These idents are: kind_EID@stage__index, eg. "aggregation_4QsLuEnriHKkXCWqbPMQ8@0__0"
+        ;; The entity_id is hashed based on created_at, so it's still always different!
+        (is (string? eid))
+        (is (=? (bare-query-exp eid)
+                (:query query)))
+
+        (testing "but not written back to appdb"
+          (let [{raw-query :dataset_query} (t2/select-one :report_card :id id)]
+            (is (string? raw-query))
+            (is (nil? (str/index-of raw-query "-idents")))))
+
+        (testing "converted to pMBQL"
+          (let [converted   (lib/query (lib.metadata.jvm/application-database-metadata-provider (mt/id)) query)
+                agg-idents  (-> query :query :source-query :aggregation-idents)
+                brk-idents  (-> query :query :source-query :breakout-idents)
+                expr-idents (-> query :query :source-query :expression-idents)
+                [jid1 jid2] (->> query :query :joins (map :ident))
+                expected    {:stages [{:aggregation [[:count {:ident (get agg-idents 0)}]
+                                                     [:sum   {:ident (get agg-idents 1)} some?]]
+                                       :breakout    [[:field      {:ident (get brk-idents 0)} some?]
+                                                     [:expression {:ident (get brk-idents 1)} some?]]
+                                       :expressions [[:+ {:lib/expression-name "yo"
+                                                          :ident               (get expr-idents "yo")}
+                                                      vector? 7]]}
+                                      {:joins [{:alias "a_join"
+                                                :ident jid1}
+                                               {:alias "another_join"
+                                                :ident jid2}]}]}
+                exp-legacy  {:query {:source-query {:aggregation-idents agg-idents
+                                                    :breakout-idents    brk-idents
+                                                    :expression-idents  expr-idents}
+                                     :joins [{:alias "a_join"
+                                              :ident jid1}
+                                             {:alias "another_join"
+                                              :ident jid2}]}}]
+            (is (=? expected converted))
+
+            (testing "and converted back to legacy"
+              (is (=? exp-legacy (lib.convert/->legacy-MBQL converted))))
+
+            (testing "edited without changing the idents"
+              (let [[expr] (lib/expressions converted 0)
+                    edited (lib/replace-clause converted 0 expr (lib/with-expression-name expr "new name"))]
+                (is (=? (assoc-in expected [:stages 0 :expressions 0 1 :lib/expression-name] "new name")
+                        edited))
+
+                (testing "converted back to legacy"
+                  (let [round-trip (lib.convert/->legacy-MBQL edited)
+                        exp-edited (update-in exp-legacy [:query :source-query :expression-idents]
+                                              update-keys (constantly "new name"))]
+                    (is (=? exp-edited round-trip))
+
+                    (testing "saved to appdb, preserving the idents"
+                      (t2/update! :model/Card id {:dataset_query round-trip})
+                      (let [{raw    :dataset_query} (t2/select-one :report_card :id id)
+                            {cooked :dataset_query} (t2/select-one :model/Card  :id id)]
+                        (doseq [ident (concat (vals agg-idents)
+                                              (vals brk-idents)
+                                              (vals expr-idents)
+                                              [jid1 jid2])]
+                          (is (number? (str/index-of raw ident))))
+                        (is (=? exp-edited cooked))))))))))))))
+
+(defn- nano-id? [x]
+  (and (string? x)
+       (boolean (re-matches #"^[A-Za-z0-9_-]{21}$" x))))
+
+(def ^:private idents-randomized
+  {:query {:joins        [{:ident nano-id?}
+                          {:ident nano-id?}]
+           :source-query {:aggregation-idents {0 nano-id?, 1 nano-id?}
+                          :breakout-idents    {0 nano-id?, 1 nano-id?}
+                          :expression-idents  {"yo" nano-id?}}}})
+
+(def ^:private idents-backfilled
+  {:query {:joins        [{:ident #"^join_[A-Za-z0-9_-]{21}@1__a_join"}
+                          {:ident #"^join_[A-Za-z0-9_-]{21}@1__another_join"}]
+           :source-query {:aggregation-idents {0 #"aggregation_[A-Za-z0-9_-]{21}@0__0"
+                                               1 #"aggregation_[A-Za-z0-9_-]{21}@0__1"}
+                          :breakout-idents    {0 #"breakout_[A-Za-z0-9_-]{21}@0__0"
+                                               1 #"breakout_[A-Za-z0-9_-]{21}@0__1"}
+                          :expression-idents  {"yo" #"expression_[A-Za-z0-9_-]{21}@0__yo"}}}})
+
+(deftest ^:sequential ident-invariant-test-1a-two-cards-with-identical-queries
+  (testing ":ident invariant: two cards with identical queries get unique idents"
+    (mt/with-temp [:model/Card {id1 :id} {:name          "First card"
+                                          :dataset_query (bare-query)}
+
+                   :model/Card {id2 :id} {:name          "Second card"
+                                          :dataset_query (bare-query)}]
+      (testing "with randomized idents from initial insert"
+        (let [{q1 :dataset_query} (t2/select-one :model/Card :id id1)
+              {q2 :dataset_query} (t2/select-one :model/Card :id id2)]
+          ;; Comparing the diff here implies (1) they are different, and (2) each one matches the pattern.
+          (is (=? [idents-randomized idents-randomized some?]
+                  (data/diff q1 q2)))))
+
+      (testing "with :idents removed from one card"
+        ;; Strip the idents off `id1`. update! does not populate idents like insert! does.
+        (t2/update! :model/Card id1 {:dataset_query (bare-query)})
+        (let [{q1 :dataset_query} (t2/select-one :model/Card :id id1)
+              {q2 :dataset_query} (t2/select-one :model/Card :id id2)]
+          (is (=? idents-backfilled q1))
+          (is (=? idents-randomized q2))))
+
+      (testing "with :idents removed from both cards"
+        ;; Strip the idents off `id2` as well.
+        (t2/update! :model/Card id2 {:dataset_query (bare-query)})
+        (let [{q1 :dataset_query} (t2/select-one :model/Card :id id1)
+              {q2 :dataset_query} (t2/select-one :model/Card :id id2)]
+          ;; Using diff again: implies that they're different, and that both match `idents-backfilled`.
+          (is (=? [idents-backfilled idents-backfilled some?]
+                  (data/diff q1 q2))))))))
+
+(deftest ^:sequential ident-invariant-test-1b-agg-in-two-stages
+  (testing ":ident invariant: two identical aggregations in different stages get unique idents"
+    (let [query (mt/$ids orders
+                  {:database (mt/id)
+                   :type     :query
+                   :query    {:source-query {:source-table $$orders
+                                             :aggregation  [[:count]]}
+                              :aggregation  [[:count]]}})]
+      (mt/with-temp [:model/Card {id :id} {:name          "The card"
+                                           :dataset_query query}]
+        (testing "with randomized idents from initial insert"
+          (let [query (->> (t2/select-one :model/Card :id id) :dataset_query :query)]
+            (is (=? nano-id? (get-in query [:aggregation-idents 0])))
+            (is (=? nano-id? (get-in query [:source-query :aggregation-idents 0])))
+            (is (not= (get-in query [:aggregation-idents 0])
+                      (get-in query [:source-query :aggregation-idents 0])))))
+
+        (testing "with :idents backfilled"
+          ;; Strip the idents off `id`. update! does not populate idents like insert! does.
+          (t2/update! :model/Card id {:dataset_query query})
+          (let [query (->> (t2/select-one :model/Card :id id) :dataset_query :query)]
+            (is (=? #"aggregation_[A-Za-z0-9_-]{21}@1__0" (get-in query [:aggregation-idents 0])))
+            (is (=? #"aggregation_[A-Za-z0-9_-]{21}@0__0" (get-in query [:source-query :aggregation-idents 0])))
+            (is (not= (get-in query [:aggregation-idents 0])
+                      (get-in query [:source-query :aggregation-idents 0])))))))))
+
+(deftest ^:sequential ident-invariant-test-1c-duplicate-aggs
+  (testing ":ident invariant: two identical aggregations in one stage get unique idents"
+    (let [query (mt/$ids orders
+                  {:database (mt/id)
+                   :type     :query
+                   :query    {:source-table $$orders
+                              :aggregation  [[:count] [:count]]}})]
+      (mt/with-temp [:model/Card {id :id} {:name          "The card"
+                                           :dataset_query query}]
+        (testing "with randomized idents from initial insert"
+          (let [{ident0 0
+                 ident1 1} (->> (t2/select-one :model/Card :id id) :dataset_query :query :aggregation-idents)]
+            (is (=? nano-id? ident0))
+            (is (=? nano-id? ident1))
+            (is (not= ident0 ident1))))
+
+        (testing "with :idents backfilled"
+          ;; Strip the idents off `id`. update! does not populate idents like insert! does.
+          (t2/update! :model/Card id {:dataset_query query})
+          (let [{ident0 0
+                 ident1 1} (->> (t2/select-one :model/Card :id id) :dataset_query :query :aggregation-idents)]
+            (is (=? #"aggregation_[A-Za-z0-9_-]{21}@0__0" ident0))
+            (is (=? #"aggregation_[A-Za-z0-9_-]{21}@0__1" ident1))
+            (is (not= ident0 ident1))))))))
+
+(deftest ^:sequential ident-invariant-test-1d-time-granularity
+  (testing ":ident invariant: two breakouts with different time granularity get unique idents"
+    (let [query (mt/$ids orders
+                  {:database (mt/id)
+                   :type     :query
+                   :query    {:source-table $$orders
+                              :aggregation  [[:count]]
+                              :breakout     [!month.created_at !day.created_at]}})]
+      (mt/with-temp [:model/Card {id :id} {:name          "The card"
+                                           :dataset_query query}]
+        (testing "with randomized idents from initial insert"
+          (let [{{agg0 0} :aggregation-idents
+                 {brk0 0
+                  brk1 1} :breakout-idents} (->> (t2/select-one :model/Card :id id) :dataset_query :query)]
+            (is (=? nano-id? agg0))
+            (is (=? nano-id? brk0))
+            (is (=? nano-id? brk1))
+            (is (= 3 (count #{agg0 brk0 brk1})))))
+
+        (testing "with :idents backfilled"
+          ;; Strip the idents off `id`. update! does not populate idents like insert! does.
+          (t2/update! :model/Card id {:dataset_query query})
+          (let [{{agg0 0} :aggregation-idents
+                 {brk0 0
+                  brk1 1} :breakout-idents} (->> (t2/select-one :model/Card :id id) :dataset_query :query)]
+            (is (=? #"aggregation_[A-Za-z0-9_-]{21}@0__0" agg0))
+            (is (=? #"breakout_[A-Za-z0-9_-]{21}@0__0"    brk0))
+            (is (=? #"breakout_[A-Za-z0-9_-]{21}@0__1"    brk1))
+            (is (= 3 (count #{agg0 brk0 brk1})))))))))
+
+(deftest ^:sequential ident-invariant-test-2a-new-clause-random-ident
+  (testing ":ident invariant: a new clause keeps its randomized ident"
+    (let [base  (mt/$ids orders
+                  {:database (mt/id)
+                   :type     :query
+                   :query    {:source-table $$orders
+                              :aggregation  [[:count]]
+                              :breakout     [!month.created_at]}})
+          touch (fn [query]
+                  (-> (lib/query (lib.metadata.jvm/application-database-metadata-provider (mt/id)) query)
+                      (lib/aggregate (lib/sum (meta/field-metadata :orders :subtotal)))
+                      lib.convert/->legacy-MBQL))]
+      (mt/with-temp [:model/Card {id :id} {:name          "The card"
+                                           :dataset_query base}]
+        (testing "with randomized idents from initial insert"
+          (let [original  (:dataset_query (t2/select-one :model/Card :id id))
+                modified  (touch original)
+                new-ident (get-in modified [:query :aggregation-idents 1])
+                _         (t2/update! :model/Card id {:dataset_query modified})
+                reread    (:dataset_query (t2/select-one :model/Card :id id))]
+            (is (= modified reread))
+            ;; Expects a diff with nothing removed, and only the new aggregation and its ident added.
+            (is (=? [nil
+                     {:query {:aggregation   [nil [:sum some?]]
+                              :aggregation-idents {1 new-ident}}}
+                     some?]
+                    (data/diff original modified)))))
+
+        (testing "with :idents backfilled"
+          ;; Strip the idents off `id`. update! does not populate idents like insert! does.
+          (t2/update! :model/Card id {:dataset_query base})
+          (let [original  (:dataset_query (t2/select-one :model/Card :id id))
+                modified  (touch original)
+                new-ident (get-in modified [:query :aggregation-idents 1])
+                _         (t2/update! :model/Card id {:dataset_query modified})
+                reread    (:dataset_query (t2/select-one :model/Card :id id))]
+            (is (= modified reread))
+            (is (nano-id? new-ident))
+            ;; Expects a diff with nothing removed, and only the new aggregation and its ident added.
+            (is (=? [nil
+                     {:query {:aggregation   [nil [:sum some?]]
+                              :aggregation-idents {1 new-ident}}}
+                     some?]
+                    (data/diff original modified)))))))))
+
+(deftest ^:sequential ident-invariant-test-2b-removed-clause
+  (testing ":ident invariant: removing a clause preserves other idents - EVEN IF they encode now-incorrect indexes!"
+    (let [base  (mt/$ids orders
+                  {:database (mt/id)
+                   :type     :query
+                   :query    {:source-table $$orders
+                              :aggregation  [[:count] [:sum $subtotal]]
+                              :breakout     [!month.created_at $products.category]}})
+          touch (fn [query]
+                  (let [converted (lib/query (lib.metadata.jvm/application-database-metadata-provider (mt/id)) query)
+                        [agg0]    (lib/aggregations converted)
+                        [brk0]    (lib/breakouts converted)]
+                    (-> converted
+                        (lib/remove-clause agg0)
+                        (lib/remove-clause brk0)
+                        lib.convert/->legacy-MBQL)))]
+      (mt/with-temp [:model/Card {id :id} {:name          "The card"
+                                           :dataset_query base}]
+        (testing "with randomized idents from initial insert"
+          (let [original   (:dataset_query (t2/select-one :model/Card :id id))
+                modified   (touch original)
+                _          (t2/update! :model/Card id {:dataset_query modified})
+                reread     (:dataset_query (t2/select-one :model/Card :id id))
+                agg-idents (-> original :query :aggregation-idents)
+                brk-idents (-> original :query :breakout-idents)]
+            (is (= modified reread))
+            (is (= 2
+                   (-> agg-idents vals set count)
+                   (-> brk-idents vals set count)))
+            ;; NOTE: What were previously the 1st clauses is now 0th; their idents have not changed.
+            (is (= {0 (get agg-idents 1)}
+                   (-> modified :query :aggregation-idents)))
+            (is (= {0 (get brk-idents 1)}
+                   (-> modified :query :breakout-idents)))))
+
+        (testing "with :idents backfilled"
+          ;; Strip the idents off `id`. update! does not populate idents like insert! does.
+          (t2/update! :model/Card id {:dataset_query base})
+          (let [original   (:dataset_query (t2/select-one :model/Card :id id))
+                modified   (touch original)
+                _          (t2/update! :model/Card id {:dataset_query modified})
+                reread     (:dataset_query (t2/select-one :model/Card :id id))
+                agg-idents (-> original :query :aggregation-idents)
+                brk-idents (-> original :query :breakout-idents)]
+            (is (= modified reread))
+            (is (= 2
+                   (-> agg-idents vals set count)
+                   (-> brk-idents vals set count)))
+            ;; NOTE: What were previously the 1st clauses is now 0th; their idents have not changed.
+            (is (= {0 (get agg-idents 1)}
+                   (-> modified :query :aggregation-idents)))
+            (is (= {0 (get brk-idents 1)}
+                   (-> modified :query :breakout-idents)))
+
+            ;; Specific check: the backfilled idents "enshrine" a now-incorrect index forever; that's okay!
+            (is (=? {0 #"aggregation_[A-Za-z0-9_-]{21}@0__1"}
+                    (-> modified :query :aggregation-idents)))
+            (is (=? {0 #"breakout_[A-Za-z0-9_-]{21}@0__1"}
+                    (-> modified :query :breakout-idents)))))))))
+
+(deftest ^:sequential ident-invariant-test-2c-edit-would-change-ident-but-does-not
+  (testing ":ident invariant: removing a clause preserves other idents - EVEN IF they encode now-incorrect indexes!"
+    (let [name1 "tax rate"
+          name2 "My name is Michael J. Caboose and I HATE TAXES!!!"
+          base  (mt/$ids orders
+                  {:database (mt/id)
+                   :type     :query
+                   :query    {:source-table $$orders
+                              :expressions  {name1 [:/ $tax $subtotal]}}})
+          touch (fn [query]
+                  (let [converted (lib/query (lib.metadata.jvm/application-database-metadata-provider (mt/id)) query)
+                        [expr]    (lib/expressions converted)]
+                    (-> converted
+                        (lib/replace-clause expr (lib/with-expression-name expr name2))
+                        lib.convert/->legacy-MBQL)))]
+      (mt/with-temp [:model/Card {id :id} {:name          "The card"
+                                           :dataset_query base}]
+        (testing "with randomized idents from initial insert"
+          (let [original (:dataset_query (t2/select-one :model/Card :id id))
+                modified (touch original)
+                _        (t2/update! :model/Card id {:dataset_query modified})
+                reread   (:dataset_query (t2/select-one :model/Card :id id))
+                idents   (-> original :query :expression-idents)]
+            (is (= modified reread))
+            (is (= {name2 (get idents name1)}
+                   (-> modified :query :expression-idents)))
+            (is (=? {name1 nano-id?} idents))))
+
+        (testing "with :idents backfilled"
+          ;; Strip the idents off `id`. update! does not populate idents like insert! does.
+          (t2/update! :model/Card id {:dataset_query base})
+          (let [original (:dataset_query (t2/select-one :model/Card :id id))
+                modified (touch original)
+                _        (t2/update! :model/Card id {:dataset_query modified})
+                reread   (:dataset_query (t2/select-one :model/Card :id id))
+                idents   (-> original :query :expression-idents)]
+            (is (= modified reread))
+            (is (= {name2 (get idents name1)}
+                   (-> modified :query :expression-idents)))
+            ;; NOTE: Both the original and modified queries use the original ident for the expression, even though
+            ;; it "enshrines" the original expression name forever! This is intentional - idents should never change.
+            (is (=? {name1 #"expression_[A-Za-z0-9_-]{21}@0__tax rate"} idents))
+            (is (=? {name2 #"expression_[A-Za-z0-9_-]{21}@0__tax rate"}
+                    (-> modified :query :expression-idents)))))))))

--- a/test/metabase/search/appdb/scoring_test.clj
+++ b/test/metabase/search/appdb/scoring_test.clj
@@ -193,7 +193,7 @@
                ;; Flake alert - we need to insert the outlier so that it is not chosen over the card it ties with.
                 ;; NOTE: we have brought in the outlier *a lot* to compensate for h2 not calculating a real percentile.
                 outlier-card-id (t2/insert-returning-pk! :model/Card (card-with-view 88 #_100000))
-                _               (t2/insert! :model/Card (concat (repeat 20 (card-with-view 0))
+                _               (t2/insert! :model/Card (concat (repeatedly 20 #(card-with-view 0))
                                                                 (for [i (range 1 81)]
                                                                   (card-with-view i))))
                 _               (search.ingestion/consume!

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -104,6 +104,7 @@
              :database_id            (data/id)
              :dataset_query          {}
              :display                :table
+             :entity_id              (u/generate-nano-id)
              :name                   (u.random/random-name)
              :visualization_settings {}}))
 


### PR DESCRIPTION
Closes #49684.

### Description

Ensure all column-creating clauses have idents on read.

That is: aggregations, breakouts, expressions and joins.

Nothing is consuming these yet, but the BE populates them when reading cards.

#### MBQL changes

These new `:ident`s have been present for new clauses for a few weeks, but now they'll be generated for existing queries on read.

The new idents are stable, including across serialization. They aren't written back until the card is saved again.

#### Backfilling

Here's the constraints for generating idents for pre-existing clauses:

- If the same query exists across serdes instances, produce the same ident
- Globally unique, even if:
    - two cards have identical queries
    - two stages of the same card have identical `:count` aggregations.
    - a single stage has multiple aggregations of the same type
    - a single stage has duplicate breakouts with different time granularity
- Never change, even if the query does
    - mbql-lib assumes these are (in theory) randomly generated, and never examines or updates them.
    - If new clauses are added, they get random idents.
    - If clauses are removed, that's no problem.
    - If clauses are edited (eg. changing an expression name) then the BE *would* generate a new ident!
        - But when the card gets saved, the original ident with the original expression name is enshrined forever as the ident - it just needs to be unique!

The backfilled idents have this form:

```clojure
"${kind}_${entity_id of the card}@${stage-number}__${name or index}"
;; eg. 
"aggregation_ThisIsAValidNanoIdxxx@0__1"
"breakout_ThisIsAValidNanoIdxxx@1__1"
"expression_ThisIsAValidNanoIdxxx@0__exprname"
"join_ThisIsAValidNanoIdxxx@1__alias"
```

I think I have achieved these goals with that plan and its implementation, but I would appreciate more eyeballs on both!

### How to verify

Cards returned from the API should now have `:aggregation-idents` et al in their legacy MBQL on the wire.

Try editing an expression's name, and it should get saved in appdb with the original name as its generated key.

**New clauses** still get randomly generated IDs - these backfilled names are just for pre-existing clauses that
now need IDs.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
