### PR TITLE
Fix serdes of missing cards in click behavior

### DIFF
--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -844,9 +844,19 @@
       (cond
         (nil? entity)      (throw (ex-info "FK target not found" {:model model
                                                                   :id    id
-                                                                  :skip  true}))
+                                                                  :skip  true
+                                                                  ::type :target-not-found}))
         (= (count path) 1) (first path)
         :else              path))))
+
+(defn- export-fk?
+  "Exactly like the above `*export-fk*`, except returns `nil` if the target was not found"
+  [id model]
+  (try (*export-fk* id model)
+       (catch clojure.lang.ExceptionInfo e
+         (when-not (= (::type (ex-data e)) :target-not-found)
+           (throw e))
+         nil)))
 
 (defn ^:dynamic ^::cache *import-fk*
   "Given an identifier, and the model it represents (symbol, name or IModel), looks up the corresponding
@@ -1329,9 +1339,12 @@
       json/generate-string))
 
 (defn- export-viz-click-behavior-link
-  [{:keys [linkType type] :as click-behavior}]
-  (cond-> click-behavior
-    (= type "link") (update :targetId *export-fk* (link-card-model->toucan-model linkType))))
+  [{:keys [linkType type] old-target-id :targetId :as click-behavior}]
+  (if-not (= type "link")
+    click-behavior
+    ;; if the card doesn't exist anymore, just remove the entire click behavior
+    (when-let [new-target-id (export-fk? old-target-id (link-card-model->toucan-model linkType))]
+      (assoc click-behavior :targetId new-target-id))))
 
 (defn- import-viz-click-behavior-link
   [{:keys [linkType type] :as click-behavior}]
@@ -1537,7 +1550,9 @@
   (when-let [{:keys [linkType targetId type]} click_behavior]
     (case type
       "link" (when-let [model (link-card-model->toucan-model linkType)]
-               {[(name model) targetId] src})
+               ;; if the card was deleted, just ignore it.
+               (when (export-fk? targetId model)
+                 {[(name model) targetId] src}))
       ;; TODO: We might need to handle the click behavior that updates dashboard filters? I can't figure out how get
       ;; that to actually attach to a filter to check what it looks like.
       nil)))

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -849,7 +849,7 @@
         (= (count path) 1) (first path)
         :else              path))))
 
-(defn- export-fk?
+(defn- maybe-export-fk
   "Exactly like the above `*export-fk*`, except returns `nil` if the target was not found"
   [id model]
   (try (*export-fk* id model)
@@ -1343,7 +1343,7 @@
   (if-not (= type "link")
     click-behavior
     ;; if the card doesn't exist anymore, just remove the entire click behavior
-    (when-let [new-target-id (export-fk? old-target-id (link-card-model->toucan-model linkType))]
+    (when-let [new-target-id (maybe-export-fk old-target-id (link-card-model->toucan-model linkType))]
       (assoc click-behavior :targetId new-target-id))))
 
 (defn- import-viz-click-behavior-link
@@ -1555,7 +1555,7 @@
     (case type
       "link" (when-let [model (link-card-model->toucan-model linkType)]
                ;; if the card was deleted, just ignore it.
-               (when (export-fk? targetId model)
+               (when (maybe-export-fk targetId model)
                  {[(name model) targetId] src}))
       ;; TODO: We might need to handle the click behavior that updates dashboard filters? I can't figure out how get
       ;; that to actually attach to a filter to check what it looks like.

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1394,9 +1394,8 @@
           (m/update-existing    :click_behavior export-viz-click-behavior-link)
           (m/update-existing-in [:click_behavior :parameterMapping] export-viz-click-behavior-mappings)
           (as-> updated-settings
-                (if (nil? (:click_behavior updated-settings))
-                  (dissoc updated-settings :click_behavior)
-                  updated-settings))))
+                (cond-> updated-settings
+                  (nil? (:click_behavior updated-settings)) (dissoc :click_behavior)))))
 
 (defn- import-viz-click-behavior [settings]
   (some-> settings

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1392,7 +1392,11 @@
 (defn- export-viz-click-behavior [settings]
   (some-> settings
           (m/update-existing    :click_behavior export-viz-click-behavior-link)
-          (m/update-existing-in [:click_behavior :parameterMapping] export-viz-click-behavior-mappings)))
+          (m/update-existing-in [:click_behavior :parameterMapping] export-viz-click-behavior-mappings)
+          (as-> updated-settings
+                (if (nil? (:click_behavior updated-settings))
+                  (dissoc updated-settings :click_behavior)
+                  updated-settings))))
 
 (defn- import-viz-click-behavior [settings]
   (some-> settings


### PR DESCRIPTION
When exporting a dashboard, we export its dashcards, including cards referenced inside its viz_settings.

The problem is that viz_settings might have references to now-nonexistent cards.

This is an initial stab at cleaning up the problem, specifically for click behavior. If Dashboard D has Dashcard DC, which has a click-behavior that links to Card C, then when we collect the descendants of D, we'll include a reference to C - even if C has been deleted.

So this makes two changes: first, when calculating the descendants of a dashcard, don't include links to cards that don't exist. And, when exporting the click behavior, remove the whole thing entirely if the card it points to doesn't exist.

Note that this is a bit hacky, and we're only solving the problem for click behaviors, not e.g. Card C uses card D as a source, and card D got deleted (which will trigger the same issue).

Fixes #49667