### PR TITLE
For new search, default to excluding other people's collections

### DIFF
--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -122,10 +122,11 @@
   - The `verified` filter supports models and cards.
 
   A search query that has both filters applied will only return models and cards."
-  [q archived created_at created_by table_db_id models last_edited_at last_edited_by
+  [q context archived created_at created_by table_db_id models last_edited_at last_edited_by
    filter_items_in_personal_collection model_ancestors search_engine search_native_query
    verified ids calculate_available_models]
   {q                                   [:maybe ms/NonBlankString]
+   context                             [:maybe :keyword]
    archived                            [:maybe :boolean]
    table_db_id                         [:maybe ms/PositiveInt]
    models                              [:maybe (ms/QueryVectorOf search/SearchableModel)]
@@ -147,6 +148,7 @@
     (search/search
      (search/search-context
       {:archived                            archived
+       :context                             context
        :created-at                          created_at
        :created-by                          (set created_by)
        :current-user-id                     api/*current-user-id*

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -129,7 +129,7 @@
    archived                            [:maybe :boolean]
    table_db_id                         [:maybe ms/PositiveInt]
    models                              [:maybe (ms/QueryVectorOf search/SearchableModel)]
-   filter_items_in_personal_collection [:maybe[:enum "all" "only" "only-mine" "exclude" "exclude-others"]]
+   filter_items_in_personal_collection [:maybe [:enum "all" "only" "only-mine" "exclude" "exclude-others"]]
    created_at                          [:maybe ms/NonBlankString]
    created_by                          [:maybe (ms/QueryVectorOf ms/PositiveInt)]
    last_edited_at                      [:maybe ms/NonBlankString]

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -129,7 +129,7 @@
    archived                            [:maybe :boolean]
    table_db_id                         [:maybe ms/PositiveInt]
    models                              [:maybe (ms/QueryVectorOf search/SearchableModel)]
-   filter_items_in_personal_collection [:maybe [:enum "only" "exclude"]]
+   filter_items_in_personal_collection [:maybe [:enum "only" "exclude" "all" "not-others"]]
    created_at                          [:maybe ms/NonBlankString]
    created_by                          [:maybe (ms/QueryVectorOf ms/PositiveInt)]
    last_edited_at                      [:maybe ms/NonBlankString]

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -129,7 +129,7 @@
    archived                            [:maybe :boolean]
    table_db_id                         [:maybe ms/PositiveInt]
    models                              [:maybe (ms/QueryVectorOf search/SearchableModel)]
-   filter_items_in_personal_collection [:maybe [:enum "only" "exclude" "all" "not-others"]]
+   filter_items_in_personal_collection [:maybe[:enum "all" "only" "only-mine" "exclude" "exclude-others"]]
    created_at                          [:maybe ms/NonBlankString]
    created_by                          [:maybe (ms/QueryVectorOf ms/PositiveInt)]
    last_edited_at                      [:maybe ms/NonBlankString]

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -199,7 +199,7 @@
    ;;
    [:created-at                          {:optional true} ms/NonBlankString]
    [:created-by                          {:optional true} [:set {:min 1} ms/PositiveInt]]
-   [:filter-items-in-personal-collection {:optional true} [:enum "only" "exclude"]]
+   [:filter-items-in-personal-collection {:optional true} [:enum "only" "exclude" "all" "not-others"]]
    [:last-edited-at                      {:optional true} ms/NonBlankString]
    [:last-edited-by                      {:optional true} [:set {:min 1} ms/PositiveInt]]
    [:limit-int                           {:optional true} ms/Int]

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -182,6 +182,7 @@
    ;; required
    ;;
    [:archived?          [:maybe :boolean]]
+   [:context            :keyword]
    [:current-user-id    pos-int?]
    [:is-superuser?      :boolean]
    ;; TODO only optional and maybe for tests, clean that up!

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -199,7 +199,7 @@
    ;;
    [:created-at                          {:optional true} ms/NonBlankString]
    [:created-by                          {:optional true} [:set {:min 1} ms/PositiveInt]]
-   [:filter-items-in-personal-collection {:optional true} [:enum "only" "exclude" "all" "not-others"]]
+   [:filter-items-in-personal-collection [:enum "all" "only" "only-mine" "exclude" "exclude-others"]]
    [:last-edited-at                      {:optional true} ms/NonBlankString]
    [:last-edited-by                      {:optional true} [:set {:min 1} ms/PositiveInt]]
    [:limit-int                           {:optional true} ms/Int]

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -182,10 +182,10 @@
    ;; required
    ;;
    [:archived?          [:maybe :boolean]]
-   [:context            :keyword]
    [:current-user-id    pos-int?]
    [:is-superuser?      :boolean]
    ;; TODO only optional and maybe for tests, clean that up!
+   [:context               {:optional true} [:maybe :keyword]]
    [:is-impersonated-user? {:optional true} [:maybe :boolean]]
    [:is-sandboxed-user?    {:optional true} [:maybe :boolean]]
    [:current-user-perms [:set perms.u/PathSchema]]

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -199,7 +199,7 @@
    ;;
    [:created-at                          {:optional true} ms/NonBlankString]
    [:created-by                          {:optional true} [:set {:min 1} ms/PositiveInt]]
-   [:filter-items-in-personal-collection [:enum "all" "only" "only-mine" "exclude" "exclude-others"]]
+   [:filter-items-in-personal-collection {:optional true} [:enum "all" "only" "only-mine" "exclude" "exclude-others"]]
    [:last-edited-at                      {:optional true} ms/NonBlankString]
    [:last-edited-by                      {:optional true} [:set {:min 1} ms/PositiveInt]]
    [:limit-int                           {:optional true} ms/Int]

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -312,9 +312,9 @@
                         :calculate-available-models?         (boolean calculate-available-models?)
                         :current-user-id                     current-user-id
                         :current-user-perms                  current-user-perms
-                        :filter-items-in-personal-collection #p (or filter-items-in-personal-collection
+                        :filter-items-in-personal-collection (or filter-items-in-personal-collection
                                                                  (if (and (not= engine :search.engine/in-place)
-                                                                      (#{:search-app :command-palette} context))
+                                                                          (#{:search-app :command-palette} context))
                                                                    "exclude-others"
                                                                    "all"))
                         :is-impersonated-user?               is-impersonated-user?

--- a/src/metabase/search/postgres/core.clj
+++ b/src/metabase/search/postgres/core.clj
@@ -93,8 +93,7 @@
   "Add a `WHERE` clause to the query to only return Collections the Current User has access to; join against Collection,
   so we can return its `:name`."
   [search-ctx qry]
-  (let [search-ctx             (update search-ctx :filter-items-in-personal-collection #(or % "not-others"))
-        collection-id-col      :search_index.collection_id
+  (let [collection-id-col      :search_index.collection_id
         permitted-clause       (search.permissions/permitted-collections-clause search-ctx collection-id-col)
         personal-clause        (search.filter/personal-collections-where-clause search-ctx collection-id-col)]
     (cond-> qry

--- a/src/metabase/search/postgres/core.clj
+++ b/src/metabase/search/postgres/core.clj
@@ -93,7 +93,8 @@
   "Add a `WHERE` clause to the query to only return Collections the Current User has access to; join against Collection,
   so we can return its `:name`."
   [search-ctx qry]
-  (let [collection-id-col      :search_index.collection_id
+  (let [search-ctx             (update search-ctx :filter-items-in-personal-collection #(or % "not-others"))
+        collection-id-col      :search_index.collection_id
         permitted-clause       (search.permissions/permitted-collections-clause search-ctx collection-id-col)
         personal-clause        (search.filter/personal-collections-where-clause search-ctx collection-id-col)]
     (cond-> qry


### PR DESCRIPTION
Adds a 4th type of personal collection filter, and make it the default for full text search.

We shouldn't release this without adding a way for the frontend's Search Results page to relax this filter to "all".