### PR TITLE
Render table header when dataset is empty

### DIFF
--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -19,6 +19,7 @@ import {
   getPinnedSection,
   hovercard,
   join,
+  main,
   mapColumnTo,
   modal,
   navigationSidebar,
@@ -1363,6 +1364,36 @@ describe("issue 20624", () => {
     tableInteractive().within(() => {
       cy.findByText("Retailer").should("be.visible");
       cy.findByText("Vendor").should("not.exist");
+    });
+  });
+});
+
+describe("issue 37300", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+
+    createQuestion(
+      {
+        type: "model",
+        query: {
+          "source-table": PRODUCTS_ID,
+          filter: ["=", ["field", PRODUCTS.ID, null], "999991"],
+        },
+      },
+      { visitQuestion: true },
+    );
+  });
+
+  it("should show the table headers even when there are no results (metabase/metabase#37300)", () => {
+    openQuestionActions();
+    popover().findByText("Edit metadata").click();
+
+    main().within(() => {
+      cy.findByText("ID").should("be.visible");
+      cy.findByText("Ean").should("be.visible");
+
+      cy.findByText("No results!").should("be.visible");
     });
   });
 });

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -542,6 +542,7 @@ function DatasetEditor(props) {
                 tableHeaderHeight={isEditingMetadata && TABLE_HEADER_HEIGHT}
                 renderTableHeaderWrapper={renderTableHeaderWrapper}
                 scrollToColumn={focusedFieldIndex + scrollToColumnModifier}
+                renderEmptyMessage={isEditingMetadata}
               />
             </DebouncedFrame>
             <TabHintToastContainer

--- a/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
@@ -23,6 +23,7 @@ const ALLOWED_VISUALIZATION_PROPS = [
   "scrollToColumn",
   "renderTableHeaderWrapper",
   "mode",
+  "renderEmptyMessage",
 ];
 
 export default class VisualizationResult extends Component {
@@ -60,11 +61,12 @@ export default class VisualizationResult extends Component {
       onNavigateBack,
       className,
       isRunning,
+      renderEmptyMessage,
     } = this.props;
     const { showCreateAlertModal } = this.state;
 
     const noResults = datasetContainsNoResults(result.data);
-    if (noResults && !isRunning) {
+    if (noResults && !isRunning && !renderEmptyMessage) {
       const supportsRowsPresentAlert = question.alertType() === ALERT_TYPE_ROWS;
 
       // successful query but there were 0 rows returned with the result

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -1151,7 +1151,7 @@ class TableInteractive extends Component {
         0,
       ) + (gutterColumn ? SIDEBAR_WIDTH : 0);
 
-    const isEmpty = rows === null || rows.length === 0;
+    const isEmpty = rows == null || rows.length === 0;
 
     return (
       <DelayGroup>

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -8,6 +8,7 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import { EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID } from "embedding-sdk/config";
+import { ErrorMessage } from "metabase/components/ErrorMessage";
 import ExplicitSize from "metabase/components/ExplicitSize";
 import { QueryColumnInfoPopover } from "metabase/components/MetadataInfo/ColumnInfoPopover";
 import Button from "metabase/core/components/Button";
@@ -1109,6 +1110,18 @@ class TableInteractive extends Component {
     return false;
   }
 
+  renderEmptyMessage = () => {
+    return (
+      <div className={cx(TableS.fill, CS.flex)}>
+        <ErrorMessage
+          type="noRows"
+          title={t`No results!`}
+          message={t`This may be the answer you’re looking for. If not, try removing or changing your filters to make them less specific.`}
+        />
+      </div>
+    );
+  };
+
   render() {
     const {
       width,
@@ -1118,6 +1131,7 @@ class TableInteractive extends Component {
       scrollToColumn,
       scrollToLastColumn,
       theme,
+      renderEmptyMessage,
     } = this.props;
 
     if (!width || !height) {
@@ -1136,6 +1150,8 @@ class TableInteractive extends Component {
         (sum, _c, index) => sum + this.getColumnWidth({ index }),
         0,
       ) + (gutterColumn ? SIDEBAR_WIDTH : 0);
+
+    const isEmpty = rows === null || rows.length === 0;
 
     return (
       <DelayGroup>
@@ -1261,6 +1277,7 @@ class TableInteractive extends Component {
                   tabIndex={null}
                   scrollToColumn={scrollToColumn}
                 />
+                {isEmpty && renderEmptyMessage && this.renderEmptyMessage()}
                 <Grid
                   id="main-data-grid"
                   ref={this.gridRef}

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.module.css
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.module.css
@@ -106,3 +106,7 @@
 .isOverflowing {
   border-left: 1px solid var(--mb-color-border);
 }
+
+.fill {
+  height: 100%;
+}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/37300

### Description

This PR allows the visualization to render its own empty message, thus allowing it to render other parts for the visualization too.


### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> Orders
2. Add a filter to make the result set empty, ie. Tax < 0
3. Switch to Metadata by clicking the button in the header
4. The table headers should be visible and clickable

### Demo

<img width="1474" alt="Screenshot 2024-11-18 at 22 47 14" src="https://github.com/user-attachments/assets/b2facc68-1b25-4189-b153-e8acddf8f477">


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
