### PR TITLE
fix: :bug: adjust metabot logo styling to fix padding issue

### DIFF
--- a/frontend/src/metabase/home/components/HomeGreeting/HomeGreeting.styled.tsx
+++ b/frontend/src/metabase/home/components/HomeGreeting/HomeGreeting.styled.tsx
@@ -9,14 +9,10 @@ export const GreetingRoot = styled.div`
 `;
 
 export const GreetingLogo = styled(MetabotLogo)<{ isCool: boolean }>`
-  height: 2.5rem;
   position: absolute;
   top: 0;
   opacity: ${props => (props.isCool ? 1 : 0)};
-
-  ${breakpointMinExtraLarge} {
-    height: 3rem;
-  }
+  width: 100%;
 `;
 
 export interface GreetingMessageProps {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50012

### Description

Made changes to GreetingLogo styles that fixed the overflowing the logo

### How to verify

Please check the screenshot

### Demo

![CleanShot 2024-11-16 at 18 10 50@2x](https://github.com/user-attachments/assets/6681cd4b-1be1-44b9-88d8-c5089f77793f)

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
