### PR TITLE
Normalize view count scores by p90 for corresponding model

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/search/scoring.clj
+++ b/enterprise/backend/src/metabase_enterprise/search/scoring.clj
@@ -25,7 +25,7 @@
   "Return the select-item expressions used to calculate the score for each search result."
   :feature :none
   []
-  (merge fulltext.scoring/base-scorers (select-keys enterprise-scorers (additional-scorers))))
+  (merge (fulltext.scoring/base-scorers) (select-keys enterprise-scorers (additional-scorers))))
 
 ;; ------------ LEGACY ----------
 

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -41,8 +41,14 @@
   10)
 
 (def ^:const view-count-scaling
-  "The larger this value, the longer it will take for the score to approach 1.0. It will never quite reach it."
-  50)
+  "A constant factor influencing how quickly the incremental score grows with view count for a given search model.
+  The larger this value, the longer it will take for the score to approach 1.0. It will never quite reach it."
+  0.2)
+
+(def ^:const view-count-scaling-percentile
+  "The percentile of the given search model's view counts, to be multiplied by [[view-count-scaling]].
+  The larger this value, the longer it will take for the score to approach 1.0. It will never quite reach it."
+  0.9)
 
 (def ^:const surrounding-match-context
   "Show this many words of context before/after matches in long search results"


### PR DESCRIPTION
This is an attempt to keep the score relevant for customers (and models) of very different scales.

Here's an example of the effective ranking term:

```edn
[:*
 [:/ [:inline 2] [:pi]]
 [:atan
  [:/
   [:cast [:coalesce :view_count [:inline 0.0]] :float]
   [:*
     0.25
     [:greatest
      1
      [:case
       [:= :model "card"]
       16.0
       [:= :model "dashboard"]
       1.0000000000000009
       [:= :model "table"]
       8.100000000000005]]]]]]
```

And here's an example of the final scores for my small database:

```
SELECT model, view_count, 
  (2 / PI()) * ATAN(CAST(COALESCE(view_count, 0.0) AS FLOAT) / 
    (0.2 * GREATEST(1, CASE 
      WHEN model = 'card' THEN 16.0 
      WHEN model = 'dashboard' THEN 1.0000000000000009 
      WHEN model = 'table' THEN 8.100000000000005 END))) AS view_count_score 
FROM search_index 
GROUP BY model, view_count
ORDER BY model, view_count;

   model    | view_count |  view_count_score
------------+------------+--------------------
 card       |          0 |                  0
 card       |          4 | 0.5704465749545545
 card       |         16 | 0.8743340836219977
 collection |            |                  0
 dashboard  |          0 |                  0
 dashboard  |          5 | 0.9745487773040163
 database   |            |                  0
 table      |          0 |                  0
 table      |         27 | 0.9618485515283276
(9 rows)
```