### PR TITLE
Prevent an exception in api.table/batch-fetch-card-query-metadatas when cards is empty

### DIFF
--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -509,7 +509,9 @@
                                           :limit    1} :r]
                                         [:= :r.moderated_item_id :c.id]]
                             :where      [:in :c.id ids]})
-          dbs (t2/select-pk->fn identity Database :id [:in (into #{} (map :database_id) cards)])
+          dbs (if (seq cards)
+                (t2/select-pk->fn identity Database :id [:in (into #{} (map :database_id) cards)])
+                {})
           metadata-field-ids (into #{}
                                    (comp (mapcat :result_metadata)
                                          (keep :id))

--- a/test/metabase/api/automagic_dashboards_test.clj
+++ b/test/metabase/api/automagic_dashboards_test.clj
@@ -572,7 +572,4 @@
        {:tables (sort-by :id [{:id (mt/id :venues)}
                               {:id (mt/id :categories)}])}
        (-> (mt/user-http-request :crowberto :get 200 (str "automagic-dashboards/table/" (mt/id :venues) "/query_metadata"))
-            ;; The output is so large, these help debugging
-           #_#_#_(update :fields #(map (fn [x] (select-keys x [:id])) %))
-               (update :databases #(map (fn [x] (select-keys x [:id :engine])) %))
-             (update :tables #(map (fn [x] (select-keys x [:id :name])) %))))))
+           #_(api.test-util/select-query-metadata-keys-for-debugging)))))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -3772,6 +3772,42 @@
                (update :databases #(map (fn [x] (select-keys x [:id :engine])) %))
                (update :tables #(map (fn [x] (select-keys x [:id :name])) %))))))))
 
+(deftest card-query-metadata-with-archived-and-deleted-source-card-test
+  (testing "Don't throw an error if source card is deleted (#48461)"
+    (mt/with-temp
+      [Card {card-id-1 :id} {:dataset_query (mt/mbql-query products)
+                             :database_id (mt/id)}
+       Card {card-id-2 :id} {:dataset_query
+                             {:type     :query
+                              :query    {:source-table (str "card__" card-id-1)}
+                              :database (mt/id)}
+                             :database_id (mt/id)}]
+      (testing "Archive source card"
+        (is (=?
+             {:archived true
+              :can_delete true
+              :id card-id-1
+              :database_id (mt/id)
+              :table_id (mt/id :products)}
+             (-> (mt/user-http-request :crowberto :put 200 (str "card/" card-id-1) {:archived true})))))
+      (testing "Before delete"
+        (is (=?
+             {:fields empty?
+              :tables [{:id (str "card__" card-id-1)}]
+              :databases [{:id (mt/id) :engine string?}]}
+             (-> (mt/user-http-request :crowberto :get 200 (str "card/" card-id-2 "/query_metadata"))
+                 ;; The output is so large, these help debugging
+                 (update :fields #(map (fn [x] (select-keys x [:id])) %))
+                 (update :databases #(map (fn [x] (select-keys x [:id :engine])) %))
+                 (update :tables #(map (fn [x] (select-keys x [:id :name])) %))))))
+      (testing "Delete source card"
+        (is (nil? (mt/user-http-request :crowberto :delete 204 (str "card/" card-id-1)))))
+      (testing "After delete"
+        (is (= "Not found."
+               (mt/user-http-request :crowberto :get 404 (str "card/" card-id-1 "/query_metadata"))))
+        (is (= "Not found."
+               (mt/user-http-request :crowberto :get 404 (str "card/" card-id-2 "/query_metadata"))))))))
+
 (deftest card-query-metadata-no-tables-test
   (testing "Don't throw an error if users doesn't have access to any tables #44043"
     (let [original-can-read? mi/can-read?]

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -12,6 +12,7 @@
    [medley.core :as m]
    [metabase.api.card :as api.card]
    [metabase.api.pivots :as api.pivots]
+   [metabase.api.test-util :as api.test-util]
    [metabase.config :as config]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
@@ -3775,38 +3776,26 @@
 (deftest card-query-metadata-with-archived-and-deleted-source-card-test
   (testing "Don't throw an error if source card is deleted (#48461)"
     (mt/with-temp
-      [Card {card-id-1 :id} {:dataset_query (mt/mbql-query products)
-                             :database_id (mt/id)}
-       Card {card-id-2 :id} {:dataset_query
-                             {:type     :query
-                              :query    {:source-table (str "card__" card-id-1)}
-                              :database (mt/id)}
-                             :database_id (mt/id)}]
-      (testing "Archive source card"
-        (is (=?
-             {:archived true
-              :can_delete true
-              :id card-id-1
-              :database_id (mt/id)
-              :table_id (mt/id :products)}
-             (-> (mt/user-http-request :crowberto :put 200 (str "card/" card-id-1) {:archived true})))))
-      (testing "Before delete"
-        (is (=?
-             {:fields empty?
-              :tables [{:id (str "card__" card-id-1)}]
-              :databases [{:id (mt/id) :engine string?}]}
-             (-> (mt/user-http-request :crowberto :get 200 (str "card/" card-id-2 "/query_metadata"))
-                 ;; The output is so large, these help debugging
-                 (update :fields #(map (fn [x] (select-keys x [:id])) %))
-                 (update :databases #(map (fn [x] (select-keys x [:id :engine])) %))
-                 (update :tables #(map (fn [x] (select-keys x [:id :name])) %))))))
-      (testing "Delete source card"
-        (is (nil? (mt/user-http-request :crowberto :delete 204 (str "card/" card-id-1)))))
-      (testing "After delete"
-        (is (= "Not found."
-               (mt/user-http-request :crowberto :get 404 (str "card/" card-id-1 "/query_metadata"))))
-        (is (= "Not found."
-               (mt/user-http-request :crowberto :get 404 (str "card/" card-id-2 "/query_metadata"))))))))
+      [Card {card-id-1 :id} {:dataset_query (mt/mbql-query products)}
+       Card {card-id-2 :id} {:dataset_query {:type  :query
+                                             :query {:source-table (str "card__" card-id-1)}}}]
+      (letfn [(query-metadata [expected-status card-id]
+                (-> (mt/user-http-request :crowberto :get expected-status (str "card/" card-id "/query_metadata"))
+                    (api.test-util/select-query-metadata-keys-for-debugging)))]
+        (api.test-util/before-and-after-deleted-card
+         card-id-1
+         #(testing "Before delete"
+            (doseq [[card-id table-id] [[card-id-1 (mt/id :products)]
+                                        [card-id-2 (str "card__" card-id-1)]]]
+              (is (=?
+                   {:fields empty?
+                    :tables [{:id table-id}]
+                    :databases [{:id (mt/id) :engine string?}]}
+                   (query-metadata 200 card-id)))))
+         #(testing "After delete"
+            (doseq [card-id [card-id-1 card-id-2]]
+              (is (= "Not found."
+                     (query-metadata 404 card-id))))))))))
 
 (deftest card-query-metadata-no-tables-test
   (testing "Don't throw an error if users doesn't have access to any tables #44043"

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -3753,10 +3753,7 @@
             :tables (sort-by :id [{:id (mt/id :products)}])
             :databases [{:id (mt/id) :engine string?}]}
            (-> (mt/user-http-request :crowberto :get 200 (str "card/" card-id-1 "/query_metadata"))
-                ;; The output is so large, these help debugging
-               (update :fields #(map (fn [x] (select-keys x [:id])) %))
-               (update :databases #(map (fn [x] (select-keys x [:id :engine])) %))
-               (update :tables #(map (fn [x] (select-keys x [:id :name])) %))))))
+               (api.test-util/select-query-metadata-keys-for-debugging)))))
     (testing "Parameterized native query"
       (is (=?
            {:fields (sort-by :id
@@ -3768,10 +3765,7 @@
                              [{:id (str "card__" card-id-2)}])
             :databases [{:id (mt/id) :engine string?}]}
            (-> (mt/user-http-request :crowberto :get 200 (str "card/" card-id-2 "/query_metadata"))
-                ;; The output is so large, these help debugging
-               (update :fields #(map (fn [x] (select-keys x [:id])) %))
-               (update :databases #(map (fn [x] (select-keys x [:id :engine])) %))
-               (update :tables #(map (fn [x] (select-keys x [:id :name])) %))))))))
+               (api.test-util/select-query-metadata-keys-for-debugging)))))))
 
 (deftest card-query-metadata-with-archived-and-deleted-source-card-test
   (testing "Don't throw an error if source card is deleted (#48461)"

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4618,10 +4618,7 @@
           :databases [{:id (mt/id) :engine string?}]
           :dashboards [{:id link-dash}]}
          (-> (mt/user-http-request :crowberto :get 200 (str "dashboard/" dashboard-id "/query_metadata"))
-              ;; The output is so large, these help debugging
-             #_#_#_(update :fields #(map (fn [x] (select-keys x [:id])) %))
-                 (update :databases #(map (fn [x] (select-keys x [:id :engine])) %))
-               (update :tables #(map (fn [x] (select-keys x [:id :name])) %)))))))
+             #_(api.test-util/select-query-metadata-keys-for-debugging))))))
 
 (deftest dashboard-query-metadata-with-archived-and-deleted-source-card-test
   (testing "Don't throw an error if source card is deleted (#48461)"

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4622,6 +4622,50 @@
                  (update :databases #(map (fn [x] (select-keys x [:id :engine])) %))
                (update :tables #(map (fn [x] (select-keys x [:id :name])) %)))))))
 
+(deftest dashboard-query-metadata-with-archived-and-deleted-source-card-test
+  (testing "Don't throw an error if source card is deleted (#48461)"
+    (mt/with-temp
+      [Card          {card-id-1 :id}    {:dataset_query (mt/mbql-query products)
+                                         :database_id   (mt/id)}
+       Card          {card-id-2 :id}    {:dataset_query
+                                         {:type     :query
+                                          :query    {:source-table (str "card__" card-id-1)}
+                                          :database (mt/id)}
+                                         :database_id (mt/id)}
+       Dashboard     {dashboard-id :id} {}
+       DashboardCard _                  {:dashboard_id dashboard-id,
+                                         :card_id      card-id-2}]
+
+      (testing "Archive source card"
+        (is (=?
+             {:archived    true
+              :can_delete  true
+              :id          card-id-1
+              :database_id (mt/id)
+              :table_id    (mt/id :products)}
+             (-> (mt/user-http-request :crowberto :put 200 (str "card/" card-id-1) {:archived true})))))
+      (testing "Before delete"
+        (is (=?
+             {:fields     empty?
+              :tables     [{:id (str "card__" card-id-1)}]
+              :databases  [{:id (mt/id) :engine string?}]
+              :cards      empty?
+              :dashboards empty?}
+             (-> (mt/user-http-request :crowberto :get 200 (str "dashboard/" dashboard-id "/query_metadata"))
+                 ;; The output is so large, these help debugging
+                 (update :fields #(map (fn [x] (select-keys x [:id])) %))
+                 (update :databases #(map (fn [x] (select-keys x [:id :engine])) %))
+                 (update :tables #(map (fn [x] (select-keys x [:id :name])) %))))))
+      (testing "Delete source card"
+        (is (nil? (mt/user-http-request :crowberto :delete 204 (str "card/" card-id-1)))))
+      (testing "After delete"
+        (is (= {:databases  []
+                :tables     []
+                :fields     []
+                :cards      []
+                :dashboards []}
+               (mt/user-http-request :crowberto :get 200 (str "dashboard/" dashboard-id "/query_metadata"))))))))
+
 (deftest dashboard-query-metadata-no-tables-test
   (testing "Don't throw an error if users doesn't have access to any tables #44043"
     (let [original-can-read? mi/can-read?]

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -11,6 +11,7 @@
    [medley.core :as m]
    [metabase.api.dataset :as api.dataset]
    [metabase.api.pivots :as api.pivots]
+   [metabase.api.test-util :as api.test-util]
    [metabase.driver :as driver]
    [metabase.http-client :as client]
    [metabase.lib.core :as lib]
@@ -757,43 +758,29 @@
 (deftest dataset-query-metadata-with-archived-and-deleted-source-card-test
   (testing "Don't throw an error if source card is deleted (#48461)"
     (mt/with-temp
-      [Card {card-id-1 :id} {:dataset_query (mt/mbql-query products)
-                             :database_id   (mt/id)}
-       Card {card-id-2 :id} {:dataset_query
-                             {:type     :query
-                              :query    {:source-table (str "card__" card-id-1)}
-                              :database (mt/id)}
-                             :database_id (mt/id)}]
-      (let [query {:type     :query
-                   :query    {:source-table (str "card__" card-id-2)}
-                   :database (mt/id)}]
-        (testing "Archive source card"
-          (is (=?
-               {:archived    true
-                :can_delete  true
-                :id          card-id-1
-                :database_id (mt/id)
-                :table_id    (mt/id :products)}
-               (-> (mt/user-http-request :crowberto :put 200 (str "card/" card-id-1) {:archived true})))))
-        (testing "Before delete"
-          (is (=?
-               {:fields    empty?
-                :tables    [{:id (str "card__" card-id-2)}]
-                :databases [{:id (mt/id) :engine string?}]}
-               (-> (mt/user-http-request :crowberto :post 200 "dataset/query_metadata" query)
-                   ;; The output is so large, these help debugging
-                   (update :fields #(map (fn [x] (select-keys x [:id])) %))
-                   (update :databases #(map (fn [x] (select-keys x [:id :engine])) %))
-                   (update :tables #(map (fn [x] (select-keys x [:id :name])) %))))))
-        (testing "Delete source card"
-          (is (nil? (mt/user-http-request :crowberto :delete 204 (str "card/" card-id-1)))))
-        (testing "After delete"
-          (is (=?
-               {:fields    empty?
-                :tables    empty?
-                :databases [{:id (mt/id) :engine string?}]}
-               (-> (mt/user-http-request :crowberto :post 200 "dataset/query_metadata" query)
-                   ;; The output is so large, these help debugging
-                   (update :fields #(map (fn [x] (select-keys x [:id])) %))
-                   (update :databases #(map (fn [x] (select-keys x [:id :engine])) %))
-                   (update :tables #(map (fn [x] (select-keys x [:id :name])) %))))))))))
+      [Card {card-id-1 :id} {:dataset_query (mt/mbql-query products)}
+       Card {card-id-2 :id} {:dataset_query {:type  :query
+                                             :query {:source-table (str "card__" card-id-1)}}}]
+      (letfn [(query-metadata [expected-status card-id]
+                (-> (mt/user-http-request :crowberto :post expected-status
+                                          "dataset/query_metadata"
+                                          {:type     :query
+                                           :query    {:source-table (str "card__" card-id)}
+                                           :database (mt/id)})
+                    (api.test-util/select-query-metadata-keys-for-debugging)))]
+        (api.test-util/before-and-after-deleted-card
+         card-id-1
+         #(testing "Before delete"
+            (doseq [card-id [card-id-1 card-id-2]]
+              (is (=?
+                   {:fields    empty?
+                    :tables    [{:id (str "card__" card-id)}]
+                    :databases [{:id (mt/id) :engine string?}]}
+                   (query-metadata 200 card-id)))))
+         #(testing "After delete"
+            (doseq [card-id [card-id-1 card-id-2]]
+              (is (=?
+                   {:fields    empty?
+                    :tables    empty?
+                    :databases [{:id (mt/id) :engine string?}]}
+                   (query-metadata 200 card-id))))))))))

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -4,6 +4,7 @@
    [clojure.test :refer :all]
    [medley.core :as m]
    [metabase.api.table :as api.table]
+   [metabase.api.test-util :as api.test-util]
    [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
    [metabase.http-client :as client]
@@ -704,40 +705,24 @@
 
 (deftest ^:parallel virtual-table-metadata-deleted-cards-test
   (testing "GET /api/table/card__:id/query_metadata for deleted cards (#48461)"
-   (mt/with-temp
-     [Card {card-id-1 :id} {:name "Card 1"
-                            :database_id (mt/id)
-                            :dataset_query (mt/mbql-query products)}
-      Card {card-id-2 :id} {:name "Card 2"
-                            :database_id (mt/id)
-                            :dataset_query
-                            {:type     :query
-                             :query    {:source-table (str "card__" card-id-1)}
-                             :database (mt/id)}}]
-
-     ;; run the Cards which will populate their result_metadata column
-     ;;(mt/user-http-request :crowberto :post 202 (format "card/%d/query" card-id-1))
-     ;;(mt/user-http-request :crowberto :post 202 (format "card/%d/query" card-id-2))
-
-     (letfn [(query-metadata [expected-status card-id]
-               (->> (format "table/card__%d/query_metadata" card-id)
-                    (mt/user-http-request :crowberto :get expected-status)))]
-       (testing "Before delete"
-         (is (=? {:display_name      "Card 1"
-                  :db_id             (mt/id)
-                  :id                (str "card__" card-id-1)
-                  :type              "question"}
-                 (query-metadata 200 card-id-1)))
-         (is (=? {:display_name      "Card 2"
-                  :db_id             (mt/id)
-                  :id                (str "card__" card-id-2)
-                  :type              "question"}
-                 (query-metadata 200 card-id-2))))
-       (testing "Delete source card"
-         (is (nil? (mt/user-http-request :crowberto :delete 204 (str "card/" card-id-1)))))
-       (testing "After delete"
-         (is (empty? (query-metadata 204 card-id-1)))
-         (is (empty? (query-metadata 204 card-id-2))))))))
+    (mt/with-temp
+      [Card {card-id-1 :id} {:dataset_query (mt/mbql-query products)}
+       Card {card-id-2 :id} {:dataset_query {:type     :query
+                                             :query    {:source-table (str "card__" card-id-1)}}}]
+      (letfn [(query-metadata [expected-status card-id]
+                (->> (format "table/card__%d/query_metadata" card-id)
+                     (mt/user-http-request :crowberto :get expected-status)))]
+        (api.test-util/before-and-after-deleted-card
+         card-id-1
+         #(testing "Before delete"
+            (doseq [card-id [card-id-1 card-id-2]]
+              (is (=? {:db_id             (mt/id)
+                       :id                (str "card__" card-id)
+                       :type              "question"}
+                      (query-metadata 200 card-id)))))
+         #(testing "After delete"
+            (doseq [card-id [card-id-1 card-id-2]]
+              (is (empty? (query-metadata 204 card-id))))))))))
 
 (deftest ^:parallel include-date-dimensions-in-nested-query-test
   (testing "GET /api/table/:id/query_metadata"

--- a/test/metabase/api/test_util.clj
+++ b/test/metabase/api/test_util.clj
@@ -18,11 +18,10 @@
     GET  card/:id/query_metadata
     POST dataset/query_metadata"
   [query-metadata-result]
-  ;; If query-metadata-result is not a map, then probably the API call that produced it failed and returned a
-  ;; different type, like "Not found" for a 404. In such cases, don't attempt to update the keys, which will throw an
-  ;; exception and obscure the true failure.
   (cond-> query-metadata-result
-    ;; The output is so large, these help debugging
+    ;; If query-metadata-result is not a map, then probably the API call that produced it failed and returned a
+    ;; different type, like "Not found" for a 404. In such cases, don't attempt to update the keys, which will throw an
+    ;; exception and obscure the true failure. If it is a map, select specific keys to make the output easier to debug.
     (map? query-metadata-result) (-> (update :fields #(map (fn [x] (select-keys x [:id])) %))
                                      (update :databases #(map (fn [x] (select-keys x [:id :engine])) %))
                                      (update :tables #(map (fn [x] (select-keys x [:id :name])) %)))))

--- a/test/metabase/api/test_util.clj
+++ b/test/metabase/api/test_util.clj
@@ -1,0 +1,54 @@
+(ns metabase.api.test-util
+  "Utilities for writing API tests."
+  (:require
+   [clojure.test :refer :all]
+   [metabase.test :as mt]))
+
+(set! *warn-on-reflection* true)
+
+(defn select-query-metadata-keys-for-debugging
+  "Select a subset of keys from `query-metadata-result` to help debugging failed test assertions.
+
+  `query-metadata-result` should be the result of some call to one of the query_metadata endpoints that return these
+  keys: :fields, :databases, :tables.
+
+  At time of writing, these endpoints include:
+
+    GET  dashboard/:id/query_metadata
+    GET  card/:id/query_metadata
+    POST dataset/query_metadata"
+  [query-metadata-result]
+  ;; If query-metadata-result is not a map, then probably the API call that produced it failed and returned a
+  ;; different type, like "Not found" for a 404. In such cases, don't attempt to update the keys, which will throw an
+  ;; exception and obscure the true failure.
+  (cond-> query-metadata-result
+    ;; The output is so large, these help debugging
+    (map? query-metadata-result) (-> (update :fields #(map (fn [x] (select-keys x [:id])) %))
+                                     (update :databases #(map (fn [x] (select-keys x [:id :engine])) %))
+                                     (update :tables #(map (fn [x] (select-keys x [:id :name])) %)))))
+
+(defn before-and-after-deleted-card
+  "Helper for testing behavior before and after deleting a card.
+
+  Performs the following actions:
+
+  1. Archive `card-id`
+  2. Run the `before-delete` thunk
+  3. Delete `card-id`
+  4. Run the `after-delete` thunk"
+  [card-id
+   before-delete
+   after-delete]
+  (testing "Archive card"
+    (is (=?
+         {:archived    true
+          :can_delete  true
+          :id          card-id}
+         (-> (mt/user-http-request :crowberto :put 200 (str "card/" card-id) {:archived true})))))
+
+  (before-delete)
+
+  (testing "Delete card"
+    (is (nil? (mt/user-http-request :crowberto :delete 204 (str "card/" card-id)))))
+
+  (after-delete))


### PR DESCRIPTION
### Description

Closes #48461

Ensure we don't throw an exception by attempting to fetch an empty set of `Databases` associated with potentially-deleted card ids in api.table/batch-fetch-card-query-metadatas.

In particular, this ensures we don't generate an exception if the user does the following

1. Create a card "Source Card"
2. Create another card "Derived Card" with a :source-table of "Source Card"
3. Add Derived Card to a dashboard
4. Permanently delete (not just archive) the Source Card

### How to verify

Note that this actually won't reproduce if you do everything on v51+ due to changes in #46356 where we added a new `report_card.source_card_id` column with a corresponding "ON DELETE CASCADE" constraint (`fk_report_card_source_card_id_ref_report_card_id`), so that on v51+ when you delete the source card, the derived card is also deleted. No dangling card is left, which also fixes the bug as described in #48461.

In order to repro, you need start from v50 or earlier and do the steps described above or in the linked issue. If you then upgrade to v51, the card remains dangling and the dashboard is broken.

In addition, some of the new tests added in this PR do still trigger the bug even with cascading deletes of the source card, in particular the tests for the `POST "/dataset/query_metadata"` and `GET "/table/card__:id/query_metadata"` endpoints can still trigger the issue without this fix.


### Demo

Prior to this change, you might (depending on app DB) get an error like this one when attempting to view a dashboard that contained only "dangling" cards created via the above process.

<img width="638" alt="Screenshot 2024-11-15 at 3 07 47 PM" src="https://github.com/user-attachments/assets/839a8ff6-9b0e-43fa-8f92-6d0b9500506b">

Whether you see an error depends on whether your DBMS is ok with a query like `SELECT * FROM "metabase_database" WHERE "id" IN ()`. E.g. Postgres considers it an error, but H2 is fine with it.

After this change, you'll instead see

<img width="576" alt="Screenshot 2024-11-15 at 3 23 26 PM" src="https://github.com/user-attachments/assets/4f5656b9-0911-4f2f-b762-e5faae1d403d">

We still can't display the card, but the rest of the dashboard displays and you can remove the offending card(s).

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
