### PR TITLE
fix(sdk): handle relative urls for metabaseInstance in loading maps

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -110,7 +110,7 @@ const mapStateToProps = state => ({
 
 const connector = connect(mapStateToProps, null);
 
-const addTrailingSlash = url => (url.endsWith("/") ? url : url + "/");
+const ensureTrailingSlash = url => (url.endsWith("/") ? url : url + "/");
 
 export function getMapUrl(details, props) {
   if (details.builtin) {
@@ -122,7 +122,7 @@ export function getMapUrl(details, props) {
 
       // if the second parameter ends with a slash, it will join them together
       // new URL("/sub-path", "http://example.org/proxy/") => "http://example.org/proxy/sub-path"
-      return new URL(details.url, addTrailingSlash(baseUrl)).href;
+      return new URL(details.url, ensureTrailingSlash(baseUrl)).href;
     }
     return details.url;
   }

--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -110,10 +110,19 @@ const mapStateToProps = state => ({
 
 const connector = connect(mapStateToProps, null);
 
-function getMapUrl(details, props) {
+const addTrailingSlash = url => (url.endsWith("/") ? url : url + "/");
+
+export function getMapUrl(details, props) {
   if (details.builtin) {
     if (props?.isSdk && props?.sdkMetabaseInstanceUrl) {
-      return new URL(details.url, props.sdkMetabaseInstanceUrl).href;
+      const baseUrl = new URL(
+        props.sdkMetabaseInstanceUrl,
+        window.location.origin,
+      ).href;
+
+      // if the second parameter ends with a slash, it will join them together
+      // new URL("/sub-path", "http://example.org/proxy/") => "http://example.org/proxy/sub-path"
+      return new URL(details.url, addTrailingSlash(baseUrl)).href;
     }
     return details.url;
   }

--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.unit.spec.js
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.unit.spec.js
@@ -1,4 +1,7 @@
-import { getLegendTitles } from "metabase/visualizations/components/ChoroplethMap";
+import {
+  getLegendTitles,
+  getMapUrl,
+} from "metabase/visualizations/components/ChoroplethMap";
 
 describe("getLegendTitles", () => {
   it("should not format short values compactly", () => {
@@ -35,5 +38,42 @@ describe("getLegendTitles", () => {
     const titles = getLegendTitles(groups, columnSettings);
 
     expect(titles).toEqual(["$1.0k - $1.2k", "$2.0k - $2.5k", "$11.0k +"]);
+  });
+
+  describe("getMapUrl", () => {
+    describe("when using the embedding SDK", () => {
+      const setup = ({ sdkMetabaseInstanceUrl }) => {
+        return getMapUrl(
+          { builtin: true, url: "api/geojson/world.json" },
+          { isSdk: true, sdkMetabaseInstanceUrl },
+        );
+      };
+
+      it("should handle relative paths for `sdkMetabaseInstanceUrl`", () => {
+        const url = setup({ sdkMetabaseInstanceUrl: "/proxy-to-mb" });
+
+        expect(url).toBe("http://localhost/proxy-to-mb/api/geojson/world.json");
+      });
+
+      it("should handle root absolute paths for `sdkMetabaseInstanceUrl`", () => {
+        const url = setup({
+          sdkMetabaseInstanceUrl: "http://mb-instance.example.com",
+        });
+
+        expect(url).toBe(
+          "http://mb-instance.example.com/api/geojson/world.json",
+        );
+      });
+
+      it("should handle absolute paths (with subpaths) for `sdkMetabaseInstanceUrl`", () => {
+        const url = setup({
+          sdkMetabaseInstanceUrl: "http://mb-instance.example.com/sub-path",
+        });
+
+        expect(url).toBe(
+          "http://mb-instance.example.com/sub-path/api/geojson/world.json",
+        );
+      });
+    });
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50132


To reproduce the error (and check that it doesn't show up in this pr)

Make a new vite project with the following config to enable the proxy:
```ts
import { defineConfig } from "vite";
import react from "@vitejs/plugin-react";

// https://vitejs.dev/config/
export default defineConfig({
  plugins: [react()],
  resolve: {
    alias: {},
  },
  server: {
    proxy: {
      "/metabase-proxy/": {
        target: "http://localhost:3000",
        changeOrigin: true,
        rewrite: (path) => path.replace(/^\/metabase-proxy/, ""),
      },
    },
  },
});
```

Use the following sdk config: (it should work with both, but will fail with `/metabase-proxy` without this fix)
```
  const config = defineEmbeddingSdkConfig({
    // metabaseInstanceUrl: "http://localhost:5173/metabase-proxy",
    metabaseInstanceUrl: "/metabase-proxy",
```

If using the example db, render `<StaticDashboard dashboardId={1} />` and open the Demographics tab, it should contain a map card