### PR TITLE
Add general type for `className` and `style`

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Title.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Title.tsx
@@ -1,8 +1,14 @@
-import { useInteractiveQuestionContext } from "embedding-sdk/components/private/InteractiveQuestion/context";
 import { QuestionTitle } from "embedding-sdk/components/private/QuestionTitle";
+import type { PropsWithHTMLStyle } from "embedding-sdk/types/default-style-props";
 
-export const Title = () => {
+import { useInteractiveQuestionContext } from "../context";
+
+export const Title = ({ className, style }: PropsWithHTMLStyle) => {
   const { question } = useInteractiveQuestionContext();
 
-  return question && <QuestionTitle question={question} />;
+  return (
+    question && (
+      <QuestionTitle question={question} className={className} style={style} />
+    )
+  );
 };

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Title.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Title.tsx
@@ -1,9 +1,9 @@
 import { QuestionTitle } from "embedding-sdk/components/private/QuestionTitle";
-import type { PropsWithHTMLStyle } from "embedding-sdk/types/default-style-props";
+import type { PropsWithHTMLAttributes } from "embedding-sdk/types/default-style-props";
 
 import { useInteractiveQuestionContext } from "../context";
 
-export const Title = ({ className, style }: PropsWithHTMLStyle) => {
+export const Title = ({ className, style }: PropsWithHTMLAttributes) => {
   const { question } = useInteractiveQuestionContext();
 
   return (

--- a/enterprise/frontend/src/embedding-sdk/components/private/QuestionTitle.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/QuestionTitle.tsx
@@ -2,6 +2,7 @@ import cx from "classnames";
 import type React from "react";
 import { t } from "ttag";
 
+import type { PropsWithHTMLStyle } from "embedding-sdk/types/default-style-props";
 import CS from "metabase/css/core/index.css";
 import { AdHocQuestionDescription } from "metabase/query_builder/components/view/ViewHeader/components/AdHocQuestionDescription";
 import * as Lib from "metabase-lib";
@@ -13,14 +14,16 @@ interface QuestionTitleProps {
 
 export const QuestionTitle = ({
   question,
-}: QuestionTitleProps): React.JSX.Element => {
+  className,
+  style,
+}: PropsWithHTMLStyle<QuestionTitleProps>): React.JSX.Element => {
   const isSaved = question.isSaved();
 
   const query = question.query();
   const { isNative } = Lib.queryDisplayInfo(query);
 
   return (
-    <h2 className={cx(CS.h2, CS.textWrap)}>
+    <h2 className={cx(CS.h2, CS.textWrap, className)} style={style}>
       {isSaved ? (
         question.displayName()
       ) : !isNative && AdHocQuestionDescription.shouldRender(question) ? (

--- a/enterprise/frontend/src/embedding-sdk/components/private/QuestionTitle.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/QuestionTitle.tsx
@@ -1,8 +1,7 @@
 import cx from "classnames";
-import type React from "react";
 import { t } from "ttag";
 
-import type { PropsWithHTMLStyle } from "embedding-sdk/types/default-style-props";
+import type { PropsWithHTMLAttributes } from "embedding-sdk/types/default-style-props";
 import CS from "metabase/css/core/index.css";
 import { AdHocQuestionDescription } from "metabase/query_builder/components/view/ViewHeader/components/AdHocQuestionDescription";
 import * as Lib from "metabase-lib";
@@ -16,7 +15,7 @@ export const QuestionTitle = ({
   question,
   className,
   style,
-}: PropsWithHTMLStyle<QuestionTitleProps>): React.JSX.Element => {
+}: PropsWithHTMLAttributes<"h2", QuestionTitleProps>) => {
   const isSaved = question.isSaved();
 
   const query = question.query();

--- a/enterprise/frontend/src/embedding-sdk/types/default-style-props.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/default-style-props.ts
@@ -1,0 +1,8 @@
+import type { CSSProperties, HTMLProps } from "react";
+
+export type PropsWithHTMLStyle<
+  T extends Record<string, any> = NonNullable<Record<string, any>>,
+> = {
+  className?: HTMLProps<HTMLElement>["className"];
+  style?: CSSProperties;
+} & T;

--- a/enterprise/frontend/src/embedding-sdk/types/default-style-props.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/default-style-props.ts
@@ -1,8 +1,6 @@
-import type { CSSProperties } from "react";
+import type { ComponentProps, ElementType } from "react";
 
-export type PropsWithHTMLStyle<
-  T extends Record<string, any> = NonNullable<Record<string, any>>,
-> = {
-  className?: string;
-  style?: CSSProperties;
-} & T;
+export type PropsWithHTMLAttributes<
+  E extends ElementType = ElementType,
+  T extends Record<string, any> = Record<never, never>,
+> = ComponentProps<E> & T;

--- a/enterprise/frontend/src/embedding-sdk/types/default-style-props.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/default-style-props.ts
@@ -1,8 +1,8 @@
-import type { CSSProperties, HTMLProps } from "react";
+import type { CSSProperties } from "react";
 
 export type PropsWithHTMLStyle<
   T extends Record<string, any> = NonNullable<Record<string, any>>,
 > = {
-  className?: HTMLProps<HTMLElement>["className"];
+  className?: string;
   style?: CSSProperties;
 } & T;


### PR DESCRIPTION
We always manually type this, so I followed the pattern of `PropsWithChildren<InsertYourPropTypeHere>` and created this type. I think it'll make us a _just a little_ happier.