### PR TITLE
Fix flaky e2e tests by using `synchronous-batch-updates: true` by default

### DIFF
--- a/e2e/snapshot-creators/default.cy.snap.js
+++ b/e2e/snapshot-creators/default.cy.snap.js
@@ -8,6 +8,7 @@ import {
   USER_GROUPS,
 } from "e2e/support/cypress_data";
 import {
+  changeSynchronousBatchUpdateSetting,
   restore,
   snapshot,
   updateSetting,
@@ -90,6 +91,12 @@ describe("snapshots", () => {
   }
 
   function updateSettings() {
+    // Asynchronous updates greatly contribute to the non-determinism of our e2e tests,
+    // significantly increasing their flakiness. These failures hardly reflect real-life
+    // scenarios, as users do not interact with the UI as quickly as Cypress does.
+    // To mitigate this type of flakiness, we use synchronous updates by default in e2e tests.
+    changeSynchronousBatchUpdateSetting(true);
+
     updateSetting("enable-public-sharing", true);
     // interactive is not enabled in the snapshots as it requires a premium feature
     // updateSetting("enable-embedding-interactive", true);

--- a/e2e/snapshot-creators/default.cy.snap.js
+++ b/e2e/snapshot-creators/default.cy.snap.js
@@ -8,7 +8,6 @@ import {
   USER_GROUPS,
 } from "e2e/support/cypress_data";
 import {
-  changeSynchronousBatchUpdateSetting,
   restore,
   snapshot,
   updateSetting,
@@ -95,7 +94,9 @@ describe("snapshots", () => {
     // significantly increasing their flakiness. These failures hardly reflect real-life
     // scenarios, as users do not interact with the UI as quickly as Cypress does.
     // To mitigate this type of flakiness, we use synchronous updates by default in e2e tests.
-    changeSynchronousBatchUpdateSetting(true);
+    //
+    // The most frequently flaky tests were the dashboard filter tests, often involving last_used_param_values.
+    updateSetting("synchronous-batch-updates", true);
 
     updateSetting("enable-public-sharing", true);
     // interactive is not enabled in the snapshots as it requires a premium feature

--- a/e2e/support/helpers/e2e-filter-helpers.js
+++ b/e2e/support/helpers/e2e-filter-helpers.js
@@ -4,8 +4,6 @@ import {
   popover,
 } from "e2e/support/helpers/e2e-ui-elements-helpers";
 
-import { updateSetting } from "./api";
-
 export function setDropdownFilterType() {
   cy.findByText("Dropdown list").click();
 }
@@ -82,8 +80,4 @@ export function checkFilterListSourceHasValue({ values }) {
 export function setConnectedFieldSource(table, field) {
   popover().findByText(table).click();
   popover().findByText(field).click();
-}
-
-export function changeSynchronousBatchUpdateSetting(value) {
-  updateSetting("synchronous-batch-updates", value);
 }

--- a/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
@@ -4,7 +4,6 @@ import {
   type StructuredQuestionDetails,
   assertQueryBuilderRowCount,
   assertTableData,
-  changeSynchronousBatchUpdateSetting,
   createDashboard,
   createQuestion,
   editDashboard,
@@ -627,14 +626,7 @@ describe("scenarios > custom column > boolean functions", () => {
     }
 
     beforeEach(() => {
-      cy.signInAsAdmin();
-      changeSynchronousBatchUpdateSetting(true);
       cy.signInAsNormalUser();
-    });
-
-    afterEach(() => {
-      cy.signInAsAdmin();
-      changeSynchronousBatchUpdateSetting(false);
     });
 
     it("should be able setup an 'open question' click behavior", () => {

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-required-simple-filter.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-required-simple-filter.cy.spec.js
@@ -1,5 +1,4 @@
 import {
-  changeSynchronousBatchUpdateSetting,
   clearFilterWidget,
   editDashboard,
   restore,
@@ -44,7 +43,6 @@ describe("scenarios > dashboard > filters > SQL > simple filter > required ", ()
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-    changeSynchronousBatchUpdateSetting(true);
 
     cy.createNativeQuestionAndDashboard({
       questionDetails,
@@ -66,10 +64,6 @@ describe("scenarios > dashboard > filters > SQL > simple filter > required ", ()
 
       visitDashboard(dashboard_id);
     });
-  });
-
-  afterEach(() => {
-    changeSynchronousBatchUpdateSetting(false);
   });
 
   it("should respect default filter precedence while properly updating the url for each step of the flow", () => {

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -5,7 +5,6 @@ import {
   ORDERS_DASHBOARD_ID,
 } from "e2e/support/cypress_sample_instance_data";
 import {
-  changeSynchronousBatchUpdateSetting,
   disconnectDashboardFilter,
   editDashboard,
   filterWidget,
@@ -47,12 +46,6 @@ describe("scenarios > dashboard > parameters", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-    changeSynchronousBatchUpdateSetting(true);
-  });
-
-  afterEach(() => {
-    cy.signInAsAdmin();
-    changeSynchronousBatchUpdateSetting(false);
   });
 
   it("one filter should search across multiple fields", () => {

--- a/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
@@ -1,7 +1,6 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   appBar,
-  changeSynchronousBatchUpdateSetting,
   clearFilterWidget,
   createNativeQuestion,
   createQuestion,
@@ -238,14 +237,7 @@ const getParameterMapping = card => ({
 describe("scenarios > dashboard > temporal unit parameters", () => {
   beforeEach(() => {
     restore();
-    cy.signInAsAdmin();
-    changeSynchronousBatchUpdateSetting(true);
     cy.signInAsNormalUser();
-  });
-
-  afterEach(() => {
-    cy.signInAsAdmin();
-    changeSynchronousBatchUpdateSetting(false);
   });
 
   describe("mapping targets", () => {

--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -11,7 +11,6 @@ import {
 import {
   addHeadingWhileEditing,
   addLinkWhileEditing,
-  changeSynchronousBatchUpdateSetting,
   createDashboardWithTabs,
   createNewTab,
   dashboardCards,
@@ -98,12 +97,6 @@ describe("scenarios > dashboard > tabs", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-    changeSynchronousBatchUpdateSetting(true);
-  });
-
-  afterEach(() => {
-    cy.signInAsAdmin();
-    changeSynchronousBatchUpdateSetting(false);
   });
 
   it("should only display cards on the selected tab", () => {

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -13,7 +13,6 @@ import {
   appBar,
   assertQueryBuilderRowCount,
   assertTabSelected,
-  changeSynchronousBatchUpdateSetting,
   commandPalette,
   commandPaletteSearch,
   createDashboard,
@@ -1469,12 +1468,6 @@ describe("issues 15279 and 24500", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-    changeSynchronousBatchUpdateSetting(true);
-  });
-
-  afterEach(() => {
-    cy.signInAsAdmin();
-    changeSynchronousBatchUpdateSetting(false);
   });
 
   it("corrupted dashboard filter should still appear in the UI without breaking other filters (metabase#15279, metabase#24500)", () => {
@@ -1788,7 +1781,6 @@ describe("issue 25374", () => {
 
     restore();
     cy.signInAsAdmin();
-    changeSynchronousBatchUpdateSetting(true); // prevent last_used_param_values from breaking test isolation
 
     cy.createNativeQuestionAndDashboard({
       questionDetails,
@@ -1829,10 +1821,6 @@ describe("issue 25374", () => {
 
       cy.location("search").should("eq", "?equal_to=1%2C2%2C3");
     });
-  });
-
-  afterEach(() => {
-    changeSynchronousBatchUpdateSetting(false);
   });
 
   it("should pass comma-separated values down to the connected question (metabase#25374-1)", () => {


### PR DESCRIPTION
### Description

Asynchronous updates make our e2e tests flaky (every usage of `changeSynchronousBatchUpdateSetting` was to fix a flake) and confusing ([1](https://metaboat.slack.com/archives/C064TCGEAV6/p1726038247433939), [2](https://metaboat.slack.com/archives/C010L1Z4F9S/p1727947712609579), [3](https://github.com/metabase/metabase/pull/49378)). Approximately 20% of recent (last 3 weeks) top flakes were due to this problem.

This PR makes all e2e tests use synchronous updates by default which should fix an entire class of flakes and prevent new ones in the future. I didn't notice any significant difference in performance (if any, it was in favor of this change).

Original PR that introduced `synchronous-batch-updates`: #45007

### This PR started as a single flake fix

Fixes one of top [flaky tests](https://github.com/metabase/metabase/blob/5203a15cdcaef74214ec9cc83fa48ca298a52a73/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js#L1129) (see https://stats.metabase.com/question/18032 but exclude branches containing `metabot`).
Example failures:
- https://github.com/metabase/metabase/actions/runs/11890954119/attempts/1
- https://github.com/metabase/metabase/actions/runs/11894791208

#### How to verify

Stress test: https://github.com/metabase/metabase/actions/runs/11894787903
