### PR TITLE
Use global e2e helper

### DIFF
--- a/e2e/support/index.ts
+++ b/e2e/support/index.ts
@@ -1,0 +1,4 @@
+// H is for helpers 🤗
+import * as H from "./helpers";
+
+export { H };

--- a/e2e/support/integration/visit-dashboard.cy.spec.js
+++ b/e2e/support/integration/visit-dashboard.cy.spec.js
@@ -1,5 +1,5 @@
+import { H } from "e2e/support";
 import { USERS } from "e2e/support/cypress_data";
-import { restore, visitDashboard } from "e2e/support/helpers";
 
 import { setup } from "./visit-dashboard";
 
@@ -7,7 +7,7 @@ describe("visitDashboard e2e helper", () => {
   Object.keys(Cypress._.omit(USERS, "sandboxed")).forEach(user => {
     context(`${user.toUpperCase()}`, () => {
       beforeEach(() => {
-        restore();
+        H.restore();
         cy.signInAsAdmin();
 
         setup();
@@ -18,27 +18,27 @@ describe("visitDashboard e2e helper", () => {
       });
 
       it("should work on an empty dashboard", () => {
-        visitDashboard("@emptyDashboard");
+        H.visitDashboard("@emptyDashboard");
       });
 
       it("should work on a dashboard with markdown card", () => {
-        visitDashboard("@markdownOnly");
+        H.visitDashboard("@markdownOnly");
       });
 
       it("should work on a dashboard with a model", () => {
-        visitDashboard("@modelDashboard");
+        H.visitDashboard("@modelDashboard");
       });
 
       it("should work on a dashboard with a GUI question", () => {
-        visitDashboard("@guiDashboard");
+        H.visitDashboard("@guiDashboard");
       });
 
       it("should work on a dashboard with a native question", () => {
-        visitDashboard("@nativeDashboard");
+        H.visitDashboard("@nativeDashboard");
       });
 
       it("should work on a dashboard with multiple cards (including markdown, models, pivot tables, GUI and native)", () => {
-        visitDashboard("@multiDashboard");
+        H.visitDashboard("@multiDashboard");
       });
     });
   });

--- a/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
@@ -1,17 +1,7 @@
 import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
 
+import { H } from "e2e/support";
 import { USER_GROUPS, WRITABLE_DB_ID } from "e2e/support/cypress_data";
-import {
-  createImplicitActions,
-  createModelFromTableName,
-  popover,
-  resetTestTable,
-  restore,
-  resyncDatabase,
-  undoToastList,
-  visitDashboard,
-  visitModel,
-} from "e2e/support/helpers";
 
 const WRITABLE_TEST_TABLE = "scoreboard_actions";
 const FIRST_SCORE_ROW_ID = 11;
@@ -37,8 +27,8 @@ describe(
         "prefetchValues",
       );
 
-      resetTestTable({ type: "postgres", table: WRITABLE_TEST_TABLE });
-      restore("postgres-writable");
+      H.resetTestTable({ type: "postgres", table: WRITABLE_TEST_TABLE });
+      H.restore("postgres-writable");
       asAdmin(() => {
         cy.updatePermissionsGraph({
           [ALL_USERS_GROUP]: {
@@ -49,12 +39,12 @@ describe(
           },
         });
 
-        resyncDatabase({
+        H.resyncDatabase({
           dbId: WRITABLE_DB_ID,
           tableName: WRITABLE_TEST_TABLE,
         });
 
-        createModelFromTableName({
+        H.createModelFromTableName({
           tableName: WRITABLE_TEST_TABLE,
           idAlias: "modelId",
         });
@@ -65,7 +55,7 @@ describe(
       beforeEach(() => {
         asAdmin(() => {
           cy.get("@modelId").then(modelId => {
-            createImplicitActions({ modelId });
+            H.createImplicitActions({ modelId });
 
             cy.createQuestionAndDashboard({
               questionDetails: {
@@ -86,7 +76,7 @@ describe(
 
       it("does not show model actions in model visualization on a dashboard", () => {
         asAdmin(() => {
-          visitDashboard("@dashboardId");
+          H.visitDashboard("@dashboardId");
 
           cy.findByTestId("dashcard").within(() => {
             assertActionsDropdownNotExists();
@@ -125,7 +115,7 @@ describe(
               });
 
               asAdmin(() => {
-                createImplicitActions({ modelId });
+                H.createImplicitActions({ modelId });
               });
 
               permissionFn(() => {
@@ -202,7 +192,7 @@ describe(
       cy.signInAsAdmin();
 
       cy.get("@modelId").then(modelId => {
-        createImplicitActions({ modelId });
+        H.createImplicitActions({ modelId });
         visitObjectDetail(modelId, FIRST_SCORE_ROW_ID);
         openUpdateObjectModal();
       });
@@ -241,7 +231,7 @@ function asNormalUser(callback) {
 }
 
 function visitObjectDetail(modelId, objectId) {
-  visitModel(modelId);
+  H.visitModel(modelId);
   cy.get("main").findByText("Loading...").should("not.exist");
   cy.findByTestId("TableInteractive-root").findByText(objectId).click();
 }
@@ -252,12 +242,12 @@ function openObjectDetailModal(objectId) {
 
 function openUpdateObjectModal() {
   cy.findByTestId("actions-menu").click();
-  popover().findByText("Update").should("be.visible").click();
+  H.popover().findByText("Update").should("be.visible").click();
 }
 
 function openDeleteObjectModal() {
   cy.findByTestId("actions-menu").click();
-  popover().findByText("Delete").should("be.visible").click();
+  H.popover().findByText("Delete").should("be.visible").click();
 }
 
 function assertActionsDropdownExists() {
@@ -311,7 +301,7 @@ function assertUpdatedScoreNotInTable() {
 
 function assertSuccessfullUpdateToast() {
   cy.log("it shows a toast informing the update was successful");
-  undoToastList()
+  H.undoToastList()
     .last()
     .should("be.visible")
     .should("have.attr", "color", "success")
@@ -320,7 +310,7 @@ function assertSuccessfullUpdateToast() {
 
 function assertSuccessfullDeleteToast() {
   cy.log("it shows a toast informing the delete was successful");
-  undoToastList()
+  H.undoToastList()
     .last()
     .should("be.visible")
     .should("have.attr", "color", "success")

--- a/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
@@ -1,20 +1,7 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  createAction,
-  editDashboard,
-  getActionCardDetails,
-  getDashboardCard,
-  getNextUnsavedDashboardCardId,
-  modal,
-  restore,
-  saveDashboard,
-  setActionsEnabledForDB,
-  undoToast,
-  updateDashboardCards,
-  visitDashboard,
-} from "e2e/support/helpers";
 import {
   createMockActionParameter,
   createMockParameter,
@@ -32,15 +19,15 @@ describe("metabase#31587", () => {
   viewports.forEach(([width, height]) => {
     describe(`Testing on resolution ${width} x ${height}`, () => {
       beforeEach(() => {
-        restore();
+        H.restore();
         cy.signInAsAdmin();
-        setActionsEnabledForDB(SAMPLE_DB_ID);
+        H.setActionsEnabledForDB(SAMPLE_DB_ID);
         cy.viewport(width, height);
       });
 
       it("should not allow action buttons to overflow when editing dashboard", () => {
-        visitDashboard(ORDERS_DASHBOARD_ID);
-        editDashboard();
+        H.visitDashboard(ORDERS_DASHBOARD_ID);
+        H.editDashboard();
         cy.button("Add action").click();
 
         cy.findByTestId("dashboard-parameters-and-cards").within(() => {
@@ -63,11 +50,11 @@ describe("metabase#31587", () => {
       });
 
       it("should not allow action buttons to overflow when viewing info sidebar", () => {
-        visitDashboard(ORDERS_DASHBOARD_ID);
-        editDashboard();
+        H.visitDashboard(ORDERS_DASHBOARD_ID);
+        H.editDashboard();
         cy.findByLabelText("Add action").click();
 
-        saveDashboard();
+        H.saveDashboard();
         cy.icon("info").click();
 
         cy.findByTestId("dashboard-parameters-and-cards").within(() => {
@@ -165,11 +152,11 @@ describe("Issue 32974", { tags: ["@external", "@actions"] }, () => {
     );
 
     cy.then(function () {
-      updateDashboardCards({
+      H.updateDashboardCards({
         dashboard_id: this.dashboardId,
         cards: [
           {
-            id: getNextUnsavedDashboardCardId(),
+            id: H.getNextUnsavedDashboardCardId(),
             card_id: this.modelId,
             // Map dashboard parameter to PRODUCTS.ID
             parameter_mappings: [
@@ -180,7 +167,7 @@ describe("Issue 32974", { tags: ["@external", "@actions"] }, () => {
               },
             ],
           },
-          getActionCardDetails({
+          H.getActionCardDetails({
             label: QUERY_ACTION.name,
             action_id: this.actionId,
             // Map action's ID parameter to dashboard parameter
@@ -200,18 +187,18 @@ describe("Issue 32974", { tags: ["@external", "@actions"] }, () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.createQuestion(MODEL_DETAILS, {
       wrapId: true,
       idAlias: "modelId",
     });
-    setActionsEnabledForDB(SAMPLE_DB_ID, true);
+    H.setActionsEnabledForDB(SAMPLE_DB_ID, true);
   });
 
   it("can submit query action linked with dashboard parameters (metabase#32974)", () => {
     cy.get("@modelId").then(modelId => {
-      createAction({ ...QUERY_ACTION, model_id: modelId }).then(
+      H.createAction({ ...QUERY_ACTION, model_id: modelId }).then(
         ({ body: { id: actionId } }) => {
           cy.wrap(actionId).as("actionId");
         },
@@ -220,15 +207,15 @@ describe("Issue 32974", { tags: ["@external", "@actions"] }, () => {
 
     setupDashboard();
 
-    visitDashboard("@dashboardId", { params: { id: 1 } });
+    H.visitDashboard("@dashboardId", { params: { id: 1 } });
 
     cy.log("Execute action");
     cy.button(QUERY_ACTION.name).click();
-    modal().button(QUERY_ACTION.name).click();
+    H.modal().button(QUERY_ACTION.name).click();
 
     cy.log("Assertions");
-    getDashboardCard().findByText(EXPECTED_UPDATED_VALUE).should("exist");
-    modal().should("not.exist");
-    undoToast().findByText("Query action ran successfully").should("exist");
+    H.getDashboardCard().findByText(EXPECTED_UPDATED_VALUE).should("exist");
+    H.modal().should("not.exist");
+    H.undoToast().findByText("Query action ran successfully").should("exist");
   });
 });

--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -1,25 +1,11 @@
 import { assocIn } from "icepick";
 
+import { H } from "e2e/support";
 import {
   SAMPLE_DB_ID,
   USER_GROUPS,
   WRITABLE_DB_ID,
 } from "e2e/support/cypress_data";
-import {
-  createAction,
-  createImplicitActions,
-  createModelFromTableName,
-  entityPickerModal,
-  fillActionQuery,
-  modal,
-  popover,
-  queryWritableDB,
-  resetTestTable,
-  restore,
-  resyncDatabase,
-  setActionsEnabledForDB,
-  setTokenFeatures,
-} from "e2e/support/helpers";
 import { getCreatePostgresRoleIfNotExistSql } from "e2e/support/test_roles";
 import { createMockActionParameter } from "metabase-types/api/mocks";
 
@@ -79,11 +65,11 @@ describe(
   { tags: ["@external", "@actions"] },
   () => {
     beforeEach(() => {
-      restore("postgres-12");
+      H.restore("postgres-12");
       cy.signInAsAdmin();
-      setActionsEnabledForDB(WRITABLE_DB_ID);
+      H.setActionsEnabledForDB(WRITABLE_DB_ID);
 
-      createModelFromTableName({
+      H.createModelFromTableName({
         tableName: "orders",
         modelName: "Order",
         idAlias: "modelId",
@@ -119,12 +105,12 @@ describe(
       });
 
       cy.findByRole("link", { name: "New action" }).click();
-      fillActionQuery("DELETE FROM orders WHERE id = {{ id }}");
+      H.fillActionQuery("DELETE FROM orders WHERE id = {{ id }}");
       cy.findByRole("radiogroup", { name: "Field type" })
         .findByText("Number")
         .click();
       cy.findByRole("button", { name: "Save" }).click();
-      modal()
+      H.modal()
         .eq(1)
         .within(() => {
           cy.findByLabelText("Name").type("Delete Order");
@@ -135,7 +121,7 @@ describe(
         .should("be.visible");
 
       openActionEditorFor("Delete Order");
-      fillActionQuery(" AND status = 'pending'");
+      H.fillActionQuery(" AND status = 'pending'");
       cy.findByRole("radiogroup", { name: "Field type" })
         .findByLabelText("Number")
         .should("be.checked");
@@ -148,9 +134,9 @@ describe(
         .should("be.visible");
 
       openActionMenuFor("Delete Order");
-      popover().findByText("Archive").click();
+      H.popover().findByText("Archive").click();
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("Archive Delete Order?").should("be.visible");
         cy.findByRole("button", { name: "Archive" }).click();
       });
@@ -158,8 +144,8 @@ describe(
       cy.findByRole("listitem", { name: "Delete Order" }).should("not.exist");
 
       cy.findByLabelText("Actions menu").click();
-      popover().findByText("Disable basic actions").click();
-      modal().within(() => {
+      H.popover().findByText("Disable basic actions").click();
+      H.modal().within(() => {
         cy.findByText("Disable basic actions?").should("be.visible");
         cy.button("Disable").click();
       });
@@ -179,10 +165,10 @@ describe(
       cy.visit("/");
 
       cy.findByTestId("app-bar").findByText("New").click();
-      popover().findByText("Action").click();
+      H.popover().findByText("Action").click();
 
       cy.wait("@getDatabase");
-      fillActionQuery(QUERY);
+      H.fillActionQuery(QUERY);
 
       cy.findByRole("dialog").within(() => {
         cy.findByText(/New Action/)
@@ -192,8 +178,8 @@ describe(
         cy.findByRole("button", { name: "Save" }).click();
       });
 
-      modal().eq(1).findByText("Select a model").click();
-      entityPickerModal().within(() => {
+      H.modal().eq(1).findByText("Select a model").click();
+      H.entityPickerModal().within(() => {
         cy.findByText("Order").click();
       });
 
@@ -214,9 +200,9 @@ describe(
     it("should respect permissions", () => {
       // Enabling actions for sample database as well
       // to test database picker behavior in the action editor
-      setActionsEnabledForDB(SAMPLE_DB_ID);
+      H.setActionsEnabledForDB(SAMPLE_DB_ID);
 
-      setTokenFeatures("all");
+      H.setTokenFeatures("all");
       cy.updatePermissionsGraph({
         [USER_GROUPS.ALL_USERS_GROUP]: {
           [WRITABLE_DB_ID]: {
@@ -243,7 +229,7 @@ describe(
       });
 
       openActionMenuFor(SAMPLE_QUERY_ACTION.name);
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Archive").should("not.exist");
         cy.findByText("View").click();
       });
@@ -272,13 +258,13 @@ describe(
 
       // Check can pick between all databases
       cy.findByRole("dialog").findByText("QA Postgres12").click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Sample Database").should("be.visible");
         cy.findByText("QA Postgres12").should("be.visible");
       });
 
       cy.signInAsAdmin();
-      setActionsEnabledForDB(SAMPLE_DB_ID, false);
+      H.setActionsEnabledForDB(SAMPLE_DB_ID, false);
       cy.signIn("normal");
       cy.reload();
 
@@ -293,16 +279,16 @@ describe(
     it("should display parameters for variable template tags only", () => {
       cy.visit("/");
       cy.findByTestId("app-bar").findByText("New").click();
-      popover().findByText("Action").click();
+      H.popover().findByText("Action").click();
 
-      fillActionQuery("{{#1-orders-model}}");
+      H.fillActionQuery("{{#1-orders-model}}");
       cy.findByLabelText("#1-orders-model").should("not.exist");
 
-      fillActionQuery("{{snippet:101}}");
+      H.fillActionQuery("{{snippet:101}}");
       cy.findByLabelText("#1-orders-model").should("not.exist");
       cy.findByLabelText("101").should("not.exist");
 
-      fillActionQuery("{{id}}");
+      H.fillActionQuery("{{id}}");
       cy.findByLabelText("#1-orders-model").should("not.exist");
       cy.findByLabelText("101").should("not.exist");
       cy.findByLabelText("ID").should("be.visible");
@@ -312,7 +298,7 @@ describe(
       const actionName = "Update";
 
       cy.get("@modelId").then(modelId => {
-        createImplicitActions({ modelId });
+        H.createImplicitActions({ modelId });
 
         cy.visit(`/model/${modelId}/detail`);
         cy.wait("@getModel");
@@ -324,7 +310,7 @@ describe(
 
       cy.wait("@getAction");
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByLabelText("ID").type("1");
         cy.findByLabelText("User ID").type("999999");
         cy.button(actionName).click();
@@ -356,19 +342,22 @@ describe(
         "disableActionSharing",
       );
 
-      resetTestTable({ type: dialect, table: WRITABLE_TEST_TABLE });
-      restore(`${dialect}-writable`);
+      H.resetTestTable({ type: dialect, table: WRITABLE_TEST_TABLE });
+      H.restore(`${dialect}-writable`);
       cy.signInAsAdmin();
-      resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: WRITABLE_TEST_TABLE });
+      H.resyncDatabase({
+        dbId: WRITABLE_DB_ID,
+        tableName: WRITABLE_TEST_TABLE,
+      });
 
-      createModelFromTableName({
+      H.createModelFromTableName({
         tableName: WRITABLE_TEST_TABLE,
         idAlias: "writableModelId",
       });
     });
 
     it("should allow action execution from the model detail page", () => {
-      queryWritableDB(
+      H.queryWritableDB(
         `SELECT * FROM ${WRITABLE_TEST_TABLE} WHERE id = 1`,
         dialect,
       ).then(result => {
@@ -377,7 +366,7 @@ describe(
       });
 
       cy.get("@writableModelId").then(modelId => {
-        createAction({
+        H.createAction({
           ...SAMPLE_WRITABLE_QUERY_ACTION,
           model_id: modelId,
         });
@@ -387,7 +376,7 @@ describe(
 
       runActionFor(SAMPLE_QUERY_ACTION.name);
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByLabelText(TEST_PARAMETER.name).type("1");
         cy.button(SAMPLE_QUERY_ACTION.name).click();
       });
@@ -396,7 +385,7 @@ describe(
         .findByText(`${SAMPLE_QUERY_ACTION.name} ran successfully`)
         .should("be.visible");
 
-      queryWritableDB(
+      H.queryWritableDB(
         `SELECT * FROM ${WRITABLE_TEST_TABLE} WHERE id = 1`,
         dialect,
       ).then(result => {
@@ -410,11 +399,11 @@ describe(
       const IMPLICIT_ACTION_NAME = "Update";
 
       cy.get("@writableModelId").then(modelId => {
-        createAction({
+        H.createAction({
           ...SAMPLE_WRITABLE_QUERY_ACTION,
           model_id: modelId,
         });
-        createAction({
+        H.createAction({
           type: "implicit",
           kind: "row/update",
           name: IMPLICIT_ACTION_NAME,
@@ -443,7 +432,7 @@ describe(
         cy.findByRole("form").should("not.exist");
         cy.button(SAMPLE_QUERY_ACTION.name).should("not.exist");
 
-        queryWritableDB(
+        H.queryWritableDB(
           `SELECT * FROM ${WRITABLE_TEST_TABLE} WHERE id = 1`,
           dialect,
         ).then(result => {
@@ -468,7 +457,7 @@ describe(
         cy.findByRole("form").should("not.exist");
         cy.button(IMPLICIT_ACTION_NAME).should("not.exist");
 
-        queryWritableDB(
+        H.queryWritableDB(
           `SELECT * FROM ${WRITABLE_TEST_TABLE} WHERE id = 2`,
           dialect,
         ).then(result => {
@@ -511,7 +500,7 @@ describe(
       verifyScoreValue(0, dialect);
 
       cy.get("@writableModelId").then(modelId => {
-        createAction({
+        H.createAction({
           ...SAMPLE_WRITABLE_QUERY_ACTION,
           model_id: modelId,
         });
@@ -521,7 +510,7 @@ describe(
 
       openActionEditorFor(SAMPLE_QUERY_ACTION.name);
 
-      fillActionQuery(" [[and status = {{ current_status}}]]");
+      H.fillActionQuery(" [[and status = {{ current_status}}]]");
       cy.findAllByTestId("form-field-container")
         .filter(":contains('Current Status')")
         .within(() => {
@@ -529,7 +518,7 @@ describe(
           cy.icon("gear").click();
         });
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByLabelText("Required").uncheck();
       });
 
@@ -537,7 +526,7 @@ describe(
 
       runActionFor(SAMPLE_QUERY_ACTION.name);
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByLabelText(TEST_PARAMETER.name).type("1");
         cy.findByLabelText("Current Status").should("not.exist");
 
@@ -558,14 +547,14 @@ describe(
           cy.icon("gear").click();
         });
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByLabelText("Required").check();
       });
       cy.findByRole("button", { name: "Update" }).click();
 
       runActionFor(SAMPLE_QUERY_ACTION.name);
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByLabelText(TEST_PARAMETER.name).type("1");
         cy.findByLabelText("Current Status").should("not.exist");
 
@@ -591,7 +580,7 @@ describe(
 
       runActionFor(SAMPLE_QUERY_ACTION.name);
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByLabelText(TEST_PARAMETER.name).type("1");
         cy.button(SAMPLE_QUERY_ACTION.name).should("be.disabled");
 
@@ -634,7 +623,7 @@ describe(
 
       runActionFor("Create");
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByLabelText("Created At").should("not.exist");
         cy.findByLabelText("Team Name").type("Zebras");
         cy.findByLabelText("Score").type("1");
@@ -647,7 +636,7 @@ describe(
         .should("be.visible");
 
       // show toast
-      queryWritableDB(
+      H.queryWritableDB(
         `SELECT * FROM ${WRITABLE_TEST_TABLE} WHERE team_name = 'Zebras'`,
         dialect,
       ).then(result => {
@@ -661,7 +650,7 @@ describe(
 
     it("should allow public sharing of query action and execution", () => {
       cy.get("@writableModelId").then(modelId => {
-        createAction({
+        H.createAction({
           ...SAMPLE_WRITABLE_QUERY_ACTION,
           model_id: modelId,
         });
@@ -676,7 +665,7 @@ describe(
 
       openActionEditorFor(SAMPLE_WRITABLE_QUERY_ACTION.name);
 
-      fillActionQuery(" [[ AND status = {{new_status}} ]]");
+      H.fillActionQuery(" [[ AND status = {{new_status}} ]]");
 
       cy.findAllByTestId("form-field-container")
         .filter(":contains('New Status')")
@@ -687,7 +676,7 @@ describe(
           cy.icon("gear").click();
         });
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByLabelText("Required").uncheck();
       });
 
@@ -706,7 +695,7 @@ describe(
           `${SAMPLE_WRITABLE_QUERY_ACTION.name} ran successfully`,
         ).should("be.visible");
 
-        queryWritableDB(
+        H.queryWritableDB(
           `SELECT * FROM ${WRITABLE_TEST_TABLE} WHERE id = 1`,
           dialect,
         ).then(result => {
@@ -759,7 +748,7 @@ describe(
 
         cy.findByText("Update ran successfully").should("be.visible");
 
-        queryWritableDB(
+        H.queryWritableDB(
           `SELECT * FROM ${WRITABLE_TEST_TABLE} WHERE id = 2`,
           dialect,
         ).then(result => {
@@ -778,8 +767,8 @@ describe(
         role,
         `GRANT SELECT ON ${WRITABLE_TEST_TABLE} TO ${role};`,
       );
-      setTokenFeatures("all");
-      queryWritableDB(sql);
+      H.setTokenFeatures("all");
+      H.queryWritableDB(sql);
 
       const impersonatedUserId = 9;
       cy.request("PUT", `/api/user/${impersonatedUserId}`, {
@@ -810,7 +799,7 @@ describe(
         ],
       );
 
-      queryWritableDB(
+      H.queryWritableDB(
         `SELECT *
          FROM ${WRITABLE_TEST_TABLE}
          WHERE id = 1`,
@@ -821,7 +810,7 @@ describe(
       });
 
       cy.get("@writableModelId").then(modelId => {
-        createAction({
+        H.createAction({
           ...SAMPLE_WRITABLE_QUERY_ACTION,
           model_id: modelId,
         });
@@ -832,7 +821,7 @@ describe(
 
       runActionFor(SAMPLE_QUERY_ACTION.name);
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByLabelText(TEST_PARAMETER.name).type("1");
         cy.button(SAMPLE_QUERY_ACTION.name).click();
 
@@ -841,7 +830,7 @@ describe(
         );
       });
 
-      queryWritableDB(
+      H.queryWritableDB(
         `SELECT *
          FROM ${WRITABLE_TEST_TABLE}
          WHERE id = 1`,
@@ -868,7 +857,7 @@ function openActionMenuFor(actionName) {
 
 function openActionEditorFor(actionName, { isReadOnly = false } = {}) {
   openActionMenuFor(actionName);
-  popover()
+  H.popover()
     .findByText(isReadOnly ? "View" : "Edit")
     .click();
 }
@@ -876,7 +865,7 @@ function openActionEditorFor(actionName, { isReadOnly = false } = {}) {
 function assertQueryEditorDisabled() {
   // Ace doesn't act as a normal input, so we can't use `should("be.disabled")`
   // Instead we'd assert that a user can't type in the editor
-  fillActionQuery("QWERTY");
+  H.fillActionQuery("QWERTY");
   cy.findByText("QWERTY").should("not.exist");
 }
 
@@ -902,7 +891,7 @@ function disableSharingFor(actionName) {
     cy.findByRole("button", { name: "Action settings" }).click();
     cy.findByLabelText("Make public").should("be.checked").click();
   });
-  modal()
+  H.modal()
     .eq(1)
     .within(() => {
       cy.findByText("Disable this public link?").should("be.visible");
@@ -917,7 +906,7 @@ function disableSharingFor(actionName) {
 function resetAndVerifyScoreValue(dialect) {
   const newValue = 0;
 
-  queryWritableDB(
+  H.queryWritableDB(
     `UPDATE ${WRITABLE_TEST_TABLE} SET score = ${newValue} WHERE id = 1`,
     dialect,
   );
@@ -926,7 +915,7 @@ function resetAndVerifyScoreValue(dialect) {
 }
 
 function verifyScoreValue(value, dialect) {
-  queryWritableDB(
+  H.queryWritableDB(
     `SELECT * FROM ${WRITABLE_TEST_TABLE} WHERE id = 1`,
     dialect,
   ).then(result => {

--- a/e2e/test/scenarios/admin-2/api-keys.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/api-keys.cy.spec.ts
@@ -1,3 +1,4 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
@@ -8,13 +9,6 @@ import {
   ORDERS_QUESTION_ID,
   READONLY_GROUP_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  createApiKey,
-  restore,
-  sidesheet,
-  visitDashboard,
-  visitQuestion,
-} from "e2e/support/helpers";
 const { PRODUCTS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > admin > settings > API keys", () => {
@@ -27,7 +21,7 @@ describe("scenarios > admin > settings > API keys", () => {
     cy.intercept("DELETE", "/api/api-key/*").as("deleteKey");
     cy.intercept("GET", "/api/permissions/group").as("getGroups");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -37,7 +31,7 @@ describe("scenarios > admin > settings > API keys", () => {
     cy.wait("@getKeyCount");
     cy.findByTestId("api-keys-setting").findByText("API Keys");
 
-    createApiKey("Test API Key One", ALL_USERS_GROUP_ID);
+    H.createApiKey("Test API Key One", ALL_USERS_GROUP_ID);
 
     cy.reload();
     cy.wait("@getKeyCount");
@@ -46,8 +40,8 @@ describe("scenarios > admin > settings > API keys", () => {
       .findByTestId("card-badge")
       .findByText("1 API Key");
 
-    createApiKey("Test API Key Two", ALL_USERS_GROUP_ID);
-    createApiKey("Test API Key Three", ALL_USERS_GROUP_ID);
+    H.createApiKey("Test API Key Two", ALL_USERS_GROUP_ID);
+    H.createApiKey("Test API Key Three", ALL_USERS_GROUP_ID);
 
     cy.reload();
     cy.wait("@getKeyCount");
@@ -58,9 +52,9 @@ describe("scenarios > admin > settings > API keys", () => {
   });
 
   it("should list existing API keys", () => {
-    createApiKey("Test API Key One", ALL_USERS_GROUP_ID);
-    createApiKey("Test API Key Two", NOSQL_GROUP_ID);
-    createApiKey("Test API Key Three", READONLY_GROUP_ID);
+    H.createApiKey("Test API Key One", ALL_USERS_GROUP_ID);
+    H.createApiKey("Test API Key Two", NOSQL_GROUP_ID);
+    H.createApiKey("Test API Key Three", READONLY_GROUP_ID);
 
     cy.visit("/admin/settings/authentication/api-keys");
     cy.wait("@getKeys");
@@ -111,7 +105,7 @@ describe("scenarios > admin > settings > API keys", () => {
   });
 
   it("should allow deleting an API key", () => {
-    createApiKey("Test API Key One", ALL_USERS_GROUP_ID);
+    H.createApiKey("Test API Key One", ALL_USERS_GROUP_ID);
     cy.visit("/admin/settings/authentication/api-keys");
     cy.wait("@getKeys");
 
@@ -129,7 +123,7 @@ describe("scenarios > admin > settings > API keys", () => {
   });
 
   it("should allow editing an API key", () => {
-    createApiKey("Development API Key", ALL_USERS_GROUP_ID);
+    H.createApiKey("Development API Key", ALL_USERS_GROUP_ID);
     cy.visit("/admin/settings/authentication/api-keys");
     cy.wait("@getKeys");
 
@@ -158,7 +152,7 @@ describe("scenarios > admin > settings > API keys", () => {
   });
 
   it("should allow regenerating an API key", () => {
-    createApiKey("Personal API Key", ALL_USERS_GROUP_ID);
+    H.createApiKey("Personal API Key", ALL_USERS_GROUP_ID);
 
     cy.visit("/admin/settings/authentication/api-keys");
     cy.wait("@getKeys").then(({ response }) => {
@@ -189,19 +183,19 @@ describe("scenarios > admin > settings > API keys", () => {
 
   describe("api key actions", () => {
     it("should allow creating questions and dashboards with an API key", () => {
-      createApiKey("Test API Key One", ADMINISTRATORS_GROUP_ID).then(
+      H.createApiKey("Test API Key One", ADMINISTRATORS_GROUP_ID).then(
         ({ body }) => {
           const apiKey = body.unmasked_key;
           createQuestionForApiKey(apiKey).then(({ body }) => {
             const questionId = body.id;
 
             cy.signInAsAdmin();
-            visitQuestion(questionId);
+            H.visitQuestion(questionId);
             cy.findByTestId("qb-header").findByText("Test Question");
             cy.findByTestId("view-footer").findByText("Showing 22 rows");
 
             cy.findByTestId("qb-header-info-button").click();
-            sidesheet().within(() => {
+            H.sidesheet().within(() => {
               cy.findByRole("tab", { name: "History" }).click();
               cy.findByText("Test API Key One created this.");
             });
@@ -211,10 +205,10 @@ describe("scenarios > admin > settings > API keys", () => {
             const dashboardId = body.id;
 
             cy.signInAsAdmin();
-            visitDashboard(dashboardId);
+            H.visitDashboard(dashboardId);
             cy.findByTestId("dashboard-header").findByText("Test Dashboard");
             cy.findByTestId("dashboard-header").icon("info").click();
-            sidesheet().within(() => {
+            H.sidesheet().within(() => {
               cy.findByRole("tab", { name: "History" }).click();
               cy.findByText("Test API Key One created this.");
             });
@@ -224,7 +218,7 @@ describe("scenarios > admin > settings > API keys", () => {
     });
 
     it("should allow editing questions and dashboards with an api key", () => {
-      createApiKey("Test API Key One", ADMINISTRATORS_GROUP_ID).then(
+      H.createApiKey("Test API Key One", ADMINISTRATORS_GROUP_ID).then(
         ({ body }) => {
           const apiKey = body.unmasked_key;
 
@@ -234,10 +228,10 @@ describe("scenarios > admin > settings > API keys", () => {
             "Edited Question Name",
           ).then(() => {
             cy.signInAsAdmin();
-            visitQuestion(ORDERS_QUESTION_ID);
+            H.visitQuestion(ORDERS_QUESTION_ID);
             cy.findByTestId("qb-header").findByText("Edited Question Name");
             cy.findByTestId("qb-header-info-button").click();
-            sidesheet().within(() => {
+            H.sidesheet().within(() => {
               cy.findByRole("tab", { name: "History" }).click();
               cy.findByText("You created this.");
               cy.findByText(
@@ -252,12 +246,12 @@ describe("scenarios > admin > settings > API keys", () => {
             "Edited Dashboard Name",
           ).then(() => {
             cy.signInAsAdmin();
-            visitDashboard(ORDERS_DASHBOARD_ID);
+            H.visitDashboard(ORDERS_DASHBOARD_ID);
             cy.findByTestId("dashboard-header").findByText(
               "Edited Dashboard Name",
             );
             cy.findByTestId("dashboard-header").icon("info").click();
-            sidesheet().within(() => {
+            H.sidesheet().within(() => {
               cy.findByRole("tab", { name: "History" }).click();
               cy.findByText("You created this.");
               cy.findByText(

--- a/e2e/test/scenarios/admin-2/authentication.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/authentication.cy.spec.ts
@@ -1,24 +1,17 @@
-import {
-  describeEE,
-  main,
-  modal,
-  onlyOnOSS,
-  restore,
-  setTokenFeatures,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 import { setupSaml } from "./sso/shared/helpers.js";
 
 describe("scenarios > admin > settings > authentication", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   describe("page layout", () => {
     describe("oss", { tags: "@OSS" }, () => {
       it("should implement a tab layout for oss customers", () => {
-        onlyOnOSS();
+        H.onlyOnOSS();
 
         cy.visit("/admin/settings/authentication");
 
@@ -35,16 +28,16 @@ describe("scenarios > admin > settings > authentication", () => {
         cy.findByRole("tab").should("not.exist");
         // no tabs on api keys
         cy.visit("/admin/settings/authentication/api-keys");
-        main().within(() => {
+        H.main().within(() => {
           cy.findByText("Manage API Keys");
         });
         cy.findByRole("tab").should("not.exist");
       });
     });
 
-    describeEE("ee", () => {
+    H.describeEE("ee", () => {
       it("should implement a tab layout for enterprise customers", () => {
-        setTokenFeatures("all");
+        H.setTokenFeatures("all");
 
         cy.visit("/admin/settings/authentication");
 
@@ -79,23 +72,23 @@ describe("scenarios > admin > settings > authentication", () => {
 
 describe("scenarios > admin > settings > user provisioning", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   describe("oss", { tags: "@OSS" }, () => {
     it("user provisioning page should not be availble for OSS customers", () => {
-      onlyOnOSS();
+      H.onlyOnOSS();
       cy.visit("/admin/settings/authentication/user-provisioning");
-      main().within(() => {
+      H.main().within(() => {
         cy.findByText("We're a little lost...");
       });
     });
   });
 
-  describeEE("scim settings management", () => {
+  H.describeEE("scim settings management", () => {
     beforeEach(() => {
-      setTokenFeatures("all");
+      H.setTokenFeatures("all");
     });
 
     it("should be able to setup and manage scim feature", () => {
@@ -112,7 +105,7 @@ describe("scenarios > admin > settings > user provisioning", () => {
       cy.log(
         "should not show endpoint and token inputs if scim has never been enabled before",
       );
-      main().within(() => {
+      H.main().within(() => {
         scimEndpointInput().should("not.exist");
         scimTokenInput().should("not.exist");
       });
@@ -123,7 +116,7 @@ describe("scenarios > admin > settings > user provisioning", () => {
 
       let initialUnmaskedToken = "";
       cy.log("should show unmasked info in modal");
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("Here's what you'll need to set SCIM up").should("exist");
         scimEndpointInput().invoke("val").should("contain", "/api/ee/scim/v2");
         scimTokenInput()
@@ -153,13 +146,13 @@ describe("scenarios > admin > settings > user provisioning", () => {
       cy.log("should be able to regenerate a token");
       cy.findByRole("button", { name: /Regenerate/ }).click();
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("Regenerate token?").should("exist");
         cy.findByRole("button", { name: /Regenerate now/ }).click();
       });
 
       let regeneratedToken = "";
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("Copy and save the SCIM token").should("exist");
         scimTokenInput()
           .invoke("val")
@@ -178,11 +171,11 @@ describe("scenarios > admin > settings > user provisioning", () => {
       cy.log("should be able to cancel regenerating a token");
       cy.findByRole("button", { name: /Regenerate/ }).click();
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("Regenerate token?").should("exist");
         cy.findByRole("button", { name: /Cancel/ }).click();
       });
-      modal().should("not.exist");
+      H.modal().should("not.exist");
 
       scimTokenInput()
         .invoke("val")
@@ -209,7 +202,7 @@ describe("scenarios > admin > settings > user provisioning", () => {
       const samlWarningMessage =
         "When enabled, SAML user provisioning will be turned off in favor of SCIM.";
 
-      main().within(() => {
+      H.main().within(() => {
         cy.log("message should exist while scim has never been enabled");
         cy.findByText(samlWarningMessage).should("exist");
 
@@ -219,11 +212,11 @@ describe("scenarios > admin > settings > user provisioning", () => {
         scimToggle().should("be.checked");
       });
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByRole("button", { name: /Done/ }).click();
       });
 
-      main().within(() => {
+      H.main().within(() => {
         cy.findByText(samlWarningMessage).should("not.exist");
 
         cy.log(
@@ -239,7 +232,7 @@ describe("scenarios > admin > settings > user provisioning", () => {
       cy.log("should show error when scim token fails to load");
       cy.intercept("GET", "/api/ee/scim/api_key", { statusCode: 500 });
       cy.visit("/admin/settings/authentication/user-provisioning");
-      main().within(() => {
+      H.main().within(() => {
         cy.findByText("Error fetching SCIM token");
       });
 
@@ -252,7 +245,7 @@ describe("scenarios > admin > settings > user provisioning", () => {
       });
       cy.request("PUT", "api/setting/scim-enabled", { value: true });
       cy.visit("/admin/settings/authentication/user-provisioning");
-      main().within(() => {
+      H.main().within(() => {
         cy.findByText("Token failed to generate, please regenerate one.");
       });
 
@@ -263,12 +256,12 @@ describe("scenarios > admin > settings > user provisioning", () => {
       });
       cy.findByRole("button", { name: /Regenerate/ }).click();
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("Regenerate token?").should("exist");
         cy.findByRole("button", { name: /Regenerate now/ }).click();
       });
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("An error occurred");
       });
     });

--- a/e2e/test/scenarios/admin-2/error-reporting.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/error-reporting.cy.spec.ts
@@ -1,25 +1,16 @@
+import { H } from "e2e/support";
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  commandPaletteAction,
-  commandPaletteButton,
-  commandPaletteInput,
-  createQuestion,
-  modal,
-  restore,
-  visitDashboard,
-  visitFullAppEmbeddingUrl,
-} from "e2e/support/helpers";
 
 const downloadsFolder = Cypress.config("downloadsFolder");
 
 describe("error reporting modal", () => {
   beforeEach(() => {
     cy.deleteDownloadsFolder();
-    restore();
+    H.restore();
   });
 
   it('should show an error reporting modal when pressing "Ctrl + F1" on the home page', () => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.visit("/");
 
@@ -30,7 +21,7 @@ describe("error reporting modal", () => {
 
     cy.realPress(["Control", "F1"]);
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Download diagnostic information").should("be.visible");
       cy.button(/Download/i).click();
     });
@@ -46,7 +37,7 @@ describe("error reporting modal", () => {
   });
 
   it("should allow you to open the error reporting modal via the command palette", () => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.visit("/");
 
@@ -54,9 +45,9 @@ describe("error reporting modal", () => {
       .findByText(/see what metabase can do/i)
       .should("exist");
 
-    commandPaletteButton().click();
-    commandPaletteInput().type("Error");
-    commandPaletteAction(/Open error diagnostic modal/).click();
+    H.commandPaletteButton().click();
+    H.commandPaletteInput().type("Error");
+    H.commandPaletteAction(/Open error diagnostic modal/).click();
 
     cy.findByRole("dialog", { name: "Download diagnostic information" }).should(
       "be.visible",
@@ -64,9 +55,9 @@ describe("error reporting modal", () => {
   });
 
   it("should not show error reporting modal in embedding", () => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    visitFullAppEmbeddingUrl({
+    H.visitFullAppEmbeddingUrl({
       url: "/",
       qs: {
         top_nav: true,
@@ -80,12 +71,12 @@ describe("error reporting modal", () => {
 
     cy.realPress(["Control", "F1"]);
 
-    modal().should("not.exist");
+    H.modal().should("not.exist");
   });
 
   it("should include question-specific data when triggered on the question page", () => {
     cy.signInAsAdmin();
-    createQuestion(
+    H.createQuestion(
       {
         name: "Diagnostic Question 1",
         query: { "source-table": 1, limit: 10 },
@@ -96,7 +87,7 @@ describe("error reporting modal", () => {
     cy.findByTestId("TableInteractive-root").realClick();
     cy.realPress(["Control", "F1"]);
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Download diagnostic information").should("be.visible");
       cy.findByLabelText("Query results").should("not.be.checked");
       cy.button(/Download/i).click();
@@ -117,7 +108,7 @@ describe("error reporting modal", () => {
 
     cy.realPress(["Control", "F1"]);
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Download diagnostic information").should("be.visible");
       cy.findByLabelText("Query results").should("not.be.checked");
       cy.findByLabelText("Query results").click(); // off by default
@@ -139,7 +130,7 @@ describe("error reporting modal", () => {
 
   it("can include query data on question pages", () => {
     cy.signInAsAdmin();
-    createQuestion(
+    H.createQuestion(
       {
         name: "Diagnostic Question 1",
         query: { "source-table": 1, limit: 10 },
@@ -150,7 +141,7 @@ describe("error reporting modal", () => {
     cy.findByTestId("TableInteractive-root").realClick();
     cy.realPress(["Control", "F1"]);
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Download diagnostic information").should("be.visible");
       cy.findByLabelText("Query results").should("not.be.checked");
       cy.findByLabelText("Query results").click(); // off by default
@@ -172,12 +163,12 @@ describe("error reporting modal", () => {
 
   it("should not include backend logs for non-admin users", () => {
     cy.signInAsNormalUser();
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
 
     cy.findByTestId("dashboard-grid").realClick();
 
     cy.realPress(["Control", "F1"]);
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Download diagnostic information").should("be.visible");
       cy.findByLabelText("Dashboard definition").should("be.visible");
       cy.findByLabelText("Query results").should("not.exist");

--- a/e2e/test/scenarios/admin-2/people.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/people.cy.spec.js
@@ -1,24 +1,12 @@
 import _ from "underscore";
 
+import { H } from "e2e/support";
 import { USERS, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   COLLECTION_GROUP_ID,
   NORMAL_USER_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  createAlert,
-  createApiKey,
-  createPulse,
-  describeEE,
-  getCurrentUser,
-  getFullName,
-  modal,
-  popover,
-  restore,
-  setTokenFeatures,
-  setupSMTP,
-} from "e2e/support/helpers";
 
 const { sandboxed, normal, admin, nodata, nocollection } = USERS;
 const { ALL_USERS_GROUP, DATA_GROUP } = USER_GROUPS;
@@ -34,9 +22,9 @@ const TEST_USER = {
   password: "12341234",
 };
 
-const adminUserName = getFullName(admin);
-const noCollectionUserName = getFullName(nocollection);
-const normalUserName = getFullName(normal);
+const adminUserName = H.getFullName(admin);
+const noCollectionUserName = H.getFullName(nocollection);
+const normalUserName = H.getFullName(normal);
 
 const totalUsers = Object.keys(USERS).length;
 
@@ -44,7 +32,7 @@ describe("scenarios > admin > people", () => {
   beforeEach(() => {
     cy.intercept("GET", "/api/permissions/group").as("getGroups");
     cy.intercept("GET", "/api/api-key").as("listApiKeys");
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -122,7 +110,7 @@ describe("scenarios > admin > people", () => {
 
       showUserOptions(noCollectionUserName);
 
-      popover().findByText("Deactivate user").click();
+      H.popover().findByText("Deactivate user").click();
 
       clickButton("Deactivate");
 
@@ -211,7 +199,7 @@ describe("scenarios > admin > people", () => {
     it("should disallow admin to deactivate themselves", () => {
       cy.visit("/admin/people");
       showUserOptions(adminUserName);
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Edit user");
         cy.findByText("Reset password");
         cy.findByText("Deactivate user").should("not.exist");
@@ -223,7 +211,7 @@ describe("scenarios > admin > people", () => {
       cy.request("PUT", `/api/user/${NORMAL_USER_ID}`, {
         is_superuser: true,
       }).then(({ body: user }) => {
-        const FULL_NAME = getFullName(user);
+        const FULL_NAME = H.getFullName(user);
 
         cy.visit("/admin/people");
         showUserOptions(FULL_NAME);
@@ -256,7 +244,7 @@ describe("scenarios > admin > people", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Edit user").click();
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.log("Should display error messages (metabase#46449)");
         cy.findByLabelText("First name").click().clear().type(" ");
         clickButton("Update");
@@ -288,7 +276,7 @@ describe("scenarios > admin > people", () => {
     });
 
     it("should not offer to reset passwords when password login is disabled", () => {
-      setTokenFeatures("all");
+      H.setTokenFeatures("all");
       cy.request("PUT", "/api/google/settings", {
         "google-auth-auto-create-accounts-domain": null,
         "google-auth-client-id": "example1.apps.googleusercontent.com",
@@ -300,14 +288,14 @@ describe("scenarios > admin > people", () => {
       });
       cy.visit("/admin/people");
       showUserOptions(normalUserName);
-      popover().findByText("Reset password").should("not.exist");
+      H.popover().findByText("Reset password").should("not.exist");
     });
 
     it(
       "should reset user password with SMTP set up",
       { tags: "@external" },
       () => {
-        setupSMTP();
+        H.setupSMTP();
 
         cy.visit("/admin/people");
         showUserOptions(normalUserName);
@@ -360,8 +348,8 @@ describe("scenarios > admin > people", () => {
         cy.findByText("My New Group").closest("tr").icon("ellipsis").click();
       });
 
-      popover().findByText("Remove Group").click();
-      modal().button("Remove group").click();
+      H.popover().findByText("Remove Group").click();
+      H.modal().button("Remove group").click();
 
       cy.wait(["@deleteGroup", "@getGroups"]);
       cy.findByTestId("admin-panel")
@@ -370,7 +358,7 @@ describe("scenarios > admin > people", () => {
     });
 
     it("should display api keys included in a group and display a warning when deleting the group", () => {
-      createApiKey("MyApiKey", COLLECTION_GROUP_ID);
+      H.createApiKey("MyApiKey", COLLECTION_GROUP_ID);
       cy.visit("/admin/people/groups");
       cy.wait(["@getGroups", "@listApiKeys"]);
 
@@ -385,9 +373,9 @@ describe("scenarios > admin > people", () => {
         .icon("ellipsis")
         .click();
 
-      popover().findByText("Remove Group").click();
+      H.popover().findByText("Remove Group").click();
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText(
           "Are you sure you want remove this group and its API key?",
         );
@@ -407,7 +395,7 @@ describe("scenarios > admin > people", () => {
     describe("email configured", { tags: "@external" }, () => {
       beforeEach(() => {
         // Setup email server, since we show different modal message when email isn't configured
-        setupSMTP();
+        H.setupSMTP();
         setupGoogleAuth();
       });
 
@@ -534,20 +522,20 @@ describe("scenarios > admin > people", () => {
   });
 });
 
-describeEE("scenarios > admin > people", () => {
+H.describeEE("scenarios > admin > people", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
   });
 
   it("should unsubscribe a user from all subscriptions and alerts", () => {
-    getCurrentUser().then(({ body: { id: user_id } }) => {
+    H.getCurrentUser().then(({ body: { id: user_id } }) => {
       cy.createQuestionAndDashboard({
         questionDetails: getQuestionDetails(),
       }).then(({ body: { card_id, dashboard_id } }) => {
-        createAlert(getAlertDetails({ user_id, card_id }));
-        createPulse(getPulseDetails({ card_id, dashboard_id }));
+        H.createAlert(getAlertDetails({ user_id, card_id }));
+        H.createPulse(getPulseDetails({ card_id, dashboard_id }));
       });
     });
 
@@ -560,11 +548,11 @@ describeEE("scenarios > admin > people", () => {
     cy.visit("/admin/people");
     showUserOptions(adminUserName);
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Unsubscribe from all subscriptions / alerts").click();
     });
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findAllByText(adminUserName, { exact: false });
       cy.findByText("Unsubscribe").click();
       cy.findByText("Unsubscribe").should("not.exist");
@@ -579,7 +567,7 @@ describeEE("scenarios > admin > people", () => {
   });
 
   it("invite member when SSO is configured metabase#23630", () => {
-    setupSMTP();
+    H.setupSMTP();
     setupGoogleAuth();
     cy.request("PUT", "/api/setting", { "enable-password-login": false });
 
@@ -618,9 +606,9 @@ describeEE("scenarios > admin > people", () => {
   });
 });
 
-describeEE("scenarios > admin > people > group managers", () => {
+H.describeEE("scenarios > admin > people > group managers", () => {
   function confirmLosingAbilityToManageGroup() {
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText(
         "You will not be able to manage users of this group anymore.",
       );
@@ -635,9 +623,9 @@ describeEE("scenarios > admin > people > group managers", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
 
     cy.visit("/admin/people");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -743,7 +731,7 @@ describeEE("scenarios > admin > people > group managers", () => {
         });
 
       // Add the user to a group
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("collection").click();
       });
       cy.get("@userRow").within(() => {
@@ -751,7 +739,7 @@ describeEE("scenarios > admin > people > group managers", () => {
       });
 
       // Remove the user from the group
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("collection").click();
       });
       cy.get("@userRow").within(() => {
@@ -759,7 +747,7 @@ describeEE("scenarios > admin > people > group managers", () => {
       });
 
       // Promote and then demote the user
-      popover().within(() => {
+      H.popover().within(() => {
         cy.icon("arrow_up").click();
         cy.icon("arrow_down").click();
       });
@@ -773,13 +761,13 @@ describeEE("scenarios > admin > people > group managers", () => {
         });
 
       // Demote myself from being manager
-      popover().within(() => {
+      H.popover().within(() => {
         cy.icon("arrow_down").eq(0).click();
       });
       confirmLosingAbilityToManageGroup();
 
       // Remove myself from another group
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("data").click();
       });
       confirmLosingAbilityToManageGroup();
@@ -800,7 +788,7 @@ describeEE("scenarios > admin > people > group managers", () => {
   });
 });
 
-describeEE("issue 23689", () => {
+H.describeEE("issue 23689", () => {
   function findUserByFullName(user) {
     const { first_name, last_name } = user;
     return cy.findByText(`${first_name} ${last_name}`);
@@ -817,9 +805,9 @@ describeEE("issue 23689", () => {
 
     cy.intercept("GET", "/api/permissions/membership").as("membership");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
 
     visitGroupPermissionsPage(COLLECTION_GROUP);
 

--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -1,3 +1,4 @@
+import { H } from "e2e/support";
 import {
   SAMPLE_DB_ID,
   SAMPLE_DB_SCHEMA_ID,
@@ -5,33 +6,6 @@ import {
 } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  WEBHOOK_TEST_URL,
-  describeEE,
-  describeWithSnowplow,
-  echartsContainer,
-  expectGoodSnowplowEvent,
-  expectNoBadSnowplowEvents,
-  isEE,
-  isOSS,
-  main,
-  modal,
-  onlyOnOSS,
-  openNativeEditor,
-  openOrdersTable,
-  popover,
-  resetSnowplow,
-  restore,
-  runNativeQuery,
-  setTokenFeatures,
-  setupMetabaseCloud,
-  setupSMTP,
-  tableHeaderClick,
-  undoToast,
-  updateSetting,
-  visitQuestion,
-  visitQuestionAdhoc,
-} from "e2e/support/helpers";
 
 import {
   WEBHOOK_TEST_DASHBOARD,
@@ -42,10 +16,10 @@ import {
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 const { SMTP_PORT, WEB_PORT } = WEBMAIL_CONFIG;
 
-describeWithSnowplow("scenarios > admin > settings", () => {
+H.describeWithSnowplow("scenarios > admin > settings", () => {
   beforeEach(() => {
-    resetSnowplow();
-    restore();
+    H.resetSnowplow();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -53,11 +27,11 @@ describeWithSnowplow("scenarios > admin > settings", () => {
     "should prompt admin to migrate to a hosted instance",
     { tags: "@OSS" },
     () => {
-      onlyOnOSS();
+      H.onlyOnOSS();
       cy.visit("/admin/settings/setup");
 
       cy.findByTestId("upsell-card").findByText(/Migrate to Metabase Cloud/);
-      expectGoodSnowplowEvent({
+      H.expectGoodSnowplowEvent({
         event: "upsell_viewed",
         promoted_feature: "hosting",
       });
@@ -65,11 +39,11 @@ describeWithSnowplow("scenarios > admin > settings", () => {
         .findAllByRole("link", { name: "Learn more" })
         .click();
       // link opens in new tab
-      expectGoodSnowplowEvent({
+      H.expectGoodSnowplowEvent({
         event: "upsell_clicked",
         promoted_feature: "hosting",
       });
-      expectNoBadSnowplowEvents();
+      H.expectNoBadSnowplowEvents();
     },
   );
 
@@ -99,7 +73,7 @@ describeWithSnowplow("scenarios > admin > settings", () => {
     //       If we update UI in the future (for example: we show an error within a popup/modal), the test in current form could fail.
     cy.log("Making sure we display an error message in UI");
     // Same reasoning for regex as above
-    undoToast().contains(/^Error: Invalid site URL/);
+    H.undoToast().contains(/^Error: Invalid site URL/);
   });
 
   it("should save a setting", () => {
@@ -152,13 +126,13 @@ describeWithSnowplow("scenarios > admin > settings", () => {
       .parent()
       .findByTestId("select-button")
       .click();
-    popover().contains("https://").click({ force: true });
+    H.popover().contains("https://").click({ force: true });
 
     cy.wait("@httpsCheck");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Redirect to HTTPS").parent().parent().contains("Disabled");
 
-    restore(); // avoid leaving https site url
+    H.restore(); // avoid leaving https site url
   });
 
   it("should display an error if the https redirect check fails", () => {
@@ -174,7 +148,7 @@ describeWithSnowplow("scenarios > admin > settings", () => {
       .parent()
       .findByTestId("select-button")
       .click();
-    popover().contains("https://").click({ force: true });
+    H.popover().contains("https://").click({ force: true });
 
     cy.wait("@httpsCheck");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -194,7 +168,7 @@ describeWithSnowplow("scenarios > admin > settings", () => {
       .findByText("January 31, 2018")
       .click({ force: true });
 
-    popover().findByText("2018/1/31").click({ force: true });
+    H.popover().findByText("2018/1/31").click({ force: true });
     cy.wait("@saveFormatting");
 
     cy.findAllByTestId("select-button-content").should("contain", "2018/1/31");
@@ -205,7 +179,7 @@ describeWithSnowplow("scenarios > admin > settings", () => {
     cy.wait("@saveFormatting");
     cy.findByDisplayValue("HH:mm").should("be.checked");
 
-    openOrdersTable({ limit: 2 });
+    H.openOrdersTable({ limit: 2 });
 
     cy.findByTextEnsureVisible("Created At");
     cy.get("[data-testid=cell-data]")
@@ -222,7 +196,7 @@ describeWithSnowplow("scenarios > admin > settings", () => {
     cy.wait("@saveFormatting");
     cy.findByDisplayValue("h:mm A").should("be.checked");
 
-    openOrdersTable({ limit: 2 });
+    H.openOrdersTable({ limit: 2 });
 
     cy.findByTextEnsureVisible("Created At");
     cy.get("[data-testid=cell-data]").and("contain", "2025/2/11, 9:40 PM");
@@ -245,7 +219,7 @@ describeWithSnowplow("scenarios > admin > settings", () => {
     });
 
     // Open the orders table
-    openOrdersTable({ limit: 2 });
+    H.openOrdersTable({ limit: 2 });
 
     cy.get("#main-data-grid").within(() => {
       // Items in the total column should have a leading dollar sign
@@ -309,9 +283,9 @@ describeWithSnowplow("scenarios > admin > settings", () => {
     "should display the order of the settings items consistently between OSS/EE versions (metabase#15441)",
     { tags: "@OSS" },
     () => {
-      isEE && setTokenFeatures("all");
+      H.isEE && H.setTokenFeatures("all");
 
-      const lastItem = isOSS ? "Cloud" : "Appearance";
+      const lastItem = H.isOSS ? "Cloud" : "Appearance";
 
       cy.visit("/admin/settings/setup");
       cy.findByTestId("admin-list-settings-items").within(() => {
@@ -324,7 +298,7 @@ describeWithSnowplow("scenarios > admin > settings", () => {
 
   // Unskip when mocking Cloud in Cypress is fixed (#18289)
   it.skip("should hide self-hosted settings when running Metabase Cloud", () => {
-    setupMetabaseCloud();
+    H.setupMetabaseCloud();
     cy.visit("/admin/settings/general");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -340,7 +314,7 @@ describeWithSnowplow("scenarios > admin > settings", () => {
 
   // Unskip when mocking Cloud in Cypress is fixed (#18289)
   it.skip("should hide the store link when running Metabase Cloud", () => {
-    setupMetabaseCloud();
+    H.setupMetabaseCloud();
     cy.visit("/admin/settings/general");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -368,8 +342,8 @@ describeWithSnowplow("scenarios > admin > settings", () => {
 
 describe("scenarios > admin > settings (OSS)", { tags: "@OSS" }, () => {
   beforeEach(() => {
-    onlyOnOSS();
-    restore();
+    H.onlyOnOSS();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -382,16 +356,16 @@ describe("scenarios > admin > settings (OSS)", { tags: "@OSS" }, () => {
   });
 });
 
-describeEE("scenarios > admin > settings (EE)", () => {
+H.describeEE("scenarios > admin > settings (EE)", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
   });
 
   // Unskip when mocking Cloud in Cypress is fixed (#18289)
   it.skip("should hide Enterprise page when running Metabase Cloud", () => {
-    setupMetabaseCloud();
+    H.setupMetabaseCloud();
     cy.visit("/admin/settings/general");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -438,7 +412,7 @@ describe.skip(
 
       cy.findByLabelText("Name").type(name);
 
-      modal().button("Save").click();
+      H.modal().button("Save").click();
 
       cy.findByText("Not now").click();
 
@@ -479,7 +453,7 @@ describe.skip(
       cy.intercept("POST", "/api/dataset").as("dataset");
       cy.intercept("POST", "/api/card/*/query").as("cardQuery");
 
-      restore("postgres-12");
+      H.restore("postgres-12");
       cy.signInAsAdmin();
     });
 
@@ -496,8 +470,8 @@ describe.skip(
         cy.findByText("Saved");
 
         // Run the query and save the question
-        openNativeEditor({ databaseName: "QA Postgres12" }).type(nativeQuery);
-        runNativeQuery();
+        H.openNativeEditor({ databaseName: "QA Postgres12" }).type(nativeQuery);
+        H.runNativeQuery();
 
         getCellText().then(res => {
           cy.wrap(res).as("tempResult");
@@ -531,7 +505,7 @@ describe.skip(
 
 describe("Cloud settings section", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -539,7 +513,7 @@ describe("Cloud settings section", () => {
     // Setting to none will give us an instance where token-features.hosting is set to true
     // Allowing us to pretend that we are a hosted instance (seems backwards though haha)
 
-    setTokenFeatures("none");
+    H.setTokenFeatures("none");
     cy.visit("/admin");
     cy.findByTestId("admin-list-settings-items").findByText("Cloud").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -553,7 +527,7 @@ describe("Cloud settings section", () => {
   });
 
   it("should prompt us to migrate to cloud if we are not hosted", () => {
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
     cy.visit("/admin");
     cy.findByTestId("admin-list-settings-items").findByText("Cloud").click();
 
@@ -567,7 +541,7 @@ describe("Cloud settings section", () => {
 
 describe("scenarios > admin > settings > email settings", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -588,7 +562,7 @@ describe("scenarios > admin > settings > email settings", () => {
 
     // SMTP settings need to manually be saved
     cy.intercept("PUT", "api/email").as("smtpSaved");
-    main().within(() => {
+    H.main().within(() => {
       cy.findByText("Save changes").click();
     });
     cy.wait("@smtpSaved");
@@ -646,7 +620,7 @@ describe("scenarios > admin > settings > email settings", () => {
     cy.button("Save changes").should("be.disabled");
 
     // should be able to clear email settings
-    main().findByText("Clear").click();
+    H.main().findByText("Clear").click();
 
     cy.reload();
 
@@ -670,7 +644,7 @@ describe("scenarios > admin > settings > email settings", () => {
       "email-smtp-username": null,
     });
     cy.visit("/admin/settings/email/smtp");
-    main().findByText("Send test email").click();
+    H.main().findByText("Send test email").click();
     cy.findAllByText(
       "Couldn't connect to host, port: localhost, 1234; timeout -1",
     );
@@ -680,10 +654,10 @@ describe("scenarios > admin > settings > email settings", () => {
     "should send a test email for a valid SMTP configuration",
     { tags: "@external" },
     () => {
-      setupSMTP();
+      H.setupSMTP();
       cy.visit("/admin/settings/email/smtp");
-      main().findByText("Send test email").click();
-      main().findByText("Sent!");
+      H.main().findByText("Send test email").click();
+      H.main().findByText("Sent!");
 
       cy.request("GET", `http://localhost:${WEB_PORT}/email`).then(
         ({ body }) => {
@@ -711,11 +685,11 @@ describe("scenarios > admin > license and billing", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
-  describeEE("store info", () => {
+  H.describeEE("store info", () => {
     it("should show the user a link to the store for an unlincensed enterprise instance", () => {
       cy.visit("/admin/settings/license");
       cy.findByTestId("license-and-billing-content")
@@ -724,7 +698,7 @@ describe("scenarios > admin > license and billing", () => {
     });
 
     it("should show the user store info for an self-hosted instance managed by the store", () => {
-      setTokenFeatures("all");
+      H.setTokenFeatures("all");
       mockBillingTokenFeatures([
         STORE_MANAGED_FEATURE_KEY,
         NO_UPSELL_FEATURE_HEY,
@@ -767,7 +741,7 @@ describe("scenarios > admin > license and billing", () => {
     });
 
     it("should not show license input for cloud-hosted instances", () => {
-      setTokenFeatures("all");
+      H.setTokenFeatures("all");
       mockBillingTokenFeatures([
         STORE_MANAGED_FEATURE_KEY,
         NO_UPSELL_FEATURE_HEY,
@@ -778,7 +752,7 @@ describe("scenarios > admin > license and billing", () => {
     });
 
     it("should render an error if something fails when fetching billing info", () => {
-      setTokenFeatures("all");
+      H.setTokenFeatures("all");
       mockBillingTokenFeatures([
         STORE_MANAGED_FEATURE_KEY,
         NO_UPSELL_FEATURE_HEY,
@@ -797,11 +771,11 @@ describe("scenarios > admin > license and billing", () => {
 
 describe("scenarios > admin > localization", () => {
   function setFirstWeekDayTo(day) {
-    updateSetting("start-of-week", day.toLowerCase());
+    H.updateSetting("start-of-week", day.toLowerCase());
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     setFirstWeekDayTo("monday");
   });
@@ -833,7 +807,7 @@ describe("scenarios > admin > localization", () => {
     cy.log("Assert the dates on the X axis");
     // it's hard and tricky to invoke hover in Cypress, especially in our graphs
     // that's why we have to assert on the x-axis, instead of a popover that shows on a dot hover
-    echartsContainer().get("text").contains("April 25, 2022");
+    H.echartsContainer().get("text").contains("April 25, 2022");
   });
 
   it("should display days on X-axis correctly when grouped by 'Day of the Week' (metabase#13604)", () => {
@@ -865,14 +839,14 @@ describe("scenarios > admin > localization", () => {
     cy.findByText("13604").click();
 
     cy.log("Reported failing on v0.37.0.2 and labeled as `.Regression`");
-    echartsContainer()
+    H.echartsContainer()
       .get("text")
       .contains(/sunday/i)
       .should("not.exist");
-    echartsContainer()
+    H.echartsContainer()
       .get("text")
       .contains(/monday/i);
-    echartsContainer()
+    H.echartsContainer()
       .get("text")
       .contains(/tuesday/i);
   });
@@ -939,9 +913,9 @@ describe("scenarios > admin > localization", () => {
     cy.findByText("US Dollar").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Euro").click();
-    undoToast().findByText("Changes saved").should("be.visible");
+    H.undoToast().findByText("Changes saved").should("be.visible");
 
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       display: "scalar",
       dataset_query: {
         type: "native",
@@ -977,7 +951,7 @@ describe("scenarios > admin > localization", () => {
       cy.findByText("January 31, 2018").click();
     });
 
-    popover().findByText("2018/1/31").click();
+    H.popover().findByText("2018/1/31").click();
     cy.wait("@updateFormatting");
 
     cy.findByTestId("custom-formatting-setting").within(() => {
@@ -992,12 +966,12 @@ describe("scenarios > admin > localization", () => {
       cy.findByDisplayValue("HH:mm").should("be.checked");
     });
 
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
 
     // create a date filter and set it to the 'On' view to see a specific date
-    tableHeaderClick("Created At");
+    H.tableHeaderClick("Created At");
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Filter by this column").click();
       cy.findByText("Specific dates…").click();
       cy.findByText("On").click();
@@ -1031,7 +1005,7 @@ describe("scenarios > admin > localization", () => {
 
 describe("scenarios > admin > settings > map settings", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -1129,7 +1103,7 @@ describe("scenarios > admin > settings > map settings", () => {
     cy.visit("/admin/settings/maps");
     cy.button("Add a map").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       // GeoJSON with an unsupported format (not a Feature or FeatureCollection)
       cy.findByPlaceholderText("Like https://my-mb-server.com/maps/my-map.json")
         .clear()
@@ -1146,7 +1120,7 @@ describe("scenarios > admin > settings > map settings", () => {
 // docker run -p 9080:8080/tcp tarampampam/webhook-tester serve --create-session 00000000-0000-0000-0000-000000000000
 describe("notifications", { tags: "@external" }, () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -1164,7 +1138,7 @@ describe("notifications", { tags: "@external" }, () => {
     const COMMON_FIELDS = [
       {
         label: "Webhook URL",
-        value: WEBHOOK_TEST_URL,
+        value: H.WEBHOOK_TEST_URL,
       },
       {
         label: "Give it a name",
@@ -1223,7 +1197,7 @@ describe("notifications", { tags: "@external" }, () => {
         cy.visit("/admin/settings/notifications");
         cy.findByRole("heading", { name: "Add a webhook" }).click();
 
-        modal().within(() => {
+        H.modal().within(() => {
           COMMON_FIELDS.forEach(field => {
             cy.findByLabelText(field.label).type(field.value);
           });
@@ -1253,14 +1227,14 @@ describe("notifications", { tags: "@external" }, () => {
 
     cy.findByRole("heading", { name: "Add a webhook" }).click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByRole("heading", { name: "New webhook destination" }).should(
         "exist",
       );
 
       cy.findByLabelText("Give it a name").type("Awesome Hook");
       cy.findByLabelText("Description").type("The best hook ever");
-      cy.findByLabelText("Webhook URL").clear().type(WEBHOOK_TEST_URL);
+      cy.findByLabelText("Webhook URL").clear().type(H.WEBHOOK_TEST_URL);
       cy.button("Create destination").click();
     });
 
@@ -1268,7 +1242,7 @@ describe("notifications", { tags: "@external" }, () => {
 
     cy.findByRole("heading", { name: "Awesome Hook" }).click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByRole("heading", { name: "Edit this webhook" }).should("exist");
       cy.findByLabelText("Give it a name").clear().type("Updated Hook");
       cy.button("Save changes").click();
@@ -1276,7 +1250,7 @@ describe("notifications", { tags: "@external" }, () => {
 
     cy.findByRole("heading", { name: "Updated Hook" }).click();
 
-    modal()
+    H.modal()
       .button(/Delete this destination/)
       .click();
 
@@ -1318,7 +1292,7 @@ describe("admin > settings > updates", () => {
   const currentVersion = "v1.86.70";
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.visit("/admin/settings/updates");
 
@@ -1360,7 +1334,7 @@ describe("admin > settings > updates", () => {
       cy.findByText("Stable releases").click();
     });
 
-    popover().findByText("Beta releases").click();
+    H.popover().findByText("Beta releases").click();
 
     cy.findByTestId("settings-updates").within(() => {
       cy.findByText(/Metabase 1\.86\.75\.309 is available/).should(
@@ -1370,7 +1344,7 @@ describe("admin > settings > updates", () => {
       cy.findByText("Beta releases").click();
     });
 
-    popover().findByText("Nightly builds").click();
+    H.popover().findByText("Nightly builds").click();
 
     cy.findByTestId("settings-updates").within(() => {
       cy.findByText(/Metabase 1\.86\.75\.311 is available/).should(

--- a/e2e/test/scenarios/admin-2/sso/google.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/sso/google.cy.spec.js
@@ -1,15 +1,10 @@
-import {
-  modal,
-  popover,
-  restore,
-  typeAndBlurUsingLabel,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 const CLIENT_ID_SUFFIX = "apps.googleusercontent.com";
 
 describe("scenarios > admin > settings > SSO > Google", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("PUT", "/api/setting").as("updateSettings");
     cy.intercept("PUT", "/api/setting/*").as("updateSetting");
@@ -19,13 +14,13 @@ describe("scenarios > admin > settings > SSO > Google", () => {
   it("should save the client id on subsequent tries (metabase#15974)", () => {
     cy.visit("/admin/settings/authentication/google");
 
-    typeAndBlurUsingLabel("Client ID", "example1.apps.googleusercontent.com");
+    H.typeAndBlurUsingLabel("Client ID", "example1.apps.googleusercontent.com");
     cy.button("Save and enable").click();
     cy.wait("@updateGoogleSettings");
     cy.reload();
     cy.findByDisplayValue(`example1.${CLIENT_ID_SUFFIX}`).should("be.visible");
 
-    typeAndBlurUsingLabel("Client ID", `example2.${CLIENT_ID_SUFFIX}`);
+    H.typeAndBlurUsingLabel("Client ID", `example2.${CLIENT_ID_SUFFIX}`);
     cy.button("Save changes").click();
     cy.wait("@updateGoogleSettings");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -37,12 +32,12 @@ describe("scenarios > admin > settings > SSO > Google", () => {
     cy.visit("/admin/settings/authentication");
 
     getGoogleCard().icon("ellipsis").click();
-    popover().findByText("Pause").click();
+    H.popover().findByText("Pause").click();
     cy.wait("@updateSetting");
     getGoogleCard().findByText("Paused").should("exist");
 
     getGoogleCard().icon("ellipsis").click();
-    popover().findByText("Resume").click();
+    H.popover().findByText("Resume").click();
     cy.wait("@updateSetting");
     getGoogleCard().findByText("Active").should("exist");
   });
@@ -52,8 +47,8 @@ describe("scenarios > admin > settings > SSO > Google", () => {
     cy.visit("/admin/settings/authentication");
 
     getGoogleCard().icon("ellipsis").click();
-    popover().findByText("Deactivate").click();
-    modal().button("Deactivate").click();
+    H.popover().findByText("Deactivate").click();
+    H.modal().button("Deactivate").click();
     cy.wait("@updateSettings");
 
     getGoogleCard().findByText("Set up").should("exist");
@@ -62,7 +57,7 @@ describe("scenarios > admin > settings > SSO > Google", () => {
   it("should show an error message if the client id does not end with the correct suffix (metabase#15975)", () => {
     cy.visit("/admin/settings/authentication/google");
 
-    typeAndBlurUsingLabel("Client ID", "fake-client-id");
+    H.typeAndBlurUsingLabel("Client ID", "fake-client-id");
     cy.button("Save and enable").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(

--- a/e2e/test/scenarios/admin-2/sso/jwt.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/sso/jwt.cy.spec.js
@@ -1,11 +1,4 @@
-import {
-  describeEE,
-  modal,
-  popover,
-  restore,
-  setTokenFeatures,
-  typeAndBlurUsingLabel,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 import { enableJwtAuth } from "e2e/support/helpers/e2e-jwt-helpers";
 
 import {
@@ -14,11 +7,11 @@ import {
 } from "./shared/group-mappings-widget";
 import { getSuccessUi, getUserProvisioningInput } from "./shared/helpers";
 
-describeEE("scenarios > admin > settings > SSO > JWT", () => {
+H.describeEE("scenarios > admin > settings > SSO > JWT", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
     cy.intercept("PUT", "/api/setting").as("updateSettings");
     cy.intercept("PUT", "/api/setting/*").as("updateSetting");
   });
@@ -39,12 +32,12 @@ describeEE("scenarios > admin > settings > SSO > JWT", () => {
     cy.visit("/admin/settings/authentication");
 
     getJwtCard().icon("ellipsis").click();
-    popover().findByText("Pause").click();
+    H.popover().findByText("Pause").click();
     cy.wait("@updateSetting");
     getJwtCard().findByText("Paused").should("exist");
 
     getJwtCard().icon("ellipsis").click();
-    popover().findByText("Resume").click();
+    H.popover().findByText("Resume").click();
     cy.wait("@updateSetting");
     getJwtCard().findByText("Active").should("exist");
   });
@@ -65,8 +58,8 @@ describeEE("scenarios > admin > settings > SSO > JWT", () => {
     cy.visit("/admin/settings/authentication");
 
     getJwtCard().icon("ellipsis").click();
-    popover().findByText("Deactivate").click();
-    modal().button("Deactivate").click();
+    H.popover().findByText("Deactivate").click();
+    H.modal().button("Deactivate").click();
     cy.wait("@updateSettings");
 
     getJwtCard().findByText("Set up").should("exist");
@@ -77,7 +70,7 @@ describeEE("scenarios > admin > settings > SSO > JWT", () => {
     cy.visit("/admin/settings/authentication/jwt");
 
     cy.button("Regenerate key").click();
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Regenerate JWT signing key?").should("exist");
       cy.findByText(
         "This will cause existing tokens to stop working until the identity provider is updated with the new key.",
@@ -116,6 +109,6 @@ const getJwtCard = () => {
 };
 
 const enterJwtSettings = () => {
-  typeAndBlurUsingLabel(/JWT Identity Provider URI/, "https://example.test");
+  H.typeAndBlurUsingLabel(/JWT Identity Provider URI/, "https://example.test");
   cy.button("Generate key").click();
 };

--- a/e2e/test/scenarios/admin-2/sso/ldap.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/sso/ldap.cy.spec.js
@@ -1,13 +1,4 @@
-import {
-  describeEE,
-  modal,
-  popover,
-  restore,
-  setTokenFeatures,
-  setupLdap,
-  typeAndBlurUsingLabel,
-  updateSetting,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 import {
   checkGroupConsistencyAfterDeletingMappings,
@@ -20,7 +11,7 @@ describe(
   { tags: "@external" },
   () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
       cy.intercept("PUT", "/api/setting").as("updateSettings");
       cy.intercept("PUT", "/api/setting/*").as("updateSetting");
@@ -40,7 +31,7 @@ describe(
     });
 
     it("should update ldap settings", () => {
-      setupLdap();
+      H.setupLdap();
       cy.visit("/admin/settings/authentication/ldap");
 
       enterLdapPort("389");
@@ -52,22 +43,22 @@ describe(
     });
 
     it("should allow to disable and enable ldap", () => {
-      setupLdap();
+      H.setupLdap();
       cy.visit("/admin/settings/authentication");
 
       getLdapCard().icon("ellipsis").click();
-      popover().findByText("Pause").click();
+      H.popover().findByText("Pause").click();
       cy.wait("@updateSetting");
       getLdapCard().findByText("Paused").should("exist");
 
       getLdapCard().icon("ellipsis").click();
-      popover().findByText("Resume").click();
+      H.popover().findByText("Resume").click();
       cy.wait("@updateSetting");
       getLdapCard().findByText("Active").should("exist");
     });
 
     it("should not show the user provision UI to OSS users", () => {
-      setupLdap();
+      H.setupLdap();
       cy.visit("/admin/settings/authentication/ldap");
 
       cy.findByTestId("admin-layout-content")
@@ -76,12 +67,12 @@ describe(
     });
 
     it("should allow to reset ldap settings", () => {
-      setupLdap();
+      H.setupLdap();
       cy.visit("/admin/settings/authentication");
 
       getLdapCard().icon("ellipsis").click();
-      popover().findByText("Deactivate").click();
-      modal().button("Deactivate").click();
+      H.popover().findByText("Deactivate").click();
+      H.modal().button("Deactivate").click();
       cy.wait("@updateSettings");
 
       getLdapCard().findByText("Set up").should("exist");
@@ -127,7 +118,7 @@ describe(
     });
 
     it("should allow user login on OSS when LDAP is enabled", () => {
-      setupLdap();
+      H.setupLdap();
       cy.signOut();
       cy.visit("/auth/login");
       cy.findByLabelText("Username or email address").type(
@@ -163,19 +154,19 @@ describe(
   },
 );
 
-describeEE(
+H.describeEE(
   "scenarios > admin > settings > SSO > LDAP",
   { tags: "@external" },
   () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
-      setTokenFeatures("all");
+      H.setTokenFeatures("all");
       cy.intercept("PUT", "/api/ldap/settings").as("updateLdapSettings");
     });
 
     it("should allow the user to enable/disable user provisioning", () => {
-      setupLdap();
+      H.setupLdap();
       cy.visit("/admin/settings/authentication/ldap");
 
       const { label, input } = getUserProvisioningInput();
@@ -188,8 +179,8 @@ describeEE(
     });
 
     it("should show the login form when ldap is enabled but password login isn't (metabase#25661)", () => {
-      setupLdap();
-      updateSetting("enable-password-login", false);
+      H.setupLdap();
+      H.updateSetting("enable-password-login", false);
       cy.signOut();
       cy.visit("/auth/login");
 
@@ -200,7 +191,7 @@ describeEE(
     });
 
     it("should allow user login on EE when LDAP is enabled", () => {
-      setupLdap();
+      H.setupLdap();
       cy.signOut();
       cy.visit("/auth/login");
       cy.findByLabelText("Username or email address").type(
@@ -224,7 +215,7 @@ describeEE(
             cy.icon("ellipsis").click();
           });
       });
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Edit user").click();
       });
       cy.findByDisplayValue("uid").should("exist");
@@ -238,13 +229,13 @@ const getLdapCard = () => {
 };
 
 const enterLdapPort = value => {
-  typeAndBlurUsingLabel("LDAP Port", value);
+  H.typeAndBlurUsingLabel("LDAP Port", value);
 };
 
 const enterLdapSettings = () => {
-  typeAndBlurUsingLabel(/LDAP Host/, "localhost");
-  typeAndBlurUsingLabel("LDAP Port", "389");
-  typeAndBlurUsingLabel("Username or DN", "cn=admin,dc=example,dc=org");
-  typeAndBlurUsingLabel("Password", "adminpass");
-  typeAndBlurUsingLabel(/User search base/, "ou=users,dc=example,dc=org");
+  H.typeAndBlurUsingLabel(/LDAP Host/, "localhost");
+  H.typeAndBlurUsingLabel("LDAP Port", "389");
+  H.typeAndBlurUsingLabel("Username or DN", "cn=admin,dc=example,dc=org");
+  H.typeAndBlurUsingLabel("Password", "adminpass");
+  H.typeAndBlurUsingLabel(/User search base/, "ou=users,dc=example,dc=org");
 };

--- a/e2e/test/scenarios/admin-2/sso/saml.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/sso/saml.cy.spec.js
@@ -1,11 +1,4 @@
-import {
-  describeEE,
-  modal,
-  popover,
-  restore,
-  setTokenFeatures,
-  typeAndBlurUsingLabel,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 import {
   checkGroupConsistencyAfterDeletingMappings,
@@ -18,11 +11,11 @@ import {
   setupSaml,
 } from "./shared/helpers";
 
-describeEE("scenarios > admin > settings > SSO > SAML", () => {
+H.describeEE("scenarios > admin > settings > SSO > SAML", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
     cy.intercept("PUT", "/api/setting").as("updateSettings");
     cy.intercept("PUT", "/api/setting/*").as("updateSetting");
     cy.intercept("PUT", "/api/saml/settings").as("updateSamlSettings");
@@ -45,7 +38,7 @@ describeEE("scenarios > admin > settings > SSO > SAML", () => {
     setupSaml();
     cy.visit("/admin/settings/authentication/saml");
 
-    typeAndBlurUsingLabel(/SAML Identity Provider URL/, "https://other.test");
+    H.typeAndBlurUsingLabel(/SAML Identity Provider URL/, "https://other.test");
     cy.button("Save changes").click();
     cy.wait("@updateSamlSettings");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -60,12 +53,12 @@ describeEE("scenarios > admin > settings > SSO > SAML", () => {
     cy.visit("/admin/settings/authentication");
 
     getSamlCard().icon("ellipsis").click();
-    popover().findByText("Pause").click();
+    H.popover().findByText("Pause").click();
     cy.wait("@updateSetting");
     getSamlCard().findByText("Paused").should("exist");
 
     getSamlCard().icon("ellipsis").click();
-    popover().findByText("Resume").click();
+    H.popover().findByText("Resume").click();
     cy.wait("@updateSetting");
     getSamlCard().findByText("Active").should("exist");
   });
@@ -75,8 +68,8 @@ describeEE("scenarios > admin > settings > SSO > SAML", () => {
     cy.visit("/admin/settings/authentication");
 
     getSamlCard().icon("ellipsis").click();
-    popover().findByText("Deactivate").click();
-    modal().button("Deactivate").click();
+    H.popover().findByText("Deactivate").click();
+    H.modal().button("Deactivate").click();
     cy.wait("@updateSettings");
 
     getSamlCard().findByText("Set up").should("exist");
@@ -119,7 +112,10 @@ const getSamlCard = () => {
 
 const enterSamlSettings = () => {
   getSamlCertificate().then(certificate => {
-    typeAndBlurUsingLabel(/SAML Identity Provider URL/, "https://example.test");
-    typeAndBlurUsingLabel(/SAML Identity Provider Certificate/, certificate);
+    H.typeAndBlurUsingLabel(
+      /SAML Identity Provider URL/,
+      "https://example.test",
+    );
+    H.typeAndBlurUsingLabel(/SAML Identity Provider Certificate/, certificate);
   });
 };

--- a/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
@@ -1,18 +1,5 @@
+import { H } from "e2e/support";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  appBar,
-  describeEE,
-  entityPickerModal,
-  main,
-  modal,
-  popover,
-  restore,
-  setTokenFeatures,
-  undoToast,
-  updateSetting,
-  visitDashboard,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 function checkFavicon(url) {
   cy.request("/api/setting/application-favicon-url")
@@ -28,11 +15,11 @@ function checkLogo() {
 
 const MB = 1024 * 1024;
 
-describeEE("formatting > whitelabel", () => {
+H.describeEE("formatting > whitelabel", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
   });
 
   describe("company name", () => {
@@ -45,7 +32,7 @@ describeEE("formatting > whitelabel", () => {
       // Helps scroll the page up in order to see "Saved" notification
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Application Name").click();
-      undoToast().findByText("Changes saved").should("be.visible");
+      H.undoToast().findByText("Changes saved").should("be.visible");
       cy.findByDisplayValue(COMPANY_NAME);
       cy.log("Company name has been updated!");
     });
@@ -73,7 +60,7 @@ describeEE("formatting > whitelabel", () => {
         cy.log("Add a logo");
         cy.readFile("e2e/support/assets/logo.jpeg", "base64").then(
           logo_data => {
-            updateSetting(
+            H.updateSetting(
               "application-logo-url",
               `data:image/jpeg;base64,${logo_data}`,
             );
@@ -103,7 +90,7 @@ describeEE("formatting > whitelabel", () => {
       it("should work for people that set favicon URL before we change the input to file input", () => {
         const faviconUrl =
           "https://cdn.ecosia.org/assets/images/ico/favicon.ico";
-        updateSetting("application-favicon-url", faviconUrl);
+        H.updateSetting("application-favicon-url", faviconUrl);
         checkFavicon(faviconUrl);
         cy.signInAsNormalUser();
         cy.visit("/");
@@ -123,7 +110,7 @@ describeEE("formatting > whitelabel", () => {
           },
           { force: true },
         );
-        undoToast().findByText("Changes saved").should("be.visible");
+        H.undoToast().findByText("Changes saved").should("be.visible");
         cy.readFile("e2e/support/assets/favicon.ico", "base64").then(
           base64Url => {
             const faviconUrl = `data:image/jpeg;base64,${base64Url}`;
@@ -158,7 +145,7 @@ describeEE("formatting > whitelabel", () => {
             cy.findByRole("searchbox", {
               name: "Login and unsubscribe pages",
             }).click();
-            popover().findByText("Custom").click();
+            H.popover().findByText("Custom").click();
             /**
              * Clicking "Choose File" doesn't actually open the file browser on Cypress,
              * so I need to use `selectFile` with the file input instead.
@@ -180,7 +167,7 @@ describeEE("formatting > whitelabel", () => {
             cy.findByRole("searchbox", {
               name: "Login and unsubscribe pages",
             }).click();
-            popover().findByText("Custom").click();
+            H.popover().findByText("Custom").click();
             cy.log("test uploading a corrupted file");
             cy.findByTestId("login-page-illustration-setting").within(() => {
               cy.findByTestId("file-input").selectFile(
@@ -214,8 +201,8 @@ describeEE("formatting > whitelabel", () => {
                 "The image you chose is corrupted. Please choose another one.",
               ).should("not.exist");
             });
-            undoToast().findByText("Changes saved").should("be.visible");
-            undoToast().icon("close").click();
+            H.undoToast().findByText("Changes saved").should("be.visible");
+            H.undoToast().icon("close").click();
 
             cy.log("test removing the custom illustration");
             cy.findByTestId("login-page-illustration-setting").within(() => {
@@ -225,14 +212,14 @@ describeEE("formatting > whitelabel", () => {
               );
               cy.findByDisplayValue("Lighthouse").should("be.visible");
             });
-            undoToast().findByText("Changes saved").should("be.visible");
-            undoToast().icon("close").click();
+            H.undoToast().findByText("Changes saved").should("be.visible");
+            H.undoToast().icon("close").click();
 
             cy.log("test uploading a valid image file");
             cy.findByTestId("login-page-illustration-setting")
               .findByRole("searchbox", { name: "Login and unsubscribe pages" })
               .click();
-            popover().findByText("Custom").click();
+            H.popover().findByText("Custom").click();
             cy.findByTestId("login-page-illustration-setting").within(() => {
               cy.findByTestId("file-input").selectFile(
                 {
@@ -243,7 +230,7 @@ describeEE("formatting > whitelabel", () => {
               );
               cy.findByText("logo.jpeg").should("be.visible");
             });
-            undoToast().findByText("Changes saved").should("be.visible");
+            H.undoToast().findByText("Changes saved").should("be.visible");
 
             cy.readFile("e2e/support/assets/logo.jpeg", "base64").then(
               logo_data => {
@@ -274,7 +261,7 @@ describeEE("formatting > whitelabel", () => {
             cy.findByRole("searchbox", {
               name: "Login and unsubscribe pages",
             }).click();
-            popover().findByText("No illustration").click();
+            H.popover().findByText("No illustration").click();
 
             cy.signOut();
             cy.visit("/");
@@ -298,7 +285,7 @@ describeEE("formatting > whitelabel", () => {
           );
 
           cy.findByRole("searchbox", { name: "Landing page" }).click();
-          popover().findByText("Custom").click();
+          H.popover().findByText("Custom").click();
 
           cy.findByTestId("landing-page-illustration-setting").within(() => {
             cy.findByTestId("file-input").selectFile(
@@ -310,7 +297,7 @@ describeEE("formatting > whitelabel", () => {
             );
             cy.findByText("logo.jpeg").should("be.visible");
           });
-          undoToast().findByText("Changes saved").should("be.visible");
+          H.undoToast().findByText("Changes saved").should("be.visible");
 
           cy.readFile("e2e/support/assets/logo.jpeg", "base64").then(
             logo_data => {
@@ -328,7 +315,7 @@ describeEE("formatting > whitelabel", () => {
           cy.visit("/admin/settings/whitelabel/conceal-metabase");
 
           cy.findByLabelText("Landing page").click();
-          popover().findByText("No illustration").click();
+          H.popover().findByText("No illustration").click();
 
           cy.visit("/");
           cy.findByTestId("landing-page-illustration").should("not.exist");
@@ -346,7 +333,7 @@ describeEE("formatting > whitelabel", () => {
           cy.findByRole("searchbox", {
             name: "When calculations return no results",
           }).click();
-          popover().findByText("Custom").click();
+          H.popover().findByText("Custom").click();
 
           cy.findByTestId("no-data-illustration-setting").within(() => {
             cy.findByTestId("file-input").selectFile(
@@ -358,7 +345,7 @@ describeEE("formatting > whitelabel", () => {
             );
             cy.findByText("logo.jpeg").should("be.visible");
           });
-          undoToast().findByText("Changes saved").should("be.visible");
+          H.undoToast().findByText("Changes saved").should("be.visible");
 
           cy.createDashboardWithQuestions({
             dashboardName: "No results dashboard",
@@ -377,7 +364,7 @@ describeEE("formatting > whitelabel", () => {
 
           cy.log("test custom illustration");
 
-          visitDashboard("@dashboardId");
+          H.visitDashboard("@dashboardId");
           cy.readFile("e2e/support/assets/logo.jpeg", "base64").then(
             logo_data => {
               const imageDataUrl = `data:image/jpeg;base64,${logo_data}`;
@@ -390,7 +377,7 @@ describeEE("formatting > whitelabel", () => {
             },
           );
 
-          visitQuestion("@questionId");
+          H.visitQuestion("@questionId");
           cy.get("@imageDataUrl").then(imageDataUrl => {
             cy.findByAltText("No results").should(
               "have.attr",
@@ -405,12 +392,12 @@ describeEE("formatting > whitelabel", () => {
           cy.findByRole("searchbox", {
             name: "When calculations return no results",
           }).click();
-          popover().findByText("No illustration").click();
+          H.popover().findByText("No illustration").click();
 
-          visitDashboard("@dashboardId");
+          H.visitDashboard("@dashboardId");
           cy.findByAltText("No results").should("not.exist");
 
-          visitQuestion("@questionId");
+          H.visitQuestion("@questionId");
           cy.findByAltText("No results").should("not.exist");
         });
       });
@@ -428,7 +415,7 @@ describeEE("formatting > whitelabel", () => {
           cy.findByRole("searchbox", {
             name: "When no objects can be found",
           }).click();
-          popover().findByText("Custom").click();
+          H.popover().findByText("Custom").click();
 
           cy.findByTestId("no-object-illustration-setting").within(() => {
             cy.findByTestId("file-input").selectFile(
@@ -440,15 +427,15 @@ describeEE("formatting > whitelabel", () => {
             );
             cy.findByText("logo.jpeg").should("be.visible");
           });
-          undoToast().findByText("Changes saved").should("be.visible");
+          H.undoToast().findByText("Changes saved").should("be.visible");
 
           cy.log("test custom illustration");
 
           cy.findByRole("navigation").findByText("Exit admin").click();
-          appBar().findByText("New").click();
-          popover().findByText("Dashboard").click();
-          modal().findByTestId("collection-picker-button").click();
-          entityPickerModal().within(() => {
+          H.appBar().findByText("New").click();
+          H.popover().findByText("Dashboard").click();
+          H.modal().findByTestId("collection-picker-button").click();
+          H.entityPickerModal().within(() => {
             cy.readFile("e2e/support/assets/logo.jpeg", "base64").then(
               logo_data => {
                 const imageDataUrl = `data:image/jpeg;base64,${logo_data}`;
@@ -475,13 +462,13 @@ describeEE("formatting > whitelabel", () => {
           cy.findByRole("searchbox", {
             name: "When no objects can be found",
           }).click();
-          popover().findByText("No illustration").click();
+          H.popover().findByText("No illustration").click();
 
           cy.findByRole("navigation").findByText("Exit admin").click();
-          appBar().findByText("New").click();
-          popover().findByText("Dashboard").click();
-          modal().findByTestId("collection-picker-button").click();
-          entityPickerModal().within(() => {
+          H.appBar().findByText("New").click();
+          H.popover().findByText("Dashboard").click();
+          H.modal().findByTestId("collection-picker-button").click();
+          H.entityPickerModal().within(() => {
             cy.findByText(emptyCollectionName).click();
             cy.findByAltText("No results").should("not.exist");
 
@@ -526,7 +513,7 @@ describeEE("formatting > whitelabel", () => {
         .findByText("Show links and references to Metabase")
         .click();
 
-      undoToast().findByText("Changes saved").should("be.visible");
+      H.undoToast().findByText("Changes saved").should("be.visible");
 
       cy.visit("/");
       cy.findByAltText("Metabot").should("not.exist");
@@ -634,7 +621,7 @@ describeEE("formatting > whitelabel", () => {
     });
 
     it("should link to metabase help when the whitelabel feature is disabled (eg OSS)", () => {
-      setTokenFeatures("none");
+      H.setTokenFeatures("none");
 
       cy.signInAsNormalUser();
       cy.visit("/");
@@ -657,17 +644,19 @@ describeEE("formatting > whitelabel", () => {
         .clear()
         .type("ftp://something")
         .blur();
-      main()
+      H.main()
         .findByText(/This needs to be/i)
         .should("exist");
 
       getHelpLinkCustomDestinationInput().clear().type("https://").blur();
 
-      main().findByText("Please make sure this is a valid URL").should("exist");
+      H.main()
+        .findByText("Please make sure this is a valid URL")
+        .should("exist");
 
       getHelpLinkCustomDestinationInput().type("example");
 
-      main()
+      H.main()
         .findByText("Please make sure this is a valid URL")
         .should("not.exist");
     });
@@ -682,7 +671,7 @@ describeEE("formatting > whitelabel", () => {
     });
 
     it("should not render the widget when users does not have a valid license", () => {
-      setTokenFeatures("none");
+      H.setTokenFeatures("none");
       cy.reload();
       cy.findByLabelText("Landing page custom destination").should("not.exist");
     });
@@ -693,7 +682,7 @@ describeEE("formatting > whitelabel", () => {
         .clear()
         .type("/test-1")
         .blur();
-      undoToast().findByText("Changes saved").should("be.visible");
+      H.undoToast().findByText("Changes saved").should("be.visible");
 
       cy.findByTestId("landing-page-error").should("not.exist");
       cy.findByRole("navigation").findByText("Exit admin").click();
@@ -706,7 +695,7 @@ describeEE("formatting > whitelabel", () => {
         .clear()
         .type("/test-2")
         .blur();
-      undoToast().findByText("Changes saved").should("be.visible");
+      H.undoToast().findByText("Changes saved").should("be.visible");
 
       // set to valid value then test invalid value is not persisted
       cy.findByLabelText("Landing page custom destination")
@@ -731,12 +720,12 @@ function changeLoadingMessage(message) {
 }
 
 function setApplicationFontTo(font) {
-  updateSetting("application-font", font);
+  H.updateSetting("application-font", font);
 }
 
-const openSettingsMenu = () => appBar().icon("gear").click();
+const openSettingsMenu = () => H.appBar().icon("gear").click();
 
-const helpLink = () => popover().findByRole("link", { name: "Help" });
+const helpLink = () => H.popover().findByRole("link", { name: "Help" });
 
 const getHelpLinkCustomDestinationInput = () =>
   cy.findByPlaceholderText("Enter a URL it should go to");

--- a/e2e/test/scenarios/admin/admin-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/admin/admin-reproductions.cy.spec.js
@@ -1,19 +1,9 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, WRITABLE_DB_ID } from "e2e/support/cypress_data";
-import {
-  appBar,
-  entityPickerModal,
-  getNotebookStep,
-  popover,
-  queryWritableDB,
-  relativeDatePicker,
-  resetTestTable,
-  restore,
-  resyncDatabase,
-} from "e2e/support/helpers";
 
 describe("issue 26470", { tags: "@external" }, () => {
   beforeEach(() => {
-    restore("postgres_12");
+    H.restore("postgres_12");
     cy.signInAsAdmin();
     cy.request("POST", "/api/persist/enable");
   });
@@ -30,7 +20,7 @@ describe("issue 26470", { tags: "@external" }, () => {
 
 describe("issue 33035", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.request("GET", "/api/user/current").then(({ body: { id: user_id } }) => {
       cy.request("PUT", `/api/user/${user_id}`, { locale: "de" });
@@ -45,7 +35,7 @@ describe("issue 33035", () => {
 
 describe("issue 21532", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -78,31 +68,31 @@ describe("issue 41765", { tags: ["@external"] }, () => {
   const COLUMN_DISPLAY_NAME = "Another Column";
 
   beforeEach(() => {
-    resetTestTable({ type: "postgres", table: TEST_TABLE });
-    restore("postgres-writable");
+    H.resetTestTable({ type: "postgres", table: TEST_TABLE });
+    H.restore("postgres-writable");
     cy.signInAsAdmin();
 
-    resyncDatabase({
+    H.resyncDatabase({
       dbId: WRITABLE_DB_ID,
       tableName: TEST_TABLE,
     });
   });
 
   function enterAdmin() {
-    appBar().icon("gear").click();
-    popover().findByText("Admin settings").click();
+    H.appBar().icon("gear").click();
+    H.popover().findByText("Admin settings").click();
   }
 
   function exitAdmin() {
-    appBar().findByText("Exit admin").click();
+    H.appBar().findByText("Exit admin").click();
   }
 
   function openWritableDatabaseQuestion() {
     // start new question without navigating
-    appBar().findByText("New").click();
-    popover().findByText("Question").click();
+    H.appBar().findByText("New").click();
+    H.popover().findByText("Question").click();
 
-    entityPickerModal().within(() => {
+    H.entityPickerModal().within(() => {
       cy.findByText("Tables").click();
       cy.findByText(WRITABLE_DB_DISPLAY_NAME).click();
       cy.findByText(TEST_TABLE_DISPLAY_NAME).click();
@@ -112,33 +102,33 @@ describe("issue 41765", { tags: ["@external"] }, () => {
   it("re-syncing a database should invalidate the table cache (metabase#41765)", () => {
     cy.visit("/");
 
-    queryWritableDB(
+    H.queryWritableDB(
       `ALTER TABLE ${TEST_TABLE} ADD ${COLUMN_NAME} text;`,
       "postgres",
     );
 
     openWritableDatabaseQuestion();
 
-    getNotebookStep("data").button("Pick columns").click();
-    popover().findByText(COLUMN_DISPLAY_NAME).should("not.exist");
+    H.getNotebookStep("data").button("Pick columns").click();
+    H.popover().findByText(COLUMN_DISPLAY_NAME).should("not.exist");
 
     enterAdmin();
 
-    appBar().findByText("Databases").click();
+    H.appBar().findByText("Databases").click();
     cy.findAllByRole("link").contains(WRITABLE_DB_DISPLAY_NAME).click();
     cy.button("Sync database schema now").click();
 
     exitAdmin();
     openWritableDatabaseQuestion();
 
-    getNotebookStep("data").button("Pick columns").click();
-    popover().findByText(COLUMN_DISPLAY_NAME).should("be.visible");
+    H.getNotebookStep("data").button("Pick columns").click();
+    H.popover().findByText(COLUMN_DISPLAY_NAME).should("be.visible");
   });
 });
 
 describe("(metabase#45042)", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -172,14 +162,14 @@ describe("(metabase#45042)", () => {
 
 describe("(metabase#46714)", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.visit("/admin/datamodel/segment/create");
 
     cy.findByTestId("segment-editor").findByText("Select a table").click();
 
-    entityPickerModal().within(() => {
+    H.entityPickerModal().within(() => {
       cy.findByText("Orders").click();
     });
 
@@ -189,21 +179,21 @@ describe("(metabase#46714)", () => {
   });
 
   it("should allow users to apply relative date options in the segment date picker", () => {
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Created At").click();
       cy.findByText("Relative dates…").click();
       cy.findByRole("tab", { name: "Previous" }).click();
       cy.findByLabelText("Starting from…").click();
     });
 
-    relativeDatePicker.setValue({ value: 68, unit: "day" });
+    H.relativeDatePicker.setValue({ value: 68, unit: "day" });
 
-    relativeDatePicker.setStartingFrom({
+    H.relativeDatePicker.setStartingFrom({
       value: 70,
       unit: "day",
     });
 
-    popover().findByText("Add filter").click();
+    H.popover().findByText("Add filter").click();
 
     cy.findByTestId("filter-pill").should(
       "have.text",
@@ -212,17 +202,17 @@ describe("(metabase#46714)", () => {
   });
 
   it("should not hide operator select menu behind the main filter popover", () => {
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Total").click();
     });
 
     cy.findByLabelText("Filter operator")
       .should("have.text", "Between")
       .click();
-    popover().last().findByText("Less than").click();
+    H.popover().last().findByText("Less than").click();
     cy.findByLabelText("Filter operator").should("have.text", "Less than");
-    popover().findByPlaceholderText("Enter a number").clear().type("1000");
-    popover().findByText("Add filter").click();
+    H.popover().findByPlaceholderText("Enter a number").clear().type("1000");
+    H.popover().findByText("Add filter").click();
 
     cy.findByTestId("filter-pill").should(
       "have.text",

--- a/e2e/test/scenarios/admin/databases.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases.cy.spec.js
@@ -1,3 +1,4 @@
+import { H } from "e2e/support";
 import {
   QA_MONGO_PORT,
   QA_MYSQL_PORT,
@@ -8,20 +9,6 @@ import {
 } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  createSegment,
-  describeWithSnowplow,
-  enableTracking,
-  expectGoodSnowplowEvent,
-  isEE,
-  modal,
-  popover,
-  resetSnowplow,
-  restore,
-  setTokenFeatures,
-  tooltip,
-  typeAndBlurUsingLabel,
-} from "e2e/support/helpers";
 
 import { visitDatabase } from "./helpers/e2e-database-helpers";
 
@@ -33,7 +20,7 @@ describe(
   () => {
     ["mysql", "postgres"].forEach(dialect => {
       it(`should show ${dialect} writable_db with actions enabled`, () => {
-        restore(`${dialect}-writable`);
+        H.restore(`${dialect}-writable`);
         cy.signInAsAdmin();
 
         visitDatabase(WRITABLE_DB_ID).then(({ response: { body } }) => {
@@ -63,7 +50,7 @@ describe("admin > database > add", () => {
 
   function selectFieldOption(fieldName, option) {
     cy.findByLabelText(fieldName).click();
-    popover().contains(option).click({ force: true });
+    H.popover().contains(option).click({ force: true });
   }
 
   function chooseDatabase(database) {
@@ -110,7 +97,7 @@ describe("admin > database > add", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.intercept("POST", "/api/database").as("createDatabase");
@@ -127,15 +114,15 @@ describe("admin > database > add", () => {
   describe("external databases", { tags: "@external" }, () => {
     describe("postgres", () => {
       beforeEach(() => {
-        popover().within(() => {
-          if (isEE) {
+        H.popover().within(() => {
+          if (H.isEE) {
             // EE should ship with Oracle and Vertica as options
             cy.findByText("Oracle");
             cy.findByText("Vertica");
           }
         });
 
-        popover().contains("PostgreSQL").click({ force: true });
+        H.popover().contains("PostgreSQL").click({ force: true });
 
         cy.findByTestId("database-form").within(() => {
           cy.findByText("Show advanced options").click();
@@ -158,7 +145,7 @@ describe("admin > database > add", () => {
           cy.findByLabelText("Host").parent().icon("info").realHover();
         });
 
-        tooltip()
+        H.tooltip()
           .findByText(/your databases ip address/i)
           .should("be.visible");
 
@@ -170,12 +157,12 @@ describe("admin > database > add", () => {
             });
 
           // make sure fields needed to connect to the database are properly trimmed (metabase#12972)
-          typeAndBlurUsingLabel("Display name", "QA Postgres12");
-          typeAndBlurUsingLabel("Host", "localhost");
-          typeAndBlurUsingLabel("Port", QA_POSTGRES_PORT);
-          typeAndBlurUsingLabel("Database name", "sample");
-          typeAndBlurUsingLabel("Username", "metabase");
-          typeAndBlurUsingLabel("Password", "metasample123");
+          H.typeAndBlurUsingLabel("Display name", "QA Postgres12");
+          H.typeAndBlurUsingLabel("Host", "localhost");
+          H.typeAndBlurUsingLabel("Port", QA_POSTGRES_PORT);
+          H.typeAndBlurUsingLabel("Database name", "sample");
+          H.typeAndBlurUsingLabel("Username", "metabase");
+          H.typeAndBlurUsingLabel("Password", "metasample123");
         });
 
         const confirmSSLFields = (visible, hidden) => {
@@ -293,13 +280,13 @@ describe("admin > database > add", () => {
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains("Additional connection string options");
 
-        typeAndBlurUsingLabel("Display name", "QA Mongo");
-        typeAndBlurUsingLabel("Host", "localhost");
-        typeAndBlurUsingLabel("Port", QA_MONGO_PORT);
-        typeAndBlurUsingLabel("Database name", "sample");
-        typeAndBlurUsingLabel("Username", "metabase");
-        typeAndBlurUsingLabel("Password", "metasample123");
-        typeAndBlurUsingLabel("Authentication database (optional)", "admin");
+        H.typeAndBlurUsingLabel("Display name", "QA Mongo");
+        H.typeAndBlurUsingLabel("Host", "localhost");
+        H.typeAndBlurUsingLabel("Port", QA_MONGO_PORT);
+        H.typeAndBlurUsingLabel("Database name", "sample");
+        H.typeAndBlurUsingLabel("Username", "metabase");
+        H.typeAndBlurUsingLabel("Password", "metasample123");
+        H.typeAndBlurUsingLabel("Authentication database (optional)", "admin");
 
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Save").should("not.be.disabled").click();
@@ -337,11 +324,11 @@ describe("admin > database > add", () => {
         const badPasswordString = `mongodb://metabase:wrongPassword@localhost:${QA_MONGO_PORT}/sample?authSource=admin`;
         const validConnectionString = `mongodb://metabase:metasample123@localhost:${QA_MONGO_PORT}/sample?authSource=admin`;
 
-        popover().findByText("MongoDB").click({ force: true });
+        H.popover().findByText("MongoDB").click({ force: true });
 
         cy.findByTestId("database-form").within(() => {
           cy.findByText("Paste a connection string").click();
-          typeAndBlurUsingLabel("Display name", "QA Mongo");
+          H.typeAndBlurUsingLabel("Display name", "QA Mongo");
           cy.findByLabelText("Port").should("not.exist");
           cy.findByLabelText("Paste your connection string").type(badDBString, {
             delay: 0,
@@ -403,16 +390,16 @@ describe("admin > database > add", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Additional JDBC connection string options");
 
-      typeAndBlurUsingLabel("Display name", "QA MySQL8");
-      typeAndBlurUsingLabel("Host", "localhost");
-      typeAndBlurUsingLabel("Port", QA_MYSQL_PORT);
-      typeAndBlurUsingLabel("Database name", "sample");
-      typeAndBlurUsingLabel("Username", "metabase");
-      typeAndBlurUsingLabel("Password", "metasample123");
+      H.typeAndBlurUsingLabel("Display name", "QA MySQL8");
+      H.typeAndBlurUsingLabel("Host", "localhost");
+      H.typeAndBlurUsingLabel("Port", QA_MYSQL_PORT);
+      H.typeAndBlurUsingLabel("Database name", "sample");
+      H.typeAndBlurUsingLabel("Username", "metabase");
+      H.typeAndBlurUsingLabel("Password", "metasample123");
 
       // Bypass the RSA public key error for MySQL database
       // https://github.com/metabase/metabase/issues/12545
-      typeAndBlurUsingLabel(
+      H.typeAndBlurUsingLabel(
         "Additional JDBC connection string options",
         "allowPublicKeyRetrieval=true",
       );
@@ -449,7 +436,7 @@ describe("admin > database > add", () => {
       cy.visit("/admin/databases/create");
 
       chooseDatabase("BigQuery");
-      typeAndBlurUsingLabel("Display name", "BQ");
+      H.typeAndBlurUsingLabel("Display name", "BQ");
       selectFieldOption("Datasets", "Only these...");
       cy.findByPlaceholderText("E.x. public,auth*").type("some-dataset");
 
@@ -465,7 +452,7 @@ describe("admin > database > add", () => {
 
 describe("scenarios > admin > databases > exceptions", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -517,9 +504,9 @@ describe("scenarios > admin > databases > exceptions", () => {
 
     cy.visit("/admin/databases/create");
 
-    typeAndBlurUsingLabel("Display name", "Test");
-    typeAndBlurUsingLabel("Database name", "db");
-    typeAndBlurUsingLabel("Username", "admin");
+    H.typeAndBlurUsingLabel("Display name", "Test");
+    H.typeAndBlurUsingLabel("Database name", "db");
+    H.typeAndBlurUsingLabel("Username", "admin");
 
     cy.button("Save").click();
     cy.wait("@createDatabase");
@@ -542,13 +529,13 @@ describe("scenarios > admin > databases > exceptions", () => {
   it("should handle a failure to `GET` the list of all databases (metabase#20471)", () => {
     const errorMessage = "Lorem ipsum dolor sit amet, consectetur adip";
 
-    isEE && setTokenFeatures("all");
+    H.isEE && H.setTokenFeatures("all");
 
     cy.intercept(
       {
         method: "GET",
         pathname: "/api/database",
-        query: isEE
+        query: H.isEE
           ? {
               exclude_uneditable_details: "true",
             }
@@ -583,7 +570,7 @@ describe("scenarios > admin > databases > exceptions", () => {
 
 describe("scenarios > admin > databases > sample database", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("PUT", "/api/database/*").as("databaseUpdate");
   });
@@ -628,7 +615,7 @@ describe("scenarios > admin > databases > sample database", () => {
     cy.findByLabelText("Choose when syncs and scans happen").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Hourly").click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Daily").click({ force: true });
     });
 
@@ -644,7 +631,7 @@ describe("scenarios > admin > databases > sample database", () => {
       .within(() => {
         cy.findByText("Daily").click();
       });
-    popover().findByText("Weekly").click();
+    H.popover().findByText("Weekly").click();
 
     cy.button("Save changes").click();
     cy.wait("@databaseUpdate").then(({ response: { body } }) => {
@@ -690,7 +677,7 @@ describe("scenarios > admin > databases > sample database", () => {
     // model
     cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, { type: "model" });
     // Create a segment through API
-    createSegment({
+    H.createSegment({
       name: "Small orders",
       description: "All orders with a total under $100.",
       table_id: ORDERS_ID,
@@ -735,7 +722,7 @@ describe("scenarios > admin > databases > sample database", () => {
       .within(() => {
         cy.button("Discard saved field values").click();
       });
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByRole("heading").should(
         "have.text",
         "Discard saved field values",
@@ -751,7 +738,7 @@ describe("scenarios > admin > databases > sample database", () => {
       cy.wait("@usage_info");
     });
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.button("Delete this content and the DB connection")
         .as("deleteButton")
         .should("be.disabled");
@@ -822,7 +809,7 @@ describe("scenarios > admin > databases > sample database", () => {
 
     cy.button("Remove this database").click();
     cy.wait("@loadDatabaseUsageInfo");
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByLabelText(/Delete \d+ saved questions?/).click();
       cy.findByLabelText(/Delete \d+ model?/).click();
       cy.findByTestId("database-name-confirmation-input").type(
@@ -867,12 +854,12 @@ describe("scenarios > admin > databases > sample database", () => {
   });
 });
 
-describeWithSnowplow("add database card", () => {
+H.describeWithSnowplow("add database card", () => {
   beforeEach(() => {
-    resetSnowplow();
-    restore();
+    H.resetSnowplow();
+    H.restore();
     cy.signInAsAdmin();
-    enableTracking();
+    H.enableTracking();
   });
 
   it("should track the click on the card", () => {
@@ -885,7 +872,7 @@ describeWithSnowplow("add database card", () => {
 
     cy.get("@addDatabaseCard").findByText("Add a database").click();
     cy.location("pathname").should("eq", "/admin/databases/create");
-    expectGoodSnowplowEvent({
+    H.expectGoodSnowplowEvent({
       event: "database_add_clicked",
       triggered_from: "db-list",
     });

--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.js
@@ -1,3 +1,4 @@
+import { H } from "e2e/support";
 import {
   SAMPLE_DB_ID,
   SAMPLE_DB_SCHEMA_ID,
@@ -5,28 +6,6 @@ import {
 } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  createSegment,
-  entityPickerModal,
-  entityPickerModalTab,
-  filter,
-  getNotebookStep,
-  modal,
-  openOrdersTable,
-  openReviewsTable,
-  openTable,
-  popover,
-  resetTestTable,
-  restore,
-  resyncDatabase,
-  saveQuestion,
-  startNewQuestion,
-  summarize,
-  visitAlias,
-  visitQuestion,
-  visitQuestionAdhoc,
-  withDatabase,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, REVIEWS, REVIEWS_ID, PRODUCTS_ID } =
   SAMPLE_DATABASE;
@@ -51,7 +30,7 @@ describe("scenarios > admin > datamodel > field > field type", () => {
   function setFieldType({ oldValue, newValue } = {}) {
     getFieldType(oldValue).click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText(oldValue).closest(".ReactVirtualized__Grid").scrollTo(0, 0); // HACK: scroll to the top of the list. Ideally we should probably disable AccordionList virtualization
       searchFieldType(newValue);
       cy.findByText(newValue).click();
@@ -61,7 +40,7 @@ describe("scenarios > admin > datamodel > field > field type", () => {
   function checkNoFieldType({ oldValue, newValue } = {}) {
     getFieldType(oldValue).click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       searchFieldType(newValue);
       cy.findByText(newValue).should("not.exist");
     });
@@ -85,13 +64,13 @@ describe("scenarios > admin > datamodel > field > field type", () => {
   function setFKTargetField(field) {
     cy.findByText("Select a target").click();
 
-    popover().contains(field).click();
+    H.popover().contains(field).click();
   }
 
   beforeEach(() => {
     cy.intercept("GET", "/api/table/*/query_metadata*").as("metadata");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     ordersColumns.forEach(column => {
@@ -104,7 +83,7 @@ describe("scenarios > admin > datamodel > field > field type", () => {
   });
 
   it("should let you change the type to 'No semantic type'", () => {
-    visitAlias("@ORDERS_PRODUCT_ID_URL");
+    H.visitAlias("@ORDERS_PRODUCT_ID_URL");
     cy.wait(["@metadata", "@metadata"]);
 
     setFieldType({ oldValue: "Foreign Key", newValue: "No semantic type" });
@@ -118,7 +97,7 @@ describe("scenarios > admin > datamodel > field > field type", () => {
   });
 
   it("should let you change the type to 'Foreign Key' and choose the target field", () => {
-    visitAlias("@ORDERS_QUANTITY_URL");
+    H.visitAlias("@ORDERS_QUANTITY_URL");
     cy.wait("@metadata");
 
     setFieldType({ oldValue: "Quantity", newValue: "Foreign Key" });
@@ -137,7 +116,7 @@ describe("scenarios > admin > datamodel > field > field type", () => {
   });
 
   it("should not let you change the type to 'Number' (metabase#16781)", () => {
-    visitAlias("@ORDERS_PRODUCT_ID_URL");
+    H.visitAlias("@ORDERS_PRODUCT_ID_URL");
     cy.wait(["@metadata", "@metadata"]);
 
     checkNoFieldType({ oldValue: "Foreign Key", newValue: "Number" });
@@ -146,7 +125,7 @@ describe("scenarios > admin > datamodel > field > field type", () => {
 
 describe("scenarios > admin > datamodel > field", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     ["CREATED_AT", "PRODUCT_ID", "QUANTITY"].forEach(name => {
@@ -160,10 +139,10 @@ describe("scenarios > admin > datamodel > field", () => {
   });
 
   describe("Name and Description", () => {
-    before(restore);
+    before(H.restore);
 
     it("lets you change field name and description", () => {
-      visitAlias("@ORDERS_CREATED_AT_URL");
+      H.visitAlias("@ORDERS_CREATED_AT_URL");
 
       cy.get('input[name="display_name"]').as("display_name");
       cy.get('input[name="description"]').as("description");
@@ -193,10 +172,10 @@ describe("scenarios > admin > datamodel > field", () => {
 
   describe("Formatting", () => {
     it("should allow you to change field formatting", () => {
-      visitAlias("@ORDERS_QUANTITY_URL");
+      H.visitAlias("@ORDERS_QUANTITY_URL");
       cy.findByRole("link", { name: "Formatting" }).click();
       cy.findByLabelText("Style").click();
-      popover().findByText("Percent").click();
+      H.popover().findByText("Percent").click();
       cy.wait("@fieldUpdate");
       cy.findByRole("list", { name: "undo-list" })
         .findByText("Updated Quantity")
@@ -205,10 +184,10 @@ describe("scenarios > admin > datamodel > field", () => {
   });
 
   describe("Visibility", () => {
-    before(restore);
+    before(H.restore);
 
     it("lets you change field visibility", () => {
-      visitAlias("@ORDERS_CREATED_AT_URL");
+      H.visitAlias("@ORDERS_CREATED_AT_URL");
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Everywhere").click();
@@ -223,10 +202,10 @@ describe("scenarios > admin > datamodel > field", () => {
   });
 
   describe("Filtering on this field", () => {
-    before(restore);
+    before(H.restore);
 
     it("lets you change to 'Search box'", () => {
-      visitAlias("@ORDERS_QUANTITY_URL");
+      H.visitAlias("@ORDERS_QUANTITY_URL");
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("A list of all values").click();
@@ -241,10 +220,10 @@ describe("scenarios > admin > datamodel > field", () => {
   });
 
   describe("Display Values", () => {
-    before(restore);
+    before(H.restore);
 
     it("lets you change to 'Use foreign key' and change the target for field with fk", () => {
-      visitAlias("@ORDERS_PRODUCT_ID_URL");
+      H.visitAlias("@ORDERS_PRODUCT_ID_URL");
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Use original value").click();
@@ -265,10 +244,10 @@ describe("scenarios > admin > datamodel > field", () => {
       const dbId = 2;
       const remappedNullValue = "nothin";
 
-      restore("withSqlite");
+      H.restore("withSqlite");
       cy.signInAsAdmin();
 
-      withDatabase(
+      H.withDatabase(
         dbId,
         ({ NUMBER_WITH_NULLS: { NUM }, NUMBER_WITH_NULLS_ID }) => {
           cy.request("GET", `/api/database/${dbId}/schemas`).then(
@@ -286,14 +265,14 @@ describe("scenarios > admin > datamodel > field", () => {
             .closest("section")
             .findByText("Use original value")
             .click();
-          popover().findByText("Custom mapping").click();
+          H.popover().findByText("Custom mapping").click();
 
           cy.findByDisplayValue("null").clear().type(remappedNullValue);
           cy.button("Save").click();
           cy.button("Saved!").should("be.visible");
 
           cy.log("Make sure custom mapping appears in QB");
-          openTable({ database: dbId, table: NUMBER_WITH_NULLS_ID });
+          H.openTable({ database: dbId, table: NUMBER_WITH_NULLS_ID });
           cy.get("[data-testid=cell-data]").should(
             "contain",
             remappedNullValue,
@@ -313,10 +292,10 @@ describe("Unfold JSON", () => {
   }
 
   beforeEach(() => {
-    resetTestTable({ type: "postgres", table: "many_data_types" });
-    restore("postgres-writable");
+    H.resetTestTable({ type: "postgres", table: "many_data_types" });
+    H.restore("postgres-writable");
     cy.signInAsAdmin();
-    resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: "many_data_types" });
+    H.resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: "many_data_types" });
   });
 
   it("lets you enable/disable 'Unfold JSON' for JSON columns", () => {
@@ -336,7 +315,7 @@ describe("Unfold JSON", () => {
     });
 
     getUnfoldJsonContent().findByText(/Yes/i).click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText(/No/i).click();
     });
 
@@ -373,7 +352,7 @@ describe("scenarios > admin > datamodel > hidden tables (metabase#9759)", () => 
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     // Toggle the table to be hidden as admin user
@@ -397,9 +376,9 @@ describe("scenarios > admin > datamodel > hidden tables (metabase#9759)", () => 
     cy.contains("Orders").should("not.exist");
 
     // It shouldn't show in a new question data picker
-    startNewQuestion();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.startNewQuestion();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.contains("Products").should("exist");
       cy.contains("Orders").should("not.exist");
     });
@@ -415,7 +394,7 @@ describe("scenarios > admin > datamodel > metadata", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.intercept("PUT", "/api/field/*").as("fieldUpdate");
@@ -426,7 +405,7 @@ describe("scenarios > admin > datamodel > metadata", () => {
       `/admin/datamodel/database/${SAMPLE_DB_ID}/schema/${SAMPLE_DB_SCHEMA_ID}/table/${ORDERS_ID}/field/${ORDERS.PRODUCT_ID}/general`,
     ).as("ORDERS_PRODUCT_ID_URL");
 
-    visitAlias("@ORDERS_PRODUCT_ID_URL");
+    H.visitAlias("@ORDERS_PRODUCT_ID_URL");
 
     cy.findByPlaceholderText("PRODUCT_ID")
       .clear()
@@ -435,7 +414,7 @@ describe("scenarios > admin > datamodel > metadata", () => {
 
     cy.wait("@fieldUpdate");
 
-    openOrdersTable({ limit: 5 });
+    H.openOrdersTable({ limit: 5 });
 
     cy.findAllByTestId("header-cell").should("contain", "Remapped Product ID");
   });
@@ -445,7 +424,7 @@ describe("scenarios > admin > datamodel > metadata", () => {
       `/admin/datamodel/database/${SAMPLE_DB_ID}/schema/${SAMPLE_DB_SCHEMA_ID}/table/${ORDERS_ID}`,
     ).as("ORDERS_TABLE_URL");
 
-    visitAlias("@ORDERS_TABLE_URL");
+    H.visitAlias("@ORDERS_TABLE_URL");
 
     cy.findByDisplayValue("Product ID")
       .clear()
@@ -454,7 +433,7 @@ describe("scenarios > admin > datamodel > metadata", () => {
 
     cy.wait("@fieldUpdate");
 
-    openOrdersTable({ limit: 5 });
+    H.openOrdersTable({ limit: 5 });
 
     cy.findAllByTestId("header-cell").should("contain", "Remapped Product ID");
   });
@@ -472,7 +451,7 @@ describe("scenarios > admin > datamodel > metadata", () => {
     cy.findByText("Use original value").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Use foreign key").click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Title").click();
     });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -481,7 +460,7 @@ describe("scenarios > admin > datamodel > metadata", () => {
     );
 
     cy.log("Name of the product should be displayed instead of its ID");
-    openOrdersTable();
+    H.openOrdersTable();
     cy.findAllByText("Awesome Concrete Shoes");
   });
 
@@ -519,7 +498,7 @@ describe("scenarios > admin > datamodel > metadata", () => {
     cy.findByText("Save").click();
 
     cy.log("Numeric ratings should be remapped to custom strings");
-    openReviewsTable();
+    H.openReviewsTable();
     Object.values(customMap).forEach(rating => {
       cy.findAllByText(rating);
     });
@@ -562,8 +541,8 @@ describe("scenarios > admin > datamodel > metadata", () => {
       fk_target_field_id: ORDERS.CREATED_AT,
     });
 
-    openReviewsTable({ mode: "notebook" });
-    summarize({ mode: "notebook" });
+    H.openReviewsTable({ mode: "notebook" });
+    H.summarize({ mode: "notebook" });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Count of rows").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -582,13 +561,13 @@ describe("scenarios > admin > datamodel > metadata", () => {
       fk_target_field_id: PRODUCTS.ID,
     });
 
-    openReviewsTable({ mode: "notebook" });
-    summarize({ mode: "notebook" });
-    getNotebookStep("summarize")
+    H.openReviewsTable({ mode: "notebook" });
+    H.summarize({ mode: "notebook" });
+    H.getNotebookStep("summarize")
       .findByText("Pick a column to group by")
       .click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findAllByTestId("dimension-list-item")
         .eq(3)
         .should("have.text", "Rating");
@@ -611,16 +590,16 @@ describe("scenarios > admin > datamodel > metadata", () => {
     );
 
     openOptionsForSection("Filtering on this field");
-    popover().findByText("Search box").click();
+    H.popover().findByText("Search box").click();
 
     openOptionsForSection("Display values");
-    popover().findByText("Custom mapping").should("not.exist");
+    H.popover().findByText("Custom mapping").should("not.exist");
 
     openOptionsForSection("Filtering on this field");
-    popover().findByText("A list of all values").click();
+    H.popover().findByText("A list of all values").click();
 
     openOptionsForSection("Display values");
-    popover().findByText("Custom mapping");
+    H.popover().findByText("Custom mapping");
   });
 
   describe("column formatting options", () => {
@@ -656,7 +635,7 @@ describe("scenarios > admin > datamodel > metadata", () => {
       });
 
       // if you change the style to currency, currency settings should appear
-      popover().findByText("Currency").click();
+      H.popover().findByText("Currency").click();
       cy.wait("@updateField");
 
       cy.findByTestId("column-settings").within(() => {
@@ -678,7 +657,7 @@ describe("scenarios > admin > datamodel > metadata", () => {
 
       cy.wait("@updateField");
 
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           database: SAMPLE_DB_ID,
           query: {
@@ -696,7 +675,7 @@ describe("scenarios > admin > datamodel > metadata", () => {
 
 describe("scenarios > admin > datamodel > segments", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.viewport(1400, 860);
   });
@@ -713,7 +692,7 @@ describe("scenarios > admin > datamodel > segments", () => {
       cy.button("New segment").click();
 
       cy.findByTestId("segment-editor").findByText("Select a table").click();
-      entityPickerModal().within(() => {
+      H.entityPickerModal().within(() => {
         cy.findByText("Orders").click();
       });
 
@@ -722,7 +701,7 @@ describe("scenarios > admin > datamodel > segments", () => {
         .click();
 
       cy.log("Fails in v0.36.0 and v0.36.3. It exists in v0.35.4");
-      popover().findByText("Custom Expression");
+      H.popover().findByText("Custom Expression");
     });
 
     it("should show no segments", () => {
@@ -739,7 +718,7 @@ describe("scenarios > admin > datamodel > segments", () => {
 
     beforeEach(() => {
       // Create a segment through API
-      createSegment({
+      H.createSegment({
         name: SEGMENT_NAME,
         description: "All orders with a total under $100.",
         table_id: ORDERS_ID,
@@ -808,10 +787,10 @@ describe("scenarios > admin > datamodel > segments", () => {
       cy.findByTestId("filter-pill").should("have.text", "Orders < 100");
       cy.findAllByTestId("cell-data").should("contain", "37.65");
 
-      summarize();
+      H.summarize();
       cy.findAllByTestId("sidebar-right").button("Done").click();
       cy.findByTestId("scalar-value").should("have.text", "13,005");
-      saveQuestion("Foo");
+      H.saveQuestion("Foo");
 
       // Check list
       cy.visit("/reference/segments/1/questions");
@@ -835,7 +814,7 @@ describe("scenarios > admin > datamodel > segments", () => {
         .parent()
         .find(".Icon-ellipsis")
         .click();
-      popover().contains("Edit Segment").click();
+      H.popover().contains("Edit Segment").click();
 
       // update the filter from "< 100" to "> 10"
       cy.url().should("match", /segment\/1$/);
@@ -843,10 +822,10 @@ describe("scenarios > admin > datamodel > segments", () => {
       cy.findByTestId("filter-pill")
         .contains(/Total\s+is less than/)
         .click();
-      popover().findByLabelText("Filter operator").click();
-      popover().contains("Greater than").click();
-      popover().findByPlaceholderText("Enter a number").type("{SelectAll}10");
-      popover().contains("Update filter").click();
+      H.popover().findByLabelText("Filter operator").click();
+      H.popover().contains("Greater than").click();
+      H.popover().findByPlaceholderText("Enter a number").type("{SelectAll}10");
+      H.popover().contains("Update filter").click();
 
       // confirm that the preview updated
       cy.findByTestId("segment-editor").contains("18758 rows");
@@ -872,9 +851,9 @@ describe("scenarios > admin > datamodel > segments", () => {
         .parent()
         .find(".Icon-ellipsis")
         .click();
-      popover().findByText("Retire Segment").click();
-      modal().find("textarea").type("delete it");
-      modal().contains("button", "Retire").click();
+      H.popover().findByText("Retire Segment").click();
+      H.modal().find("textarea").type("delete it");
+      H.modal().contains("button", "Retire").click();
     });
 
     it("should show segment revision history (metabase#45577, metabase#45594)", () => {
@@ -901,7 +880,7 @@ describe("scenarios > admin > datamodel > segments", () => {
         .filter(`:contains(${SEGMENT_NAME})`)
         .icon("ellipsis")
         .click();
-      popover().findByTextEnsureVisible("Revision History").click();
+      H.popover().findByTextEnsureVisible("Revision History").click();
 
       cy.location("pathname").should(
         "eq",
@@ -949,7 +928,7 @@ describe("scenarios > admin > databases > table", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -1026,8 +1005,8 @@ describe("scenarios > admin > databases > table", () => {
   describe.skip("turning table visibility off shouldn't prevent editing related question (metabase#15947)", () => {
     it("simple question (metabase#15947-1)", () => {
       turnTableVisibilityOff(ORDERS_ID);
-      visitQuestion(ORDERS_QUESTION_ID);
-      filter();
+      H.visitQuestion(ORDERS_QUESTION_ID);
+      H.filter();
     });
 
     it("question with joins (metabase#15947-2)", () => {

--- a/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
@@ -1,23 +1,10 @@
+import { H } from "e2e/support";
 import {
   SAMPLE_DB_ID,
   SAMPLE_DB_SCHEMA_ID,
   USER_GROUPS,
 } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  describeEE,
-  entityPickerModal,
-  entityPickerModalTab,
-  moveDnDKitElement,
-  openOrdersTable,
-  openProductsTable,
-  openReviewsTable,
-  openTable,
-  popover,
-  restore,
-  setTokenFeatures,
-  startNewQuestion,
-} from "e2e/support/helpers";
 
 const {
   ORDERS,
@@ -51,7 +38,7 @@ describe("scenarios > admin > datamodel > editor", () => {
 
   describe("table settings", () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
     });
 
@@ -63,9 +50,9 @@ describe("scenarios > admin > datamodel > editor", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated Table display_name").should("be.visible");
 
-      startNewQuestion();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.startNewQuestion();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("People").should("be.visible");
         cy.findByText("New orders").should("be.visible");
       });
@@ -110,9 +97,9 @@ describe("scenarios > admin > datamodel > editor", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("5 Hidden Tables").should("be.visible");
 
-      startNewQuestion();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.startNewQuestion();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("People").should("be.visible");
         cy.findByText("Orders").should("not.exist");
       });
@@ -124,9 +111,9 @@ describe("scenarios > admin > datamodel > editor", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("4 Hidden Tables").should("be.visible");
 
-      startNewQuestion();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.startNewQuestion();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("People").should("be.visible");
         cy.findByText("Orders").should("be.visible");
       });
@@ -142,7 +129,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated Tax").should("be.visible");
 
-      openOrdersTable();
+      H.openOrdersTable();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("New tax").should("be.visible");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -191,7 +178,7 @@ describe("scenarios > admin > datamodel > editor", () => {
     it("should allow changing the field visibility", () => {
       visitTableMetadata();
       getFieldSection("TAX").findByText("Everywhere").click();
-      popover().findByText("Do not include").click();
+      H.popover().findByText("Do not include").click();
       cy.wait("@updateField");
       getFieldSection("TAX").findByText("Do not include").should("be.visible");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -199,7 +186,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated Tax").should("be.visible");
 
-      openOrdersTable();
+      H.openOrdersTable();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Total").should("be.visible");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -219,7 +206,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       searchAndSelectValue("Canadian Dollar");
       cy.wait("@updateField");
 
-      openOrdersTable();
+      H.openOrdersTable();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Tax (CA$)").should("be.visible");
     });
@@ -227,7 +214,7 @@ describe("scenarios > admin > datamodel > editor", () => {
     it("should allow changing the field foreign key target", () => {
       visitTableMetadata();
       getFieldSection("USER_ID").findByText("People → ID").click();
-      popover().findByText("Products → ID").click();
+      H.popover().findByText("Products → ID").click();
       cy.wait("@updateField");
       getFieldSection("USER_ID")
         .findByText("Products → ID")
@@ -235,10 +222,14 @@ describe("scenarios > admin > datamodel > editor", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated User ID").should("be.visible");
 
-      openTable({ database: SAMPLE_DB_ID, table: ORDERS_ID, mode: "notebook" });
+      H.openTable({
+        database: SAMPLE_DB_ID,
+        table: ORDERS_ID,
+        mode: "notebook",
+      });
       cy.icon("join_left_outer").click();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Products").click();
       });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -248,7 +239,7 @@ describe("scenarios > admin > datamodel > editor", () => {
     it("should allow sorting fields as in the database", () => {
       visitTableMetadata({ tableId: PRODUCTS_ID });
       setTableOrder("Database");
-      openProductsTable();
+      H.openProductsTable();
       assertTableHeader([
         "ID",
         "Ean",
@@ -264,7 +255,7 @@ describe("scenarios > admin > datamodel > editor", () => {
     it("should allow sorting fields alphabetically", () => {
       visitTableMetadata({ tableId: PRODUCTS_ID });
       setTableOrder("Alphabetical");
-      openProductsTable();
+      H.openProductsTable();
       assertTableHeader([
         "Category",
         "Created At",
@@ -280,7 +271,7 @@ describe("scenarios > admin > datamodel > editor", () => {
     it("should allow sorting fields smartly", () => {
       visitTableMetadata({ tableId: PRODUCTS_ID });
       setTableOrder("Smart");
-      openProductsTable();
+      H.openProductsTable();
       assertTableHeader([
         "ID",
         "Created At",
@@ -296,11 +287,11 @@ describe("scenarios > admin > datamodel > editor", () => {
     it("should allow sorting fields in the custom order", () => {
       visitTableMetadata({ tableId: PRODUCTS_ID });
       //moveField(0, 200);
-      moveDnDKitElement(cy.findAllByTestId("grabber").first(), {
+      H.moveDnDKitElement(cy.findAllByTestId("grabber").first(), {
         vertical: 200,
       });
       cy.wait("@updateFieldOrder");
-      openProductsTable();
+      H.openProductsTable();
       assertTableHeader([
         "Ean",
         "ID",
@@ -332,7 +323,7 @@ describe("scenarios > admin > datamodel > editor", () => {
 
   describe("field settings", () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
     });
 
@@ -344,7 +335,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated Tax").should("be.visible");
 
-      openOrdersTable();
+      H.openOrdersTable();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("New tax").should("be.visible");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -372,14 +363,14 @@ describe("scenarios > admin > datamodel > editor", () => {
       visitFieldMetadata({ fieldId: ORDERS.TAX });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Everywhere").click();
-      popover().findByText("Do not include").click();
+      H.popover().findByText("Do not include").click();
       cy.wait("@updateField");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Do not include").should("be.visible");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated Tax").should("be.visible");
 
-      openOrdersTable();
+      H.openOrdersTable();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Total").should("be.visible");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -402,7 +393,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       searchAndSelectValue("Canadian Dollar");
       cy.wait("@updateField");
 
-      openOrdersTable();
+      H.openOrdersTable();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Tax (CA$)").should("be.visible");
     });
@@ -411,17 +402,21 @@ describe("scenarios > admin > datamodel > editor", () => {
       visitFieldMetadata({ fieldId: ORDERS.USER_ID });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("People → ID").click();
-      popover().findByText("Products → ID").click();
+      H.popover().findByText("Products → ID").click();
       cy.wait("@updateField");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Products → ID").should("be.visible");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated User ID").should("be.visible");
 
-      openTable({ database: SAMPLE_DB_ID, table: ORDERS_ID, mode: "notebook" });
+      H.openTable({
+        database: SAMPLE_DB_ID,
+        table: ORDERS_ID,
+        mode: "notebook",
+      });
       cy.icon("join_left_outer").click();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Products").click();
       });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -435,22 +430,22 @@ describe("scenarios > admin > datamodel > editor", () => {
       cy.log(
         "Ensure that Coercion strategy has been humanized (metabase#44723)",
       );
-      popover().should("not.contain.text", "Coercion");
-      popover().findByText("UNIX seconds → Datetime").click();
+      H.popover().should("not.contain.text", "Coercion");
+      H.popover().findByText("UNIX seconds → Datetime").click();
       cy.wait("@updateField");
 
-      openTable({ database: SAMPLE_DB_ID, table: FEEDBACK_ID });
+      H.openTable({ database: SAMPLE_DB_ID, table: FEEDBACK_ID });
       cy.findAllByTestId("cell-data")
         .contains("December 31, 1969, 4:00 PM")
         .should("have.length.greaterThan", 0);
     });
   });
 
-  describeEE("data model permissions", () => {
+  H.describeEE("data model permissions", () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
-      setTokenFeatures("all");
+      H.setTokenFeatures("all");
     });
 
     it("should allow changing the table name with data model permissions only", () => {
@@ -466,9 +461,9 @@ describe("scenarios > admin > datamodel > editor", () => {
       cy.signOut();
 
       cy.signInAsNormalUser();
-      startNewQuestion();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.startNewQuestion();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("People").should("be.visible");
         cy.findByText("New orders").should("be.visible");
       });
@@ -488,7 +483,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       cy.findByText("Updated Tax").should("be.visible");
 
       cy.signInAsNormalUser();
-      openOrdersTable();
+      H.openOrdersTable();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("New tax").should("be.visible");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -507,7 +502,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       cy.findByText("Updated Total").should("be.visible");
 
       cy.signInAsNormalUser();
-      openOrdersTable();
+      H.openOrdersTable();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("New total").should("be.visible");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -523,7 +518,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       visitFieldMetadata({ fieldId: ORDERS.USER_ID });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("People → ID").click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Reviews → ID").should("not.exist");
         cy.findByText("Products → ID").click();
       });
@@ -534,10 +529,14 @@ describe("scenarios > admin > datamodel > editor", () => {
       cy.findByText("Updated User ID").should("be.visible");
 
       cy.signInAsNormalUser();
-      openTable({ database: SAMPLE_DB_ID, table: ORDERS_ID, mode: "notebook" });
+      H.openTable({
+        database: SAMPLE_DB_ID,
+        table: ORDERS_ID,
+        mode: "notebook",
+      });
       cy.icon("join_left_outer").click();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Products").click();
       });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -553,12 +552,12 @@ describe("scenarios > admin > datamodel > editor", () => {
       visitFieldMetadata({ tableId: REVIEWS_ID, fieldId: REVIEWS.PRODUCT_ID });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Use original value").click();
-      popover().findByText("Use foreign key").click();
-      popover().findByText("Title").click();
+      H.popover().findByText("Use foreign key").click();
+      H.popover().findByText("Title").click();
       cy.wait("@updateFieldDimension");
 
       cy.signInAsNormalUser();
-      openReviewsTable({ limit: 1 });
+      H.openReviewsTable({ limit: 1 });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Rustic Paper Wallet").should("be.visible");
     });
@@ -570,7 +569,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       visitFieldMetadata({ tableId: REVIEWS_ID, fieldId: REVIEWS.PRODUCT_ID });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Use original value").click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Use original value").should("be.visible");
         cy.findByText("Use foreign key").should("not.exist");
       });
@@ -583,7 +582,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       visitFieldMetadata({ tableId: REVIEWS_ID, fieldId: REVIEWS.RATING });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Use original value").click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Use original value").should("be.visible");
         cy.findByText("Custom mapping").should("not.exist");
       });
@@ -592,7 +591,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       visitFieldMetadata({ tableId: REVIEWS_ID, fieldId: REVIEWS.RATING });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Use original value").click();
-      popover().findByText("Custom mapping").click();
+      H.popover().findByText("Custom mapping").click();
       cy.wait("@updateFieldDimension");
 
       cy.signIn("none");
@@ -606,7 +605,7 @@ describe("scenarios > admin > datamodel > editor", () => {
 
   describe("databases without schemas", { tags: ["@external"] }, () => {
     beforeEach(() => {
-      restore("mysql-8");
+      H.restore("mysql-8");
       cy.signInAsAdmin();
     });
 
@@ -626,7 +625,7 @@ describe("scenarios > admin > datamodel > editor", () => {
         schemaId: MYSQL_DB_SCHEMA_ID,
       });
       getFieldSection("TAX").findByText("Everywhere").click();
-      popover().findByText("Do not include").click();
+      H.popover().findByText("Do not include").click();
       cy.wait("@updateField");
       getFieldSection("TAX").findByText("Do not include").should("be.visible");
     });
@@ -681,7 +680,7 @@ const clearAndBlurInput = oldValue => {
 };
 
 const searchAndSelectValue = (newValue, searchText = newValue) => {
-  popover().within(() => {
+  H.popover().within(() => {
     cy.findByRole("grid").scrollTo("top", { ensureScrollable: false });
     cy.findByPlaceholderText("Find...").type(searchText, { delay: 50 });
     cy.findByText(newValue).click();
@@ -694,7 +693,7 @@ const getFieldSection = fieldName => {
 
 const setTableOrder = order => {
   cy.findByLabelText("Sort").click();
-  popover().findByText(order).click();
+  H.popover().findByText(order).click();
   cy.wait("@updateTable");
 };
 

--- a/e2e/test/scenarios/admin/datamodel/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/reproductions.cy.spec.js
@@ -1,24 +1,13 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, SAMPLE_DB_SCHEMA_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  appBar,
-  commandPalette,
-  commandPaletteButton,
-  navigationSidebar,
-  openReviewsTable,
-  popover,
-  restore,
-  summarize,
-  tableHeaderClick,
-  visitAlias,
-} from "e2e/support/helpers";
 
 const { PEOPLE_ID, PEOPLE, REVIEWS, REVIEWS_ID, ORDERS, ORDERS_ID } =
   SAMPLE_DATABASE;
 
 describe("issue 17768", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.request("PUT", `/api/field/${REVIEWS.ID}`, {
@@ -38,13 +27,13 @@ describe("issue 17768", () => {
   });
 
   it("should not show binning options for an entity key, regardless of its underlying type (metabase#17768)", () => {
-    openReviewsTable({ mode: "notebook" });
+    H.openReviewsTable({ mode: "notebook" });
 
-    summarize({ mode: "notebook" });
+    H.summarize({ mode: "notebook" });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("ID")
         .closest("[data-element-id=list-section]")
         .realHover()
@@ -56,7 +45,7 @@ describe("issue 17768", () => {
 
 describe("issue 18384", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     // Hide Reviews table
@@ -89,7 +78,7 @@ describe("issue 21984", () => {
   beforeEach(() => {
     cy.intercept("GET", "/api/table/*/query_metadata?**").as("tableMetadata");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.visit(reviewsDataModelPage);
@@ -106,8 +95,8 @@ describe("issue 21984", () => {
       cy.findByText("Reviews").should("not.exist");
     });
 
-    commandPaletteButton().click();
-    commandPalette().within(() => {
+    H.commandPaletteButton().click();
+    H.commandPalette().within(() => {
       cy.findByText("Recent items").should("not.exist");
     });
   });
@@ -115,7 +104,7 @@ describe("issue 21984", () => {
 
 describe("issue 15542", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.wrap(
@@ -126,7 +115,7 @@ describe("issue 15542", () => {
 
   function openOrdersTable() {
     // Navigate without reloading the page
-    navigationSidebar().findByText("Databases").click({
+    H.navigationSidebar().findByText("Databases").click({
       // force the click because the sidebar might be closed but
       // that is not what we are testing here.
       force: true,
@@ -143,10 +132,10 @@ describe("issue 15542", () => {
 
   function openOrdersProductIdSettings() {
     // Navigate without reloading the page
-    appBar().icon("gear").click();
-    popover().findByText("Admin settings").click();
+    H.appBar().icon("gear").click();
+    H.popover().findByText("Admin settings").click();
 
-    appBar().findByText("Table Metadata").click();
+    H.appBar().findByText("Table Metadata").click();
     cy.findByText("Orders").click();
 
     cy.findByTestId("column-PRODUCT_ID").icon("gear").click();
@@ -161,24 +150,24 @@ describe("issue 15542", () => {
     // helpers because they use cy.visit under the hood and that reloads the page,
     // clearing the in-browser cache, which is what we are testing here.
 
-    visitAlias("@ORDERS_PRODUCT_ID_URL");
+    H.visitAlias("@ORDERS_PRODUCT_ID_URL");
 
     select("Plain input box").click();
-    popover().findByText("A list of all values").click();
+    H.popover().findByText("A list of all values").click();
 
     select("Use original value").click();
-    popover().findByText("Use foreign key").click();
-    popover().findByText("Title").click();
+    H.popover().findByText("Use foreign key").click();
+    H.popover().findByText("Title").click();
 
     cy.wait("@fieldDimensionUpdate");
 
     exitAdmin();
     openOrdersTable();
 
-    tableHeaderClick("Product ID");
-    popover().findByText("Filter by this column").click();
+    H.tableHeaderClick("Product ID");
+    H.popover().findByText("Filter by this column").click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("1").should("not.exist");
       cy.findByText("Rustic Paper Wallet").should("be.visible");
     });
@@ -186,15 +175,15 @@ describe("issue 15542", () => {
     openOrdersProductIdSettings();
 
     select("Use foreign key").click();
-    popover().findByText("Use original value").click();
+    H.popover().findByText("Use original value").click();
 
     exitAdmin();
     openOrdersTable();
 
-    tableHeaderClick("Product ID");
-    popover().findByText("Filter by this column").click();
+    H.tableHeaderClick("Product ID");
+    H.popover().findByText("Filter by this column").click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("1").should("be.visible");
       cy.findByText("Rustic Paper Wallet").should("not.exist");
     });

--- a/e2e/test/scenarios/admin/performance/dashboardsAndQuestions.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/dashboardsAndQuestions.cy.spec.ts
@@ -1,10 +1,4 @@
-import {
-  describeEE,
-  queryWritableDB,
-  resetTestTable,
-  restore,
-  setTokenFeatures,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 import {
   TEST_TABLE,
@@ -57,14 +51,14 @@ const testCacheStrategy = ({
     });
 
     const expectedCacheDuration = getExpectedCacheDuration(strategy);
-    queryWritableDB(`UPDATE ${TEST_TABLE} SET my_text='Old Value';`);
+    H.queryWritableDB(`UPDATE ${TEST_TABLE} SET my_text='Old Value';`);
 
     // first visit causes us to cache it
     visitItem();
     cy.findByTestId("visualization-root").findByText("Old Value");
 
     // value changes in the DB
-    queryWritableDB(`UPDATE ${TEST_TABLE} SET my_text='New Value';`);
+    H.queryWritableDB(`UPDATE ${TEST_TABLE} SET my_text='New Value';`);
 
     // check that old value is still cached
     advanceServerClockBy(expectedCacheDuration - 1000);
@@ -100,16 +94,18 @@ const testDoNotCachePolicy = ({
       });
     }
 
-    queryWritableDB(`UPDATE ${TEST_TABLE} SET my_text='Value 2';`).then(() => {
-      visitItem();
-      cy.findByTestId("visualization-root").findByText("Value 2");
-      queryWritableDB(`UPDATE ${TEST_TABLE} SET my_text='Value 3';`).then(
-        () => {
-          visitItem();
-          cy.findByTestId("visualization-root").findByText("Value 3");
-        },
-      );
-    });
+    H.queryWritableDB(`UPDATE ${TEST_TABLE} SET my_text='Value 2';`).then(
+      () => {
+        visitItem();
+        cy.findByTestId("visualization-root").findByText("Value 2");
+        H.queryWritableDB(`UPDATE ${TEST_TABLE} SET my_text='Value 3';`).then(
+          () => {
+            visitItem();
+            cy.findByTestId("visualization-root").findByText("Value 3");
+          },
+        );
+      },
+    );
   });
 };
 
@@ -126,14 +122,14 @@ describe(
   "Cache invalidation for dashboards and questions",
   { tags: "@external" },
   () => {
-    describeEE("ee", () => {
+    H.describeEE("ee", () => {
       beforeEach(() => {
         resetServerTime();
         interceptPerformanceRoutes();
-        resetTestTable({ type: "postgres", table: TEST_TABLE });
-        restore("postgres-writable");
+        H.resetTestTable({ type: "postgres", table: TEST_TABLE });
+        H.restore("postgres-writable");
         cy.signInAsAdmin();
-        setTokenFeatures("all");
+        H.setTokenFeatures("all");
       });
 
       describe("adaptive and duration strategies", () => {
@@ -268,8 +264,8 @@ describe(
       beforeEach(() => {
         resetServerTime();
         interceptPerformanceRoutes();
-        resetTestTable({ type: "postgres", table: TEST_TABLE });
-        restore("postgres-writable");
+        H.resetTestTable({ type: "postgres", table: TEST_TABLE });
+        H.restore("postgres-writable");
         cy.signInAsAdmin();
         cy.visit("/admin/performance");
         cacheStrategyForm();

--- a/e2e/test/scenarios/admin/performance/schedule.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/schedule.cy.spec.ts
@@ -1,11 +1,6 @@
 import _ from "underscore";
 
-import {
-  describeEE,
-  popover,
-  restore,
-  setTokenFeatures,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 import type { ScheduleComponentType } from "metabase/components/Schedule/constants";
 import type { CacheableModel } from "metabase-types/api";
 
@@ -23,12 +18,12 @@ import {
  * that configuring the schedule strategy causes the cache to be invalidated at
  * the appointed time. Nor do they check that the cron expression retrieved
  * from the API is displayed in the UI. */
-describeEE("scenarios > admin > performance > schedule strategy", () => {
+H.describeEE("scenarios > admin > performance > schedule strategy", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     interceptPerformanceRoutes();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
   });
 
   /** An object describing the values to enter in the schedule strategy configuration form. */
@@ -104,7 +99,7 @@ describeEE("scenarios > admin > performance > schedule strategy", () => {
           } else {
             getScheduleComponent(componentType).click();
 
-            popover().within(() => {
+            H.popover().within(() => {
               cy.findByText(optionToClick).click();
             });
           }

--- a/e2e/test/scenarios/admin/performance/strategyForm.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/strategyForm.cy.spec.ts
@@ -1,13 +1,8 @@
+import { H } from "e2e/support";
 import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  describeEE,
-  restore,
-  setTokenFeatures,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 import {
   interceptPerformanceRoutes,
@@ -30,7 +25,7 @@ import {
 describe("scenarios > admin > performance > strategy form", () => {
   describe("oss", { tags: "@OSS" }, () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       interceptPerformanceRoutes();
       cy.signInAsAdmin();
       cy.visit("/admin");
@@ -116,12 +111,12 @@ describe("scenarios > admin > performance > strategy form", () => {
     });
   });
 
-  describeEE("ee", () => {
+  H.describeEE("ee", () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       interceptPerformanceRoutes();
       cy.signInAsAdmin();
-      setTokenFeatures("all");
+      H.setTokenFeatures("all");
     });
 
     it("has the right tabs", () => {
@@ -366,7 +361,7 @@ describe("scenarios > admin > performance > strategy form", () => {
           .contains(
             "No dashboards or questions have their own caching policies yet.",
           );
-        visitQuestion(ORDERS_QUESTION_ID);
+        H.visitQuestion(ORDERS_QUESTION_ID);
         openSidebarCacheStrategyForm("question");
         durationRadioButton().click();
         cy.findByLabelText(/Cache results for this many hours/).type("99");
@@ -393,7 +388,7 @@ describe("scenarios > admin > performance > strategy form", () => {
           .contains(
             "No dashboards or questions have their own caching policies yet.",
           );
-        visitQuestion(ORDERS_QUESTION_ID);
+        H.visitQuestion(ORDERS_QUESTION_ID);
         openSidebarCacheStrategyForm("question");
         durationRadioButton().click();
         cy.findByLabelText(/Cache results for this many hours/).type("99");
@@ -407,7 +402,7 @@ describe("scenarios > admin > performance > strategy form", () => {
         adaptiveRadioButton().click();
         saveCacheStrategyForm({ strategyType: "ttl", model: "database" });
 
-        visitQuestion(ORDERS_COUNT_QUESTION_ID);
+        H.visitQuestion(ORDERS_COUNT_QUESTION_ID);
         openSidebarCacheStrategyForm("question");
         durationRadioButton().click();
         cy.findByLabelText(/Cache results for this many hours/).type("24");

--- a/e2e/test/scenarios/admin/query-validator.cy.spec.js
+++ b/e2e/test/scenarios/admin/query-validator.cy.spec.js
@@ -1,26 +1,17 @@
+import { H } from "e2e/support";
 import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
-import {
-  createQuestion,
-  describeEE,
-  onlyOnOSS,
-  queryWritableDB,
-  resetTestTable,
-  restore,
-  resyncDatabase,
-  setTokenFeatures,
-} from "e2e/support/helpers";
 
 import { createNativeQuestion } from "../../../support/helpers/api/createNativeQuestion";
 
 const SCOREBOARD_TABLE = "scoreboard_actions";
 const COLORS_TABLE = "colors27745";
 
-describeEE("query validator", { tags: "@external" }, () => {
+H.describeEE("query validator", { tags: "@external" }, () => {
   describe("feature disbaled", () => {
     beforeEach(() => {
-      restore("postgres-writable");
+      H.restore("postgres-writable");
       cy.signInAsAdmin();
-      setTokenFeatures("none");
+      H.setTokenFeatures("none");
     });
 
     it("Should not show the page in troubleshooting or the setting in general", () => {
@@ -38,9 +29,9 @@ describeEE("query validator", { tags: "@external" }, () => {
 
   describe("feature enabled", () => {
     beforeEach(() => {
-      restore("postgres-writable");
+      H.restore("postgres-writable");
       cy.signInAsAdmin();
-      setTokenFeatures("all");
+      H.setTokenFeatures("all");
     });
 
     it("enable query analysis setting", () => {
@@ -64,10 +55,10 @@ describeEE("query validator", { tags: "@external" }, () => {
     });
 
     it("picks up inactive and unknown fields and tables", () => {
-      resetTestTable({ type: "postgres", table: SCOREBOARD_TABLE });
-      resetTestTable({ type: "postgres", table: COLORS_TABLE });
+      H.resetTestTable({ type: "postgres", table: SCOREBOARD_TABLE });
+      H.resetTestTable({ type: "postgres", table: COLORS_TABLE });
 
-      resyncDatabase({
+      H.resyncDatabase({
         dbId: WRITABLE_DB_ID,
       });
 
@@ -110,7 +101,7 @@ describeEE("query validator", { tags: "@external" }, () => {
                 field => field.name === "team_name",
               );
 
-              createQuestion({
+              H.createQuestion({
                 name: "Structured inactive field",
                 query: {
                   "source-table": scoreboardTable.id,
@@ -134,7 +125,7 @@ describeEE("query validator", { tags: "@external" }, () => {
                 field => field.name === "name",
               );
 
-              createQuestion({
+              H.createQuestion({
                 name: "Structured inactive table",
                 query: {
                   "source-table": colorsTable.id,
@@ -148,13 +139,13 @@ describeEE("query validator", { tags: "@external" }, () => {
         },
       );
 
-      queryWritableDB(
+      H.queryWritableDB(
         `ALTER TABLE ${SCOREBOARD_TABLE} RENAME COLUMN team_name TO team_name_`,
       );
 
-      queryWritableDB(`DROP TABLE ${COLORS_TABLE}`);
+      H.queryWritableDB(`DROP TABLE ${COLORS_TABLE}`);
 
-      resyncDatabase({
+      H.resyncDatabase({
         dbId: WRITABLE_DB_ID,
       });
 
@@ -189,8 +180,8 @@ describeEE("query validator", { tags: "@external" }, () => {
 
 describe("OSS", { tags: "@OSS" }, () => {
   beforeEach(() => {
-    onlyOnOSS();
-    restore();
+    H.onlyOnOSS();
+    H.restore();
     cy.signInAsAdmin();
   });
 

--- a/e2e/test/scenarios/admin/troubleshooting.cy.spec.js
+++ b/e2e/test/scenarios/admin/troubleshooting.cy.spec.js
@@ -1,24 +1,14 @@
-import {
-  appBar,
-  describeEE,
-  main,
-  modal,
-  onlyOnEE,
-  onlyOnOSS,
-  restore,
-  setTokenFeatures,
-  setupMetabaseCloud,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 describe("scenarios > admin > troubleshooting > help", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   // Unskip when mocking Cloud in Cypress is fixed (#18289)
   it.skip("should add the support link when running Metabase Cloud", () => {
-    setupMetabaseCloud();
+    H.setupMetabaseCloud();
     cy.visit("/admin/troubleshooting/help");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -30,9 +20,9 @@ describe("scenarios > admin > troubleshooting > help", () => {
 
 describe("scenarios > admin > troubleshooting > help", { tags: "@OSS" }, () => {
   beforeEach(() => {
-    onlyOnOSS();
+    H.onlyOnOSS();
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -52,11 +42,11 @@ describe("scenarios > admin > troubleshooting > help", { tags: "@OSS" }, () => {
   });
 });
 
-describeEE("scenarios > admin > troubleshooting > help (EE)", () => {
+H.describeEE("scenarios > admin > troubleshooting > help (EE)", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
   });
 
   it("should link `Get Help` to help-premium", () => {
@@ -140,7 +130,7 @@ describe("scenarios > admin > troubleshooting > tasks", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     // The only reliable way to reproduce this issue is by stubing page responses!
@@ -223,7 +213,7 @@ describe("admin > tools > erroring questions ", { tags: "@quarantine" }, () => {
 
     cy.findByText("Save").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.button("Save").click();
     });
   }
@@ -238,11 +228,11 @@ describe("admin > tools > erroring questions ", { tags: "@quarantine" }, () => {
 
   describe.skip("when feature enabled", () => {
     beforeEach(() => {
-      onlyOnEE();
+      H.onlyOnEE();
 
-      restore();
+      H.restore();
       cy.signInAsAdmin();
-      setTokenFeatures("all");
+      H.setTokenFeatures("all");
 
       cy.intercept("POST", "/api/dataset").as("dataset");
     });
@@ -326,20 +316,20 @@ describe("admin > tools > erroring questions ", { tags: "@quarantine" }, () => {
 
   describe("when feature disabled", () => {
     beforeEach(() => {
-      onlyOnEE();
+      H.onlyOnEE();
 
-      restore();
+      H.restore();
       cy.signInAsAdmin();
     });
 
     it("should not show tools -> errors", () => {
       cy.visit("/admin");
 
-      appBar().findByText("Tools").should("not.exist");
+      H.appBar().findByText("Tools").should("not.exist");
 
       cy.visit("/admin/tools/errors");
 
-      main().within(() => {
+      H.main().within(() => {
         cy.findByText("Questions that errored when last run").should(
           "not.exist",
         );

--- a/e2e/test/scenarios/binning/binning-options.cy.spec.js
+++ b/e2e/test/scenarios/binning/binning-options.cy.spec.js
@@ -1,13 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  getBinningButtonForDimension,
-  openTable,
-  popover,
-  restore,
-  summarize,
-  visitQuestionAdhoc,
-} from "e2e/support/helpers";
 
 const { ORDERS_ID, ORDERS, PEOPLE_ID, PEOPLE, PRODUCTS_ID, PRODUCTS } =
   SAMPLE_DATABASE;
@@ -102,7 +95,7 @@ const LONGITUDE_BUCKETS = [
 describe("scenarios > binning > binning options", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -193,7 +186,7 @@ describe("scenarios > binning > binning options", () => {
   context("via time series footer (metabase#11183)", () => {
     // TODO: enable again when metabase#35546 is completed
     it.skip("should render time series binning options correctly", () => {
-      openTable({ table: ORDERS_ID });
+      H.openTable({ table: ORDERS_ID });
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Created At").click();
@@ -278,8 +271,8 @@ describe("scenarios > binning > binning options", () => {
 });
 
 function chooseInitialBinningOption({ table, column, mode = null } = {}) {
-  openTable({ table, mode });
-  summarize({ mode });
+  H.openTable({ table, mode });
+  H.summarize({ mode });
 
   if (mode === "notebook") {
     cy.findByText("Count of rows").click();
@@ -294,9 +287,9 @@ function chooseInitialBinningOptionForExplicitJoin({
   baseTableQuery,
   column,
 } = {}) {
-  visitQuestionAdhoc({ dataset_query: baseTableQuery });
+  H.visitQuestionAdhoc({ dataset_query: baseTableQuery });
 
-  summarize();
+  H.summarize();
 
   cy.findByTestId("sidebar-right").within(() => {
     cy.findByText("Count"); // Test fails without this because of some weird race condition
@@ -305,7 +298,7 @@ function chooseInitialBinningOptionForExplicitJoin({
 }
 
 function openBinningListForDimension(column, binning) {
-  getBinningButtonForDimension({ name: column, isSelected: true })
+  H.getBinningButtonForDimension({ name: column, isSelected: true })
     .should("contain", binning)
     .click();
 }
@@ -321,7 +314,7 @@ function getAllOptions({ options, isSelected, shouldExpandList } = {}) {
   // Custom question has two popovers open.
   // The binning options are in the latest (last) one.
   // Using `.last()` works even when only one popover is open so it covers both scenarios.
-  popover()
+  H.popover()
     .last()
     .within(() => {
       if (shouldExpandList) {

--- a/e2e/test/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/binning/binning-reproductions.cy.spec.js
@@ -1,28 +1,12 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  cartesianChartCircle,
-  changeBinningForDimension,
-  chartPathWithFillColor,
-  entityPickerModal,
-  entityPickerModalTab,
-  getBinningButtonForDimension,
-  getNotebookStep,
-  openOrdersTable,
-  popover,
-  restore,
-  rightSidebar,
-  startNewQuestion,
-  summarize,
-  visitQuestionAdhoc,
-  visualize,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
 describe("binning related reproductions", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -32,9 +16,9 @@ describe("binning related reproductions", () => {
       native: { query: "select * from products limit 5" },
     });
 
-    startNewQuestion();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Saved questions").click();
+    H.startNewQuestion();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Saved questions").click();
       cy.findByText("16327").click();
     });
 
@@ -56,7 +40,7 @@ describe("binning related reproductions", () => {
   });
 
   it("should be able to update the bucket size / granularity on a field that has sorting applied to it (metabase#16770)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         database: SAMPLE_DB_ID,
         query: {
@@ -74,9 +58,9 @@ describe("binning related reproductions", () => {
       display: "line",
     });
 
-    summarize();
+    H.summarize();
 
-    changeBinningForDimension({
+    H.changeBinningForDimension({
       name: "Created At",
       fromBinning: "by month",
       toBinning: "Year",
@@ -104,32 +88,32 @@ describe("binning related reproductions", () => {
       { loadMetadata: true },
     );
 
-    startNewQuestion();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Saved questions").click();
+    H.startNewQuestion();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Saved questions").click();
       cy.findByText("17975").click();
     });
 
-    getNotebookStep("summarize")
+    H.getNotebookStep("summarize")
       .findByText("Pick a function or metric")
       .click();
-    popover().findByText("Count of rows").click();
-    getNotebookStep("summarize")
+    H.popover().findByText("Count of rows").click();
+    H.getNotebookStep("summarize")
       .findByText("Pick a column to group by")
       .click();
-    popover().findByText("CREATED_AT").click();
+    H.popover().findByText("CREATED_AT").click();
 
     cy.findByRole("button", { name: "Sort" }).click();
-    popover().findByText("CREATED_AT: Month").click();
+    H.popover().findByText("CREATED_AT: Month").click();
 
-    getNotebookStep("summarize").findByText("CREATED_AT: Month").click();
-    popover()
+    H.getNotebookStep("summarize").findByText("CREATED_AT: Month").click();
+    H.popover()
       .findByRole("option", { name: "CREATED_AT" })
       .findByLabelText("Temporal bucket")
       .click();
-    popover().last().findByText("Quarter").click();
+    H.popover().last().findByText("Quarter").click();
 
-    getNotebookStep("sort").findByText("CREATED_AT: Quarter");
+    H.getNotebookStep("sort").findByText("CREATED_AT: Quarter");
   });
 
   it("should render binning options when joining on the saved native question (metabase#18646)", () => {
@@ -141,31 +125,31 @@ describe("binning related reproductions", () => {
       { loadMetadata: true },
     );
 
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
 
     cy.icon("join_left_outer").click();
 
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Saved questions").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Saved questions").click();
       cy.findByText("18646").click();
     });
 
-    popover().findByText("Product ID").click();
+    H.popover().findByText("Product ID").click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("ID").click();
     });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Summarize").click();
-    popover().findByText("Count of rows").click();
+    H.popover().findByText("Count of rows").click();
 
-    getNotebookStep("summarize")
+    H.getNotebookStep("summarize")
       .findByText("Pick a column to group by")
       .click();
-    popover().findByText("18646").click();
+    H.popover().findByText("18646").click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByRole("option", { name: /CREATED_AT/ })
         .findByText("by month")
         .should("exist");
@@ -174,12 +158,12 @@ describe("binning related reproductions", () => {
       });
     });
 
-    getNotebookStep("summarize").findByText(
+    H.getNotebookStep("summarize").findByText(
       "18646 - Product → Created At: Month",
     );
 
-    visualize();
-    cartesianChartCircle();
+    H.visualize();
+    H.cartesianChartCircle();
   });
 
   it("should display date granularity on Summarize when opened from saved question (metabase#10441, metabase#11439)", () => {
@@ -190,23 +174,23 @@ describe("binning related reproductions", () => {
 
     // it is essential for this repro to find question following these exact steps
     // (for example, visiting `/collection/root` would yield different result)
-    startNewQuestion();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Saved questions").click();
+    H.startNewQuestion();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Saved questions").click();
       cy.findByText("11439").click();
     });
 
-    visualize();
-    summarize();
+    H.visualize();
+    H.summarize();
 
-    rightSidebar().within(() => {
+    H.rightSidebar().within(() => {
       cy.findAllByRole("listitem", { name: "Created At" })
         .eq(0)
         .findByLabelText("Temporal bucket")
         .click();
     });
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.button("More…").click();
       cy.findByText("Hour of day").should("exist");
     });
@@ -237,7 +221,7 @@ describe("binning related reproductions", () => {
       cy.button("Done").click();
     });
 
-    summarize();
+    H.summarize();
 
     cy.findByTestId("pinned-dimensions")
       .should("contain", "Created At")
@@ -279,13 +263,13 @@ describe("binning related reproductions", () => {
     it("should work for simple mode", () => {
       openSummarizeOptions("Simple mode");
 
-      changeBinningForDimension({
+      H.changeBinningForDimension({
         name: "Average of Subtotal",
         fromBinning: "Auto bin",
         toBinning: "10 bins",
       });
 
-      chartPathWithFillColor("#509EE3");
+      H.chartPathWithFillColor("#509EE3");
     });
 
     it("should work for notebook mode", () => {
@@ -298,15 +282,15 @@ describe("binning related reproductions", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Pick a column to group by").click();
 
-      changeBinningForDimension({
+      H.changeBinningForDimension({
         name: "Average of Subtotal",
         fromBinning: "Auto bin",
         toBinning: "10 bins",
       });
 
-      visualize();
+      H.visualize();
 
-      chartPathWithFillColor("#509EE3");
+      H.chartPathWithFillColor("#509EE3");
     });
   });
 
@@ -329,14 +313,14 @@ describe("binning related reproductions", () => {
         },
       });
 
-      startNewQuestion();
+      H.startNewQuestion();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Saved Questions").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("SQL Binning").click();
 
-      visualize();
-      summarize();
+      H.visualize();
+      H.summarize();
     });
 
     it("should render number auto binning correctly (metabase#16670)", () => {
@@ -355,7 +339,7 @@ describe("binning related reproductions", () => {
     });
 
     it("should render time series auto binning default bucket correctly (metabase#16671)", () => {
-      getBinningButtonForDimension({ name: "CREATED_AT" }).should(
+      H.getBinningButtonForDimension({ name: "CREATED_AT" }).should(
         "have.text",
         "by month",
       );
@@ -379,14 +363,14 @@ describe("binning related reproductions", () => {
 });
 
 function openSummarizeOptions(questionType) {
-  startNewQuestion();
-  entityPickerModal().within(() => {
-    entityPickerModalTab("Saved questions").click();
+  H.startNewQuestion();
+  H.entityPickerModal().within(() => {
+    H.entityPickerModalTab("Saved questions").click();
     cy.findByText("16379").click();
   });
 
   if (questionType === "Simple mode") {
-    visualize();
-    summarize();
+    H.visualize();
+    H.summarize();
   }
 }

--- a/e2e/test/scenarios/binning/correctness/longitude.cy.spec.js
+++ b/e2e/test/scenarios/binning/correctness/longitude.cy.spec.js
@@ -1,27 +1,20 @@
-import {
-  chartPathWithFillColor,
-  echartsContainer,
-  openPeopleTable,
-  popover,
-  restore,
-  summarize,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 import { LONGITUDE_OPTIONS } from "./shared/constants";
 
 describe("scenarios > binning > correctness > longitude", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    openPeopleTable();
-    summarize();
+    H.openPeopleTable();
+    H.summarize();
     openPopoverFromDefaultBucketSize("Longitude", "Auto bin");
   });
 
   Object.entries(LONGITUDE_OPTIONS).forEach(
     ([bucketSize, { selected, representativeValues }]) => {
       it(`should return correct values for ${bucketSize}`, () => {
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findByText(bucketSize).click();
         });
 
@@ -33,7 +26,7 @@ describe("scenarios > binning > correctness > longitude", () => {
         cy.findByText("Done").click();
 
         getTitle(`Count by Longitude: ${selected}`);
-        chartPathWithFillColor("#509EE3");
+        H.chartPathWithFillColor("#509EE3");
 
         assertOnXYAxisLabels();
         assertOnXAxisTicks(representativeValues);
@@ -42,7 +35,7 @@ describe("scenarios > binning > correctness > longitude", () => {
   );
 
   it("Don't bin", () => {
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Don't bin").click();
     });
 
@@ -80,13 +73,13 @@ function getTitle(title) {
 }
 
 function assertOnXYAxisLabels() {
-  echartsContainer().get("text").contains("Count");
-  echartsContainer().get("text").contains("Longitude");
+  H.echartsContainer().get("text").contains("Count");
+  H.echartsContainer().get("text").contains("Longitude");
 }
 
 function assertOnXAxisTicks(values) {
   if (values) {
-    echartsContainer().within(() => {
+    H.echartsContainer().within(() => {
       values.forEach(value => {
         cy.findByText(value);
       });

--- a/e2e/test/scenarios/binning/correctness/time-series.cy.spec.js
+++ b/e2e/test/scenarios/binning/correctness/time-series.cy.spec.js
@@ -1,11 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  getBinningButtonForDimension,
-  popover,
-  restore,
-  rightSidebar,
-  summarize,
-} from "e2e/support/helpers";
 
 import { TIME_OPTIONS } from "./shared/constants";
 
@@ -26,14 +20,14 @@ const questionDetails = {
  */
 describe("scenarios > binning > correctness > time series", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.intercept("POST", "/api/dataset").as("dataset");
 
     cy.createQuestion(questionDetails, { visitQuestion: true });
 
-    summarize();
+    H.summarize();
 
     openPopoverFromDefaultBucketSize("Created At", "by month");
   });
@@ -41,7 +35,7 @@ describe("scenarios > binning > correctness > time series", () => {
   Object.entries(TIME_OPTIONS).forEach(
     ([bucketSize, { selected, isHiddenByDefault, representativeValues }]) => {
       it(`should return correct values for ${bucketSize}`, () => {
-        popover().within(() => {
+        H.popover().within(() => {
           if (isHiddenByDefault) {
             cy.button("More…").click();
           }
@@ -49,12 +43,12 @@ describe("scenarios > binning > correctness > time series", () => {
           cy.wait("@dataset");
         });
 
-        getBinningButtonForDimension({
+        H.getBinningButtonForDimension({
           name: "Created At",
           isSelected: true,
         }).should("have.text", selected);
 
-        rightSidebar().button("Done").click();
+        H.rightSidebar().button("Done").click();
 
         getTitle(`Count by Created At: ${bucketSize}`);
 
@@ -68,7 +62,7 @@ describe("scenarios > binning > correctness > time series", () => {
 });
 
 function openPopoverFromDefaultBucketSize(name, bucket) {
-  getBinningButtonForDimension({ name })
+  H.getBinningButtonForDimension({ name })
     .should("have.text", bucket)
     .click({ force: true });
 }

--- a/e2e/test/scenarios/binning/qb-explicit-joins.cy.spec.js
+++ b/e2e/test/scenarios/binning/qb-explicit-joins.cy.spec.js
@@ -1,17 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  cartesianChartCircle,
-  changeBinningForDimension,
-  chartPathWithFillColor,
-  echartsContainer,
-  entityPickerModal,
-  entityPickerModalTab,
-  restore,
-  startNewQuestion,
-  summarize,
-  tableHeaderClick,
-  visualize,
-} from "e2e/support/helpers";
 
 const { ORDERS_ID, ORDERS, PEOPLE_ID, PEOPLE, PRODUCTS_ID, PRODUCTS } =
   SAMPLE_DATABASE;
@@ -23,7 +11,7 @@ const { ORDERS_ID, ORDERS, PEOPLE_ID, PEOPLE, PRODUCTS_ID, PRODUCTS } =
  */
 describe("scenarios > binning > from a saved QB question with explicit joins", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.createQuestion({
       name: "QB Binning",
@@ -67,19 +55,19 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
 
   context("via simple mode", () => {
     beforeEach(() => {
-      startNewQuestion();
+      H.startNewQuestion();
 
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Saved questions").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Saved questions").click();
         cy.findByText("QB Binning").click();
       });
 
-      visualize();
-      summarize();
+      H.visualize();
+      H.summarize();
     });
 
     it("should work for time series", () => {
-      changeBinningForDimension({
+      H.changeBinningForDimension({
         name: "People → Birth Date",
         fromBinning: "by month",
         toBinning: "Year",
@@ -97,7 +85,7 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
       cy.findByText("Quarter").click();
 
       cy.wait("@dataset");
-      echartsContainer()
+      H.echartsContainer()
         .get("text")
         .should("contain", "Q1 1968")
         .and("contain", "Q1 1978")
@@ -106,7 +94,7 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
     });
 
     it("should work for number", () => {
-      changeBinningForDimension({
+      H.changeBinningForDimension({
         name: "Products → Price",
         fromBinning: "Auto bin",
         toBinning: "50 bins",
@@ -119,7 +107,7 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
     });
 
     it("should work for longitude", () => {
-      changeBinningForDimension({
+      H.changeBinningForDimension({
         name: "People → Longitude",
         fromBinning: "Auto bin",
         toBinning: "Bin every 20 degrees",
@@ -134,10 +122,10 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
 
   context("via notebook mode", () => {
     beforeEach(() => {
-      startNewQuestion();
+      H.startNewQuestion();
 
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Saved questions").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Saved questions").click();
         cy.findByText("QB Binning").click();
       });
 
@@ -150,7 +138,7 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
     });
 
     it("should work for time series", () => {
-      changeBinningForDimension({
+      H.changeBinningForDimension({
         name: "People → Birth Date",
         fromBinning: "by month",
         toBinning: "Year",
@@ -169,7 +157,7 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
       cy.findByText("Quarter").click();
 
       cy.wait("@dataset");
-      echartsContainer()
+      H.echartsContainer()
         .get("text")
         .should("contain", "Q1 1965")
         .and("contain", "Q1 1972")
@@ -177,7 +165,7 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
     });
 
     it("should work for number", () => {
-      changeBinningForDimension({
+      H.changeBinningForDimension({
         name: "Products → Price",
         fromBinning: "Auto bin",
         toBinning: "50 bins",
@@ -191,7 +179,7 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
     });
 
     it("should work for longitude", () => {
-      changeBinningForDimension({
+      H.changeBinningForDimension({
         name: "People → Longitude",
         fromBinning: "Auto bin",
         toBinning: "Bin every 20 degrees",
@@ -207,18 +195,18 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
 
   context("via column popover", () => {
     beforeEach(() => {
-      startNewQuestion();
+      H.startNewQuestion();
 
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Saved questions").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Saved questions").click();
         cy.findByText("QB Binning").click();
       });
 
-      visualize();
+      H.visualize();
     });
 
     it("should work for time series", () => {
-      tableHeaderClick("People → Birth Date");
+      H.tableHeaderClick("People → Birth Date");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Distribution").click();
 
@@ -228,14 +216,14 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
 
       assertOnXYAxisLabels({ xLabel: "People → Birth Date", yLabel: "Count" });
 
-      echartsContainer()
+      H.echartsContainer()
         .get("text", { timeout: 1000 })
         .should("contain", "January 1968")
         .and("contain", "January 1978")
         .and("contain", "January 1988")
         .and("contain", "January 1998");
 
-      cartesianChartCircle();
+      H.cartesianChartCircle();
 
       // Make sure time series footer works as well
       cy.findByTestId("timeseries-bucket-button").contains("Month").click();
@@ -246,7 +234,7 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by People → Birth Date: Quarter");
 
-      echartsContainer()
+      H.echartsContainer()
         .get("text")
         .should("contain", "Q1 1965")
         .and("contain", "Q1 1972")
@@ -257,7 +245,7 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
     });
 
     it("should work for number", () => {
-      tableHeaderClick("Products → Price");
+      H.tableHeaderClick("Products → Price");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Distribution").click();
 
@@ -272,11 +260,11 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("25");
 
-      chartPathWithFillColor("#509EE3");
+      H.chartPathWithFillColor("#509EE3");
     });
 
     it("should work for longitude", () => {
-      tableHeaderClick("People → Longitude");
+      H.tableHeaderClick("People → Longitude");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Distribution").click();
 
@@ -294,15 +282,15 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("160° W");
 
-      chartPathWithFillColor("#509EE3");
+      H.chartPathWithFillColor("#509EE3");
     });
   });
 });
 
 function assertOnXYAxisLabels({ xLabel, yLabel } = {}) {
-  echartsContainer().get("text").contains(xLabel);
+  H.echartsContainer().get("text").contains(xLabel);
 
-  echartsContainer().get("text").contains(yLabel);
+  H.echartsContainer().get("text").contains(yLabel);
 }
 
 function waitAndAssertOnRequest(requestAlias) {
@@ -317,22 +305,22 @@ function assertQueryBuilderState({
   mode = null,
   values,
 } = {}) {
-  mode === "notebook" ? visualize() : waitAndAssertOnRequest("@dataset");
+  mode === "notebook" ? H.visualize() : waitAndAssertOnRequest("@dataset");
 
   const visualizationSelector = columnType === "time" ? "circle" : "bar";
 
   if (visualizationSelector === "circle") {
-    cartesianChartCircle();
+    H.cartesianChartCircle();
   } else {
-    chartPathWithFillColor("#509EE3");
+    H.chartPathWithFillColor("#509EE3");
   }
 
   cy.findByText(title);
 
-  echartsContainer().get("text").should("contain", "Count");
+  H.echartsContainer().get("text").should("contain", "Count");
 
   values &&
-    echartsContainer().within(() => {
+    H.echartsContainer().within(() => {
       values.forEach(value => {
         cy.findByText(value);
       });

--- a/e2e/test/scenarios/binning/qb-implicit-joins.cy.spec.js
+++ b/e2e/test/scenarios/binning/qb-implicit-joins.cy.spec.js
@@ -1,12 +1,5 @@
+import { H } from "e2e/support";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  changeBinningForDimension,
-  popover,
-  restore,
-  summarize,
-  visitQuestion,
-  visualize,
-} from "e2e/support/helpers";
 
 /**
  * The list of issues this spec covers:
@@ -16,7 +9,7 @@ import {
 
 describe("scenarios > binning > from a saved QB question using implicit joins", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.intercept("POST", "/api/dataset").as("dataset");
@@ -24,12 +17,12 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
 
   context("via simple question", () => {
     beforeEach(() => {
-      visitQuestion(ORDERS_QUESTION_ID);
-      summarize();
+      H.visitQuestion(ORDERS_QUESTION_ID);
+      H.summarize();
     });
 
     it("should work for time series", () => {
-      changeBinningForDimension({
+      H.changeBinningForDimension({
         name: "Birth Date",
         fromBinning: "by month",
         toBinning: "Year",
@@ -51,7 +44,7 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
     });
 
     it("should work for number", () => {
-      changeBinningForDimension({
+      H.changeBinningForDimension({
         name: "Price",
         fromBinning: "Auto bin",
         toBinning: "50 bins",
@@ -64,7 +57,7 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
     });
 
     it("should work for longitude", () => {
-      changeBinningForDimension({
+      H.changeBinningForDimension({
         name: "Longitude",
         fromBinning: "Auto bin",
         toBinning: "Bin every 20 degrees",
@@ -80,13 +73,13 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
   context("via custom question", () => {
     beforeEach(() => {
       cy.visit(`/question/${ORDERS_QUESTION_ID}/notebook`);
-      summarize({ mode: "notebook" });
+      H.summarize({ mode: "notebook" });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count of rows").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Pick a column to group by").click();
       // Click "Order" accordion to collapse it and expose the other tables
-      popover().findByText("Orders").click();
+      H.popover().findByText("Orders").click();
     });
 
     it("should work for time series", () => {
@@ -94,7 +87,7 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
       cy.findByText("User").click();
       cy.findByPlaceholderText("Find...").type("birth");
 
-      changeBinningForDimension({
+      H.changeBinningForDimension({
         name: "Birth Date",
         fromBinning: "by month",
         toBinning: "Year",
@@ -120,7 +113,7 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Product").click();
 
-      changeBinningForDimension({
+      H.changeBinningForDimension({
         name: "Price",
         fromBinning: "Auto bin",
         toBinning: "50 bins",
@@ -138,7 +131,7 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
       cy.findByText("User").click();
       cy.findByPlaceholderText("Find...").type("longitude");
 
-      changeBinningForDimension({
+      H.changeBinningForDimension({
         name: "Longitude",
         fromBinning: "Auto bin",
         toBinning: "Bin every 20 degrees",
@@ -162,7 +155,7 @@ function waitAndAssertOnRequest(requestAlias) {
 function assertQueryBuilderState({ title, mode = null, values } = {}) {
   const [firstValue, lastValue] = values;
 
-  mode === "notebook" ? visualize() : waitAndAssertOnRequest("@dataset");
+  mode === "notebook" ? H.visualize() : waitAndAssertOnRequest("@dataset");
 
   cy.findByText(title);
   cy.get("[data-testid=cell-data]")

--- a/e2e/test/scenarios/binning/qb-regular-table.cy.spec.js
+++ b/e2e/test/scenarios/binning/qb-regular-table.cy.spec.js
@@ -1,20 +1,11 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  cartesianChartCircle,
-  changeBinningForDimension,
-  chartPathWithFillColor,
-  openTable,
-  restore,
-  summarize,
-  tableHeaderClick,
-  visualize,
-} from "e2e/support/helpers";
 
 const { ORDERS_ID, PEOPLE_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > binning > binning options", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -29,7 +20,7 @@ describe("scenarios > binning > binning options", () => {
 
       getTitle("Count by Total: 50 bins");
 
-      chartPathWithFillColor("#509EE3");
+      H.chartPathWithFillColor("#509EE3");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("70");
     });
@@ -44,7 +35,7 @@ describe("scenarios > binning > binning options", () => {
 
       getTitle("Count by Created At: Quarter");
 
-      cartesianChartCircle();
+      H.cartesianChartCircle();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Q1 2023");
     });
@@ -59,7 +50,7 @@ describe("scenarios > binning > binning options", () => {
 
       getTitle("Count by Longitude: 20°");
 
-      chartPathWithFillColor("#509EE3");
+      H.chartPathWithFillColor("#509EE3");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("180° W");
     });
@@ -77,7 +68,7 @@ describe("scenarios > binning > binning options", () => {
 
       getTitle("Count by Total: 50 bins");
 
-      chartPathWithFillColor("#509EE3");
+      H.chartPathWithFillColor("#509EE3");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("70");
     });
@@ -93,7 +84,7 @@ describe("scenarios > binning > binning options", () => {
 
       getTitle("Count by Created At: Quarter");
 
-      cartesianChartCircle();
+      H.cartesianChartCircle();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Q1 2023");
     });
@@ -109,7 +100,7 @@ describe("scenarios > binning > binning options", () => {
 
       getTitle("Count by Longitude: 20°");
 
-      chartPathWithFillColor("#509EE3");
+      H.chartPathWithFillColor("#509EE3");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("180° W");
     });
@@ -117,40 +108,40 @@ describe("scenarios > binning > binning options", () => {
 
   context("via column popover", () => {
     it("should work for number", () => {
-      openTable({ table: ORDERS_ID });
-      tableHeaderClick("Total");
+      H.openTable({ table: ORDERS_ID });
+      H.tableHeaderClick("Total");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Distribution").click();
 
       getTitle("Count by Total: Auto binned");
 
-      chartPathWithFillColor("#509EE3");
+      H.chartPathWithFillColor("#509EE3");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("60");
     });
 
     it("should work for time series", () => {
-      openTable({ table: ORDERS_ID });
-      tableHeaderClick("Created At");
+      H.openTable({ table: ORDERS_ID });
+      H.tableHeaderClick("Created At");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Distribution").click();
 
       getTitle("Count by Created At: Month");
 
-      cartesianChartCircle();
+      H.cartesianChartCircle();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("January 2023");
     });
 
     it("should work for longitude/latitude", () => {
-      openTable({ table: PEOPLE_ID });
-      tableHeaderClick("Longitude");
+      H.openTable({ table: PEOPLE_ID });
+      H.tableHeaderClick("Longitude");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Distribution").click();
 
       getTitle("Count by Longitude: Auto binned");
 
-      chartPathWithFillColor("#509EE3");
+      H.chartPathWithFillColor("#509EE3");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("170° W");
     });
@@ -164,22 +155,22 @@ function chooseInitialBinningOption({
   bucketSize,
   mode = null,
 } = {}) {
-  openTable({ table, mode });
-  summarize({ mode });
+  H.openTable({ table, mode });
+  H.summarize({ mode });
 
   if (mode === "notebook") {
     cy.findByText("Count of rows").click();
     cy.findByText("Pick a column to group by").click();
 
-    changeBinningForDimension({
+    H.changeBinningForDimension({
       name: column,
       fromBinning: defaultBucket,
       toBinning: bucketSize,
     });
 
-    visualize();
+    H.visualize();
   } else {
-    changeBinningForDimension({
+    H.changeBinningForDimension({
       name: column,
       fromBinning: defaultBucket,
       toBinning: bucketSize,

--- a/e2e/test/scenarios/binning/reproductions/23851-drill-temporal-extraction.cy.spec.js
+++ b/e2e/test/scenarios/binning/reproductions/23851-drill-temporal-extraction.cy.spec.js
@@ -1,11 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  chartPathWithFillColor,
-  getNotebookStep,
-  openNotebook,
-  popover,
-  restore,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
@@ -20,7 +14,7 @@ const CREATED_AT_BREAKOUT = [
 
 describe("issue 23851", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
@@ -41,9 +35,9 @@ describe("issue 23851", () => {
       { visitQuestion: true },
     );
 
-    chartPathWithFillColor("#509EE3").should("have.length", 7);
-    chartPathWithFillColor("#509EE3").eq(5).click();
-    popover().findByText("See these Orders").click();
+    H.chartPathWithFillColor("#509EE3").should("have.length", 7);
+    H.chartPathWithFillColor("#509EE3").eq(5).click();
+    H.popover().findByText("See these Orders").click();
 
     cy.wait("@dataset");
 
@@ -52,8 +46,8 @@ describe("issue 23851", () => {
       "Created At: Day of week is equal to 6",
     );
     cy.get("[data-testid=cell-data]").should("contain", "109.22");
-    openNotebook();
-    getNotebookStep("filter")
+    H.openNotebook();
+    H.getNotebookStep("filter")
       .findByText("Created At: Day of week is equal to 6")
       .should("exist");
   });

--- a/e2e/test/scenarios/binning/reproductions/34688-34690-time-series-footer.cy.spec.js
+++ b/e2e/test/scenarios/binning/reproductions/34688-34690-time-series-footer.cy.spec.js
@@ -1,6 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { restore } from "e2e/support/helpers";
 
 const { PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
@@ -35,7 +35,7 @@ const BASE_QUERY = {
 
 describe("issues 34688 and 34690", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 

--- a/e2e/test/scenarios/binning/sql.cy.spec.js
+++ b/e2e/test/scenarios/binning/sql.cy.spec.js
@@ -1,17 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
-import {
-  cartesianChartCircle,
-  changeBinningForDimension,
-  chartPathWithFillColor,
-  echartsContainer,
-  openTable,
-  restore,
-  snapshot,
-  summarize,
-  tableHeaderClick,
-  visitQuestionAdhoc,
-  visualize,
-} from "e2e/support/helpers";
 
 const questionDetails = {
   name: "SQL Binning",
@@ -25,7 +13,7 @@ let questionId;
 
 describe("scenarios > binning > from a saved sql question", () => {
   before(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestion(questionDetails, {
@@ -35,27 +23,27 @@ describe("scenarios > binning > from a saved sql question", () => {
 
     cy.get("@questionId").then(id => (questionId = id));
 
-    snapshot("binningSql");
+    H.snapshot("binningSql");
   });
 
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore("binningSql");
+    H.restore("binningSql");
     cy.signInAsAdmin();
   });
 
   context("via simple question", () => {
     beforeEach(() => {
-      openTable({
+      H.openTable({
         database: SAMPLE_DB_ID,
         table: `card__${questionId}`,
         mode: "notebook",
       });
 
-      visualize();
+      H.visualize();
       cy.findByTextEnsureVisible("LONGITUDE");
-      summarize();
+      H.summarize();
     });
 
     it("should work for time series", () => {
@@ -63,7 +51,7 @@ describe("scenarios > binning > from a saved sql question", () => {
        * If `result_metadata` is not loaded (SQL question is not run before saving),
        * the granularity is much finer and one can see "by minute" as the default bucket (metabase#16671).
        */
-      changeBinningForDimension({
+      H.changeBinningForDimension({
         name: "CREATED_AT",
         fromBinning: "by month",
         toBinning: "Year",
@@ -73,11 +61,11 @@ describe("scenarios > binning > from a saved sql question", () => {
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by CREATED_AT: Year");
-      cartesianChartCircle();
+      H.cartesianChartCircle();
     });
 
     it("should work for number", () => {
-      changeBinningForDimension({
+      H.changeBinningForDimension({
         name: "TOTAL",
         fromBinning: "Auto bin",
         toBinning: "50 bins",
@@ -87,11 +75,11 @@ describe("scenarios > binning > from a saved sql question", () => {
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by TOTAL: 50 bins");
-      chartPathWithFillColor("#509EE3");
+      H.chartPathWithFillColor("#509EE3");
     });
 
     it("should work for longitude", () => {
-      changeBinningForDimension({
+      H.changeBinningForDimension({
         name: "LONGITUDE",
         fromBinning: "Auto bin",
         toBinning: "Bin every 10 degrees",
@@ -101,13 +89,13 @@ describe("scenarios > binning > from a saved sql question", () => {
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by LONGITUDE: 10°");
-      chartPathWithFillColor("#509EE3");
+      H.chartPathWithFillColor("#509EE3");
     });
   });
 
   context("via custom question", () => {
     beforeEach(() => {
-      visitQuestionAdhoc(
+      H.visitQuestionAdhoc(
         {
           dataset_query: {
             database: SAMPLE_DB_ID,
@@ -127,7 +115,7 @@ describe("scenarios > binning > from a saved sql question", () => {
     });
 
     it("should work for time series", () => {
-      changeBinningForDimension({
+      H.changeBinningForDimension({
         name: "CREATED_AT",
         fromBinning: "by month",
         toBinning: "Year",
@@ -136,15 +124,15 @@ describe("scenarios > binning > from a saved sql question", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by CREATED_AT: Year");
 
-      visualize(response => {
+      H.visualize(response => {
         assertOnResponse(response);
       });
 
-      cartesianChartCircle();
+      H.cartesianChartCircle();
     });
 
     it("should work for number", () => {
-      changeBinningForDimension({
+      H.changeBinningForDimension({
         name: "TOTAL",
         fromBinning: "Auto bin",
         toBinning: "50 bins",
@@ -153,15 +141,15 @@ describe("scenarios > binning > from a saved sql question", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by TOTAL: 50 bins");
 
-      visualize(response => {
+      H.visualize(response => {
         assertOnResponse(response);
       });
 
-      chartPathWithFillColor("#509EE3");
+      H.chartPathWithFillColor("#509EE3");
     });
 
     it("should work for longitude", () => {
-      changeBinningForDimension({
+      H.changeBinningForDimension({
         name: "LONGITUDE",
         fromBinning: "Auto bin",
         toBinning: "Bin every 10 degrees",
@@ -170,17 +158,17 @@ describe("scenarios > binning > from a saved sql question", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by LONGITUDE: 10°");
 
-      visualize(response => {
+      H.visualize(response => {
         assertOnResponse(response);
       });
 
-      chartPathWithFillColor("#509EE3");
+      H.chartPathWithFillColor("#509EE3");
     });
   });
 
   context("via column popover", () => {
     beforeEach(() => {
-      openTable({
+      H.openTable({
         database: SAMPLE_DB_ID,
         table: `card__${questionId}`,
       });
@@ -188,14 +176,14 @@ describe("scenarios > binning > from a saved sql question", () => {
     });
 
     it("should work for time series", () => {
-      tableHeaderClick("CREATED_AT");
+      H.tableHeaderClick("CREATED_AT");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Distribution").click();
 
       assertOnXYAxisLabels({ xLabel: "CREATED_AT", yLabel: "Count" });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by CREATED_AT: Month");
-      cartesianChartCircle();
+      H.cartesianChartCircle();
 
       // Open a popover with bucket options from the time series footer
       cy.findByTestId("timeseries-bucket-button").contains("Month").click();
@@ -209,25 +197,25 @@ describe("scenarios > binning > from a saved sql question", () => {
     });
 
     it("should work for number", () => {
-      tableHeaderClick("TOTAL");
+      H.tableHeaderClick("TOTAL");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Distribution").click();
 
       assertOnXYAxisLabels({ xLabel: "TOTAL", yLabel: "Count" });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by TOTAL: Auto binned");
-      chartPathWithFillColor("#509EE3");
+      H.chartPathWithFillColor("#509EE3");
     });
 
     it("should work for longitude", () => {
-      tableHeaderClick("LONGITUDE");
+      H.tableHeaderClick("LONGITUDE");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Distribution").click();
 
       assertOnXYAxisLabels({ xLabel: "LONGITUDE", yLabel: "Count" });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by LONGITUDE: Auto binned");
-      chartPathWithFillColor("#509EE3");
+      H.chartPathWithFillColor("#509EE3");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("170° W");
     });
@@ -235,9 +223,9 @@ describe("scenarios > binning > from a saved sql question", () => {
 });
 
 function assertOnXYAxisLabels({ xLabel, yLabel } = {}) {
-  echartsContainer().get("text").contains(xLabel);
+  H.echartsContainer().get("text").contains(xLabel);
 
-  echartsContainer().get("text").contains(yLabel);
+  H.echartsContainer().get("text").contains(yLabel);
 }
 
 function waitAndAssertOnRequest(requestAlias) {

--- a/e2e/test/scenarios/collections/collection-pinned-overview.cy.spec.js
+++ b/e2e/test/scenarios/collections/collection-pinned-overview.cy.spec.js
@@ -1,17 +1,10 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  dragAndDrop,
-  getPinnedSection,
-  openPinnedItemMenu,
-  openUnpinnedItemMenu,
-  popover,
-  restore,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PEOPLE } = SAMPLE_DATABASE;
 
@@ -76,7 +69,7 @@ const SQL_QUESTION_DETAILS_WITH_DEFAULT_VALUE = {
 
 describe("scenarios > collection pinned items overview", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.intercept("POST", "/api/card/**/query").as("getCardQuery");
@@ -85,11 +78,11 @@ describe("scenarios > collection pinned items overview", () => {
 
   it("should be able to pin a dashboard", () => {
     openRootCollection();
-    openUnpinnedItemMenu(DASHBOARD_NAME);
-    popover().findByText("Pin this").click();
+    H.openUnpinnedItemMenu(DASHBOARD_NAME);
+    H.popover().findByText("Pin this").click();
     cy.wait("@getPinnedItems");
 
-    getPinnedSection().within(() => {
+    H.getPinnedSection().within(() => {
       cy.icon("dashboard").should("be.visible");
       cy.findByText("A dashboard").should("be.visible");
       cy.findByText(DASHBOARD_NAME).click();
@@ -99,11 +92,11 @@ describe("scenarios > collection pinned items overview", () => {
 
   it("should be able to pin a question", () => {
     openRootCollection();
-    openUnpinnedItemMenu(QUESTION_NAME);
-    popover().findByText("Pin this").click();
+    H.openUnpinnedItemMenu(QUESTION_NAME);
+    H.popover().findByText("Pin this").click();
     cy.wait(["@getPinnedItems", "@getCardQuery"]);
 
-    getPinnedSection().within(() => {
+    H.getPinnedSection().within(() => {
       cy.findByText("18,760").should("be.visible");
       cy.findByText(QUESTION_NAME).click();
       cy.url().should("include", `/question/${ORDERS_COUNT_QUESTION_ID}`);
@@ -118,7 +111,7 @@ describe("scenarios > collection pinned items overview", () => {
     openRootCollection();
     cy.wait("@getCardQuery");
 
-    getPinnedSection().within(() => {
+    H.getPinnedSection().within(() => {
       cy.findByText(PIVOT_QUESTION_DETAILS.name).should("be.visible");
       cy.findByText("Created At: Month").should("be.visible");
       cy.findByText("Count").should("be.visible");
@@ -129,11 +122,11 @@ describe("scenarios > collection pinned items overview", () => {
     cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, { type: "model" });
 
     openRootCollection();
-    openUnpinnedItemMenu(MODEL_NAME);
-    popover().findByText("Pin this").click();
+    H.openUnpinnedItemMenu(MODEL_NAME);
+    H.popover().findByText("Pin this").click();
     cy.wait("@getPinnedItems");
 
-    getPinnedSection().within(() => {
+    H.getPinnedSection().within(() => {
       cy.icon("model").should("be.visible");
       cy.findByText(MODEL_NAME).should("be.visible");
       cy.findByText("A model").click();
@@ -147,11 +140,11 @@ describe("scenarios > collection pinned items overview", () => {
     });
 
     openRootCollection();
-    openPinnedItemMenu(DASHBOARD_NAME);
-    popover().findByText("Unpin").click();
+    H.openPinnedItemMenu(DASHBOARD_NAME);
+    H.popover().findByText("Unpin").click();
     cy.wait("@getPinnedItems");
 
-    getPinnedSection().should("not.exist");
+    H.getPinnedSection().should("not.exist");
   });
 
   it("should be able to move a pinned dashboard", () => {
@@ -160,8 +153,8 @@ describe("scenarios > collection pinned items overview", () => {
     });
 
     openRootCollection();
-    openPinnedItemMenu(DASHBOARD_NAME);
-    popover().findByText("Move").click();
+    H.openPinnedItemMenu(DASHBOARD_NAME);
+    H.popover().findByText("Move").click();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(`Move "${DASHBOARD_NAME}"?`).should("be.visible");
@@ -173,8 +166,8 @@ describe("scenarios > collection pinned items overview", () => {
     });
 
     openRootCollection();
-    openPinnedItemMenu(DASHBOARD_NAME);
-    popover().findByText("Duplicate").click();
+    H.openPinnedItemMenu(DASHBOARD_NAME);
+    H.popover().findByText("Duplicate").click();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(`Duplicate "${DASHBOARD_NAME}" and its questions`).should(
@@ -188,11 +181,11 @@ describe("scenarios > collection pinned items overview", () => {
     });
 
     openRootCollection();
-    openPinnedItemMenu(DASHBOARD_NAME);
-    popover().findByText("Move to trash").click();
+    H.openPinnedItemMenu(DASHBOARD_NAME);
+    H.popover().findByText("Move to trash").click();
     cy.wait("@getPinnedItems");
 
-    getPinnedSection().should("not.exist");
+    H.getPinnedSection().should("not.exist");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(DASHBOARD_NAME).should("not.exist");
   });
@@ -203,11 +196,11 @@ describe("scenarios > collection pinned items overview", () => {
     });
 
     openRootCollection();
-    openPinnedItemMenu(QUESTION_NAME);
-    popover().findByText("Don’t show visualization").click();
+    H.openPinnedItemMenu(QUESTION_NAME);
+    H.popover().findByText("Don’t show visualization").click();
     cy.wait("@getPinnedItems");
 
-    getPinnedSection().within(() => {
+    H.getPinnedSection().within(() => {
       cy.findByText("18,760").should("not.exist");
       cy.findByText("A question").should("be.visible");
       cy.findByText(QUESTION_NAME).click();
@@ -222,11 +215,11 @@ describe("scenarios > collection pinned items overview", () => {
     });
 
     openRootCollection();
-    openPinnedItemMenu(QUESTION_NAME);
-    popover().findByText("Show visualization").click();
+    H.openPinnedItemMenu(QUESTION_NAME);
+    H.popover().findByText("Show visualization").click();
     cy.wait(["@getPinnedItems", "@getCardQuery"]);
 
-    getPinnedSection().within(() => {
+    H.getPinnedSection().within(() => {
       cy.findByText(QUESTION_NAME).should("be.visible");
       cy.findByText("18,760").should("be.visible");
     });
@@ -241,7 +234,7 @@ describe("scenarios > collection pinned items overview", () => {
       );
 
       openRootCollection();
-      getPinnedSection().within(() => {
+      H.getPinnedSection().within(() => {
         cy.findByText(SQL_QUESTION_DETAILS_WITH_DEFAULT_VALUE.name).should(
           "be.visible",
         );
@@ -257,7 +250,7 @@ describe("scenarios > collection pinned items overview", () => {
       );
 
       openRootCollection();
-      getPinnedSection().within(() => {
+      H.getPinnedSection().within(() => {
         cy.findByText(SQL_QUESTION_DETAILS_WITH_DEFAULT_VALUE.name).should(
           "be.visible",
         );
@@ -287,7 +280,7 @@ describe("scenarios > collection pinned items overview", () => {
     // for example, this test would not have caught https://github.com/metabase/metabase/issues/30614
     // even libraries like https://github.com/dmtrKovalenko/cypress-real-events rely on firing events
     // on specific elements rather than truly simulating mouse movements across the screen
-    dragAndDrop("draggingViz", "pinnedItems");
+    H.dragAndDrop("draggingViz", "pinnedItems");
 
     cy.findByTestId("collection-table")
       .findByText("Orders, Count, Grouped by Created At (year)")

--- a/e2e/test/scenarios/collections/collections-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections-reproductions.cy.spec.js
@@ -1,32 +1,17 @@
+import { H } from "e2e/support";
 import {
   ADMIN_PERSONAL_COLLECTION_ID,
   FIRST_COLLECTION_ID,
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  assertPermissionTable,
-  describeEE,
-  entityPickerModal,
-  entityPickerModalTab,
-  getCollectionActions,
-  modal,
-  modifyPermission,
-  moveOpenedCollectionTo,
-  navigationSidebar,
-  openCollectionMenu,
-  popover,
-  restore,
-  setTokenFeatures,
-  startNewQuestion,
-} from "e2e/support/helpers";
 
 describe("issue 20911", () => {
   const COLLECTION_ACCESS_PERMISSION_INDEX = 0;
   const FIRST_COLLECTION = "First collection";
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("GET", "/api/collection/graph").as("getGraph");
   });
@@ -34,7 +19,7 @@ describe("issue 20911", () => {
   it("should allow to change sub-collections permissions after access change (metabase#20911)", () => {
     cy.visit("/collection/root/permissions");
     cy.wait("@getGraph");
-    assertPermissionTable([
+    H.assertPermissionTable([
       ["Administrators", "Curate"],
       ["All Users", "No access"],
       ["collection", "Curate"],
@@ -42,32 +27,32 @@ describe("issue 20911", () => {
       ["nosql", "No access"],
       ["readonly", "View"],
     ]);
-    modifyPermission(
+    H.modifyPermission(
       "collection",
       COLLECTION_ACCESS_PERMISSION_INDEX,
       "No access",
       false,
     );
-    modifyPermission(
+    H.modifyPermission(
       "collection",
       COLLECTION_ACCESS_PERMISSION_INDEX,
       "No access",
       true,
     );
-    modal().within(() => {
+    H.modal().within(() => {
       cy.button("Save").click();
     });
 
-    navigationSidebar().within(() => {
+    H.navigationSidebar().within(() => {
       cy.findByText(FIRST_COLLECTION).click();
     });
-    getCollectionActions().within(() => {
+    H.getCollectionActions().within(() => {
       cy.icon("ellipsis").click();
     });
-    popover().within(() => {
+    H.popover().within(() => {
       cy.icon("lock").click();
     });
-    assertPermissionTable([
+    H.assertPermissionTable([
       ["Administrators", "Curate"],
       ["All Users", "No access"],
       ["collection", "No access"],
@@ -107,7 +92,7 @@ describe("issue 24660", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     createParentCollectionAndMoveQuestionToIt(ORDERS_QUESTION_ID);
@@ -115,9 +100,9 @@ describe("issue 24660", () => {
   });
 
   it("should properly show contents of different collections with the same name (metabase#24660)", () => {
-    startNewQuestion();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Saved questions").click();
+    H.startNewQuestion();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Saved questions").click();
       cy.findAllByText(collectionName).first().click();
 
       cy.findByText(questions[ORDERS_QUESTION_ID]).should("exist");
@@ -126,11 +111,11 @@ describe("issue 24660", () => {
   });
 });
 
-describeEE("issue 30235", () => {
+H.describeEE("issue 30235", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
   });
 
   it("should allow to turn to official collection after moving it from personal to root parent collection (metabase#30235)", () => {
@@ -142,11 +127,11 @@ describeEE("issue 30235", () => {
     }).then(({ body: { id } }) => {
       cy.visit(`/collection/${id}`);
 
-      moveOpenedCollectionTo("Our analytics");
+      H.moveOpenedCollectionTo("Our analytics");
 
-      openCollectionMenu();
+      H.openCollectionMenu();
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Make collection official").should("be.visible");
         cy.findByText("Edit permissions").should("be.visible");
       });

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -1,6 +1,7 @@
 import { assocIn } from "icepick";
 import _ from "underscore";
 
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, USERS, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
@@ -11,28 +12,6 @@ import {
   SECOND_COLLECTION_ID,
   THIRD_COLLECTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  closeNavigationSidebar,
-  createCollection,
-  createQuestion,
-  dragAndDrop,
-  entityPickerModal,
-  entityPickerModalItem,
-  entityPickerModalTab,
-  getPinnedSection,
-  moveOpenedCollectionTo,
-  navigationSidebar,
-  openCollectionItemMenu,
-  openCollectionMenu,
-  openNavigationSidebar,
-  openOrdersTable,
-  openUnpinnedItemMenu,
-  pickEntity,
-  popover,
-  restore,
-  sidesheet,
-  visitCollection,
-} from "e2e/support/helpers";
 
 import { displaySidebarChildOf } from "./helpers/e2e-collections-sidebar.js";
 
@@ -42,7 +21,7 @@ const { ORDERS, ORDERS_ID, FEEDBACK_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > collection defaults", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("GET", "/api/**/items?pinned_state*").as("getPinnedItems");
     cy.intercept("GET", "/api/collection/tree**").as("getTree");
@@ -78,7 +57,7 @@ describe("scenarios > collection defaults", () => {
           .click();
       });
 
-      pickEntity({
+      H.pickEntity({
         path: ["Our analytics", `Collection ${COLLECTIONS_COUNT}`],
         select: true,
         tab: "Collections",
@@ -97,7 +76,7 @@ describe("scenarios > collection defaults", () => {
     it("should navigate effortlessly through collections tree", () => {
       visitRootCollection();
 
-      navigationSidebar().within(() => {
+      H.navigationSidebar().within(() => {
         cy.log(
           "should allow a user to expand a collection without navigating to it",
         );
@@ -135,9 +114,9 @@ describe("scenarios > collection defaults", () => {
         "navigating directly to a collection should expand it and show its children",
       );
 
-      visitCollection(SECOND_COLLECTION_ID);
+      H.visitCollection(SECOND_COLLECTION_ID);
 
-      navigationSidebar().within(() => {
+      H.navigationSidebar().within(() => {
         cy.findByText("Second collection");
         cy.findByText("Third collection");
 
@@ -159,10 +138,10 @@ describe("scenarios > collection defaults", () => {
         },
       );
 
-      visitCollection(THIRD_COLLECTION_ID);
+      H.visitCollection(THIRD_COLLECTION_ID);
 
       // 1. Expand so that deeply nested collection is showing
-      navigationSidebar().within(() => {
+      H.navigationSidebar().within(() => {
         displaySidebarChildOf("Fourth collection");
       });
 
@@ -183,19 +162,19 @@ describe("scenarios > collection defaults", () => {
         "should be able to toggle collections sidebar when switched to mobile screen size",
       );
 
-      navigationSidebar().should("have.attr", "aria-hidden", "true");
-      openNavigationSidebar();
+      H.navigationSidebar().should("have.attr", "aria-hidden", "true");
+      H.openNavigationSidebar();
 
-      closeNavigationSidebar();
-      navigationSidebar().should("have.attr", "aria-hidden", "true");
+      H.closeNavigationSidebar();
+      H.navigationSidebar().should("have.attr", "aria-hidden", "true");
 
       cy.log(
         "should close collections sidebar when collection is clicked in mobile screen size",
       );
 
-      openNavigationSidebar();
+      H.openNavigationSidebar();
 
-      navigationSidebar().within(() => {
+      H.navigationSidebar().within(() => {
         cy.findByText("First collection").click();
       });
 
@@ -204,7 +183,7 @@ describe("scenarios > collection defaults", () => {
         "First collection",
       );
 
-      navigationSidebar().should("have.attr", "aria-hidden", "true");
+      H.navigationSidebar().should("have.attr", "aria-hidden", "true");
     });
   });
 
@@ -213,7 +192,7 @@ describe("scenarios > collection defaults", () => {
       description: "[link](https://metabase.com)",
     });
 
-    visitCollection(FIRST_COLLECTION_ID);
+    H.visitCollection(FIRST_COLLECTION_ID);
 
     cy.get("table").within(() => {
       cy.findByText("Second collection")
@@ -234,7 +213,7 @@ describe("scenarios > collection defaults", () => {
       description: "[link](https://metabase.com)",
     });
 
-    visitCollection(FIRST_COLLECTION_ID);
+    H.visitCollection(FIRST_COLLECTION_ID);
 
     cy.log("Description visible in collection caption");
     cy.findByTestId("collection-caption")
@@ -249,7 +228,7 @@ describe("scenarios > collection defaults", () => {
 
     cy.log("Let's edit the description");
     toggleSidesheet();
-    sidesheet().within(() => {
+    H.sidesheet().within(() => {
       cy.findByTestId("editable-text").click().type("edited ");
       cy.realPress("Tab");
       cy.findByLabelText("Close").click();
@@ -264,7 +243,7 @@ describe("scenarios > collection defaults", () => {
 
     cy.log("The edited description is visible in the sidesheet");
     toggleSidesheet();
-    sidesheet().within(() => {
+    H.sidesheet().within(() => {
       cy.findByTestId("editable-text").should("have.text", "edited link");
     });
   });
@@ -323,7 +302,7 @@ describe("scenarios > collection defaults", () => {
 
   describe("Collection related issues reproductions", () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
     });
 
@@ -366,7 +345,7 @@ describe("scenarios > collection defaults", () => {
                   },
                 });
                 cy.signIn("none");
-                createQuestion(
+                H.createQuestion(
                   {
                     name: "Foo Question",
                     query: {
@@ -385,11 +364,11 @@ describe("scenarios > collection defaults", () => {
       });
 
       cy.findByTestId("qb-header").icon("ellipsis").click();
-      popover().findByText("Move").click();
-      entityPickerModalItem(1, "Collection B").should("exist");
-      entityPickerModalItem(2, "Collection E").should("exist");
+      H.popover().findByText("Move").click();
+      H.entityPickerModalItem(1, "Collection B").should("exist");
+      H.entityPickerModalItem(2, "Collection E").should("exist");
 
-      entityPickerModal().should(
+      H.entityPickerModal().should(
         "not.contain.text",
         "You don't have permissions to do that.",
       );
@@ -410,14 +389,14 @@ describe("scenarios > collection defaults", () => {
     it("should be able to drag an item to the root collection (metabase#16498)", () => {
       moveItemToCollection("Orders", "First collection");
 
-      visitCollection(FIRST_COLLECTION_ID);
+      H.visitCollection(FIRST_COLLECTION_ID);
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders").as("dragSubject");
 
-      navigationSidebar().findByText("Our analytics").as("dropTarget");
+      H.navigationSidebar().findByText("Our analytics").as("dropTarget");
 
-      dragAndDrop("dragSubject", "dropTarget");
+      H.dragAndDrop("dragSubject", "dropTarget");
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Moved question");
@@ -470,7 +449,7 @@ describe("scenarios > collection defaults", () => {
       it("should see a child collection in a sidebar even with revoked access to its parents (metabase#14114, metabase#16555, metabase#20716)", () => {
         cy.visit("/");
 
-        navigationSidebar().within(() => {
+        H.navigationSidebar().within(() => {
           cy.findByText("Our analytics").should("not.exist");
           cy.findByText("Parent").should("not.exist");
           cy.findByText("Child");
@@ -484,15 +463,15 @@ describe("scenarios > collection defaults", () => {
       });
 
       it("should be able to choose a child collection when saving a question (metabase#14052)", () => {
-        openOrdersTable();
+        H.openOrdersTable();
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Save").click();
         // Click to choose which collection should this question be saved to
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(revokedUsersPersonalCollectionName).click();
-        pickEntity({ path: [revokedUsersPersonalCollectionName] });
-        pickEntity({ path: ["Collections", "Child"] });
-        entityPickerModal().button("Select").should("be.enabled");
+        H.pickEntity({ path: [revokedUsersPersonalCollectionName] });
+        H.pickEntity({ path: ["Collections", "Child"] });
+        H.entityPickerModal().button("Select").should("be.enabled");
         cy.log("Reported failing from v0.34.3");
         cy.findByTestId("entity-picker-modal")
           .findByText("Parent")
@@ -513,11 +492,11 @@ describe("scenarios > collection defaults", () => {
 
       openEllipsisMenuFor("Orders");
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Move").click();
       });
 
-      entityPickerModal().within(() => {
+      H.entityPickerModal().within(() => {
         cy.findByRole("tab", { name: /Collections/ }).click();
         cy.findByText("Bobby Tables's Personal Collection").click();
         cy.findByText(COLLECTION).click();
@@ -538,14 +517,14 @@ describe("scenarios > collection defaults", () => {
         "when nested child collection is moved to the root collection (metabase#14482)",
       );
 
-      visitCollection(SECOND_COLLECTION_ID);
+      H.visitCollection(SECOND_COLLECTION_ID);
 
-      openCollectionMenu();
-      popover().findByText("Move").click();
+      H.openCollectionMenu();
+      H.popover().findByText("Move").click();
 
       // we need to do this manually because we need to await the correct number of api requests to keep this from flaking
 
-      entityPickerModal().within(() => {
+      H.entityPickerModal().within(() => {
         cy.findByTestId("loading-indicator").should("not.exist");
         cy.findByRole("tab", { name: /Collections/ }).click();
         cy.wait([
@@ -564,10 +543,10 @@ describe("scenarios > collection defaults", () => {
         cy.button("Move").click();
       });
 
-      entityPickerModal().should("not.exist");
+      H.entityPickerModal().should("not.exist");
       cy.wait("@getTree");
 
-      navigationSidebar().within(() => {
+      H.navigationSidebar().within(() => {
         ensureCollectionHasNoChildren("First collection");
 
         // Should be expanded automatically
@@ -580,10 +559,10 @@ describe("scenarios > collection defaults", () => {
         "should show moved collection inside a folder tree structure (metabase#14280)",
       );
 
-      moveOpenedCollectionTo(NEW_COLLECTION);
+      H.moveOpenedCollectionTo(NEW_COLLECTION);
       cy.wait("@getTree");
 
-      navigationSidebar().within(() => {
+      H.navigationSidebar().within(() => {
         ensureCollectionHasNoChildren("Second collection");
 
         ensureCollectionIsExpanded(NEW_COLLECTION, {
@@ -598,12 +577,12 @@ describe("scenarios > collection defaults", () => {
         statusCode: 500,
         body: { message: "Ryan said no" },
       });
-      openCollectionMenu();
-      popover().findByText("Move").click();
+      H.openCollectionMenu();
+      H.popover().findByText("Move").click();
 
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Collections").click();
-        entityPickerModalItem(0, "Our analytics").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Collections").click();
+        H.entityPickerModalItem(0, "Our analytics").click();
         cy.button("Move").click();
         cy.log("Entity picker should show an error message");
         cy.findByText("Ryan said no").should("exist");
@@ -616,9 +595,9 @@ describe("scenarios > collection defaults", () => {
           cy.visit("/collection/root");
 
           // Pin one item
-          openUnpinnedItemMenu("Orders, Count");
-          popover().findByText("Pin this").click();
-          getPinnedSection().within(() => {
+          H.openUnpinnedItemMenu("Orders, Count");
+          H.popover().findByText("Pin this").click();
+          H.getPinnedSection().within(() => {
             cy.findByText("18,760");
           });
 
@@ -684,7 +663,7 @@ describe("scenarios > collection defaults", () => {
 
           cy.findByTestId("toast-card").button("Move").click();
 
-          entityPickerModal().within(() => {
+          H.entityPickerModal().within(() => {
             cy.findByText("First collection").click();
             cy.button("Move").click();
           });
@@ -694,13 +673,13 @@ describe("scenarios > collection defaults", () => {
           cy.findByTestId("toast-card").should("not.exist");
 
           // Check that items were actually moved
-          navigationSidebar().findByText("First collection").click();
+          H.navigationSidebar().findByText("First collection").click();
           // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText("Orders");
 
           // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText("Undo").click();
-          navigationSidebar().findByText("Our analytics").click();
+          H.navigationSidebar().findByText("Our analytics").click();
           // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText("Orders").should("be.visible");
           // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -716,9 +695,9 @@ describe("scenarios > collection defaults", () => {
           cy.log("from the collection header");
 
           cy.findByTestId("collection-menu").icon("ellipsis").click();
-          popover().findByText("Move").click();
+          H.popover().findByText("Move").click();
 
-          entityPickerModal().within(() => {
+          H.entityPickerModal().within(() => {
             cy.findByRole("tab", { name: /Collections/ }).click();
             cy.log("parent collection should be selected");
             findPickerItem("First collection").should(
@@ -738,9 +717,9 @@ describe("scenarios > collection defaults", () => {
             openEllipsisMenuFor("Third collection");
           });
 
-          popover().findByText("Move").click();
+          H.popover().findByText("Move").click();
 
-          entityPickerModal().within(() => {
+          H.entityPickerModal().within(() => {
             cy.log("parent collection should be selected");
             cy.findByRole("tab", { name: /Collections/ }).click();
             findPickerItem("Second collection").should(
@@ -765,7 +744,7 @@ describe("scenarios > collection defaults", () => {
 
           cy.findByTestId("toast-card").button("Move").click();
 
-          entityPickerModal().within(() => {
+          H.entityPickerModal().within(() => {
             cy.log("should disable all moving collections");
             findPickerItem("First collection").should("have.attr", "disabled");
             findPickerItem("Another collection").should(
@@ -781,22 +760,22 @@ describe("scenarios > collection defaults", () => {
         });
 
         it("moving collections should disable moving into any of the moving collections in recents or search (metabase#45248)", () => {
-          createCollection({ name: "Outer collection 1" }).then(
+          H.createCollection({ name: "Outer collection 1" }).then(
             ({ body: { id: parentCollectionId } }) => {
               cy.wrap(parentCollectionId).as("outerCollectionId");
-              createCollection({
+              H.createCollection({
                 name: "Inner collection 1",
                 parent_id: parentCollectionId,
               }).then(({ body: { id: innerCollectionId } }) => {
                 cy.wrap(innerCollectionId).as("innerCollectionId");
               });
-              createCollection({
+              H.createCollection({
                 name: "Inner collection 2",
                 parent_id: parentCollectionId,
               });
             },
           );
-          createCollection({ name: "Outer collection 2" });
+          H.createCollection({ name: "Outer collection 2" });
 
           // modify the inner collection so that it shows up in recents
           cy.get("@innerCollectionId").then(innerCollectionId => {
@@ -809,13 +788,13 @@ describe("scenarios > collection defaults", () => {
           cy.log("single move");
 
           cy.findByTestId("collection-table").within(() => {
-            openCollectionItemMenu("Outer collection 1");
+            H.openCollectionItemMenu("Outer collection 1");
           });
 
-          popover().findByText("Move").click();
+          H.popover().findByText("Move").click();
 
-          entityPickerModal().within(() => {
-            entityPickerModalTab("Recents").should(
+          H.entityPickerModal().within(() => {
+            H.entityPickerModalTab("Recents").should(
               "have.attr",
               "data-active",
               "true",
@@ -835,8 +814,8 @@ describe("scenarios > collection defaults", () => {
 
           cy.findByTestId("toast-card").button("Move").click();
 
-          entityPickerModal().within(() => {
-            entityPickerModalTab("Recents").should(
+          H.entityPickerModal().within(() => {
+            H.entityPickerModalTab("Recents").should(
               "have.attr",
               "data-active",
               "true",
@@ -855,16 +834,16 @@ describe("scenarios > collection defaults", () => {
 
       cy.visit("/");
       // There is already a collection named "First collection" in the default snapshot
-      navigationSidebar().within(() => {
+      H.navigationSidebar().within(() => {
         cy.findByText("First collection");
       });
     });
 
     it("should create new collections within the current collection", () => {
-      visitCollection(THIRD_COLLECTION_ID);
+      H.visitCollection(THIRD_COLLECTION_ID);
       cy.findByTestId("app-bar").findByText("New").click();
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Collection").click();
       });
 
@@ -879,7 +858,7 @@ describe("scenarios > collection defaults", () => {
 
   describe("x-rays", () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsNormalUser();
       cy.intercept("GET", "/api/automagic-dashboards/model/*").as("dashboard");
     });
@@ -889,7 +868,7 @@ describe("scenarios > collection defaults", () => {
       cy.visit("/collection/root");
 
       openEllipsisMenuFor("Orders");
-      popover().findByText("X-ray this").click();
+      H.popover().findByText("X-ray this").click();
       cy.wait("@dashboard");
     });
   });
@@ -933,7 +912,7 @@ describe("scenarios > collection items listing", () => {
       "getCollectionItems",
     );
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 

--- a/e2e/test/scenarios/collections/instance-analytics.cy.spec.js
+++ b/e2e/test/scenarios/collections/instance-analytics.cy.spec.js
@@ -1,31 +1,15 @@
+import { H } from "e2e/support";
 import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  describeEE,
-  modal,
-  newButton,
-  onlyOnEE,
-  onlyOnOSS,
-  openDashboardInfoSidebar,
-  openQuestionInfoSidesheet,
-  popover,
-  restore,
-  setTokenFeatures,
-  sidebar,
-  tableHeaderClick,
-  visitDashboard,
-  visitModel,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 const ANALYTICS_COLLECTION_NAME = "Usage analytics";
 const CUSTOM_REPORTS_COLLECTION_NAME = "Custom reports";
 const PEOPLE_MODEL_NAME = "People";
 const METRICS_DASHBOARD_NAME = "Metabase metrics";
 
-describeEE("scenarios > Metabase Analytics Collection (AuditV2) ", () => {
+H.describeEE("scenarios > Metabase Analytics Collection (AuditV2) ", () => {
   describe("admin", () => {
     beforeEach(() => {
       cy.intercept("GET", "/api/field/*/values").as("fieldValues");
@@ -33,9 +17,9 @@ describeEE("scenarios > Metabase Analytics Collection (AuditV2) ", () => {
       cy.intercept("POST", "api/card").as("saveCard");
       cy.intercept("POST", "api/dashboard/*/copy").as("copyDashboard");
 
-      restore();
+      H.restore();
       cy.signInAsAdmin();
-      setTokenFeatures("all");
+      H.setTokenFeatures("all");
     });
 
     it("allows admins to see the instance analytics collection content", () => {
@@ -60,15 +44,15 @@ describeEE("scenarios > Metabase Analytics Collection (AuditV2) ", () => {
       () => {
         cy.log("saving edited question");
         getItemId(ANALYTICS_COLLECTION_NAME, PEOPLE_MODEL_NAME).then(id => {
-          visitModel(id);
+          H.visitModel(id);
         });
 
-        tableHeaderClick("Last Name");
+        H.tableHeaderClick("Last Name");
 
-        popover().findByText("Filter by this column").click();
+        H.popover().findByText("Filter by this column").click();
         cy.wait("@fieldValues");
-        popover().findByText("Tableton").click();
-        popover().button("Add filter").click();
+        H.popover().findByText("Tableton").click();
+        H.popover().button("Add filter").click();
 
         cy.wait("@datasetQuery");
 
@@ -92,14 +76,14 @@ describeEE("scenarios > Metabase Analytics Collection (AuditV2) ", () => {
         cy.log("saving copied question");
 
         getItemId(ANALYTICS_COLLECTION_NAME, PEOPLE_MODEL_NAME).then(id => {
-          visitModel(id);
+          H.visitModel(id);
         });
 
         cy.findByTestId("qb-header").icon("ellipsis").click();
 
-        popover().findByText("Duplicate").click();
+        H.popover().findByText("Duplicate").click();
 
-        modal().within(() => {
+        H.modal().within(() => {
           cy.findByTextEnsureVisible("Custom reports");
           cy.button("Duplicate").click();
         });
@@ -108,20 +92,20 @@ describeEE("scenarios > Metabase Analytics Collection (AuditV2) ", () => {
           expect(response.statusCode).to.eq(200);
         });
 
-        modal()
+        H.modal()
           .button(/Duplicate/i)
           .should("not.exist");
-        modal().button("Not now").click();
+        H.modal().button("Not now").click();
 
         cy.log("saving copied dashboard");
 
         getItemId(ANALYTICS_COLLECTION_NAME, "Person overview").then(id => {
-          visitDashboard(id);
+          H.visitDashboard(id);
         });
 
         cy.findByTestId("dashboard-header").findByText("Make a copy").click();
 
-        modal().within(() => {
+        H.modal().within(() => {
           cy.findByTextEnsureVisible("Custom reports");
           cy.button("Duplicate").click();
         });
@@ -155,7 +139,7 @@ describeEE("scenarios > Metabase Analytics Collection (AuditV2) ", () => {
         }
       });
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Bookmark").should("be.visible");
         cy.findByText("Move to trash").should("not.exist");
         cy.findByText("Move").should("not.exist");
@@ -179,7 +163,7 @@ describeEE("scenarios > Metabase Analytics Collection (AuditV2) ", () => {
         }
       });
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Bookmark").should("be.visible");
         cy.findByText("Move to trash").should("not.exist");
         cy.findByText("Move").should("not.exist");
@@ -189,7 +173,7 @@ describeEE("scenarios > Metabase Analytics Collection (AuditV2) ", () => {
     it("should not allow editing analytics content (metabase#36228)", () => {
       // dashboard
       getItemId(ANALYTICS_COLLECTION_NAME, METRICS_DASHBOARD_NAME).then(id => {
-        visitDashboard(id);
+        H.visitDashboard(id);
       });
 
       cy.findByTestId("dashboard-header").within(() => {
@@ -199,12 +183,12 @@ describeEE("scenarios > Metabase Analytics Collection (AuditV2) ", () => {
 
       // model
       getItemId(ANALYTICS_COLLECTION_NAME, PEOPLE_MODEL_NAME).then(id => {
-        visitModel(id);
+        H.visitModel(id);
       });
 
       cy.findByTestId("qb-header").icon("ellipsis").click();
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Duplicate").should("be.visible");
         cy.findByText("Edit query definition").should("not.exist");
       });
@@ -212,10 +196,10 @@ describeEE("scenarios > Metabase Analytics Collection (AuditV2) ", () => {
 
     it("should not leak instance analytics database into SQL query builder (metabase#44856)", () => {
       getItemId(ANALYTICS_COLLECTION_NAME, PEOPLE_MODEL_NAME).then(id => {
-        visitModel(id);
+        H.visitModel(id);
       });
 
-      newButton("SQL query").click();
+      H.newButton("SQL query").click();
 
       // sample DB should be the only one
       cy.findByTestId("gui-builder-data")
@@ -225,21 +209,21 @@ describeEE("scenarios > Metabase Analytics Collection (AuditV2) ", () => {
 
     it("should not leak instance analytics database into permissions editor (metabase#44856)", () => {
       getItemId(ANALYTICS_COLLECTION_NAME, PEOPLE_MODEL_NAME).then(id => {
-        visitModel(id);
+        H.visitModel(id);
       });
 
       // it's important that we do this manually, as this will only reproduce if theres no page load
       cy.findByTestId("app-bar").icon("gear").click();
-      popover().findByText("Admin settings").click();
+      H.popover().findByText("Admin settings").click();
       cy.findByLabelText("Navigation bar").findByText("Permissions").click();
-      sidebar().findByText("Administrators").click();
+      H.sidebar().findByText("Administrators").click();
       cy.findByTestId("permission-table")
         .findByText(/internal metabase database/i)
         .should("not.exist");
 
-      sidebar().findByText("Databases").click();
+      H.sidebar().findByText("Databases").click();
 
-      sidebar()
+      H.sidebar()
         .findByText(/internal metabase database/i)
         .should("not.exist");
     });
@@ -252,9 +236,9 @@ describeEE("scenarios > Metabase Analytics Collection (AuditV2) ", () => {
       cy.intercept("POST", "api/card").as("saveCard");
       cy.intercept("POST", "api/dashboard/*/copy").as("copyDashboard");
 
-      restore();
+      H.restore();
       cy.signInAsAdmin();
-      setTokenFeatures("all");
+      H.setTokenFeatures("all");
     });
 
     it("should not allow editing analytics content (metabase#36228)", () => {
@@ -298,20 +282,20 @@ describeEE("scenarios > Metabase Analytics Collection (AuditV2) ", () => {
 });
 
 describe("question and dashboard links", () => {
-  describeEE("ee", () => {
+  H.describeEE("ee", () => {
     beforeEach(() => {
-      onlyOnEE();
-      restore();
+      H.onlyOnEE();
+      H.restore();
       cy.signInAsAdmin();
-      setTokenFeatures("all");
+      H.setTokenFeatures("all");
     });
 
     it("should show an analytics link for questions", () => {
-      visitQuestion(ORDERS_QUESTION_ID);
+      H.visitQuestion(ORDERS_QUESTION_ID);
 
       cy.intercept("GET", "/api/collection/**").as("collection");
 
-      openQuestionInfoSidesheet()
+      H.openQuestionInfoSidesheet()
         .findByRole("link", { name: /Insights/ })
         .click();
 
@@ -337,10 +321,10 @@ describe("question and dashboard links", () => {
     });
 
     it("should show an analytics link for dashboards", () => {
-      visitDashboard(ORDERS_DASHBOARD_ID);
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
       cy.intercept("GET", "/api/collection/**").as("collection");
 
-      openDashboardInfoSidebar()
+      H.openDashboardInfoSidebar()
         .findByRole("link", { name: /Insights/ })
         .click();
 
@@ -367,14 +351,14 @@ describe("question and dashboard links", () => {
 
     it("should not show option for users with no access to Metabase Analytics", () => {
       cy.signInAsNormalUser();
-      visitQuestion(ORDERS_QUESTION_ID);
+      H.visitQuestion(ORDERS_QUESTION_ID);
 
-      openQuestionInfoSidesheet()
+      H.openQuestionInfoSidesheet()
         .findByRole("link", { name: /Insights/i })
         .should("not.exist");
 
-      visitDashboard(ORDERS_DASHBOARD_ID);
-      openDashboardInfoSidebar()
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
+      H.openDashboardInfoSidebar()
         .findByRole("link", { name: /Insights/i })
         .should("not.exist");
     });
@@ -382,21 +366,21 @@ describe("question and dashboard links", () => {
 
   describe("oss", { tags: "@OSS" }, () => {
     beforeEach(() => {
-      onlyOnOSS();
-      restore();
+      H.onlyOnOSS();
+      H.restore();
       cy.signInAsAdmin();
     });
 
     it("should never appear in OSS", () => {
-      visitQuestion(ORDERS_QUESTION_ID);
+      H.visitQuestion(ORDERS_QUESTION_ID);
 
-      openQuestionInfoSidesheet()
+      H.openQuestionInfoSidesheet()
         .findByRole("link", { name: /Insights/i })
         .should("not.exist");
 
-      visitDashboard(ORDERS_DASHBOARD_ID);
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
 
-      openDashboardInfoSidebar()
+      H.openDashboardInfoSidebar()
         .findByRole("link", { name: /Insights/i })
         .should("not.exist");
     });

--- a/e2e/test/scenarios/collections/permissions.cy.spec.js
+++ b/e2e/test/scenarios/collections/permissions.cy.spec.js
@@ -1,20 +1,8 @@
 import { onlyOn } from "@cypress/skip-test";
 
+import { H } from "e2e/support";
 import { USERS } from "e2e/support/cypress_data";
 import { FIRST_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data.js";
-import {
-  appBar,
-  entityPickerModal,
-  modal,
-  navigationSidebar,
-  openCollectionItemMenu,
-  openCollectionMenu,
-  openNativeEditor,
-  popover,
-  restore,
-  setTokenFeatures,
-  sidebar,
-} from "e2e/support/helpers";
 
 import { displaySidebarChildOf } from "./helpers/e2e-collections-sidebar.js";
 
@@ -27,7 +15,7 @@ const PERMISSIONS = {
 describe("collection permissions", () => {
   beforeEach(() => {
     cy.intercept("GET", "/api/search*").as("search");
-    restore();
+    H.restore();
   });
 
   describe("item management", () => {
@@ -43,11 +31,11 @@ describe("collection permissions", () => {
               describe("create dashboard", () => {
                 it("should offer to save dashboard to a currently opened collection", () => {
                   cy.visit("/collection/root");
-                  navigationSidebar().within(() => {
+                  H.navigationSidebar().within(() => {
                     displaySidebarChildOf("First collection");
                     cy.findByText("Second collection").click();
                   });
-                  appBar().within(() => {
+                  H.appBar().within(() => {
                     cy.icon("add").click();
                   });
                   // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -62,10 +50,10 @@ describe("collection permissions", () => {
                     cy.visit("/collection/root");
                     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
                     cy.findByText("Orders in a dashboard").click();
-                    appBar().within(() => {
+                    H.appBar().within(() => {
                       cy.icon("add").click();
                     });
-                    popover().findByText("Dashboard").click();
+                    H.popover().findByText("Dashboard").click();
                     cy.findByLabelText(/Which collection/).findByText(
                       "Our analytics",
                     );
@@ -141,15 +129,15 @@ describe("collection permissions", () => {
                 describe("archive page", () => {
                   it("should show archived items (metabase#15080, metabase#16617)", () => {
                     cy.visit("collection/root");
-                    openCollectionItemMenu("Orders");
-                    popover().within(() => {
+                    H.openCollectionItemMenu("Orders");
+                    H.popover().within(() => {
                       cy.findByText("Move to trash").click();
                     });
                     cy.findByTestId("toast-undo").within(() => {
                       cy.findByText("Trashed question");
                       cy.icon("close").click();
                     });
-                    navigationSidebar().within(() => {
+                    H.navigationSidebar().within(() => {
                       cy.findByText("Trash").click();
                     });
                     cy.location("pathname").should("eq", "/trash");
@@ -182,18 +170,18 @@ describe("collection permissions", () => {
                       cy.visit(`/collection/${THIRD_COLLECTION_ID}`);
                     });
 
-                    openCollectionMenu();
-                    popover().within(() =>
+                    H.openCollectionMenu();
+                    H.popover().within(() =>
                       // eslint-disable-next-line no-unscoped-text-selectors -- linter erroring for no reason
                       cy.findByText("Move to trash").click(),
                     );
-                    modal().findByText("Move to trash").click();
+                    H.modal().findByText("Move to trash").click();
 
                     cy.wait("@editCollection");
 
                     cy.findByTestId("archive-banner").should("exist");
 
-                    navigationSidebar().within(() => {
+                    H.navigationSidebar().within(() => {
                       cy.findByText("First collection");
                       cy.findByText("Second collection");
                       cy.findByText("Third collection").should("not.exist");
@@ -214,7 +202,7 @@ describe("collection permissions", () => {
                     cy.findByTestId("archive-banner").should("not.exist");
 
                     // But unarchived collection is now visible in the sidebar
-                    navigationSidebar().within(() => {
+                    H.navigationSidebar().within(() => {
                       cy.findByText("Third collection");
                     });
                   });
@@ -271,11 +259,11 @@ describe("collection permissions", () => {
                         collection => collection.slug === "third_collection",
                       );
                       cy.visit(`/collection/${THIRD_COLLECTION_ID}`);
-                      openCollectionMenu();
-                      popover().within(() =>
+                      H.openCollectionMenu();
+                      H.popover().within(() =>
                         cy.findByText("Move to trash").click(),
                       );
-                      modal().findByText("Cancel").click();
+                      H.modal().findByText("Cancel").click();
                       cy.location("pathname").should(
                         "eq",
                         `/collection/${THIRD_COLLECTION_ID}-third-collection`,
@@ -289,8 +277,8 @@ describe("collection permissions", () => {
 
                 function archiveUnarchive(item, expectedEntityName) {
                   cy.visit("/collection/root");
-                  openCollectionItemMenu(item);
-                  popover().within(() => {
+                  H.openCollectionItemMenu(item);
+                  H.popover().within(() => {
                     cy.findByText("Move to trash").click();
                   });
                   cy.findByText(item).should("not.exist");
@@ -321,8 +309,8 @@ describe("collection permissions", () => {
             it("should be offered to duplicate dashboard in collections they have `read` access to", () => {
               const { first_name, last_name } = USERS[user];
               cy.visit("/collection/root");
-              openCollectionItemMenu("Orders in a dashboard");
-              popover().findByText("Duplicate").click();
+              H.openCollectionItemMenu("Orders in a dashboard");
+              H.popover().findByText("Duplicate").click();
               cy.findByTestId("collection-picker-button").should(
                 "have.text",
                 `${first_name} ${last_name}'s Personal Collection`,
@@ -358,7 +346,7 @@ describe("collection permissions", () => {
                 cy.findByText("Dashboard").click();
 
                 // Coming from the root collection, the initial offered collection will be "Our analytics" (read-only access)
-                modal().within(() => {
+                H.modal().within(() => {
                   cy.findByText(
                     `${first_name} ${last_name}'s Personal Collection`,
                   ).click();
@@ -388,7 +376,7 @@ describe("collection permissions", () => {
   it("should offer to save items to 'Our analytics' if user has a 'curate' access to it", () => {
     cy.signIn("normal");
 
-    openNativeEditor().type("select * from people");
+    H.openNativeEditor().type("select * from people");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
 
@@ -397,7 +385,7 @@ describe("collection permissions", () => {
 
   it("should load the collection permissions admin pages", () => {
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
     cy.intercept("GET", "/api/collection/graph").as("permissionsGraph");
     cy.intercept("GET", "/api/permissions/group").as("permissionsGroups");
 
@@ -419,7 +407,7 @@ describe("collection permissions", () => {
     );
     cy.findByTestId("permission-table");
 
-    sidebar().findByText("Usage analytics").click();
+    H.sidebar().findByText("Usage analytics").click();
     cy.findByTestId("permissions-editor").findByText(
       "Permissions for Usage analytics",
     );
@@ -432,12 +420,12 @@ function clickButton(name) {
 }
 
 function pinItem(item) {
-  openCollectionItemMenu(item);
-  popover().icon("pin").click();
+  H.openCollectionItemMenu(item);
+  H.popover().icon("pin").click();
 }
 
 function exposeChildrenFor(collectionName) {
-  navigationSidebar()
+  H.navigationSidebar()
     .findByText(collectionName)
     .parentsUntil("[data-testid=sidebar-collection-link-root]")
     .find(".Icon-chevronright")
@@ -447,9 +435,9 @@ function exposeChildrenFor(collectionName) {
 
 function move(item) {
   cy.visit("/collection/root");
-  openCollectionItemMenu(item);
-  popover().findByText("Move").click();
-  entityPickerModal().within(() => {
+  H.openCollectionItemMenu(item);
+  H.popover().findByText("Move").click();
+  H.entityPickerModal().within(() => {
     cy.findByText(`Move "${item}"?`);
     // Let's move it into a nested collection
     cy.findByText("First collection").click();
@@ -472,9 +460,9 @@ function move(item) {
 
 function duplicate(item) {
   cy.visit("/collection/root");
-  openCollectionItemMenu(item);
+  H.openCollectionItemMenu(item);
   cy.findByText("Duplicate").click();
-  modal()
+  H.modal()
     .as("modal")
     .within(() => {
       clickButton("Duplicate");

--- a/e2e/test/scenarios/collections/personal-collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/personal-collections.cy.spec.js
@@ -1,22 +1,14 @@
+import { H } from "e2e/support";
 import { USERS } from "e2e/support/cypress_data";
 import {
   ADMIN_PERSONAL_COLLECTION_ID,
   NORMAL_USER_ID,
   NO_DATA_PERSONAL_COLLECTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  getCollectionActions,
-  modal,
-  navigationSidebar,
-  openCollectionMenu,
-  openNewCollectionItemFlowFor,
-  popover,
-  restore,
-} from "e2e/support/helpers";
 
 describe("personal collections", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
   });
 
   describe("admin", () => {
@@ -64,10 +56,10 @@ describe("personal collections", () => {
       cy.findAllByRole("tree")
         .contains("Your personal collection")
         .should("be.visible");
-      navigationSidebar().within(() => {
+      H.navigationSidebar().within(() => {
         cy.icon("ellipsis").click();
       });
-      popover().findByText("Other users' personal collections").click();
+      H.popover().findByText("Other users' personal collections").click();
       cy.location("pathname").should("eq", "/collection/users");
       cy.findByTestId("browsercrumbs").findByText(/All personal collections/i);
       Object.values(USERS).forEach(user => {
@@ -88,7 +80,7 @@ describe("personal collections", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Your personal collection").click();
 
-      getCollectionActions().within(() => {
+      H.getCollectionActions().within(() => {
         cy.icon("ellipsis").should("not.exist");
       });
 
@@ -103,12 +95,12 @@ describe("personal collections", () => {
       // });
 
       // Go to the newly created sub-collection "Foo"
-      navigationSidebar().findByText("Foo").click();
+      H.navigationSidebar().findByText("Foo").click();
 
       // It should be possible to edit sub-collections' details, but not its permissions
       cy.findByDisplayValue("Foo").should("be.enabled");
-      openCollectionMenu();
-      popover().within(() => {
+      H.openCollectionMenu();
+      H.popover().within(() => {
         cy.findByText("Edit permissions").should("not.exist");
       });
 
@@ -122,7 +114,7 @@ describe("personal collections", () => {
       // Go to random user's personal collection
       cy.visit(`/collection/${NO_DATA_PERSONAL_COLLECTION_ID}`);
 
-      getCollectionActions().within(() => {
+      H.getCollectionActions().within(() => {
         cy.icon("ellipsis").should("not.exist");
       });
     });
@@ -151,7 +143,7 @@ describe("personal collections", () => {
 
           // Create initial collection inside the personal collection and navigate to it
           addNewCollection("Foo");
-          navigationSidebar().as("sidebar").findByText("Foo").click();
+          H.navigationSidebar().as("sidebar").findByText("Foo").click();
         });
 
         it("should be able to edit collection(s) inside personal collection", () => {
@@ -168,10 +160,10 @@ describe("personal collections", () => {
             "should be able to archive collection(s) inside personal collection (metabase#15343)",
           );
 
-          openCollectionMenu();
+          H.openCollectionMenu();
           // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-          popover().within(() => cy.findByText("Move to trash").click());
-          modal().findByRole("button", { name: "Move to trash" }).click();
+          H.popover().within(() => cy.findByText("Move to trash").click());
+          H.modal().findByRole("button", { name: "Move to trash" }).click();
           // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText("Trashed collection");
           cy.get("@sidebar").findByText("Foo").should("not.exist");
@@ -182,7 +174,7 @@ describe("personal collections", () => {
 });
 
 function addNewCollection(name) {
-  openNewCollectionItemFlowFor("collection");
+  H.openNewCollectionItemFlowFor("collection");
   cy.findByPlaceholderText("My new fantastic collection").type(name, {
     delay: 0,
   });

--- a/e2e/test/scenarios/collections/revision-history.cy.spec.js
+++ b/e2e/test/scenarios/collections/revision-history.cy.spec.js
@@ -1,20 +1,10 @@
 import { onlyOn } from "@cypress/skip-test";
 
+import { H } from "e2e/support";
 import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  editDashboard,
-  openQuestionsSidebar,
-  questionInfoButton,
-  restore,
-  saveDashboard,
-  sidebar,
-  sidesheet,
-  visitDashboard,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 const PERMISSIONS = {
   curate: ["admin", "normal", "nodata"],
@@ -26,7 +16,7 @@ describe("revision history", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/revision/revert").as("revert");
 
-    restore();
+    H.restore();
   });
 
   describe("reproductions", () => {
@@ -36,14 +26,14 @@ describe("revision history", () => {
 
     it("shouldn't render revision history steps when there was no diff (metabase#1926)", () => {
       cy.createDashboard().then(({ body }) => {
-        visitDashboard(body.id);
-        editDashboard();
+        H.visitDashboard(body.id);
+        H.editDashboard();
       });
 
       // Save the dashboard without any changes made to it (TODO: we should probably disable "Save" button in the first place)
-      saveDashboard({ awaitRequest: false });
-      editDashboard();
-      saveDashboard({ awaitRequest: false });
+      H.saveDashboard({ awaitRequest: false });
+      H.editDashboard();
+      H.saveDashboard({ awaitRequest: false });
 
       openRevisionHistory();
 
@@ -78,14 +68,14 @@ describe("revision history", () => {
               cy.intercept("POST", "/api/card/*/query").as("cardQuery");
 
               cy.createDashboard().then(({ body }) => {
-                visitDashboard(body.id);
-                editDashboard();
+                H.visitDashboard(body.id);
+                H.editDashboard();
               });
 
-              openQuestionsSidebar();
-              sidebar().findByText("Orders, Count").click();
+              H.openQuestionsSidebar();
+              H.sidebar().findByText("Orders, Count").click();
               cy.wait("@cardQuery");
-              saveDashboard();
+              H.saveDashboard();
 
               // this is dirty, but seems like the only reliable way
               // to wait until SET_DASHBOARD_EDITING is dispatched,
@@ -94,7 +84,7 @@ describe("revision history", () => {
               cy.wait(100);
 
               openRevisionHistory();
-              sidesheet().within(() => {
+              H.sidesheet().within(() => {
                 cy.findByRole("tab", { name: "History" }).click();
                 cy.findByText(/added a card/)
                   .siblings("button")
@@ -105,7 +95,7 @@ describe("revision history", () => {
 
             // skipped because it's super flaky in CI
             it.skip("should be able to revert a dashboard (metabase#15237)", () => {
-              visitDashboard(ORDERS_DASHBOARD_ID);
+              H.visitDashboard(ORDERS_DASHBOARD_ID);
               openRevisionHistory();
               clickRevert(/created this/);
 
@@ -135,7 +125,7 @@ describe("revision history", () => {
             it("should be able to access the question's revision history via the revision history button in the header of the query builder", () => {
               cy.skipOn(user === "nodata");
 
-              visitQuestion(ORDERS_QUESTION_ID);
+              H.visitQuestion(ORDERS_QUESTION_ID);
 
               cy.findByTestId("revision-history-button").click();
               cy.findByRole("tab", { name: "History" }).click();
@@ -154,9 +144,9 @@ describe("revision history", () => {
             it("should be able to revert the question via the action button found in the saved question timeline", () => {
               cy.skipOn(user === "nodata");
 
-              visitQuestion(ORDERS_QUESTION_ID);
+              H.visitQuestion(ORDERS_QUESTION_ID);
 
-              questionInfoButton().click();
+              H.questionInfoButton().click();
               cy.findByRole("tab", { name: "History" }).click();
 
               // Last revert is the original state
@@ -178,13 +168,13 @@ describe("revision history", () => {
             it("should not see question nor dashboard revert buttons (metabase#13229)", () => {
               cy.signIn(user);
 
-              visitDashboard(ORDERS_DASHBOARD_ID);
+              H.visitDashboard(ORDERS_DASHBOARD_ID);
               openRevisionHistory();
               cy.findAllByRole("button", { name: "Revert" }).should(
                 "not.exist",
               );
 
-              visitQuestion(ORDERS_QUESTION_ID);
+              H.visitQuestion(ORDERS_QUESTION_ID);
               cy.findByRole("button", { name: /Edited .*/ }).click();
 
               cy.findAllByRole("button", { name: "Revert" }).should(
@@ -210,7 +200,7 @@ function openRevisionHistory() {
   cy.findByRole("tab", { name: "History" }).click();
   cy.wait("@revisionHistory");
 
-  sidesheet().within(() => {
+  H.sidesheet().within(() => {
     cy.findByText("History");
     cy.findByTestId("dashboard-history-list").should("be.visible");
   });

--- a/e2e/test/scenarios/collections/trash.cy.spec.js
+++ b/e2e/test/scenarios/collections/trash.cy.spec.js
@@ -1,40 +1,16 @@
 import { P, isMatching } from "ts-pattern";
 
+import { H } from "e2e/support";
 import {
   FIRST_COLLECTION_ID,
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_QUESTION_ID,
   READ_ONLY_PERSONAL_COLLECTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  createNativeQuestion as _createNativeQuestion,
-  createQuestion as _createQuestion,
-  archiveQuestion,
-  describeWithSnowplow,
-  entityPickerModal,
-  entityPickerModalTab,
-  expectGoodSnowplowEvent,
-  expectNoBadSnowplowEvents,
-  main,
-  modal,
-  modifyPermission,
-  navigationSidebar,
-  openNavigationSidebar,
-  popover,
-  resetSnowplow,
-  restore,
-  selectSidebarItem,
-  sharingMenuButton,
-  sidebar,
-  undo,
-  visitCollection,
-  visitDashboard,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 describe("scenarios > collections > trash", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -51,7 +27,7 @@ describe("scenarios > collections > trash", () => {
     cy.visit("/");
 
     cy.log("should show trash at bottom of the side navbar");
-    navigationSidebar().within(() => {
+    H.navigationSidebar().within(() => {
       cy.findAllByTestId("sidebar-collection-link-root")
         .last()
         .as("sidebar-trash-link")
@@ -74,7 +50,7 @@ describe("scenarios > collections > trash", () => {
       "trashed items in collection should not have option to move to trash",
     );
     toggleEllipsisMenuFor("Collection A");
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Move to trash").should("not.exist");
       cy.findByText("Restore").should("exist");
       cy.findByText("Delete permanently").should("not.exist");
@@ -100,9 +76,9 @@ describe("scenarios > collections > trash", () => {
       cy.findByText("New").click();
     });
 
-    popover().findByText("Question").click();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Models").click();
+    H.popover().findByText("Question").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Models").click();
       cy.findByText("Our analytics").should("exist");
       cy.findByText("Trash").should("not.exist");
       cy.button("Close").click();
@@ -112,25 +88,25 @@ describe("scenarios > collections > trash", () => {
     cy.findByLabelText("Navigation bar").within(() => {
       cy.findByText("New").click();
     });
-    popover().findByText("Dashboard").click();
-    modal().findByText("Our analytics").click();
-    entityPickerModal().within(() => {
+    H.popover().findByText("Dashboard").click();
+    H.modal().findByText("Our analytics").click();
+    H.entityPickerModal().within(() => {
       cy.findByText("First collection").should("exist");
       cy.findByText("Trash").should("not.exist");
     });
 
     cy.log("trash should not appear in collection permissions sidebar");
     cy.visit("/admin/permissions/collections");
-    sidebar().findByText("Trash").should("not.exist");
+    H.sidebar().findByText("Trash").should("not.exist");
   });
 
-  describeWithSnowplow("", () => {
+  H.describeWithSnowplow("", () => {
     beforeEach(() => {
-      resetSnowplow();
+      H.resetSnowplow();
     });
 
     afterEach(() => {
-      expectNoBadSnowplowEvents();
+      H.expectNoBadSnowplowEvents();
     });
 
     it("should be able to trash & restore dashboards/collections/questions on entity page and from parent collection", () => {
@@ -153,8 +129,8 @@ describe("scenarios > collections > trash", () => {
 
       cy.log("should be able to move to trash from collection view");
       toggleEllipsisMenuFor(/Collection A/);
-      popover().findByText("Move to trash").click();
-      expectGoodSnowplowEvent(event =>
+      H.popover().findByText("Move to trash").click();
+      H.expectGoodSnowplowEvent(event =>
         isMatching(
           {
             event: "moved-to-trash",
@@ -169,8 +145,8 @@ describe("scenarios > collections > trash", () => {
       );
 
       toggleEllipsisMenuFor("Dashboard A");
-      popover().findByText("Move to trash").click();
-      expectGoodSnowplowEvent(event =>
+      H.popover().findByText("Move to trash").click();
+      H.expectGoodSnowplowEvent(event =>
         isMatching(
           {
             event: "moved-to-trash",
@@ -185,8 +161,8 @@ describe("scenarios > collections > trash", () => {
       );
 
       toggleEllipsisMenuFor("Question A");
-      popover().findByText("Move to trash").click();
-      expectGoodSnowplowEvent(event =>
+      H.popover().findByText("Move to trash").click();
+      H.expectGoodSnowplowEvent(event =>
         isMatching(
           {
             event: "moved-to-trash",
@@ -203,18 +179,18 @@ describe("scenarios > collections > trash", () => {
       cy.log(
         "should be able to move to restore items from trash collection view",
       );
-      navigationSidebar().findByText("Trash").click();
+      H.navigationSidebar().findByText("Trash").click();
 
       toggleEllipsisMenuFor(/Collection A/);
-      popover().findByText("Restore").click();
+      H.popover().findByText("Restore").click();
       ensureBookmarkVisible(/Collection A/);
 
       toggleEllipsisMenuFor("Dashboard A");
-      popover().findByText("Restore").click();
+      H.popover().findByText("Restore").click();
       ensureBookmarkVisible("Dashboard A");
 
       toggleEllipsisMenuFor("Question A");
-      popover().findByText("Restore").click();
+      H.popover().findByText("Restore").click();
       ensureBookmarkVisible("Question A");
 
       cy.log("should be able to archive entities from their own views");
@@ -225,12 +201,12 @@ describe("scenarios > collections > trash", () => {
         cy.findByText("Collection A").click();
       });
       cy.findByTestId("collection-menu").find(".Icon-ellipsis").click();
-      popover().findByText("Move to trash").click();
-      modal().within(() => {
+      H.popover().findByText("Move to trash").click();
+      H.modal().within(() => {
         cy.findByText("Move this collection to trash?");
         cy.findByText("Move to trash").click();
       });
-      expectGoodSnowplowEvent(event =>
+      H.expectGoodSnowplowEvent(event =>
         isMatching(
           {
             event: "moved-to-trash",
@@ -251,12 +227,12 @@ describe("scenarios > collections > trash", () => {
         cy.findByText("Dashboard A").click();
       });
       cy.findByTestId("dashboard-header").icon("ellipsis").click();
-      popover().findByText("Move to trash").click();
-      modal().within(() => {
+      H.popover().findByText("Move to trash").click();
+      H.modal().within(() => {
         cy.findByText("Move this dashboard to trash?");
         cy.findByText("Move to trash").click();
       });
-      expectGoodSnowplowEvent(event =>
+      H.expectGoodSnowplowEvent(event =>
         isMatching(
           {
             event: "moved-to-trash",
@@ -281,12 +257,12 @@ describe("scenarios > collections > trash", () => {
         cy.findByText("Question A").click();
       });
       cy.findByTestId("qb-header-action-panel").icon("ellipsis").click();
-      popover().findByText("Move to trash").click();
-      modal().within(() => {
+      H.popover().findByText("Move to trash").click();
+      H.modal().within(() => {
         cy.findByText("Move this question to trash?");
         cy.findByText("Move to trash").click();
       });
-      expectGoodSnowplowEvent(event =>
+      H.expectGoodSnowplowEvent(event =>
         isMatching(
           {
             event: "moved-to-trash",
@@ -322,11 +298,11 @@ describe("scenarios > collections > trash", () => {
     cy.visit("/trash");
 
     toggleEllipsisMenuFor("Collection A");
-    popover().findByText("Restore").should("exist");
+    H.popover().findByText("Restore").should("exist");
     collectionTable().findByText("Collection A").click();
 
     toggleEllipsisMenuFor("Collection B");
-    popover().findByText("Restore").should("not.exist");
+    H.popover().findByText("Restore").should("not.exist");
 
     cy.log("only shows restore on entity page if in root trash collection");
     cy.visit("/trash");
@@ -349,22 +325,22 @@ describe("scenarios > collections > trash", () => {
     cy.log("can move from trash list");
     cy.visit("/trash");
     toggleEllipsisMenuFor("Collection A");
-    popover().findByText("Move").click();
-    modal().within(() => {
+    H.popover().findByText("Move").click();
+    H.modal().within(() => {
       cy.findByText("First collection").click();
       cy.findByText("Move").click();
     });
 
     toggleEllipsisMenuFor("Dashboard A");
-    popover().findByText("Move").click();
-    modal().within(() => {
+    H.popover().findByText("Move").click();
+    H.modal().within(() => {
       cy.findByText("First collection").click();
       cy.findByText("Move").click();
     });
 
     toggleEllipsisMenuFor("Question A");
-    popover().findByText("Move").click();
-    modal().within(() => {
+    H.popover().findByText("Move").click();
+    H.modal().within(() => {
       cy.findByText("First collection").click();
       cy.findByText("Move").click();
     });
@@ -391,7 +367,7 @@ describe("scenarios > collections > trash", () => {
     archiveBanner().within(() => {
       cy.findByText("Move").click();
     });
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("First collection").click();
       cy.findByText("Move").click();
     });
@@ -404,7 +380,7 @@ describe("scenarios > collections > trash", () => {
     archiveBanner().within(() => {
       cy.findByText("Move").click();
     });
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("First collection").click();
       cy.findByText("Move").click();
     });
@@ -417,7 +393,7 @@ describe("scenarios > collections > trash", () => {
     archiveBanner().within(() => {
       cy.findByText("Move").click();
     });
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("First collection").click();
       cy.findByText("Move").click();
     });
@@ -455,7 +431,7 @@ describe("scenarios > collections > trash", () => {
     cy.log("can delete from trash list");
     toggleEllipsisMenuFor("Collection A");
     // FUTURE: replace following two lines with commented out code when collections can be deleted
-    popover().findByText("Delete permanently").should("not.exist");
+    H.popover().findByText("Delete permanently").should("not.exist");
     toggleEllipsisMenuFor("Collection A");
     // popover().findByText("Delete permanently").click();
     // modal().findByText("Delete Collection A permanently?").should("exist");
@@ -465,17 +441,17 @@ describe("scenarios > collections > trash", () => {
     // });
 
     toggleEllipsisMenuFor("Dashboard A");
-    popover().findByText("Delete permanently").click();
-    modal().findByText("Delete Dashboard A permanently?").should("exist");
-    modal().findByText("Delete permanently").click();
+    H.popover().findByText("Delete permanently").click();
+    H.modal().findByText("Delete Dashboard A permanently?").should("exist");
+    H.modal().findByText("Delete permanently").click();
     collectionTable().within(() => {
       cy.findByText("Dashboard A").should("not.exist");
     });
 
     toggleEllipsisMenuFor("Question A");
-    popover().findByText("Delete permanently").click();
-    modal().findByText("Delete Question A permanently?").should("exist");
-    modal().findByText("Delete permanently").click();
+    H.popover().findByText("Delete permanently").click();
+    H.modal().findByText("Delete Question A permanently?").should("exist");
+    H.modal().findByText("Delete permanently").click();
     collectionTable().within(() => {
       cy.findByText("Question A").should("not.exist");
     });
@@ -498,8 +474,8 @@ describe("scenarios > collections > trash", () => {
       cy.findByText("Dashboard B").click();
     });
     archiveBanner().findByText("Delete permanently").click();
-    modal().findByText("Delete Dashboard B permanently?").should("exist");
-    modal().findByText("Delete permanently").click();
+    H.modal().findByText("Delete Dashboard B permanently?").should("exist");
+    H.modal().findByText("Delete permanently").click();
     collectionTable().within(() => {
       cy.findByText("Dashboard B").should("not.exist");
     });
@@ -508,8 +484,8 @@ describe("scenarios > collections > trash", () => {
       cy.findByText("Question B").click();
     });
     archiveBanner().findByText("Delete permanently").click();
-    modal().findByText("Delete Question B permanently?").should("exist");
-    modal().findByText("Delete permanently").click();
+    H.modal().findByText("Delete Question B permanently?").should("exist");
+    H.modal().findByText("Delete permanently").click();
     collectionTable().within(() => {
       cy.findByText("Question B").should("not.exist");
     });
@@ -559,7 +535,7 @@ describe("scenarios > collections > trash", () => {
           cy.findByText("Move").should("not.be.disabled").click();
         });
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("First collection").click();
         cy.findByText("Move").click();
       });
@@ -570,7 +546,7 @@ describe("scenarios > collections > trash", () => {
         cy.findByText("Question A").should("not.exist");
       });
 
-      navigationSidebar().within(() => {
+      H.navigationSidebar().within(() => {
         cy.findByText("First collection").click();
       });
 
@@ -593,7 +569,7 @@ describe("scenarios > collections > trash", () => {
           cy.findByText("Delete permanently").should("not.be.disabled").click();
         });
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("Delete 2 items permanently?");
         cy.findByText("Delete permanently").click();
       });
@@ -617,7 +593,7 @@ describe("scenarios > collections > trash", () => {
     ).as("question");
 
     cy.get("@question").then(question => {
-      visitQuestion(question.id);
+      H.visitQuestion(question.id);
       // should not have disabled actions in top navbar
       cy.findAllByTestId("qb-header-action-panel").within(() => {
         cy.findByText("Filter").should("not.exist");
@@ -625,7 +601,7 @@ describe("scenarios > collections > trash", () => {
         cy.findByTestId("notebook-button").should("not.exist");
         cy.icon("bookmark").should("not.exist");
         cy.icon("ellipsis").should("not.exist");
-        sharingMenuButton().should("not.exist");
+        H.sharingMenuButton().should("not.exist");
       });
 
       // should not have disabled action in bottom footer
@@ -635,11 +611,11 @@ describe("scenarios > collections > trash", () => {
     });
 
     cy.get("@dashboard").then(dashboard => {
-      visitDashboard(dashboard.id);
+      H.visitDashboard(dashboard.id);
 
       cy.findAllByTestId("dashboard-header").within(() => {
         cy.icon("pencil").should("not.exist");
-        sharingMenuButton().should("not.exist");
+        H.sharingMenuButton().should("not.exist");
         cy.icon("clock").should("not.exist");
         cy.icon("bookmark").should("not.exist");
         cy.icon("ellipsis").should("not.exist");
@@ -666,19 +642,23 @@ describe("scenarios > collections > trash", () => {
 
       cy.visit("/admin/permissions/collections");
 
-      selectSidebarItem("Collection A");
+      H.selectSidebarItem("Collection A");
       const COLLECTION_ACCESS_PERMISSION_INDEX = 0;
 
-      modifyPermission("All Users", COLLECTION_ACCESS_PERMISSION_INDEX, "View");
-      modifyPermission(
+      H.modifyPermission(
+        "All Users",
+        COLLECTION_ACCESS_PERMISSION_INDEX,
+        "View",
+      );
+      H.modifyPermission(
         "collection",
         COLLECTION_ACCESS_PERMISSION_INDEX,
         "View",
       );
-      modifyPermission("data", COLLECTION_ACCESS_PERMISSION_INDEX, "View");
+      H.modifyPermission("data", COLLECTION_ACCESS_PERMISSION_INDEX, "View");
 
       cy.button("Save changes").click();
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("Save permissions?");
         cy.findByText("Are you sure you want to do this?");
         cy.button("Yes").click();
@@ -690,7 +670,7 @@ describe("scenarios > collections > trash", () => {
     cy.signInAsNormalUser();
 
     cy.get("@collection").then(collection => {
-      visitCollection(collection.id);
+      H.visitCollection(collection.id);
       archiveBanner().findByText("Restore").should("not.exist");
       archiveBanner().findByText("Move").should("not.exist");
       archiveBanner().findByText("Delete permanently").should("not.exist");
@@ -759,7 +739,7 @@ describe("scenarios > collections > trash", () => {
       cy.intercept("GET", `/api/collection/${collection.id}`).as(
         "getCollection",
       );
-      visitCollection(collection.id);
+      H.visitCollection(collection.id);
       cy.wait("@getCollection");
       assertTrashSelectedInNavigationSidebar();
     });
@@ -767,9 +747,9 @@ describe("scenarios > collections > trash", () => {
     cy.log("Make sure trash is selected for a trashed dashboard");
     cy.get("@dashboard").then(dashboard => {
       cy.intercept("GET", `/api/dashboard/${dashboard.id}*`).as("getDashboard");
-      visitDashboard(dashboard.id);
+      H.visitDashboard(dashboard.id);
       cy.wait("@getDashboard");
-      openNavigationSidebar();
+      H.openNavigationSidebar();
       assertTrashSelectedInNavigationSidebar();
     });
 
@@ -779,9 +759,9 @@ describe("scenarios > collections > trash", () => {
       cy.intercept("POST", `/api/card/${question.id}/query`).as(
         "getQuestionResult",
       );
-      visitQuestion(question.id);
+      H.visitQuestion(question.id);
       cy.wait("@getQuestionResult");
-      openNavigationSidebar();
+      H.openNavigationSidebar();
       assertTrashSelectedInNavigationSidebar();
     });
   });
@@ -793,15 +773,15 @@ describe("scenarios > collections > trash", () => {
       cy.visit("/trash");
 
       dragAndDrop(
-        main().findByText("Dashboard A"),
-        navigationSidebar().findByText("Trash"),
+        H.main().findByText("Dashboard A"),
+        H.navigationSidebar().findByText("Trash"),
       );
 
       cy.wait(100); // small wait to make sure a network request could have gone out
       // assert no update request went out
       cy.get("@updateDashboard.all").should("have.length", 0);
       cy.findByTestId("toast-undo").should("not.exist");
-      main(() => {
+      H.main(() => {
         cy.findByText(/Deleted items will appear here/).should("not.exist");
         cy.findByText("Dashboard A").should("exist");
       });
@@ -813,19 +793,19 @@ describe("scenarios > collections > trash", () => {
       cy.visit("/trash");
 
       dragAndDrop(
-        main().findByText("Dashboard A"),
-        navigationSidebar().findByText("First collection"),
+        H.main().findByText("Dashboard A"),
+        H.navigationSidebar().findByText("First collection"),
       );
 
       cy.get("@updateDashboard.all").should("have.length", 1);
-      main()
+      H.main()
         .findByText(/Deleted items will appear here/)
         .should("exist");
       cy.findByTestId("toast-undo").should("exist");
-      undo();
+      H.undo();
 
       cy.get("@updateDashboard.all").should("have.length", 2);
-      main().within(() => {
+      H.main().within(() => {
         cy.findByText(/Deleted items will appear here/).should("not.exist");
         cy.findByText("Dashboard A").should("exist");
       });
@@ -837,20 +817,20 @@ describe("scenarios > collections > trash", () => {
         collection_id: FIRST_COLLECTION_ID,
       });
       cy.intercept("PUT", "/api/dashboard/**").as("updateDashboard");
-      visitCollection(FIRST_COLLECTION_ID);
+      H.visitCollection(FIRST_COLLECTION_ID);
 
       dragAndDrop(
-        main().findByText("Dashboard A"),
-        navigationSidebar().findByText("Trash"),
+        H.main().findByText("Dashboard A"),
+        H.navigationSidebar().findByText("Trash"),
       );
 
       cy.get("@updateDashboard.all").should("have.length", 1);
-      main().findByText("Dashboard A").should("not.exist");
+      H.main().findByText("Dashboard A").should("not.exist");
       cy.findByTestId("toast-undo").should("exist");
-      undo();
+      H.undo();
 
       cy.get("@updateDashboard.all").should("have.length", 2);
-      main().within(() => {
+      H.main().within(() => {
         cy.findByText("Dashboard A").should("exist");
       });
     });
@@ -901,16 +881,16 @@ function createCollection(collectionInfo, archive) {
 }
 
 function createQuestion(questionInfo, archive) {
-  return _createQuestion(questionInfo).then(({ body: question }) =>
-    Promise.all([question, archive && archiveQuestion(question.id)]).then(
+  return H.createQuestion(questionInfo).then(({ body: question }) =>
+    Promise.all([question, archive && H.archiveQuestion(question.id)]).then(
       ([question]) => question,
     ),
   );
 }
 
 function createNativeQuestion(questionInfo, archive) {
-  return _createNativeQuestion(questionInfo).then(({ body: question }) =>
-    Promise.all([question, archive && archiveQuestion(question.id)]).then(
+  return H.createNativeQuestion(questionInfo).then(({ body: question }) =>
+    Promise.all([question, archive && H.archiveQuestion(question.id)]).then(
       ([question]) => question,
     ),
   );
@@ -959,7 +939,7 @@ function selectItem(name) {
 }
 
 function assertTrashSelectedInNavigationSidebar() {
-  navigationSidebar().within(() => {
+  H.navigationSidebar().within(() => {
     cy.findByText("Trash")
       .parents("li")
       .should("have.attr", "aria-selected", "true");

--- a/e2e/test/scenarios/cross-version/source/01-generate-metadata.cy.spec.js
+++ b/e2e/test/scenarios/cross-version/source/01-generate-metadata.cy.spec.js
@@ -1,9 +1,9 @@
-import { withSampleDatabase } from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 it("should generate metadata", () => {
   cy.signInAsAdmin();
 
-  withSampleDatabase(SAMPLE_DATABASE => {
+  H.withSampleDatabase(SAMPLE_DATABASE => {
     cy.writeFile("e2e/support/cypress_sample_database.json", SAMPLE_DATABASE);
   });
 });

--- a/e2e/test/scenarios/cross-version/source/03-questions.cy.spec.js
+++ b/e2e/test/scenarios/cross-version/source/03-questions.cy.spec.js
@@ -1,4 +1,4 @@
-import { visualize } from "e2e/support/helpers";
+import { H } from "e2e/support";
 import {
   fillAreaUnderLineChart,
   newQuestion,
@@ -49,7 +49,7 @@ it("should create questions", () => {
   // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Category").click();
 
-  visualize();
+  H.visualize();
 
   cy.get(".bar").should("have.length", 4);
 
@@ -107,7 +107,7 @@ it("should create questions", () => {
   // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Created At: Quarter");
 
-  visualize();
+  H.visualize();
   cy.get("circle");
 
   cy.findByTestId("viz-type-button").click();

--- a/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
@@ -1,29 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  type DashboardDetails,
-  type StructuredQuestionDetails,
-  assertQueryBuilderRowCount,
-  assertTableData,
-  createDashboard,
-  createQuestion,
-  editDashboard,
-  enterCustomColumnDetails,
-  entityPickerModal,
-  entityPickerModalTab,
-  getDashboardCard,
-  getNotebookStep,
-  modal,
-  openNotebook,
-  popover,
-  queryBuilderHeader,
-  restore,
-  saveDashboard,
-  showDashboardCardActions,
-  sidebar,
-  tableHeaderClick,
-  visitDashboard,
-  visualize,
-} from "e2e/support/helpers";
 import type { CardId, DashboardParameterMapping } from "metabase-types/api";
 import { createMockDashboardCard } from "metabase-types/api/mocks";
 
@@ -34,7 +10,7 @@ describe("scenarios > custom column > boolean functions", () => {
   const expressionName = "Boolean column";
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("PUT", "/api/card/*").as("updateCard");
@@ -42,7 +18,7 @@ describe("scenarios > custom column > boolean functions", () => {
 
   describe("expression editor", () => {
     const stringQuestionColumns = ["Category"];
-    const stringQuestionDetails: StructuredQuestionDetails = {
+    const stringQuestionDetails: H.StructuredQuestionDetails = {
       query: {
         "source-table": PRODUCTS_ID,
         fields: [["field", PRODUCTS.CATEGORY, null]],
@@ -52,7 +28,7 @@ describe("scenarios > custom column > boolean functions", () => {
     };
 
     const numberQuestionColumns = ["Total"];
-    const numberQuestionDetails: StructuredQuestionDetails = {
+    const numberQuestionDetails: H.StructuredQuestionDetails = {
       query: {
         "source-table": ORDERS_ID,
         fields: [["field", ORDERS.TOTAL, null]],
@@ -62,7 +38,7 @@ describe("scenarios > custom column > boolean functions", () => {
     };
 
     const dateQuestionColumns = ["Created At"];
-    const dateQuestionDetails: StructuredQuestionDetails = {
+    const dateQuestionDetails: H.StructuredQuestionDetails = {
       query: {
         "source-table": ORDERS_ID,
         fields: [["field", ORDERS.CREATED_AT, null]],
@@ -79,50 +55,50 @@ describe("scenarios > custom column > boolean functions", () => {
       modifiedExpression,
       modifiedExpressionRows,
     }: {
-      questionDetails: StructuredQuestionDetails;
+      questionDetails: H.StructuredQuestionDetails;
       questionColumns: string[];
       newExpression: string;
       newExpressionRows: string[][];
       modifiedExpression: string;
       modifiedExpressionRows: string[][];
     }) {
-      createQuestion(questionDetails, { visitQuestion: true });
+      H.createQuestion(questionDetails, { visitQuestion: true });
 
       cy.log("add a new custom column");
-      openNotebook();
-      getNotebookStep("data").button("Custom column").click();
-      enterCustomColumnDetails({
+      H.openNotebook();
+      H.getNotebookStep("data").button("Custom column").click();
+      H.enterCustomColumnDetails({
         formula: newExpression,
         name: expressionName,
       });
-      popover().button("Done").click();
-      visualize();
+      H.popover().button("Done").click();
+      H.visualize();
       cy.wait("@dataset");
-      assertTableData({
+      H.assertTableData({
         columns: [...questionColumns, expressionName],
         firstRows: newExpressionRows,
       });
 
       cy.log("modify an existing custom column");
-      openNotebook();
-      getNotebookStep("expression").findByText(expressionName).click();
-      enterCustomColumnDetails({
+      H.openNotebook();
+      H.getNotebookStep("expression").findByText(expressionName).click();
+      H.enterCustomColumnDetails({
         formula: modifiedExpression,
         name: expressionName,
       });
-      popover().button("Update").click();
-      visualize();
+      H.popover().button("Update").click();
+      H.visualize();
       cy.wait("@dataset");
-      assertTableData({
+      H.assertTableData({
         columns: [...questionColumns, expressionName],
         firstRows: modifiedExpressionRows,
       });
 
       cy.log("assert that the question can be saved");
-      queryBuilderHeader().button("Save").click();
-      modal().button("Save").click();
+      H.queryBuilderHeader().button("Save").click();
+      H.modal().button("Save").click();
       cy.wait("@updateCard");
-      queryBuilderHeader().button("Save").should("not.exist");
+      H.queryBuilderHeader().button("Save").should("not.exist");
     }
 
     it("isNull", () => {
@@ -216,7 +192,7 @@ describe("scenarios > custom column > boolean functions", () => {
 
   describe("query builder", () => {
     describe("same stage", () => {
-      const questionDetails: StructuredQuestionDetails = {
+      const questionDetails: H.StructuredQuestionDetails = {
         query: {
           "source-table": PRODUCTS_ID,
           fields: [
@@ -234,29 +210,29 @@ describe("scenarios > custom column > boolean functions", () => {
       };
 
       it("should be able to add a same-stage custom column", () => {
-        createQuestion(questionDetails, { visitQuestion: true });
-        openNotebook();
+        H.createQuestion(questionDetails, { visitQuestion: true });
+        H.openNotebook();
 
         cy.log("add an identity column");
-        getNotebookStep("expression").icon("add").click();
-        enterCustomColumnDetails({
+        H.getNotebookStep("expression").icon("add").click();
+        H.enterCustomColumnDetails({
           formula: `[${expressionName}]`,
           name: "Identity column",
         });
-        popover().button("Done").click();
+        H.popover().button("Done").click();
 
         cy.log("add a simple expression");
-        getNotebookStep("expression").icon("add").click();
-        enterCustomColumnDetails({
+        H.getNotebookStep("expression").icon("add").click();
+        H.enterCustomColumnDetails({
           formula: `[${expressionName}] != True`,
           name: "Simple expression",
         });
-        popover().button("Done").click();
+        H.popover().button("Done").click();
 
         cy.log("assert query results");
-        visualize();
+        H.visualize();
         cy.wait("@dataset");
-        assertTableData({
+        H.assertTableData({
           columns: [
             "Category",
             expressionName,
@@ -268,50 +244,50 @@ describe("scenarios > custom column > boolean functions", () => {
       });
 
       it("should be able to add a same-stage filter", () => {
-        createQuestion(questionDetails, { visitQuestion: true });
-        assertQueryBuilderRowCount(200);
-        tableHeaderClick(expressionName);
-        popover().within(() => {
+        H.createQuestion(questionDetails, { visitQuestion: true });
+        H.assertQueryBuilderRowCount(200);
+        H.tableHeaderClick(expressionName);
+        H.popover().within(() => {
           cy.findByText("Filter by this column").click();
           cy.findByLabelText("True").click();
           cy.findByText("Add filter").click();
         });
-        assertQueryBuilderRowCount(51);
+        H.assertQueryBuilderRowCount(51);
       });
 
       it("should be able to add a same-stage aggregation", () => {
-        createQuestion(questionDetails, { visitQuestion: true });
-        openNotebook();
-        getNotebookStep("expression").button("Summarize").click();
-        popover().findByText("Minimum of ...").click();
-        popover().findByText(expressionName).click();
-        getNotebookStep("summarize")
+        H.createQuestion(questionDetails, { visitQuestion: true });
+        H.openNotebook();
+        H.getNotebookStep("expression").button("Summarize").click();
+        H.popover().findByText("Minimum of ...").click();
+        H.popover().findByText(expressionName).click();
+        H.getNotebookStep("summarize")
           .findByTestId("aggregate-step")
           .icon("add")
           .click();
-        popover().findByText("Maximum of ...").click();
-        popover().findByText(expressionName).click();
-        visualize();
+        H.popover().findByText("Maximum of ...").click();
+        H.popover().findByText(expressionName).click();
+        H.visualize();
         cy.wait("@dataset");
-        assertTableData({
+        H.assertTableData({
           columns: [`Min of ${expressionName}`, `Max of ${expressionName}`],
           firstRows: [["false", "true"]],
         });
       });
 
       it("should be able to add a same-stage breakout", () => {
-        createQuestion(questionDetails, { visitQuestion: true });
-        openNotebook();
-        getNotebookStep("expression").button("Summarize").click();
-        popover().findByText("Count of rows").click();
-        getNotebookStep("summarize")
+        H.createQuestion(questionDetails, { visitQuestion: true });
+        H.openNotebook();
+        H.getNotebookStep("expression").button("Summarize").click();
+        H.popover().findByText("Count of rows").click();
+        H.getNotebookStep("summarize")
           .findByTestId("breakout-step")
           .findByText("Pick a column to group by")
           .click();
-        popover().findByText(expressionName).click();
-        visualize();
+        H.popover().findByText(expressionName).click();
+        H.visualize();
         cy.wait("@dataset");
-        assertTableData({
+        H.assertTableData({
           columns: [expressionName, "Count"],
           firstRows: [
             ["false", "149"],
@@ -321,13 +297,13 @@ describe("scenarios > custom column > boolean functions", () => {
       });
 
       it("should be able to add a same-stage sorting", () => {
-        createQuestion(questionDetails, { visitQuestion: true });
-        openNotebook();
-        getNotebookStep("expression").button("Sort").click();
-        popover().findByText(expressionName).click();
-        visualize();
+        H.createQuestion(questionDetails, { visitQuestion: true });
+        H.openNotebook();
+        H.getNotebookStep("expression").button("Sort").click();
+        H.popover().findByText(expressionName).click();
+        H.visualize();
         cy.wait("@dataset");
-        assertTableData({
+        H.assertTableData({
           columns: ["Category", expressionName],
           firstRows: [["Doohickey", "false"]],
         });
@@ -335,7 +311,7 @@ describe("scenarios > custom column > boolean functions", () => {
     });
 
     describe("previous stage", () => {
-      const questionDetails: StructuredQuestionDetails = {
+      const questionDetails: H.StructuredQuestionDetails = {
         query: {
           "source-table": PRODUCTS_ID,
           expressions: {
@@ -353,17 +329,17 @@ describe("scenarios > custom column > boolean functions", () => {
       };
 
       it("should be able to add a post-aggregation custom column", () => {
-        createQuestion(questionDetails, { visitQuestion: true });
-        openNotebook();
-        getNotebookStep("summarize").button("Custom column").click();
-        enterCustomColumnDetails({
+        H.createQuestion(questionDetails, { visitQuestion: true });
+        H.openNotebook();
+        H.getNotebookStep("summarize").button("Custom column").click();
+        H.enterCustomColumnDetails({
           formula: `not([${expressionName}])`,
           name: "Simple expression",
         });
-        popover().button("Done").click();
-        visualize();
+        H.popover().button("Done").click();
+        H.visualize();
         cy.wait("@dataset");
-        assertTableData({
+        H.assertTableData({
           columns: [expressionName, "Count", "Simple expression"],
           firstRows: [
             ["false", "149", "true"],
@@ -373,46 +349,46 @@ describe("scenarios > custom column > boolean functions", () => {
       });
 
       it("should be able to add a post-aggregation filter", () => {
-        createQuestion(questionDetails, { visitQuestion: true });
-        assertQueryBuilderRowCount(2);
-        tableHeaderClick(expressionName);
-        popover().within(() => {
+        H.createQuestion(questionDetails, { visitQuestion: true });
+        H.assertQueryBuilderRowCount(2);
+        H.tableHeaderClick(expressionName);
+        H.popover().within(() => {
           cy.findByText("Filter by this column").click();
           cy.findByLabelText("True").click();
           cy.findByText("Add filter").click();
         });
-        assertQueryBuilderRowCount(1);
+        H.assertQueryBuilderRowCount(1);
       });
 
       it("should be able to add a post-aggregation aggregation", () => {
-        createQuestion(questionDetails, { visitQuestion: true });
-        openNotebook();
-        getNotebookStep("summarize").button("Summarize").click();
-        popover().findByText("Minimum of ...").click();
-        popover().findByText(expressionName).click();
-        visualize();
+        H.createQuestion(questionDetails, { visitQuestion: true });
+        H.openNotebook();
+        H.getNotebookStep("summarize").button("Summarize").click();
+        H.popover().findByText("Minimum of ...").click();
+        H.popover().findByText(expressionName).click();
+        H.visualize();
         cy.wait("@dataset");
-        assertTableData({
+        H.assertTableData({
           columns: [`Min of ${expressionName}`],
           firstRows: [["false"]],
         });
       });
 
       it("should be able to add a post-aggregation breakout and sorting", () => {
-        createQuestion(questionDetails, { visitQuestion: true });
+        H.createQuestion(questionDetails, { visitQuestion: true });
 
         cy.log("add a breakout");
-        openNotebook();
-        getNotebookStep("summarize").button("Summarize").click();
-        popover().findByText("Count of rows").click();
-        getNotebookStep("summarize", { stage: 1 })
+        H.openNotebook();
+        H.getNotebookStep("summarize").button("Summarize").click();
+        H.popover().findByText("Count of rows").click();
+        H.getNotebookStep("summarize", { stage: 1 })
           .findByTestId("breakout-step")
           .findByText("Pick a column to group by")
           .click();
-        popover().findByText(expressionName).click();
-        visualize();
+        H.popover().findByText(expressionName).click();
+        H.visualize();
         cy.wait("@dataset");
-        assertTableData({
+        H.assertTableData({
           columns: [expressionName, "Count"],
           firstRows: [
             ["false", 1],
@@ -421,12 +397,12 @@ describe("scenarios > custom column > boolean functions", () => {
         });
 
         cy.log("add sorting");
-        openNotebook();
-        getNotebookStep("summarize", { stage: 1 }).button("Sort").click();
-        popover().findByText(expressionName).click();
-        getNotebookStep("sort", { stage: 1 }).icon("arrow_up").click();
-        visualize();
-        assertTableData({
+        H.openNotebook();
+        H.getNotebookStep("summarize", { stage: 1 }).button("Sort").click();
+        H.popover().findByText(expressionName).click();
+        H.getNotebookStep("sort", { stage: 1 }).icon("arrow_up").click();
+        H.visualize();
+        H.assertTableData({
           columns: [expressionName, "Count"],
           firstRows: [
             ["true", 1],
@@ -437,7 +413,7 @@ describe("scenarios > custom column > boolean functions", () => {
     });
 
     describe("source card", () => {
-      const questionDetails: StructuredQuestionDetails = {
+      const questionDetails: H.StructuredQuestionDetails = {
         name: "Source",
         query: {
           "source-table": PRODUCTS_ID,
@@ -453,7 +429,7 @@ describe("scenarios > custom column > boolean functions", () => {
 
       function getNestedQuestionDetails(
         cardId: number,
-      ): StructuredQuestionDetails {
+      ): H.StructuredQuestionDetails {
         return {
           name: "Nested",
           query: {
@@ -463,97 +439,97 @@ describe("scenarios > custom column > boolean functions", () => {
       }
 
       it("should be able to add a custom column for a boolean column", () => {
-        createQuestion(questionDetails).then(({ body: card }) =>
-          createQuestion(getNestedQuestionDetails(card.id), {
+        H.createQuestion(questionDetails).then(({ body: card }) =>
+          H.createQuestion(getNestedQuestionDetails(card.id), {
             visitQuestion: true,
           }),
         );
 
         cy.log("add a custom column");
-        openNotebook();
-        getNotebookStep("data").button("Custom column").click();
-        enterCustomColumnDetails({
+        H.openNotebook();
+        H.getNotebookStep("data").button("Custom column").click();
+        H.enterCustomColumnDetails({
           formula: `[${expressionName}] != True`,
           name: "Simple expression",
         });
-        popover().button("Done").click();
-        visualize();
+        H.popover().button("Done").click();
+        H.visualize();
         cy.wait("@dataset");
-        assertQueryBuilderRowCount(200);
+        H.assertQueryBuilderRowCount(200);
 
         cy.log("use the new custom column in a filter");
-        tableHeaderClick("Simple expression");
-        popover().within(() => {
+        H.tableHeaderClick("Simple expression");
+        H.popover().within(() => {
           cy.findByText("Filter by this column").click();
           cy.findByLabelText("True").click();
           cy.findByText("Add filter").click();
         });
-        assertQueryBuilderRowCount(149);
+        H.assertQueryBuilderRowCount(149);
       });
 
       it("should be able to add a filter for a boolean column", () => {
-        createQuestion(questionDetails).then(({ body: card }) =>
-          createQuestion(getNestedQuestionDetails(card.id), {
+        H.createQuestion(questionDetails).then(({ body: card }) =>
+          H.createQuestion(getNestedQuestionDetails(card.id), {
             visitQuestion: true,
           }),
         );
-        assertQueryBuilderRowCount(200);
-        tableHeaderClick(expressionName);
-        popover().within(() => {
+        H.assertQueryBuilderRowCount(200);
+        H.tableHeaderClick(expressionName);
+        H.popover().within(() => {
           cy.findByText("Filter by this column").click();
           cy.findByLabelText("True").click();
           cy.findByText("Add filter").click();
         });
-        assertQueryBuilderRowCount(51);
+        H.assertQueryBuilderRowCount(51);
       });
 
       it("should be able to add an aggregation for a boolean column", () => {
-        createQuestion(questionDetails).then(({ body: card }) =>
-          createQuestion(getNestedQuestionDetails(card.id), {
+        H.createQuestion(questionDetails).then(({ body: card }) =>
+          H.createQuestion(getNestedQuestionDetails(card.id), {
             visitQuestion: true,
           }),
         );
-        openNotebook();
-        getNotebookStep("data").button("Summarize").click();
-        popover().findByText("Minimum of ...").click();
-        popover().findByText(expressionName).click();
-        visualize();
+        H.openNotebook();
+        H.getNotebookStep("data").button("Summarize").click();
+        H.popover().findByText("Minimum of ...").click();
+        H.popover().findByText(expressionName).click();
+        H.visualize();
         cy.wait("@dataset");
-        assertTableData({
+        H.assertTableData({
           columns: [`Min of ${expressionName}`],
           firstRows: [["false"]],
         });
       });
 
       it.skip("should be able to add a breakout and sorting for a boolean column (metabase#49305)", () => {
-        createQuestion(questionDetails).then(({ body: card }) =>
-          createQuestion(getNestedQuestionDetails(card.id), {
+        H.createQuestion(questionDetails).then(({ body: card }) =>
+          H.createQuestion(getNestedQuestionDetails(card.id), {
             visitQuestion: true,
           }),
         );
 
         cy.log("add a breakout");
-        openNotebook();
-        getNotebookStep("data").button("Summarize").click();
-        getNotebookStep("summarize")
+        H.openNotebook();
+        H.getNotebookStep("data").button("Summarize").click();
+        H.getNotebookStep("summarize")
           .findByTestId("breakout-step")
           .findByText("Pick a column to group by")
           .click();
-        popover().findByText(expressionName).click();
-        visualize();
+        H.popover().findByText(expressionName).click();
+        H.visualize();
         cy.wait("@dataset");
-        assertTableData({
+        H.assertTableData({
           columns: [expressionName],
           firstRows: [["false"], ["true"]],
         });
 
         cy.log("add sorting");
-        openNotebook();
-        getNotebookStep("summarize").button("Sort").click();
-        popover().findByText(expressionName).click();
-        getNotebookStep("sort").icon("arrow_up").click();
-        visualize();
-        assertTableData({
+        H.openNotebook();
+        H.getNotebookStep("summarize").button("Sort").click();
+        H.popover().findByText(expressionName).click();
+        H.getNotebookStep("sort").icon("arrow_up").click();
+        H.visualize();
+        H.assertTableData({
           columns: [expressionName],
           firstRows: [["true"], ["false"]],
         });
@@ -562,7 +538,7 @@ describe("scenarios > custom column > boolean functions", () => {
   });
 
   describe("dashboards", () => {
-    const questionDetails: StructuredQuestionDetails = {
+    const questionDetails: H.StructuredQuestionDetails = {
       name: "Q1",
       query: {
         "source-table": PEOPLE_ID,
@@ -588,7 +564,7 @@ describe("scenarios > custom column > boolean functions", () => {
       sectionId: "string",
     };
 
-    const dashboardDetails: DashboardDetails = {
+    const dashboardDetails: H.DashboardDetails = {
       name: "D1",
       parameters: [parameterDetails],
     };
@@ -604,10 +580,10 @@ describe("scenarios > custom column > boolean functions", () => {
       };
     }
 
-    function createDashboardWithQuestion(opts?: DashboardDetails) {
-      return createDashboard({ ...dashboardDetails, ...opts }).then(
+    function createDashboardWithQuestion(opts?: H.DashboardDetails) {
+      return H.createDashboard({ ...dashboardDetails, ...opts }).then(
         ({ body: dashboard }) => {
-          return createQuestion(questionDetails).then(({ body: card }) => {
+          return H.createQuestion(questionDetails).then(({ body: card }) => {
             return cy
               .request("PUT", `/api/dashboard/${dashboard.id}`, {
                 dashcards: [
@@ -631,31 +607,31 @@ describe("scenarios > custom column > boolean functions", () => {
 
     it("should be able setup an 'open question' click behavior", () => {
       createDashboardWithQuestion().then(dashboard =>
-        visitDashboard(dashboard.id),
+        H.visitDashboard(dashboard.id),
       );
 
       cy.log("setup click behavior");
-      editDashboard();
-      showDashboardCardActions();
-      getDashboardCard().findByLabelText("Click behavior").click();
-      sidebar().within(() => {
+      H.editDashboard();
+      H.showDashboardCardActions();
+      H.getDashboardCard().findByLabelText("Click behavior").click();
+      H.sidebar().within(() => {
         cy.findByText(expressionName).click();
         cy.findByText("Go to a custom destination").click();
         cy.findByText("Saved question").click();
       });
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Questions").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Questions").click();
         cy.findByText("Q1").click();
       });
-      sidebar()
+      H.sidebar()
         .findByTestId("click-mappings")
         .findByText(expressionName)
         .click();
-      popover().findByText(expressionName).click();
-      saveDashboard();
+      H.popover().findByText(expressionName).click();
+      H.saveDashboard();
 
       cy.log("verify click behavior");
-      getDashboardCard().findAllByText("false").first().click();
+      H.getDashboardCard().findAllByText("false").first().click();
       cy.wait("@dataset");
       cy.findByTestId("qb-filters-panel")
         .findByText(`${expressionName} is false`)
@@ -664,36 +640,36 @@ describe("scenarios > custom column > boolean functions", () => {
 
     it("should be able setup an 'open dashboard' click behavior for the same dashboard", () => {
       createDashboardWithQuestion().then(dashboard =>
-        visitDashboard(dashboard.id),
+        H.visitDashboard(dashboard.id),
       );
 
       cy.log("setup click behavior");
-      editDashboard();
-      showDashboardCardActions();
-      getDashboardCard().findByLabelText("Click behavior").click();
-      sidebar().within(() => {
+      H.editDashboard();
+      H.showDashboardCardActions();
+      H.getDashboardCard().findByLabelText("Click behavior").click();
+      H.sidebar().within(() => {
         cy.findByText(expressionName).click();
         cy.findByText("Go to a custom destination").click();
         cy.findByText("Dashboard").click();
       });
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Dashboards").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Dashboards").click();
         cy.findByText("D1").click();
       });
-      sidebar()
+      H.sidebar()
         .findByTestId("click-mappings")
         .findByText(parameterDetails.name)
         .click();
-      popover().findByText(expressionName).click();
-      saveDashboard();
+      H.popover().findByText(expressionName).click();
+      H.saveDashboard();
 
       cy.log("verify click behavior");
-      getDashboardCard().within(() => {
+      H.getDashboardCard().within(() => {
         cy.findByText("Hudson Borer").should("be.visible");
         cy.findByText("Sydney Rempel").should("not.exist");
         cy.findAllByText("false").first().click();
       });
-      getDashboardCard().within(() => {
+      H.getDashboardCard().within(() => {
         cy.findByText("Hudson Borer").should("not.exist");
         cy.findByText("Sydney Rempel").should("be.visible");
       });
@@ -702,37 +678,37 @@ describe("scenarios > custom column > boolean functions", () => {
     it("should be able setup an 'open dashboard' click behavior for another dashboard", () => {
       createDashboardWithQuestion({ name: "D2" });
       createDashboardWithQuestion({ name: "D1" }).then(dashboard =>
-        visitDashboard(dashboard.id),
+        H.visitDashboard(dashboard.id),
       );
 
       cy.log("setup click behavior");
-      editDashboard();
-      showDashboardCardActions();
-      getDashboardCard().findByLabelText("Click behavior").click();
-      sidebar().within(() => {
+      H.editDashboard();
+      H.showDashboardCardActions();
+      H.getDashboardCard().findByLabelText("Click behavior").click();
+      H.sidebar().within(() => {
         cy.findByText(expressionName).click();
         cy.findByText("Go to a custom destination").click();
         cy.findByText("Dashboard").click();
       });
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Dashboards").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Dashboards").click();
         cy.findByText("D2").click();
       });
-      sidebar()
+      H.sidebar()
         .findByTestId("click-mappings")
         .findByText(parameterDetails.name)
         .click();
-      popover().findByText(expressionName).click();
-      saveDashboard();
+      H.popover().findByText(expressionName).click();
+      H.saveDashboard();
 
       cy.log("verify click behavior");
-      getDashboardCard().within(() => {
+      H.getDashboardCard().within(() => {
         cy.findByText("Hudson Borer").should("be.visible");
         cy.findByText("Sydney Rempel").should("not.exist");
         cy.findAllByText("false").first().click();
       });
       cy.findByTestId("dashboard-name-heading").should("have.value", "D2");
-      getDashboardCard().within(() => {
+      H.getDashboardCard().within(() => {
         cy.findByText("Hudson Borer").should("not.exist");
         cy.findByText("Sydney Rempel").should("be.visible");
       });

--- a/e2e/test/scenarios/custom-column/cc-shortcuts-combine.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-shortcuts-combine.cy.spec.ts
@@ -1,34 +1,24 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
-import {
-  addCustomColumn,
-  describeWithSnowplow,
-  expectGoodSnowplowEvent,
-  expectNoBadSnowplowEvents,
-  expressionEditorWidget,
-  openOrdersTable,
-  popover,
-  resetSnowplow,
-  restore,
-} from "e2e/support/helpers";
 
 describe("scenarios > question > custom column > expression shortcuts > combine", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should be possible to select a combine columns shortcut", () => {
-    openOrdersTable({ mode: "notebook", limit: 5 });
-    addCustomColumn();
+    H.openOrdersTable({ mode: "notebook", limit: 5 });
+    H.addCustomColumn();
     selectCombineColumns();
 
     selectColumn(0, "Total");
 
-    expressionEditorWidget().findByText("Total").should("exist");
+    H.expressionEditorWidget().findByText("Total").should("exist");
 
     selectColumn(1, "Product", "Rating");
 
-    expressionEditorWidget().within(() => {
+    H.expressionEditorWidget().within(() => {
       cy.findByText("Product → Rating").should("exist");
 
       cy.findByTestId("combine-example").should(
@@ -58,14 +48,14 @@ describe("scenarios > question > custom column > expression shortcuts > combine"
   });
 
   it("should be possible to cancel when using the combine column shortcut", () => {
-    openOrdersTable({ mode: "notebook" });
-    addCustomColumn();
+    H.openOrdersTable({ mode: "notebook" });
+    H.addCustomColumn();
     selectCombineColumns();
 
     selectColumn(0, "Total");
     selectColumn(1, "Product", "Rating");
 
-    expressionEditorWidget().within(() => {
+    H.expressionEditorWidget().within(() => {
       // Click the back button, in the header
       cy.findByText("Select columns to combine").click();
     });
@@ -75,8 +65,8 @@ describe("scenarios > question > custom column > expression shortcuts > combine"
   });
 
   it("should be possible to add and remove more than one column", () => {
-    openOrdersTable({ mode: "notebook" });
-    addCustomColumn();
+    H.openOrdersTable({ mode: "notebook" });
+    H.addCustomColumn();
     selectCombineColumns();
 
     selectColumn(0, "Total");
@@ -98,13 +88,13 @@ describe("scenarios > question > custom column > expression shortcuts > combine"
   });
 
   it("should pick the correct default separator based on the type of the first column", () => {
-    openOrdersTable({ mode: "notebook" });
-    addCustomColumn();
+    H.openOrdersTable({ mode: "notebook" });
+    H.addCustomColumn();
     selectCombineColumns();
 
     selectColumn(0, "User", "Email");
 
-    expressionEditorWidget().within(() => {
+    H.expressionEditorWidget().within(() => {
       cy.findByText("Separated by (empty)").should("exist");
       cy.findByText(/Separated by/).click();
 
@@ -113,18 +103,18 @@ describe("scenarios > question > custom column > expression shortcuts > combine"
   });
 
   it("should be possible to edit a previous stages' columns when there is an aggregation (metabase#43226)", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
 
     cy.button("Summarize").click();
 
-    popover().findByText("Count of rows").click();
+    H.popover().findByText("Count of rows").click();
 
-    addCustomColumn();
+    H.addCustomColumn();
     selectCombineColumns();
 
     selectColumn(0, "User", "Email");
 
-    expressionEditorWidget().within(() => {
+    H.expressionEditorWidget().within(() => {
       cy.findByText("Separated by (empty)").should("exist");
       cy.findByText(/Separated by/).click();
 
@@ -133,30 +123,30 @@ describe("scenarios > question > custom column > expression shortcuts > combine"
   });
 });
 
-describeWithSnowplow(
+H.describeWithSnowplow(
   "scenarios > question > custom column > combine shortcuts",
   () => {
     beforeEach(() => {
-      restore();
-      resetSnowplow();
+      H.restore();
+      H.resetSnowplow();
       cy.signInAsNormalUser();
     });
 
     afterEach(() => {
-      expectNoBadSnowplowEvents();
+      H.expectNoBadSnowplowEvents();
     });
 
     it("should send an event for combine columns", () => {
-      openOrdersTable({ mode: "notebook" });
-      addCustomColumn();
+      H.openOrdersTable({ mode: "notebook" });
+      H.addCustomColumn();
       selectCombineColumns();
 
       selectColumn(0, "User", "Email");
       selectColumn(1, "User", "Email");
 
-      expressionEditorWidget().button("Done").click();
+      H.expressionEditorWidget().button("Done").click();
 
-      expectGoodSnowplowEvent({
+      H.expectGoodSnowplowEvent({
         event: "column_combine_via_shortcut",
         custom_expressions_used: ["concat"],
         database_id: SAMPLE_DB_ID,
@@ -173,11 +163,11 @@ function selectCombineColumns() {
 }
 
 function selectColumn(index: number, table: string, name?: string) {
-  expressionEditorWidget().within(() => {
+  H.expressionEditorWidget().within(() => {
     cy.findAllByTestId("column-input").eq(index).click();
   });
 
-  popover()
+  H.popover()
     .last()
     .within(() => {
       if (name) {
@@ -191,7 +181,7 @@ function selectColumn(index: number, table: string, name?: string) {
 }
 
 function addColumn() {
-  expressionEditorWidget().within(() => {
+  H.expressionEditorWidget().within(() => {
     cy.findByText("Add column").click();
   });
 }

--- a/e2e/test/scenarios/custom-column/cc-shortcuts.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-shortcuts.cy.spec.ts
@@ -1,17 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  addCustomColumn,
-  describeWithSnowplow,
-  expectGoodSnowplowEvent,
-  expectNoBadSnowplowEvents,
-  expressionEditorWidget,
-  openOrdersTable,
-  openTable,
-  popover,
-  resetSnowplow,
-  restore,
-} from "e2e/support/helpers";
 
 const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
 
@@ -28,11 +17,11 @@ function selectCombineColumns() {
 }
 
 function selectColumn(index: number, table: string, name?: string) {
-  expressionEditorWidget().within(() => {
+  H.expressionEditorWidget().within(() => {
     cy.findAllByTestId("column-input").eq(index).click();
   });
 
-  popover()
+  H.popover()
     .last()
     .within(() => {
       if (name) {
@@ -128,7 +117,7 @@ describe("scenarios > question > custom column > expression shortcuts > extract"
   ];
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     // Make the PRODUCT_ID column a URL column for these tests, to avoid having to create a new model
@@ -139,92 +128,92 @@ describe("scenarios > question > custom column > expression shortcuts > extract"
 
   for (const extraction of EXTRACTIONS) {
     it(`should be possible to use the ${extraction.name} extraction on ${extraction.column}`, () => {
-      openTable({ mode: "notebook", limit: 1, table: extraction.table });
-      addCustomColumn();
+      H.openTable({ mode: "notebook", limit: 1, table: extraction.table });
+      H.addCustomColumn();
       selectExtractColumn();
 
       cy.findAllByTestId("dimension-list-item")
         .contains(extraction.column)
         .click();
-      popover().findAllByRole("button").contains(extraction.name).click();
+      H.popover().findAllByRole("button").contains(extraction.name).click();
 
       cy.findByTestId("expression-editor-textfield").should(
         "contain",
         `${extraction.fn}(`,
       );
 
-      expressionEditorWidget()
+      H.expressionEditorWidget()
         .findByTestId("expression-name")
         .should("have.value", extraction.name);
     });
   }
 
   it("should be possible to create the same extraction multiple times", () => {
-    openOrdersTable({ mode: "notebook", limit: 5 });
-    addCustomColumn();
+    H.openOrdersTable({ mode: "notebook", limit: 5 });
+    H.addCustomColumn();
     selectExtractColumn();
 
     cy.findAllByTestId("dimension-list-item").contains("Created At").click();
-    popover().findAllByRole("button").contains("Hour of day").click();
+    H.popover().findAllByRole("button").contains("Hour of day").click();
 
-    expressionEditorWidget()
+    H.expressionEditorWidget()
       .findByTestId("expression-name")
       .should("have.value", "Hour of day");
 
-    expressionEditorWidget().button("Done").click();
+    H.expressionEditorWidget().button("Done").click();
 
     cy.findAllByTestId("notebook-cell-item").last().click();
     selectExtractColumn();
 
     cy.findAllByTestId("dimension-list-item").contains("Created At").click();
-    popover().findAllByRole("button").contains("Hour of day").click();
+    H.popover().findAllByRole("button").contains("Hour of day").click();
 
-    expressionEditorWidget()
+    H.expressionEditorWidget()
       .findByTestId("expression-name")
       .should("have.value", "Hour of day (1)");
   });
 
   it("should be possible to edit a previous stages' columns when an aggregation is present (metabase#43226)", () => {
-    openOrdersTable({ mode: "notebook", limit: 5 });
+    H.openOrdersTable({ mode: "notebook", limit: 5 });
 
     cy.button("Summarize").click();
-    popover().findByText("Count of rows").click();
+    H.popover().findByText("Count of rows").click();
 
-    addCustomColumn();
+    H.addCustomColumn();
     selectExtractColumn();
 
     cy.findAllByTestId("dimension-list-item").contains("Created At").click();
-    popover().findAllByRole("button").contains("Hour of day").click();
+    H.popover().findAllByRole("button").contains("Hour of day").click();
 
-    expressionEditorWidget()
+    H.expressionEditorWidget()
       .findByTestId("expression-name")
       .should("have.value", "Hour of day");
   });
 });
 
-describeWithSnowplow(
+H.describeWithSnowplow(
   "scenarios > question > custom column > expression shortcuts > extract",
   () => {
     beforeEach(() => {
-      restore();
-      resetSnowplow();
+      H.restore();
+      H.resetSnowplow();
       cy.signInAsNormalUser();
     });
 
     afterEach(() => {
-      expectNoBadSnowplowEvents();
+      H.expectNoBadSnowplowEvents();
     });
 
     it("should track column extraction via shortcut", () => {
-      openTable({ mode: "notebook", limit: 1, table: ORDERS_ID });
-      addCustomColumn();
+      H.openTable({ mode: "notebook", limit: 1, table: ORDERS_ID });
+      H.addCustomColumn();
       selectExtractColumn();
 
       cy.findAllByTestId("dimension-list-item").contains("Created At").click();
 
-      popover().findAllByRole("button").contains("Hour of day").click();
+      H.popover().findAllByRole("button").contains("Hour of day").click();
 
-      expectGoodSnowplowEvent({
+      H.expectGoodSnowplowEvent({
         event: "column_extract_via_shortcut",
         custom_expressions_used: ["get-hour"],
         database_id: SAMPLE_DB_ID,
@@ -236,28 +225,28 @@ describeWithSnowplow(
 
 describe("scenarios > question > custom column > expression shortcuts > combine", () => {
   function addColumn() {
-    expressionEditorWidget().within(() => {
+    H.expressionEditorWidget().within(() => {
       cy.findByText("Add column").click();
     });
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should be possible to select a combine columns shortcut", () => {
-    openOrdersTable({ mode: "notebook", limit: 5 });
-    addCustomColumn();
+    H.openOrdersTable({ mode: "notebook", limit: 5 });
+    H.addCustomColumn();
     selectCombineColumns();
 
     selectColumn(0, "Total");
 
-    expressionEditorWidget().findByText("Total").should("exist");
+    H.expressionEditorWidget().findByText("Total").should("exist");
 
     selectColumn(1, "Product", "Rating");
 
-    expressionEditorWidget().within(() => {
+    H.expressionEditorWidget().within(() => {
       cy.findByText("Product → Rating").should("exist");
 
       cy.findByTestId("combine-example").should(
@@ -287,14 +276,14 @@ describe("scenarios > question > custom column > expression shortcuts > combine"
   });
 
   it("should be possible to cancel when using the combine column shortcut", () => {
-    openOrdersTable({ mode: "notebook" });
-    addCustomColumn();
+    H.openOrdersTable({ mode: "notebook" });
+    H.addCustomColumn();
     selectCombineColumns();
 
     selectColumn(0, "Total");
     selectColumn(1, "Product", "Rating");
 
-    expressionEditorWidget().within(() => {
+    H.expressionEditorWidget().within(() => {
       // Click the back button, in the header
       cy.findByText("Select columns to combine").click();
     });
@@ -304,8 +293,8 @@ describe("scenarios > question > custom column > expression shortcuts > combine"
   });
 
   it("should be possible to add and remove more than one column", () => {
-    openOrdersTable({ mode: "notebook" });
-    addCustomColumn();
+    H.openOrdersTable({ mode: "notebook" });
+    H.addCustomColumn();
     selectCombineColumns();
 
     selectColumn(0, "Total");
@@ -327,13 +316,13 @@ describe("scenarios > question > custom column > expression shortcuts > combine"
   });
 
   it("should pick the correct default separator based on the type of the first column", () => {
-    openOrdersTable({ mode: "notebook" });
-    addCustomColumn();
+    H.openOrdersTable({ mode: "notebook" });
+    H.addCustomColumn();
     selectCombineColumns();
 
     selectColumn(0, "User", "Email");
 
-    expressionEditorWidget().within(() => {
+    H.expressionEditorWidget().within(() => {
       cy.findByText("Separated by (empty)").should("exist");
       cy.findByText(/Separated by/).click();
 
@@ -342,18 +331,18 @@ describe("scenarios > question > custom column > expression shortcuts > combine"
   });
 
   it("should be possible to edit a previous stages' columns when there is an aggregation (metabase#43226)", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
 
     cy.button("Summarize").click();
 
-    popover().findByText("Count of rows").click();
+    H.popover().findByText("Count of rows").click();
 
-    addCustomColumn();
+    H.addCustomColumn();
     selectCombineColumns();
 
     selectColumn(0, "User", "Email");
 
-    expressionEditorWidget().within(() => {
+    H.expressionEditorWidget().within(() => {
       cy.findByText("Separated by (empty)").should("exist");
       cy.findByText(/Separated by/).click();
 
@@ -362,30 +351,30 @@ describe("scenarios > question > custom column > expression shortcuts > combine"
   });
 });
 
-describeWithSnowplow(
+H.describeWithSnowplow(
   "scenarios > question > custom column > combine shortcuts",
   () => {
     beforeEach(() => {
-      restore();
-      resetSnowplow();
+      H.restore();
+      H.resetSnowplow();
       cy.signInAsNormalUser();
     });
 
     afterEach(() => {
-      expectNoBadSnowplowEvents();
+      H.expectNoBadSnowplowEvents();
     });
 
     it("should send an event for combine columns", () => {
-      openOrdersTable({ mode: "notebook" });
-      addCustomColumn();
+      H.openOrdersTable({ mode: "notebook" });
+      H.addCustomColumn();
       selectCombineColumns();
 
       selectColumn(0, "User", "Email");
       selectColumn(1, "User", "Email");
 
-      expressionEditorWidget().button("Done").click();
+      H.expressionEditorWidget().button("Done").click();
 
-      expectGoodSnowplowEvent({
+      H.expectGoodSnowplowEvent({
         event: "column_combine_via_shortcut",
         custom_expressions_used: ["concat"],
         database_id: SAMPLE_DB_ID,

--- a/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
@@ -1,28 +1,22 @@
-import {
-  enterCustomColumnDetails,
-  openProductsTable,
-  popover,
-  restore,
-  summarize,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 describe("scenarios > question > custom column > typing suggestion", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    openProductsTable({ mode: "notebook" });
+    H.openProductsTable({ mode: "notebook" });
   });
 
   it("should not suggest arithmetic operators", () => {
     addCustomColumn();
-    enterCustomColumnDetails({ formula: "[Price] " });
+    H.enterCustomColumnDetails({ formula: "[Price] " });
     cy.findByTestId("expression-suggestions-list").should("not.exist");
   });
 
   it("should correctly accept the chosen field suggestion", () => {
     addCustomColumn();
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: "[Rating]{leftarrow}{leftarrow}{leftarrow}",
       blur: false,
     });
@@ -38,7 +32,7 @@ describe("scenarios > question > custom column > typing suggestion", () => {
 
   it("should correctly accept the chosen function suggestion", () => {
     addCustomColumn();
-    enterCustomColumnDetails({ formula: "LTRIM([Title])", blur: false });
+    H.enterCustomColumnDetails({ formula: "LTRIM([Title])", blur: false });
 
     // Place the cursor between "is" and "empty"
     cy.get("@formula").type("{leftarrow}".repeat(13));
@@ -52,7 +46,7 @@ describe("scenarios > question > custom column > typing suggestion", () => {
 
   it("should correctly insert function suggestion with the opening parenthesis", () => {
     addCustomColumn();
-    enterCustomColumnDetails({ formula: "BET{enter}" });
+    H.enterCustomColumnDetails({ formula: "BET{enter}" });
 
     cy.findByTestId("expression-editor-textfield").should(
       "contain",
@@ -62,7 +56,7 @@ describe("scenarios > question > custom column > typing suggestion", () => {
 
   it("should show expression function helper if a proper function is typed", () => {
     addCustomColumn();
-    enterCustomColumnDetails({ formula: "lower(", blur: false });
+    H.enterCustomColumnDetails({ formula: "lower(", blur: false });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("lower(text)");
@@ -84,10 +78,10 @@ describe("scenarios > question > custom column > typing suggestion", () => {
   });
 
   it("should not show suggestions for an unfocused field (metabase#31643)", () => {
-    summarize({ mode: "notebook" });
-    popover().findByText("Custom Expression").click();
-    enterCustomColumnDetails({ formula: "Count{enter}" });
-    popover().findByLabelText("Name").focus();
+    H.summarize({ mode: "notebook" });
+    H.popover().findByText("Custom Expression").click();
+    H.enterCustomColumnDetails({ formula: "Count{enter}" });
+    H.popover().findByLabelText("Name").focus();
     cy.findByTestId("expression-suggestions-list").should("not.exist");
   });
 });

--- a/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
@@ -1,43 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  addCustomColumn,
-  addOrUpdateDashboardCard,
-  cartesianChartCircle,
-  createNativeQuestion,
-  createQuestion,
-  createSegment,
-  editDashboard,
-  enterCustomColumnDetails,
-  entityPickerModal,
-  entityPickerModalTab,
-  filter,
-  filterWidget,
-  getDashboardCard,
-  getNotebookStep,
-  main,
-  modal,
-  multiAutocompleteInput,
-  openNotebook,
-  openOrdersTable,
-  openProductsTable,
-  popover,
-  queryBuilderMain,
-  resetTestTable,
-  restore,
-  saveDashboard,
-  selectDashboardFilter,
-  selectFilterOperator,
-  setFilter,
-  startNewQuestion,
-  summarize,
-  tableHeaderClick,
-  visitDashboard,
-  visitQuestion,
-  visitQuestionAdhoc,
-  visualize,
-  withDatabase,
-} from "e2e/support/helpers";
 
 const { PRODUCTS, PRODUCTS_ID, ORDERS, ORDERS_ID, REVIEWS, REVIEWS_ID } =
   SAMPLE_DATABASE;
@@ -46,12 +9,12 @@ describe.skip("issue 12445", { tags: "@external" }, () => {
   const CC_NAME = "Abbr";
 
   beforeEach(() => {
-    restore("mysql-8");
+    H.restore("mysql-8");
     cy.signInAsAdmin();
   });
 
   it("should correctly apply substring for a custom column (metabase#12445)", () => {
-    withDatabase(2, ({ PEOPLE, PEOPLE_ID }) => {
+    H.withDatabase(2, ({ PEOPLE, PEOPLE_ID }) => {
       cy.log("Create a question with `Source` column and abbreviated CC");
       cy.createQuestion(
         {
@@ -85,39 +48,39 @@ describe("issue 13289", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom column").click();
 
     // Add custom column that will be used later in summarize (group by)
-    enterCustomColumnDetails({ formula: "1 + 1", name: CC_NAME });
+    H.enterCustomColumnDetails({ formula: "1 + 1", name: CC_NAME });
     cy.button("Done").click();
   });
 
   it("should allow 'zoom in' drill-through when grouped by custom column (metabase#13289) (metabase#13289)", () => {
-    summarize({ mode: "notebook" });
+    H.summarize({ mode: "notebook" });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Count of rows").click();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
 
-    popover().findByText(CC_NAME).click();
+    H.popover().findByText(CC_NAME).click();
 
     cy.icon("add").last().click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Created At").click();
     });
 
-    visualize();
+    H.visualize();
 
     cy.findByTestId("query-visualization-root").within(() => {
-      cartesianChartCircle()
+      H.cartesianChartCircle()
         .eq(5) // random circle in the graph (there is no specific reason for this index)
         .click();
     });
@@ -139,38 +102,38 @@ describe("issue 13751", { tags: "@external" }, () => {
   const PG_DB_NAME = "QA Postgres12";
 
   beforeEach(() => {
-    restore("postgres-12");
+    H.restore("postgres-12");
     cy.signInAsAdmin();
 
-    startNewQuestion();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.startNewQuestion();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText(PG_DB_NAME).should("be.visible").click();
       cy.findByTextEnsureVisible("People").click();
     });
   });
 
   it("should allow using strings in filter based on a custom column (metabase#13751)", () => {
-    addCustomColumn();
-    enterCustomColumnDetails({
+    H.addCustomColumn();
+    H.enterCustomColumnDetails({
       formula: 'regexextract([State], "^C[A-Z]")',
       name: CC_NAME,
     });
     cy.button("Done").click();
 
-    getNotebookStep("filter")
+    H.getNotebookStep("filter")
       .findByText(/Add filter/)
       .click();
-    popover().findByText(CC_NAME).click();
-    selectFilterOperator("Is");
-    popover().within(() => {
+    H.popover().findByText(CC_NAME).click();
+    H.selectFilterOperator("Is");
+    H.popover().within(() => {
       cy.findByPlaceholderText("Enter some text").type("CO");
       cy.button("Add filter").click();
     });
 
-    visualize();
+    H.visualize();
 
-    queryBuilderMain().findByText("Arnold Adams").should("be.visible");
+    H.queryBuilderMain().findByText("Arnold Adams").should("be.visible");
   });
 });
 
@@ -185,10 +148,10 @@ describe.skip(
     const ESCAPED_REGEX = "(?<=\\/\\/)[^\\/]*";
 
     beforeEach(() => {
-      restore("postgres-12");
+      H.restore("postgres-12");
       cy.signInAsAdmin();
 
-      startNewQuestion();
+      H.startNewQuestion();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(PG_DB_NAME).should("be.visible").click();
       cy.findByTextEnsureVisible("People").click();
@@ -197,7 +160,7 @@ describe.skip(
     it("should not remove regex escape characters (metabase#14517)", () => {
       cy.log("Create custom column using `regexextract()`");
       cy.findByLabelText("Custom Column").click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.get("[contenteditable='true']")
           .type(`regexextract([State], "${ESCAPED_REGEX}")`)
           .blur();
@@ -225,23 +188,23 @@ describe("issue 14843", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should correctly filter custom column by 'Not equal to' (metabase#14843)", () => {
     cy.createQuestion(questionDetails, { visitQuestion: true });
-    openNotebook();
+    H.openNotebook();
 
-    filter({ mode: "notebook" });
-    popover().findByText(CC_NAME).click();
-    selectFilterOperator("Not equal to");
-    popover().within(() => {
-      multiAutocompleteInput().type("3");
+    H.filter({ mode: "notebook" });
+    H.popover().findByText(CC_NAME).click();
+    H.selectFilterOperator("Not equal to");
+    H.popover().within(() => {
+      H.multiAutocompleteInput().type("3");
       cy.button("Add filter").click();
     });
 
-    visualize();
+    H.visualize();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(`${CC_NAME} is not equal to 3`);
@@ -266,7 +229,7 @@ describe("issue 18069", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestion(questionDetails).then(({ body: { id: QUESTION_ID } }) => {
@@ -275,11 +238,11 @@ describe("issue 18069", () => {
   });
 
   it("should not allow choosing text fields for SUM (metabase#18069)", () => {
-    summarize({ mode: "notebook" });
+    H.summarize({ mode: "notebook" });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sum of ...").click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       // regular fields
       cy.findByText("Price");
       cy.findByText("Rating");
@@ -294,7 +257,7 @@ describe("issue 18069", () => {
       cy.findByText("CC_ScaledRating").click();
     });
 
-    visualize();
+    H.visualize();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("1,041.45");
@@ -312,26 +275,26 @@ describe("issue 18747", () => {
     },
   };
   function addNumberParameterToDashboard() {
-    editDashboard();
+    H.editDashboard();
 
-    setFilter("Number", "Equal to");
+    H.setFilter("Number", "Equal to");
   }
 
   function mapParameterToCustomColumn() {
     cy.findByTestId("dashcard-container").contains("Select…").click();
-    popover().contains("Quantity_2").click({ force: true });
+    H.popover().contains("Quantity_2").click({ force: true });
   }
 
   function addValueToParameterFilter() {
-    filterWidget().click();
-    popover().within(() => {
+    H.filterWidget().click();
+    H.popover().within(() => {
       cy.findByRole("searchbox").type("14");
       cy.button("Add filter").click();
     });
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestionAndDashboard({ questionDetails }).then(
@@ -348,7 +311,7 @@ describe("issue 18747", () => {
             },
           ],
         }).then(() => {
-          visitDashboard(dashboard_id);
+          H.visitDashboard(dashboard_id);
         });
       },
     );
@@ -394,14 +357,14 @@ describe("issue 18814", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestion(questionDetails, { visitQuestion: true });
   });
 
   it("should be able to use a custom column in aggregation for a nested query (metabase#18814)", () => {
-    openNotebook();
+    H.openNotebook();
 
     cy.icon("sum").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -409,9 +372,9 @@ describe("issue 18814", () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
-    popover().contains(ccName).click();
+    H.popover().contains(ccName).click();
 
-    visualize();
+    H.visualize();
 
     cy.findByTestId("query-visualization-root").should("contain", "2022");
   });
@@ -445,7 +408,7 @@ describe("issue 19744", () => {
     cy.findByText("Save").click();
     cy.findByLabelText("Name").type(name);
 
-    modal().button("Save").click();
+    H.modal().button("Save").click();
 
     cy.findByText("Not now").click();
 
@@ -457,23 +420,23 @@ describe("issue 19744", () => {
   function addQuestionToDashboardAndVisit() {
     cy.createDashboard().then(({ body: { id: dashboard_id } }) => {
       cy.get("@questionId").then(card_id => {
-        addOrUpdateDashboardCard({
+        H.addOrUpdateDashboardCard({
           card_id,
           dashboard_id,
           card: { size_x: 21, size_y: 10 },
         });
       });
 
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
     });
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     // For this specific repro, it's crucial to first visit the question in order to load the `results_metadata`...
-    visitQuestionAdhoc(questionDetails);
+    H.visitQuestionAdhoc(questionDetails);
     // ...and then to save it using the UI
     saveQuestion("19744");
 
@@ -481,12 +444,12 @@ describe("issue 19744", () => {
   });
 
   it("custom column after aggregation shouldn't limit or change the behavior of dashboard filters (metabase#19744)", () => {
-    editDashboard();
+    H.editDashboard();
 
-    setFilter("Date picker", "All Options");
+    H.setFilter("Date picker", "All Options");
 
     cy.findByTestId("dashcard-container").contains("Select…").click();
-    popover().contains("Created At");
+    H.popover().contains("Created At");
   });
 });
 
@@ -529,12 +492,12 @@ describe("issue 19745", () => {
   function updateQuestionAndSelectFilter(updateExpressions) {
     cy.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
       ({ body: { card_id, dashboard_id } }) => {
-        visitQuestion(card_id);
+        H.visitQuestion(card_id);
 
         // this should modify the query and remove the second stage
-        openNotebook();
+        H.openNotebook();
         updateExpressions();
-        visualize();
+        H.visualize();
         cy.findByTestId("viz-settings-button").click();
         cy.findByRole("button", { name: "Add or remove columns" }).click();
         cy.findByLabelText("Count").should("not.be.checked").click();
@@ -542,17 +505,17 @@ describe("issue 19745", () => {
 
         // as we select all columns in the first stage of the query,
         // it should be possible to map a filter to a selected column
-        visitDashboard(dashboard_id);
-        editDashboard();
+        H.visitDashboard(dashboard_id);
+        H.editDashboard();
         cy.findByText("Date filter").click();
-        selectDashboardFilter(getDashboardCard(), "Created At");
-        saveDashboard();
+        H.selectDashboardFilter(H.getDashboardCard(), "Created At");
+        H.saveDashboard();
       },
     );
   }
 
   function removeExpression(name) {
-    getNotebookStep("expression", { stage: 1 }).within(() => {
+    H.getNotebookStep("expression", { stage: 1 }).within(() => {
       cy.findByText(name).within(() => {
         cy.icon("close").click();
       });
@@ -560,7 +523,7 @@ describe("issue 19745", () => {
   }
 
   function removeAllExpressions() {
-    getNotebookStep("expression", { stage: 1 }).within(() => {
+    H.getNotebookStep("expression", { stage: 1 }).within(() => {
       cy.findByLabelText("Remove step").click({ force: true });
     });
   }
@@ -575,7 +538,7 @@ describe("issue 19745", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -615,7 +578,7 @@ describe("issue 20229", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestion(questionDetails, { visitQuestion: true });
@@ -625,14 +588,14 @@ describe("issue 20229", () => {
     ccAssertion();
 
     // Switch to the notebook view to deselect at least one column
-    openNotebook();
+    H.openNotebook();
 
     cy.findAllByTestId("fields-picker").click();
-    popover().within(() => {
+    H.popover().within(() => {
       unselectColumn("Tax");
     });
 
-    visualize();
+    H.visualize();
 
     ccAssertion();
   });
@@ -657,10 +620,10 @@ describe("issue 21135", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.createQuestion(questionDetails, { visitQuestion: true });
-    openNotebook();
+    H.openNotebook();
   });
 
   it("should handle cc with the same name as the table column (metabase#21135)", () => {
@@ -684,22 +647,22 @@ describe("issue 21135", () => {
 
 describe("issue 21513", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should handle cc with the same name as an aggregation function (metabase#21513)", () => {
-    openProductsTable({ mode: "notebook" });
-    summarize({ mode: "notebook" });
-    popover().findByText("Count of rows").click();
+    H.openProductsTable({ mode: "notebook" });
+    H.summarize({ mode: "notebook" });
+    H.popover().findByText("Count of rows").click();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
-    popover().findByText("Category").click();
+    H.popover().findByText("Category").click();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom column").click();
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: "[Count] * 2",
       name: "Double Count",
     });
@@ -727,13 +690,13 @@ describe("issue 23862", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should group by a custom column and work in a nested question (metabase#23862)", () => {
     cy.createQuestion(questionDetails).then(({ body: { id } }) => {
-      visitQuestionAdhoc(
+      H.visitQuestionAdhoc(
         {
           dataset_query: {
             type: "query",
@@ -775,20 +738,20 @@ describe("issue 24922", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    createSegment(segmentDetails);
+    H.createSegment(segmentDetails);
   });
 
   it("should allow segments in case custom expressions (metabase#24922)", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom column").click();
-    enterCustomColumnDetails(customColumnDetails);
+    H.enterCustomColumnDetails(customColumnDetails);
     cy.button("Done").click();
 
-    visualize();
+    H.visualize();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("CustomColumn").should("be.visible");
   });
@@ -819,7 +782,7 @@ describe.skip("issue 25189", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestion(questionDetails).then(
@@ -842,8 +805,8 @@ describe.skip("issue 25189", () => {
       .and("contain", ccTable);
 
     // 2. We shouldn't see duplication in the bulk filter modal
-    filter();
-    modal().within(() => {
+    H.filter();
+    H.modal().within(() => {
       // Implicit assertion - will fail if more than one element is found
       cy.findByText(ccFunction);
       cy.findByText(ccTable);
@@ -857,7 +820,7 @@ describe.skip("issue 25189", () => {
     cy.findByText("No results!");
 
     // 3. We shouldn't see duplication in the breakout fields
-    summarize();
+    H.summarize();
     cy.findByTestId("sidebar-content").within(() => {
       // Another implicit assertion
       cy.findByText(ccFunction);
@@ -871,18 +834,18 @@ describe.skip("issue 25189", () => {
     const tableName = "colors27745";
 
     beforeEach(() => {
-      restore(`${dialect}-writable`);
+      H.restore(`${dialect}-writable`);
       cy.signInAsAdmin();
 
-      resetTestTable({ type: dialect, table: tableName });
+      H.resetTestTable({ type: dialect, table: tableName });
       cy.request("POST", `/api/database/${WRITABLE_DB_ID}/sync_schema`);
       cy.intercept("GET", "/api/search*").as("search");
     });
 
     it("should display all summarize options if the only numeric field is a custom column (metabase#27745)", () => {
-      startNewQuestion();
+      H.startNewQuestion();
 
-      entityPickerModal().within(() => {
+      H.entityPickerModal().within(() => {
         cy.findByPlaceholderText("Search this collection or everywhere…").type(
           "colors",
         );
@@ -893,16 +856,16 @@ describe.skip("issue 25189", () => {
           .click();
       });
       cy.findByLabelText("Custom column").click();
-      enterCustomColumnDetails({
+      H.enterCustomColumnDetails({
         formula: "case([ID] > 1, 25, 5)",
         name: "Numeric",
       });
       cy.button("Done").click();
 
-      visualize();
+      H.visualize();
 
-      tableHeaderClick("Numeric");
-      popover().findByText(/^Sum$/).click();
+      H.tableHeaderClick("Numeric");
+      H.popover().findByText(/^Sum$/).click();
 
       cy.wait("@dataset");
       cy.findByTestId("scalar-value").invoke("text").should("eq", "55");
@@ -933,7 +896,7 @@ describe("issue 32032", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.createQuestion({ query: QUERY }, { visitQuestion: true });
     cy.intercept("POST", "/api/dataset").as("dataset");
@@ -944,9 +907,9 @@ describe("issue 32032", () => {
       .findAllByText("xavier")
       .eq(1)
       .click();
-    popover().findByText("Is xavier").click();
+    H.popover().findByText("Is xavier").click();
     cy.wait("@dataset");
-    main()
+    H.main()
       .findByText(/There was a problem/i)
       .should("not.exist");
     cy.findByTestId("TableInteractive-root")
@@ -957,12 +920,12 @@ describe("issue 32032", () => {
 
 describe("issue 42949", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should correctly show available shortcuts for date and number columns (metabase#42949)", () => {
-    createNativeQuestion(
+    H.createNativeQuestion(
       {
         native: {
           query: `
@@ -978,22 +941,22 @@ describe("issue 42949", () => {
     cy.findByTestId("qb-header").findByText("Explore results").click();
 
     cy.log("Verify header drills - CREATED_AT");
-    tableHeaderClick("CREATED_AT");
-    popover().findByText("Extract day, month…").should("be.visible");
-    popover().findByText("Combine columns").should("not.exist");
+    H.tableHeaderClick("CREATED_AT");
+    H.popover().findByText("Extract day, month…").should("be.visible");
+    H.popover().findByText("Combine columns").should("not.exist");
     cy.realPress("Escape");
 
     cy.log("Verify header drills - V");
-    tableHeaderClick("V");
-    popover().findByText("Extract part of column").should("not.exist");
-    popover().findByText("Combine columns").should("not.exist");
+    H.tableHeaderClick("V");
+    H.popover().findByText("Extract part of column").should("not.exist");
+    H.popover().findByText("Combine columns").should("not.exist");
     cy.realPress("Escape");
 
     cy.log("Verify plus button - extract column");
     cy.button("Add column").click();
-    popover().findByText("Extract part of column").click();
-    popover().findByText("CREATED_AT").click();
-    popover().within(() => {
+    H.popover().findByText("Extract part of column").click();
+    H.popover().findByText("CREATED_AT").click();
+    H.popover().within(() => {
       cy.findByText("Day of month").should("be.visible");
       cy.findByText("Day of week").should("be.visible");
       cy.findByText("Month of year").should("be.visible");
@@ -1004,16 +967,16 @@ describe("issue 42949", () => {
 
     cy.log("Verify plus button - combine columns");
     cy.button("Add column").click();
-    popover().findByText("Combine columns").click();
-    popover().findAllByTestId("column-input").eq(0).click();
-    popover()
+    H.popover().findByText("Combine columns").click();
+    H.popover().findAllByTestId("column-input").eq(0).click();
+    H.popover()
       .last()
       .within(() => {
         cy.findByText("CREATED_AT").should("be.visible");
         cy.findByText("V").should("be.visible");
         cy.findByText("Year").should("be.visible").click();
       });
-    popover().button("Done").click();
+    H.popover().button("Done").click();
 
     cy.findAllByTestId("header-cell")
       .eq(3)
@@ -1028,7 +991,7 @@ describe("issue 42949", () => {
   });
 
   it("should correctly show available shortcuts for a number column (metabase#42949)", () => {
-    createNativeQuestion(
+    H.createNativeQuestion(
       {
         native: {
           query: "select 1 as n",
@@ -1041,21 +1004,21 @@ describe("issue 42949", () => {
     cy.findByLabelText("Switch to data").click();
 
     cy.log("Verify header drills");
-    tableHeaderClick("N");
-    popover().findByText("Extract part of column").should("not.exist");
-    popover().findByText("Combine columns").should("not.exist");
+    H.tableHeaderClick("N");
+    H.popover().findByText("Extract part of column").should("not.exist");
+    H.popover().findByText("Combine columns").should("not.exist");
     cy.realPress("Escape");
 
     cy.log("Verify plus button");
     cy.button("Add column").click();
-    popover().findByText("Extract part of column").should("not.exist");
-    popover().findByText("Combine columns").click();
-    popover().findAllByTestId("column-input").eq(0).click();
-    popover().last().findByText("N").should("be.visible");
+    H.popover().findByText("Extract part of column").should("not.exist");
+    H.popover().findByText("Combine columns").click();
+    H.popover().findAllByTestId("column-input").eq(0).click();
+    H.popover().last().findByText("N").should("be.visible");
   });
 
   it("should correctly show available shortcuts for a string column (metabase#42949)", () => {
-    createNativeQuestion(
+    H.createNativeQuestion(
       {
         native: {
           query: "select 'abc'",
@@ -1068,30 +1031,30 @@ describe("issue 42949", () => {
     cy.findByLabelText("Switch to data").click();
 
     cy.log("Verify header drills");
-    tableHeaderClick("'abc'");
-    popover().findByText("Extract part of column").should("not.exist");
-    popover().findByText("Combine columns").should("be.visible");
+    H.tableHeaderClick("'abc'");
+    H.popover().findByText("Extract part of column").should("not.exist");
+    H.popover().findByText("Combine columns").should("be.visible");
     cy.realPress("Escape");
 
     cy.log("Verify plus button");
     cy.button("Add column").click();
-    popover().findByText("Extract part of column").should("not.exist");
-    popover().findByText("Combine columns").click();
-    popover().findAllByTestId("column-input").eq(0).click();
-    popover().last().findByText("'abc'").should("be.visible");
+    H.popover().findByText("Extract part of column").should("not.exist");
+    H.popover().findByText("Combine columns").click();
+    H.popover().findAllByTestId("column-input").eq(0).click();
+    H.popover().last().findByText("'abc'").should("be.visible");
   });
 });
 
 describe("issue 49342", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should be possible to leave the expression input with the Tab key (metabase#49342)", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
     cy.findByLabelText("Custom column").click();
-    enterCustomColumnDetails({ formula: "[Tot{Enter}", blur: false });
+    H.enterCustomColumnDetails({ formula: "[Tot{Enter}", blur: false });
     cy.get(".ace_text-input").first().focus().realPress("Tab");
     cy.findByTestId("expression-name").should("be.focused");
 
@@ -1107,31 +1070,33 @@ describe("issue 49342", () => {
 
 describe("issue 49882", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("POST", "/api/dataset/query_metadata").as("queryMetadata");
 
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
     cy.wait("@queryMetadata");
     cy.findByLabelText("Custom column").click();
   });
 
   it("should not eat up subsequent characters when applying a suggestion (metabase#49882-1)", () => {
     const moveCursorTo2ndCaseArgument = "{leftarrow}".repeat(6);
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: `case([Total] > 200, , "X")${moveCursorTo2ndCaseArgument}[tot{enter}`,
     });
 
     cy.get(".ace_text-input")
       .first()
       .should("have.value", 'case([Total] > 200, [Total] , "X")\n\n');
-    popover().findByText("Expecting a closing parenthesis").should("not.exist");
+    H.popover()
+      .findByText("Expecting a closing parenthesis")
+      .should("not.exist");
   });
 
   it("does not clear expression input when expression is invalid (metabase#49882-2)", () => {
     const selectTax = `{leftarrow}${"{shift+leftarrow}".repeat(5)}`;
     const moveCursorBefore2ndCase = "{leftarrow}".repeat(41);
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: `case([Tax] > 1, case([Total] > 200, [Total], "Nothing"), [Tax])${selectTax}`,
     });
     cy.get(".ace_text-input").first().focus().realPress(["Control", "X"]);
@@ -1150,11 +1115,11 @@ describe("issue 49882", () => {
         'case([Tax] > 1, [Tax] case([Total] > 200, [Total], "Nothing"), )\n\n',
       );
 
-    popover().findByText("Invalid expression").should("be.visible");
+    H.popover().findByText("Invalid expression").should("be.visible");
   });
 
   it("should allow moving cursor between wrapped lines with arrow up and arrow down keys (metabase#49882-3)", () => {
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula:
         'case([Tax] > 1, case([Total] > 200, [Total], "Nothing"), [Tax]){leftarrow}{leftarrow}{uparrow}x{downarrow}y',
     });
@@ -1170,7 +1135,7 @@ describe("issue 49882", () => {
   it("should update currently selected suggestion when suggestions list is updated (metabase#49882-4)", () => {
     const selectProductVendor =
       "{downarrow}{downarrow}{downarrow}{downarrow}{downarrow}{enter}";
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: `[Product${selectProductVendor}{leftarrow}{leftarrow}`,
       blur: false,
     });
@@ -1189,28 +1154,28 @@ describe("issue 49304", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should be possible to switch between filter widgets and the expression editor for multi-argument operators (metabase#49304)", () => {
-    createQuestion(questionDetails, { visitQuestion: true });
-    openNotebook();
+    H.createQuestion(questionDetails, { visitQuestion: true });
+    H.openNotebook();
 
     cy.log(
       "add a filter using a filter widget and check that it is rendered in the expression editor",
     );
-    getNotebookStep("data").button("Filter").click();
-    popover().findByText("Category").click();
-    selectFilterOperator("Contains");
-    popover().within(() => {
+    H.getNotebookStep("data").button("Filter").click();
+    H.popover().findByText("Category").click();
+    H.selectFilterOperator("Contains");
+    H.popover().within(() => {
       cy.findByPlaceholderText("Enter some text").type("gadget,widget");
       cy.button("Add filter").click();
     });
-    getNotebookStep("filter")
+    H.getNotebookStep("filter")
       .findByText("Category contains 2 selections")
       .click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.button("Back").click();
       cy.findByText("Custom Expression").click();
       cy.get(".ace_content").should(
@@ -1222,17 +1187,17 @@ describe("issue 49304", () => {
     cy.log(
       "modify the expression in the expression editor and make sure it is rendered correctly in the filter widget",
     );
-    popover().within(() => {
-      enterCustomColumnDetails({
+    H.popover().within(() => {
+      H.enterCustomColumnDetails({
         formula:
           'contains([Category], "gadget", "widget", "gizmo", "case-insensitive")',
       });
       cy.button("Done").click();
     });
-    getNotebookStep("filter")
+    H.getNotebookStep("filter")
       .findByText("Category contains 3 selections")
       .click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("gadget").should("be.visible");
       cy.findByText("widget").should("be.visible");
       cy.findByText("gizmo").should("be.visible");
@@ -1242,14 +1207,14 @@ describe("issue 49304", () => {
     cy.log(
       "change options in the filter widget and make sure they get reflected in the expression editor",
     );
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByLabelText("Case sensitive").click();
       cy.button("Update filter").click();
     });
-    getNotebookStep("filter")
+    H.getNotebookStep("filter")
       .findByText("Category contains 3 selections")
       .click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.button("Back").click();
       cy.findByText("Custom Expression").click();
       cy.get(".ace_content").should(
@@ -1261,16 +1226,16 @@ describe("issue 49304", () => {
     cy.log(
       "remove options from the expression in the expression editor and make sure it is rendered correctly in the filter widget",
     );
-    popover().within(() => {
-      enterCustomColumnDetails({
+    H.popover().within(() => {
+      H.enterCustomColumnDetails({
         formula: 'contains([Category], "gadget", "widget", "gizmo")',
       });
       cy.button("Done").click();
     });
-    getNotebookStep("filter")
+    H.getNotebookStep("filter")
       .findByText("Category contains 3 selections")
       .click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("gadget").should("be.visible");
       cy.findByText("widget").should("be.visible");
       cy.findByText("gizmo").should("be.visible");

--- a/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
@@ -1,28 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  addCustomColumn,
-  cartesianChartCircle,
-  checkExpressionEditorHelperPopoverPosition,
-  createQuestion,
-  enterCustomColumnDetails,
-  entityPickerModal,
-  entityPickerModalTab,
-  filter,
-  getNotebookStep,
-  openOrdersTable,
-  openPeopleTable,
-  openProductsTable,
-  openTable,
-  popover,
-  queryBuilderMain,
-  restore,
-  startNewQuestion,
-  summarize,
-  tableHeaderClick,
-  visitQuestionAdhoc,
-  visualize,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID, PEOPLE_ID } = SAMPLE_DATABASE;
 
@@ -30,7 +8,7 @@ describe("scenarios > question > custom column", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
@@ -51,24 +29,24 @@ describe("scenarios > question > custom column", () => {
       },
       { visitQuestion: true },
     );
-    cartesianChartCircle().eq(5).click();
-    popover()
+    H.cartesianChartCircle().eq(5).click();
+    H.popover()
       .findByText(/Automatic Insights/i)
       .click();
-    popover().findByText(/X-ray/i);
-    popover()
+    H.popover().findByText(/X-ray/i);
+    H.popover()
       .findByText(/Compare to the rest/i)
       .click();
   });
 
   it("can create a custom column (metabase#13241)", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
     cy.findByLabelText("Custom column").click();
 
-    enterCustomColumnDetails({ formula: "1 + 1", name: "Math" });
+    H.enterCustomColumnDetails({ formula: "1 + 1", name: "Math" });
     cy.button("Done").click();
 
-    visualize();
+    H.visualize();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("There was a problem with your question").should("not.exist");
@@ -77,15 +55,15 @@ describe("scenarios > question > custom column", () => {
 
   it("should not show default period in date column name (metabase#36631)", () => {
     const name = "Base question";
-    createQuestion({ name, query: { "source-table": ORDERS_ID } });
+    H.createQuestion({ name, query: { "source-table": ORDERS_ID } });
 
-    startNewQuestion();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Saved questions").click();
+    H.startNewQuestion();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Saved questions").click();
       cy.findByText(name).click();
     });
     cy.button("Custom column").click();
-    enterCustomColumnDetails({ formula: "[cre", blur: false });
+    H.enterCustomColumnDetails({ formula: "[cre", blur: false });
 
     cy.findAllByTestId("expression-suggestions-list-item")
       .should("have.length", 1)
@@ -94,23 +72,23 @@ describe("scenarios > question > custom column", () => {
   });
 
   it("should not show binning for a numeric custom column", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
     cy.findByLabelText("Custom column").click();
 
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: "[Product.Price] / 2",
       name: "Half Price",
     });
     cy.button("Done").click();
 
     cy.button("Summarize").click();
-    popover().findByText("Count of rows").click();
+    H.popover().findByText("Count of rows").click();
 
-    getNotebookStep("summarize")
+    H.getNotebookStep("summarize")
       .findByText("Pick a column to group by")
       .click();
 
-    popover()
+    H.popover()
       .findByRole("option", { name: "Half Price" })
       .within(() => {
         cy.findByLabelText("Binning strategy").should("not.exist");
@@ -118,26 +96,28 @@ describe("scenarios > question > custom column", () => {
       })
       .click();
 
-    getNotebookStep("summarize").findByText("Half Price").should("be.visible");
+    H.getNotebookStep("summarize")
+      .findByText("Half Price")
+      .should("be.visible");
   });
 
   it("should show temporal units for a date/time custom column", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
     cy.findByLabelText("Custom column").click();
 
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: "[Product.Created At]",
       name: "Product Date",
     });
     cy.button("Done").click();
 
     cy.button("Summarize").click();
-    popover().findByText("Count of rows").click();
+    H.popover().findByText("Count of rows").click();
 
-    getNotebookStep("summarize")
+    H.getNotebookStep("summarize")
       .findByText("Pick a column to group by")
       .click();
-    popover()
+    H.popover()
       .findByRole("option", { name: "Product Date" })
       .within(() => {
         cy.findByLabelText("Binning strategy").should("not.exist");
@@ -145,28 +125,28 @@ describe("scenarios > question > custom column", () => {
       })
       .click();
 
-    getNotebookStep("summarize")
+    H.getNotebookStep("summarize")
       .findByText("Product Date: Month")
       .should("be.visible");
   });
 
   it("should not show binning options for a coordinate custom column", () => {
-    openPeopleTable({ mode: "notebook" });
+    H.openPeopleTable({ mode: "notebook" });
     cy.findByLabelText("Custom column").click();
 
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: "[Latitude]",
       name: "UserLAT",
     });
     cy.button("Done").click();
 
     cy.button("Summarize").click();
-    popover().findByText("Count of rows").click();
+    H.popover().findByText("Count of rows").click();
 
-    getNotebookStep("summarize")
+    H.getNotebookStep("summarize")
       .findByText("Pick a column to group by")
       .click();
-    popover()
+    H.popover()
       .findByRole("option", { name: "UserLAT" })
       .within(() => {
         cy.findByLabelText("Binning strategy").should("not.exist");
@@ -174,26 +154,26 @@ describe("scenarios > question > custom column", () => {
       })
       .click();
 
-    getNotebookStep("summarize").findByText("UserLAT").should("be.visible");
+    H.getNotebookStep("summarize").findByText("UserLAT").should("be.visible");
   });
 
   // flaky test (#19454)
   it.skip("should show info popovers when hovering over custom column dimensions in the summarize sidebar", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
     cy.findByLabelText("Custom column").click();
 
-    enterCustomColumnDetails({ formula: "1 + 1", name: "Math" });
+    H.enterCustomColumnDetails({ formula: "1 + 1", name: "Math" });
     cy.button("Done").click();
 
-    visualize();
+    H.visualize();
 
-    summarize();
+    H.summarize();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Group by").parent().findByText("Math").trigger("mouseenter");
 
-    popover().contains("Math");
-    popover().contains("No description");
+    H.popover().contains("Math");
+    H.popover().contains("No description");
   });
 
   it("can create a custom column with an existing column name", () => {
@@ -209,24 +189,24 @@ describe("scenarios > question > custom column", () => {
     ];
 
     customFormulas.forEach(({ formula, name }) => {
-      openOrdersTable({ mode: "notebook" });
+      H.openOrdersTable({ mode: "notebook" });
       cy.findByLabelText("Custom column").click();
 
-      enterCustomColumnDetails({ formula, name });
+      H.enterCustomColumnDetails({ formula, name });
       cy.button("Done").click();
 
-      visualize();
+      H.visualize();
 
       cy.findByTestId("query-visualization-root").contains(name);
     });
   });
 
   it("should create custom column with fields from aggregated data (metabase#12762)", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
 
-    summarize({ mode: "notebook" });
+    H.summarize({ mode: "notebook" });
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Sum of ...").click();
       cy.findByText("Subtotal").click();
     });
@@ -237,7 +217,7 @@ describe("scenarios > question > custom column", () => {
       .last() // This is brittle.
       .click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Sum of ...").click();
       cy.findByText("Total").click();
     });
@@ -252,13 +232,13 @@ describe("scenarios > question > custom column", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom column").click();
 
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: "[Sum of Subtotal] + [Sum of Total]",
       name: columnName,
     });
     cy.button("Done").click();
 
-    visualize();
+    H.visualize();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("There was a problem with your question").should("not.exist");
@@ -268,23 +248,23 @@ describe("scenarios > question > custom column", () => {
   });
 
   it("should not return same results for columns with the same name (metabase#12649)", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
     // join with Products
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Join data").click();
 
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Products").click();
     });
 
     // add custom column
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom column").click();
-    enterCustomColumnDetails({ formula: "1 + 1", name: "x" });
+    H.enterCustomColumnDetails({ formula: "1 + 1", name: "x" });
     cy.button("Done").click();
 
-    visualize();
+    H.visualize();
 
     cy.log(
       "**Fails in 0.35.0, 0.35.1, 0.35.2, 0.35.4 and the latest master (2026-10-21)**",
@@ -365,7 +345,7 @@ describe("scenarios > question > custom column", () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains(`Sum of ${CC_NAME}`);
-    cartesianChartCircle().should("have.length.of.at.least", 8);
+    H.cartesianChartCircle().should("have.length.of.at.least", 8);
   });
 
   it("should create custom column after aggregation with 'cum-sum/count' (metabase#13634)", () => {
@@ -496,7 +476,7 @@ describe("scenarios > question > custom column", () => {
     cy.log("Reported failing on 0.38.1-SNAPSHOT (6d77f099)");
     cy.findByTestId("step-expression-0-0").should("not.exist");
 
-    visualize(response => {
+    H.visualize(response => {
       expect(response.body.error).to.not.exist;
     });
 
@@ -507,7 +487,7 @@ describe("scenarios > question > custom column", () => {
   it("should handle using `case()` when referencing the same column names (metabase#14854)", () => {
     const CC_NAME = "CE with case";
 
-    visitQuestionAdhoc(
+    H.visitQuestionAdhoc(
       {
         dataset_query: {
           type: "query",
@@ -555,15 +535,15 @@ describe("scenarios > question > custom column", () => {
     }).then(({ body: { id: QUESTION_ID } }) => {
       cy.visit(`/question/${QUESTION_ID}/notebook`);
     });
-    summarize({ mode: "notebook" });
-    popover().within(() => {
+    H.summarize({ mode: "notebook" });
+    H.popover().within(() => {
       cy.findByText("Sum of ...").click();
       cy.findByText("MyCC [2027]").click();
     });
     cy.findAllByTestId("notebook-cell-item")
       .contains("Sum of MyCC [2027]")
       .click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.icon("chevronleft").click();
       cy.findByText("Custom Expression").click();
     });
@@ -571,16 +551,16 @@ describe("scenarios > question > custom column", () => {
   });
 
   it.skip("should work with `isNull` function (metabase#15922)", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom column").click();
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: "isnull([Discount])",
       name: "No discount",
     });
     cy.button("Done").click();
 
-    visualize(response => {
+    H.visualize(response => {
       expect(response.body.error).to.not.exist;
     });
 
@@ -591,7 +571,7 @@ describe("scenarios > question > custom column", () => {
   });
 
   it("should be able to add a date range filter to a custom column", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       display: "table",
       dataset_query: {
         database: SAMPLE_DB_ID,
@@ -603,9 +583,9 @@ describe("scenarios > question > custom column", () => {
       },
     });
 
-    tableHeaderClick("CustomDate");
+    H.tableHeaderClick("CustomDate");
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Filter by this column").click();
       cy.findByText("Specific dates…").click();
       cy.findByLabelText("Start date").clear().type("12/10/2024");
@@ -619,17 +599,17 @@ describe("scenarios > question > custom column", () => {
   });
 
   it("should work with relative date filter applied to a custom column (metabase#16273)", () => {
-    openOrdersTable({ mode: "notebook" });
-    addCustomColumn();
+    H.openOrdersTable({ mode: "notebook" });
+    H.addCustomColumn();
 
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: "case([Discount] > 0, [Created At], [Product → Created At])",
       name: "MiscDate",
     });
-    popover().button("Done").click();
+    H.popover().button("Done").click();
 
-    filter({ mode: "notebook" });
-    popover().within(() => {
+    H.filter({ mode: "notebook" });
+    H.popover().within(() => {
       cy.findByText("MiscDate").click();
       cy.findByText("Relative dates…").click();
       cy.findByText("Previous").click();
@@ -637,26 +617,26 @@ describe("scenarios > question > custom column", () => {
     });
     cy.findByRole("listbox").findByText("years").click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Include this year").click();
       cy.button("Add filter").click();
     });
 
-    visualize(({ body }) => {
+    H.visualize(({ body }) => {
       expect(body.error).to.not.exist;
     });
 
-    queryBuilderMain().findByText("MiscDate").should("be.visible");
+    H.queryBuilderMain().findByText("MiscDate").should("be.visible");
     cy.findByTestId("qb-filters-panel")
       .findByText("MiscDate is in the previous 30 years")
       .should("be.visible");
   });
 
   it("should allow switching focus with Tab", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
     cy.findByLabelText("Custom column").click();
 
-    enterCustomColumnDetails({ formula: "1 + 2" });
+    H.enterCustomColumnDetails({ formula: "1 + 2" });
 
     // next focus: the textbox for the name
     cy.realPress("Tab");
@@ -671,10 +651,10 @@ describe("scenarios > question > custom column", () => {
   });
 
   it("should allow tabbing away from, then back to editor, while formatting expression and placing caret after reformatted expression", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
     cy.findByLabelText("Custom column").click();
 
-    enterCustomColumnDetails({ formula: "1+1" });
+    H.enterCustomColumnDetails({ formula: "1+1" });
 
     cy.realPress("Tab");
     cy.realPress(["Shift", "Tab"]);
@@ -689,10 +669,10 @@ describe("scenarios > question > custom column", () => {
   });
 
   it("should allow choosing a suggestion with Tab", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
     cy.findByLabelText("Custom column").click();
 
-    enterCustomColumnDetails({ formula: "[C", blur: false });
+    H.enterCustomColumnDetails({ formula: "[C", blur: false });
 
     // Suggestion popover shows up and this select the first one ([Created At])
     cy.realPress("Tab");
@@ -718,13 +698,13 @@ describe("scenarios > question > custom column", () => {
 
   // TODO: fixme!
   it.skip("should render custom expression helper near the custom expression field", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
     cy.findByLabelText("Custom column").click();
 
-    popover().within(() => {
-      enterCustomColumnDetails({ formula: "floor" });
+    H.popover().within(() => {
+      H.enterCustomColumnDetails({ formula: "floor" });
 
-      checkExpressionEditorHelperPopoverPosition();
+      H.checkExpressionEditorHelperPopoverPosition();
     });
   });
 });
@@ -733,24 +713,24 @@ describe("scenarios > question > custom column > data type", () => {
   function addCustomColumns(columns) {
     cy.wrap(columns).each((column, index) => {
       if (index) {
-        getNotebookStep("expression").icon("add").click();
+        H.getNotebookStep("expression").icon("add").click();
       } else {
         cy.findByLabelText("Custom column").click();
       }
 
-      enterCustomColumnDetails(column);
+      H.enterCustomColumnDetails(column);
       cy.button("Done").click({ force: true });
     });
   }
 
   function openCustomColumnInTable(table) {
-    openTable({ table, mode: "notebook" });
+    H.openTable({ table, mode: "notebook" });
     cy.findByText("Custom column").click();
   }
 
   beforeEach(() => {
-    restore();
-    restore("postgres-12");
+    H.restore();
+    H.restore("postgres-12");
 
     cy.signInAsAdmin();
   });
@@ -758,16 +738,16 @@ describe("scenarios > question > custom column > data type", () => {
   it("should understand string functions (metabase#13217)", () => {
     openCustomColumnInTable(PRODUCTS_ID);
 
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: "concat([Category], [Title])",
       name: "CategoryTitle",
     });
 
     cy.button("Done").click();
 
-    filter({ mode: "notebook" });
+    H.filter({ mode: "notebook" });
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("CategoryTitle").click();
       cy.findByPlaceholderText("Enter a number").should("not.exist");
       cy.findByPlaceholderText("Enter some text").should("be.visible");
@@ -775,9 +755,9 @@ describe("scenarios > question > custom column > data type", () => {
   });
 
   it("should understand date functions", () => {
-    startNewQuestion();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.startNewQuestion();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("QA Postgres12").click();
       cy.findByText("Orders").click();
     });
@@ -810,17 +790,17 @@ describe("scenarios > question > custom column > data type", () => {
       },
     ]);
 
-    visualize();
+    H.visualize();
   });
 
   it("should relay the type of a date field", () => {
     openCustomColumnInTable(PEOPLE_ID);
 
-    enterCustomColumnDetails({ formula: "[Birth Date]", name: "DoB" });
+    H.enterCustomColumnDetails({ formula: "[Birth Date]", name: "DoB" });
     cy.button("Done").click();
 
-    filter({ mode: "notebook" });
-    popover().within(() => {
+    H.filter({ mode: "notebook" });
+    H.popover().within(() => {
       cy.findByText("DoB").click();
       cy.findByPlaceholderText("Enter a number").should("not.exist");
       cy.findByText("Relative dates…").click();
@@ -832,14 +812,14 @@ describe("scenarios > question > custom column > data type", () => {
   it("should handle CASE (metabase#13122)", () => {
     openCustomColumnInTable(ORDERS_ID);
 
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: "case([Discount] > 0, [Created At], [Product → Created At])",
       name: "MiscDate",
     });
     cy.button("Done").click();
 
-    filter({ mode: "notebook" });
-    popover().within(() => {
+    H.filter({ mode: "notebook" });
+    H.popover().within(() => {
       cy.findByText("MiscDate").click();
       cy.findByPlaceholderText("Enter a number").should("not.exist");
 
@@ -852,14 +832,14 @@ describe("scenarios > question > custom column > data type", () => {
   it("should handle COALESCE", () => {
     openCustomColumnInTable(ORDERS_ID);
 
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: "COALESCE([Product → Created At], [Created At])",
       name: "MiscDate",
     });
     cy.button("Done").click();
 
-    filter({ mode: "notebook" });
-    popover().within(() => {
+    H.filter({ mode: "notebook" });
+    H.popover().within(() => {
       cy.findByText("MiscDate").click();
       cy.findByPlaceholderText("Enter a number").should("not.exist");
       cy.findByText("Relative dates…").click();
@@ -871,16 +851,16 @@ describe("scenarios > question > custom column > data type", () => {
 
 describe("scenarios > question > custom column > error feedback", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    openProductsTable({ mode: "notebook" });
+    H.openProductsTable({ mode: "notebook" });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom column").click();
   });
 
   it("should catch non-existent field reference", () => {
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: "abcdef",
       name: "Non-existent",
     });
@@ -890,7 +870,7 @@ describe("scenarios > question > custom column > error feedback", () => {
   });
 
   it("should fail on expression validation errors", () => {
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: "SUBSTRING('foo', 0, 1)",
       name: "BadSubstring",
     });
@@ -903,17 +883,17 @@ describe("scenarios > question > custom column > error feedback", () => {
 // ExpressionEditorTextfield jsx component
 describe("scenarios > question > custom column > expression editor", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     // This is the default screen size but we need it explicitly set for this test because of the resize later on
     cy.viewport(1280, 800);
 
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom column").click();
 
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: "1+1", // Formula was intentionally written without spaces (important for this repro)!
       name: "Math",
     });
@@ -960,34 +940,34 @@ describe("scenarios > question > custom column > expression editor", () => {
 
 describe("scenarios > question > custom column > help text", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    openProductsTable({ mode: "notebook" });
+    H.openProductsTable({ mode: "notebook" });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom column").click();
   });
 
   it("should appear while inside a function", () => {
-    enterCustomColumnDetails({ formula: "Lower(", blur: false });
+    H.enterCustomColumnDetails({ formula: "Lower(", blur: false });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("lower(text)");
   });
 
   it("should appear after a field reference", () => {
-    enterCustomColumnDetails({ formula: "Lower([Category]", blur: false });
+    H.enterCustomColumnDetails({ formula: "Lower([Category]", blur: false });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("lower(text)");
   });
 
   it("should not appear while outside a function", () => {
-    enterCustomColumnDetails({ formula: "Lower([Category])", blur: false });
+    H.enterCustomColumnDetails({ formula: "Lower([Category])", blur: false });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("lower(text)").should("not.exist");
   });
 
   it("should not appear when formula field is not in focus (metabase#15891)", () => {
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: "rou{enter}1.5){leftArrow}",
       blur: false,
     });
@@ -1013,7 +993,7 @@ describe("scenarios > question > custom column > help text", () => {
   });
 
   it("should not disappear when clicked on (metabase#17548)", () => {
-    enterCustomColumnDetails({ formula: "rou{enter}", blur: false });
+    H.enterCustomColumnDetails({ formula: "rou{enter}", blur: false });
 
     // Shouldn't hide on click
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -1,43 +1,10 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_BY_YEAR_QUESTION_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  addOrUpdateDashboardCard,
-  cartesianChartCircle,
-  chartPathWithFillColor,
-  createDashboardWithTabs,
-  createQuestion,
-  createQuestionAndDashboard,
-  dashboardHeader,
-  describeEE,
-  editDashboard,
-  entityPickerModal,
-  filterWidget,
-  getActionCardDetails,
-  getDashboardCard,
-  getHeadingCardDetails,
-  getLinkCardDetails,
-  getTextCardDetails,
-  modal,
-  multiAutocompleteInput,
-  openNotebook,
-  openStaticEmbeddingModal,
-  popover,
-  queryBuilderHeader,
-  removeMultiAutocompleteValue,
-  restore,
-  saveDashboard,
-  setTokenFeatures,
-  updateDashboardCards,
-  updateSetting,
-  verifyNotebookQuery,
-  visitDashboard,
-  visitEmbeddedPage,
-  visitIframe,
-} from "e2e/support/helpers";
 import {
   createMockActionParameter,
   createMockDashboardCard,
@@ -157,34 +124,34 @@ const URL_WITH_FILLED_PARAMS = URL_WITH_PARAMS.replace(
   .replace(`{{${CREATED_AT_COLUMN_ID}}}`, POINT_CREATED_AT)
   .replace(`{{${DASHBOARD_FILTER_TEXT.slug}}}`, FILTER_VALUE);
 
-describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
+H.describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("/api/dataset").as("dataset");
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
   });
 
   describe("dashcards without click behavior", () => {
     it("does not allow to set click behavior for virtual dashcards", () => {
-      const textCard = getTextCardDetails({ size_y: 1 });
-      const headingCard = getHeadingCardDetails({ text: "Heading card" });
-      const actionCard = getActionCardDetails();
-      const linkCard = getLinkCardDetails();
+      const textCard = H.getTextCardDetails({ size_y: 1 });
+      const headingCard = H.getHeadingCardDetails({ text: "Heading card" });
+      const actionCard = H.getActionCardDetails();
+      const linkCard = H.getLinkCardDetails();
       const cards = [textCard, headingCard, actionCard, linkCard];
 
       cy.createDashboard().then(({ body: dashboard }) => {
-        updateDashboardCards({ dashboard_id: dashboard.id, cards });
-        visitDashboard(dashboard.id);
+        H.updateDashboardCards({ dashboard_id: dashboard.id, cards });
+        H.visitDashboard(dashboard.id);
       });
 
-      editDashboard();
+      H.editDashboard();
 
       cards.forEach((card, index) => {
         const display = card.visualization_settings.virtual_card.display;
         cy.log(`does not allow to set click behavior for "${display}" card`);
 
-        getDashboardCard(index).realHover().icon("click").should("not.exist");
+        H.getDashboardCard(index).realHover().icon("click").should("not.exist");
       });
     });
 
@@ -192,12 +159,12 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
       cy.createQuestionAndDashboard({
         questionDetails: OBJECT_DETAIL_CHART,
       }).then(({ body: card }) => {
-        visitDashboard(card.dashboard_id);
+        H.visitDashboard(card.dashboard_id);
       });
 
-      editDashboard();
+      H.editDashboard();
 
-      getDashboardCard().realHover().icon("click").should("not.exist");
+      H.getDashboardCard().realHover().icon("click").should("not.exist");
     });
   });
 
@@ -207,7 +174,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
     it("should open drill-through menu as a default click-behavior", () => {
       cy.createQuestionAndDashboard({ questionDetails }).then(
         ({ body: card }) => {
-          visitDashboard(card.dashboard_id);
+          H.visitDashboard(card.dashboard_id);
         },
       );
 
@@ -238,7 +205,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
           name: "Dashboard",
         },
       }).then(({ body: card }) => {
-        visitDashboard(card.dashboard_id);
+        H.visitDashboard(card.dashboard_id);
       });
 
       clickLineChartPoint();
@@ -253,18 +220,18 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
       });
       cy.createQuestionAndDashboard({ questionDetails }).then(
         ({ body: card }) => {
-          visitDashboard(card.dashboard_id);
+          H.visitDashboard(card.dashboard_id);
         },
       );
 
-      editDashboard();
+      H.editDashboard();
 
       cy.log("doesn't throw when setting default behavior (metabase#35354)");
       cy.on("uncaught:exception", err => {
         expect(err.name.includes("TypeError")).to.be.false;
       });
 
-      getDashboardCard().realHover().icon("click").click();
+      H.getDashboardCard().realHover().icon("click").click();
 
       // When the default menu is selected, it should've visual cue (metabase#34848)
       cy.get("aside")
@@ -279,7 +246,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
       cy.get("aside").findByText("No available targets").should("exist");
       cy.get("aside").button("Done").click();
 
-      saveDashboard({ waitMs: 250 });
+      H.saveDashboard({ waitMs: 250 });
 
       cy.intercept(
         "GET",
@@ -297,7 +264,9 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
       });
 
       cy.log("Should navigate to question using router (metabase#33379)");
-      dashboardHeader().findByText(TARGET_DASHBOARD.name).should("be.visible");
+      H.dashboardHeader()
+        .findByText(TARGET_DASHBOARD.name)
+        .should("be.visible");
       // If the page was reloaded, many API request would have been made and theses
       // calls are 2 of those.
       cy.get("@rootCollection").should("not.have.been.called");
@@ -329,20 +298,20 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
 
       cy.createQuestionAndDashboard({ questionDetails }).then(
         ({ body: card }) => {
-          visitDashboard(card.dashboard_id);
+          H.visitDashboard(card.dashboard_id);
         },
       );
 
-      editDashboard();
+      H.editDashboard();
 
-      getDashboardCard().realHover().icon("click").click();
+      H.getDashboardCard().realHover().icon("click").click();
       addDashboardDestination();
       cy.get("aside").findByText("Select a dashboard tab").should("not.exist");
       cy.get("aside").findByText("No available targets").should("not.exist");
       addTextParameter();
       cy.get("aside").button("Done").click();
 
-      saveDashboard({ waitMs: 250 });
+      H.saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.findAllByTestId("field-set")
@@ -384,13 +353,13 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
 
       cy.createQuestionAndDashboard({ questionDetails }).then(
         ({ body: card }) => {
-          visitDashboard(card.dashboard_id);
+          H.visitDashboard(card.dashboard_id);
         },
       );
 
-      editDashboard();
+      H.editDashboard();
 
-      getDashboardCard().realHover().icon("click").click();
+      H.getDashboardCard().realHover().icon("click").click();
       addDashboardDestination();
       cy.get("aside").findByText("Select a dashboard tab").should("not.exist");
       cy.get("aside").findByText("No available targets").should("not.exist");
@@ -398,7 +367,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
       addTimeParameter();
       cy.get("aside").button("Done").click();
 
-      saveDashboard({ waitMs: 250 });
+      H.saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.findAllByTestId("field-set")
@@ -453,14 +422,14 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
 
       cy.createQuestionAndDashboard({ questionDetails }).then(
         ({ body: card }) => {
-          visitDashboard(card.dashboard_id);
+          H.visitDashboard(card.dashboard_id);
           cy.wrap(card.dashboard_id).as("dashboardId");
         },
       );
 
-      editDashboard();
+      H.editDashboard();
 
-      getDashboardCard().realHover().icon("click").click();
+      H.getDashboardCard().realHover().icon("click").click();
       addDashboardDestination();
       cy.get("aside")
         .findByLabelText("Select a dashboard tab")
@@ -471,7 +440,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
       addTextParameter();
       cy.get("aside").button("Done").click();
 
-      saveDashboard({ waitMs: 250 });
+      H.saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.findAllByTestId("field-set")
@@ -524,12 +493,12 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
           questionDetails,
           cardDetails,
         }).then(({ body: card }) => {
-          visitDashboard(card.dashboard_id);
+          H.visitDashboard(card.dashboard_id);
         });
       });
 
-      editDashboard();
-      getDashboardCard().realHover().icon("click").click();
+      H.editDashboard();
+      H.getDashboardCard().realHover().icon("click").click();
 
       cy.get("aside")
         .findByText("The selected tab is no longer available")
@@ -547,7 +516,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
         .should("not.exist");
       cy.button("Done").should("be.enabled").click();
 
-      saveDashboard({ waitMs: 250 });
+      H.saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.get("@targetDashboardId").then(targetDashboardId => {
@@ -580,17 +549,17 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
           questionDetails,
           cardDetails,
         }).then(({ body: card }) => {
-          visitDashboard(card.dashboard_id);
+          H.visitDashboard(card.dashboard_id);
         });
       });
 
-      editDashboard();
-      getDashboardCard().realHover().icon("click").click();
+      H.editDashboard();
+      H.getDashboardCard().realHover().icon("click").click();
       cy.get("aside")
         .findByLabelText("Select a dashboard tab")
         .should("not.exist");
       cy.button("Done").should("be.enabled").click();
-      saveDashboard({ waitMs: 250 });
+      H.saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.get("@targetDashboardId").then(targetDashboardId => {
@@ -638,20 +607,20 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
           questionDetails,
           cardDetails,
         }).then(({ body: card }) => {
-          visitDashboard(card.dashboard_id);
+          H.visitDashboard(card.dashboard_id);
           cy.wrap(card.dashboard_id).as("dashboardId");
         });
       });
 
-      editDashboard();
+      H.editDashboard();
 
-      getDashboardCard().realHover().icon("click").click();
+      H.getDashboardCard().realHover().icon("click").click();
       cy.get("aside")
         .findByLabelText("Select a dashboard tab")
         .should("have.value", FIRST_TAB.name);
       cy.get("header").button("Cancel").click();
       // migrateUndefinedDashboardTabId causes detection of changes even though user did not change anything
-      modal().button("Discard changes").click();
+      H.modal().button("Discard changes").click();
       cy.button("Cancel").should("not.exist");
 
       clickLineChartPoint();
@@ -695,31 +664,31 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
             .then(() => dashboardId);
         })
         .then(dashboardId => {
-          visitDashboard(dashboardId);
+          H.visitDashboard(dashboardId);
         });
 
-      filterWidget().contains("Hello").click();
-      popover().within(() => {
-        multiAutocompleteInput().type("{backspace}World{enter}");
+      H.filterWidget().contains("Hello").click();
+      H.popover().within(() => {
+        H.multiAutocompleteInput().type("{backspace}World{enter}");
         cy.button("Update filter").click();
       });
 
       cy.createQuestionAndDashboard({ questionDetails }).then(
         ({ body: card }) => {
-          visitDashboard(card.dashboard_id);
+          H.visitDashboard(card.dashboard_id);
         },
       );
 
-      editDashboard();
+      H.editDashboard();
 
-      getDashboardCard().realHover().icon("click").click();
+      H.getDashboardCard().realHover().icon("click").click();
       addDashboardDestination();
       cy.get("aside").findByText("Select a dashboard tab").should("not.exist");
       cy.get("aside").findByText("No available targets").should("not.exist");
       addTextParameter();
       cy.get("aside").button("Done").click();
 
-      saveDashboard({ waitMs: 250 });
+      H.saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
 
@@ -774,15 +743,15 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
             .then(() => dashboardId);
         })
         .then(dashboardId => {
-          visitDashboard(dashboardId);
+          H.visitDashboard(dashboardId);
         });
 
       cy.findAllByTestId("field-set")
         .contains(DASHBOARD_FILTER_TEXT.name)
         .parent()
         .click();
-      popover().within(() => {
-        multiAutocompleteInput().type("John Doe{enter}");
+      H.popover().within(() => {
+        H.multiAutocompleteInput().type("John Doe{enter}");
         cy.button("Add filter").click();
       });
 
@@ -790,27 +759,27 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
         .contains(DASHBOARD_FILTER_TEXT_WITH_DEFAULT.name)
         .parent()
         .click();
-      popover().within(() => {
-        multiAutocompleteInput().type("{backspace}World{enter}");
+      H.popover().within(() => {
+        H.multiAutocompleteInput().type("{backspace}World{enter}");
         cy.button("Update filter").click();
       });
 
       cy.createQuestionAndDashboard({ questionDetails }).then(
         ({ body: card }) => {
-          visitDashboard(card.dashboard_id);
+          H.visitDashboard(card.dashboard_id);
         },
       );
 
-      editDashboard();
+      H.editDashboard();
 
-      getDashboardCard().realHover().icon("click").click();
+      H.getDashboardCard().realHover().icon("click").click();
       addDashboardDestination();
       cy.get("aside").findByText("Select a dashboard tab").should("not.exist");
       cy.get("aside").findByText("No available targets").should("not.exist");
       addTextWithDefaultParameter();
       cy.get("aside").button("Done").click();
 
-      saveDashboard({ waitMs: 250 });
+      H.saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.findAllByTestId("field-set")
@@ -849,34 +818,34 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
 
       cy.createQuestionAndDashboard({ questionDetails }).then(
         ({ body: card }) => {
-          visitDashboard(card.dashboard_id);
+          H.visitDashboard(card.dashboard_id);
         },
       );
 
-      editDashboard();
+      H.editDashboard();
 
-      getDashboardCard().realHover().icon("click").click();
+      H.getDashboardCard().realHover().icon("click").click();
       cy.get("aside").findByText("Go to a custom destination").click();
       cy.get("aside").findByText("Dashboard").click();
 
-      modal().findByText(RESTRICTED_COLLECTION_NAME).should("not.exist");
+      H.modal().findByText(RESTRICTED_COLLECTION_NAME).should("not.exist");
     });
 
     it("allows setting saved question as custom destination and changing it back to default click behavior", () => {
       cy.createQuestion(TARGET_QUESTION, { wrapId: true });
       cy.createQuestionAndDashboard({ questionDetails }).then(
         ({ body: card }) => {
-          visitDashboard(card.dashboard_id);
+          H.visitDashboard(card.dashboard_id);
         },
       );
 
-      editDashboard();
+      H.editDashboard();
 
-      getDashboardCard().realHover().icon("click").click();
+      H.getDashboardCard().realHover().icon("click").click();
       addSavedQuestionDestination();
       cy.get("aside").button("Done").click();
 
-      saveDashboard({ waitMs: 250 });
+      H.saveDashboard({ waitMs: 250 });
 
       cy.intercept(
         "GET",
@@ -891,7 +860,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
           .its("pathname")
           .should("contain", `/question/${questionId}`);
       });
-      queryBuilderHeader()
+      H.queryBuilderHeader()
         .findByDisplayValue(TARGET_QUESTION.name)
         .should("be.visible");
 
@@ -910,18 +879,18 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
       cy.createQuestion(TARGET_QUESTION);
       cy.createQuestionAndDashboard({ questionDetails }).then(
         ({ body: card }) => {
-          visitDashboard(card.dashboard_id);
+          H.visitDashboard(card.dashboard_id);
         },
       );
 
-      editDashboard();
+      H.editDashboard();
 
-      getDashboardCard().realHover().icon("click").click();
+      H.getDashboardCard().realHover().icon("click").click();
       addSavedQuestionDestination();
       addSavedQuestionCreatedAtParameter();
       cy.get("aside").button("Done").click();
 
-      saveDashboard({ waitMs: 250 });
+      H.saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.findByTestId("qb-filters-panel").should(
@@ -936,8 +905,8 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
       );
       verifyVizTypeIsLine();
 
-      openNotebook();
-      verifyNotebookQuery("Orders", [
+      H.openNotebook();
+      H.verifyNotebookQuery("Orders", [
         {
           filters: ["Created At is Jul 1–31, 2022"],
           aggregations: ["Count"],
@@ -956,19 +925,19 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
       cy.createQuestion(TARGET_QUESTION);
       cy.createQuestionAndDashboard({ questionDetails }).then(
         ({ body: card }) => {
-          visitDashboard(card.dashboard_id);
+          H.visitDashboard(card.dashboard_id);
         },
       );
 
-      editDashboard();
+      H.editDashboard();
 
-      getDashboardCard().realHover().icon("click").click();
+      H.getDashboardCard().realHover().icon("click").click();
       addSavedQuestionDestination();
       addSavedQuestionCreatedAtParameter();
       addSavedQuestionQuantityParameter();
       cy.get("aside").button("Done").click();
 
-      saveDashboard({ waitMs: 250 });
+      H.saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.wait("@dataset");
@@ -983,8 +952,8 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
       );
       verifyVizTypeIsLine();
 
-      openNotebook();
-      verifyNotebookQuery("Orders", [
+      H.openNotebook();
+      H.verifyNotebookQuery("Orders", [
         {
           filters: ["Created At is Jul 1–31, 2022", "Quantity is equal to 64"],
           aggregations: ["Count"],
@@ -1015,37 +984,37 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
 
       cy.createQuestionAndDashboard({ questionDetails }).then(
         ({ body: card }) => {
-          visitDashboard(card.dashboard_id);
+          H.visitDashboard(card.dashboard_id);
         },
       );
 
-      editDashboard();
+      H.editDashboard();
 
-      getDashboardCard().realHover().icon("click").click();
+      H.getDashboardCard().realHover().icon("click").click();
       cy.get("aside").findByText("Go to a custom destination").click();
       cy.get("aside").findByText("Saved question").click();
 
-      modal().findByText(RESTRICTED_COLLECTION_NAME).should("not.exist");
+      H.modal().findByText(RESTRICTED_COLLECTION_NAME).should("not.exist");
     });
 
     it("allows setting URL as custom destination and changing it back to default click behavior", () => {
       cy.createQuestionAndDashboard({ questionDetails }).then(
         ({ body: card }) => {
-          visitDashboard(card.dashboard_id);
+          H.visitDashboard(card.dashboard_id);
         },
       );
 
-      editDashboard();
+      H.editDashboard();
 
-      getDashboardCard().realHover().icon("click").click();
+      H.getDashboardCard().realHover().icon("click").click();
       addUrlDestination();
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByRole("textbox").type(URL);
         cy.button("Done").click();
       });
       cy.get("aside").button("Done").click();
 
-      saveDashboard({ waitMs: 250 });
+      H.saveDashboard({ waitMs: 250 });
 
       onNextAnchorClick(anchor => {
         expect(anchor).to.have.attr("href", URL);
@@ -1064,7 +1033,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
 
       cy.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
         ({ body: dashcard }) => {
-          addOrUpdateDashboardCard({
+          H.addOrUpdateDashboardCard({
             dashboard_id: dashcard.dashboard_id,
             card_id: dashcard.card_id,
             card: {
@@ -1073,22 +1042,22 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
               ],
             },
           });
-          visitDashboard(dashcard.dashboard_id);
+          H.visitDashboard(dashcard.dashboard_id);
         },
       );
 
-      editDashboard();
+      H.editDashboard();
 
-      getDashboardCard().realHover().icon("click").click();
+      H.getDashboardCard().realHover().icon("click").click();
       addUrlDestination();
-      modal().findByText("Values you can reference").click();
-      popover().within(() => {
+      H.modal().findByText("Values you can reference").click();
+      H.popover().within(() => {
         cy.findByText(COUNT_COLUMN_ID).should("exist");
         cy.findByText(CREATED_AT_COLUMN_ID).should("exist");
         cy.findByText(DASHBOARD_FILTER_TEXT.name).should("exist");
         cy.realPress("Escape");
       });
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByRole("textbox").type(URL_WITH_PARAMS, {
           parseSpecialCharSequences: false,
         });
@@ -1096,10 +1065,10 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
       });
       cy.get("aside").button("Done").click();
 
-      saveDashboard({ waitMs: 250 });
+      H.saveDashboard({ waitMs: 250 });
 
       cy.button(DASHBOARD_FILTER_TEXT.name).click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByPlaceholderText("Search by Name").type("Dell Adams");
         cy.button("Add filter").click();
       });
@@ -1115,13 +1084,13 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
     it("does not allow updating dashboard filters if there are none", () => {
       cy.createQuestionAndDashboard({ questionDetails }).then(
         ({ body: card }) => {
-          visitDashboard(card.dashboard_id);
+          H.visitDashboard(card.dashboard_id);
         },
       );
 
-      editDashboard();
+      H.editDashboard();
 
-      getDashboardCard().realHover().icon("click").click();
+      H.getDashboardCard().realHover().icon("click").click();
       cy.get("aside")
         .findByText("Update a dashboard filter")
         .invoke("css", "pointer-events")
@@ -1135,7 +1104,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
 
       cy.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
         ({ body: dashcard }) => {
-          addOrUpdateDashboardCard({
+          H.addOrUpdateDashboardCard({
             dashboard_id: dashcard.dashboard_id,
             card_id: dashcard.card_id,
             card: {
@@ -1144,21 +1113,21 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
               ],
             },
           });
-          visitDashboard(dashcard.dashboard_id);
+          H.visitDashboard(dashcard.dashboard_id);
           cy.location().then(({ pathname }) => {
             cy.wrap(pathname).as("originalPathname");
           });
         },
       );
 
-      editDashboard();
+      H.editDashboard();
 
-      getDashboardCard().realHover().icon("click").click();
+      H.getDashboardCard().realHover().icon("click").click();
       cy.get("aside").findByText("Update a dashboard filter").click();
       addNumericParameter();
       cy.get("aside").button("Done").click();
 
-      saveDashboard({ waitMs: 250 });
+      H.saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.findAllByTestId("field-set")
@@ -1175,7 +1144,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
 
       cy.log("reset filter state");
 
-      filterWidget().icon("close").click();
+      H.filterWidget().icon("close").click();
 
       testChangingBackToDefaultBehavior();
     });
@@ -1187,7 +1156,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
 
       cy.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
         ({ body: dashcard }) => {
-          addOrUpdateDashboardCard({
+          H.addOrUpdateDashboardCard({
             dashboard_id: dashcard.dashboard_id,
             card_id: dashcard.card_id,
             card: {
@@ -1197,16 +1166,16 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
               ],
             },
           });
-          visitDashboard(dashcard.dashboard_id);
+          H.visitDashboard(dashcard.dashboard_id);
           cy.location().then(({ pathname }) => {
             cy.wrap(pathname).as("originalPathname");
           });
         },
       );
 
-      editDashboard();
+      H.editDashboard();
 
-      getDashboardCard().realHover().icon("click").click();
+      H.getDashboardCard().realHover().icon("click").click();
       cy.get("aside").findByText("Update a dashboard filter").click();
       addTextParameter();
       addTimeParameter();
@@ -1215,15 +1184,15 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
         .should("contain.text", COUNT_COLUMN_NAME);
       cy.get("aside").button("Done").click();
 
-      saveDashboard({ waitMs: 250 });
+      H.saveDashboard({ waitMs: 250 });
 
-      editDashboard();
+      H.editDashboard();
       cy.findByTestId("edit-dashboard-parameters-widget-container")
         .findByText(DASHBOARD_FILTER_TEXT.name)
         .click();
       cy.get("aside").button("Remove").click();
 
-      saveDashboard({ waitMs: 250 });
+      H.saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.findAllByTestId("field-set")
@@ -1238,9 +1207,9 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
         });
       });
 
-      editDashboard();
+      H.editDashboard();
 
-      getDashboardCard().realHover().icon("click").click();
+      H.getDashboardCard().realHover().icon("click").click();
       cy.get("aside")
         .should("not.contain.text", DASHBOARD_FILTER_TEXT.name)
         .should("not.contain.text", COUNT_COLUMN_NAME);
@@ -1253,7 +1222,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
 
       cy.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
         ({ body: dashcard }) => {
-          addOrUpdateDashboardCard({
+          H.addOrUpdateDashboardCard({
             dashboard_id: dashcard.dashboard_id,
             card_id: dashcard.card_id,
             card: {
@@ -1263,22 +1232,22 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
               ],
             },
           });
-          visitDashboard(dashcard.dashboard_id);
+          H.visitDashboard(dashcard.dashboard_id);
           cy.location().then(({ pathname }) => {
             cy.wrap(pathname).as("originalPathname");
           });
         },
       );
 
-      editDashboard();
+      H.editDashboard();
 
-      getDashboardCard().realHover().icon("click").click();
+      H.getDashboardCard().realHover().icon("click").click();
       cy.get("aside").findByText("Update a dashboard filter").click();
       addTextParameter();
       addTimeParameter();
       cy.get("aside").button("Done").click();
 
-      saveDashboard({ waitMs: 250 });
+      H.saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.findAllByTestId("field-set")
@@ -1305,20 +1274,20 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
     it("should open drill-through menu as a default click-behavior", () => {
       cy.createQuestionAndDashboard({ questionDetails }).then(
         ({ body: card }) => {
-          visitDashboard(card.dashboard_id);
+          H.visitDashboard(card.dashboard_id);
         },
       );
 
       getTableCell(COLUMN_INDEX.COUNT).click();
-      popover().should("contain.text", "Filter by this value");
+      H.popover().should("contain.text", "Filter by this value");
 
       getTableCell(COLUMN_INDEX.CREATED_AT).click();
-      popover().should("contain.text", "Filter by this date");
+      H.popover().should("contain.text", "Filter by this date");
 
-      editDashboard();
+      H.editDashboard();
 
-      getDashboardCard().realHover().icon("click").click();
-      getDashboardCard()
+      H.getDashboardCard().realHover().icon("click").click();
+      H.getDashboardCard()
         .button()
         .should("have.text", "Open the drill-through menu");
     });
@@ -1346,13 +1315,13 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
       );
       cy.createQuestionAndDashboard({ questionDetails }).then(
         ({ body: card }) => {
-          visitDashboard(card.dashboard_id);
+          H.visitDashboard(card.dashboard_id);
         },
       );
 
-      editDashboard();
+      H.editDashboard();
 
-      getDashboardCard().realHover().icon("click").click();
+      H.getDashboardCard().realHover().icon("click").click();
 
       (function addCustomDashboardDestination() {
         cy.log("custom destination (dashboard) behavior for 'Count' column");
@@ -1371,7 +1340,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
         cy.icon("chevronleft").click();
 
         getCountToDashboardMapping().should("exist");
-        getDashboardCard()
+        H.getDashboardCard()
           .button()
           .should("have.text", "1 column has custom behavior");
       })();
@@ -1391,13 +1360,13 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
         cy.icon("chevronleft").click();
 
         getCreatedAtToQuestionMapping().should("exist");
-        getDashboardCard()
+        H.getDashboardCard()
           .button()
           .should("have.text", "2 columns have custom behavior");
       })();
 
       cy.get("aside").button("Done").click();
-      saveDashboard({ waitMs: 250 });
+      H.saveDashboard({ waitMs: 250 });
 
       (function testDashboardDestinationClick() {
         cy.log("it handles 'Count' column click");
@@ -1439,8 +1408,8 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
         );
         verifyVizTypeIsLine();
 
-        openNotebook();
-        verifyNotebookQuery("Orders", [
+        H.openNotebook();
+        H.verifyNotebookQuery("Orders", [
           {
             filters: [
               "Created At is Jul 1–31, 2022",
@@ -1494,13 +1463,13 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
 
       cy.createQuestionAndDashboard({ questionDetails }).then(
         ({ body: card }) => {
-          visitDashboard(card.dashboard_id);
+          H.visitDashboard(card.dashboard_id);
         },
       );
 
-      editDashboard();
+      H.editDashboard();
 
-      getDashboardCard().realHover().icon("click").click();
+      H.getDashboardCard().realHover().icon("click").click();
       cy.get("aside").findByText(COUNT_COLUMN_NAME).click();
       addDashboardDestination();
       cy.get("aside")
@@ -1514,12 +1483,12 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
       cy.icon("chevronleft").click();
 
       getCountToDashboardMapping().should("exist");
-      getDashboardCard()
+      H.getDashboardCard()
         .button()
         .should("have.text", "1 column has custom behavior");
 
       cy.get("aside").button("Done").click();
-      saveDashboard({ waitMs: 250 });
+      H.saveDashboard({ waitMs: 250 });
 
       getTableCell(COLUMN_INDEX.COUNT)
         .should("have.text", String(POINT_COUNT))
@@ -1564,7 +1533,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
       );
       cy.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
         ({ body: dashcard }) => {
-          addOrUpdateDashboardCard({
+          H.addOrUpdateDashboardCard({
             dashboard_id: dashcard.dashboard_id,
             card_id: dashcard.card_id,
             card: {
@@ -1573,16 +1542,16 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
               ],
             },
           });
-          visitDashboard(dashcard.dashboard_id);
+          H.visitDashboard(dashcard.dashboard_id);
           cy.location().then(({ pathname }) => {
             cy.wrap(pathname).as("originalPathname");
           });
         },
       );
 
-      editDashboard();
+      H.editDashboard();
 
-      getDashboardCard().realHover().icon("click").click();
+      H.getDashboardCard().realHover().icon("click").click();
 
       (function addUpdateDashboardFilters() {
         cy.log("update dashboard filters behavior for 'Count' column");
@@ -1598,7 +1567,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
         getCountToDashboardFilterMapping().should("exist");
       })();
 
-      getDashboardCard()
+      H.getDashboardCard()
         .button()
         .should("have.text", "1 column has custom behavior");
 
@@ -1608,7 +1577,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
         getCreatedAtToUrlMapping().should("not.exist");
         cy.get("aside").findByText(CREATED_AT_COLUMN_NAME).click();
         addUrlDestination();
-        modal().within(() => {
+        H.modal().within(() => {
           const urlInput = cy.findAllByRole("textbox").eq(0);
           const customLinkTextInput = cy.findAllByRole("textbox").eq(1);
           urlInput.type(URL_WITH_PARAMS, {
@@ -1627,12 +1596,12 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
         getCreatedAtToUrlMapping().should("exist");
       })();
 
-      getDashboardCard()
+      H.getDashboardCard()
         .button()
         .should("have.text", "2 columns have custom behavior");
 
       cy.get("aside").button("Done").click();
-      saveDashboard({ waitMs: 250 });
+      H.saveDashboard({ waitMs: 250 });
 
       (function testUpdateDashboardFiltersClick() {
         cy.log("it handles 'Count' column click");
@@ -1655,8 +1624,8 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
         cy.log("it handles 'Created at' column click");
 
         cy.button(DASHBOARD_FILTER_TEXT.name).click();
-        popover().within(() => {
-          removeMultiAutocompleteValue(0);
+        H.popover().within(() => {
+          H.removeMultiAutocompleteValue(0);
           cy.findByPlaceholderText("Search by Name").type("Dell Adams");
           cy.button("Update filter").click();
         });
@@ -1702,7 +1671,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
           questionDetails,
           dashboardDetails,
         }).then(({ body: card }) => {
-          addOrUpdateDashboardCard({
+          H.addOrUpdateDashboardCard({
             dashboard_id: card.dashboard_id,
             card_id: card.card_id,
             card: {
@@ -1718,7 +1687,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
             },
           });
 
-          visitEmbeddedPage({
+          H.visitEmbeddedPage({
             resource: { dashboard: card.dashboard_id },
             params: {},
           });
@@ -1756,7 +1725,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
           questionDetails,
           dashboardDetails,
         }).then(({ body: card }) => {
-          addOrUpdateDashboardCard({
+          H.addOrUpdateDashboardCard({
             dashboard_id: card.dashboard_id,
             card_id: card.card_id,
             card: {
@@ -1772,7 +1741,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
             },
           });
 
-          visitEmbeddedPage({
+          H.visitEmbeddedPage({
             resource: { dashboard: card.dashboard_id },
             params: {},
           });
@@ -1801,7 +1770,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
         questionDetails,
         dashboardDetails,
       }).then(({ body: dashCard }) => {
-        addOrUpdateDashboardCard({
+        H.addOrUpdateDashboardCard({
           dashboard_id: dashCard.dashboard_id,
           card_id: dashCard.card_id,
           card: {
@@ -1819,7 +1788,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
           },
         });
 
-        visitEmbeddedPage({
+        H.visitEmbeddedPage({
           resource: { dashboard: dashCard.dashboard_id },
           params: {},
         });
@@ -1828,7 +1797,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
       });
 
       cy.button(DASHBOARD_FILTER_TEXT.name).click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByPlaceholderText("Search by Name").type("Dell Adams");
         cy.button("Add filter").click();
       });
@@ -1841,7 +1810,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
     });
 
     it("allows opening custom URL destination that is not a Metabase instance URL using link (metabase#33379)", () => {
-      updateSetting("site-url", "https://localhost:4000/subpath");
+      H.updateSetting("site-url", "https://localhost:4000/subpath");
       const dashboardDetails = {
         enable_embedding: true,
       };
@@ -1851,7 +1820,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
         questionDetails,
         dashboardDetails,
       }).then(({ body: card }) => {
-        addOrUpdateDashboardCard({
+        H.addOrUpdateDashboardCard({
           dashboard_id: card.dashboard_id,
           card_id: card.card_id,
           card: {
@@ -1866,7 +1835,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
           },
         });
 
-        visitEmbeddedPage({
+        H.visitEmbeddedPage({
           resource: { dashboard: card.dashboard_id },
           params: {},
         });
@@ -1900,7 +1869,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
         questionDetails,
         dashboardDetails,
       }).then(({ body: dashCard }) => {
-        addOrUpdateDashboardCard({
+        H.addOrUpdateDashboardCard({
           dashboard_id: dashCard.dashboard_id,
           card_id: dashCard.card_id,
           card: {
@@ -1929,7 +1898,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
           },
         });
 
-        visitEmbeddedPage({
+        H.visitEmbeddedPage({
           resource: { dashboard: dashCard.dashboard_id },
           params: {},
         });
@@ -1976,14 +1945,14 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
           });
         })
         .then(({ body: dashCard }) => {
-          visitDashboard(dashCard.dashboard_id);
+          H.visitDashboard(dashCard.dashboard_id);
         });
 
-      openStaticEmbeddingModal({
+      H.openStaticEmbeddingModal({
         activeTab: "parameters",
         acceptTerms: false,
       });
-      visitIframe();
+      H.visitIframe();
       clickLineChartPoint();
 
       cy.findByRole("heading", { name: TARGET_DASHBOARD.name }).should(
@@ -2032,13 +2001,15 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
     };
 
     it("should allow navigating to questions with filters applied in every stage", () => {
-      createQuestion(targetQuestion);
-      createQuestionAndDashboard({ questionDetails }).then(({ body: card }) => {
-        visitDashboard(card.dashboard_id);
-      });
+      H.createQuestion(targetQuestion);
+      H.createQuestionAndDashboard({ questionDetails }).then(
+        ({ body: card }) => {
+          H.visitDashboard(card.dashboard_id);
+        },
+      );
 
-      editDashboard();
-      getDashboardCard().realHover().icon("click").click();
+      H.editDashboard();
+      H.getDashboardCard().realHover().icon("click").click();
 
       cy.get("aside").findByText(CREATED_AT_COLUMN_NAME).click();
       addSavedQuestionDestination();
@@ -2119,50 +2090,50 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
 
       // 1st stage - Orders
       getClickMapping("ID").click();
-      popover().findByText("ID").click();
+      H.popover().findByText("ID").click();
 
       // 1st stage - Custom columns
       getClickMapping("Net").click();
-      popover().findByText("User → Longitude").click();
+      H.popover().findByText("User → Longitude").click();
 
       // 1st stage - Reviews #1 (explicit join)
       getClickMapping("Reviews - Product → Reviewer").click();
-      popover().findByText("Product → Category").click();
+      H.popover().findByText("Product → Category").click();
 
       // 1st stage - Products (implicit join with Orders)
       getClickMapping("Product → Title").first().click();
-      popover().findByText("Product → Category").click();
+      H.popover().findByText("Product → Category").click();
 
       // 1st stage - People (implicit join with Orders)
       getClickMapping("User → Longitude").click();
-      popover().findByText("User → Longitude").click();
+      H.popover().findByText("User → Longitude").click();
 
       // 1st stage - Products (implicit join with Reviews)
       getClickMapping("Product → Vendor").last().click();
-      popover().findByText("Product → Category").click();
+      H.popover().findByText("Product → Category").click();
 
       // 1st stage - Aggregations & breakouts
       getClickMapping("Category").first().click();
-      popover().findByText("Product → Category").click();
+      H.popover().findByText("Product → Category").click();
 
       // 2nd stage - Custom columns
       getClickMapping("5 * Count").click();
-      popover().findByText("Count").click();
+      H.popover().findByText("Count").click();
 
       // 2nd stage - Reviews #2 (explicit join)
       getClickMapping("Reviews - Created At: Month → Rating").click();
-      popover().findByText("ID").click();
+      H.popover().findByText("ID").click();
 
       // 2nd stage - Aggregations & breakouts
       getClickMapping("Count").last().click();
-      popover().findByText("User → Longitude").click();
+      H.popover().findByText("User → Longitude").click();
 
       customizeLinkText(`Created at: {{${CREATED_AT_COLUMN_ID}}} - {{count}}`);
 
       cy.get("aside").button("Done").click();
-      saveDashboard({ waitMs: 250 });
+      H.saveDashboard({ waitMs: 250 });
 
-      getDashboardCard()
+      H.getDashboardCard()
         .findAllByText("Created at: May 2022 - 1")
         .first()
         .click();
@@ -2181,8 +2152,8 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
       //   .should("not.exist");
       // queryBuilderMain().findByText("No results!").should("be.visible");
 
-      openNotebook();
-      verifyNotebookQuery("Orders", [
+      H.openNotebook();
+      H.verifyNotebookQuery("Orders", [
         {
           joins: [
             {
@@ -2269,7 +2240,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
       type: "string/contains",
     };
 
-    createDashboardWithTabs({
+    H.createDashboardWithTabs({
       name: TARGET_DASHBOARD.name,
       tabs,
       parameters: [{ ...DASHBOARD_TEXT_FILTER }],
@@ -2300,7 +2271,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
       dashboard.tabs.forEach(tab => {
         cy.wrap(tab.id).as(`${tab.name}-id`);
       });
-      visitDashboard(dashboard.id);
+      H.visitDashboard(dashboard.id);
     });
 
     const TAB_SLUG_MAP = {};
@@ -2310,9 +2281,9 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
       });
     });
 
-    editDashboard();
+    H.editDashboard();
 
-    getDashboardCard().realHover().icon("click").click();
+    H.getDashboardCard().realHover().icon("click").click();
     cy.get("aside").findByText(FILTER_MAPPING_COLUMN).click();
     addDashboardDestination();
     cy.get("aside")
@@ -2321,10 +2292,10 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
       .click();
     cy.findByRole("listbox").findByText(TAB_2.name).click();
     cy.get("aside").findByText(DASHBOARD_TEXT_FILTER.name).click();
-    popover().findByText(FILTER_MAPPING_COLUMN).click();
+    H.popover().findByText(FILTER_MAPPING_COLUMN).click();
 
     cy.get("aside").button("Done").click();
-    saveDashboard({ waitMs: 250 });
+    H.saveDashboard({ waitMs: 250 });
 
     // test click behavior routing to same dashboard, different tab
     getTableCell(1).click();
@@ -2377,15 +2348,15 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
       },
     }).then(({ body: { dashboard_id } }) => {
       cy.wrap(dashboard_id).as("targetDashboardId");
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
     });
 
-    editDashboard();
+    H.editDashboard();
 
-    getDashboardCard().realHover().icon("click").click();
+    H.getDashboardCard().realHover().icon("click").click();
     addUrlDestination();
 
-    modal().within(() => {
+    H.modal().within(() => {
       const urlInput = cy.findAllByRole("textbox").eq(0);
 
       cy.get("@targetDashboardId").then(targetDashboardId => {
@@ -2401,10 +2372,10 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
 
     cy.get("aside").button("Done").click();
 
-    saveDashboard();
+    H.saveDashboard();
 
     // test top header row
-    getDashboardCard().findByText("Doohickey").click();
+    H.getDashboardCard().findByText("Doohickey").click();
     cy.get("@targetDashboardId").then(targetDashboardId => {
       cy.location().should(({ pathname, search }) => {
         expect(pathname).to.equal(`/dashboard/${targetDashboardId}`);
@@ -2413,7 +2384,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
     });
 
     // test left header row
-    getDashboardCard().findByText("Affiliate").click();
+    H.getDashboardCard().findByText("Affiliate").click();
     cy.get("@targetDashboardId").then(targetDashboardId => {
       cy.location().should(({ pathname, search }) => {
         expect(pathname).to.equal(`/dashboard/${targetDashboardId}`);
@@ -2461,16 +2432,16 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
       },
     }).then(({ body: { dashboard_id } }) => {
       cy.wrap(dashboard_id).as("targetDashboardId");
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
     });
 
-    editDashboard();
+    H.editDashboard();
 
-    getDashboardCard().realHover().icon("click").click();
+    H.getDashboardCard().realHover().icon("click").click();
     cy.get("aside").findByText("User → Source").click();
     addUrlDestination();
 
-    modal().within(() => {
+    H.modal().within(() => {
       const urlInput = cy.findAllByRole("textbox").eq(0);
 
       cy.get("@targetDashboardId").then(targetDashboardId => {
@@ -2486,10 +2457,10 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
 
     cy.get("aside").button("Done").click();
 
-    saveDashboard();
+    H.saveDashboard();
 
     // test pivoted column
-    getDashboardCard().findByText("Organic").click();
+    H.getDashboardCard().findByText("Organic").click();
     cy.get("@targetDashboardId").then(targetDashboardId => {
       cy.location().should(({ pathname, search }) => {
         expect(pathname).to.equal(`/dashboard/${targetDashboardId}`);
@@ -2525,15 +2496,15 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
       },
     }).then(({ body: { dashboard_id } }) => {
       cy.wrap(dashboard_id).as("targetDashboardId");
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
     });
 
-    editDashboard();
+    H.editDashboard();
 
-    getDashboardCard().realHover().icon("click").click();
+    H.getDashboardCard().realHover().icon("click").click();
     addUrlDestination();
 
-    modal().within(() => {
+    H.modal().within(() => {
       const urlInput = cy.findAllByRole("textbox").eq(0);
 
       cy.get("@targetDashboardId").then(targetDashboardId => {
@@ -2549,11 +2520,11 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
 
     cy.get("aside").button("Done").click();
 
-    saveDashboard();
+    H.saveDashboard();
 
     // test that normal values still work properly
-    getDashboardCard().within(() => {
-      chartPathWithFillColor("#88BF4D").eq(2).click();
+    H.getDashboardCard().within(() => {
+      H.chartPathWithFillColor("#88BF4D").eq(2).click();
     });
     cy.get("@targetDashboardId").then(targetDashboardId => {
       cy.location().should(({ pathname, search }) => {
@@ -2565,8 +2536,8 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
     });
 
     // test that null and "empty"s do not get passed through
-    getDashboardCard().within(() => {
-      chartPathWithFillColor("#88BF4D").eq(1).click();
+    H.getDashboardCard().within(() => {
+      H.chartPathWithFillColor("#88BF4D").eq(1).click();
     });
     cy.get("@targetDashboardId").then(targetDashboardId => {
       cy.location().should(({ pathname, search }) => {
@@ -2577,7 +2548,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
   });
 
   it("should navigate to correct dashboard tab via custom destination click behavior (metabase#34447 metabase#44106)", () => {
-    createDashboardWithTabs({
+    H.createDashboardWithTabs({
       name: TARGET_DASHBOARD.name,
       tabs: [
         {
@@ -2627,9 +2598,9 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
           }),
         ],
       }).then(({ body: dashboard }) => {
-        visitDashboard(dashboard.id);
+        H.visitDashboard(dashboard.id);
 
-        getDashboardCard(1).findByText("14").click();
+        H.getDashboardCard(1).findByText("14").click();
         cy.location("pathname").should(
           "eq",
           `/dashboard/${targetDashboard.id}`,
@@ -2640,7 +2611,7 @@ describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
         cy.location("pathname").should("eq", `/dashboard/${dashboard.id}`);
         cy.location("search").should("eq", "");
 
-        getDashboardCard(0).findByText("14").click();
+        H.getDashboardCard(0).findByText("14").click();
         cy.location("pathname").should(
           "eq",
           `/dashboard/${targetDashboard.id}`,
@@ -2669,7 +2640,7 @@ const onNextAnchorClick = callback => {
 };
 
 const clickLineChartPoint = () => {
-  cartesianChartCircle()
+  H.cartesianChartCircle()
     .eq(POINT_INDEX)
     /**
      * calling .click() here will result in clicking both
@@ -2690,10 +2661,10 @@ const clickLineChartPoint = () => {
 const addDashboardDestination = () => {
   cy.get("aside").findByText("Go to a custom destination").click();
   cy.get("aside").findByText("Dashboard").click();
-  entityPickerModal()
+  H.entityPickerModal()
     .findByRole("tab", { name: /Dashboards/ })
     .click();
-  entityPickerModal().findByText(TARGET_DASHBOARD.name).click();
+  H.entityPickerModal().findByText(TARGET_DASHBOARD.name).click();
 };
 
 const addUrlDestination = () => {
@@ -2704,10 +2675,10 @@ const addUrlDestination = () => {
 const addSavedQuestionDestination = () => {
   cy.get("aside").findByText("Go to a custom destination").click();
   cy.get("aside").findByText("Saved question").click();
-  entityPickerModal()
+  H.entityPickerModal()
     .findByRole("tab", { name: /Questions/ })
     .click();
-  entityPickerModal().findByText(TARGET_QUESTION.name).click();
+  H.entityPickerModal().findByText(TARGET_QUESTION.name).click();
 };
 
 const addSavedQuestionCreatedAtParameter = () => {
@@ -2715,7 +2686,7 @@ const addSavedQuestionCreatedAtParameter = () => {
     .findByTestId("click-mappings")
     .findByText("Created At")
     .click();
-  popover().within(() => {
+  H.popover().within(() => {
     cy.findByText(COUNT_COLUMN_NAME).should("not.exist");
     cy.findByText(CREATED_AT_COLUMN_NAME).should("exist").click();
   });
@@ -2723,7 +2694,7 @@ const addSavedQuestionCreatedAtParameter = () => {
 
 const addSavedQuestionQuantityParameter = () => {
   cy.get("aside").findByTestId("click-mappings").findByText("Quantity").click();
-  popover().within(() => {
+  H.popover().within(() => {
     cy.findByText(CREATED_AT_COLUMN_NAME).should("not.exist");
     cy.findByText(COUNT_COLUMN_NAME).should("exist").click();
   });
@@ -2731,7 +2702,7 @@ const addSavedQuestionQuantityParameter = () => {
 
 const addTextParameter = () => {
   cy.get("aside").findByText(DASHBOARD_FILTER_TEXT.name).click();
-  popover().within(() => {
+  H.popover().within(() => {
     cy.findByText(CREATED_AT_COLUMN_NAME).should("exist");
     cy.findByText(COUNT_COLUMN_NAME).should("exist").click();
   });
@@ -2739,7 +2710,7 @@ const addTextParameter = () => {
 
 const addTextWithDefaultParameter = () => {
   cy.get("aside").findByText(DASHBOARD_FILTER_TEXT_WITH_DEFAULT.name).click();
-  popover().within(() => {
+  H.popover().within(() => {
     cy.findByText(CREATED_AT_COLUMN_NAME).should("exist");
     cy.findByText(COUNT_COLUMN_NAME).should("exist").click();
   });
@@ -2747,7 +2718,7 @@ const addTextWithDefaultParameter = () => {
 
 const addTimeParameter = () => {
   cy.get("aside").findByText(DASHBOARD_FILTER_TIME.name).click();
-  popover().within(() => {
+  H.popover().within(() => {
     cy.findByText(COUNT_COLUMN_NAME).should("not.exist");
     cy.findByText(CREATED_AT_COLUMN_NAME).should("exist").click();
   });
@@ -2755,7 +2726,7 @@ const addTimeParameter = () => {
 
 const addNumericParameter = () => {
   cy.get("aside").findByText(DASHBOARD_FILTER_NUMBER.name).click();
-  popover().within(() => {
+  H.popover().within(() => {
     cy.findByText(CREATED_AT_COLUMN_NAME).should("exist");
     cy.findByText(COUNT_COLUMN_NAME).should("exist").click();
   });
@@ -2820,7 +2791,7 @@ const createNumberFilterMapping = ({ card_id }) => {
 };
 
 const assertDrillThroughMenuOpen = () => {
-  popover()
+  H.popover()
     .should("contain", "See these Orders")
     .and("contain", "See this month by week")
     .and("contain", "Break out by…")
@@ -2831,14 +2802,14 @@ const assertDrillThroughMenuOpen = () => {
 const testChangingBackToDefaultBehavior = () => {
   cy.log("allows to change click behavior back to the default");
 
-  editDashboard();
+  H.editDashboard();
 
-  getDashboardCard().realHover().icon("click").click();
+  H.getDashboardCard().realHover().icon("click").click();
   cy.get("aside").icon("close").first().click();
   cy.get("aside").findByText("Open the Metabase drill-through menu").click();
   cy.get("aside").button("Done").click();
 
-  saveDashboard({ waitMs: 250 });
+  H.saveDashboard({ waitMs: 250 });
   // this is necessary due to query params being reset after saving dashboard
   // with filter applied, which causes dashcard to be refetched
   cy.wait(1);

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-fetching.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-fetching.cy.spec.js
@@ -1,8 +1,8 @@
+import { H } from "e2e/support";
 import {
   ORDERS_BY_YEAR_QUESTION_ID,
   ORDERS_COUNT_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import { updateDashboardCards, visitDashboard } from "e2e/support/helpers";
 
 const cards = [
   {
@@ -30,7 +30,7 @@ describe("dashboard card fetching", () => {
   });
 
   it("should pass same dashboard_load_id to every query to enable metadata cache sharing", () => {
-    createDashboardWithCards({ cards }).then(visitDashboard);
+    createDashboardWithCards({ cards }).then(H.visitDashboard);
 
     cy.wait(["@dashcardQuery", "@dashcardQuery"]).then(interceptions => {
       const query1 = interceptions[0].request.body;
@@ -50,7 +50,7 @@ function createDashboardWithCards({
   return cy
     .createDashboard({ name: dashboardName })
     .then(({ body: { id } }) => {
-      updateDashboardCards({
+      H.updateDashboardCards({
         dashboard_id: id,
         cards,
       });

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
@@ -1,34 +1,7 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  addOrUpdateDashboardCard,
-  assertDescendantNotOverflowsContainer,
-  assertIsEllipsified,
-  assertIsNotEllipsified,
-  createNativeQuestionAndDashboard,
-  createQuestion,
-  createQuestionAndDashboard,
-  cypressWaitAll,
-  echartsContainer,
-  editDashboard,
-  focusNativeEditor,
-  getDashboardCard,
-  modal,
-  openNavigationSidebar,
-  pieSlices,
-  popover,
-  queryBuilderHeader,
-  resetTestTable,
-  restore,
-  resyncDatabase,
-  saveDashboard,
-  setActionsEnabledForDB,
-  showDashboardCardActions,
-  sidebar,
-  updateSetting,
-  visitDashboard,
-} from "e2e/support/helpers";
 import { createMockParameter } from "metabase-types/api/mocks";
 
 const { ORDERS, ORDERS_ID, REVIEWS, PRODUCTS, PRODUCTS_ID, REVIEWS_ID } =
@@ -36,7 +9,7 @@ const { ORDERS, ORDERS_ID, REVIEWS, PRODUCTS, PRODUCTS_ID, REVIEWS_ID } =
 
 describe("issue 18067", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -46,10 +19,10 @@ describe("issue 18067", () => {
     () => {
       const dialect = "mysql";
       const TEST_TABLE = "many_data_types";
-      resetTestTable({ type: dialect, table: TEST_TABLE });
-      restore(`${dialect}-writable`);
+      H.resetTestTable({ type: dialect, table: TEST_TABLE });
+      H.restore(`${dialect}-writable`);
       cy.signInAsAdmin();
-      resyncDatabase({
+      H.resyncDatabase({
         dbId: WRITABLE_DB_ID,
         tableName: TEST_TABLE,
         tableAlias: "testTable",
@@ -68,17 +41,17 @@ describe("issue 18067", () => {
           dashboardDetails,
           questionDetails,
         }).then(({ body: { dashboard_id } }) => {
-          visitDashboard(dashboard_id);
+          H.visitDashboard(dashboard_id);
         });
       });
 
-      editDashboard();
+      H.editDashboard();
 
       cy.log('Select "click behavior" option');
-      showDashboardCardActions();
+      H.showDashboardCardActions();
       cy.findByTestId("dashboardcard-actions-panel").icon("click").click();
 
-      sidebar().within(() => {
+      H.sidebar().within(() => {
         cy.findByText("Boolean").scrollIntoView().click();
         cy.contains("Click behavior for Boolean").should("be.visible");
       });
@@ -88,7 +61,7 @@ describe("issue 18067", () => {
 
 describe("issue 15993", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -103,7 +76,7 @@ describe("issue 15993", () => {
         ({ body: { id: nativeId } }) => {
           cy.createDashboard().then(({ body: { id: dashboardId } }) => {
             // Add native question to the dashboard
-            addOrUpdateDashboardCard({
+            H.addOrUpdateDashboardCard({
               dashboard_id: dashboardId,
               card_id: nativeId,
               card: {
@@ -111,7 +84,7 @@ describe("issue 15993", () => {
                 visualization_settings: getVisualizationSettings(question1Id),
               },
             });
-            visitDashboard(dashboardId);
+            H.visitDashboard(dashboardId);
           });
         },
       );
@@ -156,7 +129,7 @@ describe("issue 15993", () => {
 
 describe("issue 16334", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
@@ -172,7 +145,7 @@ describe("issue 16334", () => {
       },
     };
 
-    createQuestion({
+    H.createQuestion({
       name: "16334",
       query: {
         "source-table": PRODUCTS_ID,
@@ -181,9 +154,9 @@ describe("issue 16334", () => {
       },
       display: "pie",
     }).then(({ body: { id: question1Id } }) => {
-      createQuestionAndDashboard({ questionDetails }).then(
+      H.createQuestionAndDashboard({ questionDetails }).then(
         ({ body: { id, card_id, dashboard_id } }) => {
-          addOrUpdateDashboardCard({
+          H.addOrUpdateDashboardCard({
             dashboard_id,
             card_id,
             card: {
@@ -192,7 +165,7 @@ describe("issue 16334", () => {
             },
           });
 
-          visitDashboard(dashboard_id);
+          H.visitDashboard(dashboard_id);
           cy.wait("@dashcardQuery");
         },
       );
@@ -211,7 +184,7 @@ describe("issue 16334", () => {
     cy.findByTestId("app-bar").should("contain.text", "Started from 16334");
 
     // Make sure the original visualization didn't change
-    pieSlices().should("have.length", 2);
+    H.pieSlices().should("have.length", 2);
 
     const getVisualizationSettings = targetId => ({
       column_settings: {
@@ -294,7 +267,7 @@ describe("issue 17160", () => {
           cy.wrap(dashboardId).as("sourceDashboardId");
 
           // Add the question to the dashboard
-          addOrUpdateDashboardCard({
+          H.addOrUpdateDashboardCard({
             dashboard_id: dashboardId,
             card_id: questionId,
           }).then(({ body: { id: dashCardId } }) => {
@@ -456,7 +429,7 @@ describe("issue 17160", () => {
 
   function visitSourceDashboard() {
     cy.get("@sourceDashboardId").then(id => {
-      visitDashboard(id);
+      H.visitDashboard(id);
     });
   }
 
@@ -471,7 +444,7 @@ describe("issue 17160", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -551,12 +524,12 @@ describe("issue 18454", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestionAndDashboard({ questionDetails }).then(
       ({ body: { id, card_id, dashboard_id } }) => {
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       },
     );
   });
@@ -640,7 +613,7 @@ describe("adding an additional series to a dashcard (metabase#20637)", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -659,7 +632,7 @@ describe("adding an additional series to a dashcard (metabase#20637)", () => {
     cy.wait("@additionalSeriesCardQuery");
 
     cy.findByTestId("add-series-modal").button("Done").click();
-    saveDashboard();
+    H.saveDashboard();
 
     // refresh the page and make sure the dashcard query endpoint was used
     cy.reload();
@@ -685,7 +658,7 @@ describe("issue 22265", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.intercept("GET", "/api/card/*/series?limit=*").as("seriesQuery");
@@ -712,11 +685,11 @@ describe("issue 22265", () => {
         });
 
         cy.wrap(dashboard_id).as("dashboardId");
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       },
     );
 
-    editDashboard();
+    H.editDashboard();
     cy.findByTestId("add-series-button").click({ force: true });
     cy.wait("@seriesQuery");
 
@@ -744,8 +717,8 @@ describe("issue 22265", () => {
       cy.request("PUT", `/api/card/${invalidQuestionId}`, questionDetailUpdate);
     });
 
-    visitDashboard("@dashboardId");
-    editDashboard();
+    H.visitDashboard("@dashboardId");
+    H.editDashboard();
     cy.findByTestId("add-series-button").click({ force: true });
     cy.wait("@seriesQuery");
 
@@ -774,7 +747,7 @@ describe("issue 23137", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
   });
@@ -785,7 +758,7 @@ describe("issue 23137", () => {
     cy.createQuestionAndDashboard({
       questionDetails: GAUGE_QUESTION_DETAILS,
     }).then(({ body: { id, card_id, dashboard_id } }) => {
-      addOrUpdateDashboardCard({
+      H.addOrUpdateDashboardCard({
         card_id,
         dashboard_id,
         card: {
@@ -801,12 +774,12 @@ describe("issue 23137", () => {
         },
       });
 
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
     });
 
     cy.findByTestId("gauge-arc-1").click();
     cy.wait("@cardQuery");
-    queryBuilderHeader().findByDisplayValue("Orders").should("be.visible");
+    H.queryBuilderHeader().findByDisplayValue("Orders").should("be.visible");
   });
 
   it("should navigate to a target from a progress card (metabase#23137)", () => {
@@ -815,7 +788,7 @@ describe("issue 23137", () => {
     cy.createQuestionAndDashboard({
       questionDetails: PROGRESS_QUESTION_DETAILS,
     }).then(({ body: { id, card_id, dashboard_id } }) => {
-      addOrUpdateDashboardCard({
+      H.addOrUpdateDashboardCard({
         card_id,
         dashboard_id,
         card: {
@@ -831,12 +804,12 @@ describe("issue 23137", () => {
         },
       });
 
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
     });
 
     cy.findByTestId("progress-bar").click();
     cy.wait("@cardQuery");
-    queryBuilderHeader().findByDisplayValue("Orders").should("be.visible");
+    H.queryBuilderHeader().findByDisplayValue("Orders").should("be.visible");
   });
 });
 
@@ -883,7 +856,7 @@ describe("issues 27020 and 27105: static-viz fails to render for certain date fo
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -891,7 +864,7 @@ describe("issues 27020 and 27105: static-viz fails to render for certain date fo
     // This is currently the default setting, anyway.
     // But we want to explicitly set it in case something changes in the future,
     // because it is a crucial step for this reproduction.
-    updateSetting("custom-formatting", {
+    H.updateSetting("custom-formatting", {
       "type/Temporal": {
         date_style: "MMMM D, YYYY",
       },
@@ -961,7 +934,7 @@ describe("issue 29304", () => {
 
   describe("display: scalar", () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
       cy.intercept("api/dashboard/*/dashcard/*/card/*/query").as(
         "getDashcardQuery",
@@ -1101,7 +1074,7 @@ describe("issue 31628", () => {
 
   const setupDashboardWithQuestionInCards = (question, cards) => {
     cy.createDashboard().then(({ body: dashboard }) => {
-      cypressWaitAll(
+      H.cypressWaitAll(
         cards.map(card => {
           return cy.createQuestionAndAddToDashboard(
             question,
@@ -1111,7 +1084,7 @@ describe("issue 31628", () => {
         }),
       );
 
-      visitDashboard(dashboard.id);
+      H.visitDashboard(dashboard.id);
     });
   };
 
@@ -1121,7 +1094,7 @@ describe("issue 31628", () => {
         const descendants = dashcard.querySelectorAll(descendantsSelector);
 
         descendants.forEach(descendant => {
-          assertDescendantNotOverflowsContainer(
+          H.assertDescendantNotOverflowsContainer(
             descendant,
             dashcard,
             `dashcard[${dashcardIndex}] [data-testid="${descendant.dataset.testid}"]`,
@@ -1144,14 +1117,14 @@ describe("issue 31628", () => {
 
         describe(`${width}x${height} - ${sidebar} - ${name}`, () => {
           beforeEach(() => {
-            restore();
+            H.restore();
             cy.viewport(width, height);
             cy.signInAsAdmin();
             setupDashboardWithQuestionInCards(SCALAR_QUESTION, cards);
 
             if (openSidebar) {
               cy.wait(100);
-              openNavigationSidebar();
+              H.openNavigationSidebar();
             }
           });
 
@@ -1164,7 +1137,7 @@ describe("issue 31628", () => {
 
     describe("1x2 card", () => {
       beforeEach(() => {
-        restore();
+        H.restore();
         cy.signInAsAdmin();
         setupDashboardWithQuestionInCards(SCALAR_QUESTION, [
           { size_x: 1, size_y: 2, row: 0, col: 0 },
@@ -1177,7 +1150,7 @@ describe("issue 31628", () => {
          */
         const scalarContainer = cy.findByTestId("scalar-container");
 
-        scalarContainer.then($element => assertIsEllipsified($element[0]));
+        scalarContainer.then($element => H.assertIsEllipsified($element[0]));
         scalarContainer.realHover();
 
         cy.findByRole("tooltip").findByText("18,760").should("exist");
@@ -1200,7 +1173,7 @@ describe("issue 31628", () => {
 
     describe("2x2 card", () => {
       beforeEach(() => {
-        restore();
+        H.restore();
         cy.signInAsAdmin();
         setupDashboardWithQuestionInCards(SCALAR_QUESTION, [
           { size_x: 2, size_y: 2, row: 0, col: 0 },
@@ -1213,7 +1186,7 @@ describe("issue 31628", () => {
          */
         const scalarContainer = cy.findByTestId("scalar-container");
 
-        scalarContainer.then($element => assertIsNotEllipsified($element[0]));
+        scalarContainer.then($element => H.assertIsNotEllipsified($element[0]));
         scalarContainer.realHover();
 
         cy.findByRole("tooltip").should("not.exist");
@@ -1228,7 +1201,7 @@ describe("issue 31628", () => {
          */
         const scalarTitle = cy.findByTestId("scalar-title");
 
-        scalarTitle.then($element => assertIsEllipsified($element[0]));
+        scalarTitle.then($element => H.assertIsEllipsified($element[0]));
         scalarTitle.realHover();
 
         cy.findByRole("tooltip")
@@ -1248,7 +1221,7 @@ describe("issue 31628", () => {
 
     describe("5x3 card", () => {
       beforeEach(() => {
-        restore();
+        H.restore();
         cy.signInAsAdmin();
         setupDashboardWithQuestionInCards(SCALAR_QUESTION, [
           { size_x: 6, size_y: 3, row: 0, col: 0 },
@@ -1261,7 +1234,7 @@ describe("issue 31628", () => {
          */
         const scalarContainer = cy.findByTestId("scalar-container");
 
-        scalarContainer.then($element => assertIsNotEllipsified($element[0]));
+        scalarContainer.then($element => H.assertIsNotEllipsified($element[0]));
         scalarContainer.realHover();
 
         cy.findByRole("tooltip").should("not.exist");
@@ -1276,7 +1249,7 @@ describe("issue 31628", () => {
          */
         const scalarTitle = cy.findByTestId("scalar-title");
 
-        scalarTitle.then($element => assertIsNotEllipsified($element[0]));
+        scalarTitle.then($element => H.assertIsNotEllipsified($element[0]));
         scalarTitle.realHover();
 
         cy.findByRole("tooltip").should("not.exist");
@@ -1286,7 +1259,7 @@ describe("issue 31628", () => {
          */
         cy.findByTestId("scalar-description").realHover();
 
-        popover().findByText(SCALAR_QUESTION.description).should("exist");
+        H.popover().findByText(SCALAR_QUESTION.description).should("exist");
       });
     });
   });
@@ -1304,13 +1277,13 @@ describe("issue 31628", () => {
 
         describe(`${width}x${height} - ${sidebar} - ${name}`, () => {
           beforeEach(() => {
-            restore();
+            H.restore();
             cy.viewport(width, height);
             cy.signInAsAdmin();
             setupDashboardWithQuestionInCards(SMART_SCALAR_QUESTION, cards);
 
             if (openSidebar) {
-              openNavigationSidebar();
+              H.openNavigationSidebar();
             }
           });
 
@@ -1323,7 +1296,7 @@ describe("issue 31628", () => {
 
     describe("2x2 card", () => {
       beforeEach(() => {
-        restore();
+        H.restore();
         cy.signInAsAdmin();
         setupDashboardWithQuestionInCards(SMART_SCALAR_QUESTION, [
           { size_x: 2, size_y: 2, row: 0, col: 0 },
@@ -1336,7 +1309,7 @@ describe("issue 31628", () => {
          */
         const scalarContainer = cy.findByTestId("scalar-container");
 
-        scalarContainer.then($element => assertIsNotEllipsified($element[0]));
+        scalarContainer.then($element => H.assertIsNotEllipsified($element[0]));
         scalarContainer.realHover();
 
         cy.findByRole("tooltip").should("not.exist");
@@ -1351,7 +1324,7 @@ describe("issue 31628", () => {
          */
         const scalarTitle = cy.findByTestId("legend-caption-title");
 
-        scalarTitle.then($element => assertIsEllipsified($element[0]));
+        scalarTitle.then($element => H.assertIsEllipsified($element[0]));
         scalarTitle.realHover();
 
         cy.findByRole("tooltip")
@@ -1376,7 +1349,7 @@ describe("issue 31628", () => {
         previousValue.within(() => {
           cy.contains("34.7%").should("exist");
           cy.contains("• vs. previous month: 527").should("not.exist");
-          previousValue.then($element => assertIsNotEllipsified($element[0]));
+          previousValue.then($element => H.assertIsNotEllipsified($element[0]));
         });
       });
 
@@ -1389,7 +1362,7 @@ describe("issue 31628", () => {
           cy.contains("34.7%").should("exist");
           cy.contains("34.72%").should("not.exist");
           cy.contains("• vs. previous month: 527").should("not.exist");
-          previousValue.then($element => assertIsNotEllipsified($element[0]));
+          previousValue.then($element => H.assertIsNotEllipsified($element[0]));
         });
       });
 
@@ -1402,7 +1375,7 @@ describe("issue 31628", () => {
           cy.contains("35%").should("exist");
           cy.contains("34.72%").should("not.exist");
           cy.contains("• vs. previous month: 527").should("not.exist");
-          previousValue.then($element => assertIsNotEllipsified($element[0]));
+          previousValue.then($element => H.assertIsNotEllipsified($element[0]));
         });
       });
 
@@ -1413,13 +1386,13 @@ describe("issue 31628", () => {
 
         previousValue
           .findByText("35%")
-          .then($element => assertIsEllipsified($element[0]));
+          .then($element => H.assertIsEllipsified($element[0]));
       });
     });
 
     describe("7x3 card", () => {
       beforeEach(() => {
-        restore();
+        H.restore();
         cy.signInAsAdmin();
         setupDashboardWithQuestionInCards(SMART_SCALAR_QUESTION, [
           { size_x: 7, size_y: 3, row: 0, col: 0 },
@@ -1432,7 +1405,7 @@ describe("issue 31628", () => {
          */
         let scalarContainer = cy.findByTestId("scalar-container");
 
-        scalarContainer.then($element => assertIsNotEllipsified($element[0]));
+        scalarContainer.then($element => H.assertIsNotEllipsified($element[0]));
         scalarContainer.realHover();
 
         cy.findByRole("tooltip").should("not.exist");
@@ -1447,7 +1420,7 @@ describe("issue 31628", () => {
          */
         scalarContainer = cy.findByTestId("legend-caption-title");
 
-        scalarContainer.then($element => assertIsEllipsified($element[0]));
+        scalarContainer.then($element => H.assertIsEllipsified($element[0]));
         scalarContainer.realHover();
 
         cy.findByRole("tooltip")
@@ -1471,7 +1444,7 @@ describe("issue 31628", () => {
         previousValue.within(() => {
           cy.contains("34.72%").should("exist");
           cy.contains("• vs. previous month: 527").should("exist");
-          previousValue.then($element => assertIsNotEllipsified($element[0]));
+          previousValue.then($element => H.assertIsNotEllipsified($element[0]));
         });
 
         /**
@@ -1485,7 +1458,7 @@ describe("issue 31628", () => {
 
     describe("7x4 card", () => {
       beforeEach(() => {
-        restore();
+        H.restore();
         cy.signInAsAdmin();
         setupDashboardWithQuestionInCards(SMART_SCALAR_QUESTION, [
           { size_x: 7, size_y: 4, row: 0, col: 0 },
@@ -1498,7 +1471,7 @@ describe("issue 31628", () => {
          */
         let scalarContainer = cy.findByTestId("scalar-container");
 
-        scalarContainer.then($element => assertIsNotEllipsified($element[0]));
+        scalarContainer.then($element => H.assertIsNotEllipsified($element[0]));
         scalarContainer.realHover();
 
         cy.findByRole("tooltip").should("not.exist");
@@ -1513,7 +1486,7 @@ describe("issue 31628", () => {
          */
         scalarContainer = cy.findByTestId("legend-caption-title");
 
-        scalarContainer.then($element => assertIsEllipsified($element[0]));
+        scalarContainer.then($element => H.assertIsEllipsified($element[0]));
         scalarContainer.realHover();
 
         cy.findByRole("tooltip")
@@ -1537,7 +1510,7 @@ describe("issue 31628", () => {
         previousValue.within(() => {
           cy.contains("34.72%").should("exist");
           cy.contains("• vs. previous month: 527").should("exist");
-          previousValue.then($element => assertIsNotEllipsified($element[0]));
+          previousValue.then($element => H.assertIsNotEllipsified($element[0]));
         });
 
         /**
@@ -1584,7 +1557,7 @@ describe("issue 32231", () => {
   const defaultError = "Which fields do you want to use for the X and Y axes?";
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.intercept("GET", "/api/card/*/series?limit=*").as("seriesQuery");
@@ -1607,30 +1580,30 @@ describe("issue 32231", () => {
           ],
         });
 
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       },
     );
 
-    editDashboard();
+    H.editDashboard();
     cy.findByTestId("add-series-button").click({ force: true });
     cy.wait("@seriesQuery");
 
     cy.findByTestId("add-series-modal").within(() => {
-      echartsContainer().should("exist");
+      H.echartsContainer().should("exist");
       cy.findByText(issue32231Error).should("not.exist");
       cy.findByText(multipleSeriesError).should("not.exist");
       cy.findByText(defaultError).should("not.exist");
 
       cy.findByLabelText(incompleteQuestion.name).click();
 
-      echartsContainer().should("not.exist");
+      H.echartsContainer().should("not.exist");
       cy.findByText(issue32231Error).should("not.exist");
       cy.findByText(multipleSeriesError).should("exist");
       cy.findByText(defaultError).should("not.exist");
 
       cy.findByLabelText(incompleteQuestion.name).click();
 
-      echartsContainer().should("exist");
+      H.echartsContainer().should("exist");
       cy.findByText(issue32231Error).should("not.exist");
       cy.findByText(multipleSeriesError).should("not.exist");
       cy.findByText(defaultError).should("not.exist");
@@ -1654,7 +1627,7 @@ describe("issue 32231", () => {
         ],
       });
 
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
     });
 
     cy.findByTestId("dashcard").findByText(defaultError).should("exist");
@@ -1704,13 +1677,13 @@ describe("issue 43219", () => {
   const getQuestionAlias = index => `question-${index}`;
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    cypressWaitAll(
+    H.cypressWaitAll(
       Array.from({ length: cardsCount }, (_value, index) => {
         const name = `Series ${index + 1}`;
-        return createQuestion({ ...questionDetails, name }).then(
+        return H.createQuestion({ ...questionDetails, name }).then(
           ({ body: question }) => {
             cy.wrap(question).as(getQuestionAlias(index));
           },
@@ -1740,18 +1713,18 @@ describe("issue 43219", () => {
           },
         ],
       }).then(({ dashboard }) => {
-        visitDashboard(dashboard.id);
+        H.visitDashboard(dashboard.id);
       });
     });
   });
 
   it("is possible to map parameters to dashcards with lots of series (metabase#43219)", () => {
-    editDashboard();
+    H.editDashboard();
     cy.findByTestId("edit-dashboard-parameters-widget-container")
       .findByText("Text")
       .click();
 
-    getDashboardCard(0).within(() => {
+    H.getDashboardCard(0).within(() => {
       cy.findByText("Series 10").should("exist").and("not.be.visible");
 
       cy.findByTestId("visualization-root").scrollTo("bottom");
@@ -1764,9 +1737,9 @@ describe("issue 43219", () => {
 
 describe("issue 48878", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setActionsEnabledForDB(SAMPLE_DB_ID);
+    H.setActionsEnabledForDB(SAMPLE_DB_ID);
 
     cy.signInAsNormalUser();
     cy.intercept("POST", "/api/dataset").as("dataset");
@@ -1796,7 +1769,7 @@ describe("issue 48878", () => {
   it("does not crash the action button viz (metabase#48878)", () => {
     cy.reload();
     cy.wait("@fetchCard");
-    getDashboardCard(0).findByText("Click Me").should("be.visible");
+    H.getDashboardCard(0).findByText("Click Me").should("be.visible");
   });
 
   function setup() {
@@ -1814,7 +1787,7 @@ describe("issue 48878", () => {
     cy.log("create model");
 
     cy.button("New").click();
-    popover().findByText("Model").click();
+    H.popover().findByText("Model").click();
     createModel({
       name: "SQL Model",
       query: "select * from orders limit 5",
@@ -1823,19 +1796,19 @@ describe("issue 48878", () => {
     cy.log("create model action");
 
     cy.findByTestId("qb-header-info-button").click();
-    modal().findByText("See more about this model").click();
+    H.modal().findByText("See more about this model").click();
 
     cy.findByRole("tab", { name: "Actions" }).click();
     cy.findByTestId("model-actions-header").findByText("New action").click();
 
-    modal().within(() => {
-      focusNativeEditor().type("UPDATE orders SET plan = {{ plan ", {
+    H.modal().within(() => {
+      H.focusNativeEditor().type("UPDATE orders SET plan = {{ plan ", {
         parseSpecialCharSequences: false,
       });
       cy.button("Save").click();
     });
 
-    modal()
+    H.modal()
       .last()
       .within(() => {
         cy.findByPlaceholderText("My new fantastic action").type("Test action");
@@ -1848,9 +1821,9 @@ describe("issue 48878", () => {
     cy.log("create dashoard");
 
     cy.button("New").click();
-    popover().findByText("Dashboard").click();
+    H.popover().findByText("Dashboard").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByPlaceholderText("What is the name of your dashboard?").type(
         "Dash",
       );
@@ -1860,7 +1833,7 @@ describe("issue 48878", () => {
 
     cy.button("Add action").click();
     cy.button("Pick an action").click();
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("SQL Model").click();
       cy.findByText("Test action").click();
       cy.button("Done").click();
@@ -1875,14 +1848,14 @@ describe("issue 48878", () => {
       .findByText("Use a native query")
       .click();
 
-    focusNativeEditor().type(query);
+    H.focusNativeEditor().type(query);
     cy.findByTestId("native-query-editor-sidebar")
       .findByTestId("run-button")
       .click();
     cy.wait("@dataset");
     cy.button("Save").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByPlaceholderText("What is the name of your model?").type(name);
       cy.button("Save").click();
       cy.wait("@saveQuestion");
@@ -1902,10 +1875,10 @@ SELECT 'group_2', 'sub_group_2', 52, 'group_2__sub_group_2';
 `;
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    createNativeQuestionAndDashboard({
+    H.createNativeQuestionAndDashboard({
       questionDetails: {
         name: "46318",
         native: { query },
@@ -1918,23 +1891,23 @@ SELECT 'group_2', 'sub_group_2', 52, 'group_2__sub_group_2';
         },
       },
     }).then(response => {
-      visitDashboard(response.body.dashboard_id);
+      H.visitDashboard(response.body.dashboard_id);
     });
 
-    editDashboard();
-    getDashboardCard().realHover().icon("click").click();
+    H.editDashboard();
+    H.getDashboardCard().realHover().icon("click").click();
     cy.get("aside").within(() => {
       cy.findByText("Go to a custom destination").click();
       cy.findByText("URL").click();
     });
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByPlaceholderText("e.g. http://acme.com/id/{{user_id}}").type(
         "http://localhost:4000/?q={{group_name}}",
         { parseSpecialCharSequences: false },
       );
       cy.button("Done").click();
     });
-    saveDashboard();
+    H.saveDashboard();
   });
 
   it("passes values from unused columns of row visualization to click behavior (metabase#46318)", () => {

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
@@ -1,18 +1,8 @@
 import _ from "underscore";
 
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  createDashboard,
-  createQuestion,
-  editDashboard,
-  getDashboardCard,
-  popover,
-  resizeDashboardCard,
-  restore,
-  saveDashboard,
-  visitDashboard,
-} from "e2e/support/helpers";
 import { GRID_WIDTH } from "metabase/lib/dashboard_grid";
 
 const VISUALIZATION_SIZES = {
@@ -203,16 +193,16 @@ describe(
   { requestTimeout: 15000 },
   () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
     });
 
     it("should display all visualization cards with their default sizes", () => {
       TEST_QUESTIONS.forEach(question => {
-        createQuestion(question);
+        H.createQuestion(question);
       });
-      createDashboard().then(({ body: { id: dashId } }) => {
-        visitDashboard(dashId);
+      H.createDashboard().then(({ body: { id: dashId } }) => {
+        H.visitDashboard(dashId);
 
         cy.findByTestId("dashboard-header").within(() => {
           cy.findByLabelText("Edit dashboard").click();
@@ -242,7 +232,7 @@ describe(
           cy.wait("@cardQuery");
         });
 
-        saveDashboard();
+        H.saveDashboard();
 
         cy.request("GET", `/api/dashboard/${dashId}`).then(({ body }) => {
           body.dashcards.forEach(({ card, size_x, size_y }) => {
@@ -257,11 +247,11 @@ describe(
     it("should not allow cards to be resized smaller than min height", () => {
       const cardIds = [];
       TEST_QUESTIONS.forEach(question => {
-        createQuestion(question).then(({ body: { id } }) => {
+        H.createQuestion(question).then(({ body: { id } }) => {
           cardIds.push(id);
         });
       });
-      createDashboard().then(({ body: { id: dashId } }) => {
+      H.createDashboard().then(({ body: { id: dashId } }) => {
         cy.request("PUT", `/api/dashboard/${dashId}`, {
           dashcards: cardIds.map((cardId, index) => ({
             id: index,
@@ -272,19 +262,19 @@ describe(
             size_y: 10,
           })),
         });
-        visitDashboard(dashId);
-        editDashboard();
+        H.visitDashboard(dashId);
+        H.editDashboard();
 
         cy.request("GET", `/api/dashboard/${dashId}`).then(({ body }) => {
           body.dashcards.forEach(({ card }, index) => {
-            resizeDashboardCard({
-              card: getDashboardCard(index),
+            H.resizeDashboardCard({
+              card: H.getDashboardCard(index),
               x: -getDefaultSize(card.display).width * 200,
               y: -getDefaultSize(card.display).height * 200,
             });
           });
 
-          saveDashboard();
+          H.saveDashboard();
 
           cy.request("GET", `/api/dashboard/${dashId}`).then(({ body }) => {
             body.dashcards.forEach(({ card, size_x, size_y }) => {
@@ -300,8 +290,8 @@ describe(
 );
 
 describe("issue 31701", () => {
-  const entityCard = () => getDashboardCard(0);
-  const customCard = () => getDashboardCard(1);
+  const entityCard = () => H.getDashboardCard(0);
+  const customCard = () => H.getDashboardCard(1);
 
   const editEntityLinkContainer = () =>
     cy.findByTestId("entity-edit-display-link");
@@ -314,37 +304,37 @@ describe("issue 31701", () => {
     cy.findByTestId("custom-view-text-link");
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    createQuestion({
+    H.createQuestion({
       name: TEST_QUESTION_NAME,
       query: {
         "source-table": ORDERS_ID,
       },
     });
 
-    createDashboard({
+    H.createDashboard({
       name: TEST_DASHBOARD_NAME,
     }).then(({ body: { id: dashId } }) => {
-      visitDashboard(dashId);
+      H.visitDashboard(dashId);
     });
 
-    editDashboard();
+    H.editDashboard();
 
     cy.log("Add first link card (connected to an entity");
     cy.findByLabelText("Add a link or iframe").click();
-    popover().findByText("Link").click();
-    getDashboardCard(0).as("entityCard").click().type(TEST_QUESTION_NAME);
-    popover()
+    H.popover().findByText("Link").click();
+    H.getDashboardCard(0).as("entityCard").click().type(TEST_QUESTION_NAME);
+    H.popover()
       .findAllByTestId("search-result-item-name")
       .first()
       .trigger("click");
 
     cy.log("Add second link card (text only)");
     cy.findByLabelText("Add a link or iframe").click();
-    popover().findByText("Link").click();
-    getDashboardCard(1)
+    H.popover().findByText("Link").click();
+    H.getDashboardCard(1)
       .as("customCard")
       .click()
       .type(TEST_QUESTION_NAME)
@@ -361,7 +351,7 @@ describe("issue 31701", () => {
       assertLinkCardOverflow(editCustomLinkContainer(), customCard());
     });
 
-    saveDashboard();
+    H.saveDashboard();
 
     cy.log("when viewing a saved dashboard");
     viewports.forEach(([width, height]) => {

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-undo.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-undo.cy.spec.js
@@ -1,21 +1,8 @@
-import {
-  createNewTab,
-  editDashboard,
-  getDashboardCard,
-  getDashboardCards,
-  getTextCardDetails,
-  goToTab,
-  moveDashCardToTab,
-  removeDashboardCard,
-  restore,
-  undo,
-  updateDashboardCards,
-  visitDashboard,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 describe("scenarios > dashboard cards > undo", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -24,35 +11,35 @@ describe("scenarios > dashboard cards > undo", () => {
     { scrollBehavior: false },
     () => {
       const checkOrder = () => {
-        getDashboardCard(0).findByText("Text card 1");
-        getDashboardCard(1).findByText("Text card 2");
-        getDashboardCard(2).findByText("Text card 3");
-        getDashboardCard(3).findByText("Text card 4");
+        H.getDashboardCard(0).findByText("Text card 1");
+        H.getDashboardCard(1).findByText("Text card 2");
+        H.getDashboardCard(2).findByText("Text card 3");
+        H.getDashboardCard(3).findByText("Text card 4");
       };
 
       const cards = [
-        getTextCardDetails({
+        H.getTextCardDetails({
           text: "Text card 1",
           size_x: 4,
           size_y: 1,
           row: 0,
           col: 1,
         }),
-        getTextCardDetails({
+        H.getTextCardDetails({
           text: "Text card 2",
           size_x: 4,
           size_y: 1,
           row: 1,
           col: 0,
         }),
-        getTextCardDetails({
+        H.getTextCardDetails({
           text: "Text card 3",
           size_x: 4,
           size_y: 1,
           row: 2,
           col: 3,
         }),
-        getTextCardDetails({
+        H.getTextCardDetails({
           text: "Text card 4",
           size_x: 4,
           size_y: 1,
@@ -62,36 +49,36 @@ describe("scenarios > dashboard cards > undo", () => {
       ];
 
       cy.createDashboard().then(({ body: { id: dashboard_id } }) => {
-        updateDashboardCards({ dashboard_id, cards });
+        H.updateDashboardCards({ dashboard_id, cards });
 
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       });
 
       checkOrder();
 
-      editDashboard();
+      H.editDashboard();
 
       for (let i = 0; i < cards.length; i++) {
-        removeDashboardCard(i);
-        getDashboardCards().should("have.length", cards.length - 1);
+        H.removeDashboardCard(i);
+        H.getDashboardCards().should("have.length", cards.length - 1);
 
-        undo();
-        getDashboardCards().should("have.length", cards.length);
+        H.undo();
+        H.getDashboardCards().should("have.length", cards.length);
         checkOrder();
         // Seems to be needed to allow the UI to catch up before hovering the next element.
         // TODO: improve this.
         cy.wait(200);
       }
 
-      createNewTab();
-      goToTab("Tab 1");
+      H.createNewTab();
+      H.goToTab("Tab 1");
 
       for (let i = 0; i < cards.length; i++) {
-        moveDashCardToTab({ dashcardIndex: i, tabName: "Tab 2" });
-        getDashboardCards().should("have.length", cards.length - 1);
+        H.moveDashCardToTab({ dashcardIndex: i, tabName: "Tab 2" });
+        H.getDashboardCards().should("have.length", cards.length - 1);
 
-        undo();
-        getDashboardCards().should("have.length", cards.length);
+        H.undo();
+        H.getDashboardCards().should("have.length", cards.length);
         checkOrder();
         cy.wait(200);
       }

--- a/e2e/test/scenarios/dashboard-cards/dashboard-drill.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-drill.cy.spec.js
@@ -1,3 +1,4 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
@@ -5,29 +6,6 @@ import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  addOrUpdateDashboardCard,
-  assertQueryBuilderRowCount,
-  assertTooltipRow,
-  chartPathWithFillColor,
-  echartsContainer,
-  echartsTooltip,
-  editDashboard,
-  entityPickerModal,
-  filterWidget,
-  getDashboardCard,
-  main,
-  modal,
-  popover,
-  queryBuilderHeader,
-  queryBuilderMain,
-  restore,
-  saveDashboard,
-  showDashboardCardActions,
-  sidebar,
-  tooltipHeader,
-  visitDashboard,
-} from "e2e/support/helpers";
 
 const {
   ORDERS,
@@ -41,20 +19,20 @@ const {
 
 describe("scenarios > dashboard > dashboard drill", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should handle URL click through on a table", () => {
     createDashboardWithQuestion({}, dashboardId => {
-      visitDashboard(dashboardId);
+      H.visitDashboard(dashboardId);
 
       cy.findByTestId("dashboard-header").icon("pencil").click();
-      showDashboardCardActions();
+      H.showDashboardCardActions();
       cy.findByTestId("dashboardcard-actions-panel").icon("click").click();
 
       // configure a URL click through on the  "MY_NUMBER" column
-      sidebar()
+      H.sidebar()
         .findByText("On-click behavior for each column")
         .parent()
         .parent()
@@ -63,7 +41,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
       cy.findByText("URL").click();
 
       // set the url and text template
-      modal().within(() => {
+      H.modal().within(() => {
         cy.get("input").first().type("/foo/{{my_number}}/{{my_param}}", {
           parseSpecialCharSequences: false,
         });
@@ -81,7 +59,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
       setParamValue("My Param", "param-value");
       // click value and confirm url updates
 
-      getDashboardCard().findByText("column value: 111").click();
+      H.getDashboardCard().findByText("column value: 111").click();
       cy.location("pathname").should("eq", "/foo/111/param-value");
     });
   });
@@ -128,7 +106,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
           visualization_settings: clickBehavior,
         });
 
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       },
     );
 
@@ -164,7 +142,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
       questionId => {
         createDashboard(
           { questionId, visualization_settings: dashCardSettings },
-          dashboardIdA => visitDashboard(dashboardIdA),
+          dashboardIdA => H.visitDashboard(dashboardIdA),
         );
       },
     );
@@ -174,28 +152,30 @@ describe("scenarios > dashboard > dashboard drill", () => {
   });
 
   it("should handle question click through on a table", () => {
-    createDashboardWithQuestion({}, dashboardId => visitDashboard(dashboardId));
+    createDashboardWithQuestion({}, dashboardId =>
+      H.visitDashboard(dashboardId),
+    );
 
     cy.findByLabelText("Edit dashboard").click();
-    showDashboardCardActions();
+    H.showDashboardCardActions();
     cy.findByLabelText("Click behavior").click();
 
-    sidebar().within(() => {
+    H.sidebar().within(() => {
       // Configuring on-click behavior for MY_NUMBER column
       cy.findByText("MY_NUMBER").click();
       cy.findByText("Go to a custom destination").click();
       cy.findByText("Saved question").click();
     });
 
-    modal().findByText("Orders").click();
+    H.modal().findByText("Orders").click();
 
-    sidebar().findByText("User ID").click();
-    popover().findByText("MY_NUMBER").click();
+    H.sidebar().findByText("User ID").click();
+    H.popover().findByText("MY_NUMBER").click();
 
-    sidebar().findByText("Product → Category").click();
-    popover().findByText("My Param").click();
+    H.sidebar().findByText("Product → Category").click();
+    H.popover().findByText("My Param").click();
 
-    sidebar()
+    H.sidebar()
       .findByLabelText(/Customize link text/)
       .type("num: {{my_number}}", {
         parseSpecialCharSequences: false,
@@ -204,18 +184,18 @@ describe("scenarios > dashboard > dashboard drill", () => {
     cy.findByTestId("edit-bar").button("Save").click();
 
     // wait to leave editing mode and set a param value
-    main().findByText("You're editing this dashboard.").should("not.exist");
+    H.main().findByText("You're editing this dashboard.").should("not.exist");
     setParamValue("My Param", "Widget");
 
     // click on table value
     cy.findByTestId("dashcard").findByText("num: 111").click();
 
-    queryBuilderHeader().findByText("Orders").should("be.visible");
+    H.queryBuilderHeader().findByText("Orders").should("be.visible");
     cy.findByTestId("qb-filters-panel").within(() => {
       cy.findByText("User ID is 111").should("be.visible");
       cy.findByText("Product → Category is Widget").should("be.visible");
     });
-    assertQueryBuilderRowCount(5);
+    H.assertQueryBuilderRowCount(5);
   });
 
   it("should handle dashboard click through on a table", () => {
@@ -226,14 +206,14 @@ describe("scenarios > dashboard > dashboard drill", () => {
           createDashboardWithQuestion(
             { dashboardName: "end dash" },
             dashboardIdB => {
-              visitDashboard(dashboardIdA);
+              H.visitDashboard(dashboardIdA);
             },
           );
         },
       );
     });
     cy.icon("pencil").click();
-    showDashboardCardActions();
+    H.showDashboardCardActions();
     cy.findByTestId("dashboardcard-actions-panel").within(() => {
       cy.icon("click").click();
     });
@@ -252,7 +232,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
       .parent()
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       .within(() => cy.findByText("Dashboard").click());
-    entityPickerModal().within(() => {
+    H.entityPickerModal().within(() => {
       cy.findByRole("tab", { name: /Dashboards/ }).click();
       cy.findByText("end dash").click();
     });
@@ -262,7 +242,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       .within(() => cy.findByText("My Param").click());
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    popover().within(() => cy.findByText("MY_STRING").click());
+    H.popover().within(() => cy.findByText("MY_STRING").click());
 
     // set the text template
     cy.findByPlaceholderText("E.x. Details for {{Column Name}}").type(
@@ -288,21 +268,21 @@ describe("scenarios > dashboard > dashboard drill", () => {
 
   it("should open the same dashboard when a custom URL click behavior points to the same dashboard (metabase#22702)", () => {
     createDashboardWithQuestion({}, dashboardId => {
-      visitDashboard(dashboardId);
-      editDashboard();
-      showDashboardCardActions();
+      H.visitDashboard(dashboardId);
+      H.editDashboard();
+      H.showDashboardCardActions();
       cy.findByTestId("dashboardcard-actions-panel")
         .icon("click")
         .should("be.visible")
         .click();
 
-      sidebar().within(() => {
+      H.sidebar().within(() => {
         cy.findByText("MY_NUMBER").click();
         cy.findByText("Go to a custom destination").click();
         cy.findByText("URL").click();
       });
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.get("input")
           .first()
           .type(`/dashboard/${dashboardId}?my_param=Aaron Hand`, { delay: 0 });
@@ -310,7 +290,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
         cy.button("Done").click();
       });
 
-      saveDashboard();
+      H.saveDashboard();
 
       cy.findByTestId("dashcard").findByText("Click behavior").click();
       cy.get("fieldset").should("contain", "Aaron Hand");
@@ -322,9 +302,11 @@ describe("scenarios > dashboard > dashboard drill", () => {
 
   // This was flaking. Example: https://dashboard.cypress.io/projects/a394u1/runs/2109/test-results/91a15b66-4b80-40bf-b569-de28abe21f42
   it.skip("should handle cross-filter on a table", () => {
-    createDashboardWithQuestion({}, dashboardId => visitDashboard(dashboardId));
+    createDashboardWithQuestion({}, dashboardId =>
+      H.visitDashboard(dashboardId),
+    );
     cy.icon("pencil").click();
-    showDashboardCardActions();
+    H.showDashboardCardActions();
     cy.findByTestId("dashboardcard-actions-panel").within(() => {
       cy.icon("click").click();
     });
@@ -344,7 +326,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       .within(() => cy.findByText("My Param").click());
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    popover().within(() => cy.findByText("MY_STRING").click());
+    H.popover().within(() => cy.findByText("MY_STRING").click());
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
 
@@ -419,7 +401,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
 
     it("when clicking on the field value (metabase#13062-1)", () => {
       cy.findByTestId("dashcard").findByText("xavier").click();
-      popover().findByText("Is xavier").click();
+      H.popover().findByText("Is xavier").click();
 
       cy.findByTestId("qb-filters-panel").within(() => {
         cy.findByText("Reviewer is xavier").should("be.visible");
@@ -427,11 +409,11 @@ describe("scenarios > dashboard > dashboard drill", () => {
       });
 
       // xavier's review
-      queryBuilderMain()
+      H.queryBuilderMain()
         .contains("Reprehenderit non error")
         .should("be.visible");
 
-      assertQueryBuilderRowCount(1);
+      H.assertQueryBuilderRowCount(1);
     });
 
     it("when clicking on the card title (metabase#13062-2)", () => {
@@ -441,11 +423,11 @@ describe("scenarios > dashboard > dashboard drill", () => {
         .should("be.visible");
 
       // Sample review body
-      queryBuilderMain()
+      H.queryBuilderMain()
         .contains("Ad perspiciatis quis et consectetur.")
         .should("be.visible");
 
-      assertQueryBuilderRowCount(907);
+      H.assertQueryBuilderRowCount(907);
     });
   });
 
@@ -495,7 +477,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
       ],
     });
 
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
     cy.findAllByTestId("column-header").contains("ID").click().click();
 
     cy.get(".test-Table-ID").contains(PK_VALUE).first().click();
@@ -557,7 +539,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
     });
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
     // Product ID in the first row (query fails for User ID as well)
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("105").click();
@@ -598,7 +580,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
         });
 
         cy.log("Add question to the dashboard");
-        addOrUpdateDashboardCard({
+        H.addOrUpdateDashboardCard({
           card_id: QUESTION_ID,
           dashboard_id: DASHBOARD_ID,
           card: {
@@ -633,23 +615,23 @@ describe("scenarios > dashboard > dashboard drill", () => {
           },
         });
 
-        visitDashboard(DASHBOARD_ID);
+        H.visitDashboard(DASHBOARD_ID);
 
         cy.intercept(
           "POST",
           `/api/dashboard/${DASHBOARD_ID}/dashcard/*/card/${QUESTION_ID}/query`,
         ).as("cardQuery");
 
-        chartPathWithFillColor("#509EE3")
+        H.chartPathWithFillColor("#509EE3")
           .eq(14) // August 2023 (Total of 12 reviews, 9 unique days)
           .click();
 
         cy.wait("@cardQuery");
         cy.url().should("include", "2023-08");
-        chartPathWithFillColor("#509EE3").should("have.length", 1);
+        H.chartPathWithFillColor("#509EE3").should("have.length", 1);
         // Since hover doesn't work in Cypress we can't assert on the popover that's shown when one hovers the bar
         // But when this issue gets fixed, Y-axis should definitely show "12" (total count of reviews)
-        echartsContainer().get("text").contains("12");
+        H.echartsContainer().get("text").contains("12");
       });
     });
   });
@@ -676,16 +658,16 @@ describe("scenarios > dashboard > dashboard drill", () => {
 
     cy.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
       ({ body: { dashboard_id } }) => {
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
 
         // click the first bar on the card's graph and do a zoom drill-through
-        chartPathWithFillColor("#509EE3").eq(0).click();
+        H.chartPathWithFillColor("#509EE3").eq(0).click();
         cy.findByText("See this month by week").click();
 
         cy.wait("@dataset");
 
         // check that the display is still a bar chart by checking that a .bar element exists
-        chartPathWithFillColor("#509EE3").should("exist");
+        H.chartPathWithFillColor("#509EE3").should("exist");
       },
     );
   });
@@ -716,7 +698,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
     createQuestion({ visualization_settings: questionSettings }, questionId => {
       createDashboard(
         { questionId, visualization_settings: dashCardSettings },
-        dashboardIdA => visitDashboard(dashboardIdA),
+        dashboardIdA => H.visitDashboard(dashboardIdA),
       );
     });
 
@@ -735,7 +717,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
     }).then(({ body: { id: QUESTION_ID } }) => {
       cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
         // Add previously added question to the dashboard
-        addOrUpdateDashboardCard({
+        H.addOrUpdateDashboardCard({
           card_id: QUESTION_ID,
           dashboard_id: DASHBOARD_ID,
           card: {
@@ -755,12 +737,12 @@ describe("scenarios > dashboard > dashboard drill", () => {
           },
         });
 
-        visitDashboard(DASHBOARD_ID);
+        H.visitDashboard(DASHBOARD_ID);
         cy.icon("pencil").click();
         // Edit "Visualization options"
-        showDashboardCardActions();
+        H.showDashboardCardActions();
         cy.icon("palette").click();
-        modal().within(() => {
+        H.modal().within(() => {
           cy.findByText("Reset to defaults").click();
           cy.button("Done").click();
         });
@@ -807,7 +789,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
           ],
         });
         // Add question to the dashboard
-        addOrUpdateDashboardCard({
+        H.addOrUpdateDashboardCard({
           card_id: QUESTION_ID,
           dashboard_id: DASHBOARD_ID,
           card: {
@@ -872,7 +854,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
       }).then(({ body: { id: QUESTION2_ID } }) => {
         cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
           // Add the first question to the dashboard
-          addOrUpdateDashboardCard({
+          H.addOrUpdateDashboardCard({
             card_id: QUESTION1_ID,
             dashboard_id: DASHBOARD_ID,
             card: {
@@ -884,19 +866,19 @@ describe("scenarios > dashboard > dashboard drill", () => {
             },
           });
 
-          visitDashboard(DASHBOARD_ID);
+          H.visitDashboard(DASHBOARD_ID);
 
           const assertTooltipValues = () =>
-            echartsTooltip().within(() => {
-              tooltipHeader().should("have.text", 1);
-              assertTooltipRow("15612_1", { color: "#88BF4D", value: "5" });
-              assertTooltipRow("15612_2", { color: "#98D9D9", value: "10" });
+            H.echartsTooltip().within(() => {
+              H.tooltipHeader().should("have.text", 1);
+              H.assertTooltipRow("15612_1", { color: "#88BF4D", value: "5" });
+              H.assertTooltipRow("15612_2", { color: "#98D9D9", value: "10" });
             });
 
-          chartPathWithFillColor("#88BF4D").first().trigger("mousemove");
+          H.chartPathWithFillColor("#88BF4D").first().trigger("mousemove");
           assertTooltipValues();
 
-          chartPathWithFillColor("#98D9D9").first().trigger("mousemove");
+          H.chartPathWithFillColor("#98D9D9").first().trigger("mousemove");
           assertTooltipValues();
         });
       });
@@ -965,7 +947,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
         ],
       });
 
-      visitDashboard(ORDERS_DASHBOARD_ID);
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
     });
 
     it("should correctly drill-through on Orders filter (metabase#11503-1)", () => {
@@ -973,13 +955,13 @@ describe("scenarios > dashboard > dashboard drill", () => {
 
       drillThroughCardTitle("Orders");
 
-      queryBuilderMain().within(() => {
+      H.queryBuilderMain().within(() => {
         cy.findByText("37.65").should("be.visible");
         cy.findByText("110.93").should("be.visible");
         cy.findByText("52.72").should("not.exist");
       });
 
-      assertQueryBuilderRowCount(2);
+      H.assertQueryBuilderRowCount(2);
 
       postDrillAssertion("ID is 2 selections");
     });
@@ -988,18 +970,18 @@ describe("scenarios > dashboard > dashboard drill", () => {
       setFilterValue(productsIdFilter.name);
 
       drillThroughCardTitle("Orders");
-      queryBuilderMain().within(() => {
+      H.queryBuilderMain().within(() => {
         cy.findByText("37.65").should("not.exist");
         cy.findAllByText("105.12").should("have.length", 17);
       });
 
-      assertQueryBuilderRowCount(191);
+      H.assertQueryBuilderRowCount(191);
 
       postDrillAssertion("Product → ID is 2 selections");
     });
 
     function setFilterValue(filterName) {
-      filterWidget().contains(filterName).click();
+      H.filterWidget().contains(filterName).click();
       cy.findByPlaceholderText("Enter an ID").type("1,2,");
       cy.button("Add filter").click();
       cy.findByText("2 selections");
@@ -1007,7 +989,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
 
     function postDrillAssertion(filterName) {
       cy.findByTestId("qb-filters-panel").findByText(filterName).click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findAllByRole("combobox")
           .last()
           .should("contain", "1")
@@ -1062,7 +1044,7 @@ function createDashboard(
         ],
       });
 
-      addOrUpdateDashboardCard({
+      H.addOrUpdateDashboardCard({
         card_id: questionId,
         dashboard_id: dashboardId,
         card: {
@@ -1087,7 +1069,7 @@ function setParamValue(paramName, text) {
   // wait to leave editing mode and set a param value
   cy.findByText("You're editing this dashboard.").should("not.exist");
   cy.findByText(paramName).click();
-  popover().within(() => {
+  H.popover().within(() => {
     cy.findByPlaceholderText("Search by Name").type(text);
     cy.findByText("Add filter").click();
   });

--- a/e2e/test/scenarios/dashboard-cards/dashcard-replace-question.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashcard-replace-question.cy.spec.js
@@ -1,24 +1,10 @@
+import { H } from "e2e/support";
 import { USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   FIRST_COLLECTION_ID,
   ORDERS_COUNT_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  describeWithSnowplow,
-  enableTracking,
-  entityPickerModal,
-  expectGoodSnowplowEvent,
-  expectNoBadSnowplowEvents,
-  findDashCardAction,
-  modal,
-  popover,
-  resetSnowplow,
-  restore,
-  saveDashboard,
-  undoToastList,
-  visitDashboard,
-} from "e2e/support/helpers";
 import {
   createMockDashboardCard,
   createMockHeadingDashboardCard,
@@ -114,12 +100,12 @@ function getDashboardCards(mappedQuestionId) {
   ];
 }
 
-describeWithSnowplow("scenarios > dashboard cards > replace question", () => {
+H.describeWithSnowplow("scenarios > dashboard cards > replace question", () => {
   beforeEach(() => {
-    resetSnowplow();
-    restore();
+    H.resetSnowplow();
+    H.restore();
     cy.signInAsAdmin();
-    enableTracking();
+    H.enableTracking();
 
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
 
@@ -141,19 +127,19 @@ describeWithSnowplow("scenarios > dashboard cards > replace question", () => {
   });
 
   afterEach(() => {
-    expectNoBadSnowplowEvents();
+    H.expectNoBadSnowplowEvents();
   });
 
   it("should replace a dashboard card question (metabase#36984)", () => {
     visitDashboardAndEdit();
 
-    findDashCardAction(findHeadingDashcard(), "Replace").should("not.exist");
+    H.findDashCardAction(findHeadingDashcard(), "Replace").should("not.exist");
 
     // Ensure can replace with a question
     replaceQuestion(findTargetDashcard(), {
       nextQuestionName: "Orders",
     });
-    expectGoodSnowplowEvent({ event: "dashboard_card_replaced" });
+    H.expectGoodSnowplowEvent({ event: "dashboard_card_replaced" });
     findTargetDashcard().within(() => {
       assertDashCardTitle("Orders");
       cy.findByText("Product ID").should("exist");
@@ -171,7 +157,7 @@ describeWithSnowplow("scenarios > dashboard cards > replace question", () => {
     });
 
     // Ensure changes are persisted
-    saveDashboard();
+    H.saveDashboard();
     findTargetDashcard().within(() => {
       assertDashCardTitle("Orders Model");
       cy.findByText("Product ID").should("exist");
@@ -193,7 +179,7 @@ describeWithSnowplow("scenarios > dashboard cards > replace question", () => {
     });
 
     // There're two toasts: "Undo replace" and "Auto-connect"
-    undoToastList().eq(0).button("Undo").click();
+    H.undoToastList().eq(0).button("Undo").click();
 
     // Ensure we kept viz settings and parameter mapping changes from before
     findTargetDashcard().within(() => {
@@ -208,7 +194,7 @@ describeWithSnowplow("scenarios > dashboard cards > replace question", () => {
     });
 
     // Ensure changes are persisted
-    saveDashboard();
+    H.saveDashboard();
     findTargetDashcard().within(() => {
       assertDashCardTitle("Custom name");
       cy.findByText("18,760").should("exist");
@@ -238,7 +224,7 @@ describeWithSnowplow("scenarios > dashboard cards > replace question", () => {
     });
 
     // Ensure changes are persisted
-    saveDashboard();
+    H.saveDashboard();
     findTargetDashcard().within(() => {
       assertDashCardTitle("Next question");
       cy.findByText("Ean").should("exist");
@@ -248,7 +234,7 @@ describeWithSnowplow("scenarios > dashboard cards > replace question", () => {
 });
 
 function visitDashboardAndEdit() {
-  visitDashboard("@dashboardId");
+  H.visitDashboard("@dashboardId");
   cy.findByLabelText("Edit dashboard").click();
 }
 
@@ -265,7 +251,7 @@ function replaceQuestion(
   { nextQuestionName, collectionName, tab },
 ) {
   dashcardElement.realHover().findByLabelText("Replace").click();
-  entityPickerModal().within(() => {
+  H.entityPickerModal().within(() => {
     if (tab) {
       cy.findByRole("tablist").findByText(tab).click();
     }
@@ -282,8 +268,8 @@ function assertDashCardTitle(title) {
 }
 
 function overwriteDashCardTitle(dashcardElement, textTitle) {
-  findDashCardAction(dashcardElement, "Show visualization options").click();
-  modal().within(() => {
+  H.findDashCardAction(dashcardElement, "Show visualization options").click();
+  H.modal().within(() => {
     cy.findByLabelText("Title").type(`{selectall}{del}${textTitle}`).blur();
     cy.button("Done").click();
   });
@@ -295,7 +281,7 @@ function connectDashboardFilter(dashcardElement, { filterName, columnName }) {
   );
   filterPanel.findByText(filterName).click();
   dashcardElement.button(/Select/).click();
-  popover().findByText(columnName).click();
+  H.popover().findByText(columnName).click();
   filterPanel.findByText(filterName).click();
 }
 

--- a/e2e/test/scenarios/dashboard-cards/duplicate-dashcards-tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/duplicate-dashcards-tabs.cy.spec.js
@@ -1,20 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  dashboardCards,
-  describeWithSnowplow,
-  duplicateTab,
-  enableTracking,
-  expectGoodSnowplowEvent,
-  expectNoBadSnowplowEvents,
-  filterWidget,
-  findDashCardAction,
-  getDashboardCard,
-  popover,
-  resetSnowplow,
-  restore,
-  saveDashboard,
-  visitDashboard,
-} from "e2e/support/helpers";
 import {
   createMockDashboardCard,
   createMockParameter,
@@ -63,12 +48,12 @@ const EVENTS = {
   saveDashboard: { event: "dashboard_saved" },
 };
 
-describeWithSnowplow("scenarios > dashboard cards > duplicate", () => {
+H.describeWithSnowplow("scenarios > dashboard cards > duplicate", () => {
   beforeEach(() => {
-    restore();
-    resetSnowplow();
+    H.restore();
+    H.resetSnowplow();
     cy.signInAsAdmin();
-    enableTracking();
+    H.enableTracking();
 
     cy.createQuestion(MAPPED_QUESTION_CREATE_INFO).then(
       ({ body: { id: mappedQuestionId } }) => {
@@ -86,24 +71,24 @@ describeWithSnowplow("scenarios > dashboard cards > duplicate", () => {
   });
 
   afterEach(() => {
-    expectNoBadSnowplowEvents();
+    H.expectNoBadSnowplowEvents();
   });
 
   it("should allow the user to duplicate a dashcard", () => {
     // 1. Confirm duplication works
-    visitDashboard("@dashboardId");
+    H.visitDashboard("@dashboardId");
     cy.findByLabelText("Edit dashboard").click();
 
-    findDashCardAction(getDashboardCard(0), "Duplicate").click();
-    expectGoodSnowplowEvent(EVENTS.duplicateDashcard);
-    saveDashboard();
-    expectGoodSnowplowEvent(EVENTS.saveDashboard);
+    H.findDashCardAction(H.getDashboardCard(0), "Duplicate").click();
+    H.expectGoodSnowplowEvent(EVENTS.duplicateDashcard);
+    H.saveDashboard();
+    H.expectGoodSnowplowEvent(EVENTS.saveDashboard);
 
     cy.findAllByText("Products").should("have.length", 2);
 
     // 2. Confirm filter still works
-    filterWidget().click();
-    popover().within(() => {
+    H.filterWidget().click();
+    H.popover().within(() => {
       cy.findByText("Gadget").click();
     });
     cy.button("Add filter").click();
@@ -113,31 +98,31 @@ describeWithSnowplow("scenarios > dashboard cards > duplicate", () => {
 
   it("should allow the user to duplicate a tab", () => {
     // 1. Confirm duplication works
-    visitDashboard("@dashboardId");
+    H.visitDashboard("@dashboardId");
     cy.findByLabelText("Edit dashboard").click();
 
-    duplicateTab("Tab 1");
-    expectGoodSnowplowEvent(EVENTS.duplicateTab);
-    getDashboardCard().within(() => {
+    H.duplicateTab("Tab 1");
+    H.expectGoodSnowplowEvent(EVENTS.duplicateTab);
+    H.getDashboardCard().within(() => {
       cy.findByText("Products").should("exist");
       cy.findByText("Category").should("exist");
       cy.findByText(/(Problem|Error)/i).should("not.exist");
     });
-    saveDashboard();
-    expectGoodSnowplowEvent(EVENTS.saveDashboard);
+    H.saveDashboard();
+    H.expectGoodSnowplowEvent(EVENTS.saveDashboard);
 
-    dashboardCards().within(() => {
+    H.dashboardCards().within(() => {
       cy.findByText("Products");
     });
 
     // 2. Confirm filter still works
-    filterWidget().click();
-    popover().within(() => {
+    H.filterWidget().click();
+    H.popover().within(() => {
       cy.findByText("Gadget").click();
     });
     cy.button("Add filter").click();
 
-    dashboardCards().within(() => {
+    H.dashboardCards().within(() => {
       cy.findByText("Incredible Bronze Pants");
     });
   });

--- a/e2e/test/scenarios/dashboard-cards/visualization-options.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/visualization-options.cy.spec.js
@@ -1,57 +1,45 @@
+import { H } from "e2e/support";
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  editDashboard,
-  getDashboardCard,
-  getDashboardCardMenu,
-  getDraggableElements,
-  modal,
-  moveDnDKitElement,
-  popover,
-  restore,
-  saveDashboard,
-  showDashboardCardActions,
-  visitDashboard,
-} from "e2e/support/helpers";
 
 describe("scenarios > dashboard cards > visualization options", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should allow empty card title (metabase#12013, metabase#36788)", () => {
     const originalCardTitle = "Orders";
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
 
     cy.findByTestId("legend-caption")
       .should("contain", originalCardTitle)
       .and("be.visible");
 
-    editDashboard();
-    showDashboardCardActions();
+    H.editDashboard();
+    H.showDashboardCardActions();
     cy.icon("palette").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByDisplayValue(originalCardTitle).click().clear().blur();
       cy.button("Done").click();
     });
 
     cy.findByTestId("legend-caption").should("not.contain", originalCardTitle);
-    saveDashboard();
-    getDashboardCard().realHover();
-    getDashboardCardMenu().click();
-    popover()
+    H.saveDashboard();
+    H.getDashboardCard().realHover();
+    H.getDashboardCardMenu().click();
+    H.popover()
       .should("contain", "Edit question")
       .and("contain", "Download results");
   });
 
   it("column reordering should work (metabase#16229)", () => {
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
     cy.findByLabelText("Edit dashboard").click();
-    getDashboardCard().realHover();
+    H.getDashboardCard().realHover();
     cy.findByLabelText("Show visualization options").click();
     cy.findByTestId("chartsettings-sidebar").within(() => {
-      moveDnDKitElement(getDraggableElements().contains("ID"), {
+      H.moveDnDKitElement(H.getDraggableElements().contains("ID"), {
         vertical: 100,
       });
 
@@ -67,16 +55,16 @@ describe("scenarios > dashboard cards > visualization options", () => {
     });
 
     // The table preview should get updated immediately, reflecting the changes in columns ordering.
-    modal().findAllByTestId("column-header").first().contains("User ID");
+    H.modal().findAllByTestId("column-header").first().contains("User ID");
   });
 
   it("should refelct column settings accurately when changing (metabase#30966)", () => {
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
     cy.findByLabelText("Edit dashboard").click();
-    getDashboardCard().realHover();
+    H.getDashboardCard().realHover();
     cy.findByLabelText("Show visualization options").click();
     cy.findByTestId("Subtotal-settings-button").click();
-    popover().findByLabelText("Show a mini bar chart").click();
+    H.popover().findByLabelText("Show a mini bar chart").click();
     cy.findAllByTestId("mini-bar").should("have.length.above", 0);
   });
 });

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-query-stages.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-query-stages.cy.spec.ts
@@ -1,26 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  createDashboardWithTabs,
-  createQuestion,
-  editDashboard,
-  entityPickerModal,
-  entityPickerModalItem,
-  entityPickerModalTab,
-  filterWidget,
-  getDashboardCard,
-  getNotebookStep,
-  modal,
-  popover,
-  restore,
-  saveDashboard,
-  saveQuestion,
-  sidebar,
-  startNewQuestion,
-  visitDashboard,
-  visitEmbeddedPage,
-  visitPublicDashboard,
-  visualize,
-} from "e2e/support/helpers";
 import type {
   Card,
   ConcreteFieldReference,
@@ -122,7 +101,7 @@ const NAMELESS_SECTION = "";
  */
 describe("scenarios > dashboard > filters > query stages", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     createBaseQuestions();
 
@@ -147,7 +126,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
       });
 
       it("allows to map to all relevant columns", () => {
-        editDashboard();
+        H.editDashboard();
 
         cy.log("## date columns");
         getFilter("Date").click();
@@ -272,7 +251,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
       });
 
       it("allows to map to all relevant columns (metabase#47184)", () => {
-        editDashboard();
+        H.editDashboard();
 
         cy.log("## date columns");
         getFilter("Date").click();
@@ -353,7 +332,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
       });
 
       it("allows to map to all relevant columns", () => {
-        editDashboard();
+        H.editDashboard();
 
         cy.log("## date columns");
         getFilter("Date").click();
@@ -448,7 +427,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
       });
 
       it("allows to map to all relevant columns", () => {
-        editDashboard();
+        H.editDashboard();
 
         cy.log("## date columns");
         getFilter("Date").click();
@@ -551,7 +530,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
       });
 
       it("allows to map to all relevant columns", () => {
-        editDashboard();
+        H.editDashboard();
 
         cy.log("## date columns");
         getFilter("Date").click();
@@ -652,7 +631,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
       });
 
       it("allows to map to all relevant columns", () => {
-        editDashboard();
+        H.editDashboard();
 
         cy.log("## date columns");
         getFilter("Date").click();
@@ -881,7 +860,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
       });
 
       it("allows to map to all relevant columns", () => {
-        editDashboard();
+        H.editDashboard();
 
         cy.log("## date columns");
         getFilter("Date").click();
@@ -1170,7 +1149,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
       });
 
       it("allows to map to all relevant columns", () => {
-        editDashboard();
+        H.editDashboard();
 
         cy.log("## date columns");
         getFilter("Date").click();
@@ -1298,22 +1277,22 @@ describe("scenarios > dashboard > filters > query stages", () => {
 
           cy.log("public dashboard");
           getDashboardId().then(dashboardId =>
-            visitPublicDashboard(dashboardId),
+            H.visitPublicDashboard(dashboardId),
           );
           waitForPublicDashboardData();
           apply1stStageExplicitJoinFilter();
           waitForPublicDashboardData();
 
-          getDashboardCard(0)
+          H.getDashboardCard(0)
             .findByText("Rows 1-1 of 953")
             .should("be.visible");
-          getDashboardCard(1)
+          H.getDashboardCard(1)
             .findByText("Rows 1-1 of 953")
             .should("be.visible");
 
           cy.log("embedded dashboard");
           getDashboardId().then(dashboardId => {
-            visitEmbeddedPage({
+            H.visitEmbeddedPage({
               resource: { dashboard: dashboardId },
               params: {},
             });
@@ -1322,10 +1301,10 @@ describe("scenarios > dashboard > filters > query stages", () => {
           apply1stStageExplicitJoinFilter();
           waitForEmbeddedDashboardData();
 
-          getDashboardCard(0)
+          H.getDashboardCard(0)
             .findByText("Rows 1-1 of 953")
             .should("be.visible");
-          getDashboardCard(1)
+          H.getDashboardCard(1)
             .findByText("Rows 1-1 of 953")
             .should("be.visible");
         });
@@ -1461,18 +1440,22 @@ describe("scenarios > dashboard > filters > query stages", () => {
 
           cy.log("public dashboard");
           getDashboardId().then(dashboardId =>
-            visitPublicDashboard(dashboardId),
+            H.visitPublicDashboard(dashboardId),
           );
           waitForPublicDashboardData();
           apply2ndStageCustomColumnFilter();
           waitForPublicDashboardData();
 
-          getDashboardCard(0).findByText("Rows 1-1 of 31").should("be.visible");
-          getDashboardCard(1).findByText("Rows 1-1 of 31").should("be.visible");
+          H.getDashboardCard(0)
+            .findByText("Rows 1-1 of 31")
+            .should("be.visible");
+          H.getDashboardCard(1)
+            .findByText("Rows 1-1 of 31")
+            .should("be.visible");
 
           cy.log("embedded dashboard");
           getDashboardId().then(dashboardId => {
-            visitEmbeddedPage({
+            H.visitEmbeddedPage({
               resource: { dashboard: dashboardId },
               params: {},
             });
@@ -1481,8 +1464,12 @@ describe("scenarios > dashboard > filters > query stages", () => {
           apply2ndStageCustomColumnFilter();
           waitForEmbeddedDashboardData();
 
-          getDashboardCard(0).findByText("Rows 1-1 of 31").should("be.visible");
-          getDashboardCard(1).findByText("Rows 1-1 of 31").should("be.visible");
+          H.getDashboardCard(0)
+            .findByText("Rows 1-1 of 31")
+            .should("be.visible");
+          H.getDashboardCard(1)
+            .findByText("Rows 1-1 of 31")
+            .should("be.visible");
         });
 
         it("2nd stage aggregation", () => {
@@ -1522,20 +1509,28 @@ describe("scenarios > dashboard > filters > query stages", () => {
 
           cy.log("public dashboard");
           getDashboardId().then(dashboardId =>
-            visitPublicDashboard(dashboardId),
+            H.visitPublicDashboard(dashboardId),
           );
           waitForPublicDashboardData();
           apply2ndStageAggregationFilter();
           waitForPublicDashboardData();
 
-          getDashboardCard(0).findByText("Rows 1-1 of 6").should("be.visible");
-          getDashboardCard(1).findByText("Rows 1-1 of 6").should("be.visible");
-          getDashboardCard(2).findByText("Rows 1-1 of 6").should("be.visible");
-          getDashboardCard(3).findByText("Rows 1-1 of 6").should("be.visible");
+          H.getDashboardCard(0)
+            .findByText("Rows 1-1 of 6")
+            .should("be.visible");
+          H.getDashboardCard(1)
+            .findByText("Rows 1-1 of 6")
+            .should("be.visible");
+          H.getDashboardCard(2)
+            .findByText("Rows 1-1 of 6")
+            .should("be.visible");
+          H.getDashboardCard(3)
+            .findByText("Rows 1-1 of 6")
+            .should("be.visible");
 
           cy.log("embedded dashboard");
           getDashboardId().then(dashboardId => {
-            visitEmbeddedPage({
+            H.visitEmbeddedPage({
               resource: { dashboard: dashboardId },
               params: {},
             });
@@ -1544,10 +1539,18 @@ describe("scenarios > dashboard > filters > query stages", () => {
           apply2ndStageAggregationFilter();
           waitForEmbeddedDashboardData();
 
-          getDashboardCard(0).findByText("Rows 1-1 of 6").should("be.visible");
-          getDashboardCard(1).findByText("Rows 1-1 of 6").should("be.visible");
-          getDashboardCard(2).findByText("Rows 1-1 of 6").should("be.visible");
-          getDashboardCard(3).findByText("Rows 1-1 of 6").should("be.visible");
+          H.getDashboardCard(0)
+            .findByText("Rows 1-1 of 6")
+            .should("be.visible");
+          H.getDashboardCard(1)
+            .findByText("Rows 1-1 of 6")
+            .should("be.visible");
+          H.getDashboardCard(2)
+            .findByText("Rows 1-1 of 6")
+            .should("be.visible");
+          H.getDashboardCard(3)
+            .findByText("Rows 1-1 of 6")
+            .should("be.visible");
         });
 
         it("2nd stage breakout", () => {
@@ -1587,34 +1590,34 @@ describe("scenarios > dashboard > filters > query stages", () => {
 
           cy.log("public dashboard");
           getDashboardId().then(dashboardId =>
-            visitPublicDashboard(dashboardId),
+            H.visitPublicDashboard(dashboardId),
           );
           waitForPublicDashboardData();
           // We're not using apply2ndStageBreakoutFilter() here because in public dashboards
           // there are no field values to choose from. We need to search for those values manually.
-          filterWidget().eq(0).click();
-          popover().within(() => {
+          H.filterWidget().eq(0).click();
+          H.popover().within(() => {
             cy.findByPlaceholderText("Enter some text").type("Gadget");
             cy.button("Add filter").click();
           });
           waitForPublicDashboardData();
 
-          getDashboardCard(0)
+          H.getDashboardCard(0)
             .findByText("Rows 1-1 of 1077")
             .should("be.visible");
-          getDashboardCard(1)
+          H.getDashboardCard(1)
             .findByText("Rows 1-1 of 1077")
             .should("be.visible");
-          getDashboardCard(2)
+          H.getDashboardCard(2)
             .findByText("Rows 1-1 of 1077")
             .should("be.visible");
-          getDashboardCard(3)
+          H.getDashboardCard(3)
             .findByText("Rows 1-1 of 1077")
             .should("be.visible");
 
           cy.log("embedded dashboard");
           getDashboardId().then(dashboardId => {
-            visitEmbeddedPage({
+            H.visitEmbeddedPage({
               resource: { dashboard: dashboardId },
               params: {},
             });
@@ -1622,23 +1625,23 @@ describe("scenarios > dashboard > filters > query stages", () => {
           waitForEmbeddedDashboardData();
           // We're not using apply2ndStageBreakoutFilter() here because in public dashboards
           // there are no field values to choose from. We need to search for those values manually.
-          filterWidget().eq(0).click();
-          popover().within(() => {
+          H.filterWidget().eq(0).click();
+          H.popover().within(() => {
             cy.findByPlaceholderText("Enter some text").type("Gadget");
             cy.button("Add filter").click();
           });
           waitForEmbeddedDashboardData();
 
-          getDashboardCard(0)
+          H.getDashboardCard(0)
             .findByText("Rows 1-1 of 1077")
             .should("be.visible");
-          getDashboardCard(1)
+          H.getDashboardCard(1)
             .findByText("Rows 1-1 of 1077")
             .should("be.visible");
-          getDashboardCard(2)
+          H.getDashboardCard(2)
             .findByText("Rows 1-1 of 1077")
             .should("be.visible");
-          getDashboardCard(3)
+          H.getDashboardCard(3)
             .findByText("Rows 1-1 of 1077")
             .should("be.visible");
         });
@@ -1653,7 +1656,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
       });
 
       it("allows to map to all relevant columns", () => {
-        editDashboard();
+        H.editDashboard();
 
         cy.log("## date columns");
         getFilter("Date").click();
@@ -1891,18 +1894,18 @@ describe("scenarios > dashboard > filters > query stages", () => {
         });
 
         it("2nd stage breakout", () => {
-          editDashboard();
+          H.editDashboard();
 
           getFilter("Text").click();
 
-          getDashboardCard(0).findByText("Select…").click();
-          popover().within(() => {
+          H.getDashboardCard(0).findByText("Select…").click();
+          H.popover().within(() => {
             getPopoverList().scrollTo("bottom");
             getPopoverItem("Category", 2).click();
           });
 
-          getDashboardCard(1).findByText("Select…").click();
-          popover().within(() => {
+          H.getDashboardCard(1).findByText("Select…").click();
+          H.popover().within(() => {
             getPopoverList().scrollTo("bottom");
             getPopoverItem("Category", 2).click();
           });
@@ -1910,8 +1913,8 @@ describe("scenarios > dashboard > filters > query stages", () => {
           cy.button("Save").click();
           cy.wait("@updateDashboard");
 
-          filterWidget().eq(0).click();
-          popover().within(() => {
+          H.filterWidget().eq(0).click();
+          H.popover().within(() => {
             cy.findByLabelText("Gadget").click();
             cy.button("Add filter").click();
           });
@@ -1937,24 +1940,24 @@ describe("scenarios > dashboard > filters > query stages", () => {
 describe("scenarios > dashboard > filters > query stages + temporal unit parameters", () => {
   describe("applies filter to the the dashcard and allows to drill via dashcard header", () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
 
       cy.intercept("POST", "/api/dataset").as("dataset");
     });
 
     it("1st stage explicit join + unit of time parameter", () => {
-      startNewQuestion();
+      H.startNewQuestion();
 
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
-        entityPickerModalItem(2, "Orders").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
+        H.entityPickerModalItem(2, "Orders").click();
       });
 
-      getNotebookStep("filter")
+      H.getNotebookStep("filter")
         .findByText("Add filters to narrow your answer")
         .click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Orders").click();
         cy.findByText("Product").click();
         cy.findByText("Category").click();
@@ -1963,78 +1966,78 @@ describe("scenarios > dashboard > filters > query stages + temporal unit paramet
         cy.button("Add filter").click();
       });
 
-      getNotebookStep("summarize")
+      H.getNotebookStep("summarize")
         .findByText("Pick a function or metric")
         .click();
-      popover().findByText("Count of rows").click();
-      getNotebookStep("summarize").icon("add").click();
-      popover().within(() => {
+      H.popover().findByText("Count of rows").click();
+      H.getNotebookStep("summarize").icon("add").click();
+      H.popover().within(() => {
         cy.findByText("Sum of ...").click();
         cy.findByText("Total").click();
       });
 
-      getNotebookStep("summarize")
+      H.getNotebookStep("summarize")
         .findByText("Pick a column to group by")
         .click();
-      popover()
+      H.popover()
         .findByLabelText("Created At")
         .findByLabelText("Temporal bucket")
         .click();
-      popover().last().findByText("Week").click();
-      getNotebookStep("summarize")
+      H.popover().last().findByText("Week").click();
+      H.getNotebookStep("summarize")
         .findByTestId("breakout-step")
         .icon("add")
         .click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Orders").click();
         cy.findByText("Product").click();
         cy.findByText("Category").click();
       });
 
       cy.findAllByTestId("action-buttons").last().button("Summarize").click();
-      popover().findByText("Count of rows").click();
-      getNotebookStep("summarize", { stage: 1 })
+      H.popover().findByText("Count of rows").click();
+      H.getNotebookStep("summarize", { stage: 1 })
         .findByText("Pick a column to group by")
         .click();
-      popover().findByLabelText("Created At: Week").click();
+      H.popover().findByLabelText("Created At: Week").click();
 
-      visualize(); // need to visualize because startNewQuestion does not set "display" property on a card
+      H.visualize(); // need to visualize because startNewQuestion does not set "display" property on a card
       cy.wait("@dataset");
-      saveQuestion("test", { addToDashboard: true });
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Dashboards").click();
+      H.saveQuestion("test", { addToDashboard: true });
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Dashboards").click();
         cy.button(/create a new dashboard/i).click();
       });
-      modal()
+      H.modal()
         .last()
         .within(() => {
           cy.findByPlaceholderText("My new dashboard").type("Dash");
           cy.button("Create").click();
         });
-      entityPickerModal().button("Select").click();
+      H.entityPickerModal().button("Select").click();
 
       cy.findByLabelText("Add a filter or parameter").click();
-      popover().findByText("Text or Category").click();
-      getDashboardCard().findByText("Select…").click();
+      H.popover().findByText("Text or Category").click();
+      H.getDashboardCard().findByText("Select…").click();
       cy.findAllByText("Category").first().click();
 
       cy.findByLabelText("Add a filter or parameter").click();
-      popover().findByText("Time grouping").click();
-      getDashboardCard().findByText("Select…").click();
-      popover().findByText("Created At: Week").click();
+      H.popover().findByText("Time grouping").click();
+      H.getDashboardCard().findByText("Select…").click();
+      H.popover().findByText("Created At: Week").click();
 
-      saveDashboard();
-      filterWidget().eq(0).click();
-      popover().within(() => {
+      H.saveDashboard();
+      H.filterWidget().eq(0).click();
+      H.popover().within(() => {
         cy.findByText("Gizmo").click();
         cy.button("Add filter").click();
       });
 
-      filterWidget().eq(1).click();
-      popover().findByText("Quarter").click();
+      H.filterWidget().eq(1).click();
+      H.popover().findByText("Quarter").click();
 
-      getDashboardCard().findByText("Q1 2023").should("be.visible");
-      getDashboardCard().findByTestId("legend-caption-title").click();
+      H.getDashboardCard().findByText("Q1 2023").should("be.visible");
+      H.getDashboardCard().findByTestId("legend-caption-title").click();
       cy.wait("@dataset");
 
       // assert that new filter was applied
@@ -2057,7 +2060,7 @@ describe("pivot tables", () => {
   const QUESTION_PIVOT_INDEX = 0;
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     createBaseQuestions();
 
@@ -2067,7 +2070,7 @@ describe("pivot tables", () => {
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
 
     cy.then(function () {
-      createQuestion({
+      H.createQuestion({
         type: "question",
         query: createPivotableQuery(this.baseQuestion),
         name: "Question - pivot viz",
@@ -2107,7 +2110,7 @@ describe("pivot tables", () => {
   it("does not use extra filtering stage for pivot tables", () => {
     cy.log("dashboard parameters mapping");
 
-    editDashboard();
+    H.editDashboard();
 
     cy.log("## date columns");
     getFilter("Date").click();
@@ -2125,12 +2128,12 @@ describe("pivot tables", () => {
 
     cy.log("filter modal");
 
-    getDashboardCard(QUESTION_PIVOT_INDEX)
+    H.getDashboardCard(QUESTION_PIVOT_INDEX)
       .findByTestId("legend-caption-title")
       .click();
     cy.wait("@datasetPivot");
     cy.button("Filter").click();
-    modal().findByText("Summaries").should("not.exist");
+    H.modal().findByText("Summaries").should("not.exist");
 
     function verifyDateMappingOptions() {
       verifyDashcardMappingOptions(QUESTION_PIVOT_INDEX, [
@@ -2161,7 +2164,7 @@ describe("pivot tables", () => {
 });
 
 function createBaseQuestions() {
-  createQuestion({
+  H.createQuestion({
     type: "question",
     name: "Q0 Orders",
     description: "Question based on a database table",
@@ -2171,7 +2174,7 @@ function createBaseQuestions() {
   }).then(response => cy.wrap(response.body).as("ordersQuestion"));
 
   cy.then(function () {
-    createQuestion({
+    H.createQuestion({
       type: "question",
       name: "Base Orders Question",
       query: {
@@ -2179,7 +2182,7 @@ function createBaseQuestions() {
       },
     }).then(response => cy.wrap(response.body).as("baseQuestion"));
 
-    createQuestion({
+    H.createQuestion({
       type: "model",
       name: "Base Orders Model",
       query: {
@@ -2394,25 +2397,25 @@ type CreateQuery = (source: Card) => StructuredQuery;
 
 function createAndVisitDashboardWithCardMatrix(createQuery: CreateQuery) {
   cy.then(function () {
-    createQuestion({
+    H.createQuestion({
       type: "question",
       query: createQuery(this.baseQuestion),
       name: "Question-based Question",
     }).then(response => cy.wrap(response.body).as("qbq"));
 
-    createQuestion({
+    H.createQuestion({
       type: "question",
       query: createQuery(this.baseModel),
       name: "Model-based Question",
     }).then(response => cy.wrap(response.body).as("mbq"));
 
-    createQuestion({
+    H.createQuestion({
       type: "model",
       name: "Question-based Model",
       query: createQuery(this.baseQuestion),
     }).then(response => cy.wrap(response.body).as("qbm"));
 
-    createQuestion({
+    H.createQuestion({
       type: "model",
       name: "Model-based Model",
       query: createQuery(this.baseModel),
@@ -2429,7 +2432,7 @@ function createAndVisitDashboard(cards: Card[]) {
   let id = 0;
   const getNextId = () => --id;
 
-  createDashboardWithTabs({
+  H.createDashboardWithTabs({
     enable_embedding: true,
     embedding_params: {
       [DATE_PARAMETER.slug]: "enabled",
@@ -2449,24 +2452,24 @@ function createAndVisitDashboard(cards: Card[]) {
       })),
     ],
   }).then(dashboard => {
-    visitDashboard(dashboard.id);
+    H.visitDashboard(dashboard.id);
     cy.wrap(dashboard.id).as("dashboardId");
     cy.wait("@getDashboard");
   });
 }
 
 function setup1stStageExplicitJoinFilter() {
-  editDashboard();
+  H.editDashboard();
 
   getFilter("Text").click();
 
-  getDashboardCard(0).findByText("Select…").click();
-  popover().within(() => {
+  H.getDashboardCard(0).findByText("Select…").click();
+  H.popover().within(() => {
     getPopoverItem("Reviewer", 0).click();
   });
 
-  getDashboardCard(1).findByText("Select…").click();
-  popover().within(() => {
+  H.getDashboardCard(1).findByText("Select…").click();
+  H.popover().within(() => {
     getPopoverItem("Reviewer", 0).click();
   });
 
@@ -2475,35 +2478,35 @@ function setup1stStageExplicitJoinFilter() {
 }
 
 function apply1stStageExplicitJoinFilter() {
-  filterWidget().eq(0).click();
-  popover().within(() => {
+  H.filterWidget().eq(0).click();
+  H.popover().within(() => {
     cy.findByPlaceholderText("Search by Reviewer").type("abe.gorczany");
     cy.button("Add filter").click();
   });
 }
 
 function setup1stStageImplicitJoinFromSourceFilter() {
-  editDashboard();
+  H.editDashboard();
 
   getFilter("Number").click();
-  sidebar().findByText("Filter operator").next().click();
-  popover().findByText("Between").click();
+  H.sidebar().findByText("Filter operator").next().click();
+  H.popover().findByText("Between").click();
 
-  getDashboardCard(0).findByText("Select…").click();
-  popover().within(() => {
+  H.getDashboardCard(0).findByText("Select…").click();
+  H.popover().within(() => {
     getPopoverItem("Price", 0).click();
   });
 
-  getDashboardCard(1).findByText("Select…").click();
-  popover().within(() => {
+  H.getDashboardCard(1).findByText("Select…").click();
+  H.popover().within(() => {
     getPopoverItem("Price", 0).click();
   });
 
   cy.button("Save").click();
   cy.wait("@updateDashboard");
 
-  filterWidget().eq(0).click();
-  popover().within(() => {
+  H.filterWidget().eq(0).click();
+  H.popover().within(() => {
     cy.findAllByPlaceholderText("Enter a number").eq(0).type("0");
     cy.findAllByPlaceholderText("Enter a number").eq(1).type("16");
     cy.button("Add filter").click();
@@ -2512,25 +2515,25 @@ function setup1stStageImplicitJoinFromSourceFilter() {
 }
 
 function setup1stStageImplicitJoinFromJoinFilter() {
-  editDashboard();
+  H.editDashboard();
 
   getFilter("Text").click();
 
-  getDashboardCard(0).findByText("Select…").click();
-  popover().within(() => {
+  H.getDashboardCard(0).findByText("Select…").click();
+  H.popover().within(() => {
     getPopoverItem("Category", 1).click();
   });
 
-  getDashboardCard(1).findByText("Select…").click();
-  popover().within(() => {
+  H.getDashboardCard(1).findByText("Select…").click();
+  H.popover().within(() => {
     getPopoverItem("Category", 1).click();
   });
 
   cy.button("Save").click();
   cy.wait("@updateDashboard");
 
-  filterWidget().eq(0).click();
-  popover().within(() => {
+  H.filterWidget().eq(0).click();
+  H.popover().within(() => {
     cy.findByLabelText("Gadget").click();
     cy.button("Add filter").click();
   });
@@ -2538,27 +2541,27 @@ function setup1stStageImplicitJoinFromJoinFilter() {
 }
 
 function setup1stStageCustomColumnFilter() {
-  editDashboard();
+  H.editDashboard();
 
   getFilter("Number").click();
-  sidebar().findByText("Filter operator").next().click();
-  popover().findByText("Between").click();
+  H.sidebar().findByText("Filter operator").next().click();
+  H.popover().findByText("Between").click();
 
-  getDashboardCard(0).findByText("Select…").click();
-  popover().within(() => {
+  H.getDashboardCard(0).findByText("Select…").click();
+  H.popover().within(() => {
     getPopoverItem("Net").click();
   });
 
-  getDashboardCard(1).findByText("Select…").click();
-  popover().within(() => {
+  H.getDashboardCard(1).findByText("Select…").click();
+  H.popover().within(() => {
     getPopoverItem("Net").click();
   });
 
   cy.button("Save").click();
   cy.wait("@updateDashboard");
 
-  filterWidget().eq(0).click();
-  popover().within(() => {
+  H.filterWidget().eq(0).click();
+  H.popover().within(() => {
     cy.findAllByPlaceholderText("Enter a number").eq(0).type("0");
     cy.findAllByPlaceholderText("Enter a number").eq(1).type("20");
     cy.button("Add filter").click();
@@ -2567,20 +2570,20 @@ function setup1stStageCustomColumnFilter() {
 }
 
 function setup1stStageAggregationFilter() {
-  editDashboard();
+  H.editDashboard();
 
   getFilter("Number").click();
-  sidebar().findByText("Filter operator").next().click();
-  popover().findByText("Between").click();
+  H.sidebar().findByText("Filter operator").next().click();
+  H.popover().findByText("Between").click();
 
-  getDashboardCard(0).findByText("Select…").click();
-  popover().within(() => {
+  H.getDashboardCard(0).findByText("Select…").click();
+  H.popover().within(() => {
     getPopoverList().scrollTo("bottom");
     getPopoverItem("Count").click();
   });
 
-  getDashboardCard(1).findByText("Select…").click();
-  popover().within(() => {
+  H.getDashboardCard(1).findByText("Select…").click();
+  H.popover().within(() => {
     getPopoverList().scrollTo("bottom");
     getPopoverItem("Count").click();
   });
@@ -2588,8 +2591,8 @@ function setup1stStageAggregationFilter() {
   cy.button("Save").click();
   cy.wait("@updateDashboard");
 
-  filterWidget().eq(0).click();
-  popover().within(() => {
+  H.filterWidget().eq(0).click();
+  H.popover().within(() => {
     cy.findAllByPlaceholderText("Enter a number").eq(0).type("0");
     cy.findAllByPlaceholderText("Enter a number").eq(1).type("2");
     cy.button("Add filter").click();
@@ -2598,18 +2601,18 @@ function setup1stStageAggregationFilter() {
 }
 
 function setup1stStageBreakoutFilter() {
-  editDashboard();
+  H.editDashboard();
 
   getFilter("Text").click();
 
-  getDashboardCard(0).findByText("Select…").click();
-  popover().within(() => {
+  H.getDashboardCard(0).findByText("Select…").click();
+  H.popover().within(() => {
     getPopoverList().scrollTo("bottom");
     getPopoverItem("Category", 1).click();
   });
 
-  getDashboardCard(1).findByText("Select…").click();
-  popover().within(() => {
+  H.getDashboardCard(1).findByText("Select…").click();
+  H.popover().within(() => {
     getPopoverList().scrollTo("bottom");
     getPopoverItem("Category", 1).click();
   });
@@ -2617,8 +2620,8 @@ function setup1stStageBreakoutFilter() {
   cy.button("Save").click();
   cy.wait("@updateDashboard");
 
-  filterWidget().eq(0).click();
-  popover().within(() => {
+  H.filterWidget().eq(0).click();
+  H.popover().within(() => {
     cy.findByLabelText("Gadget").click();
     cy.button("Add filter").click();
   });
@@ -2626,25 +2629,25 @@ function setup1stStageBreakoutFilter() {
 }
 
 function setup2ndStageExplicitJoinFilter() {
-  editDashboard();
+  H.editDashboard();
 
   getFilter("Text").click();
 
-  getDashboardCard(0).findByText("Select…").click();
-  popover().within(() => {
+  H.getDashboardCard(0).findByText("Select…").click();
+  H.popover().within(() => {
     getPopoverItem("Reviewer", 1).click();
   });
 
-  getDashboardCard(1).findByText("Select…").click();
-  popover().within(() => {
+  H.getDashboardCard(1).findByText("Select…").click();
+  H.popover().within(() => {
     getPopoverItem("Reviewer", 1).click();
   });
 
   cy.button("Save").click();
   cy.wait("@updateDashboard");
 
-  filterWidget().eq(0).click();
-  popover().within(() => {
+  H.filterWidget().eq(0).click();
+  H.popover().within(() => {
     cy.findByPlaceholderText("Search by Reviewer").type("abe.gorczany");
     cy.button("Add filter").click();
   });
@@ -2652,20 +2655,20 @@ function setup2ndStageExplicitJoinFilter() {
 }
 
 function setup2ndStageCustomColumnFilter() {
-  editDashboard();
+  H.editDashboard();
 
   getFilter("Number").click();
-  sidebar().findByText("Filter operator").next().click();
-  popover().findByText("Between").click();
+  H.sidebar().findByText("Filter operator").next().click();
+  H.popover().findByText("Between").click();
 
-  getDashboardCard(0).findByText("Select…").click();
-  popover().within(() => {
+  H.getDashboardCard(0).findByText("Select…").click();
+  H.popover().within(() => {
     getPopoverList().scrollTo("bottom");
     getPopoverItem("5 * Count").click();
   });
 
-  getDashboardCard(1).findByText("Select…").click();
-  popover().within(() => {
+  H.getDashboardCard(1).findByText("Select…").click();
+  H.popover().within(() => {
     getPopoverList().scrollTo("bottom");
     getPopoverItem("5 * Count").click();
   });
@@ -2675,8 +2678,8 @@ function setup2ndStageCustomColumnFilter() {
 }
 
 function apply2ndStageCustomColumnFilter() {
-  filterWidget().eq(0).click();
-  popover().within(() => {
+  H.filterWidget().eq(0).click();
+  H.popover().within(() => {
     cy.findAllByPlaceholderText("Enter a number").eq(0).type("0");
     cy.findAllByPlaceholderText("Enter a number").eq(1).type("20");
     cy.button("Add filter").click();
@@ -2684,34 +2687,34 @@ function apply2ndStageCustomColumnFilter() {
 }
 
 function setup2ndStageAggregationFilter() {
-  editDashboard();
+  H.editDashboard();
 
   getFilter("Number").click();
-  sidebar().findByText("Filter operator").next().click();
-  popover().findByText("Between").click();
+  H.sidebar().findByText("Filter operator").next().click();
+  H.popover().findByText("Between").click();
 
-  getDashboardCard(0).findByText("Select…").click();
-  popover().within(() => {
+  H.getDashboardCard(0).findByText("Select…").click();
+  H.popover().within(() => {
     getPopoverList().scrollTo("bottom");
     getPopoverItem("Count", 1).click();
   });
   dismissToast();
 
-  getDashboardCard(1).findByText("Select…").click();
-  popover().within(() => {
+  H.getDashboardCard(1).findByText("Select…").click();
+  H.popover().within(() => {
     getPopoverList().scrollTo("bottom");
     getPopoverItem("Count", 1).click();
   });
   dismissToast();
 
-  getDashboardCard(2).findByText("Select…").click();
-  popover().within(() => {
+  H.getDashboardCard(2).findByText("Select…").click();
+  H.popover().within(() => {
     getPopoverItem("Count").click();
   });
   dismissToast();
 
-  getDashboardCard(3).findByText("Select…").click();
-  popover().within(() => {
+  H.getDashboardCard(3).findByText("Select…").click();
+  H.popover().within(() => {
     getPopoverItem("Count").click();
   });
 
@@ -2720,8 +2723,8 @@ function setup2ndStageAggregationFilter() {
 }
 
 function apply2ndStageAggregationFilter() {
-  filterWidget().eq(0).click();
-  popover().within(() => {
+  H.filterWidget().eq(0).click();
+  H.popover().within(() => {
     cy.findAllByPlaceholderText("Enter a number").eq(0).type("0");
     cy.findAllByPlaceholderText("Enter a number").eq(1).type("2");
     cy.button("Add filter").click();
@@ -2729,32 +2732,32 @@ function apply2ndStageAggregationFilter() {
 }
 
 function setup2ndStageBreakoutFilter() {
-  editDashboard();
+  H.editDashboard();
 
   getFilter("Text").click();
 
-  getDashboardCard(0).findByText("Select…").click();
-  popover().within(() => {
+  H.getDashboardCard(0).findByText("Select…").click();
+  H.popover().within(() => {
     getPopoverList().scrollTo("bottom");
     getPopoverItem("Category", 2).click();
   });
   dismissToast();
 
-  getDashboardCard(1).findByText("Select…").click();
-  popover().within(() => {
+  H.getDashboardCard(1).findByText("Select…").click();
+  H.popover().within(() => {
     getPopoverList().scrollTo("bottom");
     getPopoverItem("Category", 2).click();
   });
   dismissToast();
 
-  getDashboardCard(2).findByText("Select…").click();
-  popover().within(() => {
+  H.getDashboardCard(2).findByText("Select…").click();
+  H.popover().within(() => {
     getPopoverItem("Products Via Product ID Category").click();
   });
   dismissToast();
 
-  getDashboardCard(3).findByText("Select…").click();
-  popover().within(() => {
+  H.getDashboardCard(3).findByText("Select…").click();
+  H.popover().within(() => {
     getPopoverItem("Products Via Product ID Category").click();
   });
 
@@ -2763,8 +2766,8 @@ function setup2ndStageBreakoutFilter() {
 }
 
 function apply2ndStageBreakoutFilter() {
-  filterWidget().eq(0).click();
-  popover().within(() => {
+  H.filterWidget().eq(0).click();
+  H.popover().within(() => {
     cy.findByLabelText("Gadget").click();
     cy.button("Add filter").click();
   });
@@ -2838,17 +2841,17 @@ function verifyDashcardMappingOptions(
   dashcardIndex: number,
   sections: MappingSection[],
 ) {
-  getDashboardCard(dashcardIndex).findByText("Select…").click();
+  H.getDashboardCard(dashcardIndex).findByText("Select…").click();
   verifyPopoverMappingOptions(sections);
   clickAway();
 }
 
 function verifyNoDashcardMappingOptions(dashcardIndex: number) {
-  getDashboardCard(dashcardIndex)
+  H.getDashboardCard(dashcardIndex)
     .findByText("No valid fields")
     .should("be.visible");
 
-  getDashboardCard(dashcardIndex).findByText("No valid fields").realHover();
+  H.getDashboardCard(dashcardIndex).findByText("No valid fields").realHover();
   cy.findByRole("tooltip")
     .findByText(
       "This card doesn't have any fields or parameters that can be mapped to this parameter type.",
@@ -2867,7 +2870,7 @@ function verifyPopoverMappingOptions(sections: MappingSection[]) {
     0,
   );
 
-  popover().within(() => {
+  H.popover().within(() => {
     getPopoverItems().then($items => {
       let index = 0;
 
@@ -2899,10 +2902,12 @@ function verifyDashcardRowsCount({
   dashboardCount: string;
   queryBuilderCount: string;
 }) {
-  getDashboardCard(dashcardIndex)
+  H.getDashboardCard(dashcardIndex)
     .findByText(dashboardCount)
     .should("be.visible");
-  getDashboardCard(dashcardIndex).findByTestId("legend-caption-title").click();
+  H.getDashboardCard(dashcardIndex)
+    .findByTestId("legend-caption-title")
+    .click();
   cy.wait("@dataset");
   cy.findByTestId("question-row-count").should("have.text", queryBuilderCount);
 }
@@ -2917,14 +2922,16 @@ function verifyDashcardCellValues({
   for (let valueIndex = 0; valueIndex < values.length; ++valueIndex) {
     const value = values[valueIndex];
 
-    getDashboardCard(dashcardIndex)
+    H.getDashboardCard(dashcardIndex)
       .findByTestId("table-row")
       .findAllByTestId("cell-data")
       .eq(valueIndex)
       .should("have.text", value);
   }
 
-  getDashboardCard(dashcardIndex).findByTestId("legend-caption-title").click();
+  H.getDashboardCard(dashcardIndex)
+    .findByTestId("legend-caption-title")
+    .click();
   cy.wait("@dataset");
 
   for (let valueIndex = 0; valueIndex < values.length; ++valueIndex) {

--- a/e2e/test/scenarios/dashboard-filters/dashboard-chained-filters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-chained-filters.cy.spec.js
@@ -1,48 +1,33 @@
+import { H } from "e2e/support";
 import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  addOrUpdateDashboardCard,
-  editDashboard,
-  filterWidget,
-  getDashboardCard,
-  multiAutocompleteInput,
-  popover,
-  resetTestTable,
-  restore,
-  resyncDatabase,
-  saveDashboard,
-  setFilter,
-  showDashboardCardActions,
-  sidebar,
-  visitDashboard,
-} from "e2e/support/helpers";
 
 const { PEOPLE } = SAMPLE_DATABASE;
 
 describe("scenarios > dashboard > chained filter", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   for (const has_field_values of ["search", "list"]) {
     it(`limit ${has_field_values} options based on linked filter`, () => {
       cy.request("PUT", `/api/field/${PEOPLE.CITY}`, { has_field_values }),
-        visitDashboard(ORDERS_DASHBOARD_ID);
+        H.visitDashboard(ORDERS_DASHBOARD_ID);
 
-      editDashboard();
+      H.editDashboard();
 
       // add a state filter
-      setFilter("Location", "Is", "Location");
+      H.setFilter("Location", "Is", "Location");
 
       // connect that to people.state
-      getDashboardCard().within(() => {
+      H.getDashboardCard().within(() => {
         cy.findByText("Column to filter on");
         cy.findByText("Select…").click();
       });
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("State").click();
       });
 
@@ -53,17 +38,17 @@ describe("scenarios > dashboard > chained filter", () => {
         .findByText("add another dashboard filter")
         .click();
 
-      popover().findByText("Location").click();
+      H.popover().findByText("Location").click();
 
-      sidebar().findByText("Filter operator").next().click();
-      popover().findByText("Is").click();
+      H.sidebar().findByText("Filter operator").next().click();
+      H.popover().findByText("Is").click();
 
       // connect that to person.city
-      getDashboardCard().within(() => {
+      H.getDashboardCard().within(() => {
         cy.findByText("Column to filter on");
         cy.findByText("Select…").click();
       });
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("City").click();
       });
 
@@ -81,39 +66,39 @@ describe("scenarios > dashboard > chained filter", () => {
         cy.findByText("Filtered column");
       });
 
-      saveDashboard();
+      H.saveDashboard();
 
       // now test that it worked!
       // Select Alaska as a state. We should see Anchorage as a option but not Anacoco
-      filterWidget().contains("Location").click();
-      popover().within(() => {
+      H.filterWidget().contains("Location").click();
+      H.popover().within(() => {
         cy.findByText("AK").click();
         cy.findByText("Add filter").click();
       });
 
-      filterWidget().contains("Location 1").click();
+      H.filterWidget().contains("Location 1").click();
 
-      popover().within(() => {
+      H.popover().within(() => {
         if (has_field_values === "search") {
-          multiAutocompleteInput().type("An");
+          H.multiAutocompleteInput().type("An");
         }
         if (has_field_values === "list") {
           cy.findByPlaceholderText("Search the list").type("An");
         }
       });
 
-      popover()
+      H.popover()
         .last()
         .within(() => {
           cy.findByText("Anchorage");
           cy.findByText("Anacoco").should("not.exist");
         });
 
-      popover()
+      H.popover()
         .first()
         .within(() => {
           if (has_field_values === "search") {
-            multiAutocompleteInput()
+            H.multiAutocompleteInput()
               .type("{backspace}{backspace}")
               // close the suggestion list
               .blur();
@@ -123,8 +108,8 @@ describe("scenarios > dashboard > chained filter", () => {
           }
         });
 
-      filterWidget().contains("AK").click();
-      popover()
+      H.filterWidget().contains("AK").click();
+      H.popover()
         .last()
         .within(() => {
           cy.findByText("AK").click();
@@ -134,17 +119,17 @@ describe("scenarios > dashboard > chained filter", () => {
         });
 
       // do it again to make sure it isn't cached incorrectly
-      filterWidget().contains("Location 1").click();
-      popover().within(() => {
+      H.filterWidget().contains("Location 1").click();
+      H.popover().within(() => {
         if (has_field_values === "search") {
-          multiAutocompleteInput().type("An");
+          H.multiAutocompleteInput().type("An");
         }
         if (has_field_values === "list") {
           cy.findByPlaceholderText("Search the list").type("An");
         }
       });
 
-      popover()
+      H.popover()
         .last()
         .within(() => {
           cy.findByText("Canton");
@@ -152,16 +137,16 @@ describe("scenarios > dashboard > chained filter", () => {
         });
 
       if (has_field_values === "search") {
-        popover()
+        H.popover()
           .first()
           .within(() => {
             // close the suggestion list
-            multiAutocompleteInput().blur();
+            H.multiAutocompleteInput().blur();
           });
       }
 
-      filterWidget().contains("GA").click();
-      popover()
+      H.filterWidget().contains("GA").click();
+      H.popover()
         .last()
         .within(() => {
           cy.findByText("GA").click();
@@ -169,19 +154,19 @@ describe("scenarios > dashboard > chained filter", () => {
         });
 
       // do it again without a state filter to make sure it isn't cached incorrectly
-      filterWidget().contains("Location 1").click();
-      popover()
+      H.filterWidget().contains("Location 1").click();
+      H.popover()
         .first()
         .within(() => {
           if (has_field_values === "search") {
-            multiAutocompleteInput().type("An");
+            H.multiAutocompleteInput().type("An");
           }
           if (has_field_values === "list") {
             cy.findByRole("textbox").type("An");
           }
         });
 
-      popover()
+      H.popover()
         .last()
         .within(() => {
           cy.findByText("Adrian");
@@ -199,10 +184,10 @@ describe("scenarios > dashboard > chained filter", () => {
       const dialect = "postgres";
       const TEST_TABLE = "many_data_types";
 
-      resetTestTable({ type: dialect, table: TEST_TABLE });
-      restore(`${dialect}-writable`);
+      H.resetTestTable({ type: dialect, table: TEST_TABLE });
+      H.restore(`${dialect}-writable`);
       cy.signInAsAdmin();
-      resyncDatabase({ tableName: TEST_TABLE, tableAlias: "testTable" });
+      H.resyncDatabase({ tableName: TEST_TABLE, tableAlias: "testTable" });
 
       cy.get("@testTable").then(testTable => {
         const testTableId = testTable.id;
@@ -251,7 +236,7 @@ describe("scenarios > dashboard > chained filter", () => {
             });
 
             // Add previously created question to the dashboard
-            addOrUpdateDashboardCard({
+            H.addOrUpdateDashboardCard({
               card_id: QUESTION_ID,
               dashboard_id: DASHBOARD_ID,
             }).then(({ body: { id: DASH_CARD_ID } }) => {
@@ -277,17 +262,17 @@ describe("scenarios > dashboard > chained filter", () => {
               });
             });
 
-            visitDashboard(DASHBOARD_ID);
+            H.visitDashboard(DASHBOARD_ID);
             cy.icon("pencil").click();
-            showDashboardCardActions();
-            getDashboardCard().icon("click").click();
+            H.showDashboardCardActions();
+            H.getDashboardCard().icon("click").click();
             cy.findByText("UUID").click();
             cy.findByText("Update a dashboard filter").click();
             cy.findByText("Available filters")
               .parent()
               .findByText("ID")
               .click();
-            popover().findByText("UUID").should("be.visible");
+            H.popover().findByText("UUID").should("be.visible");
           });
         });
       });

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filter-data-permissions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filter-data-permissions.cy.spec.js
@@ -1,14 +1,8 @@
+import { H } from "e2e/support";
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  editDashboard,
-  restore,
-  selectDashboardFilter,
-  setFilter,
-  visitDashboard,
-} from "e2e/support/helpers";
 
 function filterDashboard(suggests = true) {
-  visitDashboard(ORDERS_DASHBOARD_ID);
+  H.visitDashboard(ORDERS_DASHBOARD_ID);
   cy.contains("Orders");
   cy.contains("Text").click();
 
@@ -36,18 +30,18 @@ describe("support > permissions (metabase#8472)", () => {
       `/api/dashboard/${ORDERS_DASHBOARD_ID}/params/*/search/*").as("search`,
     );
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     // Setup a dashboard with a text filter
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
 
-    editDashboard();
+    H.editDashboard();
 
-    setFilter("Text or Category", "Is");
+    H.setFilter("Text or Category", "Is");
 
     // Filter the first card by User Address
-    selectDashboardFilter(
+    H.selectDashboardFilter(
       cy.findByTestId("dashcard-container").first(),
       "Address",
     );

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filter-defaults.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filter-defaults.cy.spec.ts
@@ -1,20 +1,9 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  type StructuredQuestionDetails,
-  clearFilterWidget,
-  createQuestionAndDashboard,
-  editDashboard,
-  filterWidget,
-  popover,
-  restore,
-  saveDashboard,
-  sidebar,
-  visitDashboard,
-} from "e2e/support/helpers";
 
 const { PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
-const QUESTION: StructuredQuestionDetails = {
+const QUESTION: H.StructuredQuestionDetails = {
   name: "Return input value",
   display: "scalar",
   query: {
@@ -47,12 +36,12 @@ const DASHBOARD = {
 
 describe("scenarios > dashboard > filters > reset", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should reset a filters value when editing the default", () => {
-    createQuestionAndDashboard({
+    H.createQuestionAndDashboard({
       questionDetails: QUESTION,
       dashboardDetails: DASHBOARD,
     }).then(({ body: dashboardCard }) => {
@@ -72,7 +61,7 @@ describe("scenarios > dashboard > filters > reset", () => {
           },
         ],
       }).then(() => {
-        visitDashboard(dashboard_id, {
+        H.visitDashboard(dashboard_id, {
           params: {
             filter_one: "",
             filter_two: "Bar",
@@ -83,42 +72,42 @@ describe("scenarios > dashboard > filters > reset", () => {
 
     cy.log("Default dashboard filter");
 
-    filterWidget().contains("Filter One").should("be.visible");
-    filterWidget().contains("Bar").should("be.visible");
+    H.filterWidget().contains("Filter One").should("be.visible");
+    H.filterWidget().contains("Bar").should("be.visible");
 
     cy.location("search").should("eq", "?filter_one=&filter_two=Bar");
 
-    clearFilterWidget(1);
+    H.clearFilterWidget(1);
 
     cy.location("search").should("eq", "?filter_one=&filter_two=");
 
     cy.log(
       "Finally, when we remove dashboard filter's default value, the url should reflect that by removing the placeholder",
     );
-    editDashboard();
+    H.editDashboard();
 
     openFilterOptions("Filter Two");
 
-    sidebar().within(() => {
+    H.sidebar().within(() => {
       cy.findByLabelText("Input box").click();
       clearDefaultFilterValue();
       setDefaultFilterValue("Foo");
     });
 
-    popover().button("Add filter").click();
+    H.popover().button("Add filter").click();
 
     cy.location("search").should("eq", "?filter_one=&filter_two=Foo");
 
-    saveDashboard();
+    H.saveDashboard();
 
     cy.location("search").should("eq", "?filter_one=&filter_two=Foo");
 
-    filterWidget().contains("Filter One").should("be.visible");
-    filterWidget().contains("Foo").should("be.visible");
+    H.filterWidget().contains("Filter One").should("be.visible");
+    H.filterWidget().contains("Foo").should("be.visible");
   });
 
   it("should reset a filters value when editing the default, and leave other filters alone", () => {
-    createQuestionAndDashboard({
+    H.createQuestionAndDashboard({
       questionDetails: QUESTION,
       dashboardDetails: DASHBOARD,
     }).then(({ body: dashboardCard }) => {
@@ -138,7 +127,7 @@ describe("scenarios > dashboard > filters > reset", () => {
           },
         ],
       }).then(() => {
-        visitDashboard(dashboard_id, {
+        H.visitDashboard(dashboard_id, {
           params: {
             filter_one: "",
             filter_two: "Bar",
@@ -149,33 +138,33 @@ describe("scenarios > dashboard > filters > reset", () => {
 
     cy.log("Default dashboard filter");
 
-    filterWidget().contains("Filter One").should("be.visible");
-    filterWidget().contains("Bar").should("be.visible");
+    H.filterWidget().contains("Filter One").should("be.visible");
+    H.filterWidget().contains("Bar").should("be.visible");
 
     cy.location("search").should("eq", "?filter_one=&filter_two=Bar");
 
     cy.log(
       "Finally, when we remove dashboard filter's default value, the url should reflect that by removing the placeholder",
     );
-    editDashboard();
+    H.editDashboard();
 
     openFilterOptions("Filter One");
 
-    sidebar().within(() => {
+    H.sidebar().within(() => {
       cy.findByLabelText("Input box").click();
       setDefaultFilterValue("Foo");
     });
 
-    popover().button("Add filter").click();
+    H.popover().button("Add filter").click();
 
     cy.location("search").should("eq", "?filter_one=Foo&filter_two=Bar");
 
-    saveDashboard();
+    H.saveDashboard();
 
     cy.location("search").should("eq", "?filter_one=Foo&filter_two=Bar");
 
-    filterWidget().contains("Filter One").should("be.visible");
-    filterWidget().contains("Foo").should("be.visible");
+    H.filterWidget().contains("Filter One").should("be.visible");
+    H.filterWidget().contains("Foo").should("be.visible");
   });
 });
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
@@ -1,28 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  closeDashboardSettingsSidebar,
-  dashboardHeader,
-  dashboardParametersContainer,
-  describeWithSnowplow,
-  editDashboard,
-  enableTracking,
-  expectGoodSnowplowEvents,
-  expectNoBadSnowplowEvents,
-  filterWidget,
-  getDashboardCard,
-  openDashboardSettingsSidebar,
-  popover,
-  resetSnowplow,
-  restore,
-  saveDashboard,
-  setFilter,
-  sidebar,
-  sidesheet,
-  undoToast,
-  visitDashboard,
-  visitEmbeddedPage,
-  visitPublicDashboard,
-} from "e2e/support/helpers";
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
@@ -66,7 +43,7 @@ describe(
   { tags: "@slow" },
   () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsNormalUser();
       cy.intercept(
         "PUT",
@@ -84,82 +61,82 @@ describe(
         cy.log(
           "changing parameter values by default should reload affected questions",
         );
-        filterWidget().findByText(FILTER.name).click();
-        popover().within(() => {
+        H.filterWidget().findByText(FILTER.name).click();
+        H.popover().within(() => {
           cy.findByText("Gadget").click();
           cy.button("Add filter").click();
           cy.wait("@cardQuery");
         });
-        getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
+        H.getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
 
         cy.log(
           "parameter values should be preserved when disabling auto applying filters",
         );
-        openDashboardSettingsSidebar();
-        sidesheet().within(() => {
+        H.openDashboardSettingsSidebar();
+        H.sidesheet().within(() => {
           cy.findByText(filterToggleLabel).click();
           cy.wait("@updateDashboard");
           cy.findByLabelText(filterToggleLabel).should("not.be.checked");
         });
-        closeDashboardSettingsSidebar();
-        filterWidget().findByText("Gadget").should("be.visible");
-        getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
+        H.closeDashboardSettingsSidebar();
+        H.filterWidget().findByText("Gadget").should("be.visible");
+        H.getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
 
         cy.log("draft parameter values should be applied manually");
-        filterWidget().findByText("Gadget").click();
-        popover().within(() => {
+        H.filterWidget().findByText("Gadget").click();
+        H.popover().within(() => {
           cy.findByText("Widget").click();
           cy.button("Update filter").click();
         });
-        getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
-        dashboardParametersContainer().within(() => {
+        H.getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
+        H.dashboardParametersContainer().within(() => {
           cy.button("Apply").click();
           cy.wait("@cardQuery");
         });
-        getDashboardCard().findByText("Rows 1-4 of 107").should("be.visible");
+        H.getDashboardCard().findByText("Rows 1-4 of 107").should("be.visible");
         cy.get("@cardQuery.all").should("have.length", 3);
 
         cy.log(
           "draft parameter values should be applied when enabling auto-applying filters",
         );
-        filterWidget().findByText("2 selections").click();
-        popover().within(() => {
+        H.filterWidget().findByText("2 selections").click();
+        H.popover().within(() => {
           cy.findByText("Gadget").click();
           cy.button("Update filter").click();
         });
-        filterWidget().findByText("Widget").should("be.visible");
-        dashboardParametersContainer().button("Apply").should("be.visible");
+        H.filterWidget().findByText("Widget").should("be.visible");
+        H.dashboardParametersContainer().button("Apply").should("be.visible");
 
-        openDashboardSettingsSidebar();
-        sidesheet().within(() => {
+        H.openDashboardSettingsSidebar();
+        H.sidesheet().within(() => {
           cy.findByText(filterToggleLabel).click();
           cy.wait("@updateDashboard");
           cy.findByLabelText(filterToggleLabel).should("be.checked");
         });
-        closeDashboardSettingsSidebar();
+        H.closeDashboardSettingsSidebar();
 
-        filterWidget().findByText("Widget").should("be.visible");
-        getDashboardCard().findByText("Rows 1-4 of 54").should("be.visible");
+        H.filterWidget().findByText("Widget").should("be.visible");
+        H.getDashboardCard().findByText("Rows 1-4 of 54").should("be.visible");
         cy.get("@cardQuery.all").should("have.length", 4);
 
         cy.log(
           "last applied parameter values should be used when disabling auto applying filters, even if previously there were draft parameter values",
         );
-        filterWidget().findByText("Widget").click();
-        popover().within(() => {
+        H.filterWidget().findByText("Widget").click();
+        H.popover().within(() => {
           cy.findByText("Gadget").click();
           cy.button("Update filter").click();
         });
 
-        openDashboardSettingsSidebar();
-        sidesheet().within(() => {
+        H.openDashboardSettingsSidebar();
+        H.sidesheet().within(() => {
           cy.findByText(filterToggleLabel).click();
           cy.wait("@updateDashboard");
           cy.findByLabelText(filterToggleLabel).should("not.be.checked");
         });
-        closeDashboardSettingsSidebar();
+        H.closeDashboardSettingsSidebar();
 
-        filterWidget().findByText("2 selections").should("be.visible");
+        H.filterWidget().findByText("2 selections").should("be.visible");
         cy.get("@cardQuery.all").should("have.length", 5);
 
         cy.get("@updateDashboardSpy").should("have.callCount", 3);
@@ -170,17 +147,17 @@ describe(
       createDashboard({ dashboardDetails: { auto_apply_filters: false } });
       openDashboard();
 
-      filterWidget().findByText(FILTER.name).click();
-      popover().within(() => {
+      H.filterWidget().findByText(FILTER.name).click();
+      H.popover().within(() => {
         cy.findByText("Gadget").click();
         cy.button("Add filter").click();
       });
-      dashboardParametersContainer().button("Apply").should("be.visible");
+      H.dashboardParametersContainer().button("Apply").should("be.visible");
 
       cy.log("verify filter value is not saved");
 
-      visitDashboard("@dashboardId");
-      filterWidget().should("not.contain", "Gadget");
+      H.visitDashboard("@dashboardId");
+      H.filterWidget().should("not.contain", "Gadget");
     });
 
     describe("modifying dashboard and dashboard cards", () => {
@@ -188,23 +165,23 @@ describe(
         createDashboard({ dashboardDetails: { auto_apply_filters: false } });
         openDashboard();
 
-        filterWidget().findByText(FILTER.name).click();
-        popover().within(() => {
+        H.filterWidget().findByText(FILTER.name).click();
+        H.popover().within(() => {
           cy.findByText("Gadget").click();
           cy.button("Add filter").click();
         });
-        dashboardParametersContainer().button("Apply").should("be.visible");
+        H.dashboardParametersContainer().button("Apply").should("be.visible");
 
-        editDashboard();
+        H.editDashboard();
 
-        setFilter("Text or Category", "Is");
+        H.setFilter("Text or Category", "Is");
 
-        sidebar().findByDisplayValue("Text").clear().type("Vendor");
-        getDashboardCard().findByText("Select…").click();
-        popover().findByText("Vendor").click();
-        saveDashboard();
+        H.sidebar().findByDisplayValue("Text").clear().type("Vendor");
+        H.getDashboardCard().findByText("Select…").click();
+        H.popover().findByText("Vendor").click();
+        H.saveDashboard();
 
-        dashboardParametersContainer().within(() => {
+        H.dashboardParametersContainer().within(() => {
           cy.findByText("Category").should("be.visible");
           cy.findByText("Vendor").should("be.visible");
           cy.findByText("Gadget").should("not.exist");
@@ -220,17 +197,17 @@ describe(
         createDashboard({ dashboardDetails: { auto_apply_filters: false } });
         openDashboard();
 
-        filterWidget().findByText(FILTER.name).click();
-        popover().within(() => {
+        H.filterWidget().findByText(FILTER.name).click();
+        H.popover().within(() => {
           cy.findByText("Gadget").click();
           cy.button("Add filter").click();
         });
-        dashboardParametersContainer().button("Apply").should("be.visible");
+        H.dashboardParametersContainer().button("Apply").should("be.visible");
 
-        editDashboard();
+        H.editDashboard();
         cy.findByTestId("edit-bar").button("Cancel").click();
-        filterWidget().findByText("Gadget").should("be.visible");
-        dashboardParametersContainer().button("Apply").should("be.visible");
+        H.filterWidget().findByText("Gadget").should("be.visible");
+        H.dashboardParametersContainer().button("Apply").should("be.visible");
       });
     });
 
@@ -242,45 +219,45 @@ describe(
       it("should handle toggling auto applying filters on and off", () => {
         openDashboard();
 
-        getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
+        H.getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
 
         cy.log(
           "parameter with default value should still be applied after turning auto-apply filter off",
         );
-        openDashboardSettingsSidebar();
-        sidesheet().within(() => {
+        H.openDashboardSettingsSidebar();
+        H.sidesheet().within(() => {
           cy.findByLabelText(filterToggleLabel).should("be.checked");
           cy.findByText(filterToggleLabel).click();
           cy.wait("@updateDashboard");
           cy.findByLabelText(filterToggleLabel).should("not.be.checked");
         });
-        closeDashboardSettingsSidebar();
+        H.closeDashboardSettingsSidebar();
 
-        getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
+        H.getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
 
         cy.log(
           "card result should be updated after manually updating the filter",
         );
-        filterWidget().icon("close").click();
-        dashboardParametersContainer()
+        H.filterWidget().icon("close").click();
+        H.dashboardParametersContainer()
           .button("Apply")
           .should("be.visible")
           .click();
 
-        getDashboardCard().findByText("Rows 1-4 of 200").should("be.visible");
+        H.getDashboardCard().findByText("Rows 1-4 of 200").should("be.visible");
 
         cy.log(
           "should not use the default parameter after turning auto-apply filter on again since the parameter was manually updated",
         );
-        openDashboardSettingsSidebar();
-        sidesheet().within(() => {
+        H.openDashboardSettingsSidebar();
+        H.sidesheet().within(() => {
           cy.findByLabelText(filterToggleLabel).should("not.be.checked");
           cy.findAllByText(filterToggleLabel).click();
           cy.wait("@updateDashboard");
           cy.findByLabelText(filterToggleLabel).should("be.checked");
         });
 
-        getDashboardCard().findByText("Rows 1-4 of 200").should("be.visible");
+        H.getDashboardCard().findByText("Rows 1-4 of 200").should("be.visible");
       });
 
       it.skip("should display a toast when a dashboard takes longer than 15s to load even without parameter values (but has parameters with default values)", () => {
@@ -289,18 +266,20 @@ describe(
 
         cy.tick(TOAST_TIMEOUT);
         cy.wait("@cardQuery");
-        undoToast().within(() => {
+        H.undoToast().within(() => {
           cy.findByText(TOAST_MESSAGE).should("be.visible");
           cy.button("Turn off").click();
           cy.wait("@updateDashboard");
         });
 
-        openDashboardSettingsSidebar();
-        sidesheet().findByLabelText(filterToggleLabel).should("not.be.checked");
+        H.openDashboardSettingsSidebar();
+        H.sidesheet()
+          .findByLabelText(filterToggleLabel)
+          .should("not.be.checked");
         // Gadget
         const filterDefaultValue = FILTER_WITH_DEFAULT_VALUE.default[0];
-        filterWidget().findByText(filterDefaultValue).should("be.visible");
-        getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
+        H.filterWidget().findByText(filterDefaultValue).should("be.visible");
+        H.getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
       });
 
       it.skip("should not display the toast when we clear out parameter default value", () => {
@@ -309,8 +288,8 @@ describe(
 
         cy.tick(TOAST_TIMEOUT);
         cy.wait("@cardQuery");
-        undoToast().should("not.exist");
-        getDashboardCard().findByText("Rows 1-4 of 200").should("be.visible");
+        H.undoToast().should("not.exist");
+        H.getDashboardCard().findByText("Rows 1-4 of 200").should("be.visible");
       });
     });
 
@@ -322,17 +301,19 @@ describe(
 
         cy.tick(TOAST_TIMEOUT);
         cy.wait("@cardQuery");
-        undoToast().within(() => {
+        H.undoToast().within(() => {
           cy.findByText(TOAST_MESSAGE).should("be.visible");
           cy.button("Turn off").click();
           cy.wait("@updateDashboard");
         });
 
-        openDashboardSettingsSidebar();
-        sidesheet().findByLabelText(filterToggleLabel).should("not.be.checked");
-        closeDashboardSettingsSidebar();
-        filterWidget().findByText("Gadget").should("be.visible");
-        getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
+        H.openDashboardSettingsSidebar();
+        H.sidesheet()
+          .findByLabelText(filterToggleLabel)
+          .should("not.be.checked");
+        H.closeDashboardSettingsSidebar();
+        H.filterWidget().findByText("Gadget").should("be.visible");
+        H.getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
       });
 
       it.skip("should display the toast indefinitely unless dismissing manually", () => {
@@ -342,13 +323,13 @@ describe(
 
         cy.tick(TOAST_TIMEOUT);
         cy.wait("@cardQuery");
-        undoToast().findByText(TOAST_MESSAGE).should("be.visible");
+        H.undoToast().findByText(TOAST_MESSAGE).should("be.visible");
 
         cy.tick(100 * TOAST_TIMEOUT);
-        undoToast().findByText(TOAST_MESSAGE).should("be.visible");
+        H.undoToast().findByText(TOAST_MESSAGE).should("be.visible");
 
-        undoToast().icon("close").click();
-        undoToast().should("not.exist");
+        H.undoToast().icon("close").click();
+        H.undoToast().should("not.exist");
       });
 
       it.skip("should not display the toast when auto applying filters is disabled", () => {
@@ -358,9 +339,9 @@ describe(
 
         cy.tick(TOAST_TIMEOUT);
         cy.wait("@cardQuery");
-        undoToast().should("not.exist");
-        filterWidget().findByText("Gadget").should("be.visible");
-        getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
+        H.undoToast().should("not.exist");
+        H.filterWidget().findByText("Gadget").should("be.visible");
+        H.getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
       });
 
       it.skip("should not display the toast if there are no parameter values", () => {
@@ -370,7 +351,7 @@ describe(
 
         cy.tick(TOAST_TIMEOUT);
         cy.wait("@cardQuery");
-        undoToast().should("not.exist");
+        H.undoToast().should("not.exist");
       });
 
       it.skip("should not display the same toast twice for a dashboard", () => {
@@ -380,19 +361,19 @@ describe(
 
         cy.tick(TOAST_TIMEOUT);
         cy.wait("@cardQuery");
-        undoToast().within(() => {
+        H.undoToast().within(() => {
           cy.button("Turn off").should("be.visible");
           cy.icon("close").click();
         });
-        filterWidget().findByText("Gadget").click();
-        popover().within(() => {
+        H.filterWidget().findByText("Gadget").click();
+        H.popover().within(() => {
           cy.findByText("Widget").click();
           cy.findByText("Update filter").click();
         });
 
         cy.tick(TOAST_TIMEOUT);
         cy.wait("@cardQuery");
-        undoToast().should("not.exist");
+        H.undoToast().should("not.exist");
       });
     });
 
@@ -407,8 +388,8 @@ describe(
         cy.wait("@cardQuery");
 
         // shouldn't even show settings as an option for this user
-        dashboardHeader().icon("ellipsis").click();
-        popover().findByText("Edit settings").should("not.exist");
+        H.dashboardHeader().icon("ellipsis").click();
+        H.popover().findByText("Edit settings").should("not.exist");
       });
 
       it.skip("should not display a toast even when a dashboard takes longer than 15s to load", () => {
@@ -417,7 +398,7 @@ describe(
 
         cy.tick(TOAST_TIMEOUT);
         cy.wait("@cardQuery");
-        undoToast().should("not.exist");
+        H.undoToast().should("not.exist");
       });
     });
 
@@ -430,32 +411,36 @@ describe(
         it("should apply filters after clicking the apply button when auto-apply filters is turned off", () => {
           createDashboard({ dashboardDetails: { auto_apply_filters: false } });
           cy.get("@dashboardId").then(dashboardId => {
-            visitPublicDashboard(dashboardId);
+            H.visitPublicDashboard(dashboardId);
           });
 
-          dashboardParametersContainer().button("Apply").should("not.exist");
-          filterWidget().findByText("Category").click();
-          popover().within(() => {
+          H.dashboardParametersContainer().button("Apply").should("not.exist");
+          H.filterWidget().findByText("Category").click();
+          H.popover().within(() => {
             cy.findByText("Widget").click();
             cy.button("Add filter").click();
           });
-          getDashboardCard().findByText("Rows 1-4 of 200").should("be.visible");
-          dashboardParametersContainer()
+          H.getDashboardCard()
+            .findByText("Rows 1-4 of 200")
+            .should("be.visible");
+          H.dashboardParametersContainer()
             .button("Apply")
             .should("be.visible")
             .click();
-          getDashboardCard().findByText("Rows 1-4 of 54").should("be.visible");
+          H.getDashboardCard()
+            .findByText("Rows 1-4 of 54")
+            .should("be.visible");
         });
 
         it("should not show toast", () => {
           createDashboard();
           cy.clock();
           openSlowPublicDashboard({ [FILTER.slug]: "Gadget" });
-          filterWidget().findByText("Gadget").should("be.visible");
+          H.filterWidget().findByText("Gadget").should("be.visible");
 
           cy.tick(TOAST_TIMEOUT);
           cy.wait("@cardQuery");
-          undoToast().should("not.exist");
+          H.undoToast().should("not.exist");
         });
       });
 
@@ -475,21 +460,25 @@ describe(
               resource: { dashboard: dashboardId },
               params: {},
             };
-            visitEmbeddedPage(embeddingPayload);
+            H.visitEmbeddedPage(embeddingPayload);
           });
 
-          dashboardParametersContainer().button("Apply").should("not.exist");
-          filterWidget().findByText("Category").click();
-          popover().within(() => {
+          H.dashboardParametersContainer().button("Apply").should("not.exist");
+          H.filterWidget().findByText("Category").click();
+          H.popover().within(() => {
             cy.findByText("Widget").click();
             cy.button("Add filter").click();
           });
-          getDashboardCard().findByText("Rows 1-4 of 200").should("be.visible");
-          dashboardParametersContainer()
+          H.getDashboardCard()
+            .findByText("Rows 1-4 of 200")
+            .should("be.visible");
+          H.dashboardParametersContainer()
             .button("Apply")
             .should("be.visible")
             .click();
-          getDashboardCard().findByText("Rows 1-4 of 54").should("be.visible");
+          H.getDashboardCard()
+            .findByText("Rows 1-4 of 54")
+            .should("be.visible");
         });
 
         it("should not show toast", () => {
@@ -504,11 +493,11 @@ describe(
 
           cy.clock();
           openSlowEmbeddingDashboard({ [FILTER.slug]: "Gadget" });
-          filterWidget().findByText("Gadget").should("be.visible");
+          H.filterWidget().findByText("Gadget").should("be.visible");
 
           cy.tick(TOAST_TIMEOUT);
           cy.wait("@cardQuery");
-          undoToast().should("not.exist");
+          H.undoToast().should("not.exist");
         });
       });
 
@@ -536,18 +525,22 @@ describe(
           // Ensure that we're viewing the dashboard in full-app embedding mode, since `logo` is a full-app embedding parameter.
           cy.findByTestId("main-logo").should("not.exist");
 
-          dashboardParametersContainer().button("Apply").should("not.exist");
-          filterWidget().findByText("Category").click();
-          popover().within(() => {
+          H.dashboardParametersContainer().button("Apply").should("not.exist");
+          H.filterWidget().findByText("Category").click();
+          H.popover().within(() => {
             cy.findByText("Widget").click();
             cy.button("Add filter").click();
           });
-          getDashboardCard().findByText("Rows 1-4 of 200").should("be.visible");
-          dashboardParametersContainer()
+          H.getDashboardCard()
+            .findByText("Rows 1-4 of 200")
+            .should("be.visible");
+          H.dashboardParametersContainer()
             .button("Apply")
             .should("be.visible")
             .click();
-          getDashboardCard().findByText("Rows 1-4 of 54").should("be.visible");
+          H.getDashboardCard()
+            .findByText("Rows 1-4 of 54")
+            .should("be.visible");
         });
 
         it.skip("should display a toast when a dashboard takes longer than 15s to load", () => {
@@ -557,7 +550,7 @@ describe(
           openSlowFullAppEmbeddingDashboard({ [FILTER.slug]: "Gadget" });
           cy.tick(TOAST_TIMEOUT);
           cy.wait("@cardQuery");
-          undoToast().within(() => {
+          H.undoToast().within(() => {
             cy.findByText(TOAST_MESSAGE).should("be.visible");
             cy.button("Turn off").click();
             cy.wait("@updateDashboard");
@@ -568,22 +561,26 @@ describe(
           // so to make sure callback in `setTimeout` is called, we need to advance the clock using cy.tick().
           cy.tick();
 
-          openDashboardSettingsSidebar();
-          sidesheet()
+          H.openDashboardSettingsSidebar();
+          H.sidesheet()
             .findByLabelText(filterToggleLabel)
             .should("not.be.checked");
-          filterWidget().findByText("Gadget").should("be.visible");
+          H.filterWidget().findByText("Gadget").should("be.visible");
 
-          getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
+          H.getDashboardCard()
+            .findByText("Rows 1-4 of 53")
+            .should("be.visible");
 
           // Card result should be updated after manually updating the filter
-          filterWidget().icon("close").click();
-          dashboardParametersContainer()
+          H.filterWidget().icon("close").click();
+          H.dashboardParametersContainer()
             .button("Apply")
             .should("be.visible")
             .click();
 
-          getDashboardCard().findByText("Rows 1-4 of 200").should("be.visible");
+          H.getDashboardCard()
+            .findByText("Rows 1-4 of 200")
+            .should("be.visible");
         });
 
         it.skip("should not display a toast when a dashboard takes longer than 15s to load if users have no write access to a dashboard", () => {
@@ -594,33 +591,35 @@ describe(
           openSlowFullAppEmbeddingDashboard({ [FILTER.slug]: "Gadget" });
           cy.tick(TOAST_TIMEOUT);
           cy.wait("@cardQuery");
-          undoToast().should("not.exist");
+          H.undoToast().should("not.exist");
 
           // In embedding we'll load bookmark after the dashboard is loaded, it's the opposite in normal app because bookmark is cached from somewhere else.
           // And somehow, dashboard card query will be completed before the dashboard even start to load, and in entity loader it uses `setTimeout`,
           // so to make sure callback in `setTimeout` is called, we need to advance the clock using cy.tick().
           cy.tick();
 
-          getDashboardCard().findByText("Rows 1-4 of 53").should("be.visible");
+          H.getDashboardCard()
+            .findByText("Rows 1-4 of 53")
+            .should("be.visible");
         });
       });
     });
   },
 );
 
-describeWithSnowplow("scenarios > dashboards > filters > auto apply", () => {
+H.describeWithSnowplow("scenarios > dashboards > filters > auto apply", () => {
   const NUMBERS_OF_GOOD_SNOWPLOW_EVENTS_BEFORE_DISABLING_AUTO_APPLY_FILTERS = 2;
 
   beforeEach(() => {
-    restore();
-    resetSnowplow();
+    H.restore();
+    H.resetSnowplow();
     cy.signInAsAdmin();
-    enableTracking();
+    H.enableTracking();
     cy.intercept("PUT", "/api/dashboard/*").as("updateDashboard");
   });
 
   afterEach(() => {
-    expectNoBadSnowplowEvents();
+    H.expectNoBadSnowplowEvents();
   });
 
   it("should send snowplow events when disabling auto-apply filters", () => {
@@ -628,15 +627,15 @@ describeWithSnowplow("scenarios > dashboards > filters > auto apply", () => {
     openDashboard();
     cy.wait("@cardQuery");
 
-    openDashboardSettingsSidebar();
-    sidesheet().within(() => {
-      expectGoodSnowplowEvents(
+    H.openDashboardSettingsSidebar();
+    H.sidesheet().within(() => {
+      H.expectGoodSnowplowEvents(
         NUMBERS_OF_GOOD_SNOWPLOW_EVENTS_BEFORE_DISABLING_AUTO_APPLY_FILTERS,
       );
       cy.findByText(filterToggleLabel).click();
       cy.wait("@updateDashboard");
       cy.findByLabelText(filterToggleLabel).should("not.be.checked");
-      expectGoodSnowplowEvents(
+      H.expectGoodSnowplowEvents(
         NUMBERS_OF_GOOD_SNOWPLOW_EVENTS_BEFORE_DISABLING_AUTO_APPLY_FILTERS + 1,
       );
     });
@@ -647,15 +646,15 @@ describeWithSnowplow("scenarios > dashboards > filters > auto apply", () => {
     openDashboard();
     cy.wait("@cardQuery");
 
-    openDashboardSettingsSidebar();
-    sidesheet().within(() => {
-      expectGoodSnowplowEvents(
+    H.openDashboardSettingsSidebar();
+    H.sidesheet().within(() => {
+      H.expectGoodSnowplowEvents(
         NUMBERS_OF_GOOD_SNOWPLOW_EVENTS_BEFORE_DISABLING_AUTO_APPLY_FILTERS,
       );
       cy.findByText(filterToggleLabel).click();
       cy.wait("@updateDashboard");
       cy.findByLabelText(filterToggleLabel).should("be.checked");
-      expectGoodSnowplowEvents(
+      H.expectGoodSnowplowEvents(
         NUMBERS_OF_GOOD_SNOWPLOW_EVENTS_BEFORE_DISABLING_AUTO_APPLY_FILTERS,
       );
     });
@@ -694,7 +693,7 @@ const openDashboard = (params = {}) => {
     "cardQuery",
   );
 
-  visitDashboard("@dashboardId", { params });
+  H.visitDashboard("@dashboardId", { params });
 };
 
 const openSlowDashboard = (params = {}) => {
@@ -709,7 +708,7 @@ const openSlowDashboard = (params = {}) => {
     });
   });
 
-  getDashboardCard().should("be.visible");
+  H.getDashboardCard().should("be.visible");
 };
 
 const openSlowPublicDashboard = (params = {}) => {
@@ -718,10 +717,10 @@ const openSlowPublicDashboard = (params = {}) => {
   );
 
   cy.get("@dashboardId").then(dashboardId => {
-    visitPublicDashboard(dashboardId, { params });
+    H.visitPublicDashboard(dashboardId, { params });
   });
 
-  getDashboardCard().should("be.visible");
+  H.getDashboardCard().should("be.visible");
 };
 
 const openSlowEmbeddingDashboard = (params = {}) => {
@@ -734,12 +733,12 @@ const openSlowEmbeddingDashboard = (params = {}) => {
       resource: { dashboard: dashboardId },
       params: {},
     };
-    visitEmbeddedPage(embeddingPayload, {
+    H.visitEmbeddedPage(embeddingPayload, {
       setFilters: params,
     });
   });
 
-  getDashboardCard().should("be.visible");
+  H.getDashboardCard().should("be.visible");
 };
 
 const openSlowFullAppEmbeddingDashboard = (params = {}) => {
@@ -754,7 +753,7 @@ const openSlowFullAppEmbeddingDashboard = (params = {}) => {
     });
   });
 
-  getDashboardCard().should("be.visible");
+  H.getDashboardCard().should("be.visible");
 };
 
 const visitFullAppEmbeddingUrl = ({ url, qs }) => {

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-wiring.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-wiring.cy.spec.js
@@ -1,34 +1,9 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_BY_YEAR_QUESTION_ID,
   ORDERS_COUNT_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  createNewTab,
-  dashboardHeader,
-  dashboardParametersContainer,
-  editDashboard,
-  entityPickerModal,
-  findDashCardAction,
-  getDashboardCard,
-  goToTab,
-  modal,
-  multiAutocompleteInput,
-  openQuestionActions,
-  popover,
-  removeDashboardCard,
-  restore,
-  saveDashboard,
-  selectDashboardFilter,
-  setFilter,
-  sidebar,
-  undoToast,
-  undoToastList,
-  updateDashboardCards,
-  visitDashboard,
-  visitDashboardAndCreateTab,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 const { ORDERS_ID, PRODUCTS_ID, REVIEWS_ID, ORDERS, PEOPLE, PRODUCTS } =
   SAMPLE_DATABASE;
@@ -52,7 +27,7 @@ const cards = [
 
 describe("dashboard filters auto-wiring", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("GET", "/api/dashboard/**").as("dashboard");
   });
@@ -60,22 +35,22 @@ describe("dashboard filters auto-wiring", () => {
   describe("parameter mapping", () => {
     it("should wire parameters to cards with matching fields", () => {
       createDashboardWithCards({ cards }).then(dashboardId => {
-        visitDashboard(dashboardId);
+        H.visitDashboard(dashboardId);
       });
 
-      editDashboard();
+      H.editDashboard();
 
-      setFilter("Text or Category", "Is");
+      H.setFilter("Text or Category", "Is");
 
-      selectDashboardFilter(getDashboardCard(0), "Name");
+      H.selectDashboardFilter(H.getDashboardCard(0), "Name");
 
-      getDashboardCard(0).within(() => {
+      H.getDashboardCard(0).within(() => {
         cy.findByText("User.Name").should("exist");
       });
 
-      getDashboardCard(1).findByText("User.Name").should("not.exist");
+      H.getDashboardCard(1).findByText("User.Name").should("not.exist");
 
-      undoToast()
+      H.undoToast()
         .should(
           "contain",
           "Auto-connect this filter to all questions containing “User.Name”?",
@@ -83,22 +58,22 @@ describe("dashboard filters auto-wiring", () => {
         .should("not.contain", "in the current tab")
         .findByText("Auto-connect")
         .click();
-      undoToast().should(
+      H.undoToast().should(
         "contain",
         "The filter was auto-connected to all questions containing “User.Name”.",
       );
 
       cy.log("verify auto-connect info is shown");
 
-      getDashboardCard(1).within(() => {
+      H.getDashboardCard(1).within(() => {
         cy.findByText("Auto-connected").should("be.visible");
         cy.icon("sparkles").should("be.visible");
       });
 
       // do not wait for timeout, but close the toast
-      undoToast().icon("close").click();
+      H.undoToast().icon("close").click();
 
-      getDashboardCard(1).within(() => {
+      H.getDashboardCard(1).within(() => {
         cy.findByText("Auto-connected").should("not.exist");
         cy.icon("sparkles").should("not.exist");
       });
@@ -106,20 +81,20 @@ describe("dashboard filters auto-wiring", () => {
 
     it("should not wire parameters to cards that already have a parameter, despite matching fields", () => {
       createDashboardWithCards({ cards }).then(dashboardId => {
-        visitDashboard(dashboardId);
+        H.visitDashboard(dashboardId);
       });
 
-      editDashboard();
+      H.editDashboard();
 
-      setFilter("Text or Category", "Is");
+      H.setFilter("Text or Category", "Is");
 
-      selectDashboardFilter(getDashboardCard(0), "Name");
+      H.selectDashboardFilter(H.getDashboardCard(0), "Name");
 
-      getDashboardCard(0).within(() => {
+      H.getDashboardCard(0).within(() => {
         cy.findByText("User.Name").should("exist");
       });
 
-      undoToast()
+      H.undoToast()
         .should(
           "contain",
           "Auto-connect this filter to all questions containing “User.Name”?",
@@ -127,21 +102,21 @@ describe("dashboard filters auto-wiring", () => {
         .findByRole("button", { name: "Auto-connect" })
         .click();
 
-      getDashboardCard(1).within(() => {
+      H.getDashboardCard(1).within(() => {
         cy.findByLabelText("close icon").click();
       });
 
-      selectDashboardFilter(getDashboardCard(1), "Address");
+      H.selectDashboardFilter(H.getDashboardCard(1), "Address");
 
-      getDashboardCard(0).within(() => {
+      H.getDashboardCard(0).within(() => {
         cy.findByText("User.Name").should("exist");
       });
 
-      getDashboardCard(1).within(() => {
+      H.getDashboardCard(1).within(() => {
         cy.findByText("User.Address").should("exist");
       });
 
-      undoToast().should("contain", "Undo");
+      H.undoToast().should("contain", "Undo");
     });
 
     it("should not suggest to wire parameters to cards that don't have a matching field", () => {
@@ -167,45 +142,45 @@ describe("dashboard filters auto-wiring", () => {
             },
           ],
         }).then(dashboardId => {
-          visitDashboard(dashboardId);
+          H.visitDashboard(dashboardId);
         });
       });
 
-      editDashboard();
+      H.editDashboard();
 
-      setFilter("Text or Category", "Is");
+      H.setFilter("Text or Category", "Is");
 
-      selectDashboardFilter(getDashboardCard(0), "Name");
+      H.selectDashboardFilter(H.getDashboardCard(0), "Name");
 
-      undoToast().should("not.exist");
+      H.undoToast().should("not.exist");
     });
 
     it("should undo parameter wiring when 'Undo' is clicked", () => {
       createDashboardWithCards({ cards }).then(dashboardId => {
-        visitDashboard(dashboardId);
+        H.visitDashboard(dashboardId);
       });
 
-      editDashboard();
+      H.editDashboard();
 
-      setFilter("Text or Category", "Is");
+      H.setFilter("Text or Category", "Is");
       addCardToDashboard();
       goToFilterMapping();
 
-      selectDashboardFilter(getDashboardCard(0), "Name");
+      H.selectDashboardFilter(H.getDashboardCard(0), "Name");
 
-      undoToast().findByRole("button", { name: "Auto-connect" }).click();
+      H.undoToast().findByRole("button", { name: "Auto-connect" }).click();
 
-      getDashboardCard(0).findByText("User.Name").should("exist");
+      H.getDashboardCard(0).findByText("User.Name").should("exist");
 
       for (let i = 0; i < cards.length; i++) {
-        getDashboardCard(i).findByText("User.Name").should("exist");
+        H.getDashboardCard(i).findByText("User.Name").should("exist");
       }
 
-      undoToast().findByRole("button", { name: "Undo" }).click();
+      H.undoToast().findByRole("button", { name: "Undo" }).click();
 
-      getDashboardCard(0).findByText("User.Name").should("exist");
+      H.getDashboardCard(0).findByText("User.Name").should("exist");
       for (let i = 1; i < cards.length; i++) {
-        getDashboardCard(i).findByText("Select…").should("exist");
+        H.getDashboardCard(i).findByText("Select…").should("exist");
       }
     });
 
@@ -235,62 +210,62 @@ describe("dashboard filters auto-wiring", () => {
       ];
 
       createDashboardWithCards({ cards }).then(dashboardId => {
-        visitDashboard(dashboardId);
+        H.visitDashboard(dashboardId);
       });
 
-      editDashboard();
+      H.editDashboard();
 
       cy.clock();
 
-      setFilter("Text or Category", "Is");
+      H.setFilter("Text or Category", "Is");
 
-      selectDashboardFilter(getDashboardCard(0), "Name");
+      H.selectDashboardFilter(H.getDashboardCard(0), "Name");
 
       removeFilterFromDashCard(0);
 
       cy.tick(2000);
 
-      selectDashboardFilter(getDashboardCard(0), "Name");
+      H.selectDashboardFilter(H.getDashboardCard(0), "Name");
 
       // since we waited 2s earlier, if the toast is still visible after this other delay of 11s,
       // it means the first timeout of 12s was cleared correctly
       cy.tick(11000);
-      undoToast().should("exist");
+      H.undoToast().should("exist");
 
       cy.tick(2000);
-      undoToast().should("not.exist");
+      H.undoToast().should("not.exist");
     });
 
     describe("multiple tabs", () => {
       it("should not wire parameters to cards in different tabs", () => {
         createDashboardWithCards({ cards }).then(dashboardId => {
-          visitDashboardAndCreateTab({
+          H.visitDashboardAndCreateTab({
             dashboardId,
             save: false,
           });
         });
 
-        setFilter("Text or Category", "Is");
+        H.setFilter("Text or Category", "Is");
 
         addCardToDashboard();
         goToFilterMapping();
 
-        selectDashboardFilter(getDashboardCard(0), "Name");
+        H.selectDashboardFilter(H.getDashboardCard(0), "Name");
 
-        getDashboardCard(0).findByText("User.Name").should("exist");
+        H.getDashboardCard(0).findByText("User.Name").should("exist");
 
-        undoToast().should("not.exist");
+        H.undoToast().should("not.exist");
 
-        goToTab("Tab 1");
+        H.goToTab("Tab 1");
 
         for (let i = 0; i < cards.length; i++) {
-          getDashboardCard(i).findByText("User.Name").should("not.exist");
+          H.getDashboardCard(i).findByText("User.Name").should("not.exist");
         }
 
-        selectDashboardFilter(getDashboardCard(0), "Name");
+        H.selectDashboardFilter(H.getDashboardCard(0), "Name");
 
         cy.log("verify prefix 'in the current tab'");
-        undoToast().should(
+        H.undoToast().should(
           "contain",
           "Auto-connect this filter to all questions containing “User.Name”, in the current tab?",
         );
@@ -301,25 +276,25 @@ describe("dashboard filters auto-wiring", () => {
   describe("add a card", () => {
     it("should wire parameters to cards that are added to the dashboard", () => {
       createDashboardWithCards({ cards }).then(dashboardId => {
-        visitDashboard(dashboardId);
+        H.visitDashboard(dashboardId);
       });
 
-      editDashboard();
+      H.editDashboard();
 
-      setFilter("Text or Category", "Is");
+      H.setFilter("Text or Category", "Is");
 
-      selectDashboardFilter(getDashboardCard(0), "Name");
-      undoToast().findByRole("button", { name: "Auto-connect" }).click();
+      H.selectDashboardFilter(H.getDashboardCard(0), "Name");
+      H.undoToast().findByRole("button", { name: "Auto-connect" }).click();
 
       for (let i = 0; i < cards.length; i++) {
-        getDashboardCard(i).findByText("User.Name").should("exist");
+        H.getDashboardCard(i).findByText("User.Name").should("exist");
       }
 
       addCardToDashboard();
 
       cy.log("verify toast text and enable auto-connect");
 
-      undoToastList()
+      H.undoToastList()
         .eq(1)
         .should("contain", "Auto-connect “Orders Model” to “Text”?")
         .findByRole("button", { name: "Auto-connect" })
@@ -327,17 +302,17 @@ describe("dashboard filters auto-wiring", () => {
 
       cy.log("verify toast text after auto-connect");
 
-      undoToastList()
+      H.undoToastList()
         .eq(1)
         .should("contain", "“Orders Model” was auto-connected to “Text”.");
 
       goToFilterMapping();
 
       for (let i = 0; i < cards.length + 1; i++) {
-        getDashboardCard(i).findByText("User.Name").should("exist");
+        H.getDashboardCard(i).findByText("User.Name").should("exist");
       }
 
-      undoToastList()
+      H.undoToastList()
         .eq(1)
         .findByText("“Orders Model” was auto-connected to “Text”.")
         .should("be.visible");
@@ -345,55 +320,55 @@ describe("dashboard filters auto-wiring", () => {
 
     it("should undo parameter wiring when 'Undo' is clicked", () => {
       createDashboardWithCards({ cards }).then(dashboardId => {
-        visitDashboard(dashboardId);
+        H.visitDashboard(dashboardId);
       });
 
-      editDashboard();
+      H.editDashboard();
 
-      setFilter("Text or Category", "Is");
+      H.setFilter("Text or Category", "Is");
 
-      selectDashboardFilter(getDashboardCard(0), "Name");
-      undoToast().findByRole("button", { name: "Auto-connect" }).click();
+      H.selectDashboardFilter(H.getDashboardCard(0), "Name");
+      H.undoToast().findByRole("button", { name: "Auto-connect" }).click();
 
       for (let i = 0; i < cards.length; i++) {
-        getDashboardCard(i).findByText("User.Name").should("exist");
+        H.getDashboardCard(i).findByText("User.Name").should("exist");
       }
 
       addCardToDashboard();
       goToFilterMapping();
 
-      undoToastList()
+      H.undoToastList()
         .eq(1)
         .should("contain", "Auto-connect “Orders Model” to “Text”?")
         .findByRole("button", { name: "Auto-connect" })
         .click();
 
       for (let i = 0; i < cards.length + 1; i++) {
-        getDashboardCard(i).findByText("User.Name").should("exist");
+        H.getDashboardCard(i).findByText("User.Name").should("exist");
       }
 
       cy.log("verify undo functionality");
-      undoToastList().eq(1).findByText("Undo").click();
+      H.undoToastList().eq(1).findByText("Undo").click();
 
-      getDashboardCard(0).findByText("User.Name").should("exist");
-      getDashboardCard(1).findByText("User.Name").should("exist");
-      getDashboardCard(2).findByText("Select…").should("exist");
+      H.getDashboardCard(0).findByText("User.Name").should("exist");
+      H.getDashboardCard(1).findByText("User.Name").should("exist");
+      H.getDashboardCard(2).findByText("Select…").should("exist");
     });
 
     describe("multiple tabs", () => {
       it("should not wire parameters to cards that are added to the dashboard in a different tab", () => {
         createDashboardWithCards({ cards }).then(dashboardId => {
-          visitDashboard(dashboardId);
+          H.visitDashboard(dashboardId);
         });
 
-        editDashboard();
+        H.editDashboard();
 
-        setFilter("Number", "Equal to");
-        setFilter("Text or Category", "Is");
+        H.setFilter("Number", "Equal to");
+        H.setFilter("Text or Category", "Is");
 
-        selectDashboardFilter(getDashboardCard(0), "Name");
+        H.selectDashboardFilter(H.getDashboardCard(0), "Name");
 
-        undoToast()
+        H.undoToast()
           .should(
             "contain",
             "Auto-connect this filter to all questions containing",
@@ -402,37 +377,37 @@ describe("dashboard filters auto-wiring", () => {
           .click();
 
         for (let i = 0; i < cards.length; i++) {
-          getDashboardCard(i).findByText("User.Name").should("exist");
+          H.getDashboardCard(i).findByText("User.Name").should("exist");
         }
 
-        createNewTab();
+        H.createNewTab();
         addCardToDashboard();
         goToFilterMapping();
 
-        getDashboardCard(0).findByText("User.Name").should("not.exist");
+        H.getDashboardCard(0).findByText("User.Name").should("not.exist");
 
         cy.log(
           "verify that no new toast with suggestion to auto-wire appeared",
         );
 
-        undoToastList()
+        H.undoToastList()
           .should("have.length", 1)
           .should(
             "contain",
             "The filter was auto-connected to all questions containing “User.Name”",
           );
 
-        selectDashboardFilter(getDashboardCard(0), "Name");
+        H.selectDashboardFilter(H.getDashboardCard(0), "Name");
         goToFilterMapping("Equal to");
-        selectDashboardFilter(getDashboardCard(0), "Total");
+        H.selectDashboardFilter(H.getDashboardCard(0), "Total");
 
         addCardToDashboard();
 
-        undoToastList().eq(1).findByText("Auto-connect").click();
+        H.undoToastList().eq(1).findByText("Auto-connect").click();
 
         cy.log("verify that toast shows number of filters that were connected");
 
-        undoToastList()
+        H.undoToastList()
           .eq(1)
           .should("contain", "“Orders Model” was auto-connected to 2 filters.");
       });
@@ -442,30 +417,30 @@ describe("dashboard filters auto-wiring", () => {
   describe("replace a card", () => {
     it("should show auto-wire suggestion toast when a card is replaced", () => {
       createDashboardWithCards({ cards }).then(dashboardId => {
-        visitDashboard(dashboardId);
+        H.visitDashboard(dashboardId);
       });
 
-      editDashboard();
+      H.editDashboard();
 
-      setFilter("Text or Category", "Is");
+      H.setFilter("Text or Category", "Is");
 
-      selectDashboardFilter(getDashboardCard(0), "Name");
+      H.selectDashboardFilter(H.getDashboardCard(0), "Name");
 
-      undoToast().findByText("Auto-connect").click();
+      H.undoToast().findByText("Auto-connect").click();
 
       goToFilterMapping();
 
-      findDashCardAction(getDashboardCard(1), "Replace").click();
+      H.findDashCardAction(H.getDashboardCard(1), "Replace").click();
 
-      modal().findByText("Orders, Count").click();
+      H.modal().findByText("Orders, Count").click();
 
-      undoToastList()
+      H.undoToastList()
         .eq(2)
         .should("contain", "Auto-connect “Orders, Count” to “Text”?")
         .button("Auto-connect")
         .click();
 
-      undoToastList()
+      H.undoToastList()
         .eq(2)
         .should("contain", "“Orders, Count” was auto-connected to “Text”.");
     });
@@ -512,10 +487,10 @@ describe("dashboard filters auto-wiring", () => {
     });
 
     it("should auto-wire and filter cards with foreign keys when added to the dashboard via the sidebar", () => {
-      visitDashboard("@dashboardId");
-      editDashboard();
-      setFilter("ID");
-      selectDashboardFilter(getDashboardCard(0), "ID");
+      H.visitDashboard("@dashboardId");
+      H.editDashboard();
+      H.setFilter("ID");
+      H.selectDashboardFilter(H.getDashboardCard(0), "ID");
 
       addCardToDashboard(["Orders Question", "Reviews Question"]);
 
@@ -523,52 +498,52 @@ describe("dashboard filters auto-wiring", () => {
 
       goToFilterMapping("ID");
 
-      undoToastList()
+      H.undoToastList()
         .findByText("Auto-connect “Orders Question” to “ID”?")
         .closest("[data-testid='toast-undo']")
         .findByRole("button", { name: "Auto-connect" })
         .click();
 
-      undoToastList()
+      H.undoToastList()
         .findByText("Auto-connect “Reviews Question” to “ID”?")
         .closest("[data-testid='toast-undo']")
         .findByRole("button", { name: "Auto-connect" })
         .click();
 
-      getDashboardCard(0).findByText("Products.ID").should("exist");
-      getDashboardCard(1).findByText("Product.ID").should("exist");
-      getDashboardCard(2).findByText("Product.ID").should("exist");
+      H.getDashboardCard(0).findByText("Products.ID").should("exist");
+      H.getDashboardCard(1).findByText("Product.ID").should("exist");
+      H.getDashboardCard(2).findByText("Product.ID").should("exist");
 
-      saveDashboard();
+      H.saveDashboard();
 
-      dashboardParametersContainer().findByText("ID").click();
+      H.dashboardParametersContainer().findByText("ID").click();
 
-      popover().within(() => {
-        multiAutocompleteInput().type("1,");
+      H.popover().within(() => {
+        H.multiAutocompleteInput().type("1,");
         cy.button("Add filter").click();
       });
 
       cy.wait("@cardQuery");
 
-      getDashboardCard(0).within(() => {
+      H.getDashboardCard(0).within(() => {
         getTableCell("ID", 0).should("contain", "1");
       });
 
-      getDashboardCard(1).within(() => {
+      H.getDashboardCard(1).within(() => {
         getTableCell("Product ID", 0).should("contain", "1");
       });
 
-      getDashboardCard(2).within(() => {
+      H.getDashboardCard(2).within(() => {
         getTableCell("Product ID", 0).should("contain", "1");
       });
     });
 
     it("should auto-wire and filter cards with foreign keys when added to the dashboard via the query builder", () => {
-      visitDashboard("@dashboardId");
-      editDashboard();
-      setFilter("ID");
-      selectDashboardFilter(getDashboardCard(0), "ID");
-      saveDashboard();
+      H.visitDashboard("@dashboardId");
+      H.editDashboard();
+      H.setFilter("ID");
+      H.selectDashboardFilter(H.getDashboardCard(0), "ID");
+      H.saveDashboard();
 
       cy.get("@ordersQuestionId").then(ordersQuestionId => {
         addQuestionFromQueryBuilder({ questionId: ordersQuestionId });
@@ -585,30 +560,30 @@ describe("dashboard filters auto-wiring", () => {
 
       goToFilterMapping("ID");
 
-      getDashboardCard(0).findByText("Products.ID").should("exist");
-      getDashboardCard(1).findByText("Product.ID").should("exist");
-      getDashboardCard(2).findByText("Product.ID").should("exist");
+      H.getDashboardCard(0).findByText("Products.ID").should("exist");
+      H.getDashboardCard(1).findByText("Product.ID").should("exist");
+      H.getDashboardCard(2).findByText("Product.ID").should("exist");
 
-      saveDashboard();
+      H.saveDashboard();
 
-      dashboardParametersContainer().findByText("ID").click();
+      H.dashboardParametersContainer().findByText("ID").click();
 
-      popover().within(() => {
-        multiAutocompleteInput().type("1,");
+      H.popover().within(() => {
+        H.multiAutocompleteInput().type("1,");
         cy.button("Add filter").click();
       });
 
       cy.wait("@cardQuery");
 
-      getDashboardCard(0).within(() => {
+      H.getDashboardCard(0).within(() => {
         getTableCell("ID", 0).should("contain", "1");
       });
 
-      getDashboardCard(1).within(() => {
+      H.getDashboardCard(1).within(() => {
         getTableCell("Product ID", 0).should("contain", "1");
       });
 
-      getDashboardCard(2).within(() => {
+      H.getDashboardCard(2).within(() => {
         getTableCell("Product ID", 0).should("contain", "1");
       });
     });
@@ -617,82 +592,82 @@ describe("dashboard filters auto-wiring", () => {
   describe("dismiss toasts", () => {
     it("should dismiss auto-wire toasts on filter removal", () => {
       createDashboardWithCards({ cards }).then(dashboardId => {
-        visitDashboard(dashboardId);
+        H.visitDashboard(dashboardId);
       });
 
-      editDashboard();
-      setFilter("Text or Category", "Is");
+      H.editDashboard();
+      H.setFilter("Text or Category", "Is");
 
-      selectDashboardFilter(getDashboardCard(0), "Name");
+      H.selectDashboardFilter(H.getDashboardCard(0), "Name");
 
-      undoToast().findByRole("button", { name: "Auto-connect" }).click();
+      H.undoToast().findByRole("button", { name: "Auto-connect" }).click();
 
       addCardToDashboard();
 
-      undoToastList()
+      H.undoToastList()
         .contains("Auto-connect “Orders Model” to “Text”?")
         .should("be.visible");
 
       removeFilterFromDashboard();
 
-      undoToast().should("not.exist");
+      H.undoToast().should("not.exist");
     });
 
     it("should dismiss auto-wire toasts on card removal", () => {
       createDashboardWithCards({ cards }).then(dashboardId => {
-        visitDashboard(dashboardId);
+        H.visitDashboard(dashboardId);
       });
 
-      editDashboard();
-      setFilter("Text or Category", "Is");
+      H.editDashboard();
+      H.setFilter("Text or Category", "Is");
 
-      selectDashboardFilter(getDashboardCard(0), "Name");
+      H.selectDashboardFilter(H.getDashboardCard(0), "Name");
 
-      undoToast().findByRole("button", { name: "Auto-connect" }).click();
+      H.undoToast().findByRole("button", { name: "Auto-connect" }).click();
 
       addCardToDashboard();
 
-      undoToastList()
+      H.undoToastList()
         .contains("Auto-connect “Orders Model” to “Text”?")
         .should("be.visible");
 
-      removeDashboardCard(2);
+      H.removeDashboardCard(2);
 
-      undoToastList()
+      H.undoToastList()
         .should("have.length", 1)
         .should("contain", "Removed card");
     });
 
     it("should dismiss toasts on timeout", () => {
       createDashboardWithCards({ cards }).then(dashboardId => {
-        visitDashboard(dashboardId);
+        H.visitDashboard(dashboardId);
       });
 
-      editDashboard();
-      setFilter("Text or Category", "Is");
+      H.editDashboard();
+      H.setFilter("Text or Category", "Is");
 
       cy.clock();
-      selectDashboardFilter(getDashboardCard(0), "Name");
+      H.selectDashboardFilter(H.getDashboardCard(0), "Name");
 
-      undoToast().should("be.visible");
+      H.undoToast().should("be.visible");
 
       // AUTO_WIRE_TOAST_TIMEOUT
       cy.tick(12000);
 
-      undoToast().should("not.exist");
+      H.undoToast().should("not.exist");
 
       removeFilterFromDashCard(0);
 
-      selectDashboardFilter(getDashboardCard(0), "Name");
+      H.selectDashboardFilter(H.getDashboardCard(0), "Name");
 
       cy.clock();
-      undoToast().findByRole("button", { name: "Auto-connect" }).click();
+      H.undoToast().findByRole("button", { name: "Auto-connect" }).click();
 
-      undoToast().should("be.visible");
+      H.undoToast().should("be.visible");
 
       // AUTO_WIRE_UNDO_TOAST_TIMEOUT
       cy.tick(8000);
-      undoToast().should("not.exist");
+      H.undoToast().should("not.exist");
     });
   });
 
@@ -743,7 +718,7 @@ describe("dashboard filters auto-wiring", () => {
       dashboardDetails,
       questions: [questionDetails],
     }).then(({ dashboard, questions: [card] }) => {
-      updateDashboardCards({
+      H.updateDashboardCards({
         dashboard_id: dashboard.id,
         cards: [
           {
@@ -752,26 +727,26 @@ describe("dashboard filters auto-wiring", () => {
           },
         ],
       });
-      visitDashboard(dashboard.id);
+      H.visitDashboard(dashboard.id);
     });
 
     cy.log("add a card to the dashboard and auto-wire");
-    editDashboard();
-    dashboardHeader().icon("add").click();
+    H.editDashboard();
+    H.dashboardHeader().icon("add").click();
     cy.findByTestId("add-card-sidebar")
       .findByText(questionDetails.name)
       .click();
-    undoToast().button("Auto-connect").click();
+    H.undoToast().button("Auto-connect").click();
 
     cy.log("check auto-wired parameter mapping");
     cy.findByTestId("fixed-width-filters")
       .findByText(sourceParameter.name)
       .click();
-    getDashboardCard(1).findByText("User.Source").should("be.visible");
+    H.getDashboardCard(1).findByText("User.Source").should("be.visible");
     cy.findByTestId("fixed-width-filters")
       .findByText(categoryParameter.name)
       .click();
-    getDashboardCard(1).findByText("Product.Category").should("be.visible");
+    H.getDashboardCard(1).findByText("Product.Category").should("be.visible");
   });
 });
 
@@ -782,7 +757,7 @@ function createDashboardWithCards({
   return cy
     .createDashboard({ name: dashboardName })
     .then(({ body: { id } }) => {
-      updateDashboardCards({
+      H.updateDashboardCards({
         dashboard_id: id,
         cards,
       });
@@ -803,7 +778,7 @@ function addCardToDashboard(dashcardNames = "Orders Model") {
 function removeFilterFromDashboard(filterName = "Text") {
   goToFilterMapping(filterName);
 
-  sidebar().findByRole("button", { name: "Remove" }).click();
+  H.sidebar().findByRole("button", { name: "Remove" }).click();
 }
 
 function goToFilterMapping(name = "Text") {
@@ -813,7 +788,7 @@ function goToFilterMapping(name = "Text") {
 }
 
 function removeFilterFromDashCard(dashcardIndex = 0) {
-  getDashboardCard(dashcardIndex).icon("close").click();
+  H.getDashboardCard(dashcardIndex).icon("close").click();
 }
 
 function getTableCell(columnName, rowIndex) {
@@ -832,21 +807,21 @@ function addQuestionFromQueryBuilder({
   questionId,
   saveDashboardAfterAdd = true,
 }) {
-  visitQuestion(questionId);
+  H.visitQuestion(questionId);
 
-  openQuestionActions();
-  popover().findByText("Add to dashboard").click();
+  H.openQuestionActions();
+  H.popover().findByText("Add to dashboard").click();
 
-  entityPickerModal().within(() => {
-    modal().findByText("Dashboards").click();
-    modal().findByText("36275").click();
+  H.entityPickerModal().within(() => {
+    H.modal().findByText("Dashboards").click();
+    H.modal().findByText("36275").click();
     cy.button("Select").click();
   });
 
-  undoToast().findByRole("button", { name: "Auto-connect" }).click();
-  undoToast().should("contain", "Undo");
+  H.undoToast().findByRole("button", { name: "Auto-connect" }).click();
+  H.undoToast().should("contain", "Undo");
 
   if (saveDashboardAfterAdd) {
-    saveDashboard();
+    H.saveDashboard();
   }
 }

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-clear-and-restore.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-clear-and-restore.cy.spec.ts
@@ -1,29 +1,17 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  checkFilterListSourceHasValue,
-  createQuestionAndDashboard,
-  editDashboard,
-  modal,
-  popover,
-  restore,
-  saveDashboard,
-  setFilter,
-  setFilterListSource,
-  sidebar,
-  visitDashboard,
-} from "e2e/support/helpers";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
 
 describe("dashboard filters values source config clearing and restoring", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
   it("should clear and restore parameter static-list values when the type changes", () => {
-    createQuestionAndDashboard({
+    H.createQuestionAndDashboard({
       questionDetails: {
         display: "scalar",
         query: {
@@ -32,27 +20,27 @@ describe("dashboard filters values source config clearing and restoring", () => 
         },
       },
     }).then(({ body: { dashboard_id } }) => {
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
 
-      editDashboard();
-      setFilter("Number", "Equal to", "Foo");
+      H.editDashboard();
+      H.setFilter("Number", "Equal to", "Foo");
       mapFilterToQuestion();
-      setFilterListSource({
+      H.setFilterListSource({
         values: [["10", "Ten"], ["20", "Twenty"], "30"],
       });
-      saveDashboard();
+      H.saveDashboard();
 
-      editDashboard();
+      H.editDashboard();
       editFilter("Foo");
 
       editFilterType("Text or Category", "Is");
-      checkFilterListSourceHasValue({ values: [] });
+      H.checkFilterListSourceHasValue({ values: [] });
 
       mapFilterToQuestion("Email");
       setFilterSourceFromConnectedFields();
 
       editFilterType("Number", "Equal to");
-      checkFilterListSourceHasValue({
+      H.checkFilterListSourceHasValue({
         values: [["10", "Ten"], ["20", "Twenty"], "30"],
       });
     });
@@ -60,8 +48,8 @@ describe("dashboard filters values source config clearing and restoring", () => 
 });
 
 function setFilterSourceFromConnectedFields() {
-  sidebar().findByText("Edit").click();
-  modal().within(() => {
+  H.sidebar().findByText("Edit").click();
+  H.modal().within(() => {
     cy.findByText("From connected fields").click();
     cy.button("Done").click();
   });
@@ -69,7 +57,7 @@ function setFilterSourceFromConnectedFields() {
 
 const mapFilterToQuestion = (column = "Quantity") => {
   cy.findByText("Select…").click();
-  popover().within(() => cy.findByText(column).click());
+  H.popover().within(() => cy.findByText(column).click());
 };
 
 function editFilter(name: string) {
@@ -79,9 +67,9 @@ function editFilter(name: string) {
 }
 
 function editFilterType(type: string, subType: string) {
-  sidebar().findByText("Filter or parameter type").next().click();
-  popover().findByText(type).click();
+  H.sidebar().findByText("Filter or parameter type").next().click();
+  H.popover().findByText(type).click();
 
-  sidebar().findByText("Filter operator").next().click();
-  popover().findByText(subType).click();
+  H.sidebar().findByText("Filter operator").next().click();
+  H.popover().findByText(subType).click();
 }

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
@@ -1,24 +1,8 @@
+import { H } from "e2e/support";
 import {
   ORDERS_DASHBOARD_DASHCARD_ID,
   ORDERS_DASHBOARD_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  clearFilterWidget,
-  dashboardParametersDoneButton,
-  dashboardSaveButton,
-  editDashboard,
-  ensureDashboardCardHasText,
-  filterWidget,
-  popover,
-  resetFilterWidgetToDefault,
-  restore,
-  saveDashboard,
-  selectDashboardFilter,
-  setFilter,
-  sidebar,
-  toggleRequiredParameter,
-  visitDashboard,
-} from "e2e/support/helpers";
 
 import * as DateFilter from "../native-filters/helpers/e2e-date-filter-helpers";
 
@@ -28,30 +12,30 @@ describe("scenarios > dashboard > filters > date", () => {
   beforeEach(() => {
     cy.intercept("GET", "/api/table/*/query_metadata").as("metadata");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
 
-    editDashboard();
+    H.editDashboard();
   });
 
   it("should work when set through the filter widget", () => {
     // Add and connect every single available date filter type
     Object.entries(DASHBOARD_DATE_FILTERS).forEach(([filter]) => {
       cy.log(`Make sure we can connect ${filter} filter`);
-      setFilter("Date picker", filter);
+      H.setFilter("Date picker", filter);
 
       cy.findByText("Select…").click();
-      popover().contains("Created At").first().click();
+      H.popover().contains("Created At").first().click();
     });
 
-    saveDashboard();
+    H.saveDashboard();
 
     // Go through each of the filters and make sure they work individually
     Object.entries(DASHBOARD_DATE_FILTERS).forEach(
       ([filter, { value, representativeResult }], index) => {
-        filterWidget().eq(index).click();
+        H.filterWidget().eq(index).click();
 
         dateFilterSelector({
           filterType: filter,
@@ -63,7 +47,7 @@ describe("scenarios > dashboard > filters > date", () => {
           cy.findByText(representativeResult);
         });
 
-        clearFilterWidget(index);
+        H.clearFilterWidget(index);
         cy.wait(`@dashcardQuery${ORDERS_DASHBOARD_DASHCARD_ID}`);
       },
     );
@@ -72,7 +56,7 @@ describe("scenarios > dashboard > filters > date", () => {
   // Rather than going through every single filter type,
   // make sure the default filter works for just one of the available options
   it("should work when set as the default filter", () => {
-    setFilter("Date picker", "Month and Year");
+    H.setFilter("Date picker", "Month and Year");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Default value").next().click();
 
@@ -83,9 +67,9 @@ describe("scenarios > dashboard > filters > date", () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
-    popover().contains("Created At").first().click();
+    H.popover().contains("Created At").first().click();
 
-    saveDashboard();
+    H.saveDashboard();
 
     // The default value should immediately be applied
     cy.findByTestId("dashcard").within(() => {
@@ -95,57 +79,57 @@ describe("scenarios > dashboard > filters > date", () => {
     // Make sure we can override the default value
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("November 2022").click();
-    popover().contains("June").click();
+    H.popover().contains("June").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("33.9");
   });
 
   it("should support being required", () => {
-    setFilter("Date picker", "Month and Year", "Month and Year");
+    H.setFilter("Date picker", "Month and Year", "Month and Year");
 
     // Can't save without a default value
-    toggleRequiredParameter();
-    dashboardSaveButton().should("be.disabled");
-    dashboardSaveButton().realHover();
+    H.toggleRequiredParameter();
+    H.dashboardSaveButton().should("be.disabled");
+    H.dashboardSaveButton().realHover();
     cy.findByRole("tooltip").should(
       "contain.text",
       'The "Month and Year" parameter requires a default value but none was provided.',
     );
 
     // Can't close sidebar without a default value
-    dashboardParametersDoneButton().should("be.disabled");
-    dashboardParametersDoneButton().realHover();
+    H.dashboardParametersDoneButton().should("be.disabled");
+    H.dashboardParametersDoneButton().realHover();
     cy.findByRole("tooltip").should(
       "contain.text",
       "The parameter requires a default value but none was provided.",
     );
 
-    sidebar().findByText("Default value").next().click();
+    H.sidebar().findByText("Default value").next().click();
     DateFilter.setMonthAndYear({
       month: "November",
       year: "2023",
     });
 
-    selectDashboardFilter(cy.findByTestId("dashcard"), "Created At");
-    saveDashboard();
+    H.selectDashboardFilter(cy.findByTestId("dashcard"), "Created At");
+    H.saveDashboard();
 
     // Updates the filter value
-    filterWidget().should("contain.text", "November 2023").click();
-    popover().findByText("December").click();
-    filterWidget().findByText("December 2023");
-    ensureDashboardCardHasText("76.83");
+    H.filterWidget().should("contain.text", "November 2023").click();
+    H.popover().findByText("December").click();
+    H.filterWidget().findByText("December 2023");
+    H.ensureDashboardCardHasText("76.83");
 
     // Resets the value back by clicking widget icon
-    resetFilterWidgetToDefault();
-    filterWidget().findByText("November 2023");
-    ensureDashboardCardHasText("27.74");
+    H.resetFilterWidgetToDefault();
+    H.filterWidget().findByText("November 2023");
+    H.ensureDashboardCardHasText("27.74");
   });
 
   it("should show sub-day resolutions in relative date filter (metabase#6660)", () => {
-    visitDashboard(ORDERS_DASHBOARD_ID);
-    editDashboard();
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.editDashboard();
 
-    setFilter("Date picker", "All Options");
+    H.setFilter("Date picker", "All Options");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("No default").click();
@@ -165,7 +149,7 @@ describe("scenarios > dashboard > filters > date", () => {
     cy.findByText("minutes").click();
     // also check the "Include this minute" checkbox
     // which is actually "Include" followed by "this minute" wrapped in <strong>, so has to be clicked this way
-    popover().icon("ellipsis").click();
+    H.popover().icon("ellipsis").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Include this minute").click();
   });
@@ -175,18 +159,18 @@ describe("scenarios > dashboard > filters > date", () => {
       cy.request("PUT", `/api/user/${USER_ID}`, { locale: "fr" });
     });
 
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
     // we can't use helpers as they use english words
     cy.icon("pencil").click();
     cy.icon("filter").click();
 
-    popover().icon("calendar").click(); // "Time" -> "All Options"
+    H.popover().icon("calendar").click(); // "Time" -> "All Options"
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sélectionner...").click(); // "Select…"
-    popover().contains("Created At").first().click();
+    H.popover().contains("Created At").first().click();
 
-    saveDashboard({
+    H.saveDashboard({
       buttonLabel: "Sauvegarder",
       editBarText: "Vous êtes en train d'éditer ce tableau de bord.",
     });

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-explicit-join.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-explicit-join.cy.spec.js
@@ -1,5 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { filterWidget, restore, visitDashboard } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
@@ -41,7 +41,7 @@ describe("scenarios > dashboard > filters", () => {
       "filterValues",
     );
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
@@ -71,13 +71,13 @@ describe("scenarios > dashboard > filters", () => {
 
         cy.editDashboardCard(dashboardCard, updatedCardDetails);
 
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       },
     );
   });
 
   it("should work properly when connected to the explicitly joined field", () => {
-    filterWidget().click();
+    H.filterWidget().click();
     cy.wait("@filterValues");
 
     cy.findByPlaceholderText("Search the list").type("Awe");
@@ -91,7 +91,7 @@ describe("scenarios > dashboard > filters", () => {
       "?text=Awesome+Concrete+Shoes&text=Awesome+Iron+Hat",
     );
 
-    filterWidget().contains("2 selections");
+    H.filterWidget().contains("2 selections");
 
     cy.findByTestId("dashcard").within(() => {
       cy.findAllByText("Awesome Concrete Shoes");

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-id.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-id.cy.spec.js
@@ -1,26 +1,17 @@
+import { H } from "e2e/support";
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  checkFilterLabelAndValue,
-  editDashboard,
-  filterWidget,
-  popover,
-  restore,
-  saveDashboard,
-  setFilter,
-  visitDashboard,
-} from "e2e/support/helpers";
 
 import { addWidgetStringFilter } from "../native-filters/helpers/e2e-field-filter-helpers";
 
 describe("scenarios > dashboard > filters > ID", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
 
-    editDashboard();
-    setFilter("ID");
+    H.editDashboard();
+    H.setFilter("ID");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
@@ -40,14 +31,14 @@ describe("scenarios > dashboard > filters > ID", () => {
 
   describe("should work for the primary key", () => {
     beforeEach(() => {
-      popover().contains("ID").first().click();
+      H.popover().contains("ID").first().click();
     });
 
     it("when set through the filter widget", () => {
-      saveDashboard();
+      H.saveDashboard();
       cy.wait("@dashboardData");
 
-      filterWidget().click();
+      H.filterWidget().click();
       addWidgetStringFilter("15");
       cy.wait("@dashboardData");
       cy.findByTestId("loading-indicator").should("not.exist");
@@ -60,7 +51,7 @@ describe("scenarios > dashboard > filters > ID", () => {
       cy.findByText("Default value").next().click();
       addWidgetStringFilter("15");
 
-      saveDashboard();
+      H.saveDashboard();
       cy.wait("@dashboardData");
       cy.findByTestId("loading-indicator").should("not.exist");
 
@@ -70,20 +61,20 @@ describe("scenarios > dashboard > filters > ID", () => {
 
   describe("should work for the foreign key", () => {
     beforeEach(() => {
-      popover().contains("User ID").click();
+      H.popover().contains("User ID").click();
     });
 
     it("when set through the filter widget", () => {
-      saveDashboard();
+      H.saveDashboard();
       cy.wait("@dashboardData");
 
-      filterWidget().click();
+      H.filterWidget().click();
       addWidgetStringFilter("4");
       cy.wait("@dashboardData");
       cy.findByTestId("loading-indicator").should("not.exist");
 
       cy.findByTestId("dashcard").should("contain", "47.68");
-      checkFilterLabelAndValue("ID", "Arnold Adams - 4");
+      H.checkFilterLabelAndValue("ID", "Arnold Adams - 4");
     });
 
     it("when set as the default filter", () => {
@@ -91,18 +82,18 @@ describe("scenarios > dashboard > filters > ID", () => {
       cy.findByText("Default value").next().click();
       addWidgetStringFilter("4");
 
-      saveDashboard();
+      H.saveDashboard();
       cy.wait("@dashboardData");
       cy.findByTestId("loading-indicator").should("not.exist");
 
       cy.findByTestId("dashcard").should("contain", "47.68");
-      checkFilterLabelAndValue("ID", "Arnold Adams - 4");
+      H.checkFilterLabelAndValue("ID", "Arnold Adams - 4");
     });
   });
 
   describe("should work on the implicit join", () => {
     beforeEach(() => {
-      popover().within(() => {
+      H.popover().within(() => {
         // There are three of these, and the order is fixed:
         // "own" column first, then implicit join on People and User alphabetically.
         // We select index 1 to get the Product.ID.
@@ -111,10 +102,10 @@ describe("scenarios > dashboard > filters > ID", () => {
     });
 
     it("when set through the filter widget", () => {
-      saveDashboard();
+      H.saveDashboard();
       cy.wait("@dashboardData");
 
-      filterWidget().click();
+      H.filterWidget().click();
       addWidgetStringFilter("10");
       cy.wait("@dashboardData");
       cy.findByTestId("loading-indicator").should("not.exist");
@@ -127,7 +118,7 @@ describe("scenarios > dashboard > filters > ID", () => {
       cy.findByText("Default value").next().click();
       addWidgetStringFilter("10");
 
-      saveDashboard();
+      H.saveDashboard();
       cy.wait("@dashboardData");
       cy.findByTestId("loading-indicator").should("not.exist");
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-location.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-location.cy.spec.js
@@ -1,17 +1,8 @@
+import { H } from "e2e/support";
 import {
   ORDERS_DASHBOARD_DASHCARD_ID,
   ORDERS_DASHBOARD_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  clearFilterWidget,
-  editDashboard,
-  filterWidget,
-  popover,
-  restore,
-  saveDashboard,
-  setFilter,
-  visitDashboard,
-} from "e2e/support/helpers";
 
 import { addWidgetStringFilter } from "../native-filters/helpers/e2e-field-filter-helpers";
 
@@ -19,27 +10,27 @@ import { DASHBOARD_LOCATION_FILTERS } from "./shared/dashboard-filters-location"
 
 describe("scenarios > dashboard > filters > location", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
 
-    editDashboard();
+    H.editDashboard();
   });
 
   it("should work when set through the filter widget", () => {
     Object.entries(DASHBOARD_LOCATION_FILTERS).forEach(([filter]) => {
       cy.log(`Make sure we can connect ${filter} filter`);
-      setFilter("Location", filter);
+      H.setFilter("Location", filter);
 
       cy.findByText("Select…").click();
-      popover().contains("City").click();
+      H.popover().contains("City").click();
     });
-    saveDashboard();
+    H.saveDashboard();
 
     Object.entries(DASHBOARD_LOCATION_FILTERS).forEach(
       ([filter, { value, representativeResult }], index) => {
-        filterWidget().eq(index).click();
+        H.filterWidget().eq(index).click();
         addWidgetStringFilter(value);
 
         cy.log(`Make sure ${filter} filter returns correct result`);
@@ -47,24 +38,24 @@ describe("scenarios > dashboard > filters > location", () => {
           cy.contains(representativeResult);
         });
 
-        clearFilterWidget(index);
+        H.clearFilterWidget(index);
         cy.wait(`@dashcardQuery${ORDERS_DASHBOARD_DASHCARD_ID}`);
       },
     );
   });
 
   it("should work when set as the default filter", () => {
-    setFilter("Location", "Is");
+    H.setFilter("Location", "Is");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
-    popover().contains("City").click();
+    H.popover().contains("City").click();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Default value").next().click();
 
     addWidgetStringFilter("Abbeville");
 
-    saveDashboard();
+    H.saveDashboard();
 
     cy.findByTestId("dashcard").within(() => {
       cy.contains("1510");

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-management.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-management.cy.spec.js
@@ -1,22 +1,12 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  editDashboard,
-  filterWidget,
-  getDashboardCard,
-  popover,
-  restore,
-  saveDashboard,
-  sidebar,
-  updateDashboardCards,
-  visitDashboard,
-} from "e2e/support/helpers";
 import { createMockParameter } from "metabase-types/api/mocks";
 
 const { PEOPLE, PEOPLE_ID, ORDERS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > dashboard > filters > management", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -53,7 +43,7 @@ describe("scenarios > dashboard > filters > management", () => {
       }).then(({ dashboard, questions: cards }) => {
         const [peopleCard, ordersCard] = cards;
 
-        updateDashboardCards({
+        H.updateDashboardCards({
           dashboard_id: dashboard.id,
           cards: [
             {
@@ -89,33 +79,33 @@ describe("scenarios > dashboard > filters > management", () => {
           ],
         });
 
-        visitDashboard(dashboard.id);
+        H.visitDashboard(dashboard.id);
       });
 
       cy.log("verify filters are there");
-      filterWidget().should("contain", "Location").and("contain", "Text");
+      H.filterWidget().should("contain", "Location").and("contain", "Text");
 
-      editDashboard();
+      H.editDashboard();
 
       selectFilter("Location");
 
-      getDashboardCard().contains("People.State");
-      getDashboardCard(1).contains("User.City");
+      H.getDashboardCard().contains("People.State");
+      H.getDashboardCard(1).contains("User.City");
 
       cy.log("Disconnect cards");
-      sidebar().findByText("Disconnect from cards").click();
+      H.sidebar().findByText("Disconnect from cards").click();
 
-      getDashboardCard().should("not.contain", "People.State");
-      getDashboardCard(1).should("not.contain", "User.City");
+      H.getDashboardCard().should("not.contain", "People.State");
+      H.getDashboardCard(1).should("not.contain", "User.City");
 
       selectFilter("Text");
 
-      getDashboardCard().should("contain", "People.Name");
-      getDashboardCard(1).should("contain", "User.Name");
+      H.getDashboardCard().should("contain", "People.Name");
+      H.getDashboardCard(1).should("contain", "User.Name");
 
-      saveDashboard();
+      H.saveDashboard();
 
-      filterWidget().should("contain", "Text").and("not.contain", "Location");
+      H.filterWidget().should("contain", "Text").and("not.contain", "Location");
     });
   });
 
@@ -125,27 +115,27 @@ describe("scenarios > dashboard > filters > management", () => {
 
       selectFilter("Text");
 
-      getDashboardCard().should("contain", "People.Name");
+      H.getDashboardCard().should("contain", "People.Name");
 
       cy.log("change filter type");
 
-      sidebar().within(() => {
+      H.sidebar().within(() => {
         // verifies default value presents
         cy.findByText("value to check default").should("exist");
         cy.findByDisplayValue("Text or Category").click();
       });
 
-      popover().findByText("Number").click();
+      H.popover().findByText("Number").click();
 
-      sidebar().within(() => {
+      H.sidebar().within(() => {
         // verifies no default value
         cy.findByText("No default").should("exist");
       });
-      getDashboardCard().should("not.contain", "People.Name");
+      H.getDashboardCard().should("not.contain", "People.Name");
 
-      saveDashboard();
+      H.saveDashboard();
 
-      filterWidget().should("not.exist");
+      H.filterWidget().should("not.exist");
     });
 
     it("should preselect default value for every type of filter", () => {
@@ -154,7 +144,7 @@ describe("scenarios > dashboard > filters > management", () => {
       selectFilter("Text");
 
       cy.log("verify Text default value: Is");
-      sidebar().findByDisplayValue("Is").should("exist");
+      H.sidebar().findByDisplayValue("Is").should("exist");
 
       changeFilterType("Number");
 
@@ -164,7 +154,7 @@ describe("scenarios > dashboard > filters > management", () => {
       changeFilterType("ID");
 
       cy.log("verify ID doesn't render operator select");
-      sidebar().findAllByRole("searchbox").should("have.length", 1);
+      H.sidebar().findAllByRole("searchbox").should("have.length", 1);
 
       changeFilterType("Date picker");
 
@@ -198,7 +188,7 @@ describe("scenarios > dashboard > filters > management", () => {
       }).then(({ dashboard, questions: cards }) => {
         const [peopleCard] = cards;
 
-        updateDashboardCards({
+        H.updateDashboardCards({
           dashboard_id: dashboard.id,
           cards: [
             {
@@ -214,24 +204,24 @@ describe("scenarios > dashboard > filters > management", () => {
           ],
         });
 
-        visitDashboard(dashboard.id);
+        H.visitDashboard(dashboard.id);
       });
 
-      editDashboard();
+      H.editDashboard();
 
       selectFilter("Text Text");
 
-      sidebar().findByDisplayValue("Does not contain").should("exist");
+      H.sidebar().findByDisplayValue("Does not contain").should("exist");
 
       changeFilterType("Number");
 
       // default value for a number type
-      sidebar().findByDisplayValue("Equal to").should("exist");
+      H.sidebar().findByDisplayValue("Equal to").should("exist");
 
       changeFilterType("Text or Category");
 
       cy.log("verify the saved parameter value is restored");
-      sidebar().within(() => {
+      H.sidebar().within(() => {
         cy.findByDisplayValue("Does not contain").should("exist");
         cy.findByDisplayValue("Text or Category").should("exist");
         cy.findByDisplayValue("Text Text").should("exist");
@@ -259,7 +249,7 @@ describe("scenarios > dashboard > filters > management", () => {
       }).then(({ dashboard, questions: cards }) => {
         const [peopleCard] = cards;
 
-        updateDashboardCards({
+        H.updateDashboardCards({
           dashboard_id: dashboard.id,
           cards: [
             {
@@ -275,26 +265,26 @@ describe("scenarios > dashboard > filters > management", () => {
           ],
         });
 
-        visitDashboard(dashboard.id);
+        H.visitDashboard(dashboard.id);
       });
 
-      editDashboard();
+      H.editDashboard();
 
       selectFilter("Text Text");
 
-      sidebar().findByDisplayValue("Does not contain").should("exist");
+      H.sidebar().findByDisplayValue("Does not contain").should("exist");
 
-      getDashboardCard().should("contain", "People.Name");
+      H.getDashboardCard().should("contain", "People.Name");
 
       changeFilterType("Number");
 
       cy.log("verify that mapping is cleared");
-      getDashboardCard().should("not.contain", "People.Name");
+      H.getDashboardCard().should("not.contain", "People.Name");
 
       changeFilterType("Text or Category");
 
       cy.log("verify that mapping is restored");
-      getDashboardCard().should("contain", "People.Name");
+      H.getDashboardCard().should("contain", "People.Name");
     });
   });
 
@@ -305,20 +295,20 @@ describe("scenarios > dashboard > filters > management", () => {
       selectFilter("Text");
 
       // verifies default value is there
-      sidebar().findByText("value to check default").should("exist");
+      H.sidebar().findByText("value to check default").should("exist");
 
-      getDashboardCard().should("contain", "People.Name");
+      H.getDashboardCard().should("contain", "People.Name");
 
       changeOperator("Contains");
 
-      getDashboardCard().should("contain", "People.Name");
+      H.getDashboardCard().should("contain", "People.Name");
 
       // verifies default value does not exist
-      sidebar().findByText("No default").should("exist");
+      H.sidebar().findByText("No default").should("exist");
 
-      saveDashboard();
+      H.saveDashboard();
 
-      filterWidget().should("contain", "Text");
+      H.filterWidget().should("contain", "Text");
     });
   });
 });
@@ -345,7 +335,7 @@ function createDashboardWithFilterAndQuestionMapped() {
   }).then(({ dashboard, questions: cards }) => {
     const [peopleCard] = cards;
 
-    updateDashboardCards({
+    H.updateDashboardCards({
       dashboard_id: dashboard.id,
       cards: [
         {
@@ -361,10 +351,10 @@ function createDashboardWithFilterAndQuestionMapped() {
       ],
     });
 
-    visitDashboard(dashboard.id);
+    H.visitDashboard(dashboard.id);
   });
 
-  editDashboard();
+  H.editDashboard();
 }
 
 function selectFilter(name) {
@@ -374,17 +364,17 @@ function selectFilter(name) {
 }
 
 function changeFilterType(type) {
-  sidebar().findByText("Filter or parameter type").next().click();
-  popover().findByText(type).click();
+  H.sidebar().findByText("Filter or parameter type").next().click();
+  H.popover().findByText(type).click();
 }
 
 function changeOperator(operator) {
-  sidebar().findByText("Filter operator").next().click();
-  popover().findByText(operator).click();
+  H.sidebar().findByText("Filter operator").next().click();
+  H.popover().findByText(operator).click();
 }
 
 function verifyOperatorValue(value) {
-  sidebar()
+  H.sidebar()
     .findByText("Filter operator")
     .next()
     .findByRole("searchbox")

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-nested.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-nested.cy.spec.js
@@ -1,21 +1,11 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  editDashboard,
-  filterWidget,
-  getDashboardCard,
-  multiAutocompleteInput,
-  popover,
-  restore,
-  saveDashboard,
-  setFilter,
-  visitDashboard,
-} from "e2e/support/helpers";
 
 const { PRODUCTS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > dashboard > filters > nested questions", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
@@ -55,11 +45,11 @@ describe("scenarios > dashboard > filters > nested questions", () => {
         questionDetails: nestedQuestion,
         dashboardDetails,
       }).then(({ body: { dashboard_id } }) => {
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       });
     });
 
-    editDashboard();
+    H.editDashboard();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(filter.name).find(".Icon-gear").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -67,19 +57,19 @@ describe("scenarios > dashboard > filters > nested questions", () => {
 
     // This part reproduces metabase#13186
     cy.log("Reported failing in v0.36.4 (`Category` is missing)");
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText(/Ean/i);
       cy.findByText(/Title/i);
       cy.findByText(/Vendor/i);
       cy.findByText(/Category/i).click();
     });
 
-    saveDashboard();
+    H.saveDashboard();
 
     // Add multiple values (metabase#18113)
-    filterWidget().click();
-    popover().within(() => {
-      multiAutocompleteInput().type("Gizmo,Gadget").blur();
+    H.filterWidget().click();
+    H.popover().within(() => {
+      H.multiAutocompleteInput().type("Gizmo,Gadget").blur();
     });
 
     cy.button("Add filter").click();
@@ -99,17 +89,17 @@ describe("scenarios > dashboard > filters > nested questions", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("2 selections");
 
-    editDashboard();
+    H.editDashboard();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(filter.name).find(".Icon-gear").click();
 
-    getDashboardCard().within(() => {
+    H.getDashboardCard().within(() => {
       cy.findByText("Column to filter on");
       cy.findByText("18113 Source.CATEGORY").click();
     });
 
     // This part reproduces metabase#12614
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText(/Ean/i);
       cy.findByText(/Title/i);
       cy.findByText(/Vendor/i);
@@ -129,20 +119,20 @@ describe("scenarios > dashboard > filters > nested questions", () => {
 
       cy.createQuestionAndDashboard({ questionDetails }).then(
         ({ body: { dashboard_id } }) => {
-          visitDashboard(dashboard_id);
+          H.visitDashboard(dashboard_id);
         },
       );
     });
 
-    editDashboard();
+    H.editDashboard();
 
-    setFilter("ID");
+    H.setFilter("ID");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("No valid fields").should("not.exist");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
-    popover().contains("ID").click();
+    H.popover().contains("ID").click();
   });
 });

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-number-source.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-number-source.cy.spec.js
@@ -1,18 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  editDashboard,
-  filterWidget,
-  getDashboardCard,
-  popover,
-  restore,
-  saveDashboard,
-  setFilter,
-  setFilterListSource,
-  sidebar,
-  visitDashboard,
-  visitEmbeddedPage,
-  visitPublicDashboard,
-} from "e2e/support/helpers";
 
 const { ACCOUNTS, ORDERS_ID } = SAMPLE_DATABASE;
 
@@ -34,7 +21,7 @@ const targetQuestion = {
 
 describe("scenarios > dashboard > filters", { tags: "@slow" }, () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
@@ -44,20 +31,20 @@ describe("scenarios > dashboard > filters", { tags: "@slow" }, () => {
       cy.createQuestionAndDashboard({
         questionDetails: targetQuestion,
       }).then(({ body: { dashboard_id } }) => {
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       });
 
-      editDashboard();
-      setFilter("Number", "Equal to", "Number");
+      H.editDashboard();
+      H.setFilter("Number", "Equal to", "Number");
       mapFilterToQuestion();
-      setFilterListSource({
+      H.setFilterListSource({
         values: [["10", "Ten"], ["20", "Twenty"], "30"],
       });
-      saveDashboard();
+      H.saveDashboard();
 
       filterDashboard({ isDropdown: true });
-      filterWidget().findByText("Twenty").should("be.visible");
-      getDashboardCard().findByText("4").should("be.visible");
+      H.filterWidget().findByText("Twenty").should("be.visible");
+      H.getDashboardCard().findByText("4").should("be.visible");
     });
 
     it("should be able to use a static list source when embedded", () => {
@@ -66,11 +53,11 @@ describe("scenarios > dashboard > filters", { tags: "@slow" }, () => {
         dashboardDetails: getListDashboard(),
       }).then(({ body: card }) => {
         cy.editDashboardCard(card, getParameterMapping(card));
-        visitEmbeddedPage(getDashboardResource(card));
+        H.visitEmbeddedPage(getDashboardResource(card));
       });
 
       filterDashboard({ isDropdown: true });
-      filterWidget().findByText("Twenty").should("be.visible");
+      H.filterWidget().findByText("Twenty").should("be.visible");
     });
 
     it("should be able to use a static list source when embedded", () => {
@@ -79,11 +66,11 @@ describe("scenarios > dashboard > filters", { tags: "@slow" }, () => {
         dashboardDetails: getListDashboard(),
       }).then(({ body: card }) => {
         cy.editDashboardCard(card, getParameterMapping(card));
-        visitEmbeddedPage(getDashboardResource(card));
+        H.visitEmbeddedPage(getDashboardResource(card));
       });
 
       filterDashboard({ isDropdown: true });
-      filterWidget().findByText("Twenty").should("be.visible");
+      H.filterWidget().findByText("Twenty").should("be.visible");
     });
 
     it("should be able to use a static list source when public", () => {
@@ -92,11 +79,11 @@ describe("scenarios > dashboard > filters", { tags: "@slow" }, () => {
         dashboardDetails: getListDashboard(),
       }).then(({ body: card }) => {
         cy.editDashboardCard(card, getParameterMapping(card));
-        visitPublicDashboard(card.dashboard_id);
+        H.visitPublicDashboard(card.dashboard_id);
       });
 
       filterDashboard({ isDropdown: true });
-      filterWidget().findByText("Twenty").should("be.visible");
+      H.filterWidget().findByText("Twenty").should("be.visible");
     });
   });
 
@@ -105,20 +92,20 @@ describe("scenarios > dashboard > filters", { tags: "@slow" }, () => {
       cy.createQuestionAndDashboard({
         questionDetails: targetQuestion,
       }).then(({ body: { dashboard_id } }) => {
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       });
 
-      editDashboard();
-      setFilter("Number", "Equal to", "Number");
+      H.editDashboard();
+      H.setFilter("Number", "Equal to", "Number");
       mapFilterToQuestion();
-      sidebar().findByText("Search box").click();
-      setFilterListSource({
+      H.sidebar().findByText("Search box").click();
+      H.setFilterListSource({
         values: [[10, "Ten"], [20, "Twenty"], 30],
       });
-      saveDashboard();
+      H.saveDashboard();
 
       filterDashboard({ isLabeled: true });
-      filterWidget().findByText("Twenty").should("be.visible");
+      H.filterWidget().findByText("Twenty").should("be.visible");
     });
 
     it("should be able to use a static list source when embedded", () => {
@@ -127,11 +114,11 @@ describe("scenarios > dashboard > filters", { tags: "@slow" }, () => {
         dashboardDetails: getListDashboard("search"),
       }).then(({ body: card }) => {
         cy.editDashboardCard(card, getParameterMapping(card));
-        visitEmbeddedPage(getDashboardResource(card));
+        H.visitEmbeddedPage(getDashboardResource(card));
       });
 
       filterDashboard({ isLabeled: true });
-      filterWidget().findByText("Twenty").should("be.visible");
+      H.filterWidget().findByText("Twenty").should("be.visible");
     });
 
     it("should be able to use a static list source when public", () => {
@@ -140,25 +127,25 @@ describe("scenarios > dashboard > filters", { tags: "@slow" }, () => {
         dashboardDetails: getListDashboard("search"),
       }).then(({ body: card }) => {
         cy.editDashboardCard(card, getParameterMapping(card));
-        visitPublicDashboard(card.dashboard_id);
+        H.visitPublicDashboard(card.dashboard_id);
       });
 
       filterDashboard({ isLabeled: true });
-      filterWidget().findByText("Twenty").should("be.visible");
+      H.filterWidget().findByText("Twenty").should("be.visible");
     });
   });
 });
 
 const mapFilterToQuestion = (column = "Quantity") => {
   cy.findByText("Select…").click();
-  popover().within(() => cy.findByText(column).click());
+  H.popover().within(() => cy.findByText(column).click());
 };
 
 const filterDashboard = ({ isLabeled = false, isDropdown = false } = {}) => {
-  filterWidget().click();
+  H.filterWidget().click();
 
   if (isDropdown) {
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByPlaceholderText("Search the list");
 
       cy.findByText("Ten").should("be.visible");
@@ -171,13 +158,13 @@ const filterDashboard = ({ isLabeled = false, isDropdown = false } = {}) => {
   }
 
   if (isLabeled) {
-    popover().first().findByPlaceholderText("Enter a number").type("T");
-    popover().last().findByText("Twenty").click();
-    popover().first().button("Add filter").click();
+    H.popover().first().findByPlaceholderText("Enter a number").type("T");
+    H.popover().last().findByText("Twenty").click();
+    H.popover().first().button("Add filter").click();
     return;
   }
 
-  popover().within(() => {
+  H.popover().within(() => {
     cy.findByPlaceholderText("Enter a number").type("20");
     cy.button("Add filter").click();
   });

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
@@ -1,22 +1,5 @@
+import { H } from "e2e/support";
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  clearFilterWidget,
-  dashboardParametersDoneButton,
-  dashboardSaveButton,
-  editDashboard,
-  ensureDashboardCardHasText,
-  filterWidget,
-  popover,
-  resetFilterWidgetToDefault,
-  restore,
-  saveDashboard,
-  selectDashboardFilter,
-  setFilter,
-  setFilterWidgetValue,
-  sidebar,
-  toggleRequiredParameter,
-  visitDashboard,
-} from "e2e/support/helpers";
 
 import { addWidgetNumberFilter } from "../native-filters/helpers/e2e-field-filter-helpers";
 
@@ -26,12 +9,12 @@ describe("scenarios > dashboard > filters > number", () => {
   beforeEach(() => {
     cy.intercept("GET", "/api/table/*/query_metadata").as("metadata");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
 
-    editDashboard();
+    H.editDashboard();
 
     /**
      * Even though we're already intercepting this route in the visitDashboard helper,
@@ -49,7 +32,7 @@ describe("scenarios > dashboard > filters > number", () => {
   it("should work when set through the filter widget", () => {
     DASHBOARD_NUMBER_FILTERS.forEach(({ operator, single }) => {
       cy.log(`Make sure we can connect ${operator} filter`);
-      setFilter("Number", operator);
+      H.setFilter("Number", operator);
 
       if (single) {
         cy.findAllByRole("radio", { name: "A single value" })
@@ -58,46 +41,46 @@ describe("scenarios > dashboard > filters > number", () => {
       }
 
       cy.findByText("Select…").click();
-      popover().contains("Tax").click();
+      H.popover().contains("Tax").click();
     });
 
-    saveDashboard();
+    H.saveDashboard();
     cy.wait("@dashboardData");
 
     DASHBOARD_NUMBER_FILTERS.forEach(
       ({ operator, value, representativeResult }, index) => {
-        filterWidget().eq(index).click();
+        H.filterWidget().eq(index).click();
         addWidgetNumberFilter(value);
         cy.wait("@dashboardData");
 
         cy.log(`Make sure ${operator} filter returns correct result`);
         cy.findByTestId("dashcard").should("contain", representativeResult);
 
-        clearFilterWidget(index);
+        H.clearFilterWidget(index);
         cy.wait("@dashboardData");
       },
     );
   });
 
   it("should work when set as the default filter", () => {
-    setFilter("Number", "Equal to");
-    selectDashboardFilter(cy.findByTestId("dashcard"), "Tax");
+    H.setFilter("Number", "Equal to");
+    H.selectDashboardFilter(cy.findByTestId("dashcard"), "Tax");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Default value").next().click();
 
     addWidgetNumberFilter("2.07");
 
-    saveDashboard();
+    H.saveDashboard();
     cy.wait("@dashboardData");
 
     cy.findByTestId("dashcard")
       .should("contain", "37.65")
       .and("not.contain", "101.04");
 
-    clearFilterWidget();
+    H.clearFilterWidget();
     cy.wait("@dashboardData");
 
-    filterWidget().click();
+    H.filterWidget().click();
     addWidgetNumberFilter("5.27", { buttonLabel: "Update filter" });
     cy.wait("@dashboardData");
 
@@ -107,49 +90,49 @@ describe("scenarios > dashboard > filters > number", () => {
   });
 
   it("should support being required", () => {
-    setFilter("Number", "Equal to", "Equal to");
-    selectDashboardFilter(cy.findByTestId("dashcard"), "Tax");
+    H.setFilter("Number", "Equal to", "Equal to");
+    H.selectDashboardFilter(cy.findByTestId("dashcard"), "Tax");
 
     // Can't save without a default value
-    toggleRequiredParameter();
-    dashboardSaveButton().should("be.disabled");
-    dashboardSaveButton().realHover();
+    H.toggleRequiredParameter();
+    H.dashboardSaveButton().should("be.disabled");
+    H.dashboardSaveButton().realHover();
     cy.findByRole("tooltip").should(
       "contain.text",
       'The "Equal to" parameter requires a default value but none was provided.',
     );
 
     // Can't close sidebar without a default value
-    dashboardParametersDoneButton().should("be.disabled");
-    dashboardParametersDoneButton().realHover();
+    H.dashboardParametersDoneButton().should("be.disabled");
+    H.dashboardParametersDoneButton().realHover();
     cy.findByRole("tooltip").should(
       "contain.text",
       "The parameter requires a default value but none was provided.",
     );
 
-    sidebar().findByText("Default value").next().click();
+    H.sidebar().findByText("Default value").next().click();
     addWidgetNumberFilter("2.07", { buttonLabel: "Update filter" });
 
-    saveDashboard();
+    H.saveDashboard();
     cy.wait("@dashboardData");
-    ensureDashboardCardHasText("37.65");
+    H.ensureDashboardCardHasText("37.65");
 
     // Updates the filter value
-    setFilterWidgetValue("5.27", "Enter a number");
+    H.setFilterWidgetValue("5.27", "Enter a number");
     cy.wait("@dashboardData");
-    ensureDashboardCardHasText("95.77");
+    H.ensureDashboardCardHasText("95.77");
 
     // Resets the value back by clicking widget icon
-    resetFilterWidgetToDefault();
-    filterWidget().findByText("2.07");
+    H.resetFilterWidgetToDefault();
+    H.filterWidget().findByText("2.07");
     cy.wait("@dashboardData");
-    ensureDashboardCardHasText("37.65");
+    H.ensureDashboardCardHasText("37.65");
 
     // Removing value resets back to default
-    setFilterWidgetValue(null, "Enter a number", {
+    H.setFilterWidgetValue(null, "Enter a number", {
       buttonLabel: "Set to default",
     });
-    filterWidget().findByText("2.07");
-    ensureDashboardCardHasText("37.65");
+    H.filterWidget().findByText("2.07");
+    H.ensureDashboardCardHasText("37.65");
   });
 });

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-reset-clear.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-reset-clear.cy.spec.ts
@@ -1,21 +1,9 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  type DashboardDetails,
-  type StructuredQuestionDetails,
-  createDashboardWithTabs,
-  createQuestionAndDashboard,
-  dashboardParameterSidebar,
-  editDashboard,
-  getDashboardCard,
-  popover,
-  restore,
-  updateDashboardCards,
-  visitDashboard,
-} from "e2e/support/helpers";
 import { checkNotNull } from "metabase/lib/types";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
 import type { LocalFieldReference } from "metabase-types/api";
@@ -55,7 +43,7 @@ const PEOPLE_CITY_FIELD: LocalFieldReference = [
   },
 ];
 
-const ORDERS_COUNT_OVER_TIME: StructuredQuestionDetails = {
+const ORDERS_COUNT_OVER_TIME: H.StructuredQuestionDetails = {
   display: "line",
   query: {
     "source-table": ORDERS_ID,
@@ -64,14 +52,14 @@ const ORDERS_COUNT_OVER_TIME: StructuredQuestionDetails = {
   },
 };
 
-const PEOPLE_QUESTION: StructuredQuestionDetails = {
+const PEOPLE_QUESTION: H.StructuredQuestionDetails = {
   query: {
     "source-table": PEOPLE_ID,
     limit: 1,
   },
 };
 
-const ORDERS_QUESTION: StructuredQuestionDetails = {
+const ORDERS_QUESTION: H.StructuredQuestionDetails = {
   query: {
     "source-table": ORDERS_ID,
     limit: 1,
@@ -116,7 +104,7 @@ const DEFAULT_REQUIRED = "default value, required";
 
 describe("scenarios > dashboard > filters > reset & clear", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -158,7 +146,7 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
       otherValueFormatted: "Month",
       setValue: (label, value) => {
         filter(label).click();
-        popover().findByText(value).click();
+        H.popover().findByText(value).click();
       },
     });
   });
@@ -245,13 +233,13 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
       otherValueFormatted: "Thomson",
       setValue: (label, value) => {
         filter(label).click();
-        popover().findByRole("searchbox").clear().type(value).blur();
-        popover().button("Add filter").click();
+        H.popover().findByRole("searchbox").clear().type(value).blur();
+        H.popover().button("Add filter").click();
       },
       updateValue: (label, value) => {
         filter(label).click();
-        popover().findByRole("searchbox").clear().type(value).blur();
-        popover().button("Update filter").click();
+        H.popover().findByRole("searchbox").clear().type(value).blur();
+        H.popover().button("Update filter").click();
       },
     });
   });
@@ -290,13 +278,13 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
       otherValueFormatted: "Washington",
       setValue: (label, value) => {
         filter(label).click();
-        popover().findByRole("searchbox").focus().type(value).blur();
-        popover().button("Add filter").click();
+        H.popover().findByRole("searchbox").focus().type(value).blur();
+        H.popover().button("Add filter").click();
       },
       updateValue: (label, value) => {
         filter(label).click();
-        popover().findByRole("searchbox").clear().type(value).blur();
-        popover().button("Update filter").click();
+        H.popover().findByRole("searchbox").clear().type(value).blur();
+        H.popover().button("Update filter").click();
       },
     });
   });
@@ -338,13 +326,13 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
       otherValueFormatted: "2",
       setValue: (label, value) => {
         filter(label).click();
-        popover().findByRole("searchbox").focus().type(value).blur();
-        popover().button("Add filter").click();
+        H.popover().findByRole("searchbox").focus().type(value).blur();
+        H.popover().button("Add filter").click();
       },
       updateValue: (label, value) => {
         filter(label).click();
-        popover().findByRole("searchbox").clear().type(value).blur();
-        popover().button("Update filter").click();
+        H.popover().findByRole("searchbox").clear().type(value).blur();
+        H.popover().button("Update filter").click();
       },
     });
   });
@@ -383,13 +371,13 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
       otherValueFormatted: "3",
       setValue: (label, value) => {
         filter(label).click();
-        popover().findByRole("searchbox").focus().type(value).blur();
-        popover().button("Add filter").click();
+        H.popover().findByRole("searchbox").focus().type(value).blur();
+        H.popover().button("Add filter").click();
       },
       updateValue: (label, value) => {
         filter(label).click();
-        popover().findByRole("searchbox").clear().type(value).blur();
-        popover().button("Update filter").click();
+        H.popover().findByRole("searchbox").clear().type(value).blur();
+        H.popover().button("Update filter").click();
       },
     });
   });
@@ -428,13 +416,13 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
       otherValueFormatted: "2",
       setValue: (label, value) => {
         filter(label).click();
-        popover().findByRole("textbox").focus().type(value).blur();
-        popover().button("Add filter").click();
+        H.popover().findByRole("textbox").focus().type(value).blur();
+        H.popover().button("Add filter").click();
       },
       updateValue: (label, value) => {
         filter(label).click();
-        popover().findByRole("textbox").focus().type(value).blur();
-        popover().button("Update filter").click();
+        H.popover().findByRole("textbox").focus().type(value).blur();
+        H.popover().button("Update filter").click();
       },
     });
   });
@@ -517,13 +505,13 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
       otherValueFormatted: "Gadget",
       setValue: (label, value) => {
         filter(label).click();
-        popover().findByRole("combobox").type(value);
-        popover().button("Add filter").click();
+        H.popover().findByRole("combobox").type(value);
+        H.popover().button("Add filter").click();
       },
       updateValue: (label, value) => {
         filter(label).click();
-        popover().findByRole("combobox").type(value);
-        popover().button("Update filter").click();
+        H.popover().findByRole("combobox").type(value);
+        H.popover().button("Update filter").click();
       },
     });
   });
@@ -562,13 +550,13 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
       otherValueFormatted: "2 selections",
       setValue: (label, value) => {
         filter(label).click();
-        popover().findByRole("combobox").type(value);
-        popover().button("Add filter").click();
+        H.popover().findByRole("combobox").type(value);
+        H.popover().button("Add filter").click();
       },
       updateValue: (label, value) => {
         filter(label).click();
-        popover().findByRole("combobox").type(value);
-        popover().button("Update filter").click();
+        H.popover().findByRole("combobox").type(value);
+        H.popover().button("Update filter").click();
       },
     });
   });
@@ -587,10 +575,10 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
         },
       ],
     );
-    editDashboard();
+    H.editDashboard();
     editFilter("Time grouping");
 
-    dashboardParameterSidebar()
+    H.dashboardParameterSidebar()
       .findAllByLabelText("chevrondown icon")
       .then(([$firstChevron, ...$otherChevrons]) => {
         const firstRect = $firstChevron.getBoundingClientRect();
@@ -607,7 +595,7 @@ describe("scenarios > dashboard > filters > reset & clear", () => {
 
 describe("scenarios > dashboard > filters > reset all filters", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -653,17 +641,17 @@ describe("scenarios > dashboard > filters > reset all filters", () => {
 });
 
 function createDashboardWithParameters(
-  questionDetails: StructuredQuestionDetails,
+  questionDetails: H.StructuredQuestionDetails,
   targetField: LocalFieldReference,
-  parameters: DashboardDetails["parameters"],
+  parameters: H.DashboardDetails["parameters"],
 ) {
-  createQuestionAndDashboard({
+  H.createQuestionAndDashboard({
     questionDetails,
     dashboardDetails: {
       parameters,
     },
   }).then(({ body: { dashboard_id, card_id } }) => {
-    updateDashboardCards({
+    H.updateDashboardCards({
       dashboard_id,
       cards: [
         {
@@ -676,7 +664,7 @@ function createDashboardWithParameters(
       ],
     });
 
-    visitDashboard(dashboard_id);
+    H.visitDashboard(dashboard_id);
   });
 }
 
@@ -717,7 +705,7 @@ function checkDashboardParameters<T = string>({
 
   // reset all filters
   cy.button("Move, trash, and more…").click();
-  popover().findByText("Reset all filters").click();
+  H.popover().findByText("Reset all filters").click();
   filter(NO_DEFAULT_NON_REQUIRED).should("have.text", NO_DEFAULT_NON_REQUIRED);
   checkStatusIcon(NO_DEFAULT_NON_REQUIRED, "chevron");
   checkResetAllFiltersHidden();
@@ -743,7 +731,7 @@ function checkDashboardParameters<T = string>({
 
   // reset all filters
   cy.button("Move, trash, and more…").click();
-  popover().findByText("Reset all filters").click();
+  H.popover().findByText("Reset all filters").click();
   checkStatusIcon(DEFAULT_NON_REQUIRED, "clear");
   filter(DEFAULT_NON_REQUIRED).should("have.text", defaultValueFormatted);
 
@@ -771,7 +759,7 @@ function checkDashboardParameters<T = string>({
 
   // reset all filters
   cy.button("Move, trash, and more…").click();
-  popover().findByText("Reset all filters").click();
+  H.popover().findByText("Reset all filters").click();
   filter(DEFAULT_NON_REQUIRED).should("have.text", defaultValueFormatted);
   checkStatusIcon(DEFAULT_NON_REQUIRED, "clear");
   checkResetAllFiltersHidden();
@@ -797,7 +785,7 @@ function checkDashboardParameters<T = string>({
 
   // reset all filters
   cy.button("Move, trash, and more…").click();
-  popover().findByText("Reset all filters").click();
+  H.popover().findByText("Reset all filters").click();
   filter(DEFAULT_REQUIRED).should("have.text", defaultValueFormatted);
   checkStatusIcon(DEFAULT_REQUIRED, "none");
   checkResetAllFiltersHidden();
@@ -834,11 +822,11 @@ function checkParameterSidebarDefaultValue<T = string>({
   updateValue: (label: string, value: T) => void;
 }) {
   cy.log("parameter sidebar");
-  editDashboard();
+  H.editDashboard();
 
   cy.log(NO_DEFAULT_NON_REQUIRED);
   editFilter(NO_DEFAULT_NON_REQUIRED);
-  dashboardParameterSidebar().within(() => {
+  H.dashboardParameterSidebar().within(() => {
     filter("Default value").scrollIntoView();
     filter("Default value").should("have.text", "No default");
     checkStatusIcon("Default value", "chevron");
@@ -846,7 +834,7 @@ function checkParameterSidebarDefaultValue<T = string>({
 
   setValue("Default value", otherValue);
 
-  dashboardParameterSidebar().within(() => {
+  H.dashboardParameterSidebar().within(() => {
     filter("Default value").should("have.text", otherValueFormatted);
     checkStatusIcon("Default value", "clear");
 
@@ -857,7 +845,7 @@ function checkParameterSidebarDefaultValue<T = string>({
 
   cy.log(DEFAULT_NON_REQUIRED);
   editFilter(DEFAULT_NON_REQUIRED);
-  dashboardParameterSidebar().within(() => {
+  H.dashboardParameterSidebar().within(() => {
     filter("Default value").should("have.text", defaultValueFormatted);
     checkStatusIcon("Default value", "clear");
 
@@ -868,14 +856,14 @@ function checkParameterSidebarDefaultValue<T = string>({
 
   setValue("Default value", otherValue);
 
-  dashboardParameterSidebar().within(() => {
+  H.dashboardParameterSidebar().within(() => {
     filter("Default value").should("have.text", otherValueFormatted);
     checkStatusIcon("Default value", "clear");
   });
 
   cy.log(DEFAULT_REQUIRED);
   editFilter(DEFAULT_REQUIRED);
-  dashboardParameterSidebar().within(() => {
+  H.dashboardParameterSidebar().within(() => {
     filter("Default value").should("have.text", defaultValueFormatted);
     checkStatusIcon("Default value", "clear");
 
@@ -886,7 +874,7 @@ function checkParameterSidebarDefaultValue<T = string>({
 
   updateValue("Default value (required)", otherValue);
 
-  dashboardParameterSidebar().within(() => {
+  H.dashboardParameterSidebar().within(() => {
     filter("Default value").should("have.text", otherValueFormatted);
     checkStatusIcon("Default value", "clear");
   });
@@ -899,7 +887,7 @@ function createDashboardWithParameterInEachTab({
   autoApplyFilters: boolean;
   parameters: [UiParameter, UiParameter];
 }) {
-  createDashboardWithTabs({
+  H.createDashboardWithTabs({
     tabs: [TAB_A, TAB_B],
     parameters: [parameterA, parameterB],
     auto_apply_filters: autoApplyFilters,
@@ -937,7 +925,7 @@ function createDashboardWithParameterInEachTab({
         ],
       },
     ],
-  }).then(dashboard => visitDashboard(dashboard.id));
+  }).then(dashboard => H.visitDashboard(dashboard.id));
 }
 
 function checkResetAllFiltersWorksAcrossTabs({
@@ -947,8 +935,8 @@ function checkResetAllFiltersWorksAcrossTabs({
 }) {
   checkResetAllFiltersHidden();
   filter(PARAMETER_A.name).should("have.text", PARAMETER_A.name);
-  getDashboardCard(0).findByText("37.65").should("be.visible");
-  getDashboardCard(0).findByText("116.01").should("not.exist");
+  H.getDashboardCard(0).findByText("37.65").should("be.visible");
+  H.getDashboardCard(0).findByText("116.01").should("not.exist");
 
   addDateFilter(PARAMETER_A.name, "01/01/2024");
   filter(PARAMETER_A.name).should("have.text", "January 1, 2024");
@@ -956,13 +944,13 @@ function checkResetAllFiltersWorksAcrossTabs({
     cy.button("Apply").click();
   }
   checkResetAllFiltersShown();
-  getDashboardCard(0).findByText("116.01").should("be.visible");
-  getDashboardCard(0).findByText("37.65").should("not.exist");
+  H.getDashboardCard(0).findByText("116.01").should("be.visible");
+  H.getDashboardCard(0).findByText("37.65").should("not.exist");
 
   cy.findAllByTestId("tab-button-input-wrapper").eq(1).click();
   checkResetAllFiltersShown();
   filter(PARAMETER_B.name).should("have.text", PARAMETER_B.name);
-  getDashboardCard(0).findByText("18,760").should("be.visible");
+  H.getDashboardCard(0).findByText("18,760").should("be.visible");
 
   addDateFilter(PARAMETER_B.name, "01/01/2023");
   if (!autoApplyFilters) {
@@ -970,19 +958,19 @@ function checkResetAllFiltersWorksAcrossTabs({
   }
   checkResetAllFiltersShown();
   filter(PARAMETER_B.name).should("have.text", "January 1, 2023");
-  getDashboardCard(0).findByText("5").should("be.visible");
+  H.getDashboardCard(0).findByText("5").should("be.visible");
 
   cy.button("Move, trash, and more…").click();
-  popover().findByText("Reset all filters").click();
+  H.popover().findByText("Reset all filters").click();
   checkResetAllFiltersHidden();
   filter(PARAMETER_B.name).should("have.text", PARAMETER_B.name);
-  getDashboardCard(0).findByText("18,760").should("be.visible");
+  H.getDashboardCard(0).findByText("18,760").should("be.visible");
 
   cy.findAllByTestId("tab-button-input-wrapper").eq(0).click();
   checkResetAllFiltersHidden();
   filter(PARAMETER_A.name).should("have.text", PARAMETER_A.name);
-  getDashboardCard(0).findByText("37.65").should("be.visible");
-  getDashboardCard(0).findByText("116.01").should("not.exist");
+  H.getDashboardCard(0).findByText("37.65").should("be.visible");
+  H.getDashboardCard(0).findByText("116.01").should("not.exist");
 }
 
 function checkResetAllFiltersToDefaultWorksAcrossTabs({
@@ -992,8 +980,8 @@ function checkResetAllFiltersToDefaultWorksAcrossTabs({
 }) {
   checkResetAllFiltersHidden();
   filter(PARAMETER_A.name).should("have.text", "January 5, 2023");
-  getDashboardCard(0).findByText("73.99").should("be.visible");
-  getDashboardCard(0).findByText("116.01").should("not.exist");
+  H.getDashboardCard(0).findByText("73.99").should("be.visible");
+  H.getDashboardCard(0).findByText("116.01").should("not.exist");
 
   updateDateFilter(PARAMETER_A.name, "01/01/2024");
   filter(PARAMETER_A.name).should("have.text", "January 1, 2024");
@@ -1001,13 +989,13 @@ function checkResetAllFiltersToDefaultWorksAcrossTabs({
     cy.button("Apply").click();
   }
   checkResetAllFiltersShown();
-  getDashboardCard(0).findByText("116.01").should("be.visible");
-  getDashboardCard(0).findByText("73.99").should("not.exist");
+  H.getDashboardCard(0).findByText("116.01").should("be.visible");
+  H.getDashboardCard(0).findByText("73.99").should("not.exist");
 
   cy.findAllByTestId("tab-button-input-wrapper").eq(1).click();
   checkResetAllFiltersShown();
   filter(PARAMETER_B.name).should("have.text", "January 5, 2023");
-  getDashboardCard(0).findByText("4").should("be.visible");
+  H.getDashboardCard(0).findByText("4").should("be.visible");
 
   updateDateFilter(PARAMETER_B.name, "01/01/2023");
   if (!autoApplyFilters) {
@@ -1015,30 +1003,30 @@ function checkResetAllFiltersToDefaultWorksAcrossTabs({
   }
   checkResetAllFiltersShown();
   filter(PARAMETER_B.name).should("have.text", "January 1, 2023");
-  getDashboardCard(0).findByText("5").should("be.visible");
+  H.getDashboardCard(0).findByText("5").should("be.visible");
 
   cy.button("Move, trash, and more…").click();
-  popover().findByText("Reset all filters").click();
+  H.popover().findByText("Reset all filters").click();
   checkResetAllFiltersHidden();
   filter(PARAMETER_B.name).should("have.text", "January 5, 2023");
-  getDashboardCard(0).findByText("4").should("be.visible");
+  H.getDashboardCard(0).findByText("4").should("be.visible");
 
   cy.findAllByTestId("tab-button-input-wrapper").eq(0).click();
   checkResetAllFiltersHidden();
   filter(PARAMETER_A.name).should("have.text", "January 5, 2023");
-  getDashboardCard(0).findByText("73.99").should("be.visible");
-  getDashboardCard(0).findByText("116.01").should("not.exist");
+  H.getDashboardCard(0).findByText("73.99").should("be.visible");
+  H.getDashboardCard(0).findByText("116.01").should("not.exist");
 }
 
 function checkResetAllFiltersShown() {
   cy.button("Move, trash, and more…").click();
-  popover().findByText("Reset all filters").should("be.visible");
+  H.popover().findByText("Reset all filters").should("be.visible");
   cy.button("Move, trash, and more…").click();
 }
 
 function checkResetAllFiltersHidden() {
   cy.button("Move, trash, and more…").click();
-  popover().findByText("Reset all filters").should("not.exist");
+  H.popover().findByText("Reset all filters").should("not.exist");
   cy.button("Move, trash, and more…").click();
 }
 
@@ -1074,14 +1062,14 @@ function chevronIcon(label: string) {
 
 function addDateFilter(label: string, value: string) {
   filter(label).click();
-  popover().findByRole("textbox").clear().type(value).blur();
-  popover().button("Add filter").click();
+  H.popover().findByRole("textbox").clear().type(value).blur();
+  H.popover().button("Add filter").click();
 }
 
 function updateDateFilter(label: string, value: string) {
   filter(label).click();
-  popover().findByRole("textbox").clear().type(value).blur();
-  popover().button("Update filter").click();
+  H.popover().findByRole("textbox").clear().type(value).blur();
+  H.popover().button("Update filter").click();
 }
 
 function addRangeFilter(
@@ -1090,9 +1078,9 @@ function addRangeFilter(
   secondValue: string,
 ) {
   filter(label).click();
-  popover().findAllByRole("textbox").first().clear().type(firstValue).blur();
-  popover().findAllByRole("textbox").last().clear().type(secondValue).blur();
-  popover().button("Add filter").click();
+  H.popover().findAllByRole("textbox").first().clear().type(firstValue).blur();
+  H.popover().findAllByRole("textbox").last().clear().type(secondValue).blur();
+  H.popover().button("Add filter").click();
 }
 
 function updateRangeFilter(
@@ -1101,7 +1089,7 @@ function updateRangeFilter(
   secondValue: string,
 ) {
   filter(label).click();
-  popover().findAllByRole("textbox").first().clear().type(firstValue).blur();
-  popover().findAllByRole("textbox").last().clear().type(secondValue).blur();
-  popover().button("Update filter").click();
+  H.popover().findAllByRole("textbox").first().clear().type(firstValue).blur();
+  H.popover().findAllByRole("textbox").last().clear().type(secondValue).blur();
+  H.popover().button("Update filter").click();
 }

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-source.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-source.cy.spec.js
@@ -1,33 +1,6 @@
+import { H } from "e2e/support";
 import { USER_GROUPS, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  assertDatasetReqIsSandboxed,
-  blockUserGroupPermissions,
-  describeEE,
-  editDashboard,
-  filterWidget,
-  getDashboardCard,
-  getTable,
-  multiAutocompleteInput,
-  multiAutocompleteValue,
-  openQuestionActions,
-  popover,
-  resetTestTable,
-  restore,
-  resyncDatabase,
-  saveDashboard,
-  setDropdownFilterType,
-  setFilter,
-  setFilterListSource,
-  setFilterQuestionSource,
-  setSearchBoxFilterType,
-  setTokenFeatures,
-  sidebar,
-  visitDashboard,
-  visitEmbeddedPage,
-  visitPublicDashboard,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
@@ -66,7 +39,7 @@ const targetQuestion = {
 
 describe("scenarios > dashboard > filters", { tags: "@slow" }, () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
@@ -77,17 +50,17 @@ describe("scenarios > dashboard > filters", { tags: "@slow" }, () => {
       cy.createQuestionAndDashboard({
         questionDetails: targetQuestion,
       }).then(({ body: { dashboard_id } }) => {
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       });
 
-      editDashboard();
-      setFilter("Text or Category", "Is");
+      H.editDashboard();
+      H.setFilter("Text or Category", "Is");
       mapFilterToQuestion();
-      setFilterQuestionSource({ question: "GUI source", field: "Category" });
-      saveDashboard();
+      H.setFilterQuestionSource({ question: "GUI source", field: "Category" });
+      H.saveDashboard();
       filterDashboard();
 
-      cy.get("@questionId").then(visitQuestion);
+      cy.get("@questionId").then(H.visitQuestion);
       archiveQuestion();
     });
 
@@ -99,7 +72,7 @@ describe("scenarios > dashboard > filters", { tags: "@slow" }, () => {
             dashboardDetails: getStructuredDashboard(questionId),
           }).then(({ body: card }) => {
             cy.editDashboardCard(card, getParameterMapping(card));
-            visitEmbeddedPage(getDashboardResource(card));
+            H.visitEmbeddedPage(getDashboardResource(card));
           });
         },
       );
@@ -115,7 +88,7 @@ describe("scenarios > dashboard > filters", { tags: "@slow" }, () => {
             dashboardDetails: getStructuredDashboard(questionId),
           }).then(({ body: card }) => {
             cy.editDashboardCard(card, getParameterMapping(card));
-            visitPublicDashboard(card.dashboard_id);
+            H.visitPublicDashboard(card.dashboard_id);
           });
         },
       );
@@ -128,20 +101,20 @@ describe("scenarios > dashboard > filters", { tags: "@slow" }, () => {
       cy.createQuestionAndDashboard({
         questionDetails: targetQuestion,
       }).then(({ body: { dashboard_id } }) => {
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       });
 
-      editDashboard();
-      setFilter("Text or Category", "Contains");
+      H.editDashboard();
+      H.setFilter("Text or Category", "Contains");
       mapFilterToQuestion();
-      setDropdownFilterType();
-      setFilterQuestionSource({ question: "GUI source", field: "Category" });
-      saveDashboard();
-      getDashboardCard().findByText("200").should("be.visible");
-      filterWidget().click();
-      popover().findByText("Gizmo").click();
-      popover().button("Add filter").click();
-      getDashboardCard().findByText("51").should("be.visible");
+      H.setDropdownFilterType();
+      H.setFilterQuestionSource({ question: "GUI source", field: "Category" });
+      H.saveDashboard();
+      H.getDashboardCard().findByText("200").should("be.visible");
+      H.filterWidget().click();
+      H.popover().findByText("Gizmo").click();
+      H.popover().button("Add filter").click();
+      H.getDashboardCard().findByText("51").should("be.visible");
     });
   });
 
@@ -151,17 +124,17 @@ describe("scenarios > dashboard > filters", { tags: "@slow" }, () => {
       cy.createQuestionAndDashboard({
         questionDetails: targetQuestion,
       }).then(({ body: { dashboard_id } }) => {
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       });
 
-      editDashboard();
-      setFilter("Text or Category", "Is");
+      H.editDashboard();
+      H.setFilter("Text or Category", "Is");
       mapFilterToQuestion();
-      setFilterQuestionSource({ question: "SQL source", field: "CATEGORY" });
-      saveDashboard();
+      H.setFilterQuestionSource({ question: "SQL source", field: "CATEGORY" });
+      H.saveDashboard();
       filterDashboard();
 
-      cy.get("@questionId").then(visitQuestion);
+      cy.get("@questionId").then(H.visitQuestion);
       archiveQuestion();
     });
 
@@ -173,7 +146,7 @@ describe("scenarios > dashboard > filters", { tags: "@slow" }, () => {
             dashboardDetails: getNativeDashboard(questionId),
           }).then(({ body: card }) => {
             cy.editDashboardCard(card, getParameterMapping(card));
-            visitEmbeddedPage(getDashboardResource(card));
+            H.visitEmbeddedPage(getDashboardResource(card));
           });
         },
       );
@@ -189,7 +162,7 @@ describe("scenarios > dashboard > filters", { tags: "@slow" }, () => {
             dashboardDetails: getNativeDashboard(questionId),
           }).then(({ body: card }) => {
             cy.editDashboardCard(card, getParameterMapping(card));
-            visitPublicDashboard(card.dashboard_id);
+            H.visitPublicDashboard(card.dashboard_id);
           });
         },
       );
@@ -203,18 +176,18 @@ describe("scenarios > dashboard > filters", { tags: "@slow" }, () => {
       cy.createQuestionAndDashboard({
         questionDetails: targetQuestion,
       }).then(({ body: { dashboard_id } }) => {
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       });
 
-      editDashboard();
-      setFilter("Text or Category", "Is");
+      H.editDashboard();
+      H.setFilter("Text or Category", "Is");
       mapFilterToQuestion();
-      setFilterListSource({
+      H.setFilterListSource({
         values: [["Gadget"], ["Gizmo", "Gizmo Label"], "Widget"],
       });
-      saveDashboard();
+      H.saveDashboard();
       filterDashboard({ isLabeled: true });
-      filterWidget().findByText("Gizmo Label").should("be.visible");
+      H.filterWidget().findByText("Gizmo Label").should("be.visible");
     });
 
     it("should be able to use a static list source when embedded", () => {
@@ -223,11 +196,11 @@ describe("scenarios > dashboard > filters", { tags: "@slow" }, () => {
         dashboardDetails: getListDashboard(),
       }).then(({ body: card }) => {
         cy.editDashboardCard(card, getParameterMapping(card));
-        visitEmbeddedPage(getDashboardResource(card));
+        H.visitEmbeddedPage(getDashboardResource(card));
       });
 
       filterDashboard({ isLabeled: true });
-      filterWidget().findByText("Gizmo Label").should("be.visible");
+      H.filterWidget().findByText("Gizmo Label").should("be.visible");
     });
 
     it("should be able to use a static list source when public", () => {
@@ -236,11 +209,11 @@ describe("scenarios > dashboard > filters", { tags: "@slow" }, () => {
         dashboardDetails: getListDashboard(),
       }).then(({ body: card }) => {
         cy.editDashboardCard(card, getParameterMapping(card));
-        visitPublicDashboard(card.dashboard_id);
+        H.visitPublicDashboard(card.dashboard_id);
       });
 
       filterDashboard({ isLabeled: true });
-      filterWidget().findByText("Gizmo Label").should("be.visible");
+      H.filterWidget().findByText("Gizmo Label").should("be.visible");
     });
   });
 
@@ -249,17 +222,17 @@ describe("scenarios > dashboard > filters", { tags: "@slow" }, () => {
       cy.createQuestionAndDashboard({
         questionDetails: targetQuestion,
       }).then(({ body: { dashboard_id } }) => {
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       });
 
-      editDashboard();
-      setFilter("Text or Category", "Is");
+      H.editDashboard();
+      H.setFilter("Text or Category", "Is");
       mapFilterToQuestion();
-      sidebar().findByText("Search box").click();
-      setFilterListSource({
+      H.sidebar().findByText("Search box").click();
+      H.setFilterListSource({
         values: [["Gadget"], ["Gizmo", "Gizmo Label"], "Widget"],
       });
-      saveDashboard();
+      H.saveDashboard();
 
       setSearchFilter("Gizmo Label");
     });
@@ -270,11 +243,11 @@ describe("scenarios > dashboard > filters", { tags: "@slow" }, () => {
         dashboardDetails: getListDashboard("search"),
       }).then(({ body: card }) => {
         cy.editDashboardCard(card, getParameterMapping(card));
-        visitEmbeddedPage(getDashboardResource(card));
+        H.visitEmbeddedPage(getDashboardResource(card));
       });
 
       setSearchFilter("Gizmo Label");
-      filterWidget().findByText("Gizmo Label").should("be.visible");
+      H.filterWidget().findByText("Gizmo Label").should("be.visible");
     });
 
     it("should be able to use a static list source when public", () => {
@@ -283,7 +256,7 @@ describe("scenarios > dashboard > filters", { tags: "@slow" }, () => {
         dashboardDetails: getListDashboard("search"),
       }).then(({ body: card }) => {
         cy.editDashboardCard(card, getParameterMapping(card));
-        visitPublicDashboard(card.dashboard_id);
+        H.visitPublicDashboard(card.dashboard_id);
       });
 
       setSearchFilter("Gizmo Label");
@@ -295,14 +268,14 @@ describe("scenarios > dashboard > filters", { tags: "@slow" }, () => {
       cy.createQuestionAndDashboard({
         questionDetails: targetQuestion,
       }).then(({ body: { dashboard_id } }) => {
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       });
 
-      editDashboard();
-      setFilter("Text or Category", "Is");
+      H.editDashboard();
+      H.setFilter("Text or Category", "Is");
       mapFilterToQuestion();
-      setSearchBoxFilterType();
-      saveDashboard();
+      H.setSearchBoxFilterType();
+      H.saveDashboard();
       filterDashboard({ isField: true });
     });
   });
@@ -315,48 +288,50 @@ describe(
     const TABLE_NAME = "ip_addresses";
 
     beforeEach(() => {
-      resetTestTable({ type: "postgres", table: TABLE_NAME });
-      restore("postgres-writable");
+      H.resetTestTable({ type: "postgres", table: TABLE_NAME });
+      H.restore("postgres-writable");
       cy.signInAsAdmin();
-      resyncDatabase({
+      H.resyncDatabase({
         dbId: WRITABLE_DB_ID,
         tableName: TABLE_NAME,
       });
 
-      getTable({ databaseId: WRITABLE_DB_ID, name: TABLE_NAME }).then(table => {
-        const countField = table.fields.find(field => field.name === "count");
-        cy.request("PUT", `/api/field/${countField.id}`, {
-          semantic_type: "type/Quantity",
-        });
+      H.getTable({ databaseId: WRITABLE_DB_ID, name: TABLE_NAME }).then(
+        table => {
+          const countField = table.fields.find(field => field.name === "count");
+          cy.request("PUT", `/api/field/${countField.id}`, {
+            semantic_type: "type/Quantity",
+          });
 
-        cy.createQuestionAndDashboard({
-          questionDetails: {
-            database: WRITABLE_DB_ID,
-            query: {
-              "source-table": table.id,
+          cy.createQuestionAndDashboard({
+            questionDetails: {
+              database: WRITABLE_DB_ID,
+              query: {
+                "source-table": table.id,
+              },
             },
-          },
-        }).then(({ body: { dashboard_id } }) => {
-          visitDashboard(dashboard_id);
-        });
-      });
+          }).then(({ body: { dashboard_id } }) => {
+            H.visitDashboard(dashboard_id);
+          });
+        },
+      );
     });
 
     it("should be possible to use custom labels on IP address columns", () => {
-      editDashboard();
-      setFilter("Text or Category", "Is");
+      H.editDashboard();
+      H.setFilter("Text or Category", "Is");
       mapFilterToQuestion("Inet");
-      setFilterListSource({
+      H.setFilterListSource({
         values: [
           ["192.168.0.1/24", "Router"],
           ["127.0.0.1", "Localhost"],
           "0.0.0.1/0",
         ],
       });
-      saveDashboard();
+      H.saveDashboard();
 
       openFilter();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Router").should("be.visible");
         cy.findByText("Localhost").should("be.visible");
         cy.findByText("0.0.0.1/0").should("be.visible");
@@ -369,16 +344,16 @@ describe(
     });
 
     it("should be possible to use custom labels on type/Quantity fields", () => {
-      editDashboard();
-      setFilter("Text or Category", "Is");
+      H.editDashboard();
+      H.setFilter("Text or Category", "Is");
       mapFilterToQuestion("Count");
-      setFilterListSource({
+      H.setFilterListSource({
         values: [["10", "Ten"], ["20", "Twenty"], "30"],
       });
-      saveDashboard();
+      H.saveDashboard();
 
       openFilter();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Ten").should("be.visible");
         cy.findByText("Twenty").should("be.visible");
         cy.findByText("30").should("be.visible");
@@ -392,12 +367,12 @@ describe(
   },
 );
 
-describeEE("scenarios > dashboard > filters", () => {
+H.describeEE("scenarios > dashboard > filters", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
-    blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);
+    H.setTokenFeatures("all");
+    H.blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);
   });
 
   it("should sandbox parameter values in dashboards", () => {
@@ -417,8 +392,8 @@ describeEE("scenarios > dashboard > filters", () => {
           cy.editDashboardCard(card, getParameterMapping(card));
           cy.signOut();
           cy.signInAsSandboxedUser();
-          visitDashboard(card.dashboard_id);
-          assertDatasetReqIsSandboxed({
+          H.visitDashboard(card.dashboard_id);
+          H.assertDatasetReqIsSandboxed({
             requestAlias: `@dashcardQuery${card.id}`,
           });
         });
@@ -431,7 +406,7 @@ describeEE("scenarios > dashboard > filters", () => {
 
 const mapFilterToQuestion = (column = "Category") => {
   cy.findByText("Select…").click();
-  popover().within(() => cy.findByText(column).click());
+  H.popover().within(() => cy.findByText(column).click());
 };
 
 const filterDashboard = ({
@@ -441,7 +416,7 @@ const filterDashboard = ({
 } = {}) => {
   cy.findByText("Text").click();
 
-  popover().within(() => {
+  H.popover().within(() => {
     const GIZMO = isLabeled ? "Gizmo Label" : "Gizmo";
 
     cy.findByText(GIZMO).should("be.visible");
@@ -464,7 +439,7 @@ function openFilter() {
 }
 
 const archiveQuestion = () => {
-  openQuestionActions();
+  H.openQuestionActions();
   cy.findByTestId("archive-button").click();
   cy.findByText(
     "This question will be removed from any dashboards or alerts using it. It will also be removed from the filter that uses it to populate values.",
@@ -530,16 +505,16 @@ const getParameterMapping = ({ card_id }) => ({
 });
 
 function setSearchFilter(label) {
-  filterWidget().click();
-  popover().within(() => {
-    multiAutocompleteInput().type(label);
+  H.filterWidget().click();
+  H.popover().within(() => {
+    H.multiAutocompleteInput().type(label);
   });
 
-  popover().last().findByText(label).click();
-  popover().within(() => {
-    multiAutocompleteValue(0).should("be.visible").should("contain", label);
+  H.popover().last().findByText(label).click();
+  H.popover().within(() => {
+    H.multiAutocompleteValue(0).should("be.visible").should("contain", label);
     cy.button("Add filter").click();
   });
 
-  filterWidget().findByText(label).should("be.visible");
+  H.filterWidget().findByText(label).should("be.visible");
 }

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-date.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-date.cy.spec.js
@@ -1,14 +1,4 @@
-import {
-  clearFilterWidget,
-  editDashboard,
-  filterWidget,
-  popover,
-  restore,
-  saveDashboard,
-  setFilter,
-  visitDashboard,
-  visitQuestion,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 import * as DateFilter from "../native-filters/helpers/e2e-date-filter-helpers";
 
@@ -23,34 +13,34 @@ describe("scenarios > dashboard > filters > SQL > date", () => {
       "dashcardQuery",
     );
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestionAndDashboard({ questionDetails }).then(
       ({ body: { card_id, dashboard_id } }) => {
-        visitQuestion(card_id);
+        H.visitQuestion(card_id);
 
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       },
     );
 
-    editDashboard();
+    H.editDashboard();
   });
 
   it("should work when set through the filter widget", () => {
     Object.entries(DASHBOARD_SQL_DATE_FILTERS).forEach(([filter]) => {
       cy.log(`Make sure we can connect ${filter} filter`);
-      setFilter("Date picker", filter);
+      H.setFilter("Date picker", filter);
 
       cy.findByText("Select…").click();
-      popover().contains(filter).click();
+      H.popover().contains(filter).click();
     });
 
-    saveDashboard();
+    H.saveDashboard();
 
     Object.entries(DASHBOARD_SQL_DATE_FILTERS).forEach(
       ([filter, { value, representativeResult }], index) => {
-        filterWidget().eq(index).click();
+        H.filterWidget().eq(index).click();
         dateFilterSelector({
           filterType: filter,
           filterValue: value,
@@ -61,14 +51,14 @@ describe("scenarios > dashboard > filters > SQL > date", () => {
           cy.contains(representativeResult);
         });
 
-        clearFilterWidget(index);
+        H.clearFilterWidget(index);
         cy.wait("@dashcardQuery");
       },
     );
   });
 
   it("should work when set as the default filter", () => {
-    setFilter("Date picker", "Month and Year");
+    H.setFilter("Date picker", "Month and Year");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Default value").next().click();
@@ -79,8 +69,8 @@ describe("scenarios > dashboard > filters > SQL > date", () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
-    popover().contains("Month and Year").click();
-    saveDashboard();
+    H.popover().contains("Month and Year").click();
+    H.saveDashboard();
 
     // The default value should immediately be applied
     cy.findByTestId("dashcard").within(() => {
@@ -90,7 +80,7 @@ describe("scenarios > dashboard > filters > SQL > date", () => {
     // Make sure we can override the default value
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("October 2022").click();
-    popover().contains("August").click();
+    H.popover().contains("August").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Macy Olson");
   });

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-id.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-id.cy.spec.js
@@ -1,14 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  editDashboard,
-  filterWidget,
-  popover,
-  restore,
-  saveDashboard,
-  setFilter,
-  visitDashboard,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 import { addWidgetStringFilter } from "../native-filters/helpers/e2e-field-filter-helpers";
 
@@ -16,7 +7,7 @@ const { ORDERS } = SAMPLE_DATABASE;
 
 describe("scenarios > dashboard > filters > SQL > ID", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -26,9 +17,9 @@ describe("scenarios > dashboard > filters > SQL > ID", () => {
     });
 
     it("when set through the filter widget", () => {
-      saveDashboard();
+      H.saveDashboard();
 
-      filterWidget().click();
+      H.filterWidget().click();
       addWidgetStringFilter("15");
 
       cy.findByTestId("dashcard").within(() => {
@@ -41,7 +32,7 @@ describe("scenarios > dashboard > filters > SQL > ID", () => {
       cy.findByText("Default value").next().click();
       addWidgetStringFilter("15");
 
-      saveDashboard();
+      H.saveDashboard();
 
       cy.findByTestId("dashcard").within(() => {
         cy.findByText("114.42");
@@ -55,9 +46,9 @@ describe("scenarios > dashboard > filters > SQL > ID", () => {
     });
 
     it("when set through the filter widget", () => {
-      saveDashboard();
+      H.saveDashboard();
 
-      filterWidget().click();
+      H.filterWidget().click();
       addWidgetStringFilter("4");
 
       cy.findByTestId("dashcard").within(() => {
@@ -70,7 +61,7 @@ describe("scenarios > dashboard > filters > SQL > ID", () => {
       cy.findByText("Default value").next().click();
       addWidgetStringFilter("4");
 
-      saveDashboard();
+      H.saveDashboard();
 
       cy.findByTestId("dashcard").within(() => {
         cy.findByText("47.68");
@@ -100,15 +91,15 @@ function prepareDashboardWithFilterConnectedTo(rowId) {
 
   cy.createNativeQuestionAndDashboard({ questionDetails }).then(
     ({ body: { card_id, dashboard_id } }) => {
-      visitQuestion(card_id);
+      H.visitQuestion(card_id);
 
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
     },
   );
 
-  editDashboard();
-  setFilter("ID");
+  H.editDashboard();
+  H.setFilter("ID");
 
   cy.findByText("Select…").click();
-  popover().contains("Filter").click();
+  H.popover().contains("Filter").click();
 }

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-location.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-location.cy.spec.js
@@ -1,14 +1,4 @@
-import {
-  clearFilterWidget,
-  editDashboard,
-  filterWidget,
-  popover,
-  restore,
-  saveDashboard,
-  setFilter,
-  visitDashboard,
-  visitQuestion,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 import { addWidgetStringFilter } from "../native-filters/helpers/e2e-field-filter-helpers";
 
@@ -23,68 +13,68 @@ describe("scenarios > dashboard > filters > location", () => {
       "dashcardQuery",
     );
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestionAndDashboard({ questionDetails }).then(
       ({ body: { card_id, dashboard_id } }) => {
-        visitQuestion(card_id);
+        H.visitQuestion(card_id);
 
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       },
     );
 
-    editDashboard();
+    H.editDashboard();
   });
 
   it("should work when set through the filter widget", () => {
     Object.entries(DASHBOARD_SQL_LOCATION_FILTERS).forEach(([filter]) => {
-      setFilter("Location", filter);
+      H.setFilter("Location", filter);
 
       cy.findByText("Select…").click();
-      popover().contains(filter).click();
+      H.popover().contains(filter).click();
     });
 
-    saveDashboard();
+    H.saveDashboard();
 
     Object.entries(DASHBOARD_SQL_LOCATION_FILTERS).forEach(
       ([filter, { value, representativeResult }], index) => {
-        filterWidget().eq(index).click();
+        H.filterWidget().eq(index).click();
         addWidgetStringFilter(value);
 
         cy.findByTestId("dashcard").within(() => {
           cy.contains(representativeResult);
         });
 
-        clearFilterWidget(index);
+        H.clearFilterWidget(index);
         cy.wait("@dashcardQuery");
       },
     );
   });
 
   it("should work when set as the default filter", () => {
-    setFilter("Location", "Is");
+    H.setFilter("Location", "Is");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
-    popover().contains("Is").click();
+    H.popover().contains("Is").click();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Default value").next().click();
 
     addWidgetStringFilter("Rye");
 
-    saveDashboard();
+    H.saveDashboard();
 
     cy.findByTestId("dashcard").within(() => {
       cy.contains("Arnold Adams");
     });
 
-    clearFilterWidget();
+    H.clearFilterWidget();
 
     cy.url().should("not.include", "Rye");
 
-    filterWidget().click();
+    H.filterWidget().click();
 
     addWidgetStringFilter("Pittsburg", { buttonLabel: "Update filter" });
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-management.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-management.cy.spec.js
@@ -1,18 +1,8 @@
-import {
-  editDashboard,
-  filterWidget,
-  getDashboardCard,
-  popover,
-  restore,
-  saveDashboard,
-  setFilter,
-  sidebar,
-  visitDashboard,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 describe("scenarios > dashboard > filters > SQL > management", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -37,43 +27,43 @@ describe("scenarios > dashboard > filters > SQL > management", () => {
     beforeEach(() => {
       cy.createNativeQuestionAndDashboard({ questionDetails }).then(
         ({ body: { dashboard_id } }) => {
-          visitDashboard(dashboard_id);
+          H.visitDashboard(dashboard_id);
         },
       );
-      editDashboard();
+      H.editDashboard();
     });
 
     it("should reset mappings when current operator is '=' and new operator is not '='", () => {
-      setFilter("Number", "Equal to");
+      H.setFilter("Number", "Equal to");
 
-      getDashboardCard().findByRole("button").click();
-      popover().findByText("Tax GTE").click();
+      H.getDashboardCard().findByRole("button").click();
+      H.popover().findByText("Tax GTE").click();
 
-      saveDashboard();
+      H.saveDashboard();
 
-      filterWidget().type("10{enter}");
+      H.filterWidget().type("10{enter}");
 
-      getDashboardCard().should("contain", "1,062");
+      H.getDashboardCard().should("contain", "1,062");
 
-      editDashboard();
+      H.editDashboard();
 
       cy.findByTestId("edit-dashboard-parameters-widget-container")
         .contains("Equal to")
         .click();
 
-      sidebar().findByText("Filter operator").next().click();
-      popover().findByText("Between").click();
+      H.sidebar().findByText("Filter operator").next().click();
+      H.popover().findByText("Between").click();
 
-      getDashboardCard().should("not.contain", "Column to filter on");
+      H.getDashboardCard().should("not.contain", "Column to filter on");
 
-      sidebar().findByText("Filter operator").next().click();
-      popover().findByText("Equal to").click();
+      H.sidebar().findByText("Filter operator").next().click();
+      H.popover().findByText("Equal to").click();
 
-      getDashboardCard().should("not.contain", "Tax GTE");
+      H.getDashboardCard().should("not.contain", "Tax GTE");
 
-      saveDashboard();
+      H.saveDashboard();
 
-      filterWidget().should("not.exist");
+      H.filterWidget().should("not.exist");
     });
   });
 });

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-number.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-number.cy.spec.js
@@ -1,16 +1,4 @@
-import {
-  clearFilterWidget,
-  editDashboard,
-  filterWidget,
-  getDashboardCard,
-  popover,
-  restore,
-  saveDashboard,
-  setFilter,
-  sidebar,
-  visitDashboard,
-  visitQuestion,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 import { addWidgetNumberFilter } from "../native-filters/helpers/e2e-field-filter-helpers";
 
@@ -25,35 +13,35 @@ describe("scenarios > dashboard > filters > SQL > text/category", () => {
       "dashcardQuery",
     );
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestionAndDashboard({ questionDetails }).then(
       ({ body: { card_id, dashboard_id } }) => {
-        visitQuestion(card_id);
+        H.visitQuestion(card_id);
 
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       },
     );
 
-    editDashboard();
+    H.editDashboard();
   });
 
   it("should work when set through the filter widget", () => {
     Object.entries(DASHBOARD_SQL_NUMBER_FILTERS).forEach(([filter]) => {
       cy.log(`Make sure we can connect ${filter} filter`);
 
-      setFilter("Number", filter);
+      H.setFilter("Number", filter);
 
       clickSelect();
-      popover().contains(filter).click();
+      H.popover().contains(filter).click();
     });
 
-    saveDashboard();
+    H.saveDashboard();
 
     Object.entries(DASHBOARD_SQL_NUMBER_FILTERS).forEach(
       ([filter, { value, representativeResult }], index) => {
-        filterWidget().eq(index).click();
+        H.filterWidget().eq(index).click();
         addWidgetNumberFilter(value);
 
         cy.log(`Make sure ${filter} filter returns correct result`);
@@ -61,31 +49,31 @@ describe("scenarios > dashboard > filters > SQL > text/category", () => {
           cy.contains(representativeResult);
         });
 
-        clearFilterWidget(index);
+        H.clearFilterWidget(index);
         cy.wait("@dashcardQuery");
       },
     );
   });
 
   it("should work when set as the default filter", () => {
-    setFilter("Number", "Equal to");
-    sidebar().findByText("Default value").next().click();
+    H.setFilter("Number", "Equal to");
+    H.sidebar().findByText("Default value").next().click();
 
     addWidgetNumberFilter("3.8");
 
     clickSelect();
-    popover().contains("Equal to").click();
+    H.popover().contains("Equal to").click();
 
-    saveDashboard();
+    H.saveDashboard();
 
     cy.findByTestId("dashcard").within(() => {
       cy.contains("Small Marble Hat");
       cy.contains("Rustic Paper Wallet").should("not.exist");
     });
 
-    clearFilterWidget();
+    H.clearFilterWidget();
 
-    filterWidget().click();
+    H.filterWidget().click();
 
     addWidgetNumberFilter("4.6", { buttonLabel: "Update filter" });
 
@@ -153,7 +141,7 @@ describe("scenarios > dashboard > filters > SQL > number", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestionAndDashboard({
@@ -174,7 +162,7 @@ describe("scenarios > dashboard > filters > SQL > number", () => {
         ],
       });
 
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
     });
   });
 
@@ -196,5 +184,5 @@ describe("scenarios > dashboard > filters > SQL > number", () => {
 });
 
 function clickSelect() {
-  getDashboardCard().findByText("Select…").click();
+  H.getDashboardCard().findByText("Select…").click();
 }

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-required-field-filter.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-required-field-filter.cy.spec.js
@@ -1,12 +1,7 @@
 import { produce } from "immer";
 
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  clearFilterWidget,
-  filterWidget,
-  restore,
-  visitDashboard,
-} from "e2e/support/helpers";
 
 const { PRODUCTS } = SAMPLE_DATABASE;
 
@@ -48,7 +43,7 @@ const dashboardDetails = {
 
 describe("scenarios > dashboard > filters > SQL > field filter > required ", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -58,7 +53,7 @@ describe("scenarios > dashboard > filters > SQL > field filter > required ", () 
       dashboardDetails,
     }).then(({ body: dashboardCard }) => {
       const { dashboard_id } = dashboardCard;
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
     });
 
     // the native SQL filter is not mapped to the dashcard filter
@@ -85,10 +80,10 @@ describe("scenarios > dashboard > filters > SQL > field filter > required ", () 
         ],
       };
       cy.editDashboardCard(dashboardCard, mapFilterToCard);
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
     });
 
-    clearFilterWidget();
+    H.clearFilterWidget();
 
     // the results should show that the field filter was not applied
     cy.findByTestId("dashcard").within(() => {
@@ -112,7 +107,7 @@ describe("scenarios > dashboard > filters > SQL > field filter > required ", () 
         ],
       };
       cy.editDashboardCard(dashboardCard, mapFilterToCard);
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
     });
 
     // Default dashboard filter
@@ -120,9 +115,9 @@ describe("scenarios > dashboard > filters > SQL > field filter > required ", () 
 
     cy.findByTestId("dashcard").as("dashboardCard").contains("Widget");
 
-    filterWidget().contains("Widget");
+    H.filterWidget().contains("Widget");
 
-    clearFilterWidget();
+    H.clearFilterWidget();
 
     cy.location("search").should("eq", "?category=");
 
@@ -132,7 +127,7 @@ describe("scenarios > dashboard > filters > SQL > field filter > required ", () 
     );
 
     // The empty filter widget
-    filterWidget().contains("Category");
+    H.filterWidget().contains("Category");
 
     cy.reload();
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-required-simple-filter.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-required-simple-filter.cy.spec.js
@@ -1,11 +1,4 @@
-import {
-  clearFilterWidget,
-  editDashboard,
-  restore,
-  saveDashboard,
-  sidebar,
-  visitDashboard,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 const questionDetails = {
   name: "Return input value",
@@ -41,7 +34,7 @@ const dashboardDetails = {
 
 describe("scenarios > dashboard > filters > SQL > simple filter > required ", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestionAndDashboard({
@@ -62,7 +55,7 @@ describe("scenarios > dashboard > filters > SQL > simple filter > required ", ()
 
       cy.editDashboardCard(dashboardCard, mapFilterToCard);
 
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
     });
   });
 
@@ -74,7 +67,7 @@ describe("scenarios > dashboard > filters > SQL > simple filter > required ", ()
 
     cy.findByDisplayValue("Bar");
 
-    clearFilterWidget();
+    H.clearFilterWidget();
 
     cy.location("search").should("eq", "?text=");
 
@@ -103,15 +96,15 @@ describe("scenarios > dashboard > filters > SQL > simple filter > required ", ()
     cy.location("search").should("eq", "?text=Bar");
 
     // Finally, when we remove dashboard filter's default value, the url should reflect that by removing the placeholder
-    editDashboard();
+    H.editDashboard();
 
     openFilterOptions("Text");
 
-    sidebar().within(() => {
+    H.sidebar().within(() => {
       removeDefaultFilterValue("Bar");
     });
 
-    saveDashboard();
+    H.saveDashboard();
 
     // The URL query params should include the value from the dashboard filter default
     cy.location("search").should("eq", "?text=");

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-text-category.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-text-category.cy.spec.js
@@ -1,14 +1,4 @@
-import {
-  clearFilterWidget,
-  editDashboard,
-  filterWidget,
-  popover,
-  restore,
-  saveDashboard,
-  setFilter,
-  visitDashboard,
-  visitQuestion,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 import { applyFilterByType } from "../native-filters/helpers/e2e-field-filter-helpers";
 
@@ -23,34 +13,34 @@ describe("scenarios > dashboard > filters > SQL > text/category", () => {
       "dashcardQuery",
     );
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestionAndDashboard({ questionDetails }).then(
       ({ body: { card_id, dashboard_id } }) => {
-        visitQuestion(card_id);
+        H.visitQuestion(card_id);
 
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       },
     );
 
-    editDashboard();
+    H.editDashboard();
   });
 
   it("should work when set through the filter widget", () => {
     Object.entries(DASHBOARD_SQL_TEXT_FILTERS).forEach(([filter]) => {
       cy.log(`Make sure we can connect ${filter} filter`);
-      setFilter("Text or Category", filter);
+      H.setFilter("Text or Category", filter);
 
       cy.findByText("Select…").click();
-      popover().contains(filter).click();
+      H.popover().contains(filter).click();
     });
 
-    saveDashboard();
+    H.saveDashboard();
 
     Object.entries(DASHBOARD_SQL_TEXT_FILTERS).forEach(
       ([filter, { value, representativeResult }], index) => {
-        filterWidget().eq(index).click();
+        H.filterWidget().eq(index).click();
         applyFilterByType(filter, value);
 
         cy.log(`Make sure ${filter} filter returns correct result`);
@@ -58,35 +48,35 @@ describe("scenarios > dashboard > filters > SQL > text/category", () => {
           cy.contains(representativeResult);
         });
 
-        clearFilterWidget(index);
+        H.clearFilterWidget(index);
         cy.wait("@dashcardQuery");
       },
     );
   });
 
   it("should work when set as the default filter and when that filter is removed (metabase#20493)", () => {
-    setFilter("Text or Category", "Is");
+    H.setFilter("Text or Category", "Is");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
-    popover().contains("Is").click();
+    H.popover().contains("Is").click();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Default value").next().click();
 
     applyFilterByType("Is", "Gizmo");
 
-    saveDashboard();
+    H.saveDashboard();
 
     cy.findByTestId("dashcard").within(() => {
       cy.contains("Rustic Paper Wallet");
     });
 
-    clearFilterWidget();
+    H.clearFilterWidget();
 
     cy.url().should("not.include", "Gizmo");
 
-    filterWidget().click();
+    H.filterWidget().click();
 
     applyFilterByType("Is", "Doohickey", { buttonLabel: "Update filter" });
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
@@ -1,23 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  clearFilterWidget,
-  dashboardParametersDoneButton,
-  dashboardSaveButton,
-  editDashboard,
-  ensureDashboardCardHasText,
-  filterWidget,
-  getDashboardCard,
-  popover,
-  resetFilterWidgetToDefault,
-  restore,
-  saveDashboard,
-  selectDashboardFilter,
-  setFilter,
-  sidebar,
-  toggleFilterWidgetValues,
-  toggleRequiredParameter,
-  visitDashboard,
-} from "e2e/support/helpers";
 
 import {
   applyFilterByType,
@@ -30,7 +12,7 @@ const { ORDERS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > dashboard > filters > text/category", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestionAndDashboard({
@@ -43,24 +25,24 @@ describe("scenarios > dashboard > filters > text/category", () => {
       },
     }).then(({ body: { id, dashboard_id } }) => {
       cy.wrap(id).as("dashCardId");
-      visitDashboard(dashboard_id);
-      editDashboard();
+      H.visitDashboard(dashboard_id);
+      H.editDashboard();
     });
   });
 
   it("should drill to a question with multi-value 'contains' filter applied (metabase#42999)", () => {
-    setFilter("Text or Category", "Contains");
+    H.setFilter("Text or Category", "Contains");
     cy.findAllByRole("radio", { name: "Multiple values" }).should("be.checked");
     cy.findByTestId("visualization-root").findByText("Select…").click();
-    popover().contains("Source").click();
-    saveDashboard();
+    H.popover().contains("Source").click();
+    H.saveDashboard();
     waitDashboardCardQuery();
 
-    filterWidget().eq(0).click();
+    H.filterWidget().eq(0).click();
     applyFilterByType("Contains", "oo,aa");
     waitDashboardCardQuery();
 
-    getDashboardCard().findByText("test question").click();
+    H.getDashboardCard().findByText("test question").click();
 
     cy.location("href").should("contain", "/question#");
     cy.findByTestId("filter-pill").should(
@@ -76,7 +58,7 @@ describe("scenarios > dashboard > filters > text/category", () => {
   it("should work when set through the filter widget", () => {
     DASHBOARD_TEXT_FILTERS.forEach(({ operator, single }) => {
       cy.log(`Make sure we can connect ${operator} filter`);
-      setFilter("Text or Category", operator);
+      H.setFilter("Text or Category", operator);
       cy.findAllByRole("radio", { name: "Multiple values" }).should(
         "be.checked",
       );
@@ -88,9 +70,9 @@ describe("scenarios > dashboard > filters > text/category", () => {
       }
 
       cy.findByText("Select…").click();
-      popover().contains("Source").click();
+      H.popover().contains("Source").click();
     });
-    saveDashboard();
+    H.saveDashboard();
     waitDashboardCardQuery();
 
     DASHBOARD_TEXT_FILTERS.forEach(
@@ -98,10 +80,10 @@ describe("scenarios > dashboard > filters > text/category", () => {
         { operator, value, representativeResult, single, negativeAssertion },
         index,
       ) => {
-        filterWidget().eq(index).click();
+        H.filterWidget().eq(index).click();
         applyFilterByType(operator, value);
         waitDashboardCardQuery();
-        filterWidget()
+        H.filterWidget()
           .eq(index)
           .contains(single ? value.replace(/"/g, "") : /\d selections/);
 
@@ -110,7 +92,7 @@ describe("scenarios > dashboard > filters > text/category", () => {
           .should("contain", representativeResult)
           .and("not.contain", negativeAssertion);
 
-        clearFilterWidget(index);
+        H.clearFilterWidget(index);
         waitDashboardCardQuery();
       },
     );
@@ -121,38 +103,38 @@ describe("scenarios > dashboard > filters > text/category", () => {
     const filterValue = "Organic";
 
     cy.log(`Make sure we can connect '${filterType}' filter`);
-    setFilter("Text or Category", filterType);
+    H.setFilter("Text or Category", filterType);
 
     cy.findByTestId("dashcard").findByText("Select…").click();
-    popover().contains("Source").click();
+    H.popover().contains("Source").click();
 
-    saveDashboard();
+    H.saveDashboard();
     waitDashboardCardQuery();
 
-    filterWidget().click();
+    H.filterWidget().click();
     applyFilterByType(filterType, filterValue);
     waitDashboardCardQuery();
 
-    filterWidget().click();
+    H.filterWidget().click();
     cy.log("uncheck all values");
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText(filterValue).click();
       cy.button("Update filter").click();
       waitDashboardCardQuery();
     });
 
-    filterWidget().within(() => {
+    H.filterWidget().within(() => {
       cy.icon("close").should("not.exist");
     });
   });
 
   it("should work when set as the default filter which (if cleared) should not be preserved on reload (metabase#13960)", () => {
-    setFilter("Text or Category", "Is");
+    H.setFilter("Text or Category", "Is");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
-    popover().contains("Source").click();
+    H.popover().contains("Source").click();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Default value").next().click();
@@ -160,12 +142,12 @@ describe("scenarios > dashboard > filters > text/category", () => {
     applyFilterByType("Is", "Organic");
 
     // We need to add another filter only to reproduce metabase#13960
-    setFilter("ID");
+    H.setFilter("ID");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
-    popover().contains("User ID").click();
+    H.popover().contains("User ID").click();
 
-    saveDashboard();
+    H.saveDashboard();
     waitDashboardCardQuery();
 
     cy.location("search").should("eq", "?id=&text=Organic");
@@ -178,7 +160,7 @@ describe("scenarios > dashboard > filters > text/category", () => {
 
     cy.location("search").should("eq", "?id=&text=");
 
-    filterWidget().contains("ID").click();
+    H.filterWidget().contains("ID").click();
     cy.findByPlaceholderText("Enter an ID").type("4{enter}").blur();
     cy.button("Add filter").click();
     waitDashboardCardQuery();
@@ -189,26 +171,26 @@ describe("scenarios > dashboard > filters > text/category", () => {
     waitDashboardCardQuery();
 
     cy.location("search").should("eq", "?id=4&text=");
-    filterWidget().contains("Text");
-    filterWidget().contains("Arnold Adams");
+    H.filterWidget().contains("Text");
+    H.filterWidget().contains("Arnold Adams");
   });
 
   it("should support being required", () => {
-    setFilter("Text or Category", "Is");
-    selectDashboardFilter(cy.findByTestId("dashcard"), "Source");
+    H.setFilter("Text or Category", "Is");
+    H.selectDashboardFilter(cy.findByTestId("dashcard"), "Source");
 
     // Can't save without a default value
-    toggleRequiredParameter();
-    dashboardSaveButton().should("be.disabled");
-    dashboardSaveButton().realHover();
+    H.toggleRequiredParameter();
+    H.dashboardSaveButton().should("be.disabled");
+    H.dashboardSaveButton().realHover();
     cy.findByRole("tooltip").should(
       "contain.text",
       'The "Text" parameter requires a default value but none was provided.',
     );
 
     // Can't close sidebar without a default value
-    dashboardParametersDoneButton().should("be.disabled");
-    dashboardParametersDoneButton().realHover();
+    H.dashboardParametersDoneButton().should("be.disabled");
+    H.dashboardParametersDoneButton().realHover();
     cy.findByRole("tooltip").should(
       "contain.text",
       "The parameter requires a default value but none was provided.",
@@ -216,64 +198,64 @@ describe("scenarios > dashboard > filters > text/category", () => {
 
     // Updates the filter value
     selectDefaultValueFromPopover("Twitter", { buttonLabel: "Update filter" });
-    saveDashboard();
+    H.saveDashboard();
     waitDashboardCardQuery();
-    ensureDashboardCardHasText("37.65");
+    H.ensureDashboardCardHasText("37.65");
 
     // Resets the value back by clicking widget icon
-    toggleFilterWidgetValues(["Google", "Organic"], {
+    H.toggleFilterWidgetValues(["Google", "Organic"], {
       buttonLabel: "Update filter",
     });
     waitDashboardCardQuery();
-    resetFilterWidgetToDefault();
+    H.resetFilterWidgetToDefault();
     waitDashboardCardQuery();
-    filterWidget().findByText("Twitter");
+    H.filterWidget().findByText("Twitter");
 
     // Removing value resets back to default
-    toggleFilterWidgetValues(["Twitter"], {
+    H.toggleFilterWidgetValues(["Twitter"], {
       buttonLabel: "Set to default",
     });
-    filterWidget().findByText("Twitter").should("be.visible");
+    H.filterWidget().findByText("Twitter").should("be.visible");
   });
 
   it("should use the list value picker for single-value category filters (metabase#49323)", () => {
-    setFilter("Text or Category", "Is");
+    H.setFilter("Text or Category", "Is");
 
-    selectDashboardFilter(cy.findByTestId("dashcard"), "Title");
+    H.selectDashboardFilter(cy.findByTestId("dashcard"), "Title");
 
-    sidebar().findByText("A single value").click();
-    saveDashboard();
+    H.sidebar().findByText("A single value").click();
+    H.saveDashboard();
 
     waitDashboardCardQuery();
 
-    filterWidget().contains("Text").click();
-    popover().within(() => {
+    H.filterWidget().contains("Text").click();
+    H.popover().within(() => {
       cy.findByRole("combobox").should("not.exist");
       cy.findByText("Aerodynamic Concrete Bench").should("be.visible").click();
       cy.findByText("Aerodynamic Bronze Hat").should("be.visible").click();
       cy.button("Add filter").click();
     });
-    filterWidget().findByText("Aerodynamic Bronze Hat").should("be.visible");
+    H.filterWidget().findByText("Aerodynamic Bronze Hat").should("be.visible");
   });
 
   it("should use the list value picker for multi-value category filters (metabase#49323)", () => {
-    setFilter("Text or Category", "Is");
+    H.setFilter("Text or Category", "Is");
 
-    selectDashboardFilter(cy.findByTestId("dashcard"), "Title");
+    H.selectDashboardFilter(cy.findByTestId("dashcard"), "Title");
 
-    sidebar().findByText("Multiple values").click();
-    saveDashboard();
+    H.sidebar().findByText("Multiple values").click();
+    H.saveDashboard();
 
     waitDashboardCardQuery();
 
-    filterWidget().contains("Text").click();
-    popover().within(() => {
+    H.filterWidget().contains("Text").click();
+    H.popover().within(() => {
       cy.findByRole("combobox").should("not.exist");
       cy.findByText("Aerodynamic Concrete Bench").should("be.visible").click();
       cy.findByText("Aerodynamic Bronze Hat").should("be.visible").click();
       cy.button("Add filter").click();
     });
-    filterWidget().findByText("2 selections").should("be.visible");
+    H.filterWidget().findByText("2 selections").should("be.visible");
   });
 });
 

--- a/e2e/test/scenarios/dashboard-filters/old-parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/old-parameters.cy.spec.js
@@ -1,10 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  multiAutocompleteInput,
-  popover,
-  restore,
-  visitDashboard,
-} from "e2e/support/helpers";
 
 const { PEOPLE, PEOPLE_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
@@ -13,7 +8,7 @@ const { PEOPLE, PEOPLE_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > dashboard > OLD parameters", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -59,7 +54,7 @@ describe("scenarios > dashboard > OLD parameters", () => {
             ],
           });
 
-          visitDashboard(dashboard_id);
+          H.visitDashboard(dashboard_id);
         },
       );
     });
@@ -69,7 +64,7 @@ describe("scenarios > dashboard > OLD parameters", () => {
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Category").click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Gadget").click();
         cy.findByText("Add filter").click();
       });
@@ -120,7 +115,7 @@ describe("scenarios > dashboard > OLD parameters", () => {
             ],
           });
 
-          visitDashboard(dashboard_id);
+          H.visitDashboard(dashboard_id);
         },
       );
     });
@@ -128,8 +123,8 @@ describe("scenarios > dashboard > OLD parameters", () => {
     it("should work", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("City").click();
-      popover().within(() => {
-        multiAutocompleteInput().type("Flagstaff{enter}");
+      H.popover().within(() => {
+        H.multiAutocompleteInput().type("Flagstaff{enter}");
         cy.findByText("Add filter").click();
       });
 
@@ -193,7 +188,7 @@ describe("scenarios > dashboard > OLD parameters", () => {
           ],
         });
 
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       });
     });
 
@@ -202,7 +197,7 @@ describe("scenarios > dashboard > OLD parameters", () => {
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Category").click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Gadget").click();
         cy.findByText("Add filter").click();
       });

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -1,25 +1,10 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_DASHBOARD_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  disconnectDashboardFilter,
-  editDashboard,
-  filterWidget,
-  getDashboardCard,
-  multiAutocompleteInput,
-  popover,
-  restore,
-  saveDashboard,
-  selectDashboardFilter,
-  setFilter,
-  sidebar,
-  spyRequestFinished,
-  updateDashboardCards,
-  visitDashboard,
-} from "e2e/support/helpers";
 import { createMockParameter } from "metabase-types/api/mocks";
 
 const { ORDERS_ID, ORDERS, PRODUCTS, PRODUCTS_ID, PEOPLE, PEOPLE_ID } =
@@ -44,7 +29,7 @@ describe("scenarios > dashboard > parameters", () => {
   ];
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -53,51 +38,51 @@ describe("scenarios > dashboard > parameters", () => {
 
     cy.createDashboard({ name: "my dash" }).then(({ body: { id } }) => {
       // add the same question twice
-      updateDashboardCards({
+      H.updateDashboardCards({
         dashboard_id: id,
         cards,
       });
 
-      visitDashboard(id);
+      H.visitDashboard(id);
     });
 
-    editDashboard();
+    H.editDashboard();
 
     // add a category filter
-    setFilter("Text or Category", "Is");
+    H.setFilter("Text or Category", "Is");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("A single value").click();
 
     // connect it to people.name and product.category
     // (this doesn't make sense to do, but it illustrates the feature)
-    selectDashboardFilter(getDashboardCard(0), "Name");
+    H.selectDashboardFilter(H.getDashboardCard(0), "Name");
 
-    selectDashboardFilter(getDashboardCard(1), "Category");
+    H.selectDashboardFilter(H.getDashboardCard(1), "Category");
 
-    saveDashboard();
+    H.saveDashboard();
 
     // confirm that typing searches both fields
-    filterWidget().contains("Text").click();
+    H.filterWidget().contains("Text").click();
 
     // After typing "Ga", you should see this name!
-    popover().within(() => cy.findByPlaceholderText("Search").type("Ga"));
+    H.popover().within(() => cy.findByPlaceholderText("Search").type("Ga"));
     cy.wait("@dashboard");
-    popover().last().contains("Gabrielle Considine");
+    H.popover().last().contains("Gabrielle Considine");
 
     // Continue typing a "d" and you see "Gadget"
-    popover()
+    H.popover()
       .first()
       .within(() => cy.findByPlaceholderText("Search").type("d"));
     cy.wait("@dashboard");
 
-    popover()
+    H.popover()
       .last()
       .within(() => {
         cy.findByText("Gadget").click();
       });
 
-    popover()
+    H.popover()
       .first()
       .within(() => {
         cy.button("Add filter").click();
@@ -185,7 +170,7 @@ describe("scenarios > dashboard > parameters", () => {
           ],
         });
 
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
         cy.findByTextEnsureVisible("Created At");
       },
     );
@@ -237,13 +222,13 @@ describe("scenarios > dashboard > parameters", () => {
     cy.findByText("Remove").click();
     cy.location("search").should("eq", `?${endsWith.slug}=zmo`);
 
-    saveDashboard();
+    H.saveDashboard();
 
     cy.log(
       "There should only be one filter remaining and its value is preserved",
     );
 
-    filterWidget().contains(new RegExp(`${endsWith.name}`, "i"));
+    H.filterWidget().contains(new RegExp(`${endsWith.name}`, "i"));
 
     cy.location("search").should("eq", `?${endsWith.slug}=zmo`);
   });
@@ -309,20 +294,20 @@ describe("scenarios > dashboard > parameters", () => {
         ],
       });
 
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
       cy.findByTestId("scalar-value").invoke("text").should("eq", "53");
 
       // Confirm you can't map wrong parameter type the native question's field filter (metabase#16181)
-      editDashboard();
+      H.editDashboard();
 
-      setFilter("ID");
+      H.setFilter("ID");
 
       cy.findByText(/Add a variable to this question/).should("be.visible");
 
       // Confirm that the correct parameter type is connected to the native question's field filter
       cy.findByText(matchingFilterType.name).find(".Icon-gear").click();
 
-      getDashboardCard().within(() => {
+      H.getDashboardCard().within(() => {
         cy.findByText("Column to filter on");
         cy.findByText("Native Filter");
       });
@@ -340,10 +325,10 @@ describe("scenarios > dashboard > parameters", () => {
       });
 
       // Upon visiting the dashboard again the filter preserves its value
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
 
       cy.location("search").should("eq", "?text=Gadget");
-      filterWidget().contains("Gadget");
+      H.filterWidget().contains("Gadget");
 
       // But the question should display the new value and is not affected by the filter
       cy.findByTestId("scalar-value").invoke("text").should("eq", "1");
@@ -448,11 +433,11 @@ describe("scenarios > dashboard > parameters", () => {
     cy.get("@cardQueryRequest").should("have.been.calledOnce");
 
     // Open category dropdown
-    filterWidget().contains("Widget").click();
+    H.filterWidget().contains("Widget").click();
     cy.wait("@filterValues");
 
     // Make sure all filters were fetched (should be cached after this)
-    popover().within(() => {
+    H.popover().within(() => {
       // Widget should be selected by default
       isFilterSelected("Widget", true);
       // Select one more filter (metabase#15689)
@@ -473,7 +458,7 @@ describe("scenarios > dashboard > parameters", () => {
     cy.get("@fetchAllCategories").should("have.been.calledOnce");
 
     // As a sanity check, make sure we can deselect the filter by clicking on it
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Gizmo").click();
       isFilterSelected("Gizmo", false);
     });
@@ -481,9 +466,9 @@ describe("scenarios > dashboard > parameters", () => {
     cy.button("Update filter").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("2 selections").should("not.exist");
-    filterWidget().contains("Widget");
+    H.filterWidget().contains("Widget");
 
-    filterWidget().contains("Awesome Concrete Shoes").click();
+    H.filterWidget().contains("Awesome Concrete Shoes").click();
     // Do not limit number of results (metabase#15695)
     // Prior to the issue being fixed, the cap was 100 results
     cy.findByPlaceholderText("Search the list").type("Syner");
@@ -497,7 +482,7 @@ describe("scenarios > dashboard > parameters", () => {
     cy.findAllByTestId("table-row").should("have.length", 1);
 
     // It should not reset previously defined filters when exiting 'edit' mode without making any changes (metabase#5332, metabase#17139)
-    editDashboard();
+    H.editDashboard();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Cancel").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -512,13 +497,13 @@ describe("scenarios > dashboard > parameters", () => {
 
   describe("when the user does not have self-service data permissions", () => {
     beforeEach(() => {
-      visitDashboard(ORDERS_DASHBOARD_ID);
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
       cy.findByTextEnsureVisible("Created At");
 
-      editDashboard();
-      setFilter("ID");
+      H.editDashboard();
+      H.setFilter("ID");
 
-      selectDashboardFilter(getDashboardCard(), "User ID");
+      H.selectDashboardFilter(H.getDashboardCard(), "User ID");
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Save").click();
@@ -526,7 +511,7 @@ describe("scenarios > dashboard > parameters", () => {
       cy.findByText("You're editing this dashboard.").should("not.exist");
 
       cy.signIn("nodata");
-      visitDashboard(ORDERS_DASHBOARD_ID);
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
     });
 
     it("should not see mapping options", () => {
@@ -568,39 +553,39 @@ describe("scenarios > dashboard > parameters", () => {
 
     cy.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
       ({ body: { dashboard_id } }) => {
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       },
     );
 
-    editDashboard();
+    H.editDashboard();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(parameter1Details.name).click();
-    selectDashboardFilter(getDashboardCard(), "Category");
+    H.selectDashboardFilter(H.getDashboardCard(), "Category");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(parameter2Details.name).click();
-    selectDashboardFilter(getDashboardCard(), "Vendor");
+    H.selectDashboardFilter(H.getDashboardCard(), "Vendor");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Linked filters").click();
-    sidebar().findByRole("switch").parent().get("label").click();
-    saveDashboard();
+    H.sidebar().findByRole("switch").parent().get("label").click();
+    H.saveDashboard();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(parameter2Details.name).click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Barrows-Johns").should("exist");
       cy.findByText("Balistreri-Ankunding").should("exist");
     });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(parameter1Details.name).click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Gadget").click();
       cy.button("Add filter").click();
     });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(parameter2Details.name).click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Barrows-Johns").should("exist");
       cy.findByText("Balistreri-Ankunding").should("not.exist");
     });
@@ -609,18 +594,18 @@ describe("scenarios > dashboard > parameters", () => {
   describe("when parameters are (dis)connected to dashcards", () => {
     beforeEach(() => {
       createDashboardWithCards({ cards }).then(dashboardId =>
-        visitDashboard(dashboardId),
+        H.visitDashboard(dashboardId),
       );
 
       // create a disconnected filter + a default value
-      editDashboard();
-      setFilter("Date picker", "Relative Date");
+      H.editDashboard();
+      H.setFilter("Date picker", "Relative Date");
 
-      sidebar().findByText("Default value").next().click();
-      popover().contains("Previous 7 days").click({ force: true });
-      saveDashboard();
+      H.sidebar().findByText("Default value").next().click();
+      H.popover().contains("Previous 7 days").click({ force: true });
+      H.saveDashboard();
 
-      const { interceptor } = spyRequestFinished("dashcardRequestSpy");
+      const { interceptor } = H.spyRequestFinished("dashcardRequestSpy");
 
       cy.intercept(
         "POST",
@@ -635,16 +620,16 @@ describe("scenarios > dashboard > parameters", () => {
 
     it("should fetch dashcard data after save when parameter is mapped", () => {
       // Connect filter to 2 cards
-      editDashboard();
+      H.editDashboard();
 
       cy.findByTestId("edit-dashboard-parameters-widget-container")
         .findByText("All Options")
         .click();
 
-      selectDashboardFilter(getDashboardCard(0), "Created At");
-      selectDashboardFilter(getDashboardCard(1), "Created At");
+      H.selectDashboardFilter(H.getDashboardCard(0), "Created At");
+      H.selectDashboardFilter(H.getDashboardCard(1), "Created At");
 
-      saveDashboard();
+      H.saveDashboard();
 
       cy.get("@dashcardRequestSpy").should("have.callCount", 2);
     });
@@ -652,33 +637,33 @@ describe("scenarios > dashboard > parameters", () => {
     it("should fetch dashcard data when parameter mapping is removed", () => {
       cy.log("Connect filter to 1 card only");
 
-      editDashboard();
+      H.editDashboard();
       cy.findByTestId("edit-dashboard-parameters-widget-container")
         .findByText("All Options")
         .click();
-      selectDashboardFilter(getDashboardCard(0), "Created At");
+      H.selectDashboardFilter(H.getDashboardCard(0), "Created At");
 
-      saveDashboard();
+      H.saveDashboard();
 
       cy.get("@dashcardRequestSpy").should("have.callCount", 1);
 
       cy.log("Disconnect filter from the 1st card");
 
-      editDashboard();
+      H.editDashboard();
 
       cy.findByTestId("edit-dashboard-parameters-widget-container")
         .findByText("All Options")
         .click();
 
-      disconnectDashboardFilter(getDashboardCard(0));
-      saveDashboard();
+      H.disconnectDashboardFilter(H.getDashboardCard(0));
+      H.saveDashboard();
 
       cy.get("@dashcardRequestSpy").should("have.callCount", 2);
     });
 
     it("should not fetch dashcard data when nothing changed on save", () => {
-      editDashboard();
-      saveDashboard({ awaitRequest: false });
+      H.editDashboard();
+      H.saveDashboard({ awaitRequest: false });
 
       cy.get("@dashcardRequestSpy").should("have.callCount", 0);
     });
@@ -706,7 +691,7 @@ describe("scenarios > dashboard > parameters", () => {
       }).then(({ dashboard, questions: cards }) => {
         const [peopleCard] = cards;
 
-        updateDashboardCards({
+        H.updateDashboardCards({
           dashboard_id: dashboard.id,
           cards: [
             {
@@ -722,7 +707,7 @@ describe("scenarios > dashboard > parameters", () => {
           ],
         });
 
-        visitDashboard(dashboard.id);
+        H.visitDashboard(dashboard.id);
 
         cy.wrap(dashboard.id).as("dashboardId");
       });
@@ -731,53 +716,63 @@ describe("scenarios > dashboard > parameters", () => {
     it("should retain the last used value for a dashboard filter", () => {
       cy.intercept("GET", "/api/**/items?pinned_state*").as("getPinnedItems");
 
-      filterWidget().click();
+      H.filterWidget().click();
 
-      popover().within(() => {
-        multiAutocompleteInput().type("Antwan Fisher");
+      H.popover().within(() => {
+        H.multiAutocompleteInput().type("Antwan Fisher");
         cy.button("Add filter").click();
       });
 
-      getDashboardCard().findByText("7750 Michalik Lane").should("be.visible");
+      H.getDashboardCard()
+        .findByText("7750 Michalik Lane")
+        .should("be.visible");
 
       cy.visit("/collection/root");
       cy.wait("@getPinnedItems");
 
-      cy.get("@dashboardId").then(dashboardId => visitDashboard(dashboardId));
+      cy.get("@dashboardId").then(dashboardId => H.visitDashboard(dashboardId));
 
-      filterWidget()
+      H.filterWidget()
         .findByRole("listitem")
         .should("have.text", "Antwan Fisher");
 
       cy.log("verify filter resetting works");
 
-      filterWidget().icon("close").click();
-      getDashboardCard().findByText("761 Fish Hill Road").should("be.visible");
+      H.filterWidget().icon("close").click();
+      H.getDashboardCard()
+        .findByText("761 Fish Hill Road")
+        .should("be.visible");
     });
 
     it("should allow resetting last used value", () => {
-      filterWidget().click();
+      H.filterWidget().click();
 
-      popover().within(() => {
-        multiAutocompleteInput().type("Antwan Fisher");
+      H.popover().within(() => {
+        H.multiAutocompleteInput().type("Antwan Fisher");
         cy.button("Add filter").click();
       });
 
-      getDashboardCard().findByText("7750 Michalik Lane").should("be.visible");
+      H.getDashboardCard()
+        .findByText("7750 Michalik Lane")
+        .should("be.visible");
 
       cy.log("reset filter values from url by visiting dashboard by id");
 
-      cy.get("@dashboardId").then(dashboardId => visitDashboard(dashboardId));
+      cy.get("@dashboardId").then(dashboardId => H.visitDashboard(dashboardId));
 
-      filterWidget().icon("close").click();
+      H.filterWidget().icon("close").click();
 
-      getDashboardCard().findByText("761 Fish Hill Road").should("be.visible");
+      H.getDashboardCard()
+        .findByText("761 Fish Hill Road")
+        .should("be.visible");
 
       cy.log("verify filter value is not specified after reload");
 
-      cy.get("@dashboardId").then(dashboardId => visitDashboard(dashboardId));
+      cy.get("@dashboardId").then(dashboardId => H.visitDashboard(dashboardId));
 
-      getDashboardCard().findByText("761 Fish Hill Road").should("be.visible");
+      H.getDashboardCard()
+        .findByText("761 Fish Hill Road")
+        .should("be.visible");
     });
   });
 });
@@ -795,7 +790,7 @@ function createDashboardWithCards({
   return cy
     .createDashboard({ name: dashboardName })
     .then(({ body: { id } }) => {
-      updateDashboardCards({
+      H.updateDashboardCards({
         dashboard_id: id,
         cards,
       });

--- a/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
@@ -1,32 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  appBar,
-  clearFilterWidget,
-  createNativeQuestion,
-  createQuestion,
-  dashboardHeader,
-  dashboardParameterSidebar,
-  dashboardParametersDoneButton,
-  editDashboard,
-  filterWidget,
-  getDashboardCard,
-  modal,
-  popover,
-  queryBuilderHeader,
-  resetFilterWidgetToDefault,
-  restore,
-  saveDashboard,
-  selectDashboardFilter,
-  setFilter,
-  sidebar,
-  tableInteractive,
-  undoToast,
-  undoToastList,
-  updateDashboardCards,
-  updateSetting,
-  visitDashboard,
-  visitEmbeddedPage,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
@@ -236,226 +209,228 @@ const getParameterMapping = card => ({
 
 describe("scenarios > dashboard > temporal unit parameters", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   describe("mapping targets", () => {
     it("should connect a parameter to a question and drill thru", () => {
-      createQuestion(noBreakoutQuestionDetails);
-      createQuestion(singleBreakoutQuestionDetails);
-      createQuestion(multiBreakoutQuestionDetails);
-      createQuestion(multiStageQuestionDetails);
-      createQuestion(expressionBreakoutQuestionDetails);
-      createQuestion(binningBreakoutQuestionDetails);
-      createNativeQuestion(nativeQuestionWithDateParameterDetails);
+      H.createQuestion(noBreakoutQuestionDetails);
+      H.createQuestion(singleBreakoutQuestionDetails);
+      H.createQuestion(multiBreakoutQuestionDetails);
+      H.createQuestion(multiStageQuestionDetails);
+      H.createQuestion(expressionBreakoutQuestionDetails);
+      H.createQuestion(binningBreakoutQuestionDetails);
+      H.createNativeQuestion(nativeQuestionWithDateParameterDetails);
       cy.createDashboard(dashboardDetails).then(({ body: dashboard }) =>
-        visitDashboard(dashboard.id),
+        H.visitDashboard(dashboard.id),
       );
-      editDashboard();
+      H.editDashboard();
       addTemporalUnitParameter();
 
       cy.log("single breakout");
       addQuestion(singleBreakoutQuestionDetails.name);
       editParameter(parameterDetails.name);
-      getDashboardCard().findByText("Select…").click();
-      popover().findByText("Created At").click();
-      saveDashboard();
-      filterWidget().click();
-      popover().findByText("Year").click();
-      getDashboardCard().within(() => {
+      H.getDashboardCard().findByText("Select…").click();
+      H.popover().findByText("Created At").click();
+      H.saveDashboard();
+      H.filterWidget().click();
+      H.popover().findByText("Year").click();
+      H.getDashboardCard().within(() => {
         cy.findByText("Created At: Year").should("be.visible");
         cy.findByText(singleBreakoutQuestionDetails.name).click();
       });
-      tableInteractive().findByText("Created At: Year").should("be.visible");
+      H.tableInteractive().findByText("Created At: Year").should("be.visible");
       backToDashboard();
-      editDashboard();
+      H.editDashboard();
       removeQuestion();
 
       cy.log("multiple breakouts");
       addQuestion(multiBreakoutQuestionDetails.name);
       editParameter(parameterDetails.name);
-      getDashboardCard().findByText("Select…").click();
-      popover()
+      H.getDashboardCard().findByText("Select…").click();
+      H.popover()
         .findAllByText("Created At")
         .should("have.length", 2)
         .eq(0)
         .click();
-      saveDashboard();
-      filterWidget().click();
-      popover().findByText("Quarter").click();
-      getDashboardCard().within(() => {
+      H.saveDashboard();
+      H.filterWidget().click();
+      H.popover().findByText("Quarter").click();
+      H.getDashboardCard().within(() => {
         cy.findByText("Q2 2022").should("be.visible");
         cy.findByText(multiBreakoutQuestionDetails.name).click();
       });
-      tableInteractive().findByText("Created At: Quarter").should("be.visible");
+      H.tableInteractive()
+        .findByText("Created At: Quarter")
+        .should("be.visible");
       backToDashboard();
-      editDashboard();
+      H.editDashboard();
       removeQuestion();
 
       cy.log("multiple stages");
       addQuestion(multiStageQuestionDetails.name);
       editParameter(parameterDetails.name);
-      getDashboardCard().findByText("Select…").click();
-      popover().findByText("Created At: Month").click();
-      saveDashboard();
-      filterWidget().click();
-      popover().findByText("Quarter").click();
-      getDashboardCard().within(() => {
+      H.getDashboardCard().findByText("Select…").click();
+      H.popover().findByText("Created At: Month").click();
+      H.saveDashboard();
+      H.filterWidget().click();
+      H.popover().findByText("Quarter").click();
+      H.getDashboardCard().within(() => {
         cy.findByText("Created At: Month: Quarter").should("be.visible");
         cy.findByText(multiStageQuestionDetails.name).click();
       });
-      tableInteractive()
+      H.tableInteractive()
         .findByText("Created At: Month: Quarter")
         .should("be.visible");
       backToDashboard();
-      editDashboard();
+      H.editDashboard();
       removeQuestion();
 
       cy.log("no breakout");
       addQuestion(noBreakoutQuestionDetails.name);
       editParameter(parameterDetails.name);
-      getDashboardCard().findByText("No valid fields").should("be.visible");
-      dashboardParametersDoneButton().click();
+      H.getDashboardCard().findByText("No valid fields").should("be.visible");
+      H.dashboardParametersDoneButton().click();
       removeQuestion();
 
       cy.log("breakout by expression");
       addQuestion(expressionBreakoutQuestionDetails.name);
       editParameter(parameterDetails.name);
-      getDashboardCard().findByText("Select…").click();
-      popover().findByText("Date").click();
-      saveDashboard();
-      filterWidget().click();
-      popover().findByText("Quarter").click();
-      getDashboardCard().within(() => {
+      H.getDashboardCard().findByText("Select…").click();
+      H.popover().findByText("Date").click();
+      H.saveDashboard();
+      H.filterWidget().click();
+      H.popover().findByText("Quarter").click();
+      H.getDashboardCard().within(() => {
         cy.findByText("Date: Quarter").should("be.visible");
         cy.findByText(expressionBreakoutQuestionDetails.name).click();
       });
-      tableInteractive().findByText("Date: Quarter").should("be.visible");
+      H.tableInteractive().findByText("Date: Quarter").should("be.visible");
       backToDashboard();
-      editDashboard();
+      H.editDashboard();
       removeQuestion();
 
       cy.log("breakout by a column with a binning strategy");
       addQuestion(binningBreakoutQuestionDetails.name);
       editParameter(parameterDetails.name);
-      getDashboardCard().findByText("No valid fields").should("be.visible");
-      dashboardParametersDoneButton().click();
+      H.getDashboardCard().findByText("No valid fields").should("be.visible");
+      H.dashboardParametersDoneButton().click();
       removeQuestion();
 
       cy.log("native query");
       addQuestion(nativeQuestionWithDateParameterDetails.name);
       editParameter(parameterDetails.name);
-      getDashboardCard()
+      H.getDashboardCard()
         .findByText(/Add a variable to this question/)
         .should("be.visible");
     });
 
     it("should connect a parameter to a model", () => {
-      createQuestion({ ...singleBreakoutQuestionDetails, type: "model" });
-      createNativeQuestion({ ...nativeQuestionDetails, type: "model" });
+      H.createQuestion({ ...singleBreakoutQuestionDetails, type: "model" });
+      H.createNativeQuestion({ ...nativeQuestionDetails, type: "model" });
       cy.createDashboard(dashboardDetails).then(({ body: dashboard }) =>
-        visitDashboard(dashboard.id),
+        H.visitDashboard(dashboard.id),
       );
-      editDashboard();
+      H.editDashboard();
       addTemporalUnitParameter();
 
       cy.log("MBQL model");
       addQuestion(singleBreakoutQuestionDetails.name);
       editParameter(parameterDetails.name);
-      getDashboardCard().findByText("No valid fields").should("be.visible");
-      dashboardParametersDoneButton().click();
+      H.getDashboardCard().findByText("No valid fields").should("be.visible");
+      H.dashboardParametersDoneButton().click();
       removeQuestion();
     });
 
     it("should connect a parameter to a metric", () => {
-      createQuestion({ ...singleBreakoutQuestionDetails, type: "metric" });
+      H.createQuestion({ ...singleBreakoutQuestionDetails, type: "metric" });
       cy.createDashboard(dashboardDetails).then(({ body: dashboard }) =>
-        visitDashboard(dashboard.id),
+        H.visitDashboard(dashboard.id),
       );
-      editDashboard();
+      H.editDashboard();
       addTemporalUnitParameter();
 
       addQuestion(singleBreakoutQuestionDetails.name);
       editParameter(parameterDetails.name);
-      getDashboardCard().findByText("Select…").click();
-      popover().findByText("Created At").click();
-      saveDashboard();
-      filterWidget().click();
-      popover().findByText("Year").click();
-      getDashboardCard().within(() => {
+      H.getDashboardCard().findByText("Select…").click();
+      H.popover().findByText("Created At").click();
+      H.saveDashboard();
+      H.filterWidget().click();
+      H.popover().findByText("Year").click();
+      H.getDashboardCard().within(() => {
         cy.findByText("Created At: Year").should("be.visible");
         cy.findByText(singleBreakoutQuestionDetails.name).click();
       });
-      queryBuilderHeader()
+      H.queryBuilderHeader()
         .findByText(`${singleBreakoutQuestionDetails.name} by Created At: Year`)
         .should("be.visible");
     });
 
     it("should connect multiple parameters to a card with multiple breakouts and drill thru", () => {
-      createQuestion(multiBreakoutQuestionDetails);
+      H.createQuestion(multiBreakoutQuestionDetails);
       cy.createDashboard(dashboardDetails).then(({ body: dashboard }) =>
-        visitDashboard(dashboard.id),
+        H.visitDashboard(dashboard.id),
       );
 
-      editDashboard();
+      H.editDashboard();
       addQuestion(multiBreakoutQuestionDetails.name);
       addTemporalUnitParameter();
-      getDashboardCard().findByText("Select…").click();
-      popover().findAllByText("Created At").eq(0).click();
+      H.getDashboardCard().findByText("Select…").click();
+      H.popover().findAllByText("Created At").eq(0).click();
       addTemporalUnitParameter();
-      getDashboardCard().findByText("Select…").click();
-      popover().findAllByText("Created At").eq(1).click();
-      saveDashboard();
+      H.getDashboardCard().findByText("Select…").click();
+      H.popover().findAllByText("Created At").eq(1).click();
+      H.saveDashboard();
 
-      filterWidget().eq(0).click();
-      popover().findByText("Year").click();
-      filterWidget().eq(1).click();
-      popover().findByText("Week").click();
-      getDashboardCard().within(() => {
+      H.filterWidget().eq(0).click();
+      H.popover().findByText("Year").click();
+      H.filterWidget().eq(1).click();
+      H.popover().findByText("Week").click();
+      H.getDashboardCard().within(() => {
         cy.findByText("Created At: Year").should("be.visible");
         cy.findByText("April 24, 2022").should("be.visible");
         cy.findByText("May 1, 2022").should("be.visible");
         cy.findByText(multiBreakoutQuestionDetails.name).click();
       });
-      appBar()
+      H.appBar()
         .should("contain.text", "Started from")
         .should("contain.text", multiBreakoutQuestionDetails.name);
-      tableInteractive().within(() => {
+      H.tableInteractive().within(() => {
         cy.findByText("Created At: Year").should("be.visible");
         cy.findByText("Product → Created At: Week").should("be.visible");
       });
     });
 
     it("should connect multiple parameters to the same column in a card and drill thru, with the last parameter taking priority", () => {
-      createQuestion(singleBreakoutQuestionDetails);
+      H.createQuestion(singleBreakoutQuestionDetails);
       cy.createDashboard(dashboardDetails).then(({ body: dashboard }) =>
-        visitDashboard(dashboard.id),
+        H.visitDashboard(dashboard.id),
       );
 
-      editDashboard();
+      H.editDashboard();
       addQuestion(singleBreakoutQuestionDetails.name);
       addTemporalUnitParameter();
-      selectDashboardFilter(getDashboardCard(), "Created At");
+      H.selectDashboardFilter(H.getDashboardCard(), "Created At");
       addTemporalUnitParameter();
-      selectDashboardFilter(getDashboardCard(), "Created At");
-      saveDashboard();
+      H.selectDashboardFilter(H.getDashboardCard(), "Created At");
+      H.saveDashboard();
 
-      filterWidget().eq(0).click();
-      popover().findByText("Quarter").click();
-      filterWidget().eq(1).click();
-      popover().findByText("Year").click();
-      getDashboardCard().within(() => {
+      H.filterWidget().eq(0).click();
+      H.popover().findByText("Quarter").click();
+      H.filterWidget().eq(1).click();
+      H.popover().findByText("Year").click();
+      H.getDashboardCard().within(() => {
         // metabase#44684
         // should be "Created At: Year" and "2022" because the last parameter is "Year"
         cy.findByText("Created At: Quarter").should("be.visible");
         cy.findByText("Q2 2022").should("be.visible");
         cy.findByText(singleBreakoutQuestionDetails.name).click();
       });
-      appBar()
+      H.appBar()
         .should("contain.text", "Started from")
         .should("contain.text", singleBreakoutQuestionDetails.name);
-      tableInteractive().within(() => {
+      H.tableInteractive().within(() => {
         cy.findByText("Created At: Year").should("be.visible");
         cy.findByText("2022").should("be.visible");
       });
@@ -463,43 +438,43 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
 
     it("should connect a parameter to multiple questions within a dashcard and drill thru", () => {
       createDashboardWithMultiSeriesCard().then(dashboard =>
-        visitDashboard(dashboard.id),
+        H.visitDashboard(dashboard.id),
       );
 
-      editDashboard();
+      H.editDashboard();
       addTemporalUnitParameter();
-      getDashboardCard()
+      H.getDashboardCard()
         .findAllByText("Select…")
         .should("have.length", 2)
         .eq(0)
         .click();
-      popover().findByText("Created At").click();
-      getDashboardCard().findByText("Select…").click();
-      popover().findByText("Created At").click();
-      saveDashboard();
+      H.popover().findByText("Created At").click();
+      H.getDashboardCard().findByText("Select…").click();
+      H.popover().findByText("Created At").click();
+      H.saveDashboard();
 
-      filterWidget().click();
-      popover().findByText("Quarter").click();
-      getDashboardCard().within(() => {
+      H.filterWidget().click();
+      H.popover().findByText("Quarter").click();
+      H.getDashboardCard().within(() => {
         cy.findByText("Q1 2023").should("be.visible");
         cy.findByText("Question 1").click();
       });
-      appBar()
+      H.appBar()
         .should("contain.text", "Started from")
         .should("contain.text", "Question 1");
-      queryBuilderHeader()
+      H.queryBuilderHeader()
         .findByText("Count by Created At: Quarter")
         .should("be.visible");
       backToDashboard();
 
-      getDashboardCard().within(() => {
+      H.getDashboardCard().within(() => {
         cy.findByText("Q1 2023").should("be.visible");
         cy.findByText("Question 2").click();
       });
-      appBar()
+      H.appBar()
         .should("contain.text", "Started from")
         .should("contain.text", "Question 2");
-      queryBuilderHeader()
+      H.queryBuilderHeader()
         .findByText("Count by Created At: Quarter")
         .should("be.visible");
     });
@@ -511,15 +486,15 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
         extraQuestions: [nativeUnitQuestionDetails],
       }).then(dashboard => {
         cy.wrap(dashboard.id).as("dashboardId");
-        visitDashboard(dashboard.id);
+        H.visitDashboard(dashboard.id);
       });
 
       cy.log("unsupported column types are ignored");
-      editDashboard();
-      getDashboardCard(0)
+      H.editDashboard();
+      H.getDashboardCard(0)
         .findByLabelText("Click behavior")
         .click({ force: true });
-      sidebar().within(() => {
+      H.sidebar().within(() => {
         cy.log("datetime columns cannot be mapped");
         cy.findByText("Created At: Month").click();
         cy.findByText("Update a dashboard filter").click();
@@ -534,42 +509,44 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
       });
 
       cy.log("setup a valid click behavior with a text column");
-      getDashboardCard(1)
+      H.getDashboardCard(1)
         .findByLabelText("Click behavior")
         .click({ force: true });
-      sidebar().within(() => {
+      H.sidebar().within(() => {
         cy.findByText("UNIT").click();
         cy.findByText("Update a dashboard filter").click();
         cy.findByText(parameterDetails.name).click();
       });
-      popover().findByText("UNIT").click();
-      saveDashboard();
+      H.popover().findByText("UNIT").click();
+      H.saveDashboard();
 
       cy.log("verify click behavior with a valid temporal unit");
 
       // this is done to bypass race condition problem, the root cause for it is
       // described in `updateDashboardAndCards` from frontend/src/metabase/dashboard/actions/save.js
-      visitDashboard("@dashboardId");
+      H.visitDashboard("@dashboardId");
 
-      getDashboardCard(1).findByText("year").click();
+      H.getDashboardCard(1).findByText("year").click();
 
-      getDashboardCard(0)
+      H.getDashboardCard(0)
         .findByText("Created At: Year", { timeout: 10000 })
         .should("be.visible");
 
-      filterWidget().findByText("Year").should("be.visible");
+      H.filterWidget().findByText("Year").should("be.visible");
 
       cy.log("verify that invalid temporal units are ignored");
-      getDashboardCard(1).findByText("invalid").click();
-      filterWidget()
+      H.getDashboardCard(1).findByText("invalid").click();
+      H.filterWidget()
         .findByText(/invalid/i)
         .should("not.exist");
-      getDashboardCard(0).findByText("Created At: Month").should("be.visible");
+      H.getDashboardCard(0)
+        .findByText("Created At: Month")
+        .should("be.visible");
 
       cy.log("verify that recovering from an invalid temporal unit works");
-      getDashboardCard(1).findByText("year").click();
-      filterWidget().findByText("Year").should("be.visible");
-      getDashboardCard(0).findByText("Created At: Year").should("be.visible");
+      H.getDashboardCard(1).findByText("year").click();
+      H.filterWidget().findByText("Year").should("be.visible");
+      H.getDashboardCard(0).findByText("Created At: Year").should("be.visible");
     });
 
     it("should pass a temporal unit 'custom destination -> dashboard' click behavior", () => {
@@ -584,37 +561,37 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
         },
         questions: [nativeUnitQuestionDetails],
       }).then(({ dashboard }) => cy.wrap(dashboard.id).as("sourceDashboardId"));
-      visitDashboard("@sourceDashboardId");
+      H.visitDashboard("@sourceDashboardId");
 
       cy.log("setup click behavior");
-      editDashboard();
-      getDashboardCard()
+      H.editDashboard();
+      H.getDashboardCard()
         .findByLabelText("Click behavior")
         .click({ force: true });
-      sidebar().within(() => {
+      H.sidebar().within(() => {
         cy.findByText("UNIT").click();
         cy.findByText("Go to a custom destination").click();
         cy.findByText("Dashboard").click();
       });
-      modal().findByText("Target dashboard").click();
-      sidebar().findByText(parameterDetails.name).click();
-      popover().findByText("UNIT").click();
-      saveDashboard();
+      H.modal().findByText("Target dashboard").click();
+      H.sidebar().findByText(parameterDetails.name).click();
+      H.popover().findByText("UNIT").click();
+      H.saveDashboard();
 
       cy.log("verify that invalid temporal units are ignored");
-      getDashboardCard().findByText("invalid").click();
-      dashboardHeader().findByText("Target dashboard").should("be.visible");
-      filterWidget()
+      H.getDashboardCard().findByText("invalid").click();
+      H.dashboardHeader().findByText("Target dashboard").should("be.visible");
+      H.filterWidget()
         .findByText(/invalid/i)
         .should("not.exist");
-      getDashboardCard().findByText("Created At: Month").should("be.visible");
+      H.getDashboardCard().findByText("Created At: Month").should("be.visible");
 
       cy.log("verify click behavior with a valid temporal unit");
-      visitDashboard("@sourceDashboardId");
-      getDashboardCard().findByText("year").click();
-      dashboardHeader().findByText("Target dashboard").should("be.visible");
-      filterWidget().findByText("Year").should("be.visible");
-      getDashboardCard().findByText("Created At: Year").should("be.visible");
+      H.visitDashboard("@sourceDashboardId");
+      H.getDashboardCard().findByText("year").click();
+      H.dashboardHeader().findByText("Target dashboard").should("be.visible");
+      H.filterWidget().findByText("Year").should("be.visible");
+      H.getDashboardCard().findByText("Created At: Year").should("be.visible");
     });
 
     it("should pass a temporal unit with 'custom destination -> url' click behavior", () => {
@@ -629,25 +606,25 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
         },
         questions: [nativeUnitQuestionDetails],
       }).then(({ dashboard }) => cy.wrap(dashboard.id).as("sourceDashboardId"));
-      visitDashboard("@sourceDashboardId");
+      H.visitDashboard("@sourceDashboardId");
 
       cy.log("setup click behavior");
-      editDashboard();
-      getDashboardCard()
+      H.editDashboard();
+      H.getDashboardCard()
         .findByLabelText("Click behavior")
         .click({ force: true });
-      sidebar().within(() => {
+      H.sidebar().within(() => {
         cy.findByText("UNIT").click();
         cy.findByText("Go to a custom destination").click();
         cy.findByText("URL").click();
       });
-      modal().findByText("Values you can reference").click();
-      popover().within(() => {
+      H.modal().findByText("Values you can reference").click();
+      H.popover().within(() => {
         cy.findByText("UNIT").should("be.visible");
         cy.findByText(parameterDetails.name).should("not.exist");
       });
       cy.get("@targetDashboardId").then(targetDashboardId => {
-        modal().within(() => {
+        H.modal().within(() => {
           cy.findByPlaceholderText("e.g. http://acme.com/id/{{user_id}}").type(
             `http://localhost:4000/dashboard/${targetDashboardId}?${parameterDetails.slug}={{UNIT}}`,
             { parseSpecialCharSequences: false },
@@ -655,55 +632,55 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
           cy.button("Done").click();
         });
       });
-      saveDashboard();
+      H.saveDashboard();
 
       cy.log("verify click behavior with a temporal valid unit");
-      getDashboardCard().findByText("year").click();
-      dashboardHeader().findByText("Target dashboard").should("be.visible");
-      filterWidget().findByText("Year").should("be.visible");
-      getDashboardCard().findByText("Created At: Year").should("be.visible");
+      H.getDashboardCard().findByText("year").click();
+      H.dashboardHeader().findByText("Target dashboard").should("be.visible");
+      H.filterWidget().findByText("Year").should("be.visible");
+      H.getDashboardCard().findByText("Created At: Year").should("be.visible");
 
       cy.log("verify that invalid temporal units are ignored");
-      visitDashboard("@sourceDashboardId");
-      getDashboardCard().findByText("invalid").click();
-      dashboardHeader().findByText("Target dashboard").should("be.visible");
-      filterWidget()
+      H.visitDashboard("@sourceDashboardId");
+      H.getDashboardCard().findByText("invalid").click();
+      H.dashboardHeader().findByText("Target dashboard").should("be.visible");
+      H.filterWidget()
         .findByText(/invalid/i)
         .should("not.exist");
-      getDashboardCard().findByText("Created At: Month").should("be.visible");
+      H.getDashboardCard().findByText("Created At: Month").should("be.visible");
     });
 
     it("should not allow to use temporal unit parameter values with SQL queries", () => {
-      createNativeQuestion(nativeQuestionWithTextParameterDetails);
+      H.createNativeQuestion(nativeQuestionWithTextParameterDetails);
       createDashboardWithMappedQuestion().then(dashboard =>
-        visitDashboard(dashboard.id),
+        H.visitDashboard(dashboard.id),
       );
 
       cy.log("setup click behavior only with a temporal unit parameter");
-      editDashboard();
-      getDashboardCard()
+      H.editDashboard();
+      H.getDashboardCard()
         .findByLabelText("Click behavior")
         .click({ force: true });
-      sidebar().within(() => {
+      H.sidebar().within(() => {
         cy.findByText("Count").click();
         cy.findByText("Go to a custom destination").click();
         cy.findByText("Saved question").click();
       });
-      modal().findByText(nativeQuestionWithTextParameterDetails.name).click();
-      sidebar().findByText("No available targets").should("be.visible");
+      H.modal().findByText(nativeQuestionWithTextParameterDetails.name).click();
+      H.sidebar().findByText("No available targets").should("be.visible");
 
       cy.log("setup click behavior with a text parameter");
-      setFilter("Text or Category");
-      dashboardParametersDoneButton().click();
-      getDashboardCard()
+      H.setFilter("Text or Category");
+      H.dashboardParametersDoneButton().click();
+      H.getDashboardCard()
         .findByLabelText("Click behavior")
         .click({ force: true });
-      sidebar().within(() => {
+      H.sidebar().within(() => {
         cy.findByText(/Count goes to/).click();
         cy.findByText("Go to a custom destination").click();
         cy.findByText("Category").click();
       });
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Text").should("be.visible");
         cy.findByText(parameterDetails.name).should("not.exist");
       });
@@ -715,17 +692,17 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
       cy.createDashboardWithQuestions({
         dashboardDetails,
         questions: [noBreakoutQuestionDetails, singleBreakoutQuestionDetails],
-      }).then(({ dashboard }) => visitDashboard(dashboard.id));
-      editDashboard();
+      }).then(({ dashboard }) => H.visitDashboard(dashboard.id));
+      H.editDashboard();
       addTemporalUnitParameter();
 
       cy.log("new mapping");
-      selectDashboardFilter(getDashboardCard(1), "Created At");
-      undoToast().should("not.exist");
+      H.selectDashboardFilter(H.getDashboardCard(1), "Created At");
+      H.undoToast().should("not.exist");
 
       cy.log("new card");
       addQuestion(noBreakoutQuestionDetails.name);
-      undoToast().should("not.exist");
+      H.undoToast().should("not.exist");
     });
 
     it("should auto-wire to cards with breakouts on column selection", () => {
@@ -736,39 +713,39 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
           singleBreakoutQuestionDetails,
           multiBreakoutQuestionDetails,
         ],
-      }).then(({ dashboard }) => visitDashboard(dashboard.id));
-      editDashboard();
+      }).then(({ dashboard }) => H.visitDashboard(dashboard.id));
+      H.editDashboard();
       addTemporalUnitParameter();
 
-      selectDashboardFilter(getDashboardCard(1), "Created At");
-      undoToast().button("Auto-connect").click();
-      saveDashboard();
+      H.selectDashboardFilter(H.getDashboardCard(1), "Created At");
+      H.undoToast().button("Auto-connect").click();
+      H.saveDashboard();
 
-      filterWidget().click();
-      popover().findByText("Year").click();
-      getDashboardCard(1).findByText("Created At: Year").should("exist");
-      getDashboardCard(2).findByText("Created At: Year").should("exist");
+      H.filterWidget().click();
+      H.popover().findByText("Year").click();
+      H.getDashboardCard(1).findByText("Created At: Year").should("exist");
+      H.getDashboardCard(2).findByText("Created At: Year").should("exist");
     });
 
     it("should auto-wire to cards with breakouts after a new card is added", () => {
-      createQuestion(multiBreakoutQuestionDetails);
+      H.createQuestion(multiBreakoutQuestionDetails);
       cy.createDashboardWithQuestions({
         dashboardDetails,
         questions: [noBreakoutQuestionDetails, singleBreakoutQuestionDetails],
-      }).then(({ dashboard }) => visitDashboard(dashboard.id));
-      editDashboard();
+      }).then(({ dashboard }) => H.visitDashboard(dashboard.id));
+      H.editDashboard();
       addTemporalUnitParameter();
 
-      selectDashboardFilter(getDashboardCard(1), "Created At");
-      undoToast().should("not.exist");
+      H.selectDashboardFilter(H.getDashboardCard(1), "Created At");
+      H.undoToast().should("not.exist");
       addQuestion(multiBreakoutQuestionDetails.name);
-      undoToast().button("Auto-connect").click();
-      saveDashboard();
+      H.undoToast().button("Auto-connect").click();
+      H.saveDashboard();
 
-      filterWidget().click();
-      popover().findByText("Year").click();
-      getDashboardCard(1).findByText("Created At: Year").should("exist");
-      getDashboardCard(2).findByText("Created At: Year").should("exist");
+      H.filterWidget().click();
+      H.popover().findByText("Year").click();
+      H.getDashboardCard(1).findByText("Created At: Year").should("exist");
+      H.getDashboardCard(2).findByText("Created At: Year").should("exist");
     });
 
     it("should not overwrite parameter mappings for a card when doing auto-wiring", () => {
@@ -779,39 +756,39 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
           singleBreakoutQuestionDetails,
           multiBreakoutQuestionDetails,
         ],
-      }).then(({ dashboard }) => visitDashboard(dashboard.id));
-      getDashboardCard(1).within(() => {
+      }).then(({ dashboard }) => H.visitDashboard(dashboard.id));
+      H.getDashboardCard(1).within(() => {
         cy.findByText("199").should("not.exist");
       });
-      editDashboard();
+      H.editDashboard();
 
       cy.log("add a regular parameter");
-      setFilter("Text or Category", "Is");
-      selectDashboardFilter(getDashboardCard(0), "Category");
-      undoToast().button("Auto-connect").click();
+      H.setFilter("Text or Category", "Is");
+      H.selectDashboardFilter(H.getDashboardCard(0), "Category");
+      H.undoToast().button("Auto-connect").click();
 
       cy.log("add a temporal unit parameter");
       addTemporalUnitParameter();
-      selectDashboardFilter(getDashboardCard(1), "Created At");
-      undoToastList().last().button("Auto-connect").click();
-      saveDashboard();
+      H.selectDashboardFilter(H.getDashboardCard(1), "Created At");
+      H.undoToastList().last().button("Auto-connect").click();
+      H.saveDashboard();
 
       cy.log("verify data with 2 parameters");
-      filterWidget().eq(0).click();
-      popover().within(() => {
+      H.filterWidget().eq(0).click();
+      H.popover().within(() => {
         cy.findByText("Gadget").click();
         cy.button("Add filter").click();
       });
-      filterWidget().eq(1).click();
-      popover().findByText("Year").click();
-      getDashboardCard(1).within(() => {
+      H.filterWidget().eq(1).click();
+      H.popover().findByText("Year").click();
+      H.getDashboardCard(1).within(() => {
         cy.findByText("199").should("exist"); // sample filtered data
         cy.findByText("Created At: Year").should("be.visible");
       });
 
       cy.log("verify data without the first parameter");
-      filterWidget().eq(0).icon("close").click();
-      getDashboardCard(1).within(() => {
+      H.filterWidget().eq(0).icon("close").click();
+      H.getDashboardCard(1).within(() => {
         cy.findByText("199").should("not.exist"); // sample filtered data
         cy.findByText("Created At: Year").should("be.visible");
       });
@@ -821,136 +798,146 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
   describe("parameter settings", () => {
     it("should be able to set available temporal units", () => {
       createDashboardWithMappedQuestion().then(dashboard =>
-        visitDashboard(dashboard.id),
+        H.visitDashboard(dashboard.id),
       );
 
-      editDashboard();
+      H.editDashboard();
       editParameter(parameterDetails.name);
-      dashboardParameterSidebar().findByText("All").click();
-      popover().within(() => {
+      H.dashboardParameterSidebar().findByText("All").click();
+      H.popover().within(() => {
         cy.findByLabelText("Select none").click();
         cy.findByLabelText("Month").click();
         cy.findByLabelText("Year").click();
         cy.findByLabelText("Minute").click();
       });
-      dashboardParametersDoneButton().click();
-      saveDashboard();
+      H.dashboardParametersDoneButton().click();
+      H.saveDashboard();
 
-      filterWidget().click();
-      popover().within(() => {
+      H.filterWidget().click();
+      H.popover().within(() => {
         cy.findByText("Minute").should("not.exist");
         cy.findByText("Day").should("not.exist");
         cy.findByText("Month").should("be.visible");
         cy.findByText("Year").should("be.visible").click();
       });
-      getDashboardCard().findByText("Created At: Year").should("be.visible");
+      H.getDashboardCard().findByText("Created At: Year").should("be.visible");
     });
 
     it("should clear the default value if it is no longer within the allowed unit list", () => {
       createDashboardWithMappedQuestion().then(dashboard =>
-        visitDashboard(dashboard.id),
+        H.visitDashboard(dashboard.id),
       );
 
       cy.log("set the default value");
-      editDashboard();
+      H.editDashboard();
       editParameter(parameterDetails.name);
-      dashboardParameterSidebar().findByText("No default").click();
-      popover().findByText("Year").click();
+      H.dashboardParameterSidebar().findByText("No default").click();
+      H.popover().findByText("Year").click();
 
       cy.log("exclude an unrelated temporal unit");
-      dashboardParameterSidebar().findByText("All").click();
-      popover().findByLabelText("Month").click();
-      dashboardParameterSidebar().findByText("No default").should("not.exist");
+      H.dashboardParameterSidebar().findByText("All").click();
+      H.popover().findByLabelText("Month").click();
+      H.dashboardParameterSidebar()
+        .findByText("No default")
+        .should("not.exist");
 
       cy.log("exclude the temporal unit used for the default value");
-      popover().findByLabelText("Year").click();
-      dashboardParameterSidebar().findByText("No default").should("be.visible");
+      H.popover().findByLabelText("Year").click();
+      H.dashboardParameterSidebar()
+        .findByText("No default")
+        .should("be.visible");
     });
 
     it("should be able to set the default value and make it required", () => {
       createDashboardWithMappedQuestion().then(dashboard =>
         cy.wrap(dashboard.id).as("dashboardId"),
       );
-      visitDashboard("@dashboardId");
+      H.visitDashboard("@dashboardId");
 
       cy.log("set the default value");
-      editDashboard();
+      H.editDashboard();
       editParameter(parameterDetails.name);
-      dashboardParameterSidebar().findByText("No default").click();
-      popover().findByText("Year").click();
-      saveDashboard();
-      filterWidget().findByText("Year").should("be.visible");
-      getDashboardCard().findByText("Created At: Year").should("be.visible");
+      H.dashboardParameterSidebar().findByText("No default").click();
+      H.popover().findByText("Year").click();
+      H.saveDashboard();
+      H.filterWidget().findByText("Year").should("be.visible");
+      H.getDashboardCard().findByText("Created At: Year").should("be.visible");
 
       cy.log("clear the default value");
-      clearFilterWidget();
-      getDashboardCard().findByText("Created At: Month").should("be.visible");
+      H.clearFilterWidget();
+      H.getDashboardCard().findByText("Created At: Month").should("be.visible");
 
       cy.log("reload the dashboard and check the default value is applied");
-      visitDashboard("@dashboardId");
-      filterWidget().findByText("Year").should("be.visible");
-      getDashboardCard().findByText("Created At: Year").should("be.visible");
+      H.visitDashboard("@dashboardId");
+      H.filterWidget().findByText("Year").should("be.visible");
+      H.getDashboardCard().findByText("Created At: Year").should("be.visible");
 
       cy.log("make the parameter required");
-      editDashboard();
+      H.editDashboard();
       editParameter(parameterDetails.name);
-      dashboardParameterSidebar().findByText("Always require a value").click();
-      saveDashboard();
+      H.dashboardParameterSidebar()
+        .findByText("Always require a value")
+        .click();
+      H.saveDashboard();
 
       cy.log("change the parameter value and reset it to the default value");
-      filterWidget().click();
-      popover().findByText("Quarter").click();
-      getDashboardCard().findByText("Created At: Quarter").should("be.visible");
-      resetFilterWidgetToDefault();
-      getDashboardCard().findByText("Created At: Year").should("be.visible");
+      H.filterWidget().click();
+      H.popover().findByText("Quarter").click();
+      H.getDashboardCard()
+        .findByText("Created At: Quarter")
+        .should("be.visible");
+      H.resetFilterWidgetToDefault();
+      H.getDashboardCard().findByText("Created At: Year").should("be.visible");
     });
 
     it("should show an error message when an incompatible temporal unit is used", () => {
       cy.log("setup dashboard with a time column");
-      createNativeQuestion(nativeTimeQuestionDetails).then(({ body: card }) => {
-        cy.createDashboardWithQuestions({
-          questions: [getNativeTimeQuestionBasedQuestionDetails(card)],
-        }).then(({ dashboard }) => {
-          visitDashboard(dashboard.id);
-        });
-      });
-      editDashboard();
+      H.createNativeQuestion(nativeTimeQuestionDetails).then(
+        ({ body: card }) => {
+          cy.createDashboardWithQuestions({
+            questions: [getNativeTimeQuestionBasedQuestionDetails(card)],
+          }).then(({ dashboard }) => {
+            H.visitDashboard(dashboard.id);
+          });
+        },
+      );
+      H.editDashboard();
       addTemporalUnitParameter();
-      selectDashboardFilter(getDashboardCard(), "TIME");
-      saveDashboard();
+      H.selectDashboardFilter(H.getDashboardCard(), "TIME");
+      H.saveDashboard();
 
       cy.log("use an invalid temporal unit");
-      filterWidget().click();
-      popover().findByText("Year").click();
-      getDashboardCard().should(
+      H.filterWidget().click();
+      H.popover().findByText("Year").click();
+      H.getDashboardCard().should(
         "contain.text",
         "This chart can not be broken out by the selected unit of time: year.",
       );
 
       cy.log("use an valid temporal unit");
-      filterWidget().click();
-      popover().findByText("Minute").click();
-      getDashboardCard().findByText("TIME: Minute").should("be.visible");
+      H.filterWidget().click();
+      H.popover().findByText("Minute").click();
+      H.getDashboardCard().findByText("TIME: Minute").should("be.visible");
     });
   });
 
   describe("query string parameters", () => {
     it("should be able to parse the parameter value from the url", () => {
       createDashboardWithMappedQuestion().then(dashboard => {
-        visitDashboard(dashboard.id, { params: { unit_of_time: "year" } });
+        H.visitDashboard(dashboard.id, { params: { unit_of_time: "year" } });
       });
-      getDashboardCard().findByText("Created At: Year").should("be.visible");
+      H.getDashboardCard().findByText("Created At: Year").should("be.visible");
     });
 
     it("should ignore invalid temporal unit values from the url", () => {
       createDashboardWithMappedQuestion().then(dashboard => {
-        visitDashboard(dashboard.id, { params: { unit_of_time: "invalid" } });
+        H.visitDashboard(dashboard.id, { params: { unit_of_time: "invalid" } });
       });
-      filterWidget().within(() => {
+      H.filterWidget().within(() => {
         cy.findByText(parameterDetails.name).should("be.visible");
         cy.findByText(/invalid/i).should("not.exist");
       });
-      getDashboardCard().findByText("Created At: Month").should("be.visible");
+      H.getDashboardCard().findByText("Created At: Month").should("be.visible");
     });
 
     it("should accept temporal units outside of the allowlist if they are otherwise valid values from the url", () => {
@@ -964,10 +951,10 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
           ],
         },
       }).then(dashboard => {
-        visitDashboard(dashboard.id, { params: { unit_of_time: "year" } });
+        H.visitDashboard(dashboard.id, { params: { unit_of_time: "year" } });
       });
-      filterWidget().findByText("Year").should("be.visible");
-      getDashboardCard().findByText("Created At: Year").should("be.visible");
+      H.filterWidget().findByText("Year").should("be.visible");
+      H.getDashboardCard().findByText("Created At: Year").should("be.visible");
     });
   });
 
@@ -975,11 +962,11 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
     it("should add a temporal unit parameter and connect it to a card and drill thru", () => {
       createDashboardWithMappedQuestion().then(dashboard => {
         cy.signIn("nodata");
-        visitDashboard(dashboard.id);
+        H.visitDashboard(dashboard.id);
       });
-      filterWidget().click();
-      popover().findByText("Year").click();
-      getDashboardCard().within(() => {
+      H.filterWidget().click();
+      H.popover().findByText("Year").click();
+      H.getDashboardCard().within(() => {
         cy.findByText("Created At: Year").should("be.visible");
         cy.findByText(singleBreakoutQuestionDetails.name).click();
       });
@@ -992,7 +979,7 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
   describe("embedding", () => {
     beforeEach(() => {
       cy.signInAsAdmin();
-      updateSetting("enable-public-sharing", true);
+      H.updateSetting("enable-public-sharing", true);
     });
 
     it("should be able to use temporal unit parameters in a public dashboard", () => {
@@ -1005,9 +992,9 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
         );
       });
 
-      filterWidget().click();
-      popover().findByText("Year").click();
-      getDashboardCard().findByText("Created At: Year").should("be.visible");
+      H.filterWidget().click();
+      H.popover().findByText("Year").click();
+      H.getDashboardCard().findByText("Created At: Year").should("be.visible");
     });
 
     it("should be able to use temporal unit parameters in a embedded dashboard", () => {
@@ -1019,15 +1006,15 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
           },
         },
       }).then(dashboard => {
-        visitEmbeddedPage({
+        H.visitEmbeddedPage({
           resource: { dashboard: dashboard.id },
           params: {},
         });
       });
 
-      filterWidget().click();
-      popover().findByText("Year").click();
-      getDashboardCard().findByText("Created At: Year").should("be.visible");
+      H.filterWidget().click();
+      H.popover().findByText("Year").click();
+      H.getDashboardCard().findByText("Created At: Year").should("be.visible");
     });
   });
 });
@@ -1037,7 +1024,7 @@ function backToDashboard() {
 }
 
 function addTemporalUnitParameter() {
-  setFilter("Time grouping");
+  H.setFilter("Time grouping");
 }
 
 function addQuestion(name) {
@@ -1046,7 +1033,7 @@ function addQuestion(name) {
 }
 
 function removeQuestion() {
-  getDashboardCard().icon("close").click({ force: true });
+  H.getDashboardCard().icon("close").click({ force: true });
 }
 
 function editParameter(name) {
@@ -1068,7 +1055,7 @@ function createDashboardWithMappedQuestion({
       questions: [singleBreakoutQuestionDetails, ...extraQuestions],
     })
     .then(({ dashboard, questions: [card, ...extraCards] }) => {
-      return updateDashboardCards({
+      return H.updateDashboardCards({
         dashboard_id: dashboard.id,
         cards: [
           {
@@ -1083,17 +1070,17 @@ function createDashboardWithMappedQuestion({
 
 function createDashboardWithMultiSeriesCard() {
   return cy.createDashboard(dashboardDetails).then(({ body: dashboard }) => {
-    return createQuestion({
+    return H.createQuestion({
       ...singleBreakoutQuestionDetails,
       name: "Question 1",
       display: "line",
     }).then(({ body: card1 }) => {
-      return createQuestion({
+      return H.createQuestion({
         ...singleBreakoutQuestionDetails,
         name: "Question 2",
         display: "line",
       }).then(({ body: card2 }) => {
-        updateDashboardCards({
+        H.updateDashboardCards({
           dashboard_id: dashboard.id,
           cards: [
             {

--- a/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
@@ -1,3 +1,4 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
@@ -5,32 +6,6 @@ import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  appBar,
-  collectionTable,
-  createAction,
-  filterWidget,
-  getActionCardDetails,
-  getDashboardCard,
-  getDashboardCardMenu,
-  getDashboardCards,
-  getTextCardDetails,
-  modal,
-  nativeEditor,
-  openNotebook,
-  openQuestionsSidebar,
-  popover,
-  queryBuilderHeader,
-  restore,
-  rightSidebar,
-  saveDashboard,
-  setActionsEnabledForDB,
-  sidebar,
-  summarize,
-  visitDashboard,
-  visitDashboardAndCreateTab,
-  visualize,
-} from "e2e/support/helpers";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
 const PG_DB_ID = 2;
@@ -40,9 +15,9 @@ const MAX_XRAY_WAIT_TIMEOUT = 15000;
 
 describe("scenarios > dashboard > dashboard back navigation", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setActionsEnabledForDB(SAMPLE_DB_ID);
+    H.setActionsEnabledForDB(SAMPLE_DB_ID);
 
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("GET", "/api/card/*").as("card");
@@ -58,49 +33,49 @@ describe("scenarios > dashboard > dashboard back navigation", () => {
     const dashboardName = "Orders in a dashboard";
     const backButtonLabel = `Back to ${dashboardName}`;
 
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
     cy.wait("@dashboard");
     cy.findByTestId("dashcard").findByText("Orders").click();
     cy.wait("@cardQuery");
     cy.findByLabelText(backButtonLabel).should("be.visible");
-    openNotebook();
-    summarize({ mode: "notebook" });
-    popover().findByText("Count of rows").click();
+    H.openNotebook();
+    H.summarize({ mode: "notebook" });
+    H.popover().findByText("Count of rows").click();
     cy.findByLabelText(backButtonLabel).should("be.visible");
-    visualize();
+    H.visualize();
     cy.findByLabelText(backButtonLabel).click();
-    modal().button("Discard changes").click();
+    H.modal().button("Discard changes").click();
     cy.findByTestId("dashboard-header")
       .findByText(dashboardName)
       .should("be.visible");
 
-    getDashboardCard().realHover();
-    getDashboardCardMenu().click();
-    popover().findByText("Edit question").click();
+    H.getDashboardCard().realHover();
+    H.getDashboardCardMenu().click();
+    H.popover().findByText("Edit question").click();
     cy.findByLabelText(backButtonLabel).click();
     cy.findByTestId("dashboard-header")
       .findByText(dashboardName)
       .should("be.visible");
 
-    appBar().findByText("Our analytics").click();
+    H.appBar().findByText("Our analytics").click();
     cy.findByTestId("collection-table").findByText("Orders").click();
     cy.findByLabelText(backButtonLabel).should("not.exist");
   });
 
   it("should expand the native editor when editing a question from a dashboard", () => {
     createDashboardWithNativeCard();
-    visitDashboard("@dashboardId");
-    getDashboardCard().realHover();
-    getDashboardCardMenu().click();
-    popover().findByText("Edit question").click();
-    nativeEditor().should("be.visible");
+    H.visitDashboard("@dashboardId");
+    H.getDashboardCard().realHover();
+    H.getDashboardCardMenu().click();
+    H.popover().findByText("Edit question").click();
+    H.nativeEditor().should("be.visible");
 
-    queryBuilderHeader().findByLabelText("Back to Test Dashboard").click();
-    getDashboardCard().findByText("Orders SQL").click();
+    H.queryBuilderHeader().findByLabelText("Back to Test Dashboard").click();
+    H.getDashboardCard().findByText("Orders SQL").click();
     cy.findByTestId("native-query-top-bar")
       .findByText("This question is written in SQL.")
       .should("be.visible");
-    nativeEditor().should("not.be.visible");
+    H.nativeEditor().should("not.be.visible");
   });
 
   it("should display a back to the dashboard button in table x-ray dashboards", () => {
@@ -108,17 +83,17 @@ describe("scenarios > dashboard > dashboard back navigation", () => {
     cy.visit(`/auto/dashboard/table/${ORDERS_ID}?#show=${MAX_CARDS}`);
     cy.wait("@dataset", { timeout: MAX_XRAY_WAIT_TIMEOUT });
 
-    getDashboardCards()
+    H.getDashboardCards()
       .filter(`:contains("${cardTitle}")`)
       .findByText(cardTitle)
       .click();
     cy.wait("@dataset");
 
-    queryBuilderHeader()
+    H.queryBuilderHeader()
       .findByLabelText(/Back to .*Orders.*/)
       .click();
 
-    getDashboardCards().filter(`:contains("${cardTitle}")`).should("exist");
+    H.getDashboardCards().filter(`:contains("${cardTitle}")`).should("exist");
   });
 
   it("should display a back to the dashboard button in model x-ray dashboards", () => {
@@ -127,44 +102,44 @@ describe("scenarios > dashboard > dashboard back navigation", () => {
     cy.visit(`/auto/dashboard/model/${ORDERS_QUESTION_ID}?#show=${MAX_CARDS}`);
     cy.wait("@dataset", { timeout: MAX_XRAY_WAIT_TIMEOUT });
 
-    getDashboardCards()
+    H.getDashboardCards()
       .filter(`:contains("${cardTitle}")`)
       .findByText(cardTitle)
       .click();
     cy.wait("@dataset");
 
-    queryBuilderHeader()
+    H.queryBuilderHeader()
       .findByLabelText(/Back to .*Orders.*/)
       .click();
 
-    getDashboardCards().filter(`:contains("${cardTitle}")`).should("exist");
+    H.getDashboardCards().filter(`:contains("${cardTitle}")`).should("exist");
   });
 
   it("should preserve query results when navigating between the dashboard and the query builder", () => {
     createDashboardWithCards();
-    visitDashboard("@dashboardId");
+    H.visitDashboard("@dashboardId");
     cy.wait("@dashboard");
     cy.wait("@dashcardQuery");
 
-    getDashboardCard().within(() => {
+    H.getDashboardCard().within(() => {
       cy.findByText("110.93").should("be.visible"); // table data
       cy.findByText("Orders").click();
       cy.wait("@cardQuery");
     });
 
-    queryBuilderHeader().findByLabelText("Back to Test Dashboard").click();
+    H.queryBuilderHeader().findByLabelText("Back to Test Dashboard").click();
 
     // cached data
-    getDashboardCard(0).findByText("110.93").should("be.visible");
-    getDashboardCard(1).findByText("Text card").should("be.visible");
-    getDashboardCard(2).findByText("Action card").should("be.visible");
+    H.getDashboardCard(0).findByText("110.93").should("be.visible");
+    H.getDashboardCard(1).findByText("Text card").should("be.visible");
+    H.getDashboardCard(2).findByText("Action card").should("be.visible");
 
     cy.get("@dashboard.all").should("have.length", 1);
     cy.get("@dashcardQuery.all").should("have.length", 1);
 
-    appBar().findByText("Our analytics").click();
+    H.appBar().findByText("Our analytics").click();
 
-    collectionTable().within(() => {
+    H.collectionTable().within(() => {
       cy.findByText("Test Dashboard").click();
       cy.wait("@dashboard");
       cy.wait("@dashcardQuery");
@@ -173,27 +148,27 @@ describe("scenarios > dashboard > dashboard back navigation", () => {
   });
 
   it("should not preserve query results when the question changes during navigation", () => {
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
     cy.wait("@dashboard");
     cy.wait("@dashcardQuery");
 
-    getDashboardCard().within(() => {
+    H.getDashboardCard().within(() => {
       cy.findByText("134.91").should("be.visible"); // table data
       cy.findByText("Orders").click();
       cy.wait("@cardQuery");
     });
 
-    queryBuilderHeader().within(() => {
+    H.queryBuilderHeader().within(() => {
       cy.findByDisplayValue("Orders").clear().type("Orders question").blur();
       cy.wait("@updateCard");
       cy.button("Summarize").click();
     });
 
-    rightSidebar().within(() => {
+    H.rightSidebar().within(() => {
       cy.findByText("Total").click();
     });
 
-    queryBuilderHeader().within(() => {
+    H.queryBuilderHeader().within(() => {
       cy.findByText("Save").click();
     });
 
@@ -202,13 +177,13 @@ describe("scenarios > dashboard > dashboard back navigation", () => {
       cy.wait("@updateCard");
     });
 
-    queryBuilderHeader().within(() => {
+    H.queryBuilderHeader().within(() => {
       cy.findByLabelText("Back to Orders in a dashboard").click();
       cy.wait("@dashcardQuery");
       cy.get("@dashboard.all").should("have.length", 1);
     });
 
-    getDashboardCard().within(() => {
+    H.getDashboardCard().within(() => {
       cy.findByText("Orders question").should("be.visible");
       cy.findByText("Count").should("be.visible"); // aggregated data
     });
@@ -217,43 +192,43 @@ describe("scenarios > dashboard > dashboard back navigation", () => {
   it("should navigate back to a dashboard with permission errors", () => {
     createDashboardWithPermissionError();
     cy.signInAsNormalUser();
-    visitDashboard("@dashboardId");
+    H.visitDashboard("@dashboardId");
     cy.wait("@dashboard");
     cy.wait("@dashcardQuery");
 
-    getDashboardCard(1).findByText(PERMISSION_ERROR);
-    getDashboardCard(0).findByText("Orders 1").click();
+    H.getDashboardCard(1).findByText(PERMISSION_ERROR);
+    H.getDashboardCard(0).findByText("Orders 1").click();
     cy.wait("@card");
 
-    queryBuilderHeader()
+    H.queryBuilderHeader()
       .findByLabelText("Back to Orders in a dashboard")
       .click();
 
-    getDashboardCard(1).findByText(PERMISSION_ERROR);
+    H.getDashboardCard(1).findByText(PERMISSION_ERROR);
     cy.get("@dashboard.all").should("have.length", 1);
     cy.get("@dashcardQuery.all").should("have.length", 1);
   });
 
   it("should return to dashboard with specific tab selected", () => {
-    visitDashboardAndCreateTab({
+    H.visitDashboardAndCreateTab({
       dashboardId: ORDERS_DASHBOARD_ID,
       save: false,
     });
 
     // Add card to second tab
     cy.icon("pencil").click();
-    openQuestionsSidebar();
-    sidebar().within(() => {
+    H.openQuestionsSidebar();
+    H.sidebar().within(() => {
       cy.findByText("Orders, Count").click();
     });
-    saveDashboard();
+    H.saveDashboard();
 
-    getDashboardCard().within(() => {
+    H.getDashboardCard().within(() => {
       cy.findByText("Orders, Count").click();
       cy.wait("@card");
     });
 
-    queryBuilderHeader()
+    H.queryBuilderHeader()
       .findByLabelText("Back to Orders in a dashboard")
       .click();
 
@@ -266,7 +241,7 @@ describe(
   { tags: ["@external", "@actions"] },
   () => {
     beforeEach(() => {
-      restore("postgres-12");
+      H.restore("postgres-12");
       cy.signInAsAdmin();
       cy.intercept("GET", "/api/dashboard/*").as("dashboard");
       cy.intercept("GET", "/api/card/*").as("card");
@@ -288,7 +263,7 @@ describe(
       // initial loading of the dashboard with card
       cy.get("@dashcardQuery.all").should("have.length", 1);
 
-      filterWidget().findByPlaceholderText("sleep").clear().type("1{enter}");
+      H.filterWidget().findByPlaceholderText("sleep").clear().type("1{enter}");
 
       cy.wait("@dashcardQuery");
 
@@ -296,22 +271,22 @@ describe(
       cy.get("@dashcardQuery.all").should("have.length", 2);
 
       cy.log("drill down to the question");
-      getDashboardCard().within(() => {
+      H.getDashboardCard().within(() => {
         cy.findByText("Sleep card").click();
       });
 
-      filterWidget().findByPlaceholderText("sleep").should("have.value", "1");
+      H.filterWidget().findByPlaceholderText("sleep").should("have.value", "1");
       // if we do not wait for this query, it's canceled and re-trigered on dashboard
       cy.wait("@card");
 
       cy.log("navigate back to the dashboard");
-      queryBuilderHeader().findByLabelText("Back to Sleep dashboard").click();
+      H.queryBuilderHeader().findByLabelText("Back to Sleep dashboard").click();
 
-      getDashboardCard().within(() => {
+      H.getDashboardCard().within(() => {
         cy.findByText("Sleep card").should("be.visible");
       });
 
-      filterWidget().findByPlaceholderText("sleep").should("have.value", "1");
+      H.filterWidget().findByPlaceholderText("sleep").should("have.value", "1");
 
       // cached data is used, no re-fetching should happen
       cy.get("@dashcardQuery.all").should("have.length", 2);
@@ -330,17 +305,17 @@ describe(
       });
       cy.wait("@dashboard");
 
-      getDashboardCard().within(() => {
+      H.getDashboardCard().within(() => {
         cy.findByTestId("loading-indicator").should("be.visible");
         cy.findByText("Sleep card").click();
         cy.wait("@card");
       });
 
-      queryBuilderHeader().within(() => {
+      H.queryBuilderHeader().within(() => {
         cy.findByLabelText("Back to Sleep dashboard").click();
       });
 
-      getDashboardCard().within(() => {
+      H.getDashboardCard().within(() => {
         cy.findByText("Sleep card").should("be.visible");
       });
 
@@ -392,13 +367,13 @@ const createDashboardWithCards = () => {
   cy.createDashboard().then(({ body: { id: dashboard_id } }) => {
     cy.createQuestion(questionDetails).then(({ body: { id: question_id } }) => {
       cy.createQuestion(modelDetails).then(({ body: { id: model_id } }) => {
-        createAction({ ...actionDetails, model_id }).then(
+        H.createAction({ ...actionDetails, model_id }).then(
           ({ body: { id: action_id } }) => {
             cy.request("PUT", `/api/dashboard/${dashboard_id}`, {
               dashcards: [
                 { id: -1, card_id: question_id, ...questionDashcardDetails },
-                getTextCardDetails({ id: -2, size_y: 1 }),
-                getActionCardDetails({ id: -3, action_id }),
+                H.getTextCardDetails({ id: -2, size_y: 1 }),
+                H.getActionCardDetails({ id: -3, action_id }),
               ],
             });
           },

--- a/e2e/test/scenarios/dashboard/dashboard-management.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-management.cy.spec.js
@@ -1,24 +1,8 @@
 import { onlyOn } from "@cypress/skip-test";
 
+import { H } from "e2e/support";
 import { USERS } from "e2e/support/cypress_data";
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  appBar,
-  closeDashboardInfoSidebar,
-  collectionOnTheGoModal,
-  entityPickerModal,
-  getDashboardCard,
-  modal,
-  navigationSidebar,
-  openDashboardInfoSidebar,
-  openDashboardMenu,
-  openNavigationSidebar,
-  popover,
-  restore,
-  sidesheet,
-  undoToast,
-  visitDashboard,
-} from "e2e/support/helpers";
 
 const PERMISSIONS = {
   curate: ["admin", "normal", "nodata"],
@@ -36,7 +20,7 @@ const dashboardName = "FooBar";
 
 describe("managing dashboard from the dashboard's edit menu", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
   });
 
   Object.entries(PERMISSIONS).forEach(([permission, userGroup]) => {
@@ -60,11 +44,11 @@ describe("managing dashboard from the dashboard's edit menu", () => {
 
                 cy.signIn(user);
 
-                visitDashboard(dashboard_id);
+                H.visitDashboard(dashboard_id);
                 assertOnRequest("getDashboard");
               });
 
-              openDashboardMenu();
+              H.openDashboardMenu();
             });
 
             it("should be able to change title and description", () => {
@@ -72,13 +56,13 @@ describe("managing dashboard from the dashboard's edit menu", () => {
               assertOnRequest("updateDashboard");
               assertOnRequest("getDashboard");
 
-              openDashboardInfoSidebar();
+              H.openDashboardInfoSidebar();
 
-              sidesheet()
+              H.sidesheet()
                 .findByPlaceholderText("Add description")
                 .type("Foo")
                 .blur();
-              closeDashboardInfoSidebar();
+              H.closeDashboardInfoSidebar();
 
               assertOnRequest("updateDashboard");
               assertOnRequest("getDashboard");
@@ -99,10 +83,13 @@ describe("managing dashboard from the dashboard's edit menu", () => {
                 const newQuestionName = `${originalQuestionName} - Duplicate`;
                 const newDashboardId = id + 1;
 
-                popover().findByText("Duplicate").should("be.visible").click();
+                H.popover()
+                  .findByText("Duplicate")
+                  .should("be.visible")
+                  .click();
                 cy.location("pathname").should("eq", `/dashboard/${id}/copy`);
 
-                modal().within(() => {
+                H.modal().within(() => {
                   cy.findByRole("heading", {
                     name: `Duplicate "${dashboardName}" and its questions`,
                   });
@@ -122,7 +109,7 @@ describe("managing dashboard from the dashboard's edit menu", () => {
                 cy.url().should("contain", `/dashboard/${newDashboardId}`);
 
                 cy.findByDisplayValue(newDashboardName);
-                appBar().findByText("Our analytics").click();
+                H.appBar().findByText("Our analytics").click();
 
                 cy.findAllByTestId("collection-entry-name")
                   .should("contain", dashboardName)
@@ -142,10 +129,13 @@ describe("managing dashboard from the dashboard's edit menu", () => {
                 const newQuestionName = `${originalQuestionName} - Duplicate`;
                 const newDashboardId = id + 1;
 
-                popover().findByText("Duplicate").should("be.visible").click();
+                H.popover()
+                  .findByText("Duplicate")
+                  .should("be.visible")
+                  .click();
                 cy.location("pathname").should("eq", `/dashboard/${id}/copy`);
 
-                modal().within(() => {
+                H.modal().within(() => {
                   cy.findByRole("heading", {
                     name: `Duplicate "${dashboardName}" and its questions`,
                   });
@@ -160,7 +150,7 @@ describe("managing dashboard from the dashboard's edit menu", () => {
                 cy.url().should("contain", `/dashboard/${newDashboardId}`);
 
                 cy.findByDisplayValue(newDashboardName);
-                appBar().findByText("Our analytics").click();
+                H.appBar().findByText("Our analytics").click();
 
                 cy.findAllByTestId("collection-entry-name")
                   .should("contain", dashboardName)
@@ -180,10 +170,13 @@ describe("managing dashboard from the dashboard's edit menu", () => {
                 const newQuestionName = originalQuestionName;
                 const newDashboardId = id + 1;
 
-                popover().findByText("Duplicate").should("be.visible").click();
+                H.popover()
+                  .findByText("Duplicate")
+                  .should("be.visible")
+                  .click();
                 cy.location("pathname").should("eq", `/dashboard/${id}/copy`);
 
-                modal().within(() => {
+                H.modal().within(() => {
                   cy.findByRole("heading", {
                     name: `Duplicate "${dashboardName}" and its questions`,
                   });
@@ -196,16 +189,16 @@ describe("managing dashboard from the dashboard's edit menu", () => {
 
                 if (user === "admin") {
                   // admin has recents tab
-                  entityPickerModal()
+                  H.entityPickerModal()
                     .findByRole("tab", { name: /Collections/ })
                     .click();
                 }
 
-                entityPickerModal()
+                H.entityPickerModal()
                   .findByText("Create a new collection")
                   .click();
                 const NEW_COLLECTION = "Foo Collection";
-                collectionOnTheGoModal().within(() => {
+                H.collectionOnTheGoModal().within(() => {
                   cy.findByPlaceholderText("My new collection").type(
                     NEW_COLLECTION,
                   );
@@ -218,13 +211,13 @@ describe("managing dashboard from the dashboard's edit menu", () => {
                 cy.url().should("contain", `/dashboard/${newDashboardId}`);
 
                 cy.findByDisplayValue(newDashboardName);
-                appBar().findByText(NEW_COLLECTION).click();
+                H.appBar().findByText(NEW_COLLECTION).click();
                 cy.findAllByTestId("collection-entry-name")
                   .should("contain", newDashboardName)
                   .and("contain", newQuestionName);
 
-                openNavigationSidebar();
-                navigationSidebar().findByText("Our analytics").click();
+                H.openNavigationSidebar();
+                H.navigationSidebar().findByText("Our analytics").click();
                 cy.findAllByTestId("collection-entry-name")
                   .should("contain", dashboardName)
                   .and("contain", originalQuestionName);
@@ -233,39 +226,39 @@ describe("managing dashboard from the dashboard's edit menu", () => {
 
             it("should be able to move/undo move a dashboard (metabase#13059, metabase#25705)", () => {
               cy.get("@originalDashboardId").then(id => {
-                appBar().contains("Our analytics");
+                H.appBar().contains("Our analytics");
 
-                popover().findByText("Move").click();
+                H.popover().findByText("Move").click();
                 cy.location("pathname").should("eq", `/dashboard/${id}/move`);
 
-                entityPickerModal().within(() => {
+                H.entityPickerModal().within(() => {
                   cy.findByText("First collection").click();
                   cy.button("Move").click();
                 });
 
                 assertOnRequest("updateDashboard");
-                getDashboardCard().contains("42");
+                H.getDashboardCard().contains("42");
 
                 cy.log(
                   "it should update dashboard's collection after the move without the page reload (metabase#13059)",
                 );
-                appBar().contains("First collection");
-                appBar().should("not.contain", "Our analytics");
+                H.appBar().contains("First collection");
+                H.appBar().should("not.contain", "Our analytics");
 
-                undoToast().within(() => {
+                H.undoToast().within(() => {
                   cy.contains("Dashboard moved to First collection");
                   cy.button("Undo").click();
                 });
                 assertOnRequest("updateDashboard");
 
-                appBar().contains("Our analytics");
-                appBar().should("not.contain", "First collection");
+                H.appBar().contains("Our analytics");
+                H.appBar().should("not.contain", "First collection");
               });
             });
 
             it("should be able to archive/unarchive a dashboard", () => {
               cy.get("@originalDashboardId").then(id => {
-                popover()
+                H.popover()
                   .findByText("Move to trash")
                   .should("be.visible")
                   .click();
@@ -274,7 +267,7 @@ describe("managing dashboard from the dashboard's edit menu", () => {
                   "eq",
                   `/dashboard/${id}/archive`,
                 );
-                modal().within(() => {
+                H.modal().within(() => {
                   cy.findByRole("heading", {
                     name: "Move this dashboard to trash?",
                   }); //Without this, there is some race condition and the button click fails
@@ -286,7 +279,7 @@ describe("managing dashboard from the dashboard's edit menu", () => {
 
                 cy.findByTestId("archive-banner").should("exist");
 
-                undoToast().within(() => {
+                H.undoToast().within(() => {
                   cy.findByText("FooBar has been moved to the trash.");
                   cy.button("Undo").click();
                   assertOnRequest("updateDashboard");
@@ -306,7 +299,7 @@ describe("managing dashboard from the dashboard's edit menu", () => {
           beforeEach(() => {
             cy.signIn(user);
 
-            visitDashboard(ORDERS_DASHBOARD_ID);
+            H.visitDashboard(ORDERS_DASHBOARD_ID);
 
             cy.get("main header").within(() => {
               cy.icon("ellipsis").should("be.visible").click();
@@ -314,15 +307,17 @@ describe("managing dashboard from the dashboard's edit menu", () => {
           });
 
           it("should not be offered to edit dashboard details or archive the dashboard for dashboard in collections they have `read` access to (metabase#15280)", () => {
-            popover().findByText("Edit dashboard details").should("not.exist");
+            H.popover()
+              .findByText("Edit dashboard details")
+              .should("not.exist");
 
-            popover().findByText("Move to trash").should("not.exist");
+            H.popover().findByText("Move to trash").should("not.exist");
           });
 
           it("should be offered to duplicate dashboard in collections they have `read` access to", () => {
             const { first_name, last_name } = USERS[user];
 
-            popover().findByText("Duplicate").click();
+            H.popover().findByText("Duplicate").click();
             cy.findByTestId("collection-picker-button").should(
               "have.text",
               `${first_name} ${last_name}'s Personal Collection`,
@@ -341,5 +336,5 @@ function assertOnRequest(xhr_alias) {
   cy.findByText("Sorry, you don’t have permission to see that.").should(
     "not.exist",
   );
-  modal().should("not.exist");
+  H.modal().should("not.exist");
 }

--- a/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
@@ -1,57 +1,13 @@
 import { assoc } from "icepick";
 import _ from "underscore";
 
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, USERS, USER_GROUPS } from "e2e/support/cypress_data";
 import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  addTextBox,
-  appBar,
-  assertDatasetReqIsSandboxed,
-  assertQueryBuilderRowCount,
-  assertTabSelected,
-  cartesianChartCircle,
-  closeDashboardInfoSidebar,
-  closeDashboardSettingsSidebar,
-  createDashboard,
-  createDashboardWithTabs,
-  createSegment,
-  dashboardGrid,
-  dashboardHeader,
-  dashboardParametersContainer,
-  describeEE,
-  editDashboard,
-  entityPickerModal,
-  filterWidget,
-  getDashboardCard,
-  getDashboardCards,
-  getTextCardDetails,
-  goToTab,
-  main,
-  modal,
-  navigationSidebar,
-  openDashboardInfoSidebar,
-  openDashboardSettingsSidebar,
-  openQuestionsSidebar,
-  popover,
-  queryBuilderHeader,
-  removeDashboardCard,
-  restore,
-  saveDashboard,
-  setFilter,
-  setTokenFeatures,
-  showDashboardCardActions,
-  sidebar,
-  sidesheet,
-  undo,
-  undoToast,
-  updateDashboardCards,
-  visitDashboard,
-  visitQuestion,
-} from "e2e/support/helpers";
 import { DASHBOARD_SLOW_TIMEOUT } from "metabase/dashboard/constants";
 import {
   createMockDashboardCard,
@@ -76,7 +32,7 @@ describe("issue 12578", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -84,14 +40,14 @@ describe("issue 12578", () => {
     cy.clock(Date.now());
     cy.createQuestionAndDashboard({ questionDetails: ORDERS_QUESTION }).then(
       ({ body: { dashboard_id } }) => {
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       },
     );
 
     // Without tick the dashboard header will not load
     cy.tick();
     cy.findByLabelText("Auto Refresh").click();
-    popover().findByText("1 minute").click();
+    H.popover().findByText("1 minute").click();
 
     // Mock slow card request
     cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query", req => {
@@ -149,9 +105,9 @@ describe("issue 12926", () => {
   }
 
   function removeCard() {
-    editDashboard();
+    H.editDashboard();
 
-    showDashboardCardActions();
+    H.showDashboardCardActions();
 
     cy.findByTestId("dashboardcard-actions-panel")
       .findByLabelText("close icon")
@@ -159,7 +115,7 @@ describe("issue 12926", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -195,25 +151,25 @@ describe("issue 12926", () => {
 
       restoreDashcardQuery();
 
-      undo();
+      H.undo();
 
       cy.wait("@dashcardQueryRestored");
 
-      getDashboardCard().findByText(queryResult);
+      H.getDashboardCard().findByText(queryResult);
     });
 
     it("should not break virtual cards (metabase#35545)", () => {
       cy.createDashboard().then(({ body: { id: dashboardId } }) => {
-        visitDashboard(dashboardId);
+        H.visitDashboard(dashboardId);
       });
 
-      addTextBox("Text card content");
+      H.addTextBox("Text card content");
 
-      removeDashboardCard();
+      H.removeDashboardCard();
 
-      undo();
+      H.undo();
 
-      getDashboardCard().findByText("Text card content");
+      H.getDashboardCard().findByText("Text card content");
     });
   });
 
@@ -223,31 +179,31 @@ describe("issue 12926", () => {
       cy.createNativeQuestion(questionDetails);
 
       cy.createDashboard().then(({ body: { id: dashboardId } }) => {
-        visitDashboard(dashboardId);
+        H.visitDashboard(dashboardId);
       });
 
-      editDashboard();
+      H.editDashboard();
 
-      openQuestionsSidebar();
+      H.openQuestionsSidebar();
       // when the card is added to a dashboard, it doesn't use the dashcard endpoint but instead uses the card one
       slowDownCardQuery("cardQuerySlowed");
-      sidebar().findByText(questionDetails.name).click();
+      H.sidebar().findByText(questionDetails.name).click();
 
-      setFilter("Number", "Equal to");
-      sidebar().findByText("No default").click();
-      popover().findByPlaceholderText("Enter a number").type(parameterValue);
-      popover().findByText("Add filter").click();
+      H.setFilter("Number", "Equal to");
+      H.sidebar().findByText("No default").click();
+      H.popover().findByPlaceholderText("Enter a number").type(parameterValue);
+      H.popover().findByText("Add filter").click();
 
-      getDashboardCard().findByText("Select…").click();
-      popover().contains(filterDisplayName).eq(0).click();
+      H.getDashboardCard().findByText("Select…").click();
+      H.popover().contains(filterDisplayName).eq(0).click();
 
-      saveDashboard();
+      H.saveDashboard();
 
       cy.wait("@cardQuerySlowed").then(xhrProxy =>
         expect(xhrProxy.state).to.eq("Errored"),
       );
 
-      getDashboardCard().findByText(queryResult + parameterValue);
+      H.getDashboardCard().findByText(queryResult + parameterValue);
     });
   });
 });
@@ -262,7 +218,7 @@ describe("issue 13736", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -299,7 +255,7 @@ describe("issue 13736", () => {
         },
       );
 
-      updateDashboardCards({
+      H.updateDashboardCards({
         dashboard_id: dashboardId,
         cards: [
           {
@@ -311,14 +267,14 @@ describe("issue 13736", () => {
           },
         ],
       });
-      visitDashboard(dashboardId);
+      H.visitDashboard(dashboardId);
     });
 
-    getDashboardCards()
+    H.getDashboardCards()
       .eq(0)
       .findByText("There was a problem displaying this chart.");
 
-    getDashboardCards().eq(1).findByText("18,760").should("be.visible");
+    H.getDashboardCards().eq(1).findByText("18,760").should("be.visible");
   });
 });
 
@@ -328,11 +284,11 @@ describe("issue 16559", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    createDashboard(dashboardDetails).then(response => {
-      visitDashboard(response.body.id);
+    H.createDashboard(dashboardDetails).then(response => {
+      H.visitDashboard(response.body.id);
     });
 
     cy.intercept("GET", "/api/collection/tree?*").as("getCollections");
@@ -341,8 +297,8 @@ describe("issue 16559", () => {
   });
 
   it("should always show the most recent revision (metabase#16559)", () => {
-    openDashboardInfoSidebar();
-    sidesheet().within(() => {
+    H.openDashboardInfoSidebar();
+    H.sidesheet().within(() => {
       cy.findByRole("tab", { name: "History" }).click();
       cy.log("Dashboard creation");
       cy.findByTestId("dashboard-history-list")
@@ -351,18 +307,18 @@ describe("issue 16559", () => {
         .findByText("You created this.")
         .should("be.visible");
     });
-    closeDashboardInfoSidebar();
+    H.closeDashboardInfoSidebar();
 
     cy.log("Edit dashboard");
-    editDashboard();
-    openQuestionsSidebar();
-    sidebar().findByText("Orders, Count").click();
+    H.editDashboard();
+    H.openQuestionsSidebar();
+    H.sidebar().findByText("Orders, Count").click();
     cy.wait("@cardQuery");
     cy.button("Save").click();
     cy.wait("@saveDashboard");
 
-    openDashboardInfoSidebar();
-    sidesheet().within(() => {
+    H.openDashboardInfoSidebar();
+    H.sidesheet().within(() => {
       cy.findByRole("tab", { name: "History" }).click();
       cy.findByTestId("dashboard-history-list")
         .findAllByRole("listitem")
@@ -370,14 +326,14 @@ describe("issue 16559", () => {
         .findByText("You added a card.")
         .should("be.visible");
     });
-    closeDashboardInfoSidebar();
+    H.closeDashboardInfoSidebar();
 
     cy.log("Change dashboard name");
     cy.findByTestId("dashboard-name-heading").click().type(" modified").blur();
     cy.wait("@saveDashboard");
 
-    openDashboardInfoSidebar();
-    sidesheet().within(() => {
+    H.openDashboardInfoSidebar();
+    H.sidesheet().within(() => {
       cy.findByRole("tab", { name: "History" }).click();
 
       cy.findByTestId("dashboard-history-list")
@@ -407,15 +363,15 @@ describe("issue 16559", () => {
 
       cy.log("Toggle auto-apply filters");
     });
-    closeDashboardInfoSidebar();
+    H.closeDashboardInfoSidebar();
 
-    openDashboardSettingsSidebar();
-    sidesheet().findByText("Auto-apply filters").click();
+    H.openDashboardSettingsSidebar();
+    H.sidesheet().findByText("Auto-apply filters").click();
     cy.wait("@saveDashboard");
-    closeDashboardSettingsSidebar();
+    H.closeDashboardSettingsSidebar();
 
-    openDashboardInfoSidebar();
-    sidesheet().within(() => {
+    H.openDashboardInfoSidebar();
+    H.sidesheet().within(() => {
       cy.findByRole("tab", { name: "History" }).click();
 
       cy.findByTestId("dashboard-history-list")
@@ -424,19 +380,19 @@ describe("issue 16559", () => {
         .findByText("You set auto apply filters to false.")
         .should("be.visible");
     });
-    closeDashboardInfoSidebar();
+    H.closeDashboardInfoSidebar();
 
     cy.log("Move dashboard to another collection");
-    dashboardHeader().icon("ellipsis").click();
-    popover().findByText("Move").click();
-    entityPickerModal().within(() => {
+    H.dashboardHeader().icon("ellipsis").click();
+    H.popover().findByText("Move").click();
+    H.entityPickerModal().within(() => {
       cy.findByText("First collection").click();
       cy.button("Move").click();
       cy.wait(["@saveDashboard", "@getCollections"]);
     });
 
-    openDashboardInfoSidebar();
-    sidesheet().within(() => {
+    H.openDashboardInfoSidebar();
+    H.sidesheet().within(() => {
       cy.findByRole("tab", { name: "History" }).click();
       cy.findByTestId("dashboard-history-list")
         .findAllByRole("listitem")
@@ -497,10 +453,10 @@ describe("issue 17879", () => {
         `/api/dashboard/${dashboard.id}/dashcard/*/card/*/query`,
       ).as("getCardQuery");
 
-      visitDashboard(dashboard.id);
-      editDashboard(dashboard.id);
+      H.visitDashboard(dashboard.id);
+      H.editDashboard(dashboard.id);
 
-      showDashboardCardActions();
+      H.showDashboardCardActions();
       cy.findByTestId("dashboardcard-actions-panel").icon("click").click();
 
       cy.findByText("Go to a custom destination").click();
@@ -508,7 +464,7 @@ describe("issue 17879", () => {
       cy.findByText("Q1 - 17879").click();
       cy.findByText("Created At").click();
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText(
           "Created At: " + capitalize(sourceDateUnit.replace(/-/g, " ")),
         ).click();
@@ -516,12 +472,12 @@ describe("issue 17879", () => {
 
       cy.findByText("Done").click();
 
-      saveDashboard();
+      H.saveDashboard();
 
       cy.wait("@getCardQuery");
 
       cy.findByTestId("visualization-root").within(() => {
-        cartesianChartCircle().first().click({ force: true });
+        H.cartesianChartCircle().first().click({ force: true });
       });
 
       cy.url().should("include", "/question");
@@ -534,7 +490,7 @@ describe("issue 17879", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
@@ -574,7 +530,7 @@ describe("issue 17879", () => {
 
 describe("issue 21830", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -598,10 +554,10 @@ describe("issue 21830", () => {
     cy.wait("@getDashboard");
 
     // it's crucial that we try to click on this icon BEFORE we wait for the `getCardQuery` response!
-    editDashboard();
-    showDashboardCardActions();
+    H.editDashboard();
+    H.showDashboardCardActions();
 
-    getDashboardCard().within(() => {
+    H.getDashboardCard().within(() => {
       cy.icon("close").should("be.visible");
       cy.icon("click").should("not.exist");
       cy.icon("palette").should("not.exist");
@@ -609,7 +565,7 @@ describe("issue 21830", () => {
 
     cy.wait("@getCardQuery");
 
-    getDashboardCard().within(() => {
+    H.getDashboardCard().within(() => {
       cy.icon("close").should("be.visible");
       cy.icon("click").should("be.visible");
       cy.icon("palette").should("be.visible");
@@ -643,7 +599,7 @@ describe("issue 28756", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createCollection({ name: RESTRICTED_COLLECTION_NAME }).then(
@@ -677,23 +633,23 @@ describe("issue 28756", () => {
     cy.clock();
 
     cy.get("@dashboardId").then(dashboardId => {
-      visitDashboard(dashboardId);
+      H.visitDashboard(dashboardId);
       cy.tick(TOAST_TIMEOUT);
 
-      undoToast().should("not.exist");
+      H.undoToast().should("not.exist");
       cy.findByText(TOAST_MESSAGE).should("not.exist");
     });
   });
 });
 
-describeEE("issue 29076", () => {
+H.describeEE("issue 29076", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
 
     cy.intercept("/api/dashboard/*/dashcard/*/card/*/query").as("cardQuery");
 
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
 
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
@@ -719,17 +675,17 @@ describeEE("issue 29076", () => {
   });
 
   it("should be able to drilldown to a saved question in a dashboard with sandboxing (metabase#29076)", () => {
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
     cy.wait("@cardQuery");
     // test that user is sandboxed - normal users has over 2000 rows
-    getDashboardCard().find("tbody > tr").should("have.length", 1);
+    H.getDashboardCard().find("tbody > tr").should("have.length", 1);
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Visualization").should("be.visible");
-    assertQueryBuilderRowCount(1); // test that user is sandboxed - normal users has over 2000 rows
-    assertDatasetReqIsSandboxed({
+    H.assertQueryBuilderRowCount(1); // test that user is sandboxed - normal users has over 2000 rows
+    H.assertDatasetReqIsSandboxed({
       requestAlias: "@cardQuery",
       columnId: ORDERS.USER_ID,
       columnAssertion: USERS.sandboxed.login_attributes.attr_uid,
@@ -740,7 +696,7 @@ describeEE("issue 29076", () => {
 describe("issue 31274", () => {
   const createTextCards = length => {
     return Array.from({ length }).map((_, index) => {
-      return getTextCardDetails({
+      return H.getTextCardDetails({
         size_x: 2,
         size_y: 2,
         row: (length - index - 1) * 2,
@@ -754,7 +710,7 @@ describe("issue 31274", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -765,12 +721,12 @@ describe("issue 31274", () => {
         dashcards,
       });
 
-      visitDashboard(dashboard.id);
-      editDashboard(dashboard.id);
+      H.visitDashboard(dashboard.id);
+      H.editDashboard(dashboard.id);
 
-      assertTabSelected("Tab 1");
+      H.assertTabSelected("Tab 1");
 
-      getDashboardCard(1).realHover({
+      H.getDashboardCard(1).realHover({
         scrollBehavior: false, // prevents flaky tests
       });
 
@@ -789,12 +745,12 @@ describe("issue 31274", () => {
 
   it("renders cross icon on the link card without clipping", () => {
     cy.createDashboard().then(({ body: dashboard }) => {
-      visitDashboard(dashboard.id);
-      editDashboard(dashboard.id);
+      H.visitDashboard(dashboard.id);
+      H.editDashboard(dashboard.id);
     });
 
     cy.findByLabelText("Add a link or iframe").click();
-    popover().findByText("Link").click();
+    H.popover().findByText("Link").click();
     cy.findByPlaceholderText("https://example.com").realHover();
 
     cy.log(
@@ -836,19 +792,19 @@ describe("issue 31697", () => {
   });
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    createSegment(segmentDetails).then(({ body: segment }) => {
+    H.createSegment(segmentDetails).then(({ body: segment }) => {
       cy.createQuestion(getQuestionDetails(segment), { wrapId: true });
     });
     cy.intercept("GET", "/api/automagic-dashboards/**").as("xrayDashboard");
   });
 
   it("should allow x-rays for questions with segments (metabase#31697)", () => {
-    cy.get("@questionId").then(visitQuestion);
-    cartesianChartCircle().eq(0).click();
-    popover().findByText("Automatic insights…").click();
-    popover().findByText("X-ray").click();
+    cy.get("@questionId").then(H.visitQuestion);
+    H.cartesianChartCircle().eq(0).click();
+    H.popover().findByText("Automatic insights…").click();
+    H.popover().findByText("X-ray").click();
     cy.wait("@xrayDashboard");
 
     cy.findByRole("main").within(() => {
@@ -869,11 +825,11 @@ describe("issue 31766", () => {
 
   function assertQuestionIsUpdatedWithoutError() {
     cy.wait("@updateQuestion");
-    modal().should("not.exist");
+    H.modal().should("not.exist");
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -890,7 +846,7 @@ describe("issue 31766", () => {
       dashboardDetails,
       cardDetails: { size_x: 16, size_y: 8 },
     }).then(({ body: { dashboard_id, question_id, id: dashcard_id } }) => {
-      const textCard = getTextCardDetails({
+      const textCard = H.getTextCardDetails({
         row: 0,
         size_x: 24,
         size_y: 1,
@@ -904,16 +860,16 @@ describe("issue 31766", () => {
         card_id: question_id,
       };
 
-      updateDashboardCards({ dashboard_id, cards: [textCard, questionCard] });
+      H.updateDashboardCards({ dashboard_id, cards: [textCard, questionCard] });
 
-      visitDashboard(dashboard_id);
-      editDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
+      H.editDashboard(dashboard_id);
     });
 
     // update text card
     cy.findByTestId("editing-dashboard-text-preview").type(1);
 
-    saveDashboard();
+    H.saveDashboard();
 
     // visit question
     cy.findAllByTestId("dashcard").eq(1).findByText("Orders").click();
@@ -991,15 +947,15 @@ describe("issue 34382", () => {
   };
 
   function addFilterValue(value) {
-    filterWidget().click();
-    popover().within(() => {
+    H.filterWidget().click();
+    H.popover().within(() => {
       cy.findByText(value).click();
       cy.findByRole("button", { name: "Add filter" }).click();
     });
   }
 
   function applyFilter() {
-    dashboardParametersContainer()
+    H.dashboardParametersContainer()
       .findByRole("button", { name: "Apply" })
       .click();
 
@@ -1007,7 +963,7 @@ describe("issue 34382", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
 
     cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
@@ -1017,23 +973,23 @@ describe("issue 34382", () => {
 
   it("should preserve filter value when navigating between the dashboard and the query builder with auto-apply disabled (metabase#34382)", () => {
     createDashboardWithCards();
-    visitDashboard("@dashboardId");
+    H.visitDashboard("@dashboardId");
 
     addFilterValue("Gizmo");
     applyFilter();
 
     cy.log("Navigate to Products question");
-    getDashboardCard().findByText("Products").click();
+    H.getDashboardCard().findByText("Products").click();
 
     cy.log("Navigate back to dashboard");
-    queryBuilderHeader()
+    H.queryBuilderHeader()
       .findByLabelText("Back to Products in a dashboard")
       .click();
 
     cy.location("search").should("eq", "?category=Gizmo");
-    filterWidget().contains("Gizmo");
+    H.filterWidget().contains("Gizmo");
 
-    getDashboardCard().within(() => {
+    H.getDashboardCard().within(() => {
       // only products with category "Gizmo" are filtered
       cy.findAllByTestId("table-row")
         .find("td")
@@ -1048,22 +1004,22 @@ describe("should not redirect users to other pages when linking an entity (metab
   const TEST_QUESTION_NAME = "Question#35037";
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("GET", "/api/search?q=*").as("search");
     cy.intercept("GET", "/api/activity/recents?*").as("recentViews");
   });
 
   it("should not redirect users to recent item", () => {
-    visitDashboard(ORDERS_DASHBOARD_ID);
-    editDashboard();
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.editDashboard();
 
     cy.url().then(url => {
       cy.wrap(url).as("originUrl");
     });
 
     cy.icon("link").click();
-    popover().findByText("Link").click();
+    H.popover().findByText("Link").click();
     cy.wait("@recentViews");
 
     cy.findByTestId("recents-list-container").within(() => {
@@ -1086,15 +1042,15 @@ describe("should not redirect users to other pages when linking an entity (metab
       name: TEST_QUESTION_NAME,
       native: { query: "SELECT 1" },
     });
-    visitDashboard(ORDERS_DASHBOARD_ID);
-    editDashboard();
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.editDashboard();
 
     cy.url().then(url => {
       cy.wrap(url).as("originUrl");
     });
 
     cy.icon("link").click();
-    popover().findByText("Link").click();
+    H.popover().findByText("Link").click();
     cy.findByTestId("custom-edit-text-link").type(TEST_QUESTION_NAME);
     cy.findByTestId("search-results-list").within(() => {
       cy.findByText(TEST_QUESTION_NAME).click();
@@ -1293,19 +1249,19 @@ describe("issue 39863", () => {
 
   function setDateFilter() {
     cy.findByLabelText("Date filter").click();
-    popover()
+    H.popover()
       .findByText(/Last 12 months/i)
       .click();
   }
 
   function assertNoLoadingSpinners() {
-    dashboardGrid()
+    H.dashboardGrid()
       .findAllByTestId("loading-indicator")
       .should("have.length", 0);
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
       "dashcardQuery",
@@ -1313,7 +1269,7 @@ describe("issue 39863", () => {
   });
 
   it("should not rerun queries when switching tabs and there are no parameter changes", () => {
-    createDashboardWithTabs({
+    H.createDashboardWithTabs({
       tabs: [TAB_1, TAB_2],
       parameters: [DATE_FILTER],
       dashcards: [
@@ -1328,7 +1284,7 @@ describe("issue 39863", () => {
           dashboard_tab_id: TAB_2.id,
         }),
       ],
-    }).then(dashboard => visitDashboard(dashboard.id));
+    }).then(dashboard => H.visitDashboard(dashboard.id));
 
     // Initial query for 1st tab
     cy.wait("@dashcardQuery");
@@ -1336,13 +1292,13 @@ describe("issue 39863", () => {
     cy.get("@dashcardQuery.all").should("have.length", 1);
 
     // Initial query for 2nd tab
-    goToTab(TAB_2.name);
+    H.goToTab(TAB_2.name);
     cy.wait("@dashcardQuery");
     assertNoLoadingSpinners();
     cy.get("@dashcardQuery.all").should("have.length", 2);
 
     // No parameters change, no query rerun
-    goToTab(TAB_1.name);
+    H.goToTab(TAB_1.name);
     assertNoLoadingSpinners();
     cy.get("@dashcardQuery.all").should("have.length", 2);
 
@@ -1353,20 +1309,20 @@ describe("issue 39863", () => {
     cy.get("@dashcardQuery.all").should("have.length", 3);
 
     // Rerun 2nd tab query with new parameters
-    goToTab(TAB_2.name);
+    H.goToTab(TAB_2.name);
     cy.wait("@dashcardQuery");
     assertNoLoadingSpinners();
     cy.get("@dashcardQuery.all").should("have.length", 4);
 
     // No parameters change, no query rerun
-    goToTab(TAB_1.name);
-    goToTab(TAB_2.name);
+    H.goToTab(TAB_1.name);
+    H.goToTab(TAB_2.name);
     assertNoLoadingSpinners();
     cy.get("@dashcardQuery.all").should("have.length", 4);
   });
 
   it("should not rerun queries just because there are 9 or more attached filters to a dash-card", () => {
-    createDashboardWithTabs({
+    H.createDashboardWithTabs({
       tabs: [TAB_1, TAB_2],
       parameters: [
         DATE_FILTER,
@@ -1391,7 +1347,7 @@ describe("issue 39863", () => {
           dashboard_tab_id: TAB_2.id,
         }),
       ],
-    }).then(dashboard => visitDashboard(dashboard.id));
+    }).then(dashboard => H.visitDashboard(dashboard.id));
 
     // Initial query for 1st tab
     cy.wait("@dashcardQuery");
@@ -1399,13 +1355,13 @@ describe("issue 39863", () => {
     cy.get("@dashcardQuery.all").should("have.length", 1);
 
     // Initial query for 2nd tab
-    goToTab(TAB_2.name);
+    H.goToTab(TAB_2.name);
     cy.wait("@dashcardQuery");
     assertNoLoadingSpinners();
     cy.get("@dashcardQuery.all").should("have.length", 2);
 
     // No parameters change, no query rerun
-    goToTab(TAB_1.name);
+    H.goToTab(TAB_1.name);
     assertNoLoadingSpinners();
     cy.get("@dashcardQuery.all").should("have.length", 2);
 
@@ -1416,14 +1372,14 @@ describe("issue 39863", () => {
     cy.get("@dashcardQuery.all").should("have.length", 3);
 
     // Rerun 2nd tab query with new parameters
-    goToTab(TAB_2.name);
+    H.goToTab(TAB_2.name);
     cy.wait("@dashcardQuery");
     assertNoLoadingSpinners();
     cy.get("@dashcardQuery.all").should("have.length", 4);
 
     // No parameters change, no query rerun
-    goToTab(TAB_1.name);
-    goToTab(TAB_2.name);
+    H.goToTab(TAB_1.name);
+    H.goToTab(TAB_2.name);
     assertNoLoadingSpinners();
     cy.get("@dashcardQuery.all").should("have.length", 4);
   });
@@ -1440,12 +1396,12 @@ describe("issue 40695", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should not show dashcards from other tabs after entering and leaving editing mode", () => {
-    createDashboardWithTabs({
+    H.createDashboardWithTabs({
       tabs: [TAB_1, TAB_2],
       dashcards: [
         createMockDashboardCard({
@@ -1463,15 +1419,15 @@ describe("issue 40695", () => {
           card_id: ORDERS_COUNT_QUESTION_ID,
         }),
       ],
-    }).then(dashboard => visitDashboard(dashboard.id));
+    }).then(dashboard => H.visitDashboard(dashboard.id));
 
-    editDashboard();
+    H.editDashboard();
     cy.findByTestId("edit-bar").button("Cancel").click();
 
-    dashboardGrid().within(() => {
+    H.dashboardGrid().within(() => {
       cy.findByText("Orders").should("exist");
       cy.findByText("Orders, Count").should("not.exist");
-      getDashboardCards().should("have.length", 1);
+      H.getDashboardCards().should("have.length", 1);
     });
   });
 });
@@ -1489,7 +1445,7 @@ describe("issue 42165", () => {
   ];
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.intercept("POST", "/api/dataset").as("dataset");
@@ -1547,13 +1503,13 @@ describe("issue 42165", () => {
 
   it("should use card name instead of series names when navigating to QB from dashcard title", () => {
     cy.get("@dashboardId").then(dashboardId => {
-      visitDashboard(dashboardId);
+      H.visitDashboard(dashboardId);
 
-      filterWidget().click();
-      popover().findByText("Last 30 Days").click();
+      H.filterWidget().click();
+      H.popover().findByText("Last 30 Days").click();
       cy.wait("@dashcardQuery");
 
-      getDashboardCard(0).findByText("fooBarQuestion").click();
+      H.getDashboardCard(0).findByText("fooBarQuestion").click();
 
       cy.wait("@dataset");
       cy.title().should("eq", "fooBarQuestion · Metabase");
@@ -1563,12 +1519,12 @@ describe("issue 42165", () => {
 
 describe("issue 47170", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.request("POST", `/api/bookmark/dashboard/${ORDERS_DASHBOARD_ID}`);
 
-    createDashboard({ name: "Dashboard A" }, { wrapId: true }).then(
+    H.createDashboard({ name: "Dashboard A" }, { wrapId: true }).then(
       dashboardId => {
         cy.request("POST", `/api/bookmark/dashboard/${dashboardId}`);
       },
@@ -1589,10 +1545,10 @@ describe("issue 47170", () => {
   it("should not show error when dashboard fetch request is cancelled (metabase#47170)", () => {
     cy.visit(`/dashboard/${ORDERS_DASHBOARD_ID}`);
 
-    appBar().button("Toggle sidebar").click();
-    navigationSidebar().findByText("Dashboard A").click();
+    H.appBar().button("Toggle sidebar").click();
+    H.navigationSidebar().findByText("Dashboard A").click();
 
-    main().within(() => {
+    H.main().within(() => {
       cy.findByText("Something’s gone wrong").should("not.exist");
       cy.findByText("Dashboard A").should("be.visible");
     });

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1,6 +1,7 @@
 import { assoc } from "icepick";
 import _ from "underscore";
 
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
@@ -8,56 +9,6 @@ import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  addIFrameWhileEditing,
-  addOrUpdateDashboardCard,
-  appBar,
-  assertDashboardFixedWidth,
-  assertDashboardFullWidth,
-  closeDashboardInfoSidebar,
-  closeNavigationSidebar,
-  collectionOnTheGoModal,
-  commandPalette,
-  commandPaletteButton,
-  createDashboard,
-  createDashboardWithTabs,
-  createQuestionAndDashboard,
-  dashboardHeader,
-  describeEE,
-  describeWithSnowplow,
-  editDashboard,
-  editIFrameWhileEditing,
-  enableTracking,
-  entityPickerModal,
-  expectGoodSnowplowEvent,
-  expectNoBadSnowplowEvents,
-  filterWidget,
-  getDashboardCard,
-  getDashboardCardMenu,
-  getDashboardCards,
-  getTextCardDetails,
-  modal,
-  openDashboardInfoSidebar,
-  openDashboardMenu,
-  openProductsTable,
-  openQuestionsSidebar,
-  openSharingMenu,
-  popover,
-  queryBuilderHeader,
-  removeDashboardCard,
-  resetSnowplow,
-  restore,
-  saveDashboard,
-  selectDashboardFilter,
-  setFilter,
-  setTokenFeatures,
-  showDashboardCardActions,
-  sidebar,
-  sidesheet,
-  updateDashboardCards,
-  updateSetting,
-  visitDashboard,
-} from "e2e/support/helpers";
 import { GRID_WIDTH } from "metabase/lib/dashboard_grid";
 import {
   createMockVirtualCard,
@@ -75,7 +26,7 @@ const { ORDERS, ORDERS_ID, PRODUCTS, PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > dashboard", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -90,19 +41,19 @@ describe("scenarios > dashboard", () => {
       const existingQuestionName = "Orders, Count";
 
       cy.visit("/");
-      appBar().findByText("New").click();
-      popover().findByText("Dashboard").should("be.visible").click();
+      H.appBar().findByText("New").click();
+      H.popover().findByText("Dashboard").should("be.visible").click();
 
       cy.log(
         "pressing escape should only close the entity picker modal, not the new dashboard modal",
       );
-      modal().findByTestId("collection-picker-button").click();
-      entityPickerModal().findByText("Select a collection");
+      H.modal().findByTestId("collection-picker-button").click();
+      H.entityPickerModal().findByText("Select a collection");
       cy.realPress("Escape");
-      modal().findByText("New dashboard").should("be.visible");
+      H.modal().findByText("New dashboard").should("be.visible");
 
       cy.log("Create a new dashboard");
-      modal().within(() => {
+      H.modal().within(() => {
         // Without waiting for this, the test was constantly flaking locally.
         cy.findByText("Our analytics");
 
@@ -132,7 +83,7 @@ describe("scenarios > dashboard", () => {
         .findByRole("link", { name: "ask a new one" })
         .click();
 
-      entityPickerModal().within(() => {
+      H.entityPickerModal().within(() => {
         cy.findByPlaceholderText("Search this collection or everywhere…").type(
           "Pro",
         );
@@ -140,17 +91,17 @@ describe("scenarios > dashboard", () => {
         cy.findByText("Products").click();
       });
 
-      queryBuilderHeader().findByText("Save").click();
+      H.queryBuilderHeader().findByText("Save").click();
       cy.findByTestId("save-question-modal").within(modal => {
         cy.findByLabelText("Name").clear().type(newQuestionName);
         cy.findByText("Save").click();
       });
       cy.wait("@createQuestion");
-      modal().within(() => {
+      H.modal().within(() => {
         cy.button("Yes please!").click();
       });
 
-      entityPickerModal().within(() => {
+      H.entityPickerModal().within(() => {
         cy.findByRole("tab", { name: /Dashboards/ }).click();
         cy.findByText(dashboardName)
           .closest("button")
@@ -160,15 +111,15 @@ describe("scenarios > dashboard", () => {
         cy.button("Select").click();
       });
 
-      openQuestionsSidebar();
-      sidebar().findByText(existingQuestionName).click();
+      H.openQuestionsSidebar();
+      H.sidebar().findByText(existingQuestionName).click();
 
-      getDashboardCards().should("have.length", 2);
+      H.getDashboardCards().should("have.length", 2);
 
-      saveDashboard();
+      H.saveDashboard();
 
       cy.log("Breadcrumbs should show a collection dashboard was saved in");
-      appBar().findByText("Our analytics").click();
+      H.appBar().findByText("Our analytics").click();
 
       cy.log("New dashboard should appear in the collection");
       cy.findAllByTestId("collection-entry-name")
@@ -183,9 +134,9 @@ describe("scenarios > dashboard", () => {
       () => {
         cy.intercept("POST", "api/collection").as("createCollection");
         cy.visit("/");
-        closeNavigationSidebar();
-        appBar().findByText("New").click();
-        popover().findByText("Dashboard").should("be.visible").click();
+        H.closeNavigationSidebar();
+        H.appBar().findByText("New").click();
+        H.popover().findByText("Dashboard").should("be.visible").click();
         const NEW_DASHBOARD = "Foo";
         cy.findByTestId("new-dashboard-modal").then(modal => {
           cy.findByRole("heading", { name: "New dashboard" });
@@ -195,14 +146,14 @@ describe("scenarios > dashboard", () => {
             .click();
         });
 
-        entityPickerModal()
+        H.entityPickerModal()
           .findByRole("tab", { name: /Collections/ })
           .click();
-        entityPickerModal()
+        H.entityPickerModal()
           .findByText("Create a new collection")
           .click({ force: true });
         const NEW_COLLECTION = "Bar";
-        collectionOnTheGoModal().within(() => {
+        H.collectionOnTheGoModal().within(() => {
           cy.findByText("Create a new collection");
           cy.findByPlaceholderText(/My new collection/)
             .type(NEW_COLLECTION)
@@ -210,11 +161,11 @@ describe("scenarios > dashboard", () => {
           cy.findByText("Create").click();
           cy.wait("@createCollection");
         });
-        entityPickerModal().within(() => {
+        H.entityPickerModal().within(() => {
           cy.findByText(NEW_COLLECTION).click();
           cy.button("Select").click();
         });
-        modal().within(() => {
+        H.modal().within(() => {
           cy.findByText("New dashboard");
           cy.findByTestId("collection-picker-button").should(
             "have.text",
@@ -223,7 +174,7 @@ describe("scenarios > dashboard", () => {
           cy.button("Create").click();
         });
 
-        saveDashboard({ awaitRequest: false });
+        H.saveDashboard({ awaitRequest: false });
         cy.findByTestId("app-bar").findByText(NEW_COLLECTION);
       },
     );
@@ -231,10 +182,10 @@ describe("scenarios > dashboard", () => {
     it("adding question to one dashboard shouldn't affect previously visited unrelated dashboards (metabase#26826)", () => {
       cy.intercept("POST", "/api/card").as("saveQuestion");
 
-      visitDashboard(ORDERS_DASHBOARD_ID);
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
 
       cy.log("Save new question from an ad-hoc query");
-      openProductsTable();
+      H.openProductsTable();
       cy.findByTestId("qb-header").findByText("Save").click();
       cy.findByTestId("save-question-modal").within(modal => {
         cy.findByText("Save").click();
@@ -242,35 +193,35 @@ describe("scenarios > dashboard", () => {
       cy.wait("@saveQuestion");
 
       cy.log("Add this new question to a dashboard created on the fly");
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("Saved! Add this to a dashboard?");
         cy.button("Yes please!").click();
       });
 
-      entityPickerModal()
+      H.entityPickerModal()
         .findByRole("tab", { name: /Dashboards/ })
         .click();
-      entityPickerModal().findByText("Create a new dashboard").click();
+      H.entityPickerModal().findByText("Create a new dashboard").click();
       cy.findByTestId("create-dashboard-on-the-go").within(() => {
         cy.findByPlaceholderText("My new dashboard").type("Foo");
         cy.findByText("Create").click();
       });
-      entityPickerModal().button("Select").click();
+      H.entityPickerModal().button("Select").click();
 
-      saveDashboard();
+      H.saveDashboard();
 
       cy.log(
         "Find the originally visited (unrelated) dashboard in search and go to it",
       );
 
-      commandPaletteButton().click();
-      commandPalette().within(() => {
+      H.commandPaletteButton().click();
+      H.commandPalette().within(() => {
         cy.findByText("Recent items").should("exist");
         cy.findByRole("option", { name: "Orders in a dashboard" }).click();
       });
 
       cy.log("It should not contain an alien card from the other dashboard");
-      getDashboardCards().should("have.length", 1).and("contain", "37.65");
+      H.getDashboardCards().should("have.length", 1).and("contain", "37.65");
       cy.log("It should not open in editing mode");
       cy.findByTestId("edit-bar").should("not.exist");
     });
@@ -282,18 +233,18 @@ describe("scenarios > dashboard", () => {
     beforeEach(() => {
       cy.createDashboard({ name: originalDashboardName }).then(
         ({ body: { id } }) => {
-          visitDashboard(id);
+          H.visitDashboard(id);
         },
       );
     });
 
     context("add a question (dashboard card)", () => {
       it("should be possible via questions sidebar", () => {
-        editDashboard();
-        openQuestionsSidebar();
+        H.editDashboard();
+        H.openQuestionsSidebar();
 
         cy.log("The list of saved questions");
-        sidebar().findByText("Orders, Count").click();
+        H.sidebar().findByText("Orders, Count").click();
 
         cy.log("The search component");
         cy.intercept("GET", "/api/search*").as("search");
@@ -307,8 +258,8 @@ describe("scenarios > dashboard", () => {
         assertBothCardsArePresent();
 
         cy.log("Remove one card");
-        removeDashboardCard(0);
-        getDashboardCards().should("have.length", 1);
+        H.removeDashboardCard(0);
+        H.getDashboardCards().should("have.length", 1);
 
         cy.log("It should be possible to undo remove that card");
         cy.findByTestId("toast-undo").within(() => {
@@ -317,11 +268,11 @@ describe("scenarios > dashboard", () => {
         });
 
         assertBothCardsArePresent();
-        saveDashboard();
+        H.saveDashboard();
         assertBothCardsArePresent();
 
         function assertBothCardsArePresent() {
-          getDashboardCards()
+          H.getDashboardCards()
             .should("have.length", 2)
             .and("contain", "Orders, Count")
             .and("contain", "18,760");
@@ -337,13 +288,13 @@ describe("scenarios > dashboard", () => {
         cy.createDashboard({
           name: "dashboard in root collection",
         }).then(({ body: { id: dashboardId } }) => {
-          visitDashboard(dashboardId);
+          H.visitDashboard(dashboardId);
         });
 
         cy.log("assert that personal collections are not visible");
-        editDashboard();
-        openQuestionsSidebar();
-        sidebar().within(() => {
+        H.editDashboard();
+        H.openQuestionsSidebar();
+        H.sidebar().within(() => {
           cy.findByText("Our analytics").should("be.visible");
           cy.findByText(myPersonalCollection).should("not.exist");
           cy.findByText(collectionInRoot.name).should("be.visible");
@@ -351,17 +302,17 @@ describe("scenarios > dashboard", () => {
 
         cy.log("Move dashboard to a personal collection");
         cy.findByTestId("edit-bar").button("Cancel").click();
-        openDashboardMenu();
-        popover().findByText("Move").click();
-        entityPickerModal().within(() => {
+        H.openDashboardMenu();
+        H.popover().findByText("Move").click();
+        H.entityPickerModal().within(() => {
           cy.findByRole("tab", { name: /Collections/ }).click();
           cy.findByText("Bobby Tables's Personal Collection").click();
           cy.button("Move").click();
         });
 
-        editDashboard();
-        openQuestionsSidebar();
-        sidebar().within(() => {
+        H.editDashboard();
+        H.openQuestionsSidebar();
+        H.sidebar().within(() => {
           cy.log("go to the root collection");
           cy.findByText("Our analytics").click();
           cy.findByText(myPersonalCollection).should("be.visible");
@@ -370,17 +321,17 @@ describe("scenarios > dashboard", () => {
 
         cy.log("Move dashboard back to a root collection");
         cy.findByTestId("edit-bar").button("Cancel").click();
-        openDashboardMenu();
-        popover().findByText("Move").click();
-        entityPickerModal().within(() => {
+        H.openDashboardMenu();
+        H.popover().findByText("Move").click();
+        H.entityPickerModal().within(() => {
           cy.findByRole("tab", { name: /Collections/ }).click();
           cy.findByText("Our analytics").click();
           cy.button("Move").click();
         });
 
-        editDashboard();
-        openQuestionsSidebar();
-        sidebar().within(() => {
+        H.editDashboard();
+        H.openQuestionsSidebar();
+        H.sidebar().within(() => {
           cy.findByText("Our analytics").should("be.visible");
           cy.findByText(myPersonalCollection).should("not.exist");
           cy.findByText(collectionInRoot.name).should("be.visible");
@@ -393,26 +344,26 @@ describe("scenarios > dashboard", () => {
           cy.findByText("Add a saved question").click();
         });
 
-        sidebar().findByText("Orders, Count").click();
+        H.sidebar().findByText("Orders, Count").click();
 
-        saveDashboard();
+        H.saveDashboard();
 
-        getDashboardCards()
+        H.getDashboardCards()
           .should("have.length", 1)
           .and("contain", "Orders, Count")
           .and("contain", "18,760");
       });
 
       it("should allow navigating to the notebook editor directly from a dashboard card", () => {
-        visitDashboard(ORDERS_DASHBOARD_ID);
-        showDashboardCardActions();
-        getDashboardCardMenu().click();
-        popover().findByText("Edit question").should("be.visible").click();
+        H.visitDashboard(ORDERS_DASHBOARD_ID);
+        H.showDashboardCardActions();
+        H.getDashboardCardMenu().click();
+        H.popover().findByText("Edit question").should("be.visible").click();
         cy.findByRole("button", { name: "Visualize" }).should("be.visible");
       });
 
       it("should allow navigating to the model editor directly from a dashboard card", () => {
-        createQuestionAndDashboard({
+        H.createQuestionAndDashboard({
           questionDetails: {
             name: "orders",
             type: "model",
@@ -425,19 +376,19 @@ describe("scenarios > dashboard", () => {
           },
         }).then(({ body: { dashboard_id, card } }) => {
           cy.wrap(`${card.id}-${card.name}`).as("slug");
-          visitDashboard(dashboard_id);
+          H.visitDashboard(dashboard_id);
         });
 
-        showDashboardCardActions();
-        getDashboardCardMenu().click();
-        popover().findByText("Edit model").should("be.visible").click();
+        H.showDashboardCardActions();
+        H.getDashboardCardMenu().click();
+        H.popover().findByText("Edit model").should("be.visible").click();
         cy.get("@slug").then(slug => {
           cy.location("pathname").should("eq", `/model/${slug}/query`);
         });
       });
 
       it("should allow navigating to the metric editor directly from a dashboard card", () => {
-        createQuestionAndDashboard({
+        H.createQuestionAndDashboard({
           questionDetails: {
             name: "orders",
             type: "metric",
@@ -451,12 +402,12 @@ describe("scenarios > dashboard", () => {
           },
         }).then(({ body: { dashboard_id, card } }) => {
           cy.wrap(`${card.id}-${card.name}`).as("slug");
-          visitDashboard(dashboard_id);
+          H.visitDashboard(dashboard_id);
         });
 
-        showDashboardCardActions();
-        getDashboardCardMenu().click();
-        popover().findByText("Edit metric").should("be.visible").click();
+        H.showDashboardCardActions();
+        H.getDashboardCardMenu().click();
+        H.popover().findByText("Edit metric").should("be.visible").click();
         cy.get("@slug").then(slug => {
           cy.location("pathname").should("eq", `/metric/${slug}/query`);
         });
@@ -482,9 +433,9 @@ describe("scenarios > dashboard", () => {
         cy.wait("@updateDashboard");
         cy.wait("@getDashboard");
 
-        openDashboardInfoSidebar();
+        H.openDashboardInfoSidebar();
 
-        sidesheet()
+        H.sidesheet()
           .findByPlaceholderText("Add description")
           .type(newDescription)
           .blur();
@@ -498,22 +449,22 @@ describe("scenarios > dashboard", () => {
         cy.reload();
         cy.wait("@getDashboard");
 
-        dashboardHeader().findByDisplayValue(newTitle);
-        openDashboardInfoSidebar();
-        sidesheet().findByText(newDescription);
-        closeDashboardInfoSidebar();
+        H.dashboardHeader().findByDisplayValue(newTitle);
+        H.openDashboardInfoSidebar();
+        H.sidesheet().findByText(newDescription);
+        H.closeDashboardInfoSidebar();
 
         cy.log("should not call unnecessary API requests (metabase#31721)");
         cy.get("@updateDashboardSpy").should("have.callCount", 2);
 
         cy.log("Should revert the title change if escaped");
-        dashboardHeader().findByDisplayValue(newTitle).type("Whatever{esc}");
-        dashboardHeader().findByDisplayValue(newTitle);
+        H.dashboardHeader().findByDisplayValue(newTitle).type("Whatever{esc}");
+        H.dashboardHeader().findByDisplayValue(newTitle);
         cy.get("@updateDashboardSpy").should("have.callCount", 2);
 
         cy.log("Should revert the description change if escaped");
-        openDashboardInfoSidebar();
-        sidesheet().within(() => {
+        H.openDashboardInfoSidebar();
+        H.sidesheet().within(() => {
           cy.findByText(newDescription).type("Baz{esc}");
           cy.findByText(newDescription);
         });
@@ -521,28 +472,28 @@ describe("scenarios > dashboard", () => {
       });
 
       it("should update the name and description in the dashboard edit mode", () => {
-        editDashboard();
+        H.editDashboard();
 
         cy.log("Should revert the title change if editing is cancelled");
         cy.findByTestId("dashboard-name-heading").clear().type(newTitle).blur();
         cy.findByTestId("edit-bar").button("Cancel").click();
-        modal().button("Discard changes").click();
+        H.modal().button("Discard changes").click();
         cy.findByTestId("edit-bar").should("not.exist");
         cy.get("@updateDashboardSpy").should("not.have.been.called");
         cy.findByDisplayValue(originalDashboardName);
 
-        editDashboard();
+        H.editDashboard();
 
         cy.log("should not take you out of the edit mode when updating title");
         cy.findByTestId("dashboard-name-heading").clear().type(newTitle).blur();
         cy.log(
           "The only way to open a sidebar in edit mode is to click on a revision history",
         );
-        dashboardHeader()
+        H.dashboardHeader()
           .findByText(/^Edited a few seconds ago/)
           .click();
 
-        sidesheet()
+        H.sidesheet()
           .findByPlaceholderText("Add description")
           .type(newDescription)
           .blur();
@@ -551,27 +502,27 @@ describe("scenarios > dashboard", () => {
         // This might be a bug! We're applying the description while still in the edit mode!
         // OTOH, the title is preserved only on save.
         cy.wait("@updateDashboard");
-        closeDashboardInfoSidebar();
+        H.closeDashboardInfoSidebar();
 
-        saveDashboard();
+        H.saveDashboard();
         cy.wait("@updateDashboard");
         cy.get("@updateDashboardSpy").should("have.callCount", 2);
       });
 
       it("should not have markdown content overflow the description area (metabase#31326)", () => {
-        openDashboardInfoSidebar();
+        H.openDashboardInfoSidebar();
 
         const testMarkdownContent =
           "# Heading 1{enter}{enter}**bold** https://www.metabase.com/community_posts/how-to-measure-the-success-of-new-product-features-and-why-it-is-important{enter}{enter}![alt](/app/assets/img/welcome-modal-2.png){enter}{enter}This is my description. ";
 
-        sidesheet()
+        H.sidesheet()
           .findByPlaceholderText("Add description")
           .type(testMarkdownContent, { delay: 0 })
           .blur();
 
         cy.wait("@updateDashboard");
 
-        sidesheet().within(() => {
+        H.sidesheet().within(() => {
           cy.log("Markdown content should not be bigger than its container");
           cy.findByTestId("editable-text").then($markdown => {
             const el = $markdown[0];
@@ -631,13 +582,13 @@ describe("scenarios > dashboard", () => {
         cy.createDashboard().then(({ body: { id: dashboard_id } }) => {
           const cards = [
             // the bottom card intentionally goes first to have unsorted cards coming from the BE
-            getTextCardDetails({
+            H.getTextCardDetails({
               row: 1,
               size_x: 24,
               size_y: 1,
               text: "bottom",
             }),
-            getTextCardDetails({
+            H.getTextCardDetails({
               row: 0,
               size_x: 24,
               size_y: 1,
@@ -645,13 +596,13 @@ describe("scenarios > dashboard", () => {
             }),
           ];
 
-          updateDashboardCards({ dashboard_id, cards });
+          H.updateDashboardCards({ dashboard_id, cards });
 
-          visitDashboard(dashboard_id);
+          H.visitDashboard(dashboard_id);
         });
 
-        getDashboardCard(0).contains("top");
-        getDashboardCard(1).contains("bottom");
+        H.getDashboardCard(0).contains("top");
+        H.getDashboardCard(1).contains("bottom");
       },
     );
   });
@@ -690,16 +641,16 @@ describe("scenarios > dashboard", () => {
         },
       ];
 
-      updateSetting("allowed-iframe-hosts", "*");
+      H.updateSetting("allowed-iframe-hosts", "*");
 
       cy.createDashboard().then(({ body: { id } }) => {
-        visitDashboard(id);
+        H.visitDashboard(id);
       });
 
-      editDashboard();
+      H.editDashboard();
 
       testCases.forEach(({ input, expected }, index) => {
-        addIFrameWhileEditing(input);
+        H.addIFrameWhileEditing(input);
         cy.button("Done").click();
         validateIFrame(expected, index);
       });
@@ -708,53 +659,56 @@ describe("scenarios > dashboard", () => {
     it("should respect allowed-iframe-hosts setting", () => {
       const errorMessage = /can not be embedded in iframe cards/;
 
-      updateSetting(
+      H.updateSetting(
         "allowed-iframe-hosts",
         ["youtube.com", "player.videos.com"].join("\n"),
       );
 
-      cy.createDashboard().then(({ body: { id } }) => visitDashboard(id));
-      editDashboard();
+      cy.createDashboard().then(({ body: { id } }) => H.visitDashboard(id));
+      H.editDashboard();
 
       // Test allowed domain with subdomains
-      addIFrameWhileEditing("https://youtube.com/watch?v=dQw4w9WgXcQ");
+      H.addIFrameWhileEditing("https://youtube.com/watch?v=dQw4w9WgXcQ");
       cy.button("Done").click();
       validateIFrame("https://www.youtube.com/embed/dQw4w9WgXcQ");
 
-      editIFrameWhileEditing(0, "https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+      H.editIFrameWhileEditing(
+        0,
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      );
       cy.button("Done").click();
       validateIFrame("https://www.youtube.com/embed/dQw4w9WgXcQ");
 
       // Test allowed subdomain, but no other domains
-      editIFrameWhileEditing(0, "player.videos.com/video/123456789");
+      H.editIFrameWhileEditing(0, "player.videos.com/video/123456789");
       cy.button("Done").click();
       validateIFrame("https://player.videos.com/video/123456789");
 
-      editIFrameWhileEditing(0, "videos.com/video/123456789");
+      H.editIFrameWhileEditing(0, "videos.com/video/123456789");
       cy.button("Done").click();
-      getDashboardCard().within(() => {
+      H.getDashboardCard().within(() => {
         cy.findByText(errorMessage).should("be.visible");
         cy.get("iframe").should("not.exist");
       });
 
-      editIFrameWhileEditing(0, "www.videos.com/video");
+      H.editIFrameWhileEditing(0, "www.videos.com/video");
       cy.button("Done").click();
-      getDashboardCard().within(() => {
+      H.getDashboardCard().within(() => {
         cy.findByText(errorMessage).should("be.visible");
         cy.get("iframe").should("not.exist");
       });
 
       // Test forbidden domain and subdomains
-      editIFrameWhileEditing(0, "https://example.com");
+      H.editIFrameWhileEditing(0, "https://example.com");
       cy.button("Done").click();
-      getDashboardCard().within(() => {
+      H.getDashboardCard().within(() => {
         cy.findByText(errorMessage).should("be.visible");
         cy.get("iframe").should("not.exist");
       });
 
-      editIFrameWhileEditing(0, "www.example.com");
+      H.editIFrameWhileEditing(0, "www.example.com");
       cy.button("Done").click();
-      getDashboardCard().within(() => {
+      H.getDashboardCard().within(() => {
         cy.findByText(errorMessage).should("be.visible");
         cy.get("iframe").should("not.exist");
       });
@@ -762,21 +716,21 @@ describe("scenarios > dashboard", () => {
   });
 
   it("should add a filter", () => {
-    visitDashboard(ORDERS_DASHBOARD_ID);
-    editDashboard();
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.editDashboard();
 
     // Adding location/state doesn't make much sense for this case,
     // but we're testing just that the filter is added to the dashboard
-    setFilter("Location", "Is");
+    H.setFilter("Location", "Is");
 
-    getDashboardCard().findByText("Select…").click();
+    H.getDashboardCard().findByText("Select…").click();
 
-    popover().findByText("State").click();
+    H.popover().findByText("State").click();
 
     cy.icon("close");
     cy.button("Done").click();
 
-    saveDashboard();
+    H.saveDashboard();
 
     cy.log("Assert that the selected filter is present in the dashboard");
     cy.icon("location");
@@ -817,25 +771,31 @@ describe("scenarios > dashboard", () => {
     cy.findByText("This dashboard is looking empty.");
     // add previously created question to it
     cy.icon("pencil").click();
-    openQuestionsSidebar();
+    H.openQuestionsSidebar();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("11007").click();
 
-    setFilter("Date picker", "All Options");
+    H.setFilter("Date picker", "All Options");
 
     // and connect it to the card
-    selectDashboardFilter(cy.findByTestId("dashcard-container"), "Created At");
+    H.selectDashboardFilter(
+      cy.findByTestId("dashcard-container"),
+      "Created At",
+    );
 
     // add second filter
-    setFilter("ID");
+    H.setFilter("ID");
 
     // and connect it to the card
-    selectDashboardFilter(cy.findByTestId("dashcard-container"), "Product ID");
+    H.selectDashboardFilter(
+      cy.findByTestId("dashcard-container"),
+      "Product ID",
+    );
 
     // add third filter
-    setFilter("Text or Category", "Starts with");
+    H.setFilter("Text or Category", "Starts with");
     // and connect it to the card
-    selectDashboardFilter(cy.findByTestId("dashcard-container"), "Category");
+    H.selectDashboardFilter(cy.findByTestId("dashcard-container"), "Category");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
@@ -866,7 +826,7 @@ describe("scenarios > dashboard", () => {
           ],
         });
 
-        addOrUpdateDashboardCard({
+        H.addOrUpdateDashboardCard({
           card_id: questionId,
           dashboard_id: dashboardId,
           card: {
@@ -896,7 +856,7 @@ describe("scenarios > dashboard", () => {
           },
         });
 
-        visitDashboard(dashboardId);
+        H.visitDashboard(dashboardId);
         cy.get(".leaflet-marker-icon") // pin icon
           .eq(0)
           .click({ force: true });
@@ -935,13 +895,13 @@ describe("scenarios > dashboard", () => {
           ],
         });
 
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       },
     );
 
     // Add cross-filter click behavior manually
     cy.icon("pencil").click();
-    showDashboardCardActions();
+    H.showDashboardCardActions();
     cy.findByTestId("dashboardcard-actions-panel").within(() => {
       cy.icon("click").click();
     });
@@ -1009,9 +969,9 @@ describe("scenarios > dashboard", () => {
       cy.spy().as("fetchFieldValues"),
     );
 
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
 
-    filterWidget().as("filterWidget").click();
+    H.filterWidget().as("filterWidget").click();
 
     ["Doohickey", "Gadget", "Gizmo", "Widget"].forEach(category => {
       cy.findByText(category);
@@ -1067,7 +1027,7 @@ describe("scenarios > dashboard", () => {
       },
     );
     cy.signInAsNormalUser();
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
 
     cy.wait("@queryMetadata");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -1094,17 +1054,17 @@ describe("scenarios > dashboard", () => {
       ],
     });
 
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("37.65");
     assertScrollBarExists();
 
-    openSharingMenu("Embed");
+    H.openSharingMenu("Embed");
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.icon("close").click();
     });
-    modal().should("not.exist");
+    H.modal().should("not.exist");
     assertScrollBarExists();
   });
 
@@ -1145,8 +1105,8 @@ describe("scenarios > dashboard", () => {
       ],
     });
 
-    visitDashboard(ORDERS_DASHBOARD_ID);
-    editDashboard();
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.editDashboard();
 
     cy.findByTestId("dashboardcard-actions-panel").within(() => {
       cy.icon("palette").click({ force: true });
@@ -1159,11 +1119,11 @@ describe("scenarios > dashboard", () => {
       cy.button("Done").click();
     });
 
-    saveDashboard();
+    H.saveDashboard();
 
     // Verify the card is hidden when the value is correct but produces empty results
-    filterWidget().click();
-    popover().within(() => {
+    H.filterWidget().click();
+    H.popover().within(() => {
       cy.findByPlaceholderText("Enter an ID").type("-1{enter}");
       cy.button("Add filter").click();
     });
@@ -1171,15 +1131,15 @@ describe("scenarios > dashboard", () => {
     cy.findByTestId("dashcard").should("not.exist");
 
     // Verify it becomes visible once the filter is cleared
-    filterWidget().within(() => {
+    H.filterWidget().within(() => {
       cy.icon("close").click();
     });
 
     cy.findByTestId("dashcard").findByText("Orders");
 
     // Verify the card is visible when it returned an error
-    filterWidget().click();
-    popover().within(() => {
+    H.filterWidget().click();
+    H.popover().within(() => {
       cy.findByPlaceholderText("Enter an ID").type("text{enter}");
       cy.button("Add filter").click();
     });
@@ -1190,35 +1150,35 @@ describe("scenarios > dashboard", () => {
   });
 });
 
-describeWithSnowplow("scenarios > dashboard", () => {
+H.describeWithSnowplow("scenarios > dashboard", () => {
   beforeEach(() => {
     cy.intercept("GET", "/api/activity/recents?*").as("recentViews");
-    resetSnowplow();
-    restore();
+    H.resetSnowplow();
+    H.restore();
     cy.signInAsAdmin();
-    enableTracking();
+    H.enableTracking();
   });
 
   afterEach(() => {
-    expectNoBadSnowplowEvents();
+    H.expectNoBadSnowplowEvents();
   });
 
   it("should be possible to add an iframe card", () => {
-    updateSetting("allowed-iframe-hosts", "*");
-    createDashboard({ name: "iframe card" }).then(({ body: { id } }) => {
-      visitDashboard(id);
+    H.updateSetting("allowed-iframe-hosts", "*");
+    H.createDashboard({ name: "iframe card" }).then(({ body: { id } }) => {
+      H.visitDashboard(id);
 
-      editDashboard();
-      addIFrameWhileEditing("https://example.com");
+      H.editDashboard();
+      H.addIFrameWhileEditing("https://example.com");
       cy.findByTestId("dashboardcard-actions-panel").should("not.exist");
       cy.button("Done").click();
-      getDashboardCard(0).realHover();
+      H.getDashboardCard(0).realHover();
       cy.findByTestId("dashboardcard-actions-panel").should("be.visible");
       validateIFrame("https://example.com");
-      saveDashboard();
+      H.saveDashboard();
       validateIFrame("https://example.com");
 
-      expectGoodSnowplowEvent({
+      H.expectGoodSnowplowEvent({
         event: "new_iframe_card_created",
         target_id: id,
         event_detail: "example.com",
@@ -1227,26 +1187,26 @@ describeWithSnowplow("scenarios > dashboard", () => {
   });
 
   it("saving a dashboard should track a 'dashboard_saved' snowplow event", () => {
-    visitDashboard(ORDERS_DASHBOARD_ID);
-    editDashboard();
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.editDashboard();
     const newTitle = "New title";
     cy.findByTestId("dashboard-name-heading").clear().type(newTitle).blur();
-    saveDashboard();
-    expectGoodSnowplowEvent({
+    H.saveDashboard();
+    H.expectGoodSnowplowEvent({
       event: "dashboard_saved",
     });
   });
 
   it("should allow users to add link cards to dashboards", () => {
-    visitDashboard(ORDERS_DASHBOARD_ID);
-    editDashboard();
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.editDashboard();
     cy.findByLabelText("Add a link or iframe").click();
-    popover().findByText("Link").click();
+    H.popover().findByText("Link").click();
 
     cy.wait("@recentViews");
     cy.findByTestId("custom-edit-text-link").click().type("Orders");
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText(/Loading/i).should("not.exist");
       cy.findByText("Orders in a dashboard").click();
     });
@@ -1255,20 +1215,20 @@ describeWithSnowplow("scenarios > dashboard", () => {
       /orders in a dashboard/i,
     );
 
-    saveDashboard();
+    H.saveDashboard();
 
     cy.findByTestId("entity-view-display-link").findByText(
       /orders in a dashboard/i,
     );
 
-    expectGoodSnowplowEvent({
+    H.expectGoodSnowplowEvent({
       event: "new_link_card_created",
     });
   });
 
   it("should track enabling the hide empty cards setting", () => {
-    visitDashboard(ORDERS_DASHBOARD_ID);
-    editDashboard();
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.editDashboard();
 
     cy.findByTestId("dashboardcard-actions-panel").within(() => {
       cy.icon("palette").click({ force: true });
@@ -1282,7 +1242,7 @@ describeWithSnowplow("scenarios > dashboard", () => {
         .click() // disable
         .click(); // enable
 
-      expectGoodSnowplowEvent(
+      H.expectGoodSnowplowEvent(
         {
           event: "card_set_to_hide_when_no_results",
           dashboard_id: ORDERS_DASHBOARD_ID,
@@ -1308,7 +1268,7 @@ describeWithSnowplow("scenarios > dashboard", () => {
       type: "string/contains",
     };
 
-    createDashboardWithTabs({
+    H.createDashboardWithTabs({
       tabs: [TAB_1, TAB_2],
       parameters: [{ ...DASHBOARD_TEXT_FILTER, default: "Example Input" }],
       dashcards: [
@@ -1334,32 +1294,32 @@ describeWithSnowplow("scenarios > dashboard", () => {
           },
         }),
       ],
-    }).then(dashboard => visitDashboard(dashboard.id));
+    }).then(dashboard => H.visitDashboard(dashboard.id));
 
     // new dashboards should default to 'fixed' width
-    assertDashboardFixedWidth();
+    H.assertDashboardFixedWidth();
 
     // toggle full-width
-    editDashboard();
+    H.editDashboard();
     cy.findByLabelText("Toggle width").click();
-    popover().findByText("Full width").click();
-    assertDashboardFullWidth();
-    expectGoodSnowplowEvent({
+    H.popover().findByText("Full width").click();
+    H.assertDashboardFullWidth();
+    H.expectGoodSnowplowEvent({
       event: "dashboard_width_toggled",
       full_width: true,
     });
 
     // confirm it saves the state after saving and refreshing
-    saveDashboard();
+    H.saveDashboard();
     cy.reload();
-    assertDashboardFullWidth();
+    H.assertDashboardFullWidth();
 
     // toggle back to fixed
-    editDashboard();
+    H.editDashboard();
     cy.findByLabelText("Toggle width").click();
-    popover().findByText("Full width").click();
-    assertDashboardFixedWidth();
-    expectGoodSnowplowEvent({
+    H.popover().findByText("Full width").click();
+    H.assertDashboardFixedWidth();
+    H.expectGoodSnowplowEvent({
       event: "dashboard_width_toggled",
       full_width: false,
     });
@@ -1368,7 +1328,7 @@ describeWithSnowplow("scenarios > dashboard", () => {
 
 function checkOptionsForFilter(filter) {
   cy.findByText("Available filters").parent().contains(filter).click();
-  popover()
+  H.popover()
     .should("contain", "Columns")
     .and("contain", "COUNT(*)")
     .and("not.contain", "Dashboard filters");
@@ -1387,7 +1347,7 @@ function assertScrollBarExists() {
 
 describe("LOCAL TESTING ONLY > dashboard", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -1423,7 +1383,7 @@ describe("LOCAL TESTING ONLY > dashboard", () => {
         ],
       },
     }).then(({ body: { card_id, dashboard_id } }) => {
-      addOrUpdateDashboardCard({
+      H.addOrUpdateDashboardCard({
         card_id,
         dashboard_id,
         card: {
@@ -1438,16 +1398,16 @@ describe("LOCAL TESTING ONLY > dashboard", () => {
       });
 
       cy.visit(`/dashboard/${dashboard_id}?location=AK&location=CA`);
-      filterWidget().contains(/\{0\}/).should("not.exist");
+      H.filterWidget().contains(/\{0\}/).should("not.exist");
     });
   });
 });
 
-describeEE("scenarios > dashboard > caching", () => {
+H.describeEE("scenarios > dashboard > caching", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
   });
 
   /**
@@ -1456,11 +1416,11 @@ describeEE("scenarios > dashboard > caching", () => {
    */
   it("can configure cache for a dashboard, on an enterprise instance", () => {
     interceptPerformanceRoutes();
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
 
     openSidebarCacheStrategyForm("dashboard");
 
-    sidesheet().within(() => {
+    H.sidesheet().within(() => {
       cy.findByText(/Caching settings/).should("be.visible");
       durationRadioButton().click();
       cy.findByLabelText("Cache results for this many hours").type("48");
@@ -1487,11 +1447,11 @@ describeEE("scenarios > dashboard > caching", () => {
 
   it("can click 'Clear cache' for a dashboard", () => {
     interceptPerformanceRoutes();
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
 
     openSidebarCacheStrategyForm("dashboard");
 
-    sidesheet().within(() => {
+    H.sidesheet().within(() => {
       cy.findByText(/Caching settings/).should("be.visible");
       cy.findByRole("button", {
         name: /Clear cache for this dashboard/,
@@ -1502,7 +1462,7 @@ describeEE("scenarios > dashboard > caching", () => {
       cy.findByRole("button", { name: /Clear cache/ }).click();
     });
     cy.wait("@invalidateCache");
-    sidesheet().within(() => {
+    H.sidesheet().within(() => {
       cy.findByText("Cache cleared").should("be.visible");
     });
   });
@@ -1512,7 +1472,7 @@ describe("scenarios > dashboard > permissions", () => {
   let dashboardId;
 
   beforeEach(() => {
-    restore();
+    H.restore();
     // This first test creates a dashboard with two questions.
     // One is in Our Analytics the other is in a more locked down collection.
     cy.signInAsAdmin();
@@ -1569,7 +1529,7 @@ describe("scenarios > dashboard > permissions", () => {
     cy.createDashboard().then(({ body: { id: dashId } }) => {
       dashboardId = dashId;
 
-      updateDashboardCards({
+      H.updateDashboardCards({
         dashboard_id: dashId,
         cards: [
           { card_id: firstQuestionId, row: 0, col: 0, size_x: 8, size_y: 6 },
@@ -1580,7 +1540,7 @@ describe("scenarios > dashboard > permissions", () => {
   });
 
   it("should let admins view all cards in a dashboard", () => {
-    visitDashboard(dashboardId);
+    H.visitDashboard(dashboardId);
     // Admin can see both questions
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("First Question");
@@ -1594,7 +1554,7 @@ describe("scenarios > dashboard > permissions", () => {
 
   it("should display dashboards with some cards locked down", () => {
     cy.signIn("nodata");
-    visitDashboard(dashboardId);
+    H.visitDashboard(dashboardId);
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sorry, you don't have permission to see this card.");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -1605,14 +1565,14 @@ describe("scenarios > dashboard > permissions", () => {
 
   it("should display an error if they don't have perms for the dashboard", () => {
     cy.signIn("nocollection");
-    visitDashboard(dashboardId);
+    H.visitDashboard(dashboardId);
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sorry, you don’t have permission to see that.");
   });
 });
 
 function validateIFrame(src, index = 0) {
-  getDashboardCards()
+  H.getDashboardCards()
     .get("iframe")
     .eq(index)
     .should("have.attr", "src", src)

--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -1,3 +1,4 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ADMIN_PERSONAL_COLLECTION_ID,
@@ -8,49 +9,6 @@ import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  addHeadingWhileEditing,
-  addLinkWhileEditing,
-  createDashboardWithTabs,
-  createNewTab,
-  dashboardCards,
-  dashboardGrid,
-  deleteTab,
-  describeWithSnowplow,
-  duplicateTab,
-  editDashboard,
-  enableTracking,
-  expectGoodSnowplowEvent,
-  expectGoodSnowplowEvents,
-  expectNoBadSnowplowEvents,
-  filterWidget,
-  getDashboardCard,
-  getDashboardCards,
-  getHeadingCardDetails,
-  getLinkCardDetails,
-  getTextCardDetails,
-  goToTab,
-  main,
-  modal,
-  moveDashCardToTab,
-  openQuestionsSidebar,
-  openStaticEmbeddingModal,
-  popover,
-  publishChanges,
-  resetSnowplow,
-  restore,
-  saveDashboard,
-  selectDashboardFilter,
-  setFilter,
-  sidebar,
-  undo,
-  updateDashboardCards,
-  updateSetting,
-  visitCollection,
-  visitDashboard,
-  visitDashboardAndCreateTab,
-  visitIframe,
-} from "e2e/support/helpers";
 import { createMockDashboardCard } from "metabase-types/api/mocks";
 
 const { ORDERS, PEOPLE } = SAMPLE_DATABASE;
@@ -95,42 +53,42 @@ const TAB_2 = {
 
 describe("scenarios > dashboard > tabs", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should only display cards on the selected tab", () => {
     // Create new tab
-    visitDashboardAndCreateTab({
+    H.visitDashboardAndCreateTab({
       dashboardId: ORDERS_DASHBOARD_ID,
       save: false,
     });
-    dashboardCards().within(() => {
+    H.dashboardCards().within(() => {
       cy.findByText("Orders").should("not.exist");
       cy.findByText("There's nothing here, yet.").should("be.visible");
     });
 
     // Add card to second tab
     cy.icon("pencil").click();
-    openQuestionsSidebar();
-    sidebar().within(() => {
+    H.openQuestionsSidebar();
+    H.sidebar().within(() => {
       cy.findByText("Orders, Count").click();
     });
-    saveDashboard();
+    H.saveDashboard();
     cy.url().should("match", /\d+\-tab\-2/); // id is not stable
 
     // Go back to first tab
-    goToTab("Tab 1");
-    dashboardCards().within(() => {
+    H.goToTab("Tab 1");
+    H.dashboardCards().within(() => {
       cy.findByText("Orders, count").should("not.exist");
     });
-    dashboardCards().within(() => {
+    H.dashboardCards().within(() => {
       cy.findByText("Orders").should("be.visible");
     });
   });
 
   it("should only display filters mapped to cards on the selected tab", () => {
-    createDashboardWithTabs({
+    H.createDashboardWithTabs({
       tabs: [TAB_1, TAB_2],
       parameters: [
         DASHBOARD_DATE_FILTER,
@@ -158,7 +116,7 @@ describe("scenarios > dashboard > tabs", () => {
           ],
         }),
       ],
-    }).then(dashboard => visitDashboard(dashboard.id));
+    }).then(dashboard => H.visitDashboard(dashboard.id));
 
     assertFiltersVisibility({
       visible: [DASHBOARD_DATE_FILTER, DASHBOARD_TEXT_FILTER],
@@ -172,7 +130,7 @@ describe("scenarios > dashboard > tabs", () => {
       [DASHBOARD_LOCATION_FILTER, undefined],
     ]);
 
-    goToTab(TAB_2.name);
+    H.goToTab(TAB_2.name);
 
     assertFiltersVisibility({
       visible: [DASHBOARD_DATE_FILTER, DASHBOARD_NUMBER_FILTER],
@@ -188,44 +146,44 @@ describe("scenarios > dashboard > tabs", () => {
   });
 
   it("should handle canceling adding a new tab (#38055, #38278)", () => {
-    visitDashboardAndCreateTab({
+    H.visitDashboardAndCreateTab({
       dashboardId: ORDERS_DASHBOARD_ID,
       save: false,
     });
 
     cy.findByTestId("edit-bar").button("Cancel").click();
-    modal().button("Discard changes").click();
+    H.modal().button("Discard changes").click();
 
     // Reproduces #38055
-    dashboardGrid().within(() => {
+    H.dashboardGrid().within(() => {
       cy.findByText(/There's nothing here/).should("not.exist");
-      getDashboardCards().should("have.length", 1);
+      H.getDashboardCards().should("have.length", 1);
     });
 
     // Reproduces #38278
-    editDashboard();
-    addHeadingWhileEditing("New heading");
-    saveDashboard();
-    dashboardGrid().within(() => {
+    H.editDashboard();
+    H.addHeadingWhileEditing("New heading");
+    H.saveDashboard();
+    H.dashboardGrid().within(() => {
       cy.findByText("New heading").should("exist");
-      getDashboardCards().should("have.length", 2);
+      H.getDashboardCards().should("have.length", 2);
     });
   });
 
   it("should allow undoing a tab deletion", () => {
-    visitDashboardAndCreateTab({
+    H.visitDashboardAndCreateTab({
       dashboardId: ORDERS_DASHBOARD_ID,
       save: false,
     });
 
     // Delete first tab
-    deleteTab("Tab 1");
+    H.deleteTab("Tab 1");
     cy.findByRole("tab", { name: "Tab 1" }).should("not.exist");
 
     // Undo then go back to first tab
-    undo();
-    goToTab("Tab 1");
-    dashboardCards().within(() => {
+    H.undo();
+    H.goToTab("Tab 1");
+    H.dashboardCards().within(() => {
       cy.findByText("Orders").should("be.visible");
     });
   });
@@ -234,39 +192,39 @@ describe("scenarios > dashboard > tabs", () => {
     "should allow moving dashcards between tabs",
     { scrollBehavior: false },
     () => {
-      visitDashboardAndCreateTab({
+      H.visitDashboardAndCreateTab({
         dashboardId: ORDERS_DASHBOARD_ID,
         save: false,
       });
 
-      goToTab("Tab 1");
+      H.goToTab("Tab 1");
 
       cy.log("add second card");
-      addLinkWhileEditing("https://www.metabase.com");
+      H.addLinkWhileEditing("https://www.metabase.com");
 
       cy.log("should stay on the same tab");
       cy.findByRole("tab", { selected: true }).should("have.text", "Tab 1");
 
-      getDashboardCard(0).then(element => {
+      H.getDashboardCard(0).then(element => {
         cy.wrap({
           width: element.outerWidth(),
           height: element.outerHeight(),
         }).as("card1OriginalSize");
       });
 
-      getDashboardCard(1).then(element => {
+      H.getDashboardCard(1).then(element => {
         cy.wrap(element.offset()).as("card2OriginalPosition");
       });
 
       cy.log("move second card to second tab first, then the first card");
       // moving the second card first to invert their position, this allows us
       // to check if the position is restored when undoing the movement of the second one
-      moveDashCardToTab({ tabName: "Tab 2", dashcardIndex: 1 });
-      moveDashCardToTab({ tabName: "Tab 2", dashcardIndex: 0 });
+      H.moveDashCardToTab({ tabName: "Tab 2", dashcardIndex: 1 });
+      H.moveDashCardToTab({ tabName: "Tab 2", dashcardIndex: 0 });
 
       cy.log("fist tab should be empty");
       cy.findAllByTestId("toast-undo").should("have.length", 2);
-      getDashboardCards().should("have.length", 0);
+      H.getDashboardCards().should("have.length", 0);
 
       cy.log("should show undo toast with the correct text");
       cy.findByTestId("undo-list").within(() => {
@@ -275,12 +233,12 @@ describe("scenarios > dashboard > tabs", () => {
       });
 
       cy.log("cards should be in second tab");
-      goToTab("Tab 2");
-      getDashboardCards().should("have.length", 2);
+      H.goToTab("Tab 2");
+      H.getDashboardCards().should("have.length", 2);
 
       cy.log("size should stay the same");
 
-      getDashboardCard(1).then(element => {
+      H.getDashboardCard(1).then(element => {
         cy.get("@card1OriginalSize").then(originalSize => {
           expect({
             width: element.outerWidth(),
@@ -293,13 +251,13 @@ describe("scenarios > dashboard > tabs", () => {
 
       cy.findAllByTestId("toast-undo").eq(0).findByRole("button").click();
 
-      goToTab("Tab 1");
+      H.goToTab("Tab 1");
 
-      getDashboardCards().should("have.length", 1);
+      H.getDashboardCards().should("have.length", 1);
 
       cy.log("second card should be in the original position");
 
-      getDashboardCard().then(element => {
+      H.getDashboardCard().then(element => {
         cy.get("@card2OriginalPosition").then(originalPosition => {
           const position = element.offset();
           // approximately to avoid possibly flakiness, we just want it to be in the same grid cell
@@ -316,47 +274,47 @@ describe("scenarios > dashboard > tabs", () => {
     { scrollBehavior: false },
     () => {
       const cards = [
-        getTextCardDetails({
+        H.getTextCardDetails({
           text: "Text card",
           // small card aligned to the left so that move icon is out of the viewport
           // unless the left alignment logic kicks in
           size_x: 1,
         }),
-        getHeadingCardDetails({
+        H.getHeadingCardDetails({
           text: "Heading card",
         }),
-        getLinkCardDetails({
+        H.getLinkCardDetails({
           url: "https://metabase.com",
         }),
       ];
 
       cy.createDashboard().then(({ body: { id: dashboard_id } }) => {
-        updateDashboardCards({ dashboard_id, cards });
+        H.updateDashboardCards({ dashboard_id, cards });
 
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       });
 
-      editDashboard();
-      createNewTab();
-      goToTab("Tab 1");
+      H.editDashboard();
+      H.createNewTab();
+      H.goToTab("Tab 1");
 
       cy.log("moving dashcards to second tab");
 
       cards.forEach(() => {
-        moveDashCardToTab({ tabName: "Tab 2" });
+        H.moveDashCardToTab({ tabName: "Tab 2" });
       });
 
-      getDashboardCards().should("have.length", 0);
+      H.getDashboardCards().should("have.length", 0);
 
-      goToTab("Tab 2");
+      H.goToTab("Tab 2");
 
-      getDashboardCards().should("have.length", cards.length);
+      H.getDashboardCards().should("have.length", cards.length);
 
       cy.findAllByTestId("toast-undo").should("have.length", cards.length);
 
       cy.log("'Undo' toasts should be dismissed when saving the dashboard");
 
-      saveDashboard();
+      H.saveDashboard();
 
       cy.findAllByTestId("toast-undo").should("have.length", 0);
     },
@@ -376,34 +334,34 @@ describe("scenarios > dashboard > tabs", () => {
       },
     }).then(({ body: { dashboard_id } }) => {
       cy.signInAsNormalUser();
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
     });
 
-    editDashboard();
-    createNewTab();
+    H.editDashboard();
+    H.createNewTab();
 
-    goToTab("Tab 1");
+    H.goToTab("Tab 1");
 
-    getDashboardCard()
+    H.getDashboardCard()
       .findByText(/you don't have permission/)
       .should("exist");
 
-    moveDashCardToTab({ tabName: "Tab 2" });
+    H.moveDashCardToTab({ tabName: "Tab 2" });
 
-    saveDashboard();
+    H.saveDashboard();
 
-    getDashboardCards().should("have.length", 0);
+    H.getDashboardCards().should("have.length", 0);
   });
 
   it("should leave dashboard if navigating back after initial load", () => {
-    visitDashboardAndCreateTab({ dashboardId: ORDERS_DASHBOARD_ID });
-    visitCollection("root");
+    H.visitDashboardAndCreateTab({ dashboardId: ORDERS_DASHBOARD_ID });
+    H.visitCollection("root");
 
-    main().within(() => {
+    H.main().within(() => {
       cy.findByText("Orders in a dashboard").click();
     });
     cy.go("back");
-    main().within(() => {
+    H.main().within(() => {
       cy.findByText("Our analytics").should("be.visible");
     });
   });
@@ -412,21 +370,21 @@ describe("scenarios > dashboard > tabs", () => {
     cy.intercept("PUT", "/api/dashboard/*").as("saveDashboardCards");
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
 
-    visitDashboardAndCreateTab({
+    H.visitDashboardAndCreateTab({
       dashboardId: ORDERS_DASHBOARD_ID,
       save: false,
     });
 
     // Add card to second tab
     cy.icon("pencil").click();
-    openQuestionsSidebar();
-    sidebar().within(() => {
+    H.openQuestionsSidebar();
+    H.sidebar().within(() => {
       cy.findByText("Orders, Count").click();
     });
 
     cy.wait("@cardQuery");
 
-    saveDashboard();
+    H.saveDashboard();
 
     cy.wait("@saveDashboardCards").then(({ response }) => {
       cy.wrap(response.body.dashcards[1].id).as("secondTabDashcardId");
@@ -464,7 +422,7 @@ describe("scenarios > dashboard > tabs", () => {
     });
 
     // Visit first tab and confirm only first card was queried
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
 
     cy.get("@firstTabQuerySpy").should("have.been.calledOnce");
     cy.get("@secondTabQuerySpy").should("not.have.been.called");
@@ -478,7 +436,7 @@ describe("scenarios > dashboard > tabs", () => {
     });
 
     // Visit second tab and confirm only second card was queried
-    goToTab("Tab 2");
+    H.goToTab("Tab 2");
     cy.get("@secondTabQuerySpy").should("have.been.calledOnce");
     cy.get("@firstTabQuerySpy").should("have.been.calledOnce");
     cy.wait("@secondTabQuery").then(r => {
@@ -491,7 +449,7 @@ describe("scenarios > dashboard > tabs", () => {
     });
 
     // Go back to first tab, expect no additional queries
-    goToTab("Tab 1");
+    H.goToTab("Tab 1");
     cy.findAllByTestId("dashcard").contains("37.65");
     cy.get("@firstTabQuerySpy").should("have.been.calledOnce");
     cy.get("@secondTabQuerySpy").should("have.been.calledOnce");
@@ -504,7 +462,7 @@ describe("scenarios > dashboard > tabs", () => {
     });
 
     // Go to public dashboard
-    updateSetting("enable-public-sharing", true);
+    H.updateSetting("enable-public-sharing", true);
     cy.request(
       "POST",
       `/api/dashboard/${ORDERS_DASHBOARD_ID}/public_link`,
@@ -538,7 +496,7 @@ describe("scenarios > dashboard > tabs", () => {
     });
 
     // Visit second tab and confirm only second card was queried
-    goToTab("Tab 2");
+    H.goToTab("Tab 2");
     cy.get("@publicSecondTabQuerySpy").should("have.been.calledOnce");
     cy.get("@publicFirstTabQuerySpy").should("have.been.calledOnce");
     cy.wait("@publicSecondTabQuery").then(r => {
@@ -550,7 +508,7 @@ describe("scenarios > dashboard > tabs", () => {
       });
     });
 
-    goToTab("Tab 1");
+    H.goToTab("Tab 1");
     // This is a bug. publicFirstTabQuery should not be called again
     cy.get("@publicFirstTabQuerySpy").should("have.been.calledTwice");
     cy.get("@publicSecondTabQuerySpy").should("have.been.calledOnce");
@@ -568,19 +526,19 @@ describe("scenarios > dashboard > tabs", () => {
     cy.intercept("PUT", "/api/dashboard/*").as("saveDashboardCards");
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
 
-    visitDashboardAndCreateTab({
+    H.visitDashboardAndCreateTab({
       dashboardId: ORDERS_DASHBOARD_ID,
       save: false,
     });
 
     // Add card to second tab
     cy.icon("pencil").click();
-    openQuestionsSidebar();
-    sidebar().within(() => {
+    H.openQuestionsSidebar();
+    H.sidebar().within(() => {
       cy.findByText("Orders, Count").click();
     });
     cy.wait("@cardQuery");
-    saveDashboard();
+    H.saveDashboard();
     cy.wait("@saveDashboardCards").then(({ response }) => {
       cy.wrap(response.body.dashcards[1].id).as("secondTabDashcardId");
     });
@@ -612,12 +570,12 @@ describe("scenarios > dashboard > tabs", () => {
       cy.spy().as("secondTabQuerySpy"),
     ).as("secondTabQuery");
 
-    openStaticEmbeddingModal({ activeTab: "parameters", acceptTerms: true });
+    H.openStaticEmbeddingModal({ activeTab: "parameters", acceptTerms: true });
 
     // publish the embedded dashboard so that we can directly navigate to its url
-    publishChanges("dashboard", () => {});
+    H.publishChanges("dashboard", () => {});
     // directly navigate to the embedded dashboard, starting on Tab 1
-    visitIframe();
+    H.visitIframe();
     // wait for results
     cy.findAllByTestId("dashcard").contains("37.65");
     cy.signInAsAdmin();
@@ -633,7 +591,7 @@ describe("scenarios > dashboard > tabs", () => {
       });
     });
 
-    goToTab("Tab 2");
+    H.goToTab("Tab 2");
     cy.get("@secondTabQuerySpy").should("have.been.calledOnce");
     cy.get("@firstTabQuerySpy").should("have.been.calledOnce");
     cy.wait("@secondTabQuery").then(r => {
@@ -645,7 +603,7 @@ describe("scenarios > dashboard > tabs", () => {
       });
     });
 
-    goToTab("Tab 1");
+    H.goToTab("Tab 1");
     // This is a bug. firstTabQuery should not be called again
     cy.get("@firstTabQuerySpy").should("have.been.calledTwice");
     cy.get("@secondTabQuerySpy").should("have.been.calledOnce");
@@ -660,22 +618,22 @@ describe("scenarios > dashboard > tabs", () => {
   });
 
   it("should apply filter and show loading spinner when changing tabs (#33767)", () => {
-    visitDashboard(ORDERS_DASHBOARD_ID);
-    editDashboard();
-    createNewTab();
-    saveDashboard();
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.editDashboard();
+    H.createNewTab();
+    H.saveDashboard();
 
-    goToTab("Tab 2");
-    editDashboard();
-    openQuestionsSidebar();
-    sidebar().within(() => {
+    H.goToTab("Tab 2");
+    H.editDashboard();
+    H.openQuestionsSidebar();
+    H.sidebar().within(() => {
       cy.findByText("Orders, Count").click();
     });
 
-    setFilter("Date picker", "Relative Date");
+    H.setFilter("Date picker", "Relative Date");
 
-    selectDashboardFilter(getDashboardCard(0), "Created At");
-    saveDashboard();
+    H.selectDashboardFilter(H.getDashboardCard(0), "Created At");
+    H.saveDashboard();
 
     cy.intercept(
       "POST",
@@ -683,11 +641,11 @@ describe("scenarios > dashboard > tabs", () => {
       delayResponse(500),
     ).as("saveCard");
 
-    filterWidget().click();
-    popover().findByText("Previous 7 days").click();
+    H.filterWidget().click();
+    H.popover().findByText("Previous 7 days").click();
 
     // Loader in the 2nd tab
-    getDashboardCard(0).within(() => {
+    H.getDashboardCard(0).within(() => {
       cy.findByTestId("loading-indicator").should("exist");
       cy.wait("@saveCard");
       cy.findAllByTestId("table-row").should("exist");
@@ -695,18 +653,18 @@ describe("scenarios > dashboard > tabs", () => {
 
     // we do not auto-wire automatically in different tabs anymore, so first tab
     // should not show a loader and re-run query
-    goToTab("Tab 1");
-    getDashboardCard(0).within(() => {
+    H.goToTab("Tab 1");
+    H.getDashboardCard(0).within(() => {
       cy.findByTestId("loading-indicator").should("not.exist");
       cy.findAllByTestId("table-row").should("exist");
     });
   });
 
   it("should allow me to rearrange long tabs (#34970)", () => {
-    visitDashboard(ORDERS_DASHBOARD_ID);
-    editDashboard();
-    createNewTab();
-    createNewTab();
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.editDashboard();
+    H.createNewTab();
+    H.createNewTab();
 
     // Assert initial tab order
     cy.findAllByTestId("tab-button-input-wrapper").eq(0).findByText("Tab 1");
@@ -746,7 +704,7 @@ describe("scenarios > dashboard > tabs", () => {
     cy.findAllByTestId("tab-button-input-wrapper").eq(1).findByText("Tab 1");
     cy.findAllByTestId("tab-button-input-wrapper").eq(2).findByText("Tab 2");
 
-    saveDashboard();
+    H.saveDashboard();
 
     // Confirm positions are the same after saving
     cy.findAllByTestId("tab-button-input-wrapper").eq(0).findByText(longName);
@@ -755,27 +713,27 @@ describe("scenarios > dashboard > tabs", () => {
   });
 
   it("should allow users to duplicate and delete tabs more than once (#45364)", () => {
-    visitDashboard(ORDERS_DASHBOARD_ID);
-    editDashboard();
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.editDashboard();
 
-    duplicateTab("Tab 1");
+    H.duplicateTab("Tab 1");
 
     cy.findAllByRole("tab").eq(0).should("have.text", "Tab 1");
     cy.findAllByRole("tab").eq(1).should("have.text", "Copy of Tab 1");
 
-    duplicateTab("Tab 1");
+    H.duplicateTab("Tab 1");
 
     cy.findAllByRole("tab").eq(0).should("have.text", "Tab 1");
     cy.findAllByRole("tab").eq(1).should("have.text", "Copy of Tab 1");
     cy.findAllByRole("tab").eq(2).should("have.text", "Copy of Tab 1");
 
-    deleteTab("Tab 1");
+    H.deleteTab("Tab 1");
 
     cy.findAllByRole("tab").eq(0).should("have.text", "Copy of Tab 1");
     cy.findAllByRole("tab").eq(1).should("have.text", "Copy of Tab 1");
 
     cy.findAllByRole("tab").eq(0).findByRole("button").click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Delete").click();
     });
 
@@ -783,56 +741,56 @@ describe("scenarios > dashboard > tabs", () => {
   });
 });
 
-describeWithSnowplow("scenarios > dashboard > tabs", () => {
+H.describeWithSnowplow("scenarios > dashboard > tabs", () => {
   const PAGE_VIEW_EVENT = 1;
 
   beforeEach(() => {
-    restore();
-    resetSnowplow();
+    H.restore();
+    H.resetSnowplow();
     cy.signInAsAdmin();
-    enableTracking();
+    H.enableTracking();
   });
 
   afterEach(() => {
-    expectNoBadSnowplowEvents();
+    H.expectNoBadSnowplowEvents();
   });
 
   it("should send snowplow events when dashboard tabs are created and deleted", () => {
-    visitDashboard(ORDERS_DASHBOARD_ID);
-    expectGoodSnowplowEvents(PAGE_VIEW_EVENT);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.expectGoodSnowplowEvents(PAGE_VIEW_EVENT);
 
-    editDashboard();
-    createNewTab();
-    saveDashboard();
-    expectGoodSnowplowEvent({ event: "dashboard_saved" }, 1);
-    expectGoodSnowplowEvent({ event: "dashboard_tab_created" }, 1);
+    H.editDashboard();
+    H.createNewTab();
+    H.saveDashboard();
+    H.expectGoodSnowplowEvent({ event: "dashboard_saved" }, 1);
+    H.expectGoodSnowplowEvent({ event: "dashboard_tab_created" }, 1);
 
-    editDashboard();
-    deleteTab("Tab 2");
-    saveDashboard();
-    expectGoodSnowplowEvent({ event: "dashboard_saved" }, 2);
-    expectGoodSnowplowEvent({ event: "dashboard_tab_deleted" }, 1);
+    H.editDashboard();
+    H.deleteTab("Tab 2");
+    H.saveDashboard();
+    H.expectGoodSnowplowEvent({ event: "dashboard_saved" }, 2);
+    H.expectGoodSnowplowEvent({ event: "dashboard_tab_deleted" }, 1);
   });
 
   it("should send snowplow events when cards are moved between tabs", () => {
     const cardMovedEventName = "card_moved_to_tab";
 
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
 
-    expectGoodSnowplowEvent(
+    H.expectGoodSnowplowEvent(
       {
         event: cardMovedEventName,
       },
       0,
     );
 
-    editDashboard();
-    createNewTab();
-    goToTab("Tab 1");
+    H.editDashboard();
+    H.createNewTab();
+    H.goToTab("Tab 1");
 
-    moveDashCardToTab({ tabName: "Tab 2" });
+    H.moveDashCardToTab({ tabName: "Tab 2" });
 
-    expectGoodSnowplowEvent(
+    H.expectGoodSnowplowEvent(
       {
         event: cardMovedEventName,
       },
@@ -905,7 +863,7 @@ function assertFiltersVisibility({ visible = [], hidden = [] }) {
   });
 
   // Ensure all filters are visible in edit mode
-  editDashboard();
+  H.editDashboard();
   cy.findByTestId("edit-dashboard-parameters-widget-container", () => {
     [...visible, ...hidden].forEach(filter =>
       cy.findByText(filter.name).should("exist"),

--- a/e2e/test/scenarios/dashboard/text-cards.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/text-cards.cy.spec.js
@@ -1,58 +1,38 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  addHeadingWhileEditing,
-  addTextBox,
-  addTextBoxWhileEditing,
-  describeWithSnowplow,
-  editDashboard,
-  enableTracking,
-  expectGoodSnowplowEvent,
-  expectNoBadSnowplowEvents,
-  filterWidget,
-  getDashboardCard,
-  multiAutocompleteInput,
-  popover,
-  resetSnowplow,
-  restore,
-  saveDashboard,
-  selectDashboardFilter,
-  setFilter,
-  updateSetting,
-  visitDashboard,
-} from "e2e/support/helpers";
 import { createMockParameter } from "metabase-types/api/mocks";
 
 const { PRODUCTS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > dashboard > text and headings", () => {
   beforeEach(() => {
-    resetSnowplow();
-    restore();
+    H.resetSnowplow();
+    H.restore();
     cy.signInAsAdmin();
-    enableTracking();
+    H.enableTracking();
   });
 
-  describeWithSnowplow("text", () => {
+  H.describeWithSnowplow("text", () => {
     beforeEach(() => {
-      visitDashboard(ORDERS_DASHBOARD_ID);
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
     });
 
     afterEach(() => {
-      expectNoBadSnowplowEvents();
+      H.expectNoBadSnowplowEvents();
     });
 
     it("should allow creation, editing, and saving of text boxes", () => {
       // should be able to create new text box
-      editDashboard();
+      H.editDashboard();
       cy.findByLabelText("Add a heading or text box").click();
-      popover().findByText("Text").click();
+      H.popover().findByText("Text").click();
 
-      expectGoodSnowplowEvent({
+      H.expectGoodSnowplowEvent({
         event: "new_text_card_created",
       });
 
-      getDashboardCard(1).within(() => {
+      H.getDashboardCard(1).within(() => {
         // textarea should:
         //   1. be auto-focused on creation
         //   2. have no value
@@ -72,7 +52,7 @@ describe("scenarios > dashboard > text and headings", () => {
         .findByText("You're editing this dashboard.")
         .click(); // un-focus text
 
-      getDashboardCard(1).within(() => {
+      H.getDashboardCard(1).within(() => {
         // preview should have no textarea element
         cy.get("textarea").should("not.exist");
 
@@ -83,7 +63,7 @@ describe("scenarios > dashboard > text and headings", () => {
       });
 
       // should focus textarea editor on click
-      getDashboardCard(1)
+      H.getDashboardCard(1)
         .click()
         .within(() => {
           cy.get("textarea").should("have.focus");
@@ -96,10 +76,10 @@ describe("scenarios > dashboard > text and headings", () => {
       cy.findByTestId("edit-bar")
         .findByText("You're editing this dashboard.")
         .click(); // un-focus text
-      getDashboardCard(1).contains("Text text text").should("be.visible");
+      H.getDashboardCard(1).contains("Text text text").should("be.visible");
 
       // should render visualization options
-      getDashboardCard(1)
+      H.getDashboardCard(1)
         .realHover()
         .within(() => {
           cy.findByLabelText("Show visualization options").click();
@@ -116,7 +96,7 @@ describe("scenarios > dashboard > text and headings", () => {
       });
 
       // should not render edit and preview actions
-      getDashboardCard(1)
+      H.getDashboardCard(1)
         .realHover()
         .within(() => {
           cy.findByLabelText("Edit card").should("not.exist");
@@ -124,25 +104,25 @@ describe("scenarios > dashboard > text and headings", () => {
         });
 
       // should allow saving and show up after refresh
-      saveDashboard();
+      H.saveDashboard();
 
-      getDashboardCard(1).contains("Text text text").should("be.visible");
+      H.getDashboardCard(1).contains("Text text text").should("be.visible");
     });
 
     it("should have a scroll bar for long text (metabase#8333)", () => {
-      addTextBox(
+      H.addTextBox(
         "Lorem ipsum dolor sit amet,\n\nfoo\n\nbar\n\nbaz\n\nboo\n\nDonec quis enim porta.",
         { delay: 0.5 },
       );
 
-      expectGoodSnowplowEvent({
+      H.expectGoodSnowplowEvent({
         event: "new_text_card_created",
       });
 
       cy.findByTestId("edit-bar").findByText("Save").click();
 
       // The test fails if there is no scroll bar
-      getDashboardCard(1)
+      H.getDashboardCard(1)
         .get(".text-card-markdown")
         .should("have.css", "overflow-x", "hidden")
         .should("have.css", "overflow-y", "auto")
@@ -150,41 +130,41 @@ describe("scenarios > dashboard > text and headings", () => {
     });
 
     it("should let you add a parameter to a dashboard with a text box (metabase#11927)", () => {
-      addTextBox("text text text");
+      H.addTextBox("text text text");
 
-      setFilter("Text or Category", "Is");
+      H.setFilter("Text or Category", "Is");
 
-      selectDashboardFilter(cy.findAllByTestId("dashcard").first(), "Name");
+      H.selectDashboardFilter(cy.findAllByTestId("dashcard").first(), "Name");
       cy.findByTestId("edit-bar").findByText("Save").click();
 
       // confirm text box and filter are still there
-      getDashboardCard(1).contains("text text text").should("be.visible");
+      H.getDashboardCard(1).contains("text text text").should("be.visible");
       cy.findByTestId("dashboard-parameters-widget-container")
         .findByText("Text")
         .should("be.visible");
     });
   });
 
-  describeWithSnowplow("heading", () => {
+  H.describeWithSnowplow("heading", () => {
     beforeEach(() => {
-      visitDashboard(ORDERS_DASHBOARD_ID);
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
     });
 
     afterEach(() => {
-      expectNoBadSnowplowEvents();
+      H.expectNoBadSnowplowEvents();
     });
 
     it("should allow creation, editing, and saving of heading component", () => {
       // should be able to create new heading
-      editDashboard();
+      H.editDashboard();
       cy.findByLabelText("Add a heading or text box").click();
-      popover().findByText("Heading").click();
+      H.popover().findByText("Heading").click();
 
-      expectGoodSnowplowEvent({
+      H.expectGoodSnowplowEvent({
         event: "new_heading_card_created",
       });
 
-      getDashboardCard(1).within(() => {
+      H.getDashboardCard(1).within(() => {
         // heading input should
         //   1. be auto-focused on creation
         //   2. have no value
@@ -199,7 +179,7 @@ describe("scenarios > dashboard > text and headings", () => {
       cy.findByTestId("edit-bar")
         .findByText("You're editing this dashboard.")
         .click(); // un-focus heading
-      getDashboardCard(1).within(() => {
+      H.getDashboardCard(1).within(() => {
         // preview mode should have no input
         cy.get("input").should("not.exist");
 
@@ -208,7 +188,7 @@ describe("scenarios > dashboard > text and headings", () => {
       });
 
       // should focus input editor on click
-      getDashboardCard(1)
+      H.getDashboardCard(1)
         .click()
         .within(() => {
           cy.get("input").should("have.focus");
@@ -221,20 +201,20 @@ describe("scenarios > dashboard > text and headings", () => {
       cy.findByTestId("edit-bar")
         .findByText("You're editing this dashboard.")
         .click(); // un-focus heading
-      getDashboardCard(1)
+      H.getDashboardCard(1)
         .get("h2")
         .findByText("Example Heading")
         .should("be.visible");
 
       // should have no visualization options
-      getDashboardCard(1)
+      H.getDashboardCard(1)
         .realHover()
         .within(() => {
           cy.findByLabelText("Show visualization options").should("not.exist");
         });
 
       // should not render edit and preview actions
-      getDashboardCard(1)
+      H.getDashboardCard(1)
         .realHover()
         .within(() => {
           cy.findByLabelText("Edit card").should("not.exist");
@@ -242,9 +222,9 @@ describe("scenarios > dashboard > text and headings", () => {
         });
 
       // should allow saving and show up after refresh
-      saveDashboard();
+      H.saveDashboard();
 
-      getDashboardCard(1)
+      H.getDashboardCard(1)
         .get("h2")
         .findByText("Example Heading")
         .should("be.visible");
@@ -254,87 +234,87 @@ describe("scenarios > dashboard > text and headings", () => {
 
 describe("scenarios > dashboard > parameters in text and heading cards", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
-      visitDashboard(DASHBOARD_ID);
+      H.visitDashboard(DASHBOARD_ID);
     });
   });
 
   it("should allow dashboard filters to be connected to tags in text cards", () => {
-    editDashboard();
+    H.editDashboard();
 
-    addTextBoxWhileEditing("Variable: {{foo}}", {
+    H.addTextBoxWhileEditing("Variable: {{foo}}", {
       parseSpecialCharSequences: false,
     });
-    addHeadingWhileEditing("Variable: {{foo}}", {
+    H.addHeadingWhileEditing("Variable: {{foo}}", {
       parseSpecialCharSequences: false,
     });
 
-    setFilter("Number", "Equal to", "Equal to");
+    H.setFilter("Number", "Equal to", "Equal to");
 
-    getDashboardCard(0).findByText("Select…").click();
-    popover().findByText("foo").click();
+    H.getDashboardCard(0).findByText("Select…").click();
+    H.popover().findByText("foo").click();
 
-    getDashboardCard(1).findByText("Select…").click();
-    popover().findByText("foo").click();
+    H.getDashboardCard(1).findByText("Select…").click();
+    H.popover().findByText("foo").click();
 
-    saveDashboard();
+    H.saveDashboard();
 
-    filterWidget().click();
-    popover().within(() => multiAutocompleteInput().type("1"));
+    H.filterWidget().click();
+    H.popover().within(() => H.multiAutocompleteInput().type("1"));
     cy.button("Add filter").click();
-    getDashboardCard(0).findByText("Variable: 1").should("exist");
-    getDashboardCard(1).findByText("Variable: 1").should("exist");
+    H.getDashboardCard(0).findByText("Variable: 1").should("exist");
+    H.getDashboardCard(1).findByText("Variable: 1").should("exist");
 
     cy.findByTestId("dashboard-parameters-widget-container")
       .findByText("1")
       .click();
-    popover().within(() => {
-      multiAutocompleteInput().type("2");
+    H.popover().within(() => {
+      H.multiAutocompleteInput().type("2");
       cy.button("Update filter").click();
     });
-    getDashboardCard(0).findByText("Variable: 1 and 2").should("exist");
-    getDashboardCard(1).findByText("Variable: 1 and 2").should("exist");
+    H.getDashboardCard(0).findByText("Variable: 1 and 2").should("exist");
+    H.getDashboardCard(1).findByText("Variable: 1 and 2").should("exist");
 
-    editDashboard();
+    H.editDashboard();
 
     cy.findByTestId("edit-dashboard-parameters-widget-container")
       .findByText("Equal to")
       .click();
-    getDashboardCard(0).findByText("foo").should("exist");
-    getDashboardCard(1).findByText("foo").should("exist");
+    H.getDashboardCard(0).findByText("foo").should("exist");
+    H.getDashboardCard(1).findByText("foo").should("exist");
   });
 
   it("should not transform text variables to plain text (metabase#31626)", () => {
-    editDashboard();
+    H.editDashboard();
 
     const textContent = "Variable: {{foo}}";
-    addTextBoxWhileEditing(textContent, { parseSpecialCharSequences: false });
-    addHeadingWhileEditing(textContent, { parseSpecialCharSequences: false });
+    H.addTextBoxWhileEditing(textContent, { parseSpecialCharSequences: false });
+    H.addHeadingWhileEditing(textContent, { parseSpecialCharSequences: false });
 
-    setFilter("Number", "Equal to");
+    H.setFilter("Number", "Equal to");
 
-    getDashboardCard(0).findByText("Select…").click();
-    popover().findByText("foo").click();
+    H.getDashboardCard(0).findByText("Select…").click();
+    H.popover().findByText("foo").click();
 
-    getDashboardCard(1).findByText("Select…").click();
-    popover().findByText("foo").click();
+    H.getDashboardCard(1).findByText("Select…").click();
+    H.popover().findByText("foo").click();
 
-    saveDashboard();
+    H.saveDashboard();
 
-    filterWidget().click();
+    H.filterWidget().click();
     cy.findByPlaceholderText("Enter a number").type("1{enter}");
     cy.button("Add filter").click();
 
     // view mode
-    getDashboardCard(0).findByText("Variable: 1").should("be.visible");
-    getDashboardCard(1).findByText("Variable: 1").should("be.visible");
+    H.getDashboardCard(0).findByText("Variable: 1").should("be.visible");
+    H.getDashboardCard(1).findByText("Variable: 1").should("be.visible");
 
-    editDashboard();
+    H.editDashboard();
 
-    getDashboardCard(0).findByText(textContent).should("be.visible");
-    getDashboardCard(1).findByText(textContent).should("be.visible");
+    H.getDashboardCard(0).findByText(textContent).should("be.visible");
+    H.getDashboardCard(1).findByText(textContent).should("be.visible");
   });
 
   it("should translate parameter values into the instance language", () => {
@@ -343,34 +323,34 @@ describe("scenarios > dashboard > parameters in text and heading cards", () => {
     cy.request("GET", "/api/user/current").then(({ body: { id: USER_ID } }) => {
       cy.request("PUT", `/api/user/${USER_ID}`, { locale: "en" });
     });
-    updateSetting("site-locale", "fr");
+    H.updateSetting("site-locale", "fr");
     cy.reload();
 
-    editDashboard();
+    H.editDashboard();
 
-    addTextBoxWhileEditing("Variable: {{foo}}", {
+    H.addTextBoxWhileEditing("Variable: {{foo}}", {
       parseSpecialCharSequences: false,
     });
-    addHeadingWhileEditing("Variable: {{foo}}", {
+    H.addHeadingWhileEditing("Variable: {{foo}}", {
       parseSpecialCharSequences: false,
     });
-    setFilter("Date picker", "Relative Date");
+    H.setFilter("Date picker", "Relative Date");
 
-    getDashboardCard(0).findByText("Select…").click();
-    popover().findByText("foo").click();
+    H.getDashboardCard(0).findByText("Select…").click();
+    H.popover().findByText("foo").click();
 
-    getDashboardCard(1).findByText("Select…").click();
-    popover().findByText("foo").click();
+    H.getDashboardCard(1).findByText("Select…").click();
+    H.popover().findByText("foo").click();
 
-    saveDashboard();
+    H.saveDashboard();
 
-    filterWidget().click();
-    popover().within(() => {
+    H.filterWidget().click();
+    H.popover().within(() => {
       cy.findByText("Today").click();
     });
 
-    getDashboardCard(0).findByText("Variable: Aujourd'hui").should("exist");
-    getDashboardCard(1).findByText("Variable: Aujourd'hui").should("exist");
+    H.getDashboardCard(0).findByText("Variable: Aujourd'hui").should("exist");
+    H.getDashboardCard(1).findByText("Variable: Aujourd'hui").should("exist");
 
     // Let's make sure the localization was reset back to the user locale by checking that specific text exists in
     // English on the homepage.
@@ -383,7 +363,7 @@ describe("scenarios > dashboard > parameters in text and heading cards", () => {
     cy.request("GET", "/api/user/current").then(({ body: { id: USER_ID } }) => {
       cy.request("PUT", `/api/user/${USER_ID}`, { locale: "en" });
     });
-    updateSetting("site-locale", "fr");
+    H.updateSetting("site-locale", "fr");
 
     // Create dashboard with a single date parameter, and a single question
     cy.createQuestionAndDashboard({
@@ -406,15 +386,15 @@ describe("scenarios > dashboard > parameters in text and heading cards", () => {
         size_y: 6,
       };
       cy.editDashboardCard(card, updatedSize);
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
 
-      editDashboard();
+      H.editDashboard();
 
       // Create text card and connect parameter
-      addTextBoxWhileEditing("Variable: {{foo}}", {
+      H.addTextBoxWhileEditing("Variable: {{foo}}", {
         parseSpecialCharSequences: false,
       });
-      addHeadingWhileEditing("Variable: {{foo}}", {
+      H.addHeadingWhileEditing("Variable: {{foo}}", {
         parseSpecialCharSequences: false,
       });
 
@@ -422,27 +402,27 @@ describe("scenarios > dashboard > parameters in text and heading cards", () => {
         .findByText("Single Date")
         .click();
 
-      getDashboardCard(0).findByText("Select…").click();
-      popover().findByText("Created At").click();
+      H.getDashboardCard(0).findByText("Select…").click();
+      H.popover().findByText("Created At").click();
 
-      getDashboardCard(1).findByText("Select…").click();
-      popover().findByText("foo").click();
+      H.getDashboardCard(1).findByText("Select…").click();
+      H.popover().findByText("foo").click();
 
-      getDashboardCard(2).findByText("Select…").click();
-      popover().findByText("foo").click();
+      H.getDashboardCard(2).findByText("Select…").click();
+      H.popover().findByText("foo").click();
 
-      saveDashboard();
+      H.saveDashboard();
 
       cy.findByTestId("dashboard-parameters-widget-container")
         .findByText("Single Date")
         .click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByRole("textbox").click().clear().type("07/19/2023").blur();
         cy.button("Add filter").click();
       });
 
       // Question should be filtered appropriately
-      getDashboardCard(0).within(() => {
+      H.getDashboardCard(0).within(() => {
         cy.findByText("Rustic Paper Wallet").should("exist");
         cy.findByText("Small Marble Shoes").should("not.exist");
       });
@@ -453,10 +433,10 @@ describe("scenarios > dashboard > parameters in text and heading cards", () => {
         .should("exist");
 
       // Parameter value in dashboard should use site localization (French)
-      getDashboardCard(1)
+      H.getDashboardCard(1)
         .findByText("Variable: juillet 19, 2023")
         .should("exist");
-      getDashboardCard(2)
+      H.getDashboardCard(2)
         .findByText("Variable: juillet 19, 2023")
         .should("exist");
     });

--- a/e2e/test/scenarios/dashboard/title-drill.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/title-drill.cy.spec.js
@@ -1,15 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  addOrUpdateDashboardCard,
-  appBar,
-  filterWidget,
-  getDashboardCard,
-  multiAutocompleteInput,
-  popover,
-  queryBuilderMain,
-  restore,
-  visitDashboard,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PEOPLE, PEOPLE_ID, PRODUCTS, PRODUCTS_ID } =
   SAMPLE_DATABASE;
@@ -17,7 +7,7 @@ const { ORDERS, ORDERS_ID, PEOPLE, PEOPLE_ID, PRODUCTS, PRODUCTS_ID } =
 describe("scenarios > dashboard > title drill", () => {
   describe("on a native question without connected dashboard parameters", () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
 
       const questionDetails = {
@@ -33,7 +23,7 @@ describe("scenarios > dashboard > title drill", () => {
       cy.createNativeQuestionAndDashboard({ questionDetails }).then(
         ({ body: { dashboard_id }, questionId }) => {
           cy.wrap(questionId).as("questionId");
-          visitDashboard(dashboard_id);
+          H.visitDashboard(dashboard_id);
         },
       );
     });
@@ -43,14 +33,14 @@ describe("scenarios > dashboard > title drill", () => {
         cy.get("@questionId").then(questionId => {
           cy.findByTestId("loading-indicator").should("not.exist");
 
-          getDashboardCard().findByRole("link", { name: "Q1" }).as("title");
+          H.getDashboardCard().findByRole("link", { name: "Q1" }).as("title");
           cy.get("@title").realHover();
           cy.get("@title")
             .should("have.attr", "href")
             .and("include", `/question/${questionId}`);
           cy.get("@title").click();
 
-          queryBuilderMain().within(() => {
+          H.queryBuilderMain().within(() => {
             cy.findByText("This question is written in SQL.").should(
               "be.visible",
             );
@@ -73,14 +63,14 @@ describe("scenarios > dashboard > title drill", () => {
         cy.get("@questionId").then(questionId => {
           cy.findByTestId("loading-indicator").should("not.exist");
 
-          getDashboardCard().findByRole("link", { name: "Q1" }).as("title");
+          H.getDashboardCard().findByRole("link", { name: "Q1" }).as("title");
           cy.get("@title").realHover();
           cy.get("@title")
             .should("have.attr", "href")
             .and("include", `/question/${questionId}`);
           cy.get("@title").click();
 
-          queryBuilderMain().within(() => {
+          H.queryBuilderMain().within(() => {
             cy.findByText("This question is written in SQL.").should(
               "be.visible",
             );
@@ -96,7 +86,7 @@ describe("scenarios > dashboard > title drill", () => {
 
   describe("on a native question with a connected dashboard parameter", () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
 
       const filter = {
@@ -153,7 +143,7 @@ describe("scenarios > dashboard > title drill", () => {
           ],
         });
 
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
         checkScalarResult("200");
       });
     });
@@ -232,7 +222,7 @@ describe("scenarios > dashboard > title drill", () => {
     };
 
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
 
       cy.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
@@ -263,7 +253,7 @@ describe("scenarios > dashboard > title drill", () => {
             `/api/dashboard/${dashboard_id}/dashcard/*/card/${card_id}/query`,
           ).as("cardQuery");
 
-          visitDashboard(dashboard_id);
+          H.visitDashboard(dashboard_id);
         },
       );
     });
@@ -273,9 +263,9 @@ describe("scenarios > dashboard > title drill", () => {
         cy.wait("@cardQuery");
 
         // make sure query results are correct
-        getDashboardCard().findByText("42");
+        H.getDashboardCard().findByText("42");
 
-        getDashboardCard()
+        H.getDashboardCard()
           .findByRole("link", { name: "GUI Question" })
           .as("title");
         cy.get("@title").realHover();
@@ -290,7 +280,7 @@ describe("scenarios > dashboard > title drill", () => {
           .should("be.visible");
 
         // make sure the results match
-        queryBuilderMain().findByText("42").should("be.visible");
+        H.queryBuilderMain().findByText("42").should("be.visible");
         cy.location("href").should("include", "/question#");
       });
     });
@@ -305,9 +295,9 @@ describe("scenarios > dashboard > title drill", () => {
         cy.wait("@cardQuery");
 
         // make sure query results are correct
-        getDashboardCard().findByText("42").should("be.visible");
+        H.getDashboardCard().findByText("42").should("be.visible");
 
-        getDashboardCard()
+        H.getDashboardCard()
           .findByRole("link", { name: "GUI Question" })
           .as("title");
         cy.get("@title").realHover();
@@ -317,7 +307,7 @@ describe("scenarios > dashboard > title drill", () => {
         cy.get("@title").click();
 
         // make sure the results match
-        queryBuilderMain().findByText("42").should("be.visible");
+        H.queryBuilderMain().findByText("42").should("be.visible");
         cy.get("@questionId").then(questionId => {
           cy.location("href").should(
             "include",
@@ -326,9 +316,9 @@ describe("scenarios > dashboard > title drill", () => {
         });
 
         // update the parameter filter to a new value
-        filterWidget().contains("Doohickey").click();
-        popover().within(() => {
-          multiAutocompleteInput().type("{backspace}Gadget,");
+        H.filterWidget().contains("Doohickey").click();
+        H.popover().within(() => {
+          H.multiAutocompleteInput().type("{backspace}Gadget,");
           cy.findByText("Update filter").click();
         });
 
@@ -337,18 +327,18 @@ describe("scenarios > dashboard > title drill", () => {
         cy.wait("@cardQuery");
 
         // make sure the results reflect the new filter
-        queryBuilderMain().findByText("53").should("be.visible");
+        H.queryBuilderMain().findByText("53").should("be.visible");
 
         // make sure the set parameter filter persists after a page refresh
         cy.reload();
         cy.wait("@cardQuery");
 
-        queryBuilderMain().findByText("53").should("be.visible");
+        H.queryBuilderMain().findByText("53").should("be.visible");
 
         // make sure the unset id parameter works
-        filterWidget().last().click();
-        popover().within(() => {
-          multiAutocompleteInput().type("5");
+        H.filterWidget().last().click();
+        H.popover().within(() => {
+          H.multiAutocompleteInput().type("5");
           cy.findByText("Add filter").click();
         });
 
@@ -356,7 +346,7 @@ describe("scenarios > dashboard > title drill", () => {
         cy.findAllByTestId("run-button").first().click();
         cy.wait("@cardQuery");
 
-        queryBuilderMain().findByText("1").should("be.visible");
+        H.queryBuilderMain().findByText("1").should("be.visible");
       });
     });
   });
@@ -380,7 +370,7 @@ describe("scenarios > dashboard > title drill", () => {
     };
 
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
 
       cy.createQuestion(questionDetails, {
@@ -408,7 +398,7 @@ describe("scenarios > dashboard > title drill", () => {
       );
 
       cy.then(function () {
-        addOrUpdateDashboardCard({
+        H.addOrUpdateDashboardCard({
           card_id: this.nestedQuestionId,
           dashboard_id: this.dashboardId,
           card: {
@@ -426,16 +416,16 @@ describe("scenarios > dashboard > title drill", () => {
 
     it("should lead you to a table question with filtered ID (metabase#17213)", () => {
       const productRecordId = 3;
-      visitDashboard("@dashboardId", { params: { id: productRecordId } });
+      H.visitDashboard("@dashboardId", { params: { id: productRecordId } });
 
-      getDashboardCard()
+      H.getDashboardCard()
         .findByRole("link", { name: baseNestedQuestionDetails.name })
         .as("title");
       cy.get("@title").realHover();
       cy.get("@title").should("have.attr", "href").and("include", "/question#");
       cy.get("@title").click();
 
-      appBar()
+      H.appBar()
         .contains(`Started from ${baseNestedQuestionDetails.name}`)
         .should("be.visible");
       cy.findByTestId("question-row-count")
@@ -449,7 +439,7 @@ describe("scenarios > dashboard > title drill", () => {
 
   describe("on various charts", () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
     });
 
@@ -507,23 +497,23 @@ describe("scenarios > dashboard > title drill", () => {
           { row: 6, col: 6, size_x: 6, size_y: 6 },
         ],
       }).then(({ dashboard, questions }) => {
-        visitDashboard(dashboard.id);
+        H.visitDashboard(dashboard.id);
 
         // make cursor start from a place where subsequent realHover() calls
         // won't make the cursor move over the other cards during test
         // (which would interfere with assertions)
         cy.findByTestId("sidebar-toggle").realHover();
 
-        getDashboardCard(0)
+        H.getDashboardCard(0)
           .findByRole("link", { name: "Line chart" })
           .as("line-chart-title");
-        getDashboardCard(1)
+        H.getDashboardCard(1)
           .findByRole("link", { name: "Row chart" })
           .as("row-chart-title");
-        getDashboardCard(2)
+        H.getDashboardCard(2)
           .findByRole("link", { name: "Map chart" })
           .as("map-chart-title");
-        getDashboardCard(3)
+        H.getDashboardCard(3)
           .findByRole("link", { name: "Funnel chart" })
           .as("funnel-chart-title");
 
@@ -561,8 +551,8 @@ describe("scenarios > dashboard > title drill", () => {
 });
 
 function checkFilterLabelAndValue(label, value) {
-  filterWidget().find("legend").invoke("text").should("eq", label);
-  filterWidget().contains(value);
+  H.filterWidget().find("legend").invoke("text").should("eq", label);
+  H.filterWidget().contains(value);
 }
 
 function checkScalarResult(result) {

--- a/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
@@ -1,27 +1,14 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_BY_YEAR_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  addOrUpdateDashboardCard,
-  assertEChartsTooltip,
-  cartesianChartCircle,
-  chartPathWithFillColor,
-  dashboardGrid,
-  getDashboardCards,
-  main,
-  popover,
-  restore,
-  saveDashboard,
-  visitDashboardAndCreateTab,
-  visitQuestionAdhoc,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID, PEOPLE, PEOPLE_ID } =
   SAMPLE_DATABASE;
 
 describe("scenarios > x-rays", { tags: "@slow" }, () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -79,7 +66,7 @@ describe("scenarios > x-rays", { tags: "@slow" }, () => {
 
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    cartesianChartCircle()
+    H.cartesianChartCircle()
       .eq(23) // Random dot
       .click({ force: true });
 
@@ -124,9 +111,9 @@ describe("scenarios > x-rays", { tags: "@slow" }, () => {
           { visitQuestion: true },
         );
 
-        chartPathWithFillColor("#509EE3").first().click({ force: true });
+        H.chartPathWithFillColor("#509EE3").first().click({ force: true });
 
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findByText("Automatic insights…").click();
           cy.findByText(action).click();
         });
@@ -144,7 +131,7 @@ describe("scenarios > x-rays", { tags: "@slow" }, () => {
           expect(xhr.response.statusCode).not.to.eq(500);
         });
 
-        main().within(() => {
+        H.main().within(() => {
           cy.findByText("A look at the number of 15655").should("exist");
         });
 
@@ -154,7 +141,7 @@ describe("scenarios > x-rays", { tags: "@slow" }, () => {
 
     it(`"${action.toUpperCase()}" should not show NULL in titles of generated dashboard cards (metabase#15737)`, () => {
       cy.intercept("GET", "/api/automagic-dashboards/**").as("xray");
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         name: "15737",
         dataset_query: {
           database: SAMPLE_DB_ID,
@@ -168,7 +155,7 @@ describe("scenarios > x-rays", { tags: "@slow" }, () => {
         display: "bar",
       });
 
-      chartPathWithFillColor("#509EE3").first().click();
+      H.chartPathWithFillColor("#509EE3").first().click();
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Automatic insights…").click();
@@ -226,7 +213,7 @@ describe("scenarios > x-rays", { tags: "@slow" }, () => {
     cy.wait("@dataset");
     cy.wait("@datasetFailed");
 
-    getDashboardCards().eq(1).contains("Total transactions");
+    H.getDashboardCards().eq(1).contains("Total transactions");
   });
 
   it("should be able to click the title of an x-ray dashcard to see it in the query builder (metabase#19405)", () => {
@@ -285,9 +272,9 @@ describe("scenarios > x-rays", { tags: "@slow" }, () => {
       NUMBER_OF_DATASET_REQUESTS,
     );
 
-    getDashboardCards().contains("18,760").click();
+    H.getDashboardCards().contains("18,760").click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Break out by…").click();
       cy.findByText("Category").click();
       cy.findByText("Source").click();
@@ -296,10 +283,10 @@ describe("scenarios > x-rays", { tags: "@slow" }, () => {
     cy.url().should("contain", "/question");
 
     // Bars
-    chartPathWithFillColor("#509EE3").should("have.length", 5);
-    chartPathWithFillColor("#509EE3").eq(0).realHover();
+    H.chartPathWithFillColor("#509EE3").should("have.length", 5);
+    H.chartPathWithFillColor("#509EE3").eq(0).realHover();
 
-    assertEChartsTooltip({
+    H.assertEChartsTooltip({
       header: "Affiliate",
       rows: [
         {
@@ -322,7 +309,7 @@ describe("scenarios > x-rays", { tags: "@slow" }, () => {
     return cy
       .createDashboard({ name: "my dashboard" })
       .then(({ body: { id: dashboard_id } }) => {
-        addOrUpdateDashboardCard({
+        H.addOrUpdateDashboardCard({
           card_id: ORDERS_BY_YEAR_QUESTION_ID,
           dashboard_id,
           card: {
@@ -333,13 +320,16 @@ describe("scenarios > x-rays", { tags: "@slow" }, () => {
             visualization_settings: {},
           },
         });
-        visitDashboardAndCreateTab({ dashboardId: dashboard_id, save: false });
+        H.visitDashboardAndCreateTab({
+          dashboardId: dashboard_id,
+          save: false,
+        });
         cy.findByRole("tab", { name: "Tab 1" }).click();
-        saveDashboard();
+        H.saveDashboard();
 
-        cartesianChartCircle().eq(0).click({ force: true });
-        popover().findByText("Automatic insights…").click();
-        popover().findByText("X-ray").click();
+        H.cartesianChartCircle().eq(0).click({ force: true });
+        H.popover().findByText("Automatic insights…").click();
+        H.popover().findByText("X-ray").click();
         cy.wait("@dataset", { timeout: 60000 });
 
         // Ensure charts actually got rendered
@@ -426,5 +416,7 @@ function waitForSatisfyingResponse(
 }
 
 function getDashcardByTitle(title) {
-  return dashboardGrid().findByText(title).closest("[data-testid='dashcard']");
+  return H.dashboardGrid()
+    .findByText(title)
+    .closest("[data-testid='dashcard']");
 }

--- a/e2e/test/scenarios/embedding-sdk/static-dashboard-cors.cy.spec.js
+++ b/e2e/test/scenarios/embedding-sdk/static-dashboard-cors.cy.spec.js
@@ -1,14 +1,9 @@
+import { H } from "e2e/support";
 import { USERS } from "e2e/support/cypress_data";
 import {
   ORDERS_DASHBOARD_DASHCARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  describeEE,
-  getTextCardDetails,
-  restore,
-  setTokenFeatures,
-} from "e2e/support/helpers";
 import { visitFullAppEmbeddingUrl } from "e2e/support/helpers/e2e-embedding-helpers";
 import {
   EMBEDDING_SDK_STORY_HOST,
@@ -21,14 +16,14 @@ import {
 
 const STORYBOOK_ID = "embeddingsdk-cypressstaticdashboardwithcors--default";
 
-describeEE("scenarios > embedding-sdk > static-dashboard", () => {
+H.describeEE("scenarios > embedding-sdk > static-dashboard", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
     enableJwtAuth();
 
-    const textCard = getTextCardDetails({ col: 16, text: "Text text card" });
+    const textCard = H.getTextCardDetails({ col: 16, text: "Text text card" });
     const questionCard = {
       id: ORDERS_DASHBOARD_DASHCARD_ID,
       card_id: ORDERS_QUESTION_ID,

--- a/e2e/test/scenarios/embedding/embed-resource-downloads.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embed-resource-downloads.cy.spec.ts
@@ -1,25 +1,9 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_BY_YEAR_QUESTION_ID,
   ORDERS_DASHBOARD_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  addOrUpdateDashboardCard,
-  createDashboardWithQuestions,
-  createNativeQuestion,
-  describeWithSnowplowEE,
-  expectGoodSnowplowEvent,
-  expectNoBadSnowplowEvents,
-  exportFromDashcard,
-  getDashboardCardMenu,
-  main,
-  popover,
-  resetSnowplow,
-  restore,
-  setTokenFeatures,
-  showDashboardCardActions,
-  visitEmbeddedPage,
-} from "e2e/support/helpers";
 import { createMockParameter } from "metabase-types/api/mocks";
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -28,34 +12,34 @@ const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
  *  Unless the product changes, these should test the same things as `public-resource-downloads.cy.spec.ts`
  */
 
-describeWithSnowplowEE(
+H.describeWithSnowplowEE(
   "Static embed dashboards/questions downloads (results and export as pdf)",
   () => {
     beforeEach(() => {
-      resetSnowplow();
+      H.resetSnowplow();
       cy.deleteDownloadsFolder();
     });
 
     describe("Static embed dashboards", () => {
       before(() => {
-        restore("default");
+        H.restore("default");
         cy.signInAsAdmin();
 
         cy.request("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}`, {
           enable_embedding: true,
         });
 
-        setTokenFeatures("all");
+        H.setTokenFeatures("all");
 
         cy.signOut();
       });
 
       afterEach(() => {
-        expectNoBadSnowplowEvents();
+        H.expectNoBadSnowplowEvents();
       });
 
       it("#downloads=false should disable both PDF downloads and dashcard results downloads", () => {
-        visitEmbeddedPage(
+        H.visitEmbeddedPage(
           {
             resource: { dashboard: ORDERS_DASHBOARD_ID },
             params: {},
@@ -72,11 +56,11 @@ describeWithSnowplowEE(
         cy.findByText("Export as PDF").should("not.exist");
 
         // we should not have any dashcard action in a static embedded/embed scenario, so the menu should not be there
-        getDashboardCardMenu().should("not.exist");
+        H.getDashboardCardMenu().should("not.exist");
       });
 
       it("should be able to download a static embedded dashboard as PDF", () => {
-        visitEmbeddedPage(
+        H.visitEmbeddedPage(
           {
             resource: { dashboard: ORDERS_DASHBOARD_ID },
             params: {},
@@ -93,7 +77,7 @@ describeWithSnowplowEE(
 
         cy.verifyDownload("Orders in a dashboard.pdf");
 
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: "dashboard_pdf_exported",
           dashboard_id: 0,
           dashboard_accessed_via: "static-embed",
@@ -101,7 +85,7 @@ describeWithSnowplowEE(
       });
 
       it("should be able to download a static embedded dashcard as CSV", () => {
-        visitEmbeddedPage(
+        H.visitEmbeddedPage(
           {
             resource: { dashboard: ORDERS_DASHBOARD_ID },
             params: {},
@@ -115,12 +99,12 @@ describeWithSnowplowEE(
 
         waitLoading();
 
-        showDashboardCardActions();
-        getDashboardCardMenu().click();
-        exportFromDashcard(".csv");
+        H.showDashboardCardActions();
+        H.getDashboardCardMenu().click();
+        H.exportFromDashcard(".csv");
         cy.verifyDownload(".csv", { contains: true });
 
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: "download_results_clicked",
           resource_type: "dashcard",
           accessed_via: "static-embed",
@@ -132,7 +116,7 @@ describeWithSnowplowEE(
         beforeEach(() => {
           cy.signInAsAdmin();
 
-          setTokenFeatures("all");
+          H.setTokenFeatures("all");
 
           // Test parameter with accentuation (metabase#49118)
           const CATEGORY_FILTER = createMockParameter({
@@ -147,7 +131,7 @@ describeWithSnowplowEE(
               "source-table": PRODUCTS_ID,
             },
           };
-          createDashboardWithQuestions({
+          H.createDashboardWithQuestions({
             // Can't figure out the type if I extracted `dashboardDetails` to a variable.
             dashboardDetails: {
               name: "Dashboard with a parameter",
@@ -162,7 +146,7 @@ describeWithSnowplowEE(
             const dashboardId = dashboard.id;
             cy.wrap(dashboardId).as("dashboardId");
             const questionId = questions[0].id;
-            addOrUpdateDashboardCard({
+            H.addOrUpdateDashboardCard({
               dashboard_id: dashboardId,
               card_id: questionId,
               card: {
@@ -182,7 +166,7 @@ describeWithSnowplowEE(
 
         it("should be able to download a static embedded dashcard as CSV", () => {
           cy.get("@dashboardId").then(dashboardId => {
-            visitEmbeddedPage(
+            H.visitEmbeddedPage(
               {
                 resource: { dashboard: Number(dashboardId) },
                 params: {},
@@ -197,12 +181,12 @@ describeWithSnowplowEE(
 
           waitLoading();
 
-          showDashboardCardActions();
-          getDashboardCardMenu().click();
-          exportFromDashcard(".csv");
+          H.showDashboardCardActions();
+          H.getDashboardCardMenu().click();
+          H.exportFromDashcard(".csv");
           cy.verifyDownload(".csv", { contains: true });
 
-          expectGoodSnowplowEvent({
+          H.expectGoodSnowplowEvent({
             event: "download_results_clicked",
             resource_type: "dashcard",
             accessed_via: "static-embed",
@@ -214,20 +198,20 @@ describeWithSnowplowEE(
 
     describe("Static embed questions", () => {
       before(() => {
-        restore("default");
+        H.restore("default");
         cy.signInAsAdmin();
 
         cy.request("PUT", `/api/card/${ORDERS_BY_YEAR_QUESTION_ID}`, {
           enable_embedding: true,
         });
 
-        setTokenFeatures("all");
+        H.setTokenFeatures("all");
 
         cy.signOut();
       });
 
       it("#downloads=false should disable result downloads", () => {
-        visitEmbeddedPage(
+        H.visitEmbeddedPage(
           {
             resource: { question: ORDERS_BY_YEAR_QUESTION_ID },
             params: {},
@@ -245,7 +229,7 @@ describeWithSnowplowEE(
       });
 
       it("should be able to download the question as PNG", () => {
-        visitEmbeddedPage(
+        H.visitEmbeddedPage(
           {
             resource: { question: ORDERS_BY_YEAR_QUESTION_ID },
             params: {},
@@ -260,14 +244,14 @@ describeWithSnowplowEE(
         waitLoading();
 
         cy.findByTestId("download-button").click();
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findByText(".png").click();
           cy.findByTestId("download-results-button").click();
         });
 
         cy.verifyDownload(".png", { contains: true });
 
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: "download_results_clicked",
           resource_type: "question",
           accessed_via: "static-embed",
@@ -276,7 +260,7 @@ describeWithSnowplowEE(
       });
 
       it("should be able to download a static embedded card as CSV", () => {
-        visitEmbeddedPage(
+        H.visitEmbeddedPage(
           {
             resource: { question: ORDERS_BY_YEAR_QUESTION_ID },
             params: {},
@@ -292,14 +276,14 @@ describeWithSnowplowEE(
 
         cy.findByTestId("download-button").click();
 
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findByText(".csv").click();
           cy.findByTestId("download-results-button").click();
         });
 
         cy.verifyDownload(".csv", { contains: true });
 
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: "download_results_clicked",
           resource_type: "question",
           accessed_via: "static-embed",
@@ -311,10 +295,10 @@ describeWithSnowplowEE(
         beforeEach(() => {
           cy.signInAsAdmin();
 
-          setTokenFeatures("all");
+          H.setTokenFeatures("all");
 
           // Can't figure out the type if I extracted `questionDetails` to a variable.
-          createNativeQuestion(
+          H.createNativeQuestion(
             {
               name: "Native question with a parameter",
               native: {
@@ -356,7 +340,7 @@ describeWithSnowplowEE(
         it("should be able to download a static embedded dashcard as CSV", () => {
           const value = 9999;
           cy.get("@questionId").then(questionId => {
-            visitEmbeddedPage(
+            H.visitEmbeddedPage(
               {
                 resource: { question: Number(questionId) },
                 params: {
@@ -373,18 +357,18 @@ describeWithSnowplowEE(
 
           waitLoading();
 
-          main().findByText(value).should("exist");
+          H.main().findByText(value).should("exist");
 
           cy.findByTestId("download-button").click();
 
-          popover().within(() => {
+          H.popover().within(() => {
             cy.findByText(".csv").click();
             cy.findByTestId("download-results-button").click();
           });
 
           cy.verifyDownload(".csv", { contains: true });
 
-          expectGoodSnowplowEvent({
+          H.expectGoodSnowplowEvent({
             event: "download_results_clicked",
             resource_type: "question",
             accessed_via: "static-embed",
@@ -396,4 +380,4 @@ describeWithSnowplowEE(
   },
 );
 
-const waitLoading = () => main().findByText("Loading...").should("not.exist");
+const waitLoading = () => H.main().findByText("Loading...").should("not.exist");

--- a/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -1,38 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  addOrUpdateDashboardCard,
-  assertEmbeddingParameter,
-  assertSheetRowsCount,
-  closeStaticEmbeddingModal,
-  createDashboardWithTabs,
-  createQuestion,
-  dashboardParametersContainer,
-  describeEE,
-  downloadAndAssert,
-  editDashboard,
-  filterWidget,
-  getDashboardCard,
-  getEmbeddedPageUrl,
-  getIframeBody,
-  getRequiredToggle,
-  goToTab,
-  main,
-  modal,
-  multiAutocompleteInput,
-  openStaticEmbeddingModal,
-  popover,
-  publishChanges,
-  restore,
-  saveDashboard,
-  setEmbeddingParameter,
-  setTokenFeatures,
-  sidebar,
-  toggleRequiredParameter,
-  visitDashboard,
-  visitEmbeddedPage,
-  visitIframe,
-} from "e2e/support/helpers";
 import { createMockParameter } from "metabase-types/api/mocks";
 
 import { addWidgetStringFilter } from "../native-filters/helpers/e2e-field-filter-helpers";
@@ -48,7 +16,7 @@ const { ORDERS, PEOPLE, PRODUCTS, ORDERS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > embedding > dashboard parameters", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.request("POST", `/api/field/${ORDERS.USER_ID}/dimension`, {
@@ -73,9 +41,12 @@ describe("scenarios > embedding > dashboard parameters", () => {
 
   context("UI", () => {
     it("should be disabled by default but able to be set to editable and/or locked (metabase#20357)", () => {
-      visitDashboard("@dashboardId");
+      H.visitDashboard("@dashboardId");
 
-      openStaticEmbeddingModal({ activeTab: "parameters", acceptTerms: true });
+      H.openStaticEmbeddingModal({
+        activeTab: "parameters",
+        acceptTerms: true,
+      });
 
       cy.findByLabelText("Configuring parameters").as("allParameters");
 
@@ -94,7 +65,7 @@ describe("scenarios > embedding > dashboard parameters", () => {
           });
       });
 
-      popover().findByText("Editable").click();
+      H.popover().findByText("Editable").click();
 
       cy.get("@allParameters")
         .findByText("Id")
@@ -102,9 +73,9 @@ describe("scenarios > embedding > dashboard parameters", () => {
         .findByText("Disabled")
         .click();
 
-      popover().findByText("Locked").click();
+      H.popover().findByText("Locked").click();
 
-      modal().within(() => {
+      H.modal().within(() => {
         // set the locked parameter's value
         cy.findByText("Previewing locked parameters")
           .parent()
@@ -112,14 +83,14 @@ describe("scenarios > embedding > dashboard parameters", () => {
           .click();
       });
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByPlaceholderText("Search by Name or enter an ID").type("1,3,");
 
         cy.button("Add filter").click();
       });
 
       // publish the embedded dashboard so that we can directly navigate to its url
-      publishChanges("dashboard", ({ request }) => {
+      H.publishChanges("dashboard", ({ request }) => {
         assert.deepEqual(request.body.embedding_params, {
           id: "locked",
           name: "enabled",
@@ -127,10 +98,10 @@ describe("scenarios > embedding > dashboard parameters", () => {
       });
 
       // directly navigate to the embedded dashboard
-      visitIframe();
+      H.visitIframe();
 
       // verify that the Id parameter doesn't show up but that its value is reflected in the dashcard
-      filterWidget().contains("Id").should("not.exist");
+      H.filterWidget().contains("Id").should("not.exist");
 
       cy.findByTestId("scalar-value").invoke("text").should("eq", "2");
 
@@ -144,7 +115,7 @@ describe("scenarios > embedding > dashboard parameters", () => {
       openFilterOptions("Name");
 
       cy.findByPlaceholderText("Search by Name").type("L");
-      popover().last().findByText("Lina Heaney").click();
+      H.popover().last().findByText("Lina Heaney").click();
 
       cy.button("Add filter").click();
 
@@ -155,26 +126,29 @@ describe("scenarios > embedding > dashboard parameters", () => {
       );
       cy.signInAsAdmin();
 
-      visitDashboard("@dashboardId");
+      H.visitDashboard("@dashboardId");
 
-      openStaticEmbeddingModal({ activeTab: "parameters", acceptTerms: false });
+      H.openStaticEmbeddingModal({
+        activeTab: "parameters",
+        acceptTerms: false,
+      });
 
       cy.get("@allParameters").findByText("Locked").click();
-      popover().contains("Disabled").click();
+      H.popover().contains("Disabled").click();
 
       cy.get("@allParameters").findByText("Editable").click();
-      popover().contains("Disabled").click();
+      H.popover().contains("Disabled").click();
 
-      publishChanges("dashboard", ({ request }) => {
+      H.publishChanges("dashboard", ({ request }) => {
         assert.deepEqual(request.body.embedding_params, {
           name: "disabled",
           id: "disabled",
         });
       });
 
-      visitIframe();
+      H.visitIframe();
 
-      filterWidget().should("not.exist");
+      H.filterWidget().should("not.exist");
 
       cy.findByTestId("scalar-value").invoke("text").should("eq", "2,500");
     });
@@ -196,14 +170,14 @@ describe("scenarios > embedding > dashboard parameters", () => {
           params: {},
         };
 
-        visitEmbeddedPage(payload);
+        H.visitEmbeddedPage(payload);
 
         // wait for the results to load
         cy.contains("Test Dashboard");
         cy.contains("2,500");
       });
 
-      dashboardParametersContainer().within(() => {
+      H.dashboardParametersContainer().within(() => {
         cy.findByText("Id").should("be.visible");
         cy.findByText("Name").should("be.visible");
         cy.findByText("Source").should("be.visible");
@@ -211,9 +185,9 @@ describe("scenarios > embedding > dashboard parameters", () => {
         cy.findByText("Not Used Filter").should("not.exist");
       });
 
-      goToTab("Tab 2");
+      H.goToTab("Tab 2");
 
-      dashboardParametersContainer().should("not.exist");
+      H.dashboardParametersContainer().should("not.exist");
       cy.findByTestId("embed-frame").within(() => {
         cy.findByText("Id").should("not.exist");
         cy.findByText("Name").should("not.exist");
@@ -224,39 +198,42 @@ describe("scenarios > embedding > dashboard parameters", () => {
     });
 
     it("should handle required parameters", () => {
-      visitDashboard("@dashboardId");
-      editDashboard();
+      H.visitDashboard("@dashboardId");
+      H.editDashboard();
 
       // Make one parameter required
       getDashboardFilter("Name").click();
-      toggleRequiredParameter();
-      sidebar().findByText("Default value").next().click();
+      H.toggleRequiredParameter();
+      H.sidebar().findByText("Default value").next().click();
       addWidgetStringFilter("Ferne Rosenbaum", {
         buttonLabel: "Update filter",
       });
-      saveDashboard();
+      H.saveDashboard();
 
       // Check that parameter visibility is correct
-      openStaticEmbeddingModal({ activeTab: "parameters", acceptTerms: true });
-      assertEmbeddingParameter("Id", "Disabled");
-      assertEmbeddingParameter("Name", "Editable");
-      assertEmbeddingParameter("Source", "Disabled");
-      assertEmbeddingParameter("User", "Disabled");
-      assertEmbeddingParameter("Not Used Filter", "Disabled");
+      H.openStaticEmbeddingModal({
+        activeTab: "parameters",
+        acceptTerms: true,
+      });
+      H.assertEmbeddingParameter("Id", "Disabled");
+      H.assertEmbeddingParameter("Name", "Editable");
+      H.assertEmbeddingParameter("Source", "Disabled");
+      H.assertEmbeddingParameter("User", "Disabled");
+      H.assertEmbeddingParameter("Not Used Filter", "Disabled");
 
       // We only expect name to be "enabled" because the rest
       // weren't touched and therefore aren't changed, whereas
       // "enabled" must be set by default for required params.
-      publishChanges("dashboard", ({ request }) => {
+      H.publishChanges("dashboard", ({ request }) => {
         assert.deepEqual(request.body.embedding_params, {
           name: "enabled",
         });
       });
 
-      visitIframe();
+      H.visitIframe();
 
       // Filter widget must be visible
-      filterWidget().contains("Name");
+      H.filterWidget().contains("Name");
       // Its default value must be in the URL
       cy.location("search").should("contain", "name=Ferne+Rosenbaum");
       // And the default should be applied giving us only 1 result
@@ -264,21 +241,24 @@ describe("scenarios > embedding > dashboard parameters", () => {
     });
 
     it("should (dis)allow setting parameters as required for a published embedding", () => {
-      visitDashboard("@dashboardId");
+      H.visitDashboard("@dashboardId");
 
       // Set an "editable" and "locked" parameters and leave the rest "disabled"
-      openStaticEmbeddingModal({ activeTab: "parameters", acceptTerms: true });
-      setEmbeddingParameter("Name", "Editable");
-      setEmbeddingParameter("Source", "Locked");
-      publishChanges("dashboard", ({ request }) => {
+      H.openStaticEmbeddingModal({
+        activeTab: "parameters",
+        acceptTerms: true,
+      });
+      H.setEmbeddingParameter("Name", "Editable");
+      H.setEmbeddingParameter("Source", "Locked");
+      H.publishChanges("dashboard", ({ request }) => {
         assert.deepEqual(request.body.embedding_params, {
           name: "enabled",
           source: "locked",
         });
       });
 
-      closeStaticEmbeddingModal();
-      editDashboard();
+      H.closeStaticEmbeddingModal();
+      H.editDashboard();
 
       // Check each parameter's required state
       assertRequiredEnabledForName({ name: "Name", enabled: true });
@@ -290,7 +270,7 @@ describe("scenarios > embedding > dashboard parameters", () => {
     });
 
     it("should render cursor pointer on hover over a toggle (metabase#46223)", () => {
-      visitDashboard("@dashboardId");
+      H.visitDashboard("@dashboardId");
 
       cy.findAllByTestId("parameter-value-widget-target")
         .first()
@@ -317,7 +297,7 @@ describe("scenarios > embedding > dashboard parameters", () => {
           params: {},
         };
 
-        visitEmbeddedPage(payload);
+        H.visitEmbeddedPage(payload);
 
         // wait for the results to load
         cy.contains("Test Dashboard");
@@ -329,54 +309,54 @@ describe("scenarios > embedding > dashboard parameters", () => {
       cy.log("should allow searching PEOPLE.ID by PEOPLE.NAME");
 
       openFilterOptions("Id");
-      popover().within(() => {
-        multiAutocompleteInput().type("Aly");
+      H.popover().within(() => {
+        H.multiAutocompleteInput().type("Aly");
       });
 
-      popover().last().contains("Alycia McCullough - 2016");
+      H.popover().last().contains("Alycia McCullough - 2016");
 
       // close the suggestions popover
-      popover()
+      H.popover()
         .first()
         .within(() => {
-          multiAutocompleteInput().blur();
+          H.multiAutocompleteInput().blur();
         });
 
       cy.log("should allow searching PEOPLE.NAME by PEOPLE.NAME");
 
       openFilterOptions("Name");
-      popover().within(() => {
-        multiAutocompleteInput().type("{backspace}Aly");
+      H.popover().within(() => {
+        H.multiAutocompleteInput().type("{backspace}Aly");
       });
 
-      popover().last().contains("Alycia McCullough");
+      H.popover().last().contains("Alycia McCullough");
 
       // close the suggestions popover
-      popover()
+      H.popover()
         .first()
         .within(() => {
-          multiAutocompleteInput().blur();
+          H.multiAutocompleteInput().blur();
         });
 
       cy.log("should show values for PEOPLE.SOURCE");
 
       openFilterOptions("Source");
-      popover().contains("Affiliate");
+      H.popover().contains("Affiliate");
 
       cy.log("should allow searching ORDER.USER_ID by PEOPLE.NAME");
 
       openFilterOptions("User");
-      popover().within(() => {
-        multiAutocompleteInput().type("Aly");
+      H.popover().within(() => {
+        H.multiAutocompleteInput().type("Aly");
       });
 
-      popover().last().contains("Alycia McCullough - 2016");
+      H.popover().last().contains("Alycia McCullough - 2016");
 
       // close the suggestions popover
-      popover()
+      H.popover()
         .first()
         .within(() => {
-          multiAutocompleteInput().blur();
+          H.multiAutocompleteInput().blur();
         });
 
       cy.log("should accept url parameters");
@@ -407,9 +387,9 @@ describe("scenarios > embedding > dashboard parameters", () => {
         params: invalidParamsValue,
       };
 
-      visitEmbeddedPage(payload);
+      H.visitEmbeddedPage(payload);
 
-      getDashboardCard()
+      H.getDashboardCard()
         .findByText("There was a problem displaying this chart.")
         .should("be.visible");
     });
@@ -467,7 +447,7 @@ describe("scenarios > embedding > dashboard parameters", () => {
     }).then(({ body: { card_id, dashboard_id } }) => {
       cy.wrap(dashboard_id).as("dashboardId2");
 
-      addOrUpdateDashboardCard({
+      H.addOrUpdateDashboardCard({
         card_id,
         dashboard_id,
         card: {
@@ -505,24 +485,24 @@ describe("scenarios > embedding > dashboard parameters", () => {
         params: {},
       };
 
-      visitEmbeddedPage(payload);
+      H.visitEmbeddedPage(payload);
     });
 
     cy.log("The whole page would have crashed before the fix at this point");
-    getDashboardCard()
+    H.getDashboardCard()
       .findByText("There was a problem displaying this chart.")
       .should("be.visible");
 
     cy.log("Add a filter to complete the query");
-    filterWidget().findByPlaceholderText("Category").type("Widget{enter}");
+    H.filterWidget().findByPlaceholderText("Category").type("Widget{enter}");
 
-    getDashboardCard()
+    H.getDashboardCard()
       .findByText("Practical Bronze Computer")
       .should("be.visible");
 
     cy.log("test downloading result (metabase#36721)");
-    getDashboardCard().realHover();
-    downloadAndAssert(
+    H.getDashboardCard().realHover();
+    H.downloadAndAssert(
       {
         fileType: "csv",
         isDashboard: true,
@@ -537,7 +517,7 @@ describe("scenarios > embedding > dashboard parameters", () => {
         expect(sheet["B1"].v).to.eq("EAN");
         expect(sheet["B2"].v).to.eq(7217466997444);
 
-        assertSheetRowsCount(54)(sheet);
+        H.assertSheetRowsCount(54)(sheet);
       },
     );
   });
@@ -556,7 +536,7 @@ describe("scenarios > embedding > dashboard parameters", () => {
         params: {},
       };
 
-      visitEmbeddedPage(payload, {
+      H.visitEmbeddedPage(payload, {
         onBeforeLoad: window => {
           window.Cypress = undefined;
         },
@@ -573,7 +553,7 @@ describe("scenarios > embedding > dashboard parameters", () => {
 
 describe("scenarios > embedding > dashboard parameters with defaults", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestionAndDashboard({
@@ -585,16 +565,16 @@ describe("scenarios > embedding > dashboard parameters with defaults", () => {
       mapParameters({ id, card_id, dashboard_id });
     });
 
-    visitDashboard("@dashboardId");
+    H.visitDashboard("@dashboardId");
   });
 
   it("card parameter defaults should apply for disabled parameters, but not for editable or locked parameters", () => {
-    openStaticEmbeddingModal({ activeTab: "parameters" });
+    H.openStaticEmbeddingModal({ activeTab: "parameters" });
 
     // ID param is disabled by default
-    setEmbeddingParameter("Name", "Editable");
-    setEmbeddingParameter("Source", "Locked");
-    publishChanges("dashboard", ({ request }) => {
+    H.setEmbeddingParameter("Name", "Editable");
+    H.setEmbeddingParameter("Source", "Locked");
+    H.publishChanges("dashboard", ({ request }) => {
       assert.deepEqual(request.body.embedding_params, {
         source: "locked",
         name: "enabled",
@@ -607,7 +587,7 @@ describe("scenarios > embedding > dashboard parameters with defaults", () => {
         params: { source: [] },
       };
 
-      visitEmbeddedPage(payload);
+      H.visitEmbeddedPage(payload);
 
       // wait for the results to load
 
@@ -644,14 +624,14 @@ describe("scenarios > embedding > dashboard parameters with defaults", () => {
         params: { source: null },
       };
 
-      visitEmbeddedPage(payload);
+      H.visitEmbeddedPage(payload);
     });
 
     // The Source parameter is 'locked', and no value has been specified in the token,
     // thus the API responds with "You must specify a value for :source in the JWT."
     // and the card will not display.
 
-    getDashboardCard()
+    H.getDashboardCard()
       .findByText("There was a problem displaying this chart.")
       .should("be.visible");
   });
@@ -674,17 +654,17 @@ describe("scenarios > embedding > dashboard parameters with defaults", () => {
       });
     });
 
-    visitDashboard("@dashboardId");
-    openStaticEmbeddingModal({ activeTab: "parameters" });
-    visitIframe();
+    H.visitDashboard("@dashboardId");
+    H.openStaticEmbeddingModal({ activeTab: "parameters" });
+    H.visitIframe();
 
     cy.log("should show card results by default");
-    getDashboardCard().findByText("2").should("be.visible");
-    getDashboardCard().findByText("test question").should("be.visible");
+    H.getDashboardCard().findByText("2").should("be.visible");
+    H.getDashboardCard().findByText("test question").should("be.visible");
   });
 });
 
-describeEE("scenarios > embedding > dashboard appearance", () => {
+H.describeEE("scenarios > embedding > dashboard appearance", () => {
   const originalBaseUrl = Cypress.config("baseUrl");
 
   beforeEach(() => {
@@ -692,9 +672,9 @@ describeEE("scenarios > embedding > dashboard appearance", () => {
     // needed because we do `Cypress.config("baseUrl", null);` in the iframe test
     Cypress.config("baseUrl", originalBaseUrl);
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
   });
 
   it("should not rerender the static embed preview unnecessarily (metabase#38271)", () => {
@@ -732,7 +712,7 @@ describeEE("scenarios > embedding > dashboard appearance", () => {
       questionDetails,
       dashboardDetails,
     }).then(({ body: { dashboard_id } }) => {
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
     });
 
     cy.intercept(
@@ -741,7 +721,7 @@ describeEE("scenarios > embedding > dashboard appearance", () => {
       cy.spy().as("previewEmbedSpy"),
     ).as("previewEmbed");
 
-    openStaticEmbeddingModal({
+    H.openStaticEmbeddingModal({
       activeTab: "parameters",
       previewMode: "preview",
       // EE users don't have to accept terms
@@ -750,12 +730,12 @@ describeEE("scenarios > embedding > dashboard appearance", () => {
 
     cy.wait("@previewEmbed");
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByRole("tab", { name: "Look and Feel" }).click();
       cy.get("@previewEmbedSpy").should("have.callCount", 1);
 
       cy.log("Assert dashboard theme");
-      getIframeBody()
+      H.getIframeBody()
         .findByTestId("embed-frame")
         .invoke("attr", "data-embed-theme")
         .then(embedTheme => {
@@ -765,7 +745,7 @@ describeEE("scenarios > embedding > dashboard appearance", () => {
       // We're getting an input element which is 0x0 in size
       cy.findByLabelText("Dark").click({ force: true });
       cy.wait(1000);
-      getIframeBody()
+      H.getIframeBody()
         .findByTestId("embed-frame")
         .invoke("attr", "data-embed-theme")
         .then(embedTheme => {
@@ -775,32 +755,32 @@ describeEE("scenarios > embedding > dashboard appearance", () => {
       cy.get("@previewEmbedSpy").should("have.callCount", 1);
 
       cy.log("Assert dashboard title");
-      getIframeBody().findByText(dashboardDetails.name).should("exist");
+      H.getIframeBody().findByText(dashboardDetails.name).should("exist");
       // We're getting an input element which is 0x0 in size
       cy.findByLabelText("Dashboard title").click({ force: true });
-      getIframeBody().findByText(dashboardDetails.name).should("not.exist");
+      H.getIframeBody().findByText(dashboardDetails.name).should("not.exist");
       cy.get("@previewEmbedSpy").should("have.callCount", 1);
 
       cy.log("Assert dashboard border");
-      getIframeBody()
+      H.getIframeBody()
         .findByTestId("embed-frame")
         .should("have.css", "border-top-width", "1px");
       // We're getting an input element which is 0x0 in size
       cy.findByLabelText("Dashboard border").click({ force: true });
-      getIframeBody()
+      H.getIframeBody()
         .findByTestId("embed-frame")
         .should("have.css", "border-top-width", "0px");
       cy.get("@previewEmbedSpy").should("have.callCount", 1);
 
       cy.log("Assert font");
-      getIframeBody().should("have.css", "font-family", "Lato, sans-serif");
+      H.getIframeBody().should("have.css", "font-family", "Lato, sans-serif");
       cy.findByLabelText("Font").click();
     });
 
     // Since the select popover is rendered outside of the modal, we need to exit the modal context first.
-    popover().findByText("Oswald").click();
-    modal().within(() => {
-      getIframeBody().should("have.css", "font-family", "Oswald, sans-serif");
+    H.popover().findByText("Oswald").click();
+    H.modal().within(() => {
+      H.getIframeBody().should("have.css", "font-family", "Oswald, sans-serif");
       cy.get("@previewEmbedSpy").should("have.callCount", 1);
     });
   });
@@ -840,9 +820,9 @@ describeEE("scenarios > embedding > dashboard appearance", () => {
         "source-table": ORDERS_ID,
       },
     };
-    createQuestion(questionDetails)
+    H.createQuestion(questionDetails)
       .then(({ body: { id: card_id } }) => {
-        createDashboardWithTabs({
+        H.createDashboardWithTabs({
           ...dashboardDetails,
           dashcards: [
             {
@@ -858,7 +838,7 @@ describeEE("scenarios > embedding > dashboard appearance", () => {
         });
       })
       .then(dashboard => {
-        visitDashboard(dashboard.id);
+        H.visitDashboard(dashboard.id);
       });
 
     cy.intercept(
@@ -867,7 +847,7 @@ describeEE("scenarios > embedding > dashboard appearance", () => {
       cy.spy().as("previewEmbedSpy"),
     ).as("previewEmbed");
 
-    openStaticEmbeddingModal({
+    H.openStaticEmbeddingModal({
       activeTab: "parameters",
       previewMode: "preview",
       // EE users don't have to accept terms
@@ -876,12 +856,12 @@ describeEE("scenarios > embedding > dashboard appearance", () => {
 
     cy.wait("@previewEmbed");
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByRole("tab", { name: "Look and Feel" }).click();
       cy.get("@previewEmbedSpy").should("have.callCount", 1);
 
       cy.log("Assert dashboard theme");
-      getIframeBody()
+      H.getIframeBody()
         .findByTestId("embed-frame")
         .invoke("attr", "data-embed-theme")
         .then(embedTheme => {
@@ -891,7 +871,7 @@ describeEE("scenarios > embedding > dashboard appearance", () => {
       // We're getting an input element which is 0x0 in size
       cy.findByLabelText("Dark").click({ force: true });
       cy.wait(1000);
-      getIframeBody()
+      H.getIframeBody()
         .findByTestId("embed-frame")
         .invoke("attr", "data-embed-theme")
         .then(embedTheme => {
@@ -901,32 +881,32 @@ describeEE("scenarios > embedding > dashboard appearance", () => {
       cy.get("@previewEmbedSpy").should("have.callCount", 1);
 
       cy.log("Assert dashboard title");
-      getIframeBody().findByText(dashboardDetails.name).should("exist");
+      H.getIframeBody().findByText(dashboardDetails.name).should("exist");
       // We're getting an input element which is 0x0 in size
       cy.findByLabelText("Dashboard title").click({ force: true });
-      getIframeBody().findByText(dashboardDetails.name).should("not.exist");
+      H.getIframeBody().findByText(dashboardDetails.name).should("not.exist");
       cy.get("@previewEmbedSpy").should("have.callCount", 1);
 
       cy.log("Assert dashboard border");
-      getIframeBody()
+      H.getIframeBody()
         .findByTestId("embed-frame")
         .should("have.css", "border-top-width", "1px");
       // We're getting an input element which is 0x0 in size
       cy.findByLabelText("Dashboard border").click({ force: true });
-      getIframeBody()
+      H.getIframeBody()
         .findByTestId("embed-frame")
         .should("have.css", "border-top-width", "0px");
       cy.get("@previewEmbedSpy").should("have.callCount", 1);
 
       cy.log("Assert font");
-      getIframeBody().should("have.css", "font-family", "Lato, sans-serif");
+      H.getIframeBody().should("have.css", "font-family", "Lato, sans-serif");
       cy.findByLabelText("Font").click();
     });
 
     // Since the select popover is rendered outside of the modal, we need to exit the modal context first.
-    popover().findByText("Oswald").click();
-    modal().within(() => {
-      getIframeBody().should("have.css", "font-family", "Oswald, sans-serif");
+    H.popover().findByText("Oswald").click();
+    H.modal().within(() => {
+      H.getIframeBody().should("have.css", "font-family", "Oswald, sans-serif");
       cy.get("@previewEmbedSpy").should("have.callCount", 1);
     });
   });
@@ -953,9 +933,9 @@ describeEE("scenarios > embedding > dashboard appearance", () => {
       },
       display: "bar",
     };
-    createQuestion(questionDetails)
+    H.createQuestion(questionDetails)
       .then(({ body: { id: card_id } }) => {
-        createDashboardWithTabs({
+        H.createDashboardWithTabs({
           ...dashboardDetails,
           dashcards: [
             {
@@ -970,7 +950,7 @@ describeEE("scenarios > embedding > dashboard appearance", () => {
         });
       })
       .then(dashboard => {
-        return getEmbeddedPageUrl({
+        return H.getEmbeddedPageUrl({
           resource: { dashboard: dashboard.id },
           params: {},
         });
@@ -983,7 +963,7 @@ describeEE("scenarios > embedding > dashboard appearance", () => {
         );
       });
 
-    getIframeBody().within(() => {
+    H.getIframeBody().within(() => {
       cy.findByText(questionDetails.name).should("exist");
       cy.findByText("April 2022").should("exist");
 
@@ -1015,7 +995,7 @@ describeEE("scenarios > embedding > dashboard appearance", () => {
     });
     cy.signOut();
 
-    visitEmbeddedPage(
+    H.visitEmbeddedPage(
       {
         resource: { dashboard: ORDERS_DASHBOARD_ID },
         params: {},
@@ -1027,7 +1007,7 @@ describeEE("scenarios > embedding > dashboard appearance", () => {
       },
     );
 
-    main().findByText("Februar 11, 2025, 9:40 PM");
+    H.main().findByText("Februar 11, 2025, 9:40 PM");
     // eslint-disable-next-line no-unscoped-text-selectors -- we don't care where the text is
     cy.findByText("exportieren", { exact: false });
 
@@ -1036,7 +1016,7 @@ describeEE("scenarios > embedding > dashboard appearance", () => {
 });
 
 function openFilterOptions(name) {
-  filterWidget().contains(name).click();
+  H.filterWidget().contains(name).click();
 }
 
 function getDashboardFilter(name) {
@@ -1047,5 +1027,5 @@ function getDashboardFilter(name) {
 
 function assertRequiredEnabledForName({ name, enabled }) {
   getDashboardFilter(name).click();
-  getRequiredToggle().should(enabled ? "be.enabled" : "not.be.enabled");
+  H.getRequiredToggle().should(enabled ? "be.enabled" : "not.be.enabled");
 }

--- a/e2e/test/scenarios/embedding/embedding-linked-filters.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-linked-filters.cy.spec.js
@@ -1,15 +1,4 @@
-import {
-  assertEChartsTooltip,
-  chartPathWithFillColor,
-  echartsContainer,
-  filterWidget,
-  getDashboardCard,
-  multiAutocompleteInput,
-  popover,
-  removeMultiAutocompleteValue,
-  restore,
-  visitEmbeddedPage,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 import {
   guiDashboard,
@@ -22,7 +11,7 @@ import {
 
 describe("scenarios > embedding > dashboard > linked filters (metabase#13639, metabase#13868)", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -54,37 +43,37 @@ describe("scenarios > embedding > dashboard > linked filters (metabase#13639, me
           params: {},
         };
 
-        visitEmbeddedPage(payload);
+        H.visitEmbeddedPage(payload);
       });
 
       cy.findByRole("heading", { name: nativeDashboardDetails.name });
-      getDashboardCard().contains(nativeQuestionDetails.name);
+      H.getDashboardCard().contains(nativeQuestionDetails.name);
 
-      chartPathWithFillColor("#509EE3").should("have.length", 49);
+      H.chartPathWithFillColor("#509EE3").should("have.length", 49);
 
       assertOnXYAxisLabels({ xLabel: "STATE", yLabel: "count" });
 
-      echartsContainer()
+      H.echartsContainer()
         .get("text")
         .should("contain", "TX")
         .and("contain", "AK");
 
       openFilterOptions("State");
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("AK").click();
         cy.button("Add filter").click();
       });
 
       cy.location("search").should("eq", "?city=&state=AK");
 
-      echartsContainer()
+      H.echartsContainer()
         .get("text")
         .should("contain", "AK")
         .and("not.contain", "TX");
 
-      chartPathWithFillColor("#509EE3").should("have.length", 1).realHover();
-      assertEChartsTooltip({
+      H.chartPathWithFillColor("#509EE3").should("have.length", 1).realHover();
+      H.assertEChartsTooltip({
         header: "AK",
         rows: [{ color: "#509EE3", name: "count", value: "68" }],
         blurAfter: true,
@@ -94,18 +83,18 @@ describe("scenarios > embedding > dashboard > linked filters (metabase#13639, me
 
       searchMultiAutocompleteFilter();
 
-      popover()
+      H.popover()
         .filter(":contains('Add filter')")
         .within(() => {
-          multiAutocompleteInput().blur();
+          H.multiAutocompleteInput().blur();
           cy.button("Add filter").click();
         });
 
       cy.location("search").should("eq", "?city=Anchorage&state=AK");
 
-      chartPathWithFillColor("#509EE3").should("have.length", 1).realHover();
+      H.chartPathWithFillColor("#509EE3").should("have.length", 1).realHover();
 
-      assertEChartsTooltip({
+      H.assertEChartsTooltip({
         header: "AK",
         rows: [{ color: "#509EE3", name: "count", value: "1" }],
       });
@@ -122,16 +111,16 @@ describe("scenarios > embedding > dashboard > linked filters (metabase#13639, me
           auto_apply_filters: false,
         });
 
-        visitEmbeddedPage(payload);
+        H.visitEmbeddedPage(payload);
       });
 
       cy.findByRole("heading", { name: nativeDashboardDetails.name });
-      getDashboardCard().contains(nativeQuestionDetails.name);
+      H.getDashboardCard().contains(nativeQuestionDetails.name);
 
       assertOnXYAxisLabels({ xLabel: "STATE", yLabel: "count" });
 
-      chartPathWithFillColor("#509EE3").should("have.length", 49);
-      echartsContainer()
+      H.chartPathWithFillColor("#509EE3").should("have.length", 49);
+      H.echartsContainer()
         .get("text")
         .should("contain", "AK")
         .and("contain", "TX");
@@ -140,7 +129,7 @@ describe("scenarios > embedding > dashboard > linked filters (metabase#13639, me
 
       cy.button("Apply").should("not.exist");
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("AK").click();
         cy.button("Add filter").click();
       });
@@ -150,14 +139,14 @@ describe("scenarios > embedding > dashboard > linked filters (metabase#13639, me
 
       cy.location("search").should("eq", "?city=&state=AK");
 
-      echartsContainer()
+      H.echartsContainer()
         .get("text")
         .should("contain", "AK")
         .and("not.contain", "TX");
 
-      chartPathWithFillColor("#509EE3").should("have.length", 1).realHover();
+      H.chartPathWithFillColor("#509EE3").should("have.length", 1).realHover();
 
-      assertEChartsTooltip({
+      H.assertEChartsTooltip({
         header: "AK",
         rows: [{ color: "#509EE3", name: "count", value: "68" }],
         blurAfter: true,
@@ -167,10 +156,10 @@ describe("scenarios > embedding > dashboard > linked filters (metabase#13639, me
 
       searchMultiAutocompleteFilter();
 
-      popover()
+      H.popover()
         .filter(":contains('Add filter')")
         .within(() => {
-          multiAutocompleteInput().blur();
+          H.multiAutocompleteInput().blur();
           cy.button("Add filter").click();
         });
 
@@ -179,9 +168,9 @@ describe("scenarios > embedding > dashboard > linked filters (metabase#13639, me
 
       cy.location("search").should("eq", "?city=Anchorage&state=AK");
 
-      chartPathWithFillColor("#509EE3").should("have.length", 1).realHover();
+      H.chartPathWithFillColor("#509EE3").should("have.length", 1).realHover();
 
-      assertEChartsTooltip({
+      H.assertEChartsTooltip({
         header: "AK",
         rows: [{ color: "#509EE3", name: "count", value: "1" }],
       });
@@ -194,16 +183,16 @@ describe("scenarios > embedding > dashboard > linked filters (metabase#13639, me
           params: {},
         };
 
-        visitEmbeddedPage(payload, {
+        H.visitEmbeddedPage(payload, {
           setFilters: { state: "AK" },
         });
       });
 
-      filterWidget().should("have.length", 2);
+      H.filterWidget().should("have.length", 2);
 
-      chartPathWithFillColor("#509EE3").should("have.length", 1).realHover();
+      H.chartPathWithFillColor("#509EE3").should("have.length", 1).realHover();
 
-      assertEChartsTooltip({
+      H.assertEChartsTooltip({
         header: "AK",
         rows: [{ color: "#509EE3", name: "count", value: "68" }],
         blurAfter: true,
@@ -213,18 +202,18 @@ describe("scenarios > embedding > dashboard > linked filters (metabase#13639, me
 
       searchMultiAutocompleteFilter();
 
-      popover()
+      H.popover()
         .filter(":contains('Add filter')")
         .within(() => {
-          multiAutocompleteInput().blur();
+          H.multiAutocompleteInput().blur();
           cy.button("Add filter").click();
         });
 
       cy.location("search").should("eq", "?city=Anchorage&state=AK");
 
-      chartPathWithFillColor("#509EE3").should("have.length", 1).realHover();
+      H.chartPathWithFillColor("#509EE3").should("have.length", 1).realHover();
 
-      assertEChartsTooltip({
+      H.assertEChartsTooltip({
         header: "AK",
         rows: [{ color: "#509EE3", name: "count", value: "1" }],
       });
@@ -237,7 +226,7 @@ describe("scenarios > embedding > dashboard > linked filters (metabase#13639, me
           params: {},
         };
 
-        visitEmbeddedPage(payload, {
+        H.visitEmbeddedPage(payload, {
           setFilters: { state: "AK" },
           additionalHashOptions: {
             hideFilters: ["state"],
@@ -245,30 +234,30 @@ describe("scenarios > embedding > dashboard > linked filters (metabase#13639, me
         });
       });
 
-      chartPathWithFillColor("#509EE3").should("have.length", 1).realHover();
+      H.chartPathWithFillColor("#509EE3").should("have.length", 1).realHover();
 
-      assertEChartsTooltip({
+      H.assertEChartsTooltip({
         header: "AK",
         rows: [{ color: "#509EE3", name: "count", value: "68" }],
         blurAfter: true,
       });
 
-      filterWidget().should("have.length", 1).and("contain", "City").click();
+      H.filterWidget().should("have.length", 1).and("contain", "City").click();
 
       searchMultiAutocompleteFilter();
 
-      popover()
+      H.popover()
         .filter(":contains('Add filter')")
         .within(() => {
-          multiAutocompleteInput().blur();
+          H.multiAutocompleteInput().blur();
           cy.button("Add filter").click();
         });
 
       cy.location("search").should("eq", "?city=Anchorage&state=AK");
 
-      chartPathWithFillColor("#509EE3").should("have.length", 1).realHover();
+      H.chartPathWithFillColor("#509EE3").should("have.length", 1).realHover();
 
-      assertEChartsTooltip({
+      H.assertEChartsTooltip({
         header: "AK",
         rows: [{ color: "#509EE3", name: "count", value: "1" }],
       });
@@ -288,17 +277,17 @@ describe("scenarios > embedding > dashboard > linked filters (metabase#13639, me
           params: { state: ["AK"] },
         };
 
-        visitEmbeddedPage(payload);
+        H.visitEmbeddedPage(payload);
       });
 
-      filterWidget().should("have.length", 1).and("contain", "City").click();
+      H.filterWidget().should("have.length", 1).and("contain", "City").click();
 
       searchMultiAutocompleteFilter();
 
-      popover()
+      H.popover()
         .filter(":contains('Add filter')")
         .within(() => {
-          multiAutocompleteInput().blur();
+          H.multiAutocompleteInput().blur();
           cy.button("Add filter").click();
         });
 
@@ -333,16 +322,16 @@ describe("scenarios > embedding > dashboard > linked filters (metabase#13639, me
           params: {},
         };
 
-        visitEmbeddedPage(payload);
+        H.visitEmbeddedPage(payload);
       });
 
       // ID filter already comes with the default value
       cy.location("search").should("eq", "?category=&id_filter=1");
 
       // But it should still be editable, and that's why we see two filter widgets
-      filterWidget().should("have.length", 2).contains("Category").click();
+      H.filterWidget().should("have.length", 2).contains("Category").click();
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Gizmo").click();
         cy.findByText("Doohickey").should("not.exist");
         cy.findByText("Gadget").should("not.exist");
@@ -365,13 +354,13 @@ describe("scenarios > embedding > dashboard > linked filters (metabase#13639, me
         };
 
         cy.log("Make sure we can override the default value");
-        visitEmbeddedPage(payload, { setFilters: { id_filter: 4 } });
+        H.visitEmbeddedPage(payload, { setFilters: { id_filter: 4 } });
 
         cy.location("search").should("eq", "?id_filter=4");
 
-        filterWidget().should("have.length", 2).contains("Category").click();
+        H.filterWidget().should("have.length", 2).contains("Category").click();
 
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findByText("Doohickey").click();
           cy.findByText("Gizmo").should("not.exist");
           cy.findByText("Gadget").should("not.exist");
@@ -392,7 +381,7 @@ describe("scenarios > embedding > dashboard > linked filters (metabase#13639, me
             (win.location.search = "?category=Widget&id_filter=4&id_filter=29"),
         );
 
-        filterWidget()
+        H.filterWidget()
           .should("have.length", 2)
           .and("contain", "2 selections")
           .and("contain", "Widget");
@@ -413,7 +402,7 @@ describe("scenarios > embedding > dashboard > linked filters (metabase#13639, me
         cy.findByText("2 selections").click();
 
         // Remove one of the previously set filter values
-        popover().within(() => removeMultiAutocompleteValue(1));
+        H.popover().within(() => H.removeMultiAutocompleteValue(1));
 
         cy.button("Update filter").click();
 
@@ -423,7 +412,7 @@ describe("scenarios > embedding > dashboard > linked filters (metabase#13639, me
 
         openFilterOptions("Category");
 
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findByText("Doohickey");
           cy.findByText("Gizmo").should("not.exist");
           cy.findByText("Gadget").should("not.exist");
@@ -439,7 +428,7 @@ describe("scenarios > embedding > dashboard > linked filters (metabase#13639, me
           params: {},
         };
 
-        visitEmbeddedPage(payload, {
+        H.visitEmbeddedPage(payload, {
           additionalHashOptions: {
             hideFilters: ["id_filter"],
           },
@@ -450,12 +439,12 @@ describe("scenarios > embedding > dashboard > linked filters (metabase#13639, me
         .should("have.length", 1)
         .and("contain", "Gizmo");
 
-      filterWidget()
+      H.filterWidget()
         .should("have.length", 1)
         .and("contain", "Category")
         .click();
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Gizmo");
         cy.findByText("Doohickey").should("not.exist");
         cy.findByText("Gadget").should("not.exist");
@@ -477,19 +466,19 @@ describe("scenarios > embedding > dashboard > linked filters (metabase#13639, me
           params: { id_filter: [1] },
         };
 
-        visitEmbeddedPage(payload);
+        H.visitEmbeddedPage(payload);
       });
 
       cy.findByTestId("table-row")
         .should("have.length", 1)
         .and("contain", "Gizmo");
 
-      filterWidget()
+      H.filterWidget()
         .should("have.length", 1)
         .and("contain", "Category")
         .click();
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Gizmo");
         cy.findByText("Doohickey").should("not.exist");
         cy.findByText("Gadget").should("not.exist");
@@ -500,18 +489,18 @@ describe("scenarios > embedding > dashboard > linked filters (metabase#13639, me
 });
 
 function openFilterOptions(name) {
-  filterWidget().contains(name).click();
+  H.filterWidget().contains(name).click();
 }
 
 function assertOnXYAxisLabels({ xLabel, yLabel } = {}) {
-  echartsContainer().get("text").contains(xLabel);
+  H.echartsContainer().get("text").contains(xLabel);
 
-  echartsContainer().get("text").contains(yLabel);
+  H.echartsContainer().get("text").contains(yLabel);
 }
 
 function searchMultiAutocompleteFilter() {
   cy.findByTestId("parameter-value-dropdown").within(() => {
-    multiAutocompleteInput().type("An");
+    H.multiAutocompleteInput().type("An");
   });
 
   cy.findByTestId("select-dropdown").within(() => {

--- a/e2e/test/scenarios/embedding/embedding-native.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-native.cy.spec.js
@@ -1,18 +1,4 @@
-import {
-  assertEmbeddingParameter,
-  clearFilterWidget,
-  closeStaticEmbeddingModal,
-  createNativeQuestion,
-  filterWidget,
-  openStaticEmbeddingModal,
-  popover,
-  publishChanges,
-  restore,
-  setEmbeddingParameter,
-  visitEmbeddedPage,
-  visitIframe,
-  visitQuestion,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 import * as SQLFilter from "../native-filters/helpers/e2e-sql-filter-helpers";
 
@@ -24,7 +10,7 @@ import { questionDetails } from "./shared/embedding-native";
 
 describe("scenarios > embedding > native questions", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -42,17 +28,17 @@ describe("scenarios > embedding > native questions", () => {
         visitQuestion: true,
       });
 
-      openStaticEmbeddingModal({ activeTab: "parameters" });
+      H.openStaticEmbeddingModal({ activeTab: "parameters" });
     }
 
     it("should not display disabled parameters", () => {
       createAndVisitQuestion();
 
-      publishChanges("card", ({ request }) => {
+      H.publishChanges("card", ({ request }) => {
         assert.deepEqual(request.body.embedding_params, {});
       });
 
-      visitIframe();
+      H.visitIframe();
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Lora Cronin");
@@ -61,19 +47,19 @@ describe("scenarios > embedding > native questions", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("39.58");
 
-      filterWidget().should("not.exist");
+      H.filterWidget().should("not.exist");
     });
 
     it("should display and work with enabled parameters while hiding the locked one", () => {
       createAndVisitQuestion();
 
-      setEmbeddingParameter("Order ID", "Editable");
-      setEmbeddingParameter("Created At", "Editable");
-      setEmbeddingParameter("Total", "Locked");
-      setEmbeddingParameter("State", "Editable");
-      setEmbeddingParameter("Product ID", "Editable");
+      H.setEmbeddingParameter("Order ID", "Editable");
+      H.setEmbeddingParameter("Created At", "Editable");
+      H.setEmbeddingParameter("Total", "Locked");
+      H.setEmbeddingParameter("State", "Editable");
+      H.setEmbeddingParameter("Product ID", "Editable");
 
-      publishChanges("card", ({ request }) => {
+      H.publishChanges("card", ({ request }) => {
         const actual = request.body.embedding_params;
 
         const expected = {
@@ -93,7 +79,7 @@ describe("scenarios > embedding > native questions", () => {
           params: { total: [] },
         };
 
-        visitEmbeddedPage(payload);
+        H.visitEmbeddedPage(payload);
       });
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -102,14 +88,14 @@ describe("scenarios > embedding > native questions", () => {
       cy.contains("Twitter").should("not.exist");
 
       // Created At: Q2 2023
-      filterWidget().contains("Created At").click();
+      H.filterWidget().contains("Created At").click();
       cy.findByTestId("select-year-picker").click();
-      popover().last().contains("2023").click();
+      H.popover().last().contains("2023").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Q2").click();
 
       // State: is not KS
-      filterWidget().contains("State").click();
+      H.filterWidget().contains("State").click();
       cy.findByPlaceholderText("Search the list").type("KS{enter}");
       cy.findAllByTestId(/-filter-value$/).should("have.length", 1);
       cy.findByLabelText("KS").should("be.visible").click();
@@ -133,7 +119,7 @@ describe("scenarios > embedding > native questions", () => {
         });
 
       // Order ID is 926 - there should be only one result after this
-      filterWidget().contains("Order ID").click();
+      H.filterWidget().contains("Order ID").click();
       cy.findByPlaceholderText("Enter an ID").type("926");
       cy.button("Add filter").click();
 
@@ -155,9 +141,9 @@ describe("scenarios > embedding > native questions", () => {
     it("should handle required parameters", () => {
       createAndVisitQuestion({ requiredTagName: "total", defaultValue: [100] });
 
-      assertEmbeddingParameter("Total", "Editable");
+      H.assertEmbeddingParameter("Total", "Editable");
 
-      publishChanges("card", ({ request }) => {
+      H.publishChanges("card", ({ request }) => {
         const actual = request.body.embedding_params;
 
         // We only expect total to be "enabled" because the rest
@@ -170,10 +156,10 @@ describe("scenarios > embedding > native questions", () => {
         assert.deepEqual(actual, expected);
       });
 
-      visitIframe();
+      H.visitIframe();
 
       // Filter widget must be visible
-      filterWidget().contains("Total");
+      H.filterWidget().contains("Total");
 
       // And its default value must be in the URL
       cy.location("search").should("eq", "?total=100");
@@ -182,11 +168,11 @@ describe("scenarios > embedding > native questions", () => {
     it("should (dis)allow setting parameters as required for a published embedding", () => {
       createAndVisitQuestion();
       // Make one parameter editable and one locked
-      setEmbeddingParameter("Order ID", "Editable");
-      setEmbeddingParameter("Total", "Locked");
+      H.setEmbeddingParameter("Order ID", "Editable");
+      H.setEmbeddingParameter("Total", "Locked");
 
-      publishChanges("card");
-      closeStaticEmbeddingModal();
+      H.publishChanges("card");
+      H.closeStaticEmbeddingModal();
 
       cy.findByTestId("native-query-editor-container")
         .findByText("Open Editor")
@@ -233,7 +219,7 @@ describe("scenarios > embedding > native questions", () => {
 
         // It should be possible to both set the filter value and hide it at the same time.
         // That's the synonymous to the locked filter.
-        visitEmbeddedPage(payload, {
+        H.visitEmbeddedPage(payload, {
           setFilters: { id: 92 },
           additionalHashOptions: {
             hideFilters: ["id", "product_id", "state", "created_at", "total"],
@@ -243,7 +229,7 @@ describe("scenarios > embedding > native questions", () => {
         cy.findByTestId("table-row").should("have.length", 1);
         cy.findByText("92");
 
-        filterWidget().should("not.exist");
+        H.filterWidget().should("not.exist");
       });
     });
 
@@ -264,11 +250,11 @@ describe("scenarios > embedding > native questions", () => {
           params: {},
         };
 
-        visitEmbeddedPage(payload, {
+        H.visitEmbeddedPage(payload, {
           setFilters: { created_at: "Q2-2025", source: "Organic", state: "OR" },
         });
 
-        filterWidget()
+        H.filterWidget()
           .should("have.length", 4)
           .and("contain", "OR")
           .and("contain", "Q2 2025");
@@ -282,7 +268,7 @@ describe("scenarios > embedding > native questions", () => {
         cy.contains("35.7");
 
         // OTOH, we should also be able to override the default filter value by eplixitly setting it
-        visitEmbeddedPage(payload, {
+        H.visitEmbeddedPage(payload, {
           setFilters: { total: 80 },
         });
 
@@ -318,12 +304,12 @@ describe("scenarios > embedding > native questions", () => {
           },
         };
 
-        visitEmbeddedPage(payload);
+        H.visitEmbeddedPage(payload);
 
         cy.findByTestId("table-row").should("have.length", 1);
         cy.findByText("66.8");
 
-        filterWidget().should("not.exist");
+        H.filterWidget().should("not.exist");
       });
     });
   });
@@ -334,7 +320,7 @@ describe("scenarios > embedding > native questions", () => {
       const sourceParameter =
         questionDetails2.native["template-tags"]["source"];
 
-      createNativeQuestion(questionDetails2, {
+      H.createNativeQuestion(questionDetails2, {
         wrapId: true,
       });
 
@@ -356,7 +342,7 @@ describe("scenarios > embedding > native questions", () => {
           params: { source: null },
         };
 
-        visitEmbeddedPage(payload);
+        H.visitEmbeddedPage(payload);
       });
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -366,9 +352,9 @@ describe("scenarios > embedding > native questions", () => {
     });
 
     it("locked parameters should still render results in the preview by default (metabase#47570)", () => {
-      visitQuestion("@questionId");
-      openStaticEmbeddingModal({ activeTab: "parameters" });
-      visitIframe();
+      H.visitQuestion("@questionId");
+      H.openStaticEmbeddingModal({ activeTab: "parameters" });
+      H.visitIframe();
 
       cy.log("should show card results by default");
       cy.findByTestId("visualization-root")
@@ -383,7 +369,7 @@ describe("scenarios > embedding > native questions", () => {
 
 describe("scenarios > embedding > native questions with default parameters", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestion(questionDetailsWithDefaults, {
@@ -391,12 +377,12 @@ describe("scenarios > embedding > native questions with default parameters", () 
       wrapId: true,
     });
 
-    openStaticEmbeddingModal({ activeTab: "parameters" });
+    H.openStaticEmbeddingModal({ activeTab: "parameters" });
 
     // Note: ID is disabled
-    setEmbeddingParameter("Source", "Locked");
-    setEmbeddingParameter("Name", "Editable");
-    publishChanges("card", ({ request }) => {
+    H.setEmbeddingParameter("Source", "Locked");
+    H.setEmbeddingParameter("Name", "Editable");
+    H.publishChanges("card", ({ request }) => {
       assert.deepEqual(request.body.embedding_params, {
         source: "locked",
         name: "enabled",
@@ -411,10 +397,10 @@ describe("scenarios > embedding > native questions with default parameters", () 
         params: { source: [] },
       };
 
-      visitEmbeddedPage(payload);
+      H.visitEmbeddedPage(payload);
     });
     // Remove default filter value
-    clearFilterWidget();
+    H.clearFilterWidget();
     // The ID default (1, 2) should apply, because it is disabled.
     // The Name default ('Lina Heaney') should not apply, because the Name param is editable and empty
     // The Source default ('Facebook') should not apply because the param is locked but the value is unset

--- a/e2e/test/scenarios/embedding/embedding-questions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-questions.cy.spec.js
@@ -1,20 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  assertEChartsTooltip,
-  cartesianChartCircle,
-  describeEE,
-  echartsContainer,
-  filterWidget,
-  main,
-  openStaticEmbeddingModal,
-  popover,
-  restore,
-  setTokenFeatures,
-  visitEmbeddedPage,
-  visitIframe,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 import {
   joinedQuestion,
@@ -26,7 +12,7 @@ const { ORDERS, PRODUCTS } = SAMPLE_DATABASE;
 
 describe("scenarios > embedding > questions", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     // Remap Product ID -> Product Title
@@ -48,18 +34,18 @@ describe("scenarios > embedding > questions", () => {
     cy.createQuestion(regularQuestion).then(({ body: { id } }) => {
       cy.request("PUT", `/api/card/${id}`, { enable_embedding: true });
 
-      visitQuestion(id);
+      H.visitQuestion(id);
     });
 
-    openStaticEmbeddingModal({ activeTab: "parameters" });
+    H.openStaticEmbeddingModal({ activeTab: "parameters" });
 
-    visitIframe();
+    H.visitIframe();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(title);
 
     cy.icon("info").realHover();
-    popover().contains(description);
+    H.popover().contains(description);
 
     // Data model: Renamed column
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -91,26 +77,26 @@ describe("scenarios > embedding > questions", () => {
     cy.createQuestion(questionWithAggregation).then(({ body: { id } }) => {
       cy.request("PUT", `/api/card/${id}`, { enable_embedding: true });
 
-      visitQuestion(id);
+      H.visitQuestion(id);
     });
 
-    openStaticEmbeddingModal({ activeTab: "parameters" });
+    H.openStaticEmbeddingModal({ activeTab: "parameters" });
 
-    visitIframe();
+    H.visitIframe();
 
     assertOnXYAxisLabels({ xLabel: "Created At", yLabel: "Count" });
 
-    echartsContainer()
+    H.echartsContainer()
       .findAllByText(/2022/)
       .should("have.length", 5)
       .and("contain", "Apr 2022");
 
-    echartsContainer().should("contain", "60");
+    H.echartsContainer().should("contain", "60");
 
     // Check the tooltip for the last point on the line
-    cartesianChartCircle().last().trigger("mousemove");
+    H.cartesianChartCircle().last().trigger("mousemove");
 
-    assertEChartsTooltip({
+    H.assertEChartsTooltip({
       header: "Aug 2022",
       rows: [{ name: "2", value: "79" }],
     });
@@ -125,13 +111,13 @@ describe("scenarios > embedding > questions", () => {
       cy.createQuestion(nestedQuestion).then(({ body: { id: nestedId } }) => {
         cy.request("PUT", `/api/card/${nestedId}`, { enable_embedding: true });
 
-        visitQuestion(nestedId);
+        H.visitQuestion(nestedId);
       });
     });
 
-    openStaticEmbeddingModal({ activeTab: "parameters" });
+    H.openStaticEmbeddingModal({ activeTab: "parameters" });
 
-    visitIframe();
+    H.visitIframe();
 
     // Global (Data model) settings should be preserved
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -162,12 +148,12 @@ describe("scenarios > embedding > questions", () => {
     cy.createQuestion(joinedQuestion).then(({ body: { id } }) => {
       cy.request("PUT", `/api/card/${id}`, { enable_embedding: true });
 
-      visitQuestion(id);
+      H.visitQuestion(id);
     });
 
-    openStaticEmbeddingModal({ activeTab: "parameters" });
+    H.openStaticEmbeddingModal({ activeTab: "parameters" });
 
-    visitIframe();
+    H.visitIframe();
 
     // Base question assertions
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -200,11 +186,11 @@ describe("scenarios > embedding > questions", () => {
   });
 });
 
-describeEE("scenarios [EE] > embedding > questions", () => {
+H.describeEE("scenarios [EE] > embedding > questions", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
 
     // Remap Product ID -> Product Title
     cy.request("POST", `/api/field/${ORDERS.PRODUCT_ID}/dimension`, {
@@ -224,11 +210,11 @@ describeEE("scenarios [EE] > embedding > questions", () => {
       enable_embedding: true,
     });
 
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
 
-    openStaticEmbeddingModal({ activeTab: "parameters", acceptTerms: false });
+    H.openStaticEmbeddingModal({ activeTab: "parameters", acceptTerms: false });
 
-    visitIframe();
+    H.visitIframe();
 
     cy.url().then(url => {
       cy.visit({
@@ -237,20 +223,20 @@ describeEE("scenarios [EE] > embedding > questions", () => {
       });
     });
 
-    main().findByText("Februar 11, 2025, 9:40 PM");
-    main().findByText("Zeilen", { exact: false });
+    H.main().findByText("Februar 11, 2025, 9:40 PM");
+    H.main().findByText("Zeilen", { exact: false });
 
     cy.url().should("include", "locale=de");
   });
 });
 
 function assertOnXYAxisLabels({ xLabel, yLabel } = {}) {
-  echartsContainer().get("text").contains(xLabel);
+  H.echartsContainer().get("text").contains(xLabel);
 
-  echartsContainer().get("text").contains(yLabel);
+  H.echartsContainer().get("text").contains(yLabel);
 }
 
-describeEE("scenarios > embedding > questions > downloads", () => {
+H.describeEE("scenarios > embedding > questions > downloads", () => {
   const questionDetails = {
     name: "Simple SQL Query for Embedding",
     native: {
@@ -271,7 +257,7 @@ describeEE("scenarios > embedding > questions > downloads", () => {
     cy.intercept("PUT", "/api/card/*").as("publishChanges");
     cy.intercept("GET", "/api/embed/card/**/query").as("dl");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestion(questionDetails, {
@@ -282,9 +268,9 @@ describeEE("scenarios > embedding > questions > downloads", () => {
   context("without token", () => {
     it("should not be possible to disable downloads", () => {
       cy.get("@questionId").then(questionId => {
-        visitQuestion(questionId);
+        H.visitQuestion(questionId);
 
-        openStaticEmbeddingModal({ activeTab: "lookAndFeel" });
+        H.openStaticEmbeddingModal({ activeTab: "lookAndFeel" });
 
         cy.log(
           "Embedding settings page should not show option to disable downloads",
@@ -310,14 +296,14 @@ describeEE("scenarios > embedding > questions > downloads", () => {
         cy.log(
           "Visit embedded question and set its filter through query parameters",
         );
-        visitEmbeddedPage(payload, {
+        H.visitEmbeddedPage(payload, {
           setFilters: { text: "Foo" },
         });
 
         cy.get("[data-testid=cell-data]").should("have.text", "Foo");
         cy.findByRole("contentinfo").icon("download").click();
 
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findAllByText("Download").should("have.length", 2);
           cy.findByText(".csv");
           cy.findByText(".xlsx");
@@ -338,13 +324,13 @@ describeEE("scenarios > embedding > questions > downloads", () => {
   });
 
   context("premium token with paid features", () => {
-    beforeEach(() => setTokenFeatures("all"));
+    beforeEach(() => H.setTokenFeatures("all"));
 
     it("should be possible to disable downloads", () => {
       cy.get("@questionId").then(questionId => {
-        visitQuestion(questionId);
+        H.visitQuestion(questionId);
 
-        openStaticEmbeddingModal({
+        H.openStaticEmbeddingModal({
           activeTab: "lookAndFeel",
           acceptTerms: false,
         });
@@ -365,9 +351,9 @@ describeEE("scenarios > embedding > questions > downloads", () => {
           },
         });
 
-        visitIframe();
+        H.visitIframe();
 
-        filterWidget().type("Foo{enter}");
+        H.filterWidget().type("Foo{enter}");
         cy.get("[data-testid=cell-data]").should("have.text", "Foo");
 
         cy.location("search").should("eq", "?text=Foo");

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -1,30 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  addOrUpdateDashboardCard,
-  createDashboardWithQuestions,
-  createNativeQuestion,
-  createQuestionAndDashboard,
-  describeEE,
-  filterWidget,
-  getDashboardCard,
-  getIframeBody,
-  modal,
-  openStaticEmbeddingModal,
-  popover,
-  queryBuilderMain,
-  restore,
-  setTokenFeatures,
-  toggleFilterWidgetValues,
-  updateDashboardCards,
-  visitDashboard,
-  visitEmbeddedPage,
-  visitIframe,
-  visitPublicDashboard,
-  visitPublicQuestion,
-  visitQuestion,
-  withDatabase,
-} from "e2e/support/helpers";
 
 const { PRODUCTS, PRODUCTS_ID, ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
@@ -77,7 +53,7 @@ describe.skip("issue 15860", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestionAndDashboard({
@@ -110,7 +86,7 @@ describe.skip("issue 15860", () => {
         name: "Q2",
         query: { "source-table": PRODUCTS_ID },
       }).then(({ body: { id: q2 } }) => {
-        updateDashboardCards({
+        H.updateDashboardCards({
           dashboard_id,
           cards: [
             // Add card for second question with parameter mappings
@@ -163,7 +139,7 @@ describe.skip("issue 15860", () => {
         enable_embedding: true,
       });
 
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
     });
   });
 
@@ -175,12 +151,12 @@ describe.skip("issue 15860", () => {
     setDefaultValueForLockedFilter("Q1 ID", 1);
     setDefaultValueForLockedFilter("Q2 ID", 3);
 
-    visitIframe();
+    H.visitIframe();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Q1 Category").click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByRole("listitem")
         .should("have.length", 1)
         .and("contain", "Gizmo");
@@ -189,7 +165,7 @@ describe.skip("issue 15860", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Q2 Category").click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByRole("listitem")
         .should("have.length", 1)
         .and("contain", "Doohickey");
@@ -232,7 +208,7 @@ describe("issue 20438", () => {
   beforeEach(() => {
     cy.intercept("GET", "/api/embed/dashboard/**").as("getEmbed");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestionAndDashboard({
@@ -266,21 +242,21 @@ describe("issue 20438", () => {
         embedding_params: { [filter.slug]: "enabled" },
       });
 
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
     });
   });
 
   it("dashboard filter connected to the field filter should work with a single value in embedded dashboards (metabase#20438)", () => {
-    openStaticEmbeddingModal({ activeTab: "parameters" });
+    H.openStaticEmbeddingModal({ activeTab: "parameters" });
 
-    visitIframe();
+    H.visitIframe();
 
     cy.wait("@getEmbed");
 
-    filterWidget().click();
+    H.filterWidget().click();
     cy.wait("@getEmbed");
 
-    popover().contains("Doohickey").click();
+    H.popover().contains("Doohickey").click();
     cy.wait("@getEmbed");
 
     cy.button("Add filter").click();
@@ -298,7 +274,7 @@ describe("locked parameters in embedded question (metabase#20634)", () => {
   beforeEach(() => {
     cy.intercept("PUT", "/api/card/*").as("publishChanges");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestion(
@@ -322,9 +298,9 @@ describe("locked parameters in embedded question (metabase#20634)", () => {
   });
 
   it("should let the user lock parameters to specific values", () => {
-    openStaticEmbeddingModal({ activeTab: "parameters" });
+    H.openStaticEmbeddingModal({ activeTab: "parameters" });
 
-    modal().within(() => {
+    H.modal().within(() => {
       // select the dropdown next to the Text parameter so that we can set the value to "Locked"
       cy.findByText("Text")
         .parent()
@@ -336,7 +312,7 @@ describe("locked parameters in embedded question (metabase#20634)", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Locked").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       // set a parameter value
       cy.findByPlaceholderText("Text").type("foo{enter}");
 
@@ -346,7 +322,7 @@ describe("locked parameters in embedded question (metabase#20634)", () => {
     });
 
     // directly navigate to the embedded question
-    visitIframe();
+    H.visitIframe();
 
     // verify that the Text parameter doesn't show up but that its value is reflected in the dashcard
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -402,7 +378,7 @@ describe("issues 20845, 25031", () => {
     beforeEach(() => {
       cy.intercept("PUT", "/api/card/*").as("publishChanges");
 
-      restore();
+      H.restore();
       cy.signInAsAdmin();
 
       const questionDetails = getQuestionDetails(value);
@@ -414,7 +390,7 @@ describe("issues 20845, 25031", () => {
         cy.wrap(card_id).as("questionId");
         cy.wrap(dashboard_id).as("dashboardId");
 
-        visitQuestion(card_id);
+        H.visitQuestion(card_id);
 
         // Connect dashbaord filter to the card
         cy.request("PUT", `/api/dashboard/${dashboard_id}`, {
@@ -455,7 +431,7 @@ describe("issues 20845, 25031", () => {
             `Make sure it works with ${type.toUpperCase()} in the payload`,
           );
 
-          visitEmbeddedPage({
+          H.visitEmbeddedPage({
             resource: { question: questionId },
             params: {
               qty_locked: type === "string" ? "15" : 15, // IMPORTANT: integer
@@ -470,7 +446,7 @@ describe("issues 20845, 25031", () => {
 
     it(`DASHBOARD: locked parameter should work with numeric values ${conditionalPartOfTestTitle} (metabase#25031)`, () => {
       cy.get("@dashboardId").then(dashboardId => {
-        visitDashboard(dashboardId);
+        H.visitDashboard(dashboardId);
         cy.request("PUT", `/api/dashboard/${dashboardId}`, {
           enable_embedding: true,
           embedding_params: {
@@ -492,7 +468,7 @@ describe("issues 20845, 25031", () => {
             },
           };
 
-          visitEmbeddedPage(payload);
+          H.visitEmbeddedPage(payload);
 
           // wait for the results to load
           cy.contains(dashboardDetails.name);
@@ -539,9 +515,9 @@ describe("issue 27643", () => {
 
   beforeEach(() => {
     // This issue was only reproducible against the Postgres database.
-    restore("postgres-12");
+    H.restore("postgres-12");
     cy.signInAsAdmin();
-    withDatabase(PG_DB_ID, ({ INVOICES }) => {
+    H.withDatabase(PG_DB_ID, ({ INVOICES }) => {
       cy.wrap(INVOICES.EXPECTED_INVOICE).as(
         "postgresInvoicesExpectedInvoiceId",
       );
@@ -595,32 +571,32 @@ describe("issue 27643", () => {
 
     it("in static embedding and in public dashboard scenarios (metabase#27643-1)", () => {
       cy.log("Test the dashboard");
-      visitDashboard("@dashboardId");
-      getDashboardCard().should("contain", "true");
-      toggleFilterWidgetValues(["false"]);
-      getDashboardCard().should("contain", "false");
+      H.visitDashboard("@dashboardId");
+      H.getDashboardCard().should("contain", "true");
+      H.toggleFilterWidgetValues(["false"]);
+      H.getDashboardCard().should("contain", "false");
 
       cy.log("Test the embedded dashboard");
       cy.get("@dashboardId").then(dashboard => {
-        visitEmbeddedPage({
+        H.visitEmbeddedPage({
           resource: { dashboard },
           params: {},
         });
 
-        getDashboardCard().should("contain", "true");
-        toggleFilterWidgetValues(["false"]);
-        getDashboardCard().should("contain", "false");
+        H.getDashboardCard().should("contain", "true");
+        H.toggleFilterWidgetValues(["false"]);
+        H.getDashboardCard().should("contain", "false");
       });
 
       cy.log("Test the public dashboard");
       cy.get("@dashboardId").then(dashboardId => {
         // We were signed out due to the previous visitEmbeddedPage
         cy.signInAsAdmin();
-        visitPublicDashboard(dashboardId);
+        H.visitPublicDashboard(dashboardId);
 
-        getDashboardCard().should("contain", "true");
-        toggleFilterWidgetValues(["false"]);
-        getDashboardCard().should("contain", "false");
+        H.getDashboardCard().should("contain", "true");
+        H.toggleFilterWidgetValues(["false"]);
+        H.getDashboardCard().should("contain", "false");
       });
     });
   });
@@ -628,7 +604,7 @@ describe("issue 27643", () => {
   describe("should allow a native question filter to map to a boolean field filter parameter (metabase#27643)", () => {
     beforeEach(() => {
       cy.get("@postgresInvoicesExpectedInvoiceId").then(fieldId => {
-        createNativeQuestion(getQuestionDetails(fieldId), {
+        H.createNativeQuestion(getQuestionDetails(fieldId), {
           wrapId: true,
           idAlias: "questionId",
         });
@@ -637,21 +613,21 @@ describe("issue 27643", () => {
 
     it("in static embedding and in public question scenarios (metabase#27643-2)", () => {
       cy.log("Test the question");
-      visitQuestion("@questionId");
+      H.visitQuestion("@questionId");
       cy.findAllByTestId("cell-data").should("contain", "true");
-      toggleFilterWidgetValues(["false"]);
-      queryBuilderMain().button("Get Answer").click();
+      H.toggleFilterWidgetValues(["false"]);
+      H.queryBuilderMain().button("Get Answer").click();
       cy.findAllByTestId("cell-data").should("contain", "false");
 
       cy.log("Test the embedded question");
       cy.get("@questionId").then(question => {
-        visitEmbeddedPage({
+        H.visitEmbeddedPage({
           resource: { question },
           params: {},
         });
 
         cy.findAllByTestId("cell-data").should("contain", "true");
-        toggleFilterWidgetValues(["false"]);
+        H.toggleFilterWidgetValues(["false"]);
         cy.findAllByTestId("cell-data").should("contain", "false");
       });
 
@@ -659,17 +635,17 @@ describe("issue 27643", () => {
       cy.get("@questionId").then(questionId => {
         // We were signed out due to the previous visitEmbeddedPage
         cy.signInAsAdmin();
-        visitPublicQuestion(questionId);
+        H.visitPublicQuestion(questionId);
 
         cy.findAllByTestId("cell-data").should("contain", "true");
-        toggleFilterWidgetValues(["false"]);
+        H.toggleFilterWidgetValues(["false"]);
         cy.findAllByTestId("cell-data").should("contain", "false");
       });
     });
   });
 });
 
-describeEE("issue 30535", () => {
+H.describeEE("issue 30535", () => {
   const questionDetails = {
     name: "3035",
     query: {
@@ -679,9 +655,9 @@ describeEE("issue 30535", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
 
     cy.sandboxTable({
       table_id: PRODUCTS_ID,
@@ -693,12 +669,12 @@ describeEE("issue 30535", () => {
     cy.createQuestion(questionDetails).then(({ body: { id } }) => {
       cy.request("PUT", `/api/card/${id}`, { enable_embedding: true });
 
-      visitQuestion(id);
+      H.visitQuestion(id);
     });
   });
 
   it("user session should not apply sandboxing to a signed embedded question (metabase#30535)", () => {
-    openStaticEmbeddingModal({
+    H.openStaticEmbeddingModal({
       activeTab: "parameters",
       previewMode: "preview",
       acceptTerms: false,
@@ -761,7 +737,7 @@ describe("dashboard preview", () => {
       "previewValues",
     );
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -779,7 +755,7 @@ describe("dashboard preview", () => {
       questionDetails,
       dashboardDetails,
     }).then(({ body: { card_id, dashboard_id } }) => {
-      addOrUpdateDashboardCard({
+      H.addOrUpdateDashboardCard({
         dashboard_id,
         card_id,
         card: {
@@ -812,25 +788,25 @@ describe("dashboard preview", () => {
         },
       });
 
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
     });
 
-    openStaticEmbeddingModal({
+    H.openStaticEmbeddingModal({
       activeTab: "parameters",
       previewMode: "preview",
     });
 
-    modal().within(() => {
+    H.modal().within(() => {
       // Makes it less likely to flake.
       cy.wait("@previewDashboard");
 
-      getIframeBody().within(() => {
+      H.getIframeBody().within(() => {
         cy.log(
           "Set filter 2 value, so filter 1 should be filtered by filter 2",
         );
         cy.button(filter2.name).click();
         cy.wait("@previewValues");
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findByText("Gadget").should("be.visible");
           cy.findByText("Gizmo").should("be.visible");
           cy.findByText("Widget").should("be.visible");
@@ -840,7 +816,7 @@ describe("dashboard preview", () => {
 
         cy.log("Assert filter 1");
         cy.button(filter.name).click();
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findByText("Gadget").should("not.exist");
           cy.findByText("Gizmo").should("not.exist");
           cy.findByText("Widget").should("not.exist");
@@ -864,7 +840,7 @@ describe("dashboard preview", () => {
       questionDetails,
       dashboardDetails,
     }).then(({ body: { card_id, dashboard_id } }) => {
-      addOrUpdateDashboardCard({
+      H.addOrUpdateDashboardCard({
         dashboard_id,
         card_id,
         card: {
@@ -897,10 +873,10 @@ describe("dashboard preview", () => {
         },
       });
 
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
     });
 
-    openStaticEmbeddingModal({
+    H.openStaticEmbeddingModal({
       activeTab: "parameters",
       previewMode: "preview",
     });
@@ -909,31 +885,31 @@ describe("dashboard preview", () => {
     cy.wait("@previewDashboard");
 
     cy.log("Set the first locked parameter values");
-    modal()
+    H.modal()
       .findByRole("generic", { name: "Previewing locked parameters" })
       .findByText("Text 1")
       .click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Doohickey").click();
       cy.button("Add filter").click();
     });
 
     cy.log("Set the second locked parameter values");
-    modal()
+    H.modal()
       .findByRole("generic", { name: "Previewing locked parameters" })
       .findByText("Text 2")
       .click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Doohickey").click();
       cy.findByText("Gizmo").click();
       cy.findByText("Gadget").click();
       cy.button("Add filter").click();
     });
 
-    getIframeBody().within(() => {
+    H.getIframeBody().within(() => {
       cy.log("Assert filter 1");
       cy.button(filter.name).click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Gadget").should("not.exist");
         cy.findByText("Gizmo").should("not.exist");
         cy.findByText("Widget").should("not.exist");
@@ -959,29 +935,29 @@ describe("issue 40660", () => {
       "previewDashboard",
     );
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestionAndDashboard({
       questionDetails,
       dashboardDetails,
     }).then(({ body: { id, card_id, dashboard_id } }) => {
-      updateDashboardCards({
+      H.updateDashboardCards({
         dashboard_id,
         cards: [{ card_id }, { card_id }, { card_id }],
       });
 
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
     });
   });
 
   it("static dashboard content shouldn't overflow its container (metabase#40660)", () => {
-    openStaticEmbeddingModal({
+    H.openStaticEmbeddingModal({
       activeTab: "parameters",
       previewMode: "preview",
     });
 
-    getIframeBody().within(() => {
+    H.getIframeBody().within(() => {
       cy.findByTestId("embed-frame").scrollTo("bottom");
 
       cy.findByRole("link", { name: "Powered by Metabase" }).should(
@@ -1004,19 +980,19 @@ describe.skip("issue 49142", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    createQuestionAndDashboard({
+    H.createQuestionAndDashboard({
       questionDetails,
       dashboardDetails,
     }).then(({ body: { dashboard_id } }) => {
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
     });
   });
 
   it("embedding preview should be always working", () => {
-    openStaticEmbeddingModal({
+    H.openStaticEmbeddingModal({
       activeTab: "lookAndFeel",
       previewMode: "preview",
     });
@@ -1027,13 +1003,13 @@ describe.skip("issue 49142", () => {
   });
 });
 
-describeEE("issue 8490", () => {
+H.describeEE("issue 8490", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
 
-    createDashboardWithQuestions({
+    H.createDashboardWithQuestions({
       dashboardDetails: {
         name: "Dashboard to test locale",
         enable_embedding: true,
@@ -1138,7 +1114,7 @@ describeEE("issue 8490", () => {
   it("static embeddings should respect `#locale` hash parameter (metabase#8490, metabase#50182)", () => {
     cy.log("test a static embedded dashboard");
     cy.get("@dashboardId").then(dashboardId => {
-      visitEmbeddedPage(
+      H.visitEmbeddedPage(
         {
           resource: { dashboard: dashboardId },
           params: {},
@@ -1156,7 +1132,7 @@ describeEE("issue 8490", () => {
       cy.findByText("PDF로 내보내기").should("be.visible");
 
       cy.log("assert the line chart");
-      getDashboardCard(0).within(() => {
+      H.getDashboardCard(0).within(() => {
         // X-axis labels: Jan 2024 (or some other year)
         cy.findByText(/1월 20\d\d\b/).should("be.visible");
         // Aggregation "count"
@@ -1166,7 +1142,7 @@ describeEE("issue 8490", () => {
 
     cy.findByTestId("embed-frame").within(() => {
       cy.log("assert the trend chart");
-      getDashboardCard(2).within(() => {
+      H.getDashboardCard(2).within(() => {
         // N/A
         cy.findByText("해당 없음").should("be.visible");
         // (No data)
@@ -1174,7 +1150,7 @@ describeEE("issue 8490", () => {
       });
 
       cy.log("assert the pie chart");
-      getDashboardCard(1).within(() => {
+      H.getDashboardCard(1).within(() => {
         // Total
         cy.findByText("합계").should("be.visible");
         // Other
@@ -1186,7 +1162,7 @@ describeEE("issue 8490", () => {
 
     cy.log("assert the line chart");
     cy.get("@lineChartQuestionId").then(lineChartQuestionId => {
-      visitEmbeddedPage(
+      H.visitEmbeddedPage(
         {
           resource: { question: lineChartQuestionId },
           params: {},
@@ -1231,6 +1207,6 @@ describe("issue 50373", () => {
       },
     );
 
-    visitEmbeddedPage({ resource: { dashboard: ORDERS_DASHBOARD_ID } });
+    H.visitEmbeddedPage({ resource: { dashboard: ORDERS_DASHBOARD_ID } });
   });
 });

--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -1,20 +1,9 @@
+import { H } from "e2e/support";
 import { METABASE_SECRET_KEY } from "e2e/support/cypress_data";
 import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  modal,
-  openSharingMenu,
-  openStaticEmbeddingModal,
-  restore,
-  sharingMenu,
-  sharingMenuButton,
-  updateSetting,
-  visitDashboard,
-  visitIframe,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 const embeddingPage = "/admin/settings/embedding-in-other-applications";
 const standalonePath =
@@ -26,7 +15,7 @@ const embeddingDescription =
 // These tests will run on both OSS and EE instances. Both without a token!
 describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -38,7 +27,7 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
     cy.visit(`/model/${ORDERS_QUESTION_ID}`);
     cy.wait("@dataset");
 
-    sharingMenuButton().should("not.exist");
+    H.sharingMenuButton().should("not.exist");
 
     cy.findByTestId("view-footer").within(() => {
       cy.icon("download").should("exist");
@@ -122,12 +111,12 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
     });
 
     it("should not let you embed the question", () => {
-      visitQuestion(ORDERS_QUESTION_ID);
+      H.visitQuestion(ORDERS_QUESTION_ID);
       ensureEmbeddingIsDisabled();
     });
 
     it("should not let you embed the dashboard", () => {
-      visitDashboard(ORDERS_DASHBOARD_ID);
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
       ensureEmbeddingIsDisabled();
     });
   });
@@ -155,7 +144,7 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
 
         visitAndEnableSharing(object);
 
-        modal().within(() => {
+        H.modal().within(() => {
           cy.findByRole("tab", { name: "Look and Feel" }).click();
 
           cy.findByText("Theme");
@@ -187,7 +176,7 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
           cy.wait("@embedObject");
         });
 
-        visitIframe();
+        H.visitIframe();
 
         cy.findByTestId("embed-frame").within(() => {
           cy.findByRole("heading", { name: objectName });
@@ -220,7 +209,7 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
         cy.log(`Unpublish ${object}`);
         visitAndEnableSharing(object, false);
 
-        modal().within(() => {
+        H.modal().within(() => {
           cy.findByText(
             `This ${object} is published and ready to be embedded.`,
           );
@@ -231,7 +220,7 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
           cy.findByRole("tab", { name: "Parameters" }).click();
         });
 
-        visitIframe();
+        H.visitIframe();
 
         cy.findByTestId("embed-frame").findByText(
           "Embedding is not enabled for this object.",
@@ -257,7 +246,7 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
       });
       visitAndEnableSharing("question");
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByRole("tab", { name: "Parameters" }).click();
 
         cy.findByText("Preview").click();
@@ -281,7 +270,7 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
 
         cy.button("Regenerate key").click();
 
-        modal().within(() => {
+        H.modal().within(() => {
           cy.intercept("GET", "/api/util/random_token").as("regenerateKey");
           cy.findByRole("heading", { name: "Regenerate embedding key?" });
           cy.findByText(
@@ -315,8 +304,8 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
 });
 
 function resetEmbedding() {
-  updateSetting("enable-embedding-static", false);
-  updateSetting("embedding-secret-key", null);
+  H.updateSetting("enable-embedding-static", false);
+  H.updateSetting("embedding-secret-key", null);
 }
 
 function getTokenValue() {
@@ -330,20 +319,20 @@ function assertLinkMatchesUrl(text, url) {
 }
 
 function ensureEmbeddingIsDisabled() {
-  openSharingMenu();
-  sharingMenu().findByText(/embedding is off/i);
+  H.openSharingMenu();
+  H.sharingMenu().findByText(/embedding is off/i);
 }
 
 function visitAndEnableSharing(object, acceptTerms = true) {
   if (object === "question") {
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
   }
 
   if (object === "dashboard") {
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
   }
 
-  openStaticEmbeddingModal({ acceptTerms });
+  H.openStaticEmbeddingModal({ acceptTerms });
 }
 
 function sidebar() {

--- a/e2e/test/scenarios/embedding/embedding-snippets.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-snippets.cy.spec.js
@@ -1,16 +1,8 @@
+import { H } from "e2e/support";
 import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  modal,
-  openStaticEmbeddingModal,
-  popover,
-  restore,
-  setTokenFeatures,
-  visitDashboard,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 import { IFRAME_CODE, getEmbeddingJsCode } from "./shared/embedding-snippets";
 
@@ -19,17 +11,17 @@ const features = ["none", "all"];
 features.forEach(feature => {
   describe(`[tokenFeatures=${feature}] scenarios > embedding > code snippets`, () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
-      setTokenFeatures(feature);
+      H.setTokenFeatures(feature);
     });
 
     it("dashboard should have the correct embed snippet", () => {
       const defaultDownloadsValue = feature === "all" ? true : undefined;
-      visitDashboard(ORDERS_DASHBOARD_ID);
-      openStaticEmbeddingModal({ acceptTerms: false });
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
+      H.openStaticEmbeddingModal({ acceptTerms: false });
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText(
           "To embed this dashboard in your application you’ll just need to publish it, and paste these code snippets in the proper places in your app.",
         );
@@ -55,7 +47,7 @@ features.forEach(feature => {
           .click();
       });
 
-      popover()
+      H.popover()
         .should("contain", "Node.js")
         .and("contain", "Ruby")
         .and("contain", "Python")
@@ -63,18 +55,18 @@ features.forEach(feature => {
 
       cy.get(".ace_content").last().should("have.text", IFRAME_CODE);
 
-      modal()
+      H.modal()
         .findAllByTestId("embed-frontend-select-button")
         .should("contain", "Pug / Jade")
         .click();
 
-      popover()
+      H.popover()
         .should("contain", "Mustache")
         .and("contain", "Pug / Jade")
         .and("contain", "ERB")
         .and("contain", "JSX");
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByRole("tab", { name: "Look and Feel" }).click();
 
         // set transparent background metabase#23477
@@ -113,10 +105,10 @@ features.forEach(feature => {
 
     it("question should have the correct embed snippet", () => {
       const defaultDownloadsValue = feature === "all" ? true : undefined;
-      visitQuestion(ORDERS_QUESTION_ID);
-      openStaticEmbeddingModal({ acceptTerms: false });
+      H.visitQuestion(ORDERS_QUESTION_ID);
+      H.openStaticEmbeddingModal({ acceptTerms: false });
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText(
           "To embed this question in your application you’ll just need to publish it, and paste these code snippets in the proper places in your app.",
         );
@@ -160,7 +152,7 @@ features.forEach(feature => {
           .click();
       });
 
-      popover()
+      H.popover()
         .should("contain", "Node.js")
         .and("contain", "Ruby")
         .and("contain", "Python")

--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -1,3 +1,4 @@
+import { H } from "e2e/support";
 import { USER_GROUPS, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
@@ -9,29 +10,6 @@ import {
   THIRD_COLLECTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
 import {
-  adhocQuestionHash,
-  appBar,
-  createDashboardWithTabs,
-  createQuestion,
-  dashboardGrid,
-  describeEE,
-  exportFromDashcard,
-  getDashboardCard,
-  getDashboardCardMenu,
-  getNextUnsavedDashboardCardId,
-  getNotebookStep,
-  getTextCardDetails,
-  goToTab,
-  navigationSidebar,
-  popover,
-  resetTestTable,
-  restore,
-  resyncDatabase,
-  setTokenFeatures,
-  updateDashboardCards,
-  visitFullAppEmbeddingUrl,
-} from "e2e/support/helpers";
-import {
   createMockDashboardCard,
   createMockTextDashboardCard,
 } from "metabase-types/api/mocks";
@@ -39,11 +17,11 @@ import {
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 const { ALL_USERS_GROUP } = USER_GROUPS;
 
-describeEE("scenarios > embedding > full app", () => {
+H.describeEE("scenarios > embedding > full app", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
     cy.intercept("POST", "/api/card/*/query").as("getCardQuery");
     cy.intercept("POST", "/api/dashboard/**/query").as("getDashCardQuery");
     cy.intercept("GET", "/api/dashboard/*").as("getDashboard");
@@ -52,10 +30,10 @@ describeEE("scenarios > embedding > full app", () => {
 
   describe("home page navigation", () => {
     it("should show the top and side nav by default", () => {
-      visitFullAppEmbeddingUrl({ url: "/" });
+      H.visitFullAppEmbeddingUrl({ url: "/" });
       cy.wait("@getXrayDashboard");
 
-      appBar()
+      H.appBar()
         .should("be.visible")
         .within(() => {
           cy.findByTestId("main-logo").should("be.visible");
@@ -67,28 +45,28 @@ describeEE("scenarios > embedding > full app", () => {
     });
 
     it("should hide the top nav when nothing is shown", () => {
-      visitFullAppEmbeddingUrl({
+      H.visitFullAppEmbeddingUrl({
         url: "/",
         qs: { side_nav: false, logo: false },
       });
       cy.wait("@getXrayDashboard");
-      appBar().should("not.exist");
+      H.appBar().should("not.exist");
     });
 
     it("should hide the top nav by an explicit param", () => {
-      visitFullAppEmbeddingUrl({ url: "/", qs: { top_nav: false } });
+      H.visitFullAppEmbeddingUrl({ url: "/", qs: { top_nav: false } });
       cy.wait("@getXrayDashboard");
-      appBar().should("not.exist");
+      H.appBar().should("not.exist");
     });
 
     it("should not hide the top nav when the logo is still visible", () => {
-      visitFullAppEmbeddingUrl({
+      H.visitFullAppEmbeddingUrl({
         url: "/question/" + ORDERS_QUESTION_ID,
         qs: { breadcrumbs: false },
       });
       cy.wait("@getCardQuery");
 
-      appBar().within(() => {
+      H.appBar().within(() => {
         cy.findByTestId("main-logo").should("be.visible");
         cy.findByRole("treeitem", { name: "Our analytics" }).should(
           "not.exist",
@@ -97,7 +75,7 @@ describeEE("scenarios > embedding > full app", () => {
     });
 
     it("should keep showing sidebar toggle button when logo, breadcrumbs, the new button, and search are hidden", () => {
-      visitFullAppEmbeddingUrl({
+      H.visitFullAppEmbeddingUrl({
         url: "/",
         qs: {
           logo: false,
@@ -109,7 +87,7 @@ describeEE("scenarios > embedding > full app", () => {
       cy.wait("@getXrayDashboard");
 
       sideNav().should("be.visible");
-      appBar()
+      H.appBar()
         .should("be.visible")
         .within(() => {
           cy.button("Toggle sidebar").should("be.visible").click();
@@ -118,8 +96,8 @@ describeEE("scenarios > embedding > full app", () => {
     });
 
     it("should hide the side nav by a param", () => {
-      visitFullAppEmbeddingUrl({ url: "/", qs: { side_nav: false } });
-      appBar().within(() => {
+      H.visitFullAppEmbeddingUrl({ url: "/", qs: { side_nav: false } });
+      H.appBar().within(() => {
         cy.findByTestId("main-logo").should("be.visible");
         cy.button("Toggle sidebar").should("not.exist");
       });
@@ -139,23 +117,23 @@ describeEE("scenarios > embedding > full app", () => {
     });
 
     it("should show question creation controls by a param", () => {
-      visitFullAppEmbeddingUrl({ url: "/", qs: { new_button: true } });
-      appBar().within(() => {
+      H.visitFullAppEmbeddingUrl({ url: "/", qs: { new_button: true } });
+      H.appBar().within(() => {
         cy.button(/New/).should("be.visible");
       });
     });
 
     it("should show search controls by a param", () => {
-      visitFullAppEmbeddingUrl({ url: "/", qs: { search: true } });
-      appBar().within(() => {
+      H.visitFullAppEmbeddingUrl({ url: "/", qs: { search: true } });
+      H.appBar().within(() => {
         cy.findByPlaceholderText("Search…").should("be.visible");
       });
     });
 
     it("should preserve params when navigating", () => {
-      visitFullAppEmbeddingUrl({ url: "/", qs: { search: true } });
+      H.visitFullAppEmbeddingUrl({ url: "/", qs: { search: true } });
 
-      appBar().within(() => {
+      H.appBar().within(() => {
         cy.findByPlaceholderText("Search…").should("be.visible");
       });
 
@@ -165,7 +143,7 @@ describeEE("scenarios > embedding > full app", () => {
         .should("contain", "Orders in a dashboard")
         .and("be.visible");
 
-      appBar().within(() => {
+      H.appBar().within(() => {
         cy.findByPlaceholderText("Search…").should("be.visible");
       });
     });
@@ -173,7 +151,7 @@ describeEE("scenarios > embedding > full app", () => {
 
   describe("browse data", () => {
     it("should hide the top nav when nothing is shown", () => {
-      visitFullAppEmbeddingUrl({
+      H.visitFullAppEmbeddingUrl({
         url: "/browse/databases",
         qs: { side_nav: false, logo: false },
       });
@@ -182,7 +160,7 @@ describeEE("scenarios > embedding > full app", () => {
         "not.exist",
       );
       cy.findByRole("treeitem", { name: "Our analytics" }).should("not.exist");
-      appBar().should("not.exist");
+      H.appBar().should("not.exist");
     });
   });
 
@@ -236,7 +214,7 @@ describeEE("scenarios > embedding > full app", () => {
     });
 
     it("should send 'X-Metabase-Client' header for api requests", () => {
-      visitFullAppEmbeddingUrl({
+      H.visitFullAppEmbeddingUrl({
         url: "/question/" + ORDERS_QUESTION_ID,
         qs: { action_buttons: false },
       });
@@ -255,14 +233,14 @@ describeEE("scenarios > embedding > full app", () => {
       });
 
       it("should allow to create a new question from the navbar (metabase#21511)", () => {
-        visitFullAppEmbeddingUrl({
+        H.visitFullAppEmbeddingUrl({
           url: "/collection/root",
           qs: { top_nav: true, new_button: true, side_nav: false },
         });
 
         cy.button("New").click();
-        popover().findByText("Question").click();
-        popover().within(() => {
+        H.popover().findByText("Question").click();
+        H.popover().within(() => {
           cy.findByText("Raw Data").click();
           cy.findByText("Orders").click();
         });
@@ -280,8 +258,8 @@ describeEE("scenarios > embedding > full app", () => {
           visualization_settings: {},
         };
 
-        visitFullAppEmbeddingUrl({
-          url: `/question#${adhocQuestionHash(newQuestionQuery)}`,
+        H.visitFullAppEmbeddingUrl({
+          url: `/question#${H.adhocQuestionHash(newQuestionQuery)}`,
           qs: { side_nav: false },
         });
 
@@ -351,13 +329,13 @@ describeEE("scenarios > embedding > full app", () => {
     };
 
     function startNewEmbeddingQuestion() {
-      visitFullAppEmbeddingUrl({ url: "/", qs: { new_button: true } });
+      H.visitFullAppEmbeddingUrl({ url: "/", qs: { new_button: true } });
       cy.button("New").click();
-      popover().findByText("Question").click();
+      H.popover().findByText("Question").click();
     }
 
     function selectTable({ tableName, schemaName, databaseName }) {
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Raw Data").click();
         if (databaseName) {
           cy.findByText(databaseName).click();
@@ -371,7 +349,7 @@ describeEE("scenarios > embedding > full app", () => {
     }
 
     function selectCard({ cardName, cardType, collectionNames }) {
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText(cardTypeToLabel[cardType]).click();
         collectionNames.forEach(collectionName =>
           cy.findByText(collectionName).click(),
@@ -385,18 +363,18 @@ describeEE("scenarios > embedding > full app", () => {
     }
 
     function clickOnDataSource(sourceName) {
-      getNotebookStep("data").findByText(sourceName).click();
+      H.getNotebookStep("data").findByText(sourceName).click();
     }
 
     function clickOnJoinDataSource(sourceName) {
-      getNotebookStep("join")
+      H.getNotebookStep("join")
         .findByLabelText("Right table")
         .findByText(sourceName)
         .click();
     }
 
     function verifyTableSelected({ tableName, schemaName, databaseName }) {
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByLabelText(tableName).should(
           "have.attr",
           "aria-selected",
@@ -412,7 +390,7 @@ describeEE("scenarios > embedding > full app", () => {
     }
 
     function verifyCardSelected({ cardName, collectionName }) {
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText(collectionName).should("be.visible");
         cy.findByLabelText(cardName).should(
           "have.attr",
@@ -423,7 +401,7 @@ describeEE("scenarios > embedding > full app", () => {
     }
 
     function verifyMetricClause(metricName) {
-      getNotebookStep("summarize")
+      H.getNotebookStep("summarize")
         .findByTestId("aggregate-step")
         .findByText(metricName)
         .should("be.visible");
@@ -450,7 +428,7 @@ describeEE("scenarios > embedding > full app", () => {
         "should select a table when there are multiple databases",
         { tags: "@external" },
         () => {
-          restore("postgres-12");
+          H.restore("postgres-12");
           cy.signInAsAdmin();
           startNewEmbeddingQuestion();
           selectTable({ tableName: "Orders", databaseName: "QA Postgres12" });
@@ -466,7 +444,7 @@ describeEE("scenarios > embedding > full app", () => {
         "should select a table in a schema-less database",
         { tags: "@external" },
         () => {
-          restore("mysql-8");
+          H.restore("mysql-8");
           cy.signInAsAdmin();
           startNewEmbeddingQuestion();
           selectTable({ tableName: "Reviews", databaseName: "QA MySQL8" });
@@ -482,10 +460,10 @@ describeEE("scenarios > embedding > full app", () => {
         "should select a table when there are multiple schemas",
         { tags: "@external" },
         () => {
-          resetTestTable({ type: "postgres", table: "multi_schema" });
-          restore("postgres-writable");
+          H.resetTestTable({ type: "postgres", table: "multi_schema" });
+          H.restore("postgres-writable");
           cy.signInAsAdmin();
-          resyncDatabase({ dbId: WRITABLE_DB_ID });
+          H.resyncDatabase({ dbId: WRITABLE_DB_ID });
           startNewEmbeddingQuestion();
           selectTable({
             tableName: "Animals",
@@ -506,8 +484,8 @@ describeEE("scenarios > embedding > full app", () => {
         selectTable({
           tableName: "Orders",
         });
-        getNotebookStep("data").button("Join data").click();
-        popover().findByText("Products").click();
+        H.getNotebookStep("data").button("Join data").click();
+        H.popover().findByText("Products").click();
         clickOnJoinDataSource("Products");
         verifyTableSelected({
           tableName: "Products",
@@ -522,8 +500,8 @@ describeEE("scenarios > embedding > full app", () => {
           cardType: "question",
           collectionNames: [],
         });
-        getNotebookStep("data").button("Join data").click();
-        popover().within(() => {
+        H.getNotebookStep("data").button("Join data").click();
+        H.popover().within(() => {
           cy.icon("chevronleft").click();
           cy.icon("chevronleft").click();
         });
@@ -547,7 +525,7 @@ describeEE("scenarios > embedding > full app", () => {
             type: cardType,
             collection_id: null,
           };
-          createQuestion(cardDetails);
+          H.createQuestion(cardDetails);
           startNewEmbeddingQuestion();
           selectCard({
             cardName: cardDetails.name,
@@ -567,7 +545,7 @@ describeEE("scenarios > embedding > full app", () => {
             type: cardType,
             collection_id: FIRST_COLLECTION_ID,
           };
-          createQuestion(cardDetails);
+          H.createQuestion(cardDetails);
           startNewEmbeddingQuestion();
           selectCard({
             cardName: cardDetails.name,
@@ -587,7 +565,7 @@ describeEE("scenarios > embedding > full app", () => {
             type: cardType,
             collection_id: SECOND_COLLECTION_ID,
           };
-          createQuestion(cardDetails);
+          H.createQuestion(cardDetails);
           startNewEmbeddingQuestion();
           selectCard({
             cardName: cardDetails.name,
@@ -607,7 +585,7 @@ describeEE("scenarios > embedding > full app", () => {
             type: cardType,
             collection_id: NORMAL_PERSONAL_COLLECTION_ID,
           };
-          createQuestion(cardDetails);
+          H.createQuestion(cardDetails);
           startNewEmbeddingQuestion();
           selectCard({
             cardName: cardDetails.name,
@@ -628,7 +606,7 @@ describeEE("scenarios > embedding > full app", () => {
             type: cardType,
             collection_id: NORMAL_PERSONAL_COLLECTION_ID,
           };
-          createQuestion(cardDetails);
+          H.createQuestion(cardDetails);
           startNewEmbeddingQuestion();
           selectCard({
             cardName: cardDetails.name,
@@ -653,7 +631,7 @@ describeEE("scenarios > embedding > full app", () => {
           };
 
           cy.signInAsAdmin();
-          createQuestion(cardDetails);
+          H.createQuestion(cardDetails);
           cy.log("grant `nocollection` user access to `First collection`");
           cy.updateCollectionGraph({
             [ALL_USERS_GROUP]: { [FIRST_COLLECTION_ID]: "read" },
@@ -681,7 +659,7 @@ describeEE("scenarios > embedding > full app", () => {
           };
 
           cy.signInAsAdmin();
-          createQuestion(cardDetails);
+          H.createQuestion(cardDetails);
           cy.updateCollectionGraph({
             [ALL_USERS_GROUP]: {
               [FIRST_COLLECTION_ID]: "read",
@@ -709,13 +687,13 @@ describeEE("scenarios > embedding > full app", () => {
             type: cardType,
             collection_id: FIRST_COLLECTION_ID,
           };
-          createQuestion(cardDetails);
+          H.createQuestion(cardDetails);
           startNewEmbeddingQuestion();
           selectTable({
             tableName: "Products",
           });
-          getNotebookStep("data").button("Join data").click();
-          popover().within(() => {
+          H.getNotebookStep("data").button("Join data").click();
+          H.popover().within(() => {
             cy.icon("chevronleft").click();
             cy.icon("chevronleft").click();
           });
@@ -737,15 +715,15 @@ describeEE("scenarios > embedding > full app", () => {
             type: cardType,
             collection_id: FIRST_COLLECTION_ID,
           };
-          createQuestion(cardDetails);
+          H.createQuestion(cardDetails);
           startNewEmbeddingQuestion();
           selectCard({
             cardName: "Orders",
             cardType: "question",
             collectionNames: [],
           });
-          getNotebookStep("data").button("Join data").click();
-          popover().within(() => {
+          H.getNotebookStep("data").button("Join data").click();
+          H.popover().within(() => {
             cy.icon("chevronleft").click();
             cy.icon("chevronleft").click();
           });
@@ -754,8 +732,8 @@ describeEE("scenarios > embedding > full app", () => {
             cardType,
             collectionNames: ["First collection"],
           });
-          popover().findByText("ID").click();
-          popover().findByText("ID").click();
+          H.popover().findByText("ID").click();
+          H.popover().findByText("ID").click();
           clickOnJoinDataSource(cardDetails.name);
           verifyCardSelected({
             cardName: cardDetails.name,
@@ -772,7 +750,7 @@ describeEE("scenarios > embedding > full app", () => {
           type: "metric",
           collection_id: null,
         };
-        createQuestion(cardDetails);
+        H.createQuestion(cardDetails);
         startNewEmbeddingQuestion();
         selectCard({
           cardName: cardDetails.name,
@@ -793,7 +771,7 @@ describeEE("scenarios > embedding > full app", () => {
           type: "metric",
           collection_id: FIRST_COLLECTION_ID,
         };
-        createQuestion(cardDetails);
+        H.createQuestion(cardDetails);
         startNewEmbeddingQuestion();
         selectCard({
           cardName: cardDetails.name,
@@ -814,7 +792,7 @@ describeEE("scenarios > embedding > full app", () => {
           type: "metric",
           collection_id: SECOND_COLLECTION_ID,
         };
-        createQuestion(cardDetails);
+        H.createQuestion(cardDetails);
         startNewEmbeddingQuestion();
         selectCard({
           cardName: cardDetails.name,
@@ -835,7 +813,7 @@ describeEE("scenarios > embedding > full app", () => {
           type: "metric",
           collection_id: NORMAL_PERSONAL_COLLECTION_ID,
         };
-        createQuestion(cardDetails);
+        H.createQuestion(cardDetails);
         startNewEmbeddingQuestion();
         selectCard({
           cardName: cardDetails.name,
@@ -857,7 +835,7 @@ describeEE("scenarios > embedding > full app", () => {
           type: "metric",
           collection_id: NORMAL_PERSONAL_COLLECTION_ID,
         };
-        createQuestion(cardDetails);
+        H.createQuestion(cardDetails);
         startNewEmbeddingQuestion();
         selectCard({
           cardName: cardDetails.name,
@@ -881,13 +859,13 @@ describeEE("scenarios > embedding > full app", () => {
           type: "metric",
           collection_id: null,
         };
-        createQuestion(cardDetails);
+        H.createQuestion(cardDetails);
         startNewEmbeddingQuestion();
         selectTable({
           tableName: "Orders",
         });
-        getNotebookStep("data").button("Join data").click();
-        popover().within(() => {
+        H.getNotebookStep("data").button("Join data").click();
+        H.popover().within(() => {
           cy.icon("chevronleft").click();
           cy.icon("chevronleft").click();
           cy.findByText("Raw Data").should("be.visible");
@@ -915,13 +893,15 @@ describeEE("scenarios > embedding > full app", () => {
       cy.findByRole("heading", { name: "Orders in a dashboard" }).should(
         "not.exist",
       );
-      dashboardGrid().findByText("Rows 1-6 of first 2000").should("be.visible");
+      H.dashboardGrid()
+        .findByText("Rows 1-6 of first 2000")
+        .should("be.visible");
     });
 
     it("should hide the dashboard with multiple tabs header by a param and allow selecting tabs (metabase#38429, metabase#39002)", () => {
       const FIRST_TAB = { id: 1, name: "Tab 1" };
       const SECOND_TAB = { id: 2, name: "Tab 2" };
-      createDashboardWithTabs({
+      H.createDashboardWithTabs({
         dashboard: {
           name: "Dashboard with tabs",
         },
@@ -943,8 +923,10 @@ describeEE("scenarios > embedding > full app", () => {
       cy.findByRole("heading", { name: "Orders in a dashboard" }).should(
         "not.exist",
       );
-      dashboardGrid().findByText("Rows 1-6 of first 2000").should("be.visible");
-      goToTab(SECOND_TAB.name);
+      H.dashboardGrid()
+        .findByText("Rows 1-6 of first 2000")
+        .should("be.visible");
+      H.goToTab(SECOND_TAB.name);
       cy.findByTestId("dashboard-parameters-and-cards")
         .findByText("There's nothing here, yet.")
         .should("be.visible");
@@ -1003,7 +985,7 @@ describeEE("scenarios > embedding > full app", () => {
       };
       cy.createDashboard(dashboardDetails).then(
         ({ body: { id: dashboardId } }) => {
-          const textDashcard = getTextCardDetails({
+          const textDashcard = H.getTextCardDetails({
             col: 0,
             row: 0,
             size_x: 6,
@@ -1011,7 +993,7 @@ describeEE("scenarios > embedding > full app", () => {
             text: "I am a very long text card",
           });
           const dashcard = createMockDashboardCard({
-            id: getNextUnsavedDashboardCardId(),
+            id: H.getNextUnsavedDashboardCardId(),
             col: 8,
             row: 0,
             card_id: ORDERS_QUESTION_ID,
@@ -1026,24 +1008,26 @@ describeEE("scenarios > embedding > full app", () => {
               },
             ],
           });
-          updateDashboardCards({
+          H.updateDashboardCards({
             dashboard_id: dashboardId,
             cards: [dashcard, textDashcard],
           });
         },
       );
 
-      visitFullAppEmbeddingUrl({ url: "/" });
+      H.visitFullAppEmbeddingUrl({ url: "/" });
 
       cy.log("Navigate to a dashboard via in-app navigation");
-      navigationSidebar().findByText("Our analytics").click();
+      H.navigationSidebar().findByText("Our analytics").click();
       cy.findByRole("main").findByText(dashboardDetails.name).click();
-      navigationSidebar().findByText("Our analytics").should("not.be.visible");
+      H.navigationSidebar()
+        .findByText("Our analytics")
+        .should("not.be.visible");
 
       cy.get("main header")
         .findByText(dashboardDetails.name)
         .should("be.visible");
-      getDashboardCard()
+      H.getDashboardCard()
         .findByText("I am a very long text card")
         .should("be.visible");
 
@@ -1053,7 +1037,7 @@ describeEE("scenarios > embedding > full app", () => {
       const FPS = 1000 / 60;
       cy.findByRole("main").scrollTo("bottom", { duration: 2 * FPS });
 
-      getDashboardCard()
+      H.getDashboardCard()
         .findByText("I am a very long text card")
         .should("not.be.visible");
       cy.findByTestId("dashboard-parameters-widget-container").then(
@@ -1068,7 +1052,7 @@ describeEE("scenarios > embedding > full app", () => {
     it("should send `frame` message with dashboard height when the dashboard is resized (metabase#37437)", () => {
       const TAB_1 = { id: 1, name: "Tab 1" };
       const TAB_2 = { id: 2, name: "Tab 2" };
-      createDashboardWithTabs({
+      H.createDashboardWithTabs({
         tabs: [TAB_1, TAB_2],
         name: "Dashboard",
         dashcards: [
@@ -1080,7 +1064,7 @@ describeEE("scenarios > embedding > full app", () => {
           }),
         ],
       }).then(dashboard => {
-        visitFullAppEmbeddingUrl({
+        H.visitFullAppEmbeddingUrl({
           url: `/dashboard/${dashboard.id}`,
           onBeforeLoad(window) {
             cy.spy(window.parent, "postMessage").as("postMessage");
@@ -1142,10 +1126,10 @@ describeEE("scenarios > embedding > full app", () => {
         url: `/dashboard/${ORDERS_DASHBOARD_ID}`,
       });
 
-      getDashboardCard().realHover();
-      getDashboardCardMenu().click();
+      H.getDashboardCard().realHover();
+      H.getDashboardCardMenu().click();
 
-      exportFromDashcard(".csv");
+      H.exportFromDashcard(".csv");
 
       cy.wait("@CsvDownload").then(interception => {
         expect(
@@ -1155,7 +1139,7 @@ describeEE("scenarios > embedding > full app", () => {
     });
 
     it("should send 'X-Metabase-Client' header for api requests", () => {
-      visitFullAppEmbeddingUrl({ url: `/dashboard/${ORDERS_DASHBOARD_ID}` });
+      H.visitFullAppEmbeddingUrl({ url: `/dashboard/${ORDERS_DASHBOARD_ID}` });
 
       cy.wait("@getDashboard").then(({ request }) => {
         expect(request?.headers?.["x-metabase-client"]).to.equal(
@@ -1186,18 +1170,18 @@ describeEE("scenarios > embedding > full app", () => {
 });
 
 const visitQuestionUrl = urlOptions => {
-  visitFullAppEmbeddingUrl(urlOptions);
+  H.visitFullAppEmbeddingUrl(urlOptions);
   cy.wait("@getCardQuery");
 };
 
 const visitDashboardUrl = urlOptions => {
-  visitFullAppEmbeddingUrl(urlOptions);
+  H.visitFullAppEmbeddingUrl(urlOptions);
   cy.wait("@getDashboard");
   cy.wait("@getDashCardQuery");
 };
 
 const visitXrayDashboardUrl = urlOptions => {
-  visitFullAppEmbeddingUrl(urlOptions);
+  H.visitFullAppEmbeddingUrl(urlOptions);
   cy.wait("@getXrayDashboard");
 };
 

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -1,5 +1,6 @@
 import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
 
+import { H } from "e2e/support";
 import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
@@ -8,45 +9,6 @@ import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  addOrUpdateDashboardCard,
-  appBar,
-  assertQueryBuilderRowCount,
-  assertTabSelected,
-  commandPalette,
-  commandPaletteSearch,
-  createDashboard,
-  createDashboardWithTabs,
-  createNativeQuestion,
-  createQuestion,
-  dashboardParameterSidebar,
-  dashboardParametersContainer,
-  editDashboard,
-  filterWidget,
-  getDashboardCard,
-  goToTab,
-  multiAutocompleteInput,
-  navigationSidebar,
-  openNavigationSidebar,
-  openQuestionsSidebar,
-  popover,
-  resetTestTable,
-  restore,
-  resyncDatabase,
-  saveDashboard,
-  selectDashboardFilter,
-  setFilter,
-  setModelMetadata,
-  sidebar,
-  tableHeaderClick,
-  tableInteractive,
-  undoToast,
-  updateDashboardCards,
-  visitDashboard,
-  visitEmbeddedPage,
-  visitModel,
-  visitPublicDashboard,
-} from "e2e/support/helpers";
 import {
   createMockDashboardCard,
   createMockParameter,
@@ -118,7 +80,7 @@ describe("issue 8030 + 32444", () => {
   };
 
   const setFilterMapping = ({ dashboard_id, card1_id, card2_id }) => {
-    return updateDashboardCards({
+    return H.updateDashboardCards({
       dashboard_id,
       cards: [
         {
@@ -166,14 +128,14 @@ describe("issue 8030 + 32444", () => {
   };
 
   const addFilterValue = value => {
-    filterWidget().click();
+    H.filterWidget().click();
     cy.findByText(value).click();
     cy.button("Add filter").click();
   };
 
   describe("issue 8030", () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
     });
 
@@ -188,9 +150,9 @@ describe("issue 8030 + 32444", () => {
             cy.wait("@getCardQuery2");
 
             cy.findByText(filterDetails.name).click();
-            popover().within(() => {
+            H.popover().within(() => {
               // the filter is connected only to the first card
-              multiAutocompleteInput().type("1{enter}");
+              H.multiAutocompleteInput().type("1{enter}");
               cy.button("Add filter").click();
             });
             cy.wait("@getCardQuery1");
@@ -204,7 +166,7 @@ describe("issue 8030 + 32444", () => {
 
   describe("issue 32444", () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
     });
 
@@ -217,22 +179,25 @@ describe("issue 8030 + 32444", () => {
           `/api/dashboard/${dashboard.id}/dashcard/*/card/*/query`,
         ).as("getCardQuery");
 
-        visitDashboard(dashboard.id);
-        editDashboard(dashboard.id);
+        H.visitDashboard(dashboard.id);
+        H.editDashboard(dashboard.id);
 
         cy.get("@getCardQuery.all").should("have.length", 2);
 
-        setFilter("Text or Category", "Is");
-        selectDashboardFilter(cy.findAllByTestId("dashcard").first(), "Title");
+        H.setFilter("Text or Category", "Is");
+        H.selectDashboardFilter(
+          cy.findAllByTestId("dashcard").first(),
+          "Title",
+        );
 
-        undoToast().findByRole("button", { name: "Auto-connect" }).click();
+        H.undoToast().findByRole("button", { name: "Auto-connect" }).click();
 
         cy.findAllByTestId("dashcard")
           .eq(1)
           .findByLabelText("Disconnect")
           .click();
 
-        saveDashboard();
+        H.saveDashboard();
 
         cy.wait("@getCardQuery");
         cy.get("@getCardQuery.all").should("have.length", 4);
@@ -248,11 +213,11 @@ describe("issue 8030 + 32444", () => {
 
 describe("issue 12720, issue 47172", () => {
   function clickThrough(title) {
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
     cy.findAllByTestId("dashcard-container").contains(title).click();
 
     cy.location("search").should("contain", dashboardFilter.default);
-    filterWidget().contains("After January 1, 2026");
+    H.filterWidget().contains("After January 1, 2026");
   }
   // After January 1st, 2026
   const dashboardFilter = {
@@ -282,7 +247,7 @@ describe("issue 12720, issue 47172", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     // In this test we're using already present question ("Orders") and the dashboard with that question ("Orders in a dashboard")
@@ -292,7 +257,7 @@ describe("issue 12720, issue 47172", () => {
 
     cy.createNativeQuestion(questionDetails).then(
       ({ body: { id: SQL_ID } }) => {
-        updateDashboardCards({
+        H.updateDashboardCards({
           dashboard_id: ORDERS_DASHBOARD_ID,
           cards: [
             {
@@ -339,9 +304,9 @@ describe("issue 12720, issue 47172", () => {
   });
 
   it("should apply the specific (before|after) filter on a native question with field filter (metabase#47172)", () => {
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
 
-    getDashboardCard(1).within(() => {
+    H.getDashboardCard(1).within(() => {
       cy.findByTestId("TableFooter").should("exist");
       cy.findByText("There was a problem displaying this chart.").should(
         "not.exist",
@@ -354,7 +319,7 @@ describe("issue 12720, issue 47172", () => {
 
     cy.location("search").should("eq", `?filter=${dashboardFilter.default}`);
     cy.wait("@cardQuery");
-    tableInteractive().should("be.visible").and("contain", "97.44");
+    H.tableInteractive().should("be.visible").and("contain", "97.44");
     cy.findByTestId("question-row-count").should(
       "not.have.text",
       "Showing 0 rows",
@@ -378,7 +343,7 @@ describe("issue 12985 > dashboard filter dropdown/search", () => {
   const dashboardDetails = { parameters: [categoryFilter] };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -422,14 +387,14 @@ describe("issue 12985 > dashboard filter dropdown/search", () => {
           ],
         });
 
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       });
     });
 
-    filterWidget().contains("Category").click();
+    H.filterWidget().contains("Category").click();
     cy.log("Failing to show dropdown in v0.36.0 through v.0.37.0");
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Doohickey");
       cy.findByText("Gizmo");
       cy.findByText("Widget");
@@ -485,13 +450,13 @@ describe("issue 12985 > dashboard filter dropdown/search", () => {
           ],
         });
 
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       },
     );
 
-    filterWidget().contains("Category").click();
+    H.filterWidget().contains("Category").click();
     // It will fail at this point until the issue is fixed because popover never appears
-    popover().contains("Gadget").click();
+    H.popover().contains("Gadget").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add filter").click();
     cy.url().should("contain", "?category=Gadget");
@@ -502,7 +467,7 @@ describe("issue 12985 > dashboard filter dropdown/search", () => {
 
 describe("issues 15119 and 16112", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.request("PUT", `/api/field/${REVIEWS.REVIEWER}`, {
@@ -570,24 +535,24 @@ describe("issues 15119 and 16112", () => {
         });
 
         // Actually need to setup the linked filter:
-        visitDashboard(dashboard_id);
-        editDashboard();
+        H.visitDashboard(dashboard_id);
+        H.editDashboard();
         cy.findByText("Rating Filter").click();
         cy.findByText("Linked filters").click();
 
         // turn on the toggle
-        sidebar().findByRole("switch").parent().get("label").click();
+        H.sidebar().findByRole("switch").parent().get("label").click();
 
         cy.findByText("Save").click();
 
         cy.signIn("nodata");
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       },
     );
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(reviewerFilter.name).click();
-    popover().contains("adam").click();
+    H.popover().contains("adam").click();
     cy.button("Add filter").click();
 
     cy.findByTestId("dashcard-container").should("contain", "adam");
@@ -596,7 +561,7 @@ describe("issues 15119 and 16112", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(ratingFilter.name).click();
 
-    popover().contains("5").click();
+    H.popover().contains("5").click();
     cy.button("Add filter").click();
 
     cy.findByTestId("dashcard-container").should("contain", "adam");
@@ -624,7 +589,7 @@ describe("issue 16663", () => {
   const dashboardDetails = { parameters: [FILTER] };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -636,7 +601,7 @@ describe("issue 16663", () => {
       ({ body: dashboardCard }) => {
         const { dashboard_id } = dashboardCard;
 
-        addOrUpdateDashboardCard({
+        H.addOrUpdateDashboardCard({
           dashboard_id: dashboardCard.dashboard_id,
           card_id: dashboardCard.card_id,
           card: {
@@ -658,14 +623,14 @@ describe("issue 16663", () => {
             ],
           },
         });
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       },
     );
 
     cy.url().should("include", queryParam);
 
-    commandPaletteSearch(dashboardToRedirect, false);
-    commandPalette().within(() => {
+    H.commandPaletteSearch(dashboardToRedirect, false);
+    H.commandPalette().within(() => {
       cy.findByRole("option", { name: dashboardToRedirect }).click();
     });
 
@@ -694,7 +659,7 @@ describe("issue 17211", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
@@ -730,13 +695,13 @@ describe("issue 17211", () => {
           ],
         });
 
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       },
     );
   });
 
   it("should not falsely alert that no matching dashboard filter has been found (metabase#17211)", () => {
-    filterWidget().click();
+    H.filterWidget().click();
 
     cy.findByPlaceholderText("Search by City").type("abb");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -749,7 +714,7 @@ describe("issue 17211", () => {
 
 describe("issue 17551", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestion({
@@ -800,13 +765,13 @@ describe("issue 17551", () => {
 
         cy.editDashboardCard(card, mapFilterToCard);
 
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       });
     });
   });
 
   it("should include today in the 'All time' date filter when chosen 'Next' (metabase#17551)", () => {
-    filterWidget().click();
+    H.filterWidget().click();
     setAdHocFilter({ condition: "Next", includeCurrent: true });
 
     cy.url().should("include", "?date_filter=next30days~");
@@ -848,7 +813,7 @@ describe("issue 17775", () => {
   const dashboardDetails = { parameters };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
@@ -859,11 +824,11 @@ describe("issue 17775", () => {
 
         cy.editDashboardCard(dashboardCard, updatedSize);
 
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       },
     );
 
-    editDashboard();
+    H.editDashboard();
 
     // Make sure filter can be connected to the custom column using UI, rather than using API.
     cy.findByTestId("edit-dashboard-parameters-widget-container")
@@ -878,15 +843,15 @@ describe("issue 17775", () => {
         cy.findByText("Select…").click();
       });
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("CC Date").click();
     });
 
-    saveDashboard();
+    H.saveDashboard();
   });
 
   it("should be able to apply dashboard filter to a custom column (metabase#17775)", () => {
-    filterWidget().click();
+    H.filterWidget().click();
 
     setQuarterAndYear({ quarter: "Q1", year: "2023" });
 
@@ -916,13 +881,13 @@ describe("issue 19494", () => {
 
     cy.findAllByText("Select…").eq(cardPosition).click();
 
-    popover().contains("Category").click();
+    H.popover().contains("Category").click();
   }
 
   function setDefaultFilter(value) {
     cy.findByText("No default").click();
 
-    popover().contains(value).click();
+    H.popover().contains(value).click();
 
     cy.button("Add filter").click();
   }
@@ -932,11 +897,11 @@ describe("issue 19494", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     // Add two "Orders" questions to the existing "Orders in a dashboard" dashboard
-    updateDashboardCards({
+    H.updateDashboardCards({
       dashboard_id: ORDERS_DASHBOARD_ID,
       cards: [
         {
@@ -965,9 +930,9 @@ describe("issue 19494", () => {
   it("should correctly apply different filters with default values to all cards of the same question (metabase#19494)", () => {
     // Instead of using the API to connect filters to the cards,
     // let's use UI to replicate user experience as closely as possible
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
 
-    editDashboard();
+    H.editDashboard();
 
     connectFilterToCard({ filterName: "Card 1 Filter", cardPosition: 0 });
     setDefaultFilter("Doohickey");
@@ -975,21 +940,21 @@ describe("issue 19494", () => {
     connectFilterToCard({ filterName: "Card 2 Filter", cardPosition: -1 });
     setDefaultFilter("Gizmo");
 
-    saveDashboard();
+    H.saveDashboard();
 
     checkAppliedFilter("Card 1 Filter", "Doohickey");
 
-    getDashboardCard(0).should("contain", "148.23");
+    H.getDashboardCard(0).should("contain", "148.23");
 
     checkAppliedFilter("Card 2 Filter", "Gizmo");
 
-    getDashboardCard(1).should("contain", "110.93");
+    H.getDashboardCard(1).should("contain", "110.93");
   });
 });
 
 describe("issue 16177", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.request("PUT", `/api/field/${ORDERS.QUANTITY}`, {
       coercion_strategy: "Coercion/UNIXSeconds->DateTime",
@@ -998,16 +963,16 @@ describe("issue 16177", () => {
   });
 
   it("should not lose the default value of the parameter connected to a field with a coercion strategy applied (metabase#16177)", () => {
-    visitDashboard(ORDERS_DASHBOARD_ID);
-    editDashboard();
-    setFilter("Date picker", "All Options");
-    selectDashboardFilter(getDashboardCard(), "Quantity");
-    dashboardParameterSidebar().findByText("No default").click();
-    popover().findByText("Yesterday").click();
-    saveDashboard();
-    filterWidget().findByText("Yesterday").should("be.visible");
-    visitDashboard(ORDERS_DASHBOARD_ID);
-    filterWidget().findByText("Yesterday").should("be.visible");
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.editDashboard();
+    H.setFilter("Date picker", "All Options");
+    H.selectDashboardFilter(H.getDashboardCard(), "Quantity");
+    H.dashboardParameterSidebar().findByText("No default").click();
+    H.popover().findByText("Yesterday").click();
+    H.saveDashboard();
+    H.filterWidget().findByText("Yesterday").should("be.visible");
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.filterWidget().findByText("Yesterday").should("be.visible");
   });
 });
 
@@ -1031,7 +996,7 @@ describe("issue 20656", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -1060,23 +1025,23 @@ describe("issue 20656", () => {
 
         cy.signInAsNormalUser();
 
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       },
     );
 
     // Make sure the filter widget is there
-    filterWidget();
+    H.filterWidget();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sorry, you don't have permission to see this card.");
 
     // Trying to edit the filter should not show mapping fields and shouldn't break frontend (metabase#24536)
-    editDashboard();
+    H.editDashboard();
 
     cy.findByTestId("edit-dashboard-parameters-widget-container")
       .find(".Icon-gear")
       .click();
 
-    getDashboardCard().within(() => {
+    H.getDashboardCard().within(() => {
       cy.findByText("Column to filter on");
       cy.icon("key");
     });
@@ -1124,7 +1089,7 @@ describe("issue 21528", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestion(NATIVE_QUESTION_DETAILS, {
@@ -1153,7 +1118,7 @@ describe("issue 21528", () => {
     );
 
     cy.then(function () {
-      addOrUpdateDashboardCard({
+      H.addOrUpdateDashboardCard({
         card_id: this.questionId,
         dashboard_id: this.dashboardId,
         card: {
@@ -1175,21 +1140,21 @@ describe("issue 21528", () => {
     });
 
     cy.findByTestId("native-query-top-bar").findByText("Product ID").click();
-    popover().contains("Rustic Paper Wallet - 1").should("be.visible");
+    H.popover().contains("Rustic Paper Wallet - 1").should("be.visible");
 
     // Navigating to another page via JavaScript is faster than using `cy.visit("/dashboard/:dashboard-id")` to load the whole page again.
-    openNavigationSidebar();
-    navigationSidebar().findByText("Our analytics").click();
+    H.openNavigationSidebar();
+    H.navigationSidebar().findByText("Our analytics").click();
     cy.findByRole("main").findByText(DASHBOARD_DETAILS.name).click();
 
-    dashboardParametersContainer().findByText("Product ID").click();
-    popover().contains("Aerodynamic Bronze Hat - 144").should("be.visible");
+    H.dashboardParametersContainer().findByText("Product ID").click();
+    H.popover().contains("Aerodynamic Bronze Hat - 144").should("be.visible");
 
     cy.log("The following scenario breaks on 46");
     // Navigating to another page via JavaScript is faster than using `cy.visit("/admin/datamodel")` to load the whole page again.
-    appBar().icon("gear").click();
-    popover().findByText("Admin settings").click();
-    appBar().findByText("Table Metadata").click();
+    H.appBar().icon("gear").click();
+    H.popover().findByText("Admin settings").click();
+    H.appBar().findByText("Table Metadata").click();
     cy.findByRole("main")
       .findByText(
         "Select any table to see its schema and add or edit metadata.",
@@ -1197,13 +1162,13 @@ describe("issue 21528", () => {
       .should("be.visible");
     cy.findByRole("navigation").findByText("Exit admin").click();
 
-    openNavigationSidebar();
-    navigationSidebar().findByText("Our analytics").click();
+    H.openNavigationSidebar();
+    H.navigationSidebar().findByText("Our analytics").click();
     cy.findByRole("main").findByText(DASHBOARD_DETAILS.name).click();
 
     // Assert that the dashboard ID filter values is still showing correctly again.
-    dashboardParametersContainer().findByText("Product ID").click();
-    popover().contains("Aerodynamic Bronze Hat - 144").should("be.visible");
+    H.dashboardParametersContainer().findByText("Product ID").click();
+    H.popover().contains("Aerodynamic Bronze Hat - 144").should("be.visible");
   });
 });
 
@@ -1213,21 +1178,21 @@ describe("issue 22482", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
 
-    editDashboard();
-    setFilter("Date picker", "All Options");
+    H.editDashboard();
+    H.setFilter("Date picker", "All Options");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
-    popover().contains("Created At").eq(0).click();
+    H.popover().contains("Created At").eq(0).click();
 
-    saveDashboard();
+    H.saveDashboard();
 
-    filterWidget().click();
+    H.filterWidget().click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Relative dates...").click();
   });
@@ -1275,8 +1240,8 @@ describe("issue 22788", () => {
   };
 
   function addFilterAndAssert() {
-    filterWidget().click();
-    popover().within(() => {
+    H.filterWidget().click();
+    H.popover().within(() => {
       cy.findByRole("searchbox").type("Gizmo");
       cy.button("Add filter").click();
     });
@@ -1292,7 +1257,7 @@ describe("issue 22788", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
@@ -1317,7 +1282,7 @@ describe("issue 22788", () => {
           ],
         });
 
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       },
     );
   });
@@ -1325,24 +1290,24 @@ describe("issue 22788", () => {
   it("should not drop filter connected to a custom column on a second dashboard edit (metabase#22788)", () => {
     addFilterAndAssert();
 
-    editDashboard();
+    H.editDashboard();
 
     openFilterSettings();
 
     // Make sure the filter is still connected to the custom column
 
-    getDashboardCard().within(() => {
+    H.getDashboardCard().within(() => {
       cy.findByText("Column to filter on");
       cy.findByText(ccDisplayName);
     });
 
     // need to actually change the dashboard to test a real save
-    sidebar().within(() => {
+    H.sidebar().within(() => {
       cy.findByDisplayValue("Text").clear().type("my filter text");
       cy.button("Done").click();
     });
 
-    saveDashboard();
+    H.saveDashboard();
 
     cy.findAllByText("Gizmo");
     cy.findAllByText("Doohickey").should("not.exist");
@@ -1392,7 +1357,7 @@ describe("issue 24235", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dashboard/**/query").as("getCardQuery");
   });
@@ -1401,20 +1366,20 @@ describe("issue 24235", () => {
     cy.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
       ({ body: { id, card_id, dashboard_id } }) => {
         mapParameterToDashboardCard({ id, card_id, dashboard_id });
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       },
     );
 
-    filterWidget().contains(parameter.name).click();
-    popover().within(() => {
+    H.filterWidget().contains(parameter.name).click();
+    H.popover().within(() => {
       cy.findByText("Exclude...").click();
       cy.findByText("Days of the week...").click();
       cy.findByText("Select all").click();
       cy.findByText("Add filter").click();
     });
 
-    filterWidget().click();
-    popover().within(() => {
+    H.filterWidget().click();
+    H.popover().within(() => {
       cy.findByText("Select none").click();
       cy.findByText("Update filter").click();
     });
@@ -1466,7 +1431,7 @@ describe("issues 15279 and 24500", () => {
   const dashboardDetails = { parameters };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -1501,14 +1466,14 @@ describe("issues 15279 and 24500", () => {
           ],
         });
 
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       },
     );
 
     cy.log("Make sure the list filter works");
-    filterWidget().contains("List").click();
+    H.filterWidget().contains("List").click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByTextEnsureVisible("Organic").click();
       cy.findByTestId("Organic-filter-value").should("be.checked");
       cy.button("Add filter").click();
@@ -1519,8 +1484,8 @@ describe("issues 15279 and 24500", () => {
       .and("contain", "Dagmar Fay");
 
     cy.log("Make sure the search filter works");
-    filterWidget().contains("Search").click();
-    popover().within(() => {
+    H.filterWidget().contains("Search").click();
+    H.popover().within(() => {
       cy.findByPlaceholderText("Search by Name").type("Lora Cronin");
       cy.button("Add filter").click();
     });
@@ -1531,7 +1496,7 @@ describe("issues 15279 and 24500", () => {
 
     cy.log("Make sure corrupted filter cannot connect to any field");
     // The corrupted filter is only visible when editing the dashboard
-    editDashboard();
+    H.editDashboard();
     cy.findByTestId("edit-dashboard-parameters-widget-container")
       .findByText("unnamed")
       .icon("gear")
@@ -1549,21 +1514,21 @@ describe("issues 15279 and 24500", () => {
       .should("contain", "Lora Cronin")
       .and("not.contain", "Dagmar Fay");
 
-    saveDashboard();
+    H.saveDashboard();
 
     cy.log("Make sure the list filter still works");
-    filterWidget().contains("Organic").click();
-    popover().findByTestId("Organic-filter-value").should("be.checked");
+    H.filterWidget().contains("Organic").click();
+    H.popover().findByTestId("Organic-filter-value").should("be.checked");
 
     cy.log("Make sure the search filter still works");
     // reset filter value
-    filterWidget().contains("Search").parent().icon("close").click();
+    H.filterWidget().contains("Search").parent().icon("close").click();
     cy.findByTestId("dashcard-container")
       .should("contain", "Lora Cronin")
       .and("contain", "Dagmar Fay");
 
-    filterWidget().contains("Search").click();
-    popover().within(() => {
+    H.filterWidget().contains("Search").click();
+    H.popover().within(() => {
       cy.findByPlaceholderText("Search by Name").type("Lora Cronin");
       cy.button("Add filter").click();
     });
@@ -1599,7 +1564,7 @@ describe("issue 25322", () => {
       .then(({ body: { id: card_id } }) => {
         cy.createDashboard(dashboardDetails).then(
           ({ body: { id: dashboard_id } }) => {
-            addOrUpdateDashboardCard({
+            H.addOrUpdateDashboardCard({
               dashboard_id,
               card_id,
               card: {
@@ -1628,19 +1593,19 @@ describe("issue 25322", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should show a loader when loading field values (metabase#25322)", () => {
     createDashboard().then(({ dashboard_id }) => {
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
       throttleFieldValuesRequest(dashboard_id);
     });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(parameterDetails.name).click();
-    popover().findByTestId("loading-indicator").should("exist");
+    H.popover().findByTestId("loading-indicator").should("exist");
   });
 });
 
@@ -1708,23 +1673,23 @@ describe("issue 25248", () => {
           });
         },
       );
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
     });
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should allow mapping parameters to combined cards individually (metabase#25248)", () => {
     createDashboard();
-    editDashboard();
+    H.editDashboard();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(parameterDetails.name).click();
     cy.findAllByText("Select…").first().click();
-    popover().findAllByText("Created At").first().click();
+    H.popover().findAllByText("Created At").first().click();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders.Created At").should("be.visible");
@@ -1779,7 +1744,7 @@ describe("issue 25374", () => {
       "dashcardQuery",
     );
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestionAndDashboard({
@@ -1807,11 +1772,11 @@ describe("issue 25374", () => {
         ],
       });
 
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
       cy.wait("@dashcardQuery");
       cy.location("search").should("eq", "?equal_to=");
 
-      filterWidget().type("1,2,3{enter}");
+      H.filterWidget().type("1,2,3{enter}");
       cy.wait("@dashcardQuery");
 
       cy.get(".CardVisualization")
@@ -1825,7 +1790,7 @@ describe("issue 25374", () => {
 
   it("should pass comma-separated values down to the connected question (metabase#25374-1)", () => {
     // Drill-through and go to the question
-    getDashboardCard(0).findByText(questionDetails.name).click();
+    H.getDashboardCard(0).findByText(questionDetails.name).click();
     cy.wait("@cardQuery");
 
     cy.get("[data-testid=cell-data]")
@@ -1851,19 +1816,21 @@ describe("issue 25374", () => {
   });
 
   it("should retain comma-separated values when reverting to default (metabase#25374-3)", () => {
-    editDashboard();
+    H.editDashboard();
     cy.findByTestId("edit-dashboard-parameters-widget-container")
       .findByText("Equal to")
       .click();
-    dashboardParameterSidebar().findByLabelText("Default value").type("1,2,3");
+    H.dashboardParameterSidebar()
+      .findByLabelText("Default value")
+      .type("1,2,3");
 
-    saveDashboard();
+    H.saveDashboard();
     cy.location("search").should("eq", "?equal_to=1%2C2%2C3");
-    getDashboardCard().findAllByTestId("cell-data").should("have.text", "3");
+    H.getDashboardCard().findAllByTestId("cell-data").should("have.text", "3");
 
     cy.button("Clear").click();
     cy.wait("@dashcardQuery");
-    getDashboardCard().should(
+    H.getDashboardCard().should(
       "contain.text",
       "There was a problem displaying this chart.",
     );
@@ -1871,11 +1838,11 @@ describe("issue 25374", () => {
 
     cy.button("Reset filter to default state").click();
     cy.wait("@dashcardQuery");
-    getDashboardCard().findAllByTestId("cell-data").should("have.text", "3");
+    H.getDashboardCard().findAllByTestId("cell-data").should("have.text", "3");
     cy.location("search").should("eq", "?equal_to=1%2C2%2C3");
 
     // Drill-through and go to the question
-    getDashboardCard(0).findByText(questionDetails.name).click();
+    H.getDashboardCard(0).findByText(questionDetails.name).click();
     cy.wait("@cardQuery");
 
     cy.get("[data-testid=cell-data]")
@@ -1886,32 +1853,34 @@ describe("issue 25374", () => {
   });
 
   it("should retain comma-separated values when reverting to default via 'Reset all filters' (metabase#25374-4)", () => {
-    editDashboard();
+    H.editDashboard();
     cy.findByTestId("edit-dashboard-parameters-widget-container")
       .findByText("Equal to")
       .click();
-    dashboardParameterSidebar().findByLabelText("Default value").type("1,2,3");
-    saveDashboard();
+    H.dashboardParameterSidebar()
+      .findByLabelText("Default value")
+      .type("1,2,3");
+    H.saveDashboard();
     cy.location("search").should("eq", "?equal_to=1%2C2%2C3");
-    getDashboardCard().findAllByTestId("cell-data").should("have.text", "3");
+    H.getDashboardCard().findAllByTestId("cell-data").should("have.text", "3");
 
     cy.button("Clear").click();
     cy.wait("@dashcardQuery");
     cy.location("search").should("eq", "?equal_to=");
-    getDashboardCard().should(
+    H.getDashboardCard().should(
       "contain.text",
       "There was a problem displaying this chart.",
     );
 
     cy.button("Move, trash, and more…").click();
-    popover().findByText("Reset all filters").should("be.visible").click();
+    H.popover().findByText("Reset all filters").should("be.visible").click();
     cy.wait("@dashcardQuery");
     cy.location("search").should("eq", "?equal_to=1%2C2%2C3");
     cy.location("search").should("eq", "?equal_to=1%2C2%2C3");
-    getDashboardCard().findAllByTestId("cell-data").should("have.text", "3");
+    H.getDashboardCard().findAllByTestId("cell-data").should("have.text", "3");
 
     // Drill-through and go to the question
-    getDashboardCard(0).findByText(questionDetails.name).click();
+    H.getDashboardCard(0).findByText(questionDetails.name).click();
     cy.wait("@cardQuery");
 
     cy.get("[data-testid=cell-data]")
@@ -1947,7 +1916,7 @@ describe("issue 25908", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
@@ -2031,7 +2000,7 @@ describe("issue 26230", () => {
     }).then(({ body: { id } }) => {
       createDashCard(id, FILTER_2);
       bookmarkDashboard(id);
-      visitDashboard(id);
+      H.visitDashboard(id);
     });
   }
 
@@ -2068,7 +2037,7 @@ describe("issue 26230", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     prepareAndVisitDashboards();
@@ -2114,7 +2083,7 @@ describe("issue 27356", () => {
 
   beforeEach(() => {
     cy.intercept("GET", "/api/dashboard/*").as("getDashboard");
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createDashboard(paramDashboard).then(({ body: { id } }) => {
@@ -2123,24 +2092,24 @@ describe("issue 27356", () => {
 
     cy.createDashboard(regularDashboard).then(({ body: { id } }) => {
       cy.request("POST", `/api/bookmark/dashboard/${id}`);
-      visitDashboard(id);
+      H.visitDashboard(id);
     });
   });
 
   it("should seamlessly move between dashboards with or without filters without triggering an error (metabase#27356)", () => {
-    openNavigationSidebar();
+    H.openNavigationSidebar();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(paramDashboard.name).click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("This dashboard is looking empty.");
 
-    openNavigationSidebar();
+    H.openNavigationSidebar();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(regularDashboard.name).click({ force: true });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("This dashboard is looking empty.");
 
-    openNavigationSidebar();
+    H.openNavigationSidebar();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(paramDashboard.name).click({ force: true });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -2171,7 +2140,7 @@ describe("issue 27768", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestionAndDashboard({ questionDetails }).then(
@@ -2180,7 +2149,7 @@ describe("issue 27768", () => {
           parameters: [filter],
         });
 
-        visitDashboard(dashboard_id, { queryParams: { cat: "Gizmo" } });
+        H.visitDashboard(dashboard_id, { queryParams: { cat: "Gizmo" } });
       },
     );
   });
@@ -2188,15 +2157,15 @@ describe("issue 27768", () => {
   it("filter connected to custom column should visually indicate it is connected (metabase#27768)", () => {
     // We need to manually connect the filter to the custom column using the UI,
     // but when we fix the issue, it should be safe to do this via API
-    editDashboard();
+    H.editDashboard();
     getFilterOptions(filter.name);
 
-    getDashboardCard().findByText("Select…").click();
-    popover().contains("CCategory").click();
-    saveDashboard();
+    H.getDashboardCard().findByText("Select…").click();
+    H.popover().contains("CCategory").click();
+    H.saveDashboard();
 
-    filterWidget().click();
-    popover().within(() => {
+    H.filterWidget().click();
+    H.popover().within(() => {
       cy.findByRole("searchbox").type("Gizmo");
       cy.button("Add filter").click();
     });
@@ -2204,10 +2173,10 @@ describe("issue 27768", () => {
     cy.findAllByText("Doohickey").should("not.exist");
 
     // Make sure the filter is still connected to the custom column
-    editDashboard();
+    H.editDashboard();
     getFilterOptions(filter.name);
 
-    getDashboardCard().within(() => {
+    H.getDashboardCard().within(() => {
       cy.findByText("Select…").should("not.exist");
       cy.contains("Products.CCategory");
     });
@@ -2301,11 +2270,11 @@ describe("issues 29347, 29346", () => {
   };
 
   const filterOnRemappedValues = fieldValue => {
-    filterWidget().within(() => {
+    H.filterWidget().within(() => {
       cy.findByText(filterDetails.name).click();
     });
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText(getRemappedValue(fieldValue)).click();
       cy.button("Add filter").click();
     });
@@ -2317,19 +2286,19 @@ describe("issues 29347, 29346", () => {
   };
 
   const verifyRemappedFilterValues = fieldValue => {
-    filterWidget().within(() => {
+    H.filterWidget().within(() => {
       cy.findByText(getRemappedValue(fieldValue)).should("be.visible");
     });
   };
 
   const verifyRemappedCardValues = fieldValue => {
-    getDashboardCard().within(() => {
+    H.getDashboardCard().within(() => {
       cy.findAllByText(getRemappedValue(fieldValue)).should("have.length", 2);
     });
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     addFieldRemapping(ORDERS.QUANTITY);
   });
@@ -2342,7 +2311,7 @@ describe("issues 29347, 29346", () => {
 
     it("should be able to filter on remapped values (metabase#29347, metabase#29346)", () => {
       createDashboard();
-      visitDashboard("@dashboardId");
+      H.visitDashboard("@dashboardId");
       cy.wait("@dashboard");
       cy.wait("@cardQuery");
 
@@ -2354,7 +2323,7 @@ describe("issues 29347, 29346", () => {
 
     it("should be able to filter on remapped values in the url (metabase#29347, metabase#29346)", () => {
       createDashboard();
-      visitDashboard("@dashboardId", {
+      H.visitDashboard("@dashboardId", {
         params: { [filterDetails.slug]: filterValue },
       });
 
@@ -2374,7 +2343,7 @@ describe("issues 29347, 29346", () => {
     it("should be able to filter on remapped values (metabase#29347, metabase#29346)", () => {
       createDashboard();
       cy.get("@dashboardId").then(dashboardId =>
-        visitEmbeddedPage({
+        H.visitEmbeddedPage({
           resource: { dashboard: dashboardId },
           params: {},
         }),
@@ -2391,7 +2360,7 @@ describe("issues 29347, 29346", () => {
     it("should be able to filter on remapped values in the token (metabase#29347, metabase#29346)", () => {
       createDashboard({ dashboardDetails: lockedDashboardDetails });
       cy.get("@dashboardId").then(dashboardId => {
-        visitEmbeddedPage({
+        H.visitEmbeddedPage({
           resource: { dashboard: dashboardId },
           params: {
             [filterDetails.slug]: filterValue,
@@ -2407,7 +2376,7 @@ describe("issues 29347, 29346", () => {
     it("should be able to filter on remapped values in the url (metabase#29347, metabase#29346)", () => {
       createDashboard();
       cy.get("@dashboardId").then(dashboardId => {
-        visitEmbeddedPage(
+        H.visitEmbeddedPage(
           {
             resource: { dashboard: dashboardId },
             params: {},
@@ -2433,7 +2402,7 @@ describe("issues 29347, 29346", () => {
     it("should be able to filter on remapped values (metabase#29347, metabase#29346)", () => {
       createDashboard();
       cy.get("@dashboardId").then(dashboardId =>
-        visitPublicDashboard(dashboardId),
+        H.visitPublicDashboard(dashboardId),
       );
       cy.wait("@dashboard");
       cy.wait("@cardQuery");
@@ -2447,7 +2416,7 @@ describe("issues 29347, 29346", () => {
     it("should be able to filter on remapped values in the url (metabase#29347, metabase#29346)", () => {
       createDashboard();
       cy.get("@dashboardId").then(dashboardId => {
-        visitPublicDashboard(dashboardId, {
+        H.visitPublicDashboard(dashboardId, {
           params: { [filterDetails.slug]: filterValue },
         });
       });
@@ -2474,7 +2443,7 @@ describe("issue 31662", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("/api/dashboard/*").as("dashboard");
   });
@@ -2487,12 +2456,12 @@ describe("issue 31662", () => {
       },
     );
     cy.findByTestId("dashboard-empty-state").should("be.visible");
-    editDashboard();
+    H.editDashboard();
     cy.findByTestId("edit-dashboard-parameters-widget-container")
       .findByText("Between")
       .click();
-    sidebar().findByText("2 selections").click();
-    popover().within(() => {
+    H.sidebar().findByText("2 selections").click();
+    H.popover().within(() => {
       cy.findByDisplayValue("3").should("be.visible");
       cy.findByDisplayValue("5").should("be.visible");
     });
@@ -2506,8 +2475,8 @@ describe("issue 38245", () => {
 
   function mapDashCardToFilter(dashcardElement, filterName, columnName) {
     filterPanel().findByText(filterName).click();
-    selectDashboardFilter(dashcardElement, columnName);
-    sidebar().button("Done").click();
+    H.selectDashboardFilter(dashcardElement, columnName);
+    H.sidebar().button("Done").click();
   }
   const TAB_1 = {
     id: 1,
@@ -2528,34 +2497,34 @@ describe("issue 38245", () => {
 
   beforeEach(() => {
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should not make a request to the server if the parameters are not saved (metabase#38245)", () => {
-    createDashboardWithTabs({
+    H.createDashboardWithTabs({
       tabs: [TAB_1, TAB_2],
       parameters: [DASHBOARD_TEXT_FILTER],
       dashcards: [],
-    }).then(dashboard => visitDashboard(dashboard.id));
+    }).then(dashboard => H.visitDashboard(dashboard.id));
 
-    editDashboard();
-    openQuestionsSidebar();
+    H.editDashboard();
+    H.openQuestionsSidebar();
 
-    sidebar().findByText("Orders").click();
+    H.sidebar().findByText("Orders").click();
 
     cy.wait("@cardQuery");
 
     mapDashCardToFilter(
-      getDashboardCard(),
+      H.getDashboardCard(),
       DASHBOARD_TEXT_FILTER.name,
       "Source",
     );
 
-    goToTab(TAB_2.name);
-    goToTab(TAB_1.name);
+    H.goToTab(TAB_2.name);
+    H.goToTab(TAB_1.name);
 
-    getDashboardCard().within(() => {
+    H.getDashboardCard().within(() => {
       cy.findByText("Orders").should("exist");
       cy.findByText("Product ID").should("exist");
       cy.findByText(/(Problem|Error)/i).should("not.exist");
@@ -2611,29 +2580,29 @@ describe("issue 43154", () => {
   });
 
   function verifyNestedFilter(questionDetails) {
-    createQuestion(modelDetails).then(({ body: model }) => {
+    H.createQuestion(modelDetails).then(({ body: model }) => {
       cy.createDashboardWithQuestions({
         questions: [questionDetails(model.id)],
       }).then(({ dashboard }) => {
-        visitDashboard(dashboard.id);
+        H.visitDashboard(dashboard.id);
       });
     });
 
-    editDashboard();
-    setFilter("Text or Category", "Is");
-    getDashboardCard().findByText("Select…").click();
-    popover().findByText("People - User → Source").click();
-    saveDashboard();
+    H.editDashboard();
+    H.setFilter("Text or Category", "Is");
+    H.getDashboardCard().findByText("Select…").click();
+    H.popover().findByText("People - User → Source").click();
+    H.saveDashboard();
 
-    filterWidget().click();
-    popover().within(() => {
+    H.filterWidget().click();
+    H.popover().within(() => {
       cy.findByText("Twitter").click();
       cy.button("Add filter").click();
     });
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
@@ -2696,29 +2665,29 @@ describe("issue 42829", () => {
   });
 
   function filterAndVerifyResults() {
-    filterWidget().click();
-    popover().within(() => {
+    H.filterWidget().click();
+    H.popover().within(() => {
       cy.findByText("AK").click();
       cy.findByText("AR").click();
       cy.button("Add filter").click();
     });
-    getDashboardCard().findByTestId("scalar-value").should("have.text", "2");
+    H.getDashboardCard().findByTestId("scalar-value").should("have.text", "2");
   }
 
   function drillAndVerifyResults() {
-    getDashboardCard().findByText("SQL model-based question").click();
+    H.getDashboardCard().findByText("SQL model-based question").click();
     cy.findByTestId("qb-filters-panel").findByText("State is 2 selections");
     cy.findByTestId("scalar-value").should("have.text", "2");
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    createNativeQuestion(modelDetails).then(({ body: model }) => {
+    H.createNativeQuestion(modelDetails).then(({ body: model }) => {
       // populate result_metadata
       cy.request("POST", `/api/card/${model.id}/query`);
-      setModelMetadata(model.id, field => {
+      H.setModelMetadata(model.id, field => {
         if (field.display_name === "STATE") {
           return { ...field, ...stateFieldDetails };
         }
@@ -2728,7 +2697,7 @@ describe("issue 42829", () => {
         dashboardDetails,
         questions: [getQuestionDetails(model.id)],
       }).then(({ dashboard, questions: [question] }) => {
-        updateDashboardCards({
+        H.updateDashboardCards({
           dashboard_id: dashboard.id,
           cards: [
             {
@@ -2743,21 +2712,21 @@ describe("issue 42829", () => {
   });
 
   it("should be able to get field values coming from a sql model-based question in a regular dashboard (metabase#42829)", () => {
-    visitDashboard("@dashboardId");
+    H.visitDashboard("@dashboardId");
     filterAndVerifyResults();
     drillAndVerifyResults();
   });
 
   it("should be able to get field values coming from a sql model-based question in a public dashboard (metabase#42829)", () => {
     cy.get("@dashboardId").then(dashboardId =>
-      visitPublicDashboard(dashboardId),
+      H.visitPublicDashboard(dashboardId),
     );
     filterAndVerifyResults();
   });
 
   it("should be able to get field values coming from a sql model-based question in a embedded dashboard (metabase#42829)", () => {
     cy.get("@dashboardId").then(dashboardId =>
-      visitEmbeddedPage({
+      H.visitEmbeddedPage({
         resource: { dashboard: dashboardId },
         params: {},
       }),
@@ -2846,27 +2815,27 @@ describe("issue 43799", () => {
   it("should be able to map a parameter to an explicitly joined column in the model query", () => {
     cy.createDashboardWithQuestions({ questions: [modelDetails] }).then(
       ({ dashboard }) => {
-        visitDashboard(dashboard.id);
+        H.visitDashboard(dashboard.id);
       },
     );
-    editDashboard();
+    H.editDashboard();
     cy.findByTestId("dashboard-header")
       .findByLabelText("Add a filter or parameter")
       .click();
-    popover().findByText("Text or Category").click();
-    getDashboardCard().findByText("Select…").click();
-    popover().findByText("People - User → Source").click();
-    saveDashboard();
-    filterWidget().click();
-    popover().within(() => {
+    H.popover().findByText("Text or Category").click();
+    H.getDashboardCard().findByText("Select…").click();
+    H.popover().findByText("People - User → Source").click();
+    H.saveDashboard();
+    H.filterWidget().click();
+    H.popover().within(() => {
       cy.findByText("Google").click();
       cy.button("Add filter").click();
     });
-    getDashboardCard().findByText("43799").click();
+    H.getDashboardCard().findByText("43799").click();
     cy.findByTestId("qb-filters-panel")
       .findByText("People - User → Source is Google")
       .should("be.visible");
-    assertQueryBuilderRowCount(4);
+    H.assertQueryBuilderRowCount(4);
   });
 });
 
@@ -2937,38 +2906,40 @@ describe("issue 44288", () => {
     cy.findByTestId("edit-dashboard-parameters-widget-container")
       .findByText(parameterDetails.name)
       .click();
-    getDashboardCard(0).within(() => {
+    H.getDashboardCard(0).within(() => {
       cy.findByText(/Category/i).should("be.visible");
     });
-    getDashboardCard(1).within(() => {
+    H.getDashboardCard(1).within(() => {
       cy.findByText(/Category/i).should("not.exist");
       cy.findByText(/Models are data sources/).should("be.visible");
     });
   }
 
   function verifyFilter() {
-    filterWidget().click();
-    popover().within(() => {
+    H.filterWidget().click();
+    H.popover().within(() => {
       cy.findByText("Gadget").click();
       cy.button("Add filter").click();
     });
-    getDashboardCard(0).within(() => {
+    H.getDashboardCard(0).within(() => {
       cy.findAllByText("Gadget").should("have.length.gte", 1);
       cy.findByText("Doohickey").should("not.exist");
     });
-    getDashboardCard(1).within(() => {
+    H.getDashboardCard(1).within(() => {
       cy.findAllByText("Gadget").should("have.length.gte", 1);
       cy.findAllByText("Doohickey").should("have.length.gte", 1);
     });
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    createQuestion(questionDetails).then(({ body: question }) => {
-      createNativeQuestion(modelDetails).then(({ body: model }) => {
+    H.createQuestion(questionDetails).then(({ body: question }) => {
+      H.createNativeQuestion(modelDetails).then(({ body: model }) => {
         cy.createDashboard(dashboardDetails).then(({ body: dashboard }) => {
-          updateDashboardCards(getDashcardDetails(dashboard, question, model));
+          H.updateDashboardCards(
+            getDashcardDetails(dashboard, question, model),
+          );
           cy.wrap(dashboard.id).as("dashboardId");
         });
       });
@@ -2979,23 +2950,23 @@ describe("issue 44288", () => {
   it("should ignore parameter mappings to a native model in a dashboard (metabase#44288)", () => {
     cy.log("regular dashboards");
     cy.signInAsNormalUser();
-    visitDashboard("@dashboardId");
-    editDashboard();
+    H.visitDashboard("@dashboardId");
+    H.editDashboard();
     verifyMapping();
-    saveDashboard({ awaitRequest: false });
+    H.saveDashboard({ awaitRequest: false });
     verifyFilter();
     cy.signOut();
 
     cy.log("public dashboards");
     cy.signInAsAdmin();
     cy.get("@dashboardId").then(dashboardId =>
-      visitPublicDashboard(dashboardId),
+      H.visitPublicDashboard(dashboardId),
     );
     verifyFilter();
 
     cy.log("embedded dashboards");
     cy.get("@dashboardId").then(dashboardId =>
-      visitEmbeddedPage({
+      H.visitEmbeddedPage({
         resource: { dashboard: dashboardId },
         params: {},
       }),
@@ -3006,18 +2977,18 @@ describe("issue 44288", () => {
 
 describe("issue 27579", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should be able to remove the last exclude hour option (metabase#27579)", () => {
-    visitDashboard(ORDERS_DASHBOARD_ID);
-    editDashboard();
-    setFilter("Date picker", "All Options");
-    selectDashboardFilter(getDashboardCard(), "Created At");
-    saveDashboard();
-    filterWidget().click();
-    popover().within(() => {
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.editDashboard();
+    H.setFilter("Date picker", "All Options");
+    H.selectDashboardFilter(H.getDashboardCard(), "Created At");
+    H.saveDashboard();
+    H.filterWidget().click();
+    H.popover().within(() => {
       cy.findByText("Exclude...").click();
       cy.findByText("Hours of the day...").click();
       cy.findByText("Select all").click();
@@ -3071,17 +3042,17 @@ describe("issue 32804", () => {
   });
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should retain source query filters when drilling-thru from a dashboard (metabase#32804)", () => {
-    createQuestion(question1Details).then(({ body: card1 }) => {
+    H.createQuestion(question1Details).then(({ body: card1 }) => {
       cy.createDashboardWithQuestions({
         dashboardDetails,
         questions: [getQuestion2Details(card1)],
       }).then(({ dashboard, questions: [card2] }) => {
-        updateDashboardCards({
+        H.updateDashboardCards({
           dashboard_id: dashboard.id,
           cards: [
             {
@@ -3090,13 +3061,13 @@ describe("issue 32804", () => {
             },
           ],
         });
-        visitDashboard(dashboard.id, {
+        H.visitDashboard(dashboard.id, {
           params: { [parameterDetails.slug]: "4" },
         });
       });
     });
-    filterWidget().findByText("4").should("be.visible");
-    getDashboardCard(0).findByText("Q2").click();
+    H.filterWidget().findByText("4").should("be.visible");
+    H.getDashboardCard(0).findByText("Q2").click();
     cy.findByTestId("qb-filters-panel").within(() => {
       cy.findByText("Category is Gadget").should("be.visible");
       cy.findByText("Rating is equal to 4").should("be.visible");
@@ -3183,13 +3154,13 @@ describe("issue 44231", () => {
     const productId = 144;
     const productName = "Aerodynamic Bronze Hat";
 
-    filterWidget().click();
-    popover().within(() => {
+    H.filterWidget().click();
+    H.popover().within(() => {
       cy.findByText(productName).click();
       cy.button("Add filter").click();
     });
-    getDashboardCard(0).findByText(productName).should("be.visible");
-    getDashboardCard(1)
+    H.getDashboardCard(0).findByText(productName).should("be.visible");
+    H.getDashboardCard(1)
       .findAllByText(String(productId))
       .should("have.length.above", 0);
   }
@@ -3199,15 +3170,17 @@ describe("issue 44231", () => {
       dashboardDetails,
       questions: [getPkCardDetails(type), getFkCardDetails(type)],
     }).then(({ dashboard, questions: [pkCard, fkCard] }) => {
-      updateDashboardCards(getDashcardDetails(type, dashboard, pkCard, fkCard));
+      H.updateDashboardCards(
+        getDashcardDetails(type, dashboard, pkCard, fkCard),
+      );
 
-      visitDashboard(dashboard.id);
+      H.visitDashboard(dashboard.id);
       verifyFilterByRemappedValue();
 
-      visitPublicDashboard(dashboard.id);
+      H.visitPublicDashboard(dashboard.id);
       verifyFilterByRemappedValue();
 
-      visitEmbeddedPage({
+      H.visitEmbeddedPage({
         resource: { dashboard: dashboard.id },
         params: {},
       });
@@ -3216,7 +3189,7 @@ describe("issue 44231", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.request("PUT", `/api/field/${PRODUCTS.ID}`, {
@@ -3314,8 +3287,8 @@ describe("44047", () => {
   }
 
   function verifyFilterWithRemapping() {
-    filterWidget().click();
-    popover().within(() => {
+    H.filterWidget().click();
+    H.popover().within(() => {
       cy.findByPlaceholderText("Search the list").type("Remapped");
       cy.findByText("Remapped").click();
       cy.button("Add filter").click();
@@ -3323,7 +3296,7 @@ describe("44047", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.request("PUT", `/api/field/${REVIEWS.RATING}`, {
       semantic_type: "type/Category",
@@ -3338,12 +3311,12 @@ describe("44047", () => {
   });
 
   it("should be able to use remapped values from an integer field with an overridden semantic type used for a custom dropdown source in public dashboards (metabase#44047)", () => {
-    createQuestion(sourceQuestionDetails);
+    H.createQuestion(sourceQuestionDetails);
     cy.createDashboardWithQuestions({
       dashboardDetails,
       questions: [questionDetails, modelDetails],
     }).then(({ dashboard, questions: cards }) => {
-      updateDashboardCards({
+      H.updateDashboardCards({
         dashboard_id: dashboard.id,
         cards: [
           getQuestionDashcardDetails(dashboard, cards[0]),
@@ -3354,11 +3327,11 @@ describe("44047", () => {
     });
 
     cy.log("verify filtering works in a regular dashboard");
-    visitDashboard("@dashboardId");
+    H.visitDashboard("@dashboardId");
     verifyFilterWithRemapping();
 
     cy.log("verify filtering works in a public dashboard");
-    cy.get("@dashboardId").then(visitPublicDashboard);
+    cy.get("@dashboardId").then(H.visitPublicDashboard);
     verifyFilterWithRemapping();
   });
 });
@@ -3394,7 +3367,7 @@ describe("issue 45659", () => {
         questions: [questionDetails],
       })
       .then(({ dashboard, questions: [card] }) => {
-        addOrUpdateDashboardCard({
+        H.addOrUpdateDashboardCard({
           dashboard_id: dashboard.id,
           card_id: card.id,
           card: {
@@ -3414,11 +3387,11 @@ describe("issue 45659", () => {
   }
 
   function verifyFilterWithRemapping() {
-    filterWidget().findByText("Tressa White").should("be.visible");
+    H.filterWidget().findByText("Tressa White").should("be.visible");
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.request("PUT", `/api/field/${PEOPLE.ID}`, {
       has_field_values: "list",
@@ -3427,14 +3400,14 @@ describe("issue 45659", () => {
 
   it("should remap initial parameter values in public dashboards (metabase#45659)", () => {
     createDashboard().then(({ dashboard }) =>
-      visitPublicDashboard(dashboard.id),
+      H.visitPublicDashboard(dashboard.id),
     );
     verifyFilterWithRemapping();
   });
 
   it("should remap initial parameter values in embedded dashboards (metabase#45659)", () => {
     createDashboard().then(({ dashboard }) =>
-      visitEmbeddedPage({
+      H.visitEmbeddedPage({
         resource: { dashboard: dashboard.id },
         params: {},
       }),
@@ -3479,7 +3452,7 @@ describe("44266", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -3488,24 +3461,24 @@ describe("44266", () => {
       dashboardDetails,
       questions: [regularQuestion, nativeQuestion],
     }).then(({ dashboard }) => {
-      visitDashboard(dashboard.id);
-      editDashboard();
+      H.visitDashboard(dashboard.id);
+      H.editDashboard();
       cy.findByTestId("edit-dashboard-parameters-widget-container")
         .findByText("Equal to")
         .click();
 
-      getDashboardCard(1).findByText("Select…").click();
+      H.getDashboardCard(1).findByText("Select…").click();
 
-      popover().findByText("Price").click();
+      H.popover().findByText("Price").click();
 
-      getDashboardCard(1).findByText("Price").should("be.visible");
+      H.getDashboardCard(1).findByText("Price").should("be.visible");
     });
   });
 });
 
 describe("issue 44790", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
@@ -3540,7 +3513,7 @@ describe("issue 44790", () => {
 
       cy.wrap(dashboard.id).as("dashboardId");
 
-      updateDashboardCards({
+      H.updateDashboardCards({
         dashboard_id: dashboard.id,
         cards: [
           {
@@ -3563,21 +3536,21 @@ describe("issue 44790", () => {
     });
 
     cy.log("wrong value for id filter should be ignored");
-    visitDashboard("@dashboardId", {
+    H.visitDashboard("@dashboardId", {
       params: {
         [idFilter.slug]: "{{test}}",
       },
     });
-    getDashboardCard().should("contain", "borer-hudson@yahoo.com");
+    H.getDashboardCard().should("contain", "borer-hudson@yahoo.com");
 
     cy.log("wrong value for number filter should be ignored");
-    visitDashboard("@dashboardId", {
+    H.visitDashboard("@dashboardId", {
       params: {
         [numberFilter.slug]: "{{test}}",
         [idFilter.slug]: "1",
       },
     });
-    getDashboardCard().should("contain", "borer-hudson@yahoo.com");
+    H.getDashboardCard().should("contain", "borer-hudson@yahoo.com");
   });
 });
 
@@ -3623,7 +3596,7 @@ describe("issue 34955", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestionAndDashboard({
@@ -3635,16 +3608,16 @@ describe("issue 34955", () => {
     }).then(({ body: { dashboard_id } }) => {
       cy.wrap(dashboard_id).as("dashboardId");
 
-      visitDashboard(dashboard_id);
-      editDashboard();
+      H.visitDashboard(dashboard_id);
+      H.editDashboard();
 
-      setFilter("Date picker", "Single Date", "On");
+      H.setFilter("Date picker", "Single Date", "On");
       connectFilterToColumn(ccName);
 
-      setFilter("Date picker", "Date Range", "Between");
+      H.setFilter("Date picker", "Date Range", "Between");
       connectFilterToColumn(ccName);
 
-      saveDashboard();
+      H.saveDashboard();
 
       cy.findAllByTestId("column-header")
         .eq(-2)
@@ -3686,12 +3659,12 @@ describe("issue 34955", () => {
   });
 
   function connectFilterToColumn(column) {
-    getDashboardCard().within(() => {
+    H.getDashboardCard().within(() => {
       cy.findByText("Column to filter on");
       cy.findByText("Select…").click();
     });
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText(column).click();
     });
   }
@@ -3707,13 +3680,13 @@ describe("issue 35852", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should show filter values for a model based on sql query (metabase#35852)", () => {
-    createNativeQuestion(model).then(({ body: { id: modelId } }) => {
-      setModelMetadata(modelId, field => {
+    H.createNativeQuestion(model).then(({ body: { id: modelId } }) => {
+      H.setModelMetadata(modelId, field => {
         if (field.display_name === "CATEGORY") {
           return {
             ...field,
@@ -3728,21 +3701,21 @@ describe("issue 35852", () => {
       });
 
       createDashboardWithFilterAndQuestionMapped(modelId);
-      visitModel(modelId);
+      H.visitModel(modelId);
     });
 
-    tableHeaderClick("Category");
-    popover().findByText("Filter by this column").click();
+    H.tableHeaderClick("Category");
+    H.popover().findByText("Filter by this column").click();
 
     cy.log("Verify filter values are available");
 
-    popover()
+    H.popover()
       .should("contain", "Gizmo")
       .should("contain", "Doohickey")
       .should("contain", "Gadget")
       .should("contain", "Widget");
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Gizmo").click();
       cy.button("Add filter").click();
     });
@@ -3753,16 +3726,16 @@ describe("issue 35852", () => {
       .filter(":contains(Gizmo)")
       .should("have.length", 2);
 
-    visitDashboard("@dashboardId");
+    H.visitDashboard("@dashboardId");
 
-    filterWidget().click();
+    H.filterWidget().click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Gizmo").click();
       cy.button("Add filter").click();
     });
 
-    getDashboardCard().findAllByText("Gizmo").should("have.length", 2);
+    H.getDashboardCard().findAllByText("Gizmo").should("have.length", 2);
   });
 
   function createDashboardWithFilterAndQuestionMapped(modelId) {
@@ -3789,7 +3762,7 @@ describe("issue 35852", () => {
     }).then(({ dashboard, questions: [card] }) => {
       cy.wrap(dashboard.id).as("dashboardId");
 
-      updateDashboardCards({
+      H.updateDashboardCards({
         dashboard_id: dashboard.id,
         cards: [
           {
@@ -3856,15 +3829,15 @@ describe("issue 32573", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should not crash a dashboard when there is a missing parameter column (metabase#32573)", () => {
-    createQuestion(modelDetails).then(({ body: model }) => {
-      createQuestion(getQuestionDetails(model.id)).then(
+    H.createQuestion(modelDetails).then(({ body: model }) => {
+      H.createQuestion(getQuestionDetails(model.id)).then(
         ({ body: question }) => {
-          createDashboard(dashboardDetails).then(({ body: dashboard }) => {
+          H.createDashboard(dashboardDetails).then(({ body: dashboard }) => {
             return cy
               .request("PUT", `/api/dashboard/${dashboard.id}`, {
                 dashcards: [
@@ -3876,23 +3849,23 @@ describe("issue 32573", () => {
                   }),
                 ],
               })
-              .then(() => visitDashboard(dashboard.id));
+              .then(() => H.visitDashboard(dashboard.id));
           });
         },
       );
     });
-    getDashboardCard()
+    H.getDashboardCard()
       .findByText("There was a problem displaying this chart.")
       .should("be.visible");
 
-    editDashboard();
+    H.editDashboard();
     cy.findByTestId("fixed-width-filters").findByText("ID").click();
-    getDashboardCard().within(() => {
+    H.getDashboardCard().within(() => {
       cy.findByText("Unknown Field").should("be.visible");
       cy.findByLabelText("Disconnect").click();
     });
-    saveDashboard();
-    getDashboardCard().within(() => {
+    H.saveDashboard();
+    H.getDashboardCard().within(() => {
       cy.findByText("Q1").should("be.visible");
       cy.findByText("Tax").should("be.visible");
     });
@@ -3955,18 +3928,18 @@ describe("issue 45670", { tags: ["@external"] }, () => {
   }
 
   beforeEach(() => {
-    resetTestTable({ type: dialect, table: tableName });
-    restore(`${dialect}-writable`);
+    H.resetTestTable({ type: dialect, table: tableName });
+    H.restore(`${dialect}-writable`);
     cy.signInAsAdmin();
-    resyncDatabase({ dbId: WRITABLE_DB_ID, tableName });
+    H.resyncDatabase({ dbId: WRITABLE_DB_ID, tableName });
     cy.intercept("PUT", "/api/card/*").as("updateCard");
   });
 
   it("should be able to pass query string parameters for boolean parameters in dashboards (metabase#45670)", () => {
     getField().then(field => {
-      createNativeQuestion(getQuestionDetails(field.id)).then(
+      H.createNativeQuestion(getQuestionDetails(field.id)).then(
         ({ body: card }) => {
-          createDashboard(dashboardDetails).then(({ body: dashboard }) => {
+          H.createDashboard(dashboardDetails).then(({ body: dashboard }) => {
             cy.request("PUT", `/api/dashboard/${dashboard.id}`, {
               dashcards: [
                 createMockDashboardCard({
@@ -3977,7 +3950,7 @@ describe("issue 45670", { tags: ["@external"] }, () => {
                 }),
               ],
             });
-            visitDashboard(dashboard.id, {
+            H.visitDashboard(dashboard.id, {
               params: {
                 [parameterDetails.slug]: "true",
               },
@@ -3986,8 +3959,8 @@ describe("issue 45670", { tags: ["@external"] }, () => {
         },
       );
     });
-    filterWidget().should("contain.text", "true");
-    getDashboardCard().within(() => {
+    H.filterWidget().should("contain.text", "true");
+    H.getDashboardCard().within(() => {
       cy.findByText("true").should("be.visible");
       cy.findByText("false").should("not.exist");
     });
@@ -3996,12 +3969,12 @@ describe("issue 45670", { tags: ["@external"] }, () => {
 
 describe("issue 48351", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should navigate to the specified tab with click behaviors (metabase#48351)", () => {
-    createDashboardWithTabs({
+    H.createDashboardWithTabs({
       name: "Dashboard 1",
       tabs: [
         { id: 1, name: "Tab 1" },
@@ -4025,7 +3998,7 @@ describe("issue 48351", () => {
         }),
       ],
     }).then(dashboard1 => {
-      createDashboardWithTabs({
+      H.createDashboardWithTabs({
         name: "Dashboard 2",
         tabs: [
           { id: 3, name: "Tab 3" },
@@ -4061,16 +4034,16 @@ describe("issue 48351", () => {
             size_y: 8,
           }),
         ],
-      }).then(dashboard2 => visitDashboard(dashboard2.id));
+      }).then(dashboard2 => H.visitDashboard(dashboard2.id));
     });
-    goToTab("Tab 4");
-    getDashboardCard().within(() =>
+    H.goToTab("Tab 4");
+    H.getDashboardCard().within(() =>
       cy.findAllByTestId("cell-data").eq(0).click(),
     );
     cy.findByTestId("dashboard-name-heading").should(
       "have.value",
       "Dashboard 1",
     );
-    assertTabSelected("Tab 2");
+    H.assertTabSelected("Tab 2");
   });
 });

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-with-question-revert.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-with-question-revert.cy.spec.js
@@ -1,23 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  editDashboard,
-  filterWidget,
-  getDashboardCard,
-  getIframeBody,
-  modal,
-  openSharingMenu,
-  popover,
-  questionInfoButton,
-  restore,
-  saveDashboard,
-  setFilter,
-  snapshot,
-  updateSetting,
-  visitDashboard,
-  visitEmbeddedPage,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 const { REVIEWS, REVIEWS_ID } = SAMPLE_DATABASE;
 
@@ -70,7 +53,7 @@ describe("issue 35954", () => {
     "dashboard filter that loses connection should not crash the UI (metabase#35954)",
     () => {
       before(() => {
-        restore();
+        H.restore();
         cy.signInAsAdmin();
 
         cy.createQuestionAndDashboard({
@@ -86,16 +69,16 @@ describe("issue 35954", () => {
 
           cy.request("PUT", `/api/card/${card_id}`, updatedQuestionDetails);
 
-          visitDashboard(dashboard_id);
-          editDashboard();
+          H.visitDashboard(dashboard_id);
+          H.editDashboard();
           cy.log("Add the number filter");
-          setFilter("Number");
+          H.setFilter("Number");
           connectFilterToColumn("Field-mapped Rating");
-          saveDashboard();
+          H.saveDashboard();
 
           cy.log("Give it a value and make sure that the filer applies");
-          filterWidget().click();
-          popover().within(() => {
+          H.filterWidget().click();
+          H.popover().within(() => {
             cy.findByText("3").click();
             cy.button("Add filter").click();
           });
@@ -113,7 +96,7 @@ describe("issue 35954", () => {
 
           cy.log("Revert the question to its original (GUI) version");
           cy.intercept("POST", "/api/revision/revert").as("revertQuestion");
-          questionInfoButton().click();
+          H.questionInfoButton().click();
           cy.findByRole("tab", { name: "History" }).click();
 
           cy.findByTestId("saved-question-history-list")
@@ -155,36 +138,36 @@ describe("issue 35954", () => {
           cy.log(
             "Make sure the UI shows the filter is not connected to the GUI card",
           );
-          editDashboard();
+          H.editDashboard();
 
           cy.findByTestId("fixed-width-filters").icon("gear").click();
-          getDashboardCard().should("contain", "Unknown Field");
+          H.getDashboardCard().should("contain", "Unknown Field");
 
-          snapshot("35954");
+          H.snapshot("35954");
         });
       });
 
       beforeEach(() => {
-        restore("35954");
+        H.restore("35954");
         cy.signInAsAdmin();
       });
 
       it("should be able to remove the broken connection and connect the filter to the GUI question", function () {
-        visitDashboard(this.dashboardId);
-        editDashboard();
+        H.visitDashboard(this.dashboardId);
+        H.editDashboard();
         openFilterSettings();
-        getDashboardCard().findByLabelText("Disconnect").click();
+        H.getDashboardCard().findByLabelText("Disconnect").click();
         connectFilterToColumn("Rating");
-        saveDashboard();
+        H.saveDashboard();
 
         cy.location("search").should("eq", "?equal_to=3");
         assertFilterIsApplied();
       });
 
       it("filter should automatically be re-connected when the question is reverted back to the SQL version", function () {
-        visitQuestion(this.questionId);
+        H.visitQuestion(this.questionId);
 
-        questionInfoButton().click();
+        H.questionInfoButton().click();
         cy.findByRole("tab", { name: "History" }).click();
         cy.findByTestId("saved-question-history-list")
           .find("li")
@@ -195,7 +178,7 @@ describe("issue 35954", () => {
         cy.location("search").should("eq", "?RATING=");
         assertFilterIsDisconnected();
 
-        visitDashboard(this.dashboardId);
+        H.visitDashboard(this.dashboardId);
         cy.location("search").should("eq", "?equal_to=3");
         assertFilterIsApplied();
       });
@@ -222,11 +205,11 @@ describe("issue 35954", () => {
         });
 
         // Discard the legalese modal so we don't need to do an extra click in the UI
-        updateSetting("show-static-embed-terms", false);
+        H.updateSetting("show-static-embed-terms", false);
 
-        visitDashboard(id);
-        openSharingMenu("Embed");
-        modal().findByText("Static embedding").click();
+        H.visitDashboard(id);
+        H.openSharingMenu("Embed");
+        H.modal().findByText("Static embedding").click();
 
         cy.findByTestId("embedding-preview").within(() => {
           cy.intercept("GET", "api/preview_embed/dashboard/**").as(
@@ -238,12 +221,12 @@ describe("issue 35954", () => {
           cy.wait(["@previewEmbed", "@previewEmbed"]);
         });
 
-        getIframeBody().within(() => {
+        H.getIframeBody().within(() => {
           cy.findByRole("heading", { name: dashboardDetails.name });
 
           assertFilterIsDisconnected();
 
-          filterWidget().click();
+          H.filterWidget().click();
           cy.findByPlaceholderText("Enter a number").type("3{enter}");
           cy.button("Add filter").click();
 
@@ -266,10 +249,10 @@ describe("issue 35954", () => {
           params: {},
         };
 
-        visitEmbeddedPage(payload);
+        H.visitEmbeddedPage(payload);
         assertFilterIsDisconnected();
 
-        filterWidget().click();
+        H.filterWidget().click();
         cy.findByPlaceholderText("Enter a number").type("3{enter}");
         cy.button("Add filter").click();
 
@@ -291,7 +274,7 @@ describe("issue 35954", () => {
           params: { equal_to: [3] },
         };
 
-        visitEmbeddedPage(payload);
+        H.visitEmbeddedPage(payload);
         assertFilterIsDisconnected();
       });
     },
@@ -299,12 +282,12 @@ describe("issue 35954", () => {
 });
 
 function connectFilterToColumn(column, index = 0) {
-  getDashboardCard().within(() => {
+  H.getDashboardCard().within(() => {
     cy.findByText("Column to filter on");
     cy.findByText("Select…").click();
   });
 
-  popover().within(() => {
+  H.popover().within(() => {
     cy.findAllByText(column).eq(index).click();
   });
 }

--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -1,45 +1,10 @@
+import { H } from "e2e/support";
 import {
   SAMPLE_DB_ID,
   SAMPLE_DB_SCHEMA_ID,
   WRITABLE_DB_ID,
 } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  POPOVER_ELEMENT,
-  assertQueryBuilderRowCount,
-  cartesianChartCircle,
-  createDashboard,
-  createNativeQuestion,
-  createQuestion,
-  editDashboard,
-  enterCustomColumnDetails,
-  entityPickerModal,
-  entityPickerModalTab,
-  filter,
-  filterWidget,
-  getNotebookStep,
-  modal,
-  openNativeEditor,
-  openNotebook,
-  openOrdersTable,
-  openPeopleTable,
-  openProductsTable,
-  popover,
-  queryBuilderHeader,
-  queryBuilderMain,
-  resetTestTable,
-  restore,
-  resyncDatabase,
-  saveDashboard,
-  selectFilterOperator,
-  setFilter,
-  sidebar,
-  startNewQuestion,
-  tableHeaderClick,
-  visitDashboard,
-  visitQuestionAdhoc,
-  visualize,
-} from "e2e/support/helpers";
 
 const {
   ORDERS_ID,
@@ -55,17 +20,17 @@ const {
 
 describe("issue 9339", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should not paste non-numeric values into single-value numeric filters (metabase#9339)", () => {
-    openOrdersTable();
+    H.openOrdersTable();
 
-    tableHeaderClick("Total");
+    H.tableHeaderClick("Total");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter by this column").click();
-    selectFilterOperator("Greater than");
+    H.selectFilterOperator("Greater than");
     cy.findByPlaceholderText("Enter a number").type("9339,1234").blur();
     cy.findByDisplayValue("9339").should("be.visible");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -76,7 +41,7 @@ describe("issue 9339", () => {
 
 describe.skip("issue 12496", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -111,12 +76,12 @@ describe.skip("issue 12496", () => {
 
   it("should display correct day range in filter pill when drilling into a week", () => {
     setup("week");
-    cartesianChartCircle().eq(0).click({ force: true });
-    popover().contains("See this Order").click();
+    H.cartesianChartCircle().eq(0).click({ force: true });
+    H.popover().contains("See this Order").click();
     cy.findByTestId("qb-filters-panel")
       .contains("Created At is April 24–30, 2022")
       .click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByTestId("between-date-picker").within(() => {
         datePickerInput(0, 0).should("have.value", "04/24/2022");
         datePickerInput(1, 0).should("have.value", "04/30/2022");
@@ -126,12 +91,12 @@ describe.skip("issue 12496", () => {
 
   it("should display correct day range in filter pill when drilling into a month", () => {
     setup("month");
-    cartesianChartCircle().eq(0).click({ force: true });
-    popover().contains("See this Order").click();
+    H.cartesianChartCircle().eq(0).click({ force: true });
+    H.popover().contains("See this Order").click();
     cy.findByTestId("qb-filters-panel")
       .contains("Created At is April 2022")
       .click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByTestId("between-date-picker").within(() => {
         datePickerInput(0, 0).should("have.value", "04/01/2022");
         datePickerInput(1, 0).should("have.value", "04/30/2022");
@@ -141,12 +106,12 @@ describe.skip("issue 12496", () => {
 
   it("should display correct day range in filter pill when drilling into a hour", () => {
     setup("hour");
-    cartesianChartCircle().eq(0).click({ force: true });
-    popover().contains("See this Order").click();
+    H.cartesianChartCircle().eq(0).click({ force: true });
+    H.popover().contains("See this Order").click();
     cy.findByTestId("qb-filters-panel")
       .contains("Created At is April 30, 2022, 6:00–59 PM")
       .click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByTestId("between-date-picker").within(() => {
         datePickerInput(0, 0).should("have.value", "04/30/2022");
         datePickerInput(0, 1).should("have.value", "6");
@@ -160,12 +125,12 @@ describe.skip("issue 12496", () => {
 
   it("should display correct minute in filter pill when drilling into a minute", () => {
     setup("minute");
-    cartesianChartCircle().eq(0).click({ force: true });
-    popover().contains("See this Order").click();
+    H.cartesianChartCircle().eq(0).click({ force: true });
+    H.popover().contains("See this Order").click();
     cy.findByTestId("qb-filters-panel")
       .contains("Created At is April 30, 2022, 6:56 PM")
       .click();
-    popover().within(() => {
+    H.popover().within(() => {
       datePickerInput(0, 0).should("have.value", "04/30/2022");
       datePickerInput(0, 1).should("have.value", "6");
       datePickerInput(0, 2).should("have.value", "56");
@@ -174,12 +139,12 @@ describe.skip("issue 12496", () => {
 
   it("should display correct minute in filter pill when drilling into a day", () => {
     setup("day");
-    cartesianChartCircle().eq(0).click({ force: true });
-    popover().contains("See this Order").click();
+    H.cartesianChartCircle().eq(0).click({ force: true });
+    H.popover().contains("See this Order").click();
     cy.findByTestId("qb-filters-panel")
       .contains("Created At is April 30, 2022")
       .click();
-    popover().within(() => {
+    H.popover().within(() => {
       datePickerInput(0, 0).should("have.value", "04/30/2022");
     });
   });
@@ -187,14 +152,14 @@ describe.skip("issue 12496", () => {
 
 describe("issue 16621", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    openProductsTable({ limit: 3 });
+    H.openProductsTable({ limit: 3 });
   });
 
   it("should be possible to create multiple filter that start with the same value (metabase#16621)", () => {
-    tableHeaderClick("Category");
-    popover().within(() => {
+    H.tableHeaderClick("Category");
+    H.popover().within(() => {
       cy.findByText("Filter by this column").click();
       cy.findByPlaceholderText("Search the list").type("Gadget");
       cy.findByText("Gadget").click();
@@ -203,7 +168,7 @@ describe("issue 16621", () => {
     cy.findByTestId("qb-filters-panel").within(() => {
       cy.findByText("Category is Gadget").click();
     });
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Gizmo").click();
       cy.button("Update filter").click();
     });
@@ -229,30 +194,30 @@ describe("issue 18770", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    createQuestion(questionDetails, { visitQuestion: true });
+    H.createQuestion(questionDetails, { visitQuestion: true });
   });
 
   it("post-aggregation filter shouldn't affect the drill-through options (metabase#18770)", () => {
-    openNotebook();
+    H.openNotebook();
     // It is important to manually triger "visualize" in order to generate the `result_metadata`
     // Otherwise, we might get false negative even when this issue gets resolved.
     // In order to do that, we have to change the breakout field first or it will never generate and send POST /api/dataset request.
     cy.findAllByTestId("notebook-cell-item")
       .contains(/Products? → Title/)
       .click();
-    popover().findByText("Category").click();
+    H.popover().findByText("Category").click();
     cy.findAllByTestId("notebook-cell-item").contains(/Products? → Category/);
 
-    visualize();
+    H.visualize();
 
     cy.findAllByTestId("cell-data")
       .filter(":contains(4,784)")
       .should("have.length", 1)
       .click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Filter by this value").should("be.visible");
       cy.findAllByRole("button")
         .should("have.length", 5)
@@ -267,15 +232,15 @@ describe("issue 18770", () => {
 
 describe("issue 20551", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should allow filtering with includes, rather than starts with (metabase#20551)", () => {
-    openProductsTable({ mode: "notebook" });
-    filter({ mode: "notebook" });
+    H.openProductsTable({ mode: "notebook" });
+    H.filter({ mode: "notebook" });
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Category").click();
       cy.findByPlaceholderText("Search the list").type("i");
 
@@ -289,23 +254,23 @@ describe("issue 20551", () => {
 
 describe("issue 20683", { tags: "@external" }, () => {
   beforeEach(() => {
-    restore("postgres-12");
+    H.restore("postgres-12");
     cy.signInAsAdmin();
   });
 
   it("should filter postgres with the 'current quarter' filter (metabase#20683)", () => {
-    startNewQuestion();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.startNewQuestion();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("QA Postgres12").click();
       cy.findByText("Orders").click();
     });
 
-    getNotebookStep("filter")
+    H.getNotebookStep("filter")
       .findByText(/Add filter/)
       .click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Created At").click();
       cy.findByText("Relative dates…").click();
       cy.findByText("Previous").click();
@@ -313,24 +278,24 @@ describe("issue 20683", { tags: "@external" }, () => {
       cy.findByText("Quarter").click();
     });
 
-    visualize();
+    H.visualize();
 
-    queryBuilderMain().findByText("No results!").should("be.visible");
+    H.queryBuilderMain().findByText("No results!").should("be.visible");
   });
 });
 
 describe("issue 21979", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
   it("exclude 'day of the week' should show the correct day reference in the UI (metabase#21979)", () => {
-    openProductsTable({ mode: "notebook" });
+    H.openProductsTable({ mode: "notebook" });
 
-    filter({ mode: "notebook" });
-    popover().within(() => {
+    H.filter({ mode: "notebook" });
+    H.popover().within(() => {
       cy.findByText("Created At").click();
       cy.findByText("Exclude…").click();
       cy.findByText("Days of the week…").click();
@@ -338,28 +303,30 @@ describe("issue 21979", () => {
       cy.button("Add filter").click();
     });
 
-    getNotebookStep("filter")
+    H.getNotebookStep("filter")
       .findByText("Created At excludes Mondays")
       .should("be.visible");
 
-    visualize();
+    H.visualize();
 
     // Make sure the query is correct
     // (a product called "Enormous Marble Wallet" is created on Monday)
-    queryBuilderMain().findByText("Enormous Marble Wallet").should("not.exist");
+    H.queryBuilderMain()
+      .findByText("Enormous Marble Wallet")
+      .should("not.exist");
 
     cy.findByTestId("qb-filters-panel")
       .findByText("Created At excludes Mondays")
       .click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByLabelText("Monday").click();
       cy.findByLabelText("Thursday").click();
       cy.button("Update filter").click();
     });
     cy.wait("@dataset");
 
-    queryBuilderMain()
+    H.queryBuilderMain()
       .findByText("Enormous Marble Wallet")
       .should("be.visible");
 
@@ -384,29 +351,29 @@ describe("issue 22230", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    visitQuestionAdhoc(questionDetails, { mode: "notebook" });
+    H.visitQuestionAdhoc(questionDetails, { mode: "notebook" });
   });
 
   it("should be able to filter on an aggregation (metabase#22230)", () => {
     cy.findAllByTestId("action-buttons").last().findByText("Filter").click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Max of Name").click();
       cy.findByText("Is").click();
     });
     cy.findByRole("menu").findByText("Starts with").click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByPlaceholderText("Enter some text").type("Zo").blur();
       cy.button("Add filter").click();
     });
 
-    visualize();
+    H.visualize();
 
-    assertQueryBuilderRowCount(2);
-    queryBuilderMain(() => {
+    H.assertQueryBuilderRowCount(2);
+    H.queryBuilderMain(() => {
       cy.findByText("Zora Schamberger").should("be.visible");
       cy.findByText("Zoie Kozey").should("be.visible");
     });
@@ -415,7 +382,7 @@ describe("issue 22230", () => {
 
 describe("issue 22730", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestion(
@@ -437,9 +404,9 @@ describe("issue 22730", () => {
     cy.findByText("Explore results").click();
     cy.wait("@dataset");
 
-    tableHeaderClick("time");
+    H.tableHeaderClick("time");
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Filter by this column").click();
       cy.findByDisplayValue("00:00").clear().type("14:03");
       cy.button("Add filter").click();
@@ -454,28 +421,28 @@ describe("issue 22730", () => {
 
 describe("issue 24664", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    openProductsTable({ limit: 3 });
+    H.openProductsTable({ limit: 3 });
   });
 
   it("should be possible to create multiple filter that start with the same value (metabase#24664)", () => {
-    tableHeaderClick("Category");
-    popover().within(() => {
+    H.tableHeaderClick("Category");
+    H.popover().within(() => {
       cy.findByText("Filter by this column").click();
       cy.findByText("Doohickey").click();
       cy.button("Add filter").click();
     });
 
-    tableHeaderClick("Category");
-    popover().within(() => {
+    H.tableHeaderClick("Category");
+    H.popover().within(() => {
       cy.findByText("Filter by this column").click();
       cy.findByText("Gizmo").click();
       cy.button("Add filter").click();
     });
 
     cy.findByTestId("qb-filters-panel").findByText("Category is Gizmo").click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Widget").click();
       cy.button("Update filter").click();
     });
@@ -521,7 +488,7 @@ describe("issue 24994", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -550,14 +517,14 @@ function assertFilterValueIsSelected(value) {
 
 describe("issue 45410", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should not overflow the last filter value with a chevron icon (metabase#45410)", () => {
-    openPeopleTable({ mode: "notebook" });
-    filter({ mode: "notebook" });
-    popover().within(() => {
+    H.openPeopleTable({ mode: "notebook" });
+    H.filter({ mode: "notebook" });
+    H.popover().within(() => {
       cy.findByText("Email").click();
       cy.findByPlaceholderText("Search by Email")
         .type("abc@example.com,abc2@example.com")
@@ -591,27 +558,27 @@ describe("issue 25378", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    visitQuestionAdhoc(questionDetails, { mode: "notebook" });
+    H.visitQuestionAdhoc(questionDetails, { mode: "notebook" });
   });
 
   it("should be able to use relative date filter on a breakout after the aggregation (metabase#25378)", () => {
     cy.findAllByTestId("action-buttons").last().findByText("Filter").click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Created At: Month").click();
       cy.findByText("Relative dates…").click();
       cy.findByDisplayValue("days").click();
     });
     cy.findByRole("listbox").findByText("months").click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByLabelText("Starting from…").click();
       cy.button("Add filter").click();
     });
 
-    visualize(response => {
+    H.visualize(response => {
       expect(response.body.error).to.not.exist;
     });
   });
@@ -639,14 +606,14 @@ describe("issue 25927", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    visitQuestionAdhoc(query);
+    H.visitQuestionAdhoc(query);
   });
 
   it("column filter should work for questions with custom column (metabase#25927)", () => {
-    tableHeaderClick("Created At: Month");
-    popover().within(() => {
+    H.tableHeaderClick("Created At: Month");
+    H.popover().within(() => {
       cy.findByText("Filter by this column").click();
       cy.findByText("Last 30 days").click();
     });
@@ -658,7 +625,7 @@ describe("issue 25927", () => {
       .contains("Created At: Month is in the previous 30 days")
       .click();
 
-    popover().button("Update filter").should("not.be.disabled");
+    H.popover().button("Update filter").should("not.be.disabled");
   });
 });
 
@@ -693,17 +660,17 @@ describe("issue 25990", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
   it("should allow to filter by a column in a joined table (metabase#25990)", () => {
-    visitQuestionAdhoc(questionDetails);
+    H.visitQuestionAdhoc(questionDetails);
 
-    queryBuilderHeader().button("Filter").click();
+    H.queryBuilderHeader().button("Filter").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("People").click();
       cy.findByPlaceholderText("Enter an ID").type("10").blur();
       cy.button("Apply filters").click();
@@ -733,15 +700,15 @@ describe("issue 25994", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    visitQuestionAdhoc(questionDetails, { mode: "notebook" });
+    H.visitQuestionAdhoc(questionDetails, { mode: "notebook" });
   });
 
   it("should be possible to use 'between' dates filter after aggregation (metabase#25994)", () => {
     cy.findAllByTestId("action-buttons").last().findByText("Filter").click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Min of Created At: Day").click();
       cy.findByText("Specific dates…").click();
 
@@ -749,7 +716,7 @@ describe("issue 25994", () => {
       cy.button("Add filter").click();
     });
 
-    visualize(response => {
+    H.visualize(response => {
       expect(response.body.error).to.not.exist;
     });
   });
@@ -779,14 +746,14 @@ describe.skip("issue 26861", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestion(nativeQuery, { visitQuestion: true });
   });
 
   it("exclude filter shouldn't break native questions with field filters (metabase#26861)", () => {
-    filterWidget().click();
+    H.filterWidget().click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Exclude...").click();
 
@@ -816,14 +783,14 @@ describe("issue 27123", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestion(questionDetails, { visitQuestion: true });
   });
 
   it("exclude filter should not resolve to 'Days of the week' regardless of the chosen granularity  (metabase#27123)", () => {
-    tableHeaderClick("Created At");
+    H.tableHeaderClick("Created At");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter by this column").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -831,7 +798,7 @@ describe("issue 27123", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Months of the year…").click();
 
-    popover()
+    H.popover()
       .should("contain", "Months of the year…")
       .and("contain", "January");
   });
@@ -840,25 +807,25 @@ describe("issue 27123", () => {
 // TODO: Unskip this test when we bring back expression type checking. See #31877.
 describe.skip("issue 29094", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("disallows adding a filter using non-boolean custom expression (metabase#29094)", () => {
-    startNewQuestion();
+    H.startNewQuestion();
 
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Orders").click();
     });
 
-    getNotebookStep("filter")
+    H.getNotebookStep("filter")
       .findByText("Add filters to narrow your answer")
       .click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Custom Expression").click();
-      enterCustomColumnDetails({ formula: "[Tax] * 22" });
+      H.enterCustomColumnDetails({ formula: "[Tax] * 22" });
       cy.realPress("Tab");
       cy.button("Done").should("be.disabled");
       cy.findByText("Invalid expression").should("exist");
@@ -877,7 +844,7 @@ describe("issue 30312", () => {
   ];
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
@@ -897,18 +864,18 @@ describe("issue 30312", () => {
 
     cy.findAllByTestId("header-cell").eq(1).should("have.text", "Count");
 
-    tableHeaderClick("Count");
+    H.tableHeaderClick("Count");
 
-    popover().findByText("Filter by this column").click();
-    selectFilterOperator("Equal to");
-    popover().within(() => {
+    H.popover().findByText("Filter by this column").click();
+    H.selectFilterOperator("Equal to");
+    H.popover().within(() => {
       cy.findByPlaceholderText("Enter a number").type("10");
       cy.realPress("Tab");
       cy.button("Add filter").should("be.enabled").click();
     });
 
     cy.findByTestId("filter-pill").should("have.text", "Count is equal to 10");
-    queryBuilderMain().findByText("No results!").should("be.visible");
+    H.queryBuilderMain().findByText("No results!").should("be.visible");
   });
 });
 
@@ -917,7 +884,7 @@ describe("issue 31340", () => {
     "Some very very very very long column name that should have a line break";
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.intercept("PUT", "/api/field/*").as("fieldUpdate");
@@ -946,11 +913,11 @@ describe("issue 31340", () => {
   });
 
   it("should properly display long column names in filter options search results (metabase#31340)", () => {
-    tableHeaderClick(LONG_COLUMN_NAME);
+    H.tableHeaderClick(LONG_COLUMN_NAME);
 
-    popover().findByText("Filter by this column").click();
-    selectFilterOperator("Is");
-    popover().within(() => {
+    H.popover().findByText("Filter by this column").click();
+    H.selectFilterOperator("Is");
+    H.popover().within(() => {
       cy.findByPlaceholderText(`Search by ${LONG_COLUMN_NAME}`).type(
         "nonexistingvalue",
       );
@@ -961,15 +928,15 @@ describe("issue 31340", () => {
 
 describe("issue 34794", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should not crash when navigating to filter popover's custom expression section (metabase#34794)", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
 
-    filter({ mode: "notebook" });
-    popover().within(() => {
+    H.filter({ mode: "notebook" });
+    H.popover().within(() => {
       cy.findByText("Created At").click();
       cy.icon("chevronleft").click(); // go back to the main filter popover
       cy.findByText("Custom Expression").click();
@@ -977,7 +944,7 @@ describe("issue 34794", () => {
       cy.button("Done").click();
     });
 
-    getNotebookStep("filter")
+    H.getNotebookStep("filter")
       .findByText("Total is greater than 10")
       .should("be.visible");
   });
@@ -985,12 +952,12 @@ describe("issue 34794", () => {
 
 describe("issue 36508", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should treat 'Number of distinct values' aggregation as numerical (metabase#36508)", () => {
-    createQuestion(
+    H.createQuestion(
       {
         query: {
           "source-table": PEOPLE_ID,
@@ -1006,7 +973,7 @@ describe("issue 36508", () => {
 
     cy.button("Filter").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Summaries").click();
 
       cy.findByTestId("filter-column-Distinct values of Email")
@@ -1015,7 +982,7 @@ describe("issue 36508", () => {
         .click();
     });
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Equal to").should("exist");
       cy.findByText("Greater than").should("exist");
       cy.findByText("Less than").should("exist");
@@ -1033,7 +1000,7 @@ describe("metabase#32985", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -1051,9 +1018,9 @@ describe("metabase#32985", () => {
 
     cy.createQuestion(questionDetails, { visitQuestion: true });
 
-    tableHeaderClick("Email");
+    H.tableHeaderClick("Email");
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Filter by this column").click();
       cy.findByPlaceholderText("Search by Email").type("foo");
     });
@@ -1062,7 +1029,7 @@ describe("metabase#32985", () => {
 
 describe.skip("metabase#44550", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -1102,7 +1069,7 @@ describe.skip("metabase#44550", () => {
       type: "query",
     };
 
-    createQuestion(questionDetails, { visitQuestion: true });
+    H.createQuestion(questionDetails, { visitQuestion: true });
     cy.findByTestId("filters-visibility-control").click();
     cy.findByTestId("filter-pill").should(
       "have.text",
@@ -1116,7 +1083,7 @@ describe.skip("metabase#44550", () => {
       .and("contain", /7 days ago/i);
 
     cy.log("Repro for the filter modal");
-    filter();
+    H.filter();
     // Not entirely sure how the DOM looks like in this scenario.
     // TODO: Update the test if needed.
     cy.findByTestId("filter-column-Created At")
@@ -1127,7 +1094,7 @@ describe.skip("metabase#44550", () => {
 
 describe("issue 35043", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -1153,7 +1120,7 @@ describe("issue 35043", () => {
       type: "query",
     };
 
-    createQuestion(questionDetails, { visitQuestion: true });
+    H.createQuestion(questionDetails, { visitQuestion: true });
 
     cy.findByTestId("filters-visibility-control").click();
     cy.findByTestId("filter-pill")
@@ -1178,7 +1145,7 @@ describe("issue 35043", () => {
 
 describe("issue 40622", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -1189,7 +1156,7 @@ describe("issue 40622", () => {
       display_name: LONG_COLUMN_NAME,
     });
 
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         database: SAMPLE_DB_ID,
         type: "query",
@@ -1220,7 +1187,7 @@ describe("issue 40622", () => {
       },
     });
 
-    filter();
+    H.filter();
     assertTablesAreEquallyLeftRightPositioned();
 
     cy.log("Resize and make sure the filter sidebar is intact");
@@ -1262,37 +1229,37 @@ describe("issue 40622", () => {
 
 describe("45252", { tags: "@external" }, () => {
   beforeEach(() => {
-    resetTestTable({ type: "postgres", table: "many_data_types" });
-    restore("postgres-writable");
+    H.resetTestTable({ type: "postgres", table: "many_data_types" });
+    H.restore("postgres-writable");
     cy.signInAsAdmin();
-    resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: "many_data_types" });
+    H.resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: "many_data_types" });
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
   it("should allow using is-null and not-null operators with unsupported data types (metabase#45252,metabase#38111)", () => {
-    startNewQuestion();
+    H.startNewQuestion();
 
     cy.log("filter picker - new filter");
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Writable Postgres12").click();
       cy.findByText("Many Data Types").click();
     });
-    getNotebookStep("filter")
+    H.getNotebookStep("filter")
       .findByText("Add filters to narrow your answer")
       .click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Binary").scrollIntoView().click();
       cy.findByLabelText("Is empty").click();
       cy.button("Add filter").click();
     });
-    visualize();
+    H.visualize();
     cy.wait("@dataset");
-    assertQueryBuilderRowCount(0);
+    H.assertQueryBuilderRowCount(0);
 
     cy.log("filter picker - existing filter");
     cy.findByTestId("qb-filters-panel").findByText("Binary is empty").click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByLabelText("Not empty").click();
       cy.button("Update filter").click();
       cy.wait("@dataset");
@@ -1300,11 +1267,11 @@ describe("45252", { tags: "@external" }, () => {
     cy.findByTestId("qb-filters-panel")
       .findByText("Binary is not empty")
       .should("be.visible");
-    assertQueryBuilderRowCount(2);
+    H.assertQueryBuilderRowCount(2);
 
     cy.log("filter modal - existing filter");
-    queryBuilderHeader().button("Filter").click();
-    modal().within(() => {
+    H.queryBuilderHeader().button("Filter").click();
+    H.modal().within(() => {
       cy.findByTestId("filter-column-Binary")
         .findByLabelText("Is empty")
         .click();
@@ -1312,11 +1279,11 @@ describe("45252", { tags: "@external" }, () => {
       cy.wait("@dataset");
     });
     cy.wait("@dataset");
-    assertQueryBuilderRowCount(0);
+    H.assertQueryBuilderRowCount(0);
 
     cy.log("filter modal - json column");
-    queryBuilderHeader().button("Filter").click();
-    modal().within(() => {
+    H.queryBuilderHeader().button("Filter").click();
+    H.modal().within(() => {
       cy.findByTestId("filter-column-Binary")
         .findByLabelText("Not empty")
         .click();
@@ -1327,7 +1294,7 @@ describe("45252", { tags: "@external" }, () => {
       cy.wait("@dataset");
     });
     cy.wait("@dataset");
-    assertQueryBuilderRowCount(2);
+    H.assertQueryBuilderRowCount(2);
   });
 });
 
@@ -1337,12 +1304,12 @@ describe.skip("issue 44435", () => {
   const longString = alphabet.repeat(10);
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("filter pill should not overflow the window width when the filter string is very long (metabase#44435)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         database: SAMPLE_DB_ID,
         type: "query",
@@ -1372,7 +1339,7 @@ describe.skip("issue 44435", () => {
 // This reproduction can possibly be replaced with the unit test for the `ListField` component in the future
 describe("issue 45877", () => {
   beforeEach(() => {
-    restore("setup");
+    H.restore("setup");
     cy.signInAsAdmin();
   });
 
@@ -1394,9 +1361,9 @@ describe("issue 45877", () => {
       },
     };
 
-    createNativeQuestion(questionDetails, { visitQuestion: true });
+    H.createNativeQuestion(questionDetails, { visitQuestion: true });
     cy.get("fieldset").should("contain", "Expected Invoice").click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByPlaceholderText("Search the list").should("exist");
 
       cy.findAllByLabelText("true")
@@ -1412,9 +1379,9 @@ describe("issue 45877", () => {
 
     // We don't even have to run the query to reproduce this issue
     // so let's not waste time and resources doing so.
-    cy.get(POPOVER_ELEMENT).should("not.exist");
+    cy.get(H.POPOVER_ELEMENT).should("not.exist");
     cy.get("fieldset").should("contain", "false").click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findAllByLabelText("true").should("have.length", 1);
       cy.findAllByLabelText("false")
         .should("have.length", 1)
@@ -1425,12 +1392,12 @@ describe("issue 45877", () => {
 
 describe("issue 47887", () => {
   beforeEach(() => {
-    restore("setup");
+    H.restore("setup");
     cy.signInAsAdmin();
   });
 
   it("Case expression with type/Date default value and type/DateTime case value has Date filter popover enabled (metabase#47887)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         database: SAMPLE_DB_ID,
         type: "query",
@@ -1484,7 +1451,7 @@ describe("issue 47887", () => {
     cy.findByTestId("notebook-button").click();
     cy.findAllByTestId("action-buttons").last().findByText("Filter").click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByLabelText("asdfdsa").click();
       cy.findByText("Specific dates…").click();
     });
@@ -1493,7 +1460,7 @@ describe("issue 47887", () => {
 
 describe("Issue 48851", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.viewport(1050, 300);
   });
@@ -1504,50 +1471,50 @@ describe("Issue 48851", () => {
     .join(", ");
 
   it("should not overflow the filter popover, even when there are a lot of values (metabase#48851)", () => {
-    openProductsTable();
-    tableHeaderClick("Title");
+    H.openProductsTable();
+    H.tableHeaderClick("Title");
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Filter by this column").click();
       cy.findByText("Is").click();
     });
 
-    popover().last().findByText("Contains").click();
-    popover()
+    H.popover().last().findByText("Contains").click();
+    H.popover()
       .first()
       .findByPlaceholderText("Enter some text")
       .type(manyValues, { timeout: 0 });
 
-    popover().button("Add filter").should("be.visible");
+    H.popover().button("Add filter").should("be.visible");
   });
 });
 
 describe("issue 49321", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should not require multiple clicks to apply a filter (metabase#49321)", () => {
-    openProductsTable({ mode: "notebook" });
-    filter({ mode: "notebook" });
-    popover().within(() => {
+    H.openProductsTable({ mode: "notebook" });
+    H.filter({ mode: "notebook" });
+    H.popover().within(() => {
       cy.findByText("Title").click();
       cy.findByText("Is").click();
     });
-    popover().last().findByText("Contains").click();
+    H.popover().last().findByText("Contains").click();
 
-    popover().then($popover => {
+    H.popover().then($popover => {
       const { width } = $popover[0].getBoundingClientRect();
       cy.wrap(width).as("initialWidth");
     });
 
-    popover()
+    H.popover()
       .findByPlaceholderText("Enter some text")
       .type("aaaaaaaaaa, bbbbbbbbbbb,");
 
     cy.get("@initialWidth").then(initialWidth => {
-      popover().should($popover => {
+      H.popover().should($popover => {
         const { width } = $popover[0].getBoundingClientRect();
         expect(width).to.eq(initialWidth);
       });
@@ -1557,7 +1524,7 @@ describe("issue 49321", () => {
 
 describe("issue 49642", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -1569,22 +1536,22 @@ describe("issue 49642", () => {
   };
 
   it("should allow searching for more values when the filter contains more than 1000 values (metabase#49642)", () => {
-    createDashboard().then(({ body: dashboard }) => {
-      visitDashboard(dashboard.id);
+    H.createDashboard().then(({ body: dashboard }) => {
+      H.visitDashboard(dashboard.id);
     });
-    editDashboard();
+    H.editDashboard();
 
-    createQuestion(QUESTION);
+    H.createQuestion(QUESTION);
     addQuestion(QUESTION.name);
 
-    setFilter("Text or Category", "Is");
+    H.setFilter("Text or Category", "Is");
     mapFilterToQuestion("Name");
-    sidebar().findByText("A single value").click();
+    H.sidebar().findByText("A single value").click();
 
-    saveDashboard();
+    H.saveDashboard();
 
-    filterWidget().click();
-    popover().within(() => {
+    H.filterWidget().click();
+    H.popover().within(() => {
       cy.findByText("Zackery Bailey").should("not.exist");
       cy.findByPlaceholderText("Search by Name").type("Zackery");
       cy.findByText("Zackery Bailey").should("be.visible");
@@ -1607,33 +1574,33 @@ describe("issue 49642", () => {
 
   const mapFilterToQuestion = (column = "Category") => {
     cy.findByText("Select…").click();
-    popover().within(() => cy.findByText(column).click());
+    H.popover().within(() => cy.findByText(column).click());
   };
 });
 
 describe("issue 44665", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should use the correct widget for the default value picker (metabase#44665)", () => {
-    openNativeEditor().type("select * from {{param");
-    sidebar()
+    H.openNativeEditor().type("select * from {{param");
+    H.sidebar()
       .last()
       .within(() => {
         cy.findByText("Search box").click();
         cy.findByText("Edit").click();
       });
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Custom list").click();
       cy.findByRole("textbox").type("foo\nbar\nbaz\nfoobar");
       cy.button("Done").click();
     });
 
-    sidebar().last().findByText("Enter a default value…").click();
-    popover().within(() => {
+    H.sidebar().last().findByText("Enter a default value…").click();
+    H.popover().within(() => {
       cy.findByPlaceholderText("Enter a default value…")
         .should("be.visible")
         .type("foo");
@@ -1644,7 +1611,7 @@ describe("issue 44665", () => {
       cy.findByText("baz").should("not.exist");
     });
 
-    sidebar()
+    H.sidebar()
       .last()
       .within(() => {
         cy.findByText("Enter a default value…").click();
@@ -1652,7 +1619,7 @@ describe("issue 44665", () => {
         cy.findByText("Enter a default value…").click();
       });
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByPlaceholderText("Enter a default value…").should("be.visible");
 
       cy.findByText("foo").should("be.visible");

--- a/e2e/test/scenarios/filters/filter-bulk.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter-bulk.cy.spec.js
@@ -1,19 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  assertQueryBuilderRowCount,
-  createSegment,
-  filter,
-  filterField,
-  filterFieldPopover,
-  filterSelectField,
-  hovercard,
-  modal,
-  popover,
-  restore,
-  setupBooleanQuery,
-  visitQuestionAdhoc,
-} from "e2e/support/helpers";
 
 const { ORDERS_ID, ORDERS, PEOPLE_ID, PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
@@ -97,15 +84,15 @@ const multiStageQuestionDetails = {
 
 describe("scenarios > filters > bulk filtering", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should sort database fields by relevance", () => {
-    visitQuestionAdhoc(rawQuestionDetails);
-    filter();
+    H.visitQuestionAdhoc(rawQuestionDetails);
+    H.filter();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findAllByTestId(/filter-column-/)
         .eq(0)
         .should("include.text", "Created At");
@@ -121,11 +108,11 @@ describe("scenarios > filters > bulk filtering", () => {
   });
 
   it("should add a filter for a raw query", () => {
-    visitQuestionAdhoc(rawQuestionDetails);
-    filter();
+    H.visitQuestionAdhoc(rawQuestionDetails);
+    H.filter();
 
-    filterField("Quantity", { operator: "equal to" });
-    filterFieldPopover("Quantity").within(() => {
+    H.filterField("Quantity", { operator: "equal to" });
+    H.filterFieldPopover("Quantity").within(() => {
       cy.findByText("20").click();
     });
 
@@ -138,28 +125,28 @@ describe("scenarios > filters > bulk filtering", () => {
   });
 
   it("should have an info icon on the filter modal filters", () => {
-    visitQuestionAdhoc(rawQuestionDetails);
-    filter();
+    H.visitQuestionAdhoc(rawQuestionDetails);
+    H.filter();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.get("li").findByLabelText("More info").realHover();
     });
 
-    hovercard().within(() => {
+    H.hovercard().within(() => {
       cy.contains("The date and time an order was submitted");
       cy.contains("Creation timestamp");
     });
   });
 
   it("should add a filter for an aggregated query", () => {
-    visitQuestionAdhoc(aggregatedQuestionDetails);
-    filter();
+    H.visitQuestionAdhoc(aggregatedQuestionDetails);
+    H.filter();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Summaries").click();
     });
 
-    filterField("Count", {
+    H.filterField("Count", {
       placeholder: "Min",
       value: "500",
     });
@@ -173,12 +160,12 @@ describe("scenarios > filters > bulk filtering", () => {
   });
 
   it("should add a filter for linked tables", () => {
-    visitQuestionAdhoc(rawQuestionDetails);
-    filter();
+    H.visitQuestionAdhoc(rawQuestionDetails);
+    H.filter();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Product").click({ force: true });
-      filterField("Category").findByText("Gadget").click();
+      H.filterField("Category").findByText("Gadget").click();
     });
 
     applyFilters();
@@ -193,10 +180,10 @@ describe("scenarios > filters > bulk filtering", () => {
   });
 
   it("should update an existing filter", () => {
-    visitQuestionAdhoc(filteredQuestionDetails);
-    filter();
+    H.visitQuestionAdhoc(filteredQuestionDetails);
+    H.filter();
 
-    filterField("Quantity", { order: 1, value: "{backspace}{backspace}25" });
+    H.filterField("Quantity", { order: 1, value: "{backspace}{backspace}25" });
 
     applyFilters();
 
@@ -209,10 +196,10 @@ describe("scenarios > filters > bulk filtering", () => {
   });
 
   it("should remove an existing filter", () => {
-    visitQuestionAdhoc(filteredQuestionDetails);
-    filter();
+    H.visitQuestionAdhoc(filteredQuestionDetails);
+    H.filter();
 
-    filterField("Quantity", { order: 1, value: "{backspace}{backspace}" });
+    H.filterField("Quantity", { order: 1, value: "{backspace}{backspace}" });
 
     applyFilters();
 
@@ -225,11 +212,11 @@ describe("scenarios > filters > bulk filtering", () => {
   });
 
   it("should be able to add and remove filters for all query stages", () => {
-    visitQuestionAdhoc(multiStageQuestionDetails);
+    H.visitQuestionAdhoc(multiStageQuestionDetails);
 
     cy.log("add filters for all stages in the filter modal");
-    filter();
-    modal().within(() => {
+    H.filter();
+    H.modal().within(() => {
       cy.log("stage 0");
       cy.findByText("Products").click();
       cy.findByLabelText("Gadget").click();
@@ -257,8 +244,8 @@ describe("scenarios > filters > bulk filtering", () => {
     });
 
     cy.log("check filters from all stages to be present in the filter modal");
-    filter();
-    modal().within(() => {
+    H.filter();
+    H.modal().within(() => {
       cy.log("stage 0");
       cy.findByText("Products").click();
       cy.findByLabelText("Gadget").should("be.checked");
@@ -281,7 +268,7 @@ describe("scenarios > filters > bulk filtering", () => {
     });
 
     cy.log("clear all filters");
-    modal().button("Clear all filters").click();
+    H.modal().button("Clear all filters").click();
     applyFilters();
     cy.findByTestId("qb-filters-panel").should("not.exist");
   });
@@ -291,7 +278,7 @@ describe("scenarios > filters > bulk filtering", () => {
     const SEGMENT_2_NAME = "Discounted Orders";
 
     beforeEach(() => {
-      createSegment({
+      H.createSegment({
         name: SEGMENT_1_NAME,
         description: "All orders with a total under $100.",
         table_id: ORDERS_ID,
@@ -302,7 +289,7 @@ describe("scenarios > filters > bulk filtering", () => {
         },
       });
 
-      createSegment({
+      H.createSegment({
         name: SEGMENT_2_NAME,
         description: "All orders with a discount",
         table_id: ORDERS_ID,
@@ -315,16 +302,16 @@ describe("scenarios > filters > bulk filtering", () => {
     });
 
     it("should apply and remove segment filter", () => {
-      visitQuestionAdhoc(rawQuestionDetails);
-      filter();
+      H.visitQuestionAdhoc(rawQuestionDetails);
+      H.filter();
 
-      modal().within(() => {
-        filterField("segments").within(() =>
+      H.modal().within(() => {
+        H.filterField("segments").within(() =>
           cy.findByPlaceholderText("Filter segments").click(),
         );
       });
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText(SEGMENT_1_NAME);
         cy.findByText(SEGMENT_2_NAME).click();
       });
@@ -335,10 +322,10 @@ describe("scenarios > filters > bulk filtering", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 1,915 rows");
 
-      filter();
+      H.filter();
 
-      modal().within(() => {
-        filterField("segments").within(() =>
+      H.modal().within(() => {
+        H.filterField("segments").within(() =>
           cy.findByText(SEGMENT_2_NAME).next().click(),
         );
       });
@@ -362,11 +349,11 @@ describe("scenarios > filters > bulk filtering", () => {
         },
       };
 
-      visitQuestionAdhoc(segmentFilterQuestion);
-      filter();
+      H.visitQuestionAdhoc(segmentFilterQuestion);
+      H.filter();
 
-      modal().within(() => {
-        filterField("segments").within(() => {
+      H.modal().within(() => {
+        H.filterField("segments").within(() => {
           cy.findByText(SEGMENT_1_NAME);
           cy.findByText(SEGMENT_2_NAME).should("not.exist");
         });
@@ -376,12 +363,12 @@ describe("scenarios > filters > bulk filtering", () => {
 
   describe("boolean filters", () => {
     beforeEach(() => {
-      setupBooleanQuery();
-      filter();
+      H.setupBooleanQuery();
+      H.filter();
     });
 
     it("should apply a boolean filter", () => {
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("True").click();
       });
       applyFilters();
@@ -391,7 +378,7 @@ describe("scenarios > filters > bulk filtering", () => {
     });
 
     it("should change a boolean filter", () => {
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("True").click();
       });
       applyFilters();
@@ -399,9 +386,9 @@ describe("scenarios > filters > bulk filtering", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 2 rows").should("be.visible");
 
-      filter();
+      H.filter();
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("False").click();
       });
       applyFilters();
@@ -411,7 +398,7 @@ describe("scenarios > filters > bulk filtering", () => {
     });
 
     it("should remove a boolean filter", () => {
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("True").click();
       });
       applyFilters();
@@ -419,9 +406,9 @@ describe("scenarios > filters > bulk filtering", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 2 rows").should("be.visible");
 
-      filter();
+      H.filter();
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("True").click();
       });
       applyFilters();
@@ -433,12 +420,12 @@ describe("scenarios > filters > bulk filtering", () => {
 
   describe("date filters", () => {
     beforeEach(() => {
-      visitQuestionAdhoc(rawQuestionDetails);
-      filter();
+      H.visitQuestionAdhoc(rawQuestionDetails);
+      H.filter();
     });
 
     it("can add a date shortcut filter", () => {
-      modal().findByText("Today").click();
+      H.modal().findByText("Today").click();
       applyFilters();
 
       cy.findByTestId("qb-filters-panel")
@@ -447,9 +434,9 @@ describe("scenarios > filters > bulk filtering", () => {
     });
 
     it("can add a date shortcut filter from the popover", () => {
-      filterField("Created At").findByLabelText("More options").click();
-      popover().contains("Last 3 months").findByText("Last 3 months").click();
-      modal().findByText("Previous 3 Months").should("be.visible");
+      H.filterField("Created At").findByLabelText("More options").click();
+      H.popover().contains("Last 3 months").findByText("Last 3 months").click();
+      H.modal().findByText("Previous 3 Months").should("be.visible");
       applyFilters();
 
       cy.findByTestId("qb-filters-panel")
@@ -459,7 +446,7 @@ describe("scenarios > filters > bulk filtering", () => {
 
     // if this gets flaky, disable, it's an issue with internal state in the datepicker component
     it.skip("can add a date range filter", () => {
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByLabelText("Created At").within(() => {
           cy.findByLabelText("More options").click();
         });
@@ -469,13 +456,13 @@ describe("scenarios > filters > bulk filtering", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Before").click();
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.get("input").eq(0).clear().type("01/01/2023", { delay: 0 });
 
         cy.findByText("Add filter").click();
       });
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByLabelText("Created At").within(() => {
           cy.findByText("is before January 1, 2023").should("be.visible");
         });
@@ -491,11 +478,11 @@ describe("scenarios > filters > bulk filtering", () => {
     });
 
     it("Can cancel adding date filter", () => {
-      filterField("Created At").findByLabelText("More options").click();
+      H.filterField("Created At").findByLabelText("More options").click();
 
-      filterField("Created At").click({ position: "topRight", force: true });
+      H.filterField("Created At").click({ position: "topRight", force: true });
 
-      filterField("Created At").within(() => {
+      H.filterField("Created At").within(() => {
         // there should be no filter so the X should not populate
         cy.get(".Icon-close").should("not.exist");
       });
@@ -504,12 +491,12 @@ describe("scenarios > filters > bulk filtering", () => {
 
   describe("category filters", () => {
     beforeEach(() => {
-      visitQuestionAdhoc(peopleQuestion);
-      filter();
+      H.visitQuestionAdhoc(peopleQuestion);
+      H.filter();
     });
 
     it("should show inline category picker for referral source", () => {
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("Affiliate").click();
       });
       applyFilters();
@@ -521,7 +508,7 @@ describe("scenarios > filters > bulk filtering", () => {
     });
 
     it("should show value picker for state", () => {
-      filterFieldPopover("State").within(() => {
+      H.filterFieldPopover("State").within(() => {
         cy.findByText("AZ").click();
       });
       applyFilters();
@@ -535,12 +522,12 @@ describe("scenarios > filters > bulk filtering", () => {
 
   describe("key filters", () => {
     beforeEach(() => {
-      visitQuestionAdhoc(rawQuestionDetails);
-      filter();
+      H.visitQuestionAdhoc(rawQuestionDetails);
+      H.filter();
     });
 
     it("filters by primary keys", () => {
-      filterField("ID", {
+      H.filterField("ID", {
         value: ["17", "18"],
       });
 
@@ -555,7 +542,7 @@ describe("scenarios > filters > bulk filtering", () => {
     });
 
     it("filters by a foreign key", () => {
-      filterField("Product ID", {
+      H.filterField("Product ID", {
         value: "65",
       });
 
@@ -568,12 +555,12 @@ describe("scenarios > filters > bulk filtering", () => {
 
   describe("text filters", () => {
     beforeEach(() => {
-      visitQuestionAdhoc(peopleQuestion);
-      filter();
+      H.visitQuestionAdhoc(peopleQuestion);
+      H.filter();
     });
 
     it("adds a contains text filter", () => {
-      filterField("City", {
+      H.filterField("City", {
         operator: "contains",
         value: "Indian",
       });
@@ -585,7 +572,7 @@ describe("scenarios > filters > bulk filtering", () => {
     });
 
     it("adds an ends with text filter", () => {
-      filterField("City", {
+      H.filterField("City", {
         operator: "ends with",
         value: "Valley",
       });
@@ -597,7 +584,7 @@ describe("scenarios > filters > bulk filtering", () => {
     });
 
     it("adds multiple is text filters", () => {
-      filterSelectField("City", {
+      H.filterSelectField("City", {
         operator: "is",
         value: ["Indiantown", "Indian Valley"],
       });
@@ -613,17 +600,17 @@ describe("scenarios > filters > bulk filtering", () => {
 
   describe("number filters", () => {
     beforeEach(() => {
-      visitQuestionAdhoc(productsQuestion);
-      filter();
+      H.visitQuestionAdhoc(productsQuestion);
+      H.filter();
     });
 
     it("applies a between filter", () => {
-      filterField("Price", {
+      H.filterField("Price", {
         placeholder: "Min",
         value: "50",
       });
 
-      filterField("Price", {
+      H.filterField("Price", {
         placeholder: "Max",
         value: "80",
       });
@@ -634,11 +621,11 @@ describe("scenarios > filters > bulk filtering", () => {
         .findByText("Price is between 50 and 80")
         .should("be.visible");
 
-      assertQueryBuilderRowCount(72);
+      H.assertQueryBuilderRowCount(72);
     });
 
     it("applies a greater than filter", () => {
-      filterField("Price", {
+      H.filterField("Price", {
         operator: "greater than",
         value: "50",
       });
@@ -652,7 +639,7 @@ describe("scenarios > filters > bulk filtering", () => {
     });
 
     it("infers a <= filter from an invalid between filter", () => {
-      filterField("Price", {
+      H.filterField("Price", {
         placeholder: "Max",
         value: "50",
       });
@@ -668,12 +655,12 @@ describe("scenarios > filters > bulk filtering", () => {
 
   describe("column search", () => {
     beforeEach(() => {
-      visitQuestionAdhoc(productsQuestion);
-      filter();
+      H.visitQuestionAdhoc(productsQuestion);
+      H.filter();
     });
 
     it("can search for a column", () => {
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("In").should("not.exist");
         cy.findByText("Category").should("be.visible");
 
@@ -681,23 +668,23 @@ describe("scenarios > filters > bulk filtering", () => {
 
         cy.findByText("Category").should("not.exist");
 
-        filterField("Vendor")
+        H.filterField("Vendor")
           .findByText("in") // "In Products"
           .should("be.visible");
 
-        filterField("Vendor").findByText("Vendor").should("be.visible");
+        H.filterField("Vendor").findByText("Vendor").should("be.visible");
       });
     });
 
     it("can apply a filter from a searched column", () => {
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByPlaceholderText("Search for a column…").clear().type("price");
 
         // need to block until filter is applied
         cy.findByText("Category").should("not.exist");
       });
 
-      filterField("Price", {
+      H.filterField("Price", {
         operator: "greater than",
         value: "90",
       });
@@ -713,6 +700,6 @@ describe("scenarios > filters > bulk filtering", () => {
 });
 
 const applyFilters = () => {
-  modal().findByTestId("apply-filters").click();
+  H.modal().findByTestId("apply-filters").click();
   cy.wait("@dataset");
 };

--- a/e2e/test/scenarios/filters/filter-sources.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter-sources.cy.spec.js
@@ -1,15 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  assertQueryBuilderRowCount,
-  filter,
-  getNotebookStep,
-  popover,
-  restore,
-  selectFilterOperator,
-  visitQuestionAdhoc,
-  visualize,
-} from "e2e/support/helpers";
 
 const { PRODUCTS_ID, PRODUCTS, ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
 
@@ -228,425 +219,427 @@ const nestedQuestionWithAggregations = card => ({
 
 describe("scenarios > filters > filter sources", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   describe("tables", () => {
     it("column from a table", () => {
-      visitQuestionAdhoc(tableQuestion, { mode: "notebook" });
-      filter({ mode: "notebook" });
-      popover().findByText("Tax").click();
-      selectFilterOperator("Equal to");
-      popover().within(() => {
+      H.visitQuestionAdhoc(tableQuestion, { mode: "notebook" });
+      H.filter({ mode: "notebook" });
+      H.popover().findByText("Tax").click();
+      H.selectFilterOperator("Equal to");
+      H.popover().within(() => {
         cy.findByPlaceholderText("Enter a number").type("6.1");
         cy.button("Add filter").click();
       });
       assertFilterName("Tax is equal to 6.1");
-      visualize();
-      assertQueryBuilderRowCount(10);
+      H.visualize();
+      H.assertQueryBuilderRowCount(10);
     });
 
     it("column from an expression based on another table column", () => {
-      visitQuestionAdhoc(tableQuestionWithExpression, { mode: "notebook" });
-      filter({ mode: "notebook" });
-      popover().findByText("Total100").click();
-      selectFilterOperator("Greater than");
-      popover().within(() => {
+      H.visitQuestionAdhoc(tableQuestionWithExpression, { mode: "notebook" });
+      H.filter({ mode: "notebook" });
+      H.popover().findByText("Total100").click();
+      H.selectFilterOperator("Greater than");
+      H.popover().within(() => {
         cy.findByPlaceholderText("Enter a number").type("250.5");
         cy.button("Add filter").click();
       });
       assertFilterName("Total100 is greater than 250.5");
-      visualize();
-      assertQueryBuilderRowCount(239);
+      H.visualize();
+      H.assertQueryBuilderRowCount(239);
     });
 
     it("column from an explicit join", () => {
-      visitQuestionAdhoc(tableQuestionWithJoin, { mode: "notebook" });
-      filter({ mode: "notebook" });
-      popover().within(() => {
+      H.visitQuestionAdhoc(tableQuestionWithJoin, { mode: "notebook" });
+      H.filter({ mode: "notebook" });
+      H.popover().within(() => {
         cy.findByText("Products").click();
         cy.findByText("Vendor").click();
         cy.findByText("Aufderhar-Boehm").click();
         cy.button("Add filter").click();
       });
       assertFilterName("Products → Vendor is Aufderhar-Boehm");
-      visualize();
-      assertQueryBuilderRowCount(95);
+      H.visualize();
+      H.assertQueryBuilderRowCount(95);
     });
 
     it("column from an explicit join with fields", () => {
-      visitQuestionAdhoc(tableQuestionWithJoinAndFields, { mode: "notebook" });
-      filter({ mode: "notebook" });
-      popover().within(() => {
+      H.visitQuestionAdhoc(tableQuestionWithJoinAndFields, {
+        mode: "notebook",
+      });
+      H.filter({ mode: "notebook" });
+      H.popover().within(() => {
         cy.findByText("Products").click();
         cy.findByText("Rating").click();
       });
-      selectFilterOperator("Equal to");
-      popover().within(() => {
+      H.selectFilterOperator("Equal to");
+      H.popover().within(() => {
         cy.findByPlaceholderText("Enter a number").type("3.7");
         cy.button("Add filter").click();
       });
       assertFilterName("Products → Rating is equal to 3.7");
-      visualize();
-      assertQueryBuilderRowCount(883);
+      H.visualize();
+      H.assertQueryBuilderRowCount(883);
     });
 
     it("column from an implicit join", () => {
-      visitQuestionAdhoc(tableQuestion, { mode: "notebook" });
-      filter({ mode: "notebook" });
-      popover().within(() => {
+      H.visitQuestionAdhoc(tableQuestion, { mode: "notebook" });
+      H.filter({ mode: "notebook" });
+      H.popover().within(() => {
         cy.findByText("Product").click();
         cy.findByText("Ean").click();
       });
-      selectFilterOperator("Is");
-      popover().within(() => {
+      H.selectFilterOperator("Is");
+      H.popover().within(() => {
         cy.findByText("0001664425970").click();
         cy.button("Add filter").click();
       });
       assertFilterName("Product → Ean is 0001664425970");
-      visualize();
-      assertQueryBuilderRowCount(104);
+      H.visualize();
+      H.assertQueryBuilderRowCount(104);
     });
 
     it("column from a nested aggregation without column", () => {
-      visitQuestionAdhoc(tableWithAggregations, { mode: "notebook" });
+      H.visitQuestionAdhoc(tableWithAggregations, { mode: "notebook" });
       addNewFilter();
-      popover().findByText("Count").click();
-      selectFilterOperator("Equal to");
-      popover().within(() => {
+      H.popover().findByText("Count").click();
+      H.selectFilterOperator("Equal to");
+      H.popover().within(() => {
         cy.findByPlaceholderText("Enter a number").type("90");
         cy.button("Add filter").click();
       });
       assertFilterName("Count is equal to 90", { stage: 1 });
-      visualize();
-      assertQueryBuilderRowCount(7);
+      H.visualize();
+      H.assertQueryBuilderRowCount(7);
     });
 
     it("column from a nested aggregation with column", () => {
-      visitQuestionAdhoc(tableWithAggregations, { mode: "notebook" });
+      H.visitQuestionAdhoc(tableWithAggregations, { mode: "notebook" });
       addNewFilter();
-      popover().findByText("Sum of Quantity").click();
-      selectFilterOperator("Less than");
-      popover().within(() => {
+      H.popover().findByText("Sum of Quantity").click();
+      H.selectFilterOperator("Less than");
+      H.popover().within(() => {
         cy.findByPlaceholderText("Enter a number").type("350");
         cy.button("Add filter").click();
       });
       assertFilterName("Sum of Quantity is less than 350", { stage: 1 });
-      visualize();
-      assertQueryBuilderRowCount(115);
+      H.visualize();
+      H.assertQueryBuilderRowCount(115);
     });
 
     it("column from a nested breakout", () => {
-      visitQuestionAdhoc(tableWithAggregations, { mode: "notebook" });
+      H.visitQuestionAdhoc(tableWithAggregations, { mode: "notebook" });
       addNewFilter();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Product ID").click();
         cy.findByPlaceholderText("Enter an ID").type("10");
         cy.button("Add filter").click();
       });
       assertFilterName("Product ID is 10", { stage: 1 });
-      visualize();
-      assertQueryBuilderRowCount(1);
+      H.visualize();
+      H.assertQueryBuilderRowCount(1);
     });
   });
 
   describe("nested structured questions", () => {
     it("column from a question", () => {
       cy.createQuestion(structuredQuestion).then(({ body: card }) => {
-        visitQuestionAdhoc(nestedQuestion(card), { mode: "notebook" });
+        H.visitQuestionAdhoc(nestedQuestion(card), { mode: "notebook" });
       });
-      filter({ mode: "notebook" });
-      popover().findByText("Tax").click();
-      selectFilterOperator("Equal to");
-      popover().within(() => {
+      H.filter({ mode: "notebook" });
+      H.popover().findByText("Tax").click();
+      H.selectFilterOperator("Equal to");
+      H.popover().within(() => {
         cy.findByPlaceholderText("Enter a number").type("6.1");
         cy.button("Add filter").click();
       });
       assertFilterName("Tax is equal to 6.1");
-      visualize();
-      assertQueryBuilderRowCount(10);
+      H.visualize();
+      H.assertQueryBuilderRowCount(10);
     });
 
     it("column from an expression based on a question column", () => {
       cy.createQuestion(structuredQuestion).then(({ body: card }) => {
-        visitQuestionAdhoc(nestedQuestionWithExpression(card), {
+        H.visitQuestionAdhoc(nestedQuestionWithExpression(card), {
           mode: "notebook",
         });
       });
-      filter({ mode: "notebook" });
-      popover().findByText("Total100").click();
-      selectFilterOperator("Greater than");
-      popover().within(() => {
+      H.filter({ mode: "notebook" });
+      H.popover().findByText("Total100").click();
+      H.selectFilterOperator("Greater than");
+      H.popover().within(() => {
         cy.findByPlaceholderText("Enter a number").type("250.5");
         cy.button("Add filter").click();
       });
       assertFilterName("Total100 is greater than 250.5");
-      visualize();
-      assertQueryBuilderRowCount(239);
+      H.visualize();
+      H.assertQueryBuilderRowCount(239);
     });
 
     it("column from an explicit join", () => {
       cy.createQuestion(structuredQuestion).then(({ body: card }) => {
-        visitQuestionAdhoc(nestedQuestionWithJoin(card), {
+        H.visitQuestionAdhoc(nestedQuestionWithJoin(card), {
           mode: "notebook",
         });
       });
-      filter({ mode: "notebook" });
-      popover().within(() => {
+      H.filter({ mode: "notebook" });
+      H.popover().within(() => {
         cy.findByText("Products").click();
         cy.findByText("Vendor").click();
         cy.findByText("Aufderhar-Boehm").click();
         cy.button("Add filter").click();
       });
       assertFilterName("Products → Vendor is Aufderhar-Boehm");
-      visualize();
-      assertQueryBuilderRowCount(95);
+      H.visualize();
+      H.assertQueryBuilderRowCount(95);
     });
 
     it("column from an explicit join with fields", () => {
       cy.createQuestion(structuredQuestion).then(({ body: card }) => {
-        visitQuestionAdhoc(nestedQuestionWithJoinAndFields(card), {
+        H.visitQuestionAdhoc(nestedQuestionWithJoinAndFields(card), {
           mode: "notebook",
         });
       });
-      filter({ mode: "notebook" });
-      popover().within(() => {
+      H.filter({ mode: "notebook" });
+      H.popover().within(() => {
         cy.findByText("Products").click();
         cy.findByText("Rating").click();
       });
-      selectFilterOperator("Equal to");
-      popover().within(() => {
+      H.selectFilterOperator("Equal to");
+      H.popover().within(() => {
         cy.findByPlaceholderText("Enter a number").type("3.7");
         cy.button("Add filter").click();
       });
       assertFilterName("Products → Rating is equal to 3.7");
-      visualize();
-      assertQueryBuilderRowCount(883);
+      H.visualize();
+      H.assertQueryBuilderRowCount(883);
     });
 
     it("column from an implicit join with fields", () => {
       cy.createQuestion(structuredQuestion).then(({ body: card }) => {
-        visitQuestionAdhoc(nestedQuestionWithJoinAndFields(card), {
+        H.visitQuestionAdhoc(nestedQuestionWithJoinAndFields(card), {
           mode: "notebook",
         });
       });
-      filter({ mode: "notebook" });
-      popover().within(() => {
+      H.filter({ mode: "notebook" });
+      H.popover().within(() => {
         cy.findByText("Products").click();
         cy.findByText("Ean").click();
       });
-      selectFilterOperator("Is");
-      popover().within(() => {
+      H.selectFilterOperator("Is");
+      H.popover().within(() => {
         cy.findByText("0001664425970").click();
         cy.button("Add filter").click();
       });
       assertFilterName("Products → Ean is 0001664425970");
-      visualize();
-      assertQueryBuilderRowCount(104);
+      H.visualize();
+      H.assertQueryBuilderRowCount(104);
     });
 
     it("column from a nested aggregation without column", () => {
       cy.createQuestion(structuredQuestion).then(({ body: card }) => {
-        visitQuestionAdhoc(nestedQuestionWithAggregations(card), {
+        H.visitQuestionAdhoc(nestedQuestionWithAggregations(card), {
           mode: "notebook",
         });
       });
       addNewFilter();
-      popover().findByText("Count").click();
-      selectFilterOperator("Equal to");
-      popover().within(() => {
+      H.popover().findByText("Count").click();
+      H.selectFilterOperator("Equal to");
+      H.popover().within(() => {
         cy.findByPlaceholderText("Enter a number").type("90");
         cy.button("Add filter").click();
       });
       assertFilterName("Count is equal to 90", { stage: 1 });
-      visualize();
-      assertQueryBuilderRowCount(7);
+      H.visualize();
+      H.assertQueryBuilderRowCount(7);
     });
 
     it("column from a nested aggregation with column", () => {
       cy.createQuestion(structuredQuestion).then(({ body: card }) => {
-        visitQuestionAdhoc(nestedQuestionWithAggregations(card), {
+        H.visitQuestionAdhoc(nestedQuestionWithAggregations(card), {
           mode: "notebook",
         });
       });
       addNewFilter();
-      popover().findByText("Sum of Quantity").click();
-      selectFilterOperator("Less than");
-      popover().within(() => {
+      H.popover().findByText("Sum of Quantity").click();
+      H.selectFilterOperator("Less than");
+      H.popover().within(() => {
         cy.findByPlaceholderText("Enter a number").type("350");
         cy.button("Add filter").click();
       });
       assertFilterName("Sum of Quantity is less than 350", { stage: 1 });
-      visualize();
-      assertQueryBuilderRowCount(115);
+      H.visualize();
+      H.assertQueryBuilderRowCount(115);
     });
 
     it("column from a nested breakout", () => {
       cy.createQuestion(structuredQuestion).then(({ body: card }) => {
-        visitQuestionAdhoc(nestedQuestionWithAggregations(card), {
+        H.visitQuestionAdhoc(nestedQuestionWithAggregations(card), {
           mode: "notebook",
         });
       });
       addNewFilter();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Product ID").click();
         cy.findByPlaceholderText("Enter an ID").type("10");
         cy.button("Add filter").click();
       });
       assertFilterName("Product ID is 10", { stage: 1 });
-      visualize();
-      assertQueryBuilderRowCount(1);
+      H.visualize();
+      H.assertQueryBuilderRowCount(1);
     });
   });
 
   describe("nested native questions", () => {
     it("column from a question", () => {
       cy.createNativeQuestion(nativeQuestion).then(({ body: card }) => {
-        visitQuestionAdhoc(nestedQuestion(card), { mode: "notebook" });
+        H.visitQuestionAdhoc(nestedQuestion(card), { mode: "notebook" });
       });
-      filter({ mode: "notebook" });
-      popover().findByText("TAX").click();
-      selectFilterOperator("Equal to");
-      popover().within(() => {
+      H.filter({ mode: "notebook" });
+      H.popover().findByText("TAX").click();
+      H.selectFilterOperator("Equal to");
+      H.popover().within(() => {
         cy.findByPlaceholderText("Enter a number").type("6.1");
         cy.button("Add filter").click();
       });
       assertFilterName("TAX is equal to 6.1");
-      visualize();
-      assertQueryBuilderRowCount(10);
+      H.visualize();
+      H.assertQueryBuilderRowCount(10);
     });
 
     it("column from an expression based on a question column", () => {
       cy.createNativeQuestion(nativeQuestion).then(({ body: card }) => {
-        visitQuestionAdhoc(nestedQuestionWithExpression(card), {
+        H.visitQuestionAdhoc(nestedQuestionWithExpression(card), {
           mode: "notebook",
         });
       });
-      filter({ mode: "notebook" });
-      popover().findByText("Total100").click();
-      selectFilterOperator("Greater than");
-      popover().within(() => {
+      H.filter({ mode: "notebook" });
+      H.popover().findByText("Total100").click();
+      H.selectFilterOperator("Greater than");
+      H.popover().within(() => {
         cy.findByPlaceholderText("Enter a number").type("250.5");
         cy.button("Add filter").click();
       });
       assertFilterName("Total100 is greater than 250.5");
-      visualize();
-      assertQueryBuilderRowCount(239);
+      H.visualize();
+      H.assertQueryBuilderRowCount(239);
     });
 
     it("column from an explicit join", () => {
       cy.createNativeQuestion(nativeQuestion).then(({ body: card }) => {
-        visitQuestionAdhoc(nestedQuestionWithJoin(card), {
+        H.visitQuestionAdhoc(nestedQuestionWithJoin(card), {
           mode: "notebook",
         });
       });
-      filter({ mode: "notebook" });
-      popover().within(() => {
+      H.filter({ mode: "notebook" });
+      H.popover().within(() => {
         cy.findByText("Products").click();
         cy.findByText("Vendor").click();
         cy.findByText("Aufderhar-Boehm").click();
         cy.button("Add filter").click();
       });
       assertFilterName("Products → Vendor is Aufderhar-Boehm");
-      visualize();
-      assertQueryBuilderRowCount(95);
+      H.visualize();
+      H.assertQueryBuilderRowCount(95);
     });
 
     it("column from an explicit join with fields", () => {
       cy.createNativeQuestion(nativeQuestion).then(({ body: card }) => {
-        visitQuestionAdhoc(nestedQuestionWithJoinAndFields(card), {
+        H.visitQuestionAdhoc(nestedQuestionWithJoinAndFields(card), {
           mode: "notebook",
         });
       });
-      filter({ mode: "notebook" });
-      popover().within(() => {
+      H.filter({ mode: "notebook" });
+      H.popover().within(() => {
         cy.findByText("Products").click();
         cy.findByText("Rating").click();
       });
-      selectFilterOperator("Equal to");
-      popover().within(() => {
+      H.selectFilterOperator("Equal to");
+      H.popover().within(() => {
         cy.findByPlaceholderText("Enter a number").type("3.7");
         cy.button("Add filter").click();
       });
       assertFilterName("Products → Rating is equal to 3.7");
-      visualize();
-      assertQueryBuilderRowCount(883);
+      H.visualize();
+      H.assertQueryBuilderRowCount(883);
     });
 
     it("column from an implicit join with fields", () => {
       cy.createNativeQuestion(nativeQuestion).then(({ body: card }) => {
-        visitQuestionAdhoc(nestedQuestionWithJoinAndFields(card), {
+        H.visitQuestionAdhoc(nestedQuestionWithJoinAndFields(card), {
           mode: "notebook",
         });
       });
-      filter({ mode: "notebook" });
-      popover().within(() => {
+      H.filter({ mode: "notebook" });
+      H.popover().within(() => {
         cy.findByText("Products").click();
         cy.findByText("Ean").click();
       });
-      selectFilterOperator("Is");
-      popover().within(() => {
+      H.selectFilterOperator("Is");
+      H.popover().within(() => {
         cy.findByText("0001664425970").click();
         cy.button("Add filter").click();
       });
       assertFilterName("Products → Ean is 0001664425970");
-      visualize();
-      assertQueryBuilderRowCount(104);
+      H.visualize();
+      H.assertQueryBuilderRowCount(104);
     });
 
     it("column from a nested aggregation without column", () => {
       cy.createNativeQuestion(nativeQuestion).then(({ body: card }) => {
-        visitQuestionAdhoc(nestedQuestionWithAggregations(card), {
+        H.visitQuestionAdhoc(nestedQuestionWithAggregations(card), {
           mode: "notebook",
         });
       });
       addNewFilter();
-      popover().findByText("Count").click();
-      selectFilterOperator("Equal to");
-      popover().within(() => {
+      H.popover().findByText("Count").click();
+      H.selectFilterOperator("Equal to");
+      H.popover().within(() => {
         cy.findByPlaceholderText("Enter a number").type("90");
         cy.button("Add filter").click();
       });
       assertFilterName("Count is equal to 90", { stage: 1 });
-      visualize();
-      assertQueryBuilderRowCount(7);
+      H.visualize();
+      H.assertQueryBuilderRowCount(7);
     });
 
     it("column from a nested aggregation with column", () => {
       cy.createNativeQuestion(nativeQuestion).then(({ body: card }) => {
-        visitQuestionAdhoc(nestedQuestionWithAggregations(card), {
+        H.visitQuestionAdhoc(nestedQuestionWithAggregations(card), {
           mode: "notebook",
         });
       });
       addNewFilter();
-      popover().findByText("Sum of QUANTITY").click();
-      selectFilterOperator("Less than");
-      popover().within(() => {
+      H.popover().findByText("Sum of QUANTITY").click();
+      H.selectFilterOperator("Less than");
+      H.popover().within(() => {
         cy.findByPlaceholderText("Enter a number").type("350");
         cy.button("Add filter").click();
       });
       assertFilterName("Sum of QUANTITY is less than 350", { stage: 1 });
-      visualize();
-      assertQueryBuilderRowCount(115);
+      H.visualize();
+      H.assertQueryBuilderRowCount(115);
     });
 
     it("column from a nested breakout", () => {
       cy.createNativeQuestion(nativeQuestion).then(({ body: card }) => {
-        visitQuestionAdhoc(nestedQuestionWithAggregations(card), {
+        H.visitQuestionAdhoc(nestedQuestionWithAggregations(card), {
           mode: "notebook",
         });
       });
       addNewFilter();
-      popover().findByText("PRODUCT_ID").click();
-      selectFilterOperator("Equal to");
-      popover().within(() => {
+      H.popover().findByText("PRODUCT_ID").click();
+      H.selectFilterOperator("Equal to");
+      H.popover().within(() => {
         cy.findByPlaceholderText("Enter a number").type("10");
         cy.button("Add filter").click();
       });
       assertFilterName("PRODUCT_ID is equal to 10", { stage: 1 });
-      visualize();
-      assertQueryBuilderRowCount(1);
+      H.visualize();
+      H.assertQueryBuilderRowCount(1);
     });
   });
 });
@@ -656,7 +649,7 @@ function addNewFilter() {
 }
 
 function assertFilterName(filterName, options) {
-  getNotebookStep("filter", options)
+  H.getNotebookStep("filter", options)
     .findByText(filterName)
     .should("be.visible");
 }

--- a/e2e/test/scenarios/filters/filter-types.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter-types.cy.spec.js
@@ -1,14 +1,4 @@
-import {
-  assertQueryBuilderRowCount,
-  filter,
-  getNotebookStep,
-  openProductsTable,
-  popover,
-  relativeDatePicker,
-  restore,
-  selectFilterOperator,
-  visualize,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 const STRING_CASES = [
   {
@@ -462,7 +452,7 @@ const RELATIVE_DATE_CASES = [
 
 describe("scenarios > filters > filter types", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
@@ -478,12 +468,12 @@ describe("scenarios > filters > filter types", () => {
         expectedRowCount,
       }) => {
         it(title, () => {
-          openProductsTable({ mode: "notebook" });
-          filter({ mode: "notebook" });
+          H.openProductsTable({ mode: "notebook" });
+          H.filter({ mode: "notebook" });
 
-          popover().findByText(columnName).click();
-          selectFilterOperator(operator);
-          popover().within(() => {
+          H.popover().findByText(columnName).click();
+          H.selectFilterOperator(operator);
+          H.popover().within(() => {
             values.forEach(value => {
               cy.findByLabelText("Filter value")
                 .focus()
@@ -495,8 +485,8 @@ describe("scenarios > filters > filter types", () => {
           });
 
           assertFilterName(expectedDisplayName);
-          visualize();
-          assertQueryBuilderRowCount(expectedRowCount);
+          H.visualize();
+          H.assertQueryBuilderRowCount(expectedRowCount);
         });
       },
     );
@@ -513,12 +503,12 @@ describe("scenarios > filters > filter types", () => {
         expectedRowCount,
       }) => {
         it(title, () => {
-          openProductsTable({ mode: "notebook" });
-          filter({ mode: "notebook" });
+          H.openProductsTable({ mode: "notebook" });
+          H.filter({ mode: "notebook" });
 
-          popover().findByText(columnName).click();
-          selectFilterOperator(operator);
-          popover()
+          H.popover().findByText(columnName).click();
+          H.selectFilterOperator(operator);
+          H.popover()
             .first()
             .within(() => {
               values.forEach(value => {
@@ -531,8 +521,8 @@ describe("scenarios > filters > filter types", () => {
             });
 
           assertFilterName(expectedDisplayName);
-          visualize();
-          assertQueryBuilderRowCount(expectedRowCount);
+          H.visualize();
+          H.assertQueryBuilderRowCount(expectedRowCount);
         });
       },
     );
@@ -543,15 +533,15 @@ describe("scenarios > filters > filter types", () => {
       DATE_SHORTCUT_CASES.forEach(
         ({ title, shortcut, expectedDisplayName }) => {
           it(title, () => {
-            openProductsTable({ mode: "notebook" });
-            filter({ mode: "notebook" });
+            H.openProductsTable({ mode: "notebook" });
+            H.filter({ mode: "notebook" });
 
-            popover().within(() => {
+            H.popover().within(() => {
               cy.findByText("Created At").click();
               cy.findByText(shortcut).click();
             });
             assertFilterName(expectedDisplayName);
-            visualize();
+            H.visualize();
             assertFiltersExist();
           });
         },
@@ -571,30 +561,30 @@ describe("scenarios > filters > filter types", () => {
           expectedDisplayName,
         }) => {
           it(title, () => {
-            openProductsTable({ mode: "notebook" });
-            filter({ mode: "notebook" });
+            H.openProductsTable({ mode: "notebook" });
+            H.filter({ mode: "notebook" });
 
-            popover().within(() => {
+            H.popover().within(() => {
               cy.findByText("Created At").click();
               cy.findByText("Relative dates…").click();
               cy.findByRole("tab", { name: offset }).click();
             });
 
-            relativeDatePicker.setValue({ value, unit });
+            H.relativeDatePicker.setValue({ value, unit });
 
             if (includeCurrent) {
-              relativeDatePicker.toggleCurrentInterval();
+              H.relativeDatePicker.toggleCurrentInterval();
             } else if (offsetUnit && offsetValue) {
-              relativeDatePicker.addStartingFrom({
+              H.relativeDatePicker.addStartingFrom({
                 value: offsetValue,
                 unit: offsetUnit,
               });
             }
 
-            popover().button("Add filter").click();
+            H.popover().button("Add filter").click();
 
             assertFilterName(expectedDisplayName);
-            visualize();
+            H.visualize();
             assertFiltersExist();
           });
         },
@@ -605,10 +595,10 @@ describe("scenarios > filters > filter types", () => {
       EXCLUDE_DATE_CASES.forEach(
         ({ title, label, options, expectedDisplayName, expectedRowCount }) => {
           it(title, () => {
-            openProductsTable({ mode: "notebook" });
-            filter({ mode: "notebook" });
+            H.openProductsTable({ mode: "notebook" });
+            H.filter({ mode: "notebook" });
 
-            popover().within(() => {
+            H.popover().within(() => {
               cy.findByText("Created At").click();
               cy.findByText("Exclude…").click();
               cy.findByText(label).click();
@@ -618,8 +608,8 @@ describe("scenarios > filters > filter types", () => {
               }
             });
             assertFilterName(expectedDisplayName);
-            visualize();
-            assertQueryBuilderRowCount(expectedRowCount);
+            H.visualize();
+            H.assertQueryBuilderRowCount(expectedRowCount);
           });
         },
       );
@@ -628,7 +618,7 @@ describe("scenarios > filters > filter types", () => {
 });
 
 function assertFilterName(filterName, options) {
-  getNotebookStep("filter", options)
+  H.getNotebookStep("filter", options)
     .findByText(filterName)
     .should("be.visible");
 }

--- a/e2e/test/scenarios/filters/filter.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter.cy.spec.js
@@ -1,68 +1,42 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  cartesianChartCircleWithColors,
-  checkExpressionEditorHelperPopoverPosition,
-  enterCustomColumnDetails,
-  expressionEditorWidget,
-  filter,
-  filterField,
-  filterFieldPopover,
-  getNotebookStep,
-  join,
-  joinTable,
-  openNotebook,
-  openOrdersTable,
-  openPeopleTable,
-  openProductsTable,
-  openReviewsTable,
-  popover,
-  queryBuilderMain,
-  restore,
-  selectFilterOperator,
-  setupBooleanQuery,
-  summarize,
-  tableHeaderClick,
-  verifyNotebookQuery,
-  visitQuestionAdhoc,
-  visualize,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID, REVIEWS, REVIEWS_ID } =
   SAMPLE_DATABASE;
 
 describe("scenarios > question > filter", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should filter a joined table by 'Is not' filter (metabase#13534)", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
 
-    join();
-    joinTable("Products");
+    H.join();
+    H.joinTable("Products");
 
-    filter({ mode: "notebook" });
-    popover().within(() => {
+    H.filter({ mode: "notebook" });
+    H.popover().within(() => {
       cy.findByText("Products").click();
       cy.findByText("Category").click();
       cy.findByText("Is").click();
     });
     cy.findByRole("menu").findByText("Is not").click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Gizmo").click();
       cy.button("Add filter").click();
     });
-    getNotebookStep("filter")
+    H.getNotebookStep("filter")
       .findByText("Products → Category is not Gizmo")
       .should("be.visible");
 
-    visualize(response => {
+    H.visualize(response => {
       expect(response.body.error).to.not.exist;
     });
 
-    queryBuilderMain().within(() => {
+    H.queryBuilderMain().within(() => {
       cy.contains("37.65").should("exist");
       cy.findByText("3621077291879").should("not.exist"); // one of the "Gizmo" EANs
     });
@@ -127,10 +101,12 @@ describe("scenarios > question > filter", () => {
     });
 
     // Add filter as remapped Product ID (Product name)
-    openOrdersTable();
-    filter();
+    H.openOrdersTable();
+    H.filter();
 
-    filterFieldPopover("Product ID").contains("Aerodynamic Linen Coat").click();
+    H.filterFieldPopover("Product ID")
+      .contains("Aerodynamic Linen Coat")
+      .click();
 
     cy.findByTestId("apply-filters").click();
 
@@ -215,7 +191,7 @@ describe("scenarios > question > filter", () => {
   });
 
   it("should display original custom expression filter with dates on subsequent click (metabase#12492)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "query",
         query: {
@@ -239,7 +215,7 @@ describe("scenarios > question > filter", () => {
       .findByText("Created At is greater than Product → Created At")
       .click();
 
-    popover()
+    H.popover()
       .contains("[Created At] > [Product → Created At]")
       .should("be.visible");
   });
@@ -285,12 +261,12 @@ describe("scenarios > question > filter", () => {
   });
 
   it("should reject Enter when the filter expression is invalid", () => {
-    openReviewsTable({ mode: "notebook" });
-    filter({ mode: "notebook" });
+    H.openReviewsTable({ mode: "notebook" });
+    H.filter({ mode: "notebook" });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
 
-    enterCustomColumnDetails({ formula: "[Rating] > 2E{enter}" }); // there should numbers after 'E'
+    H.enterCustomColumnDetails({ formula: "[Rating] > 2E{enter}" }); // there should numbers after 'E'
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Missing exponent");
@@ -301,13 +277,13 @@ describe("scenarios > question > filter", () => {
   it("should offer case expression in the auto-complete suggestions", () => {
     openExpressionEditorFromFreshlyLoadedPage();
 
-    enterCustomColumnDetails({ formula: "c", blur: false });
-    popover().contains(/case/i);
+    H.enterCustomColumnDetails({ formula: "c", blur: false });
+    H.popover().contains(/case/i);
 
     cy.get("@formula").type("a");
 
     // "case" is still there after typing a bit
-    popover().contains(/case/i);
+    H.popover().contains(/case/i);
   });
 
   it("should enable highlighting suggestions with keyboard up and down arrows (metabase#16210)", () => {
@@ -315,7 +291,7 @@ describe("scenarios > question > filter", () => {
 
     openExpressionEditorFromFreshlyLoadedPage();
 
-    enterCustomColumnDetails({ formula: "c", blur: false });
+    H.enterCustomColumnDetails({ formula: "c", blur: false });
 
     cy.findAllByTestId("expression-suggestions-list-item")
       .filter(":contains('case')")
@@ -338,14 +314,14 @@ describe("scenarios > question > filter", () => {
   it("should highlight the correct matching for suggestions", () => {
     openExpressionEditorFromFreshlyLoadedPage();
 
-    enterCustomColumnDetails({ formula: "[", blur: false });
+    H.enterCustomColumnDetails({ formula: "[", blur: false });
 
-    popover().last().findByText("Body");
+    H.popover().last().findByText("Body");
 
     cy.get("@formula").type("p");
 
     // only "P" (of Products etc) should be highlighted, and not "Pr"
-    popover()
+    H.popover()
       .last()
       .within(() => {
         cy.findAllByText("P").should("have.length.above", 1);
@@ -369,19 +345,19 @@ describe("scenarios > question > filter", () => {
     cy.findByText("Filter").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
-    enterCustomColumnDetails({ formula: "su", blur: false });
-    popover().contains(/Sum of Total/i);
+    H.enterCustomColumnDetails({ formula: "su", blur: false });
+    H.popover().contains(/Sum of Total/i);
     cy.get("@formula").type("m");
-    popover().contains(/Sum of Total/i);
+    H.popover().contains(/Sum of Total/i);
   });
 
   it("should filter using IsNull() and IsEmpty()", () => {
-    openReviewsTable({ mode: "notebook" });
-    filter({ mode: "notebook" });
+    H.openReviewsTable({ mode: "notebook" });
+    H.filter({ mode: "notebook" });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
 
-    enterCustomColumnDetails({ formula: "NOT IsNull([Rating])" });
+    H.enterCustomColumnDetails({ formula: "NOT IsNull([Rating])" });
 
     cy.button("Done").should("not.be.disabled").click();
 
@@ -390,25 +366,25 @@ describe("scenarios > question > filter", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
 
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: "NOT IsEmpty([Reviewer])",
     });
 
     cy.button("Done").should("not.be.disabled").click();
 
     // check that filter is applied and rows displayed
-    visualize();
+    H.visualize();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Showing 1,112 rows");
   });
 
   it("should convert 'is empty' on a text column to a custom expression using IsEmpty()", () => {
-    openReviewsTable();
-    tableHeaderClick("Reviewer");
+    H.openReviewsTable();
+    H.tableHeaderClick("Reviewer");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter by this column").click();
-    selectFilterOperator("Is empty");
+    H.selectFilterOperator("Is empty");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add filter").click();
 
@@ -432,11 +408,11 @@ describe("scenarios > question > filter", () => {
   });
 
   it("should convert 'is empty' on a numeric column to a custom expression using IsNull()", () => {
-    openReviewsTable();
-    tableHeaderClick("Rating");
+    H.openReviewsTable();
+    H.tableHeaderClick("Rating");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter by this column").click();
-    selectFilterOperator("Is empty");
+    H.selectFilterOperator("Is empty");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add filter").click();
 
@@ -463,7 +439,7 @@ describe("scenarios > question > filter", () => {
   });
 
   it("should convert negative filter to custom expression (metabase#14880)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "query",
         query: {
@@ -490,7 +466,7 @@ describe("scenarios > question > filter", () => {
   });
 
   it("should convert negative filter to custom expression (metabase#14880)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "query",
         query: {
@@ -517,10 +493,10 @@ describe("scenarios > question > filter", () => {
   });
 
   it("should be able to convert time interval filter to custom expression (metabase#12457)", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
 
-    filter({ mode: "notebook" });
-    popover().within(() => {
+    H.filter({ mode: "notebook" });
+    H.popover().within(() => {
       cy.findByText("Created At").click();
       cy.findByText("Relative dates…").click();
       cy.findByText("Previous").click();
@@ -528,11 +504,11 @@ describe("scenarios > question > filter", () => {
       cy.button("Add filter").click();
     });
 
-    getNotebookStep("filter")
+    H.getNotebookStep("filter")
       .findByText("Created At is in the previous 30 days")
       .click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.button("Back").click();
       cy.button("Back").click();
       cy.findByText("Custom Expression").click();
@@ -540,17 +516,17 @@ describe("scenarios > question > filter", () => {
     });
 
     // Back to GUI and "Include today" should be still checked
-    getNotebookStep("filter")
+    H.getNotebookStep("filter")
       .findByText("Created At is in the previous 30 days")
       .click();
 
-    popover()
+    H.popover()
       .findByTestId("include-current-interval-option")
       .should("have.attr", "aria-checked", "true");
   });
 
   it("should be able to convert case-insensitive filter to custom expression (metabase#14959)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "query",
         query: {
@@ -585,12 +561,12 @@ describe("scenarios > question > filter", () => {
   });
 
   it("should reject a number literal", () => {
-    openProductsTable({ mode: "notebook" });
-    filter({ mode: "notebook" });
+    H.openProductsTable({ mode: "notebook" });
+    H.filter({ mode: "notebook" });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
 
-    enterCustomColumnDetails({ formula: "3.14159" });
+    H.enterCustomColumnDetails({ formula: "3.14159" });
 
     cy.button("Done").should("be.disabled");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -598,12 +574,12 @@ describe("scenarios > question > filter", () => {
   });
 
   it("should reject a string literal", () => {
-    openProductsTable({ mode: "notebook" });
-    filter({ mode: "notebook" });
+    H.openProductsTable({ mode: "notebook" });
+    H.filter({ mode: "notebook" });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
 
-    enterCustomColumnDetails({ formula: '"TheAnswer"' });
+    H.enterCustomColumnDetails({ formula: '"TheAnswer"' });
 
     cy.button("Done").should("be.disabled");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -611,7 +587,7 @@ describe("scenarios > question > filter", () => {
   });
 
   it.skip("column filters should work for metrics (metabase#15333)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "query",
         query: {
@@ -636,23 +612,23 @@ describe("scenarios > question > filter", () => {
   });
 
   it("custom expression filter should reference fields by their name, not by their id (metabase#15748)", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
 
-    filter({ mode: "notebook" });
-    popover().within(() => {
+    H.filter({ mode: "notebook" });
+    H.popover().within(() => {
       cy.findByText("Custom Expression").click();
-      enterCustomColumnDetails({ formula: "[Total] < [Subtotal]" });
+      H.enterCustomColumnDetails({ formula: "[Total] < [Subtotal]" });
       cy.button("Done").click();
     });
 
-    getNotebookStep("filter")
+    H.getNotebookStep("filter")
       .findByText("Total is less than Subtotal")
       .should("be.visible");
   });
 
   it("custom expression filter should allow the use of parentheses in combination with logical operators (metabase#15754)", () => {
-    openOrdersTable({ mode: "notebook" });
-    filter({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
+    H.filter({ mode: "notebook" });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
     cy.get(".ace_text-input")
@@ -668,8 +644,8 @@ describe("scenarios > question > filter", () => {
   it("custom expression filter should refuse to work with numeric value before an operator (metabase#15893)", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    openOrdersTable({ mode: "notebook" });
-    filter({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
+    H.filter({ mode: "notebook" });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
     cy.get(".ace_text-input").type("0 < [ID]").blur();
@@ -678,8 +654,8 @@ describe("scenarios > question > filter", () => {
   });
 
   it("should allow switching focus with Tab", () => {
-    openOrdersTable({ mode: "notebook" });
-    filter({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
+    H.filter({ mode: "notebook" });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
     cy.get(".ace_text-input").type("[Tax] > 0");
@@ -691,8 +667,8 @@ describe("scenarios > question > filter", () => {
   });
 
   it("should allow choosing a suggestion with Tab", () => {
-    openOrdersTable({ mode: "notebook" });
-    filter({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
+    H.filter({ mode: "notebook" });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
 
@@ -715,8 +691,8 @@ describe("scenarios > question > filter", () => {
   });
 
   it("should allow hiding the suggestion list with Escape", () => {
-    openOrdersTable({ mode: "notebook" });
-    filter({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
+    H.filter({ mode: "notebook" });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
 
@@ -734,7 +710,7 @@ describe("scenarios > question > filter", () => {
   });
 
   it("should work on twice summarized questions and preserve both summaries (metabase#15620)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         database: SAMPLE_DB_ID,
         type: "query",
@@ -754,14 +730,14 @@ describe("scenarios > question > filter", () => {
     });
 
     cy.findByTestId("scalar-value").contains("5.41");
-    filter();
+    H.filter();
 
-    filterField("Category").findByText("Gizmo").click();
+    H.filterField("Category").findByText("Gizmo").click();
 
     cy.findByTestId("apply-filters").click();
-    openNotebook();
+    H.openNotebook();
 
-    verifyNotebookQuery("Products", [
+    H.verifyNotebookQuery("Products", [
       {
         filters: ["Category is Gizmo"],
         aggregations: ["Count"],
@@ -775,16 +751,16 @@ describe("scenarios > question > filter", () => {
 
   it("user shouldn't need to scroll to add filter (metabase#14307)", () => {
     cy.viewport(1280, 720);
-    openPeopleTable({ mode: "notebook" });
-    filter({ mode: "notebook" });
-    popover().findByText("State").click({ force: true });
+    H.openPeopleTable({ mode: "notebook" });
+    H.filter({ mode: "notebook" });
+    H.popover().findByText("State").click({ force: true });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("AL").click();
     cy.button("Add filter").isVisibleInPopover();
   });
 
   it("should retain all data series after saving a question where custom expression formula is the first metric (metabase#15882)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         database: SAMPLE_DB_ID,
         query: {
@@ -812,7 +788,7 @@ describe("scenarios > question > filter", () => {
     });
 
     assertOnLegendLabels();
-    cartesianChartCircleWithColors(["#88BF4D", "#509EE3", "#A989C5"]);
+    H.cartesianChartCircleWithColors(["#88BF4D", "#509EE3", "#A989C5"]);
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
     cy.findByTestId("save-question-modal").within(modal => {
@@ -821,7 +797,7 @@ describe("scenarios > question > filter", () => {
     cy.button("Not now").click();
     assertOnLegendLabels();
 
-    cartesianChartCircleWithColors(["#88BF4D", "#509EE3", "#A989C5"]);
+    H.cartesianChartCircleWithColors(["#88BF4D", "#509EE3", "#A989C5"]);
 
     function assertOnLegendLabels() {
       cy.findAllByTestId("legend-item")
@@ -835,7 +811,7 @@ describe("scenarios > question > filter", () => {
     it("shouldn't display chosen category in a breadcrumb (metabase#16198-1)", () => {
       const chosenCategory = "Gizmo";
 
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           database: SAMPLE_DB_ID,
           query: {
@@ -857,8 +833,8 @@ describe("scenarios > question > filter", () => {
     });
 
     it("adding an ID filter shouldn't cause page error and page reload (metabase#16198-2)", () => {
-      openOrdersTable({ mode: "notebook" });
-      filter({ mode: "notebook" });
+      H.openOrdersTable({ mode: "notebook" });
+      H.filter({ mode: "notebook" });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Custom Expression").click();
       cy.get(".ace_text-input").type("[Total] < [Product → Price]").blur();
@@ -868,7 +844,7 @@ describe("scenarios > question > filter", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/^Total/);
       cy.icon("add").last().click();
-      popover().findByText(/^ID$/i).click();
+      H.popover().findByText(/^ID$/i).click();
       cy.findByPlaceholderText("Enter an ID").type("1");
       cy.button("Add filter").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -878,19 +854,19 @@ describe("scenarios > question > filter", () => {
     });
 
     it("removing first filter in a sequence shouldn't result in an empty page (metabase#16198-3)", () => {
-      openOrdersTable({ mode: "notebook" });
+      H.openOrdersTable({ mode: "notebook" });
 
-      filter({ mode: "notebook" });
-      popover().findByText("Total").click();
-      selectFilterOperator("Equal to");
-      popover().within(() => {
+      H.filter({ mode: "notebook" });
+      H.popover().findByText("Total").click();
+      H.selectFilterOperator("Equal to");
+      H.popover().within(() => {
         cy.findByPlaceholderText("Enter a number").type("123");
         cy.button("Add filter").click();
       });
 
-      getNotebookStep("filter").icon("add").click();
+      H.getNotebookStep("filter").icon("add").click();
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Custom Expression").click();
         cy.get(".ace_text-input").type("[Total] < [Product → Price]").blur();
         cy.button("Done").click();
@@ -898,7 +874,7 @@ describe("scenarios > question > filter", () => {
 
       // cy.findByText(/^Total/);
       cy.icon("add").last().click();
-      popover().findByText(/^ID$/i).click();
+      H.popover().findByText(/^ID$/i).click();
       cy.findByPlaceholderText("Enter an ID").type("1");
       cy.button("Add filter").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -907,7 +883,7 @@ describe("scenarios > question > filter", () => {
         .find(".Icon-close")
         .click();
 
-      visualize();
+      H.visualize();
     });
   });
 
@@ -917,14 +893,14 @@ describe("scenarios > question > filter", () => {
     const integerAssociatedWithCondition = condition === "True" ? "0" : "1";
 
     describe(`should be able to filter on the boolean column ${condition.toUpperCase()} (metabase#16386)`, () => {
-      beforeEach(setupBooleanQuery);
+      beforeEach(H.setupBooleanQuery);
 
       it("from the column popover (metabase#16386-1)", () => {
-        tableHeaderClick("boolean");
+        H.tableHeaderClick("boolean");
 
-        popover().findByText("Filter by this column").click();
+        H.popover().findByText("Filter by this column").click();
 
-        popover().within(() => {
+        H.popover().within(() => {
           // Not sure exactly what this popover will look like when this issue is fixed.
           // In one of the previous versions it said "Update filter" instead of "Add filter".
           // If that's the case after the fix, this part of the test might need to be updated accordingly.
@@ -939,33 +915,33 @@ describe("scenarios > question > filter", () => {
       });
 
       it("from the custom question (metabase#16386-3)", () => {
-        openNotebook();
+        H.openNotebook();
 
-        filter({ mode: "notebook" });
+        H.filter({ mode: "notebook" });
 
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findByText("boolean").click();
           addBooleanFilter();
         });
 
-        visualize(() => {
+        H.visualize(() => {
           assertOnTheResult();
         });
       });
 
       it("from custom expressions", () => {
-        openNotebook();
+        H.openNotebook();
 
-        filter({ mode: "notebook" });
+        H.filter({ mode: "notebook" });
 
-        popover().contains("Custom Expression").click();
-        expressionEditorWidget().within(() => {
-          enterCustomColumnDetails({ formula: `boolean = ${condition}` });
+        H.popover().contains("Custom Expression").click();
+        H.expressionEditorWidget().within(() => {
+          H.enterCustomColumnDetails({ formula: `boolean = ${condition}` });
 
           cy.button("Done").click();
         });
 
-        visualize(() => {
+        H.visualize(() => {
           assertOnTheResult();
         });
       });
@@ -990,41 +966,41 @@ describe("scenarios > question > filter", () => {
   });
 
   describe("should handle boolean arguments", () => {
-    beforeEach(setupBooleanQuery);
+    beforeEach(H.setupBooleanQuery);
 
     it("with case", () => {
-      openNotebook();
+      H.openNotebook();
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Custom column").click();
-      enterCustomColumnDetails({
+      H.enterCustomColumnDetails({
         formula: "Case(boolean, 45, -10)",
         name: "Test",
       });
 
       cy.button("Done").click();
 
-      filter({ mode: "notebook" });
+      H.filter({ mode: "notebook" });
 
-      popover().contains("Custom Expression").click();
-      expressionEditorWidget().within(() => {
-        enterCustomColumnDetails({ formula: "boolean = true" });
+      H.popover().contains("Custom Expression").click();
+      H.expressionEditorWidget().within(() => {
+        H.enterCustomColumnDetails({ formula: "boolean = true" });
 
         cy.button("Done").click();
       });
 
-      visualize(() => {
+      H.visualize(() => {
         cy.contains("45").should("exist");
         cy.contains("-10").should("not.exist");
       });
     });
 
     it("with CountIf", () => {
-      openNotebook();
-      summarize({ mode: "notebook" });
-      popover().contains("Custom Expression").click();
-      expressionEditorWidget().within(() => {
-        enterCustomColumnDetails({
+      H.openNotebook();
+      H.summarize({ mode: "notebook" });
+      H.popover().contains("Custom Expression").click();
+      H.expressionEditorWidget().within(() => {
+        H.enterCustomColumnDetails({
           formula: "CountIf(boolean)",
           name: "count if boolean is true",
         });
@@ -1033,7 +1009,7 @@ describe("scenarios > question > filter", () => {
       cy.findByTestId("aggregate-step")
         .contains("count if boolean is true")
         .should("exist");
-      visualize(() => {
+      H.visualize(() => {
         cy.contains("2").should("exist");
       });
     });
@@ -1041,21 +1017,21 @@ describe("scenarios > question > filter", () => {
 
   // TODO: fixme!
   it.skip("should render custom expression helper near the custom expression field", () => {
-    openReviewsTable({ mode: "notebook" });
-    filter({ mode: "notebook" });
+    H.openReviewsTable({ mode: "notebook" });
+    H.filter({ mode: "notebook" });
 
-    expressionEditorWidget().within(() => {
+    H.expressionEditorWidget().within(() => {
       cy.findByText("Custom Expression").click();
 
-      enterCustomColumnDetails({ formula: "floor" });
+      H.enterCustomColumnDetails({ formula: "floor" });
 
-      checkExpressionEditorHelperPopoverPosition();
+      H.checkExpressionEditorHelperPopoverPosition();
     });
   });
 });
 
 function openExpressionEditorFromFreshlyLoadedPage() {
-  openReviewsTable({ mode: "notebook" });
-  filter({ mode: "notebook" });
+  H.openReviewsTable({ mode: "notebook" });
+  H.filter({ mode: "notebook" });
   cy.findByText("Custom Expression").click();
 }

--- a/e2e/test/scenarios/filters/operators.cy.spec.js
+++ b/e2e/test/scenarios/filters/operators.cy.spec.js
@@ -1,11 +1,11 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { openTable, popover, restore } from "e2e/support/helpers";
 
 const { PRODUCTS_ID, PEOPLE_ID } = SAMPLE_DATABASE;
 
 describe("operators in questions", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
@@ -70,7 +70,7 @@ describe("operators in questions", () => {
     it("text operators", () => {
       setup(PRODUCTS_ID);
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Title").click();
         cy.findByText("Is").click();
       });
@@ -84,7 +84,7 @@ describe("operators in questions", () => {
     it("number operators", () => {
       setup(PRODUCTS_ID);
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Price").click();
         cy.findByText("Between").click();
       });
@@ -98,13 +98,13 @@ describe("operators in questions", () => {
     it("relative date operators", () => {
       setup(PRODUCTS_ID);
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Created At").click();
         cy.findByText("Relative dates…").click();
         cy.findByText("Previous").click();
       });
 
-      popover().within(() => {
+      H.popover().within(() => {
         expected.relativeDates.expected.map(e =>
           cy.contains(e).should("exist"),
         );
@@ -123,13 +123,13 @@ describe("operators in questions", () => {
     it("specific date operators", () => {
       setup(PRODUCTS_ID);
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Created At").click();
         cy.findByText("Specific dates…").click();
         cy.findByText("Between").click();
       });
 
-      popover().within(() => {
+      H.popover().within(() => {
         expected.specificDates.expected.map(e =>
           cy.contains(e).should("exist"),
         );
@@ -148,12 +148,12 @@ describe("operators in questions", () => {
     it("exclude date operators", () => {
       setup(PRODUCTS_ID);
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Created At").click();
         cy.findByText("Exclude…").click();
       });
 
-      popover().within(() => {
+      H.popover().within(() => {
         expected.excludeDates.expected.map(e => cy.contains(e).should("exist"));
         expected.relativeDates.expected.map(e =>
           cy.contains(e).should("not.exist"),
@@ -170,7 +170,7 @@ describe("operators in questions", () => {
     it("id operators", () => {
       setup(PRODUCTS_ID);
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("ID").click();
         cy.findByText("Is").click();
       });
@@ -184,7 +184,7 @@ describe("operators in questions", () => {
     it("geo operators", () => {
       setup(PEOPLE_ID);
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("State").click({ force: true });
         cy.findByText("Is").click();
       });
@@ -198,6 +198,6 @@ describe("operators in questions", () => {
 });
 
 function setup(tableId) {
-  openTable({ table: tableId, mode: "notebook" });
+  H.openTable({ table: tableId, mode: "notebook" });
   cy.findByRole("button", { name: "Filter" }).click();
 }

--- a/e2e/test/scenarios/filters/relative-datetime.cy.spec.js
+++ b/e2e/test/scenarios/filters/relative-datetime.cy.spec.js
@@ -1,12 +1,6 @@
 import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
 
-import {
-  openOrdersTable,
-  popover,
-  queryBuilderMain,
-  restore,
-  tableHeaderClick,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 const STARTING_FROM_UNITS = [
   "minutes",
@@ -22,7 +16,7 @@ describe("scenarios > question > relative-datetime", () => {
   const now = moment().utc();
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
@@ -61,11 +55,11 @@ describe("scenarios > question > relative-datetime", () => {
     );
 
     it("should not clobber filter when value is set to 1", () => {
-      openOrdersTable();
+      H.openOrdersTable();
 
-      tableHeaderClick("Created At");
+      H.tableHeaderClick("Created At");
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Filter by this column").click();
         cy.icon("chevronleft").should("not.exist");
         cy.findByText("Last 30 days").click();
@@ -82,7 +76,7 @@ describe("scenarios > question > relative-datetime", () => {
       addStartingFrom();
       setStartingFromValue(2);
 
-      popover().button("Update filter").should("be.enabled");
+      H.popover().button("Update filter").should("be.enabled");
     });
   });
 
@@ -94,17 +88,17 @@ describe("scenarios > question > relative-datetime", () => {
 
   describe("basic functionality", () => {
     it("starting from should contain units only equal or greater than the filter unit", () => {
-      openOrdersTable();
+      H.openOrdersTable();
 
-      tableHeaderClick("Created At");
-      popover().within(() => {
+      H.tableHeaderClick("Created At");
+      H.popover().within(() => {
         cy.findByText("Filter by this column").click();
         cy.findByText("Relative dates…").click();
       });
 
       addStartingFrom();
 
-      popover().findByLabelText("Starting from unit").click();
+      H.popover().findByLabelText("Starting from unit").click();
 
       assertOptions([
         "days ago",
@@ -115,16 +109,16 @@ describe("scenarios > question > relative-datetime", () => {
       ]);
 
       setRelativeDatetimeUnit("quarters");
-      popover().findByLabelText("Starting from unit").click();
+      H.popover().findByLabelText("Starting from unit").click();
 
       assertOptions(["quarters ago", "years ago"]);
     });
 
     it("should go back to shortcuts view", () => {
-      openOrdersTable();
+      H.openOrdersTable();
 
-      tableHeaderClick("Created At");
-      popover().within(() => {
+      H.tableHeaderClick("Created At");
+      H.popover().within(() => {
         cy.findByText("Filter by this column").click();
         cy.findByText("Specific dates…").click();
         cy.icon("chevronleft").first().click();
@@ -134,10 +128,10 @@ describe("scenarios > question > relative-datetime", () => {
     });
 
     it("current filters should work (metabase#21977)", () => {
-      openOrdersTable();
+      H.openOrdersTable();
 
-      tableHeaderClick("Created At");
-      popover().within(() => {
+      H.tableHeaderClick("Created At");
+      H.popover().within(() => {
         cy.findByText("Filter by this column").click();
         cy.findByText("Relative dates…").click();
         cy.findByText("Current").click();
@@ -145,7 +139,7 @@ describe("scenarios > question > relative-datetime", () => {
       });
       cy.wait("@dataset");
 
-      queryBuilderMain()
+      H.queryBuilderMain()
         .findByText("There was a problem with your question")
         .should("not.exist");
 
@@ -155,10 +149,10 @@ describe("scenarios > question > relative-datetime", () => {
     });
 
     it("Relative dates should default to past filter (metabase#22027)", () => {
-      openOrdersTable();
+      H.openOrdersTable();
 
-      tableHeaderClick("Created At");
-      popover().within(() => {
+      H.tableHeaderClick("Created At");
+      H.popover().within(() => {
         cy.findByText("Filter by this column").click();
         cy.findByText("Relative dates…").click();
         cy.findByText("Day").should("not.exist");
@@ -170,25 +164,25 @@ describe("scenarios > question > relative-datetime", () => {
     });
 
     it("should change the starting from units to match (metabase#22222)", () => {
-      openOrdersTable();
+      H.openOrdersTable();
 
       openCreatedAt("Previous");
       addStartingFrom();
       setRelativeDatetimeUnit("months");
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByDisplayValue("days ago").should("not.exist");
         cy.findByDisplayValue("months ago").should("exist");
       });
     });
 
     it("should allow changing values with starting from (metabase#22227)", () => {
-      openOrdersTable();
+      H.openOrdersTable();
 
       openCreatedAt("Previous");
       addStartingFrom();
       setRelativeDatetimeUnit("months");
       setRelativeDatetimeValue(1);
-      popover().button("Add filter").click();
+      H.popover().button("Add filter").click();
       cy.wait("@dataset");
 
       cy.findByTestId("qb-filters-panel")
@@ -197,7 +191,7 @@ describe("scenarios > question > relative-datetime", () => {
         )
         .click();
       setRelativeDatetimeValue(3);
-      popover().button("Update filter").click();
+      H.popover().button("Update filter").click();
       cy.wait("@dataset");
 
       cy.findByTestId("qb-filters-panel")
@@ -206,7 +200,7 @@ describe("scenarios > question > relative-datetime", () => {
         )
         .click();
       setStartingFromValue(30);
-      popover().button("Update filter").click();
+      H.popover().button("Update filter").click();
       cy.wait("@dataset");
 
       cy.findByTestId("qb-filters-panel")
@@ -217,11 +211,11 @@ describe("scenarios > question > relative-datetime", () => {
     });
 
     it("starting from option should set correct sign (metabase#22228)", () => {
-      openOrdersTable();
+      H.openOrdersTable();
 
       openCreatedAt("Next");
       addStartingFrom();
-      popover().button("Add filter").click();
+      H.popover().button("Add filter").click();
       cy.wait("@dataset");
 
       cy.findByTestId("qb-filters-panel").within(() => {
@@ -258,8 +252,8 @@ const nativeSQL = values => {
 };
 
 const openCreatedAt = tab => {
-  tableHeaderClick("Created At");
-  popover().within(() => {
+  H.tableHeaderClick("Created At");
+  H.popover().within(() => {
     cy.findByText("Filter by this column").click();
     cy.findByText("Relative dates…").click();
     tab && cy.findByText(tab).click();
@@ -267,7 +261,7 @@ const openCreatedAt = tab => {
 };
 
 const addStartingFrom = () => {
-  popover()
+  H.popover()
     .findByLabelText(/Starting from/)
     .click();
 };
@@ -295,10 +289,10 @@ const setStartingFromValue = value => {
 };
 
 const withStartingFrom = (dir, [num, unit], [startNum, startUnit]) => {
-  tableHeaderClick("testcol");
+  H.tableHeaderClick("testcol");
   cy.findByTextEnsureVisible("Filter by this column").click();
   cy.findByTextEnsureVisible("Relative dates…").click();
-  popover().within(() => {
+  H.popover().within(() => {
     cy.findByText(dir).click();
   });
   addStartingFrom();
@@ -310,6 +304,6 @@ const withStartingFrom = (dir, [num, unit], [startNum, startUnit]) => {
   setStartingFromUnit(startUnit + (dir === "Previous" ? " ago" : " from now"));
 
   cy.intercept("POST", "/api/dataset").as("dataset");
-  popover().within(() => cy.findByText("Add filter").click());
+  H.popover().within(() => cy.findByText("Add filter").click());
   cy.wait("@dataset");
 };

--- a/e2e/test/scenarios/filters/time-series-chrome.cy.spec.ts
+++ b/e2e/test/scenarios/filters/time-series-chrome.cy.spec.ts
@@ -1,18 +1,18 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { restore, visitQuestionAdhoc } from "e2e/support/helpers";
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 describe("time-series chrome filter widget", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   describe("smoke tests", () => {
     beforeEach(() => {
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           database: SAMPLE_DB_ID,
           query: {
@@ -135,7 +135,7 @@ describe("time-series chrome filter widget", () => {
 
   describe("'Include this' switch", () => {
     beforeEach(() => {
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           database: SAMPLE_DB_ID,
           query: {

--- a/e2e/test/scenarios/filters/view.cy.spec.js
+++ b/e2e/test/scenarios/filters/view.cy.spec.js
@@ -1,17 +1,11 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  addOrUpdateDashboardCard,
-  popover,
-  restore,
-  visitDashboard,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 const { PRODUCTS } = SAMPLE_DATABASE;
 
 describe("scenarios > question > view", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -59,7 +53,7 @@ describe("scenarios > question > view", () => {
 
       cy.get("@questionId").then(questionId => {
         cy.get("@dashboardId").then(dashboardId => {
-          addOrUpdateDashboardCard({
+          H.addOrUpdateDashboardCard({
             dashboard_id: dashboardId,
             card_id: questionId,
           });
@@ -68,10 +62,10 @@ describe("scenarios > question > view", () => {
     });
 
     it("should show filters by search for Vendor", () => {
-      visitQuestion("@questionId");
+      H.visitQuestion("@questionId");
 
       cy.findAllByText("VENDOR").first().click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByPlaceholderText("Search the list");
         cy.findByText("Search the list").should("not.exist");
       });
@@ -79,19 +73,19 @@ describe("scenarios > question > view", () => {
 
     it("should be able to filter Q by Category as no data user (from Q link) (metabase#12654)", () => {
       cy.signIn("nodata");
-      visitQuestion("@questionId");
+      H.visitQuestion("@questionId");
 
       // Filter by category and vendor
       // TODO: this should show values and allow searching
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("This question is written in SQL.");
       cy.findAllByText("VENDOR").first().click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByPlaceholderText("Enter some text").type("Balistreri-Muller");
         cy.findByText("Add filter").click();
       });
       cy.findAllByText("CATEGORY").first().click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByPlaceholderText("Enter some text").type("Widget");
         cy.findByText("Add filter").click();
       });
@@ -105,7 +99,7 @@ describe("scenarios > question > view", () => {
     it("should be able to filter Q by Vendor as user (from Dashboard) (metabase#12654)", () => {
       // Navigate to Q from Dashboard
       cy.signIn("nodata");
-      visitDashboard("@dashboardId");
+      H.visitDashboard("@dashboardId");
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Question").click();
@@ -115,7 +109,7 @@ describe("scenarios > question > view", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("This question is written in SQL.");
       cy.findAllByText("VENDOR").first().click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByPlaceholderText("Enter some text")
           .focus()
           .clear()
@@ -124,7 +118,7 @@ describe("scenarios > question > view", () => {
       });
       cy.findAllByTestId("run-button").first().click();
       cy.findAllByText("CATEGORY").first().click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByPlaceholderText("Enter some text")
           .click()
           .clear()

--- a/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
@@ -1,38 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  assertJoinValid,
-  assertQueryBuilderRowCount,
-  cartesianChartCircle,
-  chartPathWithFillColor,
-  createQuestion,
-  dashboardGrid,
-  echartsContainer,
-  enterCustomColumnDetails,
-  entityPickerModal,
-  entityPickerModalTab,
-  filter,
-  getDashboardCards,
-  getNotebookStep,
-  join,
-  modal,
-  newButton,
-  openNotebook,
-  openOrdersTable,
-  openProductsTable,
-  popover,
-  queryBuilderHeader,
-  queryBuilderMain,
-  restore,
-  saveQuestion,
-  selectSavedQuestionsToJoin,
-  startNewQuestion,
-  summarize,
-  tableInteractive,
-  visitDashboard,
-  visitQuestionAdhoc,
-  visualize,
-} from "e2e/support/helpers";
 
 const {
   ORDERS,
@@ -105,7 +73,7 @@ describe("issue 12928", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -116,15 +84,15 @@ describe("issue 12928", () => {
       idAlias: "joinedQuestionId",
     });
 
-    startNewQuestion();
-    selectSavedQuestionsToJoin(SOURCE_QUESTION_NAME, JOINED_QUESTION_NAME);
-    popover().findByText("Products → Category").click();
-    popover().findByText("Products → Category").click();
+    H.startNewQuestion();
+    H.selectSavedQuestionsToJoin(SOURCE_QUESTION_NAME, JOINED_QUESTION_NAME);
+    H.popover().findByText("Products → Category").click();
+    H.popover().findByText("Products → Category").click();
 
-    visualize();
+    H.visualize();
 
     cy.get("@joinedQuestionId").then(joinedQuestionId => {
-      assertJoinValid({
+      H.assertJoinValid({
         lhsTable: SOURCE_QUESTION_NAME,
         rhsTable: JOINED_QUESTION_NAME,
         lhsSampleColumn: "Products → Category",
@@ -132,7 +100,7 @@ describe("issue 12928", () => {
       });
     });
 
-    assertQueryBuilderRowCount(20);
+    H.assertQueryBuilderRowCount(20);
   });
 });
 
@@ -167,19 +135,19 @@ describe("issue 14793", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("GET", "/api/automagic-dashboards/adhoc/**").as("xray");
     cy.intercept("POST", "/api/dataset").as("postDataset");
   });
 
   it("x-rays should work on explicit joins when metric is for the joined table (metabase#14793)", () => {
-    visitQuestionAdhoc(QUESTION_DETAILS);
+    H.visitQuestionAdhoc(QUESTION_DETAILS);
 
-    cartesianChartCircle().eq(2).click({ force: true });
+    H.cartesianChartCircle().eq(2).click({ force: true });
 
-    popover().findByText("Automatic insights…").click();
-    popover().findByText("X-ray").click();
+    H.popover().findByText("Automatic insights…").click();
+    H.popover().findByText("X-ray").click();
 
     cy.wait("@xray").then(xhr => {
       for (let i = 0; i < XRAY_DATASETS; ++i) {
@@ -189,7 +157,7 @@ describe("issue 14793", () => {
       expect(xhr.response.body.cause).not.to.exist;
     });
 
-    dashboardGrid()
+    H.dashboardGrid()
       .findByText("How this metric is distributed across different numbers")
       .should("exist");
 
@@ -197,7 +165,7 @@ describe("issue 14793", () => {
       .findByText(/^A closer look at/)
       .should("be.visible");
 
-    getDashboardCards().should("have.length", 18);
+    H.getDashboardCards().should("have.length", 18);
   });
 });
 
@@ -205,31 +173,31 @@ describe("issue 15342", { tags: "@external" }, () => {
   const MYSQL_DB_NAME = "QA MySQL8";
 
   beforeEach(() => {
-    restore("mysql-8");
+    H.restore("mysql-8");
     cy.signInAsAdmin();
 
     cy.viewport(4000, 1200); // huge width required so three joined tables can fit
   });
 
   it("should correctly order joins for MySQL queries (metabase#15342)", () => {
-    startNewQuestion();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.startNewQuestion();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText(MYSQL_DB_NAME).click();
       cy.findByText("People").click();
     });
 
     cy.icon("join_left_outer").click();
-    entityPickerModal().findByText("Orders").click();
-    getNotebookStep("join").findByLabelText("Right column").click();
-    popover().findByText("Product ID").click();
+    H.entityPickerModal().findByText("Orders").click();
+    H.getNotebookStep("join").findByLabelText("Right column").click();
+    H.popover().findByText("Product ID").click();
 
     cy.icon("join_left_outer").last().click();
-    entityPickerModal().findByText("Products").click();
-    getNotebookStep("join").icon("join_left_outer").click();
-    popover().findByText("Inner join").click();
+    H.entityPickerModal().findByText("Products").click();
+    H.getNotebookStep("join").icon("join_left_outer").click();
+    H.popover().findByText("Inner join").click();
 
-    visualize();
+    H.visualize();
 
     cy.findByTestId("query-visualization-root").within(() => {
       cy.findByText("Email"); // from People table
@@ -243,7 +211,7 @@ describe("issue 15578", () => {
   const JOINED_QUESTION_NAME = "15578";
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dataset").as("dataset");
 
@@ -261,24 +229,24 @@ describe("issue 15578", () => {
   });
 
   it("joining on a question with remapped values should work (metabase#15578)", () => {
-    openProductsTable({ mode: "notebook" });
+    H.openProductsTable({ mode: "notebook" });
 
     cy.button("Join data").click();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Saved questions").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Saved questions").click();
       cy.findByText(JOINED_QUESTION_NAME).click();
     });
 
-    visualize();
+    H.visualize();
 
-    queryBuilderHeader()
+    H.queryBuilderHeader()
       .findByTestId("question-table-badges")
       .within(() => {
         cy.findByText("Products").should("be.visible");
         cy.findByText(JOINED_QUESTION_NAME).should("be.visible");
       });
 
-    queryBuilderMain().within(() => {
+    H.queryBuilderMain().within(() => {
       cy.findByText("Category").should("be.visible");
       cy.findByText(`${JOINED_QUESTION_NAME} → ID`).should("be.visible");
     });
@@ -288,27 +256,27 @@ describe("issue 15578", () => {
 describe("issue 17710", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should remove only invalid join clauses (metabase#17710)", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
 
     cy.button("Join data").click();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Products").click();
     });
 
-    getNotebookStep("join").icon("add").click();
+    H.getNotebookStep("join").icon("add").click();
 
     // Close the LHS column popover that opens automatically
-    getNotebookStep("join").parent().click();
+    H.getNotebookStep("join").parent().click();
 
-    visualize();
+    H.visualize();
 
-    openNotebook();
+    H.openNotebook();
 
     cy.findByTestId("step-join-0-0").within(() => {
       cy.findByText("ID");
@@ -333,25 +301,25 @@ describe("issue 17767", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should be able to do subsequent joins on question with the aggregation that uses implicit joins (metabase#17767)", () => {
     cy.createQuestion(questionDetails, { visitQuestion: true });
 
-    openNotebook();
+    H.openNotebook();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Join data").click();
 
     // Join "Previous results" with
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Reviews").click();
     });
 
-    visualize(response => {
+    H.visualize(response => {
       expect(response.body.error).to.not.exist;
     });
 
@@ -362,29 +330,29 @@ describe("issue 17767", () => {
 
 describe("issue 17968", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should show 'Previous results' instead of a table name for non-field dimensions (metabase#17968)", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
 
-    summarize({ mode: "notebook" });
-    popover().findByText("Count of rows").click();
+    H.summarize({ mode: "notebook" });
+    H.popover().findByText("Count of rows").click();
 
-    getNotebookStep("summarize")
+    H.getNotebookStep("summarize")
       .findByText("Pick a column to group by")
       .click();
-    popover().findByText("Created At").click();
+    H.popover().findByText("Created At").click();
 
     cy.findAllByTestId("action-buttons").last().button("Join data").click();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Products").click();
     });
-    popover().findByText("Count").click();
+    H.popover().findByText("Count").click();
 
-    getNotebookStep("join", { stage: 1 })
+    H.getNotebookStep("join", { stage: 1 })
       .findByLabelText("Left column")
       .findByText("Previous results");
   });
@@ -409,7 +377,7 @@ describe("issue 18502", () => {
 
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -419,15 +387,15 @@ describe("issue 18502", () => {
     cy.createQuestion(question1);
     cy.createQuestion(question2);
 
-    startNewQuestion();
-    selectSavedQuestionsToJoin("18502#1", "18502#2");
+    H.startNewQuestion();
+    H.selectSavedQuestionsToJoin("18502#1", "18502#2");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At: Month").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Birth Date: Month").click();
 
-    visualize(response => {
+    H.visualize(response => {
       expect(response.body.error).to.not.exist;
     });
 
@@ -479,7 +447,7 @@ describe("issue 18512", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -487,13 +455,13 @@ describe("issue 18512", () => {
     cy.createQuestion(question1);
     cy.createQuestion(question2);
 
-    startNewQuestion();
-    selectSavedQuestionsToJoin("18512#1", "18512#2");
+    H.startNewQuestion();
+    H.selectSavedQuestionsToJoin("18512#1", "18512#2");
 
-    popover().findByText("Products → Created At: Month").click();
-    popover().findByText("Products → Created At: Month").click();
+    H.popover().findByText("Products → Created At: Month").click();
+    H.popover().findByText("Products → Created At: Month").click();
 
-    visualize(response => {
+    H.visualize(response => {
       expect(response.body.error).to.not.exist;
     });
 
@@ -505,33 +473,33 @@ describe("issue 18512", () => {
 describe("issue 18589", () => {
   function joinTable(table) {
     cy.findByText("Join data").click();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText(table).click();
     });
   }
 
   function selectFromDropdown(option, clickOpts) {
-    popover().findByText(option).click(clickOpts);
+    H.popover().findByText(option).click(clickOpts);
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
   it("should not bin numeric fields in join condition by default (metabase#18589)", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
 
     joinTable("Reviews");
     selectFromDropdown("Quantity");
     selectFromDropdown("Rating");
 
-    summarize({ mode: "notebook" });
+    H.summarize({ mode: "notebook" });
     selectFromDropdown("Count of rows");
 
-    visualize();
+    H.visualize();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("2,860,368");
@@ -540,7 +508,7 @@ describe("issue 18589", () => {
 
 describe("issue 18630", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -603,7 +571,7 @@ describe("issue 18630", () => {
 describe("issue 18818", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -631,7 +599,7 @@ describe("issue 18818", () => {
       { visitQuestion: true },
     );
 
-    openNotebook();
+    H.openNotebook();
     cy.findAllByText("CC Rating");
   });
 });
@@ -664,27 +632,29 @@ describe("issue 20519", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestion(questionDetails, { visitQuestion: true });
-    openNotebook();
+    H.openNotebook();
   });
 
   // Tightly related issue: metabase#17767
   it("should allow subsequent joins and nested query after summarizing on the implicit joins (metabase#20519)", () => {
     cy.findAllByLabelText("Custom column").last().click();
 
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: "1 + 1",
       name: "Two",
     });
 
     cy.button("Done").click();
 
-    getNotebookStep("expression", { stage: 1 }).contains("Two").should("exist");
+    H.getNotebookStep("expression", { stage: 1 })
+      .contains("Two")
+      .should("exist");
 
-    visualize(response => {
+    H.visualize(response => {
       expect(response.body.error).not.to.exist;
     });
 
@@ -722,7 +692,7 @@ describe("issue 22859 - multiple levels of nesting", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestion(questionDetails, { wrapId: true, idAlias: "q1Id" });
@@ -777,13 +747,13 @@ describe("issue 22859 - multiple levels of nesting", () => {
   });
 
   it("third level of nesting with joins should result in proper column aliasing (metabase#22859-2)", () => {
-    startNewQuestion();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Saved questions").click();
+    H.startNewQuestion();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Saved questions").click();
       cy.findByText("22859-Q2").click();
     });
 
-    visualize();
+    H.visualize();
 
     getJoinedTableColumnHeader();
   });
@@ -808,21 +778,21 @@ describe("issue 23293", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.intercept("POST", "/api/card").as("saveQuestion");
   });
 
   it("should retain the filter when drilling through the dashboard card with implicitly added column (metabase#23293)", () => {
-    openOrdersTable();
+    H.openOrdersTable();
 
     cy.findByTestId("viz-settings-button").click();
     modifyColumn("Product ID", "remove");
     modifyColumn("Category", "add");
     cy.wait("@dataset");
 
-    queryBuilderHeader().button("Save").click();
+    H.queryBuilderHeader().button("Save").click();
     cy.findByTestId("save-question-modal").within(modal => {
       cy.findByText("Save").click();
     });
@@ -850,13 +820,13 @@ describe("issue 23293", () => {
 
       cy.createQuestionAndDashboard({ questionDetails }).then(
         ({ body: { dashboard_id } }) => {
-          visitDashboard(dashboard_id);
+          H.visitDashboard(dashboard_id);
         },
       );
 
       // Click on the first bar
-      chartPathWithFillColor("#509EE3").first().realClick();
-      popover()
+      H.chartPathWithFillColor("#509EE3").first().realClick();
+      H.popover()
         .findByText(/^See these/)
         .click();
 
@@ -881,7 +851,7 @@ describe("issue 27380", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -902,21 +872,21 @@ describe("issue 27380", () => {
     };
     cy.createQuestionAndDashboard({ questionDetails }).then(
       ({ body: { dashboard_id } }) => {
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       },
     );
 
     // Doesn't really matter which 'circle" we click on the graph
-    cartesianChartCircle().last().click();
+    H.cartesianChartCircle().last().click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("See this month by week").click();
     cy.wait("@dataset");
 
     // Graph should still exist
     // Checks the y-axis label
-    echartsContainer().findByText("Count");
+    H.echartsContainer().findByText("Count");
 
-    openNotebook();
+    H.openNotebook();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").should("not.exist");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -954,13 +924,13 @@ describe("issue 27873", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should show a group by column from the joined field in the summarize sidebar (metabase#27873)", () => {
-    visitQuestionAdhoc(questionDetails);
-    summarize();
+    H.visitQuestionAdhoc(questionDetails);
+    H.summarize();
 
     cy.findByTestId("aggregation-item").should("have.text", "Count");
     cy.findByTestId("pinned-dimensions")
@@ -971,7 +941,7 @@ describe("issue 27873", () => {
 
 describe("issue 29795", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -986,24 +956,24 @@ describe("issue 29795", () => {
       { loadMetadata: true },
     );
 
-    openOrdersTable({ mode: "notebook", limit: LIMIT });
+    H.openOrdersTable({ mode: "notebook", limit: LIMIT });
 
     cy.icon("join_left_outer").click();
 
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Saved questions").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Saved questions").click();
       cy.findByText(NATIVE_QUESTION).click();
     });
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByRole("option", { name: "ID" }).click();
     });
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByRole("option", { name: "USER_ID" }).click();
     });
 
-    visualize(() => {
+    H.visualize(() => {
       cy.findAllByText(/User ID/i).should("have.length", 2);
     });
   });
@@ -1035,19 +1005,19 @@ describe("issue 30743", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    visitQuestionAdhoc(query, { mode: "notebook" });
+    H.visitQuestionAdhoc(query, { mode: "notebook" });
   });
 
   it("should be possible to sort on the breakout column (metabase#30743)", () => {
     cy.findByLabelText("Sort").click();
-    popover().contains("Category").click();
+    H.popover().contains("Category").click();
 
-    visualize();
+    H.visualize();
     // Check bars count
-    chartPathWithFillColor("#509EE3").should("have.length", 4);
+    H.chartPathWithFillColor("#509EE3").should("have.length", 4);
   });
 });
 
@@ -1093,24 +1063,24 @@ describe("issue 31769", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestion({ name: "Q1", query: Q1 }).then(() => {
       cy.createQuestion({ name: "Q2", query: Q2 }).then(response => {
         cy.wrap(response.body.id).as("card_id_q2");
-        startNewQuestion();
+        H.startNewQuestion();
       });
     });
   });
 
   it("shouldn't drop joins using MLv2 format (metabase#31769)", () => {
-    selectSavedQuestionsToJoin("Q1", "Q2");
+    H.selectSavedQuestionsToJoin("Q1", "Q2");
 
-    popover().findByText("Products → Category").click();
-    popover().findByText("Category").click();
+    H.popover().findByText("Products → Category").click();
+    H.popover().findByText("Category").click();
 
-    visualize();
+    H.visualize();
 
     // Asserting there're two columns from Q1 and two columns from Q2
     cy.findAllByTestId("header-cell").should("have.length", 4);
@@ -1129,18 +1099,18 @@ describe("issue 31769", () => {
 
 describe("issue 39448", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should load joined table metadata for suggested join conditions (metabase#39448)", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
     cy.findByTestId("action-buttons").button("Join data").click();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Products").click();
     });
-    getNotebookStep("join").within(() => {
+    H.getNotebookStep("join").within(() => {
       cy.findByLabelText("Right table").should("have.text", "Products");
       cy.findByLabelText("Left column")
         .findByText("Product ID")
@@ -1154,7 +1124,7 @@ describe("issue 39448", () => {
 // See TODO inside this test when unskipping
 describe.skip("issue 27521", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
@@ -1162,65 +1132,65 @@ describe.skip("issue 27521", () => {
     cy.visit("/");
 
     cy.log("Create Q1");
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
 
-    getNotebookStep("data").button("Pick columns").click();
-    popover().findByText("Select none").click();
+    H.getNotebookStep("data").button("Pick columns").click();
+    H.popover().findByText("Select none").click();
 
-    join();
+    H.join();
 
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Orders").click();
     });
 
-    popover().findByText("ID").click();
-    popover().findByText("ID").click();
+    H.popover().findByText("ID").click();
+    H.popover().findByText("ID").click();
 
-    getNotebookStep("join", { stage: 0, index: 0 })
+    H.getNotebookStep("join", { stage: 0, index: 0 })
       .button("Pick columns")
       .click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Select none").click();
       cy.findByText("ID").click();
     });
 
-    visualize();
+    H.visualize();
     assertTableHeader(0, "ID");
     assertTableHeader(1, "Orders → ID");
 
-    saveQuestion("Q1");
+    H.saveQuestion("Q1");
 
     assertTableHeader(0, "ID");
     assertTableHeader(1, "Orders → ID");
 
     cy.log("Create second question (Products + Q1)");
-    newButton("Question").click();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.newButton("Question").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("People").click();
     });
 
-    getNotebookStep("data").button("Pick columns").click();
-    popover().findByText("Select none").click();
+    H.getNotebookStep("data").button("Pick columns").click();
+    H.popover().findByText("Select none").click();
 
-    join();
+    H.join();
 
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Saved questions").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Saved questions").click();
       cy.findByText("Q1").click();
     });
 
-    popover().findByText("ID").click();
-    popover().findByText("Orders → ID").should("be.visible").click();
-    getNotebookStep("join")
+    H.popover().findByText("ID").click();
+    H.popover().findByText("Orders → ID").should("be.visible").click();
+    H.getNotebookStep("join")
       .findByLabelText("Right column")
       .findByText("Orders → ID")
       .should("be.visible")
       .click();
-    popover().findByText("ID").should("be.visible").click();
+    H.popover().findByText("ID").should("be.visible").click();
 
-    visualize();
+    H.visualize();
 
     assertTableHeader(0, "ID");
     assertTableHeader(1, "Q1 → ID");
@@ -1248,25 +1218,25 @@ describe.skip("issue 27521", () => {
 
 describe("issue 42385", { tags: "@external" }, () => {
   beforeEach(() => {
-    restore("postgres-12");
+    H.restore("postgres-12");
     cy.signInAsAdmin();
   });
 
   it("should remove invalid draft join clause when query database changes (metabase#42385)", () => {
-    openOrdersTable({ mode: "notebook" });
-    join();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.openOrdersTable({ mode: "notebook" });
+    H.join();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Reviews").click();
     });
 
-    getNotebookStep("data").findByTestId("data-step-cell").click();
-    entityPickerModal().within(() => {
+    H.getNotebookStep("data").findByTestId("data-step-cell").click();
+    H.entityPickerModal().within(() => {
       cy.findByText("QA Postgres12").click();
       cy.findByText("Reviews").click();
     });
 
-    getNotebookStep("join").within(() => {
+    H.getNotebookStep("join").within(() => {
       cy.findByLabelText("Right table")
         .findByText("Pick data…")
         .should("be.visible");
@@ -1276,38 +1246,38 @@ describe("issue 42385", { tags: "@external" }, () => {
   });
 
   it("should remove invalid join clause in incomplete draft state when query database changes (metabase#42385)", () => {
-    openOrdersTable({ mode: "notebook" });
-    join();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.openOrdersTable({ mode: "notebook" });
+    H.join();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Products").click();
     });
 
-    getNotebookStep("join")
+    H.getNotebookStep("join")
       .findByLabelText("Right table")
       .findByText("Products")
       .click();
 
-    entityPickerModal().findByText("Reviews").click();
+    H.entityPickerModal().findByText("Reviews").click();
 
-    getNotebookStep("data").findByTestId("data-step-cell").click();
-    entityPickerModal().within(() => {
+    H.getNotebookStep("data").findByTestId("data-step-cell").click();
+    H.entityPickerModal().within(() => {
       cy.findByText("QA Postgres12").click();
       cy.findByText("Reviews").click();
     });
 
-    getNotebookStep("join").should("not.exist");
+    H.getNotebookStep("join").should("not.exist");
   });
 });
 
 describe("issue 45300", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("joins using the foreign key only should not break the filter modal (metabase#45300)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         database: SAMPLE_DB_ID,
         type: "query",
@@ -1338,9 +1308,9 @@ describe("issue 45300", () => {
       },
     });
 
-    filter();
+    H.filter();
 
-    modal().within(() => {
+    H.modal().within(() => {
       // sidebar
       cy.findByRole("tablist").within(() => {
         cy.findAllByRole("tab", { name: "Product" }).eq(0).click();
@@ -1372,57 +1342,57 @@ describe("issue 46675", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
 
     cy.log("create draft state with a rhs table and a lhs column");
-    createQuestion(questionDetails, { visitQuestion: true });
-    openNotebook();
-    getNotebookStep("data").findByLabelText("Join data").click();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.createQuestion(questionDetails, { visitQuestion: true });
+    H.openNotebook();
+    H.getNotebookStep("data").findByLabelText("Join data").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Reviews").click();
     });
-    popover().findByText("ID").click();
+    H.popover().findByText("ID").click();
   });
 
   it("should reset the draft join state when the source table changes (metabase#46675)", () => {
     cy.log("change the source table and verify that the state was reset");
-    getNotebookStep("data").findByText("Orders").click();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.getNotebookStep("data").findByText("Orders").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Products").click();
     });
-    getNotebookStep("join").within(() => {
+    H.getNotebookStep("join").within(() => {
       cy.findByLabelText("Left table").should("have.text", "Products");
       cy.findByLabelText("Right table").should("have.text", "Pick data…");
       cy.findByLabelText("Left column").should("not.exist");
     });
 
     cy.log("complete the join and make sure the query can be executed");
-    getNotebookStep("join")
+    H.getNotebookStep("join")
       .findByLabelText("Right table")
       .findByText("Pick data…")
       .click();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Orders").click();
     });
-    visualize();
-    tableInteractive().should("be.visible");
+    H.visualize();
+    H.tableInteractive().should("be.visible");
   });
 
   it("should reset the draft join state when the source table changes (metabase#46675)", () => {
     cy.log("change the rhs table and verify that the state was reset");
-    getNotebookStep("join")
+    H.getNotebookStep("join")
       .findByLabelText("Right table")
       .findByText("Reviews")
       .click();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Orders").click();
     });
-    getNotebookStep("join").within(() => {
+    H.getNotebookStep("join").within(() => {
       cy.findByLabelText("Left table").should("have.text", "Orders");
       cy.findByLabelText("Right table").should("have.text", "Orders");
       cy.findByLabelText("Left column").should(
@@ -1432,9 +1402,9 @@ describe("issue 46675", () => {
     });
 
     cy.log("complete the join and make sure the query can be executed");
-    popover().findByText("ID").click();
-    popover().findByText("ID").click();
-    visualize();
-    tableInteractive().should("be.visible");
+    H.popover().findByText("ID").click();
+    H.popover().findByText("ID").click();
+    H.visualize();
+    H.tableInteractive().should("be.visible");
   });
 });

--- a/e2e/test/scenarios/joins/joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins.cy.spec.js
@@ -1,106 +1,82 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  addCustomColumn,
-  addSummaryField,
-  addSummaryGroupingField,
-  assertJoinValid,
-  assertQueryBuilderRowCount,
-  enterCustomColumnDetails,
-  entityPickerModal,
-  filter,
-  getNotebookStep,
-  join,
-  joinTable,
-  openNotebook,
-  openOrdersTable,
-  popover,
-  queryBuilderMain,
-  restore,
-  saveQuestion,
-  selectFilterOperator,
-  selectSavedQuestionsToJoin,
-  startNewQuestion,
-  summarize,
-  visitQuestionAdhoc,
-  visualize,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > question > joined questions", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should join raw tables (metabase#11452, metabase#12221, metabase#13468, metabase#15570)", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
 
-    join();
-    joinTable("Reviews", "Product ID", "Product ID");
+    H.join();
+    H.joinTable("Reviews", "Product ID", "Product ID");
 
-    visualize();
-    assertJoinValid({
+    H.visualize();
+    H.assertJoinValid({
       lhsTable: "Orders",
       rhsTable: "Reviews",
       lhsSampleColumn: "Product ID",
       rhsSampleColumn: "Reviews - Product → ID",
     });
 
-    openNotebook();
-    getNotebookStep("join").icon("chevrondown").click();
-    popover().within(() => {
+    H.openNotebook();
+    H.getNotebookStep("join").icon("chevrondown").click();
+    H.popover().within(() => {
       cy.findByText("Product ID").click();
       cy.findByText("Body").click();
       cy.findByText("Created At").click();
     });
-    visualize();
+    H.visualize();
 
-    assertJoinValid({
+    H.assertJoinValid({
       lhsTable: "Orders",
       rhsTable: "Reviews",
       lhsSampleColumn: "Product ID",
       rhsSampleColumn: "Reviews - Product → Reviewer",
     });
-    queryBuilderMain().findByText("Body").should("not.exist");
+    H.queryBuilderMain().findByText("Body").should("not.exist");
 
     // Post-join filters on the joined table (metabase#12221, metabase#15570)
-    openNotebook();
-    filter({ mode: "notebook" });
-    popover().within(() => {
+    H.openNotebook();
+    H.filter({ mode: "notebook" });
+    H.popover().within(() => {
       cy.findByText("Reviews").click();
       cy.findByText("Rating").click();
     });
-    selectFilterOperator("Equal to");
-    popover().within(() => {
+    H.selectFilterOperator("Equal to");
+    H.popover().within(() => {
       cy.findByLabelText("2").click();
       cy.button("Add filter").click();
     });
 
     // Post-join aggregation (metabase#11452):
-    summarize({ mode: "notebook" });
-    addSummaryField({
+    H.summarize({ mode: "notebook" });
+    H.addSummaryField({
       metric: "Average of ...",
       table: "Reviews",
       field: "Rating",
     });
-    addSummaryGroupingField({ table: "Reviews", field: "Reviewer" });
+    H.addSummaryGroupingField({ table: "Reviews", field: "Reviewer" });
 
-    visualize();
+    H.visualize();
 
     cy.findByTestId("qb-filters-panel").findByText(
       "Reviews - Product → Rating is equal to 2",
     );
-    assertQueryBuilderRowCount(89);
+    H.assertQueryBuilderRowCount(89);
 
     // Make sure UI overlay doesn't obstruct viewing results after we save this question (metabase#13468)
-    saveQuestion();
+    H.saveQuestion();
 
     cy.findByTestId("qb-filters-panel").findByText(
       "Reviews - Product → Rating is equal to 2",
     );
-    assertQueryBuilderRowCount(89);
+    H.assertQueryBuilderRowCount(89);
   });
 
   it("should join a native question (metabase#37100)", () => {
@@ -114,56 +90,56 @@ describe("scenarios > question > joined questions", () => {
       native: { query: "select * from products" },
     });
 
-    startNewQuestion();
-    selectSavedQuestionsToJoin("question a", "question b");
-    popover().findByText("PRODUCT_ID").click();
-    popover().findByText("ID").click();
+    H.startNewQuestion();
+    H.selectSavedQuestionsToJoin("question a", "question b");
+    H.popover().findByText("PRODUCT_ID").click();
+    H.popover().findByText("ID").click();
 
-    visualize();
+    H.visualize();
 
-    assertJoinValid({
+    H.assertJoinValid({
       lhsTable: "question a",
       rhsTable: "question b",
       lhsSampleColumn: "TOTAL",
       rhsSampleColumn: "question b - PRODUCT_ID → ID",
     });
 
-    openNotebook();
-    getNotebookStep("join").icon("chevrondown").click();
-    popover().within(() => {
+    H.openNotebook();
+    H.getNotebookStep("join").icon("chevrondown").click();
+    H.popover().within(() => {
       cy.findByText("EAN").click();
       cy.findByText("VENDOR").click();
       cy.findByText("PRICE").click();
       cy.findByText("CATEGORY").click();
       cy.findByText("CREATED_AT").click();
     });
-    visualize();
-    assertJoinValid({
+    H.visualize();
+    H.assertJoinValid({
       lhsTable: "question a",
       rhsTable: "question b",
       lhsSampleColumn: "TOTAL",
       rhsSampleColumn: "question b - PRODUCT_ID → Rating",
     });
-    queryBuilderMain().findByText("EAN").should("not.exist");
+    H.queryBuilderMain().findByText("EAN").should("not.exist");
 
-    openNotebook();
-    filter({ mode: "notebook" });
-    popover().within(() => {
+    H.openNotebook();
+    H.filter({ mode: "notebook" });
+    H.popover().within(() => {
       cy.findByText("question b").click();
       cy.findByText("CATEGORY").click();
     });
-    selectFilterOperator("Is");
-    popover().within(() => {
+    H.selectFilterOperator("Is");
+    H.popover().within(() => {
       cy.findByPlaceholderText("Enter some text").type("Gadget");
       cy.button("Add filter").click();
     });
 
-    summarize({ mode: "notebook" });
-    addSummaryGroupingField({
+    H.summarize({ mode: "notebook" });
+    H.addSummaryGroupingField({
       table: "question b",
       field: "CATEGORY",
     });
-    visualize();
+    H.visualize();
 
     cy.findByTestId("qb-filters-panel")
       .findByText("question b - PRODUCT_ID → Category is Gadget")
@@ -196,50 +172,50 @@ describe("scenarios > question > joined questions", () => {
       },
     });
 
-    startNewQuestion();
-    selectSavedQuestionsToJoin("Q1", "Q2");
-    visualize();
+    H.startNewQuestion();
+    H.selectSavedQuestionsToJoin("Q1", "Q2");
+    H.visualize();
 
-    assertJoinValid({
+    H.assertJoinValid({
       lhsTable: "Q1",
       rhsTable: "Q2",
       lhsSampleColumn: "Product ID",
       rhsSampleColumn: "Q2 - Product → ID",
     });
 
-    openNotebook();
-    getNotebookStep("join").icon("chevrondown").click();
-    popover().findByText("ID").click();
-    visualize();
+    H.openNotebook();
+    H.getNotebookStep("join").icon("chevrondown").click();
+    H.popover().findByText("ID").click();
+    H.visualize();
 
-    assertJoinValid({
+    H.assertJoinValid({
       lhsTable: "Q1",
       rhsTable: "Q2",
       lhsSampleColumn: "Product ID",
       rhsSampleColumn: "Q2 - Product → Sum of Total",
     });
-    queryBuilderMain().findByText("Q2 → ID").should("not.exist");
+    H.queryBuilderMain().findByText("Q2 → ID").should("not.exist");
 
-    openNotebook();
+    H.openNotebook();
     // add a custom column on top of the steps from the #13000 repro which was simply asserting
     // that a question could be made by joining two previously saved questions
-    addCustomColumn();
-    enterCustomColumnDetails({
+    H.addCustomColumn();
+    H.enterCustomColumnDetails({
       formula: "[Q2 - Product → Sum of Rating] / [Sum of Total]",
       name: "Sum Divide",
     });
-    popover().button("Done").click();
+    H.popover().button("Done").click();
 
-    filter({ mode: "notebook" });
-    popover().within(() => {
+    H.filter({ mode: "notebook" });
+    H.popover().within(() => {
       cy.findByText("Q2").click();
       cy.findByText("ID").click();
       cy.findByPlaceholderText("Enter an ID").type("12");
       cy.button("Add filter").click();
     });
 
-    visualize();
-    queryBuilderMain().findByText("Sum Divide");
+    H.visualize();
+    H.queryBuilderMain().findByText("Sum Divide");
 
     cy.findByTestId("qb-filters-panel")
       .findByText("Q2 - Product → ID is 12")
@@ -247,64 +223,64 @@ describe("scenarios > question > joined questions", () => {
   });
 
   it("should handle joins on different stages", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
 
-    join();
-    joinTable("Products");
+    H.join();
+    H.joinTable("Products");
 
-    summarize({ mode: "notebook" });
-    addSummaryField({ metric: "Count of rows" });
-    addSummaryGroupingField({ table: "Products", field: "ID" });
+    H.summarize({ mode: "notebook" });
+    H.addSummaryField({ metric: "Count of rows" });
+    H.addSummaryGroupingField({ table: "Products", field: "ID" });
 
     cy.findAllByTestId("action-buttons").last().button("Join data").click();
-    joinTable("Reviews");
-    visualize();
+    H.joinTable("Reviews");
+    H.visualize();
 
-    assertJoinValid({
+    H.assertJoinValid({
       lhsSampleColumn: "Count",
       rhsSampleColumn: "Reviews → ID",
     });
-    assertQueryBuilderRowCount(1136);
+    H.assertQueryBuilderRowCount(1136);
   });
 
   it("should allow joins with multiple conditions", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
 
-    join();
-    joinTable("Products");
+    H.join();
+    H.joinTable("Products");
     selectJoinStrategy("Inner join");
 
-    getNotebookStep("join").icon("add").click();
-    popover().findByText("Created At").click();
-    popover().findByText("Created At").click();
+    H.getNotebookStep("join").icon("add").click();
+    H.popover().findByText("Created At").click();
+    H.popover().findByText("Created At").click();
 
-    visualize();
+    H.visualize();
 
-    assertJoinValid({
+    H.assertJoinValid({
       lhsTable: "Orders",
       rhsTable: "Products",
       lhsSampleColumn: "Product ID",
       rhsSampleColumn: "Products → ID",
     });
-    assertQueryBuilderRowCount(415);
+    H.assertQueryBuilderRowCount(415);
   });
 
   it("should sync join condition's date-time column units", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
 
-    join();
-    joinTable("Products");
+    H.join();
+    H.joinTable("Products");
     selectJoinStrategy("Inner join");
 
     // Test LHS column infers RHS column's temporal unit
 
     cy.findByLabelText("Left column").click();
-    popover().findByText("Created At").click();
+    H.popover().findByText("Created At").click();
 
     cy.findByLabelText("Right column").click();
-    popover().findByText("by month").click({ force: true });
-    popover().last().findByText("Week").click();
+    H.popover().findByText("by month").click({ force: true });
+    H.popover().last().findByText("Week").click();
 
     assertJoinColumnName("left", "Created At: Week");
     assertJoinColumnName("right", "Created At: Week");
@@ -312,22 +288,22 @@ describe("scenarios > question > joined questions", () => {
     // Test changing a temporal unit on one column would update a second one
 
     cy.findByLabelText("Right column").click();
-    popover().findByText("by week").click({ force: true });
-    popover().last().findByText("Day").click();
+    H.popover().findByText("by week").click({ force: true });
+    H.popover().last().findByText("Day").click();
 
     assertJoinColumnName("left", "Created At: Day");
     assertJoinColumnName("right", "Created At: Day");
 
-    summarize({ mode: "notebook" });
-    addSummaryField({ metric: "Count of rows" });
+    H.summarize({ mode: "notebook" });
+    H.addSummaryField({ metric: "Count of rows" });
 
-    visualize();
+    H.visualize();
 
     cy.findByTestId("scalar-value").contains("2,087");
   });
 
   it("should remove a join when changing the source table", () => {
-    visitQuestionAdhoc(
+    H.visitQuestionAdhoc(
       {
         dataset_query: {
           type: "query",
@@ -352,13 +328,13 @@ describe("scenarios > question > joined questions", () => {
       { mode: "notebook" },
     );
 
-    getNotebookStep("data").findByTestId("data-step-cell").click();
-    entityPickerModal().findByText("People").click();
+    H.getNotebookStep("data").findByTestId("data-step-cell").click();
+    H.entityPickerModal().findByText("People").click();
 
-    getNotebookStep("join").should("not.exist");
+    H.getNotebookStep("join").should("not.exist");
 
-    visualize();
-    queryBuilderMain()
+    H.visualize();
+    H.queryBuilderMain()
       .findAllByText(/Product/)
       .should("have.length", 0);
   });
@@ -366,7 +342,7 @@ describe("scenarios > question > joined questions", () => {
 
 function selectJoinStrategy(strategy) {
   cy.findByLabelText("Change join type").click();
-  popover().findByText(strategy).click();
+  H.popover().findByText(strategy).click();
 }
 
 function assertJoinColumnName(side, name) {

--- a/e2e/test/scenarios/metrics/browse.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/browse.cy.spec.ts
@@ -1,25 +1,13 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   FIRST_COLLECTION_ID,
   ORDERS_MODEL_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  type StructuredQuestionDetails,
-  assertIsEllipsified,
-  createQuestion,
-  describeEE,
-  getSidebarSectionTitle,
-  main,
-  navigationSidebar,
-  openNavigationSidebar,
-  popover,
-  restore,
-  setTokenFeatures,
-} from "e2e/support/helpers";
 
 const { ORDERS_ID, ORDERS, PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
-type StructuredQuestionDetailsWithName = StructuredQuestionDetails & {
+type StructuredQuestionDetailsWithName = H.StructuredQuestionDetails & {
   name: string;
 };
 
@@ -98,7 +86,7 @@ const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
 describe("scenarios > browse > metrics", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
@@ -106,12 +94,12 @@ describe("scenarios > browse > metrics", () => {
   describe("no metrics", () => {
     it("should not hide the browse metrics link in the sidebar", () => {
       cy.visit("/");
-      navigationSidebar().findByText("Metrics").should("be.visible");
+      H.navigationSidebar().findByText("Metrics").should("be.visible");
     });
 
     it("should show the empty metrics page", () => {
       cy.visit("/browse/metrics");
-      main().within(() => {
+      H.main().within(() => {
         cy.findByText(
           "Create Metrics to define the official way to calculate important numbers for your team",
         ).should("be.visible");
@@ -123,7 +111,7 @@ describe("scenarios > browse > metrics", () => {
     it("should not show the create metric button if the user does not have data access", () => {
       cy.signInAsSandboxedUser();
       cy.visit("/browse/metrics");
-      main().within(() => {
+      H.main().within(() => {
         cy.findByText(
           "Create Metrics to define the official way to calculate important numbers for your team",
         ).should("be.visible");
@@ -136,7 +124,7 @@ describe("scenarios > browse > metrics", () => {
     it("can browse metrics", () => {
       createMetrics(ALL_METRICS);
       cy.visit("/browse/metrics");
-      navigationSidebar().findByText("Metrics").should("be.visible");
+      H.navigationSidebar().findByText("Metrics").should("be.visible");
 
       ALL_METRICS.forEach(metric => {
         findMetric(metric.name).should("be.visible");
@@ -202,7 +190,7 @@ describe("scenarios > browse > metrics", () => {
       metricsTable()
         .findByText(/This is a/)
         .should("be.visible")
-        .then(el => assertIsEllipsified(el[0]));
+        .then(el => H.assertIsEllipsified(el[0]));
 
       metricsTable()
         .findByText(/This is a/)
@@ -252,12 +240,12 @@ describe("scenarios > browse > metrics", () => {
       shouldNotHaveBookmark(ORDERS_SCALAR_METRIC.name);
 
       metricsTable().findByLabelText("Metric options").click();
-      popover().findByText("Bookmark").should("be.visible").click();
+      H.popover().findByText("Bookmark").should("be.visible").click();
 
       shouldHaveBookmark(ORDERS_SCALAR_METRIC.name);
 
       metricsTable().findByLabelText("Metric options").click();
-      popover()
+      H.popover()
         .findByText("Remove from bookmarks")
         .should("be.visible")
         .click();
@@ -265,7 +253,7 @@ describe("scenarios > browse > metrics", () => {
       shouldNotHaveBookmark(ORDERS_SCALAR_METRIC.name);
 
       metricsTable().findByLabelText("Metric options").click();
-      popover().findByText("Bookmark").should("be.visible");
+      H.popover().findByText("Bookmark").should("be.visible");
     });
 
     it("should be possible to navigate to the collection from the dot menu", () => {
@@ -274,7 +262,7 @@ describe("scenarios > browse > metrics", () => {
       cy.visit("/browse/metrics");
 
       metricsTable().findByLabelText("Metric options").click();
-      popover().findByText("Open collection").should("be.visible").click();
+      H.popover().findByText("Open collection").should("be.visible").click();
 
       cy.location("pathname").should(
         "match",
@@ -288,19 +276,19 @@ describe("scenarios > browse > metrics", () => {
       cy.visit("/browse/metrics");
 
       metricsTable().findByLabelText("Metric options").click();
-      popover().findByText("Move to trash").should("be.visible").click();
+      H.popover().findByText("Move to trash").should("be.visible").click();
 
-      main()
+      H.main()
         .findByText(
           "Create Metrics to define the official way to calculate important numbers for your team",
         )
         .should("be.visible");
 
-      navigationSidebar().findByText("Trash").should("be.visible").click();
+      H.navigationSidebar().findByText("Trash").should("be.visible").click();
       cy.button("Actions").click();
-      popover().findByText("Restore").should("be.visible").click();
+      H.popover().findByText("Restore").should("be.visible").click();
 
-      navigationSidebar().findByText("Metrics").should("be.visible").click();
+      H.navigationSidebar().findByText("Metrics").should("be.visible").click();
       metricsTable().findByText(ORDERS_SCALAR_METRIC.name).should("be.visible");
     });
 
@@ -312,7 +300,7 @@ describe("scenarios > browse > metrics", () => {
         cy.visit("/browse/metrics");
 
         metricsTable().findByLabelText("Metric options").click();
-        popover().findByText("Move to trash").should("not.exist");
+        H.popover().findByText("Move to trash").should("not.exist");
       });
 
       it("should be possible to navigate to the collection from the dot menu", () => {
@@ -322,7 +310,7 @@ describe("scenarios > browse > metrics", () => {
         cy.visit("/browse/metrics");
 
         metricsTable().findByLabelText("Metric options").click();
-        popover().findByText("Open collection").should("be.visible").click();
+        H.popover().findByText("Open collection").should("be.visible").click();
 
         cy.location("pathname").should("eq", "/collection/root");
       });
@@ -336,12 +324,12 @@ describe("scenarios > browse > metrics", () => {
         shouldNotHaveBookmark(ORDERS_SCALAR_METRIC.name);
 
         metricsTable().findByLabelText("Metric options").click();
-        popover().findByText("Bookmark").should("be.visible").click();
+        H.popover().findByText("Bookmark").should("be.visible").click();
 
         shouldHaveBookmark(ORDERS_SCALAR_METRIC.name);
 
         metricsTable().findByLabelText("Metric options").click();
-        popover()
+        H.popover()
           .findByText("Remove from bookmarks")
           .should("be.visible")
           .click();
@@ -349,16 +337,16 @@ describe("scenarios > browse > metrics", () => {
         shouldNotHaveBookmark(ORDERS_SCALAR_METRIC.name);
 
         metricsTable().findByLabelText("Metric options").click();
-        popover().findByText("Bookmark").should("be.visible");
+        H.popover().findByText("Bookmark").should("be.visible");
       });
     });
   });
 
   describe("verified metrics", () => {
-    describeEE("on enterprise", () => {
+    H.describeEE("on enterprise", () => {
       beforeEach(() => {
         cy.signInAsAdmin();
-        setTokenFeatures("all");
+        H.setTokenFeatures("all");
       });
 
       it("should not the verified metrics filter when there are no verified metrics", () => {
@@ -421,7 +409,7 @@ describe("scenarios > browse > metrics", () => {
         verifyMetric(ORDERS_SCALAR_METRIC);
 
         cy.findByLabelText("Filters").should("be.visible").click();
-        popover()
+        H.popover()
           .findByLabelText("Show verified metrics only")
           .should("be.checked");
 
@@ -434,7 +422,7 @@ describe("scenarios > browse > metrics", () => {
 
         cy.visit("/browse/metrics");
         cy.findByLabelText("Filters").should("be.visible").click();
-        popover()
+        H.popover()
           .findByLabelText("Show verified metrics only")
           .should("not.be.checked");
       });
@@ -445,7 +433,7 @@ describe("scenarios > browse > metrics", () => {
 function createMetrics(
   metrics: StructuredQuestionDetailsWithName[] = ALL_METRICS,
 ) {
-  metrics.forEach(metric => createQuestion(metric));
+  metrics.forEach(metric => H.createQuestion(metric));
 }
 
 function metricsTable() {
@@ -461,24 +449,24 @@ function getMetricsTableItem(index: number) {
 }
 
 function shouldHaveBookmark(name: string) {
-  getSidebarSectionTitle(/Bookmarks/).should("be.visible");
-  navigationSidebar().findByText(name).should("be.visible");
+  H.getSidebarSectionTitle(/Bookmarks/).should("be.visible");
+  H.navigationSidebar().findByText(name).should("be.visible");
 }
 
 function shouldNotHaveBookmark(name: string) {
-  getSidebarSectionTitle(/Bookmarks/).should("not.exist");
-  navigationSidebar().findByText(name).should("not.exist");
+  H.getSidebarSectionTitle(/Bookmarks/).should("not.exist");
+  H.navigationSidebar().findByText(name).should("not.exist");
 }
 
 function verifyMetric(metric: StructuredQuestionDetailsWithName) {
   metricsTable().findByText(metric.name).should("be.visible").click();
 
   cy.button("Move, trash, and more...").click();
-  popover().findByText("Verify this metric").click();
+  H.popover().findByText("Verify this metric").click();
 
-  openNavigationSidebar();
+  H.openNavigationSidebar();
 
-  navigationSidebar()
+  H.navigationSidebar()
     .findByRole("listitem", { name: "Browse metrics" })
     .click();
 }
@@ -487,17 +475,17 @@ function unverifyMetric(metric: StructuredQuestionDetailsWithName) {
   metricsTable().findByText(metric.name).should("be.visible").click();
 
   cy.button("Move, trash, and more...").click();
-  popover().findByText("Remove verification").click();
+  H.popover().findByText("Remove verification").click();
 
-  openNavigationSidebar();
+  H.openNavigationSidebar();
 
-  navigationSidebar()
+  H.navigationSidebar()
     .findByRole("listitem", { name: "Browse metrics" })
     .click();
 }
 
 function toggleVerifiedMetricsFilter() {
   cy.findByLabelText("Filters").should("be.visible").click();
-  popover().findByText("Show verified metrics only").click();
+  H.popover().findByText("Show verified metrics only").click();
   cy.findByLabelText("Filters").should("be.visible").click();
 }

--- a/e2e/test/scenarios/metrics/metrics-collection.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-collection.cy.spec.js
@@ -1,25 +1,10 @@
+import { H } from "e2e/support";
 import { USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   FIRST_COLLECTION_ID,
   ORDERS_MODEL_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  createQuestion,
-  echartsContainer,
-  getPinnedSection,
-  getUnpinnedSection,
-  modal,
-  navigationSidebar,
-  openPinnedItemMenu,
-  openUnpinnedItemMenu,
-  popover,
-  restore,
-  undo,
-  undoToast,
-  undoToastList,
-  visitCollection,
-} from "e2e/support/helpers";
 
 const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
 
@@ -65,142 +50,148 @@ const ORDERS_TIMESERIES_METRIC = {
 
 describe("scenarios > metrics > collection", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should show metrics in collections", () => {
-    createQuestion(ORDERS_SCALAR_METRIC);
-    createQuestion(ORDERS_TIMESERIES_METRIC);
+    H.createQuestion(ORDERS_SCALAR_METRIC);
+    H.createQuestion(ORDERS_TIMESERIES_METRIC);
     cy.visit("/collection/root");
-    getPinnedSection().within(() => {
+    H.getPinnedSection().within(() => {
       cy.findByText("Metrics").should("be.visible");
       cy.findByText(ORDERS_SCALAR_METRIC.name).should("be.visible");
       cy.findByTestId("scalar-container")
         .findByText("18,760")
         .should("be.visible");
       cy.findByText(ORDERS_TIMESERIES_METRIC.name).should("be.visible");
-      echartsContainer().should("be.visible");
+      H.echartsContainer().should("be.visible");
     });
   });
 
   it("should be possible to pin and unpin metrics", () => {
-    createQuestion(ORDERS_SCALAR_METRIC);
+    H.createQuestion(ORDERS_SCALAR_METRIC);
     cy.visit("/collection/root");
-    getPinnedSection()
+    H.getPinnedSection()
       .findByText(ORDERS_SCALAR_METRIC.name)
       .should("be.visible");
-    getUnpinnedSection()
+    H.getUnpinnedSection()
       .findByText(ORDERS_SCALAR_METRIC.name)
       .should("not.exist");
-    openPinnedItemMenu(ORDERS_SCALAR_METRIC.name);
-    popover().findByText("Unpin").click();
-    getPinnedSection().should("not.exist");
-    getUnpinnedSection()
+    H.openPinnedItemMenu(ORDERS_SCALAR_METRIC.name);
+    H.popover().findByText("Unpin").click();
+    H.getPinnedSection().should("not.exist");
+    H.getUnpinnedSection()
       .findByText(ORDERS_SCALAR_METRIC.name)
       .should("be.visible");
-    openUnpinnedItemMenu(ORDERS_SCALAR_METRIC.name);
-    popover().findByText("Pin this").click();
-    getPinnedSection()
+    H.openUnpinnedItemMenu(ORDERS_SCALAR_METRIC.name);
+    H.popover().findByText("Pin this").click();
+    H.getPinnedSection()
       .findByText(ORDERS_SCALAR_METRIC.name)
       .should("be.visible");
-    getUnpinnedSection()
+    H.getUnpinnedSection()
       .findByText(ORDERS_SCALAR_METRIC.name)
       .should("not.exist");
   });
 
   it("should be possible to add and remove a metric from bookmarks", () => {
-    createQuestion(ORDERS_SCALAR_METRIC);
-    createQuestion({ ...ORDERS_TIMESERIES_METRIC, collection_position: null });
+    H.createQuestion(ORDERS_SCALAR_METRIC);
+    H.createQuestion({
+      ...ORDERS_TIMESERIES_METRIC,
+      collection_position: null,
+    });
     cy.visit("/collection/root");
 
-    openPinnedItemMenu(ORDERS_SCALAR_METRIC.name);
-    popover().findByText("Bookmark").click();
-    navigationSidebar()
+    H.openPinnedItemMenu(ORDERS_SCALAR_METRIC.name);
+    H.popover().findByText("Bookmark").click();
+    H.navigationSidebar()
       .findByText(ORDERS_SCALAR_METRIC.name)
       .should("be.visible");
-    openPinnedItemMenu(ORDERS_SCALAR_METRIC.name);
-    popover().findByText("Remove from bookmarks").click();
-    navigationSidebar()
+    H.openPinnedItemMenu(ORDERS_SCALAR_METRIC.name);
+    H.popover().findByText("Remove from bookmarks").click();
+    H.navigationSidebar()
       .findByText(ORDERS_SCALAR_METRIC.name)
       .should("not.exist");
 
-    openUnpinnedItemMenu(ORDERS_TIMESERIES_METRIC.name);
-    popover().findByText("Bookmark").click();
-    navigationSidebar()
+    H.openUnpinnedItemMenu(ORDERS_TIMESERIES_METRIC.name);
+    H.popover().findByText("Bookmark").click();
+    H.navigationSidebar()
       .findByText(ORDERS_TIMESERIES_METRIC.name)
       .should("be.visible");
-    openUnpinnedItemMenu(ORDERS_TIMESERIES_METRIC.name);
-    popover().findByText("Remove from bookmarks").click();
-    navigationSidebar()
+    H.openUnpinnedItemMenu(ORDERS_TIMESERIES_METRIC.name);
+    H.popover().findByText("Remove from bookmarks").click();
+    H.navigationSidebar()
       .findByText(ORDERS_TIMESERIES_METRIC.name)
       .should("not.exist");
   });
 
   it("should be possible to hide the visualization for a pinned metric", () => {
-    createQuestion(ORDERS_SCALAR_METRIC);
+    H.createQuestion(ORDERS_SCALAR_METRIC);
     cy.visit("/collection/root");
-    getPinnedSection().within(() => {
+    H.getPinnedSection().within(() => {
       cy.findByText(ORDERS_SCALAR_METRIC.name).should("be.visible");
       cy.findByTestId("scalar-container").should("be.visible");
     });
 
-    openPinnedItemMenu(ORDERS_SCALAR_METRIC.name);
-    popover().findByText("Don’t show visualization").click();
-    getPinnedSection().within(() => {
+    H.openPinnedItemMenu(ORDERS_SCALAR_METRIC.name);
+    H.popover().findByText("Don’t show visualization").click();
+    H.getPinnedSection().within(() => {
       cy.findByText(ORDERS_SCALAR_METRIC.name).should("be.visible");
       cy.findByTestId("scalar-container").should("not.exist");
     });
 
-    openPinnedItemMenu(ORDERS_SCALAR_METRIC.name);
-    popover().findByText("Show visualization").click();
-    getPinnedSection().within(() => {
+    H.openPinnedItemMenu(ORDERS_SCALAR_METRIC.name);
+    H.popover().findByText("Show visualization").click();
+    H.getPinnedSection().within(() => {
       cy.findByText(ORDERS_SCALAR_METRIC.name).should("be.visible");
       cy.findByTestId("scalar-container").should("be.visible");
     });
   });
 
   it("should be possible to archive, unarchive, and delete a metric", () => {
-    createQuestion(ORDERS_SCALAR_METRIC);
-    createQuestion({ ...ORDERS_TIMESERIES_METRIC, collection_position: null });
+    H.createQuestion(ORDERS_SCALAR_METRIC);
+    H.createQuestion({
+      ...ORDERS_TIMESERIES_METRIC,
+      collection_position: null,
+    });
     cy.visit("/collection/root");
 
-    openPinnedItemMenu(ORDERS_SCALAR_METRIC.name);
-    popover().findByText("Move to trash").click();
-    getPinnedSection().should("not.exist");
-    undoToast().findByText("Trashed metric").should("be.visible");
-    undo();
-    getPinnedSection()
+    H.openPinnedItemMenu(ORDERS_SCALAR_METRIC.name);
+    H.popover().findByText("Move to trash").click();
+    H.getPinnedSection().should("not.exist");
+    H.undoToast().findByText("Trashed metric").should("be.visible");
+    H.undo();
+    H.getPinnedSection()
       .findByText(ORDERS_SCALAR_METRIC.name)
       .should("be.visible");
 
-    openUnpinnedItemMenu(ORDERS_TIMESERIES_METRIC.name);
-    popover().findByText("Move to trash").click();
-    getUnpinnedSection()
+    H.openUnpinnedItemMenu(ORDERS_TIMESERIES_METRIC.name);
+    H.popover().findByText("Move to trash").click();
+    H.getUnpinnedSection()
       .findByText(ORDERS_TIMESERIES_METRIC.name)
       .should("not.exist");
-    undoToastList().last().findByText("Trashed metric").should("be.visible");
+    H.undoToastList().last().findByText("Trashed metric").should("be.visible");
 
     openArchive();
-    openUnpinnedItemMenu(ORDERS_TIMESERIES_METRIC.name);
-    popover().findByText("Restore").click();
-    getUnpinnedSection()
+    H.openUnpinnedItemMenu(ORDERS_TIMESERIES_METRIC.name);
+    H.popover().findByText("Restore").click();
+    H.getUnpinnedSection()
       .findByText(ORDERS_TIMESERIES_METRIC.name)
       .should("not.exist");
-    undoToastList()
+    H.undoToastList()
       .last()
       .findByText(`${ORDERS_TIMESERIES_METRIC.name} has been restored.`)
       .should("be.visible");
 
-    navigationSidebar().findByText("Our analytics").click();
-    openUnpinnedItemMenu(ORDERS_TIMESERIES_METRIC.name);
-    popover().findByText("Move to trash").click();
+    H.navigationSidebar().findByText("Our analytics").click();
+    H.openUnpinnedItemMenu(ORDERS_TIMESERIES_METRIC.name);
+    H.popover().findByText("Move to trash").click();
     openArchive();
-    openUnpinnedItemMenu(ORDERS_TIMESERIES_METRIC.name);
-    popover().findByText("Delete permanently").click();
-    modal().button("Delete permanently").click();
-    getUnpinnedSection().should("not.exist");
-    undoToastList()
+    H.openUnpinnedItemMenu(ORDERS_TIMESERIES_METRIC.name);
+    H.popover().findByText("Delete permanently").click();
+    H.modal().button("Delete permanently").click();
+    H.getUnpinnedSection().should("not.exist");
+    H.undoToastList()
       .last()
       .findByText("This item has been permanently deleted.")
       .should("be.visible");
@@ -214,14 +205,14 @@ describe("scenarios > metrics > collection", () => {
         [FIRST_COLLECTION_ID]: "read",
       },
     });
-    createQuestion({
+    H.createQuestion({
       ...ORDERS_SCALAR_MODEL_METRIC,
       collection_id: FIRST_COLLECTION_ID,
     }).then(({ body: card }) => {
       cy.signIn("nocollection");
-      visitCollection(FIRST_COLLECTION_ID);
+      H.visitCollection(FIRST_COLLECTION_ID);
     });
-    getPinnedSection()
+    H.getPinnedSection()
       .findByTestId("scalar-container")
       .findByText("18,760")
       .should("be.visible");
@@ -229,5 +220,5 @@ describe("scenarios > metrics > collection", () => {
 });
 
 function openArchive() {
-  navigationSidebar().findByText("Trash").click();
+  H.navigationSidebar().findByText("Trash").click();
 }

--- a/e2e/test/scenarios/metrics/metrics-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-dashboard.cy.spec.js
@@ -1,3 +1,4 @@
+import { H } from "e2e/support";
 import { USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
@@ -5,24 +6,6 @@ import {
   ORDERS_DASHBOARD_ID,
   ORDERS_MODEL_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  assertQueryBuilderRowCount,
-  cartesianChartCircle,
-  createQuestion,
-  echartsContainer,
-  editDashboard,
-  filterWidget,
-  getDashboardCard,
-  getDashboardCards,
-  modal,
-  openQuestionActions,
-  popover,
-  restore,
-  saveDashboard,
-  sidebar,
-  undoToastList,
-  visitDashboard,
-} from "e2e/support/helpers";
 
 const { ORDERS_ID, ORDERS, PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
@@ -92,48 +75,50 @@ const PRODUCTS_TIMESERIES_METRIC = {
 
 describe("scenarios > metrics > dashboard", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
   it("should be possible to add metric to a dashboard via context menu (metabase#44220)", () => {
-    createQuestion(ORDERS_SCALAR_METRIC).then(({ body: { id: metricId } }) => {
-      cy.intercept("POST", "/api/dataset").as("dataset");
-      cy.visit(`/metric/${metricId}`);
-      cy.wait("@dataset");
-      cy.findByTestId("scalar-value").should("have.text", "18,760");
+    H.createQuestion(ORDERS_SCALAR_METRIC).then(
+      ({ body: { id: metricId } }) => {
+        cy.intercept("POST", "/api/dataset").as("dataset");
+        cy.visit(`/metric/${metricId}`);
+        cy.wait("@dataset");
+        cy.findByTestId("scalar-value").should("have.text", "18,760");
 
-      cy.log("Add metric to a dashboard via context menu");
-      openQuestionActions();
-      popover().findByTextEnsureVisible("Add to dashboard").click();
-      modal().within(() => {
-        cy.findByRole("heading", {
-          name: "Add this metric to a dashboard",
-        }).should("be.visible");
-        cy.findByText("Orders in a dashboard").click();
-        cy.button("Select").click();
-      });
+        cy.log("Add metric to a dashboard via context menu");
+        H.openQuestionActions();
+        H.popover().findByTextEnsureVisible("Add to dashboard").click();
+        H.modal().within(() => {
+          cy.findByRole("heading", {
+            name: "Add this metric to a dashboard",
+          }).should("be.visible");
+          cy.findByText("Orders in a dashboard").click();
+          cy.button("Select").click();
+        });
 
-      cy.log("Assert it's been added before the save");
-      cy.location("pathname").should(
-        "eq",
-        `/dashboard/${ORDERS_DASHBOARD_ID}-orders-in-a-dashboard`,
-      );
-      cy.location("hash").should("eq", `#add=${metricId}&edit`);
-      cy.findByTestId("scalar-value").should("have.text", "18,760");
+        cy.log("Assert it's been added before the save");
+        cy.location("pathname").should(
+          "eq",
+          `/dashboard/${ORDERS_DASHBOARD_ID}-orders-in-a-dashboard`,
+        );
+        cy.location("hash").should("eq", `#add=${metricId}&edit`);
+        cy.findByTestId("scalar-value").should("have.text", "18,760");
 
-      cy.log("Assert we can save the dashboard with the metric");
-      saveDashboard();
-      getDashboardCards().should("have.length", 2);
-      cy.findByTestId("scalar-value").should("have.text", "18,760");
-    });
+        cy.log("Assert we can save the dashboard with the metric");
+        H.saveDashboard();
+        H.getDashboardCards().should("have.length", 2);
+        cy.findByTestId("scalar-value").should("have.text", "18,760");
+      },
+    );
   });
 
   it("should be possible to add metrics to a dashboard", () => {
-    createQuestion(ORDERS_SCALAR_METRIC);
-    createQuestion(ORDERS_TIMESERIES_METRIC);
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.createQuestion(ORDERS_SCALAR_METRIC);
+    H.createQuestion(ORDERS_TIMESERIES_METRIC);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
     cy.findByTestId("dashboard-header").within(() => {
       cy.findByLabelText("Edit dashboard").click();
       cy.findByLabelText("Add questions").click();
@@ -144,13 +129,13 @@ describe("scenarios > metrics > dashboard", () => {
       cy.findByText(ORDERS_SCALAR_METRIC.name).should("not.exist");
       cy.findByText(ORDERS_TIMESERIES_METRIC.name).click();
     });
-    getDashboardCard(1).within(() => {
+    H.getDashboardCard(1).within(() => {
       cy.findByText(ORDERS_SCALAR_METRIC.name).should("be.visible");
       cy.findByText("18,760").should("be.visible");
     });
-    getDashboardCard(2).within(() => {
+    H.getDashboardCard(2).within(() => {
       cy.findByText(ORDERS_TIMESERIES_METRIC.name).should("be.visible");
-      echartsContainer().should("be.visible");
+      H.echartsContainer().should("be.visible");
     });
   });
 
@@ -158,23 +143,23 @@ describe("scenarios > metrics > dashboard", () => {
     cy.createDashboardWithQuestions({
       questions: [ORDERS_SCALAR_METRIC],
     }).then(({ dashboard }) => {
-      visitDashboard(dashboard.id);
+      H.visitDashboard(dashboard.id);
     });
-    getDashboardCard().findByText("18,760").should("be.visible");
+    H.getDashboardCard().findByText("18,760").should("be.visible");
     cy.findByTestId("dashboard-header").within(() => {
       cy.findByLabelText("Edit dashboard").click();
       cy.findByLabelText("Add a filter or parameter").click();
     });
-    popover().findByText("Text or Category").click();
-    getDashboardCard().findByText("Select…").click();
-    popover().findByText("Category").click();
-    saveDashboard();
-    filterWidget().click();
-    popover().within(() => {
+    H.popover().findByText("Text or Category").click();
+    H.getDashboardCard().findByText("Select…").click();
+    H.popover().findByText("Category").click();
+    H.saveDashboard();
+    H.filterWidget().click();
+    H.popover().within(() => {
       cy.findByText("Gadget").click();
       cy.button("Add filter").click();
     });
-    getDashboardCard().within(() => {
+    H.getDashboardCard().within(() => {
       cy.findByText("4,939").should("be.visible");
       cy.findByText(ORDERS_SCALAR_METRIC.name).click();
     });
@@ -190,39 +175,42 @@ describe("scenarios > metrics > dashboard", () => {
     cy.createDashboardWithQuestions({
       questions: [ORDERS_TIMESERIES_METRIC],
     }).then(({ dashboard }) => {
-      visitDashboard(dashboard.id);
+      H.visitDashboard(dashboard.id);
     });
-    getDashboardCard().within(() => {
-      cartesianChartCircle()
+    H.getDashboardCard().within(() => {
+      H.cartesianChartCircle()
         .eq(23) // random dot
         .click({ force: true });
     });
-    popover().findByText("See these Orders").click();
-    assertQueryBuilderRowCount(445);
+    H.popover().findByText("See these Orders").click();
+    H.assertQueryBuilderRowCount(445);
   });
 
   it("should be able to replace a card with a metric", () => {
-    createQuestion(ORDERS_SCALAR_METRIC);
-    visitDashboard(ORDERS_DASHBOARD_ID);
-    editDashboard();
-    getDashboardCard().realHover().findByLabelText("Replace").click();
-    modal().within(() => {
+    H.createQuestion(ORDERS_SCALAR_METRIC);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.editDashboard();
+    H.getDashboardCard().realHover().findByLabelText("Replace").click();
+    H.modal().within(() => {
       cy.findByText("Metrics").click();
       cy.findByText(ORDERS_SCALAR_METRIC.name).click();
     });
-    undoToastList().last().findByText("Question replaced").should("be.visible");
-    getDashboardCard().within(() => {
+    H.undoToastList()
+      .last()
+      .findByText("Question replaced")
+      .should("be.visible");
+    H.getDashboardCard().within(() => {
       cy.findByText(ORDERS_SCALAR_METRIC.name).should("be.visible");
       cy.findByText("18,760").should("be.visible");
     });
-    getDashboardCard().realHover().findByLabelText("Replace").click();
-    modal().within(() => {
+    H.getDashboardCard().realHover().findByLabelText("Replace").click();
+    H.modal().within(() => {
       cy.findByText(ORDERS_SCALAR_METRIC.name).should("be.visible");
       cy.findByText("Questions").click();
       cy.findByText("Orders").click();
     });
-    undoToastList().last().findByText("Metric replaced").should("be.visible");
-    getDashboardCard().findByText("Orders").should("be.visible");
+    H.undoToastList().last().findByText("Metric replaced").should("be.visible");
+    H.getDashboardCard().findByText("Orders").should("be.visible");
   });
 
   it("should be able to combine scalar metrics on a dashcard", () => {
@@ -240,21 +228,21 @@ describe("scenarios > metrics > dashboard", () => {
     cy.createDashboardWithQuestions({
       questions: [ORDERS_TIMESERIES_METRIC],
     }).then(({ dashboard }) => {
-      visitDashboard(dashboard.id);
+      H.visitDashboard(dashboard.id);
     });
-    editDashboard();
-    getDashboardCard().realHover().findByLabelText("Click behavior").click();
-    sidebar().within(() => {
+    H.editDashboard();
+    H.getDashboardCard().realHover().findByLabelText("Click behavior").click();
+    H.sidebar().within(() => {
       cy.findByText("Go to a custom destination").click();
       cy.findByText("Saved question").click();
     });
-    modal().findByText("Orders").click();
-    sidebar().findByText("User ID").click();
-    popover().findByText("Count").click();
-    sidebar().button("Done").click();
-    saveDashboard();
-    getDashboardCard().within(() => {
-      cartesianChartCircle()
+    H.modal().findByText("Orders").click();
+    H.sidebar().findByText("User ID").click();
+    H.popover().findByText("Count").click();
+    H.sidebar().button("Done").click();
+    H.saveDashboard();
+    H.getDashboardCard().within(() => {
+      H.cartesianChartCircle()
         .eq(5) // random dot
         .click({ force: true });
     });
@@ -262,7 +250,7 @@ describe("scenarios > metrics > dashboard", () => {
     cy.findByTestId("qb-filters-panel")
       .findByText("User ID is 92")
       .should("be.visible");
-    assertQueryBuilderRowCount(8);
+    H.assertQueryBuilderRowCount(8);
   });
 
   it("should be able to view a model-based metric without data access", () => {
@@ -271,9 +259,9 @@ describe("scenarios > metrics > dashboard", () => {
       questions: [ORDERS_SCALAR_METRIC],
     }).then(({ dashboard }) => {
       cy.signIn("nodata");
-      visitDashboard(dashboard.id);
+      H.visitDashboard(dashboard.id);
     });
-    getDashboardCard()
+    H.getDashboardCard()
       .findByTestId("scalar-container")
       .findByText("18,760")
       .should("be.visible");
@@ -297,9 +285,9 @@ describe("scenarios > metrics > dashboard", () => {
       ],
     }).then(({ dashboard }) => {
       cy.signIn("nocollection");
-      visitDashboard(dashboard.id);
+      H.visitDashboard(dashboard.id);
     });
-    getDashboardCard()
+    H.getDashboardCard()
       .findByTestId("scalar-container")
       .findByText("18,760")
       .should("be.visible");
@@ -309,13 +297,13 @@ describe("scenarios > metrics > dashboard", () => {
 function combineAndVerifyMetrics(metric1, metric2) {
   cy.createDashboardWithQuestions({ questions: [metric1] }).then(
     ({ dashboard }) => {
-      createQuestion(metric2);
-      visitDashboard(dashboard.id);
+      H.createQuestion(metric2);
+      H.visitDashboard(dashboard.id);
     },
   );
-  editDashboard();
-  getDashboardCard().realHover().findByTestId("add-series-button").click();
-  modal().within(() => {
+  H.editDashboard();
+  H.getDashboardCard().realHover().findByTestId("add-series-button").click();
+  H.modal().within(() => {
     cy.findByText(metric2.name).click();
     cy.findByLabelText("Legend").within(() => {
       cy.findByText(metric1.name).should("be.visible");
@@ -323,8 +311,8 @@ function combineAndVerifyMetrics(metric1, metric2) {
     });
     cy.button("Done").click();
   });
-  saveDashboard();
-  getDashboardCard().within(() => {
+  H.saveDashboard();
+  H.getDashboardCard().within(() => {
     cy.findByLabelText("Legend").within(() => {
       cy.findByText(metric1.name).should("be.visible");
       cy.findByText(metric2.name).should("be.visible");

--- a/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
@@ -1,25 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_MODEL_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  appBar,
-  commandPalette,
-  createQuestion,
-  echartsContainer,
-  enterCustomColumnDetails,
-  entityPickerModal,
-  entityPickerModalTab,
-  getNotebookStep,
-  hovercard,
-  modal,
-  openQuestionActions,
-  popover,
-  queryBuilderHeader,
-  restore,
-  startNewMetric,
-  startNewQuestion,
-  visitMetric,
-  visualize,
-} from "e2e/support/helpers";
 
 const { ORDERS_ID, ORDERS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
@@ -87,7 +68,7 @@ const ORDERS_MULTI_STAGE_QUESTION = {
 
 describe("scenarios > metrics > editing", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
@@ -95,9 +76,9 @@ describe("scenarios > metrics > editing", () => {
     it("should be able to create a new metric from the homepage", () => {
       cy.visit("/");
       cy.findByTestId("app-bar").findByText("New").click();
-      popover().findByText("Metric").click();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.popover().findByText("Metric").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Orders").click();
       });
       addAggregation({ operatorName: "Count of rows" });
@@ -107,28 +88,30 @@ describe("scenarios > metrics > editing", () => {
       cy.log(
         "newly created metric should be visible in recents (metabase#44223)",
       );
-      appBar()
+      H.appBar()
         .findByText(/search/i)
         .click();
-      commandPalette().findByText("my new metric").should("be.visible");
+      H.commandPalette().findByText("my new metric").should("be.visible");
     });
 
     it("should be able to rename a metric", () => {
       const newTitle = "New metric name";
-      createQuestion(ORDERS_SCALAR_METRIC).then(({ body: card }) => {
-        visitMetric(card.id);
+      H.createQuestion(ORDERS_SCALAR_METRIC).then(({ body: card }) => {
+        H.visitMetric(card.id);
         renameMetric(newTitle);
-        visitMetric(card.id);
-        queryBuilderHeader().findByDisplayValue(newTitle).should("be.visible");
+        H.visitMetric(card.id);
+        H.queryBuilderHeader()
+          .findByDisplayValue(newTitle)
+          .should("be.visible");
       });
     });
 
     it("should be able to change the query definition of a metric", () => {
-      createQuestion(ORDERS_SCALAR_METRIC).then(({ body: card }) =>
-        visitMetric(card.id),
+      H.createQuestion(ORDERS_SCALAR_METRIC).then(({ body: card }) =>
+        H.visitMetric(card.id),
       );
-      openQuestionActions();
-      popover().findByText("Edit metric definition").click();
+      H.openQuestionActions();
+      H.popover().findByText("Edit metric definition").click();
       addBreakout({ tableName: "Product", columnName: "Created At" });
       updateMetric();
       verifyLineAreaBarChart({
@@ -138,11 +121,11 @@ describe("scenarios > metrics > editing", () => {
     });
 
     it("should be able to change the query definition of a metric based on a model", () => {
-      createQuestion(ORDERS_SCALAR_MODEL_METRIC).then(({ body: card }) =>
-        visitMetric(card.id),
+      H.createQuestion(ORDERS_SCALAR_MODEL_METRIC).then(({ body: card }) =>
+        H.visitMetric(card.id),
       );
-      openQuestionActions();
-      popover().findByText("Edit metric definition").click();
+      H.openQuestionActions();
+      H.popover().findByText("Edit metric definition").click();
       addBreakout({ tableName: "Product", columnName: "Created At" });
       updateMetric();
       verifyLineAreaBarChart({
@@ -154,9 +137,9 @@ describe("scenarios > metrics > editing", () => {
     it("should pin new metrics automatically", () => {
       cy.visit("/");
       cy.findByTestId("app-bar").findByText("New").click();
-      popover().findByText("Metric").click();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.popover().findByText("Metric").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Orders").click();
       });
       saveMetric({ name: "New metric" });
@@ -172,20 +155,20 @@ describe("scenarios > metrics > editing", () => {
     });
 
     it("should not crash when cancelling creation of a new metric (metabase#48024)", () => {
-      startNewMetric();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.startNewMetric();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Orders").click();
       });
       cancelMetricEditing();
     });
 
     it("should not crash when cancelling editing of an existing metric (metabase#48024)", () => {
-      createQuestion(ORDERS_SCALAR_METRIC).then(({ body: card }) =>
-        visitMetric(card.id),
+      H.createQuestion(ORDERS_SCALAR_METRIC).then(({ body: card }) =>
+        H.visitMetric(card.id),
       );
-      openQuestionActions();
-      popover().findByText("Edit metric definition").click();
+      H.openQuestionActions();
+      H.popover().findByText("Edit metric definition").click();
       addBreakout({ tableName: "Product", columnName: "Created At" });
       cancelMetricEditing();
       verifyScalarValue("18,760");
@@ -194,9 +177,9 @@ describe("scenarios > metrics > editing", () => {
 
   describe("data source", () => {
     it("should create a metric based on a table", () => {
-      startNewMetric();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.startNewMetric();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Orders").click();
       });
       addStringCategoryFilter({
@@ -209,9 +192,9 @@ describe("scenarios > metrics > editing", () => {
     });
 
     it("should create a metric based on a saved question", () => {
-      startNewMetric();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Saved questions").click();
+      H.startNewMetric();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Saved questions").click();
         cy.findByText("Orders").click();
       });
       addStringCategoryFilter({
@@ -224,10 +207,10 @@ describe("scenarios > metrics > editing", () => {
     });
 
     it("should create a metric based on a multi-stage saved question", () => {
-      createQuestion(ORDERS_MULTI_STAGE_QUESTION);
-      startNewMetric();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Saved questions").click();
+      H.createQuestion(ORDERS_MULTI_STAGE_QUESTION);
+      H.startNewMetric();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Saved questions").click();
         cy.findByText(ORDERS_MULTI_STAGE_QUESTION.name).click();
       });
       addNumberBetweenFilter({
@@ -240,9 +223,9 @@ describe("scenarios > metrics > editing", () => {
     });
 
     it("should create a metric based on a model", () => {
-      startNewMetric();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Models").click();
+      H.startNewMetric();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Models").click();
         cy.findByText("Orders Model").click();
       });
       addStringCategoryFilter({
@@ -255,10 +238,10 @@ describe("scenarios > metrics > editing", () => {
     });
 
     it("should create a metric based on a multi-stage model", () => {
-      createQuestion({ ...ORDERS_MULTI_STAGE_QUESTION, type: "model" });
-      startNewMetric();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Models").click();
+      H.createQuestion({ ...ORDERS_MULTI_STAGE_QUESTION, type: "model" });
+      H.startNewMetric();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Models").click();
         cy.findByText(ORDERS_MULTI_STAGE_QUESTION.name).click();
       });
       addNumberBetweenFilter({
@@ -271,18 +254,18 @@ describe("scenarios > metrics > editing", () => {
     });
 
     it("should not allow to create a multi-stage metric", () => {
-      startNewMetric();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Models").click();
+      H.startNewMetric();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Models").click();
         cy.findByText("Orders Model").click();
       });
       getActionButton("Summarize").should("not.exist");
     });
 
     it("should allow to run the query from the metric empty state", () => {
-      startNewMetric();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.startNewMetric();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Orders").click();
       });
       cy.intercept("POST", "/api/dataset").as("dataset");
@@ -294,18 +277,18 @@ describe("scenarios > metrics > editing", () => {
 
   describe("joins", () => {
     it("should join a table", () => {
-      startNewMetric();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.startNewMetric();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Products").click();
       });
       startNewJoin();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Orders").click();
       });
       startNewFilter();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("User").click();
         cy.findByText("State").click();
         cy.findByText("CA").click();
@@ -316,27 +299,27 @@ describe("scenarios > metrics > editing", () => {
     });
 
     it("should not be possible to join a metric", () => {
-      createQuestion(ORDERS_SCALAR_METRIC);
-      startNewMetric();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.createQuestion(ORDERS_SCALAR_METRIC);
+      H.startNewMetric();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Orders").click();
       });
       startNewJoin();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").should("be.visible");
-        entityPickerModalTab("Metrics").should("not.exist");
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").should("be.visible");
+        H.entityPickerModalTab("Metrics").should("not.exist");
       });
     });
 
     it("should be possible to join data on the first stage of a metric-based query", () => {
-      createQuestion(ORDERS_SCALAR_METRIC);
-      startNewQuestion();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Metrics").click();
+      H.createQuestion(ORDERS_SCALAR_METRIC);
+      H.startNewQuestion();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Metrics").click();
         cy.findByText(ORDERS_SCALAR_METRIC.name).click();
       });
-      getNotebookStep("data").within(() => {
+      H.getNotebookStep("data").within(() => {
         getActionButton("Custom column").should("be.visible");
         getActionButton("Join data").should("be.visible");
       });
@@ -345,19 +328,19 @@ describe("scenarios > metrics > editing", () => {
 
   describe("custom columns", () => {
     it("should be able to use custom columns in metric queries (metabase#42360)", () => {
-      startNewMetric();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.startNewMetric();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Orders").click();
       });
       startNewCustomColumn();
-      enterCustomColumnDetails({
+      H.enterCustomColumnDetails({
         formula: "[Total] / 2",
         name: "Total2",
       });
-      popover().button("Done").click();
-      getNotebookStep("summarize").findByText("Count").click();
-      popover().within(() => {
+      H.popover().button("Done").click();
+      H.getNotebookStep("summarize").findByText("Count").click();
+      H.popover().within(() => {
         cy.findByText("Sum of ...").click();
         cy.findByText("Total2").click();
       });
@@ -366,19 +349,19 @@ describe("scenarios > metrics > editing", () => {
     });
 
     it("should be able to use implicitly joinable columns in custom columns in metric queries (metabase#42360)", () => {
-      startNewMetric();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.startNewMetric();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Orders").click();
       });
       startNewCustomColumn();
-      enterCustomColumnDetails({
+      H.enterCustomColumnDetails({
         formula: "[Product → Price] * 2",
         name: "Price2",
       });
-      popover().button("Done").click();
-      getNotebookStep("summarize").findByText("Count").click();
-      popover().within(() => {
+      H.popover().button("Done").click();
+      H.getNotebookStep("summarize").findByText("Count").click();
+      H.popover().within(() => {
         cy.findByText("Average of ...").click();
         cy.findByText("Price2").click();
       });
@@ -389,13 +372,13 @@ describe("scenarios > metrics > editing", () => {
 
   describe("breakouts", () => {
     it("should create a timeseries metric", () => {
-      startNewMetric();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.startNewMetric();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Orders").click();
       });
-      getNotebookStep("summarize").findByText("Count").click();
-      popover().within(() => {
+      H.getNotebookStep("summarize").findByText("Count").click();
+      H.popover().within(() => {
         cy.findByText("Sum of ...").click();
         cy.findByText("Total").click();
       });
@@ -410,35 +393,35 @@ describe("scenarios > metrics > editing", () => {
 
   describe("aggregations", () => {
     it("should create a metric with a custom aggregation expression based on 1 metric", () => {
-      createQuestion(ORDERS_SCALAR_METRIC);
-      startNewMetric();
+      H.createQuestion(ORDERS_SCALAR_METRIC);
+      H.startNewMetric();
       cy.intercept("POST", "/api/dataset/query_metadata").as("queryMetadata");
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Metrics").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Metrics").click();
         cy.findByText(ORDERS_SCALAR_METRIC.name).click();
       });
       cy.wait("@queryMetadata");
-      getNotebookStep("summarize")
+      H.getNotebookStep("summarize")
         .findByText(ORDERS_SCALAR_METRIC.name)
         .click();
-      enterCustomColumnDetails({
+      H.enterCustomColumnDetails({
         formula: `[${ORDERS_SCALAR_METRIC.name}] / 2`,
         name: "",
       });
-      popover().button("Update").click();
+      H.popover().button("Update").click();
       saveMetric();
       verifyScalarValue("9,380");
     });
 
     it("should have metric-specific summarize step copy", () => {
-      createQuestion(ORDERS_SCALAR_METRIC).then(({ body: card }) =>
-        visitMetric(card.id),
+      H.createQuestion(ORDERS_SCALAR_METRIC).then(({ body: card }) =>
+        H.visitMetric(card.id),
       );
-      openQuestionActions();
-      popover().findByText("Edit metric definition").click();
+      H.openQuestionActions();
+      H.popover().findByText("Edit metric definition").click();
 
       cy.log("regular screen");
-      getNotebookStep("summarize").within(() => {
+      H.getNotebookStep("summarize").within(() => {
         cy.findByText("Formula").should("be.visible");
         cy.findAllByText("Default time dimension")
           .filter(":visible")
@@ -447,7 +430,7 @@ describe("scenarios > metrics > editing", () => {
 
       cy.log("mobile screen");
       cy.viewport(800, 600);
-      getNotebookStep("summarize").within(() => {
+      H.getNotebookStep("summarize").within(() => {
         cy.findByText("Formula").should("be.visible");
         cy.findAllByText("Default time dimension")
           .filter(":visible")
@@ -458,16 +441,16 @@ describe("scenarios > metrics > editing", () => {
 
   describe("compatible metrics", () => {
     it("should allow adding an aggregation based on a compatible metric for the same table in questions (metabase#42470)", () => {
-      createQuestion(ORDERS_SCALAR_METRIC);
-      createQuestion(ORDERS_SCALAR_FILTER_METRIC);
-      createQuestion(PRODUCTS_SCALAR_METRIC);
-      startNewQuestion();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.createQuestion(ORDERS_SCALAR_METRIC);
+      H.createQuestion(ORDERS_SCALAR_FILTER_METRIC);
+      H.createQuestion(PRODUCTS_SCALAR_METRIC);
+      H.startNewQuestion();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Orders").click();
       });
       startNewAggregation();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Metrics").click();
         cy.findByText(ORDERS_SCALAR_METRIC.name).should("be.visible");
         cy.findByText(ORDERS_SCALAR_FILTER_METRIC.name).should("be.visible");
@@ -475,21 +458,21 @@ describe("scenarios > metrics > editing", () => {
         cy.findByText(ORDERS_SCALAR_MODEL_METRIC.name).should("not.exist");
         cy.findByText(ORDERS_SCALAR_METRIC.name).click();
       });
-      visualize();
+      H.visualize();
       verifyScalarValue("18,760");
     });
 
     it("should for searching for metrics", () => {
-      createQuestion(ORDERS_SCALAR_METRIC);
-      createQuestion(ORDERS_SCALAR_FILTER_METRIC);
-      createQuestion(PRODUCTS_SCALAR_METRIC);
-      startNewQuestion();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.createQuestion(ORDERS_SCALAR_METRIC);
+      H.createQuestion(ORDERS_SCALAR_FILTER_METRIC);
+      H.createQuestion(PRODUCTS_SCALAR_METRIC);
+      H.startNewQuestion();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Orders").click();
       });
       startNewAggregation();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByPlaceholderText("Find...").type("with filter");
         cy.findByText("Metrics").should("be.visible");
         cy.findByText(ORDERS_SCALAR_METRIC.name).should("not.exist");
@@ -500,14 +483,14 @@ describe("scenarios > metrics > editing", () => {
     });
 
     it("should show the description for metrics", () => {
-      createQuestion(ORDERS_SCALAR_FILTER_METRIC);
-      startNewQuestion();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.createQuestion(ORDERS_SCALAR_FILTER_METRIC);
+      H.startNewQuestion();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Orders").click();
       });
       startNewAggregation();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Metrics").click();
         cy.findByText(ORDERS_SCALAR_FILTER_METRIC.name).should("be.visible");
         cy.findByText(ORDERS_SCALAR_FILTER_METRIC.name).realHover();
@@ -515,7 +498,7 @@ describe("scenarios > metrics > editing", () => {
         cy.findByLabelText("More info").should("exist").realHover();
       });
 
-      hovercard().within(() => {
+      H.hovercard().within(() => {
         cy.contains("This is a description").should("be.visible");
         cy.contains("with markdown").should("be.visible");
       });
@@ -532,38 +515,38 @@ function getPlusButton() {
 }
 
 function startNewJoin({ stageIndex } = {}) {
-  getNotebookStep("data", { stage: stageIndex }).within(() =>
+  H.getNotebookStep("data", { stage: stageIndex }).within(() =>
     getActionButton("Join data").click(),
   );
 }
 
 function startNewCustomColumn({ stageIndex } = {}) {
-  getNotebookStep("data", { stage: stageIndex }).within(() =>
+  H.getNotebookStep("data", { stage: stageIndex }).within(() =>
     getActionButton("Custom column").click(),
   );
 }
 
 function startNewFilter({ stageIndex } = {}) {
-  getNotebookStep("filter", { stage: stageIndex }).within(() =>
+  H.getNotebookStep("filter", { stage: stageIndex }).within(() =>
     getPlusButton().click(),
   );
 }
 
 function startNewAggregation({ stageIndex } = {}) {
-  getNotebookStep("summarize", { stage: stageIndex })
+  H.getNotebookStep("summarize", { stage: stageIndex })
     .findByTestId("aggregate-step")
     .within(() => getPlusButton().click());
 }
 
 function startNewBreakout({ stageIndex } = {}) {
-  getNotebookStep("summarize", { stage: stageIndex })
+  H.getNotebookStep("summarize", { stage: stageIndex })
     .findByTestId("breakout-step")
     .within(() => getPlusButton().click());
 }
 
 function addStringCategoryFilter({ tableName, columnName, values }) {
   startNewFilter();
-  popover().within(() => {
+  H.popover().within(() => {
     if (tableName) {
       cy.findByText(tableName).click();
     }
@@ -575,7 +558,7 @@ function addStringCategoryFilter({ tableName, columnName, values }) {
 
 function addNumberBetweenFilter({ tableName, columnName, minValue, maxValue }) {
   startNewFilter();
-  popover().within(() => {
+  H.popover().within(() => {
     if (tableName) {
       cy.findByText(tableName).click();
     }
@@ -589,7 +572,7 @@ function addNumberBetweenFilter({ tableName, columnName, minValue, maxValue }) {
 function addAggregation({ operatorName, columnName, stageIndex }) {
   startNewAggregation({ stageIndex });
 
-  popover().within(() => {
+  H.popover().within(() => {
     cy.findByText(operatorName).click();
     if (columnName) {
       cy.findByText(columnName).click();
@@ -600,20 +583,20 @@ function addAggregation({ operatorName, columnName, stageIndex }) {
 function addBreakout({ tableName, columnName, bucketName, stageIndex }) {
   startNewBreakout({ stageIndex });
   if (tableName) {
-    popover().findByText(tableName).click();
+    H.popover().findByText(tableName).click();
   }
   if (bucketName) {
-    popover().findByLabelText(columnName).findByText("by month").click();
-    popover().last().findByText(bucketName).click();
+    H.popover().findByLabelText(columnName).findByText("by month").click();
+    H.popover().last().findByText(bucketName).click();
   } else {
-    popover().findByText(columnName).click();
+    H.popover().findByText(columnName).click();
   }
 }
 
 function saveMetric({ name } = {}) {
   cy.intercept("POST", "/api/card").as("createCard");
   cy.button("Save").click();
-  modal().within(() => {
+  H.modal().within(() => {
     cy.findByText("Save metric").should("be.visible");
     if (name) {
       cy.findByLabelText("Name").clear().type(name);
@@ -640,7 +623,7 @@ function verifyScalarValue(value) {
 }
 
 function verifyLineAreaBarChart({ xAxis, yAxis }) {
-  echartsContainer().within(() => {
+  H.echartsContainer().within(() => {
     cy.findByText(yAxis).should("be.visible");
     cy.findByText(xAxis).should("be.visible");
   });
@@ -649,12 +632,12 @@ function verifyLineAreaBarChart({ xAxis, yAxis }) {
 function cancelMetricEditing() {
   cy.log("click cancel but do not confirm");
   cy.button("Cancel").click();
-  modal().button("Cancel").click();
-  modal().should("not.exist");
-  appBar().should("not.exist");
+  H.modal().button("Cancel").click();
+  H.modal().should("not.exist");
+  H.appBar().should("not.exist");
 
   cy.log("click cancel and confirm");
   cy.button("Cancel").click();
-  modal().button("Discard changes").click();
-  appBar().should("be.visible");
+  H.modal().button("Discard changes").click();
+  H.appBar().should("be.visible");
 }

--- a/e2e/test/scenarios/metrics/metrics-question.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-question.cy.spec.js
@@ -1,24 +1,10 @@
+import { H } from "e2e/support";
 import { USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   FIRST_COLLECTION_ID,
   ORDERS_MODEL_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  assertQueryBuilderRowCount,
-  cartesianChartCircle,
-  createQuestion,
-  echartsContainer,
-  enterCustomColumnDetails,
-  modal,
-  openQuestionActions,
-  popover,
-  queryBuilderHeader,
-  restore,
-  summarize,
-  undoToast,
-  visitMetric,
-} from "e2e/support/helpers";
 
 const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
 
@@ -61,30 +47,30 @@ const ORDERS_TIMESERIES_METRIC = {
 
 describe("scenarios > metrics > question", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
   it("should be able to move a metric to a different collection", () => {
-    createQuestion(ORDERS_SCALAR_METRIC, { visitQuestion: true });
-    openQuestionActions();
-    popover().findByText("Move").click();
-    modal().within(() => {
+    H.createQuestion(ORDERS_SCALAR_METRIC, { visitQuestion: true });
+    H.openQuestionActions();
+    H.popover().findByText("Move").click();
+    H.modal().within(() => {
       cy.findByText("First collection").click();
       cy.button("Move").click();
     });
-    undoToast().within(() => {
+    H.undoToast().within(() => {
       cy.findByText(/Metric moved to/).should("be.visible");
       cy.findByText("First collection").should("be.visible");
     });
-    queryBuilderHeader().findByText("First collection").should("be.visible");
+    H.queryBuilderHeader().findByText("First collection").should("be.visible");
   });
 
   it("should be able to add a filter with an ad-hoc question", () => {
-    createQuestion(ORDERS_SCALAR_METRIC, { visitQuestion: true });
+    H.createQuestion(ORDERS_SCALAR_METRIC, { visitQuestion: true });
     cy.findByTestId("qb-header-action-panel").button("Filter").click();
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Product").click();
       cy.findByText("Gadget").click();
       cy.button("Apply filters").click();
@@ -95,70 +81,70 @@ describe("scenarios > metrics > question", () => {
   });
 
   it("should be able to add a custom aggregation expression based on a metric", () => {
-    createQuestion(ORDERS_TIMESERIES_METRIC, { visitQuestion: true });
+    H.createQuestion(ORDERS_TIMESERIES_METRIC, { visitQuestion: true });
     cy.findByTestId("qb-header-action-panel").button("Summarize").click();
     cy.findByTestId("sidebar-content")
       .button(ORDERS_TIMESERIES_METRIC.name)
       .click();
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: `[${ORDERS_TIMESERIES_METRIC.name}] * 2`,
       name: "Expression",
     });
-    popover().button("Update").click();
-    echartsContainer().findByText("Expression").should("be.visible");
+    H.popover().button("Update").click();
+    H.echartsContainer().findByText("Expression").should("be.visible");
   });
 
   it("should be able to add a breakout with an ad-hoc question", () => {
-    createQuestion(ORDERS_TIMESERIES_METRIC, { visitQuestion: true });
+    H.createQuestion(ORDERS_TIMESERIES_METRIC, { visitQuestion: true });
     cy.findByTestId("qb-header-action-panel").button("Summarize").click();
     cy.findByTestId("sidebar-content").findByText("Category").click();
-    echartsContainer().findByText("Product → Category").should("be.visible");
+    H.echartsContainer().findByText("Product → Category").should("be.visible");
   });
 
   it("should be able to change the temporal unit when consuming a timeseries metric", () => {
-    createQuestion(ORDERS_TIMESERIES_METRIC, { visitQuestion: true });
-    assertQueryBuilderRowCount(49);
+    H.createQuestion(ORDERS_TIMESERIES_METRIC, { visitQuestion: true });
+    H.assertQueryBuilderRowCount(49);
     cy.findByTestId("qb-header-action-panel").button("Summarize").click();
     cy.findByTestId("sidebar-content")
       .findByTestId("pinned-dimensions")
       .findByLabelText("Created At")
       .findByText("by month")
       .click();
-    popover().findByText("Year").click();
-    assertQueryBuilderRowCount(5);
+    H.popover().findByText("Year").click();
+    H.assertQueryBuilderRowCount(5);
   });
 
   it("should be able to drill-thru with a metric", () => {
-    createQuestion(ORDERS_TIMESERIES_METRIC, { visitQuestion: true });
-    cartesianChartCircle()
+    H.createQuestion(ORDERS_TIMESERIES_METRIC, { visitQuestion: true });
+    H.cartesianChartCircle()
       .eq(23) // random dot
       .click({ force: true });
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Break out by…").click();
       cy.findByText("Category").click();
       cy.findByText("Source").click();
     });
     cy.wait("@dataset");
-    echartsContainer().findByText("User → Source").should("be.visible");
+    H.echartsContainer().findByText("User → Source").should("be.visible");
   });
 
   it("should be able to drill-thru with a metric without the aggregation clause", () => {
-    createQuestion(ORDERS_TIMESERIES_METRIC, { visitQuestion: true });
-    cartesianChartCircle()
+    H.createQuestion(ORDERS_TIMESERIES_METRIC, { visitQuestion: true });
+    H.cartesianChartCircle()
       .eq(23) // random dot
       .click({ force: true });
-    popover().findByText("See these Orders").click();
+    H.popover().findByText("See these Orders").click();
     cy.wait("@dataset");
     cy.findByTestId("qb-filters-panel")
       .findByText("Created At is Mar 1–31, 2024")
       .should("be.visible");
-    assertQueryBuilderRowCount(445);
+    H.assertQueryBuilderRowCount(445);
   });
 
   it("should be able to view a table-based metric without data access", () => {
-    createQuestion(ORDERS_SCALAR_METRIC).then(({ body: card }) => {
+    H.createQuestion(ORDERS_SCALAR_METRIC).then(({ body: card }) => {
       cy.signInAsSandboxedUser();
-      visitMetric(card.id, { hasDataAccess: false });
+      H.visitMetric(card.id, { hasDataAccess: false });
     });
     cy.findByTestId("scalar-container")
       .findByText("18,760")
@@ -170,9 +156,9 @@ describe("scenarios > metrics > question", () => {
   });
 
   it("should be able to view a model-based metric without data access", () => {
-    createQuestion(ORDERS_SCALAR_MODEL_METRIC).then(({ body: card }) => {
+    H.createQuestion(ORDERS_SCALAR_MODEL_METRIC).then(({ body: card }) => {
       cy.signInAsSandboxedUser();
-      visitMetric(card.id, { hasDataAccess: false });
+      H.visitMetric(card.id, { hasDataAccess: false });
     });
     cy.findByTestId("scalar-container")
       .findByText("18,760")
@@ -191,12 +177,12 @@ describe("scenarios > metrics > question", () => {
         [FIRST_COLLECTION_ID]: "read",
       },
     });
-    createQuestion({
+    H.createQuestion({
       ...ORDERS_SCALAR_MODEL_METRIC,
       collection_id: FIRST_COLLECTION_ID,
     }).then(({ body: card }) => {
       cy.signIn("nocollection");
-      visitMetric(card.id, { hasDataAccess: false });
+      H.visitMetric(card.id, { hasDataAccess: false });
     });
     cy.findByTestId("scalar-container")
       .findByText("18,760")
@@ -209,12 +195,12 @@ describe("scenarios > metrics > question", () => {
 
   it("should not show 'Replace existing question' option when saving an edited ad-hoc question from a metric (metabase#48555)", () => {
     cy.signInAsNormalUser();
-    createQuestion(ORDERS_SCALAR_METRIC, { visitQuestion: true });
+    H.createQuestion(ORDERS_SCALAR_METRIC, { visitQuestion: true });
 
-    summarize();
+    H.summarize();
     cy.button("Done").click();
 
-    queryBuilderHeader().button("Save").click();
-    modal().findByText("Replace or save as new?").should("not.exist");
+    H.queryBuilderHeader().button("Save").click();
+    H.modal().findByText("Replace or save as new?").should("not.exist");
   });
 });

--- a/e2e/test/scenarios/metrics/metrics-search.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-search.cy.spec.js
@@ -1,13 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  commandPalette,
-  commandPaletteSearch,
-  createQuestion,
-  navigationSidebar,
-  popover,
-  restore,
-  visitMetric,
-} from "e2e/support/helpers";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
 
@@ -23,17 +15,17 @@ const ORDERS_SCALAR_METRIC = {
 
 describe("scenarios > metrics > search", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("GET", "/api/search?q=*").as("search");
   });
 
   it("should be able to search for metrics in global search", () => {
-    createQuestion(ORDERS_SCALAR_METRIC);
+    H.createQuestion(ORDERS_SCALAR_METRIC);
     cy.visit("/");
-    commandPaletteSearch(ORDERS_SCALAR_METRIC.name, false);
-    commandPalette()
+    H.commandPaletteSearch(ORDERS_SCALAR_METRIC.name, false);
+    H.commandPalette()
       .findByRole("option", { name: ORDERS_SCALAR_METRIC.name })
       .click();
     cy.wait("@dataset");
@@ -41,16 +33,16 @@ describe("scenarios > metrics > search", () => {
   });
 
   it("should be able to search for metrics on the search page", () => {
-    createQuestion(ORDERS_SCALAR_METRIC);
+    H.createQuestion(ORDERS_SCALAR_METRIC);
     cy.visit("/");
-    commandPaletteSearch(ORDERS_SCALAR_METRIC.name, true);
+    H.commandPaletteSearch(ORDERS_SCALAR_METRIC.name, true);
     cy.wait("@search");
     cy.findByTestId("search-app").within(() => {
       cy.findByText(ORDERS_SCALAR_METRIC.name).should("be.visible");
       cy.findByText("Orders in a dashboard").should("be.visible");
       cy.findByTestId("type-search-filter").click();
     });
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Metric").click();
       cy.findByText("Apply").click();
     });
@@ -64,13 +56,13 @@ describe("scenarios > metrics > search", () => {
   });
 
   it("should see metrics in recent items in global search", () => {
-    createQuestion(ORDERS_SCALAR_METRIC).then(({ body: card }) => {
-      visitMetric(card.id);
+    H.createQuestion(ORDERS_SCALAR_METRIC).then(({ body: card }) => {
+      H.visitMetric(card.id);
       cy.wait("@dataset");
     });
-    navigationSidebar().findByText("Home").click();
-    commandPaletteSearch(ORDERS_SCALAR_METRIC.name, false);
-    commandPalette()
+    H.navigationSidebar().findByText("Home").click();
+    H.commandPaletteSearch(ORDERS_SCALAR_METRIC.name, false);
+    H.commandPalette()
       .findByRole("option", { name: ORDERS_SCALAR_METRIC.name })
       .click();
     cy.wait("@dataset");

--- a/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
@@ -1,32 +1,17 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  type StructuredQuestionDetails,
-  createDashboard,
-  createQuestion,
-  editDashboard,
-  getDashboardCard,
-  getNotebookStep,
-  main,
-  modal,
-  openQuestionActions,
-  popover,
-  restore,
-  showDashboardCardActions,
-  sidebar,
-  visitDashboard,
-} from "e2e/support/helpers";
 
 const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
 
 describe("issue 47058", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("GET", "/api/card/*/query_metadata", req =>
       req.continue(() => new Promise(resolve => setTimeout(resolve, 1000))),
     ).as("metadata");
 
-    createQuestion({
+    H.createQuestion({
       name: "Metric 47058",
       type: "metric",
       query: {
@@ -34,7 +19,7 @@ describe("issue 47058", () => {
         aggregation: [["count"]],
       },
     }).then(({ body: { id: metricId } }) => {
-      createQuestion({
+      H.createQuestion({
         name: "Question 47058",
         type: "question",
         query: {
@@ -53,9 +38,9 @@ describe("issue 47058", () => {
   });
 
   it("should show the loading page while the question metadata is being fetched (metabase#47058)", () => {
-    main().within(() => {
+    H.main().within(() => {
       cy.findByText("Loading...").should("be.visible");
-      getNotebookStep("summarize").should("not.exist");
+      H.getNotebookStep("summarize").should("not.exist");
 
       cy.findByText("[Unknown Metric]").should("not.exist");
 
@@ -65,7 +50,7 @@ describe("issue 47058", () => {
       );
 
       cy.findByText("Loading...").should("not.exist");
-      getNotebookStep("summarize").should("be.visible");
+      H.getNotebookStep("summarize").should("be.visible");
 
       cy.findByText("[Unknown Metric]").should("not.exist");
     });
@@ -73,7 +58,7 @@ describe("issue 47058", () => {
 });
 
 describe("issue 44171", () => {
-  const METRIC_A: StructuredQuestionDetails = {
+  const METRIC_A: H.StructuredQuestionDetails = {
     name: "Metric 44171-A",
     type: "metric",
     display: "line",
@@ -90,7 +75,7 @@ describe("issue 44171", () => {
     },
   };
 
-  const METRIC_B: StructuredQuestionDetails = {
+  const METRIC_B: H.StructuredQuestionDetails = {
     name: "Metric 44171-B",
     type: "metric",
     display: "line",
@@ -108,12 +93,12 @@ describe("issue 44171", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    createQuestion(METRIC_A);
-    createQuestion(METRIC_B, { visitQuestion: true });
-    createDashboard(
+    H.createQuestion(METRIC_A);
+    H.createQuestion(METRIC_B, { visitQuestion: true });
+    H.createDashboard(
       {
         name: "Dashboard 44171",
         dashcards: [],
@@ -125,16 +110,16 @@ describe("issue 44171", () => {
   it("should not save viz settings on metrics", () => {
     cy.intercept("PUT", "/api/card/*").as("saveCard");
 
-    openQuestionActions();
-    popover().findByText("Edit metric definition").click();
-    getNotebookStep("summarize").button("Count").click();
-    popover().within(() => {
+    H.openQuestionActions();
+    H.popover().findByText("Edit metric definition").click();
+    H.getNotebookStep("summarize").button("Count").click();
+    H.popover().within(() => {
       cy.findByText("Sum of ...").click();
       cy.findByText("Total").click();
     });
     cy.button("Save changes").click();
     cy.get<number>("@dashboardId").then(id => {
-      visitDashboard(id);
+      H.visitDashboard(id);
     });
 
     cy.get("@saveCard")
@@ -142,15 +127,15 @@ describe("issue 44171", () => {
       .its("visualization_settings")
       .should("not.exist");
 
-    editDashboard();
+    H.editDashboard();
     cy.findByTestId("dashboard-header")
       .findByLabelText("Add questions")
       .click();
 
-    sidebar().findByText("Metric 44171-A").click();
+    H.sidebar().findByText("Metric 44171-A").click();
 
-    showDashboardCardActions(0);
-    getDashboardCard(0).findByLabelText("Add series").click();
-    modal().findByText("Metric 44171-B").should("be.visible");
+    H.showDashboardCardActions(0);
+    H.getDashboardCard(0).findByLabelText("Add series").click();
+    H.modal().findByText("Metric 44171-B").should("be.visible");
   });
 });

--- a/e2e/test/scenarios/models/create.cy.spec.js
+++ b/e2e/test/scenarios/models/create.cy.spec.js
@@ -1,18 +1,11 @@
+import { H } from "e2e/support";
 import { THIRD_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  entityPickerModal,
-  entityPickerModalTab,
-  focusNativeEditor,
-  modal,
-  restore,
-  visitCollection,
-} from "e2e/support/helpers";
 
 const modelName = "A name";
 
 describe("scenarios > models > create", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
@@ -24,7 +17,7 @@ describe("scenarios > models > create", () => {
 
     // Cancel creation with confirmation modal
     cy.findByTestId("dataset-edit-bar").button("Cancel").click();
-    modal().button("Discard changes").click();
+    H.modal().button("Discard changes").click();
 
     // Now we will create a model
     navigateToNewModelPage();
@@ -32,7 +25,7 @@ describe("scenarios > models > create", () => {
     // Clicking on metadata should not work until we run a query
     cy.findByTestId("editor-tabs-metadata").should("be.disabled");
 
-    focusNativeEditor().type("select * from ORDERS");
+    H.focusNativeEditor().type("select * from ORDERS");
 
     cy.findByTestId("native-query-editor-container").icon("play").click();
     cy.wait("@dataset");
@@ -51,10 +44,10 @@ describe("scenarios > models > create", () => {
   });
 
   it("suggest the currently viewed collection when saving a new native query", () => {
-    visitCollection(THIRD_COLLECTION_ID);
+    H.visitCollection(THIRD_COLLECTION_ID);
 
     navigateToNewModelPage();
-    focusNativeEditor().type("select * from ORDERS");
+    H.focusNativeEditor().type("select * from ORDERS");
     cy.findByTestId("native-query-editor-container").icon("play").click();
     cy.wait("@dataset");
 
@@ -70,12 +63,12 @@ describe("scenarios > models > create", () => {
   });
 
   it("suggest the currently viewed collection when saving a new structured query", () => {
-    visitCollection(THIRD_COLLECTION_ID);
+    H.visitCollection(THIRD_COLLECTION_ID);
 
     navigateToNewModelPage("structured");
 
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Orders").click();
     });
 
@@ -103,7 +96,7 @@ function navigateToNewModelPage(queryType = "native") {
 }
 
 function checkIfPinned() {
-  visitCollection("root");
+  H.visitCollection("root");
 
   cy.findByText(modelName)
     .closest("a")

--- a/e2e/test/scenarios/models/model-indexes.cy.spec.js
+++ b/e2e/test/scenarios/models/model-indexes.cy.spec.js
@@ -1,13 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  commandPalette,
-  commandPaletteSearch,
-  openColumnOptions,
-  openQuestionActions,
-  popover,
-  restore,
-  sidebar,
-} from "e2e/support/helpers";
 import { createModelIndex } from "e2e/support/helpers/e2e-model-index-helper";
 
 const { PRODUCTS_ID, PEOPLE_ID } = SAMPLE_DATABASE;
@@ -16,7 +8,7 @@ describe("scenarios > model indexes", () => {
   let modelId;
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("GET", "/api/search?q=*").as("searchQuery");
     cy.intercept("POST", "/api/dataset").as("dataset");
@@ -45,7 +37,7 @@ describe("scenarios > model indexes", () => {
 
     editTitleMetadata();
 
-    sidebar()
+    H.sidebar()
       .findByLabelText(/surface individual records/i)
       .click({ force: true }); // needs to be forced because Mantine
 
@@ -63,7 +55,7 @@ describe("scenarios > model indexes", () => {
 
     editTitleMetadata();
 
-    sidebar()
+    H.sidebar()
       .findByLabelText(/surface individual records/i)
       .click({ force: true });
 
@@ -80,7 +72,7 @@ describe("scenarios > model indexes", () => {
 
     editTitleMetadata();
 
-    sidebar()
+    H.sidebar()
       .findByLabelText(/surface individual records/i)
       .click({ force: true });
 
@@ -104,18 +96,18 @@ describe("scenarios > model indexes", () => {
 
     editTitleMetadata();
 
-    sidebar()
+    H.sidebar()
       .findByLabelText(/surface individual records/i)
       .click({ force: true });
 
-    openColumnOptions("ID");
+    H.openColumnOptions("ID");
 
     // change the entity key to a foreign key so no key exists
-    sidebar()
+    H.sidebar()
       .findByText(/entity key/i)
       .click();
 
-    popover()
+    H.popover()
       .findByText(/foreign key/i)
       .click();
 
@@ -124,9 +116,9 @@ describe("scenarios > model indexes", () => {
     cy.wait("@cardUpdate");
 
     // search should fail
-    commandPaletteSearch("marble shoes", false);
+    H.commandPaletteSearch("marble shoes", false);
 
-    commandPalette()
+    H.commandPalette()
       .findByRole("option", { name: /No results for/ })
       .should("exist");
   });
@@ -136,8 +128,8 @@ describe("scenarios > model indexes", () => {
 
     cy.visit("/");
 
-    commandPaletteSearch("marble shoes", false);
-    commandPalette()
+    H.commandPaletteSearch("marble shoes", false);
+    H.commandPalette()
       .findByRole("option", { name: "Small Marble Shoes" })
       .click();
 
@@ -173,8 +165,8 @@ describe("scenarios > model indexes", () => {
 
     cy.visit("/");
 
-    commandPaletteSearch("anais", false);
-    commandPalette().findByRole("option", { name: "Anais Zieme" }).click();
+    H.commandPaletteSearch("anais", false);
+    H.commandPalette().findByRole("option", { name: "Anais Zieme" }).click();
 
     cy.wait("@dataset");
     cy.wait("@dataset"); // second query gets the additional record
@@ -190,8 +182,8 @@ describe("scenarios > model indexes", () => {
 
     cy.visit("/");
 
-    commandPaletteSearch("marble shoes", false);
-    commandPalette()
+    H.commandPaletteSearch("marble shoes", false);
+    H.commandPalette()
       .findByRole("option", { name: "Small Marble Shoes" })
       .click();
 
@@ -207,8 +199,8 @@ describe("scenarios > model indexes", () => {
 
     cy.get("body").type("{esc}");
 
-    commandPaletteSearch("silk coat", false);
-    commandPalette()
+    H.commandPaletteSearch("silk coat", false);
+    H.commandPalette()
       .findByRole("option", { name: "Ergonomic Silk Coat" })
       .click();
 
@@ -221,12 +213,12 @@ describe("scenarios > model indexes", () => {
 });
 
 function editTitleMetadata() {
-  openQuestionActions();
-  popover().findByText("Edit metadata").click();
+  H.openQuestionActions();
+  H.popover().findByText("Edit metadata").click();
   cy.url().should("include", "/metadata");
   cy.findByTestId("TableInteractive-root").findByTextEnsureVisible("Title");
 
-  openColumnOptions("Title");
+  H.openColumnOptions("Title");
 }
 
 const expectCardQueries = num =>

--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -1,26 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  addOrUpdateDashboardCard,
-  createNativeQuestion,
-  main,
-  mapColumnTo,
-  modal,
-  openColumnOptions,
-  openNotebook,
-  openQuestionActions,
-  popover,
-  queryBuilderHeader,
-  questionInfoButton,
-  renameColumn,
-  restore,
-  saveMetadataChanges,
-  setColumnType,
-  setModelMetadata,
-  sidebar,
-  visitDashboard,
-  visitModel,
-  visualize,
-} from "e2e/support/helpers";
 
 import { startQuestionFromModel } from "./helpers/e2e-models-helpers";
 
@@ -29,7 +8,7 @@ const { PEOPLE, PRODUCTS, PRODUCTS_ID, REVIEWS, ORDERS_ID, ORDERS } =
 
 describe("scenarios > models metadata", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
     cy.intercept("POST", "/api/dataset").as("dataset");
@@ -53,9 +32,9 @@ describe("scenarios > models metadata", () => {
     });
 
     it("should edit GUI model metadata", () => {
-      openQuestionActions();
+      H.openQuestionActions();
 
-      popover().findByTextEnsureVisible("89%").realHover();
+      H.popover().findByTextEnsureVisible("89%").realHover();
 
       cy.findByTestId("tooltip-content").within(() => {
         cy.findByText(
@@ -66,19 +45,19 @@ describe("scenarios > models metadata", () => {
         );
       });
 
-      popover().findByTextEnsureVisible("Edit metadata").click();
+      H.popover().findByTextEnsureVisible("Edit metadata").click();
       cy.url().should("include", "/metadata");
 
-      openColumnOptions("Subtotal");
-      renameColumn("Subtotal", "Pre-tax");
-      setColumnType("No special type", "Cost");
-      saveMetadataChanges();
+      H.openColumnOptions("Subtotal");
+      H.renameColumn("Subtotal", "Pre-tax");
+      H.setColumnType("No special type", "Cost");
+      H.saveMetadataChanges();
 
       cy.log(
         "Ensure that a question created from this model inherits its metadata.",
       );
       startQuestionFromModel("GUI Model");
-      visualize();
+      H.visualize();
 
       cy.findAllByTestId("header-cell")
         .should("contain", "Pre-tax ($)")
@@ -86,15 +65,15 @@ describe("scenarios > models metadata", () => {
     });
 
     it("allows for canceling changes", () => {
-      openQuestionActions();
-      popover().findByTextEnsureVisible("Edit metadata").click();
+      H.openQuestionActions();
+      H.popover().findByTextEnsureVisible("Edit metadata").click();
 
-      openColumnOptions("Subtotal");
-      renameColumn("Subtotal", "Pre-tax");
-      setColumnType("No special type", "Cost");
+      H.openColumnOptions("Subtotal");
+      H.renameColumn("Subtotal", "Pre-tax");
+      H.setColumnType("No special type", "Cost");
 
       cy.findByTestId("dataset-edit-bar").button("Cancel").click();
-      modal().button("Discard changes").click();
+      H.modal().button("Discard changes").click();
 
       cy.findAllByTestId("header-cell")
         .should("contain", "Subtotal")
@@ -105,20 +84,20 @@ describe("scenarios > models metadata", () => {
       "clears custom metadata when a model is turned back into a question",
       { tags: "@flaky" },
       () => {
-        openQuestionActions();
-        popover().findByTextEnsureVisible("Edit metadata").click();
+        H.openQuestionActions();
+        H.popover().findByTextEnsureVisible("Edit metadata").click();
 
-        openColumnOptions("Subtotal");
-        renameColumn("Subtotal", "Pre-tax");
-        setColumnType("No special type", "Cost");
-        saveMetadataChanges();
+        H.openColumnOptions("Subtotal");
+        H.renameColumn("Subtotal", "Pre-tax");
+        H.setColumnType("No special type", "Cost");
+        H.saveMetadataChanges();
 
         cy.findAllByTestId("header-cell")
           .should("contain", "Pre-tax ($)")
           .and("not.contain", "Subtotal");
 
-        openQuestionActions();
-        popover()
+        H.openQuestionActions();
+        H.popover()
           .findByTextEnsureVisible("Turn back to saved question")
           .click();
         cy.wait("@cardQuery");
@@ -142,9 +121,9 @@ describe("scenarios > models metadata", () => {
       { visitQuestion: true },
     );
 
-    openQuestionActions();
+    H.openQuestionActions();
 
-    popover().findByTextEnsureVisible("37%").realHover();
+    H.popover().findByTextEnsureVisible("37%").realHover();
 
     cy.findByTestId("tooltip-content").within(() => {
       cy.findByText(
@@ -155,15 +134,15 @@ describe("scenarios > models metadata", () => {
       );
     });
 
-    popover().findByTextEnsureVisible("Edit metadata").click();
+    H.popover().findByTextEnsureVisible("Edit metadata").click();
     cy.url().should("include", "/metadata");
 
-    openColumnOptions("SUBTOTAL");
+    H.openColumnOptions("SUBTOTAL");
 
-    mapColumnTo({ table: "Orders", column: "Subtotal" });
-    renameColumn("Subtotal", "Pre-tax");
-    setColumnType("No special type", "Cost");
-    saveMetadataChanges();
+    H.mapColumnTo({ table: "Orders", column: "Subtotal" });
+    H.renameColumn("Subtotal", "Pre-tax");
+    H.setColumnType("No special type", "Cost");
+    H.saveMetadataChanges();
 
     cy.findAllByTestId("header-cell")
       .should("contain", "Pre-tax ($)")
@@ -173,7 +152,7 @@ describe("scenarios > models metadata", () => {
       "Ensure that a question created from this model inherits its metadata.",
     );
     startQuestionFromModel("Native Model");
-    visualize();
+    H.visualize();
 
     cy.findAllByTestId("header-cell")
       .should("contain", "Pre-tax ($)")
@@ -191,13 +170,13 @@ describe("scenarios > models metadata", () => {
       },
       { visitQuestion: true },
     );
-    openQuestionActions();
-    popover().findByTextEnsureVisible("Edit metadata").click();
-    openColumnOptions("USER_ID");
-    setColumnType("No special type", "Foreign Key");
-    sidebar().findByText("Select a target").click();
-    popover().findByText("People → ID").click();
-    saveMetadataChanges();
+    H.openQuestionActions();
+    H.popover().findByTextEnsureVisible("Edit metadata").click();
+    H.openColumnOptions("USER_ID");
+    H.setColumnType("No special type", "Foreign Key");
+    H.sidebar().findByText("Select a target").click();
+    H.popover().findByText("People → ID").click();
+    H.saveMetadataChanges();
     // TODO: Not much to do with it at the moment beyond saving it.
     // Check that the relation is automatically suggested in the notebook once it is implemented.
   });
@@ -214,10 +193,10 @@ describe("scenarios > models metadata", () => {
       { visitQuestion: true },
     );
 
-    openQuestionActions();
-    popover().findByTextEnsureVisible("Edit query definition").click();
+    H.openQuestionActions();
+    H.popover().findByTextEnsureVisible("Edit query definition").click();
 
-    main().within(() => {
+    H.main().within(() => {
       cy.get("textarea")
         .focus()
         .invoke("val", "")
@@ -247,10 +226,10 @@ describe("scenarios > models metadata", () => {
       cy.wait("@cardQuery");
     });
 
-    openColumnOptions("SUBTOTAL");
-    mapColumnTo({ table: "Orders", column: "Subtotal" });
-    setColumnType("No special type", "Cost");
-    saveMetadataChanges();
+    H.openColumnOptions("SUBTOTAL");
+    H.mapColumnTo({ table: "Orders", column: "Subtotal" });
+    H.setColumnType("No special type", "Cost");
+    H.saveMetadataChanges();
 
     cy.log("Revision 1");
     cy.findByTestId("TableInteractive-root").within(() => {
@@ -258,14 +237,14 @@ describe("scenarios > models metadata", () => {
       cy.findByText("SUBTOTAL").should("not.exist");
     });
 
-    openQuestionActions();
-    popover().findByTextEnsureVisible("Edit metadata").click();
+    H.openQuestionActions();
+    H.popover().findByTextEnsureVisible("Edit metadata").click();
 
     cy.log("Revision 2");
-    openColumnOptions("TAX");
-    mapColumnTo({ table: "Orders", column: "Tax" });
-    setColumnType("No special type", "Cost");
-    saveMetadataChanges();
+    H.openColumnOptions("TAX");
+    H.mapColumnTo({ table: "Orders", column: "Tax" });
+    H.setColumnType("No special type", "Cost");
+    H.saveMetadataChanges();
 
     cy.findAllByTestId("header-cell")
       .should("contain", "Subtotal ($)")
@@ -273,7 +252,7 @@ describe("scenarios > models metadata", () => {
       .and("not.contain", "TAX");
 
     cy.reload();
-    questionInfoButton().click();
+    H.questionInfoButton().click();
 
     cy.findByTestId("sidesheet").within(() => {
       cy.findByRole("tab", { name: "History" }).click();
@@ -301,7 +280,7 @@ describe("scenarios > models metadata", () => {
       );
 
       cy.get("@modelId").then(modelId => {
-        setModelMetadata(modelId, field => {
+        H.setModelMetadata(modelId, field => {
           if (field.display_name === "USER_ID") {
             return {
               ...field,
@@ -362,9 +341,9 @@ describe("scenarios > models metadata", () => {
 
         // Drill to People table
         // FK column is mapped to real DB column
-        queryBuilderHeader().button("Filter").click();
+        H.queryBuilderHeader().button("Filter").click();
 
-        modal().within(() => {
+        H.modal().within(() => {
           cy.findByRole("tablist").within(() => {
             cy.get("button").should("have.length", 2); // Just the two we're expecting and not the other fake FK.
             cy.findByText("Native Model").should("exist");
@@ -393,18 +372,18 @@ describe("scenarios > models metadata", () => {
       cy.get("@modelId").then(modelId => {
         cy.createDashboard().then(response => {
           const dashboardId = response.body.id;
-          addOrUpdateDashboardCard({
+          H.addOrUpdateDashboardCard({
             dashboard_id: dashboardId,
             card_id: modelId,
             card: { size_x: 24, size_y: 9 },
           });
 
-          visitDashboard(dashboardId);
+          H.visitDashboard(dashboardId);
 
           // Drill to People table
           // FK column is mapped to real DB column
           drillDashboardFK({ id: 1 });
-          popover().findByText("View details").click();
+          H.popover().findByText("View details").click();
           cy.wait("@dataset");
           cy.findByTestId("object-detail").within(() => {
             cy.findAllByText("1");
@@ -416,7 +395,7 @@ describe("scenarios > models metadata", () => {
           // Drill to Reviews table
           // FK column has a FK semantic type, no mapping to real DB columns
           drillDashboardFK({ id: 7 });
-          popover().findByText("View details").click();
+          H.popover().findByText("View details").click();
           cy.wait("@dataset");
           cy.findByTestId("object-detail").within(() => {
             cy.findAllByText("7");
@@ -443,8 +422,8 @@ describe("scenarios > models metadata", () => {
       cy.createQuestion(questionDetails, { visitQuestion: true });
       cy.findAllByTestId("header-cell").should("not.contain", "Vendor");
 
-      openQuestionActions();
-      popover().findByTextEnsureVisible("Edit metadata").click();
+      H.openQuestionActions();
+      H.popover().findByTextEnsureVisible("Edit metadata").click();
 
       cy.findAllByTestId("header-cell")
         .contains(/^Vendor$/)
@@ -453,7 +432,7 @@ describe("scenarios > models metadata", () => {
   });
 
   it("does not confuse the names of various native model columns mapped to the same database field", () => {
-    createNativeQuestion(
+    H.createNativeQuestion(
       {
         type: "model",
         native: {
@@ -464,19 +443,19 @@ describe("scenarios > models metadata", () => {
     );
 
     cy.get("@modelId").then(modelId => {
-      setModelMetadata(modelId, (field, index) => ({
+      H.setModelMetadata(modelId, (field, index) => ({
         ...field,
         id: ORDERS.ID,
         display_name: `ID${index + 1}`,
         semantic_type: "type/PK",
       }));
 
-      visitModel(modelId);
+      H.visitModel(modelId);
     });
 
-    openNotebook();
+    H.openNotebook();
     cy.findByTestId("fields-picker").click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("ID1").should("be.visible");
       cy.findByText("ID2").should("be.visible");
       cy.findByText("ID3").should("be.visible");
@@ -486,7 +465,7 @@ describe("scenarios > models metadata", () => {
 
 function drillFK({ id }) {
   cy.get(".test-Table-FK").contains(id).first().click();
-  popover().findByTextEnsureVisible("View details").click();
+  H.popover().findByTextEnsureVisible("View details").click();
 }
 
 function drillDashboardFK({ id }) {

--- a/e2e/test/scenarios/models/models-query-editor.cy.spec.js
+++ b/e2e/test/scenarios/models/models-query-editor.cy.spec.js
@@ -1,13 +1,5 @@
+import { H } from "e2e/support";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  focusNativeEditor,
-  modal,
-  openQuestionActions,
-  popover,
-  restore,
-  runNativeQuery,
-  summarize,
-} from "e2e/support/helpers";
 
 import { selectFromDropdown } from "./helpers/e2e-models-helpers";
 
@@ -17,7 +9,7 @@ describe("scenarios > models query editor", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -37,9 +29,9 @@ describe("scenarios > models query editor", () => {
         .should("contain", "37.65")
         .and("contain", "109.22");
 
-      openQuestionActions();
+      H.openQuestionActions();
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Edit query definition").click();
       });
 
@@ -78,9 +70,9 @@ describe("scenarios > models query editor", () => {
         .should("contain", "37.65")
         .and("contain", "109.22");
 
-      openQuestionActions();
+      H.openQuestionActions();
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Edit query definition").click();
       });
 
@@ -96,7 +88,7 @@ describe("scenarios > models query editor", () => {
         .and("not.contain", "109.22");
 
       cy.button("Cancel").click();
-      modal().button("Discard changes").click();
+      H.modal().button("Discard changes").click();
       cy.wait("@cardQuery");
 
       cy.url()
@@ -112,7 +104,7 @@ describe("scenarios > models query editor", () => {
     it("locks display to table", () => {
       cy.visit(`/model/${ORDERS_QUESTION_ID}/query`);
 
-      summarize({ mode: "notebook" });
+      H.summarize({ mode: "notebook" });
 
       selectFromDropdown("Count of rows");
 
@@ -143,18 +135,18 @@ describe("scenarios > models query editor", () => {
         .should("contain", "37.65")
         .and("contain", "109.22");
 
-      openQuestionActions();
+      H.openQuestionActions();
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Edit query definition").click();
       });
 
       cy.url().should("include", "/query");
       cy.button("Save changes").should("be.disabled");
 
-      focusNativeEditor().type("{backspace}2");
+      H.focusNativeEditor().type("{backspace}2");
 
-      runNativeQuery();
+      H.runNativeQuery();
 
       cy.get("[data-testid=cell-data]")
         .should("contain", "37.65")
@@ -184,25 +176,25 @@ describe("scenarios > models query editor", () => {
         .should("contain", "37.65")
         .and("contain", "109.22");
 
-      openQuestionActions();
+      H.openQuestionActions();
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Edit query definition").click();
       });
 
       cy.url().should("include", "/query");
       cy.button("Save changes").should("be.disabled");
 
-      focusNativeEditor().type("{backspace}2");
+      H.focusNativeEditor().type("{backspace}2");
 
-      runNativeQuery();
+      H.runNativeQuery();
 
       cy.get("[data-testid=cell-data]")
         .should("contain", "37.65")
         .and("not.contain", "109.22");
 
       cy.button("Cancel").click();
-      modal().button("Discard changes").click();
+      H.modal().button("Discard changes").click();
       cy.wait("@cardQuery");
 
       cy.get("[data-testid=cell-data]")
@@ -223,9 +215,9 @@ describe("scenarios > models query editor", () => {
         { visitQuestion: true },
       );
 
-      openQuestionActions();
+      H.openQuestionActions();
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Edit metadata").click();
       });
 
@@ -238,8 +230,8 @@ describe("scenarios > models query editor", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Syntax error in SQL/).should("be.visible");
 
-      focusNativeEditor().type("{backspace}".repeat(" FROM".length));
-      runNativeQuery();
+      H.focusNativeEditor().type("{backspace}".repeat(" FROM".length));
+      H.runNativeQuery();
 
       cy.get("[data-testid=cell-data]").contains(1);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/models/models-revision-history.cy.spec.js
+++ b/e2e/test/scenarios/models/models-revision-history.cy.spec.js
@@ -1,15 +1,9 @@
+import { H } from "e2e/support";
 import { ORDERS_BY_YEAR_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  echartsContainer,
-  questionInfoButton,
-  restore,
-  sidesheet,
-  visitModel,
-} from "e2e/support/helpers";
 
 describe("scenarios > models > revision history", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.request("PUT", `/api/card/${ORDERS_BY_YEAR_QUESTION_ID}`, {
       name: "Orders Model",
@@ -18,15 +12,15 @@ describe("scenarios > models > revision history", () => {
   });
 
   it("should allow reverting to a saved question state and back into a model again", () => {
-    visitModel(ORDERS_BY_YEAR_QUESTION_ID);
+    H.visitModel(ORDERS_BY_YEAR_QUESTION_ID);
 
     openRevisionHistory();
     revertTo("You created this");
 
     cy.location("pathname").should("match", /^\/question\/\d+/);
-    echartsContainer();
+    H.echartsContainer();
 
-    sidesheet().findByRole("tab", { name: "History" }).click();
+    H.sidesheet().findByRole("tab", { name: "History" }).click();
     revertTo("You edited this");
 
     cy.location("pathname").should("match", /^\/model\/\d+/);
@@ -35,8 +29,8 @@ describe("scenarios > models > revision history", () => {
 });
 
 function openRevisionHistory() {
-  questionInfoButton().click();
-  sidesheet().findByRole("tab", { name: "History" }).click();
+  H.questionInfoButton().click();
+  H.sidesheet().findByRole("tab", { name: "History" }).click();
   cy.findByTestId("saved-question-history-list").should("be.visible");
 }
 

--- a/e2e/test/scenarios/models/models-with-aggregation-and-breakout.cy.spec.js
+++ b/e2e/test/scenarios/models/models-with-aggregation-and-breakout.cy.spec.js
@@ -1,12 +1,12 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { restore } from "e2e/support/helpers";
 
 import { turnIntoModel } from "./helpers/e2e-models-helpers";
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > models with aggregation and breakout", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("PUT", "/api/card/*").as("updateCard");

--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -1,40 +1,10 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_BY_YEAR_QUESTION_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  closeQuestionActions,
-  echartsContainer,
-  editDashboard,
-  entityPickerModal,
-  entityPickerModalTab,
-  filter,
-  filterField,
-  focusNativeEditor,
-  getDashboardCard,
-  getNotebookStep,
-  mockSessionProperty,
-  modal,
-  openNativeEditor,
-  openQuestionActions,
-  openQuestionsSidebar,
-  popover,
-  questionInfoButton,
-  restore,
-  saveDashboard,
-  selectFilterOperator,
-  sidebar,
-  startNewQuestion,
-  summarize,
-  tableHeaderClick,
-  undo,
-  visitCollection,
-  visitDashboard,
-  visitQuestion,
-  visualize,
-} from "e2e/support/helpers";
 
 import {
   assertIsModel,
@@ -50,7 +20,7 @@ const { PRODUCTS, ORDERS_ID, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > models", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dataset").as("dataset");
 
@@ -71,14 +41,14 @@ describe("scenarios > models", () => {
       cy.request("PUT", `/api/card/${id}`, {
         name: "Products Model",
       });
-      visitQuestion(id);
+      H.visitQuestion(id);
 
       turnIntoModel();
-      openQuestionActions();
+      H.openQuestionActions();
       assertIsModel();
 
-      filter();
-      filterField("Vendor", {
+      H.filter();
+      H.filterField("Vendor", {
         operator: "Contains",
         value: "Fisher",
       });
@@ -124,11 +94,11 @@ describe("scenarios > models", () => {
     );
 
     turnIntoModel();
-    openQuestionActions();
+    H.openQuestionActions();
     assertIsModel();
 
-    filter();
-    filterField("VENDOR", {
+    H.filter();
+    H.filterField("VENDOR", {
       operator: "Contains",
       value: "Fisher",
     });
@@ -181,7 +151,7 @@ describe("scenarios > models", () => {
     );
 
     turnIntoModel();
-    openQuestionActions();
+    H.openQuestionActions();
     assertIsModel();
 
     cy.get("@questionId").then(questionId => {
@@ -210,8 +180,8 @@ describe("scenarios > models", () => {
     //   expect(response.body.error).to.not.exist;
     // });
 
-    filter();
-    filterField("COUN", {
+    H.filter();
+    H.filterField("COUN", {
       operator: "Greater than",
       value: 30,
     });
@@ -248,9 +218,9 @@ describe("scenarios > models", () => {
   });
 
   it("changes model's display to table", () => {
-    visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
+    H.visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
 
-    echartsContainer();
+    H.echartsContainer();
     // TODO (styles): migrate
     cy.get(".test-TableInteractive").should("not.exist");
 
@@ -258,12 +228,12 @@ describe("scenarios > models", () => {
 
     // TODO (styles): migrate
     cy.get(".test-TableInteractive");
-    echartsContainer().should("not.exist");
+    H.echartsContainer().should("not.exist");
   });
 
   it("allows to undo turning a question into a model", () => {
-    visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
-    echartsContainer();
+    H.visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
+    H.echartsContainer();
 
     turnIntoModel();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -271,8 +241,8 @@ describe("scenarios > models", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Undo").click();
 
-    echartsContainer();
-    openQuestionActions();
+    H.echartsContainer();
+    H.openQuestionActions();
     assertIsQuestion();
   });
 
@@ -281,8 +251,8 @@ describe("scenarios > models", () => {
     cy.intercept("PUT", `/api/card/${ORDERS_QUESTION_ID}`).as("cardUpdate");
     cy.visit(`/model/${ORDERS_QUESTION_ID}`);
 
-    openQuestionActions();
-    popover().within(() => {
+    H.openQuestionActions();
+    H.popover().within(() => {
       cy.findByText("Turn back to saved question").click();
     });
 
@@ -290,13 +260,13 @@ describe("scenarios > models", () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("This is a question now.");
-    openQuestionActions();
+    H.openQuestionActions();
     assertIsQuestion();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Undo").click();
     cy.wait("@cardUpdate");
-    openQuestionActions();
+    H.openQuestionActions();
     assertIsModel();
   });
 
@@ -311,7 +281,7 @@ describe("scenarios > models", () => {
     // Important - do not use visitQuestion(ORDERS_QUESTION_ID) here!
     cy.visit("/question/" + ORDERS_QUESTION_ID);
     cy.wait("@dataset");
-    openQuestionActions();
+    H.openQuestionActions();
     assertIsModel();
     cy.url().should("include", "/model");
   });
@@ -323,15 +293,15 @@ describe("scenarios > models", () => {
     });
 
     it("transforms the data picker", () => {
-      startNewQuestion();
+      H.startNewQuestion();
 
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Models").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Models").click();
         cy.findByText("Orders").should("exist");
         cy.findByText("Orders Model").should("exist");
         cy.findByText("Orders, Count").should("not.exist");
 
-        entityPickerModalTab("Saved questions").click();
+        H.entityPickerModalTab("Saved questions").click();
         cy.findByText("Orders").should("not.exist");
         cy.findByText("Orders Model").should("not.exist");
         cy.findByText("Orders, Count").should("exist");
@@ -340,7 +310,7 @@ describe("scenarios > models", () => {
         );
         cy.findByText("Products").should("exist");
 
-        entityPickerModalTab("Tables").click();
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Orders").should("exist");
         cy.findByText("People").should("exist");
         cy.findByText("Products").should("exist");
@@ -388,15 +358,15 @@ describe("scenarios > models", () => {
     it("allows to create a question based on a model", () => {
       cy.intercept(`/api/database/${SAMPLE_DB_ID}/schema/PUBLIC`).as("schema");
 
-      startNewQuestion();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Models").click();
+      H.startNewQuestion();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Models").click();
         cy.findByText("Orders").click();
       });
 
       cy.icon("join_left_outer").click();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Orders").should("exist");
         cy.findByText("People").should("exist");
         cy.findByText("Products").should("exist");
@@ -405,15 +375,15 @@ describe("scenarios > models", () => {
         cy.findByText("Products").click();
       });
 
-      getNotebookStep("filter")
+      H.getNotebookStep("filter")
         .findByText("Add filters to narrow your answer")
         .click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Products").click();
         cy.findByText("Price").click();
       });
-      selectFilterOperator("Less than");
-      popover().within(() => {
+      H.selectFilterOperator("Less than");
+      H.popover().within(() => {
         cy.findByPlaceholderText("Enter a number").type("50");
         cy.button("Add filter").click();
       });
@@ -426,8 +396,8 @@ describe("scenarios > models", () => {
       cy.findByText("Pick a column to group by").click();
       selectFromDropdown("Created At");
 
-      visualize();
-      echartsContainer();
+      H.visualize();
+      H.echartsContainer();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Save").click();
 
@@ -439,9 +409,9 @@ describe("scenarios > models", () => {
     });
 
     it("should not display models if nested queries are disabled", () => {
-      mockSessionProperty("enable-nested-queries", false);
-      startNewQuestion();
-      entityPickerModal().within(() => {
+      H.mockSessionProperty("enable-nested-queries", false);
+      H.startNewQuestion();
+      H.entityPickerModal().within(() => {
         cy.findAllByRole("tab").should("not.exist");
 
         cy.findByText("Orders").should("exist");
@@ -464,8 +434,8 @@ describe("scenarios > models", () => {
       cy.visit(`/model/${ORDERS_QUESTION_ID}`);
       cy.wait("@dataset");
 
-      filter();
-      filterField("Discount", {
+      H.filter();
+      H.filterField("Discount", {
         operator: "Not empty",
       });
       cy.findByTestId("apply-filters").click();
@@ -477,7 +447,7 @@ describe("scenarios > models", () => {
         table: "Orders",
       });
 
-      summarize();
+      H.summarize();
 
       selectDimensionOptionFromSidebar("Created At");
       cy.wait("@dataset");
@@ -506,7 +476,7 @@ describe("scenarios > models", () => {
       cy.visit(`/model/${ORDERS_QUESTION_ID}`);
       cy.wait("@dataset");
 
-      tableHeaderClick("Subtotal");
+      H.tableHeaderClick("Subtotal");
       selectFromDropdown("Sum over time");
 
       assertQuestionIsBasedOnModel({
@@ -536,7 +506,7 @@ describe("scenarios > models", () => {
       cy.findByTestId("saved-question-header-title").clear().type("M1").blur();
       cy.wait("@updateCard");
 
-      questionInfoButton().click();
+      H.questionInfoButton().click();
 
       cy.findByPlaceholderText("Add description").type("foo").blur();
       cy.wait("@updateCard");
@@ -568,23 +538,23 @@ describe("scenarios > models", () => {
       { visitQuestion: true },
     );
 
-    openQuestionActions();
-    popover().within(() => {
+    H.openQuestionActions();
+    H.popover().within(() => {
       cy.icon("model").click();
     });
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Variables in models aren't supported yet");
       cy.button("Turn this into a model").should("not.exist");
       cy.icon("close").click();
     });
-    openQuestionActions();
+    H.openQuestionActions();
     assertIsQuestion();
-    closeQuestionActions();
+    H.closeQuestionActions();
 
     // Check card tags are supported by models
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Open editor/i).click();
-    focusNativeEditor().type(
+    H.focusNativeEditor().type(
       "{leftarrow}{leftarrow}{backspace}{backspace}#1-orders",
     );
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -595,7 +565,7 @@ describe("scenarios > models", () => {
     });
 
     turnIntoModel();
-    openQuestionActions();
+    H.openQuestionActions();
     assertIsModel();
   });
 
@@ -605,7 +575,7 @@ describe("scenarios > models", () => {
     }).then(({ body: { id: modelId } }) => {
       cy.request("PUT", `/api/card/${modelId}`, { type: "model" }).then(() => {
         cy.visit(`/model/${modelId}/query`);
-        focusNativeEditor().type("{movetoend}").type(" WHERE {{F", {
+        H.focusNativeEditor().type("{movetoend}").type(" WHERE {{F", {
           parseSpecialCharSequences: false,
         });
         cy.findByTestId("tag-editor-sidebar").should("not.exist");
@@ -630,9 +600,9 @@ describe("scenarios > models", () => {
   });
 
   it("should automatically pin newly created models", () => {
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
     turnIntoModel();
-    visitCollection("root");
+    H.visitCollection("root");
     cy.findByTestId("pinned-items").within(() => {
       cy.findByText("Models");
       cy.findByText("A model");
@@ -640,13 +610,13 @@ describe("scenarios > models", () => {
   });
 
   it("should undo pinning a question if turning into a model was undone", () => {
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
 
     turnIntoModel();
-    undo();
+    H.undo();
     cy.wait("@cardUpdate");
 
-    visitCollection("root");
+    H.visitCollection("root");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Useful data").should("not.exist");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -669,16 +639,16 @@ describe("scenarios > models", () => {
 
     it("should allow adding models to dashboards", () => {
       cy.createDashboard().then(({ body: { id: dashboardId } }) => {
-        visitDashboard(dashboardId);
-        editDashboard();
-        openQuestionsSidebar();
-        sidebar().findByText(modelDetails.name).click();
-        getDashboardCard().within(() => {
+        H.visitDashboard(dashboardId);
+        H.editDashboard();
+        H.openQuestionsSidebar();
+        H.sidebar().findByText(modelDetails.name).click();
+        H.getDashboardCard().within(() => {
           cy.findByText(modelDetails.name);
           cy.findByText("37.65");
         });
-        saveDashboard();
-        getDashboardCard().within(() => {
+        H.saveDashboard();
+        H.getDashboardCard().within(() => {
           cy.findByText(modelDetails.name);
           cy.findByText("37.65");
         });
@@ -688,7 +658,7 @@ describe("scenarios > models", () => {
     it("should allow using models in native queries", () => {
       cy.intercept("POST", "/api/dataset").as("query");
       cy.get("@modelId").then(id => {
-        openNativeEditor().type(`select * from {{#${id}}}`, {
+        H.openNativeEditor().type(`select * from {{#${id}}}`, {
           parseSpecialCharSequences: false,
         });
       });

--- a/e2e/test/scenarios/models/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.js
@@ -1,60 +1,10 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, SAMPLE_DB_SCHEMA_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  addOrUpdateDashboardCard,
-  appBar,
-  assertQueryBuilderRowCount,
-  cartesianChartCircle,
-  closeCommandPalette,
-  commandPalette,
-  commandPaletteSearch,
-  createAction,
-  createNativeQuestion,
-  createQuestion,
-  editDashboard,
-  enterCustomColumnDetails,
-  entityPickerModal,
-  entityPickerModalLevel,
-  entityPickerModalTab,
-  filter,
-  filterField,
-  filterFieldPopover,
-  filterWidget,
-  focusNativeEditor,
-  getDashboardCard,
-  getNotebookStep,
-  leftSidebar,
-  main,
-  modal,
-  nativeEditor,
-  navigationSidebar,
-  onlyOnOSS,
-  openNativeEditor,
-  openNavigationSidebar,
-  openNotebook,
-  openQuestionActions,
-  popover,
-  restore,
-  rightSidebar,
-  saveMetadataChanges,
-  saveQuestion,
-  setActionsEnabledForDB,
-  setFilter,
-  setModelMetadata,
-  sidebar,
-  startNewNativeModel,
-  startNewQuestion,
-  summarize,
-  tableHeaderClick,
-  visitDashboard,
-  visitModel,
-  visitQuestion,
-  visualize,
-} from "e2e/support/helpers";
 import {
   createMockActionParameter,
   createMockDashboardCard,
@@ -84,7 +34,7 @@ describe("issue 19180", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("/api/card/*/query").as("cardQuery");
   });
@@ -112,9 +62,9 @@ describe("issue 19737", () => {
 
   function moveModel(modelName, collectionName) {
     openEllipsisMenuFor(modelName);
-    popover().findByText("Move").click();
+    H.popover().findByText("Move").click();
 
-    entityPickerModal().within(() => {
+    H.entityPickerModal().within(() => {
       cy.findByRole("tab", { name: /Collections/ }).click();
       cy.findByText(collectionName).click();
       cy.button("Move").click();
@@ -126,7 +76,7 @@ describe("issue 19737", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -143,8 +93,8 @@ describe("issue 19737", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Question").should("be.visible").click();
 
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Models").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Models").click();
       cy.findByText(personalCollectionName).click();
       cy.findByText(modelName);
     });
@@ -167,8 +117,8 @@ describe("issue 19737", () => {
     cy.findByText("Question").should("be.visible").click();
 
     // Open question picker (this is crucial) so the collection list are loaded.
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Models").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Models").click();
       cy.findByText("First collection").click();
       cy.findByText(modelName);
     });
@@ -177,8 +127,8 @@ describe("issue 19737", () => {
     cy.go("back");
 
     // move "Orders Model" from a custom collection ("First collection") to another collection
-    openNavigationSidebar();
-    navigationSidebar().findByText("First collection").click();
+    H.openNavigationSidebar();
+    H.navigationSidebar().findByText("First collection").click();
 
     moveModel(modelName, personalCollectionName);
 
@@ -190,10 +140,10 @@ describe("issue 19737", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Question").should("be.visible").click();
 
-    entityPickerModal().within(() => {
+    H.entityPickerModal().within(() => {
       cy.findByText("First collection").should("not.exist");
-      entityPickerModalLevel(1).should("not.exist");
-      entityPickerModalLevel(2).should("not.exist");
+      H.entityPickerModalLevel(1).should("not.exist");
+      H.entityPickerModalLevel(2).should("not.exist");
     });
   });
 });
@@ -206,8 +156,8 @@ describe("issue 19776", { tags: "@OSS" }, () => {
   }
 
   beforeEach(() => {
-    onlyOnOSS();
-    restore();
+    H.onlyOnOSS();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -215,24 +165,24 @@ describe("issue 19776", { tags: "@OSS" }, () => {
     cy.visit("/");
 
     cy.findByTestId("app-bar").button("New").click();
-    popover().findByText("Question").click();
-    entityPickerModalTab("Models").should("be.visible"); // now you see it
-    entityPickerModal().findByLabelText("Close").click();
+    H.popover().findByText("Question").click();
+    H.entityPickerModalTab("Models").should("be.visible"); // now you see it
+    H.entityPickerModal().findByLabelText("Close").click();
 
     // navigate without a page load
     cy.findByTestId("sidebar-toggle").click();
-    navigationSidebar().findByText("Our analytics").click();
+    H.navigationSidebar().findByText("Our analytics").click();
 
     // archive the only model
     cy.findByTestId("collection-table").within(() => {
       openEllipsisMenuFor(modelName);
     });
-    popover().contains("Move to trash").click();
+    H.popover().contains("Move to trash").click();
     cy.findByTestId("undo-list").findByText("Trashed model");
 
     cy.findByTestId("app-bar").button("New").click();
-    popover().findByText("Question").click();
-    entityPickerModalTab("Models").should("not.exist"); // now you don't
+    H.popover().findByText("Question").click();
+    H.entityPickerModalTab("Models").should("not.exist"); // now you don't
   });
 });
 
@@ -240,7 +190,7 @@ describe("issue 20042", () => {
   beforeEach(() => {
     cy.intercept("POST", `/api/card/${ORDERS_QUESTION_ID}/query`).as("query");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, {
@@ -267,7 +217,7 @@ describe("issue 20045", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, {
@@ -310,7 +260,7 @@ describe("issue 20517", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestion(modelDetails).then(({ body: { id } }) => {
@@ -355,7 +305,7 @@ describe.skip("issue 20624", () => {
   beforeEach(() => {
     cy.intercept("PUT", "/api/card/*").as("updateCard");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestion(questionDetails, { visitQuestion: true });
@@ -384,20 +334,20 @@ describe("issue 20963", () => {
   const questionName = "Converting questions with snippets to models";
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should allow converting questions with static snippets to models (metabase#20963)", () => {
     cy.visit("/");
 
-    openNativeEditor();
+    H.openNativeEditor();
 
     // Creat a snippet
     cy.icon("snippet").click();
     cy.findByTestId("sidebar-content").findByText("Create a snippet").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByLabelText("Enter some SQL here so you can reuse it later").type(
         "'test'",
       );
@@ -407,15 +357,15 @@ describe("issue 20963", () => {
 
     cy.get("@editor").type("{moveToStart}select ");
 
-    saveQuestion(questionName, { wrapId: true });
+    H.saveQuestion(questionName, { wrapId: true });
 
     // Convert into to a model
-    openQuestionActions();
-    popover().within(() => {
+    H.openQuestionActions();
+    H.popover().within(() => {
       cy.icon("model").click();
     });
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Turn this into a model").click();
     });
   });
@@ -430,7 +380,7 @@ describe("issue 22517", () => {
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
     cy.intercept("PUT", "/api/card/*").as("updateMetadata");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestion(
@@ -442,7 +392,7 @@ describe("issue 22517", () => {
       { visitQuestion: true },
     );
 
-    openQuestionActions();
+    H.openQuestionActions();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Edit metadata").click();
 
@@ -453,7 +403,7 @@ describe("issue 22517", () => {
   });
 
   it.skip("adding or removing a column should not drop previously edited metadata (metabase#22517)", () => {
-    openQuestionActions();
+    H.openQuestionActions();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Edit query definition").click();
 
@@ -463,7 +413,7 @@ describe("issue 22517", () => {
 
     // This will edit the original query and add the `SIZE` column
     // Updated query: `select *, case when quantity > 4 then 'large' else 'small' end size from orders`
-    focusNativeEditor().type(
+    H.focusNativeEditor().type(
       "{leftarrow}".repeat(" from orders".length) +
         ", case when quantity > 4 then 'large' else 'small' end size ",
     );
@@ -484,7 +434,7 @@ describe("issue 22517", () => {
 
 describe("issue 22518", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.createNativeQuestion(
@@ -499,11 +449,11 @@ describe("issue 22518", () => {
   });
 
   it("UI should immediately reflect model query changes upon saving (metabase#22518)", () => {
-    openQuestionActions();
+    H.openQuestionActions();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Edit query definition").click();
 
-    focusNativeEditor().type(", 'b' bar");
+    H.focusNativeEditor().type(", 'b' bar");
     cy.findByTestId("native-query-editor-container").icon("play").click();
     cy.wait("@dataset");
 
@@ -513,9 +463,9 @@ describe("issue 22518", () => {
       .should("have.length", 3)
       .and("contain", "BAR");
 
-    summarize();
+    H.summarize();
 
-    sidebar()
+    H.sidebar()
       .should("contain", "ID")
       .and("contain", "FOO")
       .and("contain", "BAR");
@@ -535,7 +485,7 @@ describe.skip("issue 22519", () => {
     cy.intercept("PUT", "/api/field/*").as("updateField");
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.visit(ratingDataModelUrl);
@@ -568,15 +518,15 @@ describe("filtering based on the remapped column name should result in a correct
       .contains("None")
       .click();
 
-    popover().findByText(table).click();
-    popover().findByText(column).click();
+    H.popover().findByText(table).click();
+    H.popover().findByText(column).click();
   }
 
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("PUT", "/api/card/*").as("updateModel");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestion({
@@ -586,7 +536,7 @@ describe("filtering based on the remapped column name should result in a correct
       },
     }).then(({ body: { id } }) => {
       // Visit the question to first load metadata
-      visitQuestion(id);
+      H.visitQuestion(id);
 
       // Turn the question into a model
       cy.request("PUT", `/api/card/${id}`, { type: "model" });
@@ -620,7 +570,7 @@ describe("filtering based on the remapped column name should result in a correct
   });
 
   it("when done through the column header action (metabase#22715-1)", () => {
-    tableHeaderClick("Created At");
+    H.tableHeaderClick("Created At");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter by this column").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -636,9 +586,9 @@ describe("filtering based on the remapped column name should result in a correct
   });
 
   it("when done through the filter trigger (metabase#22715-2)", () => {
-    filter();
+    H.filter();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Today").click();
       cy.findByText("Apply filters").click();
     });
@@ -655,13 +605,13 @@ describe("issue 23024", () => {
   function addModelToDashboardAndVisit() {
     cy.createDashboard().then(({ body: { id } }) => {
       cy.get("@modelId").then(cardId => {
-        addOrUpdateDashboardCard({
+        H.addOrUpdateDashboardCard({
           dashboard_id: id,
           card_id: cardId,
         });
       });
 
-      visitDashboard(id);
+      H.visitDashboard(id);
     });
   }
 
@@ -669,7 +619,7 @@ describe("issue 23024", () => {
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
     cy.intercept("PUT", "/api/card/*").as("updateMetadata");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestion(
@@ -684,7 +634,7 @@ describe("issue 23024", () => {
     );
 
     cy.get("@modelId").then(modelId => {
-      setModelMetadata(modelId, field => {
+      H.setModelMetadata(modelId, field => {
         if (field.display_name === "CATEGORY") {
           return {
             ...field,
@@ -702,11 +652,11 @@ describe("issue 23024", () => {
   });
 
   it("should not be possible to apply the dashboard filter to the native model (metabase#23024)", () => {
-    editDashboard();
+    H.editDashboard();
 
-    setFilter("Text or Category", "Is");
+    H.setFilter("Text or Category", "Is");
 
-    getDashboardCard().within(() => {
+    H.getDashboardCard().within(() => {
       cy.findByText(/Models are data sources/).should("be.visible");
       cy.findByText("Select…").should("not.exist");
     });
@@ -757,7 +707,7 @@ describe("issue 23421", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -765,10 +715,10 @@ describe("issue 23421", () => {
     cy.createNativeQuestion(emptyColumnsQuestionDetails, {
       visitQuestion: true,
     });
-    openQuestionActions();
-    popover().findByText("Edit query definition").click();
+    H.openQuestionActions();
+    H.popover().findByText("Edit query definition").click();
 
-    nativeEditor().should("be.visible").and("contain", query);
+    H.nativeEditor().should("be.visible").and("contain", query);
     cy.findByRole("columnheader", { name: "id" }).should("be.visible");
     cy.findByRole("columnheader", { name: "created_at" }).should("be.visible");
     cy.button("Save changes").should("be.visible");
@@ -778,10 +728,10 @@ describe("issue 23421", () => {
     cy.createNativeQuestion(hiddenColumnsQuestionDetails, {
       visitQuestion: true,
     });
-    openQuestionActions();
-    popover().findByText("Edit query definition").click();
+    H.openQuestionActions();
+    H.popover().findByText("Edit query definition").click();
 
-    nativeEditor().should("be.visible").and("contain", query);
+    H.nativeEditor().should("be.visible").and("contain", query);
     cy.findByTestId("visualization-root")
       .findByText("Every field is hidden right now")
       .should("be.visible");
@@ -794,7 +744,7 @@ describe("issue 23449", () => {
   function turnIntoModel() {
     cy.intercept("PUT", "/api/card/*").as("cardUpdate");
 
-    openQuestionActions();
+    H.openQuestionActions();
     cy.findByText("Turn into a model").click();
     cy.findByText("Turn this into a model").click();
 
@@ -804,7 +754,7 @@ describe("issue 23449", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.request("POST", `/api/field/${REVIEWS.RATING}/dimension`, {
@@ -845,7 +795,7 @@ describe("issue 25537", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("GET", "/api/collection/*/items?*").as("getCollectionContent");
   });
@@ -854,8 +804,8 @@ describe("issue 25537", () => {
     setLocale("de");
     cy.createQuestion(questionDetails);
 
-    startNewQuestion();
-    entityPickerModal().within(() => {
+    H.startNewQuestion();
+    H.entityPickerModal().within(() => {
       cy.findByText(/Modelle/i).click();
       cy.wait("@getCollectionContent");
       cy.findByText(questionDetails.name).should("exist");
@@ -872,11 +822,11 @@ describe("issue 26091", () => {
 
   const startNewQuestion = () => {
     cy.findByText("New").click();
-    popover().within(() => cy.findByText("Question").click());
+    H.popover().within(() => cy.findByText("Question").click());
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/card").as("saveQuestion");
   });
@@ -886,8 +836,8 @@ describe("issue 26091", () => {
     cy.visit("/");
 
     startNewQuestion();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Orders").click();
     });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -903,8 +853,8 @@ describe("issue 26091", () => {
     turnIntoModel();
 
     startNewQuestion();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Models").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Models").click();
       cy.findByText("New model").should("be.visible");
       cy.findByText("Old model").should("be.visible");
       cy.findByText("Orders Model").should("be.visible");
@@ -926,7 +876,7 @@ describe("issue 28193", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     // Turn the question into a model
@@ -939,7 +889,7 @@ describe("issue 28193", () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom column").click();
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: "[Tax]",
       name: ccName,
     });
@@ -962,7 +912,7 @@ describe("issue 28193", () => {
 
 describe("issue 28971", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("POST", "/api/card").as("createCard");
     cy.intercept("POST", "/api/dataset").as("dataset");
@@ -973,11 +923,11 @@ describe("issue 28971", () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("New").click();
-    popover().findByText("Model").click();
+    H.popover().findByText("Model").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Use the notebook editor").click();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Orders").click();
     });
     cy.button("Save").click();
@@ -986,10 +936,10 @@ describe("issue 28971", () => {
     });
     cy.wait("@createCard");
 
-    filter();
-    filterField("Quantity", { operator: "equal to" });
+    H.filter();
+    H.filterField("Quantity", { operator: "equal to" });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    filterFieldPopover("Quantity").within(() => cy.findByText("20").click());
+    H.filterFieldPopover("Quantity").within(() => cy.findByText("20").click());
     cy.button("Apply filters").click();
     cy.wait("@dataset");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -1001,7 +951,7 @@ describe("issue 28971", () => {
 
 describe("issue 28971", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("POST", "/api/card").as("createCard");
     cy.intercept("POST", "/api/dataset").as("dataset");
@@ -1012,11 +962,11 @@ describe("issue 28971", () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("New").click();
-    popover().findByText("Model").click();
+    H.popover().findByText("Model").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Use the notebook editor").click();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Orders").click();
     });
     cy.button("Save").click();
@@ -1025,10 +975,10 @@ describe("issue 28971", () => {
     });
     cy.wait("@createCard");
 
-    filter();
-    filterField("Quantity", { operator: "equal to" });
+    H.filter();
+    H.filterField("Quantity", { operator: "equal to" });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    filterFieldPopover("Quantity").within(() => cy.findByText("20").click());
+    H.filterFieldPopover("Quantity").within(() => cy.findByText("20").click());
     cy.button("Apply filters").click();
     cy.wait("@dataset");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -1059,14 +1009,14 @@ describe("issue 29378", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setActionsEnabledForDB(SAMPLE_DB_ID);
+    H.setActionsEnabledForDB(SAMPLE_DB_ID);
   });
 
   it("should not crash the model detail page after searching for an action (metabase#29378)", () => {
     cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, { type: "model" });
-    createAction(ACTION_DETAILS);
+    H.createAction(ACTION_DETAILS);
 
     cy.visit(`/model/${ORDERS_QUESTION_ID}/detail`);
     cy.findByRole("tab", { name: "Actions" }).click();
@@ -1078,11 +1028,11 @@ describe("issue 29378", () => {
     );
 
     cy.findByRole("tab", { name: "Used by" }).click();
-    commandPaletteSearch(ACTION_DETAILS.name, false);
-    commandPalette()
+    H.commandPaletteSearch(ACTION_DETAILS.name, false);
+    H.commandPalette()
       .findByRole("option", { name: ACTION_DETAILS.name })
       .should("exist");
-    closeCommandPalette();
+    H.closeCommandPalette();
 
     cy.findByRole("tab", { name: "Actions" }).click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -1109,8 +1059,8 @@ describe("issue 29517 - nested question based on native model with remapped valu
       .parent()
       .findByTestId("select-button")
       .click();
-    popover().findByRole("option", { name: table }).click();
-    popover().findByRole("option", { name: field }).click();
+    H.popover().findByRole("option", { name: table }).click();
+    H.popover().findByRole("option", { name: field }).click();
     cy.contains(`${table} → ${field}`).should("be.visible");
     cy.findByDisplayValue(field);
     cy.findByLabelText("Description").should("not.be.empty");
@@ -1121,7 +1071,7 @@ describe("issue 29517 - nested question based on native model with remapped valu
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestion(questionDetails).then(({ body: { id } }) => {
@@ -1178,11 +1128,11 @@ describe("issue 29517 - nested question based on native model with remapped valu
 
   it("drill-through should work (metabase#29517-1)", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
-    visitQuestion("@nestedQuestionId");
+    H.visitQuestion("@nestedQuestionId");
 
     // We can click on any circle; this index was chosen randomly
-    cartesianChartCircle().eq(25).click({ force: true });
-    popover()
+    H.cartesianChartCircle().eq(25).click({ force: true });
+    H.popover()
       .findByText(/^See these/)
       .click();
     cy.wait("@dataset");
@@ -1191,7 +1141,7 @@ describe("issue 29517 - nested question based on native model with remapped valu
       "Created At is May 1–31, 2024",
     );
 
-    assertQueryBuilderRowCount(520);
+    H.assertQueryBuilderRowCount(520);
   });
 
   it("click behavior to custom destination should work (metabase#29517-2)", () => {
@@ -1199,12 +1149,12 @@ describe("issue 29517 - nested question based on native model with remapped valu
       "dashcardQuery",
     );
 
-    visitDashboard("@dashboardId");
+    H.visitDashboard("@dashboardId");
 
     cy.intercept("GET", `/api/dashboard/${ORDERS_DASHBOARD_ID}*`).as(
       "loadTargetDashboard",
     );
-    cartesianChartCircle().eq(25).click({ force: true });
+    H.cartesianChartCircle().eq(25).click({ force: true });
     cy.wait("@loadTargetDashboard");
 
     cy.location("pathname").should("eq", `/dashboard/${ORDERS_DASHBOARD_ID}`);
@@ -1229,7 +1179,7 @@ describe("issue 29951", { requestTimeout: 10000, viewportWidth: 1600 }, () => {
     type: "model",
   };
   const removeExpression = name => {
-    getNotebookStep("expression")
+    H.getNotebookStep("expression")
       .findByText(name)
       .findByLabelText("close icon")
       .click();
@@ -1245,7 +1195,7 @@ describe("issue 29951", { requestTimeout: 10000, viewportWidth: 1600 }, () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("PUT", "/api/card/*").as("updateCard");
   });
@@ -1259,7 +1209,7 @@ describe("issue 29951", { requestTimeout: 10000, viewportWidth: 1600 }, () => {
     // The UI shows us the "play" icon, indicating we should refresh the query,
     // but the point of this repro is to save without refreshing
     cy.button("Get Answer").should("be.visible");
-    saveMetadataChanges();
+    H.saveMetadataChanges();
 
     cy.findAllByTestId("header-cell").last().should("have.text", "CC1");
 
@@ -1290,7 +1240,7 @@ describe("issue 31309", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -1307,19 +1257,19 @@ describe("issue 31309", () => {
       },
     );
 
-    openQuestionActions();
-    popover().findByText("Duplicate").click();
+    H.openQuestionActions();
+    H.popover().findByText("Duplicate").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Duplicate").click();
     });
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Not now").click();
     });
 
-    openQuestionActions();
-    popover().within(() => {
+    H.openQuestionActions();
+    H.popover().within(() => {
       cy.findByText("Edit query definition").click();
     });
 
@@ -1331,15 +1281,15 @@ describe("issue 31309", () => {
 
     cy.findByTestId("breakout-step").findByText("User → Name").should("exist");
 
-    getNotebookStep("filter", { stage: 1, index: 0 })
+    H.getNotebookStep("filter", { stage: 1, index: 0 })
       .findByText("Sum of Total is less than 100")
       .should("exist");
 
-    getNotebookStep("sort", { stage: 1, index: 0 })
+    H.getNotebookStep("sort", { stage: 1, index: 0 })
       .findByText("Sum of Total")
       .should("exist");
 
-    getNotebookStep("limit", { stage: 1, index: 0 })
+    H.getNotebookStep("limit", { stage: 1, index: 0 })
       .findByDisplayValue("10")
       .should("exist");
   });
@@ -1348,7 +1298,7 @@ describe("issue 31309", () => {
 // Should be removed once proper model FK support is implemented
 describe("issue 31663", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.intercept("POST", "/api/dataset").as("dataset");
@@ -1368,17 +1318,17 @@ describe("issue 31663", () => {
 
   it("shouldn't list model IDs as possible model FK targets (metabase#31663)", () => {
     // It's important to have product model's metadata loaded to reproduce this
-    appBar().findByText("Our analytics").click();
+    H.appBar().findByText("Our analytics").click();
 
-    main().findByText("Orders Model").click();
+    H.main().findByText("Orders Model").click();
     cy.wait("@dataset");
     cy.findByLabelText("Move, trash, and more...").click();
-    popover().findByText("Edit metadata").click();
+    H.popover().findByText("Edit metadata").click();
 
     cy.findByTestId("TableInteractive-root").findByText("Product ID").click();
     cy.wait("@idFields");
     cy.findByLabelText("Foreign key target").click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Orders Model → ID").should("not.exist");
       cy.findByText("Products Model → ID").should("not.exist");
 
@@ -1392,7 +1342,7 @@ describe("issue 31663", () => {
 
 describe("issue 31905", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.intercept("GET", "/api/card/*").as("card");
@@ -1429,7 +1379,7 @@ describe("issue 32483", () => {
   });
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -1460,7 +1410,7 @@ describe("issue 32483", () => {
       },
     };
 
-    createQuestion(questionDetails, { wrapId: true });
+    H.createQuestion(questionDetails, { wrapId: true });
 
     cy.get("@questionId").then(questionId => {
       const modelDetails = {
@@ -1496,7 +1446,7 @@ describe("issue 32483", () => {
         },
       };
 
-      createQuestion(modelDetails).then(({ body: { id: modelId } }) => {
+      H.createQuestion(modelDetails).then(({ body: { id: modelId } }) => {
         const dashboardDetails = {
           name: "32483 Dashboard",
           parameters: [DASHBOARD_FILTER_TEXT],
@@ -1543,23 +1493,23 @@ describe("issue 32483", () => {
 
         cy.createDashboard(dashboardDetails).then(
           ({ body: { id: dashboardId } }) => {
-            visitDashboard(dashboardId);
+            H.visitDashboard(dashboardId);
           },
         );
       });
     });
 
-    filterWidget().click();
+    H.filterWidget().click();
     addWidgetStringFilter("Facebook MN");
 
-    getDashboardCard(1).should("contain", "Orders + People Question Model");
+    H.getDashboardCard(1).should("contain", "Orders + People Question Model");
   });
 });
 
 describe("issue 32963", () => {
   function assertLineChart() {
     cy.findByTestId("viz-type-button").click();
-    leftSidebar().within(() => {
+    H.leftSidebar().within(() => {
       cy.findByTestId("Line-container").should(
         "have.attr",
         "aria-selected",
@@ -1574,7 +1524,7 @@ describe("issue 32963", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.createQuestion(
       {
@@ -1590,7 +1540,7 @@ describe("issue 32963", () => {
     cy.findByTestId("qb-header").button("Summarize").click();
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    rightSidebar().within(() => {
+    H.rightSidebar().within(() => {
       cy.findAllByText("Created At").eq(0).click();
       cy.button("Done").click();
     });
@@ -1599,15 +1549,15 @@ describe("issue 32963", () => {
 
     // Go back to the original model
     cy.findByTestId("qb-header").findByText("Orders Model").click();
-    openNotebook();
+    H.openNotebook();
 
     cy.button("Summarize").click();
-    popover().findByText("Count of rows").click();
-    getNotebookStep("summarize")
+    H.popover().findByText("Count of rows").click();
+    H.getNotebookStep("summarize")
       .findByText("Pick a column to group by")
       .click();
-    popover().findByText("Created At").click();
-    visualize();
+    H.popover().findByText("Created At").click();
+    H.visualize();
     assertLineChart();
   });
 });
@@ -1624,11 +1574,11 @@ describe("issues 35039 and 37009", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.signInAsNormalUser();
 
-    createNativeQuestion(cardDetails).then(({ body: { id } }) => {
+    H.createNativeQuestion(cardDetails).then(({ body: { id } }) => {
       // It is crucial for this repro to go directly to the "edit query definition" page!
       // When the repro was created back in v47-v48, it was still possible to save a new model
       // without running the query first. This resulted in the missing `result_metadata`.
@@ -1643,7 +1593,7 @@ describe("issues 35039 and 37009", () => {
   it("should show columns available in the model (metabase#35039) (metabase#37009)", () => {
     // The repro requires that we update the query in a minor, non-impactful way.
     cy.log("Update the query and save");
-    focusNativeEditor().type("{backspace}");
+    H.focusNativeEditor().type("{backspace}");
     cy.findByTestId("native-query-editor-container").icon("play").click();
     cy.wait("@dataset");
 
@@ -1655,9 +1605,9 @@ describe("issues 35039 and 37009", () => {
     assertResultsLoaded();
 
     cy.log("Start new ad-hoc question and make sure all columns are there");
-    openNotebook();
+    H.openNotebook();
     cy.findByTestId("fields-picker").click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("ID").should("exist");
       cy.findByText("EAN").should("exist");
       cy.findByText("TITLE").should("exist");
@@ -1676,7 +1626,7 @@ describe("issues 35039 and 37009", () => {
 
 describe("issue 37009", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("POST", "/api/card").as("saveCard");
     cy.intercept("PUT", "/api/card/*").as("updateCard");
@@ -1684,7 +1634,7 @@ describe("issue 37009", () => {
   });
 
   it("should prevent saving new and updating existing models without result_metadata (metabase#37009)", () => {
-    startNewNativeModel({ query: "select * from products" });
+    H.startNewNativeModel({ query: "select * from products" });
 
     cy.findByTestId("dataset-edit-bar")
       .button("Save")
@@ -1701,7 +1651,7 @@ describe("issue 37009", () => {
       .button("Save")
       .should("be.enabled")
       .click();
-    modal()
+    H.modal()
       .last()
       .within(() => {
         cy.findByLabelText("Name").type("Model");
@@ -1712,9 +1662,9 @@ describe("issue 37009", () => {
       .its("result_metadata")
       .should("not.be.null");
 
-    openQuestionActions();
-    popover().findByText("Edit query definition").click();
-    focusNativeEditor().type(" WHERE CATEGORY = 'Gadget'");
+    H.openQuestionActions();
+    H.popover().findByText("Edit query definition").click();
+    H.focusNativeEditor().type(" WHERE CATEGORY = 'Gadget'");
     cy.findByTestId("dataset-edit-bar")
       .button("Save changes")
       .should("be.disabled")
@@ -1751,13 +1701,13 @@ describe("issue 40252", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("shouldn't crash during save of metadata (metabase#40252)", () => {
-    createNativeQuestion(modelA, { wrapId: true, idAlias: "modelA" });
-    createNativeQuestion(modelB, { wrapId: true, idAlias: "modelB" });
+    H.createNativeQuestion(modelA, { wrapId: true, idAlias: "modelA" });
+    H.createNativeQuestion(modelB, { wrapId: true, idAlias: "modelB" });
 
     cy.get("@modelA").then(modelAId => {
       cy.get("@modelB").then(modelBId => {
@@ -1795,13 +1745,13 @@ describe("issue 40252", () => {
           },
         };
 
-        createQuestion(questionDetails, { visitQuestion: true });
+        H.createQuestion(questionDetails, { visitQuestion: true });
       });
     });
 
-    openQuestionActions();
+    H.openQuestionActions();
 
-    popover().findByText("Edit metadata").click();
+    H.popover().findByText("Edit metadata").click();
 
     cy.findAllByTestId("header-cell").contains("Model B - A1 → B1").click();
     cy.findByLabelText("Display name").type("Upd");
@@ -1825,12 +1775,12 @@ describe("issue 40252", () => {
 
 describe("issue 42355", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should allow overriding database fields for models with manually ordered columns (metabase#42355)", () => {
-    createNativeQuestion({
+    H.createNativeQuestion({
       type: "model",
       native: { query: "SELECT ID, PRODUCT_ID FROM ORDERS" },
       visualization_settings: {
@@ -1850,26 +1800,26 @@ describe("issue 42355", () => {
         ],
         "table.cell_column": "ID",
       },
-    }).then(({ body: card }) => visitModel(card.id));
+    }).then(({ body: card }) => H.visitModel(card.id));
 
     cy.log("update metadata");
-    openQuestionActions();
-    popover().findByText("Edit metadata").click();
-    rightSidebar()
+    H.openQuestionActions();
+    H.popover().findByText("Edit metadata").click();
+    H.rightSidebar()
       .findByText("Database column this maps to")
       .next()
       .findByText("None")
       .click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Orders").click();
       cy.findByText("ID").click();
     });
     cy.button("Save changes").click();
 
     cy.log("check metadata changes are visible");
-    openQuestionActions();
-    popover().findByText("Edit metadata").click();
-    rightSidebar()
+    H.openQuestionActions();
+    H.popover().findByText("Edit metadata").click();
+    H.rightSidebar()
       .findByText("Database column this maps to")
       .next()
       .findByText("Orders → ID")
@@ -1888,10 +1838,10 @@ describe("cumulative count - issue 33330", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    createQuestion(questionDetails, { visitQuestion: true });
+    H.createQuestion(questionDetails, { visitQuestion: true });
     cy.findAllByTestId("header-cell")
       .should("contain", "Created At: Month")
       .and("contain", "Cumulative count");
@@ -1907,7 +1857,7 @@ describe("cumulative count - issue 33330", () => {
   });
 
   it("should still work after applying a post-aggregation filter (metabase#33330-2)", () => {
-    filter();
+    H.filter();
     cy.findByRole("dialog").within(() => {
       cy.intercept("POST", "/api/dataset").as("dataset");
       cy.findByTestId("filter-column-Created At").findByText("Today").click();

--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -1,54 +1,10 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   FIRST_COLLECTION_ID,
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  type NativeQuestionDetails,
-  type StructuredQuestionDetails,
-  assertQueryBuilderRowCount,
-  createNativeQuestion,
-  createQuestion,
-  describeEE,
-  editDashboard,
-  enterCustomColumnDetails,
-  entityPickerModal,
-  entityPickerModalTab,
-  getNotebookStep,
-  getPinnedSection,
-  hovercard,
-  join,
-  main,
-  mapColumnTo,
-  modal,
-  navigationSidebar,
-  newButton,
-  openColumnOptions,
-  openNotebook,
-  openQuestionActions,
-  popover,
-  questionInfoButton,
-  renameColumn,
-  restore,
-  rightSidebar,
-  saveMetadataChanges,
-  saveQuestion,
-  setDropdownFilterType,
-  setFilter,
-  setTokenFeatures,
-  sidebar,
-  sidesheet,
-  startNewModel,
-  startNewQuestion,
-  summarize,
-  tableHeaderClick,
-  tableInteractive,
-  undoToast,
-  visitDashboard,
-  visitModel,
-  visualize,
-} from "e2e/support/helpers";
 import type { CardId, FieldReference } from "metabase-types/api";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -90,13 +46,13 @@ describe("issue 29943", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
   it("selects the right column when clicking a column header (metabase#29943)", () => {
-    createQuestion(
+    H.createQuestion(
       {
         type: "model",
         query: {
@@ -115,28 +71,28 @@ describe("issue 29943", () => {
       { visitQuestion: true },
     );
 
-    openQuestionActions();
-    popover().findByText("Edit metadata").click();
+    H.openQuestionActions();
+    H.popover().findByText("Edit metadata").click();
 
     reorderTotalAndCustomColumns();
     cy.button("Save changes").click();
     cy.wait("@dataset");
 
-    openQuestionActions();
-    popover().findByText("Edit metadata").click();
+    H.openQuestionActions();
+    H.popover().findByText("Edit metadata").click();
 
     assertColumnSelected(0, "ID");
 
     getHeaderCell(1, "Custom");
-    tableHeaderClick("Custom");
+    H.tableHeaderClick("Custom");
     assertColumnSelected(1, "Custom");
 
     getHeaderCell(2, "Total");
-    tableHeaderClick("Total");
+    H.tableHeaderClick("Total");
     assertColumnSelected(2, "Total");
 
     getHeaderCell(0, "ID");
-    tableHeaderClick("ID");
+    H.tableHeaderClick("ID");
     assertColumnSelected(0, "ID");
   });
 });
@@ -180,12 +136,12 @@ describe("issue 35711", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("can edit metadata of a model with a custom column (metabase#35711)", () => {
-    createQuestion(
+    H.createQuestion(
       {
         type: "model",
         query: {
@@ -199,8 +155,8 @@ describe("issue 35711", () => {
       { visitQuestion: true },
     );
 
-    openQuestionActions();
-    popover().findByText("Edit metadata").click();
+    H.openQuestionActions();
+    H.popover().findByText("Edit metadata").click();
     reorderTaxAndTotalColumns();
     assertNoError();
 
@@ -214,12 +170,12 @@ describe("issues 25884 and 34349", () => {
     "This is a unique ID for the product. It is also called the “Invoice number” or “Confirmation number” in customer facing emails and screens.";
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should show empty description input for columns without description in metadata (metabase#25884, metabase#34349)", () => {
-    createQuestion(
+    H.createQuestion(
       {
         type: "model",
         query: {
@@ -237,28 +193,28 @@ describe("issues 25884 and 34349", () => {
       { visitQuestion: true },
     );
 
-    openQuestionActions();
-    popover().findByText("Edit metadata").click();
+    H.openQuestionActions();
+    H.popover().findByText("Edit metadata").click();
 
     cy.findByLabelText("Description").should("have.text", ID_DESCRIPTION);
 
-    tableHeaderClick("Country");
+    H.tableHeaderClick("Country");
     cy.findByLabelText("Description").should("have.text", "");
 
-    tableHeaderClick("ID");
+    H.tableHeaderClick("ID");
     cy.findByLabelText("Description").should("have.text", ID_DESCRIPTION);
   });
 });
 
 describe("issue 23103", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("PUT", "/api/card/*").as("updateModel");
   });
 
   it("shows correct number of distinct values (metabase#23103)", () => {
-    createNativeQuestion(
+    H.createNativeQuestion(
       {
         type: "model",
         native: {
@@ -268,12 +224,12 @@ describe("issue 23103", () => {
       { visitQuestion: true },
     );
 
-    openQuestionActions();
-    popover().findByText("Edit metadata").click();
+    H.openQuestionActions();
+    H.popover().findByText("Edit metadata").click();
 
     cy.findAllByTestId("header-cell").contains("CATEGORY").click();
     cy.findAllByTestId("select-button").contains("None").click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Products").click();
       cy.findByText("Category").click();
     });
@@ -284,20 +240,20 @@ describe("issue 23103", () => {
 
     cy.findAllByTestId("header-cell").contains("Category").trigger("mouseover");
 
-    hovercard().findByText("4 distinct values").should("exist");
+    H.hovercard().findByText("4 distinct values").should("exist");
   });
 });
 
 describe("issue 39150", { viewportWidth: 1600 }, () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("allows custom columns with the same name in nested models (metabase#39150-1)", () => {
     const ccName = "CC Rating";
 
-    createQuestion({
+    H.createQuestion({
       name: "Source Model",
       type: "model",
       query: {
@@ -317,7 +273,7 @@ describe("issue 39150", { viewportWidth: 1600 }, () => {
         limit: 2,
       },
     }).then(({ body: { id: sourceModelId } }) => {
-      createQuestion(
+      H.createQuestion(
         {
           name: "Nested Model",
           type: "model",
@@ -329,10 +285,10 @@ describe("issue 39150", { viewportWidth: 1600 }, () => {
       );
     });
 
-    openNotebook();
+    H.openNotebook();
     cy.findByTestId("action-buttons").findByText("Custom column").click();
 
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: "floor([Rating])",
       name: ccName,
       blur: true,
@@ -340,7 +296,7 @@ describe("issue 39150", { viewportWidth: 1600 }, () => {
 
     cy.button("Done").click();
 
-    visualize();
+    H.visualize();
 
     cy.findAllByTestId("header-cell")
       .filter(`:contains('${ccName}')`)
@@ -348,7 +304,7 @@ describe("issue 39150", { viewportWidth: 1600 }, () => {
   });
 
   it("allows custom columns with the same name as the aggregation column from the souce model (metabase#39150-2)", () => {
-    createQuestion({
+    H.createQuestion({
       name: "Source Model",
       type: "model",
       query: {
@@ -366,7 +322,7 @@ describe("issue 39150", { viewportWidth: 1600 }, () => {
         limit: 2,
       },
     }).then(({ body: { id: sourceModelId } }) => {
-      createQuestion(
+      H.createQuestion(
         {
           type: "model",
           query: {
@@ -377,10 +333,10 @@ describe("issue 39150", { viewportWidth: 1600 }, () => {
       );
     });
 
-    openNotebook();
+    H.openNotebook();
     cy.findByTestId("action-buttons").findByText("Custom column").click();
 
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: "[Count] + 1",
       name: "Count",
       blur: true,
@@ -388,17 +344,17 @@ describe("issue 39150", { viewportWidth: 1600 }, () => {
 
     cy.button("Done").click();
 
-    visualize();
+    H.visualize();
 
     cy.findAllByTestId("header-cell")
       .filter(":contains('Count')")
       .should("have.length", 2);
 
-    saveQuestion("Nested Model", { wrapId: true, idAlias: "nestedModelId" });
+    H.saveQuestion("Nested Model", { wrapId: true, idAlias: "nestedModelId" });
 
     cy.log("Make sure this works for the deeply nested models as well");
     cy.get("@nestedModelId").then(nestedModelId => {
-      createQuestion(
+      H.createQuestion(
         {
           type: "model",
           query: {
@@ -409,10 +365,10 @@ describe("issue 39150", { viewportWidth: 1600 }, () => {
       );
     });
 
-    openNotebook();
+    H.openNotebook();
     cy.findByTestId("action-buttons").findByText("Custom column").click();
 
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: "[Count] + 5",
       name: "Count",
       blur: true,
@@ -420,7 +376,7 @@ describe("issue 39150", { viewportWidth: 1600 }, () => {
 
     cy.button("Done").click();
 
-    visualize();
+    H.visualize();
 
     cy.findAllByTestId("header-cell")
       .filter(":contains('Count')")
@@ -430,31 +386,31 @@ describe("issue 39150", { viewportWidth: 1600 }, () => {
 
 describe.skip("issue 41785, issue 46756", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
   it("does not break the question when removing column with the same mapping as another column (metabase#41785) (metabase#46756)", () => {
     // it's important to create the model through UI to reproduce this issue
-    startNewModel();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.startNewModel();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Products").click();
     });
-    join();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.join();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Products").click();
     });
-    popover().findByText("ID").click();
-    popover().findByText("ID").click();
+    H.popover().findByText("ID").click();
+    H.popover().findByText("ID").click();
 
     cy.findByTestId("run-button").click();
     cy.wait("@dataset");
 
     cy.button("Save").click();
-    modal().button("Save").click();
+    H.modal().button("Save").click();
 
     cy.findByTestId("loading-indicator").should("exist");
     cy.findByTestId("loading-indicator").should("not.exist");
@@ -485,84 +441,87 @@ describe.skip("issue 41785, issue 46756", () => {
       .filter(":contains(Ean)")
       .should("be.visible");
 
-    tableInteractive().should("contain", "Small Marble Shoes");
+    H.tableInteractive().should("contain", "Small Marble Shoes");
   });
 });
 
 describe.skip("issue 40635", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
   it("correctly displays question's and nested model's column names (metabase#40635)", () => {
-    startNewQuestion();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.startNewQuestion();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Orders").click();
     });
 
-    getNotebookStep("data").button("Pick columns").click();
-    popover().findByText("Select none").click();
+    H.getNotebookStep("data").button("Pick columns").click();
+    H.popover().findByText("Select none").click();
 
-    join();
+    H.join();
 
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Products").click();
     });
 
-    getNotebookStep("join", { stage: 0, index: 0 })
+    H.getNotebookStep("join", { stage: 0, index: 0 })
       .button("Pick columns")
       .click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Select none").click();
       cy.findByText("ID").click();
     });
 
-    join();
+    H.join();
 
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Products").click();
     });
 
-    getNotebookStep("join", { stage: 0, index: 1 })
+    H.getNotebookStep("join", { stage: 0, index: 1 })
       .button("Pick columns")
       .click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Select none").click();
       cy.findByText("ID").click();
     });
 
-    getNotebookStep("join", { stage: 0, index: 1 })
+    H.getNotebookStep("join", { stage: 0, index: 1 })
       .findByText("Product ID")
       .click();
-    popover().findByText("User ID").click();
+    H.popover().findByText("User ID").click();
 
-    visualize();
+    H.visualize();
     assertSettingsSidebar();
     assertVisualizationColumns();
 
     cy.button("Save").click();
-    modal().button("Save").click();
-    modal().findByText("Not now").click();
+    H.modal().button("Save").click();
+    H.modal().findByText("Not now").click();
 
     assertSettingsSidebar();
     assertVisualizationColumns();
 
-    openQuestionActions();
-    popover().findByTextEnsureVisible("Turn into a model").click();
-    modal().button("Turn this into a model").click();
-    undoToast().should("contain", "This is a model now").icon("close").click();
+    H.openQuestionActions();
+    H.popover().findByTextEnsureVisible("Turn into a model").click();
+    H.modal().button("Turn this into a model").click();
+    H.undoToast()
+      .should("contain", "This is a model now")
+      .icon("close")
+      .click();
 
     assertSettingsSidebar();
     assertVisualizationColumns();
 
-    openNotebook();
-    getNotebookStep("data").button("Pick columns").click();
-    popover().within(() => {
+    H.openNotebook();
+    H.getNotebookStep("data").button("Pick columns").click();
+    H.popover().within(() => {
       cy.findAllByText("ID").should("have.length", 1);
       cy.findAllByText("Products → ID").should("have.length", 1);
       cy.findAllByText("Products_2 → ID").should("have.length", 1);
@@ -599,12 +558,12 @@ describe.skip("issue 40635", () => {
 
 describe("issue 33427", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("does not confuse the names of various native model columns mapped to the same database field (metabase#33427)", () => {
-    createNativeQuestion(
+    H.createNativeQuestion(
       {
         type: "model",
         native: {
@@ -622,24 +581,24 @@ describe("issue 33427", () => {
     assertColumnHeaders();
 
     cy.findByLabelText("Move, trash, and more...").click();
-    popover().findByText("Edit metadata").click();
+    H.popover().findByText("Edit metadata").click();
 
-    openColumnOptions("CREATED_BY");
-    mapColumnTo({ table: "Products", column: "Title" });
-    renameColumn("Title", "CREATED_BY");
+    H.openColumnOptions("CREATED_BY");
+    H.mapColumnTo({ table: "Products", column: "Title" });
+    H.renameColumn("Title", "CREATED_BY");
 
-    openColumnOptions("UPDATED_BY");
-    mapColumnTo({ table: "Products", column: "Title" });
-    renameColumn("Title", "UPDATED_BY");
-
-    assertColumnHeaders();
-    saveMetadataChanges();
+    H.openColumnOptions("UPDATED_BY");
+    H.mapColumnTo({ table: "Products", column: "Title" });
+    H.renameColumn("Title", "UPDATED_BY");
 
     assertColumnHeaders();
+    H.saveMetadataChanges();
 
-    openNotebook();
-    getNotebookStep("data").button("Pick columns").click();
-    popover().within(() => {
+    assertColumnHeaders();
+
+    H.openNotebook();
+    H.getNotebookStep("data").button("Pick columns").click();
+    H.popover().within(() => {
       cy.findByText("CREATED_BY").should("be.visible");
       cy.findByText("UPDATED_BY").should("be.visible");
     });
@@ -653,7 +612,7 @@ describe("issue 33427", () => {
 });
 
 describe("issue 39749", () => {
-  const modelDetails: StructuredQuestionDetails = {
+  const modelDetails: H.StructuredQuestionDetails = {
     type: "model",
     query: {
       "source-table": ORDERS_ID,
@@ -672,40 +631,42 @@ describe("issue 39749", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("PUT", "/api/card/*").as("updateModel");
   });
 
   it("should not overwrite the description of one column with the description of another column (metabase#39749)", () => {
-    createQuestion(modelDetails).then(({ body: card }) => visitModel(card.id));
+    H.createQuestion(modelDetails).then(({ body: card }) =>
+      H.visitModel(card.id),
+    );
 
     cy.log("edit metadata");
-    openQuestionActions();
-    popover().findByText("Edit metadata").click();
-    tableHeaderClick("Count");
+    H.openQuestionActions();
+    H.popover().findByText("Edit metadata").click();
+    H.tableHeaderClick("Count");
     cy.findByLabelText("Description").type("A");
-    tableHeaderClick("Sum of Total");
+    H.tableHeaderClick("Sum of Total");
     cy.findByLabelText("Description").should("have.text", "").type("B");
-    tableHeaderClick("Count");
+    H.tableHeaderClick("Count");
     cy.findByLabelText("Description").should("have.text", "A");
-    tableHeaderClick("Sum of Total");
+    H.tableHeaderClick("Sum of Total");
     cy.findByLabelText("Description").should("have.text", "B");
     cy.button("Save changes").click();
     cy.wait("@updateModel");
 
     cy.log("verify that the description was updated successfully");
-    openQuestionActions();
-    popover().findByText("Edit metadata").click();
-    tableHeaderClick("Count");
+    H.openQuestionActions();
+    H.popover().findByText("Edit metadata").click();
+    H.tableHeaderClick("Count");
     cy.findByLabelText("Description").should("have.text", "A");
-    tableHeaderClick("Sum of Total");
+    H.tableHeaderClick("Sum of Total");
     cy.findByLabelText("Description").should("have.text", "B");
   });
 });
 
 describe("issue 25885", () => {
-  const mbqlModelDetails: StructuredQuestionDetails = {
+  const mbqlModelDetails: H.StructuredQuestionDetails = {
     type: "model",
     query: {
       "source-table": ORDERS_ID,
@@ -758,32 +719,32 @@ describe("issue 25885", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("PUT", "/api/card/*").as("updateModel");
   });
 
   function setColumnName(oldName: string, newName: string) {
-    tableHeaderClick(oldName);
+    H.tableHeaderClick(oldName);
     cy.findByLabelText("Display name")
       .should("have.value", oldName)
       .clear()
       .type(newName)
       .blur();
-    tableInteractive().findByTextEnsureVisible(newName);
+    H.tableInteractive().findByTextEnsureVisible(newName);
   }
 
   function verifyColumnName(name: string) {
-    tableHeaderClick(name);
+    H.tableHeaderClick(name);
     cy.findByLabelText("Display name").should("have.value", name);
   }
 
   it("should allow to edit metadata for mbql models with self joins columns (metabase#25885)", () => {
-    createQuestion(mbqlModelDetails).then(({ body: card }) =>
-      visitModel(card.id),
+    H.createQuestion(mbqlModelDetails).then(({ body: card }) =>
+      H.visitModel(card.id),
     );
-    openQuestionActions();
-    popover().findByText("Edit metadata").click();
+    H.openQuestionActions();
+    H.popover().findByText("Edit metadata").click();
     setColumnName("ID", "ID1");
     setColumnName("Orders → ID", "ID2");
     setColumnName("Orders_2 → ID", "ID3");
@@ -795,7 +756,7 @@ describe("issue 25885", () => {
 
 describe("issue 33844", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, { type: "model" });
     cy.intercept("POST", "/api/dataset").as("dataset");
@@ -806,45 +767,45 @@ describe("issue 33844", () => {
   function testModelMetadata(isNew: boolean) {
     cy.log("make a column visible only in detail views");
     cy.findByTestId("detail-shortcut").should("not.exist");
-    tableHeaderClick("ID");
+    H.tableHeaderClick("ID");
     cy.findByLabelText("Detail views only").click();
     cy.button(isNew ? "Save" : "Save changes").click();
     if (isNew) {
-      modal().button("Save").click();
+      H.modal().button("Save").click();
       cy.wait("@createModel");
     } else {
       cy.wait("@updateModel");
       cy.wait("@dataset");
     }
-    tableInteractive().findByText("User ID").should("be.visible");
-    tableInteractive().findByText("ID").should("not.exist");
+    H.tableInteractive().findByText("User ID").should("be.visible");
+    H.tableInteractive().findByText("ID").should("not.exist");
     cy.findAllByTestId("detail-shortcut").first().click();
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Order").should("be.visible");
       cy.findByText("ID").should("be.visible");
       cy.findByTestId("object-detail-close-button").click();
     });
 
     cy.log("make the column visible in table views");
-    openQuestionActions();
-    popover().findByText("Edit metadata").click();
-    tableHeaderClick("ID");
+    H.openQuestionActions();
+    H.popover().findByText("Edit metadata").click();
+    H.tableHeaderClick("ID");
     cy.findByLabelText("Detail views only").should("be.checked");
     cy.findByLabelText("Table and details views").click();
     cy.button("Save changes").click();
     cy.wait("@updateModel");
     cy.wait("@dataset");
-    tableInteractive().findByText("ID").should("be.visible");
+    H.tableInteractive().findByText("ID").should("be.visible");
   }
 
   it("should show hidden PKs in model metadata editor and object details after creating a model (metabase#33844)", () => {
     cy.visit("/");
-    newButton("Model").click();
+    H.newButton("Model").click();
     cy.findByTestId("new-model-options")
       .findByText("Use the notebook editor")
       .click();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Orders").click();
     });
     cy.findByTestId("run-button").click();
@@ -854,17 +815,17 @@ describe("issue 33844", () => {
   });
 
   it("should show hidden PKs in model metadata editor and object details after updating a model (metabase#33844,metabase#45924)", () => {
-    visitModel(ORDERS_QUESTION_ID);
+    H.visitModel(ORDERS_QUESTION_ID);
     cy.wait("@dataset");
-    openQuestionActions();
-    popover().findByText("Edit metadata").click();
+    H.openQuestionActions();
+    H.popover().findByText("Edit metadata").click();
     testModelMetadata(false);
   });
 });
 
 describe("issue 45924", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, { type: "model" });
     cy.intercept("POST", "/api/dataset").as("dataset");
@@ -872,51 +833,51 @@ describe("issue 45924", () => {
   });
 
   it("should preserve model metadata when re-running the query (metabase#45924)", () => {
-    visitModel(ORDERS_QUESTION_ID);
+    H.visitModel(ORDERS_QUESTION_ID);
     cy.wait("@dataset");
-    openQuestionActions();
-    popover().findByText("Edit metadata").click();
-    tableHeaderClick("ID");
+    H.openQuestionActions();
+    H.popover().findByText("Edit metadata").click();
+    H.tableHeaderClick("ID");
     cy.findByLabelText("Display name").clear().type("ID1");
     cy.findByTestId("dataset-edit-bar").findByText("Query").click();
     cy.findByTestId("action-buttons").button("Sort").click();
-    popover().findByText("ID").click();
+    H.popover().findByText("ID").click();
     cy.findByTestId("run-button").click();
     cy.wait("@dataset");
     cy.findByTestId("dataset-edit-bar").findByText("Metadata").click();
-    tableHeaderClick("ID1");
+    H.tableHeaderClick("ID1");
     cy.findByLabelText("Display name").should("have.value", "ID1");
     cy.findByTestId("dataset-edit-bar").button("Save changes").click();
     cy.wait("@updateCard");
     cy.wait("@dataset");
-    tableInteractive().findByText("ID1").should("be.visible");
+    H.tableInteractive().findByText("ID1").should("be.visible");
   });
 });
 
-describeEE("issue 43088", () => {
+H.describeEE("issue 43088", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
   it("should be able to create ad-hoc questions based on instance analytics models (metabase#43088)", () => {
     cy.visit("/");
-    navigationSidebar().findByText("Usage analytics").click();
-    getPinnedSection().findByText("People").scrollIntoView().click();
+    H.navigationSidebar().findByText("Usage analytics").click();
+    H.getPinnedSection().findByText("People").scrollIntoView().click();
     cy.wait("@dataset");
-    summarize();
-    rightSidebar().button("Done").click();
+    H.summarize();
+    H.rightSidebar().button("Done").click();
     cy.wait("@dataset");
-    assertQueryBuilderRowCount(1);
+    H.assertQueryBuilderRowCount(1);
   });
 });
 
 describe("issue 39993", () => {
   const columnName = "Exp";
 
-  const modelDetails: StructuredQuestionDetails = {
+  const modelDetails: H.StructuredQuestionDetails = {
     type: "model",
     query: {
       "source-table": ORDERS_ID,
@@ -941,15 +902,17 @@ describe("issue 39993", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("PUT", "/api/card/*").as("updateModel");
   });
 
   it("should preserve viz settings for models with custom expressions (metabase#39993)", () => {
-    createQuestion(modelDetails).then(({ body: card }) => visitModel(card.id));
-    openQuestionActions();
-    popover().findByText("Edit metadata").click();
+    H.createQuestion(modelDetails).then(({ body: card }) =>
+      H.visitModel(card.id),
+    );
+    H.openQuestionActions();
+    H.popover().findByText("Edit metadata").click();
     cy.log("drag & drop the custom column 100 px to the left");
     dragAndDrop(columnName, -100);
     cy.button("Save changes").click();
@@ -961,7 +924,7 @@ describe("issue 39993", () => {
 
 describe("issue 34574", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("GET", "/api/card/*/query_metadata").as("metadata");
     cy.intercept("GET", "/api/card/*").as("card");
@@ -972,7 +935,7 @@ describe("issue 34574", () => {
   });
 
   it("should accept markdown for model description and render it properly (metabase#34574)", () => {
-    const modelDetails: StructuredQuestionDetails = {
+    const modelDetails: H.StructuredQuestionDetails = {
       name: "34574",
       type: "model",
       query: {
@@ -980,18 +943,18 @@ describe("issue 34574", () => {
         limit: 2,
       },
     };
-    createQuestion(modelDetails).then(({ body: { id: modelId } }) =>
-      visitModel(modelId),
+    H.createQuestion(modelDetails).then(({ body: { id: modelId } }) =>
+      H.visitModel(modelId),
     );
     cy.wait(["@card", "@metadata", "@dataset"]);
 
     cy.findByTestId("qb-header-action-panel").within(() => {
       // make sure the model fully loaded
       cy.findByTestId("run-button").should("exist");
-      questionInfoButton().click();
+      H.questionInfoButton().click();
     });
 
-    sidesheet().within(() => {
+    H.sidesheet().within(() => {
       cy.log("Set the model description to a markdown text");
       cy.findByPlaceholderText("Add description").type(
         "# Hello{enter}## World{enter}This is an **important** description!",
@@ -1039,20 +1002,20 @@ describe("issue 34574", () => {
 
 describe("issue 34517", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should not change the url when reloading the page while editing a model (metabase#34517)", () => {
-    startNewModel();
+    H.startNewModel();
     cy.location("pathname").should("eq", "/model/query");
 
     // wait for the model editor to be fully loaded
-    entityPickerModal().should("exist");
+    H.entityPickerModal().should("exist");
     cy.reload();
 
     // wait for the model editor to be fully loaded
-    entityPickerModal().should("exist");
+    H.entityPickerModal().should("exist");
     cy.location("pathname").should("eq", "/model/query");
   });
 });
@@ -1061,7 +1024,7 @@ describe("issue 35840", () => {
   const modelName = "M1";
   const questionName = "Q1";
 
-  const modelDetails: StructuredQuestionDetails = {
+  const modelDetails: H.StructuredQuestionDetails = {
     type: "model",
     name: modelName,
     query: {
@@ -1072,7 +1035,9 @@ describe("issue 35840", () => {
     },
   };
 
-  const getQuestionDetails = (modelId: CardId): StructuredQuestionDetails => ({
+  const getQuestionDetails = (
+    modelId: CardId,
+  ): H.StructuredQuestionDetails => ({
     type: "question",
     name: questionName,
     query: {
@@ -1081,18 +1046,18 @@ describe("issue 35840", () => {
   });
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   function checkColumnMapping(entityTab: string, entityName: string) {
-    entityPickerModal().within(() => {
-      entityPickerModalTab(entityTab).click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab(entityTab).click();
       cy.findByText(entityName).click();
     });
-    modal().findByText("Pick a column…").click();
-    popover().findAllByText("Category").eq(0).click();
-    modal().within(() => {
+    H.modal().findByText("Pick a column…").click();
+    H.popover().findAllByText("Category").eq(0).click();
+    H.modal().within(() => {
       cy.findByText("Category").should("be.visible");
       cy.findByText("Category, Category").should("not.exist");
     });
@@ -1100,31 +1065,31 @@ describe("issue 35840", () => {
 
   it("should not confuse a model field with an expression that has the same name in dashboard parameter sources (metabase#35840)", () => {
     cy.log("Setup dashboard");
-    createQuestion(modelDetails).then(({ body: model }) =>
-      createQuestion(getQuestionDetails(model.id)),
+    H.createQuestion(modelDetails).then(({ body: model }) =>
+      H.createQuestion(getQuestionDetails(model.id)),
     );
-    visitDashboard(ORDERS_DASHBOARD_ID);
-    editDashboard();
-    setFilter("Text or Category", "Is");
-    setDropdownFilterType();
-    sidebar().findByText("Edit").click();
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.editDashboard();
+    H.setFilter("Text or Category", "Is");
+    H.setDropdownFilterType();
+    H.sidebar().findByText("Edit").click();
 
     cy.log("Use model for dropdown source");
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("From another model or question").click();
       cy.findByText("Pick a model or question…").click();
     });
     checkColumnMapping("Models", modelName);
 
     cy.log("Use model-based question for dropdown source");
-    modal().findByText(modelName).click();
+    H.modal().findByText(modelName).click();
     checkColumnMapping("Questions", questionName);
   });
 });
 
 describe("issue 34514", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("GET", "/api/database/*/schema/*").as("fetchTables");
@@ -1133,15 +1098,15 @@ describe("issue 34514", () => {
     cy.visit("/");
     // It's important to navigate via UI so that there are
     // enough entries in the browser history to go back to.
-    newButton("Model").click();
+    H.newButton("Model").click();
     cy.findByTestId("new-model-options")
       .findByText("Use the notebook editor")
       .click();
   });
 
   it("should not make network request with invalid query (metabase#34514)", () => {
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.wait("@fetchTables");
       cy.findByText("Orders").click();
     });
@@ -1155,8 +1120,8 @@ describe("issue 34514", () => {
   });
 
   it("should allow browser history navigation between tabs (metabase#34514)", () => {
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.wait("@fetchTables");
       cy.findByText("Orders").click();
     });
@@ -1181,9 +1146,9 @@ describe("issue 34514", () => {
   });
 
   function assertQueryTabState() {
-    entityPickerModal().should("not.exist");
+    H.entityPickerModal().should("not.exist");
     cy.button("Save").should("be.enabled");
-    getNotebookStep("data").findByText("Orders").should("be.visible");
+    H.getNotebookStep("data").findByText("Orders").should("be.visible");
     cy.findByTestId("TableInteractive-root")
       .findByText("39.72")
       .should("be.visible");
@@ -1197,12 +1162,12 @@ describe("issue 34514", () => {
   }
 
   function assertBackToEmptyState() {
-    entityPickerModal().should("be.visible");
-    entityPickerModal().button("Close").click();
+    H.entityPickerModal().should("be.visible");
+    H.entityPickerModal().button("Close").click();
 
     cy.findByTestId("editor-tabs-metadata").should("be.disabled");
     cy.button("Save").should("be.disabled");
-    getNotebookStep("data")
+    H.getNotebookStep("data")
       .findByText("Pick your starting data")
       .should("be.visible");
     cy.findByTestId("TableInteractive-root").should("not.exist");
@@ -1217,10 +1182,10 @@ describe("issue 34514", () => {
 
 describe.skip("issues 28270, 33708", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    createQuestion(
+    H.createQuestion(
       {
         type: "model",
         query: {
@@ -1234,14 +1199,14 @@ describe.skip("issues 28270, 33708", () => {
 
   it("shows object relationships when model-based ad-hoc question has a filter (metabase#28270)", () => {
     checkRelationships();
-    modal().icon("close").click();
+    H.modal().icon("close").click();
 
-    tableHeaderClick("Title");
-    popover().findByText("Filter by this column").click();
-    popover().findByLabelText("Filter operator").click();
-    popover().last().findByText("Contains").click();
-    popover().findByLabelText("Filter value").type("a,");
-    popover().button("Add filter").click();
+    H.tableHeaderClick("Title");
+    H.popover().findByText("Filter by this column").click();
+    H.popover().findByLabelText("Filter operator").click();
+    H.popover().last().findByText("Contains").click();
+    H.popover().findByLabelText("Filter value").type("a,");
+    H.popover().button("Add filter").click();
 
     checkRelationships();
   });
@@ -1249,7 +1214,7 @@ describe.skip("issues 28270, 33708", () => {
   it("shows object relationships after navigating back from relationships question (metabase#33708)", () => {
     checkRelationships();
 
-    modal().findByText("Orders").click();
+    H.modal().findByText("Orders").click();
     cy.wait("@dataset");
     cy.go("back");
     cy.go("back"); // TODO: remove this when (metabase#33709) is fixed
@@ -1266,7 +1231,7 @@ describe.skip("issues 28270, 33708", () => {
 
     cy.wait(["@dataset", "@dataset"]);
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByTestId("fk-relation-orders")
         .should("be.visible")
         .and("contain.text", "93")
@@ -1281,7 +1246,7 @@ describe.skip("issues 28270, 33708", () => {
 });
 
 describe("issue 46221", () => {
-  const modelDetails: NativeQuestionDetails = {
+  const modelDetails: H.NativeQuestionDetails = {
     name: "46221",
     native: { query: "select 42" },
     type: "model",
@@ -1289,10 +1254,10 @@ describe("issue 46221", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    createNativeQuestion(modelDetails, { visitQuestion: true });
+    H.createNativeQuestion(modelDetails, { visitQuestion: true });
   });
 
   it("should retain the same collection name between ad-hoc question based on a model and a model itself (metabase#46221)", () => {
@@ -1317,7 +1282,7 @@ describe("issue 46221", () => {
 });
 
 describe("issue 20624", () => {
-  const questionDetails: StructuredQuestionDetails = {
+  const questionDetails: H.StructuredQuestionDetails = {
     name: "Question",
     type: "question",
     query: {
@@ -1331,37 +1296,37 @@ describe("issue 20624", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("PUT", "/api/card/*").as("updateCard");
   });
 
   it("should reset the question's viz settings when converting to a model (metabase#20624)", () => {
     cy.log("check that a column is renamed via the viz settings");
-    createQuestion(questionDetails, { visitQuestion: true });
-    tableInteractive().within(() => {
+    H.createQuestion(questionDetails, { visitQuestion: true });
+    H.tableInteractive().within(() => {
       cy.findByText("Retailer").should("be.visible");
       cy.findByText("Vendor").should("not.exist");
     });
 
     cy.log("check that the viz settings are reset when converting to a model");
-    openQuestionActions();
-    popover().findByText("Turn into a model").click();
-    modal().findByText("Turn this into a model").click();
+    H.openQuestionActions();
+    H.popover().findByText("Turn into a model").click();
+    H.modal().findByText("Turn this into a model").click();
     cy.wait("@updateCard");
-    tableInteractive().within(() => {
+    H.tableInteractive().within(() => {
       cy.findByText("Vendor").should("be.visible");
       cy.findByText("Retailer").should("not.exist");
     });
 
     cy.log("rename the column using the model's metadata");
-    openQuestionActions();
-    popover().findByText("Edit metadata").click();
-    tableHeaderClick("Vendor");
+    H.openQuestionActions();
+    H.popover().findByText("Edit metadata").click();
+    H.tableHeaderClick("Vendor");
     cy.findByLabelText("Display name").clear().type("Retailer");
     cy.button("Save changes").should("be.enabled").click();
     cy.wait("@updateCard");
-    tableInteractive().within(() => {
+    H.tableInteractive().within(() => {
       cy.findByText("Retailer").should("be.visible");
       cy.findByText("Vendor").should("not.exist");
     });
@@ -1370,10 +1335,10 @@ describe("issue 20624", () => {
 
 describe("issue 37300", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
 
-    createQuestion(
+    H.createQuestion(
       {
         type: "model",
         query: {
@@ -1386,10 +1351,10 @@ describe("issue 37300", () => {
   });
 
   it("should show the table headers even when there are no results (metabase/metabase#37300)", () => {
-    openQuestionActions();
-    popover().findByText("Edit metadata").click();
+    H.openQuestionActions();
+    H.popover().findByText("Edit metadata").click();
 
-    main().within(() => {
+    H.main().within(() => {
       cy.findByText("ID").should("be.visible");
       cy.findByText("Ean").should("be.visible");
 

--- a/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
@@ -1,25 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  filterWidget,
-  focusNativeEditor,
-  getDashboardCard,
-  modal,
-  moveDnDKitElement,
-  nativeEditor,
-  openNativeEditor,
-  openSharingMenu,
-  popover,
-  queryBuilderMain,
-  removeMultiAutocompleteValue,
-  restore,
-  sidebar,
-  sidesheet,
-  tableInteractive,
-  visitDashboard,
-  visitQuestion,
-  visitQuestionAdhoc,
-} from "e2e/support/helpers";
 
 import * as FieldFilter from "./helpers/e2e-field-filter-helpers";
 import * as SQLFilter from "./helpers/e2e-sql-filter-helpers";
@@ -38,18 +19,18 @@ function runQuery() {
 
 describe("issue 9357", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should reorder template tags by drag and drop (metabase#9357)", () => {
-    openNativeEditor();
+    H.openNativeEditor();
     SQLFilter.enterParameterizedQuery(
       "{{firstparameter}} {{nextparameter}} {{lastparameter}}",
     );
 
     // Drag the firstparameter to last position
-    moveDnDKitElement(cy.get("fieldset").findAllByRole("listitem").first(), {
+    H.moveDnDKitElement(cy.get("fieldset").findAllByRole("listitem").first(), {
       horizontal: 430,
     });
 
@@ -66,12 +47,12 @@ describe("issue 11480", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should clear a template tag's default value when the type changes (metabase#11480)", () => {
-    openNativeEditor();
+    H.openNativeEditor();
     // Parameter `x` defaults to a text parameter.
     SQLFilter.enterParameterizedQuery(
       "select * from orders where total = {{x}}",
@@ -106,12 +87,12 @@ describe("issue 11580", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("shouldn't reorder template tags when updated (metabase#11580)", () => {
-    openNativeEditor();
+    H.openNativeEditor();
     SQLFilter.enterParameterizedQuery("{{foo}} {{bar}}");
 
     cy.findAllByText("Variable name").next().as("variableLabels");
@@ -155,7 +136,7 @@ describe("issue 12228", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -193,7 +174,7 @@ describe("issue 12581", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestion(nativeQuery, { visitQuestion: true });
@@ -210,7 +191,7 @@ describe("issue 12581", () => {
 
     // Both delay and a repeated sequence of `{selectall}{backspace}` are there to prevent typing flakes
     // Without them at least 1 in 10 test runs locally didn't fully clear the field or type correctly
-    focusNativeEditor()
+    H.focusNativeEditor()
       .as("editor")
       .click()
       .type("{selectall}{backspace}", { delay: 50 })
@@ -228,7 +209,7 @@ describe("issue 12581", () => {
     cy.wait("@cardQuery");
 
     cy.findByTestId("revision-history-button").click();
-    sidesheet().within(() => {
+    H.sidesheet().within(() => {
       cy.findByRole("tab", { name: "History" }).click();
       // Make sure sidebar opened and the history loaded
       cy.findByText(/You created this/i);
@@ -247,12 +228,12 @@ describe("issue 12581", () => {
       .click();
 
     cy.log("Reported failing on v0.35.3");
-    focusNativeEditor().should("be.visible").and("contain", ORIGINAL_QUERY);
+    H.focusNativeEditor().should("be.visible").and("contain", ORIGINAL_QUERY);
 
-    tableInteractive().findByText("37.65");
+    H.tableInteractive().findByText("37.65");
 
     // Filter dropdown field
-    filterWidget().contains("Filter");
+    H.filterWidget().contains("Filter");
   });
 });
 
@@ -288,7 +269,7 @@ describe.skip("issue 13961", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestion(nativeQuery, { visitQuestion: true });
@@ -344,7 +325,7 @@ describe("issue 14302", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestion(nativeQuery, { visitQuestion: true });
@@ -394,7 +375,7 @@ describe("issue 14302", () => {
     beforeEach(() => {
       cy.intercept("POST", "/api/card/*/query").as("cardQuery");
 
-      restore();
+      H.restore();
       cy.signInAsAdmin();
 
       cy.createNativeQuestionAndDashboard({
@@ -452,7 +433,7 @@ describe("issue 14302", () => {
         expect(xhr.response.body.error).not.to.exist;
       });
 
-      nativeEditor().should("not.be.visible");
+      H.nativeEditor().should("not.be.visible");
       cy.get("[data-testid=cell-data]").should("contain", "51");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 1 row");
@@ -462,14 +443,14 @@ describe("issue 14302", () => {
 
 describe("issue 15444", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
   it("should run with the default field filter set (metabase#15444)", () => {
-    openNativeEditor();
+    H.openNativeEditor();
     SQLFilter.enterParameterizedQuery(
       "select * from products where {{category}}",
     );
@@ -487,7 +468,7 @@ describe("issue 15444", () => {
     FieldFilter.openEntryForm({ isFilterRequired: true });
     // We could've used `FieldFilter.addDefaultStringFilter("Doohickey")` but that's been covered already in the filter test matrix.
     // This flow tests the ability to pick the filter from a dropdown when there are not too many results (easy to choose from).
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Doohickey").click();
       cy.button("Update filter").click();
     });
@@ -527,17 +508,17 @@ describe("issue 15460", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    visitQuestionAdhoc(questionQuery);
+    H.visitQuestionAdhoc(questionQuery);
   });
 
   it("should be possible to use field filter on a query with joins where tables have similar columns (metabase#15460)", () => {
     // Set the filter value by picking the value from the dropdown
-    filterWidget().contains(filter["display-name"]).click();
+    H.filterWidget().contains(filter["display-name"]).click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Doohickey").click();
       cy.button("Add filter").click();
     });
@@ -555,12 +536,12 @@ describe("issue 15700", () => {
   const widgetType = "String is not";
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should be able to select 'Field Filter' category in native query (metabase#15700)", () => {
-    openNativeEditor();
+    H.openNativeEditor();
     SQLFilter.enterParameterizedQuery("{{filter}}");
 
     SQLFilter.openTypePickerFromDefaultFilterType();
@@ -577,10 +558,10 @@ describe("issue 15700", () => {
 
 describe("issue 15981", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    openNativeEditor();
+    H.openNativeEditor();
 
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
@@ -630,7 +611,7 @@ describe("issue 16739", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -648,7 +629,7 @@ describe("issue 16739", () => {
           cy.signIn(user);
         }
 
-        visitQuestion(id);
+        H.visitQuestion(id);
       });
 
       cy.icon("play").should("not.exist");
@@ -678,7 +659,7 @@ describe("issue 16756", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestion(questionDetails).then(({ body: { id } }) => {
@@ -698,16 +679,16 @@ describe("issue 16756", () => {
     // Update the filter widget type
     cy.findByTestId("sidebar-right").findByDisplayValue("Date Range").click();
 
-    popover().contains("Single Date").click();
+    H.popover().contains("Single Date").click();
 
     // The previous filter value should reset
     cy.location("search").should("eq", "?filter=");
 
     cy.log("Set the date to the 15th of October 2023");
     cy.clock(new Date("2023-10-31"), ["Date"]);
-    filterWidget().click();
+    H.filterWidget().click();
 
-    popover().contains("15").click();
+    H.popover().contains("15").click();
 
     cy.button("Add filter").click();
 
@@ -737,19 +718,19 @@ describe("issue 17019", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestion(question).then(({ body: { id } }) => {
       // Enable sharing
       cy.request("POST", `/api/card/${id}/public_link`);
 
-      visitQuestion(id);
+      H.visitQuestion(id);
     });
   });
 
   it("question filters should work for embedding/public sharing scenario (metabase#17019)", () => {
-    openSharingMenu(/public link/i);
+    H.openSharingMenu(/public link/i);
 
     cy.findByTestId("public-link-popover-content")
       .findByTestId("public-link-input")
@@ -790,12 +771,12 @@ describe("issue 17490", () => {
   beforeEach(() => {
     mockDatabaseTables();
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it.skip("nav bar shouldn't cut off the popover with the tables for field filter selection (metabase#17490)", () => {
-    openNativeEditor();
+    H.openNativeEditor();
     SQLFilter.enterParameterizedQuery("{{f}}");
 
     SQLFilter.openTypePickerFromDefaultFilterType();
@@ -840,7 +821,7 @@ describe("issue 21160", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestion(questionDetails, { visitQuestion: true });
@@ -870,7 +851,7 @@ describe("issue 21246", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestion(questionDetails).then(({ body: { id } }) => {
@@ -945,20 +926,20 @@ describe("issue 27257", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    openNativeEditor();
+    H.openNativeEditor();
     SQLFilter.enterParameterizedQuery("SELECT {{number}}");
 
-    filterWidget().within(() => {
+    H.filterWidget().within(() => {
       cy.icon("string");
     });
 
     cy.findByTestId("variable-type-select").click();
-    popover().contains("Number").click();
+    H.popover().contains("Number").click();
 
-    filterWidget().within(() => {
+    H.filterWidget().within(() => {
       cy.icon("number");
       cy.findByPlaceholderText("Number").type("0").blur();
       cy.findByDisplayValue("0");
@@ -981,7 +962,7 @@ describe("issue 29786", { tags: "@external" }, () => {
   const SQL_QUERY = "SELECT * FROM PRODUCTS WHERE {{f1}} AND {{f2}}";
 
   beforeEach(() => {
-    restore("mysql-8");
+    H.restore("mysql-8");
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.signInAsAdmin();
   });
@@ -990,7 +971,7 @@ describe("issue 29786", { tags: "@external" }, () => {
     "should allow using field filters with null schema (metabase#29786)",
     { tags: "@flaky" },
     () => {
-      openNativeEditor({ databaseName: "QA MySQL8" });
+      H.openNativeEditor({ databaseName: "QA MySQL8" });
       SQLFilter.enterParameterizedQuery(SQL_QUERY);
 
       cy.findAllByTestId("variable-type-select").first().click();
@@ -1000,9 +981,9 @@ describe("issue 29786", { tags: "@external" }, () => {
       SQLFilter.chooseType("Field Filter");
       FieldFilter.mapTo({ table: "Products", field: "Vendor" });
 
-      filterWidget().first().click();
+      H.filterWidget().first().click();
       FieldFilter.addWidgetStringFilter("Widget");
-      filterWidget().last().click();
+      H.filterWidget().last().click();
       FieldFilter.addWidgetStringFilter("Von-Gulgowski");
 
       SQLFilter.runQuery();
@@ -1018,12 +999,12 @@ describe("issue 31606", { tags: "@external" }, () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should clear values on UI for Text, Number, Date and Field Filter Types (metabase#31606)", () => {
-    openNativeEditor();
+    H.openNativeEditor();
 
     SQLFilter.enterParameterizedQuery(SQL_QUERY);
 
@@ -1031,18 +1012,18 @@ describe("issue 31606", { tags: "@external" }, () => {
     SQLFilter.setWidgetValue("Gizmo");
     SQLFilter.runQuery();
 
-    queryBuilderMain()
+    H.queryBuilderMain()
       .findByText(/missing required parameters/)
       .should("not.exist");
 
-    filterWidget().findByRole("textbox").clear();
+    H.filterWidget().findByRole("textbox").clear();
 
     SQLFilter.runQuery();
-    queryBuilderMain()
+    H.queryBuilderMain()
       .findByText(/missing required parameters/)
       .should("be.visible");
 
-    filterWidget().within(() => {
+    H.filterWidget().within(() => {
       cy.icon("close").should("not.exist");
     });
 
@@ -1052,17 +1033,17 @@ describe("issue 31606", { tags: "@external" }, () => {
 
     SQLFilter.runQuery();
 
-    queryBuilderMain()
+    H.queryBuilderMain()
       .findByText(/missing required parameters/)
       .should("not.exist");
 
-    filterWidget().findByRole("textbox").clear();
+    H.filterWidget().findByRole("textbox").clear();
     SQLFilter.runQuery();
-    queryBuilderMain()
+    H.queryBuilderMain()
       .findByText(/missing required parameters/)
       .should("be.visible");
 
-    filterWidget().within(() => {
+    H.filterWidget().within(() => {
       cy.icon("close").should("not.exist");
     });
 
@@ -1090,8 +1071,8 @@ describe("issue 31606", { tags: "@external" }, () => {
         .click();
     });
 
-    popover().within(() => {
-      removeMultiAutocompleteValue(0);
+    H.popover().within(() => {
+      H.removeMultiAutocompleteValue(0);
       cy.findByText("Update filter").click();
     });
     cy.findByTestId("sidebar-content").within(() => {
@@ -1099,27 +1080,27 @@ describe("issue 31606", { tags: "@external" }, () => {
     });
 
     // Field Filter
-    filterWidget().click();
-    popover().findByPlaceholderText("Enter an ID").type("23");
-    popover().findByText("Add filter").click();
+    H.filterWidget().click();
+    H.popover().findByPlaceholderText("Enter an ID").type("23");
+    H.popover().findByText("Add filter").click();
 
-    filterWidget().within(() => {
+    H.filterWidget().within(() => {
       cy.icon("close").should("be.visible");
     });
 
     SQLFilter.runQuery();
-    queryBuilderMain()
+    H.queryBuilderMain()
       .findByText(/missing required parameters/)
       .should("not.exist");
 
-    filterWidget().click();
+    H.filterWidget().click();
 
-    popover().within(() => {
-      removeMultiAutocompleteValue(0);
+    H.popover().within(() => {
+      H.removeMultiAutocompleteValue(0);
       cy.findByText("Update filter").click();
     });
 
-    filterWidget().within(() => {
+    H.filterWidget().within(() => {
       cy.icon("close").should("not.exist");
     });
   });
@@ -1165,7 +1146,7 @@ describe("issue 34129", () => {
   });
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("/api/card/*/query").as("cardQuery");
     cy.intercept("/api/dashboard/*/dashcard/*/card/*/query").as(
@@ -1181,40 +1162,40 @@ describe("issue 34129", () => {
       const { card_id, dashboard_id } = card;
       const mapping = getParameterMapping(card_id, parameter.id);
       cy.editDashboardCard(card, { parameter_mappings: [mapping] });
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
       cy.wait("@dashcardQuery");
     });
 
-    filterWidget().click();
-    popover().findByText("Today").click();
+    H.filterWidget().click();
+    H.popover().findByText("Today").click();
     cy.wait("@dashcardQuery");
 
-    getDashboardCard().findByText(questionDetails.name).click();
+    H.getDashboardCard().findByText(questionDetails.name).click();
     cy.wait("@cardQuery");
 
-    filterWidget().findByText("Today").should("exist");
+    H.filterWidget().findByText("Today").should("exist");
   });
 });
 
 describe("issue 31606", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should not start drag and drop from clicks on popovers", () => {
-    openNativeEditor();
+    H.openNativeEditor();
 
     SQLFilter.enterParameterizedQuery("{{foo}} {{bar}}");
 
     cy.findAllByRole("radio", { name: "Search box" }).first().click();
-    filterWidget().first().click();
+    H.filterWidget().first().click();
 
-    moveDnDKitElement(popover().findByText("Add filter"), {
+    H.moveDnDKitElement(H.popover().findByText("Add filter"), {
       horizontal: 300,
     });
 
-    filterWidget()
+    H.filterWidget()
       .should("have.length", 2)
       .first()
       .should("contain.text", "Foo");
@@ -1223,28 +1204,28 @@ describe("issue 31606", () => {
 
 describe("issue 49577", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should not show the values initially when using a single select search box (metabase#49577)", () => {
-    openNativeEditor().type("select * from {{param");
-    sidebar()
+    H.openNativeEditor().type("select * from {{param");
+    H.sidebar()
       .last()
       .within(() => {
         cy.findByText("Search box").click();
         cy.findByText("Edit").click();
       });
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Custom list").click();
       cy.findByRole("textbox").type("foo\nbar\nbaz");
       cy.button("Done").click();
     });
 
-    filterWidget().click();
+    H.filterWidget().click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("foo").should("not.exist");
       cy.findByText("bar").should("not.exist");
       cy.findByText("baz").should("not.exist");
@@ -1254,11 +1235,11 @@ describe("issue 49577", () => {
       cy.findByText("foo").should("be.visible");
     });
 
-    sidebar().last().findByText("Dropdown list").click();
+    H.sidebar().last().findByText("Dropdown list").click();
 
-    filterWidget().click();
+    H.filterWidget().click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByPlaceholderText("Search the list").should("be.visible");
       cy.findByText("foo").should("be.visible");
       cy.findByText("bar").should("be.visible");

--- a/e2e/test/scenarios/native-filters/sql-field-filter-types.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-field-filter-types.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, startNewNativeQuestion } from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 import * as DateFilter from "./helpers/e2e-date-filter-helpers";
 import {
@@ -61,12 +61,12 @@ describe("scenarios > filters > sql filters > field filter > Date", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.intercept("POST", "api/dataset").as("dataset");
 
     cy.signInAsAdmin();
 
-    startNewNativeQuestion();
+    H.startNewNativeQuestion();
 
     SQLFilter.enterParameterizedQuery("SELECT * FROM products WHERE {{f}}");
 
@@ -125,12 +125,12 @@ describe("scenarios > filters > sql filters > field filter > Number", () => {
   const numericFilters = Object.entries(NUMBER_FILTER_SUBTYPES);
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.intercept("POST", "api/dataset").as("dataset");
 
     cy.signInAsAdmin();
 
-    startNewNativeQuestion();
+    H.startNewNativeQuestion();
     SQLFilter.enterParameterizedQuery("SELECT * FROM products WHERE {{f}}");
 
     SQLFilter.openTypePickerFromDefaultFilterType();
@@ -184,12 +184,12 @@ describe("scenarios > filters > sql filters > field filter > String", () => {
   const stringFilters = Object.entries(STRING_FILTER_SUBTYPES);
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.intercept("POST", "api/dataset").as("dataset");
 
     cy.signInAsAdmin();
 
-    startNewNativeQuestion();
+    H.startNewNativeQuestion();
     SQLFilter.enterParameterizedQuery("SELECT * FROM products WHERE {{f}}");
 
     SQLFilter.openTypePickerFromDefaultFilterType();

--- a/e2e/test/scenarios/native-filters/sql-field-filter.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-field-filter.cy.spec.js
@@ -1,13 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  clearFilterWidget,
-  filterWidget,
-  multiAutocompleteInput,
-  openNativeEditor,
-  popover,
-  removeMultiAutocompleteValue,
-  restore,
-} from "e2e/support/helpers";
 
 import * as FieldFilter from "./helpers/e2e-field-filter-helpers";
 import * as SQLFilter from "./helpers/e2e-sql-filter-helpers";
@@ -16,7 +8,7 @@ const { PRODUCTS } = SAMPLE_DATABASE;
 
 describe("scenarios > filters > sql filters > field filter", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.intercept("POST", "api/dataset").as("dataset");
 
     cy.signInAsAdmin();
@@ -24,7 +16,7 @@ describe("scenarios > filters > sql filters > field filter", () => {
 
   describe("required tag", () => {
     beforeEach(() => {
-      openNativeEditor();
+      H.openNativeEditor();
       SQLFilter.enterParameterizedQuery(
         "SELECT * FROM products WHERE {{filter}}",
       );
@@ -46,7 +38,7 @@ describe("scenarios > filters > sql filters > field filter", () => {
       cy.findByTestId("sidebar-content")
         .findByText("Enter a default value…")
         .click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByPlaceholderText("Enter a default value…").type(value);
         cy.button("Add filter").click();
       });
@@ -60,21 +52,23 @@ describe("scenarios > filters > sql filters > field filter", () => {
 
     it("when there's a default value, enabling required sets it as a parameter value", () => {
       setDefaultFieldValue(5);
-      filterWidget().click();
-      clearFilterWidget();
+      H.filterWidget().click();
+      H.clearFilterWidget();
       SQLFilter.toggleRequired();
-      filterWidget().findByTestId("field-set-content").should("have.text", "5");
+      H.filterWidget()
+        .findByTestId("field-set-content")
+        .should("have.text", "5");
     });
 
     it("when there's a default value and value is unset, updating filter sets the default back", () => {
       setDefaultFieldValue(10);
       SQLFilter.toggleRequired();
-      filterWidget().click();
-      popover().within(() => {
-        removeMultiAutocompleteValue(0);
+      H.filterWidget().click();
+      H.popover().within(() => {
+        H.removeMultiAutocompleteValue(0);
         cy.findByText("Set to default").click();
       });
-      filterWidget()
+      H.filterWidget()
         .findByTestId("field-set-content")
         .should("have.text", "10");
     });
@@ -82,19 +76,21 @@ describe("scenarios > filters > sql filters > field filter", () => {
     it("when there's a default value and template tag is required, can reset it back", () => {
       setDefaultFieldValue(8);
       SQLFilter.toggleRequired();
-      filterWidget().click();
-      popover().within(() => {
-        multiAutocompleteInput().type("10,");
+      H.filterWidget().click();
+      H.popover().within(() => {
+        H.multiAutocompleteInput().type("10,");
         cy.findByText("Update filter").click();
       });
-      filterWidget().icon("revert").click();
-      filterWidget().findByTestId("field-set-content").should("have.text", "8");
+      H.filterWidget().icon("revert").click();
+      H.filterWidget()
+        .findByTestId("field-set-content")
+        .should("have.text", "8");
     });
   });
 
   context("ID filter", () => {
     beforeEach(() => {
-      openNativeEditor();
+      H.openNativeEditor();
       SQLFilter.enterParameterizedQuery(
         "SELECT * FROM products WHERE {{filter}}",
       );
@@ -121,7 +117,7 @@ describe("scenarios > filters > sql filters > field filter", () => {
       });
 
       cy.log("the default value should not apply when the value is cleared");
-      clearFilterWidget();
+      H.clearFilterWidget();
       SQLFilter.runQuery();
       cy.findByTestId("query-visualization-root").within(() => {
         cy.findByText("Small Marble Shoes");
@@ -132,7 +128,7 @@ describe("scenarios > filters > sql filters > field filter", () => {
 
   context("None", () => {
     beforeEach(() => {
-      openNativeEditor();
+      H.openNativeEditor();
       SQLFilter.enterParameterizedQuery(
         "SELECT * FROM people WHERE {{filter}}",
       );
@@ -149,7 +145,7 @@ describe("scenarios > filters > sql filters > field filter", () => {
         .should("have.value", "None")
         .should("be.disabled");
 
-      filterWidget().should("not.exist");
+      H.filterWidget().should("not.exist");
     });
 
     it("should be runnable with the None filter being ignored (metabase#20643)", () => {
@@ -207,10 +203,10 @@ describe("scenarios > filters > sql filters > field filter", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 42 rows");
 
-      clearFilterWidget();
-      filterWidget().click();
+      H.clearFilterWidget();
+      H.filterWidget().click();
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Gizmo").click();
         cy.button("Update filter").click();
       });
@@ -229,7 +225,7 @@ describe("scenarios > filters > sql filters > field filter", () => {
         .findByTestId("filter-widget-type-select")
         .click();
 
-      popover().contains("String");
+      H.popover().contains("String");
     });
   });
 });

--- a/e2e/test/scenarios/native-filters/sql-filters-reset-clear.cy.spec.ts
+++ b/e2e/test/scenarios/native-filters/sql-filters-reset-clear.cy.spec.ts
@@ -1,5 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { createNativeQuestion, popover, restore } from "e2e/support/helpers";
 import type { TemplateTag } from "metabase-types/api";
 
 type SectionId =
@@ -21,7 +21,7 @@ const DEFAULT_REQUIRED = "default value, required";
 
 describe("scenarios > filters > sql filters > reset & clear", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -211,12 +211,12 @@ describe("scenarios > filters > sql filters > reset & clear", () => {
       otherValue: "{backspace}Gadget",
       otherValueFormatted: "Gadget",
       setValue: value => {
-        popover().findByRole("searchbox").clear().type(value).blur();
-        popover().button("Add filter").click();
+        H.popover().findByRole("searchbox").clear().type(value).blur();
+        H.popover().button("Add filter").click();
       },
       updateValue: value => {
-        popover().findByRole("searchbox").clear().type(value).blur();
-        popover().button("Update filter").click();
+        H.popover().findByRole("searchbox").clear().type(value).blur();
+        H.popover().button("Update filter").click();
       },
     });
 
@@ -225,12 +225,12 @@ describe("scenarios > filters > sql filters > reset & clear", () => {
       otherValue: "{backspace}Gadget",
       otherValueFormatted: "Gadget",
       setValue: value => {
-        popover().findByRole("searchbox").clear().type(value).blur();
-        popover().button("Add filter").click();
+        H.popover().findByRole("searchbox").clear().type(value).blur();
+        H.popover().button("Add filter").click();
       },
       updateValue: value => {
-        popover().findByRole("searchbox").clear().type(value).blur();
-        popover().button("Update filter").click();
+        H.popover().findByRole("searchbox").clear().type(value).blur();
+        H.popover().button("Update filter").click();
       },
     });
   });
@@ -238,7 +238,7 @@ describe("scenarios > filters > sql filters > reset & clear", () => {
   function createNativeQuestionWithParameters(
     templateTags: Record<SectionId, TemplateTag>,
   ) {
-    createNativeQuestion(
+    H.createNativeQuestion(
       {
         native: {
           query:
@@ -548,8 +548,8 @@ describe("scenarios > filters > sql filters > reset & clear", () => {
       filter("Default filter widget value").click();
     });
 
-    popover().findByRole("textbox").clear().type(otherValue).blur();
-    popover().button("Add filter").click();
+    H.popover().findByRole("textbox").clear().type(otherValue).blur();
+    H.popover().button("Add filter").click();
 
     filterSection("no_default_non_required").within(() => {
       filter("Default filter widget value").should(
@@ -577,8 +577,8 @@ describe("scenarios > filters > sql filters > reset & clear", () => {
       filter("Default filter widget value (required)").click();
     });
 
-    popover().findByRole("textbox").clear().type(otherValue).blur();
-    popover().button("Update filter").click();
+    H.popover().findByRole("textbox").clear().type(otherValue).blur();
+    H.popover().button("Update filter").click();
 
     filterSection("no_default_required").within(() => {
       filter("Default filter widget value").should(
@@ -609,8 +609,8 @@ describe("scenarios > filters > sql filters > reset & clear", () => {
       filter("Default filter widget value").click();
     });
 
-    popover().findByRole("textbox").clear().type(otherValue).blur();
-    popover().button("Add filter").click();
+    H.popover().findByRole("textbox").clear().type(otherValue).blur();
+    H.popover().button("Add filter").click();
 
     filterSection("default_non_required").within(() => {
       filter("Default filter widget value").should(
@@ -638,8 +638,8 @@ describe("scenarios > filters > sql filters > reset & clear", () => {
       filter("Default filter widget value (required)").click();
     });
 
-    popover().findByRole("textbox").clear().type(otherValue).blur();
-    popover().button("Update filter").click();
+    H.popover().findByRole("textbox").clear().type(otherValue).blur();
+    H.popover().button("Update filter").click();
 
     filterSection("default_required").within(() => {
       filter("Default filter widget value").should(
@@ -812,12 +812,12 @@ describe("scenarios > filters > sql filters > reset & clear", () => {
   }
 
   function addDateFilter(value: string) {
-    popover().findByRole("textbox").clear().type(value).blur();
-    popover().button("Add filter").click();
+    H.popover().findByRole("textbox").clear().type(value).blur();
+    H.popover().button("Add filter").click();
   }
 
   function updateDateFilter(value: string) {
-    popover().findByRole("textbox").clear().type(value).blur();
-    popover().button("Update filter").click();
+    H.popover().findByRole("textbox").clear().type(value).blur();
+    H.popover().button("Update filter").click();
   }
 });

--- a/e2e/test/scenarios/native-filters/sql-filters-source.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-filters-source.cy.spec.js
@@ -1,26 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  blockUserGroupPermissions,
-  checkFilterListSourceHasValue,
-  describeEE,
-  multiAutocompleteInput,
-  multiAutocompleteValue,
-  openNativeEditor,
-  popover,
-  restore,
-  saveQuestion,
-  setConnectedFieldSource,
-  setDropdownFilterType,
-  setFilterListSource,
-  setFilterQuestionSource,
-  setSearchBoxFilterType,
-  setTokenFeatures,
-  updateSetting,
-  visitEmbeddedPage,
-  visitPublicQuestion,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 import * as FieldFilter from "./helpers/e2e-field-filter-helpers";
 import * as SQLFilter from "./helpers/e2e-sql-filter-helpers";
@@ -47,9 +27,9 @@ const nativeSourceQuestion = {
 
 describe("scenarios > filters > sql filters > values source", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    updateSetting("enable-public-sharing", true);
+    H.updateSetting("enable-public-sharing", true);
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("GET", "/api/session/properties").as("sessionProperties");
     cy.intercept("PUT", "/api/card/*").as("updateQuestion");
@@ -64,13 +44,13 @@ describe("scenarios > filters > sql filters > values source", () => {
     it("should be able to use a structured question source", () => {
       cy.createQuestion(structuredSourceQuestion);
 
-      openNativeEditor();
+      H.openNativeEditor();
       SQLFilter.enterParameterizedQuery("SELECT * FROM PRODUCTS WHERE {{tag}}");
       SQLFilter.openTypePickerFromDefaultFilterType();
       SQLFilter.chooseType("Field Filter");
       FieldFilter.mapTo({ table: "Products", field: "Category" });
-      setFilterQuestionSource({ question: "MBQL source", field: "Category" });
-      saveQuestion("SQL filter");
+      H.setFilterQuestionSource({ question: "MBQL source", field: "Category" });
+      H.saveQuestion("SQL filter");
 
       FieldFilter.openEntryForm();
       checkFilterValueNotInList("Doohickey");
@@ -87,13 +67,13 @@ describe("scenarios > filters > sql filters > values source", () => {
     it("should be able to use a structured question source with a text tag", () => {
       cy.createQuestion(structuredSourceQuestion);
 
-      openNativeEditor();
+      H.openNativeEditor();
       SQLFilter.enterParameterizedQuery(
         "SELECT * FROM PRODUCTS WHERE CATEGORY = {{tag}}",
       );
-      setDropdownFilterType();
-      setFilterQuestionSource({ question: "MBQL source", field: "Category" });
-      saveQuestion("SQL filter");
+      H.setDropdownFilterType();
+      H.setFilterQuestionSource({ question: "MBQL source", field: "Category" });
+      H.saveQuestion("SQL filter");
 
       FieldFilter.openEntryForm();
       checkFilterValueNotInList("Doohickey");
@@ -108,7 +88,7 @@ describe("scenarios > filters > sql filters > values source", () => {
         .findByText("Enter a default value…")
         .click();
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Gadget").click();
         cy.button("Update filter").click();
       });
@@ -117,12 +97,12 @@ describe("scenarios > filters > sql filters > values source", () => {
     it("should be able to use a structured question source without saving the question", () => {
       cy.createQuestion(structuredSourceQuestion);
 
-      openNativeEditor();
+      H.openNativeEditor();
       SQLFilter.enterParameterizedQuery(
         "SELECT * FROM PRODUCTS WHERE CATEGORY = {{tag}}",
       );
-      setDropdownFilterType();
-      setFilterQuestionSource({ question: "MBQL source", field: "Category" });
+      H.setDropdownFilterType();
+      H.setFilterQuestionSource({ question: "MBQL source", field: "Category" });
 
       FieldFilter.openEntryForm();
       checkFilterValueNotInList("Doohickey");
@@ -132,13 +112,13 @@ describe("scenarios > filters > sql filters > values source", () => {
 
     it("should properly cache parameter values api calls", () => {
       cy.createQuestion(structuredSourceQuestion);
-      openNativeEditor();
+      H.openNativeEditor();
       SQLFilter.enterParameterizedQuery(
         "SELECT * FROM PRODUCTS WHERE CATEGORY = {{tag}}",
       );
 
-      setDropdownFilterType();
-      setFilterQuestionSource({ question: "MBQL source", field: "Category" });
+      H.setDropdownFilterType();
+      H.setFilterQuestionSource({ question: "MBQL source", field: "Category" });
       FieldFilter.openEntryForm();
       cy.wait("@parameterValues");
       checkFilterValueInList("Gizmo");
@@ -146,12 +126,12 @@ describe("scenarios > filters > sql filters > values source", () => {
       FieldFilter.openEntryForm();
       checkFilterValueInList("Gizmo");
       cy.get("@parameterValues.all").should("have.length", 1);
-      setFilterListSource({ values: ["A", "B"] });
+      H.setFilterListSource({ values: ["A", "B"] });
       FieldFilter.openEntryForm();
       cy.wait("@parameterValues");
       checkFilterValueInList("A");
 
-      saveQuestion("SQL filter");
+      H.saveQuestion("SQL filter");
       FieldFilter.openEntryForm();
       cy.wait("@cardParameterValues");
       checkFilterValueInList("A");
@@ -159,7 +139,7 @@ describe("scenarios > filters > sql filters > values source", () => {
       FieldFilter.openEntryForm();
       checkFilterValueInList("A");
       cy.get("@cardParameterValues.all").should("have.length", 1);
-      setFilterQuestionSource({ question: "MBQL source", field: "Category" });
+      H.setFilterQuestionSource({ question: "MBQL source", field: "Category" });
       updateQuestion();
       FieldFilter.openEntryForm();
       cy.wait("@cardParameterValues");
@@ -172,7 +152,7 @@ describe("scenarios > filters > sql filters > values source", () => {
           cy.createNativeQuestion(
             getStructuredDimensionTargetQuestion(sourceQuestionId),
           ).then(({ body: { id: targetQuestionId } }) => {
-            visitEmbeddedPage(getQuestionResource(targetQuestionId));
+            H.visitEmbeddedPage(getQuestionResource(targetQuestionId));
           });
         },
       );
@@ -188,7 +168,7 @@ describe("scenarios > filters > sql filters > values source", () => {
           cy.createNativeQuestion(
             getStructuredTextTargetQuestion(sourceQuestionId),
           ).then(({ body: { id: targetQuestionId } }) => {
-            visitEmbeddedPage(getQuestionResource(targetQuestionId));
+            H.visitEmbeddedPage(getQuestionResource(targetQuestionId));
           });
         },
       );
@@ -204,7 +184,7 @@ describe("scenarios > filters > sql filters > values source", () => {
           cy.createNativeQuestion(
             getStructuredDimensionTargetQuestion(sourceQuestionId),
           ).then(({ body: { id: targetQuestionId } }) => {
-            visitPublicQuestion(targetQuestionId);
+            H.visitPublicQuestion(targetQuestionId);
           });
         },
       );
@@ -220,7 +200,7 @@ describe("scenarios > filters > sql filters > values source", () => {
           cy.createNativeQuestion(
             getStructuredTextTargetQuestion(sourceQuestionId),
           ).then(({ body: { id: targetQuestionId } }) => {
-            visitPublicQuestion(targetQuestionId);
+            H.visitPublicQuestion(targetQuestionId);
           });
         },
       );
@@ -235,14 +215,14 @@ describe("scenarios > filters > sql filters > values source", () => {
     it("should be able to use a native question source in the query builder", () => {
       cy.createNativeQuestion(nativeSourceQuestion);
 
-      openNativeEditor();
+      H.openNativeEditor();
       SQLFilter.enterParameterizedQuery("SELECT * FROM PRODUCTS WHERE {{tag}}");
       SQLFilter.openTypePickerFromDefaultFilterType();
       SQLFilter.chooseType("Field Filter");
       FieldFilter.mapTo({ table: "Products", field: "Ean" });
       FieldFilter.setWidgetType("String");
-      setFilterQuestionSource({ question: "SQL source", field: "EAN" });
-      saveQuestion("SQL filter");
+      H.setFilterQuestionSource({ question: "SQL source", field: "EAN" });
+      H.saveQuestion("SQL filter");
 
       FieldFilter.openEntryForm();
       checkFilterValueNotInList("0001664425970");
@@ -256,7 +236,7 @@ describe("scenarios > filters > sql filters > values source", () => {
           cy.createNativeQuestion(
             getNativeDimensionTargetQuestion(sourceQuestionId),
           ).then(({ body: { id: targetQuestionId } }) => {
-            visitEmbeddedPage(getQuestionResource(targetQuestionId));
+            H.visitEmbeddedPage(getQuestionResource(targetQuestionId));
           });
         },
       );
@@ -272,7 +252,7 @@ describe("scenarios > filters > sql filters > values source", () => {
           cy.createNativeQuestion(
             getNativeTextTargetQuestion(sourceQuestionId),
           ).then(({ body: { id: targetQuestionId } }) => {
-            visitEmbeddedPage(getQuestionResource(targetQuestionId));
+            H.visitEmbeddedPage(getQuestionResource(targetQuestionId));
           });
         },
       );
@@ -288,7 +268,7 @@ describe("scenarios > filters > sql filters > values source", () => {
           cy.createNativeQuestion(
             getNativeDimensionTargetQuestion(sourceQuestionId),
           ).then(({ body: { id: targetQuestionId } }) => {
-            visitPublicQuestion(targetQuestionId);
+            H.visitPublicQuestion(targetQuestionId);
           });
         },
       );
@@ -304,7 +284,7 @@ describe("scenarios > filters > sql filters > values source", () => {
           cy.createNativeQuestion(
             getNativeTextTargetQuestion(sourceQuestionId),
           ).then(({ body: { id: targetQuestionId } }) => {
-            visitPublicQuestion(targetQuestionId);
+            H.visitPublicQuestion(targetQuestionId);
           });
         },
       );
@@ -317,14 +297,14 @@ describe("scenarios > filters > sql filters > values source", () => {
 
   describe("static list source (dropdown)", () => {
     it("should be able to use a static list source in the query builder", () => {
-      openNativeEditor();
+      H.openNativeEditor();
       SQLFilter.enterParameterizedQuery("SELECT * FROM PRODUCTS WHERE {{tag}}");
       SQLFilter.openTypePickerFromDefaultFilterType();
       SQLFilter.chooseType("Field Filter");
       FieldFilter.mapTo({ table: "Products", field: "Ean" });
       FieldFilter.setWidgetType("String");
-      setFilterListSource({ values: ["1018947080336", "7663515285824"] });
-      saveQuestion("SQL filter");
+      H.setFilterListSource({ values: ["1018947080336", "7663515285824"] });
+      H.saveQuestion("SQL filter");
 
       FieldFilter.openEntryForm();
       checkFilterValueNotInList("0001664425970");
@@ -339,7 +319,7 @@ describe("scenarios > filters > sql filters > values source", () => {
           values: ["1018947080336", "7663515285824"],
         }),
       ).then(({ body: { id: targetQuestionId } }) => {
-        visitEmbeddedPage(getQuestionResource(targetQuestionId));
+        H.visitEmbeddedPage(getQuestionResource(targetQuestionId));
       });
 
       FieldFilter.openEntryForm();
@@ -354,7 +334,7 @@ describe("scenarios > filters > sql filters > values source", () => {
           values: ["1018947080336", "7663515285824"],
         }),
       ).then(({ body: { id: targetQuestionId } }) => {
-        visitPublicQuestion(targetQuestionId);
+        H.visitPublicQuestion(targetQuestionId);
       });
 
       FieldFilter.openEntryForm();
@@ -366,16 +346,16 @@ describe("scenarios > filters > sql filters > values source", () => {
 
   describe("static list source with custom labels (dropdown)", () => {
     it("should be able to use a static list source in the query builder", () => {
-      openNativeEditor();
+      H.openNativeEditor();
       SQLFilter.enterParameterizedQuery("SELECT * FROM PRODUCTS WHERE {{tag}}");
       SQLFilter.openTypePickerFromDefaultFilterType();
       SQLFilter.chooseType("Field Filter");
       FieldFilter.mapTo({ table: "Products", field: "Ean" });
       FieldFilter.setWidgetType("String");
-      setFilterListSource({
+      H.setFilterListSource({
         values: [["1018947080336", "Custom Label"], "7663515285824"],
       });
-      saveQuestion("SQL filter");
+      H.saveQuestion("SQL filter");
 
       FieldFilter.openEntryForm();
       checkFilterValueNotInList("0001664425970");
@@ -391,7 +371,7 @@ describe("scenarios > filters > sql filters > values source", () => {
           values: [["1018947080336", "Custom Label"], "7663515285824"],
         }),
       ).then(({ body: { id: targetQuestionId } }) => {
-        visitEmbeddedPage(getQuestionResource(targetQuestionId));
+        H.visitEmbeddedPage(getQuestionResource(targetQuestionId));
       });
 
       FieldFilter.openEntryForm();
@@ -407,7 +387,7 @@ describe("scenarios > filters > sql filters > values source", () => {
           values: [["1018947080336", "Custom Label"], "7663515285824"],
         }),
       ).then(({ body: { id: targetQuestionId } }) => {
-        visitPublicQuestion(targetQuestionId);
+        H.visitPublicQuestion(targetQuestionId);
       });
 
       FieldFilter.openEntryForm();
@@ -420,28 +400,28 @@ describe("scenarios > filters > sql filters > values source", () => {
 
   describe("static list source (search box)", () => {
     it("should be able to use a static list source in the query builder", () => {
-      openNativeEditor();
+      H.openNativeEditor();
       SQLFilter.enterParameterizedQuery("SELECT * FROM PRODUCTS WHERE {{tag}}");
       SQLFilter.openTypePickerFromDefaultFilterType();
       SQLFilter.chooseType("Field Filter");
       FieldFilter.mapTo({ table: "Products", field: "Ean" });
       FieldFilter.setWidgetType("String");
 
-      setSearchBoxFilterType();
-      setFilterListSource({
+      H.setSearchBoxFilterType();
+      H.setFilterListSource({
         values: ["1018947080336", "7663515285824"],
       });
-      saveQuestion("SQL filter");
+      H.saveQuestion("SQL filter");
 
       FieldFilter.openEntryForm();
 
-      multiAutocompleteInput().type("101");
-      popover().last().findByText("1018947080336").click();
+      H.multiAutocompleteInput().type("101");
+      H.popover().last().findByText("1018947080336").click();
 
-      multiAutocompleteValue(0)
+      H.multiAutocompleteValue(0)
         .should("be.visible")
         .should("contain", "1018947080336");
-      popover().button("Add filter").click();
+      H.popover().button("Add filter").click();
 
       cy.findByLabelText("Tag").should("contain.text", "1018947080336");
     });
@@ -453,17 +433,17 @@ describe("scenarios > filters > sql filters > values source", () => {
           values: ["1018947080336", "7663515285824"],
         }),
       ).then(({ body: { id: targetQuestionId } }) => {
-        visitEmbeddedPage(getQuestionResource(targetQuestionId));
+        H.visitEmbeddedPage(getQuestionResource(targetQuestionId));
       });
 
       FieldFilter.openEntryForm();
 
-      multiAutocompleteInput().type("101");
-      popover().last().findByText("1018947080336").click();
-      multiAutocompleteValue(0)
+      H.multiAutocompleteInput().type("101");
+      H.popover().last().findByText("1018947080336").click();
+      H.multiAutocompleteValue(0)
         .should("be.visible")
         .should("contain", "1018947080336");
-      popover().button("Add filter").click();
+      H.popover().button("Add filter").click();
 
       cy.findByLabelText("Tag").should("contain.text", "1018947080336");
     });
@@ -475,17 +455,17 @@ describe("scenarios > filters > sql filters > values source", () => {
           values: ["1018947080336", "7663515285824"],
         }),
       ).then(({ body: { id: targetQuestionId } }) => {
-        visitPublicQuestion(targetQuestionId);
+        H.visitPublicQuestion(targetQuestionId);
       });
 
       FieldFilter.openEntryForm();
 
-      multiAutocompleteInput().type("101");
-      popover().last().findByText("1018947080336").click();
-      multiAutocompleteValue(0)
+      H.multiAutocompleteInput().type("101");
+      H.popover().last().findByText("1018947080336").click();
+      H.multiAutocompleteValue(0)
         .should("be.visible")
         .should("contain", "1018947080336");
-      popover().button("Add filter").click();
+      H.popover().button("Add filter").click();
 
       cy.findByLabelText("Tag").should("contain.text", "1018947080336");
     });
@@ -493,28 +473,28 @@ describe("scenarios > filters > sql filters > values source", () => {
 
   describe("static list source with custom labels (search box)", () => {
     it("should be able to use a static list source in the query builder", () => {
-      openNativeEditor();
+      H.openNativeEditor();
       SQLFilter.enterParameterizedQuery("SELECT * FROM PRODUCTS WHERE {{tag}}");
       SQLFilter.openTypePickerFromDefaultFilterType();
       SQLFilter.chooseType("Field Filter");
       FieldFilter.mapTo({ table: "Products", field: "Ean" });
       FieldFilter.setWidgetType("String");
 
-      setSearchBoxFilterType();
-      setFilterListSource({
+      H.setSearchBoxFilterType();
+      H.setFilterListSource({
         values: [["1018947080336", "Custom Label"], "7663515285824"],
       });
-      saveQuestion("SQL filter");
+      H.saveQuestion("SQL filter");
 
       FieldFilter.openEntryForm();
 
-      multiAutocompleteInput().type("Custom Label");
-      popover().last().findByText("1018947080336").should("not.exist");
-      popover().last().findByText("Custom Label").click();
-      multiAutocompleteValue(0)
+      H.multiAutocompleteInput().type("Custom Label");
+      H.popover().last().findByText("1018947080336").should("not.exist");
+      H.popover().last().findByText("Custom Label").click();
+      H.multiAutocompleteValue(0)
         .should("be.visible")
         .should("contain", "Custom Label");
-      popover().button("Add filter").click();
+      H.popover().button("Add filter").click();
 
       cy.findByLabelText("Tag").should("contain.text", "Custom Label");
     });
@@ -526,18 +506,18 @@ describe("scenarios > filters > sql filters > values source", () => {
           values: [["1018947080336", "Custom Label"], "7663515285824"],
         }),
       ).then(({ body: { id: targetQuestionId } }) => {
-        visitEmbeddedPage(getQuestionResource(targetQuestionId));
+        H.visitEmbeddedPage(getQuestionResource(targetQuestionId));
       });
 
       FieldFilter.openEntryForm();
 
-      multiAutocompleteInput().type("Custom Label");
-      popover().last().findByText("1018947080336").should("not.exist");
-      popover().last().findByText("Custom Label").click();
-      multiAutocompleteValue(0)
+      H.multiAutocompleteInput().type("Custom Label");
+      H.popover().last().findByText("1018947080336").should("not.exist");
+      H.popover().last().findByText("Custom Label").click();
+      H.multiAutocompleteValue(0)
         .should("be.visible")
         .should("contain", "Custom Label");
-      popover().button("Add filter").click();
+      H.popover().button("Add filter").click();
 
       cy.findByLabelText("Tag").should("contain.text", "Custom Label");
     });
@@ -549,30 +529,30 @@ describe("scenarios > filters > sql filters > values source", () => {
           values: [["1018947080336", "Custom Label"], "7663515285824"],
         }),
       ).then(({ body: { id: targetQuestionId } }) => {
-        visitPublicQuestion(targetQuestionId);
+        H.visitPublicQuestion(targetQuestionId);
       });
 
       FieldFilter.openEntryForm();
 
-      multiAutocompleteInput().type("Custom Label");
-      popover().last().findByText("1018947080336").should("not.exist");
-      popover().last().findByText("Custom Label").click();
-      multiAutocompleteValue(0)
+      H.multiAutocompleteInput().type("Custom Label");
+      H.popover().last().findByText("1018947080336").should("not.exist");
+      H.popover().last().findByText("Custom Label").click();
+      H.multiAutocompleteValue(0)
         .should("be.visible")
         .should("contain", "Custom Label");
-      popover().button("Add filter").click();
+      H.popover().button("Add filter").click();
 
       cy.findByLabelText("Tag").should("contain.text", "Custom Label");
     });
   });
 });
 
-describeEE("scenarios > filters > sql filters > values source", () => {
+H.describeEE("scenarios > filters > sql filters > values source", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
-    blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);
+    H.setTokenFeatures("all");
+    H.blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);
     cy.intercept("POST", "/api/dataset/parameter/values").as("parameterValues");
     cy.intercept("GET", "/api/card/*/params/*/values").as(
       "cardParameterValues",
@@ -603,7 +583,7 @@ describeEE("scenarios > filters > sql filters > values source", () => {
         ).then(({ body: { id: targetQuestionId } }) => {
           cy.signOut();
           cy.signInAsSandboxedUser();
-          visitQuestion(targetQuestionId);
+          H.visitQuestion(targetQuestionId);
         });
       },
     );
@@ -619,9 +599,9 @@ describeEE("scenarios > filters > sql filters > values source", () => {
 
 describe("scenarios > filters > sql filters > values source > number parameter", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    updateSetting("enable-public-sharing", true);
+    H.updateSetting("enable-public-sharing", true);
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("GET", "/api/session/properties").as("sessionProperties");
     cy.intercept("PUT", "/api/card/*").as("updateQuestion");
@@ -634,16 +614,16 @@ describe("scenarios > filters > sql filters > values source > number parameter",
 
   describe("static list source (dropdown)", () => {
     it("should be able to use a static list source in the query builder", () => {
-      openNativeEditor();
+      H.openNativeEditor();
       SQLFilter.enterParameterizedQuery("SELECT {{ x }}");
       SQLFilter.openTypePickerFromDefaultFilterType();
       SQLFilter.chooseType("Number");
 
-      setDropdownFilterType();
-      setFilterListSource({
+      H.setDropdownFilterType();
+      H.setFilterListSource({
         values: [["10", "Ten"], ["20", "Twenty"], "30"],
       });
-      saveQuestion("SQL filter");
+      H.saveQuestion("SQL filter");
 
       FieldFilter.openEntryForm();
       checkFilterValueNotInList("10");
@@ -664,7 +644,7 @@ describe("scenarios > filters > sql filters > values source > number parameter",
           },
         }),
       ).then(({ body: { id: targetQuestionId } }) => {
-        visitEmbeddedPage(getQuestionResource(targetQuestionId));
+        H.visitEmbeddedPage(getQuestionResource(targetQuestionId));
       });
 
       FieldFilter.openEntryForm();
@@ -685,7 +665,7 @@ describe("scenarios > filters > sql filters > values source > number parameter",
           },
         }),
       ).then(({ body: { id: targetQuestionId } }) => {
-        visitPublicQuestion(targetQuestionId);
+        H.visitPublicQuestion(targetQuestionId);
       });
 
       FieldFilter.openEntryForm();
@@ -697,22 +677,22 @@ describe("scenarios > filters > sql filters > values source > number parameter",
 
   describe("static list source with custom labels (dropdown)", () => {
     it("should be able to use a static list source in the query builder", () => {
-      openNativeEditor();
+      H.openNativeEditor();
       SQLFilter.enterParameterizedQuery("SELECT * FROM {{ tag }}");
       SQLFilter.openTypePickerFromDefaultFilterType();
       SQLFilter.chooseType("Number");
-      setSearchBoxFilterType();
-      setFilterListSource({
+      H.setSearchBoxFilterType();
+      H.setFilterListSource({
         values: [["10", "Ten"], ["20", "Twenty"], "30"],
       });
-      saveQuestion("SQL filter");
+      H.saveQuestion("SQL filter");
 
       FieldFilter.openEntryForm();
-      multiAutocompleteInput().type("Tw");
+      H.multiAutocompleteInput().type("Tw");
       checkFilterValueNotInList("10");
       checkFilterValueNotInList("20");
-      popover().last().findByText("Twenty").click();
-      popover().button("Add filter").click();
+      H.popover().last().findByText("Twenty").click();
+      H.popover().button("Add filter").click();
 
       cy.findByLabelText("Tag").should("contain.text", "Twenty");
       SQLFilter.runQuery("cardQuery");
@@ -730,16 +710,16 @@ describe("scenarios > filters > sql filters > values source > number parameter",
           },
         }),
       ).then(({ body: { id: targetQuestionId } }) => {
-        visitEmbeddedPage(getQuestionResource(targetQuestionId));
+        H.visitEmbeddedPage(getQuestionResource(targetQuestionId));
       });
 
       FieldFilter.openEntryForm();
-      multiAutocompleteInput().type("Tw");
+      H.multiAutocompleteInput().type("Tw");
       checkFilterValueNotInList("10");
       checkFilterValueNotInList("20");
 
-      popover().last().findByText("Twenty").click();
-      popover().button("Add filter").click();
+      H.popover().last().findByText("Twenty").click();
+      H.popover().button("Add filter").click();
 
       cy.findByLabelText("Tag").should("contain.text", "Twenty");
     });
@@ -756,16 +736,16 @@ describe("scenarios > filters > sql filters > values source > number parameter",
           },
         }),
       ).then(({ body: { id: targetQuestionId } }) => {
-        visitPublicQuestion(targetQuestionId);
+        H.visitPublicQuestion(targetQuestionId);
       });
 
       FieldFilter.openEntryForm();
-      multiAutocompleteInput().type("Tw");
+      H.multiAutocompleteInput().type("Tw");
       checkFilterValueNotInList("10");
       checkFilterValueNotInList("20");
 
-      popover().last().findByText("Twenty").click();
-      popover().button("Add filter").click();
+      H.popover().last().findByText("Twenty").click();
+      H.popover().button("Add filter").click();
 
       cy.findByLabelText("Tag").should("contain.text", "Twenty");
     });
@@ -773,26 +753,26 @@ describe("scenarios > filters > sql filters > values source > number parameter",
 
   describe("static list source (search box)", () => {
     it("should be able to use a static list source in the query builder", () => {
-      openNativeEditor();
+      H.openNativeEditor();
       SQLFilter.enterParameterizedQuery("SELECT {{ tag }}");
       SQLFilter.openTypePickerFromDefaultFilterType();
       SQLFilter.chooseType("Number");
 
-      setSearchBoxFilterType();
-      setFilterListSource({
+      H.setSearchBoxFilterType();
+      H.setFilterListSource({
         values: [["10", "Ten"], ["20", "Twenty"], "30"],
       });
-      saveQuestion("SQL filter");
+      H.saveQuestion("SQL filter");
 
       FieldFilter.openEntryForm();
 
-      multiAutocompleteInput().type("Tw");
-      popover().last().findByText("Twenty").click();
+      H.multiAutocompleteInput().type("Tw");
+      H.popover().last().findByText("Twenty").click();
 
-      multiAutocompleteValue(0)
+      H.multiAutocompleteValue(0)
         .should("be.visible")
         .should("contain", "Twenty");
-      popover().button("Add filter").click();
+      H.popover().button("Add filter").click();
 
       cy.findByLabelText("Tag").should("contain.text", "Twenty");
     });
@@ -809,30 +789,30 @@ describe("scenarios > filters > sql filters > values source > number parameter",
           },
         }),
       ).then(({ body: { id: targetQuestionId } }) => {
-        visitEmbeddedPage(getQuestionResource(targetQuestionId));
+        H.visitEmbeddedPage(getQuestionResource(targetQuestionId));
       });
 
       FieldFilter.openEntryForm();
 
-      multiAutocompleteInput().type("Twenty");
-      popover().last().findByText("Twenty").click();
-      multiAutocompleteValue(0)
+      H.multiAutocompleteInput().type("Twenty");
+      H.popover().last().findByText("Twenty").click();
+      H.multiAutocompleteValue(0)
         .should("be.visible")
         .should("contain", "Twenty");
-      popover().button("Add filter").click();
+      H.popover().button("Add filter").click();
 
       cy.findByLabelText("Tag").should("contain.text", "Twenty");
     });
   });
 
   it("should show the values when picking the default value", () => {
-    openNativeEditor();
+    H.openNativeEditor();
     SQLFilter.enterParameterizedQuery("SELECT {{ x }}");
     SQLFilter.openTypePickerFromDefaultFilterType();
     SQLFilter.chooseType("Number");
 
-    setDropdownFilterType();
-    setFilterListSource({
+    H.setDropdownFilterType();
+    H.setFilterListSource({
       values: [["10", "Ten"], ["20", "Twenty"], "30"],
     });
 
@@ -840,44 +820,44 @@ describe("scenarios > filters > sql filters > values source > number parameter",
       .findByText("Enter a default value…")
       .click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Twenty").click();
       cy.button("Add filter").click();
     });
 
-    saveQuestion("SQL filter");
+    H.saveQuestion("SQL filter");
 
     cy.findByLabelText("X").should("contain.text", "Twenty");
     SQLFilter.runQuery("cardQuery");
   });
 
   it("should clear the value type and config when changing the template tag type and restore them when changing the type back", () => {
-    openNativeEditor();
+    H.openNativeEditor();
     SQLFilter.enterParameterizedQuery("SELECT * FROM PRODUCTS WHERE {{tag}}");
     SQLFilter.openTypePickerFromDefaultFilterType();
     SQLFilter.chooseType("Text");
-    setSearchBoxFilterType();
-    setFilterListSource({
+    H.setSearchBoxFilterType();
+    H.setFilterListSource({
       values: ["Foo", "Bar"],
     });
-    saveQuestion("SQL filter");
+    H.saveQuestion("SQL filter");
 
     SQLFilter.openTypePickerFromSelectedFilterType("Text");
     SQLFilter.chooseType("Number");
 
     cy.get("[data-checked='true']").should("have.text", "Input box");
 
-    setSearchBoxFilterType();
-    checkFilterListSourceHasValue({ values: [] });
+    H.setSearchBoxFilterType();
+    H.checkFilterListSourceHasValue({ values: [] });
 
     SQLFilter.openTypePickerFromSelectedFilterType("Number");
     SQLFilter.chooseType("Field Filter");
-    setConnectedFieldSource("Orders", "Total");
+    H.setConnectedFieldSource("Orders", "Total");
 
     SQLFilter.openTypePickerFromSelectedFilterType("Number");
     SQLFilter.chooseType("Text");
     cy.get("[data-checked='true']").should("have.text", "Search box");
-    checkFilterListSourceHasValue({ values: ["Foo", "Bar"] });
+    H.checkFilterListSourceHasValue({ values: ["Foo", "Bar"] });
   });
 });
 
@@ -1044,7 +1024,7 @@ const updateQuestion = () => {
 };
 
 const checkFilterValueInList = value => {
-  popover()
+  H.popover()
     .last()
     .within(() => {
       cy.findByText(value).should("exist");
@@ -1052,7 +1032,7 @@ const checkFilterValueInList = value => {
 };
 
 const checkFilterValueNotInList = value => {
-  popover()
+  H.popover()
     .last()
     .within(() => {
       cy.findByText(value).should("not.exist");

--- a/e2e/test/scenarios/native-filters/sql-filters.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-filters.cy.spec.js
@@ -1,21 +1,16 @@
-import {
-  filterWidget,
-  openNativeEditor,
-  popover,
-  restore,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 import * as DateFilter from "./helpers/e2e-date-filter-helpers";
 import * as SQLFilter from "./helpers/e2e-sql-filter-helpers";
 
 describe("scenarios > filters > sql filters > basic filter types", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.intercept("POST", "api/dataset").as("dataset");
 
     cy.signInAsAdmin();
 
-    openNativeEditor();
+    H.openNativeEditor();
   });
 
   describe("should work for text", () => {
@@ -57,15 +52,15 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
 
       it("when there's a default value, enabling required sets it as a parameter value", () => {
         SQLFilter.setDefaultValue("New value");
-        filterWidget().find("input").invoke("val", "");
+        H.filterWidget().find("input").invoke("val", "");
         SQLFilter.toggleRequired();
-        filterWidget().find("input").should("have.value", "New value");
+        H.filterWidget().find("input").should("have.value", "New value");
       });
 
       it("when there's a default value and input is empty, blur sets default value back", () => {
         SQLFilter.setDefaultValue("default");
         SQLFilter.toggleRequired();
-        filterWidget().within(() => {
+        H.filterWidget().within(() => {
           cy.get("input")
             .type("{selectAll}{backspace}")
             .should("have.value", "");
@@ -76,7 +71,7 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
       it("when there's a default value and template tag is required, can reset it back", () => {
         SQLFilter.setDefaultValue("default");
         SQLFilter.toggleRequired();
-        filterWidget().within(() => {
+        H.filterWidget().within(() => {
           cy.get("input").type("abc").should("have.value", "defaultabc");
           cy.icon("revert").click();
           cy.get("input").should("have.value", "default");
@@ -127,15 +122,15 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
 
       it("when there's a default value, enabling required sets it as a parameter value", () => {
         SQLFilter.setDefaultValue("3");
-        filterWidget().find("input").invoke("val", "");
+        H.filterWidget().find("input").invoke("val", "");
         SQLFilter.toggleRequired();
-        filterWidget().find("input").should("have.value", "3");
+        H.filterWidget().find("input").should("have.value", "3");
       });
 
       it("when there's a default value and input is empty, blur sets default value back", () => {
         SQLFilter.setDefaultValue("3");
         SQLFilter.toggleRequired();
-        filterWidget().within(() => {
+        H.filterWidget().within(() => {
           cy.get("input")
             .type("{selectAll}{backspace}")
             .should("have.value", "");
@@ -146,7 +141,7 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
       it("when there's a default value and template tag is required, can reset it back", () => {
         SQLFilter.setDefaultValue("3");
         SQLFilter.toggleRequired();
-        filterWidget().within(() => {
+        H.filterWidget().within(() => {
           cy.get("input").type(".11").should("have.value", "3.11");
           cy.icon("revert").click();
           cy.get("input").should("have.value", "3");
@@ -166,11 +161,11 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
     });
 
     it("when set through the filter widget", () => {
-      filterWidget().click();
+      H.filterWidget().click();
       // Since we have fixed dates in Sample Database (dating back a couple of years), it'd be cumbersome to click back month by month.
       // Instead, let's choose the 15th of the current month and assert that there are no products / no results.
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("15").click();
         cy.findByText("Add filter").click();
       });
@@ -188,7 +183,7 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
       cy.findByTestId("sidebar-content")
         .findByText("Select a default value…")
         .click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("15").click();
         cy.findByText("Update filter").click();
       });
@@ -204,7 +199,7 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
       cy.findByTestId("sidebar-content")
         .findByText("Select a default value…")
         .click();
-      popover().within(() => {
+      H.popover().within(() => {
         DateFilter.setSingleDate(`${month}/${day}/${year}`);
         cy.findByText("Add filter").click();
       });
@@ -219,9 +214,9 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
 
       it("when there's a default value, enabling required sets it as a parameter value", () => {
         setDefaultDate("2023", "11", "01");
-        filterWidget().icon("close").click();
+        H.filterWidget().icon("close").click();
         SQLFilter.toggleRequired();
-        filterWidget()
+        H.filterWidget()
           .findByTestId("field-set-content")
           .should("have.text", "November 1, 2023");
       });
@@ -229,13 +224,13 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
       it("when there's a default value and template tag is required, can reset it back", () => {
         setDefaultDate("2023", "11", "01");
         SQLFilter.toggleRequired();
-        filterWidget().click();
-        popover().within(() => {
+        H.filterWidget().click();
+        H.popover().within(() => {
           cy.findByText("15").click();
           cy.findByText("Update filter").click();
         });
-        filterWidget().icon("revert").click();
-        filterWidget()
+        H.filterWidget().icon("revert").click();
+        H.filterWidget()
           .findByTestId("field-set-content")
           .should("have.text", "November 1, 2023");
       });
@@ -279,12 +274,12 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
     SQLFilter.openTypePickerFromDefaultFilterType();
     SQLFilter.chooseType("Field Filter");
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("People").click();
       cy.findByText("City").trigger("mouseenter");
     });
 
-    popover().contains("City");
-    popover().contains("1,966 distinct values");
+    H.popover().contains("City");
+    H.popover().contains("1,966 distinct values");
   });
 });

--- a/e2e/test/scenarios/native/native-database-source.cy.spec.js
+++ b/e2e/test/scenarios/native/native-database-source.cy.spec.js
@@ -1,14 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
-import {
-  POPOVER_ELEMENT,
-  addPostgresDatabase,
-  focusNativeEditor,
-  openNativeEditor,
-  popover,
-  restore,
-  setTokenFeatures,
-  updateSetting,
-} from "e2e/support/helpers";
 
 const PG_DB_ID = 2;
 const mongoName = "QA Mongo";
@@ -27,7 +18,7 @@ describe(
         "persistDatabase",
       );
 
-      restore("postgres-12");
+      H.restore("postgres-12");
       cy.signInAsAdmin();
       cy.updatePermissionsGraph({
         [ALL_USERS_GROUP]: {
@@ -70,7 +61,7 @@ describe(
     });
 
     it("deleting previously persisted database should result in the new database selection prompt", () => {
-      addPostgresDatabase(additionalPG);
+      H.addPostgresDatabase(additionalPG);
 
       startNativeQuestion();
       assertNoDatabaseSelected();
@@ -109,7 +100,7 @@ describe(
     });
 
     it("should not update the setting when the same database is selected again", () => {
-      updateSetting("last-used-native-database-id", SAMPLE_DB_ID);
+      H.updateSetting("last-used-native-database-id", SAMPLE_DB_ID);
 
       startNativeQuestion();
       cy.findByTestId("selected-database")
@@ -152,12 +143,12 @@ describe(
           .should("have.text", postgresName)
           .click();
 
-        cy.get(POPOVER_ELEMENT).should("not.exist");
+        cy.get(H.POPOVER_ELEMENT).should("not.exist");
 
         cy.signOut();
         cy.signInAsAdmin();
 
-        addPostgresDatabase(additionalPG);
+        H.addPostgresDatabase(additionalPG);
         cy.updatePermissionsGraph({
           [ALL_USERS_GROUP]: {
             [ADDITIONAL_PG_DB_ID]: {
@@ -174,7 +165,7 @@ describe(
           .should("have.text", postgresName)
           .click();
 
-        popover()
+        H.popover()
           .should("contain", postgresName)
           .and("contain", "New Database");
       });
@@ -189,7 +180,7 @@ describe(
         .should("have.text", postgresName)
         .click();
 
-      cy.get(POPOVER_ELEMENT).should("not.exist");
+      cy.get(H.POPOVER_ELEMENT).should("not.exist");
     });
 
     it("users that lose permissions to the last used database should not have that database preselected anymore", () => {
@@ -199,7 +190,7 @@ describe(
 
       cy.signOut();
       cy.signInAsAdmin();
-      setTokenFeatures("all");
+      H.setTokenFeatures("all");
       cy.updatePermissionsGraph({
         [DATA_GROUP]: {
           [SAMPLE_DB_ID]: {
@@ -220,7 +211,7 @@ describe(
 
 describe("mongo as the default database", { tags: "@mongo" }, () => {
   beforeEach(() => {
-    restore("mongo-5");
+    H.restore("mongo-5");
     cy.signInAsAdmin();
   });
 
@@ -232,7 +223,7 @@ describe("mongo as the default database", { tags: "@mongo" }, () => {
     cy.findByTestId("native-query-top-bar")
       .findByText("Select a table")
       .click();
-    popover().findByText("Reviews").click();
+    H.popover().findByText("Reviews").click();
     cy.findByTestId("native-query-top-bar").should(
       "not.contain",
       "Select a table",
@@ -252,13 +243,13 @@ describe("scenatios > question > native > mysql", { tags: "@external" }, () => {
     cy.intercept("POST", "/api/card").as("createQuestion");
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore("mysql-8");
+    H.restore("mysql-8");
     cy.signInAsAdmin();
   });
 
   it("can write a native MySQL query with a field filter", () => {
     // Write Native query that includes a filter
-    openNativeEditor({ databaseName: MYSQL_DB_NAME }).type(
+    H.openNativeEditor({ databaseName: MYSQL_DB_NAME }).type(
       "SELECT TOTAL, CATEGORY FROM ORDERS LEFT JOIN PRODUCTS ON ORDERS.PRODUCT_ID = PRODUCTS.ID [[WHERE PRODUCTS.ID = {{id}}]];",
       {
         parseSpecialCharSequences: false,
@@ -283,7 +274,7 @@ describe("scenatios > question > native > mysql", { tags: "@external" }, () => {
   });
 
   it("can save a native MySQL query", () => {
-    openNativeEditor({ databaseName: MYSQL_DB_NAME }).type(
+    H.openNativeEditor({ databaseName: MYSQL_DB_NAME }).type(
       "SELECT * FROM ORDERS",
     );
     cy.findByTestId("native-query-editor-container").icon("play").click();
@@ -320,7 +311,7 @@ describe("scenarios > question > native > mongo", { tags: "@mongo" }, () => {
     cy.intercept("POST", "/api/card").as("createQuestion");
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore("mongo-5");
+    H.restore("mongo-5");
     cy.signInAsAdmin();
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
@@ -348,7 +339,7 @@ describe("scenarios > question > native > mongo", { tags: "@mongo" }, () => {
   });
 
   it("can save a native MongoDB query", () => {
-    focusNativeEditor().type('[ { $count: "Total" } ]', {
+    H.focusNativeEditor().type('[ { $count: "Total" } ]', {
       parseSpecialCharSequences: false,
     });
     cy.findByTestId("native-query-editor-container").icon("play").click();
@@ -380,7 +371,7 @@ describe("scenarios > question > native > mongo", { tags: "@mongo" }, () => {
 function startNativeQuestion() {
   cy.visit("/");
   cy.findByTestId("app-bar").findByText("New").click();
-  popover()
+  H.popover()
     .findByTextEnsureVisible(/(SQL|Native) query/)
     .click();
 }
@@ -395,7 +386,7 @@ function startNativeModel() {
 function startNewAction() {
   cy.visit("/");
   cy.findByTestId("app-bar").findByText("New").click();
-  popover().findByTextEnsureVisible("Action").click();
+  H.popover().findByTextEnsureVisible("Action").click();
 }
 
 function assertNoDatabaseSelected() {
@@ -407,7 +398,7 @@ function assertNoDatabaseSelected() {
 }
 
 function selectDatabase(database) {
-  popover().findByText(database).click();
+  H.popover().findByText(database).click();
   cy.findByTestId("selected-database").should("have.text", database);
 }
 

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.js
@@ -1,22 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  POPOVER_ELEMENT,
-  addPostgresDatabase,
-  cartesianChartCircle,
-  createQuestion,
-  focusNativeEditor,
-  modal,
-  openNativeEditor,
-  popover,
-  restore,
-  runNativeQuery,
-  sidebar,
-  startNewNativeModel,
-  updateSetting,
-  visitQuestion,
-  visitQuestionAdhoc,
-} from "e2e/support/helpers";
 
 import {
   getRunQueryButton,
@@ -55,10 +39,10 @@ describe("issue 12439", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    visitQuestionAdhoc(questionDetails);
+    H.visitQuestionAdhoc(questionDetails);
   });
 
   it("should allow clicking on a legend in a native question without breaking the UI (metabase#12439)", () => {
@@ -69,25 +53,25 @@ describe("issue 12439", () => {
       cy.findByText("Gizmo").should("be.visible");
       cy.findByText("Doohickey").should("be.visible");
 
-      cartesianChartCircle();
+      H.cartesianChartCircle();
     });
 
     // Make sure buttons are clickable
     cy.findByTestId("viz-settings-button").click();
 
-    sidebar().contains("X-axis");
-    sidebar().contains("Y-axis");
+    H.sidebar().contains("X-axis");
+    H.sidebar().contains("Y-axis");
   });
 });
 
 describe("issue 15029", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should allow dots in the variable reference (metabase#15029)", () => {
-    openNativeEditor();
+    H.openNativeEditor();
     cy.realType(
       `select * from products where RATING = ${DOUBLE_LEFT_BRACKET}number.of.stars}}`,
       {
@@ -104,12 +88,12 @@ describe("issue 16886", () => {
   const SELECTED_TEXT = "select 1";
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("shouldn't remove parts of the query when choosing 'Run selected text' (metabase#16886)", () => {
-    openNativeEditor();
+    H.openNativeEditor();
     cy.realType(ORIGINAL_QUERY);
     cy.realPress("Home");
     Cypress._.range(SELECTED_TEXT.length).forEach(() =>
@@ -126,7 +110,7 @@ describe("issue 16886", () => {
 
 describe("issue 16914", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.intercept("POST", "api/dataset").as("dataset");
     cy.signInAsAdmin();
   });
@@ -134,7 +118,7 @@ describe("issue 16914", () => {
   it("should recover visualization settings after a failed query (metabase#16914)", () => {
     const FAILING_PIECE = " foo";
 
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       display: "table",
       dataset_query: {
         database: SAMPLE_DB_ID,
@@ -153,17 +137,17 @@ describe("issue 16914", () => {
       .click();
     cy.button("Done").click();
 
-    focusNativeEditor();
+    H.focusNativeEditor();
     cy.realType(FAILING_PIECE);
-    runNativeQuery();
+    H.runNativeQuery();
 
-    focusNativeEditor();
+    H.focusNativeEditor();
     cy.realPress("End");
     Cypress._.range(FAILING_PIECE.length).forEach(() =>
       cy.realPress(["Shift", "ArrowLeft"]),
     );
     cy.realPress("Backspace");
-    runNativeQuery();
+    H.runNativeQuery();
 
     cy.findByTestId("query-visualization-root").within(() => {
       cy.findByText("Every field is hidden right now").should("not.exist");
@@ -191,9 +175,9 @@ describe("issue 17060", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       display: "table",
       dataset_query: {
         database: SAMPLE_DB_ID,
@@ -212,7 +196,7 @@ describe("issue 17060", () => {
   });
 
   it("should not render duplicated columns (metabase#17060)", () => {
-    focusNativeEditor();
+    H.focusNativeEditor();
     cy.realPress("Home");
     Cypress._.range(SECTION.length).forEach(() => cy.realPress("ArrowRight"));
     Cypress._.range(SELECTED_TEXT.length).forEach(() =>
@@ -231,14 +215,14 @@ describe("issue 18148", () => {
   const dbName = "sqlite";
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.addSQLiteDatabase({
       name: dbName,
     });
 
-    openNativeEditor();
+    H.openNativeEditor();
   });
 
   it("should not offer to save the question before it is actually possible to save it (metabase#18148)", () => {
@@ -254,7 +238,7 @@ describe("issue 18148", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(dbName).click();
 
-    focusNativeEditor();
+    H.focusNativeEditor();
     cy.realType("select foo");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -273,7 +257,7 @@ describe("issue 18418", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/card").as("cardCreated");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -292,11 +276,11 @@ describe("issue 18418", () => {
 
     cy.button("Not now").click();
 
-    openNativeEditor({ fromCurrentPage: true });
+    H.openNativeEditor({ fromCurrentPage: true });
 
     // Clicking native question's database picker usually opens a popover with a list of databases
     // As default Cypress environment has only the sample database available, we expect no popup to appear
-    cy.get(POPOVER_ELEMENT).should("not.exist");
+    cy.get(H.POPOVER_ELEMENT).should("not.exist");
   });
 });
 
@@ -321,7 +305,7 @@ describe("issue 19451", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestion(question, { visitQuestion: true });
@@ -355,7 +339,7 @@ describe("issue 20044", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -363,7 +347,7 @@ describe("issue 20044", () => {
     cy.createNativeQuestion(questionDetails).then(({ body: { id } }) => {
       cy.signIn("nodata");
 
-      visitQuestion(id);
+      H.visitQuestion(id);
 
       cy.get("[data-testid=cell-data]").contains("1");
       cy.findByText("Explore results").should("not.exist");
@@ -373,9 +357,9 @@ describe("issue 20044", () => {
 
 describe("issue 20625", { tags: "@quarantine" }, () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    updateSetting("native-query-autocomplete-match-style", "prefix");
+    H.updateSetting("native-query-autocomplete-match-style", "prefix");
     cy.signInAsNormalUser();
     cy.intercept("GET", "/api/database/*/autocomplete_suggestions**").as(
       "autocomplete",
@@ -384,7 +368,7 @@ describe("issue 20625", { tags: "@quarantine" }, () => {
 
   // realpress messes with cypress 13
   it("should continue to request more prefix matches (metabase#20625)", () => {
-    openNativeEditor();
+    H.openNativeEditor();
     cy.realType("s");
 
     // autocomplete_suggestions?prefix=s
@@ -400,9 +384,9 @@ describe("issue 20625", { tags: "@quarantine" }, () => {
 
 describe("issue 21034", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    openNativeEditor();
+    H.openNativeEditor();
     cy.intercept(
       "GET",
       "/api/database/**/autocomplete_suggestions?**",
@@ -411,7 +395,7 @@ describe("issue 21034", () => {
   });
 
   it("should not invoke API calls for autocomplete twice in a row (metabase#18148)", () => {
-    focusNativeEditor();
+    H.focusNativeEditor();
     cy.realType("p");
 
     // Wait until another explicit autocomplete is triggered
@@ -425,7 +409,7 @@ describe("issue 21034", () => {
 
 describe("issue 21550", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.intercept("GET", "/api/collection/root/items?**").as("rootCollection");
@@ -433,13 +417,13 @@ describe("issue 21550", () => {
   });
 
   it("should not show scrollbars for very short snippet (metabase#21550)", () => {
-    openNativeEditor();
+    H.openNativeEditor();
 
     cy.icon("snippet").click();
     cy.wait("@rootCollection");
     cy.findByTestId("sidebar-content").findByText("Create a snippet").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByLabelText("Enter some SQL here so you can reuse it later").type(
         "select * from people",
       );
@@ -468,7 +452,7 @@ describe("issue 21597", { tags: "@external" }, () => {
   const secondDatabaseId = SAMPLE_DB_ID + 1;
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -476,10 +460,10 @@ describe("issue 21597", { tags: "@external" }, () => {
     cy.intercept("POST", "/api/card").as("saveNativeQuestion");
 
     // Second DB (copy)
-    addPostgresDatabase(databaseCopyName);
+    H.addPostgresDatabase(databaseCopyName);
 
     // Create a native query and run it
-    openNativeEditor({
+    H.openNativeEditor({
       databaseName,
     });
     cy.realType(
@@ -487,13 +471,13 @@ describe("issue 21597", { tags: "@external" }, () => {
     );
 
     cy.findByTestId("variable-type-select").click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Field Filter").click();
     });
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Products").click();
     });
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Category").click();
     });
 
@@ -506,7 +490,7 @@ describe("issue 21597", { tags: "@external" }, () => {
     cy.findByTestId("native-query-editor-container")
       .findByText("Sample Database")
       .click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText(databaseCopyName).click();
     });
     cy.findByTestId("native-query-editor-container").icon("play").click();
@@ -528,7 +512,7 @@ describe("issue 21597", { tags: "@external" }, () => {
 
 describe("issue 23510", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -573,15 +557,15 @@ describe("issue 23510", () => {
 
 describe("issue 30680", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should not render native editor buttons when 'Metadata' tab is open (metabase#30680)", () => {
-    startNewNativeModel({ query: "select 1" });
+    H.startNewNativeModel({ query: "select 1" });
     cy.findByTestId("editor-tabs-metadata").should("be.disabled");
 
-    runNativeQuery();
+    H.runNativeQuery();
     cy.findByTestId("editor-tabs-metadata").should("not.be.disabled");
     cy.findByTestId("editor-tabs-metadata-name").click();
 
@@ -592,7 +576,7 @@ describe("issue 30680", () => {
 
 describe("issue 34330", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("GET", "/api/database/*/autocomplete_suggestions**").as(
       "autocomplete",
@@ -600,7 +584,7 @@ describe("issue 34330", () => {
   });
 
   it("should only call the autocompleter with all text typed (metabase#34330)", () => {
-    openNativeEditor();
+    H.openNativeEditor();
     cy.realType("USER");
 
     cy.wait("@autocomplete").then(({ request }) => {
@@ -613,7 +597,7 @@ describe("issue 34330", () => {
   });
 
   it("should call the autocompleter eventually, even when only 1 character was typed (metabase#34330)", () => {
-    openNativeEditor();
+    H.openNativeEditor();
     cy.realType("U");
 
     cy.wait("@autocomplete").then(({ request }) => {
@@ -626,7 +610,7 @@ describe("issue 34330", () => {
   });
 
   it("should call the autocompleter when backspacing to a 1-character prefix(metabase#34330)", () => {
-    openNativeEditor();
+    H.openNativeEditor();
     cy.realType("SE{backspace}");
 
     cy.wait("@autocomplete").then(({ request }) => {
@@ -646,7 +630,7 @@ describe("issue 35344", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
@@ -656,18 +640,18 @@ describe("issue 35344", () => {
     cy.findByTestId("query-builder-main").findByText("Open Editor").click();
 
     // make sure normal undo still works
-    focusNativeEditor();
+    H.focusNativeEditor();
     cy.realType("--");
-    expect(focusNativeEditor().findByText("--")).to.exist;
+    expect(H.focusNativeEditor().findByText("--")).to.exist;
 
-    focusNativeEditor();
+    H.focusNativeEditor();
     cy.realPress(["Meta", "z"]);
-    focusNativeEditor().findByText("--").should("not.exist");
+    H.focusNativeEditor().findByText("--").should("not.exist");
 
     // more undoing does not change to empty editor
-    focusNativeEditor();
+    H.focusNativeEditor();
     cy.realPress(["Meta", "z"]);
-    expect(focusNativeEditor().findByText("select")).to.exist;
+    expect(H.focusNativeEditor().findByText("select")).to.exist;
   });
 });
 
@@ -700,7 +684,7 @@ describe("issue 35785", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
 
     cy.createNativeQuestion(questionDetails, { visitQuestion: true });
@@ -712,7 +696,7 @@ describe("issue 35785", () => {
     cy.findByTestId("native-query-editor-container")
       .findByTestId("visibility-toggler")
       .click();
-    focusNativeEditor();
+    H.focusNativeEditor();
     cy.realType("{backspace}4");
 
     cy.findByTestId("qb-header").findByRole("button", { name: "Save" }).click();
@@ -729,7 +713,7 @@ describe("issue 35785", () => {
 
 describe("issue 22991", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -750,7 +734,7 @@ describe("issue 22991", () => {
           },
         });
 
-        createQuestion(
+        H.createQuestion(
           {
             ...questionDetails,
             collection_id: restrictedCollection.id,
@@ -763,7 +747,7 @@ describe("issue 22991", () => {
     cy.signOut();
     cy.signInAsNormalUser();
 
-    openNativeEditor();
+    H.openNativeEditor();
     cy.get("@questionId").then(questionId => {
       // can't use cy.type because it does not simulate the bug
       cy.realType(`select * from ${DOUBLE_LEFT_BRACKET}#${questionId}`);
@@ -800,7 +784,7 @@ describe("issue 46308", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.createNativeQuestion(questionDetails, { visitQuestion: true });
   });
@@ -819,6 +803,6 @@ describe("issue 46308", () => {
     cy.findByPlaceholderText("Exclude Category").type("Doohickey");
     getRunQueryButton().click();
 
-    cartesianChartCircle().should("have.length", 3);
+    H.cartesianChartCircle().should("have.length", 3);
   });
 });

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -1,16 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  adhocQuestionHash,
-  createNativeQuestion,
-  createQuestion,
-  focusNativeEditor,
-  nativeEditor,
-  nativeEditorCompletions,
-  openNativeEditor,
-  restore,
-  runNativeQuery,
-  withDatabase,
-} from "e2e/support/helpers";
 
 import { getRunQueryButton } from "../native-filters/helpers/e2e-sql-filter-helpers";
 const { ORDERS_ID } = SAMPLE_DATABASE;
@@ -29,17 +18,17 @@ describe("issue 11727", { tags: "@external" }, () => {
   };
 
   beforeEach(() => {
-    restore("postgres-12");
+    H.restore("postgres-12");
     cy.signInAsAdmin();
     cy.intercept("GET", "/api/database").as("getDatabases");
   });
 
   it("should cancel the native query via the keyboard shortcut (metabase#11727)", () => {
-    withDatabase(PG_DB_ID, () => {
-      cy.visit("/question#" + adhocQuestionHash(questionDetails));
+    H.withDatabase(PG_DB_ID, () => {
+      cy.visit("/question#" + H.adhocQuestionHash(questionDetails));
       cy.wait("@getDatabases");
 
-      runNativeQuery({ wait: false });
+      H.runNativeQuery({ wait: false });
       cy.findByText("Doing science...").should("be.visible");
       cy.get("body").type("{cmd}{enter}");
       cy.findByText("Here's where your results will appear").should(
@@ -51,7 +40,7 @@ describe("issue 11727", { tags: "@external" }, () => {
 
 describe("issue 16584", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
@@ -61,7 +50,7 @@ describe("issue 16584", () => {
     // - the issue is unrelated to using a date filter, using a text filter works too
     // - the issue is unrelated to whether or not the parameter is required or if default value is set
     // - the space at the end of the query is not needed to reproduce this issue
-    openNativeEditor()
+    H.openNativeEditor()
       .type(
         "SELECT COUNTRY FROM ACCOUNTS WHERE COUNTRY = {{ country }} LIMIT 1",
         {
@@ -73,7 +62,7 @@ describe("issue 16584", () => {
 
     cy.findByPlaceholderText("Country").type("NL", { delay: 0 });
 
-    runNativeQuery();
+    H.runNativeQuery();
 
     cy.findByTestId("query-visualization-root")
       .findByText("NL")
@@ -101,12 +90,12 @@ describe("issue 38083", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should not show the revert to default icon when the default value is selected (metabase#38083)", () => {
-    createNativeQuestion(QUESTION, {
+    H.createNativeQuestion(QUESTION, {
       visitQuestion: true,
     });
 
@@ -121,13 +110,13 @@ describe("issue 38083", () => {
 
 describe("issue 33327", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should recover from a visualization error (metabase#33327)", () => {
     const query = "SELECT 1";
-    createNativeQuestion(
+    H.createNativeQuestion(
       { native: { query }, display: "scalar" },
       {
         visitQuestion: true,
@@ -137,17 +126,17 @@ describe("issue 33327", () => {
     cy.findByTestId("scalar-value").should("have.text", "1");
 
     cy.findByTestId("visibility-toggler").click();
-    focusNativeEditor().should("contain", query).type("{leftarrow}--");
+    H.focusNativeEditor().should("contain", query).type("{leftarrow}--");
 
     cy.intercept("POST", "/api/dataset").as("dataset");
-    nativeEditor().should("be.visible").and("contain", "SELECT --1");
+    H.nativeEditor().should("be.visible").and("contain", "SELECT --1");
     getRunQueryButton().click();
     cy.wait("@dataset");
 
     cy.findByTestId("visualization-root").icon("warning").should("be.visible");
     cy.findByTestId("scalar-value").should("not.exist");
 
-    focusNativeEditor()
+    H.focusNativeEditor()
       .should("contain", "SELECT --1")
       .type("{leftarrow}{backspace}{backspace}")
       .should("contain", query);
@@ -162,10 +151,10 @@ describe("issue 33327", () => {
 
 describe("issue 49454", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    createQuestion({
+    H.createQuestion({
       name: "Test Metric 49454",
       type: "metric",
       query: {
@@ -173,7 +162,7 @@ describe("issue 49454", () => {
         aggregation: [["count"]],
       },
     });
-    createQuestion({
+    H.createQuestion({
       name: "Test Question 49454",
       type: "question",
       query: {
@@ -184,9 +173,9 @@ describe("issue 49454", () => {
   });
 
   it("should be possible to use metrics in native queries (metabase#49454)", () => {
-    openNativeEditor().type("select * from {{ #test");
+    H.openNativeEditor().type("select * from {{ #test");
 
-    nativeEditorCompletions().within(() => {
+    H.nativeEditorCompletions().within(() => {
       cy.findByText("-question-49454").should("be.visible");
       cy.findByText("-metric-49454").should("be.visible");
     });

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -1,3 +1,4 @@
+import { H } from "e2e/support";
 import {
   SAMPLE_DB_ID,
   USER_GROUPS,
@@ -5,22 +6,6 @@ import {
 } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { THIRD_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  createQuestion,
-  entityPickerModal,
-  filter,
-  filterField,
-  focusNativeEditor,
-  nativeEditor,
-  openNativeEditor,
-  openQuestionActions,
-  popover,
-  restore,
-  rightSidebar,
-  summarize,
-  visitCollection,
-  visitQuestionAdhoc,
-} from "e2e/support/helpers";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
 
@@ -44,12 +29,12 @@ describe("scenarios > question > native", () => {
     cy.intercept("POST", "api/card").as("card");
     cy.intercept("POST", "api/dataset").as("dataset");
     cy.intercept("POST", "api/dataset/native").as("datasetNative");
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("lets you create and run a SQL question", () => {
-    openNativeEditor();
+    H.openNativeEditor();
     cy.realType("select count(*) from orders");
     runQuery();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -57,9 +42,9 @@ describe("scenarios > question > native", () => {
   });
 
   it("should suggest the currently viewed collection when saving question", () => {
-    visitCollection(THIRD_COLLECTION_ID);
+    H.visitCollection(THIRD_COLLECTION_ID);
 
-    openNativeEditor({ fromCurrentPage: true });
+    H.openNativeEditor({ fromCurrentPage: true });
     cy.realType("select count(*) from orders");
 
     cy.findByTestId("qb-header").within(() => {
@@ -74,7 +59,7 @@ describe("scenarios > question > native", () => {
   });
 
   it("displays an error", () => {
-    openNativeEditor();
+    H.openNativeEditor();
     cy.realType("select * from not_a_table");
     runQuery();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -82,7 +67,7 @@ describe("scenarios > question > native", () => {
   });
 
   it("displays an error when running selected text", () => {
-    openNativeEditor();
+    H.openNativeEditor();
     cy.realType("select * from orders");
     // move left three
     Cypress._.range(3).forEach(() => cy.realPress("ArrowLeft"));
@@ -94,7 +79,7 @@ describe("scenarios > question > native", () => {
   });
 
   it("should handle template tags", () => {
-    openNativeEditor();
+    H.openNativeEditor();
     cy.realType(
       `select * from PRODUCTS where RATING > ${DOUBLE_LEFT_BRACKET}Stars}}`,
     );
@@ -105,7 +90,7 @@ describe("scenarios > question > native", () => {
   });
 
   it("should modify parameters accordingly when tags are modified", () => {
-    openNativeEditor();
+    H.openNativeEditor();
     cy.realType(
       `select * from PRODUCTS where CATEGORY = ${DOUBLE_LEFT_BRACKET}cat}}`,
     );
@@ -135,7 +120,7 @@ describe("scenarios > question > native", () => {
   });
 
   it("can save a question with no rows", () => {
-    openNativeEditor();
+    H.openNativeEditor();
     cy.realType("select * from people where false");
     runQuery();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -166,7 +151,7 @@ describe("scenarios > question > native", () => {
     };
 
     cy.createNativeQuestion(questionDetails).then(({ body: { id } }) => {
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           database: SAMPLE_DB_ID,
           query: {
@@ -182,8 +167,8 @@ describe("scenarios > question > native", () => {
 
     FILTERS.forEach(operator => {
       cy.log("Apply a filter");
-      filter();
-      filterField("V", {
+      H.filter();
+      H.filterField("V", {
         operator,
         value: "This has a value",
       });
@@ -200,15 +185,15 @@ describe("scenarios > question > native", () => {
         "**Final assertion: Count of rows with 'null' value should be 1**",
       );
       // "Count" is pre-selected option for "Summarize"
-      summarize();
+      H.summarize();
       cy.findByText("Done").click();
       cy.findByTestId("scalar-value").contains("1");
 
       cy.findByTestId("qb-filters-panel").within(() => {
         cy.icon("close").click();
       });
-      summarize();
-      rightSidebar().within(() => {
+      H.summarize();
+      H.rightSidebar().within(() => {
         cy.icon("close").click();
       });
       cy.findByText("Done").click();
@@ -216,7 +201,7 @@ describe("scenarios > question > native", () => {
   });
 
   it("should be able to add new columns after hiding some (metabase#15393)", () => {
-    openNativeEditor();
+    H.openNativeEditor();
     cy.realType("select 1 as visible, 2 as hidden");
     cy.findByTestId("native-query-editor-container")
       .icon("play")
@@ -235,7 +220,7 @@ describe("scenarios > question > native", () => {
   });
 
   it("should recognize template tags and save them as parameters", () => {
-    openNativeEditor();
+    H.openNativeEditor();
     cy.realType(
       `select * from PRODUCTS where CATEGORY=${DOUBLE_LEFT_BRACKET}cat}} and RATING >= ${DOUBLE_LEFT_BRACKET}stars}}`,
     );
@@ -273,7 +258,7 @@ describe("scenarios > question > native", () => {
   });
 
   it("should not autorun ad-hoc native queries by default", () => {
-    visitQuestionAdhoc(
+    H.visitQuestionAdhoc(
       {
         display: "scalar",
         dataset_query: {
@@ -292,7 +277,7 @@ describe("scenarios > question > native", () => {
   });
 
   it("should allow to preview a fully parameterized query", () => {
-    openNativeEditor();
+    H.openNativeEditor();
     cy.realType(
       `select * from PRODUCTS where CATEGORY=${DOUBLE_LEFT_BRACKET}category}}`,
     );
@@ -305,7 +290,7 @@ describe("scenarios > question > native", () => {
   });
 
   it("should show errors when previewing a query", () => {
-    openNativeEditor();
+    H.openNativeEditor();
     cy.realType(
       `select * from PRODUCTS where CATEGORY=${DOUBLE_LEFT_BRACKET}category}}`,
     );
@@ -320,7 +305,7 @@ describe("scenarios > question > native", () => {
 // causes error in cypress 13
 describe("no native access", { tags: ["@external", "@quarantine"] }, () => {
   beforeEach(() => {
-    restore("postgres-12");
+    H.restore("postgres-12");
     cy.signInAsAdmin();
     cy.intercept("/api/database?saved=true").as("database");
     cy.updatePermissionsGraph({
@@ -374,7 +359,7 @@ describe("no native access", { tags: ["@external", "@quarantine"] }, () => {
 
     cy.log("#32387");
     cy.findByRole("button", { name: /New/ }).click();
-    popover().findByText("SQL query").click();
+    H.popover().findByText("SQL query").click();
 
     cy.wait("@database");
     cy.go("back");
@@ -394,19 +379,19 @@ describe("no native access", { tags: ["@external", "@quarantine"] }, () => {
       cy.intercept("POST", "/api/card").as("createQuestion");
       cy.intercept("POST", "/api/dataset").as("dataset");
 
-      restore("mongo-5");
+      H.restore("mongo-5");
       cy.signInAsNormalUser();
 
-      openNativeEditor({ newMenuItemTitle: "Native query" });
-      popover().findByText(MONGO_DB_NAME).click();
+      H.openNativeEditor({ newMenuItemTitle: "Native query" });
+      H.popover().findByText(MONGO_DB_NAME).click();
       cy.findByLabelText("Format query").should("not.exist");
 
       cy.findByTestId("native-query-top-bar").findByText(MONGO_DB_NAME).click();
 
       // Switch to SQL engine which is supported by the formatter
-      popover().findByText("Sample Database").click();
+      H.popover().findByText("Sample Database").click();
 
-      focusNativeEditor().type("select * from orders", {
+      H.focusNativeEditor().type("select * from orders", {
         parseSpecialCharSequences: false,
       });
 
@@ -417,7 +402,7 @@ describe("no native access", { tags: ["@external", "@quarantine"] }, () => {
 
       cy.wait("@sqlFormatter");
 
-      nativeEditor().should("be.visible").get(".ace_line").as("lines");
+      H.nativeEditor().should("be.visible").get(".ace_line").as("lines");
 
       cy.get("@lines").eq(0).should("have.text", "SELECT");
       cy.get("@lines").eq(1).should("have.text", "  *");
@@ -429,12 +414,12 @@ describe("no native access", { tags: ["@external", "@quarantine"] }, () => {
 
 describe("scenarios > native question > data reference sidebar", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should show tables", () => {
-    openNativeEditor();
+    H.openNativeEditor();
     referenceButton().click();
 
     sidebarHeaderTitle().should("have.text", "Sample Database");
@@ -467,16 +452,16 @@ describe("scenarios > native question > data reference sidebar", () => {
       { visitQuestion: true },
     );
     // Move question to personal collection
-    openQuestionActions();
-    popover().findByTestId("move-button").click();
+    H.openQuestionActions();
+    H.popover().findByTestId("move-button").click();
 
-    entityPickerModal().within(() => {
+    H.entityPickerModal().within(() => {
       cy.findByRole("tab", { name: /Collections/ }).click();
       cy.findByText("Bobby Tables's Personal Collection").click();
       cy.button("Move").click();
     });
 
-    openNativeEditor();
+    H.openNativeEditor();
     referenceButton().click();
 
     dataReferenceSidebar().within(() => {
@@ -492,7 +477,7 @@ describe("scenarios > native question > data reference sidebar", () => {
 
   describe("metrics", () => {
     it("should not show metrics when they are not defined on the selected table", () => {
-      openNativeEditor();
+      H.openNativeEditor();
       referenceButton().click();
       sidebarHeaderTitle().should("have.text", "Sample Database");
 
@@ -503,9 +488,9 @@ describe("scenarios > native question > data reference sidebar", () => {
     });
 
     it("should show metrics defined on tables", () => {
-      createQuestion(ORDERS_SCALAR_METRIC);
+      H.createQuestion(ORDERS_SCALAR_METRIC);
 
-      openNativeEditor();
+      H.openNativeEditor();
       referenceButton().click();
       sidebarHeaderTitle().should("have.text", "Sample Database");
 

--- a/e2e/test/scenarios/native/native_subquery.cy.spec.js
+++ b/e2e/test/scenarios/native/native_subquery.cy.spec.js
@@ -1,23 +1,12 @@
+import { H } from "e2e/support";
 import {
   ADMIN_PERSONAL_COLLECTION_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  createNativeQuestion,
-  createQuestion,
-  focusNativeEditor,
-  nativeEditor,
-  nativeEditorCompletions,
-  openNativeEditor,
-  restore,
-  runNativeQuery,
-  startNewNativeQuestion,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 describe("scenarios > question > native subquery", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -46,13 +35,13 @@ describe("scenarios > question > native subquery", () => {
           cy.reload();
           cy.findByText("Open Editor").click();
           // placing the cursor inside an existing template tag should open the data reference
-          focusNativeEditor().type("{leftarrow}");
+          H.focusNativeEditor().type("{leftarrow}");
           cy.findByText("A People Question");
           // subsequently moving the cursor out from the tag should keep the data reference open
-          focusNativeEditor().type("{rightarrow}");
+          H.focusNativeEditor().type("{rightarrow}");
           cy.findByText("A People Question");
           // typing a template tag id should open the editor
-          focusNativeEditor()
+          H.focusNativeEditor()
             .type(" ")
             .type("{{#")
             .type(`{leftarrow}{leftarrow}${questionId2}`);
@@ -78,16 +67,16 @@ describe("scenarios > question > native subquery", () => {
         type: "model",
         collection_id: ADMIN_PERSONAL_COLLECTION_ID,
       }).then(({ body: { id: questionId2 } }) => {
-        openNativeEditor();
+        H.openNativeEditor();
         cy.reload(); // Refresh the state, so previously created questions need to be loaded again.
-        focusNativeEditor().realType(" {{#people");
+        H.focusNativeEditor().realType(" {{#people");
 
         // Wait until another explicit autocomplete is triggered
         // (slightly longer than AUTOCOMPLETE_DEBOUNCE_DURATION)
         // See https://github.com/metabase/metabase/pull/20970
         cy.wait(1000);
 
-        nativeEditorCompletions().within(() => {
+        H.nativeEditorCompletions().within(() => {
           cy.findByText(`${questionId2}-a-`).should("be.visible");
           cy.findByText("Model in Bobby Tables's Personal Collection").should(
             "be.visible",
@@ -137,18 +126,18 @@ describe("scenarios > question > native subquery", () => {
           // Refresh the state, so previously created questions need to be loaded again.
           cy.reload();
           cy.findByText("Open Editor").click();
-          focusNativeEditor().type(" ").type("a_unique");
+          H.focusNativeEditor().type(" ").type("a_unique");
 
           // Wait until another explicit autocomplete is triggered
           // (slightly longer than AUTOCOMPLETE_DEBOUNCE_DURATION)
           // See https://github.com/metabase/metabase/pull/20970
           cy.wait(1000);
 
-          nativeEditorCompletions().findByText("A_UNIQUE");
+          H.nativeEditorCompletions().findByText("A_UNIQUE");
 
           // For some reason, typing `{{#${questionId2}}}` in one go isn't deterministic,
           // so type it in two parts
-          focusNativeEditor()
+          H.focusNativeEditor()
             .type(" {{#")
             .type(`{leftarrow}{leftarrow}${questionId2}`);
 
@@ -157,9 +146,9 @@ describe("scenarios > question > native subquery", () => {
 
           // Again, typing in in one go doesn't always work
           // so type it in two parts
-          focusNativeEditor().type(" ").type("another");
+          H.focusNativeEditor().type(" ").type("another");
 
-          nativeEditorCompletions().findByText("ANOTHER");
+          H.nativeEditorCompletions().findByText("ANOTHER");
         });
       });
     });
@@ -193,7 +182,7 @@ describe("scenarios > question > native subquery", () => {
         cy.visit(`/question/${questionId2}`);
         cy.findByText("Open Editor").click();
         cy.get("@questionId").then(questionId => {
-          nativeEditor()
+          H.nativeEditor()
             .should("be.visible")
             .and("contain", `{{#${questionId}-a-people-question-1}}`);
         });
@@ -208,7 +197,7 @@ describe("scenarios > question > native subquery", () => {
         cy.visit(`/question/${questionId2}`);
         cy.findByText("Open Editor").click();
         cy.get("@questionId").then(questionId => {
-          nativeEditor()
+          H.nativeEditor()
             .should("be.visible")
             .and("contain", `{{#${questionId}-a-people-question-1-changed}}`);
         });
@@ -255,13 +244,13 @@ describe("scenarios > question > native subquery", () => {
     cy.signIn("nodata");
 
     // They should be able to access both questions
-    visitQuestion("@nestedQuestionId");
+    H.visitQuestion("@nestedQuestionId");
     cy.findByTestId("question-row-count").should(
       "have.text",
       "Showing 41 rows",
     );
 
-    visitQuestion("@toplevelQuestionId");
+    H.visitQuestion("@toplevelQuestionId");
     cy.get("#main-data-grid [data-testid=cell-data]").should("have.text", "41");
   });
 
@@ -274,20 +263,20 @@ describe("scenarios > question > native subquery", () => {
       },
     };
 
-    createQuestion(questionDetails).then(
+    H.createQuestion(questionDetails).then(
       ({ body: { id: nestedQuestionId } }) => {
         const tagID = `#${nestedQuestionId}`;
         cy.intercept("GET", `/api/card/${nestedQuestionId}`).as("loadQuestion");
 
-        startNewNativeQuestion();
-        focusNativeEditor().type(`SELECT * FROM {{${tagID}`);
+        H.startNewNativeQuestion();
+        H.focusNativeEditor().type(`SELECT * FROM {{${tagID}`);
         cy.wait("@loadQuestion");
         cy.findByTestId("sidebar-header-title").should(
           "have.text",
           questionDetails.name,
         );
 
-        runNativeQuery();
+        H.runNativeQuery();
         cy.findAllByTestId("cell-data").should("contain", "37.65");
       },
     );
@@ -299,14 +288,14 @@ describe("scenarios > question > native subquery", () => {
       native: { query: "select 1;" }, // semicolon is important here
     };
 
-    createNativeQuestion(questionDetails).then(
+    H.createNativeQuestion(questionDetails).then(
       ({ body: { id: baseQuestionId } }) => {
         const tagID = `#${baseQuestionId}`;
 
-        startNewNativeQuestion();
-        focusNativeEditor().type(`SELECT * FROM {{${tagID}`);
+        H.startNewNativeQuestion();
+        H.focusNativeEditor().type(`SELECT * FROM {{${tagID}`);
 
-        runNativeQuery();
+        H.runNativeQuery();
         cy.findAllByTestId("cell-data").should("contain", "1");
       },
     );

--- a/e2e/test/scenarios/native/snippets.cy.spec.js
+++ b/e2e/test/scenarios/native/snippets.cy.spec.js
@@ -1,18 +1,5 @@
+import { H } from "e2e/support";
 import { USER_GROUPS } from "e2e/support/cypress_data";
-import {
-  collectionOnTheGoModal,
-  describeEE,
-  entityPickerModal,
-  focusNativeEditor,
-  modal,
-  nativeEditor,
-  onlyOnOSS,
-  openNativeEditor,
-  popover,
-  restore,
-  rightSidebar,
-  setTokenFeatures,
-} from "e2e/support/helpers";
 
 const { ALL_USERS_GROUP } = USER_GROUPS;
 
@@ -28,13 +15,13 @@ function _clearAndIterativelyTypeUsingLabel(label, string) {
 
 describe("scenarios > question > snippets", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should let you create and use a snippet", () => {
     cy.log("Type a query and highlight some of the text");
-    openNativeEditor().type(
+    H.openNativeEditor().type(
       "select 'stuff'" + "{shift}{leftarrow}".repeat("'stuff'".length),
     );
 
@@ -42,7 +29,7 @@ describe("scenarios > question > snippets", () => {
     cy.findByTestId("native-query-editor-sidebar").icon("snippet").click();
     cy.findByTestId("sidebar-content").findByText("Create a snippet").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByLabelText("Give your snippet a name").type("stuff-snippet");
       cy.button("Save").click();
     });
@@ -64,7 +51,7 @@ describe("scenarios > question > snippets", () => {
 
     // Populate the native editor first
     // 1. select
-    openNativeEditor().type("select ");
+    H.openNativeEditor().type("select ");
     // 2. snippet
     cy.icon("snippet").click();
     cy.findByTestId("sidebar-right").within(() => {
@@ -76,7 +63,7 @@ describe("scenarios > question > snippets", () => {
     });
 
     // Update the name and content
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Editing stuff-snippet");
 
       _clearAndIterativelyTypeUsingLabel(
@@ -139,18 +126,18 @@ describe("scenarios > question > snippets", () => {
     cy.findByText(/Open Editor/i).click();
     // We need these mid-point checks to make sure Cypress typed the sequence/query correctly
     // Check 1
-    nativeEditor()
+    H.nativeEditor()
       .should("be.visible")
       .and("have.text", "select * from {{snippet: Table: Orders}} limit 1");
     // Replace "Orders" with "Reviews"
-    focusNativeEditor().type(
+    H.focusNativeEditor().type(
       "{end}" +
         "{leftarrow}".repeat("}} limit 1".length) + // move left to "reach" the "Orders"
         "{backspace}".repeat("Orders".length) + // Delete orders character by character
         "Reviews",
     );
     // Check 2
-    nativeEditor()
+    H.nativeEditor()
       .should("be.visible")
       .and("have.text", "select * from {{snippet: Table: Reviews}} limit 1");
     // Rerun the query
@@ -161,29 +148,29 @@ describe("scenarios > question > snippets", () => {
 
 describe("scenarios > question > snippets (OSS)", { tags: "@OSS" }, () => {
   beforeEach(() => {
-    onlyOnOSS();
-    restore();
+    H.onlyOnOSS();
+    H.restore();
   });
 
   it("should display nested snippets in a flat list", () => {
     createNestedSnippet();
 
     // Open editor and sidebar
-    openNativeEditor();
+    H.openNativeEditor();
     cy.icon("snippet").click();
 
     // Confirm snippet is not in folder
-    rightSidebar().within(() => {
+    H.rightSidebar().within(() => {
       cy.findByText("snippet 1").should("be.visible");
     });
   });
 });
 
-describeEE("scenarios > question > snippets (EE)", () => {
+H.describeEE("scenarios > question > snippets (EE)", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
   });
 
   ["admin", "normal"].forEach(user => {
@@ -192,11 +179,11 @@ describeEE("scenarios > question > snippets (EE)", () => {
 
       cy.signIn(user);
 
-      openNativeEditor();
+      H.openNativeEditor();
       cy.icon("snippet").click();
       cy.findByTestId("sidebar-content").findByText("Create a snippet").click();
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByLabelText(
           "Enter some SQL here so you can reuse it later",
         ).type("SELECT 1", { delay: 0 });
@@ -224,14 +211,14 @@ describeEE("scenarios > question > snippets (EE)", () => {
       collection_id: null,
     });
 
-    openNativeEditor();
+    H.openNativeEditor();
 
     // create folder
     cy.icon("snippet").click();
     cy.findByTestId("sidebar-right").as("sidebar").find(".Icon-add").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    popover().within(() => cy.findByText("New folder").click());
-    modal().within(() => {
+    H.popover().within(() => cy.findByText("New folder").click());
+    H.modal().within(() => {
       cy.findByText("Create your new folder");
       cy.findByLabelText("Give your folder a name").type(
         "my favorite snippets",
@@ -249,13 +236,13 @@ describeEE("scenarios > question > snippets (EE)", () => {
         cy.icon("chevrondown").click({ force: true });
       });
 
-    rightSidebar().within(() => {
+    H.rightSidebar().within(() => {
       cy.findByText("Edit").click();
     });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    modal().within(() => cy.findByText("Top folder").click());
-    entityPickerModal().within(() => {
+    H.modal().within(() => cy.findByText("Top folder").click());
+    H.entityPickerModal().within(() => {
       cy.findByText("my favorite snippets").click();
       cy.findByText("Select").click();
     });
@@ -263,7 +250,7 @@ describeEE("scenarios > question > snippets (EE)", () => {
       "updateList",
     );
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    modal().within(() => cy.findByText("Save").click());
+    H.modal().within(() => cy.findByText("Save").click());
 
     // check that everything is in the right spot
     cy.wait("@updateList");
@@ -282,16 +269,16 @@ describeEE("scenarios > question > snippets (EE)", () => {
       cy.button(/Edit/).click();
     });
 
-    modal().findByTestId("collection-picker-button").click();
-    entityPickerModal()
+    H.modal().findByTestId("collection-picker-button").click();
+    H.entityPickerModal()
       .findByRole("button", { name: /Create a new collection/ })
       .click();
-    collectionOnTheGoModal()
+    H.collectionOnTheGoModal()
       .findByLabelText("Give it a name")
       .type("my special snippets");
-    collectionOnTheGoModal().findByRole("button", { name: "Create" }).click();
-    entityPickerModal().findByRole("button", { name: "Select" }).click();
-    modal().findByRole("button", { name: "Save" }).click();
+    H.collectionOnTheGoModal().findByRole("button", { name: "Create" }).click();
+    H.entityPickerModal().findByRole("button", { name: "Select" }).click();
+    H.modal().findByRole("button", { name: "Save" }).click();
 
     cy.findByTestId("sidebar-right").within(() => {
       cy.findByText("snippet 1").should("not.exist");
@@ -307,11 +294,11 @@ describeEE("scenarios > question > snippets (EE)", () => {
       cy.signIn(user);
 
       // Open editor and sidebar
-      openNativeEditor();
+      H.openNativeEditor();
       cy.icon("snippet").click();
 
       // Confirm snippet is in folder
-      rightSidebar().within(() => {
+      H.rightSidebar().within(() => {
         cy.findByText("Snippet Folder").click();
         cy.findByText("snippet 1").click();
       });
@@ -340,7 +327,7 @@ describeEE("scenarios > question > snippets (EE)", () => {
     });
 
     it("should not allow you to move a snippet collection into a itself or a child (metabase#44930)", () => {
-      openNativeEditor();
+      H.openNativeEditor();
       cy.icon("snippet").click();
 
       // Edit snippet folder
@@ -351,10 +338,10 @@ describeEE("scenarios > question > snippets (EE)", () => {
           .click({ force: true });
       });
 
-      popover().findByText("Edit folder details").click();
-      modal().findByTestId("collection-picker-button").click();
+      H.popover().findByText("Edit folder details").click();
+      H.modal().findByTestId("collection-picker-button").click();
 
-      entityPickerModal()
+      H.entityPickerModal()
         .findByRole("button", { name: /Snippet Folder/ })
         .should("be.disabled");
     });
@@ -372,7 +359,7 @@ describeEE("scenarios > question > snippets (EE)", () => {
         "updatePermissions",
       );
 
-      openNativeEditor();
+      H.openNativeEditor();
       cy.icon("snippet").click();
 
       // Edit permissions for a snippet folder
@@ -387,13 +374,13 @@ describeEE("scenarios > question > snippets (EE)", () => {
       cy.findByText("Change permissions").click();
 
       // Update permissions for "All users" and let them only "View" this folder
-      modal().within(() => {
+      H.modal().within(() => {
         getPermissionsForUserGroup("All Users")
           .should("contain", "Curate")
           .click();
       });
 
-      popover().contains("View").click();
+      H.popover().contains("View").click();
       cy.button("Save").click();
 
       cy.wait("@updatePermissions");
@@ -405,7 +392,7 @@ describeEE("scenarios > question > snippets (EE)", () => {
       cy.findByText("Change permissions").click();
 
       // UI check
-      modal().within(() => {
+      H.modal().within(() => {
         getPermissionsForUserGroup("All Users").should("contain", "Curate");
       });
 

--- a/e2e/test/scenarios/navigation/navbar.cy.spec.js
+++ b/e2e/test/scenarios/navigation/navbar.cy.spec.js
@@ -1,14 +1,5 @@
+import { H } from "e2e/support";
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  appBar,
-  describeEE,
-  navigationSidebar,
-  popover,
-  restore,
-  setTokenFeatures,
-  updateSetting,
-  visitDashboard,
-} from "e2e/support/helpers";
 
 describe("scenarios > navigation > navbar", () => {
   describe("OSS", () => {
@@ -18,97 +9,97 @@ describe("scenarios > navigation > navbar", () => {
 
     it("should be open after logging in", () => {
       cy.visit("/");
-      navigationSidebar().should("be.visible");
+      H.navigationSidebar().should("be.visible");
     });
 
     it("should display error ui when data fetching fails", () => {
       cy.intercept("GET", "/api/database", req => req.reply(500));
       cy.visit("/");
-      navigationSidebar().findByText(/An error occurred/);
+      H.navigationSidebar().findByText(/An error occurred/);
     });
 
     it("state should preserve when clicking the mb logo", () => {
       cy.visit("/collection/root");
-      navigationSidebar().should("be.visible");
+      H.navigationSidebar().should("be.visible");
       cy.findByTestId("main-logo-link").click();
-      navigationSidebar().should("be.visible");
-      visitDashboard(ORDERS_DASHBOARD_ID);
-      navigationSidebar().should("not.be.visible");
+      H.navigationSidebar().should("be.visible");
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
+      H.navigationSidebar().should("not.be.visible");
       cy.findByTestId("main-logo-link").click();
-      navigationSidebar().should("not.be.visible");
+      H.navigationSidebar().should("not.be.visible");
     });
 
     it("should close when visiting a dashboard", () => {
-      visitDashboard(ORDERS_DASHBOARD_ID);
-      navigationSidebar().should("not.be.visible");
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
+      H.navigationSidebar().should("not.be.visible");
     });
 
     it("should preserve state when visting a collection", () => {
-      visitDashboard(ORDERS_DASHBOARD_ID);
-      navigationSidebar().should("not.be.visible");
-      appBar().contains("Our analytics").parentsUntil("a").first().click();
-      navigationSidebar().should("not.be.visible");
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
+      H.navigationSidebar().should("not.be.visible");
+      H.appBar().contains("Our analytics").parentsUntil("a").first().click();
+      H.navigationSidebar().should("not.be.visible");
     });
 
     it("should close when creating a new question", () => {
       cy.visit("/");
-      navigationSidebar().should("be.visible");
-      appBar().findByText("New").click();
-      popover()
+      H.navigationSidebar().should("be.visible");
+      H.appBar().findByText("New").click();
+      H.popover()
         .findByText(/Question/)
         .click();
-      navigationSidebar().should("not.be.visible");
+      H.navigationSidebar().should("not.be.visible");
     });
 
     it("should close when opening a sql editor", () => {
       cy.visit("/");
-      navigationSidebar().should("be.visible");
-      appBar().findByText("New").click();
-      popover()
+      H.navigationSidebar().should("be.visible");
+      H.appBar().findByText("New").click();
+      H.popover()
         .findByText(/SQL query/)
         .click();
-      navigationSidebar().should("not.be.visible");
+      H.navigationSidebar().should("not.be.visible");
     });
 
     it("should be open when visiting home with a custom home page configured", () => {
       cy.signInAsAdmin();
-      updateSetting("custom-homepage", true);
-      updateSetting("custom-homepage-dashboard", ORDERS_DASHBOARD_ID);
+      H.updateSetting("custom-homepage", true);
+      H.updateSetting("custom-homepage-dashboard", ORDERS_DASHBOARD_ID);
       cy.visit("/");
       cy.reload();
       cy.url().should("contain", "question");
-      navigationSidebar().should("be.visible");
+      H.navigationSidebar().should("be.visible");
     });
 
     it("should preserve state when clicking the mb logo and a custom home page is configured", () => {
       cy.signInAsAdmin();
-      updateSetting("custom-homepage", true);
-      updateSetting("custom-homepage-dashboard", ORDERS_DASHBOARD_ID);
-      visitDashboard(ORDERS_DASHBOARD_ID);
+      H.updateSetting("custom-homepage", true);
+      H.updateSetting("custom-homepage-dashboard", ORDERS_DASHBOARD_ID);
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
       cy.findByTestId("main-logo-link").click();
-      navigationSidebar().should("not.be.visible");
+      H.navigationSidebar().should("not.be.visible");
     });
   });
 
-  describeEE("EE", () => {
+  H.describeEE("EE", () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
-      setTokenFeatures("all");
+      H.setTokenFeatures("all");
     });
 
     it("should be open when logging in with a landing page configured", () => {
-      updateSetting("landing-page", "/question/76");
+      H.updateSetting("landing-page", "/question/76");
       cy.visit("/");
       cy.url().should("contain", "question");
-      navigationSidebar().should("be.visible");
+      H.navigationSidebar().should("be.visible");
     });
 
     it("should preserve state when clicking the mb logo and landing page is configured", () => {
-      updateSetting("landing-page", "/question/76");
-      visitDashboard(ORDERS_DASHBOARD_ID);
+      H.updateSetting("landing-page", "/question/76");
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
       cy.findByTestId("main-logo-link").click();
-      navigationSidebar().should("not.be.visible");
+      H.navigationSidebar().should("not.be.visible");
     });
   });
 });

--- a/e2e/test/scenarios/onboarding/about.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/about.cy.spec.js
@@ -1,8 +1,8 @@
-import { restore } from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 describe("scenarios > about Metabase", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.visit("/");

--- a/e2e/test/scenarios/onboarding/add-initial-data.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/add-initial-data.cy.spec.ts
@@ -1,50 +1,39 @@
-import {
-  CSV_FILES,
-  describeWithSnowplow,
-  enableTracking,
-  enableUploads,
-  expectGoodSnowplowEvent,
-  expectNoBadSnowplowEvents,
-  mockSessionPropertiesTokenFeatures,
-  resetSnowplow,
-  restore,
-  uploadFile,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 
-describeWithSnowplow(
+H.describeWithSnowplow(
   "better onboarding via sidebar",
   { tags: "@external" },
   () => {
     afterEach(() => {
-      expectNoBadSnowplowEvents();
+      H.expectNoBadSnowplowEvents();
     });
 
     describe("Upload CSV for DWH", () => {
       beforeEach(() => {
-        resetSnowplow();
-        restore("postgres-12");
+        H.resetSnowplow();
+        H.restore("postgres-12");
 
         cy.signInAsAdmin();
-        enableTracking();
-        enableUploads("postgres");
-        mockSessionPropertiesTokenFeatures({ attached_dwh: true });
+        H.enableTracking();
+        H.enableUploads("postgres");
+        H.mockSessionPropertiesTokenFeatures({ attached_dwh: true });
       });
 
-      CSV_FILES.forEach(testFile => {
+      H.CSV_FILES.forEach(testFile => {
         it(`${testFile.valid ? "Can" : "Cannot"} upload ${
           testFile.fileName
         } to "Our analytics" using DWH`, () => {
           cy.visit("/");
           cy.findByTestId("main-navbar-root").findByText("Upload CSV").click();
 
-          uploadFile("#dwh-upload-csv-input", "Our analytics", testFile);
+          H.uploadFile("#dwh-upload-csv-input", "Our analytics", testFile);
 
-          expectGoodSnowplowEvent({
+          H.expectGoodSnowplowEvent({
             event: "csv_upload_clicked",
             triggered_from: "left-nav",
           });
 
-          expectGoodSnowplowEvent({
+          H.expectGoodSnowplowEvent({
             event: testFile.valid
               ? "csv_upload_successful"
               : "csv_upload_failed",
@@ -55,18 +44,18 @@ describeWithSnowplow(
 
     describe("Add initial database", () => {
       beforeEach(() => {
-        resetSnowplow();
-        restore();
+        H.resetSnowplow();
+        H.restore();
 
         cy.signInAsAdmin();
-        enableTracking();
+        H.enableTracking();
       });
 
       it("should track the button click", () => {
         cy.visit("/");
         cy.findByTestId("main-navbar-root").findByText("Add database").click();
         cy.location("pathname").should("eq", "/admin/databases/create");
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: "database_add_clicked",
           triggered_from: "left-nav",
         });

--- a/e2e/test/scenarios/onboarding/auth/forgot_password.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/auth/forgot_password.cy.spec.js
@@ -1,14 +1,14 @@
+import { H } from "e2e/support";
 import { USERS } from "e2e/support/cypress_data";
-import { getInbox, restore, setupSMTP } from "e2e/support/helpers";
 
 const { admin } = USERS;
 
 describe("scenarios > auth > password", { tags: "@external" }, () => {
   beforeEach(() => {
-    restore();
+    H.restore();
 
     cy.signInAsAdmin();
-    setupSMTP();
+    H.setupSMTP();
     cy.signOut();
   });
 
@@ -21,7 +21,7 @@ describe("scenarios > auth > password", { tags: "@external" }, () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Check your email/);
 
-    getInbox().then(({ body: [{ html }] }) => {
+    H.getInbox().then(({ body: [{ html }] }) => {
       cy.visit(getResetLink(html));
 
       cy.findByLabelText("Create a password").type(admin.password);

--- a/e2e/test/scenarios/onboarding/auth/signin.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/auth/signin.cy.spec.js
@@ -1,5 +1,5 @@
+import { H } from "e2e/support";
 import { USERS } from "e2e/support/cypress_data";
-import { browseDatabases, restore } from "e2e/support/helpers";
 
 const sizes = [
   [1280, 800],
@@ -9,7 +9,7 @@ const { admin } = USERS;
 
 describe("scenarios > auth > signin", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signOut();
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
@@ -75,7 +75,7 @@ describe("scenarios > auth > signin", () => {
   it("should redirect to an unsaved question after login", () => {
     cy.signInAsAdmin();
     cy.visit("/");
-    browseDatabases().click();
+    H.browseDatabases().click();
     cy.findByRole("heading", { name: "Sample Database" }).click();
     cy.findByRole("heading", { name: "Orders" }).click();
     cy.wait("@dataset");

--- a/e2e/test/scenarios/onboarding/auth/sso.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/auth/sso.cy.spec.js
@@ -1,16 +1,11 @@
+import { H } from "e2e/support";
 import { USERS } from "e2e/support/cypress_data";
-import {
-  describeEE,
-  mockCurrentUserProperty,
-  restore,
-  setTokenFeatures,
-} from "e2e/support/helpers";
 
 const { admin } = USERS;
 
 describe("scenarios > auth > signin > SSO", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     // Set fake Google client ID and enable Google auth
     cy.request("PUT", "/api/google/settings", {
@@ -21,7 +16,7 @@ describe("scenarios > auth > signin > SSO", () => {
 
   ["ldap_auth", "google_auth"].forEach(auth => {
     it(`login history tab should be available with ${auth} enabled (metabase#15558)`, () => {
-      mockCurrentUserProperty(auth, true);
+      H.mockCurrentUserProperty(auth, true);
       cy.visit("/account/profile");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Login History");
@@ -74,9 +69,9 @@ describe("scenarios > auth > signin > SSO", () => {
     });
   });
 
-  describeEE("EE", () => {
+  H.describeEE("EE", () => {
     beforeEach(() => {
-      setTokenFeatures("all");
+      H.setTokenFeatures("all");
       // Disable password log-in
       cy.request("PUT", "api/setting/enable-password-login", {
         value: false,

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -1,27 +1,15 @@
+import { H } from "e2e/support";
 import { USERS } from "e2e/support/cypress_data";
 import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_DASHBOARD_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  closeCommandPalette,
-  commandPalette,
-  commandPaletteButton,
-  commandPaletteInput,
-  openCommandPalette,
-  pressEnd,
-  pressHome,
-  pressPageDown,
-  pressPageUp,
-  restore,
-  visitFullAppEmbeddingUrl,
-} from "e2e/support/helpers";
 
 const { admin } = USERS;
 
 describe("command palette", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -36,12 +24,12 @@ describe("command palette", () => {
     cy.visit("/");
 
     cy.findByRole("button", { name: /Search/ }).click();
-    closeCommandPalette();
+    H.closeCommandPalette();
 
     cy.log("open the command palette with keybinding");
-    openCommandPalette();
-    commandPalette().within(() => {
-      commandPaletteInput().should("exist");
+    H.openCommandPalette();
+    H.commandPalette().within(() => {
+      H.commandPaletteInput().should("exist");
 
       cy.log("limit to 5 basic actions");
       cy.findByText("New question");
@@ -58,7 +46,7 @@ describe("command palette", () => {
       );
 
       cy.log("Should search entities and docs");
-      commandPaletteInput().type("Orders, Count");
+      H.commandPaletteInput().type("Orders, Count");
 
       cy.findByRole("option", { name: "Orders, Count" })
         .should("contain.text", "Our analytics")
@@ -68,15 +56,15 @@ describe("command palette", () => {
 
       // Since the command palette list is virtualized, we will search for a few
       // to ensure they're reachable
-      commandPaletteInput().clear().type("People");
+      H.commandPaletteInput().clear().type("People");
       cy.findByRole("option", { name: "People" }).should("exist");
 
-      commandPaletteInput().clear().type("Uploads");
+      H.commandPaletteInput().clear().type("Uploads");
       cy.findByRole("option", { name: "Settings - Uploads" }).should("exist");
 
       // When entering a query, if there are results that come before search results, highlight
       // the first action, otherwise, highlight the first search result
-      commandPaletteInput().clear().type("For");
+      H.commandPaletteInput().clear().type("For");
       cy.findByRole("option", { name: "Performance" }).should(
         "have.attr",
         "aria-selected",
@@ -85,7 +73,7 @@ describe("command palette", () => {
       cy.findByRole("option", { name: /View and filter/ }).should("exist");
 
       // Check that we are not filtering search results by action name
-      commandPaletteInput().clear().type("Company");
+      H.commandPaletteInput().clear().type("Company");
       cy.findByRole("option", { name: /View and filter/ }).should("exist");
       cy.findByRole("option", { name: "REVIEWS" }).should(
         "have.attr",
@@ -94,47 +82,47 @@ describe("command palette", () => {
       );
       cy.findByRole("option", { name: "PEOPLE" }).should("exist");
       cy.findByRole("option", { name: "PRODUCTS" }).should("exist");
-      commandPaletteInput().clear();
+      H.commandPaletteInput().clear();
 
-      commandPaletteInput().clear().type("New met");
+      H.commandPaletteInput().clear().type("New met");
       cy.findByText("New metric").should("exist");
     });
 
     cy.log("We can close the command palette using escape");
-    closeCommandPalette();
-    commandPalette().should("not.exist");
+    H.closeCommandPalette();
+    H.commandPalette().should("not.exist");
 
-    openCommandPalette();
+    H.openCommandPalette();
 
-    commandPalette()
+    H.commandPalette()
       .findByRole("option", { name: "Orders in a dashboard" })
       .should("have.attr", "aria-selected", "true");
 
-    pressPageDown();
+    H.pressPageDown();
 
-    commandPalette()
+    H.commandPalette()
       .findByRole("option", { name: "New dashboard" })
       .should("have.attr", "aria-selected", "true");
 
-    pressPageDown();
+    H.pressPageDown();
 
-    commandPalette()
+    H.commandPalette()
       .findByRole("option", { name: "New model" })
       .should("have.attr", "aria-selected", "true");
 
-    pressPageUp();
-    commandPalette()
+    H.pressPageUp();
+    H.commandPalette()
       .findByRole("option", { name: "New question" })
       .should("have.attr", "aria-selected", "true");
 
-    pressEnd();
+    H.pressEnd();
 
-    commandPalette()
+    H.commandPalette()
       .findByRole("option", { name: "New model" })
       .should("have.attr", "aria-selected", "true");
 
-    pressHome();
-    commandPalette()
+    H.pressHome();
+    H.commandPalette()
       .findByRole("option", { name: "Orders in a dashboard" })
       .should("have.attr", "aria-selected", "true");
   });
@@ -145,8 +133,8 @@ describe("command palette", () => {
     cy.findByRole("button", { name: /Search/ }).click();
     cy.intercept("/api/search?*").as("searchData");
 
-    commandPalette().within(() => {
-      commandPaletteInput().type("Cou");
+    H.commandPalette().within(() => {
+      H.commandPaletteInput().type("Cou");
       cy.wait("@searchData");
       cy.findByText("Loading...").should("not.exist");
 
@@ -165,10 +153,10 @@ describe("command palette", () => {
   it("should render links to site settings in settings pages", () => {
     cy.visit("/admin");
     cy.findByRole("heading", { name: "Getting set up" }).should("exist");
-    openCommandPalette();
+    H.openCommandPalette();
 
-    commandPalette().within(() => {
-      commandPaletteInput().type("Custom Homepage");
+    H.commandPalette().within(() => {
+      H.commandPaletteInput().type("Custom Homepage");
       cy.findByRole("option", { name: "Custom Homepage" }).click();
     });
 
@@ -177,10 +165,10 @@ describe("command palette", () => {
     cy.location("pathname").should("contain", "settings/general");
     cy.location("hash").should("contain", "#custom-homepage");
 
-    openCommandPalette();
+    H.openCommandPalette();
 
-    commandPalette().within(() => {
-      commandPaletteInput().clear().type("Week");
+    H.commandPalette().within(() => {
+      H.commandPaletteInput().clear().type("Week");
       cy.findByRole("option", { name: "First day of the week" }).click();
     });
 
@@ -189,7 +177,7 @@ describe("command palette", () => {
   });
 
   it("should not be accessible when doing full app embedding", () => {
-    visitFullAppEmbeddingUrl({
+    H.visitFullAppEmbeddingUrl({
       url: "/",
       qs: {
         top_nav: true,
@@ -202,8 +190,8 @@ describe("command palette", () => {
 
     cy.get("body").type("{esc}");
 
-    openCommandPalette();
-    commandPalette().should("not.exist");
+    H.openCommandPalette();
+    H.commandPalette().should("not.exist");
   });
 
   it("should not be accessible when a user is not logged in", () => {
@@ -215,8 +203,8 @@ describe("command palette", () => {
 
     cy.findByRole("heading", { name: "Sign in to Metabase" });
 
-    openCommandPalette();
-    commandPalette().should("not.exist");
+    H.openCommandPalette();
+    H.commandPalette().should("not.exist");
 
     cy.get("@database").should("be.null");
     cy.get("@search").should("be.null");
@@ -226,22 +214,22 @@ describe("command palette", () => {
     cy.button("Sign in").click();
     cy.findByTestId("greeting-message");
 
-    openCommandPalette();
-    commandPalette().should("exist");
+    H.openCommandPalette();
+    H.commandPalette().should("exist");
   });
 
   it("The Search button should resize when on mobile", () => {
     cy.viewport("iphone-x");
     cy.visit("/");
-    commandPaletteButton().should("not.contain.text", "search");
+    H.commandPaletteButton().should("not.contain.text", "search");
   });
 
   it("Should have a new metric item", () => {
     cy.visit("/");
     cy.findByRole("button", { name: /Search/ }).click();
 
-    commandPalette().within(() => {
-      commandPaletteInput().should("exist").type("Me");
+    H.commandPalette().within(() => {
+      H.commandPaletteInput().should("exist").type("Me");
       cy.findByText("New metric").should("be.visible").click();
 
       cy.location("pathname").should("eq", "/metric/query");

--- a/e2e/test/scenarios/onboarding/embedding-homepage.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/embedding-homepage.cy.spec.ts
@@ -1,53 +1,48 @@
-import {
-  describeWithSnowplow,
-  expectGoodSnowplowEvent,
-  expectNoBadSnowplowEvents,
-  main,
-  popover,
-  resetSnowplow,
-  restore,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 
-describeWithSnowplow("scenarios > embedding-homepage > snowplow events", () => {
-  beforeEach(() => {
-    restore("default");
-    resetSnowplow();
+H.describeWithSnowplow(
+  "scenarios > embedding-homepage > snowplow events",
+  () => {
+    beforeEach(() => {
+      H.restore("default");
+      H.resetSnowplow();
 
-    cy.signInAsAdmin();
-    cy.intercept("GET", "/api/session/properties", req => {
-      req.continue(res => {
-        res.body["embedding-homepage"] = "visible";
-        res.body["example-dashboard-id"] = 1;
-        res.body["setup-license-active-at-setup"] = true;
-        res.send();
+      cy.signInAsAdmin();
+      cy.intercept("GET", "/api/session/properties", req => {
+        req.continue(res => {
+          res.body["embedding-homepage"] = "visible";
+          res.body["example-dashboard-id"] = 1;
+          res.body["setup-license-active-at-setup"] = true;
+          res.send();
+        });
       });
     });
-  });
 
-  afterEach(() => {
-    expectNoBadSnowplowEvents();
-  });
-
-  it("opening the example dashboard from the button should send the 'embedding_homepage_example_dashboard_click' event", () => {
-    cy.visit("/");
-
-    // the example-dashboard-id is mocked, it's normal that we'll get to a permision error page
-    main().findByText("Embed an example dashboard").click();
-
-    expectGoodSnowplowEvent({
-      event: "embedding_homepage_example_dashboard_click",
+    afterEach(() => {
+      H.expectNoBadSnowplowEvents();
     });
-  });
 
-  it("dismissing the homepage should send the 'embedding_homepage_dismissed' event", () => {
-    cy.visit("/");
+    it("opening the example dashboard from the button should send the 'embedding_homepage_example_dashboard_click' event", () => {
+      cy.visit("/");
 
-    main().findByText("Hide these").click();
-    popover().findByText("Embedding done, all good").click();
+      // the example-dashboard-id is mocked, it's normal that we'll get to a permision error page
+      H.main().findByText("Embed an example dashboard").click();
 
-    expectGoodSnowplowEvent({
-      event: "embedding_homepage_dismissed",
-      dismiss_reason: "dismissed-done",
+      H.expectGoodSnowplowEvent({
+        event: "embedding_homepage_example_dashboard_click",
+      });
     });
-  });
-});
+
+    it("dismissing the homepage should send the 'embedding_homepage_dismissed' event", () => {
+      cy.visit("/");
+
+      H.main().findByText("Hide these").click();
+      H.popover().findByText("Embedding done, all good").click();
+
+      H.expectGoodSnowplowEvent({
+        event: "embedding_homepage_dismissed",
+        dismiss_reason: "dismissed-done",
+      });
+    });
+  },
+);

--- a/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
@@ -1,17 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_MODEL_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  browseDatabases,
-  describeWithSnowplow,
-  describeWithSnowplowEE,
-  enableTracking,
-  expectGoodSnowplowEvent,
-  expectNoBadSnowplowEvents,
-  navigationSidebar,
-  resetSnowplow,
-  restore,
-  setTokenFeatures,
-} from "e2e/support/helpers";
 
 const { PRODUCTS_ID } = SAMPLE_DATABASE;
 
@@ -20,22 +9,22 @@ const filterButton = () =>
     .findByTestId("browse-models-header")
     .findByRole("button", { name: /Filters/i });
 
-describeWithSnowplow("scenarios > browse", () => {
+H.describeWithSnowplow("scenarios > browse", () => {
   beforeEach(() => {
-    resetSnowplow();
-    restore();
+    H.resetSnowplow();
+    H.restore();
     cy.signInAsAdmin();
-    enableTracking();
+    H.enableTracking();
   });
 
   it("can browse to a model", () => {
     cy.visit("/");
-    navigationSidebar().findByLabelText("Browse models").click();
+    H.navigationSidebar().findByLabelText("Browse models").click();
     cy.location("pathname").should("eq", "/browse/models");
     cy.findByRole("heading", { name: "Orders Model" }).click();
     cy.url().should("include", `/model/${ORDERS_MODEL_ID}-`);
-    expectNoBadSnowplowEvents();
-    expectGoodSnowplowEvent({
+    H.expectNoBadSnowplowEvents();
+    H.expectGoodSnowplowEvent({
       event: "browse_data_model_clicked",
       model_id: ORDERS_MODEL_ID,
     });
@@ -63,13 +52,13 @@ describeWithSnowplow("scenarios > browse", () => {
 
   it("can browse to a table in a database", () => {
     cy.visit("/");
-    browseDatabases().click();
+    H.browseDatabases().click();
     cy.findByRole("heading", { name: "Sample Database" }).click();
     cy.findByRole("heading", { name: "Products" }).click();
     cy.findByRole("button", { name: "Summarize" });
     cy.findByRole("link", { name: /Sample Database/ }).click();
-    expectNoBadSnowplowEvents();
-    expectGoodSnowplowEvent({
+    H.expectNoBadSnowplowEvents();
+    H.expectGoodSnowplowEvent({
       event: "browse_data_table_clicked",
       table_id: PRODUCTS_ID,
     });
@@ -85,7 +74,7 @@ describeWithSnowplow("scenarios > browse", () => {
       cy.spy().as("schemasForOtherDatabases"),
     );
     cy.visit("/");
-    browseDatabases().click();
+    H.browseDatabases().click();
     cy.findByRole("link", { name: /Sample Database/ }).click();
     cy.wait("@schemasForSampleDatabase");
     cy.get("@schemasForOtherDatabases").should("not.have.been.called");
@@ -93,7 +82,7 @@ describeWithSnowplow("scenarios > browse", () => {
 
   it("can visit 'Learn about our data' page", () => {
     cy.visit("/");
-    browseDatabases().click();
+    H.browseDatabases().click();
     cy.findByRole("link", { name: /Learn about our data/ }).click();
     cy.location("pathname").should("eq", "/reference/databases");
     cy.go("back");
@@ -104,7 +93,7 @@ describeWithSnowplow("scenarios > browse", () => {
 
   it("on an open-source instance, the Browse models page has no controls for setting filters", () => {
     cy.visit("/");
-    navigationSidebar().findByLabelText("Browse models").click();
+    H.navigationSidebar().findByLabelText("Browse models").click();
     filterButton().should("not.exist");
     cy.findByRole("switch", { name: /Show verified models only/ }).should(
       "not.exist",
@@ -116,7 +105,7 @@ describeWithSnowplow("scenarios > browse", () => {
     cy.intercept("GET", "/api/search*", req => {
       req.reply({ statusCode: 400 });
     });
-    navigationSidebar().findByLabelText("Browse models").click();
+    H.navigationSidebar().findByLabelText("Browse models").click();
     cy.findByLabelText("Models")
       .findAllByText("An error occurred")
       .should("have.length", 2);
@@ -127,20 +116,20 @@ describeWithSnowplow("scenarios > browse", () => {
     cy.intercept("GET", "/api/search*", req => {
       req.reply({ statusCode: 400 });
     });
-    navigationSidebar().findByLabelText("Browse metrics").click();
+    H.navigationSidebar().findByLabelText("Browse metrics").click();
     cy.findByLabelText("Metrics")
       .findByText("An error occurred")
       .should("be.visible");
   });
 });
 
-describeWithSnowplowEE("scenarios > browse (EE)", () => {
+H.describeWithSnowplowEE("scenarios > browse (EE)", () => {
   beforeEach(() => {
-    resetSnowplow();
-    restore();
+    H.resetSnowplow();
+    H.restore();
     cy.signInAsAdmin();
-    enableTracking();
-    setTokenFeatures("all");
+    H.enableTracking();
+    H.setTokenFeatures("all");
     cy.intercept("PUT", "/api/setting/browse-filter-only-verified-models").as(
       "updateFilter",
     );
@@ -186,7 +175,7 @@ describeWithSnowplowEE("scenarios > browse (EE)", () => {
   const browseModels = () => {
     cy.visit("/");
 
-    navigationSidebar()
+    H.navigationSidebar()
       .findByRole("listitem", { name: "Browse models" })
       .click();
   };

--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -1,34 +1,10 @@
+import { H } from "e2e/support";
 import { USERS } from "e2e/support/cypress_data";
 import {
   ADMIN_PERSONAL_COLLECTION_ID,
   ORDERS_BY_YEAR_QUESTION_ID,
   ORDERS_DASHBOARD_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  createDashboard,
-  dashboardGrid,
-  dashboardHeader,
-  describeEE,
-  describeWithSnowplow,
-  enableTracking,
-  entityPickerModal,
-  entityPickerModalTab,
-  expectGoodSnowplowEvent,
-  expectNoBadSnowplowEvents,
-  main,
-  modal,
-  navigationSidebar,
-  openNavigationSidebar,
-  popover,
-  repeatAssertion,
-  resetSnowplow,
-  restore,
-  setTokenFeatures,
-  undoToast,
-  updateSetting,
-  visitDashboard,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 const { admin } = USERS;
 
@@ -45,7 +21,7 @@ describe("scenarios > home > homepage", () => {
 
   describe("after setup", () => {
     beforeEach(() => {
-      restore("setup");
+      H.restore("setup");
     });
 
     it("should display x-rays for the sample database", () => {
@@ -107,7 +83,7 @@ describe("scenarios > home > homepage", () => {
         .findByTestId("loading-indicator")
         .should("not.exist");
 
-      repeatAssertion(() =>
+      H.repeatAssertion(() =>
         cy
           .findByTestId("home-page")
           .findByTestId("loading-indicator", { timeout: 0 })
@@ -144,14 +120,14 @@ describe("scenarios > home > homepage", () => {
 
   describe("after content creation", () => {
     beforeEach(() => {
-      restore("default");
+      H.restore("default");
       cy.signInAsAdmin();
     });
 
     it("should display recent items", () => {
       cy.signInAsAdmin();
 
-      visitDashboard(ORDERS_DASHBOARD_ID);
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders in a dashboard");
 
@@ -184,25 +160,25 @@ describe("scenarios > home > homepage", () => {
       });
 
       cy.intercept("PUT", "/api/user/*/modal/qbnewb").as("modalDismiss");
-      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
-      modal()
+      H.visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
+      H.modal()
         .should("be.visible")
         .and("contain", "It's okay to play around with saved questions");
 
       cy.realPress("Escape");
       cy.wait("@modalDismiss");
-      modal().should("not.exist");
+      H.modal().should("not.exist");
     });
 
     // TODO: popular items endpoint is currently broken in OSS. Re-enable test once endpoint has been fixed.
-    describeEE("EE", () => {
+    H.describeEE("EE", () => {
       it("should display popular items for a new user", () => {
         cy.signInAsAdmin();
         // Setting this to true so that displaying popular items for new users works.
         // This requires the audit-app feature to be enabled
-        setTokenFeatures("all");
+        H.setTokenFeatures("all");
 
-        visitDashboard(ORDERS_DASHBOARD_ID);
+        H.visitDashboard(ORDERS_DASHBOARD_ID);
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Orders in a dashboard");
         cy.signOut();
@@ -223,7 +199,7 @@ describe("scenarios > home > homepage", () => {
     it("should not show pinned questions in recent items when viewed in a collection", () => {
       cy.signInAsAdmin();
 
-      visitDashboard(ORDERS_DASHBOARD_ID);
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders in a dashboard");
 
@@ -280,7 +256,7 @@ describe("scenarios > home > homepage", () => {
 describe("scenarios > home > custom homepage", () => {
   describe("setting custom homepage", () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
       cy.intercept("GET", "/api/search*").as("search");
     });
@@ -298,9 +274,9 @@ describe("scenarios > home > custom homepage", () => {
         .findByRole("button")
         .click();
 
-      entityPickerModal().findByText("Orders in a dashboard").click();
+      H.entityPickerModal().findByText("Orders in a dashboard").click();
 
-      undoToast().findByText("Changes saved").should("be.visible");
+      H.undoToast().findByText("Changes saved").should("be.visible");
 
       cy.findByTestId("custom-homepage-dashboard-setting").should(
         "contain",
@@ -317,7 +293,7 @@ describe("scenarios > home > custom homepage", () => {
         cy.findByText("Disabled").should("exist");
       });
 
-      undoToast().findByText("Changes saved").should("be.visible");
+      H.undoToast().findByText("Changes saved").should("be.visible");
 
       cy.findByTestId("custom-homepage-setting").within(() => {
         cy.findByText("Disabled").should("exist");
@@ -334,7 +310,7 @@ describe("scenarios > home > custom homepage", () => {
         .findByRole("button")
         .click();
 
-      entityPickerModal().findByText("Orders in a dashboard").click();
+      H.entityPickerModal().findByText("Orders in a dashboard").click();
 
       cy.findByTestId("custom-homepage-dashboard-setting").should(
         "contain",
@@ -381,13 +357,13 @@ describe("scenarios > home > custom homepage", () => {
       cy.visit("/");
       cy.get("main").findByText("Customize").click();
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByRole("button", { name: "Save" }).should("be.disabled");
         cy.findByText(/Select a dashboard/i).click();
       });
 
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Dashboards").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Dashboards").click();
         //Ensure that personal collections have been removed
         cy.findByText("First collection").should("exist");
         cy.findByText(/personal collection/).should("not.exist");
@@ -402,7 +378,7 @@ describe("scenarios > home > custom homepage", () => {
         cy.findByText("Orders in a dashboard").click();
       });
 
-      modal().findByRole("button", { name: "Save" }).click();
+      H.modal().findByRole("button", { name: "Save" }).click();
       cy.location("pathname").should(
         "equal",
         `/dashboard/${ORDERS_DASHBOARD_ID}`,
@@ -421,10 +397,10 @@ describe("scenarios > home > custom homepage", () => {
 
   describe("custom homepage set", () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
-      updateSetting("custom-homepage", true);
-      updateSetting("custom-homepage-dashboard", ORDERS_DASHBOARD_ID);
+      H.updateSetting("custom-homepage", true);
+      H.updateSetting("custom-homepage-dashboard", ORDERS_DASHBOARD_ID);
     });
 
     it("should not flash the homescreen before redirecting (#37089)", () => {
@@ -470,11 +446,11 @@ describe("scenarios > home > custom homepage", () => {
       });
 
       cy.log("let the dashboard load");
-      dashboardHeader().findByText("Orders in a dashboard");
+      H.dashboardHeader().findByText("Orders in a dashboard");
 
       cy.log("Ensure that internal state was updated");
-      navigationSidebar().findByText("Home").click();
-      dashboardHeader().findByText("Orders in a dashboard");
+      H.navigationSidebar().findByText("Home").click();
+      H.dashboardHeader().findByText("Orders in a dashboard");
 
       cy.findByTestId("undo-list")
         .contains(/Your admin has set this dashboard as your homepage/)
@@ -482,7 +458,7 @@ describe("scenarios > home > custom homepage", () => {
 
       cy.log("Ensure that on refresh, the proper settings are given");
       cy.visit("/");
-      dashboardHeader().findByText("Orders in a dashboard");
+      H.dashboardHeader().findByText("Orders in a dashboard");
       cy.findByTestId("undo-list")
         .contains(/Your admin has set this dashboard as your homepage/)
         .should("not.exist");
@@ -511,23 +487,23 @@ describe("scenarios > home > custom homepage", () => {
             "getCollection",
           );
           // Archive dashboard
-          visitDashboard(ORDERS_DASHBOARD_ID);
-          dashboardHeader().findByLabelText("Move, trash, and more…").click();
-          popover().within(() => {
+          H.visitDashboard(ORDERS_DASHBOARD_ID);
+          H.dashboardHeader().findByLabelText("Move, trash, and more…").click();
+          H.popover().within(() => {
             cy.findByText("Move to trash").click();
           });
-          modal().within(() => {
+          H.modal().within(() => {
             cy.findByText("Move to trash").click();
           });
 
           cy.wait(["@getCollection"]);
 
           // Navigate to home
-          openNavigationSidebar();
-          navigationSidebar().within(() => {
+          H.openNavigationSidebar();
+          H.navigationSidebar().within(() => {
             cy.findByText("Home").click();
           });
-          main().within(() => {
+          H.main().within(() => {
             cy.findByText("We're a little lost...").should("not.exist");
             cy.findByText("Customize").should("be.visible");
           });
@@ -546,14 +522,14 @@ describe("scenarios > home > custom homepage", () => {
       ).as("runDashCardQuery");
 
       cy.visit("/");
-      dashboardGrid()
+      H.dashboardGrid()
         .findAllByTestId("loading-indicator")
         .should("have.length", 0);
 
       cy.findByTestId("main-logo-link").click().click();
-      navigationSidebar().findByText("Home").click().click();
+      H.navigationSidebar().findByText("Home").click().click();
 
-      main()
+      H.main()
         .findByText(/Something.s gone wrong/)
         .should("not.exist");
       cy.get("@getDashboardMetadata.all").should("have.length", 1);
@@ -571,27 +547,27 @@ describe("scenarios > home > custom homepage", () => {
       );
 
       const dashboardName = "Test Dashboard";
-      createDashboard({ name: dashboardName }).then(({ body: dashboard }) =>
-        visitDashboard(dashboard.id),
+      H.createDashboard({ name: dashboardName }).then(({ body: dashboard }) =>
+        H.visitDashboard(dashboard.id),
       );
 
-      dashboardHeader().findByText(dashboardName).should("be.visible");
+      H.dashboardHeader().findByText(dashboardName).should("be.visible");
       cy.get("@getDashboard.all").should("have.length", 1);
       cy.get("@getDashboardMetadata.all").should("have.length", 1);
     });
   });
 });
 
-describeWithSnowplow("scenarios > setup", () => {
+H.describeWithSnowplow("scenarios > setup", () => {
   beforeEach(() => {
-    restore();
-    resetSnowplow();
+    H.restore();
+    H.resetSnowplow();
     cy.signInAsAdmin();
-    enableTracking();
+    H.enableTracking();
   });
 
   afterEach(() => {
-    expectNoBadSnowplowEvents();
+    H.expectNoBadSnowplowEvents();
   });
 
   it("should send snowplow events through admin settings", () => {
@@ -602,11 +578,11 @@ describeWithSnowplow("scenarios > setup", () => {
       .findByRole("button")
       .click();
 
-    entityPickerModal().findByText("Orders in a dashboard").click();
+    H.entityPickerModal().findByText("Orders in a dashboard").click();
 
-    undoToast().findByText("Changes saved").should("be.visible");
+    H.undoToast().findByText("Changes saved").should("be.visible");
 
-    expectGoodSnowplowEvent({
+    H.expectGoodSnowplowEvent({
       event: "homepage_dashboard_enabled",
       source: "admin",
     });
@@ -615,13 +591,13 @@ describeWithSnowplow("scenarios > setup", () => {
   it("should send snowplow events through homepage", () => {
     cy.visit("/");
     cy.get("main").findByText("Customize").click();
-    modal()
+    H.modal()
       .findByText(/Select a dashboard/i)
       .click();
 
-    entityPickerModal().findByText("Orders in a dashboard").click();
-    modal().findByText("Save").click();
-    expectGoodSnowplowEvent({
+    H.entityPickerModal().findByText("Orders in a dashboard").click();
+    H.modal().findByText("Save").click();
+    H.expectGoodSnowplowEvent({
       event: "homepage_dashboard_enabled",
       source: "homepage",
     });
@@ -631,7 +607,7 @@ describeWithSnowplow("scenarios > setup", () => {
 const pinItem = name => {
   cy.findByText(name).closest("tr").icon("ellipsis").click();
 
-  popover().icon("pin").click();
+  H.popover().icon("pin").click();
 };
 
 const getXrayCandidates = () => [

--- a/e2e/test/scenarios/onboarding/navbar/new-menu.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/navbar/new-menu.cy.spec.js
@@ -1,8 +1,8 @@
-import { nativeEditor, popover, restore } from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 describe("metabase > scenarios > navbar > new menu", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.visit("/");
@@ -11,7 +11,7 @@ describe("metabase > scenarios > navbar > new menu", () => {
   });
 
   it("question item opens question notebook editor", () => {
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Question").click();
     });
 
@@ -19,16 +19,16 @@ describe("metabase > scenarios > navbar > new menu", () => {
   });
 
   it("question item opens SQL query editor", () => {
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("SQL query").click();
     });
 
     cy.url("should.contain", "/question#");
-    nativeEditor().should("be.visible");
+    H.nativeEditor().should("be.visible");
   });
 
   it("collection opens modal and redirects to a created collection after saving", () => {
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Collection").click();
     });
 

--- a/e2e/test/scenarios/onboarding/navbar/whats-new.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/navbar/whats-new.cy.spec.js
@@ -1,4 +1,4 @@
-import { navigationSidebar, restore } from "e2e/support/helpers";
+import { H } from "e2e/support";
 import {
   createMockVersionInfo,
   createMockVersionInfoRecord as mockVersion,
@@ -6,7 +6,7 @@ import {
 
 describe("nav > what's new notification", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
 
     mockVersions({
       currentVersion: "v0.48.0",
@@ -28,29 +28,29 @@ describe("nav > what's new notification", () => {
     cy.request("PUT", "api/setting/last-acknowledged-version", { value: null });
 
     loadHomepage();
-    navigationSidebar().findByText("See what's new");
+    H.navigationSidebar().findByText("See what's new");
 
     // should persist reloads
     loadHomepage();
-    navigationSidebar().findByText("See what's new");
+    H.navigationSidebar().findByText("See what's new");
 
-    navigationSidebar().icon("close").click();
-    navigationSidebar().findByText("See what's new").should("not.exist");
+    H.navigationSidebar().icon("close").click();
+    H.navigationSidebar().findByText("See what's new").should("not.exist");
 
     loadHomepage();
-    navigationSidebar().findByText("See what's new").should("not.exist");
+    H.navigationSidebar().findByText("See what's new").should("not.exist");
   });
 
   it("it should show the notification for other users after one user dismissed it", () => {
     cy.signInAsAdmin();
     cy.request("PUT", "api/setting/last-acknowledged-version", { value: null });
     loadHomepage();
-    navigationSidebar().findByText("See what's new");
-    navigationSidebar().icon("close").click();
+    H.navigationSidebar().findByText("See what's new");
+    H.navigationSidebar().icon("close").click();
 
     cy.signInAsNormalUser();
     loadHomepage();
-    navigationSidebar().findByText("See what's new");
+    H.navigationSidebar().findByText("See what's new");
   });
 });
 
@@ -72,5 +72,5 @@ function loadHomepage() {
   // make sure page is loaded
   cy.findByText("loading").should("not.exist");
 
-  navigationSidebar().findByText("Home").should("exist");
+  H.navigationSidebar().findByText("Home").should("exist");
 }

--- a/e2e/test/scenarios/onboarding/notifications.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/notifications.cy.spec.js
@@ -1,11 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  createAlert,
-  createPulse,
-  getCurrentUser,
-  modal,
-  restore,
-} from "e2e/support/helpers";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
 
@@ -60,18 +54,20 @@ const getPulseDetails = ({ card_id, dashboard_id }) => ({
 
 describe("scenarios > account > notifications", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
   });
 
   describe("alerts", () => {
     beforeEach(() => {
       cy.signInAsAdmin().then(() => {
-        getCurrentUser().then(({ body: { id: admin_id } }) => {
+        H.getCurrentUser().then(({ body: { id: admin_id } }) => {
           cy.signInAsNormalUser().then(() => {
-            getCurrentUser().then(({ body: { id: user_id } }) => {
+            H.getCurrentUser().then(({ body: { id: user_id } }) => {
               cy.createQuestion(getQuestionDetails()).then(
                 ({ body: { id: card_id } }) => {
-                  createAlert(getAlertDetails({ card_id, user_id, admin_id }));
+                  H.createAlert(
+                    getAlertDetails({ card_id, user_id, admin_id }),
+                  );
                 },
               );
             });
@@ -86,12 +82,12 @@ describe("scenarios > account > notifications", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Not seeing one here?").click();
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("Not seeing something listed here?");
         cy.findByText("Got it").click();
       });
 
-      modal().should("not.exist");
+      H.modal().should("not.exist");
     });
 
     it("should be able to see alerts notifications", () => {
@@ -112,18 +108,18 @@ describe("scenarios > account > notifications", () => {
       cy.findByText("Question");
       clickUnsubscribe();
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("Confirm you want to unsubscribe");
         cy.findByText("Unsubscribe").click();
         cy.findByText("Unsubscribe").should("not.exist");
       });
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("You’re unsubscribed. Delete this alert as well?");
         cy.findByText("Delete this alert").click();
       });
 
-      modal().should("not.exist");
+      H.modal().should("not.exist");
       cy.findByTestId("notification-list").should("not.exist");
     });
 
@@ -136,7 +132,7 @@ describe("scenarios > account > notifications", () => {
       cy.findByText("Question");
       clickUnsubscribe();
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("Confirm you want to unsubscribe");
         cy.findByText("Unsubscribe").click();
       });
@@ -152,7 +148,7 @@ describe("scenarios > account > notifications", () => {
         cy.createQuestionAndDashboard({
           questionDetails: getQuestionDetails(),
         }).then(({ body: { card_id, dashboard_id } }) => {
-          createPulse(getPulseDetails({ card_id, dashboard_id }));
+          H.createPulse(getPulseDetails({ card_id, dashboard_id }));
         });
       });
     });
@@ -163,12 +159,12 @@ describe("scenarios > account > notifications", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Not seeing one here?").click();
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("Not seeing something listed here?");
         cy.findByText("Got it").click();
       });
 
-      modal().should("not.exist");
+      H.modal().should("not.exist");
     });
 
     it("should be able to see pulses notifications", () => {
@@ -189,7 +185,7 @@ describe("scenarios > account > notifications", () => {
       cy.findByText("Subscription");
       clickUnsubscribe();
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("Delete this subscription?");
         cy.findByText("Yes, delete this subscription").click();
       });

--- a/e2e/test/scenarios/onboarding/onboarding-checklist.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/onboarding-checklist.cy.spec.ts
@@ -1,21 +1,9 @@
-import {
-  describeEE,
-  describeWithSnowplow,
-  enableTracking,
-  expectGoodSnowplowEvent,
-  expectGoodSnowplowEvents,
-  expectNoBadSnowplowEvents,
-  resetSnowplow,
-  restore,
-  setTokenFeatures,
-  updateSetting,
-  visitFullAppEmbeddingUrl,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 import type { ChecklistItemValue } from "metabase/home/components/Onboarding/types";
 
 describe("Onboarding checklist page", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
   });
 
   it("should let non-admins access this page", () => {
@@ -41,15 +29,15 @@ describe("Onboarding checklist page", () => {
   });
 });
 
-describeEE("Inaccessible Onboarding checklist", () => {
+H.describeEE("Inaccessible Onboarding checklist", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
   });
 
   it("should not render when embedded in an iframe or when the instance is whitelabelled", () => {
-    visitFullAppEmbeddingUrl({ url: "/", qs: {} });
+    H.visitFullAppEmbeddingUrl({ url: "/", qs: {} });
     cy.findByTestId("main-navbar-root").within(() => {
       cy.findByRole("listitem", { name: "Home" }).should("be.visible");
       cy.findByRole("listitem", { name: "How to use Metabase" }).should(
@@ -58,12 +46,12 @@ describeEE("Inaccessible Onboarding checklist", () => {
     });
 
     cy.log("Redirects to the home page");
-    visitFullAppEmbeddingUrl({ url: "/getting-started", qs: {} });
+    H.visitFullAppEmbeddingUrl({ url: "/getting-started", qs: {} });
     cy.location("pathname").should("eq", "/");
   });
 
   it("should not render when the instance is whitelabelled", () => {
-    updateSetting("application-name", "Acme, corp.");
+    H.updateSetting("application-name", "Acme, corp.");
 
     cy.visit("/");
     cy.findByTestId("main-navbar-root").within(() => {
@@ -79,17 +67,17 @@ describeEE("Inaccessible Onboarding checklist", () => {
   });
 });
 
-describeWithSnowplow("Onboarding checklist events", () => {
+H.describeWithSnowplow("Onboarding checklist events", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    resetSnowplow();
-    enableTracking();
+    H.resetSnowplow();
+    H.enableTracking();
   });
 
   afterEach(() => {
-    expectNoBadSnowplowEvents();
+    H.expectNoBadSnowplowEvents();
   });
 
   it('should track clicking on "How to use Metabase" button', () => {
@@ -98,7 +86,7 @@ describeWithSnowplow("Onboarding checklist events", () => {
       .findByRole("listitem", { name: "How to use Metabase" })
       .click();
     cy.location("pathname").should("eq", "/getting-started");
-    expectGoodSnowplowEvent({
+    H.expectGoodSnowplowEvent({
       event: "onboarding_checklist_opened",
     });
   });
@@ -121,11 +109,11 @@ describeWithSnowplow("Onboarding checklist events", () => {
       cy.log(
         "The default open accordion item is not tracked - only the page view is",
       );
-      expectGoodSnowplowEvents(PAGE_VIEW);
+      H.expectGoodSnowplowEvents(PAGE_VIEW);
 
       items.forEach(i => {
         cy.findByTestId(`${i}-item`).click();
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: "onboarding_checklist_item_expanded",
           triggered_from: i,
         });
@@ -142,7 +130,7 @@ describeWithSnowplow("Onboarding checklist events", () => {
         .should("have.attr", "aria-selected", "true");
 
       cy.findByTestId("database-cta").button("Add Database").click();
-      expectGoodSnowplowEvent({
+      H.expectGoodSnowplowEvent({
         event: "onboarding_checklist_cta_clicked",
         triggered_from: "database",
         event_detail: "primary",
@@ -152,7 +140,7 @@ describeWithSnowplow("Onboarding checklist events", () => {
 
       cy.findByTestId("invite-item").click();
       cy.findByTestId("invite-cta").button("Invite people").click();
-      expectGoodSnowplowEvent({
+      H.expectGoodSnowplowEvent({
         event: "onboarding_checklist_cta_clicked",
         triggered_from: "invite",
         event_detail: "primary",
@@ -161,7 +149,7 @@ describeWithSnowplow("Onboarding checklist events", () => {
       cy.go("back");
 
       cy.findByTestId("invite-cta").button("Set up Single Sign-on").click();
-      expectGoodSnowplowEvent({
+      H.expectGoodSnowplowEvent({
         event: "onboarding_checklist_cta_clicked",
         triggered_from: "invite",
         event_detail: "secondary",

--- a/e2e/test/scenarios/onboarding/reference/databases.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/reference/databases.cy.spec.js
@@ -1,14 +1,8 @@
-import {
-  entityPickerModal,
-  entityPickerModalTab,
-  popover,
-  restore,
-  startNewQuestion,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 describe("scenarios > reference > databases", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -84,9 +78,9 @@ describe("scenarios > reference > databases", () => {
     });
 
     it("should sort databases in new UI based question data selection popover", () => {
-      startNewQuestion();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.startNewQuestion();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByTestId("item-picker-level-0").within(() => {
           cy.get("[data-index='0']").should("contain.text", "a");
           cy.get("[data-index='1']").should("contain.text", "b");
@@ -113,8 +107,8 @@ function checkQuestionSourceDatabasesOrder() {
   const lastDatabaseIndex = -1;
   const selector = "[data-element-id=list-item]-title";
 
-  startNewQuestion();
-  popover().within(() => {
+  H.startNewQuestion();
+  H.popover().within(() => {
     cy.findByText("Raw Data").click();
     cy.get(selector).as("databaseName").eq(1).should("have.text", "a");
     cy.get("@databaseName")

--- a/e2e/test/scenarios/onboarding/reference/reproductions/5276-remove-field-type.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/reference/reproductions/5276-remove-field-type.cy.spec.js
@@ -1,8 +1,8 @@
-import { popover, restore } from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 describe("issue 5276", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("PUT", "/api/field/*").as("updateField");
   });
@@ -26,7 +26,7 @@ describe("issue 5276", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Score").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    popover().within(() => cy.findByText("No field type").click());
+    H.popover().within(() => cy.findByText("No field type").click());
     cy.button("Save").click();
     cy.wait("@updateField");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -1,20 +1,5 @@
+import { H } from "e2e/support";
 import { USERS } from "e2e/support/cypress_data";
-import {
-  blockSnowplow,
-  describeEE,
-  describeWithSnowplow,
-  expectGoodSnowplowEvent,
-  expectGoodSnowplowEvents,
-  expectNoBadSnowplowEvents,
-  isEE,
-  main,
-  mockSessionProperty,
-  onlyOnEE,
-  popover,
-  resetSnowplow,
-  restore,
-  setTokenFeatures,
-} from "e2e/support/helpers";
 import { SUBSCRIBE_URL } from "metabase/setup/constants";
 
 const { admin } = USERS;
@@ -24,7 +9,7 @@ const locales = ["en", "xx"];
 
 describe("scenarios > setup", () => {
   locales.forEach(locale => {
-    beforeEach(() => restore("blank"));
+    beforeEach(() => H.restore("blank"));
 
     it(
       `should allow you to sign up using "${locale}" browser locale`,
@@ -207,7 +192,7 @@ describe("scenarios > setup", () => {
 
     cy.location("pathname").should("eq", "/");
 
-    main().findByText("Embed Metabase in your app").should("not.exist");
+    H.main().findByText("Embed Metabase in your app").should("not.exist");
 
     cy.wait("@subscribe").then(({ request }) => {
       const formData = request.body;
@@ -237,9 +222,9 @@ describe("scenarios > setup", () => {
   });
 
   it("should pre-fill user info for hosted instances (infra-frontend#1109)", () => {
-    onlyOnEE();
-    setTokenFeatures("none");
-    mockSessionProperty("is-hosted?", true);
+    H.onlyOnEE();
+    H.setTokenFeatures("none");
+    H.mockSessionProperty("is-hosted?", true);
 
     cy.visit(
       "/setup?first_name=John&last_name=Doe&email=john@doe.test&site_name=Doe%20Unlimited",
@@ -389,29 +374,29 @@ describe("scenarios > setup", () => {
 
     cy.location("pathname").should("eq", "/");
 
-    main()
+    H.main()
       .findByText("Get started with Embedding Metabase in your app")
       .should("exist");
 
     // should persist page loads
     cy.reload();
 
-    main()
+    H.main()
       .findByText("Get started with Embedding Metabase in your app")
       .should("exist");
 
-    main().findByText("Hide these").realHover();
+    H.main().findByText("Hide these").realHover();
 
-    popover().findByText("Embedding done, all good").click();
+    H.popover().findByText("Embedding done, all good").click();
 
-    main()
+    H.main()
       .findByText("Get started with Embedding Metabase in your app")
       .should("not.exist");
   });
 });
 
-describeEE("scenarios > setup (EE)", () => {
-  beforeEach(() => restore("blank"));
+H.describeEE("scenarios > setup (EE)", () => {
+  beforeEach(() => H.restore("blank"));
 
   it("should ask for a license token on self-hosted", () => {
     cy.visit("/setup");
@@ -444,7 +429,7 @@ describeEE("scenarios > setup (EE)", () => {
 
     cy.visit("/admin/settings/license");
 
-    main().findByText("Looking for more?").should("exist");
+    H.main().findByText("Looking for more?").should("exist");
 
     cy.wait("@tokenStatus").then(request => {
       expect(request.response?.body.valid).to.equal(true);
@@ -452,14 +437,14 @@ describeEE("scenarios > setup (EE)", () => {
   });
 });
 
-describeWithSnowplow("scenarios > setup", () => {
+H.describeWithSnowplow("scenarios > setup", () => {
   beforeEach(() => {
-    restore("blank");
-    resetSnowplow();
+    H.restore("blank");
+    H.resetSnowplow();
   });
 
   afterEach(() => {
-    expectNoBadSnowplowEvents();
+    H.expectNoBadSnowplowEvents();
   });
 
   it("should send snowplow events", () => {
@@ -470,7 +455,7 @@ describeWithSnowplow("scenarios > setup", () => {
     cy.visit("/setup");
 
     goodEvents++; // 3 - setup/step_seen "welcome"
-    expectGoodSnowplowEvent({
+    H.expectGoodSnowplowEvent({
       event: "step_seen",
       step_number: 0,
       step: "welcome",
@@ -478,7 +463,7 @@ describeWithSnowplow("scenarios > setup", () => {
     skipWelcomePage();
 
     goodEvents++; // 4 - setup/step_seen  "language"
-    expectGoodSnowplowEvent({
+    H.expectGoodSnowplowEvent({
       event: "step_seen",
       step_number: 1,
       step: "language",
@@ -486,7 +471,7 @@ describeWithSnowplow("scenarios > setup", () => {
     selectPreferredLanguageAndContinue();
 
     goodEvents++; // 5 - setup/step_seen "user_info"
-    expectGoodSnowplowEvent({
+    H.expectGoodSnowplowEvent({
       event: "step_seen",
       step_number: 2,
       step: "user_info",
@@ -500,7 +485,7 @@ describeWithSnowplow("scenarios > setup", () => {
 
       cy.findByText("What will you use Metabase for?").should("exist");
       goodEvents++; // 6 - setup/step_seen "usage_question"
-      expectGoodSnowplowEvent({
+      H.expectGoodSnowplowEvent({
         event: "step_seen",
         step_number: 3,
         step: "usage_question",
@@ -508,13 +493,13 @@ describeWithSnowplow("scenarios > setup", () => {
       cy.button("Next").click();
 
       goodEvents++; // 7 - setup/usage_reason_selected
-      expectGoodSnowplowEvent({
+      H.expectGoodSnowplowEvent({
         event: "usage_reason_selected",
         usage_reason: "self-service-analytics",
       });
 
       goodEvents++; // 8 - setup/step_seen "db_connection"
-      expectGoodSnowplowEvent({
+      H.expectGoodSnowplowEvent({
         event: "step_seen",
         step_number: 4,
         step: "db_connection",
@@ -522,14 +507,14 @@ describeWithSnowplow("scenarios > setup", () => {
       cy.findByText("I'll add my data later").click();
 
       goodEvents++; // 9/10 - setup/add_data_later_clicked
-      expectGoodSnowplowEvent({
+      H.expectGoodSnowplowEvent({
         event: "add_data_later_clicked",
       });
 
       // This step is only visile on EE builds
-      if (isEE) {
+      if (H.isEE) {
         goodEvents++; // 10/11 - setup/step_seen "commercial_license"
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: "step_seen",
           step_number: 5,
           step: "license_token",
@@ -537,16 +522,16 @@ describeWithSnowplow("scenarios > setup", () => {
 
         cy.button("Skip").click();
         goodEvents++; // 11/12 - setup/step_seen "commercial_license"
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: "license_token_step_submitted",
           valid_token_present: false,
         });
       }
 
       goodEvents++; // 11/12 - setup/step_seen "data_usage"
-      expectGoodSnowplowEvent({
+      H.expectGoodSnowplowEvent({
         event: "step_seen",
-        step_number: isEE ? 6 : 5,
+        step_number: H.isEE ? 6 : 5,
         step: "data_usage",
       });
 
@@ -554,19 +539,19 @@ describeWithSnowplow("scenarios > setup", () => {
       goodEvents++; // 12/13- - new_user_created (from BE)
 
       goodEvents++; // 13/14- setup/step_seen "completed"
-      expectGoodSnowplowEvent({
+      H.expectGoodSnowplowEvent({
         event: "step_seen",
-        step_number: isEE ? 7 : 6,
+        step_number: H.isEE ? 7 : 6,
         step: "completed",
       });
 
-      expectGoodSnowplowEvents(goodEvents);
+      H.expectGoodSnowplowEvents(goodEvents);
 
       cy.findByText(
         "Get infrequent emails about new releases and feature updates.",
       ).click();
 
-      expectGoodSnowplowEvent({
+      H.expectGoodSnowplowEvent({
         event: "newsletter-toggle-clicked",
         triggered_from: "setup",
         event_detail: "opted-in",
@@ -576,7 +561,7 @@ describeWithSnowplow("scenarios > setup", () => {
         "Get infrequent emails about new releases and feature updates.",
       ).click();
 
-      expectGoodSnowplowEvent({
+      H.expectGoodSnowplowEvent({
         event: "newsletter-toggle-clicked",
         triggered_from: "setup",
         event_detail: "opted-out",
@@ -585,12 +570,12 @@ describeWithSnowplow("scenarios > setup", () => {
   });
 
   it("should ignore snowplow failures and work as normal", () => {
-    blockSnowplow();
+    H.blockSnowplow();
     cy.visit("/setup");
     skipWelcomePage();
 
     // 1 event is sent from the BE, which isn't blocked by blockSnowplow()
-    expectGoodSnowplowEvents(1);
+    H.expectGoodSnowplowEvents(1);
   });
 });
 
@@ -644,7 +629,7 @@ const fillUserAndContinue = ({
 };
 
 const skipLicenseStepOnEE = () => {
-  if (isEE) {
+  if (H.isEE) {
     cy.findByText("Activate your commercial license").should("exist");
     cy.button("Skip").click();
   }

--- a/e2e/test/scenarios/onboarding/setup/user_settings.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/setup/user_settings.cy.spec.js
@@ -1,21 +1,16 @@
+import { H } from "e2e/support";
 import { USERS } from "e2e/support/cypress_data";
 import { NORMAL_USER_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  entityPickerModal,
-  getFullName,
-  popover,
-  restore,
-} from "e2e/support/helpers";
 
 const { normal } = USERS;
 
 const { first_name, last_name, email, password } = normal;
 
 describe("user > settings", () => {
-  const fullName = getFullName(normal);
+  const fullName = H.getFullName(normal);
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
@@ -128,7 +123,7 @@ describe("user > settings", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Use site default").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    popover().within(() => cy.findByText("Indonesian").click());
+    H.popover().within(() => cy.findByText("Indonesian").click());
 
     cy.button("Update").click();
     cy.wait("@updateUserSettings");
@@ -170,7 +165,7 @@ describe("user > settings", () => {
 
     // should be redirected to new question page
     cy.wait("@getUser");
-    entityPickerModal().findByText("Orders Model").click();
+    H.entityPickerModal().findByText("Orders Model").click();
     cy.findByTestId("step-summarize-0-0")
       .findByText("Summarize")
       .should("not.exist");

--- a/e2e/test/scenarios/onboarding/urls.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/urls.cy.spec.js
@@ -1,3 +1,4 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, USERS } from "e2e/support/cypress_data";
 import {
   ADMIN_PERSONAL_COLLECTION_ID,
@@ -6,19 +7,13 @@ import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  getFullName,
-  navigationSidebar,
-  popover,
-  restore,
-} from "e2e/support/helpers";
 import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase-lib/v1/metadata/utils/saved-questions";
 
 const { admin, normal } = USERS;
 
 describe("URLs", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -96,10 +91,10 @@ describe("URLs", () => {
 
     it("should not slugify users' collections page URL", () => {
       cy.visit("/collection/root");
-      navigationSidebar().within(() => {
+      H.navigationSidebar().within(() => {
         cy.icon("ellipsis").click();
       });
-      popover().findByText("Other users' personal collections").click();
+      H.popover().findByText("Other users' personal collections").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("All personal collections");
       cy.location("pathname").should("eq", "/collection/users");
@@ -119,7 +114,7 @@ describe("URLs", () => {
       );
       cy.findByTestId("collection-name-heading").should(
         "have.text",
-        `${getFullName(admin)}'s Personal Collection`,
+        `${H.getFullName(admin)}'s Personal Collection`,
       );
 
       cy.visit(
@@ -129,7 +124,7 @@ describe("URLs", () => {
       );
       cy.findByTestId("collection-name-heading").should(
         "have.text",
-        `${getFullName(normal)}'s Personal Collection`,
+        `${H.getFullName(normal)}'s Personal Collection`,
       );
     });
   });

--- a/e2e/test/scenarios/organization/bookmarks-collection.cy.spec.js
+++ b/e2e/test/scenarios/organization/bookmarks-collection.cy.spec.js
@@ -1,15 +1,9 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_TABLES, USERS } from "e2e/support/cypress_data";
 import {
   ADMIN_PERSONAL_COLLECTION_ID,
   FIRST_COLLECTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  getSidebarSectionTitle,
-  navigationSidebar,
-  popover,
-  restore,
-  visitCollection,
-} from "e2e/support/helpers";
 
 const adminFullName = USERS.admin.first_name + " " + USERS.admin.last_name;
 const adminPersonalCollectionName = adminFullName + "'s Personal Collection";
@@ -18,7 +12,7 @@ const { STATIC_ORDERS_ID } = SAMPLE_DB_TABLES;
 
 describe("scenarios > organization > bookmarks > collection", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -31,36 +25,36 @@ describe("scenarios > organization > bookmarks > collection", () => {
 
     cy.wait("@fetchRootCollectionItems");
 
-    getSidebarSectionTitle("Collections");
+    H.getSidebarSectionTitle("Collections");
     cy.icon("bookmark").should("not.exist");
   });
 
   it("can add, update bookmark name when collection name is updated, and remove bookmarks from collection from its page", () => {
-    visitCollection(FIRST_COLLECTION_ID);
+    H.visitCollection(FIRST_COLLECTION_ID);
 
     // Add bookmark
     cy.icon("bookmark").click();
 
-    navigationSidebar().within(() => {
-      getSidebarSectionTitle(/Bookmarks/);
+    H.navigationSidebar().within(() => {
+      H.getSidebarSectionTitle(/Bookmarks/);
       cy.findAllByText("First collection").should("have.length", 2);
 
       // Once there is a list of bookmarks,
       // we add a heading to the list of collections below the list of bookmarks
-      getSidebarSectionTitle("Collections");
+      H.getSidebarSectionTitle("Collections");
     });
 
     // Rename bookmarked collection
     cy.findByTestId("collection-name-heading").click().type(" 2").blur();
 
-    navigationSidebar()
+    H.navigationSidebar()
       .findAllByText("First collection 2")
       .should("have.length", 2);
 
     // Remove bookmark
     cy.findByTestId("collection-menu").icon("bookmark_filled").click();
 
-    navigationSidebar()
+    H.navigationSidebar()
       .findAllByText("First collection 2")
       .should("have.length", 1);
 
@@ -122,11 +116,11 @@ describe("scenarios > organization > bookmarks > collection", () => {
     // Add bookmark
     cy.findByTestId("collection-menu").icon("bookmark").click();
 
-    navigationSidebar().within(() => {
+    H.navigationSidebar().within(() => {
       cy.icon("bookmark_filled").click({ force: true });
     });
 
-    getSidebarSectionTitle(/Bookmarks/).should("not.exist");
+    H.getSidebarSectionTitle(/Bookmarks/).should("not.exist");
   });
 
   it("can toggle bookmark list visibility", () => {
@@ -135,12 +129,12 @@ describe("scenarios > organization > bookmarks > collection", () => {
     // Add bookmark
     cy.icon("bookmark").click();
 
-    navigationSidebar().within(() => {
-      getSidebarSectionTitle(/Bookmarks/).click();
+    H.navigationSidebar().within(() => {
+      H.getSidebarSectionTitle(/Bookmarks/).click();
 
       cy.findByText(adminPersonalCollectionName).should("not.exist");
 
-      getSidebarSectionTitle(/Bookmarks/).click();
+      H.getSidebarSectionTitle(/Bookmarks/).click();
 
       cy.findByText(adminPersonalCollectionName);
     });
@@ -158,8 +152,8 @@ function addBookmarkTo(name) {
   openEllipsisMenuFor(name);
   cy.findByText("Bookmark").click();
 
-  navigationSidebar().within(() => {
-    getSidebarSectionTitle(/Bookmarks/);
+  H.navigationSidebar().within(() => {
+    H.getSidebarSectionTitle(/Bookmarks/);
     cy.findByText(name);
   });
 }
@@ -169,8 +163,8 @@ function removeBookmarkFrom(name) {
 
   cy.findByText("Remove from bookmarks").click();
 
-  navigationSidebar().within(() => {
-    getSidebarSectionTitle(/Bookmarks/).should("not.exist");
+  H.navigationSidebar().within(() => {
+    H.getSidebarSectionTitle(/Bookmarks/).should("not.exist");
     cy.findByText(name).should("not.exist");
   });
 }
@@ -190,14 +184,14 @@ function bookmarkThenArchive(name) {
 
 function pin(name) {
   openEllipsisMenuFor(name);
-  popover().within(() => {
+  H.popover().within(() => {
     cy.findByText("Pin this").click();
   });
 }
 
 function archive(name) {
   openEllipsisMenuFor(name);
-  popover().within(() => {
+  H.popover().within(() => {
     cy.findByText("Move to trash").click();
   });
 }
@@ -210,8 +204,8 @@ function bookmarkPinnedItem(name) {
 
   cy.findByText("Bookmark").click();
 
-  navigationSidebar().within(() => {
-    getSidebarSectionTitle(/Bookmarks/);
+  H.navigationSidebar().within(() => {
+    H.getSidebarSectionTitle(/Bookmarks/);
     cy.findByText(name);
   });
 }

--- a/e2e/test/scenarios/organization/bookmarks-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/organization/bookmarks-dashboard.cy.spec.js
@@ -1,39 +1,34 @@
+import { H } from "e2e/support";
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  navigationSidebar,
-  openNavigationSidebar,
-  restore,
-  visitDashboard,
-} from "e2e/support/helpers";
 
 describe("scenarios > dashboard > bookmarks", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should add, update bookmark name when dashboard name is updated, and then remove bookmark", () => {
-    visitDashboard(ORDERS_DASHBOARD_ID);
-    openNavigationSidebar();
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.openNavigationSidebar();
 
     // Add bookmark
     cy.get("main header").icon("bookmark").click();
 
-    navigationSidebar().within(() => {
+    H.navigationSidebar().within(() => {
       cy.findByText("Orders in a dashboard");
     });
 
     // Rename bookmarked dashboard
     cy.findByTestId("dashboard-name-heading").click().type(" 2").blur();
 
-    navigationSidebar().within(() => {
+    H.navigationSidebar().within(() => {
       cy.findByText("Orders in a dashboard 2");
     });
 
     // Remove bookmark
     cy.get("main header").icon("bookmark_filled").click();
 
-    navigationSidebar().within(() => {
+    H.navigationSidebar().within(() => {
       cy.findByText("Orders in a dashboard 2").should("not.exist");
     });
   });

--- a/e2e/test/scenarios/organization/bookmarks-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/bookmarks-question.cy.spec.js
@@ -1,41 +1,34 @@
+import { H } from "e2e/support";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  getSidebarSectionTitle,
-  navigationSidebar,
-  openNavigationSidebar,
-  openQuestionActions,
-  restore,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 import { toggleQuestionBookmarkStatus } from "./helpers/bookmark-helpers";
 
 describe("scenarios > question > bookmarks", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.intercept("/api/bookmark/card/*").as("toggleBookmark");
     cy.signInAsAdmin();
   });
 
   it("should add, update bookmark name when question name is updated, then remove bookmark from question page", () => {
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
     toggleQuestionBookmarkStatus();
 
-    openNavigationSidebar();
-    navigationSidebar().within(() => {
-      getSidebarSectionTitle(/Bookmarks/);
+    H.openNavigationSidebar();
+    H.navigationSidebar().within(() => {
+      H.getSidebarSectionTitle(/Bookmarks/);
       cy.findByText("Orders");
     });
 
     // Rename bookmarked question
     cy.findByTestId("saved-question-header-title").click().type(" 2").blur();
 
-    navigationSidebar().within(() => {
+    H.navigationSidebar().within(() => {
       cy.findByText("Orders 2");
     });
 
     cy.log("Turn the question into a model");
-    openQuestionActions();
+    H.openQuestionActions();
     cy.findByRole("dialog").contains("Turn into a model").click();
     cy.findByRole("dialog").contains("Turn this into a model").click();
     cy.findByRole("status")
@@ -46,20 +39,20 @@ describe("scenarios > question > bookmarks", () => {
       .icon("close")
       .click();
 
-    navigationSidebar().within(() => {
+    H.navigationSidebar().within(() => {
       cy.findByLabelText(/Bookmarks/)
         .icon("model")
         .should("exist");
     });
 
     cy.log("Turn the model back into a question");
-    openQuestionActions();
+    H.openQuestionActions();
     cy.findByRole("dialog").contains("Turn back to saved question").click();
     cy.findByRole("status").should("contain", "This is a question now.");
 
-    openNavigationSidebar();
+    H.openNavigationSidebar();
     cy.log("Should not find bookmark");
-    navigationSidebar().within(() => {
+    H.navigationSidebar().within(() => {
       cy.findByLabelText(/Bookmarks/)
         .icon("model")
         .should("not.exist");
@@ -68,8 +61,8 @@ describe("scenarios > question > bookmarks", () => {
     // Remove bookmark
     toggleQuestionBookmarkStatus({ wasSelected: true });
 
-    navigationSidebar().within(() => {
-      getSidebarSectionTitle(/Bookmarks/).should("not.exist");
+    H.navigationSidebar().within(() => {
+      H.getSidebarSectionTitle(/Bookmarks/).should("not.exist");
       cy.findByText("Orders 2").should("not.exist");
     });
   });

--- a/e2e/test/scenarios/organization/bookmarks-reordering.cy.spec.ts
+++ b/e2e/test/scenarios/organization/bookmarks-reordering.cy.spec.ts
@@ -1,12 +1,8 @@
+import { H } from "e2e/support";
 import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  openNavigationSidebar,
-  restore,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 import {
   createAndBookmarkQuestion,
@@ -17,7 +13,7 @@ import {
 
 describe("scenarios > nav > bookmarks", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.intercept("/api/bookmark/card/*").as("toggleBookmark");
     cy.intercept("/api/bookmark/ordering").as("reorderBookmarks");
     cy.signInAsAdmin();
@@ -28,7 +24,7 @@ describe("scenarios > nav > bookmarks", () => {
     ["Question 1", "Question 2", "Question 3"].forEach(
       createAndBookmarkQuestion,
     );
-    openNavigationSidebar();
+    H.openNavigationSidebar();
     verifyBookmarksOrder(["Question 3", "Question 2", "Question 1"]);
     moveBookmark("Question 1", -100);
     verifyBookmarksOrder(["Question 1", "Question 3", "Question 2"]);
@@ -42,11 +38,11 @@ describe("scenarios > nav > bookmarks", () => {
       { statusCode: 500 },
     ).as("failedToReorderBookmarks");
     cy.log("Create two bookmarks");
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
     toggleQuestionBookmarkStatus();
-    visitQuestion(ORDERS_COUNT_QUESTION_ID);
+    H.visitQuestion(ORDERS_COUNT_QUESTION_ID);
     toggleQuestionBookmarkStatus();
-    openNavigationSidebar();
+    H.openNavigationSidebar();
     const initialOrder = ["Orders, Count", "Orders"];
     verifyBookmarksOrder(initialOrder);
     moveBookmark("Orders, Count", 100, {

--- a/e2e/test/scenarios/organization/content-verification.cy.spec.js
+++ b/e2e/test/scenarios/organization/content-verification.cy.spec.js
@@ -1,36 +1,17 @@
+import { H } from "e2e/support";
 import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_DASHBOARD_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  closeCommandPalette,
-  commandPalette,
-  commandPaletteInput,
-  commandPaletteSearch,
-  createModerationReview,
-  describeEE,
-  getPartialPremiumFeatureError,
-  openCommandPalette,
-  openDashboardInfoSidebar,
-  openDashboardMenu,
-  openQuestionActions,
-  popover,
-  questionInfoButton,
-  restore,
-  setTokenFeatures,
-  sidesheet,
-  visitDashboard,
-  visitQuestion,
-} from "e2e/support/helpers";
 
-describeEE("scenarios > premium > content verification", () => {
+H.describeEE("scenarios > premium > content verification", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   context("without a token", () => {
-    beforeEach(() => setTokenFeatures("none"));
+    beforeEach(() => H.setTokenFeatures("none"));
 
     it("should not be able to verify a saved question", () => {
       cy.log("Gate the API");
@@ -45,16 +26,16 @@ describeEE("scenarios > premium > content verification", () => {
         },
       }).then(({ body, status, statusText }) => {
         expect(body).to.deep.include(
-          getPartialPremiumFeatureError("Content verification"),
+          H.getPartialPremiumFeatureError("Content verification"),
         );
         expect(status).to.eq(402);
         expect(statusText).to.eq("Payment Required");
       });
 
       cy.log("Gate the UI");
-      visitQuestion(ORDERS_COUNT_QUESTION_ID);
-      openQuestionActions();
-      popover()
+      H.visitQuestion(ORDERS_COUNT_QUESTION_ID);
+      H.openQuestionActions();
+      H.popover()
         .should("contain", "Add to dashboard")
         .and("not.contain", "Verify this question");
 
@@ -67,8 +48,8 @@ describeEE("scenarios > premium > content verification", () => {
       cy.visit(`/model/${ORDERS_COUNT_QUESTION_ID}`);
       cy.wait("@dataset");
 
-      openQuestionActions();
-      popover()
+      H.openQuestionActions();
+      H.popover()
         .should("contain", "Edit query definition")
         .and("not.contain", "Verify this question");
     });
@@ -86,27 +67,27 @@ describeEE("scenarios > premium > content verification", () => {
         },
       }).then(({ body, status, statusText }) => {
         expect(body).to.deep.include(
-          getPartialPremiumFeatureError("Content verification"),
+          H.getPartialPremiumFeatureError("Content verification"),
         );
         expect(status).to.eq(402);
         expect(statusText).to.eq("Payment Required");
       });
 
       cy.log("Gate the UI");
-      visitDashboard(ORDERS_DASHBOARD_ID);
-      openDashboardMenu();
-      popover()
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
+      H.openDashboardMenu();
+      H.popover()
         .should("contain", "Enter fullscreen")
         .and("not.contain", "Verify this question");
     });
   });
 
   context("premium token with paid features", () => {
-    beforeEach(() => setTokenFeatures("all"));
+    beforeEach(() => H.setTokenFeatures("all"));
 
     describe("an admin", () => {
       it("should be able to verify and unverify a saved question", () => {
-        visitQuestion(ORDERS_COUNT_QUESTION_ID);
+        H.visitQuestion(ORDERS_COUNT_QUESTION_ID);
 
         verifyQuestion();
 
@@ -117,8 +98,8 @@ describeEE("scenarios > premium > content verification", () => {
         });
 
         // 2. Question's history
-        questionInfoButton().click();
-        sidesheet().within(() => {
+        H.questionInfoButton().click();
+        H.sidesheet().within(() => {
           cy.findByText(/You verified this/);
           cy.findByRole("tab", { name: "History" }).click();
           cy.findByText("You verified this");
@@ -126,18 +107,18 @@ describeEE("scenarios > premium > content verification", () => {
         cy.findByLabelText("Close").click();
 
         // 3. Recently viewed list
-        openCommandPalette();
-        commandPalette()
+        H.openCommandPalette();
+        H.commandPalette()
           .findByRole("option", { name: "Orders, Count" })
           .find(".Icon-verified_filled");
-        commandPaletteInput().type("Orders");
-        commandPalette()
+        H.commandPaletteInput().type("Orders");
+        H.commandPalette()
           .findByRole("option", { name: "Orders, Count" })
           .find(".Icon-verified_filled");
-        closeCommandPalette();
+        H.closeCommandPalette();
 
         // 4. Search results
-        commandPaletteSearch("orders");
+        H.commandPaletteSearch("orders");
         cy.findAllByTestId("search-result-item")
           .contains("Orders, Count")
           .siblings(".Icon-verified_filled");
@@ -150,7 +131,7 @@ describeEE("scenarios > premium > content verification", () => {
           .icon("verified");
 
         cy.log("Go back to the question and remove the verification");
-        visitQuestion(ORDERS_COUNT_QUESTION_ID);
+        H.visitQuestion(ORDERS_COUNT_QUESTION_ID);
 
         removeQuestionVerification();
 
@@ -160,8 +141,8 @@ describeEE("scenarios > premium > content verification", () => {
           .should("not.exist");
 
         // 2. Question's history
-        questionInfoButton().click();
-        sidesheet().within(() => {
+        H.questionInfoButton().click();
+        H.sidesheet().within(() => {
           cy.findByRole("tab", { name: "History" }).click();
           cy.findByText("You removed verification");
           cy.findByText("You verified this"); // Implicit assertion - there can be only one :)
@@ -169,20 +150,20 @@ describeEE("scenarios > premium > content verification", () => {
         cy.findByLabelText("Close").click();
 
         // 3. Recently viewed list
-        openCommandPalette();
-        commandPalette()
+        H.openCommandPalette();
+        H.commandPalette()
           .findByRole("option", { name: "Orders, Count" })
           .find(".Icon-verified_filled")
           .should("not.exist");
-        commandPaletteInput().type("Orders");
-        commandPalette()
+        H.commandPaletteInput().type("Orders");
+        H.commandPalette()
           .findByRole("option", { name: "Orders, Count" })
           .find(".Icon-verified_filled")
           .should("not.exist");
-        closeCommandPalette();
+        H.closeCommandPalette();
 
         // 4. Search results
-        commandPaletteSearch("orders");
+        H.commandPaletteSearch("orders");
         cy.findAllByTestId("search-result-item")
           .contains("Orders, Count")
           .siblings(".Icon-verified_filed")
@@ -198,7 +179,7 @@ describeEE("scenarios > premium > content verification", () => {
       });
 
       it("should be able to verify and unverify a dashboard", () => {
-        visitDashboard(ORDERS_DASHBOARD_ID);
+        H.visitDashboard(ORDERS_DASHBOARD_ID);
 
         verifyDashboard();
 
@@ -209,8 +190,8 @@ describeEE("scenarios > premium > content verification", () => {
         });
 
         // 2. Question's history
-        openDashboardInfoSidebar();
-        sidesheet().within(() => {
+        H.openDashboardInfoSidebar();
+        H.sidesheet().within(() => {
           cy.findByText(/You verified this/);
           cy.findByRole("tab", { name: "History" }).click();
           cy.findByText("You verified this");
@@ -218,14 +199,14 @@ describeEE("scenarios > premium > content verification", () => {
         cy.findByLabelText("Close").click();
 
         // // 3. Recently viewed list
-        openCommandPalette();
-        commandPalette()
+        H.openCommandPalette();
+        H.commandPalette()
           .findByRole("option", { name: "Orders in a dashboard" })
           .find(".Icon-verified_filled");
-        closeCommandPalette();
+        H.closeCommandPalette();
 
         // // 4. Search results
-        commandPaletteSearch("orders");
+        H.commandPaletteSearch("orders");
         cy.findAllByTestId("search-result-item")
           .contains("Orders in a dashboard")
           .siblings(".Icon-verified_filled");
@@ -238,7 +219,7 @@ describeEE("scenarios > premium > content verification", () => {
           .icon("verified");
 
         cy.log("Go back to the question and remove the verification");
-        visitDashboard(ORDERS_DASHBOARD_ID);
+        H.visitDashboard(ORDERS_DASHBOARD_ID);
 
         removeDashboardVerification();
 
@@ -248,8 +229,8 @@ describeEE("scenarios > premium > content verification", () => {
           .should("not.exist");
 
         // 2. Question's history
-        openDashboardInfoSidebar().click();
-        sidesheet().within(() => {
+        H.openDashboardInfoSidebar().click();
+        H.sidesheet().within(() => {
           cy.findByRole("tab", { name: "History" }).click();
           cy.findByText("You removed verification");
           cy.findByText("You verified this"); // Implicit assertion - there can be only one :)
@@ -257,15 +238,15 @@ describeEE("scenarios > premium > content verification", () => {
         cy.findByLabelText("Close").click();
 
         // 3. Recently viewed list
-        openCommandPalette();
-        commandPalette()
+        H.openCommandPalette();
+        H.commandPalette()
           .findByRole("option", { name: "Orders in a dashboard" })
           .find(".Icon-verified_filled")
           .should("not.exist");
-        closeCommandPalette();
+        H.closeCommandPalette();
 
         // 4. Search results
-        commandPaletteSearch("orders");
+        H.commandPaletteSearch("orders");
         cy.findAllByTestId("search-result-item")
           .contains("Orders in a dashboard")
           .siblings(".Icon-verified_filed")
@@ -283,13 +264,13 @@ describeEE("scenarios > premium > content verification", () => {
 
     describe("non-admin user", () => {
       beforeEach(() => {
-        createModerationReview({
+        H.createModerationReview({
           status: "verified",
           moderated_item_type: "card",
           moderated_item_id: ORDERS_COUNT_QUESTION_ID,
         });
 
-        createModerationReview({
+        H.createModerationReview({
           status: "verified",
           moderated_item_type: "dashboard",
           moderated_item_id: ORDERS_DASHBOARD_ID,
@@ -299,7 +280,7 @@ describeEE("scenarios > premium > content verification", () => {
       });
 
       it("should be able to see that a question has been verified but can't moderate the question themselves", () => {
-        visitQuestion(ORDERS_COUNT_QUESTION_ID);
+        H.visitQuestion(ORDERS_COUNT_QUESTION_ID);
 
         cy.findByTestId("qb-header").within(() => {
           cy.findByText("Orders, Count");
@@ -307,20 +288,20 @@ describeEE("scenarios > premium > content verification", () => {
         });
 
         cy.log("Non-admin users cannot change question verification status.");
-        openQuestionActions();
-        popover()
+        H.openQuestionActions();
+        H.popover()
           .should("contain", "Add to dashboard")
           .and("not.contain", "Remove verification");
 
-        questionInfoButton().click();
-        sidesheet().within(() => {
+        H.questionInfoButton().click();
+        H.sidesheet().within(() => {
           cy.findAllByText(/A moderator verified this/); // overview tab
           cy.findByRole("tab", { name: "History" }).click();
           cy.findAllByText("A moderator verified this"); // history tab
         });
         cy.findByLabelText("Close").click();
 
-        commandPaletteSearch("orders");
+        H.commandPaletteSearch("orders");
         cy.log("Verified content should show up higher in search results");
         cy.findAllByTestId("search-result-item")
           .eq(1)
@@ -337,7 +318,7 @@ describeEE("scenarios > premium > content verification", () => {
       });
 
       it("should be able to see that a dashboard has been verified but can't moderate the dashboard themselves", () => {
-        visitDashboard(ORDERS_DASHBOARD_ID);
+        H.visitDashboard(ORDERS_DASHBOARD_ID);
 
         cy.findByTestId("dashboard-header").within(() => {
           cy.findByText("Orders in a dashboard");
@@ -345,20 +326,20 @@ describeEE("scenarios > premium > content verification", () => {
         });
 
         cy.log("Non-admin users cannot change question verification status.");
-        openDashboardMenu();
-        popover()
+        H.openDashboardMenu();
+        H.popover()
           .should("contain", "Enter fullscreen")
           .and("not.contain", "Remove verification");
 
-        openDashboardInfoSidebar();
-        sidesheet().within(() => {
+        H.openDashboardInfoSidebar();
+        H.sidesheet().within(() => {
           cy.findAllByText(/A moderator verified this/); // overview tab
           cy.findByRole("tab", { name: "History" }).click();
           cy.findAllByText("A moderator verified this"); // history tab
         });
         cy.findByLabelText("Close").click();
 
-        commandPaletteSearch("orders");
+        H.commandPaletteSearch("orders");
         cy.log("Verified content should show up higher in search results");
         cy.findAllByTestId("search-result-item")
           .first()
@@ -378,51 +359,51 @@ describeEE("scenarios > premium > content verification", () => {
 
   context("token expired or removed", () => {
     beforeEach(() => {
-      setTokenFeatures("all");
-      createModerationReview({
+      H.setTokenFeatures("all");
+      H.createModerationReview({
         status: "verified",
         moderated_item_type: "card",
         moderated_item_id: ORDERS_COUNT_QUESTION_ID,
       });
 
-      createModerationReview({
+      H.createModerationReview({
         status: "verified",
         moderated_item_type: "dashboard",
         moderated_item_id: ORDERS_DASHBOARD_ID,
       });
 
-      setTokenFeatures("none");
+      H.setTokenFeatures("none");
     });
 
     it("should not treat the question as verified anymore", () => {
-      visitQuestion(ORDERS_COUNT_QUESTION_ID);
+      H.visitQuestion(ORDERS_COUNT_QUESTION_ID);
 
       cy.findByTestId("qb-header").within(() => {
         cy.findByText("Orders, Count");
         cy.icon("verified").should("not.exist");
       });
 
-      questionInfoButton().click();
-      sidesheet().within(() => {
+      H.questionInfoButton().click();
+      H.sidesheet().within(() => {
         cy.findByRole("tab", { name: "History" }).click();
         cy.contains(/created this./);
         cy.contains(/verified this/).should("not.exist");
       });
       cy.findByLabelText("Close").click();
 
-      openCommandPalette();
-      commandPalette()
+      H.openCommandPalette();
+      H.commandPalette()
         .findByRole("option", { name: "Orders, Count" })
         .find(".Icon-verified_filled")
         .should("not.exist");
-      commandPaletteInput().type("Orders");
-      commandPalette()
+      H.commandPaletteInput().type("Orders");
+      H.commandPalette()
         .findByRole("option", { name: "Orders, Count" })
         .find(".Icon-verified_filled")
         .should("not.exist");
-      closeCommandPalette();
+      H.closeCommandPalette();
 
-      commandPaletteSearch("orders");
+      H.commandPaletteSearch("orders");
       cy.log(
         "The question lost the verification status and does not appear high in search results anymore",
       );
@@ -435,22 +416,22 @@ describeEE("scenarios > premium > content verification", () => {
     });
 
     it("should not treat the dashboard as verified anymore", () => {
-      visitDashboard(ORDERS_DASHBOARD_ID);
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
 
       cy.findByTestId("dashboard-header").within(() => {
         cy.findByText("Orders in a dashboard");
         cy.icon("verified").should("not.exist");
       });
 
-      openDashboardInfoSidebar();
-      sidesheet().within(() => {
+      H.openDashboardInfoSidebar();
+      H.sidesheet().within(() => {
         cy.findByRole("tab", { name: "History" }).click();
         cy.contains(/created this./);
         cy.contains(/verified this/).should("not.exist");
       });
       cy.findByLabelText("Close").click();
 
-      commandPaletteSearch("orders");
+      H.commandPaletteSearch("orders");
       cy.log(
         "The question lost the verification status and does not appear high in search results anymore",
       );
@@ -467,7 +448,7 @@ describeEE("scenarios > premium > content verification", () => {
 function verifyQuestion() {
   cy.intercept("GET", "/api/card/*").as("loadCard");
 
-  openQuestionActions();
+  H.openQuestionActions();
   cy.findByTextEnsureVisible("Verify this question").click();
 
   cy.wait("@loadCard").then(({ response: { body } }) => {
@@ -496,7 +477,7 @@ function verifyQuestion() {
 function verifyDashboard() {
   cy.intercept("GET", "/api/dashboard/*").as("loadDashboard");
 
-  openDashboardMenu();
+  H.openDashboardMenu();
   cy.findByTextEnsureVisible("Verify this dashboard").click();
 
   cy.wait("@loadDashboard").then(({ response: { body } }) => {
@@ -523,11 +504,11 @@ function verifyDashboard() {
 }
 
 function removeQuestionVerification() {
-  openQuestionActions();
+  H.openQuestionActions();
   cy.findByTextEnsureVisible("Remove verification").click();
 }
 
 function removeDashboardVerification() {
-  openDashboardMenu();
+  H.openDashboardMenu();
   cy.findByTextEnsureVisible("Remove verification").click();
 }

--- a/e2e/test/scenarios/organization/edit-history-metadata.cy.spec.js
+++ b/e2e/test/scenarios/organization/edit-history-metadata.cy.spec.js
@@ -1,13 +1,13 @@
+import { H } from "e2e/support";
 import { USERS } from "e2e/support/cypress_data";
 import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import { restore, visitDashboard, visitQuestion } from "e2e/support/helpers";
 
 describe("scenarios > collection items metadata", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
   });
 
   describe("last edit date", () => {
@@ -16,14 +16,14 @@ describe("scenarios > collection items metadata", () => {
     });
 
     it("should display last edit moment for dashboards", () => {
-      visitDashboard(ORDERS_DASHBOARD_ID);
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
       changeDashboard();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Edited a few seconds ago/i);
     });
 
     it("should display last edit moment for questions", () => {
-      visitQuestion(ORDERS_QUESTION_ID);
+      H.visitQuestion(ORDERS_QUESTION_ID);
       changeQuestion();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Edited a few seconds ago/i);
@@ -33,10 +33,10 @@ describe("scenarios > collection items metadata", () => {
   describe("last editor", () => {
     it("should display if user is the last editor", () => {
       cy.signInAsAdmin();
-      visitDashboard(ORDERS_DASHBOARD_ID);
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Edited .* by you/i);
-      visitQuestion(ORDERS_QUESTION_ID);
+      H.visitQuestion(ORDERS_QUESTION_ID);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Edited .* by you/i);
       cy.signOut();
@@ -48,10 +48,10 @@ describe("scenarios > collection items metadata", () => {
       const expectedName = `${first_name} ${last_name.charAt(0)}.`;
 
       cy.signIn("normal");
-      visitDashboard(ORDERS_DASHBOARD_ID);
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(new RegExp(`Edited .* by ${expectedName}`, "i"));
-      visitQuestion(ORDERS_QUESTION_ID);
+      H.visitQuestion(ORDERS_QUESTION_ID);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(new RegExp(`Edited .* by ${expectedName}`, "i"));
     });

--- a/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
+++ b/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
@@ -1,3 +1,4 @@
+import { H } from "e2e/support";
 import { USER_GROUPS, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
@@ -8,37 +9,13 @@ import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  type DashboardDetails,
-  type StructuredQuestionDetails,
-  createCollection,
-  createDashboard,
-  createQuestion,
-  editDashboard,
-  entityPickerModal,
-  entityPickerModalItem,
-  entityPickerModalTab,
-  getDashboardCard,
-  getNotebookStep,
-  openQuestionActions,
-  popover,
-  resetTestTable,
-  restore,
-  resyncDatabase,
-  startNewQuestion,
-  undoToast,
-  updateDashboardCards,
-  visitDashboard,
-  visitQuestion,
-  visualize,
-} from "e2e/support/helpers";
 import * as H from "e2e/support/helpers";
 import type { DashboardCard } from "metabase-types/api";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
 const { ALL_USERS_GROUP } = USER_GROUPS;
 
-const cardDetails: StructuredQuestionDetails = {
+const cardDetails: H.StructuredQuestionDetails = {
   name: "Question",
   type: "question",
   query: {
@@ -49,16 +26,16 @@ const cardDetails: StructuredQuestionDetails = {
 
 describe("scenarios > organization > entity picker", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   describe("data picker", () => {
     describe("tables", () => {
       it("should select a table from local search results", () => {
-        startNewQuestion();
-        entityPickerModal().within(() => {
-          entityPickerModalTab("Tables").click();
+        H.startNewQuestion();
+        H.entityPickerModal().within(() => {
+          H.entityPickerModalTab("Tables").click();
           enterSearchText({
             text: "prod",
             placeholder: "Search this database or everywhere…",
@@ -70,13 +47,13 @@ describe("scenarios > organization > entity picker", () => {
           });
           cy.findByText("Products").click();
         });
-        getNotebookStep("data").findByText("Products").should("be.visible");
+        H.getNotebookStep("data").findByText("Products").should("be.visible");
       });
 
       it("should select a table from global search results", () => {
-        startNewQuestion();
-        entityPickerModal().within(() => {
-          entityPickerModalTab("Tables").click();
+        H.startNewQuestion();
+        H.entityPickerModal().within(() => {
+          H.entityPickerModalTab("Tables").click();
           enterSearchText({
             text: "prod",
             placeholder: "Search this database or everywhere…",
@@ -88,32 +65,32 @@ describe("scenarios > organization > entity picker", () => {
           });
           cy.findByText("Products").click();
         });
-        getNotebookStep("data").findByText("Products").should("be.visible");
+        H.getNotebookStep("data").findByText("Products").should("be.visible");
       });
 
       it("should switch between recents and table tabs", () => {
         cy.signInAsAdmin();
-        startNewQuestion();
+        H.startNewQuestion();
 
         cy.log("create a recent item");
-        entityPickerModal().within(() => {
-          entityPickerModalTab("Tables").click();
+        H.entityPickerModal().within(() => {
+          H.entityPickerModalTab("Tables").click();
           cy.findByText("Products").click();
         });
 
         cy.log(
           "should search globally for recents and locally for tables by default",
         );
-        getNotebookStep("data").findByText("Products").click();
-        entityPickerModal().within(() => {
+        H.getNotebookStep("data").findByText("Products").click();
+        H.entityPickerModal().within(() => {
           cy.log("local -> global transition without changing search text");
-          entityPickerModalTab("Tables").click();
+          H.entityPickerModalTab("Tables").click();
           enterSearchText({
             text: "Orders",
             placeholder: "Search this database or everywhere…",
           });
           localSearchTab("Sample Database").should("be.checked");
-          entityPickerModalTab("Recents").click();
+          H.entityPickerModalTab("Recents").click();
           existingSearchTab().click();
           globalSearchTab().should("not.exist");
           localSearchTab("Sample Database").should("not.exist");
@@ -122,7 +99,7 @@ describe("scenarios > organization > entity picker", () => {
           });
 
           cy.log("global -> local transition without changing search text");
-          entityPickerModalTab("Tables").click();
+          H.entityPickerModalTab("Tables").click();
           existingSearchTab().click();
           localSearchTab("Sample Database").should("be.checked");
           assertSearchResults({
@@ -131,7 +108,7 @@ describe("scenarios > organization > entity picker", () => {
           });
 
           cy.log("local -> global transition with changing search text");
-          entityPickerModalTab("Recents").click();
+          H.entityPickerModalTab("Recents").click();
           enterSearchText({
             text: "people",
             placeholder: "Search…",
@@ -144,7 +121,7 @@ describe("scenarios > organization > entity picker", () => {
 
           cy.log("return to the previous tab when the search input is cleared");
           cy.findByPlaceholderText("Search…").clear();
-          entityPickerModalTab("Recents").should(
+          H.entityPickerModalTab("Recents").should(
             "have.attr",
             "aria-selected",
             "true",
@@ -153,9 +130,9 @@ describe("scenarios > organization > entity picker", () => {
       });
 
       it("should search for tables in the only database", () => {
-        startNewQuestion();
-        entityPickerModal().within(() => {
-          entityPickerModalTab("Tables").click();
+        H.startNewQuestion();
+        H.entityPickerModal().within(() => {
+          H.entityPickerModalTab("Tables").click();
           enterSearchText({
             text: "prod",
             placeholder: "Search this database or everywhere…",
@@ -168,7 +145,7 @@ describe("scenarios > organization > entity picker", () => {
           });
           cy.findByText("Products").click();
         });
-        getNotebookStep("data").findByText("Products").should("be.visible");
+        H.getNotebookStep("data").findByText("Products").should("be.visible");
       });
 
       it("should search by table display names and not real names", () => {
@@ -177,11 +154,11 @@ describe("scenarios > organization > entity picker", () => {
           display_name: "Events",
         });
         cy.signInAsNormalUser();
-        startNewQuestion();
+        H.startNewQuestion();
 
         cy.log("real table name should give no results");
-        entityPickerModal().within(() => {
-          entityPickerModalTab("Tables").click();
+        H.entityPickerModal().within(() => {
+          H.entityPickerModalTab("Tables").click();
           enterSearchText({
             text: "Orders",
             placeholder: "Search this database or everywhere…",
@@ -195,7 +172,7 @@ describe("scenarios > organization > entity picker", () => {
         });
 
         cy.log("display table name should be used to search for a table");
-        entityPickerModal().within(() => {
+        H.entityPickerModal().within(() => {
           enterSearchText({
             text: "Events",
             placeholder: "Search this database or everywhere…",
@@ -208,22 +185,22 @@ describe("scenarios > organization > entity picker", () => {
           });
           cy.findByText("Events").click();
         });
-        getNotebookStep("data").findByText("Events").should("be.visible");
+        H.getNotebookStep("data").findByText("Events").should("be.visible");
       });
 
       it(
         "should search for tables when there are multiple databases",
         { tags: "@external" },
         () => {
-          resetTestTable({ type: "postgres", table: "multi_schema" });
-          restore("postgres-writable");
+          H.resetTestTable({ type: "postgres", table: "multi_schema" });
+          H.restore("postgres-writable");
           cy.signInAsAdmin();
-          resyncDatabase({ dbId: WRITABLE_DB_ID });
+          H.resyncDatabase({ dbId: WRITABLE_DB_ID });
 
           cy.log("first database - pre-selected");
-          startNewQuestion();
-          entityPickerModal().within(() => {
-            entityPickerModalTab("Tables").click();
+          H.startNewQuestion();
+          H.entityPickerModal().within(() => {
+            H.entityPickerModalTab("Tables").click();
             enterSearchText({
               text: "prod",
               placeholder: "Search this database or everywhere…",
@@ -237,8 +214,8 @@ describe("scenarios > organization > entity picker", () => {
           });
 
           cy.log("second database");
-          entityPickerModal().within(() => {
-            entityPickerModalTab("Tables").click();
+          H.entityPickerModal().within(() => {
+            H.entityPickerModalTab("Tables").click();
             cy.findByText("Writable Postgres12").click();
             enterSearchText({
               text: "s",
@@ -253,9 +230,9 @@ describe("scenarios > organization > entity picker", () => {
           });
 
           cy.log("first database - manually selected");
-          startNewQuestion();
-          entityPickerModal().within(() => {
-            entityPickerModalTab("Tables").click();
+          H.startNewQuestion();
+          H.entityPickerModal().within(() => {
+            H.entityPickerModalTab("Tables").click();
             cy.findByText("Sample Database").click();
             enterSearchText({
               text: "prod",
@@ -275,15 +252,15 @@ describe("scenarios > organization > entity picker", () => {
         "should search for tables in a multi-schema database",
         { tags: "@external" },
         () => {
-          resetTestTable({ type: "postgres", table: "multi_schema" });
-          restore("postgres-writable");
+          H.resetTestTable({ type: "postgres", table: "multi_schema" });
+          H.restore("postgres-writable");
           cy.signInAsAdmin();
-          resyncDatabase({ dbId: WRITABLE_DB_ID });
+          H.resyncDatabase({ dbId: WRITABLE_DB_ID });
 
           cy.log("first schema");
-          startNewQuestion();
-          entityPickerModal().within(() => {
-            entityPickerModalTab("Tables").click();
+          H.startNewQuestion();
+          H.entityPickerModal().within(() => {
+            H.entityPickerModalTab("Tables").click();
             cy.findByText("Writable Postgres12").click();
             enterSearchText({
               text: "s",
@@ -298,8 +275,8 @@ describe("scenarios > organization > entity picker", () => {
           });
 
           cy.log("second schema");
-          entityPickerModal().within(() => {
-            entityPickerModalTab("Tables").click();
+          H.entityPickerModal().within(() => {
+            H.entityPickerModalTab("Tables").click();
             cy.findByText("Wild").click();
             enterSearchText({
               text: "s",
@@ -318,11 +295,11 @@ describe("scenarios > organization > entity picker", () => {
         "should search for tables in a schema-less database",
         { tags: "@external" },
         () => {
-          restore("mysql-8");
+          H.restore("mysql-8");
           cy.signInAsAdmin();
-          startNewQuestion();
-          entityPickerModal().within(() => {
-            entityPickerModalTab("Tables").click();
+          H.startNewQuestion();
+          H.entityPickerModal().within(() => {
+            H.entityPickerModalTab("Tables").click();
             cy.findByText("QA MySQL8").click();
             enterSearchText({
               text: "orders",
@@ -365,17 +342,17 @@ describe("scenarios > organization > entity picker", () => {
           },
         ];
         testCases.forEach(({ tab, cardName, sourceName }) => {
-          startNewQuestion();
-          entityPickerModal().within(() => {
-            entityPickerModalTab(tab).click();
+          H.startNewQuestion();
+          H.entityPickerModal().within(() => {
+            H.entityPickerModalTab(tab).click();
             enterSearchText({
               text: cardName,
               placeholder: "Search this collection or everywhere…",
             });
             cy.findByText(cardName).click();
           });
-          getNotebookStep("data").findByText(sourceName).should("be.visible");
-          visualize();
+          H.getNotebookStep("data").findByText(sourceName).should("be.visible");
+          H.visualize();
         });
       });
 
@@ -402,9 +379,9 @@ describe("scenarios > organization > entity picker", () => {
           },
         ];
         testCases.forEach(({ tab, cardName, sourceName }) => {
-          startNewQuestion();
-          entityPickerModal().within(() => {
-            entityPickerModalTab(tab).click();
+          H.startNewQuestion();
+          H.entityPickerModal().within(() => {
+            H.entityPickerModalTab(tab).click();
             enterSearchText({
               text: cardName,
               placeholder: "Search this collection or everywhere…",
@@ -412,8 +389,8 @@ describe("scenarios > organization > entity picker", () => {
             selectGlobalSearchTab();
             cy.findByText(cardName).click();
           });
-          getNotebookStep("data").findByText(sourceName).should("be.visible");
-          visualize();
+          H.getNotebookStep("data").findByText(sourceName).should("be.visible");
+          H.visualize();
         });
       });
 
@@ -421,7 +398,7 @@ describe("scenarios > organization > entity picker", () => {
         cy.signInAsAdmin();
         createTestCards();
         cy.signInAsNormalUser();
-        startNewQuestion();
+        H.startNewQuestion();
         testCardSearchForNormalUser({ tabs });
       });
 
@@ -435,7 +412,7 @@ describe("scenarios > organization > entity picker", () => {
         });
 
         cy.signIn("nocollection");
-        startNewQuestion();
+        H.startNewQuestion();
         testCardSearchForInaccessibleRootCollection({
           tabs,
           isRootSelected: true,
@@ -445,7 +422,7 @@ describe("scenarios > organization > entity picker", () => {
       it("should not allow local search for `all personal collections`", () => {
         cy.signInAsAdmin();
         createTestCards();
-        startNewQuestion();
+        H.startNewQuestion();
         testCardSearchForAllPersonalCollections({ tabs });
       });
     });
@@ -466,15 +443,15 @@ describe("scenarios > organization > entity picker", () => {
       ];
       testCases.forEach(({ tab, cardName }) => {
         selectQuestionFromDashboard();
-        entityPickerModal().within(() => {
-          entityPickerModalTab(tab).click();
+        H.entityPickerModal().within(() => {
+          H.entityPickerModalTab(tab).click();
           enterSearchText({
             text: cardName,
             placeholder: "Search this collection or everywhere…",
           });
           cy.findByText(cardName).click();
         });
-        getDashboardCard().findByText(cardName).should("be.visible");
+        H.getDashboardCard().findByText(cardName).should("be.visible");
       });
     });
 
@@ -490,8 +467,8 @@ describe("scenarios > organization > entity picker", () => {
       ];
       testCases.forEach(({ tab, cardName }) => {
         selectQuestionFromDashboard();
-        entityPickerModal().within(() => {
-          entityPickerModalTab(tab).click();
+        H.entityPickerModal().within(() => {
+          H.entityPickerModalTab(tab).click();
           enterSearchText({
             text: cardName,
             placeholder: "Search this collection or everywhere…",
@@ -499,7 +476,7 @@ describe("scenarios > organization > entity picker", () => {
           selectGlobalSearchTab();
           cy.findByText(cardName).click();
         });
-        getDashboardCard().findByText(cardName).should("be.visible");
+        H.getDashboardCard().findByText(cardName).should("be.visible");
       });
     });
 
@@ -538,11 +515,11 @@ describe("scenarios > organization > entity picker", () => {
 
   describe("collection picker", () => {
     it("should select a collection from local search results", () => {
-      visitQuestion(ORDERS_QUESTION_ID);
-      openQuestionActions();
-      popover().findByText("Move").click();
+      H.visitQuestion(ORDERS_QUESTION_ID);
+      H.openQuestionActions();
+      H.popover().findByText("Move").click();
 
-      entityPickerModal().within(() => {
+      H.entityPickerModal().within(() => {
         enterSearchText({
           text: "first",
           placeholder: "Search this collection or everywhere…",
@@ -551,15 +528,15 @@ describe("scenarios > organization > entity picker", () => {
         cy.findByText("First collection").click();
         cy.button("Move").click();
       });
-      undoToast().findByText("First collection").should("be.visible");
+      H.undoToast().findByText("First collection").should("be.visible");
     });
 
     it("should select a collection from global search results", () => {
-      visitQuestion(ORDERS_QUESTION_ID);
-      openQuestionActions();
-      popover().findByText("Move").click();
+      H.visitQuestion(ORDERS_QUESTION_ID);
+      H.openQuestionActions();
+      H.popover().findByText("Move").click();
 
-      entityPickerModal().within(() => {
+      H.entityPickerModal().within(() => {
         enterSearchText({
           text: "second",
           placeholder: "Search this collection or everywhere…",
@@ -568,19 +545,19 @@ describe("scenarios > organization > entity picker", () => {
         cy.findByText("Second collection").click();
         cy.button("Move").click();
       });
-      undoToast().findByText("Second collection").should("be.visible");
+      H.undoToast().findByText("Second collection").should("be.visible");
     });
 
     it("should search for collections for a normal user", () => {
       cy.signInAsAdmin();
       createTestCollections();
       cy.signInAsNormalUser();
-      visitQuestion(ORDERS_QUESTION_ID);
-      openQuestionActions();
-      popover().findByText("Move").click();
+      H.visitQuestion(ORDERS_QUESTION_ID);
+      H.openQuestionActions();
+      H.popover().findByText("Move").click();
 
       cy.log("root collection - automatically selected");
-      entityPickerModal().within(() => {
+      H.entityPickerModal().within(() => {
         enterSearchText({
           text: "collection",
           placeholder: "Search this collection or everywhere…",
@@ -602,8 +579,8 @@ describe("scenarios > organization > entity picker", () => {
       });
 
       cy.log("regular collection");
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Collections").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Collections").click();
         cy.findByText("First collection").click();
         enterSearchText({
           text: "collection",
@@ -617,8 +594,8 @@ describe("scenarios > organization > entity picker", () => {
       });
 
       cy.log("personal collection");
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Collections").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Collections").click();
         cy.findByText(/Personal Collection/).click();
         enterSearchText({
           text: "personal collection 1",
@@ -650,12 +627,12 @@ describe("scenarios > organization > entity picker", () => {
       });
 
       cy.signIn("nocollection");
-      visitQuestion(ORDERS_QUESTION_ID);
-      openQuestionActions();
-      popover().findByText("Move").click();
+      H.visitQuestion(ORDERS_QUESTION_ID);
+      H.openQuestionActions();
+      H.popover().findByText("Move").click();
 
       cy.log("root collection");
-      entityPickerModal().within(() => {
+      H.entityPickerModal().within(() => {
         cy.findByText("Collections").click();
         enterSearchText({
           text: "collection",
@@ -676,8 +653,8 @@ describe("scenarios > organization > entity picker", () => {
       });
 
       cy.log("personal collection");
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Collections").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Collections").click();
         cy.findByText(/Personal Collection/).click();
         enterSearchText({
           text: "personal collection 2",
@@ -700,12 +677,12 @@ describe("scenarios > organization > entity picker", () => {
     it("should not allow local search for `all personal collections`", () => {
       cy.signInAsAdmin();
       createTestCollections();
-      visitQuestion(ORDERS_QUESTION_ID);
-      openQuestionActions();
-      popover().findByText("Move").click();
+      H.visitQuestion(ORDERS_QUESTION_ID);
+      H.openQuestionActions();
+      H.popover().findByText("Move").click();
 
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Collections").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Collections").click();
         cy.findByText("All personal collections").click();
         enterSearchText({
           text: "personal collection",
@@ -734,14 +711,14 @@ describe("scenarios > organization > entity picker", () => {
         cy.findByLabelText("Which collection should this go in?").click();
       });
 
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Collections").click();
-        entityPickerModalItem(0, "All personal collections").click();
-        entityPickerModalItem(
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Collections").click();
+        H.entityPickerModalItem(0, "All personal collections").click();
+        H.entityPickerModalItem(
           1,
           "Robert Tableton's Personal Collection",
         ).click();
-        entityPickerModalItem(2, "Normal personal collection 2").click();
+        H.entityPickerModalItem(2, "Normal personal collection 2").click();
         cy.button("Select").click();
       });
 
@@ -752,18 +729,18 @@ describe("scenarios > organization > entity picker", () => {
         cy.findByLabelText("Which collection should this go in?").click();
       });
 
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Collections").click();
-        entityPickerModalItem(0, "All personal collections").should(
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Collections").click();
+        H.entityPickerModalItem(0, "All personal collections").should(
           "have.attr",
           "data-active",
           "true",
         );
-        entityPickerModalItem(
+        H.entityPickerModalItem(
           1,
           "Robert Tableton's Personal Collection",
         ).should("have.attr", "data-active", "true");
-        entityPickerModalItem(2, "Normal personal collection 2").should(
+        H.entityPickerModalItem(2, "Normal personal collection 2").should(
           "have.attr",
           "data-active",
           "true",
@@ -774,11 +751,11 @@ describe("scenarios > organization > entity picker", () => {
 
   describe("dashboard picker", () => {
     it("should select a dashboard from local search results", () => {
-      visitQuestion(ORDERS_COUNT_QUESTION_ID);
-      openQuestionActions();
-      popover().findByText("Add to dashboard").click();
+      H.visitQuestion(ORDERS_COUNT_QUESTION_ID);
+      H.openQuestionActions();
+      H.popover().findByText("Add to dashboard").click();
 
-      entityPickerModal().within(() => {
+      H.entityPickerModal().within(() => {
         cy.findByText("Our analytics").click();
         enterSearchText({
           text: "dashboard",
@@ -788,15 +765,15 @@ describe("scenarios > organization > entity picker", () => {
         cy.findByText("Orders in a dashboard").click();
         cy.button("Select").click();
       });
-      getDashboardCard(1).findByText("Orders, Count").should("be.visible");
+      H.getDashboardCard(1).findByText("Orders, Count").should("be.visible");
     });
 
     it("should select a dashboard from global search results", () => {
-      visitQuestion(ORDERS_COUNT_QUESTION_ID);
-      openQuestionActions();
-      popover().findByText("Add to dashboard").click();
+      H.visitQuestion(ORDERS_COUNT_QUESTION_ID);
+      H.openQuestionActions();
+      H.popover().findByText("Add to dashboard").click();
 
-      entityPickerModal().within(() => {
+      H.entityPickerModal().within(() => {
         cy.findByText("Our analytics").click();
         enterSearchText({
           text: "dashboard",
@@ -806,19 +783,19 @@ describe("scenarios > organization > entity picker", () => {
         cy.findByText("Orders in a dashboard").click();
         cy.button("Select").click();
       });
-      getDashboardCard(1).findByText("Orders, Count").should("be.visible");
+      H.getDashboardCard(1).findByText("Orders, Count").should("be.visible");
     });
 
     it("should search for dashboards for a normal user", () => {
       cy.signInAsAdmin();
       createTestDashboards();
       cy.signInAsNormalUser();
-      visitQuestion(ORDERS_QUESTION_ID);
-      openQuestionActions();
-      popover().findByText("Add to dashboard").click();
+      H.visitQuestion(ORDERS_QUESTION_ID);
+      H.openQuestionActions();
+      H.popover().findByText("Add to dashboard").click();
 
       cy.log("root collection - automatically selected");
-      entityPickerModal().within(() => {
+      H.entityPickerModal().within(() => {
         cy.findByText("Our analytics").click();
         enterSearchText({
           text: "dashboard 1",
@@ -845,8 +822,8 @@ describe("scenarios > organization > entity picker", () => {
       });
 
       cy.log("regular collection");
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Dashboards").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Dashboards").click();
         cy.findByText("First collection").click();
         enterSearchText({
           text: "dashboard 2",
@@ -864,8 +841,8 @@ describe("scenarios > organization > entity picker", () => {
       });
 
       cy.log("personal collection");
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Dashboards").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Dashboards").click();
         cy.findByText(/Personal Collection/).click();
         enterSearchText({
           text: "personal dashboard 1",
@@ -898,12 +875,12 @@ describe("scenarios > organization > entity picker", () => {
       });
 
       cy.signIn("nocollection");
-      visitQuestion(ORDERS_QUESTION_ID);
-      openQuestionActions();
-      popover().findByText("Add to dashboard").click();
+      H.visitQuestion(ORDERS_QUESTION_ID);
+      H.openQuestionActions();
+      H.popover().findByText("Add to dashboard").click();
 
       cy.log("root collection");
-      entityPickerModal().within(() => {
+      H.entityPickerModal().within(() => {
         cy.findByText("Collections").click();
         enterSearchText({
           text: "dashboard 1",
@@ -929,8 +906,8 @@ describe("scenarios > organization > entity picker", () => {
       });
 
       cy.log("personal collection");
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Dashboards").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Dashboards").click();
         cy.findByText(/Personal Collection/).click();
         enterSearchText({
           text: "personal dashboard 2",
@@ -954,12 +931,12 @@ describe("scenarios > organization > entity picker", () => {
     it("should not allow local search for `all personal collections`", () => {
       cy.signInAsAdmin();
       createTestDashboards();
-      visitQuestion(ORDERS_QUESTION_ID);
-      openQuestionActions();
-      popover().findByText("Add to dashboard").click();
+      H.visitQuestion(ORDERS_QUESTION_ID);
+      H.openQuestionActions();
+      H.popover().findByText("Add to dashboard").click();
 
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Dashboards").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Dashboards").click();
         cy.findByText("All personal collections").click();
         enterSearchText({
           text: "personal dashboard",
@@ -997,7 +974,7 @@ function createTestCards() {
   types.forEach(type => {
     suffixes.forEach(suffix => {
       collections.forEach(({ id, name }) => {
-        createQuestion({
+        H.createQuestion({
           ...cardDetails,
           name: `${name} ${type} ${suffix}`,
           type,
@@ -1027,7 +1004,10 @@ function createTestCollections() {
 
   suffixes.forEach(suffix => {
     collections.forEach(collection =>
-      createCollection({ ...collection, name: `${collection.name} ${suffix}` }),
+      H.createCollection({
+        ...collection,
+        name: `${collection.name} ${suffix}`,
+      }),
     );
   });
 }
@@ -1053,13 +1033,13 @@ function createTestDashboards() {
 
   suffixes.forEach(suffix => {
     dashboards.forEach(dashboard =>
-      createDashboard({ ...dashboard, name: `${dashboard.name} ${suffix}` }),
+      H.createDashboard({ ...dashboard, name: `${dashboard.name} ${suffix}` }),
     );
   });
 }
 
 function createTestDashboardWithEmptyCard(
-  dashboardDetails: DashboardDetails = {},
+  dashboardDetails: H.DashboardDetails = {},
 ) {
   const dashcardDetails: Partial<DashboardCard>[] = [
     {
@@ -1083,19 +1063,19 @@ function createTestDashboardWithEmptyCard(
     },
   ];
 
-  return createDashboard(dashboardDetails).then(({ body: dashboard }) => {
-    return updateDashboardCards({
+  return H.createDashboard(dashboardDetails).then(({ body: dashboard }) => {
+    return H.updateDashboardCards({
       dashboard_id: dashboard.id,
       cards: dashcardDetails,
     }).then(() => dashboard);
   });
 }
 
-function selectQuestionFromDashboard(dashboardDetails?: DashboardDetails) {
+function selectQuestionFromDashboard(dashboardDetails?: H.DashboardDetails) {
   createTestDashboardWithEmptyCard(dashboardDetails).then(dashboard => {
-    visitDashboard(dashboard.id);
-    editDashboard();
-    getDashboardCard().button("Select question").click();
+    H.visitDashboard(dashboard.id);
+    H.editDashboard();
+    H.getDashboardCard().button("Select question").click();
   });
 }
 
@@ -1161,8 +1141,8 @@ function assertSearchResults({
 function testCardSearchForNormalUser({ tabs }: { tabs: string[] }) {
   tabs.forEach(tab => {
     cy.log("root collection - automatically selected");
-    entityPickerModal().within(() => {
-      entityPickerModalTab(tab).click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab(tab).click();
       enterSearchText({
         text: "2",
         placeholder: "Search this collection or everywhere…",
@@ -1180,8 +1160,8 @@ function testCardSearchForNormalUser({ tabs }: { tabs: string[] }) {
     });
 
     cy.log("regular collection");
-    entityPickerModal().within(() => {
-      entityPickerModalTab(tab).click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab(tab).click();
       cy.findByText("First collection").click();
       enterSearchText({
         text: "1",
@@ -1204,8 +1184,8 @@ function testCardSearchForNormalUser({ tabs }: { tabs: string[] }) {
     });
 
     cy.log("root collection - manually selected");
-    entityPickerModal().within(() => {
-      entityPickerModalTab(tab).click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab(tab).click();
       cy.findByText("Our analytics").click();
       enterSearchText({
         text: "2",
@@ -1224,8 +1204,8 @@ function testCardSearchForNormalUser({ tabs }: { tabs: string[] }) {
     });
 
     cy.log("personal collection");
-    entityPickerModal().within(() => {
-      entityPickerModalTab(tab).click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab(tab).click();
       cy.findByText(/Personal Collection/).click();
       enterSearchText({
         text: "1",
@@ -1261,8 +1241,8 @@ function testCardSearchForInaccessibleRootCollection({
   tabs.forEach(tab => {
     if (isRootSelected) {
       cy.log("inaccessible root collection - automatically selected");
-      entityPickerModal().within(() => {
-        entityPickerModalTab(tab).click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab(tab).click();
         enterSearchText({
           text: "1",
           placeholder: "Search this collection or everywhere…",
@@ -1281,8 +1261,8 @@ function testCardSearchForInaccessibleRootCollection({
     }
 
     cy.log("regular collection");
-    entityPickerModal().within(() => {
-      entityPickerModalTab(tab).click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab(tab).click();
       cy.findByText("First collection").click();
       enterSearchText({
         text: "1",
@@ -1306,8 +1286,8 @@ function testCardSearchForInaccessibleRootCollection({
     });
 
     cy.log("inaccessible root collection - manually selected");
-    entityPickerModal().within(() => {
-      entityPickerModalTab(tab).click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab(tab).click();
       cy.findByText("Collections").click();
       enterSearchText({
         text: "1",
@@ -1326,8 +1306,8 @@ function testCardSearchForInaccessibleRootCollection({
     });
 
     cy.log("personal collection");
-    entityPickerModal().within(() => {
-      entityPickerModalTab(tab).click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab(tab).click();
       cy.findByText(/Personal Collection/).click();
       enterSearchText({
         text: "1",
@@ -1355,8 +1335,8 @@ function testCardSearchForInaccessibleRootCollection({
 
 function testCardSearchForAllPersonalCollections({ tabs }: { tabs: string[] }) {
   tabs.forEach(tab => {
-    entityPickerModal().within(() => {
-      entityPickerModalTab(tab).click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab(tab).click();
       cy.findByText("All personal collections").click();
       enterSearchText({
         text: "root",

--- a/e2e/test/scenarios/organization/official-collections.cy.spec.js
+++ b/e2e/test/scenarios/organization/official-collections.cy.spec.js
@@ -1,16 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  commandPaletteSearch,
-  describeEE,
-  getCollectionActions,
-  getPartialPremiumFeatureError,
-  navigationSidebar,
-  openCollectionMenu,
-  openNewCollectionItemFlowFor,
-  popover,
-  restore,
-  setTokenFeatures,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
@@ -22,9 +11,9 @@ const TEST_QUESTION_QUERY = {
   breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "hour-of-day" }]],
 };
 
-describeEE("official collections", () => {
+H.describeEE("official collections", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -41,7 +30,7 @@ describeEE("official collections", () => {
         },
       }).then(({ body, status, statusText }) => {
         expect(body).to.deep.include(
-          getPartialPremiumFeatureError("Official Collections"),
+          H.getPartialPremiumFeatureError("Official Collections"),
         );
         expect(status).to.eq(402);
         expect(statusText).to.eq("Payment Required");
@@ -50,20 +39,20 @@ describeEE("official collections", () => {
       // Gate the UI
       cy.visit("/collection/root");
 
-      openNewCollectionItemFlowFor("collection");
+      H.openNewCollectionItemFlowFor("collection");
       cy.findByTestId("new-collection-modal").then(modal => {
         assertNoCollectionTypeInput();
         cy.findByLabelText("Close").click();
       });
 
       openCollection("First collection");
-      openCollectionMenu();
+      H.openCollectionMenu();
       assertNoCollectionTypeOption();
     });
   });
 
   context("premium token with paid features", () => {
-    beforeEach(() => setTokenFeatures("all"));
+    beforeEach(() => H.setTokenFeatures("all"));
 
     it("should be able to manage collection authority level", () => {
       cy.visit("/collection/root");
@@ -95,14 +84,14 @@ describeEE("official collections", () => {
 
       openCollection("First collection");
 
-      openNewCollectionItemFlowFor("collection");
+      H.openNewCollectionItemFlowFor("collection");
       cy.findByTestId("new-collection-modal").then(modal => {
         assertNoCollectionTypeInput();
         cy.findByLabelText("Close").click();
       });
 
-      openCollectionMenu();
-      popover().within(() => {
+      H.openCollectionMenu();
+      H.popover().within(() => {
         assertNoCollectionTypeOption();
       });
     });
@@ -111,14 +100,14 @@ describeEE("official collections", () => {
       cy.visit("/collection/root");
 
       openCollection("Your personal collection");
-      getCollectionActions().within(() => {
+      H.getCollectionActions().within(() => {
         cy.icon("ellipsis").should("exist");
         cy.icon("ellipsis").click();
       });
 
-      popover().findByText("Make collection official").should("exist");
+      H.popover().findByText("Make collection official").should("exist");
 
-      openNewCollectionItemFlowFor("collection");
+      H.openNewCollectionItemFlowFor("collection");
       cy.findByTestId("new-collection-modal").then(modal => {
         assertHasCollectionTypeInput();
         cy.findByPlaceholderText("My new fantastic collection").type(
@@ -129,13 +118,13 @@ describeEE("official collections", () => {
 
       openCollection("Personal collection child");
 
-      getCollectionActions().within(() => {
+      H.getCollectionActions().within(() => {
         cy.icon("ellipsis").should("exist");
         cy.icon("ellipsis").click();
       });
-      popover().findByText("Make collection official").should("exist");
+      H.popover().findByText("Make collection official").should("exist");
 
-      openNewCollectionItemFlowFor("collection");
+      H.openNewCollectionItemFlowFor("collection");
       cy.findByTestId("new-collection-modal").then(modal => {
         assertHasCollectionTypeInput();
         cy.findByLabelText("Close").click();
@@ -144,7 +133,7 @@ describeEE("official collections", () => {
   });
 
   context("token expired or removed", () => {
-    beforeEach(() => setTokenFeatures("all"));
+    beforeEach(() => H.setTokenFeatures("all"));
 
     it("should not display official collection icon anymore", () => {
       testOfficialBadgePresence(false);
@@ -172,7 +161,7 @@ function testOfficialBadgePresence(expectBadge = true) {
       collection_id: collectionId,
     });
 
-    !expectBadge && setTokenFeatures("none");
+    !expectBadge && H.setTokenFeatures("none");
     cy.visit(`/collection/${collectionId}`);
   });
 
@@ -204,7 +193,7 @@ function testOfficialBadgeInSearch({
   question,
   expectBadge,
 }) {
-  commandPaletteSearch(searchQuery);
+  H.commandPaletteSearch(searchQuery);
 
   cy.findByTestId("search-app").within(() => {
     assertSearchResultBadge(collection, {
@@ -232,7 +221,7 @@ function testOfficialQuestionBadgeInRegularDashboard(expectBadge = true) {
     });
   });
 
-  !expectBadge && setTokenFeatures("none");
+  !expectBadge && H.setTokenFeatures("none");
 
   cy.visit("/collection/root");
   cy.findByText("Regular Dashboard").click();
@@ -243,24 +232,24 @@ function testOfficialQuestionBadgeInRegularDashboard(expectBadge = true) {
 }
 
 function openCollection(collectionName) {
-  navigationSidebar().findByText(collectionName).click();
+  H.navigationSidebar().findByText(collectionName).click();
 }
 
 function createAndOpenOfficialCollection({ name }) {
-  openNewCollectionItemFlowFor("collection");
+  H.openNewCollectionItemFlowFor("collection");
   cy.findByTestId("new-collection-modal").then(modal => {
     cy.findByPlaceholderText("My new fantastic collection").type(name);
     cy.findByText("Official").click();
     cy.findByText("Create").click();
   });
-  navigationSidebar().within(() => {
+  H.navigationSidebar().within(() => {
     cy.findByText(name).click();
   });
 }
 
 function changeCollectionTypeTo(type) {
-  openCollectionMenu();
-  popover().within(() => {
+  H.openCollectionMenu();
+  H.popover().within(() => {
     if (type === "official") {
       cy.findByText("Make collection official").click();
     } else {
@@ -287,7 +276,7 @@ function assertNoCollectionTypeOption() {
 }
 
 function assertSidebarIcon(collectionName, expectedIcon) {
-  navigationSidebar()
+  H.navigationSidebar()
     .findByText(collectionName)
     .parent()
     .within(() => {

--- a/e2e/test/scenarios/organization/timelines-collection.cy.spec.js
+++ b/e2e/test/scenarios/organization/timelines-collection.cy.spec.js
@@ -1,24 +1,11 @@
+import { H } from "e2e/support";
 import { USERS } from "e2e/support/cypress_data";
-import {
-  createTimeline,
-  createTimelineWithEvents,
-  describeWithSnowplow,
-  enableTracking,
-  entityPickerModal,
-  expectGoodSnowplowEvents,
-  expectNoBadSnowplowEvents,
-  getFullName,
-  modal,
-  popover,
-  resetSnowplow,
-  restore,
-} from "e2e/support/helpers";
 
 const { admin } = USERS;
 
 describe("scenarios > organization > timelines > collection", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.intercept("PUT", "/api/collection/*").as("updateCollection");
     cy.intercept("POST", "/api/timeline").as("createTimeline");
     cy.intercept("PUT", "/api/timeline/*").as("updateTimeline");
@@ -86,7 +73,7 @@ describe("scenarios > organization > timelines > collection", () => {
     });
 
     it("should search for events", () => {
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         events: [
           { name: "RC1" },
           { name: "RC2" },
@@ -117,7 +104,7 @@ describe("scenarios > organization > timelines > collection", () => {
 
       cy.findByLabelText("Event name").type("RC1");
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByRole("button", { name: "calendar icon" }).click();
       });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -169,7 +156,7 @@ describe("scenarios > organization > timelines > collection", () => {
 
       cy.findByLabelText("Event name").type("RC1");
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByRole("button", { name: "calendar icon" }).click();
       });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -201,7 +188,7 @@ describe("scenarios > organization > timelines > collection", () => {
 
       cy.findByLabelText("Event name").type("RC1");
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByRole("button", { name: "calendar icon" }).click();
       });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -223,7 +210,7 @@ describe("scenarios > organization > timelines > collection", () => {
     });
 
     it("should edit an event", () => {
-      createTimelineWithEvents({ events: [{ name: "RC1" }] });
+      H.createTimelineWithEvents({ events: [{ name: "RC1" }] });
       cy.visit("/collection/root/timelines");
 
       openMenu("RC1");
@@ -238,23 +225,23 @@ describe("scenarios > organization > timelines > collection", () => {
     });
 
     it("should move an event", () => {
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         timeline: { name: "Releases" },
         events: [{ name: "RC1" }],
       });
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         timeline: { name: "Metrics" },
         events: [{ name: "RC2" }],
       });
 
       cy.visit("/collection/root/timelines");
-      modal().findByText("Metrics").click();
+      H.modal().findByText("Metrics").click();
       openMenu("RC2");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Move event").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases").click();
-      modal().button("Move").click();
+      H.modal().button("Move").click();
       cy.wait("@updateEvent");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC2").should("not.exist");
@@ -269,23 +256,23 @@ describe("scenarios > organization > timelines > collection", () => {
     });
 
     it("should move an event and undo", () => {
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         timeline: { name: "Releases" },
         events: [{ name: "RC1" }],
       });
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         timeline: { name: "Metrics" },
         events: [{ name: "RC2" }],
       });
 
       cy.visit("/collection/root/timelines");
-      modal().findByText("Metrics").click();
+      H.modal().findByText("Metrics").click();
       openMenu("RC2");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Move event").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases").click();
-      modal().button("Move").click();
+      H.modal().button("Move").click();
       cy.wait("@updateEvent");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC2").should("not.exist");
@@ -298,7 +285,7 @@ describe("scenarios > organization > timelines > collection", () => {
     });
 
     it("should archive an event when editing this event", () => {
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         timeline: { name: "Releases" },
         events: [{ name: "RC1" }, { name: "RC2" }],
       });
@@ -319,7 +306,7 @@ describe("scenarios > organization > timelines > collection", () => {
     });
 
     it("should archive an event from the timeline and undo", () => {
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         timeline: { name: "Releases" },
         events: [{ name: "RC1" }, { name: "RC2" }],
       });
@@ -341,7 +328,7 @@ describe("scenarios > organization > timelines > collection", () => {
     });
 
     it("should unarchive an event from the archive and undo", () => {
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         timeline: { name: "Releases" },
         events: [{ name: "RC1", archived: true }],
       });
@@ -369,7 +356,7 @@ describe("scenarios > organization > timelines > collection", () => {
     });
 
     it("should delete an event", () => {
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         timeline: { name: "Releases" },
         events: [{ name: "RC1", archived: true }],
       });
@@ -392,20 +379,20 @@ describe("scenarios > organization > timelines > collection", () => {
     });
 
     it("should allow navigating back to the list of timelines", () => {
-      createTimeline({ name: "Releases" });
-      createTimeline({ name: "Metrics" });
+      H.createTimeline({ name: "Releases" });
+      H.createTimeline({ name: "Metrics" });
 
       cy.visit("/collection/root/timelines/1");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases");
 
       cy.icon("chevronleft").click();
-      modal().findByText("Releases");
-      modal().findByText("Metrics");
+      H.modal().findByText("Releases");
+      H.modal().findByText("Metrics");
     });
 
     it("should not allow navigating back when there is only one timeline in a collection", () => {
-      createTimeline({ name: "Releases" });
+      H.createTimeline({ name: "Releases" });
 
       cy.visit("/collection/root/timelines/1");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -414,7 +401,7 @@ describe("scenarios > organization > timelines > collection", () => {
     });
 
     it("should create an additional timeline", () => {
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         timeline: { name: "Releases" },
         events: [{ name: "RC1" }],
       });
@@ -435,7 +422,7 @@ describe("scenarios > organization > timelines > collection", () => {
     });
 
     it("should edit a timeline", () => {
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         timeline: { name: "Releases" },
         events: [{ name: "RC1" }],
       });
@@ -454,16 +441,16 @@ describe("scenarios > organization > timelines > collection", () => {
     });
 
     it("should move a timeline", () => {
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         timeline: { name: "Events", default: true },
         events: [{ name: "RC1" }],
       });
 
       cy.visit("/collection/root/timelines");
       openMenu("Our analytics events");
-      popover().findByText("Move timeline").click();
+      H.popover().findByText("Move timeline").click();
 
-      entityPickerModal().within(() => {
+      H.entityPickerModal().within(() => {
         cy.findByRole("tab", { name: /Collections/ }).click();
         cy.findByText("Bobby Tables's Personal Collection").click();
         cy.button("Move").click();
@@ -473,13 +460,13 @@ describe("scenarios > organization > timelines > collection", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Our analytics events").should("be.visible");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText(`${getFullName(admin)}'s Personal Collection`).should(
+      cy.findByText(`${H.getFullName(admin)}'s Personal Collection`).should(
         "be.visible",
       );
     });
 
     it("should archive a timeline and undo", () => {
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         timeline: { name: "Releases" },
         events: [{ name: "RC1" }, { name: "RC2" }],
       });
@@ -508,12 +495,12 @@ describe("scenarios > organization > timelines > collection", () => {
     });
 
     it("should support markdown in timeline description", () => {
-      createTimeline({
+      H.createTimeline({
         name: "Releases",
         description: "[Release notes](https://metabase.test)",
       });
 
-      createTimeline({
+      H.createTimeline({
         name: "Holidays",
         description: "[Holiday list](https://metabase.test)",
       });
@@ -526,7 +513,7 @@ describe("scenarios > organization > timelines > collection", () => {
     });
 
     it("should support markdown in event description", () => {
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         timeline: {
           name: "Releases",
         },
@@ -544,7 +531,7 @@ describe("scenarios > organization > timelines > collection", () => {
     });
 
     it("should archive and unarchive a timeline", () => {
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         timeline: { name: "Releases" },
         events: [{ name: "RC1" }, { name: "RC2" }],
       });
@@ -567,13 +554,13 @@ describe("scenarios > organization > timelines > collection", () => {
       cy.wait("@updateTimeline");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("No timelines found");
-      modal().icon("chevronleft").click();
+      H.modal().icon("chevronleft").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases");
     });
 
     it("should archive and delete a timeline", () => {
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         timeline: { name: "Releases" },
         events: [{ name: "RC1" }, { name: "RC2" }],
       });
@@ -598,7 +585,7 @@ describe("scenarios > organization > timelines > collection", () => {
       cy.wait("@deleteTimeline");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("No timelines found");
-      modal().icon("chevronleft").click();
+      H.modal().icon("chevronleft").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Our analytics events");
     });
@@ -637,7 +624,7 @@ describe("scenarios > organization > timelines > collection", () => {
     });
 
     it("should use custom date formatting settings", () => {
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         events: [{ name: "RC1", timestamp: "2022-10-12T18:15:30Z" }],
       });
       setFormattingSettings({
@@ -658,7 +645,7 @@ describe("scenarios > organization > timelines > collection", () => {
     });
 
     it("should use custom time formatting settings", () => {
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         events: [{ name: "RC1", timestamp: "2022-10-12T18:15:30Z" }],
       });
       setFormattingSettings({
@@ -669,10 +656,10 @@ describe("scenarios > organization > timelines > collection", () => {
       openMenu("RC1");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Edit event").click();
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByRole("button", { name: "calendar icon" }).click();
       });
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Add time").click();
         cy.findByText("AM").should("not.exist");
       });
@@ -693,7 +680,7 @@ describe("scenarios > organization > timelines > collection", () => {
 
     it("should not allow creating new events in existing timelines", () => {
       cy.signInAsAdmin();
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         timeline: { name: "Releases" },
         events: [{ name: "RC1" }],
       });
@@ -710,16 +697,16 @@ describe("scenarios > organization > timelines > collection", () => {
   });
 });
 
-describeWithSnowplow("scenarios > collections > timelines", () => {
+H.describeWithSnowplow("scenarios > collections > timelines", () => {
   beforeEach(() => {
-    restore();
-    resetSnowplow();
+    H.restore();
+    H.resetSnowplow();
     cy.signInAsAdmin();
-    enableTracking();
+    H.enableTracking();
   });
 
   afterEach(() => {
-    expectNoBadSnowplowEvents();
+    H.expectNoBadSnowplowEvents();
   });
 
   it("should send snowplow events when creating a timeline event", () => {
@@ -739,7 +726,7 @@ describeWithSnowplow("scenarios > collections > timelines", () => {
     // 5 - pageview
     cy.button("Create").click();
 
-    expectGoodSnowplowEvents(5);
+    H.expectGoodSnowplowEvents(5);
   });
 });
 

--- a/e2e/test/scenarios/organization/timelines-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/timelines-question.cy.spec.js
@@ -1,22 +1,13 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_BY_YEAR_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  createTimeline,
-  createTimelineWithEvents,
-  echartsIcon,
-  popover,
-  restore,
-  rightSidebar,
-  visitQuestion,
-  visitQuestionAdhoc,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > organization > timelines > question", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
   });
 
   describe("as admin", () => {
@@ -28,7 +19,7 @@ describe("scenarios > organization > timelines > question", () => {
     });
 
     it("should create the first event and timeline", () => {
-      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
+      H.visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
       cy.wait("@getCollection");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visualization").should("be.visible");
@@ -49,12 +40,12 @@ describe("scenarios > organization > timelines > question", () => {
     });
 
     it("should create an event within the default timeline", () => {
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         timeline: { name: "Releases" },
         events: [{ name: "RC1", timestamp: "2024-10-20T00:00:00Z" }],
       });
 
-      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
+      H.visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
       cy.wait("@getCollection");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visualization").should("be.visible");
@@ -77,7 +68,7 @@ describe("scenarios > organization > timelines > question", () => {
     });
 
     it("should display all events in data view", () => {
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         timeline: { name: "Releases" },
         events: [
           { name: "v1", timestamp: "2027-01-01T00:00:00Z" },
@@ -86,7 +77,7 @@ describe("scenarios > organization > timelines > question", () => {
         ],
       });
 
-      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
+      H.visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
       cy.wait("@getCollection");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visualization").should("be.visible");
@@ -109,12 +100,12 @@ describe("scenarios > organization > timelines > question", () => {
     });
 
     it("should edit an event", () => {
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         timeline: { name: "Releases" },
         events: [{ name: "RC1", timestamp: "2024-10-20T00:00:00Z" }],
       });
 
-      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
+      H.visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
       cy.wait("@getCollection");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visualization").should("be.visible");
@@ -122,7 +113,7 @@ describe("scenarios > organization > timelines > question", () => {
       cy.icon("calendar").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases").should("be.visible");
-      rightSidebar().icon("ellipsis").click();
+      H.rightSidebar().icon("ellipsis").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Edit event").click();
 
@@ -138,13 +129,13 @@ describe("scenarios > organization > timelines > question", () => {
     });
 
     it("should move an event", () => {
-      createTimeline({ name: "Releases" });
-      createTimelineWithEvents({
+      H.createTimeline({ name: "Releases" });
+      H.createTimelineWithEvents({
         timeline: { name: "Builds" },
         events: [{ name: "RC2", timestamp: "2024-10-20T00:00:00Z" }],
       });
 
-      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
+      H.visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
       cy.wait("@getCollection");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visualization").should("be.visible");
@@ -152,7 +143,7 @@ describe("scenarios > organization > timelines > question", () => {
       cy.icon("calendar").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Builds").should("be.visible");
-      rightSidebar().icon("ellipsis").click();
+      H.rightSidebar().icon("ellipsis").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Move event").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -167,12 +158,12 @@ describe("scenarios > organization > timelines > question", () => {
     });
 
     it("should archive and unarchive an event", () => {
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         timeline: { name: "Releases" },
         events: [{ name: "RC1", timestamp: "2024-10-20T00:00:00Z" }],
       });
 
-      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
+      H.visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
       cy.wait("@getCollection");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visualization").should("be.visible");
@@ -180,7 +171,7 @@ describe("scenarios > organization > timelines > question", () => {
       cy.icon("calendar").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases").should("be.visible");
-      rightSidebar().icon("ellipsis").click();
+      H.rightSidebar().icon("ellipsis").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Archive event").click();
       cy.wait("@updateEvent");
@@ -195,7 +186,7 @@ describe("scenarios > organization > timelines > question", () => {
     });
 
     it("should support markdown in event description", () => {
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         timeline: {
           name: "Releases",
         },
@@ -208,7 +199,7 @@ describe("scenarios > organization > timelines > question", () => {
         ],
       });
 
-      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
+      H.visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
       cy.icon("calendar").click();
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -218,12 +209,12 @@ describe("scenarios > organization > timelines > question", () => {
     });
 
     it("should show events for ad-hoc questions", () => {
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         timeline: { name: "Releases" },
         events: [{ name: "RC1", timestamp: "2024-10-20T00:00:00Z" }],
       });
 
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           type: "query",
           query: {
@@ -242,16 +233,16 @@ describe("scenarios > organization > timelines > question", () => {
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visualization").should("be.visible");
-      echartsIcon("star").should("be.visible");
+      H.echartsIcon("star").should("be.visible");
     });
 
     it("should not show events for non-timeseries questions", () => {
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         timeline: { name: "Releases" },
         events: [{ name: "RC1", timestamp: "2024-10-20T00:00:00Z" }],
       });
 
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           type: "query",
           query: {
@@ -272,16 +263,16 @@ describe("scenarios > organization > timelines > question", () => {
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visualization").should("be.visible");
-      echartsIcon("star").should("not.exist");
+      H.echartsIcon("star").should("not.exist");
     });
 
     it("should show events for native queries", () => {
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         timeline: { name: "Releases" },
         events: [{ name: "RC1", timestamp: "2024-10-20T00:00:00Z" }],
       });
 
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           type: "native",
           native: {
@@ -298,7 +289,7 @@ describe("scenarios > organization > timelines > question", () => {
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visualization").should("be.visible");
-      echartsIcon("star").should("be.visible");
+      H.echartsIcon("star").should("be.visible");
     });
 
     it("should toggle individual event visibility", () => {
@@ -306,14 +297,14 @@ describe("scenarios > organization > timelines > question", () => {
         name: "Parent",
         parent_id: null,
       }).then(({ body: { id: PARENT_COLLECTION_ID } }) => {
-        createTimelineWithEvents({
+        H.createTimelineWithEvents({
           timeline: { name: "Releases" },
           events: [
             { name: "RC1", timestamp: "2024-10-20T00:00:00Z", icon: "cloud" },
           ],
         });
 
-        createTimelineWithEvents({
+        H.createTimelineWithEvents({
           timeline: {
             name: "Timeline for collection",
             collection_id: PARENT_COLLECTION_ID,
@@ -323,24 +314,24 @@ describe("scenarios > organization > timelines > question", () => {
           ],
         });
 
-        visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
+        H.visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
 
         cy.findByTestId("view-footer")
           .findByText("Visualization")
           .should("be.visible");
-        echartsIcon("cloud").should("be.visible");
+        H.echartsIcon("cloud").should("be.visible");
 
         // should hide individual events from chart if hidden in sidebar
         cy.icon("calendar").click();
         cy.findByTestId("sidebar-content").findByText("Releases").click();
         toggleEventVisibility("RC1");
 
-        echartsIcon("cloud").should("not.exist");
+        H.echartsIcon("cloud").should("not.exist");
 
         // should show individual events in chart again
         toggleEventVisibility("RC1");
 
-        echartsIcon("cloud").should("be.visible");
+        H.echartsIcon("cloud").should("be.visible");
 
         // should show a newly created event
         cy.button("Add an event").click();
@@ -349,12 +340,12 @@ describe("scenarios > organization > timelines > question", () => {
         cy.button("Create").click();
         cy.wait("@createEvent");
 
-        echartsIcon("star").should("be.visible");
+        H.echartsIcon("star").should("be.visible");
 
         // should then hide the newly created event
         toggleEventVisibility("RC2");
 
-        echartsIcon("star").should("not.exist");
+        H.echartsIcon("star").should("not.exist");
 
         // its timeline, visible but having one hidden event
         // should display its checkbox with a "dash" icon
@@ -370,8 +361,8 @@ describe("scenarios > organization > timelines > question", () => {
           });
 
         // once timeline is visible, all its events should be visible
-        echartsIcon("star").should("be.visible");
-        echartsIcon("cloud").should("be.visible");
+        H.echartsIcon("star").should("be.visible");
+        H.echartsIcon("cloud").should("be.visible");
 
         // should initialize events in a hidden timelime
         // with event checkboxes unchecked
@@ -393,43 +384,43 @@ describe("scenarios > organization > timelines > question", () => {
           .closest("[aria-label=Timeline card header]")
           .within(() => cy.findByRole("checkbox").click());
 
-        echartsIcon("warning").should("be.visible");
+        H.echartsIcon("warning").should("be.visible");
 
         // events whose timeline was invisible on page load
         // should be hideable once their timelines are visible
         toggleEventVisibility("TC1");
 
-        echartsIcon("warning").should("not.exist");
+        H.echartsIcon("warning").should("not.exist");
       });
     });
 
     it("should color the event icon when hovering", () => {
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         timeline: { name: "Releases" },
         events: [
           { name: "RC1", timestamp: "2024-10-20T00:00:00Z", icon: "star" },
         ],
       });
 
-      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
+      H.visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
 
-      echartsIcon("star").should("be.visible");
-      echartsIcon("star").realHover();
-      echartsIcon("star", true).should("be.visible");
+      H.echartsIcon("star").should("be.visible");
+      H.echartsIcon("star").realHover();
+      H.echartsIcon("star", true).should("be.visible");
     });
 
     it("should open the sidebar when clicking an event icon", () => {
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         timeline: { name: "Releases" },
         events: [
           { name: "RC1", timestamp: "2024-10-20T00:00:00Z", icon: "star" },
         ],
       });
 
-      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
+      H.visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
 
-      echartsIcon("star").should("be.visible");
-      echartsIcon("star").realClick();
+      H.echartsIcon("star").should("be.visible");
+      H.echartsIcon("star").realClick();
 
       // event should be selected in sidebar
       timelineEventCard("RC1").should("be.visible");
@@ -440,7 +431,7 @@ describe("scenarios > organization > timelines > question", () => {
       );
 
       // after clicking the icon again, it should be deselected in sidebar
-      echartsIcon("star", true).click();
+      H.echartsIcon("star", true).click();
       timelineEventCard("RC1").should("be.visible");
       timelineEventCard("RC1").should(
         "have.css",
@@ -450,7 +441,7 @@ describe("scenarios > organization > timelines > question", () => {
     });
 
     it("should not filter out events in last period (metabase#23336)", () => {
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         events: [
           { name: "Last week", timestamp: "2026-04-21T12:00:00Z" },
           { name: "Last month", timestamp: "2026-04-27T12:00:00Z" },
@@ -459,7 +450,7 @@ describe("scenarios > organization > timelines > question", () => {
         ],
       });
 
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           type: "query",
           database: SAMPLE_DB_ID,
@@ -476,7 +467,7 @@ describe("scenarios > organization > timelines > question", () => {
       cy.icon("calendar").click();
 
       // Week
-      rightSidebar().within(() => {
+      H.rightSidebar().within(() => {
         cy.findByText("Last week").should("exist");
         cy.findByText("Last month").should("not.exist");
         cy.findByText("Last quarter").should("not.exist");
@@ -485,9 +476,9 @@ describe("scenarios > organization > timelines > question", () => {
 
       // Month
       cy.findByTestId("timeseries-chrome").findByText("Week").click();
-      popover().findByText("Month").click();
+      H.popover().findByText("Month").click();
       cy.wait("@dataset");
-      rightSidebar().within(() => {
+      H.rightSidebar().within(() => {
         cy.findByText("Last week").should("exist");
         cy.findByText("Last month").should("exist");
         cy.findByText("Last quarter").should("not.exist");
@@ -496,9 +487,9 @@ describe("scenarios > organization > timelines > question", () => {
 
       // Quarter
       cy.findByTestId("timeseries-chrome").findByText("Month").click();
-      popover().findByText("Quarter").click();
+      H.popover().findByText("Quarter").click();
       cy.wait("@dataset");
-      rightSidebar().within(() => {
+      H.rightSidebar().within(() => {
         cy.findByText("Last week").should("exist");
         cy.findByText("Last month").should("exist");
         cy.findByText("Last quarter").should("exist");
@@ -507,9 +498,9 @@ describe("scenarios > organization > timelines > question", () => {
 
       // Year
       cy.findByTestId("timeseries-chrome").findByText("Quarter").click();
-      popover().findByText("Year").click();
+      H.popover().findByText("Year").click();
       cy.wait("@dataset");
-      rightSidebar().within(() => {
+      H.rightSidebar().within(() => {
         cy.findByText("Last week").should("exist");
         cy.findByText("Last month").should("exist");
         cy.findByText("Last quarter").should("exist");
@@ -521,7 +512,7 @@ describe("scenarios > organization > timelines > question", () => {
   describe("as readonly user", () => {
     it("should not allow creating default timelines", () => {
       cy.signIn("readonly");
-      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
+      H.visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Created At: Year").should("be.visible");
 
@@ -534,13 +525,13 @@ describe("scenarios > organization > timelines > question", () => {
 
     it("should not allow creating or editing events", () => {
       cy.signInAsAdmin();
-      createTimelineWithEvents({
+      H.createTimelineWithEvents({
         timeline: { name: "Releases" },
         events: [{ name: "RC1", timestamp: "2024-10-20T00:00:00Z" }],
       });
       cy.signOut();
       cy.signIn("readonly");
-      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
+      H.visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Created At: Year").should("be.visible");
 
@@ -549,7 +540,7 @@ describe("scenarios > organization > timelines > question", () => {
       cy.findByText("Releases").should("be.visible");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add an event").should("not.exist");
-      rightSidebar().icon("ellipsis").should("not.exist");
+      H.rightSidebar().icon("ellipsis").should("not.exist");
     });
   });
 });

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -1,23 +1,9 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  assertPermissionOptions,
-  assertPermissionTable,
-  assertSidebarItems,
-  describeEE,
-  modal,
-  modifyPermission,
-  onlyOnOSS,
-  restore,
-  selectPermissionRow,
-  selectSidebarItem,
-  setTokenFeatures,
-  visitDashboard,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 const { ALL_USERS_GROUP, ADMIN_GROUP, COLLECTION_GROUP, DATA_GROUP } =
   USER_GROUPS;
@@ -28,9 +14,9 @@ const NATIVE_QUERIES_PERMISSION_INDEX = 0;
 
 describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
   beforeEach(() => {
-    onlyOnOSS();
+    H.onlyOnOSS();
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -42,7 +28,7 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
       `admin/permissions/data/group/${ALL_USERS_GROUP}/database/${SAMPLE_DB_ID}`,
     );
 
-    assertPermissionTable([
+    H.assertPermissionTable([
       ["Accounts", "No"],
       ["Analytic Events", "No"],
       ["Feedback", "No"],
@@ -90,9 +76,9 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
     it("warns about leaving with unsaved changes", () => {
       cy.visit("/admin/permissions/collections");
 
-      selectSidebarItem("First collection");
+      H.selectSidebarItem("First collection");
 
-      modifyPermission(
+      H.modifyPermission(
         "All Users",
         COLLECTION_ACCESS_PERMISSION_INDEX,
         "View",
@@ -100,14 +86,14 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
       );
 
       // Navigation to other collection should not show any warnings
-      selectSidebarItem("Our analytics");
+      H.selectSidebarItem("Our analytics");
 
-      modal().should("not.exist");
+      H.modal().should("not.exist");
 
       // Switching to data permissions page
       cy.get("label").contains("Data").click();
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("Discard your changes?");
         cy.findByText(
           "Your changes haven't been saved, so you'll lose them if you navigate away.",
@@ -121,7 +107,7 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
       // Switching to data permissions page again
       cy.get("label").contains("Data").click();
 
-      modal().button("Discard changes").click();
+      H.modal().button("Discard changes").click();
 
       cy.url().should("include", "/admin/permissions/data/group");
     });
@@ -130,14 +116,14 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
       cy.visit("/admin/permissions/collections");
 
       const collections = ["Our analytics", "First collection"];
-      assertSidebarItems(collections);
+      H.assertSidebarItems(collections);
 
-      selectSidebarItem("First collection");
-      assertSidebarItems([...collections, "Second collection"]);
+      H.selectSidebarItem("First collection");
+      H.assertSidebarItems([...collections, "Second collection"]);
 
-      selectSidebarItem("Second collection");
+      H.selectSidebarItem("Second collection");
 
-      assertPermissionTable([
+      H.assertPermissionTable([
         ["Administrators", "Curate"],
         ["All Users", "No access"],
         ["collection", "Curate"],
@@ -146,7 +132,7 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         ["readonly", "View"],
       ]);
 
-      modifyPermission(
+      H.modifyPermission(
         "All Users",
         COLLECTION_ACCESS_PERMISSION_INDEX,
         "View",
@@ -154,9 +140,9 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
       );
 
       // Navigate to children
-      selectSidebarItem("Third collection");
+      H.selectSidebarItem("Third collection");
 
-      assertPermissionTable([
+      H.assertPermissionTable([
         ["Administrators", "Curate"],
         ["All Users", "View"], // Check permission has been propagated
         ["collection", "Curate"],
@@ -166,9 +152,9 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
       ]);
 
       // Navigate to parent
-      selectSidebarItem("First collection");
+      H.selectSidebarItem("First collection");
 
-      assertPermissionTable([
+      H.assertPermissionTable([
         ["Administrators", "Curate"],
         ["All Users", "No access"],
         ["collection", "Curate"],
@@ -177,16 +163,16 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         ["readonly", "View"],
       ]);
 
-      modifyPermission(
+      H.modifyPermission(
         "All Users",
         COLLECTION_ACCESS_PERMISSION_INDEX,
         "Curate",
         false,
       );
 
-      selectSidebarItem("Second collection");
+      H.selectSidebarItem("Second collection");
 
-      assertPermissionTable([
+      H.assertPermissionTable([
         ["Administrators", "Curate"],
         ["All Users", "View"], // Check permission has not been propagated
         ["collection", "Curate"],
@@ -197,7 +183,7 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
 
       cy.button("Save changes").click();
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("Save permissions?");
         cy.findByText("Are you sure you want to do this?");
         cy.button("Yes").click();
@@ -206,7 +192,7 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Save changes").should("not.exist");
 
-      assertPermissionTable([
+      H.assertPermissionTable([
         ["Administrators", "Curate"],
         ["All Users", "View"],
         ["collection", "Curate"],
@@ -221,14 +207,14 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
     cy.visit("/admin/permissions/collections");
 
     const collections = ["Our analytics", "First collection"];
-    assertSidebarItems(collections);
+    H.assertSidebarItems(collections);
 
-    selectSidebarItem("First collection");
-    assertSidebarItems([...collections, "Second collection"]);
+    H.selectSidebarItem("First collection");
+    H.assertSidebarItems([...collections, "Second collection"]);
 
-    selectSidebarItem("Second collection");
+    H.selectSidebarItem("Second collection");
 
-    assertPermissionTable([
+    H.assertPermissionTable([
       ["Administrators", "Curate"],
       ["All Users", "No access"],
       ["collection", "Curate"],
@@ -237,14 +223,14 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
       ["readonly", "View"],
     ]);
 
-    modifyPermission(
+    H.modifyPermission(
       "All Users",
       COLLECTION_ACCESS_PERMISSION_INDEX,
       "View",
       false,
     );
 
-    modifyPermission(
+    H.modifyPermission(
       "All Users",
       COLLECTION_ACCESS_PERMISSION_INDEX,
       null,
@@ -252,9 +238,9 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
     );
 
     // Navigate to children
-    selectSidebarItem("Third collection");
+    H.selectSidebarItem("Third collection");
 
-    assertPermissionTable([
+    H.assertPermissionTable([
       ["Administrators", "Curate"],
       ["All Users", "No access"], // Check permission hasn't been propagated
       ["collection", "Curate"],
@@ -268,28 +254,28 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
     cy.visit("/admin/permissions/collections");
 
     const collections = ["Our analytics", "First collection"];
-    assertSidebarItems(collections);
+    H.assertSidebarItems(collections);
 
-    selectSidebarItem("First collection");
-    assertSidebarItems([...collections, "Second collection"]);
+    H.selectSidebarItem("First collection");
+    H.assertSidebarItems([...collections, "Second collection"]);
 
-    selectSidebarItem("Second collection");
-    selectPermissionRow("All Users", COLLECTION_ACCESS_PERMISSION_INDEX);
-    assertPermissionOptions(["Curate", "View", "No access"]);
+    H.selectSidebarItem("Second collection");
+    H.selectPermissionRow("All Users", COLLECTION_ACCESS_PERMISSION_INDEX);
+    H.assertPermissionOptions(["Curate", "View", "No access"]);
 
-    selectSidebarItem("Third collection");
-    selectPermissionRow("All Users", COLLECTION_ACCESS_PERMISSION_INDEX);
+    H.selectSidebarItem("Third collection");
+    H.selectPermissionRow("All Users", COLLECTION_ACCESS_PERMISSION_INDEX);
 
-    assertPermissionOptions(["Curate", "View"]);
+    H.assertPermissionOptions(["Curate", "View"]);
   });
 
   context("data permissions", () => {
     it("warns about leaving with unsaved changes", () => {
       cy.visit("/admin/permissions");
 
-      selectSidebarItem("All Users");
+      H.selectSidebarItem("All Users");
 
-      modifyPermission(
+      H.modifyPermission(
         "Sample Database",
         NATIVE_QUERIES_PERMISSION_INDEX,
         "Query builder and native",
@@ -302,12 +288,12 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
       cy.get("label").contains("Databases").click();
 
       cy.url().should("include", "/admin/permissions/data/database");
-      modal().should("not.exist");
+      H.modal().should("not.exist");
 
       // Switching to collection permissions page
       cy.get("label").contains("Collection").click();
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("Discard your changes?");
         cy.findByText(
           "Your changes haven't been saved, so you'll lose them if you navigate away.",
@@ -321,7 +307,7 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
       // Switching to collection permissions page again
       cy.get("label").contains("Collection").click();
 
-      modal().button("Discard changes").click();
+      H.modal().button("Discard changes").click();
 
       cy.url().should("include", "/admin/permissions/collections");
     });
@@ -343,7 +329,7 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
           "readonly",
         ];
 
-        assertSidebarItems(groups);
+        H.assertSidebarItems(groups);
 
         // filter groups
         cy.findByPlaceholderText("Search for a group").type("a");
@@ -358,13 +344,13 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         // client filter debounce
         cy.wait(300);
 
-        assertSidebarItems(filteredGroups);
+        H.assertSidebarItems(filteredGroups);
       });
 
       it("allows to only view Administrators permissions", () => {
         cy.visit("/admin/permissions");
 
-        selectSidebarItem("Administrators");
+        H.selectSidebarItem("Administrators");
 
         cy.url().should(
           "include",
@@ -376,14 +362,14 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("1 person");
 
-        assertPermissionTable([
+        H.assertPermissionTable([
           ["Sample Database", "Query builder and native"],
         ]);
 
         // Drill down to tables permissions
         cy.findByTextEnsureVisible("Sample Database").click();
 
-        assertPermissionTable([
+        H.assertPermissionTable([
           ["Accounts", "Query builder and native"],
           ["Analytic Events", "Query builder and native"],
           ["Feedback", "Query builder and native"],
@@ -399,9 +385,9 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         cy.intercept("/api/permissions/graph/group/1").as("graph");
         cy.visit("/admin/permissions");
 
-        selectSidebarItem("collection");
+        H.selectSidebarItem("collection");
 
-        modifyPermission(
+        H.modifyPermission(
           "Sample Database",
           NATIVE_QUERIES_PERMISSION_INDEX,
           "Query builder and native",
@@ -412,9 +398,9 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
             groups: {},
             revision: data.response.body.revision,
           }).then(() => {
-            selectSidebarItem("data");
+            H.selectSidebarItem("data");
 
-            modal().findByText("Someone just changed permissions");
+            H.modal().findByText("Someone just changed permissions");
           });
         });
       });
@@ -425,9 +411,9 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         cy.intercept("/api/permissions/graph/group/1").as("graph");
         cy.visit("/admin/permissions/");
 
-        selectSidebarItem("collection");
+        H.selectSidebarItem("collection");
 
-        modifyPermission(
+        H.modifyPermission(
           "Sample Database",
           NATIVE_QUERIES_PERMISSION_INDEX,
           "Query builder and native",
@@ -439,9 +425,9 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
             revision: data.response.body.revision,
           }).then(() => {
             cy.get("label").contains("Databases").click();
-            selectSidebarItem("Sample Database");
+            H.selectSidebarItem("Sample Database");
 
-            modal().findByText("Someone just changed permissions");
+            H.modal().findByText("Someone just changed permissions");
           });
         });
       });
@@ -449,11 +435,11 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
   });
 });
 
-describeEE("scenarios > admin > permissions", () => {
+H.describeEE("scenarios > admin > permissions", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
   });
 
   it("Visualization and Settings query builder buttons are not visible for questions that use blocked data sources", () => {
@@ -471,7 +457,7 @@ describeEE("scenarios > admin > permissions", () => {
     });
 
     cy.signIn("nodata");
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("There was a problem with your question");
@@ -495,7 +481,7 @@ describeEE("scenarios > admin > permissions", () => {
     });
 
     cy.signIn("nodata");
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sorry, you don't have permission to see this card.");
@@ -504,7 +490,7 @@ describeEE("scenarios > admin > permissions", () => {
 
 describe("scenarios > admin > permissions", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -681,7 +667,7 @@ describe("scenarios > admin > permissions", () => {
 
 describe("scenarios > admin > permissions", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -689,12 +675,14 @@ describe("scenarios > admin > permissions", () => {
     it("partial data permission updates should not remove permissions from other unmodified groups", () => {
       // check the we have an expected initial state
       cy.visit(`admin/permissions/data/group/${DATA_GROUP}`);
-      assertPermissionTable([["Sample Database", "Query builder and native"]]);
+      H.assertPermissionTable([
+        ["Sample Database", "Query builder and native"],
+      ]);
 
       // make a change to the permissions of another group
-      selectSidebarItem("nosql");
-      assertPermissionTable([["Sample Database", "Query builder only"]]);
-      modifyPermission(
+      H.selectSidebarItem("nosql");
+      H.assertPermissionTable([["Sample Database", "Query builder only"]]);
+      H.modifyPermission(
         "Sample Database",
         NATIVE_QUERIES_PERMISSION_INDEX,
         "No",
@@ -706,7 +694,7 @@ describe("scenarios > admin > permissions", () => {
 
       // save changes
       cy.button("Save changes").click();
-      modal().within(() => {
+      H.modal().within(() => {
         cy.button("Yes").click();
       });
 
@@ -717,16 +705,18 @@ describe("scenarios > admin > permissions", () => {
       });
 
       // make sure that our other group's permission data did not get changed
-      selectSidebarItem("data");
-      assertPermissionTable([["Sample Database", "Query builder and native"]]);
+      H.selectSidebarItem("data");
+      H.assertPermissionTable([
+        ["Sample Database", "Query builder and native"],
+      ]);
     });
 
     it("partial collection permission updates should not prevent user from making further changes", () => {
       cy.visit("/admin/permissions/collections");
 
-      selectSidebarItem("First collection");
+      H.selectSidebarItem("First collection");
 
-      modifyPermission(
+      H.modifyPermission(
         "All Users",
         COLLECTION_ACCESS_PERMISSION_INDEX,
         "View",
@@ -738,7 +728,7 @@ describe("scenarios > admin > permissions", () => {
       );
 
       cy.button("Save changes").click();
-      modal().within(() => {
+      H.modal().within(() => {
         cy.button("Yes").click();
       });
 
@@ -747,9 +737,9 @@ describe("scenarios > admin > permissions", () => {
         expect(interception.response.body).to.not.haveOwnProperty("groups");
       });
 
-      selectSidebarItem("First collection");
+      H.selectSidebarItem("First collection");
 
-      modifyPermission(
+      H.modifyPermission(
         "nosql",
         COLLECTION_ACCESS_PERMISSION_INDEX,
         "Curate",
@@ -757,7 +747,7 @@ describe("scenarios > admin > permissions", () => {
       );
 
       cy.button("Save changes").click();
-      modal().within(() => {
+      H.modal().within(() => {
         cy.button("Yes").click();
       });
 

--- a/e2e/test/scenarios/permissions/application-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/application-permissions.cy.spec.js
@@ -1,26 +1,9 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  createPulse,
-  describeEE,
-  modal,
-  modifyPermission,
-  openSharingMenu,
-  popover,
-  restore,
-  setTokenFeatures,
-  setupSMTP,
-  sharingMenu,
-  sharingMenuButton,
-  sidebar,
-  tableInteractive,
-  undoToast,
-  visitDashboard,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
 
@@ -30,11 +13,11 @@ const SUBSCRIPTIONS_INDEX = 2;
 
 const NORMAL_USER_ID = 2;
 
-describeEE("scenarios > admin > permissions > application", () => {
+H.describeEE("scenarios > admin > permissions > application", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
   });
 
   it("shows permissions help", () => {
@@ -59,11 +42,11 @@ describeEE("scenarios > admin > permissions > application", () => {
       beforeEach(() => {
         cy.visit("/admin/permissions/application");
 
-        modifyPermission("All Users", SUBSCRIPTIONS_INDEX, "No");
+        H.modifyPermission("All Users", SUBSCRIPTIONS_INDEX, "No");
 
         cy.button("Save changes").click();
 
-        modal().within(() => {
+        H.modal().within(() => {
           cy.findByText("Save permissions?");
           cy.findByText("Are you sure you want to do this?");
           cy.button("Yes").click();
@@ -75,16 +58,16 @@ describeEE("scenarios > admin > permissions > application", () => {
       });
 
       it("revokes ability to create subscriptions and alerts and manage them", () => {
-        visitDashboard(ORDERS_DASHBOARD_ID);
+        H.visitDashboard(ORDERS_DASHBOARD_ID);
 
-        openSharingMenu();
-        sharingMenu()
+        H.openSharingMenu();
+        H.sharingMenu()
           .findByText(/subscri/i)
           .should("not.exist");
 
-        visitQuestion(ORDERS_QUESTION_ID);
-        tableInteractive().should("be.visible");
-        sharingMenuButton().should("be.disabled");
+        H.visitQuestion(ORDERS_QUESTION_ID);
+        H.tableInteractive().should("be.visible");
+        H.sharingMenuButton().should("be.disabled");
 
         cy.visit("/account/notifications");
         cy.findByTestId("notifications-list").within(() => {
@@ -95,18 +78,18 @@ describeEE("scenarios > admin > permissions > application", () => {
 
     describe("granted", () => {
       it("gives ability to create dashboard subscriptions and question alerts", () => {
-        setupSMTP();
+        H.setupSMTP();
         cy.signInAsNormalUser();
 
         cy.log("Create a dashboard subscription");
-        visitDashboard(ORDERS_DASHBOARD_ID);
-        openSharingMenu(/subscriptions/i);
-        sidebar().findByText("Email this dashboard").should("exist");
+        H.visitDashboard(ORDERS_DASHBOARD_ID);
+        H.openSharingMenu(/subscriptions/i);
+        H.sidebar().findByText("Email this dashboard").should("exist");
 
         cy.log("Create a question alert");
-        visitQuestion(ORDERS_QUESTION_ID);
-        openSharingMenu(/alert/i);
-        modal().findByText("The wide world of alerts").should("be.visible");
+        H.visitQuestion(ORDERS_QUESTION_ID);
+        H.openSharingMenu(/alert/i);
+        H.modal().findByText("The wide world of alerts").should("be.visible");
       });
     });
   });
@@ -116,11 +99,11 @@ describeEE("scenarios > admin > permissions > application", () => {
       beforeEach(() => {
         cy.visit("/admin/permissions/application");
 
-        modifyPermission("All Users", MONITORING_INDEX, "Yes");
+        H.modifyPermission("All Users", MONITORING_INDEX, "Yes");
 
         cy.button("Save changes").click();
 
-        modal().within(() => {
+        H.modal().within(() => {
           cy.findByText("Save permissions?");
           cy.findByText("Are you sure you want to do this?");
           cy.button("Yes").click();
@@ -141,7 +124,7 @@ describeEE("scenarios > admin > permissions > application", () => {
         cy.visit("/");
         cy.icon("gear").click();
 
-        popover().findByText("Admin settings").click();
+        H.popover().findByText("Admin settings").click();
 
         cy.log("Tools smoke test");
         cy.location("pathname").should("eq", "/admin/tools/errors");
@@ -186,11 +169,11 @@ describeEE("scenarios > admin > permissions > application", () => {
       beforeEach(() => {
         cy.visit("/admin/permissions/application");
 
-        modifyPermission("All Users", SETTINGS_INDEX, "Yes");
+        H.modifyPermission("All Users", SETTINGS_INDEX, "Yes");
 
         cy.button("Save changes").click();
 
-        modal().within(() => {
+        H.modal().within(() => {
           cy.findByText("Save permissions?");
           cy.findByText("Are you sure you want to do this?");
           cy.button("Yes").click();
@@ -218,7 +201,7 @@ describeEE("scenarios > admin > permissions > application", () => {
         // General smoke test
         cy.get("#setting-site-name").clear().type("new name").blur();
 
-        undoToast().findByText("Changes saved").should("be.visible");
+        H.undoToast().findByText("Changes saved").should("be.visible");
       });
     });
   });
@@ -233,7 +216,7 @@ function createSubscription(user_id) {
       },
     },
   }).then(({ body: { card_id, dashboard_id } }) => {
-    createPulse({
+    H.createPulse({
       name: "Subscription",
       dashboard_id,
       cards: [

--- a/e2e/test/scenarios/permissions/create-queries.cy.spec.js
+++ b/e2e/test/scenarios/permissions/create-queries.cy.spec.js
@@ -1,13 +1,5 @@
+import { H } from "e2e/support";
 import { USER_GROUPS } from "e2e/support/cypress_data";
-import {
-  assertPermissionTable,
-  modal,
-  modifyPermission,
-  popover,
-  restore,
-  selectPermissionRow,
-  selectSidebarItem,
-} from "e2e/support/helpers";
 
 const { ALL_USERS_GROUP } = USER_GROUPS;
 
@@ -15,26 +7,26 @@ const NATIVE_QUERIES_PERMISSION_INDEX = 0;
 
 describe("scenarios > admin > permissions > create queries > granular", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should allow configuring granular permissions in group view", () => {
     cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
-    modifyPermission(
+    H.modifyPermission(
       "Sample Database",
       NATIVE_QUERIES_PERMISSION_INDEX,
       "Query builder and native",
     );
 
     // should allow choosing granular option at the db level
-    modifyPermission(
+    H.modifyPermission(
       "Sample Database",
       NATIVE_QUERIES_PERMISSION_INDEX,
       "Granular",
     );
 
-    assertPermissionTable([
+    H.assertPermissionTable([
       ["Accounts", "Query builder and native"],
       ["Analytic Events", "Query builder and native"],
       ["Feedback", "Query builder and native"],
@@ -46,15 +38,15 @@ describe("scenarios > admin > permissions > create queries > granular", () => {
     ]);
 
     // should allow setting a granular value for one table
-    modifyPermission("Orders", NATIVE_QUERIES_PERMISSION_INDEX, "No");
+    H.modifyPermission("Orders", NATIVE_QUERIES_PERMISSION_INDEX, "No");
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Change access to this database to “Granular”?");
       cy.findByText("Change").click();
     });
 
     // should also remove native permissions for all other tables
-    assertPermissionTable([
+    H.assertPermissionTable([
       ["Accounts", "Query builder only"],
       ["Analytic Events", "Query builder only"],
       ["Feedback", "Query builder only"],
@@ -66,17 +58,17 @@ describe("scenarios > admin > permissions > create queries > granular", () => {
     ]);
 
     // should not allow 'query builder and native' as a granular permissions permission options
-    selectPermissionRow("Orders", NATIVE_QUERIES_PERMISSION_INDEX);
-    popover().should("not.contain", "Query builder and native");
+    H.selectPermissionRow("Orders", NATIVE_QUERIES_PERMISSION_INDEX);
+    H.popover().should("not.contain", "Query builder and native");
 
     // should have db set to granular
-    selectSidebarItem("All Users");
-    assertPermissionTable([["Sample Database", "Granular"]]);
+    H.selectSidebarItem("All Users");
+    H.assertPermissionTable([["Sample Database", "Granular"]]);
 
     // should allow saving
     cy.intercept("PUT", "/api/permissions/graph").as("saveGraph");
     cy.button("Save changes").click();
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Save permissions?");
       cy.button("Yes").click();
     });
@@ -87,42 +79,46 @@ describe("scenarios > admin > permissions > create queries > granular", () => {
 
     // should infer value at db level if the tables are all made the same value
     cy.findByTextEnsureVisible("Sample Database").click();
-    modifyPermission(
+    H.modifyPermission(
       "Orders",
       NATIVE_QUERIES_PERMISSION_INDEX,
       "Query builder only",
     );
-    selectSidebarItem("All Users");
-    assertPermissionTable([["Sample Database", "Query builder only"]]);
+    H.selectSidebarItem("All Users");
+    H.assertPermissionTable([["Sample Database", "Query builder only"]]);
   });
 });
 
 describe("scenarios > admin > permissions > create queries > no", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should allow setting create queries to 'no' in group view", () => {
     cy.visit("/admin/permissions/data");
-    selectSidebarItem("data");
+    H.selectSidebarItem("data");
 
-    modifyPermission("Sample Database", NATIVE_QUERIES_PERMISSION_INDEX, "No");
+    H.modifyPermission(
+      "Sample Database",
+      NATIVE_QUERIES_PERMISSION_INDEX,
+      "No",
+    );
 
-    assertPermissionTable([["Sample Database", "No"]]);
+    H.assertPermissionTable([["Sample Database", "No"]]);
 
     cy.button("Save changes").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Save permissions?");
       cy.button("Yes").click();
     });
 
-    assertPermissionTable([["Sample Database", "No"]]);
+    H.assertPermissionTable([["Sample Database", "No"]]);
 
     cy.findByTextEnsureVisible("Sample Database").click();
 
-    assertPermissionTable([
+    H.assertPermissionTable([
       ["Accounts", "No"],
       ["Analytic Events", "No"],
       ["Feedback", "No"],
@@ -137,20 +133,20 @@ describe("scenarios > admin > permissions > create queries > no", () => {
 
 describe("scenarios > admin > permissions > create queries > query builder and native", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should allow setting create queries to 'query builder and native' in group view", () => {
     cy.visit("/admin/permissions");
-    selectSidebarItem("collection");
+    H.selectSidebarItem("collection");
 
-    assertPermissionTable([["Sample Database", "No"]]);
+    H.assertPermissionTable([["Sample Database", "No"]]);
 
     // Drill down to tables permissions
     cy.findByTextEnsureVisible("Sample Database").click();
 
-    assertPermissionTable([
+    H.assertPermissionTable([
       ["Accounts", "No"],
       ["Analytic Events", "No"],
       ["Feedback", "No"],
@@ -162,19 +158,19 @@ describe("scenarios > admin > permissions > create queries > query builder and n
     ]);
 
     // Test that query builder and native is not an option when it's not selected at table level
-    selectPermissionRow("Orders", NATIVE_QUERIES_PERMISSION_INDEX);
-    popover().should("not.contain", "Query builder and native");
+    H.selectPermissionRow("Orders", NATIVE_QUERIES_PERMISSION_INDEX);
+    H.popover().should("not.contain", "Query builder and native");
 
     // Navigate back
-    selectSidebarItem("collection");
+    H.selectSidebarItem("collection");
 
-    modifyPermission(
+    H.modifyPermission(
       "Sample Database",
       NATIVE_QUERIES_PERMISSION_INDEX,
       "Query builder and native",
     );
 
-    assertPermissionTable([["Sample Database", "Query builder and native"]]);
+    H.assertPermissionTable([["Sample Database", "Query builder and native"]]);
 
     // Drill down to tables permissions
     cy.findByTextEnsureVisible("Sample Database").click();
@@ -190,11 +186,11 @@ describe("scenarios > admin > permissions > create queries > query builder and n
       ["Reviews", "Query builder and native"],
     ];
 
-    assertPermissionTable(finalTablePermissions);
+    H.assertPermissionTable(finalTablePermissions);
 
     cy.button("Save changes").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Save permissions?");
       cy.contains(
         "collection will be able to use the query builder and write native queries for Sample Database.",
@@ -205,18 +201,22 @@ describe("scenarios > admin > permissions > create queries > query builder and n
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save changes").should("not.exist");
 
-    assertPermissionTable(finalTablePermissions);
+    H.assertPermissionTable(finalTablePermissions);
 
     // After saving permissions, user should be able to make further edits without refreshing the page
     // metabase#37811
-    selectSidebarItem("data");
+    H.selectSidebarItem("data");
 
-    modifyPermission("Sample Database", NATIVE_QUERIES_PERMISSION_INDEX, "No");
+    H.modifyPermission(
+      "Sample Database",
+      NATIVE_QUERIES_PERMISSION_INDEX,
+      "No",
+    );
 
     cy.button("Refresh the page").should("not.exist");
 
     // User should have the option to change permissions back to query builder and native at the database level
-    modifyPermission(
+    H.modifyPermission(
       "Sample Database",
       NATIVE_QUERIES_PERMISSION_INDEX,
       "Query builder and native",
@@ -230,9 +230,9 @@ describe("scenarios > admin > permissions > create queries > query builder and n
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select a database to see group permissions");
 
-    selectSidebarItem("Sample Database");
+    H.selectSidebarItem("Sample Database");
 
-    assertPermissionTable([
+    H.assertPermissionTable([
       ["Administrators", "Query builder and native"],
       ["All Users", "No"],
       ["collection", "No"],
@@ -241,7 +241,7 @@ describe("scenarios > admin > permissions > create queries > query builder and n
       ["readonly", "No"],
     ]);
 
-    modifyPermission(
+    H.modifyPermission(
       "readonly",
       NATIVE_QUERIES_PERMISSION_INDEX,
       "Query builder and native",
@@ -255,18 +255,18 @@ describe("scenarios > admin > permissions > create queries > query builder and n
       ["nosql", "Query builder only"],
       ["readonly", "Query builder and native"],
     ];
-    assertPermissionTable(finalPermissions);
+    H.assertPermissionTable(finalPermissions);
 
-    selectSidebarItem("Orders");
+    H.selectSidebarItem("Orders");
 
-    assertPermissionTable(finalPermissions);
+    H.assertPermissionTable(finalPermissions);
 
     // Navigate back
     cy.get("a").contains("Sample Database").click();
 
     cy.button("Save changes").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Save permissions?");
       cy.contains(
         "readonly will be able to use the query builder and write native queries for Sample Database.",
@@ -277,26 +277,26 @@ describe("scenarios > admin > permissions > create queries > query builder and n
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save changes").should("not.exist");
 
-    assertPermissionTable(finalPermissions);
+    H.assertPermissionTable(finalPermissions);
   });
 });
 
 describe("scenarios > admin > permissions > create queries > query builder only", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should allow setting create queries to 'query builder only' in group view", () => {
     cy.visit("/admin/permissions");
-    selectSidebarItem("collection");
+    H.selectSidebarItem("collection");
 
-    assertPermissionTable([["Sample Database", "No"]]);
+    H.assertPermissionTable([["Sample Database", "No"]]);
 
     // Drill down to tables permissions
     cy.findByTextEnsureVisible("Sample Database").click();
 
-    assertPermissionTable([
+    H.assertPermissionTable([
       ["Accounts", "No"],
       ["Analytic Events", "No"],
       ["Feedback", "No"],
@@ -308,15 +308,15 @@ describe("scenarios > admin > permissions > create queries > query builder only"
     ]);
 
     // Navigate back
-    selectSidebarItem("collection");
+    H.selectSidebarItem("collection");
 
-    modifyPermission(
+    H.modifyPermission(
       "Sample Database",
       NATIVE_QUERIES_PERMISSION_INDEX,
       "Query builder only",
     );
 
-    assertPermissionTable([["Sample Database", "Query builder only"]]);
+    H.assertPermissionTable([["Sample Database", "Query builder only"]]);
 
     // Drill down to tables permissions
     cy.findByTextEnsureVisible("Sample Database").click();
@@ -332,11 +332,11 @@ describe("scenarios > admin > permissions > create queries > query builder only"
       ["Reviews", "Query builder only"],
     ];
 
-    assertPermissionTable(finalTablePermissions);
+    H.assertPermissionTable(finalTablePermissions);
 
     cy.button("Save changes").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Save permissions?");
       cy.contains(
         "collection will only be able to use the query builder for Sample Database.",
@@ -347,18 +347,22 @@ describe("scenarios > admin > permissions > create queries > query builder only"
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save changes").should("not.exist");
 
-    assertPermissionTable(finalTablePermissions);
+    H.assertPermissionTable(finalTablePermissions);
 
     // After saving permissions, user should be able to make further edits without refreshing the page
     // metabase#37811
-    selectSidebarItem("data");
+    H.selectSidebarItem("data");
 
-    modifyPermission("Sample Database", NATIVE_QUERIES_PERMISSION_INDEX, "No");
+    H.modifyPermission(
+      "Sample Database",
+      NATIVE_QUERIES_PERMISSION_INDEX,
+      "No",
+    );
 
     cy.button("Refresh the page").should("not.exist");
 
     // User should have the option to change permissions back to query builder only at the database level
-    modifyPermission(
+    H.modifyPermission(
       "Sample Database",
       NATIVE_QUERIES_PERMISSION_INDEX,
       "Query builder only",
@@ -367,11 +371,11 @@ describe("scenarios > admin > permissions > create queries > query builder only"
 
   it("should set entire database to 'query builder only' if a table is changed to it while db is 'query builder only'", () => {
     cy.visit("/admin/permissions");
-    selectSidebarItem("collection");
+    H.selectSidebarItem("collection");
 
-    assertPermissionTable([["Sample Database", "No"]]);
+    H.assertPermissionTable([["Sample Database", "No"]]);
 
-    modifyPermission(
+    H.modifyPermission(
       "Sample Database",
       NATIVE_QUERIES_PERMISSION_INDEX,
       "Query builder and native",
@@ -380,7 +384,7 @@ describe("scenarios > admin > permissions > create queries > query builder only"
     // Drill down to tables permissions
     cy.findByTextEnsureVisible("Sample Database").click();
 
-    assertPermissionTable([
+    H.assertPermissionTable([
       ["Accounts", "Query builder and native"],
       ["Analytic Events", "Query builder and native"],
       ["Feedback", "Query builder and native"],
@@ -391,13 +395,13 @@ describe("scenarios > admin > permissions > create queries > query builder only"
       ["Reviews", "Query builder and native"],
     ]);
 
-    modifyPermission(
+    H.modifyPermission(
       "Orders",
       NATIVE_QUERIES_PERMISSION_INDEX,
       "Query builder only",
     );
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Change access to this database to “Granular”?");
       cy.findByText("Change").click();
     });
@@ -413,15 +417,15 @@ describe("scenarios > admin > permissions > create queries > query builder only"
       ["Reviews", "Query builder only"],
     ];
 
-    assertPermissionTable(finalTablePermissions);
+    H.assertPermissionTable(finalTablePermissions);
 
     // Navigate back
-    selectSidebarItem("collection");
-    assertPermissionTable([["Sample Database", "Query builder only"]]);
+    H.selectSidebarItem("collection");
+    H.assertPermissionTable([["Sample Database", "Query builder only"]]);
 
     cy.button("Save changes").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Save permissions?");
       cy.contains(
         "collection will only be able to use the query builder for Sample Database.",
@@ -435,19 +439,19 @@ describe("scenarios > admin > permissions > create queries > query builder only"
     // Drill down to tables permissions
     cy.findByTextEnsureVisible("Sample Database").click();
 
-    assertPermissionTable(finalTablePermissions);
+    H.assertPermissionTable(finalTablePermissions);
   });
 
   it("should allow setting create queries to 'query builder only' in group view", () => {
     cy.visit("/admin/permissions");
-    selectSidebarItem("collection");
+    H.selectSidebarItem("collection");
 
-    assertPermissionTable([["Sample Database", "No"]]);
+    H.assertPermissionTable([["Sample Database", "No"]]);
 
     // Drill down to tables permissions
     cy.findByTextEnsureVisible("Sample Database").click();
 
-    assertPermissionTable([
+    H.assertPermissionTable([
       ["Accounts", "No"],
       ["Analytic Events", "No"],
       ["Feedback", "No"],
@@ -459,15 +463,15 @@ describe("scenarios > admin > permissions > create queries > query builder only"
     ]);
 
     // Navigate back
-    selectSidebarItem("collection");
+    H.selectSidebarItem("collection");
 
-    modifyPermission(
+    H.modifyPermission(
       "Sample Database",
       NATIVE_QUERIES_PERMISSION_INDEX,
       "Query builder only",
     );
 
-    assertPermissionTable([["Sample Database", "Query builder only"]]);
+    H.assertPermissionTable([["Sample Database", "Query builder only"]]);
 
     // Drill down to tables permissions
     cy.findByTextEnsureVisible("Sample Database").click();
@@ -483,11 +487,11 @@ describe("scenarios > admin > permissions > create queries > query builder only"
       ["Reviews", "Query builder only"],
     ];
 
-    assertPermissionTable(finalTablePermissions);
+    H.assertPermissionTable(finalTablePermissions);
 
     cy.button("Save changes").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Save permissions?");
       cy.contains(
         "collection will only be able to use the query builder for Sample Database.",
@@ -498,18 +502,22 @@ describe("scenarios > admin > permissions > create queries > query builder only"
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save changes").should("not.exist");
 
-    assertPermissionTable(finalTablePermissions);
+    H.assertPermissionTable(finalTablePermissions);
 
     // After saving permissions, user should be able to make further edits without refreshing the page
     // metabase#37811
-    selectSidebarItem("data");
+    H.selectSidebarItem("data");
 
-    modifyPermission("Sample Database", NATIVE_QUERIES_PERMISSION_INDEX, "No");
+    H.modifyPermission(
+      "Sample Database",
+      NATIVE_QUERIES_PERMISSION_INDEX,
+      "No",
+    );
 
     cy.button("Refresh the page").should("not.exist");
 
     // User should have the option to change permissions back to query builder only at the database level
-    modifyPermission(
+    H.modifyPermission(
       "Sample Database",
       NATIVE_QUERIES_PERMISSION_INDEX,
       "Query builder only",
@@ -523,9 +531,9 @@ describe("scenarios > admin > permissions > create queries > query builder only"
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select a database to see group permissions");
 
-    selectSidebarItem("Sample Database");
+    H.selectSidebarItem("Sample Database");
 
-    assertPermissionTable([
+    H.assertPermissionTable([
       ["Administrators", "Query builder and native"],
       ["All Users", "No"],
       ["collection", "No"],
@@ -534,7 +542,7 @@ describe("scenarios > admin > permissions > create queries > query builder only"
       ["readonly", "No"],
     ]);
 
-    modifyPermission(
+    H.modifyPermission(
       "readonly",
       NATIVE_QUERIES_PERMISSION_INDEX,
       "Query builder only",
@@ -548,18 +556,18 @@ describe("scenarios > admin > permissions > create queries > query builder only"
       ["nosql", "Query builder only"],
       ["readonly", "Query builder only"],
     ];
-    assertPermissionTable(finalPermissions);
+    H.assertPermissionTable(finalPermissions);
 
-    selectSidebarItem("Orders");
+    H.selectSidebarItem("Orders");
 
-    assertPermissionTable(finalPermissions);
+    H.assertPermissionTable(finalPermissions);
 
     // Navigate back
     cy.get("a").contains("Sample Database").click();
 
     cy.button("Save changes").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Save permissions?");
       cy.contains(
         "readonly will only be able to use the query builder for Sample Database.",
@@ -570,6 +578,6 @@ describe("scenarios > admin > permissions > create queries > query builder only"
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save changes").should("not.exist");
 
-    assertPermissionTable(finalPermissions);
+    H.assertPermissionTable(finalPermissions);
   });
 });

--- a/e2e/test/scenarios/permissions/data-model-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/data-model-permissions.cy.spec.js
@@ -1,24 +1,17 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, SAMPLE_DB_SCHEMA_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  assertPermissionForItem,
-  describeEE,
-  modal,
-  modifyPermission,
-  restore,
-  setTokenFeatures,
-} from "e2e/support/helpers";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
 
 const DATA_ACCESS_PERMISSION_INDEX = 0;
 const DATA_MODEL_PERMISSION_INDEX = 3;
 
-describeEE("scenarios > admin > permissions", () => {
+H.describeEE("scenarios > admin > permissions", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
 
     cy.intercept("PUT", "/api/table/*").as("tableUpdate");
     cy.intercept("PUT", "/api/field/*").as("fieldUpdate");
@@ -31,13 +24,13 @@ describeEE("scenarios > admin > permissions", () => {
   it("allows data model permission for a table in database", () => {
     cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
     // Change permission
-    modifyPermission("All Users", DATA_ACCESS_PERMISSION_INDEX, "Granular");
-    modifyPermission("Orders", DATA_MODEL_PERMISSION_INDEX, "Yes");
+    H.modifyPermission("All Users", DATA_ACCESS_PERMISSION_INDEX, "Granular");
+    H.modifyPermission("Orders", DATA_MODEL_PERMISSION_INDEX, "Yes");
 
     savePermissionsGraph();
 
     // Assert the permission has changed
-    assertPermissionForItem("Orders", DATA_MODEL_PERMISSION_INDEX, "Yes");
+    H.assertPermissionForItem("Orders", DATA_MODEL_PERMISSION_INDEX, "Yes");
 
     // Check limited access as a non-admin user
     cy.signInAsNormalUser();
@@ -80,12 +73,12 @@ describeEE("scenarios > admin > permissions", () => {
   it("allows changing data model permission for an entire database", () => {
     cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
     // Change data model permission
-    modifyPermission("All Users", DATA_MODEL_PERMISSION_INDEX, "Yes");
+    H.modifyPermission("All Users", DATA_MODEL_PERMISSION_INDEX, "Yes");
 
     savePermissionsGraph();
 
     // Assert the permission has changed
-    assertPermissionForItem("All Users", DATA_MODEL_PERMISSION_INDEX, "Yes");
+    H.assertPermissionForItem("All Users", DATA_MODEL_PERMISSION_INDEX, "Yes");
 
     // Check limited access as a non-admin user
     cy.signInAsNormalUser();
@@ -114,8 +107,8 @@ describeEE("scenarios > admin > permissions", () => {
   it("shows `Field access denied` for foreign keys from tables user does not have access to (metabase#21762)", () => {
     cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
     // Change data model permission
-    modifyPermission("All Users", DATA_MODEL_PERMISSION_INDEX, "Granular");
-    modifyPermission("Orders", DATA_MODEL_PERMISSION_INDEX, "Yes");
+    H.modifyPermission("All Users", DATA_MODEL_PERMISSION_INDEX, "Granular");
+    H.modifyPermission("Orders", DATA_MODEL_PERMISSION_INDEX, "Yes");
 
     savePermissionsGraph();
 
@@ -134,7 +127,7 @@ describeEE("scenarios > admin > permissions", () => {
 
 function savePermissionsGraph() {
   cy.button("Save changes").click();
-  modal().within(() => {
+  H.modal().within(() => {
     cy.findByText("Save permissions?");
     cy.findByText("Are you sure you want to do this?");
     cy.button("Yes").click();

--- a/e2e/test/scenarios/permissions/database-details-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/database-details-permissions.cy.spec.js
@@ -1,38 +1,31 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
-import {
-  assertPermissionForItem,
-  describeEE,
-  modal,
-  modifyPermission,
-  restore,
-  setTokenFeatures,
-} from "e2e/support/helpers";
 
 const DETAILS_PERMISSION_INDEX = 4;
 
-describeEE(
+H.describeEE(
   "scenarios > admin > permissions > database details permissions",
   () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
-      setTokenFeatures("all");
+      H.setTokenFeatures("all");
     });
 
     it("allows database managers to see and edit database details but not to delete a database (metabase#22293)", () => {
       // As an admin, grant database details permissions to all users
       cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
-      modifyPermission("All Users", DETAILS_PERMISSION_INDEX, "Yes");
+      H.modifyPermission("All Users", DETAILS_PERMISSION_INDEX, "Yes");
 
       cy.button("Save changes").click();
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("Save permissions?");
         cy.findByText("Are you sure you want to do this?");
         cy.button("Yes").click();
       });
 
-      assertPermissionForItem("All Users", DETAILS_PERMISSION_INDEX, "Yes");
+      H.assertPermissionForItem("All Users", DETAILS_PERMISSION_INDEX, "Yes");
 
       // Normal user should now have the ability to manage databases
       cy.signInAsNormalUser();

--- a/e2e/test/scenarios/permissions/downgrade-ee-to-oss.cy.spec.js
+++ b/e2e/test/scenarios/permissions/downgrade-ee-to-oss.cy.spec.js
@@ -1,25 +1,16 @@
+import { H } from "e2e/support";
 import { USER_GROUPS } from "e2e/support/cypress_data";
-import {
-  assertPermissionTable,
-  describeEE,
-  isPermissionDisabled,
-  modal,
-  modifyPermission,
-  popover,
-  restore,
-  setTokenFeatures,
-} from "e2e/support/helpers";
 
 const { ALL_USERS_GROUP } = USER_GROUPS;
 
 const EE_DATA_ACCESS_PERMISSION_INDEX = 0;
 const OSS_NATIVE_QUERIES_PERMISSION_INDEX = 0;
 
-describeEE("scenarios > admin > permissions > downgrade ee to oss", () => {
+H.describeEE("scenarios > admin > permissions > downgrade ee to oss", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
   });
 
   // we have a case where users may be downgraded for not paying but then will sort out billing and upgrade back to EE again.
@@ -29,38 +20,38 @@ describeEE("scenarios > admin > permissions > downgrade ee to oss", () => {
 
   it("should allow users to edit permissions after downgrading EE to OSS", () => {
     cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
-    modifyPermission(
+    H.modifyPermission(
       "Sample Database",
       EE_DATA_ACCESS_PERMISSION_INDEX,
       "Blocked",
     );
     cy.button("Save changes").click();
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Save permissions?");
       cy.button("Yes").click();
     });
 
-    setTokenFeatures("none").then(() => {
+    H.setTokenFeatures("none").then(() => {
       cy.reload();
 
-      assertPermissionTable([["Sample Database", "No"]]);
-      isPermissionDisabled(OSS_NATIVE_QUERIES_PERMISSION_INDEX, "No", false);
+      H.assertPermissionTable([["Sample Database", "No"]]);
+      H.isPermissionDisabled(OSS_NATIVE_QUERIES_PERMISSION_INDEX, "No", false);
 
-      modifyPermission(
+      H.modifyPermission(
         "Sample Database",
         OSS_NATIVE_QUERIES_PERMISSION_INDEX,
         "Query builder and native",
       );
       cy.button("Save changes").click();
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("Save permissions?");
         cy.button("Yes").click();
       });
 
-      setTokenFeatures("all").then(() => {
+      H.setTokenFeatures("all").then(() => {
         cy.reload();
 
-        assertPermissionTable([
+        H.assertPermissionTable([
           [
             "Sample Database",
             "Can view",
@@ -80,7 +71,7 @@ describeEE("scenarios > admin > permissions > downgrade ee to oss", () => {
   it("should preserve unedited EE values in graph when OSS", () => {
     // starting as EE, set a EE only value in the graph
     cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
-    modifyPermission(
+    H.modifyPermission(
       "Sample Database",
       EE_DATA_ACCESS_PERMISSION_INDEX,
       "Granular",
@@ -91,14 +82,18 @@ describeEE("scenarios > admin > permissions > downgrade ee to oss", () => {
       ["Orders", "User ID"],
       ["People", "ID"],
     ].forEach(([tableName, colName]) => {
-      modifyPermission(tableName, EE_DATA_ACCESS_PERMISSION_INDEX, "Sandboxed");
+      H.modifyPermission(
+        tableName,
+        EE_DATA_ACCESS_PERMISSION_INDEX,
+        "Sandboxed",
+      );
 
       cy.findByText("Pick a column").click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText(colName).click();
       });
       cy.findByText("Pick a user attribute").click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("attr_uid").click();
       });
       cy.button("Save").click();
@@ -106,16 +101,16 @@ describeEE("scenarios > admin > permissions > downgrade ee to oss", () => {
 
     // save changes
     cy.button("Save changes").click();
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Save permissions?");
       cy.button("Yes").click();
     });
 
     // downgrade to OSS
-    setTokenFeatures("none");
+    H.setTokenFeatures("none");
     cy.reload();
 
-    assertPermissionTable([
+    H.assertPermissionTable([
       ["Accounts", "No"],
       ["Analytic Events", "No"],
       ["Feedback", "No"],
@@ -126,23 +121,23 @@ describeEE("scenarios > admin > permissions > downgrade ee to oss", () => {
       ["Reviews", "No"],
     ]);
 
-    modifyPermission(
+    H.modifyPermission(
       "Orders",
       EE_DATA_ACCESS_PERMISSION_INDEX,
       "Query builder only",
     );
 
     cy.button("Save changes").click();
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Save permissions?");
       cy.button("Yes").click();
     });
 
     // upgrade back to EE
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
     cy.reload();
 
-    assertPermissionTable([
+    H.assertPermissionTable([
       ["Accounts", "Can view", "No", "1 million rows", "No"],
       ["Analytic Events", "Can view", "No", "1 million rows", "No"],
       ["Feedback", "Can view", "No", "1 million rows", "No"],

--- a/e2e/test/scenarios/permissions/download-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/download-permissions.cy.spec.js
@@ -1,23 +1,10 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  assertPermissionForItem,
-  assertSheetRowsCount,
-  describeEE,
-  downloadAndAssert,
-  modal,
-  modifyPermission,
-  popover,
-  restore,
-  setTokenFeatures,
-  sidebar,
-  visitDashboard,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 const { ALL_USERS_GROUP, COLLECTION_GROUP, DATA_GROUP } = USER_GROUPS;
 
@@ -35,11 +22,11 @@ const {
 const DATA_ACCESS_PERMISSION_INDEX = 0;
 const DOWNLOAD_PERMISSION_INDEX = 2;
 
-describeEE("scenarios > admin > permissions > data > downloads", () => {
+H.describeEE("scenarios > admin > permissions > data > downloads", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
     // Restrict downloads for Collection and Data groups before each test so that they don't override All Users
     cy.updatePermissionsGraph({
       [COLLECTION_GROUP]: {
@@ -60,33 +47,37 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
 
     cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
 
-    modifyPermission("All Users", DOWNLOAD_PERMISSION_INDEX, "No");
+    H.modifyPermission("All Users", DOWNLOAD_PERMISSION_INDEX, "No");
 
     cy.button("Save changes").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Save permissions?");
       cy.findByText("Are you sure you want to do this?");
       cy.button("Yes").click();
     });
 
-    assertPermissionForItem("All Users", DOWNLOAD_PERMISSION_INDEX, "No");
+    H.assertPermissionForItem("All Users", DOWNLOAD_PERMISSION_INDEX, "No");
 
     cy.log("Make sure we can change download results permission for a table");
 
-    sidebar().contains("Orders").click();
+    H.sidebar().contains("Orders").click();
 
-    modifyPermission("All Users", DOWNLOAD_PERMISSION_INDEX, "1 million rows");
+    H.modifyPermission(
+      "All Users",
+      DOWNLOAD_PERMISSION_INDEX,
+      "1 million rows",
+    );
 
     cy.button("Save changes").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Save permissions?");
       cy.findByText("Are you sure you want to do this?");
       cy.button("Yes").click();
     });
 
-    assertPermissionForItem(
+    H.assertPermissionForItem(
       "All Users",
       DOWNLOAD_PERMISSION_INDEX,
       "1 million rows",
@@ -95,24 +86,24 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
 
   it("respects 'no download' permissions when 'All users' group data permissions are set to `Blocked` (metabase#22408)", () => {
     cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
-    modifyPermission("All Users", DATA_ACCESS_PERMISSION_INDEX, "Blocked");
+    H.modifyPermission("All Users", DATA_ACCESS_PERMISSION_INDEX, "Blocked");
 
     cy.button("Save changes").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Save permissions?");
       cy.findByText("Are you sure you want to do this?");
       cy.button("Yes").click();
     });
 
     // When data permissions are set to `Blocked`, download permissions are automatically revoked
-    assertPermissionForItem("All Users", DOWNLOAD_PERMISSION_INDEX, "No");
+    H.assertPermissionForItem("All Users", DOWNLOAD_PERMISSION_INDEX, "No");
 
     // Normal user belongs to both "data" and "collection" groups.
     // They both have restricted downloads so this user shouldn't have the right to download anything.
     cy.signInAsNormalUser();
 
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing first 2,000 rows");
@@ -131,20 +122,20 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
 
     cy.signInAsNormalUser();
 
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing first 2,000 rows");
     cy.icon("download").should("not.exist");
 
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
 
     cy.findByTestId("dashcard").within(() => {
       cy.findByTestId("legend-caption").realHover();
       cy.findByTestId("dashcard-menu").click();
     });
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Edit question").should("be.visible");
       cy.findByText("Download results").should("not.exist");
     });
@@ -161,11 +152,11 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
     });
 
     cy.signInAsNormalUser();
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
 
-    downloadAndAssert(
+    H.downloadAndAssert(
       { fileType: "xlsx", questionId: ORDERS_QUESTION_ID },
-      assertSheetRowsCount(10000),
+      H.assertSheetRowsCount(10000),
     );
   });
 
@@ -188,27 +179,30 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
       cy.signInAsNormalUser();
 
       cy.get("@nativeQuestionId").then(id => {
-        visitQuestion(id);
+        H.visitQuestion(id);
 
-        downloadAndAssert(
+        H.downloadAndAssert(
           { fileType: "xlsx", questionId: id },
-          assertSheetRowsCount(18760),
+          H.assertSheetRowsCount(18760),
         );
 
         // Make sure we can download results from an ad-hoc nested query based on a native question
         cy.findByText("Explore results").click();
         cy.wait("@dataset");
 
-        downloadAndAssert({ fileType: "xlsx" }, assertSheetRowsCount(18760));
+        H.downloadAndAssert(
+          { fileType: "xlsx" },
+          H.assertSheetRowsCount(18760),
+        );
 
         // Make sure we can download results from a native model
         cy.request("PUT", `/api/card/${id}`, { name: "Native Model" });
 
-        visitQuestion(id);
+        H.visitQuestion(id);
 
-        downloadAndAssert(
+        H.downloadAndAssert(
           { fileType: "xlsx", questionId: id },
-          assertSheetRowsCount(18760),
+          H.assertSheetRowsCount(18760),
         );
       });
     });
@@ -219,7 +213,7 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
       cy.signInAsNormalUser();
 
       cy.get("@nativeQuestionId").then(id => {
-        visitQuestion(id);
+        H.visitQuestion(id);
 
         cy.findByText("Showing first 2,000 rows");
         cy.icon("download").should("not.exist");
@@ -234,7 +228,7 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
         // Convert question to a model, which also shouldn't be downloadable
         cy.request("PUT", `/api/card/${id}`, { name: "Native Model" });
 
-        visitQuestion(id);
+        H.visitQuestion(id);
 
         cy.findByText("Showing first 2,000 rows");
         cy.icon("download").should("not.exist");
@@ -247,27 +241,30 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
       cy.signInAsNormalUser();
 
       cy.get("@nativeQuestionId").then(id => {
-        visitQuestion(id);
+        H.visitQuestion(id);
 
-        downloadAndAssert(
+        H.downloadAndAssert(
           { fileType: "xlsx", questionId: id },
-          assertSheetRowsCount(10000),
+          H.assertSheetRowsCount(10000),
         );
 
         // Ad-hoc nested query based on a native question should also have a download row limit
         cy.findByText("Explore results").click();
         cy.wait("@dataset");
 
-        downloadAndAssert({ fileType: "xlsx" }, assertSheetRowsCount(10000));
+        H.downloadAndAssert(
+          { fileType: "xlsx" },
+          H.assertSheetRowsCount(10000),
+        );
 
         // Convert question to a model, which should also have a download row limit
         cy.request("PUT", `/api/card/${id}`, { name: "Native Model" });
 
-        visitQuestion(id);
+        H.visitQuestion(id);
 
-        downloadAndAssert(
+        H.downloadAndAssert(
           { fileType: "xlsx", questionId: id },
-          assertSheetRowsCount(10000),
+          H.assertSheetRowsCount(10000),
         );
       });
     });

--- a/e2e/test/scenarios/permissions/impersonated.cy.spec.js
+++ b/e2e/test/scenarios/permissions/impersonated.cy.spec.js
@@ -1,24 +1,17 @@
+import { H } from "e2e/support";
 import { USER_GROUPS } from "e2e/support/cypress_data";
-import {
-  createTestRoles,
-  describeEE,
-  openNativeEditor,
-  restore,
-  runNativeQuery,
-  setTokenFeatures,
-} from "e2e/support/helpers";
 
 const { ALL_USERS_GROUP, COLLECTION_GROUP } = USER_GROUPS;
 
 const PG_DB_ID = 2;
 
-describeEE("impersonated permission", () => {
+H.describeEE("impersonated permission", () => {
   describe("admins", () => {
     beforeEach(() => {
-      restore("postgres-12");
-      createTestRoles({ type: "postgres" });
+      H.restore("postgres-12");
+      H.createTestRoles({ type: "postgres" });
       cy.signInAsAdmin();
-      setTokenFeatures("all");
+      H.setTokenFeatures("all");
     });
 
     describe("impersonated users", () => {
@@ -51,10 +44,10 @@ describeEE("impersonated permission", () => {
       };
 
       beforeEach(() => {
-        restore("postgres-12");
-        createTestRoles({ type: "postgres" });
+        H.restore("postgres-12");
+        H.createTestRoles({ type: "postgres" });
         cy.signInAsAdmin();
-        setTokenFeatures("all");
+        H.setTokenFeatures("all");
 
         setImpersonatedPermission();
 
@@ -79,10 +72,10 @@ describeEE("impersonated permission", () => {
         cy.findAllByTestId("header-cell").contains("Subtotal");
 
         // No access through the native query builder
-        openNativeEditor({ databaseName: "QA Postgres12" }).type(
+        H.openNativeEditor({ databaseName: "QA Postgres12" }).type(
           "select * from reviews",
         );
-        runNativeQuery();
+        H.runNativeQuery();
 
         cy.findByTestId("query-builder-main").within(() => {
           cy.findByText("An error occurred in your query");
@@ -94,7 +87,7 @@ describeEE("impersonated permission", () => {
           .type("{selectall}{backspace}", { delay: 50 })
           .type("select * from orders");
 
-        runNativeQuery();
+        H.runNativeQuery();
 
         cy.findAllByTestId("header-cell").contains("subtotal");
       });

--- a/e2e/test/scenarios/permissions/permissions-baseline.cy.spec.js
+++ b/e2e/test/scenarios/permissions/permissions-baseline.cy.spec.js
@@ -1,17 +1,13 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import {
   ADMIN_PERSONAL_COLLECTION_ID,
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  restore,
-  visitQuestion,
-  visitQuestionAdhoc,
-} from "e2e/support/helpers";
 
 describe("scenarios > permissions", () => {
-  beforeEach(restore);
+  beforeEach(H.restore);
 
   const PATHS = [
     `/dashboard/${ORDERS_DASHBOARD_ID}`,
@@ -31,7 +27,7 @@ describe("scenarios > permissions", () => {
   it("should not allow to run adhoc native questions without permissions", () => {
     cy.signIn("none");
 
-    visitQuestionAdhoc(
+    H.visitQuestionAdhoc(
       {
         display: "scalar",
         dataset_query: {
@@ -50,7 +46,7 @@ describe("scenarios > permissions", () => {
 
   it("should let a user with no data permissions view questions", () => {
     cy.signIn("nodata");
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("February 11, 2025, 9:40 PM"); // check that the data loads
   });

--- a/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.js
@@ -1,3 +1,4 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, USERS, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
@@ -5,30 +6,6 @@ import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  assertDatasetReqIsSandboxed,
-  assertQueryBuilderRowCount,
-  blockUserGroupPermissions,
-  commandPaletteSearch,
-  describeEE,
-  entityPickerModal,
-  filterWidget,
-  getFullName,
-  modal,
-  onlyOnEE,
-  openQuestionActions,
-  openSharingMenu,
-  popover,
-  restore,
-  setTokenFeatures,
-  setupSMTP,
-  sidebar,
-  startNewQuestion,
-  visitDashboard,
-  visitQuestion,
-  visitQuestionAdhoc,
-  withDatabase,
-} from "e2e/support/helpers";
 
 const { ALL_USERS_GROUP, DATA_GROUP, COLLECTION_GROUP } = USER_GROUPS;
 const { ORDERS_ID, PRODUCTS_ID, PEOPLE_ID, REVIEWS_ID, PRODUCTS } =
@@ -42,7 +19,7 @@ describe.skip("issue 13347", { tags: "@external" }, () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore("postgres-12");
+    H.restore("postgres-12");
     cy.signInAsAdmin();
 
     cy.updatePermissionsGraph({
@@ -62,7 +39,7 @@ describe.skip("issue 13347", { tags: "@external" }, () => {
       [ALL_USERS_GROUP]: { root: "read" },
     });
 
-    withDatabase(
+    H.withDatabase(
       PG_DB_ID,
       ({ ORDERS_ID }) =>
         cy.createQuestion({
@@ -83,7 +60,7 @@ describe.skip("issue 13347", { tags: "@external" }, () => {
     it(`${test.toUpperCase()} version:\n should be able to select question (from "Saved Questions") which belongs to the database user doesn't have data-permissions for (metabase#13347)`, () => {
       cy.signIn("none");
 
-      startNewQuestion();
+      H.startNewQuestion();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Saved Questions").click();
 
@@ -97,11 +74,11 @@ describe.skip("issue 13347", { tags: "@external" }, () => {
   });
 });
 
-describeEE("postgres > user > query", { tags: "@external" }, () => {
+H.describeEE("postgres > user > query", { tags: "@external" }, () => {
   beforeEach(() => {
-    restore("postgres-12");
+    H.restore("postgres-12");
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
 
     // Update basic permissions (the same starting "state" as we have for the "Sample Database")
     cy.updatePermissionsGraph({
@@ -133,7 +110,7 @@ describeEE("postgres > user > query", { tags: "@external" }, () => {
     // We need ultra-wide screen to avoid scrolling (custom column is rendered at the last position)
     cy.viewport(2200, 1200);
 
-    withDatabase(PG_DB_ID, ({ PEOPLE, PEOPLE_ID }) => {
+    H.withDatabase(PG_DB_ID, ({ PEOPLE, PEOPLE_ID }) => {
       // Question with a custom column created with `regextract`
       cy.createQuestion({
         name: "14873",
@@ -159,12 +136,12 @@ describeEE("postgres > user > query", { tags: "@external" }, () => {
         cy.signOut();
         cy.signInAsSandboxedUser();
 
-        visitQuestion(QUESTION_ID);
+        H.visitQuestion(QUESTION_ID);
 
         cy.findByText(CC_NAME);
         cy.findByText(/^Hudson$/);
-        assertQueryBuilderRowCount(1); // test that user is sandboxed - normal users has over 2000 rows
-        assertDatasetReqIsSandboxed({
+        H.assertQueryBuilderRowCount(1); // test that user is sandboxed - normal users has over 2000 rows
+        H.assertDatasetReqIsSandboxed({
           requestAlias: `@cardQuery${QUESTION_ID}`,
         });
       });
@@ -181,7 +158,7 @@ describe.skip("issue 17777", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     hideTables([ORDERS_ID, PRODUCTS_ID, PEOPLE_ID, REVIEWS_ID]);
@@ -208,13 +185,13 @@ describe.skip("issue 17777", () => {
 
     cy.findAllByText("No self-service").first().click();
 
-    popover().contains("Unrestricted");
+    H.popover().contains("Unrestricted");
   });
 });
 
 describe("issue 19603", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     // Archive second collection (nested under the first one)
@@ -235,13 +212,13 @@ describe("issue 19603", () => {
   });
 });
 
-describeEE("issue 20436", () => {
+H.describeEE("issue 20436", () => {
   const url = `/admin/permissions/data/group/${ALL_USERS_GROUP}`;
 
   function changePermissions(from, to) {
     cy.findAllByText(from).first().click();
 
-    popover().contains(to).click();
+    H.popover().contains(to).click();
   }
 
   function saveChanges() {
@@ -252,9 +229,9 @@ describeEE("issue 20436", () => {
   beforeEach(() => {
     cy.intercept("PUT", "/api/permissions/graph").as("updatePermissions");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
 
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
@@ -273,7 +250,7 @@ describeEE("issue 20436", () => {
       cy.findByText("Query builder only").click();
     });
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Granular").click();
     });
 
@@ -297,13 +274,13 @@ describeEE("issue 20436", () => {
 
 describe("UI elements that make no sense for users without data permissions (metabase#22447, metabase##22449, metabase#22450)", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
   });
 
   it("should not offer to save question to users with no data permissions", () => {
     cy.signIn("nodata");
 
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
 
     cy.findByTestId("viz-settings-button");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -333,17 +310,17 @@ describe("UI elements that make no sense for users without data permissions (met
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("New").click();
 
-    popover()
+    H.popover()
       .should("contain", "Dashboard")
       .and("contain", "Collection")
       .and("not.contain", "Question");
   });
 
   it("should not show visualization or question settings to users with block data permissions", () => {
-    onlyOnEE();
+    H.onlyOnEE();
 
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
         [SAMPLE_DB_ID]: { "view-data": "blocked" },
@@ -355,7 +332,7 @@ describe("UI elements that make no sense for users without data permissions (met
 
     cy.signIn("nodata");
 
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
 
     cy.findByTextEnsureVisible("There was a problem with your question");
 
@@ -370,7 +347,7 @@ describe("UI elements that make no sense for users without data permissions (met
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("New").click();
 
-    popover()
+    H.popover()
       .should("contain", "Dashboard")
       .and("contain", "Collection")
       .and("not.contain", "Question");
@@ -379,21 +356,21 @@ describe("UI elements that make no sense for users without data permissions (met
 
 describe("issue 22473", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setupSMTP();
+    H.setupSMTP();
   });
 
   it("nocollection user should be able to view and unsubscribe themselves from a subscription", () => {
     cy.visit(`/dashboard/${ORDERS_DASHBOARD_ID}`);
-    openSharingMenu("Subscriptions");
+    H.openSharingMenu("Subscriptions");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Email it").click();
     cy.findByPlaceholderText("Enter user names or email addresses")
       .click()
       .type(`${nocollection.first_name} ${nocollection.last_name}{enter}`)
       .blur();
-    sidebar().within(() => {
+    H.sidebar().within(() => {
       cy.button("Done").click();
     });
 
@@ -405,7 +382,7 @@ describe("issue 22473", () => {
     cy.findByTestId("notifications-list").within(() => {
       cy.findByLabelText("close icon").click();
     });
-    modal().within(() => {
+    H.modal().within(() => {
       cy.button("Unsubscribe").click();
     });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -413,11 +390,11 @@ describe("issue 22473", () => {
   });
 });
 
-describeEE("issue 22695 ", () => {
+H.describeEE("issue 22695 ", () => {
   function assert() {
     cy.visit("/");
 
-    commandPaletteSearch("S");
+    H.commandPaletteSearch("S");
     cy.wait("@searchResults");
 
     cy.findAllByTestId("search-result-item-name")
@@ -428,9 +405,9 @@ describeEE("issue 22695 ", () => {
   beforeEach(() => {
     cy.intercept("GET", "/api/search?*").as("searchResults");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
 
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
@@ -463,7 +440,7 @@ describe("issue 22726", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("POST", "/api/card").as("createCard");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     // Let's give all users a read only access to "Our analytics"
@@ -475,12 +452,12 @@ describe("issue 22726", () => {
   });
 
   it("should offer to duplicate a question in a view-only collection (metabase#22726)", () => {
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
 
-    openQuestionActions();
-    popover().findByText("Duplicate").click();
+    H.openQuestionActions();
+    H.popover().findByText("Duplicate").click();
     cy.findByTextEnsureVisible(
-      `${getFullName(nocollection)}'s Personal Collection`,
+      `${H.getFullName(nocollection)}'s Personal Collection`,
     );
 
     cy.button("Duplicate").click();
@@ -492,7 +469,7 @@ describe("issue 22727", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     // Let's give all users a read only access to "Our analytics"
@@ -506,11 +483,11 @@ describe("issue 22727", () => {
   it("should not offer to save question in view only collection (metabase#22727, metabase#20717)", () => {
     // It is important to start from a saved question and to alter it.
     // We already have a reproduction that makes sure "Our analytics" is not offered when starting from an ad-hoc question (table).
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("31.44").click();
-    popover().contains("=").click();
+    H.popover().contains("=").click();
     cy.wait("@dataset");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -532,7 +509,7 @@ describe("issue 23981", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     // Let's revoke access to "Our analytics" from "All users"
@@ -544,7 +521,7 @@ describe("issue 23981", () => {
   });
 
   it("should not show the root collection name in breadcrumbs if the user does not have access to it (metabase#23981)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       name: "23981",
       dataset_query: {
         database: SAMPLE_DB_ID,
@@ -558,9 +535,11 @@ describe("issue 23981", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(`${getFullName(nocollection)}'s Personal Collection`).click();
+    cy.findByText(
+      `${H.getFullName(nocollection)}'s Personal Collection`,
+    ).click();
 
-    entityPickerModal().within(() => {
+    H.entityPickerModal().within(() => {
       cy.findByText("Our analytics").should("not.exist");
       cy.log('ensure that "Collections" is not selectable');
       cy.findByText("Collections").should("be.visible").click();
@@ -569,7 +548,7 @@ describe("issue 23981", () => {
   });
 });
 
-describeEE("issue 24966", () => {
+H.describeEE("issue 24966", () => {
   const sandboxingQuestion = {
     name: "geadsfasd",
     native: {
@@ -606,10 +585,10 @@ describeEE("issue 24966", () => {
   const dashboardDetails = { parameters: [dashboardFilter] };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
-    blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);
+    H.setTokenFeatures("all");
+    H.blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);
 
     // Add user attribute to existing user
     cy.request("PUT", `/api/user/${NODATA_USER_ID}`, {
@@ -617,7 +596,7 @@ describeEE("issue 24966", () => {
     });
 
     cy.createNativeQuestion(sandboxingQuestion).then(({ body: { id } }) => {
-      visitQuestion(id);
+      H.visitQuestion(id);
 
       cy.sandboxTable({
         table_id: PRODUCTS_ID,
@@ -666,20 +645,20 @@ describeEE("issue 24966", () => {
 
   it("should correctly fetch field values for a filter when native question is used for sandboxing (metabase#24966)", () => {
     cy.signIn("nodata");
-    visitDashboard("@dashboardId");
-    filterWidget().click();
+    H.visitDashboard("@dashboardId");
+    H.filterWidget().click();
     cy.findByLabelText("Gizmo").click();
     cy.button("Add filter").click();
     cy.location("search").should("eq", "?text=Gizmo");
 
     cy.signInAsSandboxedUser();
-    visitDashboard("@dashboardId");
-    filterWidget().click();
+    H.visitDashboard("@dashboardId");
+    H.filterWidget().click();
     cy.findByLabelText("Widget").click();
     cy.button("Add filter").click();
     cy.location("search").should("eq", "?text=Widget");
     cy.get("@dashcardId").then(id => {
-      assertDatasetReqIsSandboxed({ requestAlias: `@dashcardQuery${id}` });
+      H.assertDatasetReqIsSandboxed({ requestAlias: `@dashcardQuery${id}` });
     });
   });
 });

--- a/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.ts
@@ -1,11 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  createQuestion,
-  openReviewsTable,
-  restore,
-  visitQuestion,
-} from "e2e/support/helpers";
 import type {
   ConcreteFieldReference,
   StructuredQuery,
@@ -38,9 +33,9 @@ const QUERY: StructuredQuery = {
 
 describe("issue 11994", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    createQuestion(
+    H.createQuestion(
       {
         database: SAMPLE_DB_ID,
         query: QUERY,
@@ -66,7 +61,7 @@ describe("issue 11994", () => {
       },
       { wrapId: true, idAlias: "pivotQuestionId" },
     );
-    createQuestion(
+    H.createQuestion(
       {
         database: SAMPLE_DB_ID,
         query: QUERY,
@@ -78,13 +73,13 @@ describe("issue 11994", () => {
   });
 
   it("does not show raw data toggle for pivot questions (metabase#11994)", () => {
-    visitQuestion("@pivotQuestionId");
+    H.visitQuestion("@pivotQuestionId");
     cy.icon("table2").should("not.exist");
     cy.findByTestId("qb-header").findByText(/Save/).should("not.exist");
   });
 
   it("does not offer to save combo question viewed in raw mode (metabase#11994)", () => {
-    visitQuestion("@comboQuestionId");
+    H.visitQuestion("@comboQuestionId");
     cy.location().then(questionLocation => {
       cy.icon("table2").click();
       cy.location("href").should("eq", questionLocation.href);
@@ -98,14 +93,14 @@ describe("issue 39221", () => {
     cy.intercept("GET", "/api/setting").as("siteSettings");
     cy.intercept("GET", "/api/session/properties").as("sessionProperties");
 
-    restore();
+    H.restore();
   });
 
   ["admin", "normal"].forEach(user => {
     it(`${user.toUpperCase()}: updating user-specific setting should not result in fetching all site settings (metabase#39221)`, () => {
       cy.signOut();
       cy.signIn(user as "admin" | "normal");
-      openReviewsTable({ mode: "notebook" });
+      H.openReviewsTable({ mode: "notebook" });
       // Opening a SQL preview sidebar will trigger a user-local setting update
       cy.findByLabelText("View the SQL").click();
 

--- a/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
@@ -1,3 +1,4 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, USERS, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
@@ -5,36 +6,6 @@ import {
   ORDERS_DASHBOARD_DASHCARD_ID,
   ORDERS_DASHBOARD_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  assertDatasetReqIsSandboxed,
-  assertQueryBuilderRowCount,
-  blockUserGroupPermissions,
-  chartPathWithFillColor,
-  describeEE,
-  entityPickerModal,
-  entityPickerModalTab,
-  filter,
-  getDashboardCards,
-  modal,
-  openNotebook,
-  openOrdersTable,
-  openPeopleTable,
-  openReviewsTable,
-  openSharingMenu,
-  popover,
-  remapDisplayValueToFK,
-  restore,
-  selectFilterOperator,
-  sendEmailAndAssert,
-  setTokenFeatures,
-  setupSMTP,
-  sidebar,
-  startNewQuestion,
-  summarize,
-  visitDashboard,
-  visitQuestion,
-  visualize,
-} from "e2e/support/helpers";
 
 const {
   ORDERS,
@@ -49,12 +20,12 @@ const {
 
 const { DATA_GROUP, COLLECTION_GROUP } = USER_GROUPS;
 
-describeEE("formatting > sandboxes", () => {
+H.describeEE("formatting > sandboxes", () => {
   describe("admin", () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
-      setTokenFeatures("all");
+      H.setTokenFeatures("all");
       preparePermissions();
       cy.visit("/admin/people");
     });
@@ -96,9 +67,9 @@ describeEE("formatting > sandboxes", () => {
     const QUESTION_NAME = "Joined test";
 
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
-      setTokenFeatures("all");
+      H.setTokenFeatures("all");
       preparePermissions();
 
       // Add user attribute to existing ("normal" / id:2) user
@@ -149,10 +120,10 @@ describeEE("formatting > sandboxes", () => {
 
     describe("table sandboxed on a user attribute", () => {
       it("should display correct number of orders", () => {
-        openOrdersTable();
+        H.openOrdersTable();
         // 10 rows filtered on User ID
         cy.findAllByText(ATTRIBUTE_VALUE).should("have.length", 10);
-        assertDatasetReqIsSandboxed({
+        H.assertDatasetReqIsSandboxed({
           columnId: ORDERS.USER_ID,
           columnAssertion: ATTRIBUTE_VALUE,
         });
@@ -162,7 +133,7 @@ describeEE("formatting > sandboxes", () => {
     describe("question with joins", () => {
       it("should be sandboxed even after applying a filter to the question", () => {
         cy.log("Open saved question with joins");
-        visitQuestion("@questionId");
+        H.visitQuestion("@questionId");
 
         cy.log("Make sure user is initially sandboxed");
         cy.get(".test-TableInteractive-cellWrapper--firstColumn").should(
@@ -171,18 +142,18 @@ describeEE("formatting > sandboxes", () => {
         );
 
         cy.log("Add filter to a question");
-        openNotebook();
-        filter({ mode: "notebook" });
-        popover().findByText("Total").click();
-        selectFilterOperator("Greater than");
-        popover().within(() => {
+        H.openNotebook();
+        H.filter({ mode: "notebook" });
+        H.popover().findByText("Total").click();
+        H.selectFilterOperator("Greater than");
+        H.popover().within(() => {
           cy.findByPlaceholderText("Enter a number").type("100");
           cy.button("Add filter").click();
         });
 
-        visualize();
+        H.visualize();
         cy.log("Make sure user is still sandboxed");
-        assertDatasetReqIsSandboxed({
+        H.assertDatasetReqIsSandboxed({
           columnId: ORDERS.USER_ID,
           columnAssetion: ATTRIBUTE_VALUE,
         });
@@ -195,8 +166,8 @@ describeEE("formatting > sandboxes", () => {
 
     describe("table sandboxed on a saved parameterized SQL question", () => {
       it("should show filtered categories", () => {
-        openPeopleTable();
-        assertDatasetReqIsSandboxed({
+        H.openPeopleTable();
+        H.assertDatasetReqIsSandboxed({
           columnId: PEOPLE.ID,
           columnAssertion: ATTRIBUTE_VALUE,
         });
@@ -214,9 +185,9 @@ describeEE("formatting > sandboxes", () => {
 
   describe("Sandboxing reproductions", () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
-      setTokenFeatures("all");
+      H.setTokenFeatures("all");
       preparePermissions();
     });
 
@@ -246,8 +217,8 @@ describeEE("formatting > sandboxes", () => {
       cy.signOut();
       cy.signInAsSandboxedUser();
 
-      openOrdersTable({ mode: "notebook" });
-      summarize({ mode: "notebook" });
+      H.openOrdersTable({ mode: "notebook" });
+      H.summarize({ mode: "notebook" });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count of rows").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -257,7 +228,7 @@ describeEE("formatting > sandboxes", () => {
         "Original issue reported failure to find 'User' group / foreign key",
       );
 
-      popover().within(() => {
+      H.popover().within(() => {
         // Collapse "Order/s/" in order to bring "User" into view (trick to get around virtualization - credits: @flamber)
         cy.get("[data-element-id=list-section-header]")
           .contains(/Orders?/)
@@ -270,14 +241,14 @@ describeEE("formatting > sandboxes", () => {
         cy.get("[data-element-id=list-item]").contains("ID").click();
       });
 
-      visualize();
+      H.visualize();
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by User → ID");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("11"); // Sum of orders for user with ID #1
-      assertQueryBuilderRowCount(2); // test that user is sandboxed - normal users has over 2000 rows
-      assertDatasetReqIsSandboxed();
+      H.assertQueryBuilderRowCount(2); // test that user is sandboxed - normal users has over 2000 rows
+      H.assertDatasetReqIsSandboxed();
     });
 
     // Note: This issue was ported from EE repo - it was previously known as (metabase-enterprise#548)
@@ -315,13 +286,13 @@ describeEE("formatting > sandboxes", () => {
         cy.signInAsSandboxedUser();
 
         // Assertion phase starts here
-        visitQuestion(QUESTION_ID);
+        H.visitQuestion(QUESTION_ID);
         cy.findByText(QUESTION_NAME);
 
         cy.log("Reported failing since v1.36.4");
         cy.contains(CC_NAME);
-        assertQueryBuilderRowCount(11); // test that user is sandboxed - normal users has over 2000 rows
-        assertDatasetReqIsSandboxed({
+        H.assertQueryBuilderRowCount(11); // test that user is sandboxed - normal users has over 2000 rows
+        H.assertDatasetReqIsSandboxed({
           columnId: ORDERS.USER_ID,
           columnAssertion: USERS.sandboxed.login_attributes.attr_uid,
           requestAlias: `@cardQuery${QUESTION_ID}`,
@@ -335,7 +306,7 @@ describeEE("formatting > sandboxes", () => {
 
         if (test === "remapped") {
           cy.log("Remap Product ID's display value to `title`");
-          remapDisplayValueToFK({
+          H.remapDisplayValueToFK({
             display_value: ORDERS.PRODUCT_ID,
             name: "Product ID",
             fk: PRODUCTS.TITLE,
@@ -400,7 +371,7 @@ describeEE("formatting > sandboxes", () => {
         // Drill-through
         cy.findByTestId("query-visualization-root").within(() => {
           // Click on the first bar in a graph (Category: "Doohickey")
-          chartPathWithFillColor("#509EE3").eq(0).click();
+          H.chartPathWithFillColor("#509EE3").eq(0).click();
         });
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("See these Orders").click();
@@ -413,8 +384,8 @@ describeEE("formatting > sandboxes", () => {
         cy.findByText("Product → Category is Doohickey");
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("97.44"); // Subtotal for order #10
-        assertQueryBuilderRowCount(2); // test that user is sandboxed - normal users has over 2000 rows
-        assertDatasetReqIsSandboxed({
+        H.assertQueryBuilderRowCount(2); // test that user is sandboxed - normal users has over 2000 rows
+        H.assertDatasetReqIsSandboxed({
           columnId: ORDERS.USER_ID,
           columnAssertion: USERS.sandboxed.login_attributes.attr_uid,
         });
@@ -487,7 +458,7 @@ describeEE("formatting > sandboxes", () => {
       // Drill-through
       cy.findByTestId("query-visualization-root").within(() => {
         // Click on the first bar in a graph (Category: "Doohickey")
-        chartPathWithFillColor("#509EE3").eq(0).click();
+        H.chartPathWithFillColor("#509EE3").eq(0).click();
       });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("See these Orders").click();
@@ -498,8 +469,8 @@ describeEE("formatting > sandboxes", () => {
       cy.findByText("Products → Category is Doohickey");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("97.44"); // Subtotal for order #10
-      assertQueryBuilderRowCount(2); // test that user is sandboxed - normal users has over 2000 rows
-      assertDatasetReqIsSandboxed({
+      H.assertQueryBuilderRowCount(2); // test that user is sandboxed - normal users has over 2000 rows
+      H.assertDatasetReqIsSandboxed({
         columnId: ORDERS.USER_ID,
         columnAssertion: USERS.sandboxed.login_attributes.attr_uid,
       });
@@ -509,7 +480,7 @@ describeEE("formatting > sandboxes", () => {
       beforeEach(() => {
         cy.intercept("POST", "/api/dataset").as("datasetQuery");
         cy.log("Remap Product ID's display value to `title`");
-        remapDisplayValueToFK({
+        H.remapDisplayValueToFK({
           display_value: ORDERS.PRODUCT_ID,
           name: "Product ID",
           fk: PRODUCTS.TITLE,
@@ -558,14 +529,14 @@ describeEE("formatting > sandboxes", () => {
         cy.signOut();
         cy.signInAsSandboxedUser();
 
-        openOrdersTable({
+        H.openOrdersTable({
           callback: xhr => expect(xhr.response.body.error).not.to.exist,
         });
 
         cy.wait("@datasetQuery");
 
-        assertQueryBuilderRowCount(11); // test that user is sandboxed - normal users has over 2000 rows
-        assertDatasetReqIsSandboxed({
+        H.assertQueryBuilderRowCount(11); // test that user is sandboxed - normal users has over 2000 rows
+        H.assertDatasetReqIsSandboxed({
           requestAlias: "@datasetQuery",
           columnId: ORDERS.USER_ID,
           columnAssertion: USERS.sandboxed.login_attributes.attr_uid,
@@ -574,7 +545,7 @@ describeEE("formatting > sandboxes", () => {
         cy.findByTestId("TableInteractive-root")
           .findByText("Awesome Concrete Shoes")
           .click();
-        popover()
+        H.popover()
           .findByText(/View details/i)
           .click();
 
@@ -644,7 +615,7 @@ describeEE("formatting > sandboxes", () => {
         cy.signOut();
         cy.signInAsSandboxedUser();
 
-        openOrdersTable();
+        H.openOrdersTable();
 
         cy.log("Reported failing on v1.36.x");
 
@@ -695,11 +666,11 @@ describeEE("formatting > sandboxes", () => {
 
         cy.signOut();
         cy.signInAsSandboxedUser();
-        openOrdersTable({
+        H.openOrdersTable({
           callback: xhr => expect(xhr.response.body.error).not.to.exist,
         });
-        assertQueryBuilderRowCount(11); // test that user is sandboxed - normal users has over 2000 rows
-        assertDatasetReqIsSandboxed({
+        H.assertQueryBuilderRowCount(11); // test that user is sandboxed - normal users has over 2000 rows
+        H.assertDatasetReqIsSandboxed({
           columnId: ORDERS.USER_ID,
           columnAssertion: USERS.sandboxed.login_attributes.attr_uid,
         });
@@ -723,7 +694,7 @@ describeEE("formatting > sandboxes", () => {
 
         if (test === "remapped") {
           cy.log("Remap Product ID's display value to `title`");
-          remapDisplayValueToFK({
+          H.remapDisplayValueToFK({
             display_value: ORDERS.PRODUCT_ID,
             name: "Product ID",
             fk: PRODUCTS.TITLE,
@@ -779,13 +750,13 @@ describeEE("formatting > sandboxes", () => {
         cy.findByText(QUESTION_NAME).click();
 
         cy.wait("@cardQuery");
-        assertQueryBuilderRowCount(2); // test that user is sandboxed - normal users has 4
-        assertDatasetReqIsSandboxed({ requestAlias: "@cardQuery" });
+        H.assertQueryBuilderRowCount(2); // test that user is sandboxed - normal users has 4
+        H.assertDatasetReqIsSandboxed({ requestAlias: "@cardQuery" });
 
         // Drill-through
         cy.findByTestId("query-visualization-root").within(() => {
           // Click on the second bar in a graph (Category: "Widget")
-          chartPathWithFillColor("#509EE3").eq(1).click();
+          H.chartPathWithFillColor("#509EE3").eq(1).click();
         });
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("See these Orders").click();
@@ -795,8 +766,8 @@ describeEE("formatting > sandboxes", () => {
         });
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains("37.65");
-        assertQueryBuilderRowCount(6); // test that user is sandboxed - normal users has over 2000
-        assertDatasetReqIsSandboxed({ requestAlias: "@dataset" });
+        H.assertQueryBuilderRowCount(6); // test that user is sandboxed - normal users has over 2000
+        H.assertDatasetReqIsSandboxed({ requestAlias: "@dataset" });
       });
     });
 
@@ -821,32 +792,32 @@ describeEE("formatting > sandboxes", () => {
       cy.icon("eye")
         .eq(1) // No better way of doing this, unfortunately (see table above)
         .click();
-      popover().findByText("Sandboxed").click();
+      H.popover().findByText("Sandboxed").click();
       cy.button("Change").click();
-      modal()
+      H.modal()
         .findByText(
           "Use a saved question to create a custom view for this table",
         )
         .click();
 
-      modal().findByText("Select a question").click();
+      H.modal().findByText("Select a question").click();
 
-      entityPickerModal().findByText(QUESTION_NAME).click();
-      modal().button("Save").click();
+      H.entityPickerModal().findByText(QUESTION_NAME).click();
+      H.modal().button("Save").click();
       cy.wait("@sandboxTable").then(({ response }) => {
         expect(response.statusCode).to.eq(400);
         expect(response.body.message).to.eq(ERROR_MESSAGE);
       });
-      modal().scrollTo("bottom");
-      modal().findByText(ERROR_MESSAGE);
+      H.modal().scrollTo("bottom");
+      H.modal().findByText(ERROR_MESSAGE);
     });
 
     it("should be able to use summarize columns from joined table based on a saved question (metabase#14766)", () => {
       createJoinedQuestion("14766_joined");
 
-      startNewQuestion();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Saved questions").click();
+      H.startNewQuestion();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Saved questions").click();
         cy.findByText("14766_joined").click();
       });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -858,7 +829,7 @@ describeEE("formatting > sandboxes", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Products? → ID/).click();
 
-      visualize(response => {
+      H.visualize(response => {
         expect(response.body.error).to.not.exist;
       });
 
@@ -901,8 +872,8 @@ describeEE("formatting > sandboxes", () => {
       cy.contains("Subtotal").should("not.exist");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("37.65").should("not.exist");
-      assertQueryBuilderRowCount(11); // test that user is sandboxed - normal users has over 2000 rows
-      assertDatasetReqIsSandboxed({
+      H.assertQueryBuilderRowCount(11); // test that user is sandboxed - normal users has over 2000 rows
+      H.assertDatasetReqIsSandboxed({
         requestAlias: "@cardQuery",
         columnId: ORDERS.USER_ID,
         columnAssertion: USERS.sandboxed.login_attributes.attr_uid,
@@ -967,8 +938,8 @@ describeEE("formatting > sandboxes", () => {
         cy.signOut();
         cy.signInAsSandboxedUser();
 
-        visitQuestion(QUESTION_ID);
-        assertDatasetReqIsSandboxed({
+        H.visitQuestion(QUESTION_ID);
+        H.assertDatasetReqIsSandboxed({
           requestAlias: `@cardQuery${QUESTION_ID}`,
         });
       });
@@ -977,11 +948,11 @@ describeEE("formatting > sandboxes", () => {
       cy.findByText("Twitter");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Row totals");
-      assertQueryBuilderRowCount(6); // test that user is sandboxed - normal users has 30
+      H.assertQueryBuilderRowCount(6); // test that user is sandboxed - normal users has 30
     });
 
     it("should show dashboard subscriptions for sandboxed user (metabase#14990)", () => {
-      setupSMTP();
+      H.setupSMTP();
 
       cy.sandboxTable({
         table_id: ORDERS_ID,
@@ -991,15 +962,15 @@ describeEE("formatting > sandboxes", () => {
       });
 
       cy.signInAsSandboxedUser();
-      visitDashboard(ORDERS_DASHBOARD_ID);
-      openSharingMenu("Subscriptions");
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
+      H.openSharingMenu("Subscriptions");
 
       // should forward to email since that is the only one setup
-      sidebar().findByText("Email this dashboard").should("exist");
+      H.sidebar().findByText("Email this dashboard").should("exist");
 
       // test that user is sandboxed - normal users has over 2000 rows
-      getDashboardCards().findByText("Rows 1-6 of 11").should("exist");
-      assertDatasetReqIsSandboxed({
+      H.getDashboardCards().findByText("Rows 1-6 of 11").should("exist");
+      H.assertDatasetReqIsSandboxed({
         requestAlias: `@dashcardQuery${ORDERS_DASHBOARD_DASHCARD_ID}`,
         columnId: ORDERS.USER_ID,
         columnAssertion: USERS.sandboxed.login_attributes.attr_uid,
@@ -1020,7 +991,7 @@ describeEE("formatting > sandboxes", () => {
       cy.signOut();
       cy.signInAsSandboxedUser();
 
-      openOrdersTable({
+      H.openOrdersTable({
         callback: xhr => expect(xhr.response.body.error).not.to.exist,
       });
 
@@ -1029,7 +1000,7 @@ describeEE("formatting > sandboxes", () => {
     });
 
     it("unsaved/dirty query should work on linked table column with multiple dimensions and remapping (metabase#15106)", () => {
-      remapDisplayValueToFK({
+      H.remapDisplayValueToFK({
         display_value: ORDERS.USER_ID,
         name: "User ID",
         fk: PEOPLE.NAME,
@@ -1074,11 +1045,11 @@ describeEE("formatting > sandboxes", () => {
       cy.signOut();
       cy.signInAsSandboxedUser();
 
-      openReviewsTable({
+      H.openReviewsTable({
         callback: xhr => expect(xhr.response.body.error).not.to.exist,
       });
-      assertQueryBuilderRowCount(57); // test that user is sandboxed - normal users has 1,112 rows
-      assertDatasetReqIsSandboxed();
+      H.assertQueryBuilderRowCount(57); // test that user is sandboxed - normal users has 1,112 rows
+      H.assertDatasetReqIsSandboxed();
 
       // Add positive assertion once this issue is fixed
     });
@@ -1087,7 +1058,7 @@ describeEE("formatting > sandboxes", () => {
       "sandboxed user should receive sandboxed dashboard subscription",
       { tags: "@external" },
       () => {
-        setupSMTP();
+        H.setupSMTP();
 
         cy.sandboxTable({
           table_id: ORDERS_ID,
@@ -1099,23 +1070,23 @@ describeEE("formatting > sandboxes", () => {
         cy.signOut();
         cy.signInAsSandboxedUser();
 
-        visitDashboard(ORDERS_DASHBOARD_ID);
+        H.visitDashboard(ORDERS_DASHBOARD_ID);
 
         // test that user is sandboxed - normal users has over 2000 rows
-        getDashboardCards().findByText("Rows 1-6 of 11").should("exist");
-        assertDatasetReqIsSandboxed({
+        H.getDashboardCards().findByText("Rows 1-6 of 11").should("exist");
+        H.assertDatasetReqIsSandboxed({
           requestAlias: `@dashcardQuery${ORDERS_DASHBOARD_DASHCARD_ID}`,
           columnId: ORDERS.USER_ID,
           columnAssertion: USERS.sandboxed.login_attributes.attr_uid,
         });
 
-        openSharingMenu("Subscriptions");
+        H.openSharingMenu("Subscriptions");
 
-        sidebar()
+        H.sidebar()
           .findByPlaceholderText("Enter user names or email addresses")
           .click();
-        popover().findByText("User 1").click();
-        sendEmailAndAssert(email => {
+        H.popover().findByText("User 1").click();
+        H.sendEmailAndAssert(email => {
           expect(email.html).to.include("Orders in a dashboard");
           expect(email.html).to.include("37.65");
           expect(email.html).not.to.include("148.23"); // Order for user with ID 3
@@ -1151,7 +1122,7 @@ function createJoinedQuestion(name, { visitQuestion = false } = {}) {
 }
 
 function preparePermissions() {
-  blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);
-  blockUserGroupPermissions(USER_GROUPS.COLLECTION_GROUP);
-  blockUserGroupPermissions(USER_GROUPS.READONLY_GROUP);
+  H.blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);
+  H.blockUserGroupPermissions(USER_GROUPS.COLLECTION_GROUP);
+  H.blockUserGroupPermissions(USER_GROUPS.READONLY_GROUP);
 }

--- a/e2e/test/scenarios/permissions/view-data.cy.spec.js
+++ b/e2e/test/scenarios/permissions/view-data.cy.spec.js
@@ -1,27 +1,7 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  assertPermissionForItem,
-  assertPermissionTable,
-  assertSameBeforeAndAfterSave,
-  createNativeQuestion,
-  createTestRoles,
-  describeEE,
-  getPermissionRowPermissions,
-  isPermissionDisabled,
-  modal,
-  modifyPermission,
-  popover,
-  restore,
-  saveImpersonationSettings,
-  savePermissions,
-  selectImpersonatedAttribute,
-  selectPermissionRow,
-  selectSidebarItem,
-  setTokenFeatures,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
 const { ALL_USERS_GROUP, COLLECTION_GROUP } = USER_GROUPS;
@@ -32,11 +12,11 @@ const DOWNLOAD_PERM_IDX = 2;
 
 // EDITOR RELATED TESTS
 
-describeEE("scenarios > admin > permissions > view data > blocked", () => {
+H.describeEE("scenarios > admin > permissions > view data > blocked", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
   });
 
   const g = "All Users";
@@ -46,22 +26,22 @@ describeEE("scenarios > admin > permissions > view data > blocked", () => {
       `/admin/permissions/data/database/${SAMPLE_DB_ID}/schema/PUBLIC/table/${ORDERS_ID}`, // table level
     );
 
-    assertPermissionForItem(g, DATA_ACCESS_PERM_IDX, "Can view", false);
-    assertPermissionForItem(g, CREATE_QUERIES_PERM_IDX, "No", false);
-    assertPermissionForItem(g, DOWNLOAD_PERM_IDX, "1 million rows", false);
+    H.assertPermissionForItem(g, DATA_ACCESS_PERM_IDX, "Can view", false);
+    H.assertPermissionForItem(g, CREATE_QUERIES_PERM_IDX, "No", false);
+    H.assertPermissionForItem(g, DOWNLOAD_PERM_IDX, "1 million rows", false);
 
-    modifyPermission(g, DATA_ACCESS_PERM_IDX, "Blocked");
+    H.modifyPermission(g, DATA_ACCESS_PERM_IDX, "Blocked");
 
-    assertSameBeforeAndAfterSave(() => {
-      assertPermissionForItem(g, DATA_ACCESS_PERM_IDX, "Blocked", false);
-      assertPermissionForItem(g, CREATE_QUERIES_PERM_IDX, "No", true);
-      assertPermissionForItem(g, DOWNLOAD_PERM_IDX, "No", true);
+    H.assertSameBeforeAndAfterSave(() => {
+      H.assertPermissionForItem(g, DATA_ACCESS_PERM_IDX, "Blocked", false);
+      H.assertPermissionForItem(g, CREATE_QUERIES_PERM_IDX, "No", true);
+      H.assertPermissionForItem(g, DOWNLOAD_PERM_IDX, "No", true);
     });
 
     cy.log(
       "assert that user properly sees native query warning related to table level blocking",
     );
-    getPermissionRowPermissions("All Users")
+    H.getPermissionRowPermissions("All Users")
       .eq(DATA_ACCESS_PERM_IDX)
       .findByLabelText("warning icon")
       .realHover();
@@ -74,16 +54,16 @@ describeEE("scenarios > admin > permissions > view data > blocked", () => {
 
     cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`); // database level
 
-    assertPermissionForItem(g, DATA_ACCESS_PERM_IDX, "Granular", false);
-    assertPermissionForItem(g, CREATE_QUERIES_PERM_IDX, "No", false);
-    assertPermissionForItem(g, DOWNLOAD_PERM_IDX, "1 million rows", false);
+    H.assertPermissionForItem(g, DATA_ACCESS_PERM_IDX, "Granular", false);
+    H.assertPermissionForItem(g, CREATE_QUERIES_PERM_IDX, "No", false);
+    H.assertPermissionForItem(g, DOWNLOAD_PERM_IDX, "1 million rows", false);
 
-    modifyPermission(g, DATA_ACCESS_PERM_IDX, "Blocked");
+    H.modifyPermission(g, DATA_ACCESS_PERM_IDX, "Blocked");
 
-    assertSameBeforeAndAfterSave(() => {
-      assertPermissionForItem(g, DATA_ACCESS_PERM_IDX, "Blocked", false);
-      assertPermissionForItem(g, CREATE_QUERIES_PERM_IDX, "No", true);
-      assertPermissionForItem(g, DOWNLOAD_PERM_IDX, "No", true);
+    H.assertSameBeforeAndAfterSave(() => {
+      H.assertPermissionForItem(g, DATA_ACCESS_PERM_IDX, "Blocked", false);
+      H.assertPermissionForItem(g, CREATE_QUERIES_PERM_IDX, "No", true);
+      H.assertPermissionForItem(g, DOWNLOAD_PERM_IDX, "No", true);
     });
   });
 
@@ -95,23 +75,27 @@ describeEE("scenarios > admin > permissions > view data > blocked", () => {
     cy.log("ensure that modify tables do not affect other rows");
     // this is the test is admittedly a little opaque, we're trying to test that
     // the calculation that upgrades view data permissions does not apply to tables
-    modifyPermission("Orders", DATA_ACCESS_PERM_IDX, "Blocked"); // add blocked to one table
-    modifyPermission("Products", CREATE_QUERIES_PERM_IDX, "Query builder only"); // increase permissions of another table to trigger upgrade flow
-    assertPermissionForItem("Orders", DATA_ACCESS_PERM_IDX, "Blocked"); // orders table should stay the same
+    H.modifyPermission("Orders", DATA_ACCESS_PERM_IDX, "Blocked"); // add blocked to one table
+    H.modifyPermission(
+      "Products",
+      CREATE_QUERIES_PERM_IDX,
+      "Query builder only",
+    ); // increase permissions of another table to trigger upgrade flow
+    H.assertPermissionForItem("Orders", DATA_ACCESS_PERM_IDX, "Blocked"); // orders table should stay the same
 
-    selectSidebarItem("All Users");
-    assertPermissionForItem(
+    H.selectSidebarItem("All Users");
+    H.assertPermissionForItem(
       "Sample Database",
       DATA_ACCESS_PERM_IDX,
       "Granular",
     );
-    modifyPermission(
+    H.modifyPermission(
       "Sample Database",
       CREATE_QUERIES_PERM_IDX,
       "Query builder only",
     );
 
-    modal()
+    H.modal()
       .should("exist")
       .within(() => {
         cy.findByText(
@@ -120,12 +104,12 @@ describeEE("scenarios > admin > permissions > view data > blocked", () => {
         cy.findByText("Okay").click();
       });
 
-    assertPermissionForItem(
+    H.assertPermissionForItem(
       "Sample Database",
       DATA_ACCESS_PERM_IDX,
       "Can view",
     );
-    assertPermissionForItem(
+    H.assertPermissionForItem(
       "Sample Database",
       CREATE_QUERIES_PERM_IDX,
       "Query builder only",
@@ -135,7 +119,7 @@ describeEE("scenarios > admin > permissions > view data > blocked", () => {
 
 describe("scenarios > admin > permissions > view data > granular", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -150,18 +134,18 @@ describe("scenarios > admin > permissions > view data > granular", () => {
   });
 });
 
-describeEE("scenarios > admin > permissions > view data > granular", () => {
+H.describeEE("scenarios > admin > permissions > view data > granular", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
     cy.intercept("PUT", "/api/permissions/graph").as("saveGraph");
   });
 
   it("should allow making permissions granular in the database focused view", () => {
     cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
 
-    modifyPermission("All Users", DATA_ACCESS_PERM_IDX, "Granular");
+    H.modifyPermission("All Users", DATA_ACCESS_PERM_IDX, "Granular");
 
     cy.url().should(
       "include",
@@ -170,15 +154,15 @@ describeEE("scenarios > admin > permissions > view data > granular", () => {
 
     makeOrdersSandboxed();
 
-    selectSidebarItem("All Users");
+    H.selectSidebarItem("All Users");
 
-    assertPermissionTable([
+    H.assertPermissionTable([
       ["Sample Database", "Granular", "No", "1 million rows", "No", "No"],
     ]);
 
     cy.button("Save changes").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Save permissions?").should("exist");
       cy.contains(
         "All Users will be given access to 1 table in Sample Database",
@@ -194,7 +178,7 @@ describeEE("scenarios > admin > permissions > view data > granular", () => {
   it("should allow making permissions granular in the group focused view", () => {
     cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
 
-    modifyPermission("Sample Database", DATA_ACCESS_PERM_IDX, "Granular");
+    H.modifyPermission("Sample Database", DATA_ACCESS_PERM_IDX, "Granular");
 
     cy.url().should(
       "include",
@@ -203,15 +187,15 @@ describeEE("scenarios > admin > permissions > view data > granular", () => {
 
     makeOrdersSandboxed();
 
-    selectSidebarItem("All Users");
+    H.selectSidebarItem("All Users");
 
-    assertPermissionTable([
+    H.assertPermissionTable([
       ["Sample Database", "Granular", "No", "1 million rows", "No", "No"],
     ]);
 
     cy.button("Save changes").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Save permissions?").should("exist");
       cy.contains(
         "All Users will be given access to 1 table in Sample Database",
@@ -229,13 +213,13 @@ describeEE("scenarios > admin > permissions > view data > granular", () => {
 
     cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
 
-    modifyPermission("Sample Database", DATA_ACCESS_PERM_IDX, "Granular");
+    H.modifyPermission("Sample Database", DATA_ACCESS_PERM_IDX, "Granular");
 
     makeOrdersSandboxed();
 
-    selectSidebarItem("All Users");
+    H.selectSidebarItem("All Users");
 
-    assertPermissionTable([
+    H.assertPermissionTable([
       ["Sample Database", "Granular", "No", "1 million rows", "No", "No"],
     ]);
 
@@ -245,11 +229,11 @@ describeEE("scenarios > admin > permissions > view data > granular", () => {
       .closest("a")
       .click();
 
-    modifyPermission("Orders", DATA_ACCESS_PERM_IDX, "Can view");
+    H.modifyPermission("Orders", DATA_ACCESS_PERM_IDX, "Can view");
 
-    selectSidebarItem("All Users");
+    H.selectSidebarItem("All Users");
 
-    assertPermissionTable([
+    H.assertPermissionTable([
       ["Sample Database", "Can view", "No", "1 million rows", "No", "No"],
     ]);
   });
@@ -257,212 +241,215 @@ describeEE("scenarios > admin > permissions > view data > granular", () => {
   it("should preserve parent value for children when selecting granular for permissions available to child entities", () => {
     cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
 
-    modifyPermission("Sample Database", DATA_ACCESS_PERM_IDX, "Blocked");
+    H.modifyPermission("Sample Database", DATA_ACCESS_PERM_IDX, "Blocked");
 
-    modifyPermission("Sample Database", DATA_ACCESS_PERM_IDX, "Granular");
+    H.modifyPermission("Sample Database", DATA_ACCESS_PERM_IDX, "Granular");
 
-    assertPermissionForItem("Orders", DATA_ACCESS_PERM_IDX, "Blocked");
+    H.assertPermissionForItem("Orders", DATA_ACCESS_PERM_IDX, "Blocked");
   });
 });
 
-describeEE("scenarios > admin > permissions > view data > impersonated", () => {
-  beforeEach(() => {
-    restore("postgres-12");
-    createTestRoles({ type: "postgres" });
-    cy.signInAsAdmin();
-    setTokenFeatures("all");
-  });
-
-  it("should allow saving 'impersonated' permissions", () => {
-    cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
-
-    // Check there is no Impersonated option on H2
-    selectPermissionRow("Sample Database", DATA_ACCESS_PERM_IDX);
-    popover().should("not.contain", "Impersonated");
-
-    // Set impersonated access on Postgres database
-    modifyPermission("QA Postgres12", DATA_ACCESS_PERM_IDX, "Impersonated");
-
-    selectImpersonatedAttribute("role");
-    saveImpersonationSettings();
-    savePermissions();
-
-    assertPermissionTable([
-      ["Sample Database", "Can view", "No", "1 million rows", "No", "No"],
-      ["QA Postgres12", "Impersonated", "No", "1 million rows", "No", "No"],
-    ]);
-
-    // Checking it shows the right state on the tables level
-    cy.get("main").findByText("QA Postgres12").click();
-
-    assertPermissionTable(
-      [
-        "Accounts",
-        "Analytic Events",
-        "Feedback",
-        "Invoices",
-        "Orders",
-        "People",
-        "Products",
-        "Reviews",
-      ].map(tableName => [
-        tableName,
-        "Impersonated",
-        "No",
-        "1 million rows",
-        "No",
-        "No",
-      ]),
-    );
-
-    // Return back to the database view
-    cy.get("main").findByText("All Users group").click();
-
-    // Edit impersonated permission
-    modifyPermission(
-      "QA Postgres12",
-      DATA_ACCESS_PERM_IDX,
-      "Edit Impersonated",
-    );
-
-    selectImpersonatedAttribute("attr_uid");
-    saveImpersonationSettings();
-    savePermissions();
-
-    assertPermissionTable([
-      ["Sample Database", "Can view", "No", "1 million rows", "No", "No"],
-      ["QA Postgres12", "Impersonated", "No", "1 million rows", "No", "No"],
-    ]);
-  });
-
-  it("should warns when All Users group has 'impersonated' access and the target group has unrestricted access", () => {
-    cy.visit(`/admin/permissions/data/group/${COLLECTION_GROUP}`);
-
-    modifyPermission("QA Postgres12", DATA_ACCESS_PERM_IDX, "Impersonated");
-
-    // Warns that All Users group has greater access
-    cy.findByRole("dialog").within(() => {
-      cy.findByText(
-        'Revoke access even though "All Users" has greater access?',
-      );
-
-      cy.findByText("Revoke access").click();
+H.describeEE(
+  "scenarios > admin > permissions > view data > impersonated",
+  () => {
+    beforeEach(() => {
+      H.restore("postgres-12");
+      H.createTestRoles({ type: "postgres" });
+      cy.signInAsAdmin();
+      H.setTokenFeatures("all");
     });
 
-    selectImpersonatedAttribute("role");
-    saveImpersonationSettings();
-    savePermissions();
+    it("should allow saving 'impersonated' permissions", () => {
+      cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
 
-    getPermissionRowPermissions("QA Postgres12")
-      .eq(DATA_ACCESS_PERM_IDX)
-      .findByLabelText("warning icon")
-      .realHover();
+      // Check there is no Impersonated option on H2
+      H.selectPermissionRow("Sample Database", DATA_ACCESS_PERM_IDX);
+      H.popover().should("not.contain", "Impersonated");
 
-    popover().findByText(
-      'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',
-    );
-  });
+      // Set impersonated access on Postgres database
+      H.modifyPermission("QA Postgres12", DATA_ACCESS_PERM_IDX, "Impersonated");
 
-  it("allows switching to the granular access and update table permissions", () => {
-    cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
+      H.selectImpersonatedAttribute("role");
+      H.saveImpersonationSettings();
+      H.savePermissions();
 
-    modifyPermission("QA Postgres12", DATA_ACCESS_PERM_IDX, "Impersonated");
+      H.assertPermissionTable([
+        ["Sample Database", "Can view", "No", "1 million rows", "No", "No"],
+        ["QA Postgres12", "Impersonated", "No", "1 million rows", "No", "No"],
+      ]);
 
-    selectImpersonatedAttribute("role");
-    saveImpersonationSettings();
-    savePermissions();
+      // Checking it shows the right state on the tables level
+      cy.get("main").findByText("QA Postgres12").click();
 
-    modifyPermission("QA Postgres12", DATA_ACCESS_PERM_IDX, "Granular");
+      H.assertPermissionTable(
+        [
+          "Accounts",
+          "Analytic Events",
+          "Feedback",
+          "Invoices",
+          "Orders",
+          "People",
+          "Products",
+          "Reviews",
+        ].map(tableName => [
+          tableName,
+          "Impersonated",
+          "No",
+          "1 million rows",
+          "No",
+          "No",
+        ]),
+      );
 
-    // Resets table permissions from Impersonated to Can view
-    assertPermissionTable(
-      [
-        "Accounts",
-        "Analytic Events",
-        "Feedback",
-        "Invoices",
-        "Orders",
-        "People",
-        "Products",
-        "Reviews",
-      ].map(tableName => [
-        tableName,
-        "Can view",
-        "No",
-        "1 million rows",
-        "No",
-        "No",
-      ]),
-    );
-    // Return back to the database view
-    cy.get("main").findByText("All Users group").click();
+      // Return back to the database view
+      cy.get("main").findByText("All Users group").click();
 
-    // On database level it got reset to Can view too
-    assertPermissionTable([
-      ["Sample Database", "Can view", "No", "1 million rows", "No", "No"],
-      ["QA Postgres12", "Can view", "No", "1 million rows", "No", "No"],
-    ]);
-  });
+      // Edit impersonated permission
+      H.modifyPermission(
+        "QA Postgres12",
+        DATA_ACCESS_PERM_IDX,
+        "Edit Impersonated",
+      );
 
-  it("impersonation modal should be positioned behind the page leave confirmation modal", () => {
-    // Try leaving the page
-    cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
+      H.selectImpersonatedAttribute("attr_uid");
+      H.saveImpersonationSettings();
+      H.savePermissions();
 
-    modifyPermission("QA Postgres12", DATA_ACCESS_PERM_IDX, "Impersonated");
+      H.assertPermissionTable([
+        ["Sample Database", "Can view", "No", "1 million rows", "No", "No"],
+        ["QA Postgres12", "Impersonated", "No", "1 million rows", "No", "No"],
+      ]);
+    });
 
-    selectImpersonatedAttribute("role");
-    saveImpersonationSettings();
+    it("should warns when All Users group has 'impersonated' access and the target group has unrestricted access", () => {
+      cy.visit(`/admin/permissions/data/group/${COLLECTION_GROUP}`);
 
-    modifyPermission(
-      "QA Postgres12",
-      DATA_ACCESS_PERM_IDX,
-      "Edit Impersonated",
-    );
+      H.modifyPermission("QA Postgres12", DATA_ACCESS_PERM_IDX, "Impersonated");
 
-    cy.findByRole("dialog").findByText("Edit settings").click();
+      // Warns that All Users group has greater access
+      cy.findByRole("dialog").within(() => {
+        cy.findByText(
+          'Revoke access even though "All Users" has greater access?',
+        );
 
-    // Page leave confirmation should be on top
-    modal()
-      .as("leaveConfirmation")
-      .findByText("Discard your changes?")
-      .should("be.visible");
+        cy.findByText("Revoke access").click();
+      });
 
-    // Cancel
-    cy.get("@leaveConfirmation").findByText("Cancel").click();
+      H.selectImpersonatedAttribute("role");
+      H.saveImpersonationSettings();
+      H.savePermissions();
 
-    // Ensure the impersonation modal is still open
-    cy.findByRole("dialog")
-      .findByText("Map a user attribute to database roles")
-      .should("be.visible");
+      H.getPermissionRowPermissions("QA Postgres12")
+        .eq(DATA_ACCESS_PERM_IDX)
+        .findByLabelText("warning icon")
+        .realHover();
 
-    // Go to settings
-    cy.findByRole("dialog").findByText("Edit settings").click();
-    cy.get("@leaveConfirmation").findByText("Discard changes").click();
+      H.popover().findByText(
+        'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',
+      );
+    });
 
-    cy.focused().should("have.attr", "placeholder", "username");
-  });
+    it("allows switching to the granular access and update table permissions", () => {
+      cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
 
-  it("should set unrestricted for children if database is set to impersonated before going granular", () => {
-    cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
+      H.modifyPermission("QA Postgres12", DATA_ACCESS_PERM_IDX, "Impersonated");
 
-    modifyPermission("QA Postgres12", DATA_ACCESS_PERM_IDX, "Impersonated");
+      H.selectImpersonatedAttribute("role");
+      H.saveImpersonationSettings();
+      H.savePermissions();
 
-    selectImpersonatedAttribute("role");
-    saveImpersonationSettings();
+      H.modifyPermission("QA Postgres12", DATA_ACCESS_PERM_IDX, "Granular");
 
-    modifyPermission("Sample Database", DATA_ACCESS_PERM_IDX, "Granular");
+      // Resets table permissions from Impersonated to Can view
+      H.assertPermissionTable(
+        [
+          "Accounts",
+          "Analytic Events",
+          "Feedback",
+          "Invoices",
+          "Orders",
+          "People",
+          "Products",
+          "Reviews",
+        ].map(tableName => [
+          tableName,
+          "Can view",
+          "No",
+          "1 million rows",
+          "No",
+          "No",
+        ]),
+      );
+      // Return back to the database view
+      cy.get("main").findByText("All Users group").click();
 
-    assertPermissionForItem("Orders", DATA_ACCESS_PERM_IDX, "Can view");
-  });
-});
+      // On database level it got reset to Can view too
+      H.assertPermissionTable([
+        ["Sample Database", "Can view", "No", "1 million rows", "No", "No"],
+        ["QA Postgres12", "Can view", "No", "1 million rows", "No", "No"],
+      ]);
+    });
 
-describeEE(
+    it("impersonation modal should be positioned behind the page leave confirmation modal", () => {
+      // Try leaving the page
+      cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
+
+      H.modifyPermission("QA Postgres12", DATA_ACCESS_PERM_IDX, "Impersonated");
+
+      H.selectImpersonatedAttribute("role");
+      H.saveImpersonationSettings();
+
+      H.modifyPermission(
+        "QA Postgres12",
+        DATA_ACCESS_PERM_IDX,
+        "Edit Impersonated",
+      );
+
+      cy.findByRole("dialog").findByText("Edit settings").click();
+
+      // Page leave confirmation should be on top
+      H.modal()
+        .as("leaveConfirmation")
+        .findByText("Discard your changes?")
+        .should("be.visible");
+
+      // Cancel
+      cy.get("@leaveConfirmation").findByText("Cancel").click();
+
+      // Ensure the impersonation modal is still open
+      cy.findByRole("dialog")
+        .findByText("Map a user attribute to database roles")
+        .should("be.visible");
+
+      // Go to settings
+      cy.findByRole("dialog").findByText("Edit settings").click();
+      cy.get("@leaveConfirmation").findByText("Discard changes").click();
+
+      cy.focused().should("have.attr", "placeholder", "username");
+    });
+
+    it("should set unrestricted for children if database is set to impersonated before going granular", () => {
+      cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
+
+      H.modifyPermission("QA Postgres12", DATA_ACCESS_PERM_IDX, "Impersonated");
+
+      H.selectImpersonatedAttribute("role");
+      H.saveImpersonationSettings();
+
+      H.modifyPermission("Sample Database", DATA_ACCESS_PERM_IDX, "Granular");
+
+      H.assertPermissionForItem("Orders", DATA_ACCESS_PERM_IDX, "Can view");
+    });
+  },
+);
+
+H.describeEE(
   "scenarios > admin > permissions > view data > legacy no self-service",
   () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
-      setTokenFeatures("all");
+      H.setTokenFeatures("all");
     });
 
     it("'no self service' should only be an option if it is the current value in the permissions graph", () => {
@@ -470,11 +457,11 @@ describeEE(
       // and test that it does not exist
       cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
 
-      selectPermissionRow("Sample Database", DATA_ACCESS_PERM_IDX);
-      popover().should("not.contain", "No self-service (Deprecated)");
+      H.selectPermissionRow("Sample Database", DATA_ACCESS_PERM_IDX);
+      H.popover().should("not.contain", "No self-service (Deprecated)");
 
-      selectPermissionRow("Sample Database", CREATE_QUERIES_PERM_IDX);
-      isPermissionDisabled(CREATE_QUERIES_PERM_IDX, "No", false);
+      H.selectPermissionRow("Sample Database", CREATE_QUERIES_PERM_IDX);
+      H.isPermissionDisabled(CREATE_QUERIES_PERM_IDX, "No", false);
 
       // load the page w/ legacy value in the graph and test that it does exist
       cy.reload();
@@ -494,7 +481,7 @@ describeEE(
         },
       });
 
-      assertPermissionTable([
+      H.assertPermissionTable([
         [
           "Sample Database",
           "No self-service (Deprecated)",
@@ -506,24 +493,24 @@ describeEE(
       ]);
 
       // User should not be able to modify Create queries permission while set to legacy-no-self-service
-      isPermissionDisabled(CREATE_QUERIES_PERM_IDX, "No", true);
+      H.isPermissionDisabled(CREATE_QUERIES_PERM_IDX, "No", true);
 
-      modifyPermission("Sample Database", DATA_ACCESS_PERM_IDX, "Can view");
+      H.modifyPermission("Sample Database", DATA_ACCESS_PERM_IDX, "Can view");
 
-      modifyPermission(
+      H.modifyPermission(
         "Sample Database",
         CREATE_QUERIES_PERM_IDX,
         "Query builder and native",
       );
 
-      modifyPermission(
+      H.modifyPermission(
         "Sample Database",
         DATA_ACCESS_PERM_IDX,
         "No self-service (Deprecated)",
       );
 
       // change something else so we can save
-      modifyPermission("Sample Database", DOWNLOAD_PERM_IDX, "No");
+      H.modifyPermission("Sample Database", DOWNLOAD_PERM_IDX, "No");
 
       // User setting the value back to legacy-no-self-service should result in Create queries going back to No
       const finalExpectedRows = [
@@ -536,13 +523,13 @@ describeEE(
           "No",
         ],
       ];
-      assertPermissionTable(finalExpectedRows);
+      H.assertPermissionTable(finalExpectedRows);
 
       cy.intercept("PUT", "/api/permissions/graph").as("saveGraph");
 
       cy.button("Save changes").click();
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("Save permissions?");
         cy.button("Yes").click();
       });
@@ -551,16 +538,16 @@ describeEE(
         expect(response.statusCode).to.equal(200);
       });
 
-      assertPermissionTable(finalExpectedRows);
+      H.assertPermissionTable(finalExpectedRows);
     });
   },
 );
 
-describeEE("scenarios > admin > permissions > view data > sandboxed", () => {
+H.describeEE("scenarios > admin > permissions > view data > sandboxed", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
   });
 
   it("allows editing sandboxed access in the database focused view", () => {
@@ -568,17 +555,17 @@ describeEE("scenarios > admin > permissions > view data > sandboxed", () => {
 
     // make sure that we have native permissions now so that we can validate that
     // permissions are droped to query builder only after we sandbox a table
-    modifyPermission(
+    H.modifyPermission(
       "All Users",
       CREATE_QUERIES_PERM_IDX,
       "Query builder and native",
     );
 
-    selectSidebarItem("Orders");
+    H.selectSidebarItem("Orders");
 
-    modifyPermission("All Users", DATA_ACCESS_PERM_IDX, "Sandboxed");
+    H.modifyPermission("All Users", DATA_ACCESS_PERM_IDX, "Sandboxed");
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Change access to this database to “Sandboxed”?");
       cy.button("Change").click();
     });
@@ -617,9 +604,9 @@ describeEE("scenarios > admin > permissions > view data > sandboxed", () => {
       ["nosql", "Can view", "Query builder only", "1 million rows", "No"],
       ["readonly", "Can view", "No", "1 million rows", "No"],
     ];
-    assertPermissionTable(expectedFinalPermissions);
+    H.assertPermissionTable(expectedFinalPermissions);
 
-    modifyPermission(
+    H.modifyPermission(
       "All Users",
       DATA_ACCESS_PERM_IDX,
       "Edit sandboxed access",
@@ -638,7 +625,7 @@ describeEE("scenarios > admin > permissions > view data > sandboxed", () => {
 
     cy.button("Save changes").click();
 
-    assertPermissionTable(expectedFinalPermissions);
+    H.assertPermissionTable(expectedFinalPermissions);
   });
 
   it("allows editing sandboxed access in the group focused view", () => {
@@ -647,7 +634,7 @@ describeEE("scenarios > admin > permissions > view data > sandboxed", () => {
 
     // make sure that we have native permissions now so that we can validate that
     // permissions are droped to query builder only after we sandbox a table
-    modifyPermission(
+    H.modifyPermission(
       "Sample Database",
       CREATE_QUERIES_PERM_IDX,
       "Query builder and native",
@@ -655,9 +642,9 @@ describeEE("scenarios > admin > permissions > view data > sandboxed", () => {
 
     cy.get("a").contains("Sample Database").click();
 
-    modifyPermission("Orders", DATA_ACCESS_PERM_IDX, "Sandboxed");
+    H.modifyPermission("Orders", DATA_ACCESS_PERM_IDX, "Sandboxed");
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Change access to this database to “Sandboxed”?");
       cy.button("Change").click();
     });
@@ -666,16 +653,16 @@ describeEE("scenarios > admin > permissions > view data > sandboxed", () => {
       "include",
       `/admin/permissions/data/group/${ALL_USERS_GROUP}/database/${SAMPLE_DB_ID}/schema/PUBLIC/${ORDERS_ID}/segmented`,
     );
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Restrict access to this table");
       cy.button("Save").should("be.disabled");
       cy.findByText("Pick a column").click();
     });
 
-    popover().findByText("User ID").click();
-    modal().findByText("Pick a user attribute").click();
-    popover().findByText("attr_uid").click();
-    modal().button("Save").click();
+    H.popover().findByText("User ID").click();
+    H.modal().findByText("Pick a user attribute").click();
+    H.popover().findByText("attr_uid").click();
+    H.modal().button("Save").click();
 
     const expectedFinalPermissions = [
       ["Accounts", "Can view", "Query builder only", "1 million rows", "No"],
@@ -694,20 +681,20 @@ describeEE("scenarios > admin > permissions > view data > sandboxed", () => {
       ["Reviews", "Can view", "Query builder only", "1 million rows", "No"],
     ];
 
-    assertPermissionTable(expectedFinalPermissions);
+    H.assertPermissionTable(expectedFinalPermissions);
 
-    modifyPermission("Orders", DATA_ACCESS_PERM_IDX, "Edit sandboxed access");
+    H.modifyPermission("Orders", DATA_ACCESS_PERM_IDX, "Edit sandboxed access");
 
     cy.url().should(
       "include",
       `/admin/permissions/data/group/${ALL_USERS_GROUP}/database/${SAMPLE_DB_ID}/schema/PUBLIC/${ORDERS_ID}/segmented`,
     );
 
-    modal().findByText("Restrict access to this table");
+    H.modal().findByText("Restrict access to this table");
 
     cy.button("Save").click();
 
-    modal().should("not.exist");
+    H.modal().should("not.exist");
 
     cy.url().should(
       "include",
@@ -716,7 +703,7 @@ describeEE("scenarios > admin > permissions > view data > sandboxed", () => {
 
     cy.button("Save changes").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Save permissions?").should("exist");
       cy.contains(
         "All Users will be given access to 1 table in Sample Database",
@@ -733,46 +720,50 @@ describeEE("scenarios > admin > permissions > view data > sandboxed", () => {
     );
     cy.reload();
 
-    assertPermissionTable(expectedFinalPermissions);
+    H.assertPermissionTable(expectedFinalPermissions);
   });
 });
 
-describeEE(
+H.describeEE(
   "scenarios > admin > permissions > view data > reproductions",
   () => {
     it("should allow you to sandbox view permissions and also edit the create queries permissions and saving should persist both (metabase#46450)", () => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
-      setTokenFeatures("all");
+      H.setTokenFeatures("all");
 
       cy.intercept("PUT", "/api/permissions/graph").as("saveGraph");
       cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
 
       cy.get("a").contains("Sample Database").click();
 
-      modifyPermission("Orders", DATA_ACCESS_PERM_IDX, "Sandboxed");
+      H.modifyPermission("Orders", DATA_ACCESS_PERM_IDX, "Sandboxed");
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("Restrict access to this table");
         cy.button("Save").should("be.disabled");
         cy.findByText("Pick a column").click();
       });
 
-      popover().findByText("User ID").click();
-      modal().findByText("Pick a user attribute").click();
-      popover().findByText("attr_uid").click();
-      modal().button("Save").click();
+      H.popover().findByText("User ID").click();
+      H.modal().findByText("Pick a user attribute").click();
+      H.popover().findByText("attr_uid").click();
+      H.modal().button("Save").click();
 
-      modifyPermission("Orders", CREATE_QUERIES_PERM_IDX, "Query builder only");
+      H.modifyPermission(
+        "Orders",
+        CREATE_QUERIES_PERM_IDX,
+        "Query builder only",
+      );
 
-      savePermissions();
+      H.savePermissions();
 
       cy.wait("@saveGraph").then(({ response }) => {
         expect(response.statusCode).to.equal(200);
       });
 
-      assertPermissionForItem("Orders", DATA_ACCESS_PERM_IDX, "Sandboxed");
-      assertPermissionForItem(
+      H.assertPermissionForItem("Orders", DATA_ACCESS_PERM_IDX, "Sandboxed");
+      H.assertPermissionForItem(
         "Orders",
         CREATE_QUERIES_PERM_IDX,
         "Query builder only",
@@ -780,39 +771,39 @@ describeEE(
     });
 
     it("should allow you to impersonate view permissions and also edit the create queries permissions and saving should persist both (metabase#46450)", () => {
-      restore("postgres-12");
-      createTestRoles({ type: "postgres" });
+      H.restore("postgres-12");
+      H.createTestRoles({ type: "postgres" });
       cy.signInAsAdmin();
-      setTokenFeatures("all");
+      H.setTokenFeatures("all");
 
       cy.intercept("PUT", "/api/permissions/graph").as("saveGraph");
 
       cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
 
       // Set impersonated access on Postgres database
-      modifyPermission("QA Postgres12", DATA_ACCESS_PERM_IDX, "Impersonated");
+      H.modifyPermission("QA Postgres12", DATA_ACCESS_PERM_IDX, "Impersonated");
 
-      selectImpersonatedAttribute("role");
-      saveImpersonationSettings();
+      H.selectImpersonatedAttribute("role");
+      H.saveImpersonationSettings();
 
-      modifyPermission(
+      H.modifyPermission(
         "QA Postgres12",
         CREATE_QUERIES_PERM_IDX,
         "Query builder only",
       );
 
-      savePermissions();
+      H.savePermissions();
 
       cy.wait("@saveGraph").then(({ response }) => {
         expect(response.statusCode).to.equal(200);
       });
 
-      assertPermissionForItem(
+      H.assertPermissionForItem(
         "QA Postgres12",
         DATA_ACCESS_PERM_IDX,
         "Impersonated",
       );
-      assertPermissionForItem(
+      H.assertPermissionForItem(
         "QA Postgres12",
         CREATE_QUERIES_PERM_IDX,
         "Query builder only",
@@ -820,55 +811,58 @@ describeEE(
     });
   },
 );
-describeEE("scenarios > admin > permissions > view data > unrestricted", () => {
-  beforeEach(() => {
-    restore();
-    cy.signInAsAdmin();
-    setTokenFeatures("all");
-  });
-
-  it("should allow perms to be set to from 'can view' to 'block' and back from database view", () => {
-    cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
-
-    modifyPermission("All Users", DATA_ACCESS_PERM_IDX, "Blocked");
-
-    cy.intercept("PUT", "/api/permissions/graph").as("saveGraph");
-
-    cy.button("Save changes").click();
-
-    modal().within(() => {
-      cy.findByText("Save permissions?");
-      cy.button("Yes").click();
+H.describeEE(
+  "scenarios > admin > permissions > view data > unrestricted",
+  () => {
+    beforeEach(() => {
+      H.restore();
+      cy.signInAsAdmin();
+      H.setTokenFeatures("all");
     });
 
-    cy.wait("@saveGraph").then(({ response }) => {
-      expect(response.statusCode).to.equal(200);
+    it("should allow perms to be set to from 'can view' to 'block' and back from database view", () => {
+      cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
+
+      H.modifyPermission("All Users", DATA_ACCESS_PERM_IDX, "Blocked");
+
+      cy.intercept("PUT", "/api/permissions/graph").as("saveGraph");
+
+      cy.button("Save changes").click();
+
+      H.modal().within(() => {
+        cy.findByText("Save permissions?");
+        cy.button("Yes").click();
+      });
+
+      cy.wait("@saveGraph").then(({ response }) => {
+        expect(response.statusCode).to.equal(200);
+      });
+
+      H.modifyPermission("All Users", DATA_ACCESS_PERM_IDX, "Can view");
+
+      cy.button("Save changes").click();
+
+      H.modal().within(() => {
+        cy.findByText("Save permissions?");
+        cy.button("Yes").click();
+      });
+
+      cy.wait("@saveGraph").then(({ response }) => {
+        expect(response.statusCode).to.equal(200);
+      });
     });
-
-    modifyPermission("All Users", DATA_ACCESS_PERM_IDX, "Can view");
-
-    cy.button("Save changes").click();
-
-    modal().within(() => {
-      cy.findByText("Save permissions?");
-      cy.button("Yes").click();
-    });
-
-    cy.wait("@saveGraph").then(({ response }) => {
-      expect(response.statusCode).to.equal(200);
-    });
-  });
-});
+  },
+);
 
 // ENFORMCENT RELATED TESTS
 
-describeEE(
+H.describeEE(
   "scenarios > admin > permissions > view data > blocked (enforcement)",
   () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
-      setTokenFeatures("all");
+      H.setTokenFeatures("all");
     });
 
     it("should deny view access to a query builder question that makes use of a blocked table", () => {
@@ -888,7 +882,7 @@ describeEE(
     });
 
     it("should deny view access to any native question if the user has blocked view data for any table or database", () => {
-      createNativeQuestion({
+      H.createNativeQuestion({
         native: { query: "select 1" },
       }).then(({ body: { id: nativeQuestionId } }) => {
         assertCollectionGroupUserHasAccess(nativeQuestionId, false);
@@ -925,7 +919,7 @@ function assertCollectionGroupUserHasAccess(questionId, isQbQuestion) {
   cy.signOut();
   cy.signIn("sandboxed");
 
-  visitQuestion(questionId);
+  H.visitQuestion(questionId);
   lackPermissionsView(isQbQuestion, false);
 
   cy.signOut();
@@ -936,29 +930,34 @@ function assertCollectionGroupHasNoAccess(questionId, isQbQuestion) {
   cy.signOut();
   cy.signIn("sandboxed");
 
-  visitQuestion(questionId);
+  H.visitQuestion(questionId);
 
   lackPermissionsView(isQbQuestion, true);
 }
 
 function removeCollectionGroupPermissions() {
-  assertPermissionForItem("All Users", DATA_ACCESS_PERM_IDX, "Can view", false);
-  assertPermissionForItem(
+  H.assertPermissionForItem(
+    "All Users",
+    DATA_ACCESS_PERM_IDX,
+    "Can view",
+    false,
+  );
+  H.assertPermissionForItem(
     "collection",
     DATA_ACCESS_PERM_IDX,
     "Can view",
     false,
   );
-  modifyPermission("All Users", DATA_ACCESS_PERM_IDX, "Blocked");
-  modifyPermission("collection", DATA_ACCESS_PERM_IDX, "Blocked");
-  assertSameBeforeAndAfterSave(() => {
-    assertPermissionForItem(
+  H.modifyPermission("All Users", DATA_ACCESS_PERM_IDX, "Blocked");
+  H.modifyPermission("collection", DATA_ACCESS_PERM_IDX, "Blocked");
+  H.assertSameBeforeAndAfterSave(() => {
+    H.assertPermissionForItem(
       "All Users",
       DATA_ACCESS_PERM_IDX,
       "Blocked",
       false,
     );
-    assertPermissionForItem(
+    H.assertPermissionForItem(
       "collection",
       DATA_ACCESS_PERM_IDX,
       "Blocked",
@@ -968,7 +967,7 @@ function removeCollectionGroupPermissions() {
 }
 
 function makeOrdersSandboxed() {
-  modifyPermission("Orders", DATA_ACCESS_PERM_IDX, "Sandboxed");
+  H.modifyPermission("Orders", DATA_ACCESS_PERM_IDX, "Sandboxed");
 
   cy.url().should(
     "include",

--- a/e2e/test/scenarios/question-reproductions/reproductions-1.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-1.cy.spec.js
@@ -1,47 +1,7 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  POPOVER_ELEMENT,
-  adhocQuestionHash,
-  appBar,
-  blurNativeEditor,
-  commandPalette,
-  commandPaletteSearch,
-  createQuestion,
-  editDashboard,
-  enterCustomColumnDetails,
-  entityPickerModal,
-  entityPickerModalTab,
-  expressionEditorWidget,
-  filterWidget,
-  focusNativeEditor,
-  getNotebookStep,
-  leftSidebar,
-  mockSessionProperty,
-  modal,
-  navigationSidebar,
-  openNativeEditor,
-  openNavigationSidebar,
-  openNotebook,
-  openOrdersTable,
-  openProductsTable,
-  openTable,
-  popover,
-  questionInfoButton,
-  restore,
-  saveDashboard,
-  showDashboardCardActions,
-  sidesheet,
-  startNewQuestion,
-  summarize,
-  tableHeaderClick,
-  visitDashboard,
-  visitQuestion,
-  visitQuestionAdhoc,
-  visualize,
-  withDatabase,
-} from "e2e/support/helpers";
 
 import { setAdHocFilter } from "../native-filters/helpers/e2e-date-filter-helpers";
 
@@ -53,10 +13,10 @@ const MONGO_DB_ID = 2;
 
 describe("issue 4482", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    openTable({
+    H.openTable({
       table: PRODUCTS_ID,
       mode: "notebook",
     });
@@ -70,7 +30,7 @@ describe("issue 4482", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Created At").click();
 
-    visualize();
+    H.visualize();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("April 1, 2022, 12:00 AM");
@@ -82,7 +42,7 @@ describe("issue 4482", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Created At").click();
 
-    visualize();
+    H.visualize();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("April 1, 2025, 12:00 AM");
@@ -106,12 +66,12 @@ function pickMetric(metric) {
 
 describe("issue 6239", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
 
-    summarize({ mode: "notebook" });
+    H.summarize({ mode: "notebook" });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
 
@@ -124,15 +84,15 @@ describe("issue 6239", () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
-    popover().contains("Created At").first().click();
+    H.popover().contains("Created At").first().click();
   });
 
   it("should be possible to sort by using custom expression (metabase#6239)", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sort").click();
-    popover().contains(/^CE$/).click();
+    H.popover().contains(/^CE$/).click();
 
-    visualize();
+    H.visualize();
 
     // Line chart renders initially. Switch to the table view.
     cy.icon("table2").click();
@@ -145,14 +105,14 @@ describe("issue 6239", () => {
     cy.get("[data-testid=cell-data]").eq(3).invoke("text").should("eq", "1");
 
     // Go back to the notebook editor
-    openNotebook();
+    H.openNotebook();
 
     // Sort descending this time
     cy.icon("arrow_up").click();
     cy.icon("arrow_up").should("not.exist");
     cy.icon("arrow_down");
 
-    visualize();
+    H.visualize();
 
     cy.get("[data-testid=cell-data]")
       .eq(1)
@@ -165,19 +125,19 @@ describe("issue 6239", () => {
 
 describe("issue 9027", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    startNewQuestion();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Saved questions").click();
+    H.startNewQuestion();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Saved questions").click();
       cy.findByText("Orders").should("exist");
       cy.button("Close").click();
     });
 
-    openNativeEditor({ fromCurrentPage: true });
+    H.openNativeEditor({ fromCurrentPage: true });
 
-    focusNativeEditor().type("select 0");
+    H.focusNativeEditor().type("select 0");
     cy.findByTestId("native-query-editor-container").icon("play").click();
 
     saveQuestion(QUESTION_NAME);
@@ -185,19 +145,19 @@ describe("issue 9027", () => {
 
   it("should display newly saved question in the 'Saved Questions' list immediately (metabase#9027)", () => {
     goToSavedQuestionPickerAndAssertQuestion(QUESTION_NAME);
-    openNavigationSidebar();
+    H.openNavigationSidebar();
     archiveQuestion(QUESTION_NAME);
     goToSavedQuestionPickerAndAssertQuestion(QUESTION_NAME, false);
-    openNavigationSidebar();
+    H.openNavigationSidebar();
     unarchiveQuestion(QUESTION_NAME);
     goToSavedQuestionPickerAndAssertQuestion(QUESTION_NAME);
   });
 });
 
 function goToSavedQuestionPickerAndAssertQuestion(questionName, exists = true) {
-  startNewQuestion();
-  entityPickerModal().within(() => {
-    entityPickerModalTab("Saved questions").click();
+  H.startNewQuestion();
+  H.entityPickerModal().within(() => {
+    H.entityPickerModalTab("Saved questions").click();
     cy.findByText(questionName).should(exists ? "exist" : "not.exist");
     cy.button("Close").click();
   });
@@ -217,17 +177,17 @@ function saveQuestion(name) {
 }
 
 function archiveQuestion(questionName) {
-  navigationSidebar().findByText("Our analytics").click();
+  H.navigationSidebar().findByText("Our analytics").click();
   openEllipsisMenuFor(questionName);
-  popover().findByText("Move to trash").click();
+  H.popover().findByText("Move to trash").click();
 }
 
 function unarchiveQuestion(questionName) {
-  navigationSidebar().within(() => {
+  H.navigationSidebar().within(() => {
     cy.findByText("Trash").click();
   });
   openEllipsisMenuFor(questionName);
-  popover().findByText("Restore").click();
+  H.popover().findByText("Restore").click();
 }
 
 function openEllipsisMenuFor(item) {
@@ -239,10 +199,10 @@ function openEllipsisMenuFor(item) {
 
 describe("issue 13097", { tags: "@mongo" }, () => {
   beforeEach(() => {
-    restore("mongo-5");
+    H.restore("mongo-5");
     cy.signInAsAdmin();
 
-    withDatabase(MONGO_DB_ID, ({ PEOPLE_ID }) => {
+    H.withDatabase(MONGO_DB_ID, ({ PEOPLE_ID }) => {
       const questionDetails = {
         dataset_query: {
           type: "query",
@@ -251,14 +211,14 @@ describe("issue 13097", { tags: "@mongo" }, () => {
         },
       };
 
-      const hash = adhocQuestionHash(questionDetails);
+      const hash = H.adhocQuestionHash(questionDetails);
 
       cy.visit(`/question/notebook#${hash}`);
     });
   });
 
   it("should correctly apply distinct count on multiple columns (metabase#13097)", () => {
-    summarize({ mode: "notebook" });
+    H.summarize({ mode: "notebook" });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Number of distinct values of ...").click();
@@ -272,7 +232,7 @@ describe("issue 13097", { tags: "@mongo" }, () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("State").click();
 
-    visualize();
+    H.visualize();
 
     // cy.log("Reported failing on stats ~v0.36.3");
     cy.get("[data-testid=cell-data]")
@@ -286,12 +246,12 @@ describe("issue 13097", { tags: "@mongo" }, () => {
 
 describe("postgres > user > query", { tags: "@external" }, () => {
   beforeEach(() => {
-    restore("postgres-12");
+    H.restore("postgres-12");
     cy.signInAsAdmin();
     cy.request(`/api/database/${WRITABLE_DB_ID}/schema/public`).then(
       ({ body }) => {
         const tableId = body.find(table => table.name === "orders").id;
-        openTable({
+        H.openTable({
           database: WRITABLE_DB_ID,
           table: tableId,
         });
@@ -322,27 +282,29 @@ describe("issue 14957", { tags: "@external" }, () => {
   const PG_DB_NAME = "QA Postgres12";
 
   beforeEach(() => {
-    restore("postgres-12");
+    H.restore("postgres-12");
     cy.signInAsAdmin();
   });
 
   it("should save a question before query has been executed (metabase#14957)", () => {
-    openNativeEditor({ databaseName: PG_DB_NAME }).type("select pg_sleep(60)");
+    H.openNativeEditor({ databaseName: PG_DB_NAME }).type(
+      "select pg_sleep(60)",
+    );
 
     saveQuestion("14957");
-    modal().should("not.exist");
+    H.modal().should("not.exist");
   });
 });
 
 describe("postgres > question > custom columns", { tags: "@external" }, () => {
   beforeEach(() => {
-    restore("postgres-12");
+    H.restore("postgres-12");
     cy.signInAsAdmin();
 
     cy.request(`/api/database/${WRITABLE_DB_ID}/schema/public`).then(
       ({ body }) => {
         const tableId = body.find(table => table.name === "orders").id;
-        openTable({
+        H.openTable({
           database: WRITABLE_DB_ID,
           table: tableId,
           mode: "notebook",
@@ -358,7 +320,7 @@ describe("postgres > question > custom columns", { tags: "@external" }, () => {
     cy.findByText("Pick a function or metric").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
-    enterCustomColumnDetails({ formula: "Percentile([Subtotal], 0.1)" });
+    H.enterCustomColumnDetails({ formula: "Percentile([Subtotal], 0.1)" });
     cy.findByPlaceholderText("Something nice and descriptive")
       .as("name")
       .click();
@@ -418,7 +380,7 @@ const correctValues = [
 
 describe("issue 15876", { tags: "@external" }, () => {
   beforeEach(() => {
-    restore("postgres-12");
+    H.restore("postgres-12");
     cy.signInAsAdmin();
   });
 
@@ -439,12 +401,12 @@ describe("issue 17512", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("custom expression should work with `case` in nested queries (metabase#17512)", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
 
     addSummarizeCustomExpression(
       "Distinct(case([Discount] > 0, [Subtotal], [Total]))",
@@ -460,7 +422,7 @@ describe("issue 17512", () => {
 
     addCustomColumn("1 + 1", "CC");
 
-    visualize(({ body }) => {
+    H.visualize(({ body }) => {
       expect(body.error).to.not.exist;
     });
 
@@ -470,11 +432,11 @@ describe("issue 17512", () => {
 });
 
 function addSummarizeCustomExpression(formula, name) {
-  summarize({ mode: "notebook" });
-  popover().contains("Custom Expression").click();
+  H.summarize({ mode: "notebook" });
+  H.popover().contains("Custom Expression").click();
 
-  expressionEditorWidget().within(() => {
-    enterCustomColumnDetails({
+  H.expressionEditorWidget().within(() => {
+    H.enterCustomColumnDetails({
       formula,
       name,
     });
@@ -484,8 +446,8 @@ function addSummarizeCustomExpression(formula, name) {
 
 function addCustomColumn(formula, name) {
   cy.findByText("Custom column").click();
-  expressionEditorWidget().within(() => {
-    enterCustomColumnDetails({
+  H.expressionEditorWidget().within(() => {
+    H.enterCustomColumnDetails({
       formula,
       name,
     });
@@ -524,7 +486,7 @@ describe("issue 17514", () => {
   const dashboardDetails = { parameters: [filter] };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
@@ -554,7 +516,7 @@ describe("issue 17514", () => {
 
         cy.editDashboardCard(card, mapFilterToCard);
 
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
 
         cy.wait("@cardQuery");
         cy.findByText("110.93").should("be.visible");
@@ -562,7 +524,7 @@ describe("issue 17514", () => {
     });
 
     it("should not show the run overlay when we apply dashboard filter on a question with removed column and then click through its title (metabase#17514-1)", () => {
-      editDashboard();
+      H.editDashboard();
 
       openVisualizationOptions();
 
@@ -570,9 +532,9 @@ describe("issue 17514", () => {
 
       closeModal();
 
-      saveDashboard();
+      H.saveDashboard();
 
-      filterWidget().click();
+      H.filterWidget().click();
       setAdHocFilter({ timeBucket: "years" });
 
       cy.location("search").should("eq", "?date_filter=past30years");
@@ -626,8 +588,8 @@ describe("issue 17514", () => {
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Join data").click();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Products").click();
       });
 
@@ -640,7 +602,7 @@ describe("issue 17514", () => {
       });
 
       // Cypress cannot click elements that are blocked by an overlay so this will immediately fail if the issue is not fixed
-      tableHeaderClick("Subtotal");
+      H.tableHeaderClick("Subtotal");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Filter by this column");
     });
@@ -648,7 +610,7 @@ describe("issue 17514", () => {
 });
 
 function openVisualizationOptions() {
-  showDashboardCardActions();
+  H.showDashboardCardActions();
   cy.icon("palette").click({ force: true });
 }
 
@@ -659,13 +621,13 @@ function hideColumn(columnName) {
 }
 
 function closeModal() {
-  modal().within(() => {
+  H.modal().within(() => {
     cy.button("Done").click();
   });
 }
 
 function openNotebookMode() {
-  openNotebook();
+  H.openNotebook();
 }
 
 function removeJoinedTable() {
@@ -690,12 +652,12 @@ function moveColumnToTop(column) {
 
 describe("issue 17910", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("revisions should work after creating a question without reloading (metabase#17910)", () => {
-    openOrdersTable();
+    H.openOrdersTable();
     cy.intercept("POST", "/api/card").as("card");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
@@ -708,9 +670,9 @@ describe("issue 17910", () => {
       cy.findByText("Not now").click();
     });
 
-    questionInfoButton().click();
+    H.questionInfoButton().click();
 
-    sidesheet().within(() => {
+    H.sidesheet().within(() => {
       cy.findAllByPlaceholderText("Add description")
         .type("A description")
         .blur();
@@ -724,12 +686,12 @@ describe("issue 17910", () => {
 
 describe("issue 17963", { tags: "@mongo" }, () => {
   beforeEach(() => {
-    restore("mongo-5");
+    H.restore("mongo-5");
     cy.signInAsAdmin();
 
     cy.request(`/api/database/${WRITABLE_DB_ID}/schema/`).then(({ body }) => {
       const tableId = body.find(table => table.name === "orders").id;
-      openTable({
+      H.openTable({
         database: WRITABLE_DB_ID,
         table: tableId,
         mode: "notebook",
@@ -740,22 +702,22 @@ describe("issue 17963", { tags: "@mongo" }, () => {
   it("should be able to compare two fields using filter expression (metabase#17963)", () => {
     cy.findByRole("button", { name: "Filter" }).click();
 
-    popover().contains("Custom Expression").click();
+    H.popover().contains("Custom Expression").click();
 
     typeAndSelect([
       { string: "dis", field: "Discount" },
       { string: "> quan", field: "Quantity" },
     ]);
 
-    blurNativeEditor();
+    H.blurNativeEditor();
     cy.button("Done").click();
 
-    getNotebookStep("filter").findByText("Discount is greater than Quantity");
+    H.getNotebookStep("filter").findByText("Discount is greater than Quantity");
 
     cy.findByRole("button", { name: "Summarize" }).click();
-    popover().findByText("Count of rows").click();
+    H.popover().findByText("Count of rows").click();
 
-    visualize();
+    H.visualize();
 
     cy.findByTestId("scalar-value").contains("1,337");
   });
@@ -765,7 +727,7 @@ function typeAndSelect(arr) {
   arr.forEach(({ string, field }) => {
     cy.get(".ace_text-input").type(string);
 
-    popover().contains(field).click();
+    H.popover().contains(field).click();
   });
 }
 
@@ -773,11 +735,11 @@ describe("issue 18207", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    openProductsTable({ mode: "notebook" });
-    summarize({ mode: "notebook" });
+    H.openProductsTable({ mode: "notebook" });
+    H.summarize({ mode: "notebook" });
   });
 
   it("should be possible to use MIN on a string column (metabase#18207, metabase#22155)", () => {
@@ -792,7 +754,7 @@ describe("issue 18207", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Category").click();
 
-    visualize();
+    H.visualize();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Doohickey");
@@ -810,7 +772,7 @@ describe("issue 18207", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Category").click();
 
-    visualize();
+    H.visualize();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Widget");
@@ -830,9 +792,9 @@ describe("issue 18207", () => {
   });
 
   it("should be possible to group by a string expression (metabase#18207)", () => {
-    popover().contains("Custom Expression").click();
-    expressionEditorWidget().within(() => {
-      enterCustomColumnDetails({
+    H.popover().contains("Custom Expression").click();
+    H.expressionEditorWidget().within(() => {
+      H.enterCustomColumnDetails({
         formula: "Max([Vendor])",
         name: "LastVendor",
       });
@@ -843,14 +805,14 @@ describe("issue 18207", () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Pick a column to group by").click();
-    popover().contains("Category").click();
+    H.popover().contains("Category").click();
 
-    visualize();
+    H.visualize();
 
     // Why is it not a table?
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Visualization").click();
-    leftSidebar().within(() => {
+    H.leftSidebar().within(() => {
       cy.icon("table2").click();
       cy.findByTestId("Table-button").realHover();
       cy.icon("gear").click();
@@ -865,9 +827,9 @@ describe("issue 18207", () => {
 
 describe("issues 11914, 18978, 18977, 23857", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    createQuestion({
+    H.createQuestion({
       name: "Repro",
       query: {
         "source-table": `card__${ORDERS_QUESTION_ID}`,
@@ -881,27 +843,27 @@ describe("issues 11914, 18978, 18977, 23857", () => {
     cy.log(
       "Make sure we don't offer to duplicate question with a query for which the user has no permission to run (metabase#23857)",
     );
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
     cy.findByLabelText("Move, trash, and more...").click();
-    popover().findByText("Duplicate").should("not.exist");
+    H.popover().findByText("Duplicate").should("not.exist");
 
     cy.log(
       "Make sure we don't offer to duplicate question based on a question with a query for which the user has no permission to run (metabase#23857)",
     );
-    commandPaletteSearch("Repro", false);
-    commandPalette().findByText("Repro").click();
+    H.commandPaletteSearch("Repro", false);
+    H.commandPalette().findByText("Repro").click();
     cy.findByLabelText("Move, trash, and more...").click();
-    popover().findByText("Duplicate").should("not.exist");
+    H.popover().findByText("Duplicate").should("not.exist");
 
     cy.log(
       "Make sure we don't prompt user to browse databases from the sidebar",
     );
-    openNavigationSidebar();
+    H.openNavigationSidebar();
     cy.findByLabelText("Browse databases").should("not.exist");
 
     cy.log("Make sure we don't prompt user to create a new query");
-    appBar().icon("add").click();
-    popover().within(() => {
+    H.appBar().icon("add").click();
+    H.popover().within(() => {
       cy.findByText("Dashboard").should("be.visible");
       cy.findByText("Question").should("not.exist");
       cy.findByText(/SQL query/).should("not.exist");
@@ -967,7 +929,7 @@ function assertNoRefreshButton() {
 }
 
 function assertNoOpenPopover() {
-  cy.get(POPOVER_ELEMENT).should("not.exist");
+  cy.get(H.POPOVER_ELEMENT).should("not.exist");
 }
 
 function saveButton() {
@@ -978,8 +940,8 @@ describe("issue 19341", () => {
   const TEST_NATIVE_QUESTION_NAME = "Native";
 
   beforeEach(() => {
-    restore();
-    mockSessionProperty("enable-nested-queries", false);
+    H.restore();
+    H.mockSessionProperty("enable-nested-queries", false);
     cy.signInAsAdmin();
     cy.createNativeQuestion({
       name: TEST_NATIVE_QUESTION_NAME,
@@ -992,8 +954,8 @@ describe("issue 19341", () => {
 
   it("should correctly disable nested queries (metabase#19341)", () => {
     // Test "Saved Questions" table is hidden in QB data selector
-    startNewQuestion();
-    entityPickerModal().within(() => {
+    H.startNewQuestion();
+    H.entityPickerModal().within(() => {
       cy.findByTestId("loading-indicator").should("not.exist");
       cy.findByText("Orders").should("exist");
       cy.findAllByRole("tab").should("not.exist");
@@ -1014,12 +976,12 @@ describe("issue 19341", () => {
         expect(modelTypes).to.include("table");
       });
 
-      entityPickerModalTab("Tables").click();
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Orders").click();
     });
 
     cy.icon("join_left_outer").click();
-    entityPickerModal().findAllByRole("tab").should("not.exist");
+    H.entityPickerModal().findAllByRole("tab").should("not.exist");
 
     // Test "Explore results" button is hidden for native questions
     cy.visit("/collection/root");
@@ -1033,7 +995,7 @@ describe("issue 19341", () => {
 
 describe("issue 19742", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -1044,14 +1006,14 @@ describe("issue 19742", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("New").click();
 
-    popover().findByText("Question").click();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.popover().findByText("Question").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Orders").should("exist");
       cy.button("Close").click();
     });
 
-    openNavigationSidebar();
+    H.openNavigationSidebar();
     cy.icon("gear").click();
     selectFromDropdown("Admin settings");
 
@@ -1063,10 +1025,10 @@ describe("issue 19742", () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("New").click();
-    popover().findByText("Question").click();
+    H.popover().findByText("Question").click();
 
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
 
       cy.findByText("Orders").should("not.exist");
       cy.findByText("Products").should("exist");
@@ -1077,7 +1039,7 @@ describe("issue 19742", () => {
 });
 
 function selectFromDropdown(optionName) {
-  popover().findByText(optionName).click();
+  H.popover().findByText(optionName).click();
 }
 
 function hideTable(tableName) {
@@ -1106,7 +1068,7 @@ const QUESTION_2 = {
 
 describe("issue 19893", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -1180,7 +1142,7 @@ const createQ1PlusQ2Question = (questionId1, questionId2) => {
 };
 
 const assertQ1PlusQ2Joins = () => {
-  getNotebookStep("join").within(() => {
+  H.getNotebookStep("join").within(() => {
     cy.findAllByTestId("notebook-cell-item").then(items => {
       cy.wrap(items[0]).should("contain", QUESTION_1.name);
       cy.wrap(items[1]).should("contain", QUESTION_2.name);
@@ -1203,7 +1165,7 @@ const newTableName = "Products with a very long name";
 
 describe("issue 20627", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     renameColumn(ORDERS.PRODUCT_ID, foreignKeyColumnName);
@@ -1211,13 +1173,13 @@ describe("issue 20627", () => {
   });
 
   it("nested queries should handle long column and/or table names (metabase#20627)", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Join data").click();
 
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText(newTableName).click();
     });
 
@@ -1228,7 +1190,7 @@ describe("issue 20627", () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText(newTableName).click();
 
       cy.findByText("Category").click();
@@ -1236,10 +1198,10 @@ describe("issue 20627", () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom column").click();
-    enterCustomColumnDetails({ formula: "1 + 1", name: "Math" });
+    H.enterCustomColumnDetails({ formula: "1 + 1", name: "Math" });
     cy.button("Done").click();
 
-    visualize();
+    H.visualize();
 
     cy.get("[data-testid=cell-data]")
       .should("contain", "Math")
@@ -1272,7 +1234,7 @@ describe("issue 20809", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestion(questionDetails).then(({ body: { id } }) => {
@@ -1302,21 +1264,21 @@ describe("issue 20809", () => {
         },
       };
 
-      visitQuestionAdhoc(nestedQuestion, { mode: "notebook" });
+      H.visitQuestionAdhoc(nestedQuestion, { mode: "notebook" });
     });
   });
 
   it("nesting should work on a saved question with a filter to implicit/explicit table (metabase#20809)", () => {
     cy.findByTextEnsureVisible("Custom column").click();
 
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: "1 + 1",
       name: "Two",
     });
 
     cy.button("Done").click();
 
-    visualize(response => {
+    H.visualize(response => {
       expect(response.body.error).to.not.exist;
     });
 

--- a/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
@@ -1,36 +1,7 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  chartPathWithFillColor,
-  commandPalette,
-  commandPaletteButton,
-  createNativeQuestion,
-  createQuestion,
-  entityPickerModal,
-  entityPickerModalItem,
-  entityPickerModalTab,
-  focusNativeEditor,
-  getNotebookStep,
-  modal,
-  newButton,
-  onlyOnOSS,
-  openNativeEditor,
-  openNotebook,
-  openOrdersTable,
-  openQuestionActions,
-  popover,
-  queryBuilderHeader,
-  restore,
-  saveQuestion,
-  saveSavedQuestion,
-  selectFilterOperator,
-  startNewQuestion,
-  tableHeaderClick,
-  visitQuestion,
-  visitQuestionAdhoc,
-  visualize,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID, PEOPLE } = SAMPLE_DATABASE;
 
@@ -65,14 +36,14 @@ describe("issue 23023", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should show only selected columns in a step preview (metabase#23023)", () => {
-    visitQuestionAdhoc(questionDetails);
+    H.visitQuestionAdhoc(questionDetails);
 
-    openNotebook();
+    H.openNotebook();
 
     cy.icon("play").eq(1).click();
 
@@ -96,12 +67,12 @@ describe("issue 24839: should be able to summarize a nested question based on th
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestion(questionDetails).then(({ body: { id } }) => {
       // Start ad-hoc nested question based on the saved one
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           database: SAMPLE_DB_ID,
           query: { "source-table": `card__${id}` },
@@ -112,20 +83,20 @@ describe("issue 24839: should be able to summarize a nested question based on th
   });
 
   it("from the notebook GUI (metabase#24839-1)", () => {
-    openNotebook();
+    H.openNotebook();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Summarize").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sum of ...").click();
-    popover()
+    H.popover()
       .should("contain", "Sum of Quantity")
       .and("contain", "Average of Total");
   });
 
   it("from a table header cell (metabase#24839-2)", () => {
-    tableHeaderClick("Average of Total");
+    H.tableHeaderClick("Average of Total");
 
-    popover().contains("Distinct values").click();
+    H.popover().contains("Distinct values").click();
 
     cy.findByTestId("scalar-value").invoke("text").should("eq", "49");
 
@@ -161,16 +132,16 @@ describe("issue 25016", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
   it("should be possible to filter by a column in a multi-stage query (metabase#25016)", () => {
-    visitQuestionAdhoc(questionDetails);
-    tableHeaderClick("Category");
+    H.visitQuestionAdhoc(questionDetails);
+    H.tableHeaderClick("Category");
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Filter by this column").click();
       cy.findByText("Gadget").click();
       cy.button("Add filter").click();
@@ -185,8 +156,8 @@ describe("issue 25016", () => {
 // this is only testable in OSS because EE always has models from auditv2
 describe("issue 25144", { tags: "@OSS" }, () => {
   beforeEach(() => {
-    onlyOnOSS();
-    restore("setup");
+    H.onlyOnOSS();
+    H.restore("setup");
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/card").as("createCard");
     cy.intercept("PUT", "/api/card/*").as("updateCard");
@@ -195,47 +166,47 @@ describe("issue 25144", { tags: "@OSS" }, () => {
   it("should show Saved Questions tab after creating the first question (metabase#25144)", () => {
     cy.visit("/");
 
-    newButton("Question").click();
+    H.newButton("Question").click();
 
-    entityPickerModal().within(() => {
+    H.entityPickerModal().within(() => {
       cy.findByText("Saved questions").should("not.exist");
-      entityPickerModalItem(2, "Orders").click();
+      H.entityPickerModalItem(2, "Orders").click();
     });
 
-    saveQuestion("Orders question");
+    H.saveQuestion("Orders question");
 
-    newButton("Question").click();
+    H.newButton("Question").click();
 
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Saved questions").should("be.visible").click();
-      entityPickerModalItem(1, "Orders question").should("be.visible");
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Saved questions").should("be.visible").click();
+      H.entityPickerModalItem(1, "Orders question").should("be.visible");
     });
   });
 
   it("should show Models tab after creation the first model (metabase#24878)", () => {
     cy.visit("/");
 
-    newButton("Model").click();
+    H.newButton("Model").click();
     cy.findByTestId("new-model-options")
       .findByText(/use the notebook/i)
       .click();
-    entityPickerModal().within(() => {
-      entityPickerModalItem(2, "Orders").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalItem(2, "Orders").click();
     });
 
     cy.findByTestId("dataset-edit-bar").button("Save").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByLabelText("Name").clear().type("Orders model");
       cy.button("Save").click();
     });
     cy.wait("@createCard");
 
-    newButton("Question").click();
+    H.newButton("Question").click();
 
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Models").should("be.visible").click();
-      entityPickerModalItem(1, "Orders model").should("be.visible");
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Models").should("be.visible").click();
+      H.entityPickerModalItem(1, "Orders model").should("be.visible");
     });
   });
 });
@@ -257,35 +228,35 @@ describe("issue 27104", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    visitQuestionAdhoc(questionDetails, { mode: "notebook" });
+    H.visitQuestionAdhoc(questionDetails, { mode: "notebook" });
   });
 
   it("should correctly format the filter operator after the aggregation (metabase#27104)", () => {
     cy.findAllByTestId("action-buttons").last().findByText("Filter").click();
-    popover().findByText("Count").click();
+    H.popover().findByText("Count").click();
     // The following line is the main assertion.
-    popover().button("Back").should("have.text", "Count");
+    H.popover().button("Back").should("have.text", "Count");
     // The rest of the test is not really needed for this reproduction.
-    selectFilterOperator("Greater than");
-    popover().within(() => {
+    H.selectFilterOperator("Greater than");
+    H.popover().within(() => {
       cy.findByPlaceholderText("Enter a number").type("0").blur();
       cy.button("Add filter").click();
     });
 
-    visualize();
+    H.visualize();
 
     cy.findByTestId("qb-filters-panel").findByText("Count is greater than 0");
     // Check bars count
-    chartPathWithFillColor("#509EE3").should("have.length", 5);
+    H.chartPathWithFillColor("#509EE3").should("have.length", 5);
   });
 });
 
 describe("issue 27462", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -304,13 +275,13 @@ describe("issue 27462", () => {
       visualization_settings: {},
     };
 
-    visitQuestionAdhoc(questionDetails, { mode: "notebook" });
+    H.visitQuestionAdhoc(questionDetails, { mode: "notebook" });
 
     cy.button("Summarize").click();
 
     cy.findByRole("option", { name: "Sum of ..." }).click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByRole("option", { name: "Count" }).click();
     });
 
@@ -323,7 +294,7 @@ describe("issue 27462", () => {
 
 describe("issue 28221", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -367,7 +338,7 @@ describe("issue 28221", () => {
 
 describe("issue 28599", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
 
     cy.createQuestion(
@@ -402,9 +373,9 @@ describe("issue 28599", () => {
       cy.findByText("Year").should("be.visible");
     });
 
-    openQuestionActions();
-    popover().findByText("Turn into a model").click();
-    modal().findByText("Turn this into a model").click();
+    H.openQuestionActions();
+    H.popover().findByText("Turn into a model").click();
+    H.modal().findByText("Turn this into a model").click();
 
     cy.wait("@updateCard");
 
@@ -431,12 +402,12 @@ describe("issue 28874", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should allow to modify a pivot question in the notebook (metabase#28874)", () => {
-    visitQuestionAdhoc(questionDetails, { mode: "notebook" });
+    H.visitQuestionAdhoc(questionDetails, { mode: "notebook" });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Product ID").parent().icon("close").click();
@@ -460,20 +431,20 @@ describe("issue 29082", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
   it("should handle nulls in quick filters (metabase#29082)", () => {
-    visitQuestionAdhoc(questionDetails);
+    H.visitQuestionAdhoc(questionDetails);
     cy.wait("@dataset");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 11 rows").should("exist");
 
     cy.get(".test-TableInteractive-emptyCell").first().click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    popover().within(() => cy.findByText("=").click());
+    H.popover().within(() => cy.findByText("=").click());
     cy.wait("@dataset");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 8 rows").should("exist");
@@ -488,7 +459,7 @@ describe("issue 29082", () => {
 
     cy.get(".test-TableInteractive-emptyCell").first().click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    popover().within(() => cy.findByText("≠").click());
+    H.popover().within(() => cy.findByText("≠").click());
     cy.wait("@dataset");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 3 rows").should("exist");
@@ -499,7 +470,7 @@ describe("issue 29082", () => {
 
 describe("issue 30165", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
@@ -508,9 +479,9 @@ describe("issue 30165", () => {
   });
 
   it("should not autorun native queries after updating a question (metabase#30165)", () => {
-    openNativeEditor();
-    focusNativeEditor().type("SELECT * FROM ORDERS");
-    queryBuilderHeader().findByText("Save").click();
+    H.openNativeEditor();
+    H.focusNativeEditor().type("SELECT * FROM ORDERS");
+    H.queryBuilderHeader().findByText("Save").click();
     cy.findByTestId("save-question-modal").within(() => {
       cy.findByLabelText("Name").clear().type("Q1");
       cy.findByText("Save").click();
@@ -518,15 +489,15 @@ describe("issue 30165", () => {
     cy.wait("@createQuestion");
     cy.button("Not now").click();
 
-    focusNativeEditor().type(" WHERE TOTAL < 20");
-    queryBuilderHeader().findByText("Save").click();
+    H.focusNativeEditor().type(" WHERE TOTAL < 20");
+    H.queryBuilderHeader().findByText("Save").click();
     cy.findByTestId("save-question-modal").within(modal => {
       cy.findByText("Save").click();
     });
     cy.wait("@updateQuestion");
 
-    focusNativeEditor().type(" LIMIT 10");
-    queryBuilderHeader().findByText("Save").click();
+    H.focusNativeEditor().type(" LIMIT 10");
+    H.queryBuilderHeader().findByText("Save").click();
     cy.findByTestId("save-question-modal").within(modal => {
       cy.findByText("Save").click();
     });
@@ -542,22 +513,22 @@ describe("issue 30165", () => {
 
 describe("issue 30610", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should remove stale metadata when saving a new question (metabase#30610)", () => {
-    openOrdersTable();
-    openNotebook();
+    H.openOrdersTable();
+    H.openNotebook();
     removeSourceColumns();
-    saveQuestion("New orders");
+    H.saveQuestion("New orders");
     createAdHocQuestion("New orders");
     visualizeAndAssertColumns();
   });
 
   it("should remove stale metadata when updating an existing question (metabase#30610)", () => {
-    visitQuestion(ORDERS_QUESTION_ID);
-    openNotebook();
+    H.visitQuestion(ORDERS_QUESTION_ID);
+    H.openNotebook();
     removeSourceColumns();
     updateQuestion();
     createAdHocQuestion("Orders");
@@ -567,7 +538,7 @@ describe("issue 30610", () => {
 
 describe("issue 36669", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("GET", "/api/search*").as("search");
   });
@@ -581,11 +552,11 @@ describe("issue 36669", () => {
       },
     };
 
-    createQuestion(questionDetails).then(() => {
-      startNewQuestion();
+    H.createQuestion(questionDetails).then(() => {
+      H.startNewQuestion();
     });
 
-    entityPickerModal().within(() => {
+    H.entityPickerModal().within(() => {
       cy.findByPlaceholderText("Search this collection or everywhere…").type(
         "Orders 36669",
       );
@@ -595,10 +566,10 @@ describe("issue 36669", () => {
       cy.findByRole("tabpanel").findByText("Orders 36669").click();
     });
 
-    getNotebookStep("data").findByText("Orders 36669").click();
+    H.getNotebookStep("data").findByText("Orders 36669").click();
 
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
 
       cy.log("verify Tables are listed");
       cy.findByRole("tabpanel").should("contain", "Orders");
@@ -608,7 +579,7 @@ describe("issue 36669", () => {
 
 describe("issue 35290", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
@@ -632,7 +603,7 @@ describe("issue 35290", () => {
       },
     };
 
-    createQuestion(questionDetails).then(({ body: { id: questionId } }) => {
+    H.createQuestion(questionDetails).then(({ body: { id: questionId } }) => {
       const questionDetails = {
         name: "35290",
         query: {
@@ -640,7 +611,7 @@ describe("issue 35290", () => {
         },
       };
 
-      createQuestion(questionDetails, { visitQuestion: true });
+      H.createQuestion(questionDetails, { visitQuestion: true });
     });
 
     cy.findByTestId("viz-settings-button").click();
@@ -658,10 +629,10 @@ describe("issue 35290", () => {
 
 describe("issue 43216", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
 
-    createNativeQuestion({
+    H.createNativeQuestion({
       name: "Source question",
       native: { query: "select 1 as A, 2 as B, 3 as C" },
     });
@@ -671,34 +642,34 @@ describe("issue 43216", () => {
     cy.visit("/");
 
     cy.log("Create target question");
-    newButton("Question").click();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Saved questions").click();
+    H.newButton("Question").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Saved questions").click();
       cy.findByText("Source question").click();
     });
-    saveQuestion("Target question");
+    H.saveQuestion("Target question");
 
     cy.log("Update source question");
-    commandPaletteButton().click();
-    commandPalette().findByText("Source question").click();
+    H.commandPaletteButton().click();
+    H.commandPalette().findByText("Source question").click();
     cy.findByTestId("native-query-editor-container")
       .findByText("Open Editor")
       .click();
-    focusNativeEditor().should("be.visible").type(" , 4 as D");
-    saveSavedQuestion();
+    H.focusNativeEditor().should("be.visible").type(" , 4 as D");
+    H.saveSavedQuestion();
 
     cy.log("Assert updated metadata in target question");
-    commandPaletteButton().click();
-    commandPalette().findByText("Target question").click();
+    H.commandPaletteButton().click();
+    H.commandPalette().findByText("Target question").click();
     cy.findAllByTestId("header-cell").eq(3).should("have.text", "D");
-    openNotebook();
-    getNotebookStep("data").button("Pick columns").click();
-    popover().findByText("D").should("be.visible");
+    H.openNotebook();
+    H.getNotebookStep("data").button("Pick columns").click();
+    H.popover().findByText("D").should("be.visible");
   });
 });
 
 function updateQuestion() {
-  queryBuilderHeader().findByText("Save").click();
+  H.queryBuilderHeader().findByText("Save").click();
   cy.findByTestId("save-question-modal").within(modal => {
     cy.findByText("Save").click();
   });
@@ -706,24 +677,24 @@ function updateQuestion() {
 
 function removeSourceColumns() {
   cy.findByTestId("fields-picker").click();
-  popover().findByText("Select none").click();
+  H.popover().findByText("Select none").click();
 }
 
 function createAdHocQuestion(questionName) {
-  startNewQuestion();
-  entityPickerModal().within(() => {
-    entityPickerModalTab("Saved questions").click();
+  H.startNewQuestion();
+  H.entityPickerModal().within(() => {
+    H.entityPickerModalTab("Saved questions").click();
     cy.findByText(questionName).click();
   });
   cy.findByTestId("fields-picker").click();
-  popover().within(() => {
+  H.popover().within(() => {
     cy.findByText("ID").should("be.visible");
     cy.findByText("Total").should("not.exist");
   });
 }
 
 function visualizeAndAssertColumns() {
-  visualize();
+  H.visualize();
   cy.findByTestId("TableInteractive-root").within(() => {
     cy.findByText("ID").should("exist");
     cy.findByText("Total").should("not.exist");
@@ -744,18 +715,18 @@ describe("Custom columns visualization settings", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.createQuestion(question).then(({ body: { id } }) => {
       cy.request("PUT", `/api/card/${id}`, { enable_embedding: true });
 
-      visitQuestion(id);
+      H.visitQuestion(id);
     });
   });
 
   it("should not show 'Save' after modifying minibar settings for a custom column", () => {
     goToExpressionSidebarVisualizationSettings();
-    popover().within(() => {
+    H.popover().within(() => {
       const miniBarSwitch = cy.findByLabelText("Show a mini bar chart");
       miniBarSwitch.click();
       miniBarSwitch.should("be.checked");
@@ -766,14 +737,14 @@ describe("Custom columns visualization settings", () => {
   it("should not show 'Save' after text formatting visualization settings", () => {
     goToExpressionSidebarVisualizationSettings();
 
-    popover().within(() => {
+    H.popover().within(() => {
       const viewAsDropdown = cy.findByLabelText("Display as");
       viewAsDropdown.click();
     });
 
     cy.findByLabelText("Email link").click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Email link").should("exist");
     });
 
@@ -781,11 +752,11 @@ describe("Custom columns visualization settings", () => {
   });
 
   it("should not show 'Save' after saving viz settings from the custom column dropdown", () => {
-    tableHeaderClick(EXPRESSION_NAME);
-    popover().within(() => {
+    H.tableHeaderClick(EXPRESSION_NAME);
+    H.popover().within(() => {
       cy.findByRole("button", { name: /gear icon/i }).click();
     });
-    popover().within(() => {
+    H.popover().within(() => {
       const miniBarSwitch = cy.findByLabelText("Show a mini bar chart");
       miniBarSwitch.click();
       miniBarSwitch.should("be.checked");

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -1,61 +1,7 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { NO_COLLECTION_PERSONAL_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  addCustomColumn,
-  appBar,
-  assertEChartsTooltip,
-  assertQueryBuilderRowCount,
-  cartesianChartCircle,
-  createNativeQuestion,
-  createQuestion,
-  echartsContainer,
-  editDashboard,
-  enterCustomColumnDetails,
-  entityPickerModal,
-  entityPickerModalTab,
-  filter,
-  getDashboardCard,
-  getDraggableElements,
-  getNotebookStep,
-  getTable,
-  join,
-  leftSidebar,
-  main,
-  modal,
-  moveColumnDown,
-  newButton,
-  openNotebook,
-  openOrdersTable,
-  openProductsTable,
-  openQuestionActions,
-  openTable,
-  popover,
-  queryBuilderFooter,
-  queryBuilderHeader,
-  queryBuilderMain,
-  questionInfoButton,
-  resetTestTable,
-  restore,
-  resyncDatabase,
-  rightSidebar,
-  saveDashboard,
-  saveQuestion,
-  setModelMetadata,
-  showDashboardCardActions,
-  sidebar,
-  sidesheet,
-  startNewQuestion,
-  summarize,
-  tableHeaderClick,
-  tableInteractive,
-  visitDashboard,
-  visitModel,
-  visitQuestion,
-  visitQuestionAdhoc,
-  visualize,
-  withDatabase,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID, PEOPLE, PEOPLE_ID } =
   SAMPLE_DATABASE;
@@ -86,23 +32,23 @@ describe("issue 32625, issue 31635", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should remove dependent clauses when a clause is removed (metabase#32625, metabase#31635)", () => {
-    visitQuestionAdhoc(QUESTION, { mode: "notebook" });
+    H.visitQuestionAdhoc(QUESTION, { mode: "notebook" });
 
-    getNotebookStep("expression")
+    H.getNotebookStep("expression")
       .findAllByTestId("notebook-cell-item")
       .first()
       .icon("close")
       .click();
 
-    getNotebookStep("expression").should("not.exist");
-    getNotebookStep("summarize").findByText(CC_NAME).should("not.exist");
+    H.getNotebookStep("expression").should("not.exist");
+    H.getNotebookStep("summarize").findByText(CC_NAME).should("not.exist");
 
-    visualize();
+    H.visualize();
 
     cy.findByTestId("query-builder-main").within(() => {
       cy.findByTestId("scalar-value").should("have.text", "200");
@@ -145,12 +91,12 @@ describe("issue 32964", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should not overflow chart settings sidebar with long column name (metabase#32964)", () => {
-    visitQuestionAdhoc(QUESTION);
+    H.visitQuestionAdhoc(QUESTION);
     cy.findByTestId("viz-settings-button").click();
     cy.findByTestId("sidebar-left").within(([sidebar]) => {
       const maxX = sidebar.getBoundingClientRect().right;
@@ -173,7 +119,7 @@ describe("issue 33079", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.intercept("POST", "/api/dataset").as("dataset");
@@ -184,8 +130,8 @@ describe("issue 33079", () => {
 
   it("underlying records drill should work in a non-English locale (metabase#33079)", () => {
     cy.createQuestion(questionDetails, { visitQuestion: true });
-    cartesianChartCircle().eq(1).click({ force: true });
-    popover()
+    H.cartesianChartCircle().eq(1).click({ force: true });
+    H.popover()
       .findByText(/Order/) // See these Orders
       .click();
     cy.wait("@dataset");
@@ -203,7 +149,7 @@ describe("issue 34414", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
@@ -211,7 +157,7 @@ describe("issue 34414", () => {
     cy.createQuestion(INVOICE_MODEL_DETAILS).then(response => {
       const modelId = response.body.id;
 
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           type: "query",
           database: SAMPLE_DB_ID,
@@ -220,10 +166,10 @@ describe("issue 34414", () => {
       });
     });
 
-    openNotebook();
-    filter({ mode: "notebook" });
+    H.openNotebook();
+    H.filter({ mode: "notebook" });
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Plan").click();
       assertPlanFieldValues();
 
@@ -246,7 +192,7 @@ function assertPlanFieldValues() {
 
 describe("issue 38176", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("PUT", "/api/card/**").as("updateQuestion");
   });
@@ -275,8 +221,8 @@ describe("issue 38176", () => {
 
     cy.findByTestId("qb-header").icon("play").click();
 
-    questionInfoButton().click();
-    sidesheet().within(() => {
+    H.questionInfoButton().click();
+    H.sidesheet().within(() => {
       cy.findByPlaceholderText("Add description")
         .type("This is a question")
         .blur();
@@ -291,7 +237,7 @@ describe("issue 38176", () => {
     });
 
     cy.findByLabelText("Close").click();
-    tableInteractive().should("contain", "NL");
+    H.tableInteractive().should("contain", "NL");
   });
 });
 
@@ -304,25 +250,25 @@ describe("issue 38354", { tags: "@external" }, () => {
   };
 
   beforeEach(() => {
-    restore();
-    restore("postgres-12");
+    H.restore();
+    H.restore("postgres-12");
     cy.signInAsAdmin();
     cy.createQuestion(QUESTION_DETAILS, { visitQuestion: true });
   });
 
   it("should be possible to change source database (metabase#38354)", () => {
-    openNotebook();
-    getNotebookStep("data").findByTestId("data-step-cell").click();
-    entityPickerModal().within(() => {
+    H.openNotebook();
+    H.getNotebookStep("data").findByTestId("data-step-cell").click();
+    H.entityPickerModal().within(() => {
       cy.findByText("QA Postgres12").click();
       cy.findByText("Orders").click();
     });
 
     // optimization: add a limit so that query runs faster
     cy.button("Row limit").click();
-    getNotebookStep("limit").findByPlaceholderText("Enter a limit").type("5");
+    H.getNotebookStep("limit").findByPlaceholderText("Enter a limit").type("5");
 
-    visualize();
+    H.visualize();
 
     cy.findByTestId("query-builder-main")
       .findByText("There was a problem with your question")
@@ -347,15 +293,15 @@ describe("issue 30056", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should show table breadcrumbs for questions with post-aggregation filters (metabase#30056)", () => {
-    createQuestion(questionDetails, { visitQuestion: true });
+    H.createQuestion(questionDetails, { visitQuestion: true });
     // the name of the table is hidden after a few seconds with a CSS animation,
     // so check for "exist" only
-    queryBuilderHeader().findByText("People").should("exist");
+    H.queryBuilderHeader().findByText("People").should("exist");
   });
 });
 
@@ -375,23 +321,23 @@ describe("issue 39102", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
   it("should be able to preview a multi-stage query (metabase#39102)", () => {
     cy.createQuestion(questionDetails, { visitQuestion: true });
-    openNotebook();
+    H.openNotebook();
 
-    getNotebookStep("data", { stage: 0 }).icon("play").click();
+    H.getNotebookStep("data", { stage: 0 }).icon("play").click();
     cy.wait("@dataset");
     cy.findByTestId("preview-root").within(() => {
       cy.findByText("Tax").should("be.visible");
       cy.icon("close").click();
     });
 
-    getNotebookStep("summarize", { stage: 0 }).icon("play").click();
+    H.getNotebookStep("summarize", { stage: 0 }).icon("play").click();
     cy.wait("@dataset");
     cy.findByTestId("preview-root").within(() => {
       cy.findByText("Count").should("be.visible");
@@ -400,7 +346,7 @@ describe("issue 39102", () => {
       cy.icon("close").click();
     });
 
-    getNotebookStep("filter", { stage: 1 }).icon("play").click();
+    H.getNotebookStep("filter", { stage: 1 }).icon("play").click();
     cy.wait("@dataset");
     cy.findByTestId("preview-root").within(() => {
       cy.findByText("Count").should("be.visible");
@@ -409,7 +355,7 @@ describe("issue 39102", () => {
       cy.icon("close").click();
     });
 
-    getNotebookStep("summarize", { stage: 1 }).icon("play").click();
+    H.getNotebookStep("summarize", { stage: 1 }).icon("play").click();
     cy.wait("@dataset");
     cy.findByTestId("preview-root").within(() => {
       cy.findByText("Count").should("be.visible");
@@ -430,14 +376,14 @@ describe("issue 13814", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should support specifying a field in 'count' MBQL clause even if the UI doesn't support it (metabase#13814)", () => {
     cy.log("verify that the API supports saving this MBQL");
-    createQuestion(questionDetails).then(({ body: card }) =>
-      visitQuestion(card.id),
+    H.createQuestion(questionDetails).then(({ body: card }) =>
+      H.visitQuestion(card.id),
     );
 
     cy.log("verify that the query is executed correctly");
@@ -446,19 +392,19 @@ describe("issue 13814", () => {
     cy.log(
       "verify that the clause is displayed correctly and won't crash if updated",
     );
-    openNotebook();
-    getNotebookStep("summarize")
+    H.openNotebook();
+    H.getNotebookStep("summarize")
       .findByText("Count of Tax")
       .should("be.visible")
       .click();
-    popover().findByText("Count of rows").click();
-    getNotebookStep("summarize").findByText("Count").should("be.visible");
+    H.popover().findByText("Count of rows").click();
+    H.getNotebookStep("summarize").findByText("Count").should("be.visible");
   });
 });
 
 describe("issue 39795", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     //If you comment out this post, then the test will pass.
@@ -470,7 +416,7 @@ describe("issue 39795", () => {
   });
 
   it("should allow me to re-order even when a field is set with a different display value (metabase#39795)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         database: SAMPLE_DB_ID,
         query: {
@@ -480,11 +426,11 @@ describe("issue 39795", () => {
       },
     });
     cy.findByTestId("viz-settings-button").click();
-    moveColumnDown(getDraggableElements().first(), 2);
+    H.moveColumnDown(H.getDraggableElements().first(), 2);
 
     // We are not able to re-order because the dataset will also contain values a column for Product ID
     // This causes the isValid() check to fire, and you are always forced into the default value for table.columns
-    getDraggableElements().eq(2).should("contain.text", "ID");
+    H.getDraggableElements().eq(2).should("contain.text", "ID");
   });
 });
 
@@ -493,10 +439,10 @@ describe("issue 40176", () => {
   const TABLE = "uuid_pk_table";
 
   beforeEach(() => {
-    restore(`${DIALECT}-writable`);
+    H.restore(`${DIALECT}-writable`);
     cy.signInAsAdmin();
-    resetTestTable({ type: DIALECT, table: TABLE });
-    resyncDatabase({
+    H.resetTestTable({ type: DIALECT, table: TABLE });
+    H.resyncDatabase({
       dbId: WRITABLE_DB_ID,
       tableName: TABLE,
     });
@@ -506,8 +452,8 @@ describe("issue 40176", () => {
     "should allow filtering on UUID PK columns (metabase#40176)",
     { tags: "@external" },
     () => {
-      getTable({ name: TABLE }).then(({ id: tableId }) => {
-        visitQuestionAdhoc({
+      H.getTable({ name: TABLE }).then(({ id: tableId }) => {
+        H.visitQuestionAdhoc({
           display: "table",
           dataset_query: {
             database: WRITABLE_DB_ID,
@@ -518,16 +464,16 @@ describe("issue 40176", () => {
           },
         });
       });
-      openNotebook();
+      H.openNotebook();
       cy.findByTestId("action-buttons").findByText("Filter").click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("ID").click();
         cy.findByLabelText("Filter value").type(
           "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
         );
         cy.button("Add filter").click();
       });
-      visualize();
+      H.visualize();
       cy.findByTestId("question-row-count")
         .findByText("Showing 1 row")
         .should("be.visible");
@@ -537,35 +483,35 @@ describe("issue 40176", () => {
 
 describe("issue 40435", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("PUT", "/api/card/*").as("updateCard");
   });
 
   it("should make new query columns visible by default (metabase#40435)", () => {
-    openOrdersTable();
-    openNotebook();
-    getNotebookStep("data").button("Pick columns").click();
-    popover().within(() => {
+    H.openOrdersTable();
+    H.openNotebook();
+    H.getNotebookStep("data").button("Pick columns").click();
+    H.popover().within(() => {
       cy.findByText("Select none").click();
       cy.findByText("User ID").click();
     });
-    getNotebookStep("data").button("Pick columns").click();
-    visualize();
+    H.getNotebookStep("data").button("Pick columns").click();
+    H.visualize();
     cy.findByTestId("viz-settings-button").click();
     cy.findByTestId("sidebar-left").within(() => {
       cy.findByTestId("ID-hide-button").click();
       cy.findByTestId("ID-show-button").click();
     });
-    saveQuestion();
+    H.saveQuestion();
 
-    openNotebook();
-    getNotebookStep("data").button("Pick columns").click();
-    popover().findByText("Product ID").click();
-    queryBuilderHeader().findByText("Save").click();
-    modal().last().findByText("Save").click();
+    H.openNotebook();
+    H.getNotebookStep("data").button("Pick columns").click();
+    H.popover().findByText("Product ID").click();
+    H.queryBuilderHeader().findByText("Save").click();
+    H.modal().last().findByText("Save").click();
     cy.wait("@updateCard");
-    visualize();
+    H.visualize();
 
     cy.findByRole("columnheader", { name: "ID" }).should("be.visible");
     cy.findByRole("columnheader", { name: "User ID" }).should("be.visible");
@@ -575,15 +521,15 @@ describe("issue 40435", () => {
 
 describe("issue 41381", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should show an error message when adding a constant-only custom expression (metabase#41381)", () => {
-    openOrdersTable({ mode: "notebook" });
-    addCustomColumn();
-    enterCustomColumnDetails({ formula: "'Test'", name: "Constant" });
-    popover().within(() => {
+    H.openOrdersTable({ mode: "notebook" });
+    H.addCustomColumn();
+    H.enterCustomColumnDetails({ formula: "'Test'", name: "Constant" });
+    H.popover().within(() => {
       cy.findByText("Invalid expression").should("be.visible");
       cy.button("Done").should("be.disabled");
     });
@@ -595,13 +541,13 @@ describe(
   { tags: "@mongo" },
   () => {
     beforeEach(() => {
-      restore("mongo-5");
+      H.restore("mongo-5");
       cy.signInAsAdmin();
 
       cy.intercept("POST", "/api/dataset").as("dataset");
       cy.request(`/api/database/${WRITABLE_DB_ID}/schema/`).then(({ body }) => {
         const tableId = body.find(table => table.name === "orders").id;
-        openTable({
+        H.openTable({
           database: WRITABLE_DB_ID,
           table: tableId,
           limit: 2,
@@ -621,7 +567,7 @@ describe(
           cy.log(
             "Scenario 1 - Make sure the simple mode filter is working correctly (metabase#40770)",
           );
-          filter();
+          H.filter();
 
           cy.findByRole("dialog").within(() => {
             cy.findByPlaceholderText("Search by ID").type(id);
@@ -637,10 +583,10 @@ describe(
           cy.log(
             "Scenario 2 - Make sure filter is working in the notebook editor (metabase#42010)",
           );
-          openNotebook();
-          filter({ mode: "notebook" });
+          H.openNotebook();
+          H.filter({ mode: "notebook" });
 
-          popover()
+          H.popover()
             .findAllByRole("option")
             .first()
             .should("have.text", "ID")
@@ -669,7 +615,7 @@ describe(
             .should("have.length.at.most", ordersColumns);
 
           cy.log("Scenario 2.2 - Make sure we can visualize the data");
-          visualize();
+          H.visualize();
           cy.findByTestId("question-row-count").should(
             "have.text",
             "Showing 1 row",
@@ -686,19 +632,19 @@ function removeFilter() {
 
 describe("issue 33439", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should show an error message when trying to use convertTimezone on an unsupported db (metabase#33439)", () => {
-    openOrdersTable({ mode: "notebook" });
-    addCustomColumn();
-    enterCustomColumnDetails({
+    H.openOrdersTable({ mode: "notebook" });
+    H.addCustomColumn();
+    H.enterCustomColumnDetails({
       formula:
         'convertTimezone("2022-12-28T12:00:00", "Canada/Pacific", "Canada/Eastern")',
       name: "Date",
     });
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Unsupported function convert-timezone");
       cy.button("Done").should("be.disabled");
     });
@@ -709,7 +655,7 @@ describe("issue 42244", () => {
   const COLUMN_NAME = "Created At".repeat(5);
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.request("PUT", `/api/field/${ORDERS.CREATED_AT}`, {
       display_name: COLUMN_NAME,
@@ -717,17 +663,17 @@ describe("issue 42244", () => {
   });
 
   it("should allow to change the temporal bucket when the column name is long (metabase#42244)", () => {
-    openOrdersTable({ mode: "notebook" });
-    summarize({ mode: "notebook" });
-    getNotebookStep("summarize")
+    H.openOrdersTable({ mode: "notebook" });
+    H.summarize({ mode: "notebook" });
+    H.getNotebookStep("summarize")
       .findByText("Pick a column to group by")
       .click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText(COLUMN_NAME).realHover();
       cy.findByText("by month").should("be.visible").click();
     });
-    popover().last().findByText("Year").click();
-    getNotebookStep("summarize")
+    H.popover().last().findByText("Year").click();
+    H.getNotebookStep("summarize")
       .findByText(`${COLUMN_NAME}: Year`)
       .should("be.visible");
   });
@@ -735,12 +681,12 @@ describe("issue 42244", () => {
 
 describe("issue 42957", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("does not show collections that contain models from different tabs (metabase#42957)", () => {
-    createQuestion({
+    H.createQuestion({
       name: "Model",
       type: "model",
       query: {
@@ -755,7 +701,7 @@ describe("issue 42957", () => {
     );
 
     cy.get("@collectionId").then(collectionId => {
-      createQuestion({
+      H.createQuestion({
         name: "Question",
         type: "question",
         query: {
@@ -765,9 +711,9 @@ describe("issue 42957", () => {
       });
     });
 
-    startNewQuestion();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Models").click();
+    H.startNewQuestion();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Models").click();
 
       cy.findByText("Collection without models").should("not.exist");
     });
@@ -776,12 +722,12 @@ describe("issue 42957", () => {
 
 describe("issue 40064", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should be able to edit a custom column with the same name as one of the columns used in the expression (metabase#40064)", () => {
-    createQuestion(
+    H.createQuestion(
       {
         query: {
           "source-table": ORDERS_ID,
@@ -795,24 +741,24 @@ describe("issue 40064", () => {
     );
 
     cy.log("check the initial expression value");
-    tableInteractive().findByText("4.14").should("be.visible");
+    H.tableInteractive().findByText("4.14").should("be.visible");
 
     cy.log("update the expression and check the value");
-    openNotebook();
-    getNotebookStep("expression").findByText("Tax").click();
-    enterCustomColumnDetails({ formula: "[Tax] * 3" });
-    popover().button("Update").click();
-    visualize();
-    tableInteractive().findByText("6.21").should("be.visible");
+    H.openNotebook();
+    H.getNotebookStep("expression").findByText("Tax").click();
+    H.enterCustomColumnDetails({ formula: "[Tax] * 3" });
+    H.popover().button("Update").click();
+    H.visualize();
+    H.tableInteractive().findByText("6.21").should("be.visible");
 
     cy.log("rename the expression and make sure you cannot create a cycle");
-    openNotebook();
-    getNotebookStep("expression").findByText("Tax").click();
-    enterCustomColumnDetails({ formula: "[Tax] * 3", name: "Tax3" });
-    popover().button("Update").click();
-    getNotebookStep("expression").findByText("Tax3").click();
-    enterCustomColumnDetails({ formula: "[Tax3] * 3", name: "Tax3" });
-    popover().within(() => {
+    H.openNotebook();
+    H.getNotebookStep("expression").findByText("Tax").click();
+    H.enterCustomColumnDetails({ formula: "[Tax] * 3", name: "Tax3" });
+    H.popover().button("Update").click();
+    H.getNotebookStep("expression").findByText("Tax3").click();
+    H.enterCustomColumnDetails({ formula: "[Tax3] * 3", name: "Tax3" });
+    H.popover().within(() => {
       cy.findByText("Cycle detected: Tax3 → Tax3").should("be.visible");
       cy.button("Update").should("be.disabled");
     });
@@ -821,13 +767,13 @@ describe("issue 40064", () => {
 
 describe.skip("issue 10493", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.signInAsAdmin();
   });
 
   it("should not reset chart axes after adding a new query stage (metabase#10493)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       display: "bar",
       dataset_query: {
         type: "query",
@@ -846,8 +792,8 @@ describe.skip("issue 10493", () => {
       },
     });
 
-    filter();
-    modal().within(() => {
+    H.filter();
+    H.modal().within(() => {
       cy.findByText("Summaries").click();
       cy.findByTestId("filter-column-Count").within(() => {
         cy.findByPlaceholderText("Min").type("0");
@@ -857,7 +803,7 @@ describe.skip("issue 10493", () => {
     });
     cy.wait("@dataset");
 
-    echartsContainer().within(() => {
+    H.echartsContainer().within(() => {
       // y axis
       cy.findByText("Count").should("exist");
       cy.findByText("21,000").should("exist");
@@ -909,48 +855,48 @@ describe("issue 32020", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
-    createQuestion(question1Details);
-    createQuestion(question2Details);
+    H.createQuestion(question1Details);
+    H.createQuestion(question2Details);
   });
 
   it("should be possible to use aggregation columns from source and joined questions in aggregation (metabase#32020)", () => {
-    startNewQuestion();
+    H.startNewQuestion();
 
     cy.log("create joined question manually");
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Saved questions").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Saved questions").click();
       cy.findByText(question1Details.name).click();
     });
-    join();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Saved questions").click();
+    H.join();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Saved questions").click();
       cy.findByText(question2Details.name).click();
     });
-    popover().findByText("ID").click();
-    popover().findByText("ID").click();
+    H.popover().findByText("ID").click();
+    H.popover().findByText("ID").click();
 
     cy.log("aggregation column from the source question");
-    getNotebookStep("summarize")
+    H.getNotebookStep("summarize")
       .findByText("Pick a function or metric")
       .click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Sum of ...").click();
       cy.findByText("Sum of Total").click();
     });
 
     cy.log("aggregation column from the joined question");
-    getNotebookStep("summarize").icon("add").click();
-    popover().within(() => {
+    H.getNotebookStep("summarize").icon("add").click();
+    H.popover().within(() => {
       cy.findByText("Sum of ...").click();
       cy.findByText(question2Details.name).click();
       cy.findByText("Max of Longitude").click();
     });
 
     cy.log("visualize and check results");
-    visualize();
-    tableInteractive().within(() => {
+    H.visualize();
+    H.tableInteractive().within(() => {
       cy.findByText("Sum of Sum of Total").should("be.visible");
       cy.findByText("Sum of Q2 → Max").should("be.visible");
     });
@@ -965,24 +911,24 @@ describe("issue 44071", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signIn("nocollection");
-    createQuestion(questionDetails);
+    H.createQuestion(questionDetails);
   });
 
   it("should be able to save questions based on another questions without collection access (metabase#44071)", () => {
     cy.visit("/");
-    newButton("Question").click();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Saved questions").click();
+    H.newButton("Question").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Saved questions").click();
       cy.findByText(/Personal Collection/).click();
       cy.findByText(questionDetails.name).click();
     });
-    getNotebookStep("data")
+    H.getNotebookStep("data")
       .findByText(questionDetails.name)
       .should("be.visible");
-    saveQuestion();
-    appBar()
+    H.saveQuestion();
+    H.appBar()
       .findByText(/Personal Collection/)
       .should("be.visible");
   });
@@ -990,9 +936,9 @@ describe("issue 44071", () => {
 
 describe("issue 44415", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signIn("admin");
-    createQuestion(
+    H.createQuestion(
       {
         query: {
           "source-table": ORDERS_ID,
@@ -1028,15 +974,15 @@ describe("issue 44415", () => {
       cy.visit(`/question/${questionId}/notebook`),
     );
 
-    getNotebookStep("filter")
+    H.getNotebookStep("filter")
       .findAllByTestId("notebook-cell-item")
       .first()
       .icon("close")
       .click();
 
-    getNotebookStep("filter").should("not.exist");
+    H.getNotebookStep("filter").should("not.exist");
 
-    visualize();
+    H.visualize();
 
     cy.findByTestId("qb-filters-panel").should("not.exist");
     cy.get("@questionId").then(questionId => {
@@ -1059,14 +1005,14 @@ describe("issue 37374", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
-    createQuestion(questionDetails, { wrapId: true });
+    H.createQuestion(questionDetails, { wrapId: true });
     cy.signIn("nodata");
   });
 
   it("should allow to change the viz type to pivot without data access (metabase#37374)", () => {
-    visitQuestion("@questionId");
+    H.visitQuestion("@questionId");
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
     cy.intercept("POST", "/api/card/pivot/*/query").as("cardPivotQuery");
 
@@ -1081,27 +1027,27 @@ describe("issue 37374", () => {
     cy.log("changing the viz type back to table and running the query works");
     cy.findByTestId("chart-type-sidebar").findByTestId("Table-button").click();
     cy.wait("@cardQuery");
-    tableInteractive().should("be.visible");
+    H.tableInteractive().should("be.visible");
   });
 });
 
 describe("issue 44532", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    openProductsTable();
+    H.openProductsTable();
   });
 
   it("should update chart metrics and dimensions with each added breakout (metabase #44532)", () => {
-    summarize();
+    H.summarize();
 
-    rightSidebar()
+    H.rightSidebar()
       .findByRole("listitem", { name: "Category" })
       .button("Add dimension")
       .click();
     cy.wait("@dataset");
 
-    echartsContainer().within(() => {
+    H.echartsContainer().within(() => {
       cy.findByText("Count").should("exist"); // y-axis
       cy.findByText("Category").should("exist"); // x-axis
 
@@ -1112,7 +1058,7 @@ describe("issue 44532", () => {
       cy.findByText("Widget").should("exist");
     });
 
-    rightSidebar()
+    H.rightSidebar()
       .findByRole("listitem", { name: "Created At" })
       .button("Add dimension")
       .click();
@@ -1125,7 +1071,7 @@ describe("issue 44532", () => {
       cy.findByText("Widget").should("exist");
     });
 
-    echartsContainer().within(() => {
+    H.echartsContainer().within(() => {
       cy.findByText("Count").should("exist"); // y-axis
       cy.findByText("Created At: Month").should("exist"); // x-axis
 
@@ -1141,7 +1087,7 @@ describe("issue 44532", () => {
       cy.findByText("Widget").should("not.exist");
     });
 
-    rightSidebar().button("Done").click();
+    H.rightSidebar().button("Done").click();
     cy.wait("@dataset");
 
     cy.findByLabelText("Legend").within(() => {
@@ -1151,7 +1097,7 @@ describe("issue 44532", () => {
       cy.findByText("Widget").should("exist");
     });
 
-    echartsContainer().within(() => {
+    H.echartsContainer().within(() => {
       cy.findByText("Count").should("exist"); // y-axis
       cy.findByText("Created At: Month").should("exist"); // x-axis
 
@@ -1171,18 +1117,18 @@ describe("issue 44532", () => {
 
 describe("issue 33441", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should show an error message for an incorrect date expression (metabase#33441)", () => {
-    openOrdersTable({ mode: "notebook" });
-    addCustomColumn();
-    enterCustomColumnDetails({
+    H.openOrdersTable({ mode: "notebook" });
+    H.addCustomColumn();
+    H.enterCustomColumnDetails({
       formula: 'datetimeDiff([Created At] , now, "days")',
       name: "Date",
     });
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Invalid expression").should("be.visible");
       cy.button("Done").should("be.disabled");
     });
@@ -1208,35 +1154,35 @@ describe("issue 31960", () => {
   const rowCount = 11;
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should apply a date range filter for a query broken out by week (metabase#31960)", () => {
     cy.createDashboardWithQuestions({ questions: [questionDetails] }).then(
       ({ dashboard }) => {
-        visitDashboard(dashboard.id);
+        H.visitDashboard(dashboard.id);
       },
     );
 
-    getDashboardCard().within(() => {
-      cartesianChartCircle().eq(dotIndex).realHover();
+    H.getDashboardCard().within(() => {
+      H.cartesianChartCircle().eq(dotIndex).realHover();
     });
-    assertEChartsTooltip({
+    H.assertEChartsTooltip({
       header: "July 10–16, 2022",
       rows: [
         { name: "Count", value: String(rowCount), secondaryValue: "+10%" },
       ],
     });
-    getDashboardCard().within(() => {
-      cartesianChartCircle().eq(dotIndex).click({ force: true });
+    H.getDashboardCard().within(() => {
+      H.cartesianChartCircle().eq(dotIndex).click({ force: true });
     });
 
-    popover().findByText("See these Orders").click();
+    H.popover().findByText("See these Orders").click();
     cy.findByTestId("qb-filters-panel")
       .findByText("Created At is Jul 10–16, 2022")
       .should("be.visible");
-    assertQueryBuilderRowCount(rowCount);
+    H.assertQueryBuilderRowCount(rowCount);
   });
 });
 
@@ -1255,13 +1201,13 @@ describe("issue 43294", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should not overwrite viz settings with click actions in raw data mode (metabase#43294)", () => {
-    createQuestion(questionDetails, { visitQuestion: true });
-    queryBuilderFooter().findByLabelText("Switch to data").click();
+    H.createQuestion(questionDetails, { visitQuestion: true });
+    H.queryBuilderFooter().findByLabelText("Switch to data").click();
 
     // TODO: reenable this test when we reenable the "Compare to the past" components.
     // cy.log("compare action");
@@ -1271,20 +1217,20 @@ describe("issue 43294", () => {
 
     cy.log("extract action");
     cy.button("Add column").click();
-    popover().findByText("Extract part of column").click();
-    popover().within(() => {
+    H.popover().findByText("Extract part of column").click();
+    H.popover().within(() => {
       cy.findByText("Created At: Month").click();
       cy.findByText("Year").click();
     });
 
     cy.log("combine action");
     cy.button("Add column").click();
-    popover().findByText("Combine columns").click();
-    popover().button("Done").click();
+    H.popover().findByText("Combine columns").click();
+    H.popover().button("Done").click();
 
     cy.log("check visualization");
-    queryBuilderFooter().findByLabelText("Switch to visualization").click();
-    echartsContainer().within(() => {
+    H.queryBuilderFooter().findByLabelText("Switch to visualization").click();
+    H.echartsContainer().within(() => {
       cy.findByText("Count").should("be.visible");
       cy.findByText("Created At: Month").should("be.visible");
     });
@@ -1293,12 +1239,12 @@ describe("issue 43294", () => {
 
 describe("issue 40399", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should not show results from other stages in a stages preview (metabase#40399)", () => {
-    createQuestion(
+    H.createQuestion(
       {
         name: "40399",
         query: {
@@ -1324,16 +1270,16 @@ describe("issue 40399", () => {
       },
     );
 
-    openNotebook();
+    H.openNotebook();
 
-    getNotebookStep("filter", { stage: 0 }).within(() => {
+    H.getNotebookStep("filter", { stage: 0 }).within(() => {
       cy.icon("play").click();
       cy.findByTestId("preview-root")
         .findAllByText("Widget")
         .should("be.visible");
     });
 
-    getNotebookStep("join", { stage: 0 }).within(() => {
+    H.getNotebookStep("join", { stage: 0 }).within(() => {
       cy.icon("play").click();
       cy.findByTestId("preview-root")
         .findAllByText("Gizmo")
@@ -1342,7 +1288,7 @@ describe("issue 40399", () => {
       cy.findByTestId("preview-root").findByText("Widget").should("not.exist");
     });
 
-    getNotebookStep("data", { stage: 0 }).within(() => {
+    H.getNotebookStep("data", { stage: 0 }).within(() => {
       cy.icon("play").click();
       cy.findByTestId("preview-root")
         .findAllByText("Gizmo")
@@ -1356,17 +1302,17 @@ describe("issue 40399", () => {
 
 describe("issue 43057", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should differentiate between date and datetime filters with 00:00 time (metabase#43057)", () => {
-    openOrdersTable();
+    H.openOrdersTable();
 
     cy.log("set the date and verify the filter and results");
     cy.intercept("POST", "/api/dataset").as("dataset");
-    tableHeaderClick("Created At");
-    popover().within(() => {
+    H.tableHeaderClick("Created At");
+    H.popover().within(() => {
       cy.findByText("Filter by this column").click();
       cy.findByText("Specific dates…").click();
       cy.findByText("On").click();
@@ -1374,7 +1320,7 @@ describe("issue 43057", () => {
       cy.button("Add filter").click();
     });
     cy.wait("@dataset");
-    assertQueryBuilderRowCount(16);
+    H.assertQueryBuilderRowCount(16);
     cy.findByTestId("qb-filters-panel")
       .findByText("Created At is on Nov 18, 2024")
       .should("be.visible");
@@ -1383,13 +1329,13 @@ describe("issue 43057", () => {
     cy.findByTestId("qb-filters-panel")
       .findByText("Created At is on Nov 18, 2024")
       .click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.button("Add time").click();
       cy.findByLabelText("Time").should("have.value", "00:00");
       cy.button("Update filter").click();
     });
     cy.wait("@dataset");
-    assertQueryBuilderRowCount(1);
+    H.assertQueryBuilderRowCount(1);
     cy.findByTestId("qb-filters-panel")
       .findByText("Created At is Nov 18, 2024, 12:00 AM")
       .should("be.visible");
@@ -1398,13 +1344,13 @@ describe("issue 43057", () => {
     cy.findByTestId("qb-filters-panel")
       .findByText("Created At is Nov 18, 2024, 12:00 AM")
       .click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByLabelText("Time").should("have.value", "00:00");
       cy.button("Remove time").click();
       cy.button("Update filter").click();
     });
     cy.wait("@dataset");
-    assertQueryBuilderRowCount(16);
+    H.assertQueryBuilderRowCount(16);
     cy.findByTestId("qb-filters-panel")
       .findByText("Created At is on Nov 18, 2024")
       .should("be.visible");
@@ -1413,12 +1359,12 @@ describe("issue 43057", () => {
 
 describe("issue 19894", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should show all columns when using the join column selecter (metabase#19894)", () => {
-    createQuestion(
+    H.createQuestion(
       {
         name: "Q1",
         query: {
@@ -1432,7 +1378,7 @@ describe("issue 19894", () => {
       },
     );
 
-    createQuestion({
+    H.createQuestion({
       name: "Q2",
       query: {
         "source-table": PRODUCTS_ID,
@@ -1441,7 +1387,7 @@ describe("issue 19894", () => {
       },
     });
 
-    createQuestion({
+    H.createQuestion({
       name: "Q3",
       query: {
         "source-table": PRODUCTS_ID,
@@ -1450,48 +1396,48 @@ describe("issue 19894", () => {
       },
     });
 
-    startNewQuestion();
+    H.startNewQuestion();
 
-    modal().findByText("Saved questions").click();
-    modal().findByText("Q1").click();
-
-    cy.button("Join data").click();
-
-    modal().findByText("Saved questions").click();
-    modal().findByText("Q2").click();
-
-    popover().findByText("Category").click();
-    popover().findByText("Category").click();
+    H.modal().findByText("Saved questions").click();
+    H.modal().findByText("Q1").click();
 
     cy.button("Join data").click();
 
-    modal().findByText("Saved questions").click();
-    modal().findByText("Q3").click();
+    H.modal().findByText("Saved questions").click();
+    H.modal().findByText("Q2").click();
 
-    popover().findByText("Category").should("be.visible");
-    popover().findByText("Count").should("be.visible");
+    H.popover().findByText("Category").click();
+    H.popover().findByText("Category").click();
 
-    popover().findByText("Q1").click();
-    popover().findByText("Q2").click();
+    cy.button("Join data").click();
 
-    popover().findByText("Category").should("be.visible");
-    popover().findByText("Sum of Price").should("be.visible");
+    H.modal().findByText("Saved questions").click();
+    H.modal().findByText("Q3").click();
 
-    popover().findByText("Q1").click();
+    H.popover().findByText("Category").should("be.visible");
+    H.popover().findByText("Count").should("be.visible");
 
-    popover().findByText("Category").should("be.visible");
-    popover().findByText("Count").should("be.visible");
+    H.popover().findByText("Q1").click();
+    H.popover().findByText("Q2").click();
+
+    H.popover().findByText("Category").should("be.visible");
+    H.popover().findByText("Sum of Price").should("be.visible");
+
+    H.popover().findByText("Q1").click();
+
+    H.popover().findByText("Category").should("be.visible");
+    H.popover().findByText("Count").should("be.visible");
   });
 });
 
 describe("issue 44637", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should not crash when rendering a line/bar chart with empty results (metabase#44637)", () => {
-    createNativeQuestion(
+    H.createNativeQuestion(
       {
         native: {
           query: "SELECT '2023-01-01'::date, 2 FROM people WHERE false",
@@ -1500,28 +1446,28 @@ describe("issue 44637", () => {
       { visitQuestion: true },
     );
 
-    assertQueryBuilderRowCount(0);
-    queryBuilderMain().findByText("No results!").should("exist");
-    queryBuilderFooter().button("Visualization").click();
-    leftSidebar().icon("bar").click();
-    queryBuilderMain().within(() => {
+    H.assertQueryBuilderRowCount(0);
+    H.queryBuilderMain().findByText("No results!").should("exist");
+    H.queryBuilderFooter().button("Visualization").click();
+    H.leftSidebar().icon("bar").click();
+    H.queryBuilderMain().within(() => {
       cy.findByText("No results!").should("exist");
       cy.findByText("Something's gone wrong").should("not.exist");
     });
 
-    queryBuilderFooter().icon("calendar").click();
-    rightSidebar().findByText("Add an event");
+    H.queryBuilderFooter().icon("calendar").click();
+    H.rightSidebar().findByText("Add an event");
   });
 });
 
 describe("issue 44668", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should not drop graph.metrics after adding a new query stage (metabase#44668)", () => {
-    createQuestion(
+    H.createQuestion(
       {
         display: "bar",
         query: {
@@ -1538,22 +1484,25 @@ describe("issue 44668", () => {
       { visitQuestion: true },
     );
 
-    openNotebook();
+    H.openNotebook();
 
     cy.findAllByTestId("action-buttons").last().button("Custom column").click();
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: 'concat("abc_", [Count])',
       name: "Custom String",
     });
-    popover().button("Done").click();
+    H.popover().button("Done").click();
 
-    getNotebookStep("expression", { stage: 1 }).icon("add").click();
-    enterCustomColumnDetails({ formula: "[Count] * 2", name: "Custom Number" });
-    popover().button("Done").click();
+    H.getNotebookStep("expression", { stage: 1 }).icon("add").click();
+    H.enterCustomColumnDetails({
+      formula: "[Count] * 2",
+      name: "Custom Number",
+    });
+    H.popover().button("Done").click();
 
-    visualize();
+    H.visualize();
 
-    echartsContainer().within(() => {
+    H.echartsContainer().within(() => {
       cy.findByText("State").should("be.visible"); // x-axis
       cy.findByText("Count").should("be.visible"); // y-axis
 
@@ -1564,39 +1513,39 @@ describe("issue 44668", () => {
     });
 
     // Ensure custom columns weren't added as series automatically
-    queryBuilderMain().findByLabelText("Legend").should("not.exist");
+    H.queryBuilderMain().findByLabelText("Legend").should("not.exist");
 
     cy.findByTestId("viz-settings-button").click();
 
     // Ensure can use Custom Number as series
-    leftSidebar().findByText("Add another series").click();
-    queryBuilderMain()
+    H.leftSidebar().findByText("Add another series").click();
+    H.queryBuilderMain()
       .findByLabelText("Legend")
       .within(() => {
         cy.findByText("Count").should("exist");
         cy.findByText("Custom Number").should("exist");
       });
-    leftSidebar().within(() => {
+    H.leftSidebar().within(() => {
       cy.findByText("Add another series").should("not.exist");
       cy.findByText("Add series breakout").should("not.exist");
       cy.findByTestId("remove-Custom Number").click();
     });
-    queryBuilderMain().findByLabelText("Legend").should("not.exist");
+    H.queryBuilderMain().findByLabelText("Legend").should("not.exist");
 
-    leftSidebar().findByText("Add series breakout").click();
-    popover().within(() => {
+    H.leftSidebar().findByText("Add series breakout").click();
+    H.popover().within(() => {
       cy.findByText("Count").should("exist");
       cy.findByText("Custom Number").should("exist");
       cy.findByText("Custom String").click();
     });
-    queryBuilderMain()
+    H.queryBuilderMain()
       .findByLabelText("Legend")
       .within(() => {
         ["68", "56", "49", "20", "90"].forEach(value => {
           cy.findByText(`abc_${value}`).should("exist");
         });
       });
-    leftSidebar().within(() => {
+    H.leftSidebar().within(() => {
       cy.findByText("Add another series").should("not.exist");
       cy.findByText("Add series breakout").should("not.exist");
     });
@@ -1607,12 +1556,12 @@ describe("issue 44974", () => {
   const PG_DB_ID = 2;
 
   beforeEach(() => {
-    restore("postgres-12");
+    H.restore("postgres-12");
     cy.signInAsAdmin();
   });
 
   it("entity picker should not offer to join with a table or a question from a different database (metabase#44974)", () => {
-    withDatabase(PG_DB_ID, ({ PEOPLE_ID }) => {
+    H.withDatabase(PG_DB_ID, ({ PEOPLE_ID }) => {
       const questionDetails = {
         name: "Question 44974 in Postgres DB",
         database: PG_DB_ID,
@@ -1622,17 +1571,17 @@ describe("issue 44974", () => {
         },
       };
 
-      createQuestion(questionDetails, {
+      H.createQuestion(questionDetails, {
         // Visit question to put it in recents
         visitQuestion: true,
       });
 
-      openOrdersTable({ mode: "notebook" });
-      join();
+      H.openOrdersTable({ mode: "notebook" });
+      H.join();
 
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Recents").should("not.exist");
-        entityPickerModalTab("Saved questions").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Recents").should("not.exist");
+        H.entityPickerModalTab("Saved questions").click();
         cy.findByText(questionDetails.name).should("not.exist");
       });
     });
@@ -1641,12 +1590,12 @@ describe("issue 44974", () => {
 
 describe("issue 38989", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should be impossible to join with a table or question which is not in the same database (metabase#38989)", () => {
-    createQuestion(
+    H.createQuestion(
       {
         query: {
           "source-table": PEOPLE_ID,
@@ -1689,12 +1638,12 @@ describe("issue 38989", () => {
 
 describe("issue 39771", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should show tooltip for ellipsified text (metabase#39771)", () => {
-    createQuestion(
+    H.createQuestion(
       {
         query: {
           aggregation: [["count"]],
@@ -1727,15 +1676,15 @@ describe("issue 39771", () => {
       { visitQuestion: true },
     );
 
-    openNotebook();
-    getNotebookStep("summarize", { stage: 1 })
+    H.openNotebook();
+    H.getNotebookStep("summarize", { stage: 1 })
       .findByTestId("breakout-step")
       .findByText("Created At: Month: Quarter of year")
       .click();
 
-    popover().findByText("by quarter of year").realHover();
+    H.popover().findByText("by quarter of year").realHover();
 
-    popover().then(([$popover]) => {
+    H.popover().then(([$popover]) => {
       const popoverStyle = window.getComputedStyle($popover);
       const popoverZindex = parseInt(popoverStyle.zIndex, 10);
 
@@ -1760,7 +1709,7 @@ describe("issue 45063", () => {
         "source-table": sourceTableId,
       },
     };
-    createQuestion(questionDetails, { wrapId: true });
+    H.createQuestion(questionDetails, { wrapId: true });
   }
 
   function createGuiModel({ sourceTableId }) {
@@ -1771,7 +1720,7 @@ describe("issue 45063", () => {
         "source-table": sourceTableId,
       },
     };
-    createQuestion(mbqlModelDetails, { wrapId: true, idAlias: "modelId" });
+    H.createQuestion(mbqlModelDetails, { wrapId: true, idAlias: "modelId" });
   }
 
   function createNativeModel({
@@ -1787,14 +1736,14 @@ describe("issue 45063", () => {
         query: `SELECT * FROM ${tableName}`,
       },
     };
-    createNativeQuestion(nativeModelDetails, {
+    H.createNativeQuestion(nativeModelDetails, {
       wrapId: true,
       idAlias: "modelId",
     }).then(({ body: model }) => {
       cy.log("populate result_metadata");
       cy.request("POST", `/api/card/${model.id}/query`);
       cy.log("map columns to database fields");
-      setModelMetadata(model.id, field => {
+      H.setModelMetadata(model.id, field => {
         if (field.name === fieldName) {
           return { ...field, id: fieldId, semantic_type: fieldSemanticType };
         }
@@ -1828,9 +1777,9 @@ describe("issue 45063", () => {
   }
 
   function verifyListFilter({ fieldDisplayName, fieldValue, fieldValueLabel }) {
-    tableHeaderClick(fieldDisplayName);
-    popover().findByText("Filter by this column").click();
-    popover().within(() => {
+    H.tableHeaderClick(fieldDisplayName);
+    H.popover().findByText("Filter by this column").click();
+    H.popover().within(() => {
       cy.findByPlaceholderText("Search the list").type(fieldValueLabel);
       cy.findByText(fieldValueLabel).click();
       cy.button("Add filter").click();
@@ -1838,7 +1787,7 @@ describe("issue 45063", () => {
     cy.findByTestId("qb-filters-panel")
       .findByText(`${fieldDisplayName} is ${fieldValue}`)
       .click();
-    popover().findByLabelText(fieldValueLabel).should("be.checked");
+    H.popover().findByLabelText(fieldValueLabel).should("be.checked");
   }
 
   function verifySearchFilter({
@@ -1846,13 +1795,13 @@ describe("issue 45063", () => {
     fieldValue,
     fieldValueLabel,
   }) {
-    tableHeaderClick(fieldDisplayName);
-    popover().findByText("Filter by this column").click();
-    popover()
+    H.tableHeaderClick(fieldDisplayName);
+    H.popover().findByText("Filter by this column").click();
+    H.popover()
       .findByPlaceholderText(`Search by ${fieldDisplayName}`)
       .type(fieldValueLabel);
-    popover().last().findByText(fieldValueLabel).click();
-    popover().first().click().button("Add filter").click();
+    H.popover().last().findByText(fieldValueLabel).click();
+    H.popover().first().click().button("Add filter").click();
     cy.findByTestId("qb-filters-panel")
       .findByText(`${fieldDisplayName} is ${fieldValue}`)
       .should("be.visible");
@@ -1872,7 +1821,7 @@ describe("issue 45063", () => {
     cy.signInAsNormalUser();
     visitCard();
     verifyListFilter({ fieldDisplayName, fieldValue, fieldValueLabel });
-    assertQueryBuilderRowCount(expectedRowCount);
+    H.assertQueryBuilderRowCount(expectedRowCount);
 
     cy.log("search values");
     cy.signInAsAdmin();
@@ -1880,11 +1829,11 @@ describe("issue 45063", () => {
     cy.signInAsNormalUser();
     visitCard();
     verifySearchFilter({ fieldDisplayName, fieldValue, fieldValueLabel });
-    assertQueryBuilderRowCount(expectedRowCount);
+    H.assertQueryBuilderRowCount(expectedRowCount);
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -1892,7 +1841,7 @@ describe("issue 45063", () => {
     it("should work with questions", () => {
       createGuiQuestion({ sourceTableId: PEOPLE_ID });
       verifyRemappedFilter({
-        visitCard: () => visitQuestion("@questionId"),
+        visitCard: () => H.visitQuestion("@questionId"),
         fieldId: PEOPLE.ID,
         fieldDisplayName: "ID",
         fieldValue: 1,
@@ -1904,7 +1853,7 @@ describe("issue 45063", () => {
     it("should work with models", () => {
       createGuiModel({ sourceTableId: PEOPLE_ID });
       verifyRemappedFilter({
-        visitCard: () => cy.get("@modelId").then(visitModel),
+        visitCard: () => cy.get("@modelId").then(H.visitModel),
         fieldId: PEOPLE.ID,
         fieldDisplayName: "ID",
         fieldValue: 1,
@@ -1921,7 +1870,7 @@ describe("issue 45063", () => {
         fieldSemanticType: "type/PK",
       });
       verifyRemappedFilter({
-        visitCard: () => cy.get("@modelId").then(visitModel),
+        visitCard: () => cy.get("@modelId").then(H.visitModel),
         fieldId: PEOPLE.ID,
         fieldDisplayName: "ID",
         fieldValue: 1,
@@ -1943,7 +1892,7 @@ describe("issue 45063", () => {
     it("should work with questions", () => {
       createGuiQuestion({ sourceTableId: ORDERS_ID });
       verifyRemappedFilter({
-        visitCard: () => visitQuestion("@questionId"),
+        visitCard: () => H.visitQuestion("@questionId"),
         fieldId: ORDERS.PRODUCT_ID,
         fieldDisplayName: "Product ID",
         fieldValue: 1,
@@ -1955,7 +1904,7 @@ describe("issue 45063", () => {
     it("should work with models", () => {
       createGuiModel({ sourceTableId: ORDERS_ID });
       verifyRemappedFilter({
-        visitCard: () => cy.get("@modelId").then(visitModel),
+        visitCard: () => cy.get("@modelId").then(H.visitModel),
         fieldId: ORDERS.PRODUCT_ID,
         fieldDisplayName: "Product ID",
         fieldValue: 1,
@@ -1972,7 +1921,7 @@ describe("issue 45063", () => {
         fieldSemanticType: "type/FK",
       });
       verifyRemappedFilter({
-        visitCard: () => cy.get("@modelId").then(visitModel),
+        visitCard: () => cy.get("@modelId").then(H.visitModel),
         fieldId: ORDERS.PRODUCT_ID,
         fieldDisplayName: "PRODUCT_ID",
         fieldValue: 1,
@@ -1985,12 +1934,12 @@ describe("issue 45063", () => {
 
 describe("issue 41464", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should not overlap 'no results' and the loading state (metabase#41464)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         database: SAMPLE_DB_ID,
         type: "query",
@@ -2034,7 +1983,7 @@ describe("issue 41464", () => {
 
 describe.skip("issue 45359", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.intercept("/app/fonts/Lato/lato-v16-latin-regular.woff2").as(
       "font-regular",
     );
@@ -2043,9 +1992,9 @@ describe.skip("issue 45359", () => {
   });
 
   it("loads app fonts correctly (metabase#45359)", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
 
-    getNotebookStep("data")
+    H.getNotebookStep("data")
       .findByText("Orders")
       .should("have.css", "font-family", "Lato, sans-serif");
 
@@ -2069,13 +2018,13 @@ describe.skip("issue 45359", () => {
 
 describe("issue 45452", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should only have one scrollbar for the summarize sidebar (metabase#45452)", () => {
-    openOrdersTable();
-    summarize();
+    H.openOrdersTable();
+    H.summarize();
 
     cy.findByTestId("summarize-aggregation-item-list").then($el => {
       const element = $el[0];
@@ -2098,13 +2047,13 @@ describe("issue 45452", () => {
 
 describe("issue 41612", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/card").as("createQuestion");
   });
 
   it("should not ignore chart viz settings when viewing raw results as a table (metabase#41612)", () => {
-    visitQuestionAdhoc(
+    H.visitQuestionAdhoc(
       {
         display: "line",
         dataset_query: {
@@ -2126,9 +2075,9 @@ describe("issue 41612", () => {
       { visitQuestion: true },
     );
 
-    queryBuilderMain().findByLabelText("Switch to data").click();
-    queryBuilderHeader().button("Save").click();
-    modal().button("Save").click();
+    H.queryBuilderMain().findByLabelText("Switch to data").click();
+    H.queryBuilderHeader().button("Save").click();
+    H.modal().button("Save").click();
 
     cy.wait("@createQuestion").then(xhr => {
       const card = xhr.request.body;
@@ -2144,7 +2093,7 @@ describe("issue 41612", () => {
 
 describe("issue 36027", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     const CONCRETE_CREATED_AT_FIELD_REF = [
@@ -2165,9 +2114,9 @@ describe("issue 36027", () => {
       "source-table": ORDERS_ID,
     };
 
-    createQuestion({ query: BASE_QUERY }, { wrapId: true }).then(
+    H.createQuestion({ query: BASE_QUERY }, { wrapId: true }).then(
       baseQuestionId => {
-        createQuestion(
+        H.createQuestion(
           {
             display: "waterfall",
             query: {
@@ -2201,16 +2150,16 @@ describe("issue 36027", () => {
   });
 
   it("should use default metrics/dimensions if they're missing after removing some query clauses (metabase#36027)", () => {
-    openNotebook();
-    getNotebookStep("summarize", { stage: 1 })
+    H.openNotebook();
+    H.getNotebookStep("summarize", { stage: 1 })
       .findByLabelText("Remove step")
       .click({ force: true });
-    getNotebookStep("join", { stage: 1 })
+    H.getNotebookStep("join", { stage: 1 })
       .findByLabelText("Remove step")
       .click({ force: true });
-    visualize();
+    H.visualize();
 
-    echartsContainer().within(() => {
+    H.echartsContainer().within(() => {
       cy.findByText("Created At: Month").should("be.visible"); // x-axis
       cy.findByText("Count").should("be.visible"); // y-axis
 
@@ -2240,18 +2189,20 @@ describe("issue 36027", () => {
 
 describe("issue 12586", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should not show the run button overlay when an error occurs (metabase#12586)", () => {
-    openOrdersTable();
-    summarize();
+    H.openOrdersTable();
+    H.summarize();
 
     cy.intercept("POST", "/api/dataset", req => req.destroy());
 
-    rightSidebar().button("Done").click();
-    main().findByText("We're experiencing server issues").should("be.visible");
+    H.rightSidebar().button("Done").click();
+    H.main()
+      .findByText("We're experiencing server issues")
+      .should("be.visible");
     cy.findByTestId("query-builder-main").icon("play").should("not.be.visible");
   });
 });
@@ -2273,89 +2224,89 @@ describe("issue 48829", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should not show the unsaved changes warning when switching back to chill mode from the notebook editor after adding a filter from headers (metabase#48829)", () => {
-    createQuestion(questionDetails, { visitQuestion: true });
+    H.createQuestion(questionDetails, { visitQuestion: true });
 
-    tableHeaderClick("Category");
-    popover().findByText("Filter by this column").click();
-    popover().within(() => {
+    H.tableHeaderClick("Category");
+    H.popover().findByText("Filter by this column").click();
+    H.popover().within(() => {
       cy.findByText("Doohickey").click();
       cy.findByText("Add filter").click();
     });
 
-    queryBuilderHeader().button("Show Editor").click();
-    getNotebookStep("filter")
+    H.queryBuilderHeader().button("Show Editor").click();
+    H.getNotebookStep("filter")
       .findAllByTestId("notebook-cell-item")
       .icon("close")
       .should("be.visible")
       .click();
 
-    visualize();
+    H.visualize();
 
-    modal().should("not.exist");
+    H.modal().should("not.exist");
   });
 
   it("should not show the unsaved changes warning when switching back to chill mode from the notebook editor after adding a filter via the filter modal (metabase#48829)", () => {
-    createQuestion(questionDetails, { visitQuestion: true });
+    H.createQuestion(questionDetails, { visitQuestion: true });
 
-    queryBuilderHeader().button("Filter").click();
-    modal().within(() => {
+    H.queryBuilderHeader().button("Filter").click();
+    H.modal().within(() => {
       cy.findByText("Doohickey").click();
       cy.button("Apply filters").click();
     });
 
-    queryBuilderHeader().button("Show Editor").click();
-    getNotebookStep("filter")
+    H.queryBuilderHeader().button("Show Editor").click();
+    H.getNotebookStep("filter")
       .findAllByTestId("notebook-cell-item")
       .icon("close")
       .should("be.visible")
       .click();
 
-    visualize();
+    H.visualize();
 
-    modal().should("not.exist");
+    H.modal().should("not.exist");
   });
 
   it("should not show the unsaved changes warning when switching back to chill mode from the notebook editor after visiting a filtered question from a dashboard click action (metabase#48829)", () => {
     // Set up dashboard
     cy.createDashboardWithQuestions({ questions: [questionDetails] }).then(
       ({ dashboard }) => {
-        visitDashboard(dashboard.id);
+        H.visitDashboard(dashboard.id);
       },
     );
 
-    showDashboardCardActions();
-    editDashboard();
-    getDashboardCard().findByLabelText("Click behavior").click();
+    H.showDashboardCardActions();
+    H.editDashboard();
+    H.getDashboardCard().findByLabelText("Click behavior").click();
 
-    sidebar().within(() => {
+    H.sidebar().within(() => {
       cy.findByText("Title").click();
       cy.findByText("Go to a custom destination").click();
       cy.findByText("Saved question").click();
     });
 
-    entityPickerModal().findByText(questionDetails.name).click();
-    sidebar().findByTestId("click-mappings").findByText("Title").click();
-    popover().findByText("Title").click();
-    saveDashboard();
+    H.entityPickerModal().findByText(questionDetails.name).click();
+    H.sidebar().findByTestId("click-mappings").findByText("Title").click();
+    H.popover().findByText("Title").click();
+    H.saveDashboard();
 
     // Navigate to question using click action in dashboard
-    main().findByText("Rustic Paper Wallet").click();
+    H.main().findByText("Rustic Paper Wallet").click();
 
-    queryBuilderHeader().button("Show Editor").click();
-    getNotebookStep("filter")
+    H.queryBuilderHeader().button("Show Editor").click();
+    H.getNotebookStep("filter")
       .findAllByTestId("notebook-cell-item")
       .icon("close")
       .should("be.visible")
       .click();
 
-    visualize();
+    H.visualize();
 
-    modal().should("not.exist");
+    H.modal().should("not.exist");
   });
 });
 
@@ -2375,18 +2326,18 @@ describe("issue 50038", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
 
-    createQuestion(QUESTION, { wrapId: true, idAlias: "questionId" });
-    createQuestion(OTHER_QUESTION, {
+    H.createQuestion(QUESTION, { wrapId: true, idAlias: "questionId" });
+    H.createQuestion(OTHER_QUESTION, {
       wrapId: true,
       idAlias: "otherQuestionId",
     });
 
     cy.get("@questionId").then(questionId => {
       cy.get("@otherQuestionId").then(otherQuestionId => {
-        createQuestion(
+        H.createQuestion(
           {
             name: "Joined question",
             query: {
@@ -2418,14 +2369,14 @@ describe("issue 50038", () => {
   }
 
   it("should not break data source and join source buttons when the source names are too long (metabase#50038)", () => {
-    openNotebook();
-    getNotebookStep("data").within(() => {
+    H.openNotebook();
+    H.getNotebookStep("data").within(() => {
       assertEqualHeight(
         cy.findByText(QUESTION.name).parent().should("be.visible"),
         cy.findByTestId("fields-picker").should("be.visible"),
       );
     });
-    getNotebookStep("join").within(() => {
+    H.getNotebookStep("join").within(() => {
       assertEqualHeight(
         cy
           .findAllByText(OTHER_QUESTION.name)
@@ -2448,7 +2399,7 @@ describe("issue 47940", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("PUT", "/api/card/*").as("updateCard");
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
@@ -2456,7 +2407,7 @@ describe("issue 47940", () => {
 
   it("should be able to convert a question with date casting to a model", () => {
     cy.log("create a question without any column casting");
-    createQuestion(questionDetails, { visitQuestion: true });
+    H.createQuestion(questionDetails, { visitQuestion: true });
     cy.wait("@cardQuery");
 
     cy.log("add coercion");
@@ -2466,15 +2417,15 @@ describe("issue 47940", () => {
     });
 
     cy.log("get new query results with coercion applied");
-    queryBuilderHeader().findByTestId("run-button").click();
+    H.queryBuilderHeader().findByTestId("run-button").click();
     cy.wait("@cardQuery");
-    queryBuilderHeader().button("Save").click();
-    modal().button("Save").click();
+    H.queryBuilderHeader().button("Save").click();
+    H.modal().button("Save").click();
     cy.wait("@updateCard");
 
     cy.log("turn into a model");
-    openQuestionActions();
-    popover().findByText("Turn into a model").click();
+    H.openQuestionActions();
+    H.popover().findByText("Turn into a model").click();
     cy.findByRole("dialog").findByText("Turn this into a model").click();
     cy.wait("@updateCard");
 

--- a/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
@@ -1,15 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  type NativeQuestionDetails,
-  createNativeQuestion,
-  createQuestion,
-  getNotebookStep,
-  modal,
-  openNotebook,
-  popover,
-  restore,
-  tableHeaderClick,
-} from "e2e/support/helpers";
 import type { Filter, LocalFieldReference } from "metabase-types/api";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -24,7 +14,7 @@ describe("issue 39487", () => {
   ];
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.viewport(1280, 1000);
   });
@@ -43,22 +33,22 @@ describe("issue 39487", () => {
 
     cy.log("filter modal");
     cy.button("Filter").click();
-    modal().findByText("After Jan 1, 2015").click();
+    H.modal().findByText("After Jan 1, 2015").click();
     checkSingleDateFilter();
-    modal().button("Close").click();
+    H.modal().button("Close").click();
 
     cy.log("filter drill");
     cy.findByLabelText("Switch to data").click();
-    tableHeaderClick("Created At: Year");
-    popover().findByText("Filter by this column").click();
-    popover().findByText("Specific dates…").click();
-    popover().findByText("After").click();
-    popover().findByRole("textbox").clear().type("2015/01/01");
+    H.tableHeaderClick("Created At: Year");
+    H.popover().findByText("Filter by this column").click();
+    H.popover().findByText("Specific dates…").click();
+    H.popover().findByText("After").click();
+    H.popover().findByRole("textbox").clear().type("2015/01/01");
     checkSingleDateFilter();
 
     cy.log("notebook editor");
-    openNotebook();
-    getNotebookStep("filter")
+    H.openNotebook();
+    H.getNotebookStep("filter")
       .findAllByTestId("notebook-cell-item")
       .first()
       .click();
@@ -84,23 +74,23 @@ describe("issue 39487", () => {
 
     cy.log("filter modal");
     cy.button("Filter").click();
-    modal().findByText("May 1 – Jun 1, 2024").click();
+    H.modal().findByText("May 1 – Jun 1, 2024").click();
     checkDateRangeFilter();
-    modal().button("Close").click();
+    H.modal().button("Close").click();
 
     cy.log("filter drill");
     cy.findByLabelText("Switch to data").click();
-    tableHeaderClick("Created At: Year");
-    popover().findByText("Filter by this column").click();
-    popover().findByText("Specific dates…").click();
-    popover().findAllByRole("textbox").first().clear().type("2024/05/01");
-    popover().findAllByRole("textbox").last().clear().type("2024/06/01");
+    H.tableHeaderClick("Created At: Year");
+    H.popover().findByText("Filter by this column").click();
+    H.popover().findByText("Specific dates…").click();
+    H.popover().findAllByRole("textbox").first().clear().type("2024/05/01");
+    H.popover().findAllByRole("textbox").last().clear().type("2024/06/01");
     previousButton().click();
     checkDateRangeFilter();
 
     cy.log("notebook editor");
-    openNotebook();
-    getNotebookStep("filter")
+    H.openNotebook();
+    H.getNotebookStep("filter")
       .findAllByTestId("notebook-cell-item")
       .first()
       .click();
@@ -115,17 +105,17 @@ describe("issue 39487", () => {
       "2015-03-01", // 6 day rows
     ]);
 
-    openNotebook();
-    getNotebookStep("filter")
+    H.openNotebook();
+    H.getNotebookStep("filter")
       .findAllByTestId("notebook-cell-item")
       .first()
       .click();
-    popover().scrollTo("bottom");
-    popover().button("Update filter").should("be.visible").click();
+    H.popover().scrollTo("bottom");
+    H.popover().button("Update filter").should("be.visible").click();
   });
 
   function createTimeSeriesQuestionWithFilter(filter: Filter) {
-    createQuestion(
+    H.createQuestion(
       {
         query: {
           "source-table": ORDERS_ID,
@@ -205,7 +195,7 @@ describe("issue 39487", () => {
   }
 
   function measureDatetimeFilterPickerHeight() {
-    return popover().then(([$element]) => {
+    return H.popover().then(([$element]) => {
       const { height } = $element.getBoundingClientRect();
       return height;
     });
@@ -224,18 +214,18 @@ describe("issue 39487", () => {
   }
 
   function nextButton() {
-    return popover().get("button[data-next]");
+    return H.popover().get("button[data-next]");
   }
 
   function previousButton() {
-    return popover().get("button[data-previous]");
+    return H.popover().get("button[data-previous]");
   }
 });
 
 const MONGO_DB_ID = 2;
 
 describe("issue 47793", () => {
-  const questionDetails: NativeQuestionDetails = {
+  const questionDetails: H.NativeQuestionDetails = {
     database: MONGO_DB_ID,
     native: {
       query: `[
@@ -272,7 +262,7 @@ describe("issue 47793", () => {
   };
 
   beforeEach(() => {
-    restore("mongo-5");
+    H.restore("mongo-5");
     cy.signInAsAdmin();
   });
 
@@ -280,14 +270,14 @@ describe("issue 47793", () => {
     "should be able to preview queries for mongodb (metabase#47793)",
     { tags: ["@external", "@mongo"] },
     () => {
-      createNativeQuestion(questionDetails, { visitQuestion: true });
+      H.createNativeQuestion(questionDetails, { visitQuestion: true });
       cy.findByTestId("visibility-toggler")
         .findByText(/open editor/i)
         .click();
       cy.findByTestId("native-query-editor-container")
         .findByLabelText("Preview the query")
         .click();
-      modal()
+      H.modal()
         .should("contain.text", "$project")
         .and("contain.text", "quantity: 10");
     },

--- a/e2e/test/scenarios/question/caching.cy.spec.js
+++ b/e2e/test/scenarios/question/caching.cy.spec.js
@@ -1,11 +1,5 @@
+import { H } from "e2e/support";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  describeEE,
-  restore,
-  setTokenFeatures,
-  sidesheet,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 import { interceptPerformanceRoutes } from "../admin/performance/helpers/e2e-performance-helpers";
 import {
@@ -14,11 +8,11 @@ import {
   openSidebarCacheStrategyForm,
 } from "../admin/performance/helpers/e2e-strategy-form-helpers";
 
-describeEE("scenarios > question > caching", () => {
+H.describeEE("scenarios > question > caching", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
   });
 
   /**
@@ -27,11 +21,11 @@ describeEE("scenarios > question > caching", () => {
    */
   it("can configure cache for a question, on an enterprise instance", () => {
     interceptPerformanceRoutes();
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
 
     openSidebarCacheStrategyForm("question");
 
-    sidesheet().within(() => {
+    H.sidesheet().within(() => {
       cy.findByText(/Caching settings/).should("be.visible");
       durationRadioButton().click();
       cy.findByLabelText("Cache results for this many hours").type("48");
@@ -61,11 +55,11 @@ describeEE("scenarios > question > caching", () => {
 
   it("can click 'Clear cache' for a question", () => {
     interceptPerformanceRoutes();
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
 
     openSidebarCacheStrategyForm("question");
 
-    sidesheet().within(() => {
+    H.sidesheet().within(() => {
       cy.findByText(/Caching settings/).should("be.visible");
       cy.findByRole("button", {
         name: /Clear cache for this question/,
@@ -74,6 +68,6 @@ describeEE("scenarios > question > caching", () => {
     cy.findByTestId("confirm-modal").button("Clear cache").click();
     cy.wait("@invalidateCache");
 
-    sidesheet().findByText("Cache cleared").should("be.visible");
+    H.sidesheet().findByText("Cache cleared").should("be.visible");
   });
 });

--- a/e2e/test/scenarios/question/column-compare.cy.spec.ts
+++ b/e2e/test/scenarios/question/column-compare.cy.spec.ts
@@ -1,22 +1,8 @@
 import _ from "underscore";
 
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  createQuestion,
-  describeWithSnowplow,
-  expectGoodSnowplowEvent,
-  expectNoBadSnowplowEvents,
-  getNotebookStep,
-  openNotebook,
-  popover,
-  queryBuilderMain,
-  resetSnowplow,
-  restore,
-  rightSidebar,
-  tableHeaderClick,
-  visualize,
-} from "e2e/support/helpers";
 import type { FieldReference, StructuredQuery } from "metabase-types/api";
 
 const { PRODUCTS_ID, PRODUCTS, ORDERS, ORDERS_ID, PEOPLE } = SAMPLE_DATABASE;
@@ -198,32 +184,32 @@ const CUSTOM_EXPRESSIONS_USED_MOVING_AVERAGE = [
 
 // TODO: reenable test when we reenable the "Compare to the past" components.
 describe.skip("scenarios > question", () => {
-  describeWithSnowplow("column compare", () => {
+  H.describeWithSnowplow("column compare", () => {
     beforeEach(() => {
-      restore();
-      resetSnowplow();
+      H.restore();
+      H.resetSnowplow();
       cy.signInAsAdmin();
     });
 
     afterEach(() => {
-      expectNoBadSnowplowEvents();
+      H.expectNoBadSnowplowEvents();
     });
 
     describe("no aggregations", () => {
       it("does not show column compare shortcut", () => {
-        createQuestion(
+        H.createQuestion(
           { query: QUERY_NO_AGGREGATION },
           { visitQuestion: true, wrapId: true, idAlias: "questionId" },
         );
 
         cy.log("chill mode - summarize sidebar");
         cy.button("Summarize").click();
-        rightSidebar().button("Count").icon("close").click();
-        rightSidebar().button("Add aggregation").click();
+        H.rightSidebar().button("Count").icon("close").click();
+        H.rightSidebar().button("Add aggregation").click();
         verifyNoColumnCompareShortcut();
 
         cy.log("chill mode - column drill");
-        tableHeaderClick("Title");
+        H.tableHeaderClick("Title");
         verifyNoColumnCompareShortcut();
 
         cy.log("chill mode - plus button");
@@ -231,7 +217,7 @@ describe.skip("scenarios > question", () => {
         verifyNoColumnCompareShortcut();
 
         cy.log("notebook editor");
-        openNotebook();
+        H.openNotebook();
         cy.button("Summarize").click();
         verifyNoColumnCompareShortcut();
       });
@@ -245,19 +231,19 @@ describe.skip("scenarios > question", () => {
       });
 
       it("no breakout", () => {
-        createQuestion(
+        H.createQuestion(
           { query: QUERY_NO_AGGREGATION },
           { visitQuestion: true, wrapId: true, idAlias: "questionId" },
         );
 
         cy.log("chill mode - summarize sidebar");
         cy.button("Summarize").click();
-        rightSidebar().button("Count").icon("close").click();
-        rightSidebar().button("Add aggregation").click();
+        H.rightSidebar().button("Count").icon("close").click();
+        H.rightSidebar().button("Add aggregation").click();
         verifyNoColumnCompareShortcut();
 
         cy.log("chill mode - column drill");
-        tableHeaderClick("Title");
+        H.tableHeaderClick("Title");
         verifyNoColumnCompareShortcut();
 
         cy.log("chill mode - plus button");
@@ -265,25 +251,25 @@ describe.skip("scenarios > question", () => {
         verifyNoColumnCompareShortcut();
 
         cy.log("notebook editor");
-        openNotebook();
+        H.openNotebook();
         cy.button("Summarize").click();
         verifyNoColumnCompareShortcut();
       });
 
       it("one breakout", () => {
-        createQuestion(
+        H.createQuestion(
           { query: QUERY_SINGLE_AGGREGATION_NON_DATETIME_BREAKOUT },
           { visitQuestion: true, wrapId: true, idAlias: "questionId" },
         );
 
         cy.log("chill mode - summarize sidebar");
         cy.button("Summarize").click();
-        rightSidebar().button("Count").icon("close").click();
-        rightSidebar().button("Add aggregation").click();
+        H.rightSidebar().button("Count").icon("close").click();
+        H.rightSidebar().button("Add aggregation").click();
         verifyNoColumnCompareShortcut();
 
         cy.log("chill mode - column drill");
-        tableHeaderClick("Category");
+        H.tableHeaderClick("Category");
         verifyNoColumnCompareShortcut();
 
         cy.log("chill mode - plus button");
@@ -291,7 +277,7 @@ describe.skip("scenarios > question", () => {
         verifyNoColumnCompareShortcut();
 
         cy.log("notebook editor");
-        openNotebook();
+        H.openNotebook();
         cy.button("Summarize").click();
         verifyNoColumnCompareShortcut();
       });
@@ -299,19 +285,19 @@ describe.skip("scenarios > question", () => {
 
     describe("offset", () => {
       it("should be possible to change the temporal bucket through a preset", () => {
-        createQuestion(
+        H.createQuestion(
           { query: QUERY_SINGLE_AGGREGATION_NO_BREAKOUT },
           { visitQuestion: true, wrapId: true, idAlias: "questionId" },
         );
 
-        openNotebook();
-        getNotebookStep("summarize")
+        H.openNotebook();
+        H.getNotebookStep("summarize")
           .findAllByTestId("aggregate-step")
           .last()
           .icon("add")
           .click();
 
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findByText("Basic functions").click();
           cy.findByText("Compare to the past").click();
 
@@ -337,19 +323,19 @@ describe.skip("scenarios > question", () => {
       });
 
       it("should be possible to change the temporal bucket with a custom offset", () => {
-        createQuestion(
+        H.createQuestion(
           { query: QUERY_SINGLE_AGGREGATION_NO_BREAKOUT },
           { visitQuestion: true, wrapId: true, idAlias: "questionId" },
         );
 
-        openNotebook();
-        getNotebookStep("summarize")
+        H.openNotebook();
+        H.getNotebookStep("summarize")
           .findAllByTestId("aggregate-step")
           .last()
           .icon("add")
           .click();
 
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findByText("Basic functions").click();
           cy.findByText("Compare to the past").click();
 
@@ -359,9 +345,9 @@ describe.skip("scenarios > question", () => {
           cy.findByLabelText("Unit").click();
         });
 
-        popover().last().findByText("Weeks").click();
+        H.popover().last().findByText("Weeks").click();
 
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findByText("Done").click();
         });
 
@@ -384,7 +370,7 @@ describe.skip("scenarios > question", () => {
 
       describe("single aggregation", () => {
         it("no breakout", () => {
-          createQuestion(
+          H.createQuestion(
             { query: QUERY_SINGLE_AGGREGATION_NO_BREAKOUT },
             { visitQuestion: true, wrapId: true, idAlias: "questionId" },
           );
@@ -402,10 +388,10 @@ describe.skip("scenarios > question", () => {
           verifyNotebookText(info);
 
           toggleColumnPickerItems(["Value difference"]);
-          popover().button("Done").click();
+          H.popover().button("Done").click();
 
           cy.get("@questionId").then(questionId => {
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
               database_id: SAMPLE_DB_ID,
@@ -435,7 +421,7 @@ describe.skip("scenarios > question", () => {
         });
 
         it("breakout on binned datetime column", () => {
-          createQuestion(
+          H.createQuestion(
             { query: QUERY_SINGLE_AGGREGATION_BINNED_DATETIME_BREAKOUT },
             { visitQuestion: true, wrapId: true, idAlias: "questionId" },
           );
@@ -449,7 +435,7 @@ describe.skip("scenarios > question", () => {
 
           verifySummarizeText(info);
 
-          tableHeaderClick("Created At: Month");
+          H.tableHeaderClick("Created At: Month");
           verifyNoColumnCompareShortcut();
 
           verifyColumnDrillText(info);
@@ -457,10 +443,10 @@ describe.skip("scenarios > question", () => {
           verifyNotebookText(info);
 
           toggleColumnPickerItems(["Value difference"]);
-          popover().button("Done").click();
+          H.popover().button("Done").click();
 
           cy.get("@questionId").then(questionId => {
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
               database_id: SAMPLE_DB_ID,
@@ -495,7 +481,7 @@ describe.skip("scenarios > question", () => {
         });
 
         it("breakout on non-binned datetime column", () => {
-          createQuestion(
+          H.createQuestion(
             { query: QUERY_SINGLE_AGGREGATION_NON_BINNED_DATETIME_BREAKOUT },
             { visitQuestion: true, wrapId: true, idAlias: "questionId" },
           );
@@ -509,7 +495,7 @@ describe.skip("scenarios > question", () => {
 
           verifySummarizeText(info);
 
-          tableHeaderClick("Created At: Day");
+          H.tableHeaderClick("Created At: Day");
           verifyNoColumnCompareShortcut();
 
           verifyColumnDrillText(info);
@@ -517,10 +503,10 @@ describe.skip("scenarios > question", () => {
           verifyNotebookText(info);
 
           toggleColumnPickerItems(["Value difference"]);
-          popover().button("Done").click();
+          H.popover().button("Done").click();
 
           cy.get("@questionId").then(questionId => {
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
               database_id: SAMPLE_DB_ID,
@@ -551,7 +537,7 @@ describe.skip("scenarios > question", () => {
         });
 
         it("breakout on non-datetime column", () => {
-          createQuestion(
+          H.createQuestion(
             { query: QUERY_SINGLE_AGGREGATION_NON_DATETIME_BREAKOUT },
             { visitQuestion: true, wrapId: true, idAlias: "questionId" },
           );
@@ -565,28 +551,28 @@ describe.skip("scenarios > question", () => {
 
           verifySummarizeText(info);
 
-          tableHeaderClick("Category");
+          H.tableHeaderClick("Category");
           verifyNoColumnCompareShortcut();
 
           verifyColumnDrillText(info);
           verifyPlusButtonText(info);
 
-          openNotebook();
+          H.openNotebook();
 
           cy.button("Summarize").click();
           verifyNoColumnCompareShortcut();
           cy.realPress("Escape");
 
           cy.button("Show Visualization").click();
-          queryBuilderMain().findByText("42").should("be.visible");
+          H.queryBuilderMain().findByText("42").should("be.visible");
 
           verifyNotebookText(info);
 
           toggleColumnPickerItems(["Value difference"]);
-          popover().button("Done").click();
+          H.popover().button("Done").click();
 
           cy.get("@questionId").then(questionId => {
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
               database_id: SAMPLE_DB_ID,
@@ -622,7 +608,7 @@ describe.skip("scenarios > question", () => {
         });
 
         it("breakout on temporal column which is an expression", () => {
-          createQuestion(
+          H.createQuestion(
             { query: QUERY_TEMPORAL_EXPRESSION_BREAKOUT },
             { visitQuestion: true, wrapId: true, idAlias: "questionId" },
           );
@@ -636,7 +622,7 @@ describe.skip("scenarios > question", () => {
 
           verifySummarizeText(info);
 
-          tableHeaderClick("Created At plus one month: Month");
+          H.tableHeaderClick("Created At plus one month: Month");
           verifyNoColumnCompareShortcut();
 
           verifyColumnDrillText(info);
@@ -644,10 +630,10 @@ describe.skip("scenarios > question", () => {
           verifyNotebookText(info);
 
           toggleColumnPickerItems(["Value difference"]);
-          popover().button("Done").click();
+          H.popover().button("Done").click();
 
           cy.get("@questionId").then(questionId => {
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
               database_id: SAMPLE_DB_ID,
@@ -683,7 +669,7 @@ describe.skip("scenarios > question", () => {
         });
 
         it("multiple breakouts", () => {
-          createQuestion(
+          H.createQuestion(
             { query: QUERY_MULTIPLE_BREAKOUTS },
             { visitQuestion: true, wrapId: true, idAlias: "questionId" },
           );
@@ -700,10 +686,10 @@ describe.skip("scenarios > question", () => {
           verifyNotebookText(info);
 
           toggleColumnPickerItems(["Value difference"]);
-          popover().button("Done").click();
+          H.popover().button("Done").click();
 
           cy.get("@questionId").then(questionId => {
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
               database_id: SAMPLE_DB_ID,
@@ -740,7 +726,7 @@ describe.skip("scenarios > question", () => {
         });
 
         it("multiple temporal breakouts", () => {
-          createQuestion(
+          H.createQuestion(
             { query: QUERY_MULTIPLE_TEMPORAL_BREAKOUTS },
             { visitQuestion: true, wrapId: true, idAlias: "questionId" },
           );
@@ -757,10 +743,10 @@ describe.skip("scenarios > question", () => {
           verifyNotebookText(info);
 
           toggleColumnPickerItems(["Value difference"]);
-          popover().button("Done").click();
+          H.popover().button("Done").click();
 
           cy.get("@questionId").then(questionId => {
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
               database_id: SAMPLE_DB_ID,
@@ -798,7 +784,7 @@ describe.skip("scenarios > question", () => {
         });
 
         it("one breakout on non-default datetime column", () => {
-          createQuestion(
+          H.createQuestion(
             { query: QUERY_SINGLE_AGGREGATION_OTHER_DATETIME },
             { visitQuestion: true, wrapId: true, idAlias: "questionId" },
           );
@@ -812,7 +798,7 @@ describe.skip("scenarios > question", () => {
 
           verifySummarizeText(info);
 
-          tableHeaderClick("Count");
+          H.tableHeaderClick("Count");
           verifyNoColumnCompareShortcut();
 
           verifyColumnDrillText(info);
@@ -820,10 +806,10 @@ describe.skip("scenarios > question", () => {
           verifyNotebookText(info);
 
           toggleColumnPickerItems(["Value difference"]);
-          popover().button("Done").click();
+          H.popover().button("Done").click();
 
           cy.get("@questionId").then(questionId => {
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
               database_id: SAMPLE_DB_ID,
@@ -864,7 +850,7 @@ describe.skip("scenarios > question", () => {
 
       describe("multiple aggregations", () => {
         it("no breakout", () => {
-          createQuestion(
+          H.createQuestion(
             { query: QUERY_MULTIPLE_AGGREGATIONS_NO_BREAKOUT },
             { visitQuestion: true, wrapId: true, idAlias: "questionId" },
           );
@@ -883,10 +869,10 @@ describe.skip("scenarios > question", () => {
           verifyNotebookText(info);
 
           toggleColumnPickerItems(["Value difference"]);
-          popover().button("Done").click();
+          H.popover().button("Done").click();
 
           cy.get("@questionId").then(questionId => {
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
               database_id: SAMPLE_DB_ID,
@@ -915,7 +901,7 @@ describe.skip("scenarios > question", () => {
         });
 
         it("breakout on binned datetime column", () => {
-          createQuestion(
+          H.createQuestion(
             { query: QUERY_MULTIPLE_AGGREGATIONS_BINNED_DATETIME_BREAKOUT },
             { visitQuestion: true, wrapId: true, idAlias: "questionId" },
           );
@@ -930,7 +916,7 @@ describe.skip("scenarios > question", () => {
 
           verifySummarizeText(info);
 
-          tableHeaderClick("Created At: Month");
+          H.tableHeaderClick("Created At: Month");
           verifyNoColumnCompareShortcut();
 
           verifyColumnDrillText(_.omit(info, "step1Title"));
@@ -938,10 +924,10 @@ describe.skip("scenarios > question", () => {
           verifyNotebookText(info);
 
           toggleColumnPickerItems(["Value difference"]);
-          popover().button("Done").click();
+          H.popover().button("Done").click();
 
           cy.get("@questionId").then(questionId => {
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
               database_id: SAMPLE_DB_ID,
@@ -972,7 +958,7 @@ describe.skip("scenarios > question", () => {
         });
 
         it("breakout on non-binned datetime column", () => {
-          createQuestion(
+          H.createQuestion(
             { query: QUERY_MULTIPLE_AGGREGATIONS_NON_BINNED_DATETIME_BREAKOUT },
             { visitQuestion: true, wrapId: true, idAlias: "questionId" },
           );
@@ -987,7 +973,7 @@ describe.skip("scenarios > question", () => {
 
           verifySummarizeText(info);
 
-          tableHeaderClick("Created At: Day");
+          H.tableHeaderClick("Created At: Day");
           verifyNoColumnCompareShortcut();
 
           verifyColumnDrillText(_.omit(info, "step1Title"));
@@ -995,10 +981,10 @@ describe.skip("scenarios > question", () => {
           verifyNotebookText(info);
 
           toggleColumnPickerItems(["Value difference"]);
-          popover().button("Done").click();
+          H.popover().button("Done").click();
 
           cy.get("@questionId").then(questionId => {
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
               database_id: SAMPLE_DB_ID,
@@ -1029,7 +1015,7 @@ describe.skip("scenarios > question", () => {
         });
 
         it("breakout on non-datetime column", () => {
-          createQuestion(
+          H.createQuestion(
             { query: QUERY_MULTIPLE_AGGREGATIONS_NON_DATETIME_BREAKOUT },
             { visitQuestion: true, wrapId: true, idAlias: "questionId" },
           );
@@ -1044,7 +1030,7 @@ describe.skip("scenarios > question", () => {
 
           verifySummarizeText(info);
 
-          tableHeaderClick("Category");
+          H.tableHeaderClick("Category");
           verifyNoColumnCompareShortcut();
 
           verifyColumnDrillText(_.omit(info, "step1Title"));
@@ -1052,10 +1038,10 @@ describe.skip("scenarios > question", () => {
           verifyNotebookText(info);
 
           toggleColumnPickerItems(["Value difference"]);
-          popover().button("Done").click();
+          H.popover().button("Done").click();
 
           cy.get("@questionId").then(questionId => {
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
               database_id: SAMPLE_DB_ID,
@@ -1089,19 +1075,19 @@ describe.skip("scenarios > question", () => {
 
     describe("moving average", () => {
       it("should be possible to change the temporal bucket with a custom offset", () => {
-        createQuestion(
+        H.createQuestion(
           { query: QUERY_SINGLE_AGGREGATION_NO_BREAKOUT },
           { visitQuestion: true, wrapId: true, idAlias: "questionId" },
         );
 
-        openNotebook();
-        getNotebookStep("summarize")
+        H.openNotebook();
+        H.getNotebookStep("summarize")
           .findAllByTestId("aggregate-step")
           .last()
           .icon("add")
           .click();
 
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findByText("Basic functions").click();
           cy.findByText("Compare to the past").click();
 
@@ -1111,9 +1097,9 @@ describe.skip("scenarios > question", () => {
           cy.findByLabelText("Unit").click();
         });
 
-        popover().last().findByText("Week").click();
+        H.popover().last().findByText("Week").click();
 
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findByText("Done").click();
         });
 
@@ -1138,7 +1124,7 @@ describe.skip("scenarios > question", () => {
 
       describe("single aggregation", () => {
         it("no breakout", () => {
-          createQuestion(
+          H.createQuestion(
             { query: QUERY_SINGLE_AGGREGATION_NO_BREAKOUT },
             { visitQuestion: true, wrapId: true, idAlias: "questionId" },
           );
@@ -1156,10 +1142,10 @@ describe.skip("scenarios > question", () => {
           verifyNotebookText(info);
 
           toggleColumnPickerItems(["Value difference"]);
-          popover().button("Done").click();
+          H.popover().button("Done").click();
 
           cy.get("@questionId").then(questionId => {
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED_MOVING_AVERAGE,
               database_id: SAMPLE_DB_ID,
@@ -1196,7 +1182,7 @@ describe.skip("scenarios > question", () => {
         });
 
         it("breakout on binned datetime column", () => {
-          createQuestion(
+          H.createQuestion(
             { query: QUERY_SINGLE_AGGREGATION_BINNED_DATETIME_BREAKOUT },
             { visitQuestion: true, wrapId: true, idAlias: "questionId" },
           );
@@ -1210,7 +1196,7 @@ describe.skip("scenarios > question", () => {
 
           verifySummarizeText(info);
 
-          tableHeaderClick("Created At: Month");
+          H.tableHeaderClick("Created At: Month");
           verifyNoColumnCompareShortcut();
 
           verifyColumnDrillText(info);
@@ -1218,10 +1204,10 @@ describe.skip("scenarios > question", () => {
           verifyNotebookText(info);
 
           toggleColumnPickerItems(["Value difference"]);
-          popover().button("Done").click();
+          H.popover().button("Done").click();
 
           cy.get("@questionId").then(questionId => {
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED_MOVING_AVERAGE,
               database_id: SAMPLE_DB_ID,
@@ -1258,7 +1244,7 @@ describe.skip("scenarios > question", () => {
         });
 
         it("breakout on non-binned datetime column", () => {
-          createQuestion(
+          H.createQuestion(
             { query: QUERY_SINGLE_AGGREGATION_NON_BINNED_DATETIME_BREAKOUT },
             { visitQuestion: true, wrapId: true, idAlias: "questionId" },
           );
@@ -1272,7 +1258,7 @@ describe.skip("scenarios > question", () => {
 
           verifySummarizeText(info);
 
-          tableHeaderClick("Created At: Day");
+          H.tableHeaderClick("Created At: Day");
           verifyNoColumnCompareShortcut();
 
           verifyColumnDrillText(info);
@@ -1280,10 +1266,10 @@ describe.skip("scenarios > question", () => {
           verifyNotebookText(info);
 
           toggleColumnPickerItems(["Value difference"]);
-          popover().button("Done").click();
+          H.popover().button("Done").click();
 
           cy.get("@questionId").then(questionId => {
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED_MOVING_AVERAGE,
               database_id: SAMPLE_DB_ID,
@@ -1319,7 +1305,7 @@ describe.skip("scenarios > question", () => {
         });
 
         it("breakout on non-datetime column", () => {
-          createQuestion(
+          H.createQuestion(
             { query: QUERY_SINGLE_AGGREGATION_NON_DATETIME_BREAKOUT },
             { visitQuestion: true, wrapId: true, idAlias: "questionId" },
           );
@@ -1333,28 +1319,28 @@ describe.skip("scenarios > question", () => {
 
           verifySummarizeText(info);
 
-          tableHeaderClick("Category");
+          H.tableHeaderClick("Category");
           verifyNoColumnCompareShortcut();
 
           verifyColumnDrillText(info);
           verifyPlusButtonText(info);
 
-          openNotebook();
+          H.openNotebook();
 
           cy.button("Summarize").click();
           verifyNoColumnCompareShortcut();
           cy.realPress("Escape");
 
           cy.button("Show Visualization").click();
-          queryBuilderMain().findByText("42").should("be.visible");
+          H.queryBuilderMain().findByText("42").should("be.visible");
 
           verifyNotebookText(info);
 
           toggleColumnPickerItems(["Value difference"]);
-          popover().button("Done").click();
+          H.popover().button("Done").click();
 
           cy.get("@questionId").then(questionId => {
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED_MOVING_AVERAGE,
               database_id: SAMPLE_DB_ID,
@@ -1391,7 +1377,7 @@ describe.skip("scenarios > question", () => {
         });
 
         it("multiple breakouts", () => {
-          createQuestion(
+          H.createQuestion(
             { query: QUERY_MULTIPLE_BREAKOUTS },
             { visitQuestion: true, wrapId: true, idAlias: "questionId" },
           );
@@ -1408,10 +1394,10 @@ describe.skip("scenarios > question", () => {
           verifyNotebookText(info);
 
           toggleColumnPickerItems(["Value difference"]);
-          popover().button("Done").click();
+          H.popover().button("Done").click();
 
           cy.get("@questionId").then(questionId => {
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED_MOVING_AVERAGE,
               database_id: SAMPLE_DB_ID,
@@ -1449,7 +1435,7 @@ describe.skip("scenarios > question", () => {
         });
 
         it("multiple temporal breakouts", () => {
-          createQuestion(
+          H.createQuestion(
             { query: QUERY_MULTIPLE_TEMPORAL_BREAKOUTS },
             { visitQuestion: true, wrapId: true, idAlias: "questionId" },
           );
@@ -1466,10 +1452,10 @@ describe.skip("scenarios > question", () => {
           verifyNotebookText(info);
 
           toggleColumnPickerItems(["Value difference"]);
-          popover().button("Done").click();
+          H.popover().button("Done").click();
 
           cy.get("@questionId").then(questionId => {
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED_MOVING_AVERAGE,
               database_id: SAMPLE_DB_ID,
@@ -1507,7 +1493,7 @@ describe.skip("scenarios > question", () => {
         });
 
         it("one breakout on non-default datetime column", () => {
-          createQuestion(
+          H.createQuestion(
             { query: QUERY_SINGLE_AGGREGATION_OTHER_DATETIME },
             { visitQuestion: true, wrapId: true, idAlias: "questionId" },
           );
@@ -1521,7 +1507,7 @@ describe.skip("scenarios > question", () => {
 
           verifySummarizeText(info);
 
-          tableHeaderClick("Count");
+          H.tableHeaderClick("Count");
           verifyNoColumnCompareShortcut();
 
           verifyColumnDrillText(info);
@@ -1529,10 +1515,10 @@ describe.skip("scenarios > question", () => {
           verifyNotebookText(info);
 
           toggleColumnPickerItems(["Value difference"]);
-          popover().button("Done").click();
+          H.popover().button("Done").click();
 
           cy.get("@questionId").then(questionId => {
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED_MOVING_AVERAGE,
               database_id: SAMPLE_DB_ID,
@@ -1574,7 +1560,7 @@ describe.skip("scenarios > question", () => {
 
       describe("multiple aggregations", () => {
         it("no breakout", () => {
-          createQuestion(
+          H.createQuestion(
             { query: QUERY_MULTIPLE_AGGREGATIONS_NO_BREAKOUT },
             { visitQuestion: true, wrapId: true, idAlias: "questionId" },
           );
@@ -1593,10 +1579,10 @@ describe.skip("scenarios > question", () => {
           verifyNotebookText(info);
 
           toggleColumnPickerItems(["Value difference"]);
-          popover().button("Done").click();
+          H.popover().button("Done").click();
 
           cy.get("@questionId").then(questionId => {
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED_MOVING_AVERAGE,
               database_id: SAMPLE_DB_ID,
@@ -1632,7 +1618,7 @@ describe.skip("scenarios > question", () => {
         });
 
         it("breakout on binned datetime column", () => {
-          createQuestion(
+          H.createQuestion(
             { query: QUERY_MULTIPLE_AGGREGATIONS_BINNED_DATETIME_BREAKOUT },
             { visitQuestion: true, wrapId: true, idAlias: "questionId" },
           );
@@ -1647,7 +1633,7 @@ describe.skip("scenarios > question", () => {
 
           verifySummarizeText(info);
 
-          tableHeaderClick("Created At: Month");
+          H.tableHeaderClick("Created At: Month");
           verifyNoColumnCompareShortcut();
 
           verifyColumnDrillText(_.omit(info, "step1Title"));
@@ -1655,10 +1641,10 @@ describe.skip("scenarios > question", () => {
           verifyNotebookText(info);
 
           toggleColumnPickerItems(["Value difference"]);
-          popover().button("Done").click();
+          H.popover().button("Done").click();
 
           cy.get("@questionId").then(questionId => {
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED_MOVING_AVERAGE,
               database_id: SAMPLE_DB_ID,
@@ -1690,7 +1676,7 @@ describe.skip("scenarios > question", () => {
         });
 
         it("breakout on non-binned datetime column", () => {
-          createQuestion(
+          H.createQuestion(
             { query: QUERY_MULTIPLE_AGGREGATIONS_NON_BINNED_DATETIME_BREAKOUT },
             { visitQuestion: true, wrapId: true, idAlias: "questionId" },
           );
@@ -1705,7 +1691,7 @@ describe.skip("scenarios > question", () => {
 
           verifySummarizeText(info);
 
-          tableHeaderClick("Created At: Day");
+          H.tableHeaderClick("Created At: Day");
           verifyNoColumnCompareShortcut();
 
           verifyColumnDrillText(_.omit(info, "step1Title"));
@@ -1713,10 +1699,10 @@ describe.skip("scenarios > question", () => {
           verifyNotebookText(info);
 
           toggleColumnPickerItems(["Value difference"]);
-          popover().button("Done").click();
+          H.popover().button("Done").click();
 
           cy.get("@questionId").then(questionId => {
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED_MOVING_AVERAGE,
               database_id: SAMPLE_DB_ID,
@@ -1748,7 +1734,7 @@ describe.skip("scenarios > question", () => {
         });
 
         it("breakout on non-datetime column", () => {
-          createQuestion(
+          H.createQuestion(
             { query: QUERY_MULTIPLE_AGGREGATIONS_NON_DATETIME_BREAKOUT },
             { visitQuestion: true, wrapId: true, idAlias: "questionId" },
           );
@@ -1764,7 +1750,7 @@ describe.skip("scenarios > question", () => {
 
           verifySummarizeText(info);
 
-          tableHeaderClick("Category");
+          H.tableHeaderClick("Category");
           verifyNoColumnCompareShortcut();
 
           verifyColumnDrillText(_.omit(info, "step1Title"));
@@ -1772,10 +1758,10 @@ describe.skip("scenarios > question", () => {
           verifyNotebookText(info);
 
           toggleColumnPickerItems(["Value difference"]);
-          popover().button("Done").click();
+          H.popover().button("Done").click();
 
           cy.get("@questionId").then(questionId => {
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "column_compare_via_shortcut",
               custom_expressions_used: CUSTOM_EXPRESSIONS_USED_MOVING_AVERAGE,
               database_id: SAMPLE_DB_ID,
@@ -1821,7 +1807,7 @@ function toggleColumnPickerItems(names: string[]) {
 }
 
 function verifyNoColumnCompareShortcut() {
-  popover()
+  H.popover()
     .findByText(/compare/)
     .should("not.exist");
 }
@@ -1851,9 +1837,9 @@ function selectCustomOffset() {
 
 function verifySummarizeText(options: CheckTextOpts) {
   cy.button("Summarize").click();
-  rightSidebar().button("Add aggregation").click();
+  H.rightSidebar().button("Add aggregation").click();
 
-  popover().within(() => {
+  H.popover().within(() => {
     cy.findByText(options.itemName).should("be.visible").click();
 
     if (options.step1Title) {
@@ -1878,9 +1864,9 @@ function verifySummarizeText(options: CheckTextOpts) {
 }
 
 function verifyColumnDrillText(options: Omit<CheckTextOpts, "step1Title">) {
-  tableHeaderClick("Count");
+  H.tableHeaderClick("Count");
 
-  popover().within(() => {
+  H.popover().within(() => {
     cy.findByText(options.itemName).should("be.visible").click();
     cy.findByText(options.step2Title).should("be.visible");
 
@@ -1901,7 +1887,7 @@ function verifyColumnDrillText(options: Omit<CheckTextOpts, "step1Title">) {
 function verifyPlusButtonText(options: CheckTextOpts) {
   cy.button("Add column").click();
 
-  popover().within(() => {
+  H.popover().within(() => {
     cy.findByText(options.itemName).should("be.visible").click();
 
     if (options.step1Title) {
@@ -1926,14 +1912,14 @@ function verifyPlusButtonText(options: CheckTextOpts) {
 }
 
 function verifyNotebookText(options: CheckTextOpts) {
-  openNotebook();
-  getNotebookStep("summarize")
+  H.openNotebook();
+  H.getNotebookStep("summarize")
     .findAllByTestId("aggregate-step")
     .last()
     .icon("add")
     .click();
 
-  popover().within(() => {
+  H.popover().within(() => {
     cy.findByText("Basic functions").click();
     cy.findByText(options.itemName).should("be.visible").click();
 
@@ -1977,7 +1963,7 @@ function verifyAggregations(results: AggregationResult[]) {
 }
 
 function verifyColumns(names: string[]) {
-  visualize();
+  H.visualize();
 
   for (const name of names) {
     cy.findAllByTestId("header-cell").contains(name).should("be.visible");

--- a/e2e/test/scenarios/question/document-title.cy.spec.js
+++ b/e2e/test/scenarios/question/document-title.cy.spec.js
@@ -1,17 +1,17 @@
-import { restore, visitQuestionAdhoc } from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 const PG_DB_ID = 2;
 
 describe("question loading changes document title", () => {
   beforeEach(() => {
-    restore("postgres-12");
+    H.restore("postgres-12");
     cy.signInAsNormalUser();
   });
 
   it("should verify document title changes while loading a slow question (metabase#40051)", () => {
     cy.log("run a slow question");
 
-    visitQuestionAdhoc(
+    H.visitQuestionAdhoc(
       {
         dataset_query: {
           type: "native",

--- a/e2e/test/scenarios/question/multiple-column-breakouts.cy.spec.ts
+++ b/e2e/test/scenarios/question/multiple-column-breakouts.cy.spec.ts
@@ -1,37 +1,9 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  type DashboardDetails,
-  type StructuredQuestionDetails,
-  assertQueryBuilderRowCount,
-  assertTableData,
-  createQuestion,
-  createQuestionAndDashboard,
-  dragField,
-  editDashboard,
-  enterCustomColumnDetails,
-  entityPickerModal,
-  entityPickerModalTab,
-  filter,
-  filterWidget,
-  getDashboardCard,
-  getNotebookStep,
-  modal,
-  openNotebook,
-  popover,
-  restore,
-  saveDashboard,
-  startNewQuestion,
-  summarize,
-  tableInteractive,
-  visitDashboard,
-  visitEmbeddedPage,
-  visitPublicDashboard,
-  visualize,
-} from "e2e/support/helpers";
 
 const { ORDERS_ID, ORDERS, PEOPLE_ID, PEOPLE } = SAMPLE_DATABASE;
 
-const questionWith2TemporalBreakoutsDetails: StructuredQuestionDetails = {
+const questionWith2TemporalBreakoutsDetails: H.StructuredQuestionDetails = {
   name: "Test question",
   query: {
     "source-table": ORDERS_ID,
@@ -55,7 +27,7 @@ const questionWith2TemporalBreakoutsDetails: StructuredQuestionDetails = {
   },
 };
 
-const multiStageQuestionWith2TemporalBreakoutsDetails: StructuredQuestionDetails =
+const multiStageQuestionWith2TemporalBreakoutsDetails: H.StructuredQuestionDetails =
   {
     name: "Test question",
     query: {
@@ -64,7 +36,7 @@ const multiStageQuestionWith2TemporalBreakoutsDetails: StructuredQuestionDetails
     },
   };
 
-const questionWith2NumBinsBreakoutsDetails: StructuredQuestionDetails = {
+const questionWith2NumBinsBreakoutsDetails: H.StructuredQuestionDetails = {
   name: "Test question",
   query: {
     "source-table": ORDERS_ID,
@@ -94,7 +66,7 @@ const questionWith2NumBinsBreakoutsDetails: StructuredQuestionDetails = {
   },
 };
 
-const multiStageQuestionWith2NumBinsBreakoutsDetails: StructuredQuestionDetails =
+const multiStageQuestionWith2NumBinsBreakoutsDetails: H.StructuredQuestionDetails =
   {
     name: "Test question",
     query: {
@@ -103,7 +75,7 @@ const multiStageQuestionWith2NumBinsBreakoutsDetails: StructuredQuestionDetails 
     },
   };
 
-const questionWith2BinWidthBreakoutsDetails: StructuredQuestionDetails = {
+const questionWith2BinWidthBreakoutsDetails: H.StructuredQuestionDetails = {
   name: "Test question",
   query: {
     "source-table": PEOPLE_ID,
@@ -133,7 +105,7 @@ const questionWith2BinWidthBreakoutsDetails: StructuredQuestionDetails = {
   },
 };
 
-const multiStageQuestionWith2BinWidthBreakoutsDetails: StructuredQuestionDetails =
+const multiStageQuestionWith2BinWidthBreakoutsDetails: H.StructuredQuestionDetails =
   {
     name: "Test question",
     query: {
@@ -142,7 +114,7 @@ const multiStageQuestionWith2BinWidthBreakoutsDetails: StructuredQuestionDetails
     },
   };
 
-const questionWith5TemporalBreakoutsDetails: StructuredQuestionDetails = {
+const questionWith5TemporalBreakoutsDetails: H.StructuredQuestionDetails = {
   name: "Test question",
   query: {
     "source-table": ORDERS_ID,
@@ -182,7 +154,7 @@ const questionWith5TemporalBreakoutsDetails: StructuredQuestionDetails = {
   },
 };
 
-const questionWith5NumBinsBreakoutsDetails: StructuredQuestionDetails = {
+const questionWith5NumBinsBreakoutsDetails: H.StructuredQuestionDetails = {
   name: "Test question",
   query: {
     "source-table": ORDERS_ID,
@@ -236,7 +208,7 @@ const questionWith5NumBinsBreakoutsDetails: StructuredQuestionDetails = {
   },
 };
 
-const dashboardDetails: DashboardDetails = {
+const dashboardDetails: H.DashboardDetails = {
   parameters: [
     {
       id: "1",
@@ -274,7 +246,7 @@ function getNestedQuestionDetails(cardId: number) {
 
 // This is used in several places for the same query.
 function assertTableDataForFilteredTemporalBreakouts() {
-  assertTableData({
+  H.assertTableData({
     columns: ["Created At: Year", "Created At: Month", "Count"],
     firstRows: [
       ["2023", "March 2023", "256"],
@@ -282,12 +254,12 @@ function assertTableDataForFilteredTemporalBreakouts() {
       ["2023", "May 2023", "271"],
     ],
   });
-  assertQueryBuilderRowCount(3);
+  H.assertQueryBuilderRowCount(3);
 }
 
 describe("scenarios > question > multiple column breakouts", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("POST", "/api/dataset/pivot").as("pivotDataset");
@@ -318,33 +290,33 @@ describe("scenarios > question > multiple column breakouts", () => {
           bucket1Name: string;
           bucket2Name: string;
         }) {
-          startNewQuestion();
-          entityPickerModal().within(() => {
-            entityPickerModalTab("Tables").click();
+          H.startNewQuestion();
+          H.entityPickerModal().within(() => {
+            H.entityPickerModalTab("Tables").click();
             cy.findByText(tableName).click();
           });
-          getNotebookStep("summarize")
+          H.getNotebookStep("summarize")
             .findByText("Pick a function or metric")
             .click();
-          popover().findByText("Count of rows").click();
-          getNotebookStep("summarize")
+          H.popover().findByText("Count of rows").click();
+          H.getNotebookStep("summarize")
             .findByText("Pick a column to group by")
             .click();
-          popover()
+          H.popover()
             .findByLabelText(columnName)
             .findByLabelText(bucketLabel)
             .click();
-          popover().last().findByText(bucket1Name).click();
-          getNotebookStep("summarize")
+          H.popover().last().findByText(bucket1Name).click();
+          H.getNotebookStep("summarize")
             .findByTestId("breakout-step")
             .icon("add")
             .click();
-          popover()
+          H.popover()
             .findByLabelText(columnName)
             .findByLabelText(bucketLabel)
             .click();
-          popover().last().findByText(bucket2Name).click();
-          visualize();
+          H.popover().last().findByText(bucket2Name).click();
+          H.visualize();
           cy.wait("@dataset");
         }
 
@@ -356,7 +328,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           bucket1Name: "Year",
           bucket2Name: "Month",
         });
-        assertQueryBuilderRowCount(49);
+        H.assertQueryBuilderRowCount(49);
 
         cy.log("'num-bins' breakouts");
         testNewQueryWithBreakouts({
@@ -366,7 +338,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           bucket1Name: "10 bins",
           bucket2Name: "50 bins",
         });
-        assertQueryBuilderRowCount(32);
+        H.assertQueryBuilderRowCount(32);
 
         cy.log("'bin-width' breakouts");
         testNewQueryWithBreakouts({
@@ -376,7 +348,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           bucket1Name: "Bin every 10 degrees",
           bucket2Name: "Bin every 20 degrees",
         });
-        assertQueryBuilderRowCount(6);
+        H.assertQueryBuilderRowCount(6);
       });
 
       it("should allow to sort by breakout columns", () => {
@@ -385,20 +357,20 @@ describe("scenarios > question > multiple column breakouts", () => {
           column1Name,
           column2Name,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: H.StructuredQuestionDetails;
           column1Name: string;
           column2Name: string;
         }) {
-          createQuestion(questionDetails, {
+          H.createQuestion(questionDetails, {
             visitQuestion: true,
           });
-          openNotebook();
-          getNotebookStep("summarize").findByText("Sort").click();
-          popover().findByText(column1Name).click();
-          getNotebookStep("sort").button("Change direction").click();
-          getNotebookStep("sort").icon("add").click();
-          popover().findByText(column2Name).click();
-          visualize();
+          H.openNotebook();
+          H.getNotebookStep("summarize").findByText("Sort").click();
+          H.popover().findByText(column1Name).click();
+          H.getNotebookStep("sort").button("Change direction").click();
+          H.getNotebookStep("sort").icon("add").click();
+          H.popover().findByText(column2Name).click();
+          H.visualize();
           cy.wait("@dataset");
         }
 
@@ -408,7 +380,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column1Name: "Created At: Year",
           column2Name: "Created At: Month",
         });
-        assertTableData({
+        H.assertTableData({
           columns: ["Created At: Year", "Created At: Month", "Count"],
           firstRows: [
             ["2026", "January 2026", "580"],
@@ -422,7 +394,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column1Name: "Total: 10 bins",
           column2Name: "Total: 50 bins",
         });
-        assertTableData({
+        H.assertTableData({
           columns: ["Total", "Total", "Count"],
           firstRows: [
             ["140  –  160", "140  –  145", "306"],
@@ -436,7 +408,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column1Name: "Latitude: 20°",
           column2Name: "Latitude: 10°",
         });
-        assertTableData({
+        H.assertTableData({
           columns: ["Latitude", "Latitude", "Count"],
           firstRows: [
             ["60° N  –  80° N", "60° N  –  70° N", "51"],
@@ -455,21 +427,21 @@ describe("scenarios > question > multiple column breakouts", () => {
           bucket1Name,
           bucket2Name,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: H.StructuredQuestionDetails;
           columnPattern: RegExp;
           bucketLabel: string;
           bucket1Name: string;
           bucket2Name: string;
         }) {
-          createQuestion(questionDetails, { visitQuestion: true });
-          summarize();
+          H.createQuestion(questionDetails, { visitQuestion: true });
+          H.summarize();
           cy.findByTestId("pinned-dimensions")
             .findAllByLabelText(columnPattern)
             .should("have.length", 2)
             .eq(0)
             .findByLabelText(bucketLabel)
             .click();
-          popover().findByText(bucket1Name).click();
+          H.popover().findByText(bucket1Name).click();
           cy.wait("@dataset");
           cy.findByTestId("pinned-dimensions")
             .findAllByLabelText(columnPattern)
@@ -477,7 +449,7 @@ describe("scenarios > question > multiple column breakouts", () => {
             .eq(1)
             .findByLabelText(bucketLabel)
             .click();
-          popover().findByText(bucket2Name).click();
+          H.popover().findByText(bucket2Name).click();
           cy.wait("@dataset");
         }
 
@@ -489,7 +461,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           bucket1Name: "Quarter",
           bucket2Name: "Week",
         });
-        assertTableData({
+        H.assertTableData({
           columns: ["Created At: Quarter", "Created At: Week", "Count"],
           firstRows: [["Q2 2022", "April 24, 2022 – April 30, 2022", "1"]],
         });
@@ -502,7 +474,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           bucket1Name: "10 bins",
           bucket2Name: "50 bins",
         });
-        assertTableData({
+        H.assertTableData({
           columns: ["Total", "Total", "Count"],
           firstRows: [["-60  –  -40", "-50  –  -45", "1"]],
         });
@@ -515,7 +487,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           bucket1Name: "Bin every 1 degree",
           bucket2Name: "Bin every 0.1 degrees",
         });
-        assertTableData({
+        H.assertTableData({
           columns: ["Latitude", "Latitude", "Count"],
           firstRows: [["25° N  –  26° N", "25.7° N  –  25.8° N", "1"]],
         });
@@ -524,7 +496,7 @@ describe("scenarios > question > multiple column breakouts", () => {
 
     describe("timeseries chrome", () => {
       it("should use the first breakout for the chrome in case there are multiple for this column", () => {
-        createQuestion(questionWith2TemporalBreakoutsDetails, {
+        H.createQuestion(questionWith2TemporalBreakoutsDetails, {
           visitQuestion: true,
         });
 
@@ -532,10 +504,10 @@ describe("scenarios > question > multiple column breakouts", () => {
         cy.findByTestId("timeseries-bucket-button")
           .should("contain.text", "Year")
           .click();
-        popover().findByText("Quarter").click();
+        H.popover().findByText("Quarter").click();
         cy.wait("@dataset");
-        assertQueryBuilderRowCount(49);
-        assertTableData({
+        H.assertQueryBuilderRowCount(49);
+        H.assertTableData({
           columns: ["Created At: Quarter", "Created At: Month", "Count"],
           firstRows: [["Q2 2022", "April 2022", "1"]],
         });
@@ -544,15 +516,15 @@ describe("scenarios > question > multiple column breakouts", () => {
         cy.findByTestId("timeseries-filter-button")
           .should("contain.text", "All time")
           .click();
-        popover().findByDisplayValue("All time").click();
-        popover().last().findByText("On").click();
-        popover().within(() => {
+        H.popover().findByDisplayValue("All time").click();
+        H.popover().last().findByText("On").click();
+        H.popover().within(() => {
           cy.findByLabelText("Date").clear().type("August 14, 2023");
           cy.button("Apply").click();
         });
         cy.wait("@dataset");
-        assertQueryBuilderRowCount(1);
-        assertTableData({
+        H.assertQueryBuilderRowCount(1);
+        H.assertTableData({
           columns: ["Created At: Quarter", "Created At: Month", "Count"],
           firstRows: [["Q3 2023", "August 2023", "9"]],
         });
@@ -561,13 +533,13 @@ describe("scenarios > question > multiple column breakouts", () => {
         cy.findByTestId("timeseries-filter-button")
           .should("contain.text", "Aug 14")
           .click();
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findByLabelText("Date").clear().type("August 14, 2022");
           cy.button("Apply").click();
         });
         cy.wait("@dataset");
-        assertQueryBuilderRowCount(1);
-        assertTableData({
+        H.assertQueryBuilderRowCount(1);
+        H.assertTableData({
           columns: ["Created At: Quarter", "Created At: Month", "Count"],
           firstRows: [["Q3 2022", "August 2022", "1"]],
         });
@@ -581,24 +553,24 @@ describe("scenarios > question > multiple column breakouts", () => {
           column1Name,
           column2Name,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: H.StructuredQuestionDetails;
           column1Name: string;
           column2Name: string;
         }) {
-          createQuestion(questionDetails, { visitQuestion: true });
+          H.createQuestion(questionDetails, { visitQuestion: true });
 
           cy.log("first breakout");
           tableHeaderClick(column1Name, { columnIndex: 0 });
-          popover().icon("gear").click();
-          popover().findByDisplayValue(column1Name).clear().type("Breakout1");
+          H.popover().icon("gear").click();
+          H.popover().findByDisplayValue(column1Name).clear().type("Breakout1");
           cy.get("body").click();
 
           cy.log("second breakout");
           tableHeaderClick(column2Name);
-          popover().icon("gear").click();
-          popover().findByDisplayValue(column2Name).clear().type("Breakout2");
+          H.popover().icon("gear").click();
+          H.popover().findByDisplayValue(column2Name).clear().type("Breakout2");
           cy.get("body").click();
-          assertTableData({ columns: ["Breakout1", "Breakout2", "Count"] });
+          H.assertTableData({ columns: ["Breakout1", "Breakout2", "Count"] });
         }
 
         cy.log("temporal breakouts");
@@ -628,10 +600,10 @@ describe("scenarios > question > multiple column breakouts", () => {
           questionDetails,
           columnNamePattern,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: H.StructuredQuestionDetails;
           columnNamePattern: RegExp;
         }) {
-          createQuestion(questionDetails, { visitQuestion: true });
+          H.createQuestion(questionDetails, { visitQuestion: true });
 
           cy.log("change display and assert the default settings");
           cy.findByTestId("viz-type-button").click();
@@ -645,14 +617,14 @@ describe("scenarios > question > multiple column breakouts", () => {
 
           cy.log("move a column from rows to columns");
           cy.findByTestId("viz-settings-button").click();
-          dragField(2, 3);
+          H.dragField(2, 3);
           cy.wait("@pivotDataset");
           cy.findByTestId("pivot-table")
             .findAllByText(columnNamePattern)
             .should("have.length", 2);
 
           cy.log("move a column from columns to rows");
-          dragField(4, 1);
+          H.dragField(4, 1);
           cy.wait("@pivotDataset");
           cy.findByTestId("pivot-table")
             .findAllByText(columnNamePattern)
@@ -675,13 +647,13 @@ describe("scenarios > question > multiple column breakouts", () => {
 
     describe("dashboards", () => {
       function setParametersAndAssertResults(queryAlias: string) {
-        filterWidget().eq(0).click();
-        popover().findByText("Quarter").click();
+        H.filterWidget().eq(0).click();
+        H.popover().findByText("Quarter").click();
         cy.wait(queryAlias);
-        filterWidget().eq(1).click();
-        popover().findByText("Week").click();
+        H.filterWidget().eq(1).click();
+        H.popover().findByText("Week").click();
         cy.wait(queryAlias);
-        getDashboardCard().within(() => {
+        H.getDashboardCard().within(() => {
           cy.findByText("Created At: Quarter").should("be.visible");
           cy.findByText("Created At: Week").should("be.visible");
         });
@@ -690,7 +662,7 @@ describe("scenarios > question > multiple column breakouts", () => {
       it("should be able to use temporal-unit parameters with multiple temporal breakouts of a column", () => {
         cy.log("create dashboard");
         cy.signInAsAdmin();
-        createQuestionAndDashboard({
+        H.createQuestionAndDashboard({
           dashboardDetails,
           questionDetails: questionWith2TemporalBreakoutsDetails,
         }).then(({ body: { dashboard_id } }) => {
@@ -699,40 +671,40 @@ describe("scenarios > question > multiple column breakouts", () => {
 
         cy.log("visit dashboard");
         cy.signInAsNormalUser();
-        visitDashboard("@dashboardId");
+        H.visitDashboard("@dashboardId");
         cy.wait("@dashcardQuery");
 
         cy.log("add parameters");
-        editDashboard();
+        H.editDashboard();
         cy.findByTestId("fixed-width-filters").findByText("Unit1").click();
-        getDashboardCard().findByText("Select…").click();
-        popover().findAllByText("Created At").eq(0).click();
+        H.getDashboardCard().findByText("Select…").click();
+        H.popover().findAllByText("Created At").eq(0).click();
         cy.findByTestId("fixed-width-filters").findByText("Unit2").click();
-        getDashboardCard().findByText("Select…").click();
-        popover().findAllByText("Created At").eq(1).click();
-        saveDashboard();
+        H.getDashboardCard().findByText("Select…").click();
+        H.popover().findAllByText("Created At").eq(1).click();
+        H.saveDashboard();
         cy.wait("@dashcardQuery");
 
         cy.log("set parameters and assert query results");
         setParametersAndAssertResults("@dashcardQuery");
 
         cy.log("drill-thru to the QB and assert query results");
-        getDashboardCard().findByText("Test question").click();
+        H.getDashboardCard().findByText("Test question").click();
         cy.wait("@dataset");
-        tableInteractive().within(() => {
+        H.tableInteractive().within(() => {
           cy.findByText("Created At: Quarter").should("be.visible");
           cy.findByText("Created At: Week").should("be.visible");
         });
 
         cy.log("set parameters in a public dashboard");
         cy.signInAsAdmin();
-        cy.get("@dashboardId").then(visitPublicDashboard);
+        cy.get("@dashboardId").then(H.visitPublicDashboard);
         cy.wait("@publicDashcardQuery");
         setParametersAndAssertResults("@publicDashcardQuery");
 
         cy.log("set parameters in an embedded dashboard");
         cy.get<number>("@dashboardId").then(dashboardId =>
-          visitEmbeddedPage({
+          H.visitEmbeddedPage({
             resource: { dashboard: dashboardId },
             params: {},
           }),
@@ -751,33 +723,33 @@ describe("scenarios > question > multiple column breakouts", () => {
           expression1,
           expression2,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: H.StructuredQuestionDetails;
           expression1: string;
           expression2: string;
         }) {
-          createQuestion(questionDetails, { visitQuestion: true });
-          openNotebook();
+          H.createQuestion(questionDetails, { visitQuestion: true });
+          H.openNotebook();
 
           cy.log("add a post-aggregation expression for the first column");
-          getNotebookStep("summarize").button("Custom column").click();
-          enterCustomColumnDetails({
+          H.getNotebookStep("summarize").button("Custom column").click();
+          H.enterCustomColumnDetails({
             formula: expression1,
             name: "Expression1",
             blur: true,
           });
-          popover().button("Done").click();
+          H.popover().button("Done").click();
 
           cy.log("add a post-aggregation expression for the second column");
-          getNotebookStep("expression", { stage: 1 }).icon("add").click();
-          enterCustomColumnDetails({
+          H.getNotebookStep("expression", { stage: 1 }).icon("add").click();
+          H.enterCustomColumnDetails({
             formula: expression2,
             name: "Expression2",
             blur: true,
           });
-          popover().button("Done").click();
+          H.popover().button("Done").click();
 
           cy.log("assert query results");
-          visualize();
+          H.visualize();
           cy.wait("@dataset");
         }
 
@@ -787,7 +759,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           expression1: 'datetimeAdd([Created At: Year], 1, "year")',
           expression2: 'datetimeAdd([Created At: Month], 1, "month")',
         });
-        assertTableData({
+        H.assertTableData({
           columns: [
             "Created At: Year",
             "Created At: Month",
@@ -812,7 +784,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           expression1: "[Total: 10 bins] + 100",
           expression2: "[Total: 10 bins] + 200",
         });
-        assertTableData({
+        H.assertTableData({
           columns: ["Total", "Total", "Count", "Expression1", "Expression2"],
           firstRows: [["-60", "-50", "1", "40", "140"]],
         });
@@ -823,7 +795,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           expression1: "[Latitude: 20°] + 100",
           expression2: "[Latitude: 10°] + 200",
         });
-        assertTableData({
+        H.assertTableData({
           columns: [
             "Latitude",
             "Latitude",
@@ -845,7 +817,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           columnMinValue: string;
           columnMaxValue: string;
         }) {
-          popover().within(() => {
+          H.popover().within(() => {
             cy.findByText(columnName).click();
             cy.findByText("Specific dates…").click();
             cy.findByText("Between").click();
@@ -864,7 +836,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue,
           column2MaxValue,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: H.StructuredQuestionDetails;
           column1Name: string;
           column1MinValue: string;
           column1MaxValue: string;
@@ -872,11 +844,11 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue: string;
           column2MaxValue: string;
         }) {
-          createQuestion(questionDetails, { visitQuestion: true });
-          openNotebook();
+          H.createQuestion(questionDetails, { visitQuestion: true });
+          H.openNotebook();
 
           cy.log("add a filter for the first column");
-          getNotebookStep("summarize").button("Filter").click();
+          H.getNotebookStep("summarize").button("Filter").click();
           addDateBetweenFilter({
             columnName: column1Name,
             columnMinValue: column1MinValue,
@@ -884,7 +856,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           });
 
           cy.log("add a filter for the second column");
-          getNotebookStep("filter", { stage: 1 }).icon("add").click();
+          H.getNotebookStep("filter", { stage: 1 }).icon("add").click();
           addDateBetweenFilter({
             columnName: column2Name,
             columnMinValue: column2MinValue,
@@ -892,7 +864,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           });
 
           cy.log("assert query results");
-          visualize();
+          H.visualize();
           cy.wait("@dataset");
         }
 
@@ -905,7 +877,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           columnMinValue: number;
           columnMaxValue: number;
         }) {
-          popover().within(() => {
+          H.popover().within(() => {
             cy.findByText(columnName).click();
             cy.findByPlaceholderText("Min")
               .clear()
@@ -926,7 +898,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue,
           column2MaxValue,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: H.StructuredQuestionDetails;
           column1Name: string;
           column1MinValue: number;
           column1MaxValue: number;
@@ -934,11 +906,11 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue: number;
           column2MaxValue: number;
         }) {
-          createQuestion(questionDetails, { visitQuestion: true });
-          openNotebook();
+          H.createQuestion(questionDetails, { visitQuestion: true });
+          H.openNotebook();
 
           cy.log("add a filter for the first column");
-          getNotebookStep("summarize").button("Filter").click();
+          H.getNotebookStep("summarize").button("Filter").click();
           addNumericBetweenFilter({
             columnName: column1Name,
             columnMinValue: column1MinValue,
@@ -946,7 +918,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           });
 
           cy.log("add a filter for the second column");
-          getNotebookStep("filter", { stage: 1 }).icon("add").click();
+          H.getNotebookStep("filter", { stage: 1 }).icon("add").click();
           addNumericBetweenFilter({
             columnName: column2Name,
             columnMinValue: column2MinValue,
@@ -954,7 +926,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           });
 
           cy.log("assert query results");
-          visualize();
+          H.visualize();
           cy.wait("@dataset");
         }
 
@@ -980,14 +952,14 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue: 10,
           column2MaxValue: 50,
         });
-        assertTableData({
+        H.assertTableData({
           columns: ["Total", "Total", "Count"],
           firstRows: [
             ["20", "20", "214"],
             ["20", "25", "396"],
           ],
         });
-        assertQueryBuilderRowCount(7);
+        H.assertQueryBuilderRowCount(7);
 
         cy.log("'bin-width' breakouts");
         testNumericPostAggregationFilter({
@@ -999,14 +971,14 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue: 10,
           column2MaxValue: 50,
         });
-        assertTableData({
+        H.assertTableData({
           columns: ["Latitude", "Latitude", "Count"],
           firstRows: [
             ["20.00000000° N", "20.00000000° N", "87"],
             ["20.00000000° N", "30.00000000° N", "1,176"],
           ],
         });
-        assertQueryBuilderRowCount(4);
+        H.assertQueryBuilderRowCount(4);
       });
 
       it("should be able to add post-aggregation aggregations for each breakout column", () => {
@@ -1015,29 +987,29 @@ describe("scenarios > question > multiple column breakouts", () => {
           column1Name,
           column2Name,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: H.StructuredQuestionDetails;
           column1Name: string;
           column2Name: string;
         }) {
-          createQuestion(questionDetails, { visitQuestion: true });
-          openNotebook();
+          H.createQuestion(questionDetails, { visitQuestion: true });
+          H.openNotebook();
 
           cy.log("add an aggregation for the first column");
-          getNotebookStep("summarize").button("Summarize").click();
-          popover().within(() => {
+          H.getNotebookStep("summarize").button("Summarize").click();
+          H.popover().within(() => {
             cy.findByText("Minimum of ...").click();
             cy.findByText(column1Name).click();
           });
 
           cy.log("add an aggregation for the second column");
-          getNotebookStep("summarize", { stage: 1 }).icon("add").click();
-          popover().within(() => {
+          H.getNotebookStep("summarize", { stage: 1 }).icon("add").click();
+          H.popover().within(() => {
             cy.findByText("Maximum of ...").click();
             cy.findByText(column2Name).click();
           });
 
           cy.log("assert query results");
-          visualize();
+          H.visualize();
           cy.wait("@dataset");
         }
 
@@ -1047,7 +1019,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column1Name: "Created At: Year",
           column2Name: "Created At: Month",
         });
-        assertTableData({
+        H.assertTableData({
           columns: ["Min of Created At: Year", "Max of Created At: Month"],
           firstRows: [["January 1, 2022, 12:00 AM", "April 1, 2026, 12:00 AM"]],
         });
@@ -1058,7 +1030,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column1Name: "Total: 10 bins",
           column2Name: "Total: 50 bins",
         });
-        assertTableData({
+        H.assertTableData({
           columns: ["Min of Total", "Max of Total"],
           firstRows: [["-60", "155"]],
         });
@@ -1069,7 +1041,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column1Name: "Latitude: 20°",
           column2Name: "Latitude: 10°",
         });
-        assertTableData({
+        H.assertTableData({
           columns: ["Min of Latitude", "Max of Latitude"],
           firstRows: [["20.00000000° N", "70.00000000° N"]],
         });
@@ -1081,33 +1053,33 @@ describe("scenarios > question > multiple column breakouts", () => {
           column1Name,
           column2Name,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: H.StructuredQuestionDetails;
           column1Name: string;
           column2Name: string;
         }) {
-          createQuestion(questionDetails, { visitQuestion: true });
-          openNotebook();
+          H.createQuestion(questionDetails, { visitQuestion: true });
+          H.openNotebook();
 
           cy.log("add an aggregation");
-          getNotebookStep("summarize").button("Summarize").click();
-          popover().findByText("Count of rows").click();
+          H.getNotebookStep("summarize").button("Summarize").click();
+          H.popover().findByText("Count of rows").click();
 
           cy.log("add a breakout for the first breakout column");
-          getNotebookStep("summarize", { stage: 1 })
+          H.getNotebookStep("summarize", { stage: 1 })
             .findByTestId("breakout-step")
             .findByText("Pick a column to group by")
             .click();
-          popover().findByText(column1Name).click();
+          H.popover().findByText(column1Name).click();
 
           cy.log("add a breakout for the second breakout column");
-          getNotebookStep("summarize", { stage: 1 })
+          H.getNotebookStep("summarize", { stage: 1 })
             .findByTestId("breakout-step")
             .icon("add")
             .click();
-          popover().findByText(column2Name).click();
+          H.popover().findByText(column2Name).click();
 
           cy.log("assert query results");
-          visualize();
+          H.visualize();
           cy.wait("@dataset");
         }
 
@@ -1117,7 +1089,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column1Name: "Created At: Year",
           column2Name: "Created At: Month",
         });
-        assertTableData({
+        H.assertTableData({
           columns: ["Created At: Year", "Created At: Month", "Count"],
           firstRows: [["2022", "April 2022", "1"]],
         });
@@ -1128,7 +1100,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column1Name: "Total: 10 bins",
           column2Name: "Total: 50 bins",
         });
-        assertTableData({
+        H.assertTableData({
           columns: ["Total", "Total", "Count"],
           firstRows: [
             ["-60  –  -40", "-60  –  -40", "1"],
@@ -1142,7 +1114,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column1Name: "Latitude: 20°",
           column2Name: "Latitude: 10°",
         });
-        assertTableData({
+        H.assertTableData({
           columns: ["Latitude", "Latitude", "Count"],
           firstRows: [
             ["20° N  –  30° N", "20° N  –  30° N", "1"],
@@ -1163,13 +1135,13 @@ describe("scenarios > question > multiple column breakouts", () => {
           columnMinValue: string;
           columnMaxValue: string;
         }) {
-          modal().within(() => {
+          H.modal().within(() => {
             cy.findByText("Summaries").click();
             cy.findByTestId(`filter-column-${columnName}`)
               .findByLabelText("More options")
               .click();
           });
-          popover().within(() => {
+          H.popover().within(() => {
             cy.findByText("Specific dates…").click();
             cy.findByText("Between").click();
             cy.findByLabelText("Start date").clear().type(columnMinValue);
@@ -1187,7 +1159,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue,
           column2MaxValue,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: H.StructuredQuestionDetails;
           column1Name: string;
           column1MinValue: string;
           column1MaxValue: string;
@@ -1195,8 +1167,8 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue: string;
           column2MaxValue: string;
         }) {
-          createQuestion(questionDetails, { visitQuestion: true });
-          filter();
+          H.createQuestion(questionDetails, { visitQuestion: true });
+          H.filter();
 
           cy.log("add a filter for the first column");
           addDateBetweenFilter({
@@ -1213,7 +1185,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           });
 
           cy.log("assert query results");
-          modal().button("Apply filters").click();
+          H.modal().button("Apply filters").click();
           cy.wait("@dataset");
         }
 
@@ -1226,7 +1198,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           columnMinValue: number;
           columnMaxValue: number;
         }) {
-          modal().within(() => {
+          H.modal().within(() => {
             cy.findByText("Summaries").click();
             cy.findByTestId(`filter-column-${columnName}`)
               .findByPlaceholderText("Min")
@@ -1248,7 +1220,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue,
           column2MaxValue,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: H.StructuredQuestionDetails;
           column1Name: string;
           column1MinValue: number;
           column1MaxValue: number;
@@ -1256,8 +1228,8 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue: number;
           column2MaxValue: number;
         }) {
-          createQuestion(questionDetails, { visitQuestion: true });
-          filter();
+          H.createQuestion(questionDetails, { visitQuestion: true });
+          H.filter();
 
           cy.log("add a filter for the first column");
           addNumericBetweenFilter({
@@ -1274,7 +1246,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           });
 
           cy.log("assert query results");
-          modal().button("Apply filters").click();
+          H.modal().button("Apply filters").click();
           cy.wait("@dataset");
         }
 
@@ -1300,14 +1272,14 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue: 10,
           column2MaxValue: 50,
         });
-        assertTableData({
+        H.assertTableData({
           columns: ["Total", "Total", "Count"],
           firstRows: [
             ["20", "20", "214"],
             ["20", "25", "396"],
           ],
         });
-        assertQueryBuilderRowCount(7);
+        H.assertQueryBuilderRowCount(7);
 
         cy.log("'bin-width' breakouts");
         testNumericPostAggregationFilter({
@@ -1319,14 +1291,14 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue: 10,
           column2MaxValue: 50,
         });
-        assertTableData({
+        H.assertTableData({
           columns: ["Latitude", "Latitude", "Count"],
           firstRows: [
             ["20.00000000° N", "20.00000000° N", "87"],
             ["20.00000000° N", "30.00000000° N", "1,176"],
           ],
         });
-        assertQueryBuilderRowCount(4);
+        H.assertQueryBuilderRowCount(4);
       });
     });
 
@@ -1350,14 +1322,14 @@ describe("scenarios > question > multiple column breakouts", () => {
           tableColumn1Name,
           tableColumn2Name,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: H.StructuredQuestionDetails;
           queryColumn1Name: string;
           queryColumn2Name: string;
           tableColumn1Name: string;
           tableColumn2Name: string;
         }) {
-          createQuestion(questionDetails, { visitQuestion: true });
-          assertTableData({
+          H.createQuestion(questionDetails, { visitQuestion: true });
+          H.assertTableData({
             columns: [tableColumn1Name, tableColumn2Name, "Count"],
           });
 
@@ -1367,18 +1339,18 @@ describe("scenarios > question > multiple column breakouts", () => {
             .click();
           toggleColumn(queryColumn1Name, false);
           cy.wait("@dataset");
-          assertTableData({ columns: [tableColumn2Name, "Count"] });
+          H.assertTableData({ columns: [tableColumn2Name, "Count"] });
 
           toggleColumn(queryColumn2Name, false);
           cy.wait("@dataset");
-          assertTableData({ columns: ["Count"] });
+          H.assertTableData({ columns: ["Count"] });
 
           toggleColumn(queryColumn1Name, true);
           cy.wait("@dataset");
-          assertTableData({ columns: ["Count", tableColumn1Name] });
+          H.assertTableData({ columns: ["Count", tableColumn1Name] });
 
           toggleColumn(queryColumn2Name, true);
-          assertTableData({
+          H.assertTableData({
             columns: ["Count", tableColumn1Name, tableColumn2Name],
           });
         }
@@ -1425,7 +1397,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           columnMinValue: string;
           columnMaxValue: string;
         }) {
-          popover().within(() => {
+          H.popover().within(() => {
             cy.findAllByText(columnName).click();
             cy.findByText("Specific dates…").click();
             cy.findByText("Between").click();
@@ -1444,7 +1416,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue,
           column2MaxValue,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: H.StructuredQuestionDetails;
           column1Name: string;
           column1MinValue: string;
           column1MaxValue: string;
@@ -1452,15 +1424,15 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue: string;
           column2MaxValue: string;
         }) {
-          createQuestion(questionDetails).then(({ body: card }) => {
-            createQuestion(getNestedQuestionDetails(card.id), {
+          H.createQuestion(questionDetails).then(({ body: card }) => {
+            H.createQuestion(getNestedQuestionDetails(card.id), {
               visitQuestion: true,
             });
           });
-          openNotebook();
+          H.openNotebook();
 
           cy.log("add a filter for the first column");
-          getNotebookStep("data").button("Filter").click();
+          H.getNotebookStep("data").button("Filter").click();
           addDateBetweenFilter({
             columnName: column1Name,
             columnMinValue: column1MinValue,
@@ -1468,7 +1440,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           });
 
           cy.log("add a filter for the second column");
-          getNotebookStep("filter").icon("add").click();
+          H.getNotebookStep("filter").icon("add").click();
           addDateBetweenFilter({
             columnName: column2Name,
             columnMinValue: column2MinValue,
@@ -1476,7 +1448,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           });
 
           cy.log("assert query results");
-          visualize();
+          H.visualize();
           cy.wait("@dataset");
         }
 
@@ -1491,7 +1463,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           columnMinValue: number;
           columnMaxValue: number;
         }) {
-          popover().within(() => {
+          H.popover().within(() => {
             cy.findAllByText(columnName).eq(columnIndex).click();
             cy.findByPlaceholderText("Min")
               .clear()
@@ -1511,22 +1483,22 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue,
           column2MaxValue,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: H.StructuredQuestionDetails;
           columnName: string;
           column1MinValue: number;
           column1MaxValue: number;
           column2MinValue: number;
           column2MaxValue: number;
         }) {
-          createQuestion(questionDetails).then(({ body: card }) => {
-            createQuestion(getNestedQuestionDetails(card.id), {
+          H.createQuestion(questionDetails).then(({ body: card }) => {
+            H.createQuestion(getNestedQuestionDetails(card.id), {
               visitQuestion: true,
             });
           });
-          openNotebook();
+          H.openNotebook();
 
           cy.log("add a filter for the first column");
-          getNotebookStep("data").button("Filter").click();
+          H.getNotebookStep("data").button("Filter").click();
           addNumericBetweenFilter({
             columnName,
             columnIndex: 0,
@@ -1535,7 +1507,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           });
 
           cy.log("add a filter for the second column");
-          getNotebookStep("filter").icon("add").click();
+          H.getNotebookStep("filter").icon("add").click();
           addNumericBetweenFilter({
             columnName,
             columnIndex: 1,
@@ -1544,7 +1516,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           });
 
           cy.log("assert query results");
-          visualize();
+          H.visualize();
           cy.wait("@dataset");
         }
 
@@ -1569,14 +1541,14 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue: 10,
           column2MaxValue: 50,
         });
-        assertTableData({
+        H.assertTableData({
           columns: ["Total", "Total", "Count"],
           firstRows: [
             ["20  –  40", "20  –  25", "214"],
             ["20  –  40", "25  –  30", "396"],
           ],
         });
-        assertQueryBuilderRowCount(7);
+        H.assertQueryBuilderRowCount(7);
 
         cy.log("'bin-width' breakouts");
         testNumericPostAggregationFilter({
@@ -1587,14 +1559,14 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue: 10,
           column2MaxValue: 50,
         });
-        assertTableData({
+        H.assertTableData({
           columns: ["Latitude", "Latitude", "Count"],
           firstRows: [
             ["20° N  –  40° N", "20° N  –  30° N", "87"],
             ["20° N  –  40° N", "30° N  –  40° N", "1,176"],
           ],
         });
-        assertQueryBuilderRowCount(4);
+        H.assertQueryBuilderRowCount(4);
       });
 
       it("should be able to add aggregations for each source column", () => {
@@ -1605,35 +1577,35 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2Name,
           column2Index,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: H.StructuredQuestionDetails;
           column1Name: string;
           column1Index: number;
           column2Name: string;
           column2Index: number;
         }) {
-          createQuestion(questionDetails).then(({ body: card }) => {
-            createQuestion(getNestedQuestionDetails(card.id), {
+          H.createQuestion(questionDetails).then(({ body: card }) => {
+            H.createQuestion(getNestedQuestionDetails(card.id), {
               visitQuestion: true,
             });
           });
-          openNotebook();
+          H.openNotebook();
 
           cy.log("add an aggregation for the first column");
-          getNotebookStep("data").button("Summarize").click();
-          popover().within(() => {
+          H.getNotebookStep("data").button("Summarize").click();
+          H.popover().within(() => {
             cy.findByText("Minimum of ...").click();
             cy.findAllByText(column1Name).eq(column1Index).click();
           });
 
           cy.log("add an aggregation for the second column");
-          getNotebookStep("summarize").icon("add").click();
-          popover().within(() => {
+          H.getNotebookStep("summarize").icon("add").click();
+          H.popover().within(() => {
             cy.findByText("Maximum of ...").click();
             cy.findAllByText(column2Name).eq(column2Index).click();
           });
 
           cy.log("assert query results");
-          visualize();
+          H.visualize();
           cy.wait("@dataset");
         }
 
@@ -1645,7 +1617,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2Name: "Created At: Month",
           column2Index: 0,
         });
-        assertTableData({
+        H.assertTableData({
           columns: ["Min of Created At: Year", "Max of Created At: Month"],
           firstRows: [["January 1, 2022, 12:00 AM", "April 1, 2026, 12:00 AM"]],
         });
@@ -1658,7 +1630,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2Name: "Total",
           column2Index: 1,
         });
-        assertTableData({
+        H.assertTableData({
           columns: ["Min of Total", "Max of Total"],
           firstRows: [["-60", "155"]],
         });
@@ -1671,7 +1643,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2Name: "Latitude",
           column2Index: 1,
         });
-        assertTableData({
+        H.assertTableData({
           columns: ["Min of Latitude", "Max of Latitude"],
           firstRows: [["20.00000000° N", "70.00000000° N"]],
         });
@@ -1685,39 +1657,39 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2Name,
           column2Index,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: H.StructuredQuestionDetails;
           column1Name: string;
           column1Index: number;
           column2Name: string;
           column2Index: number;
         }) {
-          createQuestion(questionDetails).then(({ body: card }) => {
-            createQuestion(getNestedQuestionDetails(card.id), {
+          H.createQuestion(questionDetails).then(({ body: card }) => {
+            H.createQuestion(getNestedQuestionDetails(card.id), {
               visitQuestion: true,
             });
           });
-          openNotebook();
+          H.openNotebook();
 
           cy.log("add an aggregation");
-          getNotebookStep("data").button("Summarize").click();
-          popover().findByText("Count of rows").click();
+          H.getNotebookStep("data").button("Summarize").click();
+          H.popover().findByText("Count of rows").click();
 
           cy.log("add a breakout for the first source column");
-          getNotebookStep("summarize")
+          H.getNotebookStep("summarize")
             .findByTestId("breakout-step")
             .findByText("Pick a column to group by")
             .click();
-          popover().findAllByText(column1Name).eq(column1Index).click();
+          H.popover().findAllByText(column1Name).eq(column1Index).click();
 
           cy.log("add a breakout for the second source column");
-          getNotebookStep("summarize")
+          H.getNotebookStep("summarize")
             .findByTestId("breakout-step")
             .icon("add")
             .click();
-          popover().findAllByText(column2Name).eq(column2Index).click();
+          H.popover().findAllByText(column2Name).eq(column2Index).click();
 
           cy.log("assert query results");
-          visualize();
+          H.visualize();
           cy.wait("@dataset");
         }
 
@@ -1729,7 +1701,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2Name: "Created At: Month",
           column2Index: 0,
         });
-        assertTableData({
+        H.assertTableData({
           columns: ["Created At: Year", "Created At: Month", "Count"],
           firstRows: [["2022", "April 2022", "1"]],
         });
@@ -1742,7 +1714,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2Name: "Total",
           column2Index: 1,
         });
-        assertTableData({
+        H.assertTableData({
           columns: ["Total", "Total", "Count"],
           firstRows: [
             ["-60  –  -40", "-60  –  -40", "1"],
@@ -1758,7 +1730,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2Name: "Latitude",
           column2Index: 1,
         });
-        assertTableData({
+        H.assertTableData({
           columns: ["Latitude", "Latitude", "Count"],
           firstRows: [
             ["20° N  –  30° N", "20° N  –  30° N", "1"],
@@ -1785,17 +1757,17 @@ describe("scenarios > question > multiple column breakouts", () => {
           questionDetails,
           columnName,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: H.StructuredQuestionDetails;
           columnName: string;
         }) {
-          createQuestion(questionDetails).then(({ body: card }) => {
-            createQuestion(getNestedQuestionDetails(card.id), {
+          H.createQuestion(questionDetails).then(({ body: card }) => {
+            H.createQuestion(getNestedQuestionDetails(card.id), {
               visitQuestion: true,
             });
           });
           const columnNameYear = columnName + ": Year";
           const columnNameMonth = columnName + ": Month";
-          assertTableData({
+          H.assertTableData({
             columns: [columnNameYear, columnNameMonth, "Count"],
           });
 
@@ -1805,18 +1777,18 @@ describe("scenarios > question > multiple column breakouts", () => {
             .click();
           toggleColumn(columnNameYear, false);
           cy.wait("@dataset");
-          assertTableData({ columns: [columnNameMonth, "Count"] });
+          H.assertTableData({ columns: [columnNameMonth, "Count"] });
 
           toggleColumn(columnNameMonth, false);
           cy.wait("@dataset");
-          assertTableData({ columns: ["Count"] });
+          H.assertTableData({ columns: ["Count"] });
 
           toggleColumn(columnNameYear, true);
           cy.wait("@dataset");
-          assertTableData({ columns: ["Count", columnNameYear] });
+          H.assertTableData({ columns: ["Count", columnNameYear] });
 
           toggleColumn(columnNameMonth, true);
-          assertTableData({
+          H.assertTableData({
             columns: ["Count", columnNameYear, columnNameMonth],
           });
         }
@@ -1835,12 +1807,12 @@ function tableHeaderClick(
   columnName: string,
   { columnIndex = 0 }: { columnIndex?: number } = {},
 ) {
-  tableInteractive()
+  H.tableInteractive()
     .findAllByText(columnName)
     .eq(columnIndex)
     .trigger("mousedown");
 
-  tableInteractive()
+  H.tableInteractive()
     .findAllByText(columnName)
     .eq(columnIndex)
     .trigger("mouseup");

--- a/e2e/test/scenarios/question/native-query-drill.cy.spec.ts
+++ b/e2e/test/scenarios/question/native-query-drill.cy.spec.ts
@@ -1,39 +1,21 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
-import {
-  type NativeQuestionDetails,
-  assertQueryBuilderRowCount,
-  assertTableData,
-  cartesianChartCircle,
-  createNativeQuestion,
-  createNativeQuestionAndDashboard,
-  echartsContainer,
-  ensureEchartsContainerHasSvg,
-  getDashboardCard,
-  modal,
-  popover,
-  restore,
-  tableHeaderClick,
-  tableInteractive,
-  visitDashboard,
-  visitQuestion,
-  visitQuestionAdhoc,
-} from "e2e/support/helpers";
 
-const ordersTableQuestionDetails: NativeQuestionDetails = {
+const ordersTableQuestionDetails: H.NativeQuestionDetails = {
   display: "table",
   native: {
     query: "SELECT ID, CREATED_AT, QUANTITY FROM ORDERS ORDER BY ID LIMIT 10",
   },
 };
 
-const peopleTableQuestionDetails: NativeQuestionDetails = {
+const peopleTableQuestionDetails: H.NativeQuestionDetails = {
   display: "table",
   native: {
     query: "SELECT ID, EMAIL, CREATED_AT FROM PEOPLE ORDER BY ID LIMIT 10",
   },
 };
 
-const timeseriesLineQuestionDetails: NativeQuestionDetails = {
+const timeseriesLineQuestionDetails: H.NativeQuestionDetails = {
   display: "line",
   native: {
     query: "SELECT CREATED_AT, QUANTITY FROM ORDERS ORDER BY ID LIMIT 10",
@@ -44,7 +26,7 @@ const timeseriesLineQuestionDetails: NativeQuestionDetails = {
   },
 };
 
-const timeseriesWithCategoryLineQuestionDetails: NativeQuestionDetails = {
+const timeseriesWithCategoryLineQuestionDetails: H.NativeQuestionDetails = {
   display: "line",
   native: {
     query:
@@ -56,7 +38,7 @@ const timeseriesWithCategoryLineQuestionDetails: NativeQuestionDetails = {
   },
 };
 
-const numericLineQuestionDetails: NativeQuestionDetails = {
+const numericLineQuestionDetails: H.NativeQuestionDetails = {
   display: "line",
   native: {
     query: "SELECT ID, QUANTITY FROM ORDERS ORDER BY ID LIMIT 10",
@@ -67,7 +49,7 @@ const numericLineQuestionDetails: NativeQuestionDetails = {
   },
 };
 
-const pinMapQuestionDetails: NativeQuestionDetails = {
+const pinMapQuestionDetails: H.NativeQuestionDetails = {
   display: "map",
   native: {
     query: "SELECT LATITUDE, LONGITUDE FROM PEOPLE ORDER BY ID LIMIT 10",
@@ -79,7 +61,7 @@ const pinMapQuestionDetails: NativeQuestionDetails = {
   },
 };
 
-const gridMapQuestionDetails: NativeQuestionDetails = {
+const gridMapQuestionDetails: H.NativeQuestionDetails = {
   display: "map",
   native: {
     query: "SELECT LATITUDE, LONGITUDE FROM PEOPLE ORDER BY ID LIMIT 10",
@@ -93,7 +75,7 @@ const gridMapQuestionDetails: NativeQuestionDetails = {
 
 describe("scenarios > question > native query drill", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("POST", "/api/card").as("saveCard");
@@ -101,7 +83,7 @@ describe("scenarios > question > native query drill", () => {
 
   describe("query builder metadata", () => {
     it("should allow to save an ad-hoc native query when attempting to drill", () => {
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         display: "table",
         dataset_query: {
           database: SAMPLE_DB_ID,
@@ -111,42 +93,42 @@ describe("scenarios > question > native query drill", () => {
       });
       cy.wait("@dataset");
 
-      tableInteractive().findByText("October 7, 2023, 1:34 AM").click();
-      popover().within(() => {
+      H.tableInteractive().findByText("October 7, 2023, 1:34 AM").click();
+      H.popover().within(() => {
         cy.findByText("Filter by this date").should("not.exist");
         cy.button("Save").click();
       });
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByLabelText("Name").type("SQL");
         cy.button("Save").click();
         cy.wait("@saveCard");
       });
-      modal().findByText("Not now").click();
+      H.modal().findByText("Not now").click();
 
-      tableInteractive().findByText("October 7, 2023, 1:34 AM").click();
-      popover().within(() => {
+      H.tableInteractive().findByText("October 7, 2023, 1:34 AM").click();
+      H.popover().within(() => {
         cy.findByText("Filter by this date").should("be.visible");
         cy.findByText("On").click();
       });
       cy.wait("@dataset");
-      assertQueryBuilderRowCount(1);
+      H.assertQueryBuilderRowCount(1);
     });
   });
 
   describe("query builder drills", () => {
     it("column-extract drill", () => {
       cy.log("from column header");
-      createNativeQuestion(ordersTableQuestionDetails, {
+      H.createNativeQuestion(ordersTableQuestionDetails, {
         visitQuestion: true,
         wrapId: true,
       });
-      tableHeaderClick("CREATED_AT");
-      popover().within(() => {
+      H.tableHeaderClick("CREATED_AT");
+      H.popover().within(() => {
         cy.findByText("Extract day, month…").click();
         cy.findByText("Quarter of year").click();
         cy.wait("@dataset");
       });
-      assertTableData({
+      H.assertTableData({
         columns: ["ID", "CREATED_AT", "QUANTITY", "Quarter of year"],
         firstRows: [
           ["1", "February 11, 2025, 9:40 PM", "2", "Q1"],
@@ -155,15 +137,15 @@ describe("scenarios > question > native query drill", () => {
       });
 
       cy.log("from plus button");
-      visitQuestion("@questionId");
-      tableInteractive().button("Add column").click();
-      popover().within(() => {
+      H.visitQuestion("@questionId");
+      H.tableInteractive().button("Add column").click();
+      H.popover().within(() => {
         cy.findByText("Extract part of column").click();
         cy.findByText("CREATED_AT").click();
         cy.findByText("Quarter of year").click();
         cy.wait("@dataset");
       });
-      assertTableData({
+      H.assertTableData({
         columns: ["ID", "CREATED_AT", "QUANTITY", "Quarter of year"],
         firstRows: [
           ["1", "February 11, 2025, 9:40 PM", "2", "Q1"],
@@ -174,15 +156,15 @@ describe("scenarios > question > native query drill", () => {
 
     it("combine-columns drill", () => {
       cy.log("from column header");
-      createNativeQuestion(peopleTableQuestionDetails, {
+      H.createNativeQuestion(peopleTableQuestionDetails, {
         visitQuestion: true,
         wrapId: true,
       });
-      tableHeaderClick("EMAIL");
-      popover().findByText("Combine columns").click();
-      popover().button("Done").click();
+      H.tableHeaderClick("EMAIL");
+      H.popover().findByText("Combine columns").click();
+      H.popover().button("Done").click();
       cy.wait("@dataset");
-      assertTableData({
+      H.assertTableData({
         columns: ["ID", "EMAIL", "CREATED_AT", "Combined EMAIL, ID"],
         firstRows: [
           [
@@ -195,12 +177,12 @@ describe("scenarios > question > native query drill", () => {
       });
 
       cy.log("from plus button");
-      visitQuestion("@questionId");
-      tableInteractive().button("Add column").click();
-      popover().findByText("Combine columns").click();
-      popover().button("Done").click();
+      H.visitQuestion("@questionId");
+      H.tableInteractive().button("Add column").click();
+      H.popover().findByText("Combine columns").click();
+      H.popover().button("Done").click();
       cy.wait("@dataset");
-      assertTableData({
+      H.assertTableData({
         columns: ["ID", "EMAIL", "CREATED_AT", "Combined ID, EMAIL"],
         firstRows: [
           [
@@ -214,65 +196,69 @@ describe("scenarios > question > native query drill", () => {
     });
 
     it("column-filter drill", () => {
-      createNativeQuestion(ordersTableQuestionDetails, { visitQuestion: true });
-      assertQueryBuilderRowCount(10);
-      tableHeaderClick("QUANTITY");
-      popover().findByText("Filter by this column").click();
-      popover().within(() => {
+      H.createNativeQuestion(ordersTableQuestionDetails, {
+        visitQuestion: true,
+      });
+      H.assertQueryBuilderRowCount(10);
+      H.tableHeaderClick("QUANTITY");
+      H.popover().findByText("Filter by this column").click();
+      H.popover().within(() => {
         cy.findByPlaceholderText("Min").type("2");
         cy.findByPlaceholderText("Max").type("5");
         cy.button("Add filter").click();
         cy.wait("@dataset");
       });
-      assertQueryBuilderRowCount(8);
+      H.assertQueryBuilderRowCount(8);
     });
 
     it("distribution drill", () => {
-      createNativeQuestion(ordersTableQuestionDetails, { visitQuestion: true });
-      tableHeaderClick("QUANTITY");
-      popover().findByText("Distribution").click();
+      H.createNativeQuestion(ordersTableQuestionDetails, {
+        visitQuestion: true,
+      });
+      H.tableHeaderClick("QUANTITY");
+      H.popover().findByText("Distribution").click();
       cy.wait("@dataset");
-      echartsContainer().within(() => {
+      H.echartsContainer().within(() => {
         cy.findByText("Count").should("be.visible");
         cy.findByText("QUANTITY").should("be.visible");
       });
-      assertQueryBuilderRowCount(5);
+      H.assertQueryBuilderRowCount(5);
     });
 
     it("quick-filter drill", () => {
-      createNativeQuestion(timeseriesLineQuestionDetails, {
+      H.createNativeQuestion(timeseriesLineQuestionDetails, {
         visitQuestion: true,
       });
-      assertQueryBuilderRowCount(10);
-      cartesianChartCircle().eq(0).click();
-      popover().within(() => {
+      H.assertQueryBuilderRowCount(10);
+      H.cartesianChartCircle().eq(0).click();
+      H.popover().within(() => {
         cy.findByText("Filter by this value").should("be.visible");
         cy.findByText("=").click();
         cy.wait("@dataset");
       });
-      assertQueryBuilderRowCount(3);
+      H.assertQueryBuilderRowCount(3);
     });
 
     it("sort drill", () => {
       cy.log("ascending");
-      createNativeQuestion(ordersTableQuestionDetails, {
+      H.createNativeQuestion(ordersTableQuestionDetails, {
         visitQuestion: true,
         wrapId: true,
       });
-      tableHeaderClick("QUANTITY");
-      popover().icon("arrow_up").click();
+      H.tableHeaderClick("QUANTITY");
+      H.popover().icon("arrow_up").click();
       cy.wait("@dataset");
-      assertTableData({
+      H.assertTableData({
         columns: ["ID", "CREATED_AT", "QUANTITY"],
         firstRows: [["1", "February 11, 2025, 9:40 PM", "2"]],
       });
 
       cy.log("descending");
-      visitQuestion("@questionId");
-      tableHeaderClick("QUANTITY");
-      popover().icon("arrow_down").click();
+      H.visitQuestion("@questionId");
+      H.tableHeaderClick("QUANTITY");
+      H.popover().icon("arrow_down").click();
       cy.wait("@dataset");
-      assertTableData({
+      H.assertTableData({
         columns: ["ID", "CREATED_AT", "QUANTITY"],
         firstRows: [["8", "June 17, 2025, 2:37 AM", "7"]],
       });
@@ -280,45 +266,47 @@ describe("scenarios > question > native query drill", () => {
 
     it("summarize drill", () => {
       cy.log("distinct values");
-      createNativeQuestion(ordersTableQuestionDetails, {
+      H.createNativeQuestion(ordersTableQuestionDetails, {
         visitQuestion: true,
         wrapId: true,
       });
-      tableHeaderClick("QUANTITY");
-      popover().findByText("Distinct values").click();
+      H.tableHeaderClick("QUANTITY");
+      H.popover().findByText("Distinct values").click();
       cy.wait("@dataset");
-      assertTableData({
+      H.assertTableData({
         columns: ["Distinct values of QUANTITY"],
         firstRows: [["5"]],
       });
 
       cy.log("sum");
-      visitQuestion("@questionId");
-      tableHeaderClick("QUANTITY");
-      popover().findByText("Sum").click();
+      H.visitQuestion("@questionId");
+      H.tableHeaderClick("QUANTITY");
+      H.popover().findByText("Sum").click();
       cy.wait("@dataset");
-      assertTableData({
+      H.assertTableData({
         columns: ["Sum of QUANTITY"],
         firstRows: [["38"]],
       });
 
       cy.log("avg");
-      visitQuestion("@questionId");
-      tableHeaderClick("QUANTITY");
-      popover().findByText("Avg").click();
+      H.visitQuestion("@questionId");
+      H.tableHeaderClick("QUANTITY");
+      H.popover().findByText("Avg").click();
       cy.wait("@dataset");
-      assertTableData({
+      H.assertTableData({
         columns: ["Average of QUANTITY"],
         firstRows: [["3.8"]],
       });
     });
 
     it("summarize-column-by-time drill", () => {
-      createNativeQuestion(ordersTableQuestionDetails, { visitQuestion: true });
-      tableHeaderClick("QUANTITY");
-      popover().findByText("Sum over time").click();
+      H.createNativeQuestion(ordersTableQuestionDetails, {
+        visitQuestion: true,
+      });
+      H.tableHeaderClick("QUANTITY");
+      H.popover().findByText("Sum over time").click();
       cy.wait("@dataset");
-      assertTableData({
+      H.assertTableData({
         columns: ["CREATED_AT: Month", "Sum of QUANTITY"],
         firstRows: [
           ["May 2023", "3"],
@@ -330,19 +318,19 @@ describe("scenarios > question > native query drill", () => {
 
     it("unsupported drills", () => {
       cy.log("aggregated cell click");
-      createNativeQuestion(timeseriesLineQuestionDetails, {
+      H.createNativeQuestion(timeseriesLineQuestionDetails, {
         visitQuestion: true,
       });
-      assertQueryBuilderRowCount(10);
-      cartesianChartCircle().eq(0).click();
-      popover().within(() => {
+      H.assertQueryBuilderRowCount(10);
+      H.cartesianChartCircle().eq(0).click();
+      H.popover().within(() => {
         cy.findByText(/See these/).should("not.exist");
         cy.findByText(/Breakout by/).should("not.exist");
         cy.findByText(/Automatic insights/).should("not.exist");
       });
 
       cy.log("legend item click");
-      createNativeQuestion(timeseriesWithCategoryLineQuestionDetails, {
+      H.createNativeQuestion(timeseriesWithCategoryLineQuestionDetails, {
         visitQuestion: true,
       });
       cy.findByTestId("visualization-root").findByText("Gadget").click();
@@ -352,28 +340,28 @@ describe("scenarios > question > native query drill", () => {
 
   describe("query builder brush filters", () => {
     it("timeseries filter", () => {
-      createNativeQuestion(timeseriesLineQuestionDetails, {
+      H.createNativeQuestion(timeseriesLineQuestionDetails, {
         visitQuestion: true,
       });
-      assertQueryBuilderRowCount(10);
+      H.assertQueryBuilderRowCount(10);
       applyBrushFilter({ left: 200, right: 800 });
       cy.wait("@dataset");
-      assertQueryBuilderRowCount(4);
+      H.assertQueryBuilderRowCount(4);
     });
 
     it("numeric filter", () => {
-      createNativeQuestion(numericLineQuestionDetails, {
+      H.createNativeQuestion(numericLineQuestionDetails, {
         visitQuestion: true,
       });
-      assertQueryBuilderRowCount(10);
+      H.assertQueryBuilderRowCount(10);
       applyBrushFilter({ left: 200, right: 800 });
       cy.wait("@dataset");
-      assertQueryBuilderRowCount(5);
+      H.assertQueryBuilderRowCount(5);
     });
 
     it("coordinates filter", () => {
       cy.log("pin map");
-      createNativeQuestion(pinMapQuestionDetails, { visitQuestion: true });
+      H.createNativeQuestion(pinMapQuestionDetails, { visitQuestion: true });
       cy.findByTestId("visualization-root").realHover();
       cy.findByTestId("visualization-root").within(() => {
         cy.findByText("Save as default view").should("be.visible");
@@ -386,10 +374,10 @@ describe("scenarios > question > native query drill", () => {
         bottom: 500,
       });
       cy.wait("@dataset");
-      assertQueryBuilderRowCount(1);
+      H.assertQueryBuilderRowCount(1);
 
       cy.log("grid map");
-      createNativeQuestion(gridMapQuestionDetails, { visitQuestion: true });
+      H.createNativeQuestion(gridMapQuestionDetails, { visitQuestion: true });
       cy.findByTestId("visualization-root").realHover();
       cy.findByTestId("visualization-root").within(() => {
         cy.findByText("Save as default view").should("be.visible");
@@ -401,61 +389,61 @@ describe("scenarios > question > native query drill", () => {
   describe("dashboard drills", () => {
     it("quick-filter drill", () => {
       cy.log("cell click");
-      createNativeQuestionAndDashboard({
+      H.createNativeQuestionAndDashboard({
         questionDetails: ordersTableQuestionDetails,
-      }).then(({ body }) => visitDashboard(body.dashboard_id));
-      getDashboardCard().findByText("May 15, 2024, 8:04 AM").click();
-      popover().within(() => {
+      }).then(({ body }) => H.visitDashboard(body.dashboard_id));
+      H.getDashboardCard().findByText("May 15, 2024, 8:04 AM").click();
+      H.popover().within(() => {
         cy.findByText("Filter by this date").should("be.visible");
         cy.findByText("On").click();
         cy.wait("@dataset");
       });
-      assertQueryBuilderRowCount(1);
+      H.assertQueryBuilderRowCount(1);
 
       cy.log("aggregated cell click");
-      createNativeQuestionAndDashboard({
+      H.createNativeQuestionAndDashboard({
         questionDetails: timeseriesLineQuestionDetails,
-      }).then(({ body }) => visitDashboard(body.dashboard_id));
-      getDashboardCard().within(() => cartesianChartCircle().eq(0).click());
-      popover().within(() => {
+      }).then(({ body }) => H.visitDashboard(body.dashboard_id));
+      H.getDashboardCard().within(() => H.cartesianChartCircle().eq(0).click());
+      H.popover().within(() => {
         cy.findByText("Filter by this value").should("be.visible");
         cy.findByText("=").click();
         cy.wait("@dataset");
       });
-      assertQueryBuilderRowCount(3);
+      H.assertQueryBuilderRowCount(3);
     });
   });
 
   describe("dashboard brush filters", () => {
     it("timeseries filter", () => {
-      createNativeQuestionAndDashboard({
+      H.createNativeQuestionAndDashboard({
         questionDetails: timeseriesLineQuestionDetails,
-      }).then(({ body }) => visitDashboard(body.dashboard_id));
-      getDashboardCard().within(() =>
+      }).then(({ body }) => H.visitDashboard(body.dashboard_id));
+      H.getDashboardCard().within(() =>
         applyBrushFilter({ left: 100, right: 300 }),
       );
       cy.wait("@dataset");
-      assertQueryBuilderRowCount(4);
+      H.assertQueryBuilderRowCount(4);
     });
 
     it("numeric filter", () => {
-      createNativeQuestionAndDashboard({
+      H.createNativeQuestionAndDashboard({
         questionDetails: numericLineQuestionDetails,
-      }).then(({ body }) => visitDashboard(body.dashboard_id));
-      getDashboardCard().within(() =>
+      }).then(({ body }) => H.visitDashboard(body.dashboard_id));
+      H.getDashboardCard().within(() =>
         applyBrushFilter({ left: 100, right: 300 }),
       );
       cy.wait("@dataset");
-      assertQueryBuilderRowCount(5);
+      H.assertQueryBuilderRowCount(5);
     });
   });
 });
 
 function applyBrushFilter({ left, right }: { left: number; right: number }) {
-  ensureEchartsContainerHasSvg();
+  H.ensureEchartsContainerHasSvg();
   cy.wait(100); // wait to avoid grabbing the svg before the chart redraws
 
-  echartsContainer()
+  H.echartsContainer()
     .trigger("mousedown", left, 100)
     .trigger("mousemove", left, 100)
     .trigger("mouseup", right, 100);

--- a/e2e/test/scenarios/question/nested.cy.spec.js
+++ b/e2e/test/scenarios/question/nested.cy.spec.js
@@ -1,24 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  assertQueryBuilderRowCount,
-  chartPathWithFillColor,
-  createNativeQuestion,
-  entityPickerModal,
-  entityPickerModalTab,
-  filter,
-  filterField,
-  getDimensionByName,
-  openNotebook,
-  popover,
-  remapDisplayValueToFK,
-  restore,
-  summarize,
-  tableHeaderClick,
-  visitQuestion,
-  visitQuestionAdhoc,
-  visualize,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID, PEOPLE } = SAMPLE_DATABASE;
 
@@ -40,7 +22,7 @@ const ordersJoinProductsQuery = {
 
 describe("scenarios > question > nested", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -64,19 +46,19 @@ describe("scenarios > question > nested", () => {
       { loadBaseQuestionMetadata: true },
     );
 
-    tableHeaderClick("Total");
+    H.tableHeaderClick("Total");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Distribution").click();
     cy.wait("@dataset");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Count by Total: Auto binned");
-    chartPathWithFillColor("#509EE3").should("have.length.of.at.least", 8);
+    H.chartPathWithFillColor("#509EE3").should("have.length.of.at.least", 8);
 
     // Go back to the nested question and make sure Sum over time works
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Nested GUI").click();
 
-    tableHeaderClick("Total");
+    H.tableHeaderClick("Total");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Sum over time").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -102,18 +84,18 @@ describe("scenarios > question > nested", () => {
       { loadBaseQuestionMetadata: true },
     );
 
-    tableHeaderClick("COUNT");
+    H.tableHeaderClick("COUNT");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Distribution").click();
     cy.wait("@dataset");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Count by COUNT: Auto binned");
-    chartPathWithFillColor("#509EE3").should("have.length.of.at.least", 5);
+    H.chartPathWithFillColor("#509EE3").should("have.length.of.at.least", 5);
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Nested SQL").click();
 
-    tableHeaderClick("COUNT");
+    H.tableHeaderClick("COUNT");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Sum over time").click();
     cy.wait("@dataset");
@@ -193,7 +175,7 @@ describe("scenarios > question > nested", () => {
       createNestedQuestion({ baseQuestionDetails, nestedQuestionDetails });
 
       cy.log("Reported failing since v0.35.2");
-      assertQueryBuilderRowCount(5);
+      H.assertQueryBuilderRowCount(5);
     });
   });
 
@@ -203,7 +185,7 @@ describe("scenarios > question > nested", () => {
     );
 
     cy.log("Remap Product ID's display value to `title`");
-    remapDisplayValueToFK({
+    H.remapDisplayValueToFK({
       display_value: ORDERS.PRODUCT_ID,
       name: "Product ID",
       fk: PRODUCTS.TITLE,
@@ -228,7 +210,7 @@ describe("scenarios > question > nested", () => {
     ["default", "remapped"].forEach(scenario => {
       if (scenario === "remapped") {
         cy.log("Remap Product ID's display value to `title`");
-        remapDisplayValueToFK({
+        H.remapDisplayValueToFK({
           display_value: ORDERS.PRODUCT_ID,
           name: "Product ID",
           fk: PRODUCTS.TITLE,
@@ -261,12 +243,12 @@ describe("scenarios > question > nested", () => {
     createNestedQuestion({ baseQuestionDetails });
 
     // The column title
-    tableHeaderClick("Products → Category");
+    H.tableHeaderClick("Products → Category");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Distribution").click();
     cy.wait("@dataset");
 
-    summarize();
+    H.summarize();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Group by")
@@ -278,11 +260,11 @@ describe("scenarios > question > nested", () => {
 
     // Although the test will fail on the previous step, we're including additional safeguards against regressions once the issue is fixed
     // It can potentially fail at two more places. See [1] and [2]
-    openNotebook();
+    H.openNotebook();
     cy.findAllByTestId("notebook-cell-item")
       .contains(/^Products → Category$/) /* [1] */
       .click();
-    popover().within(() => {
+    H.popover().within(() => {
       isSelected("Products → Category"); /* [2] */
     });
 
@@ -292,7 +274,7 @@ describe("scenarios > question > nested", () => {
      *  Extract it if we have the need for it anywhere else
      */
     function isSelected(text) {
-      getDimensionByName({ name: text }).should(
+      H.getDimensionByName({ name: text }).should(
         "have.attr",
         "aria-selected",
         "true",
@@ -308,25 +290,25 @@ describe("scenarios > question > nested", () => {
           "select count(*), orders.product_id from orders group by orders.product_id;",
       },
     }).then(({ body: { id } }) => {
-      visitQuestion(id);
+      H.visitQuestion(id);
 
       visitNestedQueryAdHoc(id);
 
       // Count
-      summarize();
+      H.summarize();
 
       cy.findByText("Group by").parent().findByText("COUNT(*)").click();
       cy.wait("@dataset");
 
-      chartPathWithFillColor("#509EE3").should("have.length.of.at.least", 5);
+      H.chartPathWithFillColor("#509EE3").should("have.length.of.at.least", 5);
 
       // Replace "Count" with the "Average"
       cy.findByTestId("aggregation-item").contains("Count").click();
       cy.findByText("Average of ...").click();
-      popover().findByText("COUNT(*)").click();
+      H.popover().findByText("COUNT(*)").click();
       cy.wait("@dataset");
 
-      chartPathWithFillColor("#A989C5").should("have.length.of.at.least", 5);
+      H.chartPathWithFillColor("#A989C5").should("have.length.of.at.least", 5);
     });
   });
 
@@ -375,7 +357,7 @@ describe("scenarios > question > nested", () => {
         type: "query",
         display: "scalar",
       }).then(({ body: { id } }) => {
-        visitQuestion(id);
+        H.visitQuestion(id);
         cy.findByTestId("scalar-value").findByText(value);
 
         visitNestedQueryAdHoc(id);
@@ -402,8 +384,8 @@ describe("scenarios > question > nested", () => {
       cy.findByText("New").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Question").should("be.visible").click();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Saved questions").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Saved questions").click();
         cy.findByText("15725").click();
       });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -425,7 +407,7 @@ describe("scenarios > question > nested", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("CAT").click();
 
-      visualize();
+      H.visualize();
 
       cy.get("@consoleWarn").should(
         "not.be.calledWith",
@@ -441,13 +423,13 @@ describe("scenarios > question > nested", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("CAT").click();
 
-      visualize();
+      H.visualize();
 
-      summarize();
+      H.summarize();
       cy.findByTestId("add-aggregation-button").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/^Sum of/).click();
-      popover().findByText("VAL").click();
+      H.popover().findByText("VAL").click();
       cy.wait("@dataset").then(xhr => {
         expect(xhr.response.body.error).not.to.exist;
       });
@@ -464,7 +446,7 @@ describe("scenarios > question > nested", () => {
       native: { query: "select * from products limit 3" },
     };
 
-    createNativeQuestion(questionDetails, { visitQuestion: true });
+    H.createNativeQuestion(questionDetails, { visitQuestion: true });
     cy.findAllByTestId("cell-data").should(
       "contain",
       "Swaniawski, Casper and Hilll",
@@ -494,8 +476,8 @@ describe("scenarios > question > nested", () => {
     cy.log(
       "Should be able to use integer filter on a nested query based on a saved native question (metabase#15808)",
     );
-    filter();
-    filterField("RATING", {
+    H.filter();
+    H.filterField("RATING", {
       operator: "Equal to",
       value: "4",
     });
@@ -523,7 +505,7 @@ describe("scenarios > question > nested", () => {
   });
 
   it("should create a nested question with post-aggregation filter (metabase#11561)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         database: SAMPLE_DB_ID,
         query: {
@@ -539,7 +521,7 @@ describe("scenarios > question > nested", () => {
     cy.findByText("Filter").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Summaries").click();
-    filterField("Count", {
+    H.filterField("Count", {
       operator: "Equal to",
       value: "5",
     });
@@ -557,7 +539,7 @@ describe("scenarios > question > nested", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 100 rows");
 
-    openNotebook();
+    H.openNotebook();
     cy.findAllByTestId("notebook-cell-item").contains(/Users? → ID/);
 
     function saveQuestion() {
@@ -591,7 +573,7 @@ function createNestedQuestion(
   }
 
   createBaseQuestion(baseQuestionDetails).then(({ body: { id } }) => {
-    loadBaseQuestionMetadata && visitQuestion(id);
+    loadBaseQuestionMetadata && H.visitQuestion(id);
 
     const { query: nestedQuery, ...details } = nestedQuestionDetails;
 
@@ -619,7 +601,7 @@ function createNestedQuestion(
 }
 
 function visitNestedQueryAdHoc(id) {
-  return visitQuestionAdhoc({
+  return H.visitQuestionAdhoc({
     dataset_query: {
       database: SAMPLE_DB_ID,
       type: "query",

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -1,3 +1,4 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, USERS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
@@ -6,33 +7,6 @@ import {
   SECOND_COLLECTION_ID,
   THIRD_COLLECTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  collectionOnTheGoModal,
-  createDashboard,
-  createQuestion,
-  entityPickerModal,
-  entityPickerModalItem,
-  entityPickerModalTab,
-  getPersonalCollectionName,
-  modal,
-  notebookButton,
-  onlyOnOSS,
-  openNotebook,
-  openOrdersTable,
-  pickEntity,
-  popover,
-  queryBuilderHeader,
-  restore,
-  saveQuestion,
-  shouldDisplayTabs,
-  startNewQuestion,
-  tableHeaderClick,
-  tabsShouldBe,
-  visitCollection,
-  visitQuestion,
-  visitQuestionAdhoc,
-  visualize,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
@@ -40,7 +14,7 @@ const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > question > new", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -51,9 +25,9 @@ describe("scenarios > question > new", () => {
         cy.addSQLiteDatabase({ name: "Sample" + i });
       }
 
-      startNewQuestion();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.startNewQuestion();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Sample3").should("be.visible");
       });
     });
@@ -63,12 +37,12 @@ describe("scenarios > question > new", () => {
         "search",
       );
 
-      startNewQuestion();
+      H.startNewQuestion();
 
-      entityPickerModal().within(() => {
-        tabsShouldBe("Models", ["Models", "Tables", "Saved questions"]);
+      H.entityPickerModal().within(() => {
+        H.tabsShouldBe("Models", ["Models", "Tables", "Saved questions"]);
 
-        entityPickerModalTab("Search").should("not.exist");
+        H.entityPickerModalTab("Search").should("not.exist");
 
         cy.findByPlaceholderText("Search this collection or everywhere…")
           .type("  ")
@@ -102,28 +76,28 @@ describe("scenarios > question > new", () => {
         cy.findByPlaceholderText("Search this collection or everywhere…")
           .clear()
           .blur();
-        entityPickerModalTab("Search").should("not.exist");
-        tabsShouldBe("Models", ["Models", "Tables", "Saved questions"]);
+        H.entityPickerModalTab("Search").should("not.exist");
+        H.tabsShouldBe("Models", ["Models", "Tables", "Saved questions"]);
 
-        entityPickerModalTab("Saved questions").click();
+        H.entityPickerModalTab("Saved questions").click();
         cy.findByText("Orders, Count").click();
       });
 
       cy.log("toggle notebook button should be hidden for brand new questions");
-      notebookButton().should("not.exist");
+      H.notebookButton().should("not.exist");
 
-      visualize();
+      H.visualize();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("18,760");
       // should reopen saved question picker after returning back to editor mode
-      openNotebook();
+      H.openNotebook();
 
-      notebookButton().should("be.visible");
+      H.notebookButton().should("be.visible");
 
       cy.findByTestId("data-step-cell").contains("Orders, Count").click();
-      entityPickerModal().within(() => {
+      H.entityPickerModal().within(() => {
         // It is now possible to choose another saved question
-        entityPickerModalTab("Saved questions").should(
+        H.entityPickerModalTab("Saved questions").should(
           "have.attr",
           "aria-selected",
           "true",
@@ -131,11 +105,11 @@ describe("scenarios > question > new", () => {
         cy.findByText("Orders").should("exist");
         cy.findByText("Orders, Count").should("exist");
 
-        entityPickerModalTab("Tables").click();
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Products").click();
       });
       cy.findByTestId("data-step-cell").contains("Products");
-      visualize();
+      H.visualize();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Rustic Paper Wallet");
     });
@@ -154,9 +128,9 @@ describe("scenarios > question > new", () => {
         cy.findByText("Orders");
       });
 
-      startNewQuestion();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Saved questions").click();
+      H.startNewQuestion();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Saved questions").click();
         // Note: collection name's first letter is capitalized
         cy.findByText(/foo:bar/i).click();
         cy.findByText("Orders");
@@ -169,10 +143,10 @@ describe("scenarios > question > new", () => {
         collection_id: SECOND_COLLECTION_ID,
       });
 
-      startNewQuestion();
+      H.startNewQuestion();
 
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Saved questions").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Saved questions").click();
         assertDataPickerEntitySelected(0, "Our analytics");
         cy.findByText("First collection").should("exist");
         cy.findByText("Second collection").should("not.exist");
@@ -195,21 +169,21 @@ describe("scenarios > question > new", () => {
     it("should be possible to create a question based on a question in another user personal collection", () => {
       cy.signOut();
       cy.signIn("nocollection");
-      startNewQuestion();
-      entityPickerModal().findByText("Orders").click();
-      visualize();
-      saveQuestion("Personal question");
+      H.startNewQuestion();
+      H.entityPickerModal().findByText("Orders").click();
+      H.visualize();
+      H.saveQuestion("Personal question");
 
       cy.signOut();
       cy.signInAsAdmin();
-      startNewQuestion();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Saved questions").click();
+      H.startNewQuestion();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Saved questions").click();
         cy.findByText("All personal collections").click();
-        cy.findByText(getPersonalCollectionName(USERS.nocollection)).click();
+        cy.findByText(H.getPersonalCollectionName(USERS.nocollection)).click();
         cy.findByText("Personal question").click();
       });
-      visualize();
+      H.visualize();
     });
   });
 
@@ -218,7 +192,7 @@ describe("scenarios > question > new", () => {
       semantic_type: "type/PK",
     });
 
-    openOrdersTable();
+    H.openOrdersTable();
 
     cy.get(".test-TableInteractive-cellWrapper--lastColumn") // Quantity (last in the default order for Sample Database)
       .eq(1) // first table body cell
@@ -253,7 +227,7 @@ describe("scenarios > question > new", () => {
   });
 
   it("should handle ad-hoc question with old syntax (metabase#15372)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "query",
         query: {
@@ -271,16 +245,16 @@ describe("scenarios > question > new", () => {
   });
 
   it("should suggest the currently viewed collection when saving question", () => {
-    visitCollection(THIRD_COLLECTION_ID);
+    H.visitCollection(THIRD_COLLECTION_ID);
 
     cy.findByLabelText("Navigation bar").within(() => {
       cy.findByText("New").click();
     });
 
-    popover().findByText("Question").click();
+    H.popover().findByText("Question").click();
 
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Orders").click();
     });
 
@@ -289,8 +263,8 @@ describe("scenarios > question > new", () => {
     );
 
     cy.findByRole("button", { name: /Orders/ }).click();
-    shouldDisplayTabs(["Recents", "Models", "Tables", "Saved questions"]);
-    entityPickerModalTab("Recents").click();
+    H.shouldDisplayTabs(["Recents", "Models", "Tables", "Saved questions"]);
+    H.entityPickerModalTab("Recents").click();
     cy.findByRole("dialog", { name: "Pick your starting data" })
       .findByRole("button", { name: /Orders/ })
       .should("exist");
@@ -313,12 +287,12 @@ describe("scenarios > question > new", () => {
     "should be able to save a question to a collection created on the go",
     { tags: "@smoke" },
     () => {
-      visitCollection(THIRD_COLLECTION_ID);
+      H.visitCollection(THIRD_COLLECTION_ID);
 
       cy.findByLabelText("Navigation bar").findByText("New").click();
-      popover().findByText("Question").click();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.popover().findByText("Question").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Orders").click();
       });
       cy.findByTestId("qb-header").findByText("Save").click();
@@ -331,18 +305,18 @@ describe("scenarios > question > new", () => {
         .findByLabelText(/Which collection/)
         .click();
 
-      entityPickerModal()
+      H.entityPickerModal()
         .findByRole("tab", { name: /Collections/ })
         .click();
 
-      entityPickerModal().findByText("Create a new collection").click();
+      H.entityPickerModal().findByText("Create a new collection").click();
 
       const NEW_COLLECTION = "Foo";
-      collectionOnTheGoModal().within(() => {
+      H.collectionOnTheGoModal().within(() => {
         cy.findByLabelText(/Give it a name/).type(NEW_COLLECTION);
         cy.findByText("Create").click();
       });
-      entityPickerModal().within(() => {
+      H.entityPickerModal().within(() => {
         cy.findByText("Foo").click();
         cy.findByText("Select").click();
       });
@@ -369,12 +343,12 @@ describe("scenarios > question > new", () => {
       description: originalDescription,
     });
 
-    visitQuestion(ORDERS_COUNT_QUESTION_ID);
+    H.visitQuestion(ORDERS_COUNT_QUESTION_ID);
     cy.findByDisplayValue(originalQuestionName).should("exist");
 
     cy.log("Change anything about this question to make it dirty");
-    tableHeaderClick("Count");
-    popover().icon("arrow_down").click();
+    H.tableHeaderClick("Count");
+    H.popover().icon("arrow_down").click();
 
     cy.findByTestId("qb-header-action-panel").button("Save").click();
     cy.findByTestId("save-question-modal").within(() => {
@@ -400,31 +374,31 @@ describe("scenarios > question > new", () => {
     beforeEach(() => {
       cy.intercept("POST", "/api/card").as("createQuestion");
       cy.createCollection(collectionInRoot).then(({ body: { id } }) => {
-        createDashboard({
+        H.createDashboard({
           name: "Extra Dashboard",
           collection_id: id,
         });
       });
-      createDashboard(dashboardInRoot);
+      H.createDashboard(dashboardInRoot);
       // Can't use `startNewQuestion` because it's missing `display: "table"` and
       // adding that will fail a lot of other tests and I don't want to deal with that yet.
       cy.visit("/");
       cy.findByTestId("app-bar").button("New").click();
-      popover().findByText("Question").click();
+      H.popover().findByText("Question").click();
     });
 
     it("should hide public collections when selecting a dashboard for a question in a personal collection", () => {
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Orders").click();
       });
 
-      queryBuilderHeader().button("Save").click();
+      H.queryBuilderHeader().button("Save").click();
       cy.findByTestId("save-question-modal")
         .findByLabelText(/Which collection/)
         .click();
 
-      pickEntity({
+      H.pickEntity({
         path: [myPersonalCollectionName],
         select: true,
         tab: "Collections",
@@ -435,14 +409,14 @@ describe("scenarios > question > new", () => {
 
       cy.findByTestId("save-question-modal").should("not.exist");
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText(/add this to a dashboard/i);
         cy.button("Yes please!").click();
       });
 
-      entityPickerModal().within(() => {
+      H.entityPickerModal().within(() => {
         cy.findByText("Add this question to a dashboard").should("be.visible");
-        entityPickerModalTab("Dashboards").click();
+        H.entityPickerModalTab("Dashboards").click();
         cy.findByText(/bobby tables's personal collection/i).should(
           "be.visible",
         );
@@ -451,12 +425,12 @@ describe("scenarios > question > new", () => {
     });
 
     it("should show all collections when selecting a dashboard for a question in a public collection", () => {
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Orders").click();
       });
 
-      queryBuilderHeader().button("Save").click();
+      H.queryBuilderHeader().button("Save").click();
       cy.log("default selected collection is the root collection");
 
       cy.findByTestId("save-question-modal").within(modal => {
@@ -468,7 +442,7 @@ describe("scenarios > question > new", () => {
         cy.findByText("Yes please!").click();
       });
 
-      entityPickerModal().within(() => {
+      H.entityPickerModal().within(() => {
         cy.findByText("Add this question to a dashboard").should("be.visible");
 
         cy.findByRole("tab", { name: /Dashboards/ }).click();
@@ -483,12 +457,12 @@ describe("scenarios > question > new", () => {
 
     describe("creating a new dashboard", () => {
       beforeEach(() => {
-        entityPickerModal().within(() => {
-          entityPickerModalTab("Tables").click();
+        H.entityPickerModal().within(() => {
+          H.entityPickerModalTab("Tables").click();
           cy.findByText("Orders").click();
         });
 
-        queryBuilderHeader().button("Save").click();
+        H.queryBuilderHeader().button("Save").click();
         cy.log("default selected collection is the root collection");
 
         cy.findByTestId("save-question-modal").within(modal => {
@@ -502,9 +476,9 @@ describe("scenarios > question > new", () => {
       });
 
       it("when selecting a collection", () => {
-        entityPickerModal().within(() => {
-          entityPickerModalTab("Dashboards").click();
-          entityPickerModalItem(1, "Collection in root collection").click();
+        H.entityPickerModal().within(() => {
+          H.entityPickerModalTab("Dashboards").click();
+          H.entityPickerModalItem(1, "Collection in root collection").click();
           cy.button(/Create a new dashboard/).click();
         });
 
@@ -515,28 +489,28 @@ describe("scenarios > question > new", () => {
           },
         );
 
-        entityPickerModalItem(1, "Collection in root collection").should(
+        H.entityPickerModalItem(1, "Collection in root collection").should(
           "have.attr",
           "data-active",
           "true",
         );
 
-        entityPickerModalItem(2, "New Dashboard").should(
+        H.entityPickerModalItem(2, "New Dashboard").should(
           "have.attr",
           "data-active",
           "true",
         );
 
-        entityPickerModal()
+        H.entityPickerModal()
           .button(/Select/)
           .click();
         cy.location("pathname").should("eq", "/dashboard/12-new-dashboard");
       });
 
       it("when selecting a collection with no child dashboards (metabase#47000)", () => {
-        entityPickerModal().within(() => {
-          entityPickerModalTab("Dashboards").click();
-          entityPickerModalItem(1, "First collection").click();
+        H.entityPickerModal().within(() => {
+          H.entityPickerModalTab("Dashboards").click();
+          H.entityPickerModalItem(1, "First collection").click();
           cy.button(/Create a new dashboard/).click();
         });
 
@@ -547,28 +521,28 @@ describe("scenarios > question > new", () => {
           },
         );
 
-        entityPickerModalItem(1, "First collection").should(
+        H.entityPickerModalItem(1, "First collection").should(
           "have.attr",
           "data-active",
           "true",
         );
 
-        entityPickerModalItem(2, "New Dashboard").should(
+        H.entityPickerModalItem(2, "New Dashboard").should(
           "have.attr",
           "data-active",
           "true",
         );
 
-        entityPickerModal()
+        H.entityPickerModal()
           .button(/Select/)
           .click();
         cy.location("pathname").should("eq", "/dashboard/12-new-dashboard");
       });
 
       it("when a dashboard is currently selected", () => {
-        entityPickerModal().within(() => {
-          entityPickerModalTab("Dashboards").click();
-          entityPickerModalItem(1, "Orders in a dashboard").click();
+        H.entityPickerModal().within(() => {
+          H.entityPickerModalTab("Dashboards").click();
+          H.entityPickerModalItem(1, "Orders in a dashboard").click();
           cy.button(/Create a new dashboard/).click();
         });
 
@@ -579,13 +553,13 @@ describe("scenarios > question > new", () => {
           },
         );
 
-        entityPickerModalItem(1, "New Dashboard").should(
+        H.entityPickerModalItem(1, "New Dashboard").should(
           "have.attr",
           "data-active",
           "true",
         );
 
-        entityPickerModal()
+        H.entityPickerModal()
           .button(/Select/)
           .click();
         cy.location("pathname").should("eq", "/dashboard/12-new-dashboard");
@@ -602,20 +576,20 @@ describe(
   { tags: ["@OSS", "@smoke"] },
   () => {
     beforeEach(() => {
-      onlyOnOSS();
-      restore("without-models");
+      H.onlyOnOSS();
+      H.restore("without-models");
       cy.signInAsAdmin();
     });
 
     it("can create a question from the sample database", () => {
       cy.visit("/question/new");
 
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Saved questions").should("be.visible");
-        entityPickerModalTab("Models").should("not.exist");
-        entityPickerModalTab("Tables").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Saved questions").should("be.visible");
+        H.entityPickerModalTab("Models").should("not.exist");
+        H.entityPickerModalTab("Tables").click();
 
-        entityPickerModalItem(2, "Products").click();
+        H.entityPickerModalItem(2, "Products").click();
       });
 
       // strange: we get different behavior when we go to question/new
@@ -629,9 +603,9 @@ describe(
     it("can create a question from a saved question", () => {
       cy.visit("/question/new");
 
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Saved questions").click();
-        entityPickerModalItem(1, "Orders").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Saved questions").click();
+        H.entityPickerModalItem(1, "Orders").click();
       });
 
       // strange: we get different behavior when we go to question/new
@@ -643,7 +617,7 @@ describe(
     });
 
     it("shows models and raw data options after creating a model", () => {
-      createQuestion({
+      H.createQuestion({
         name: "Orders Model",
         query: { "source-table": ORDERS_ID },
         type: "model",
@@ -653,25 +627,25 @@ describe(
 
       cy.visit("/question/notebook");
 
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Saved questions").should("be.visible");
-        entityPickerModalTab("Models").should("be.visible");
-        entityPickerModalTab("Tables").should("be.visible");
-        entityPickerModalItem(1, "Orders Model").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Saved questions").should("be.visible");
+        H.entityPickerModalTab("Models").should("be.visible");
+        H.entityPickerModalTab("Tables").should("be.visible");
+        H.entityPickerModalItem(1, "Orders Model").click();
       });
 
       cy.wait("@recents");
 
       cy.button(/Orders Model/).click();
 
-      entityPickerModal().within(() => {
-        tabsShouldBe("Models", [
+      H.entityPickerModal().within(() => {
+        H.tabsShouldBe("Models", [
           "Recents",
           "Models",
           "Tables",
           "Saved questions",
         ]);
-        entityPickerModalTab("Recents").click();
+        H.entityPickerModalTab("Recents").click();
         cy.findByTestId("result-item").should("contain.text", "Orders Model");
       });
     });
@@ -679,5 +653,9 @@ describe(
 );
 
 function assertDataPickerEntitySelected(level, name) {
-  entityPickerModalItem(level, name).should("have.attr", "data-active", "true");
+  H.entityPickerModalItem(level, name).should(
+    "have.attr",
+    "data-active",
+    "true",
+  );
 }

--- a/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
@@ -1,3 +1,4 @@
+import { H } from "e2e/support";
 import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
@@ -5,35 +6,6 @@ import {
   ORDERS_MODEL_ID,
   SECOND_COLLECTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  type StructuredQuestionDetails,
-  createCollection,
-  createQuestion,
-  entityPickerModal,
-  entityPickerModalItem,
-  entityPickerModalLevel,
-  entityPickerModalTab,
-  join,
-  navigationSidebar,
-  newButton,
-  onlyOnOSS,
-  openNotebook,
-  openOrdersTable,
-  openQuestionActions,
-  openReviewsTable,
-  popover,
-  queryBuilderMain,
-  resetTestTable,
-  restore,
-  resyncDatabase,
-  saveQuestion,
-  shouldDisplayTabs,
-  startNewQuestion,
-  tabsShouldBe,
-  visitModel,
-  visitQuestion,
-  visualize,
-} from "e2e/support/helpers";
 import { checkNotNull } from "metabase/lib/types";
 
 const { ORDERS_ID, REVIEWS_ID } = SAMPLE_DATABASE;
@@ -41,7 +13,7 @@ const { ORDERS_ID, REVIEWS_ID } = SAMPLE_DATABASE;
 describe("scenarios > notebook > data source", () => {
   describe("empty app db", () => {
     beforeEach(() => {
-      restore("setup");
+      H.restore("setup");
       cy.signInAsAdmin();
     });
 
@@ -49,22 +21,22 @@ describe("scenarios > notebook > data source", () => {
       "should display tables from the only existing database by default",
       { tags: "@OSS" },
       () => {
-        onlyOnOSS();
+        H.onlyOnOSS();
         cy.visit("/");
         cy.findByTestId("app-bar").findByText("New").click();
-        popover().findByTextEnsureVisible("Question").click();
+        H.popover().findByTextEnsureVisible("Question").click();
         cy.findByTestId("data-step-cell").should(
           "have.text",
           "Pick your starting data",
         );
 
-        entityPickerModal().within(() => {
+        H.entityPickerModal().within(() => {
           cy.log("Should not have Recents tab");
           cy.findAllByRole("tab").should("have.length", 0);
 
-          entityPickerModalLevel(0).should("not.exist");
-          entityPickerModalLevel(1).should("not.exist");
-          entityPickerModalLevel(2)
+          H.entityPickerModalLevel(0).should("not.exist");
+          H.entityPickerModalLevel(1).should("not.exist");
+          H.entityPickerModalLevel(2)
             .get("[data-index]")
             .should("have.length", 8);
           assertDataPickerEntityNotSelected(2, "Accounts");
@@ -80,68 +52,68 @@ describe("scenarios > notebook > data source", () => {
     );
 
     it("should not show saved questions if only models exist (metabase#25142)", () => {
-      createQuestion({
+      H.createQuestion({
         name: "GUI Model",
         query: { "source-table": REVIEWS_ID, limit: 1 },
         display: "table",
         type: "model",
       });
 
-      startNewQuestion();
-      entityPickerModal().within(() => {
+      H.startNewQuestion();
+      H.entityPickerModal().within(() => {
         cy.findAllByRole("tab").should("have.length", 2);
-        entityPickerModalTab("Models").should("exist");
-        entityPickerModalTab("Tables").should("exist");
-        entityPickerModalTab("Saved questions").should("not.exist");
+        H.entityPickerModalTab("Models").should("exist");
+        H.entityPickerModalTab("Tables").should("exist");
+        H.entityPickerModalTab("Saved questions").should("not.exist");
       });
     });
 
     it("should not show models if only saved questions exist", () => {
-      createQuestion({
+      H.createQuestion({
         name: "GUI Question",
         query: { "source-table": REVIEWS_ID, limit: 1 },
         display: "table",
       });
 
-      startNewQuestion();
+      H.startNewQuestion();
 
-      entityPickerModal().within(() => {
-        shouldDisplayTabs(["Tables", "Saved questions"]);
-        entityPickerModalTab("Models").should("not.exist");
+      H.entityPickerModal().within(() => {
+        H.shouldDisplayTabs(["Tables", "Saved questions"]);
+        H.entityPickerModalTab("Models").should("not.exist");
       });
     });
   });
 
   describe("table as a source", () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
     });
 
     it("should correctly display the source data for ad-hoc questions", () => {
-      openReviewsTable();
-      openNotebook();
+      H.openReviewsTable();
+      H.openNotebook();
       cy.findByTestId("data-step-cell").should("have.text", "Reviews").click();
-      entityPickerModal().within(() => {
-        tabsShouldBe("Tables", ["Models", "Tables", "Saved questions"]);
+      H.entityPickerModal().within(() => {
+        H.tabsShouldBe("Tables", ["Models", "Tables", "Saved questions"]);
         // should not show databases step if there's only 1 database
-        entityPickerModalLevel(0).should("not.exist");
+        H.entityPickerModalLevel(0).should("not.exist");
         // should not show schema step if there's only 1 schema
-        entityPickerModalLevel(1).should("not.exist");
+        H.entityPickerModalLevel(1).should("not.exist");
         assertDataPickerEntitySelected(2, "Reviews");
       });
     });
 
     it("should correctly display the source data for a simple saved question", () => {
-      visitQuestion(ORDERS_COUNT_QUESTION_ID);
-      openNotebook();
+      H.visitQuestion(ORDERS_COUNT_QUESTION_ID);
+      H.openNotebook();
       cy.findByTestId("data-step-cell").should("have.text", "Orders").click();
-      entityPickerModal().within(() => {
-        tabsShouldBe("Tables", ["Models", "Tables", "Saved questions"]);
+      H.entityPickerModal().within(() => {
+        H.tabsShouldBe("Tables", ["Models", "Tables", "Saved questions"]);
         // should not show databases step if there's only 1 database
-        entityPickerModalLevel(0).should("not.exist");
+        H.entityPickerModalLevel(0).should("not.exist");
         // should not show schema step if there's only 1 schema
-        entityPickerModalLevel(1).should("not.exist");
+        H.entityPickerModalLevel(1).should("not.exist");
         assertDataPickerEntitySelected(2, "Orders");
       });
     });
@@ -158,64 +130,64 @@ describe("scenarios > notebook > data source", () => {
         const schemaName = "Wild";
         const tableName = "Animals";
 
-        resetTestTable({ type: dialect, table: testTable1 });
-        resetTestTable({ type: dialect, table: testTable2 });
-        restore(`${dialect}-writable`);
+        H.resetTestTable({ type: dialect, table: testTable1 });
+        H.resetTestTable({ type: dialect, table: testTable2 });
+        H.restore(`${dialect}-writable`);
 
         cy.signInAsAdmin();
 
-        resyncDatabase({
+        H.resyncDatabase({
           dbId: WRITABLE_DB_ID,
         });
 
-        startNewQuestion();
-        entityPickerModal().within(() => {
-          entityPickerModalTab("Tables").click();
+        H.startNewQuestion();
+        H.entityPickerModal().within(() => {
+          H.entityPickerModalTab("Tables").click();
           cy.findByText(dbName).click();
           cy.findByText(schemaName).click();
           cy.findByText(tableName).click();
         });
-        visualize();
-        saveQuestion("Beasts");
+        H.visualize();
+        H.saveQuestion("Beasts");
 
-        openNotebook();
+        H.openNotebook();
         cy.findByTestId("data-step-cell").should("contain", tableName).click();
-        entityPickerModal().within(() => {
+        H.entityPickerModal().within(() => {
           assertDataPickerEntitySelected(0, dbName);
           assertDataPickerEntitySelected(1, schemaName);
           assertDataPickerEntitySelected(2, tableName);
 
-          entityPickerModalTab("Recents").click();
+          H.entityPickerModalTab("Recents").click();
           cy.contains("button", "Animals")
             .should("exist")
             .and("contain.text", tableName)
             .and("have.attr", "aria-selected", "true");
 
-          entityPickerModalTab("Tables").click();
+          H.entityPickerModalTab("Tables").click();
           cy.findByText(dbName).click();
           cy.findByText(schemaName).click();
           cy.findByText(tableName).click();
         });
 
         cy.log("select a table from the second schema");
-        join();
-        entityPickerModal().within(() => {
-          entityPickerModalTab("Tables").click();
+        H.join();
+        H.entityPickerModal().within(() => {
+          H.entityPickerModalTab("Tables").click();
           cy.findByText("Public").click();
           cy.findByText("Many Data Types").click();
         });
-        popover().findByText("Name").click();
-        popover().findByText("Text").click();
+        H.popover().findByText("Name").click();
+        H.popover().findByText("Text").click();
 
         cy.log("select a table from the third schema");
-        join();
-        entityPickerModal().within(() => {
-          entityPickerModalTab("Tables").click();
+        H.join();
+        H.entityPickerModal().within(() => {
+          H.entityPickerModalTab("Tables").click();
           cy.findByText("Domestic").click();
           cy.findByText("Animals").click();
         });
-        popover().findByText("Name").click();
-        popover().findByText("Name").click();
+        H.popover().findByText("Name").click();
+        H.popover().findByText("Name").click();
       },
     );
 
@@ -223,23 +195,23 @@ describe("scenarios > notebook > data source", () => {
       cy.visit(`/model/${ORDERS_MODEL_ID}/query`);
 
       cy.findByTestId("data-step-cell").should("have.text", "Orders").click();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").should(
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").should(
           "have.attr",
           "aria-selected",
           "true",
         );
         // should not show databases step if there's only 1 database
-        entityPickerModalLevel(0).should("not.exist");
+        H.entityPickerModalLevel(0).should("not.exist");
         // should not show schema step if there's only 1 schema
-        entityPickerModalLevel(1).should("not.exist");
+        H.entityPickerModalLevel(1).should("not.exist");
         assertDataPickerEntitySelected(2, "Orders");
       });
     });
   });
 
   describe("saved entity as a source (aka the virtual table)", () => {
-    const modelDetails: StructuredQuestionDetails = {
+    const modelDetails: H.StructuredQuestionDetails = {
       name: "GUI Model",
       query: { "source-table": REVIEWS_ID, limit: 1 },
       display: "table",
@@ -248,19 +220,19 @@ describe("scenarios > notebook > data source", () => {
     };
 
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
     });
 
     it("data selector should properly show a model as the source (metabase#39699)", () => {
-      createQuestion(modelDetails, { visitQuestion: true });
-      openNotebook();
+      H.createQuestion(modelDetails, { visitQuestion: true });
+      H.openNotebook();
       cy.findByTestId("data-step-cell")
         .should("have.text", modelDetails.name)
         .click();
 
-      entityPickerModal().within(() => {
-        shouldDisplayTabs(["Models", "Tables", "Saved questions"]);
+      H.entityPickerModal().within(() => {
+        H.shouldDisplayTabs(["Models", "Tables", "Saved questions"]);
 
         assertDataPickerEntitySelected(0, "Our analytics");
         assertDataPickerEntitySelected(1, "First collection");
@@ -274,12 +246,12 @@ describe("scenarios > notebook > data source", () => {
     });
 
     it("moving the model to another collection should immediately be reflected in the data selector (metabase#39812-1)", () => {
-      visitModel(ORDERS_MODEL_ID);
-      openNotebook();
+      H.visitModel(ORDERS_MODEL_ID);
+      H.openNotebook();
 
       openDataSelector();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Models").should(
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Models").should(
           "have.attr",
           "aria-selected",
           "true",
@@ -293,8 +265,8 @@ describe("scenarios > notebook > data source", () => {
       moveToCollection("First collection");
 
       openDataSelector();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Models").should(
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Models").should(
           "have.attr",
           "aria-selected",
           "true",
@@ -318,18 +290,18 @@ describe("scenarios > notebook > data source", () => {
         query: { "source-table": `card__${SOURCE_QUESTION_ID}` },
       };
 
-      createQuestion(nestedQuestionDetails, {
+      H.createQuestion(nestedQuestionDetails, {
         wrapId: true,
         idAlias: "nestedQuestionId",
       });
 
       cy.log("see nested question in our analytics");
 
-      visitQuestion("@nestedQuestionId");
-      openNotebook();
+      H.visitQuestion("@nestedQuestionId");
+      H.openNotebook();
       openDataSelector();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Saved questions").should(
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Saved questions").should(
           "have.attr",
           "aria-selected",
           "true",
@@ -341,17 +313,17 @@ describe("scenarios > notebook > data source", () => {
       });
 
       cy.log("Move the source question to another collection");
-      visitQuestion(SOURCE_QUESTION_ID);
-      openNotebook();
+      H.visitQuestion(SOURCE_QUESTION_ID);
+      H.openNotebook();
       moveToCollection("First collection");
 
       cy.log("Make sure the source change is reflected in a nested question");
-      visitQuestion("@nestedQuestionId");
-      openNotebook();
+      H.visitQuestion("@nestedQuestionId");
+      H.openNotebook();
 
       openDataSelector();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Saved questions").should(
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Saved questions").should(
           "have.attr",
           "aria-selected",
           "true",
@@ -366,45 +338,45 @@ describe("scenarios > notebook > data source", () => {
 
 describe("scenarios > notebook > data source", { tags: "@OSS" }, () => {
   beforeEach(() => {
-    onlyOnOSS();
-    restore("setup");
+    H.onlyOnOSS();
+    H.restore("setup");
     cy.signInAsAdmin();
   });
 
   it("should not show saved questions if only models exist (metabase#25142)", () => {
-    createQuestion({
+    H.createQuestion({
       name: "GUI Model",
       query: { "source-table": REVIEWS_ID, limit: 1 },
       display: "table",
       type: "model",
     });
-    startNewQuestion();
-    entityPickerModal().within(() => {
+    H.startNewQuestion();
+    H.entityPickerModal().within(() => {
       cy.findAllByRole("tab").should("have.length", 2);
-      entityPickerModalTab("Tables").should("be.visible");
-      entityPickerModalTab("Models").should("be.visible");
-      entityPickerModalTab("Saved questions").should("not.exist");
+      H.entityPickerModalTab("Tables").should("be.visible");
+      H.entityPickerModalTab("Models").should("be.visible");
+      H.entityPickerModalTab("Saved questions").should("not.exist");
     });
   });
 });
 
 describe("issue 34350", { tags: "@external" }, () => {
   beforeEach(() => {
-    restore("postgres-12");
+    H.restore("postgres-12");
     cy.signInAsAdmin();
   });
 
   it("works after changing question's source table to a one from a different database (metabase#34350)", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
     openDataSelector();
-    entityPickerModal().within(() => {
+    H.entityPickerModal().within(() => {
       cy.findByText("QA Postgres12").click();
       cy.findByText("Orders").click();
     });
 
-    visualize();
+    H.visualize();
 
-    queryBuilderMain()
+    H.queryBuilderMain()
       .findByText("There was a problem with your question")
       .should("not.exist");
     cy.findAllByTestId("cell-data").should("contain", "37.65");
@@ -415,11 +387,11 @@ describe("issue 28106", () => {
   beforeEach(() => {
     const dialect = "postgres";
 
-    resetTestTable({ type: dialect, table: "many_schemas" });
-    restore(`${dialect}-writable`);
+    H.resetTestTable({ type: dialect, table: "many_schemas" });
+    H.restore(`${dialect}-writable`);
     cy.signInAsAdmin();
 
-    resyncDatabase({ dbId: WRITABLE_DB_ID });
+    H.resyncDatabase({ dbId: WRITABLE_DB_ID });
 
     cy.intercept("GET", "/api/collection/root").as("getRootCollection");
     cy.intercept("GET", "/api/collection/tree**").as("getTree");
@@ -429,21 +401,21 @@ describe("issue 28106", () => {
     "should not jump to the top of schema list when scrolling (metabase#28106)",
     { tags: "@external" },
     () => {
-      startNewQuestion();
+      H.startNewQuestion();
       cy.wait(["@getRootCollection", "@getTree"]);
 
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Writable Postgres12").click();
 
-        entityPickerModalLevel(1)
+        H.entityPickerModalLevel(1)
           .findByTestId("scroll-container")
           .as("schemasList");
 
         scrollAllTheWayDown();
 
         // assert scrolling worked and the last item is visible
-        entityPickerModalItem(1, "Public").should("be.visible");
+        H.entityPickerModalItem(1, "Public").should("be.visible");
 
         // simulate scrolling up using mouse wheel 3 times
         for (let i = 0; i < 3; ++i) {
@@ -480,29 +452,31 @@ describe("issue 28106", () => {
 
 describe("issue 32252", () => {
   beforeEach(() => {
-    restore("setup");
+    H.restore("setup");
     cy.signInAsAdmin();
 
-    createCollection({ name: "My collection" }).then(({ body: collection }) => {
-      if (typeof collection.id !== "number") {
-        throw new Error("collection.id is not a number");
-      }
+    H.createCollection({ name: "My collection" }).then(
+      ({ body: collection }) => {
+        if (typeof collection.id !== "number") {
+          throw new Error("collection.id is not a number");
+        }
 
-      createQuestion({
-        name: "My question",
-        collection_id: collection.id,
-        query: {
-          "source-table": ORDERS_ID,
-        },
-      });
-    });
+        H.createQuestion({
+          name: "My question",
+          collection_id: collection.id,
+          query: {
+            "source-table": ORDERS_ID,
+          },
+        });
+      },
+    );
   });
 
   it("refreshes data picker sources after archiving a collection (metabase#32252)", () => {
     cy.visit("/");
 
-    newButton("Question").click();
-    entityPickerModal().within(() => {
+    H.newButton("Question").click();
+    H.entityPickerModal().within(() => {
       cy.findByTestId("loading-indicator").should("not.exist");
       cy.findByText("Recents").should("not.exist");
       cy.findByText("Saved questions").should("be.visible");
@@ -510,16 +484,16 @@ describe("issue 32252", () => {
     });
 
     cy.findByTestId("sidebar-toggle").click();
-    navigationSidebar().findByText("Our analytics").click();
+    H.navigationSidebar().findByText("Our analytics").click();
 
     cy.button("Actions").click();
-    popover().findByText("Move to trash").click();
+    H.popover().findByText("Move to trash").click();
     cy.findByTestId("toast-undo")
       .findByText("Trashed collection")
       .should("be.visible");
 
-    newButton("Question").click();
-    entityPickerModal().within(() => {
+    H.newButton("Question").click();
+    H.entityPickerModal().within(() => {
       cy.findByTestId("loading-indicator").should("not.exist");
       cy.findByText("Recents").should("not.exist");
       cy.findByText("Saved questions").should("not.exist");
@@ -530,8 +504,8 @@ describe("issue 32252", () => {
   it("refreshes data picker sources after archiving a question (metabase#32252)", () => {
     cy.visit("/");
 
-    newButton("Question").click();
-    entityPickerModal().within(() => {
+    H.newButton("Question").click();
+    H.entityPickerModal().within(() => {
       cy.findByTestId("loading-indicator").should("not.exist");
       cy.findByText("Recents").should("not.exist");
       cy.findByText("Saved questions").should("be.visible");
@@ -539,17 +513,17 @@ describe("issue 32252", () => {
     });
 
     cy.findByTestId("sidebar-toggle").click();
-    navigationSidebar().findByText("Our analytics").click();
+    H.navigationSidebar().findByText("Our analytics").click();
 
     cy.findByTestId("collection-entry-name").click();
     cy.button("Actions").click();
-    popover().findByText("Move to trash").click();
+    H.popover().findByText("Move to trash").click();
     cy.findByTestId("toast-undo")
       .findByText("Trashed question")
       .should("be.visible");
 
-    newButton("Question").click();
-    entityPickerModal().within(() => {
+    H.newButton("Question").click();
+    H.entityPickerModal().within(() => {
       cy.findByTestId("loading-indicator").should("not.exist");
       cy.findByText("Recents").should("not.exist");
       cy.findByText("Saved questions").should("not.exist");
@@ -561,10 +535,10 @@ describe("issue 32252", () => {
 function moveToCollection(collection: string) {
   cy.intercept("GET", "/api/collection/tree**").as("updateCollectionTree");
 
-  openQuestionActions();
-  popover().findByTextEnsureVisible("Move").click();
+  H.openQuestionActions();
+  H.popover().findByTextEnsureVisible("Move").click();
 
-  entityPickerModal().within(() => {
+  H.entityPickerModal().within(() => {
     cy.findByText(collection).click();
     cy.button("Move").click();
     cy.wait("@updateCollectionTree");
@@ -576,9 +550,13 @@ function openDataSelector() {
 }
 
 function assertDataPickerEntitySelected(level: number, name: string) {
-  entityPickerModalItem(level, name).should("have.attr", "data-active", "true");
+  H.entityPickerModalItem(level, name).should(
+    "have.attr",
+    "data-active",
+    "true",
+  );
 }
 
 function assertDataPickerEntityNotSelected(level: number, name: string) {
-  entityPickerModalItem(level, name).should("not.have.attr", "data-active");
+  H.entityPickerModalItem(level, name).should("not.have.attr", "data-active");
 }

--- a/e2e/test/scenarios/question/notebook-link-to-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-link-to-data-source.cy.spec.ts
@@ -1,3 +1,4 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, USERS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
@@ -6,27 +7,6 @@ import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_MODEL_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  type NativeQuestionDetails,
-  assertDatasetReqIsSandboxed,
-  createNativeQuestion,
-  createQuestion,
-  describeEE,
-  entityPickerModal,
-  entityPickerModalTab,
-  getNotebookStep,
-  openNotebook,
-  openProductsTable,
-  openReviewsTable,
-  popover,
-  restore,
-  setTokenFeatures,
-  tableInteractive,
-  visitModel,
-  visitQuestion,
-  visitQuestionAdhoc,
-  visualize,
-} from "e2e/support/helpers";
 import { DataPermissionValue } from "metabase/admin/permissions/types";
 import { METAKEY } from "metabase/lib/browser";
 
@@ -50,7 +30,7 @@ const clickConfig = {
 
 describe("scenarios > notebook > link to data source", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.on("window:before:load", win => {
@@ -64,24 +44,24 @@ describe("scenarios > notebook > link to data source", () => {
   });
 
   it("smoke test", () => {
-    openReviewsTable({ mode: "notebook" });
+    H.openReviewsTable({ mode: "notebook" });
 
     cy.log("Normal click on the data source still opens the entity picker");
-    getNotebookStep("data").findByText("Reviews").click();
+    H.getNotebookStep("data").findByText("Reviews").click();
     cy.findByTestId("entity-picker-modal").within(() => {
       cy.findByText("Pick your starting data").should("be.visible");
       cy.findByLabelText("Close").click();
     });
 
     cy.log("Meta/Ctrl click on the fields picker behaves as a regular click");
-    getNotebookStep("data").findByTestId("fields-picker").click(clickConfig);
-    popover().within(() => {
+    H.getNotebookStep("data").findByTestId("fields-picker").click(clickConfig);
+    H.popover().within(() => {
       cy.findByText("Select none").click();
     });
     // Regular click on the fields picker again to close the popover
-    getNotebookStep("data").findByTestId("fields-picker").click();
+    H.getNotebookStep("data").findByTestId("fields-picker").click();
     // Mid-test sanity-check assertion
-    visualize();
+    H.visualize();
     cy.findAllByTestId("header-cell")
       .should("have.length", 1)
       .and("have.text", "ID");
@@ -89,10 +69,10 @@ describe("scenarios > notebook > link to data source", () => {
     cy.log(
       "Deselecting columns should have no effect on the linked data source in new tab/window",
     );
-    openNotebook();
+    H.openNotebook();
 
     cy.log("Make sure tooltip is being shown on hover");
-    getNotebookStep("data")
+    H.getNotebookStep("data")
       .findByText("Reviews")
       .should("be.visible")
       .realHover();
@@ -101,12 +81,12 @@ describe("scenarios > notebook > link to data source", () => {
       `${METAKEY}+click to open in new tab`,
     );
 
-    getNotebookStep("data").findByText("Reviews").click(clickConfig);
+    H.getNotebookStep("data").findByText("Reviews").click(clickConfig);
     cy.wait("@dataset"); // already intercepted in `visualize()`
 
     cy.log("Make sure Reviews table is rendered in a simple mode");
     cy.findAllByTestId("header-cell").should("contain", "Reviewer");
-    tableInteractive().should("contain", "xavier");
+    H.tableInteractive().should("contain", "xavier");
     cy.findByTestId("question-row-count").should(
       "have.text",
       "Showing 1,112 rows",
@@ -117,13 +97,13 @@ describe("scenarios > notebook > link to data source", () => {
 
   context("questions", () => {
     it("should open the source table from a simple question", () => {
-      visitQuestion(ORDERS_COUNT_QUESTION_ID);
-      openNotebook();
-      getNotebookStep("data").findByText("Orders").click(clickConfig);
+      H.visitQuestion(ORDERS_COUNT_QUESTION_ID);
+      H.openNotebook();
+      H.getNotebookStep("data").findByText("Orders").click(clickConfig);
 
       cy.log("Make sure Orders table is rendered in a simple mode");
       cy.findAllByTestId("header-cell").should("contain", "Subtotal");
-      tableInteractive().should("contain", "37.65");
+      H.tableInteractive().should("contain", "37.65");
       cy.findByTestId("question-row-count").should(
         "have.text",
         "Showing first 2,000 rows",
@@ -133,7 +113,7 @@ describe("scenarios > notebook > link to data source", () => {
     });
 
     it("should open the source question from a nested question", () => {
-      createQuestion(
+      H.createQuestion(
         {
           name: "Nested question based on a question",
           query: { "source-table": `card__${ORDERS_COUNT_QUESTION_ID}` },
@@ -141,8 +121,8 @@ describe("scenarios > notebook > link to data source", () => {
         { visitQuestion: true },
       );
 
-      openNotebook();
-      getNotebookStep("data").findByText("Orders, Count").click(clickConfig);
+      H.openNotebook();
+      H.getNotebookStep("data").findByText("Orders, Count").click(clickConfig);
 
       cy.log("Make sure the source question rendered in a simple mode");
       cy.location("pathname").should(
@@ -152,7 +132,7 @@ describe("scenarios > notebook > link to data source", () => {
       cy.findAllByTestId("header-cell")
         .should("have.length", "1")
         .and("have.text", "Count");
-      tableInteractive().should("contain", "18,760");
+      H.tableInteractive().should("contain", "18,760");
       cy.findByTestId("question-row-count").should(
         "have.text",
         "Showing 1 row",
@@ -171,8 +151,8 @@ describe("scenarios > notebook > link to data source", () => {
         },
       };
 
-      createNativeQuestion(source).then(({ body: sourceQuestion }) => {
-        createQuestion(
+      H.createNativeQuestion(source).then(({ body: sourceQuestion }) => {
+        H.createQuestion(
           {
             name: "Nested question based on a native question",
             query: { "source-table": `card__${sourceQuestion.id}` },
@@ -180,8 +160,8 @@ describe("scenarios > notebook > link to data source", () => {
           { visitQuestion: true },
         );
 
-        openNotebook();
-        getNotebookStep("data").findByText(source.name).click(clickConfig);
+        H.openNotebook();
+        H.getNotebookStep("data").findByText(source.name).click(clickConfig);
 
         cy.log("Make sure the source question rendered in a simple mode");
         cy.location("pathname").should(
@@ -206,7 +186,7 @@ describe("scenarios > notebook > link to data source", () => {
     });
 
     it("should open the source model from a nested question", () => {
-      createQuestion(
+      H.createQuestion(
         {
           name: "Nested question based on a model",
           query: { "source-table": `card__${ORDERS_MODEL_ID}` },
@@ -214,8 +194,8 @@ describe("scenarios > notebook > link to data source", () => {
         { visitQuestion: true },
       );
 
-      openNotebook();
-      getNotebookStep("data").findByText("Orders Model").click(clickConfig);
+      H.openNotebook();
+      H.getNotebookStep("data").findByText("Orders Model").click(clickConfig);
 
       cy.log("Make sure the source model is rendered in a simple mode");
       cy.location("pathname").should(
@@ -223,7 +203,7 @@ describe("scenarios > notebook > link to data source", () => {
         `/model/${ORDERS_MODEL_ID}-orders-model`,
       );
       cy.findAllByTestId("header-cell").should("contain", "Subtotal");
-      tableInteractive().should("contain", "37.65");
+      H.tableInteractive().should("contain", "37.65");
       cy.findByTestId("question-row-count").should(
         "have.text",
         "Showing first 2,000 rows",
@@ -234,7 +214,7 @@ describe("scenarios > notebook > link to data source", () => {
     });
 
     it("should open the source model from a nested question where the source is native model", () => {
-      const source: NativeQuestionDetails = {
+      const source: H.NativeQuestionDetails = {
         name: "Native source",
         native: {
           query: "select 1 as foo",
@@ -243,8 +223,8 @@ describe("scenarios > notebook > link to data source", () => {
         type: "model",
       };
 
-      createNativeQuestion(source).then(({ body: sourceQuestion }) => {
-        createQuestion(
+      H.createNativeQuestion(source).then(({ body: sourceQuestion }) => {
+        H.createQuestion(
           {
             name: "Nested question based on a native question",
             query: { "source-table": `card__${sourceQuestion.id}` },
@@ -252,8 +232,8 @@ describe("scenarios > notebook > link to data source", () => {
           { visitQuestion: true },
         );
 
-        openNotebook();
-        getNotebookStep("data")
+        H.openNotebook();
+        H.getNotebookStep("data")
           .findByText(sourceQuestion.name)
           .click(clickConfig);
 
@@ -275,7 +255,7 @@ describe("scenarios > notebook > link to data source", () => {
     });
 
     it('should open the "trash" if the source question has been archived', () => {
-      createQuestion({
+      H.createQuestion({
         name: "Nested question based on a question",
         query: { "source-table": `card__${ORDERS_COUNT_QUESTION_ID}` },
       }).then(({ body: nestedQuestion }) => {
@@ -284,11 +264,11 @@ describe("scenarios > notebook > link to data source", () => {
           archived: true,
         });
 
-        visitQuestion(nestedQuestion.id);
+        H.visitQuestion(nestedQuestion.id);
       });
 
-      openNotebook();
-      getNotebookStep("data").findByText("Orders, Count").click(clickConfig);
+      H.openNotebook();
+      H.getNotebookStep("data").findByText("Orders, Count").click(clickConfig);
 
       cy.log('Make sure the source question opens in the "trash"');
       cy.location("pathname").should(
@@ -304,9 +284,9 @@ describe("scenarios > notebook > link to data source", () => {
 
   context("models", () => {
     it("should open the underlying model", () => {
-      visitModel(ORDERS_MODEL_ID);
-      openNotebook();
-      getNotebookStep("data").findByText("Orders Model").click(clickConfig);
+      H.visitModel(ORDERS_MODEL_ID);
+      H.openNotebook();
+      H.getNotebookStep("data").findByText("Orders Model").click(clickConfig);
 
       cy.log("Make sure the source model is rendered in a simple mode");
       cy.location("pathname").should(
@@ -314,7 +294,7 @@ describe("scenarios > notebook > link to data source", () => {
         `/model/${ORDERS_MODEL_ID}-orders-model`,
       );
       cy.findAllByTestId("header-cell").should("contain", "Subtotal");
-      tableInteractive().should("contain", "37.65");
+      H.tableInteractive().should("contain", "37.65");
       cy.findByTestId("question-row-count").should(
         "have.text",
         "Showing first 2,000 rows",
@@ -325,7 +305,7 @@ describe("scenarios > notebook > link to data source", () => {
     });
 
     it("should open the underlying native model", () => {
-      const model: NativeQuestionDetails = {
+      const model: H.NativeQuestionDetails = {
         name: "Native model",
         native: {
           query: "select 1 as foo",
@@ -334,11 +314,11 @@ describe("scenarios > notebook > link to data source", () => {
         type: "model",
       };
 
-      createNativeQuestion(model).then(({ body: { id, name } }) => {
-        visitModel(id);
+      H.createNativeQuestion(model).then(({ body: { id, name } }) => {
+        H.visitModel(id);
 
-        openNotebook();
-        getNotebookStep("data").findByText(name).click(clickConfig);
+        H.openNotebook();
+        H.getNotebookStep("data").findByText(name).click(clickConfig);
 
         cy.log("Make sure the source model rendered in a simple mode");
         cy.location("pathname").should("eq", `/model/${id}-native-model`);
@@ -355,7 +335,7 @@ describe("scenarios > notebook > link to data source", () => {
     });
 
     it("should open the nested model (based on a question) as the data source", () => {
-      createQuestion(
+      H.createQuestion(
         {
           name: "Nested model based on a question",
           query: { "source-table": `card__${ORDERS_COUNT_QUESTION_ID}` },
@@ -364,8 +344,8 @@ describe("scenarios > notebook > link to data source", () => {
         { visitQuestion: true, wrapId: true, idAlias: "nestedModelId" },
       );
 
-      openNotebook();
-      getNotebookStep("data")
+      H.openNotebook();
+      H.getNotebookStep("data")
         .findByText("Nested model based on a question")
         .click(clickConfig);
 
@@ -387,7 +367,7 @@ describe("scenarios > notebook > link to data source", () => {
     });
 
     it("should open the nested model (based on a model) as the data source", () => {
-      createQuestion(
+      H.createQuestion(
         {
           name: "Nested model based on a model",
           query: { "source-table": `card__${ORDERS_MODEL_ID}` },
@@ -396,8 +376,8 @@ describe("scenarios > notebook > link to data source", () => {
         { visitQuestion: true, wrapId: true, idAlias: "nestedModelId" },
       );
 
-      openNotebook();
-      getNotebookStep("data")
+      H.openNotebook();
+      H.getNotebookStep("data")
         .findByText("Nested model based on a model")
         .click(clickConfig);
 
@@ -408,7 +388,7 @@ describe("scenarios > notebook > link to data source", () => {
           `/model/${id}-nested-model-based-on-a-model`,
         );
         cy.findAllByTestId("header-cell").should("contain", "Subtotal");
-        tableInteractive().should("contain", "37.65");
+        H.tableInteractive().should("contain", "37.65");
         cy.findByTestId("question-row-count").should(
           "have.text",
           "Showing first 2,000 rows",
@@ -422,7 +402,7 @@ describe("scenarios > notebook > link to data source", () => {
 
   context("permissions", () => {
     it("shouldn't show the source question if it lives in a collection that user can't see", () => {
-      createQuestion({
+      H.createQuestion({
         name: "Nested question based on a question",
         query: { "source-table": `card__${ORDERS_COUNT_QUESTION_ID}` },
       }).then(({ body: nestedQuestion }) => {
@@ -432,7 +412,7 @@ describe("scenarios > notebook > link to data source", () => {
         });
 
         cy.signInAsNormalUser();
-        visitQuestion(nestedQuestion.id);
+        H.visitQuestion(nestedQuestion.id);
 
         cy.log("We should not even show the notebook icon");
         cy.findByTestId("qb-header-action-panel")
@@ -448,13 +428,13 @@ describe("scenarios > notebook > link to data source", () => {
           cy.findByLabelText("Close").click();
         });
 
-        getNotebookStep("data").should("contain", "Pick your starting data");
+        H.getNotebookStep("data").should("contain", "Pick your starting data");
 
         cy.log(
           "The same should be true for a user that additionally doesn't have write query permissions",
         );
         cy.signIn("nodata");
-        visitQuestion(nestedQuestion.id);
+        H.visitQuestion(nestedQuestion.id);
         cy.findByTestId("qb-header-action-panel")
           .icon("notebook")
           .should("not.exist");
@@ -465,17 +445,17 @@ describe("scenarios > notebook > link to data source", () => {
           cy.findByLabelText("Close").click();
         });
 
-        getNotebookStep("data").should("contain", "Pick your starting data");
+        H.getNotebookStep("data").should("contain", "Pick your starting data");
       });
     });
 
     it("user with the curate collection permissions but without write query permissions shouldn't be able to see/open the source question", () => {
-      createQuestion({
+      H.createQuestion({
         name: "Nested question based on a question",
         query: { "source-table": `card__${ORDERS_COUNT_QUESTION_ID}` },
       }).then(({ body: nestedQuestion }) => {
         cy.signIn("nodata");
-        visitQuestion(nestedQuestion.id);
+        H.visitQuestion(nestedQuestion.id);
 
         cy.log("We should not even show the notebook icon");
         cy.findByTestId("qb-header-action-panel")
@@ -487,9 +467,9 @@ describe("scenarios > notebook > link to data source", () => {
       });
     });
 
-    describeEE("sandboxing", () => {
+    H.describeEE("sandboxing", () => {
       beforeEach(() => {
-        setTokenFeatures("all");
+        H.setTokenFeatures("all");
 
         cy.updatePermissionsGraph({
           [ALL_USERS_GROUP_ID]: {
@@ -514,18 +494,18 @@ describe("scenarios > notebook > link to data source", () => {
       });
 
       it("should work for sandboxed users when opening a table/question/model", () => {
-        visitModel(ORDERS_MODEL_ID);
+        H.visitModel(ORDERS_MODEL_ID);
         cy.findByTestId("question-row-count").should(
           "have.text",
           "Showing 11 rows",
         );
-        openNotebook();
-        getNotebookStep("data").findByText("Orders Model").click(clickConfig);
+        H.openNotebook();
+        H.getNotebookStep("data").findByText("Orders Model").click(clickConfig);
         cy.findByTestId("question-row-count").should(
           "have.text",
           "Showing 11 rows",
         );
-        assertDatasetReqIsSandboxed({
+        H.assertDatasetReqIsSandboxed({
           requestAlias: `@modelQuery${ORDERS_MODEL_ID}`,
         });
       });
@@ -533,14 +513,14 @@ describe("scenarios > notebook > link to data source", () => {
       it("should work for sandboxed users when joined table is sandboxed", () => {
         cy.intercept("/api/dataset").as("dataset");
 
-        openProductsTable({ mode: "notebook" });
+        H.openProductsTable({ mode: "notebook" });
         cy.findByTestId("action-buttons").button("Join data").click();
-        entityPickerModal().within(() => {
-          entityPickerModalTab("Tables").click();
+        H.entityPickerModal().within(() => {
+          H.entityPickerModalTab("Tables").click();
           cy.findByText("Orders").click();
         });
 
-        getNotebookStep("join")
+        H.getNotebookStep("join")
           .findByLabelText("Right table")
           .should("have.text", "Orders")
           .click(clickConfig);
@@ -549,7 +529,7 @@ describe("scenarios > notebook > link to data source", () => {
           "have.text",
           "Showing 11 rows",
         );
-        assertDatasetReqIsSandboxed({
+        H.assertDatasetReqIsSandboxed({
           columnId: ORDERS.USER_ID,
           columnAssertion: USERS.sandboxed.login_attributes.attr_uid,
         });
@@ -632,19 +612,19 @@ describe("scenarios > notebook > link to data source", () => {
     };
 
     it("rhs joined data sources should open in a new tab on the meta/ctrl click", () => {
-      createQuestion({
+      H.createQuestion({
         name: "People - Saved Question",
         query: {
           "source-table": PEOPLE_ID,
         },
       }).then(({ body: savedQuestion }) => {
         const queryWithMultipleJoins = getQuery(savedQuestion.id);
-        visitQuestionAdhoc(queryWithMultipleJoins, { mode: "notebook" });
+        H.visitQuestionAdhoc(queryWithMultipleJoins, { mode: "notebook" });
 
         (function testModel() {
           cy.log("Model should open in a new tab");
 
-          getNotebookStep("join", { stage: 0, index: 0 }).within(() => {
+          H.getNotebookStep("join", { stage: 0, index: 0 }).within(() => {
             cy.findByLabelText("Right table")
               .should("have.text", "Orders Model")
               .click(clickConfig);
@@ -655,7 +635,7 @@ describe("scenarios > notebook > link to data source", () => {
             `/model/${ORDERS_MODEL_ID}-orders-model`,
           );
           cy.findAllByTestId("header-cell").should("contain", "Subtotal");
-          tableInteractive().should("contain", "37.65");
+          H.tableInteractive().should("contain", "37.65");
           cy.findByTestId("question-row-count").should(
             "have.text",
             "Showing first 2,000 rows",
@@ -669,7 +649,7 @@ describe("scenarios > notebook > link to data source", () => {
         (function testSavedQuestion() {
           cy.log("Saved question should open in a new tab");
 
-          getNotebookStep("join", { stage: 0, index: 1 }).within(() => {
+          H.getNotebookStep("join", { stage: 0, index: 1 }).within(() => {
             cy.findByLabelText("Right table")
               .should("have.text", savedQuestion.name)
               .click(clickConfig);
@@ -680,7 +660,7 @@ describe("scenarios > notebook > link to data source", () => {
             `/question/${savedQuestion.id}-people-saved-question`,
           );
           cy.findAllByTestId("header-cell").should("contain", "City");
-          tableInteractive().should("contain", "Beaver Dams");
+          H.tableInteractive().should("contain", "Beaver Dams");
           cy.findByTestId("question-row-count").should(
             "have.text",
             "Showing first 2,000 rows",
@@ -693,14 +673,14 @@ describe("scenarios > notebook > link to data source", () => {
 
         (function testRawTable() {
           cy.log("Raw table should open in a new tab");
-          getNotebookStep("join", { stage: 0, index: 2 }).within(() => {
+          H.getNotebookStep("join", { stage: 0, index: 2 }).within(() => {
             cy.findByLabelText("Right table")
               .should("have.text", "Reviews")
               .click(clickConfig);
           });
 
           cy.findAllByTestId("header-cell").should("contain", "Reviewer");
-          tableInteractive().should("contain", "xavier");
+          H.tableInteractive().should("contain", "xavier");
           cy.findByTestId("question-row-count").should(
             "have.text",
             "Showing 1,112 rows",
@@ -715,47 +695,47 @@ describe("scenarios > notebook > link to data source", () => {
           cy.log(
             "Join type selector behaves the same regardless of the click keyboard modifiers",
           );
-          getNotebookStep("join")
+          H.getNotebookStep("join")
             .findByLabelText("Change join type")
             .click(clickConfig);
-          popover().should("contain", "Inner join");
+          H.popover().should("contain", "Inner join");
 
           cy.log(
             "Pick columns selector behaves the same regardless of the click keyboard modifiers",
           );
-          getNotebookStep("join")
+          H.getNotebookStep("join")
             .findByLabelText("Pick columns")
             .click(clickConfig);
-          popover().should("contain", "Discount");
+          H.popover().should("contain", "Discount");
 
           cy.log(
             "Left column join condition selector behaves the same regardless of the click keyboard modifiers",
           );
-          getNotebookStep("join")
+          H.getNotebookStep("join")
             .findByLabelText("Left column")
             .click(clickConfig);
-          popover().should("contain", "Vendor");
+          H.popover().should("contain", "Vendor");
 
           cy.log(
             "Operator selector behaves the same regardless of the click keyboard modifiers",
           );
-          getNotebookStep("join")
+          H.getNotebookStep("join")
             .findByLabelText("Change operator")
             .click(clickConfig);
-          popover().should("contain", ">=");
+          H.popover().should("contain", ">=");
 
           cy.log(
             "Right column join condition selector behaves the same regardless of the click keyboard modifiers",
           );
-          getNotebookStep("join")
+          H.getNotebookStep("join")
             .findByLabelText("Right column")
             .click(clickConfig);
-          popover().should("contain", "Discount");
+          H.popover().should("contain", "Discount");
 
           cy.log(
             "New join condition button behaves the same regardless of the click keyboard modifiers",
           );
-          getNotebookStep("join")
+          H.getNotebookStep("join")
             .findByLabelText("Add condition")
             .click(clickConfig);
           cy.findByTestId("new-join-condition").should("be.visible");

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -1,44 +1,18 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  addCustomColumn,
-  addSummaryField,
-  addSummaryGroupingField,
-  createQuestion,
-  enterCustomColumnDetails,
-  entityPickerModal,
-  entityPickerModalTab,
-  filter,
-  filterField,
-  getNotebookStep,
-  hovercard,
-  join,
-  moveDnDKitElement,
-  openNotebook,
-  openOrdersTable,
-  openProductsTable,
-  openTable,
-  popover,
-  restore,
-  selectFilterOperator,
-  startNewQuestion,
-  summarize,
-  verifyNotebookQuery,
-  visitQuestionAdhoc,
-  visualize,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PEOPLE, PEOPLE_ID, PRODUCTS, PRODUCTS_ID } =
   SAMPLE_DATABASE;
 
 describe("scenarios > question > notebook", { tags: "@slow" }, () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("shouldn't offer to save the question when there were no changes (metabase#13470)", () => {
-    openOrdersTable();
+    H.openOrdersTable();
     // save question initially
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
@@ -48,7 +22,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Not now").click();
     // enter "notebook" and visualize without changing anything
-    openNotebook();
+    H.openNotebook();
 
     cy.button("Visualize").click();
 
@@ -58,7 +32,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
   });
 
   it("should allow post-aggregation filters", () => {
-    openTable({
+    H.openTable({
       table: ORDERS_ID,
       mode: "notebook",
     });
@@ -68,25 +42,25 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     // count orders by user id, filter to the one user with 46 orders
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Pick a function or metric").click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Count of rows").click();
     });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Pick a column to group by").click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.contains("User ID").click();
     });
     cy.findByTestId("step-summarize-0-0").within(() => {
       cy.icon("filter").click();
     });
-    popover().icon("int").click();
-    selectFilterOperator("Equal to");
-    popover().within(() => {
+    H.popover().icon("int").click();
+    H.selectFilterOperator("Equal to");
+    H.popover().within(() => {
       cy.findByPlaceholderText("Enter a number").type("46");
       cy.contains("Add filter").click();
     });
 
-    visualize();
+    H.visualize();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("2372"); // user's id in the table
@@ -95,13 +69,13 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
   });
 
   it("shouldn't show sub-dimensions for FK (metabase#16787)", () => {
-    openOrdersTable({ mode: "notebook" });
-    summarize({ mode: "notebook" });
-    getNotebookStep("summarize")
+    H.openOrdersTable({ mode: "notebook" });
+    H.summarize({ mode: "notebook" });
+    H.getNotebookStep("summarize")
       .findByText("Pick a column to group by")
       .click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("User ID")
         .findByLabelText("Binning strategy")
         .should("not.exist");
@@ -112,7 +86,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
   });
 
   it("should show the original custom expression filter field on subsequent click (metabase#14726)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         database: SAMPLE_DB_ID,
         query: {
@@ -126,7 +100,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("ID is between 96 and 97").click();
-    popover().findByText("Between").click();
+    H.popover().findByText("Between").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Is not");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -138,29 +112,29 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
   it("should append indexes to duplicate custom expression names (metabase#12104)", () => {
     cy.viewport(1920, 800); // we're looking for a column name beyond the right of the default viewport
     cy.intercept("POST", "/api/dataset").as("dataset");
-    openProductsTable({ mode: "notebook" });
+    H.openProductsTable({ mode: "notebook" });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom column").click();
     addSimpleCustomColumn("EXPR");
 
-    getNotebookStep("expression").within(() => {
+    H.getNotebookStep("expression").within(() => {
       cy.icon("add").click();
     });
     addSimpleCustomColumn("EXPR");
 
-    getNotebookStep("expression").within(() => {
+    H.getNotebookStep("expression").within(() => {
       cy.icon("add").click();
     });
     addSimpleCustomColumn("EXPR");
 
-    getNotebookStep("expression").within(() => {
+    H.getNotebookStep("expression").within(() => {
       cy.findByText("EXPR");
       cy.findByText("EXPR (1)");
       cy.findByText("EXPR (2)");
     });
 
-    visualize();
+    H.visualize();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("EXPR");
@@ -171,16 +145,16 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
   });
 
   it("should process the updated expression when pressing Enter", () => {
-    openProductsTable({ mode: "notebook" });
-    filter({ mode: "notebook" });
+    H.openProductsTable({ mode: "notebook" });
+    H.filter({ mode: "notebook" });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
 
-    enterCustomColumnDetails({ formula: "[Price] > 1" });
+    H.enterCustomColumnDetails({ formula: "[Price] > 1" });
 
     cy.button("Done").click();
 
-    getNotebookStep("filter").contains("Price is greater than 1").click();
+    H.getNotebookStep("filter").contains("Price is greater than 1").click();
 
     // change the corresponding custom expression
     cy.get(".Icon-chevronleft").click();
@@ -195,10 +169,12 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     // the input properly before typing), and this check helps to highlight that.
     cy.findByTestId("expression-editor-textfield").should("not.exist");
 
-    getNotebookStep("filter")
+    H.getNotebookStep("filter")
       .contains("Price is greater than 1")
       .should("exist");
-    getNotebookStep("filter").contains("Price is less than 5").should("exist");
+    H.getNotebookStep("filter")
+      .contains("Price is less than 5")
+      .should("exist");
   });
 
   it("should show the real number of rows instead of HARD_ROW_LIMIT when loading (metabase#17397)", () => {
@@ -232,7 +208,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Product ID is 2").click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByLabelText("Filter value").focus().type("3").blur();
       cy.button("Update filter").click();
     });
@@ -246,10 +222,10 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
   it("should show an info popover for dimensions listened by the custom expression editor", () => {
     // start a custom question with orders
-    openOrdersTable({ mode: "notebook" });
-    filter({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
+    H.filter({ mode: "notebook" });
 
-    popover().contains("Custom Expression").click();
+    H.popover().contains("Custom Expression").click();
 
     cy.findByTestId("expression-editor-textfield").within(() => {
       cy.get(".ace_text-input").focus().type("[");
@@ -262,14 +238,14 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       .findByLabelText("More info")
       .realHover();
 
-    hovercard().within(() => {
+    H.hovercard().within(() => {
       cy.contains("The date and time an order was submitted.");
       cy.contains("Creation timestamp");
     });
   });
 
   it("should show an info card filter columns in the popover", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter").click();
@@ -283,7 +259,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       .findByLabelText("More info")
       .realHover();
 
-    hovercard().within(() => {
+    H.hovercard().within(() => {
       cy.contains("Foreign Key");
       cy.findByText(/The id of the user/);
     });
@@ -291,10 +267,10 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
   describe.skip("popover rendering issues (metabase#15502)", () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
       cy.viewport(1280, 720);
-      startNewQuestion();
+      H.startNewQuestion();
       cy.findByTextEnsureVisible("Sample Database").click();
       cy.findByTextEnsureVisible("Orders").click();
     });
@@ -303,11 +279,11 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       // Initial filter popover usually renders correctly within the viewport
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add filters to narrow your answer").as("filter").click();
-      popover().isRenderedWithinViewport();
+      H.popover().isRenderedWithinViewport();
       // Click anywhere outside this popover to close it because the issue with rendering happens when popover opens for the second time
       cy.icon("gear").click();
       cy.get("@filter").click();
-      popover().isRenderedWithinViewport();
+      H.popover().isRenderedWithinViewport();
     });
 
     it("popover should not cover the button that invoked it (metabase#15502-2)", () => {
@@ -327,13 +303,13 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       // This is required because TableInteractive won't render columns
       // that don't fit into the viewport
       cy.viewport(1400, 1000);
-      openOrdersTable({ mode: "notebook" });
+      H.openOrdersTable({ mode: "notebook" });
     });
 
     it("should work on custom column with `case`", () => {
       cy.findByLabelText("Custom column").click();
 
-      enterCustomColumnDetails({
+      H.enterCustomColumnDetails({
         formula: "case([Subtotal] + Tax > 100, 'Big', 'Small')",
       });
 
@@ -343,9 +319,9 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
       cy.button("Done").should("not.be.disabled").click();
 
-      getNotebookStep("expression").contains("Example").should("exist");
+      H.getNotebookStep("expression").contains("Example").should("exist");
 
-      visualize();
+      H.visualize();
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Example");
@@ -356,18 +332,18 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     });
 
     it("should work on custom filter", () => {
-      filter({ mode: "notebook" });
+      H.filter({ mode: "notebook" });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Custom Expression").click();
 
-      enterCustomColumnDetails({ formula: "[Subtotal] - Tax > 140" });
+      H.enterCustomColumnDetails({ formula: "[Subtotal] - Tax > 140" });
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains(/^redundant input/i).should("not.exist");
 
       cy.button("Done").should("not.be.disabled").click();
 
-      visualize();
+      H.visualize();
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Showing 97 rows");
@@ -390,16 +366,16 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       const [expression, result] = formula;
 
       it(`should work on custom aggregation with ${filter}`, () => {
-        summarize({ mode: "notebook" });
-        popover().contains("Custom Expression").click();
+        H.summarize({ mode: "notebook" });
+        H.popover().contains("Custom Expression").click();
 
-        enterCustomColumnDetails({ formula: expression });
+        H.enterCustomColumnDetails({ formula: expression });
 
         cy.findByPlaceholderText("Something nice and descriptive")
           .click()
           .type(filter);
 
-        popover().within(() => {
+        H.popover().within(() => {
           cy.contains(/^expected closing parenthesis/i).should("not.exist");
           cy.contains(/^redundant input/i).should("not.exist");
         });
@@ -407,7 +383,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
         cy.findByTestId("aggregate-step").contains(filter).should("exist");
 
-        visualize();
+        H.visualize();
 
         cy.findByTestId("qb-header").contains(filter);
         cy.findByTestId("query-builder-main").contains(result);
@@ -418,14 +394,14 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
   // intentional simplification of "Select none" to quickly
   // fix users' pain caused by the inability to unselect all columns
   it("select no columns select the first one", () => {
-    openTable({
+    H.openTable({
       table: ORDERS_ID,
       mode: "notebook",
     });
 
     cy.findByTestId("fields-picker").click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Select none").click();
       cy.findByLabelText("ID").should("be.disabled");
       cy.findByText("Tax").click();
@@ -434,7 +410,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
     cy.findByTestId("step-data-0-0").findByText("Data").click(); //Dismiss popover
 
-    visualize();
+    H.visualize();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Tax");
@@ -443,15 +419,15 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
   });
 
   it("should render a field info icon in the fields picker", () => {
-    openTable({
+    H.openTable({
       table: ORDERS_ID,
       mode: "notebook",
     });
 
     cy.findByTestId("fields-picker").click();
-    popover().findAllByLabelText("More info").first().realHover();
+    H.popover().findAllByLabelText("More info").first().realHover();
 
-    hovercard().contains("This is a unique ID");
+    H.hovercard().contains("This is a unique ID");
   });
 
   it("should treat max/min on a name as a string filter (metabase#21973)", () => {
@@ -467,11 +443,11 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
     cy.createQuestion(questionDetails, { visitQuestion: true });
 
-    filter();
+    H.filter();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Summaries").click();
 
-    filterField("Max of Name", {
+    H.filterField("Max of Name", {
       operator: "Starts with",
     });
   });
@@ -489,10 +465,10 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
     cy.createQuestion(questionDetails, { visitQuestion: true });
 
-    filter();
+    H.filter();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Summaries").click();
-    filterField("Min of Vendor", {
+    H.filterField("Min of Vendor", {
       operator: "ends with",
     });
   });
@@ -517,20 +493,20 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       { visitQuestion: true },
     );
 
-    openNotebook();
+    H.openNotebook();
 
-    join();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Models").click();
+    H.join();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Models").click();
       cy.findByText("Products model").click();
     });
 
-    visualize();
+    H.visualize();
   });
 
   // flaky test
   it.skip("should show an info popover when hovering over a field picker option for a table", () => {
-    startNewQuestion();
+    H.startNewQuestion();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Sample Database").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -541,8 +517,8 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Total").trigger("mouseenter");
 
-    popover().contains("The total billed amount.");
-    popover().contains("80.36");
+    H.popover().contains("The total billed amount.");
+    H.popover().contains("80.36");
   });
 
   // flaky test
@@ -553,7 +529,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     });
 
     // start a custom question with question a
-    startNewQuestion();
+    H.startNewQuestion();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Saved Questions").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -564,8 +540,8 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("A_COLUMN").trigger("mouseenter");
 
-    popover().contains("A_COLUMN");
-    popover().contains("No description");
+    H.popover().contains("A_COLUMN");
+    H.popover().contains("No description");
   });
 
   it("should allow to pick a saved question when there are models", () => {
@@ -575,41 +551,41 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       native: { query: "SELECT * FROM ORDERS" },
     });
 
-    startNewQuestion();
+    H.startNewQuestion();
 
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Saved questions").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Saved questions").click();
       cy.findByText("Orders, Count").click();
     });
 
-    visualize();
+    H.visualize();
   });
 
   it('should not show "median" aggregation option for databases that do not support "percentile-aggregations" driver feature', () => {
-    startNewQuestion();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.startNewQuestion();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Orders").click();
     });
 
-    getNotebookStep("summarize")
+    H.getNotebookStep("summarize")
       .findByText("Pick a function or metric")
       .click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Median of ...").should("not.exist");
     });
   });
 
   describe('"median" aggregation function', { tags: "@external" }, () => {
     beforeEach(() => {
-      restore("postgres-12");
+      H.restore("postgres-12");
       cy.signInAsAdmin();
 
       cy.request(`/api/database/${WRITABLE_DB_ID}/schema/public`).then(
         ({ body }) => {
           const tableId = body.find(table => table.name === "products").id;
-          openTable({
+          H.openTable({
             database: WRITABLE_DB_ID,
             table: tableId,
             mode: "notebook",
@@ -621,23 +597,23 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     it('should show "median" aggregation option for databases that support "percentile-aggregations" driver feature', () => {
       cy.findByRole("button", { name: "Summarize" }).click();
 
-      addSummaryField({ metric: "Median of ...", field: "Price" });
+      H.addSummaryField({ metric: "Median of ...", field: "Price" });
 
-      getNotebookStep("summarize")
+      H.getNotebookStep("summarize")
         .findByText("Median of Price")
         .should("be.visible");
 
-      addSummaryGroupingField({ field: "Category" });
+      H.addSummaryGroupingField({ field: "Category" });
 
-      visualize();
+      H.visualize();
 
       cy.findByLabelText("Switch to data").click();
       cy.findAllByTestId("header-cell").should("contain", "Median of Price");
     });
 
     it("should support custom columns", () => {
-      addCustomColumn();
-      enterCustomColumnDetails({
+      H.addCustomColumn();
+      H.enterCustomColumnDetails({
         formula: "Price * 10",
         name: "Mega price",
       });
@@ -645,22 +621,22 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
       cy.findByRole("button", { name: "Summarize" }).click();
 
-      addSummaryField({ metric: "Median of ...", field: "Mega price" });
-      addSummaryField({ metric: "Count of rows" });
-      addSummaryGroupingField({ field: "Category" });
-      addSummaryGroupingField({ field: "Vendor" });
+      H.addSummaryField({ metric: "Median of ...", field: "Mega price" });
+      H.addSummaryField({ metric: "Count of rows" });
+      H.addSummaryGroupingField({ field: "Category" });
+      H.addSummaryGroupingField({ field: "Vendor" });
 
-      summarize({ mode: "notebook" });
+      H.summarize({ mode: "notebook" });
 
-      addSummaryField({
+      H.addSummaryField({
         metric: "Median of ...",
         field: "Median of Mega price",
         stage: 1,
       });
-      addSummaryField({ metric: "Median of ...", field: "Count", stage: 1 });
-      addSummaryGroupingField({ field: "Category", stage: 1 });
+      H.addSummaryField({ metric: "Median of ...", field: "Count", stage: 1 });
+      H.addSummaryGroupingField({ field: "Category", stage: 1 });
 
-      visualize();
+      H.visualize();
 
       cy.findByLabelText("Switch to data").click();
       cy.findAllByTestId("header-cell")
@@ -669,39 +645,39 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     });
 
     it("should support Summarize side panel", () => {
-      visualize();
+      H.visualize();
 
-      summarize();
+      H.summarize();
 
       cy.findByTestId("add-aggregation-button").click();
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Median of ...").should("be.visible");
       });
     });
   });
 
   it("should properly render previews (metabase#28726, metabase#29959, metabase#40608)", () => {
-    startNewQuestion();
+    H.startNewQuestion();
 
     cy.log(
       "Preview should not be possible without the source data (metabase#40608)",
     );
-    getNotebookStep("data")
+    H.getNotebookStep("data")
       .as("dataStep")
       .within(() => {
         cy.findByText("Pick your starting data").should("exist");
         cy.icon("play").should("not.be.visible");
       });
 
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Orders").click();
     });
 
     cy.get("@dataStep").icon("play").should("be.visible");
-    getNotebookStep("filter").icon("play").should("not.be.visible");
-    getNotebookStep("summarize").icon("play").should("not.be.visible");
+    H.getNotebookStep("filter").icon("play").should("not.be.visible");
+    H.getNotebookStep("summarize").icon("play").should("not.be.visible");
 
     cy.get("@dataStep").within(() => {
       cy.icon("play").click();
@@ -713,7 +689,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     });
 
     cy.button("Row limit").click();
-    getNotebookStep("limit").within(() => {
+    H.getNotebookStep("limit").within(() => {
       cy.findByPlaceholderText("Enter a limit").type("5").realPress("Tab");
 
       cy.icon("play").click();
@@ -727,7 +703,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
   it("should be able to drag-n-drop query clauses", () => {
     function moveElement({ name, horizontal, vertical, index }) {
-      moveDnDKitElement(cy.findByText(name), {
+      H.moveDnDKitElement(cy.findByText(name), {
         horizontal,
         vertical,
       });
@@ -743,14 +719,14 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       horizontal,
       vertical,
     }) {
-      getNotebookStep(type).findByText(name).click();
-      popover().within(() => {
-        moveDnDKitElement(cy.findByText("Is"), {
+      H.getNotebookStep(type).findByText(name).click();
+      H.popover().within(() => {
+        H.moveDnDKitElement(cy.findByText("Is"), {
           horizontal,
           vertical,
         });
       });
-      getNotebookStep(type)
+      H.getNotebookStep(type)
         .findAllByTestId("notebook-cell-item")
         .eq(index)
         .should("have.text", name);
@@ -787,14 +763,14 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       },
     };
     cy.createQuestion(questionDetails, { visitQuestion: true });
-    openNotebook();
-    getNotebookStep("expression").within(() => {
+    H.openNotebook();
+    H.getNotebookStep("expression").within(() => {
       moveElement({ name: "E1", horizontal: 100, index: 1 });
     });
-    getNotebookStep("filter").within(() => {
+    H.getNotebookStep("filter").within(() => {
       moveElement({ name: "ID is 2", horizontal: -100, index: 0 });
     });
-    getNotebookStep("summarize").within(() => {
+    H.getNotebookStep("summarize").within(() => {
       cy.findByTestId("aggregate-step").within(() => {
         moveElement({ name: "Count", vertical: 100, index: 4 });
       });
@@ -802,7 +778,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
         moveElement({ name: "ID", horizontal: 100, index: 1 });
       });
     });
-    getNotebookStep("sort").within(() => {
+    H.getNotebookStep("sort").within(() => {
       moveElement({ name: "Average of Total", horizontal: -100, index: 0 });
     });
     verifyPopoverDoesNotMoveElement({
@@ -840,13 +816,13 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
         },
       };
 
-      createQuestion(questionDetails, { visitQuestion: true });
+      H.createQuestion(questionDetails, { visitQuestion: true });
 
-      openNotebook();
+      H.openNotebook();
 
-      getNotebookStep("summarize").contains("Revenue").click();
+      H.getNotebookStep("summarize").contains("Revenue").click();
 
-      popover()
+      H.popover()
         .findByTestId("expression-editor-textfield")
         .contains("[Revenue]");
     });
@@ -879,7 +855,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
       cy.createQuestion(questionDetails, { visitQuestion: true });
 
-      openNotebook();
+      H.openNotebook();
 
       cy.findByText("Pick a column to group by").click();
       cy.findByText("Created At").click();
@@ -887,14 +863,14 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
       // Sorts ascending by default
       // Revenue appears twice, but it's the only integer column to order by
-      popover().icon("int").click();
+      H.popover().icon("int").click();
 
       // Let's make sure it's possible to sort descending as well
       cy.icon("arrow_up").click();
 
       cy.icon("arrow_down").parent().contains("Revenue");
 
-      visualize();
+      H.visualize();
       // Visualization will render line chart by default. Switch to the table.
       cy.icon("table2").click();
 
@@ -922,7 +898,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
   });
 
   it.skip("should open only one bucketing popover at a time (metabase#45036)", () => {
-    visitQuestionAdhoc(
+    H.visitQuestionAdhoc(
       {
         dataset_query: {
           database: SAMPLE_DB_ID,
@@ -934,16 +910,16 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       { mode: "notebook" },
     );
 
-    getNotebookStep("summarize")
+    H.getNotebookStep("summarize")
       .findByText("Pick a column to group by")
       .click();
 
-    popover()
+    H.popover()
       .findByRole("option", { name: "Created At" })
       .findByText("by month")
       .click();
 
-    popover()
+    H.popover()
       .last()
       .within(() => {
         cy.findByText("Year").should("be.visible");
@@ -952,13 +928,13 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
         cy.findByText("Hour of day").should("be.visible");
       });
 
-    popover()
+    H.popover()
       .first()
       .findByRole("option", { name: "Price" })
       .findByText("Auto bin")
       .click();
 
-    popover()
+    H.popover()
       .last()
       .within(() => {
         cy.findByText("Auto bin").should("be.visible");
@@ -977,7 +953,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     // The issue is reproducible on all viewports, but the smaller the viewport is,
     // the more likely the issue is going to occur.
     cy.viewport(300, 800);
-    createQuestion(
+    H.createQuestion(
       {
         query: {
           "source-table": ORDERS_ID,
@@ -992,9 +968,9 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       },
       { visitQuestion: true },
     );
-    openNotebook();
+    H.openNotebook();
 
-    verifyNotebookQuery("Orders", [
+    H.verifyNotebookQuery("Orders", [
       {
         expressions: [CUSTOM_COLUMN_LONG_NAME],
         filters: [`${CUSTOM_COLUMN_LONG_NAME} is less than 1000000`],
@@ -1029,7 +1005,7 @@ function assertTableRowCount(expectedCount) {
 }
 
 function addSimpleCustomColumn(name) {
-  enterCustomColumnDetails({ formula: "C", blur: false });
+  H.enterCustomColumnDetails({ formula: "C", blur: false });
   cy.findByText("ategory").click();
   cy.findByPlaceholderText("Something nice and descriptive").click().type(name);
   cy.button("Done").click();

--- a/e2e/test/scenarios/question/nulls.cy.spec.js
+++ b/e2e/test/scenarios/question/nulls.cy.spec.js
@@ -1,21 +1,11 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  addOrUpdateDashboardCard,
-  cartesianChartCircle,
-  openOrdersTable,
-  popover,
-  restore,
-  rightSidebar,
-  summarize,
-  updateDashboardCards,
-  visitDashboard,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > question > null", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -77,7 +67,7 @@ describe("scenarios > question > null", () => {
         ],
       },
     }).then(({ body: { card_id, dashboard_id } }) => {
-      addOrUpdateDashboardCard({
+      H.addOrUpdateDashboardCard({
         card_id,
         dashboard_id,
         card: {
@@ -121,7 +111,7 @@ describe("scenarios > question > null", () => {
         cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
           cy.log("Add both previously created questions to the dashboard");
 
-          updateDashboardCards({
+          H.updateDashboardCards({
             dashboard_id: DASHBOARD_ID,
             cards: [
               { card_id: Q1_ID, row: 0, col: 0, size_x: 8, size_y: 4 },
@@ -129,7 +119,7 @@ describe("scenarios > question > null", () => {
             ],
           });
 
-          visitDashboard(DASHBOARD_ID);
+          H.visitDashboard(DASHBOARD_ID);
           cy.log("P0 regression in v0.37.1!");
           cy.findByTestId("loading-indicator").should("not.exist");
           cy.findByText("13801_Q1");
@@ -141,7 +131,7 @@ describe("scenarios > question > null", () => {
   });
 
   it("should filter by clicking on the row with `null` value (metabase#18386)", () => {
-    openOrdersTable();
+    H.openOrdersTable();
 
     // Total of "39.72", and the next cell is the `discount` (which is empty)
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -153,7 +143,7 @@ describe("scenarios > question > null", () => {
       // Open the context menu that lets us apply filter using this column directly
       .click({ force: true });
 
-    popover().contains("=").click();
+    H.popover().contains("=").click();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("39.72");
@@ -164,17 +154,17 @@ describe("scenarios > question > null", () => {
 
   describe("aggregations with null values", () => {
     it("summarize with null values (metabase#12585)", () => {
-      openOrdersTable();
+      H.openOrdersTable();
 
-      summarize();
-      rightSidebar().within(() => {
+      H.summarize();
+      H.rightSidebar().within(() => {
         // remove pre-selected "Count"
         cy.icon("close").click();
       });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add a function or metric").click();
       // dropdown immediately opens with the new set of metrics to choose from
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Cumulative sum of ...").click();
         cy.findByText("Discount").click();
       });
@@ -189,7 +179,7 @@ describe("scenarios > question > null", () => {
         "not.exist",
       );
 
-      cartesianChartCircle().should("have.length.of.at.least", 40);
+      H.cartesianChartCircle().should("have.length.of.at.least", 40);
     });
   });
 });

--- a/e2e/test/scenarios/question/offset.cy.spec.ts
+++ b/e2e/test/scenarios/question/offset.cy.spec.ts
@@ -1,28 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  POPOVER_ELEMENT,
-  type StructuredQuestionDetails,
-  addSummaryField,
-  addSummaryGroupingField,
-  createQuestion,
-  createSegment,
-  echartsContainer,
-  enterCustomColumnDetails,
-  entityPickerModal,
-  entityPickerModalTab,
-  getNotebookStep,
-  modal,
-  openNotebook,
-  openTable,
-  popover,
-  restore,
-  startNewQuestion,
-  startSort,
-  summarize,
-  visitMetric,
-  visitQuestion,
-  visualize,
-} from "e2e/support/helpers";
 import { uuid } from "metabase/lib/uuid";
 import type {
   Aggregation,
@@ -70,7 +47,7 @@ const OFFSET_SUM_TOTAL_AGGREGATION: Aggregation = [
 
 describe("scenarios > question > offset", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/card").as("saveQuestion");
   });
@@ -89,18 +66,18 @@ describe("scenarios > question > offset", () => {
         "order-by": [["asc", ORDERS_TOTAL_FIELD_REF]],
       };
 
-      createQuestion({ query }, { visitQuestion: true });
-      openNotebook();
+      H.createQuestion({ query }, { visitQuestion: true });
+      H.openNotebook();
       cy.button("Custom column").click();
-      enterCustomColumnDetails({ formula: prefix });
+      H.enterCustomColumnDetails({ formula: prefix });
 
       cy.log("does not suggest offset() in custom columns");
       cy.findByTestId("expression-suggestions-list-item").should("not.exist");
 
-      enterCustomColumnDetails({ formula: expression });
+      H.enterCustomColumnDetails({ formula: expression });
       cy.realPress("Tab");
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.button("Done").should("be.disabled");
         cy.findByText("OFFSET is not supported in custom columns").should(
           "exist",
@@ -119,32 +96,32 @@ describe("scenarios > question > offset", () => {
         limit: 5,
       };
 
-      createQuestion({ query }, { visitQuestion: true });
-      openNotebook();
+      H.createQuestion({ query }, { visitQuestion: true });
+      H.openNotebook();
       cy.button("Custom column").click();
-      enterCustomColumnDetails({ formula: prefix });
+      H.enterCustomColumnDetails({ formula: prefix });
 
       cy.log("suggests offset() in custom column expressions");
       cy.findByTestId("expression-suggestions-list-item")
         .should("exist")
         .and("have.text", "Offset");
 
-      enterCustomColumnDetails({ formula: expression });
+      H.enterCustomColumnDetails({ formula: expression });
       cy.realPress("Tab");
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("OFFSET in a custom expression requires a sort order");
         cy.button("Done").should("be.disabled");
         cy.button("Cancel").click();
       });
 
       cy.button("Sort").click();
-      popover().findByText("ID").click();
-      getNotebookStep("expression").icon("add").click();
-      enterCustomColumnDetails({ formula: expression });
+      H.popover().findByText("ID").click();
+      H.getNotebookStep("expression").icon("add").click();
+      H.enterCustomColumnDetails({ formula: expression });
       cy.realPress("Tab");
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.button("Done").should("be.disabled");
 
         cy.findByPlaceholderText("Something nice and descriptive")
@@ -155,12 +132,12 @@ describe("scenarios > question > offset", () => {
       });
 
       cy.log("preview availability");
-      getNotebookStep("data").icon("play").should("be.visible");
-      getNotebookStep("expression").icon("play").should("not.be.visible");
-      getNotebookStep("sort").icon("play").should("be.visible");
-      getNotebookStep("limit").icon("play").should("be.visible");
+      H.getNotebookStep("data").icon("play").should("be.visible");
+      H.getNotebookStep("expression").icon("play").should("not.be.visible");
+      H.getNotebookStep("sort").icon("play").should("be.visible");
+      H.getNotebookStep("limit").icon("play").should("be.visible");
 
-      visualize();
+      H.visualize();
       verifyTableContent([
         ["1", "39.72", ""],
         ["2", "117.03", "39.72"],
@@ -188,7 +165,7 @@ describe("scenarios > question > offset", () => {
         limit: 5,
       };
 
-      createQuestion({ query }, { visitQuestion: true });
+      H.createQuestion({ query }, { visitQuestion: true });
 
       cy.log("custom column drills");
       const rowIndex = 1;
@@ -196,32 +173,32 @@ describe("scenarios > question > offset", () => {
       const columnsCount = 10;
       const cellIndex = rowIndex * columnsCount + columnIndex;
       cy.findAllByRole("gridcell").eq(cellIndex).click();
-      cy.get(POPOVER_ELEMENT).should("not.exist");
+      cy.get(H.POPOVER_ELEMENT).should("not.exist");
 
-      openNotebook();
+      H.openNotebook();
 
       cy.log("custom column expressions");
-      getNotebookStep("expression").icon("add").click();
+      H.getNotebookStep("expression").icon("add").click();
       verifyInvalidColumnName(offsettedColumnName, prefix, expression);
-      popover().button("Cancel").click();
+      H.popover().button("Cancel").click();
 
       cy.log("custom filter expressions");
       cy.icon("filter").click();
-      popover().findByText("Custom Expression").click();
+      H.popover().findByText("Custom Expression").click();
       verifyInvalidColumnName(offsettedColumnName, prefix, expression);
-      popover().button("Cancel").click();
+      H.popover().button("Cancel").click();
       cy.realPress("Escape");
 
       cy.log("custom aggregation expressions");
       cy.icon("sum").click();
-      popover().findByText("Custom Expression").click();
+      H.popover().findByText("Custom Expression").click();
       verifyInvalidColumnName(offsettedColumnName, prefix, expression);
-      popover().button("Cancel").click();
+      H.popover().button("Cancel").click();
       cy.realPress("Escape");
 
       cy.log("sort clause");
-      getNotebookStep("sort").icon("add").click();
-      popover().should("not.contain", offsettedColumnName);
+      H.getNotebookStep("sort").icon("add").click();
+      H.popover().should("not.contain", offsettedColumnName);
     });
   });
 
@@ -235,19 +212,19 @@ describe("scenarios > question > offset", () => {
         limit: 5,
       };
 
-      createQuestion({ query }, { visitQuestion: true });
-      openNotebook();
+      H.createQuestion({ query }, { visitQuestion: true });
+      H.openNotebook();
       cy.button("Filter").click();
-      popover().findByText("Custom Expression").click();
-      enterCustomColumnDetails({ formula: prefix });
+      H.popover().findByText("Custom Expression").click();
+      H.enterCustomColumnDetails({ formula: prefix });
 
       cy.log("does not suggest offset() in filter expressions");
       cy.findByTestId("expression-suggestions-list-item").should("not.exist");
 
-      enterCustomColumnDetails({ formula: expression });
+      H.enterCustomColumnDetails({ formula: expression });
       cy.realPress("Tab");
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.button("Done").should("be.disabled");
         cy.findByText("OFFSET is not supported in custom filters").should(
           "exist",
@@ -266,24 +243,24 @@ describe("scenarios > question > offset", () => {
         limit: 5,
       };
 
-      createQuestion({ query }, { visitQuestion: true });
-      openNotebook();
+      H.createQuestion({ query }, { visitQuestion: true });
+      H.openNotebook();
       cy.button("Summarize").click();
-      getNotebookStep("summarize")
+      H.getNotebookStep("summarize")
         .findByText("Pick a function or metric")
         .click();
-      popover().findByText("Custom Expression").click();
-      enterCustomColumnDetails({ formula: prefix, blur: false });
+      H.popover().findByText("Custom Expression").click();
+      H.enterCustomColumnDetails({ formula: prefix, blur: false });
 
       cy.log("suggests offset() in aggregation expressions");
       cy.findByTestId("expression-suggestions-list-item")
         .should("exist")
         .and("have.text", "Offset");
 
-      enterCustomColumnDetails({ formula: expression, blur: false });
+      H.enterCustomColumnDetails({ formula: expression, blur: false });
       cy.realPress("Tab");
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.button("Done").should("be.disabled");
 
         cy.findByPlaceholderText("Something nice and descriptive")
@@ -300,7 +277,7 @@ describe("scenarios > question > offset", () => {
         aggregation: [OFFSET_SUM_TOTAL_AGGREGATION],
       };
 
-      createQuestion({ query }, { visitQuestion: true });
+      H.createQuestion({ query }, { visitQuestion: true });
 
       verifyQuestionError(
         "Window function requires either breakouts or order by in the query",
@@ -316,9 +293,9 @@ describe("scenarios > question > offset", () => {
         limit: 5,
       };
 
-      createQuestion({ query }, { visitQuestion: true });
+      H.createQuestion({ query }, { visitQuestion: true });
 
-      openNotebook();
+      H.openNotebook();
 
       cy.findByLabelText("View the SQL").click();
       cy.wait("@sqlPreview");
@@ -337,7 +314,7 @@ describe("scenarios > question > offset", () => {
         limit: 5,
       };
 
-      createQuestion({ query }, { visitQuestion: true });
+      H.createQuestion({ query }, { visitQuestion: true });
 
       verifyNoQuestionError();
       verifyTableContent([
@@ -345,8 +322,8 @@ describe("scenarios > question > offset", () => {
         ["May 2022", "52.76"],
       ]);
 
-      openNotebook();
-      getNotebookStep("summarize").icon("play").should("be.visible");
+      H.openNotebook();
+      H.getNotebookStep("summarize").icon("play").should("be.visible");
     });
 
     it("works with a single breakout and sorting by breakout", () => {
@@ -358,7 +335,7 @@ describe("scenarios > question > offset", () => {
         "order-by": [["desc", ORDERS_CREATED_AT_BREAKOUT]],
       };
 
-      createQuestion({ query }, { visitQuestion: true });
+      H.createQuestion({ query }, { visitQuestion: true });
 
       verifyNoQuestionError();
       verifyTableContent([
@@ -376,7 +353,7 @@ describe("scenarios > question > offset", () => {
         "order-by": [["desc", ["aggregation", 0]]],
       };
 
-      createQuestion({ query }, { visitQuestion: true });
+      H.createQuestion({ query }, { visitQuestion: true });
 
       verifyNoQuestionError();
       verifyTableContent([
@@ -402,7 +379,7 @@ describe("scenarios > question > offset", () => {
         breakout: [ORDERS_CREATED_AT_BREAKOUT, PRODUCTS_CATEGORY_BREAKOUT],
       };
 
-      createQuestion({ query }, { visitQuestion: true });
+      H.createQuestion({ query }, { visitQuestion: true });
 
       verifyNoQuestionError();
       verifyTableContent([
@@ -420,7 +397,7 @@ describe("scenarios > question > offset", () => {
         limit: 9,
       };
 
-      createQuestion({ query }, { visitQuestion: true });
+      H.createQuestion({ query }, { visitQuestion: true });
 
       verifyNoQuestionError();
       verifyTableContent([
@@ -439,9 +416,9 @@ describe("scenarios > question > offset", () => {
     it("works after saving a question (metabase#42323)", () => {
       const breakoutName = "Created At";
 
-      startNewQuestion();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.startNewQuestion();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Orders").click();
       });
       addCustomAggregation({
@@ -451,7 +428,7 @@ describe("scenarios > question > offset", () => {
       });
       addBreakout(breakoutName);
 
-      visualize();
+      H.visualize();
       verifyNoQuestionError();
       verifyLineChart({
         xAxis: breakoutName + ": Month",
@@ -459,7 +436,7 @@ describe("scenarios > question > offset", () => {
       });
 
       saveQuestion().then(({ response }) => {
-        visitQuestion(response?.body.id);
+        H.visitQuestion(response?.body.id);
         verifyNoQuestionError();
         verifyLineChart({
           xAxis: breakoutName + ": Month",
@@ -483,9 +460,9 @@ describe("scenarios > question > offset", () => {
         rollingAverageName,
       ];
 
-      startNewQuestion();
-      entityPickerModal().within(() => {
-        entityPickerModalTab("Tables").click();
+      H.startNewQuestion();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
         cy.findByText("Orders").click();
       });
       addCustomAggregation({
@@ -513,7 +490,7 @@ describe("scenarios > question > offset", () => {
       });
       addBreakout(breakoutName);
 
-      visualize();
+      H.visualize();
       verifyNoQuestionError();
       verifyLineChart({
         xAxis: breakoutName + ": Month",
@@ -522,7 +499,7 @@ describe("scenarios > question > offset", () => {
 
       // checking data after saveQuestion is not necessary as it's covered by "works after saving a question (metabase#42323)"
       saveQuestion().then(({ response }) => {
-        visitQuestion(response?.body.id);
+        H.visitQuestion(response?.body.id);
         verifyNoQuestionError();
         verifyLineChart({
           xAxis: breakoutName + ": Month",
@@ -538,8 +515,8 @@ describe("scenarios > question > offset", () => {
         "source-table": ORDERS_ID,
       };
 
-      createQuestion({ query }, { visitQuestion: true });
-      openNotebook();
+      H.createQuestion({ query }, { visitQuestion: true });
+      H.openNotebook();
       cy.button("Summarize").click();
       addCustomAggregation({ formula, name, isFirst: true });
 
@@ -554,45 +531,45 @@ describe("scenarios > question > offset", () => {
     });
 
     it("should create filter and CC with offset aggregation and sort correctly", () => {
-      openTable({ table: ORDERS_ID });
+      H.openTable({ table: ORDERS_ID });
 
-      openNotebook();
+      H.openNotebook();
 
-      summarize({ mode: "notebook" });
+      H.summarize({ mode: "notebook" });
       addCustomAggregation({
         formula: "Offset(Sum([Total]), -1)",
         name: OFFSET_SUM_TOTAL_AGGREGATION_NAME,
         isOpened: true,
       });
 
-      addSummaryGroupingField({ field: "Created At" });
-      addSummaryGroupingField({
+      H.addSummaryGroupingField({ field: "Created At" });
+      H.addSummaryGroupingField({
         table: "Product",
         field: "Category",
       });
       cy.findAllByLabelText("Custom column").last().click();
 
-      enterCustomColumnDetails({
+      H.enterCustomColumnDetails({
         formula: `[${OFFSET_SUM_TOTAL_AGGREGATION_NAME}] * 2`,
         name: `${OFFSET_SUM_TOTAL_AGGREGATION_NAME} * 2`,
       });
-      popover().findByText("Done").click();
+      H.popover().findByText("Done").click();
 
       cy.findAllByTestId("action-buttons").last().icon("filter").click();
-      popover().findByText("Custom Expression").click();
+      H.popover().findByText("Custom Expression").click();
 
-      enterCustomColumnDetails({
+      H.enterCustomColumnDetails({
         formula: `[${OFFSET_SUM_TOTAL_AGGREGATION_NAME}] > 1000`,
       });
-      popover().findByText("Done").click();
+      H.popover().findByText("Done").click();
 
       cy.findAllByTestId("action-buttons").last().icon("sort").click();
-      popover().findByText(OFFSET_SUM_TOTAL_AGGREGATION_NAME).click();
-      getNotebookStep("sort", { stage: 1, index: 0 })
+      H.popover().findByText(OFFSET_SUM_TOTAL_AGGREGATION_NAME).click();
+      H.getNotebookStep("sort", { stage: 1, index: 0 })
         .findByText(OFFSET_SUM_TOTAL_AGGREGATION_NAME)
         .click();
 
-      visualize();
+      H.visualize();
 
       verifyNoQuestionError();
       verifyTableContent([
@@ -622,25 +599,25 @@ describe("scenarios > question > offset", () => {
         ],
       };
 
-      createQuestion({ query }, { visitQuestion: true });
-      openNotebook();
+      H.createQuestion({ query }, { visitQuestion: true });
+      H.openNotebook();
 
-      summarize({ mode: "notebook" });
-      addSummaryField({ metric: "Sum of ...", field: "Total" });
+      H.summarize({ mode: "notebook" });
+      H.addSummaryField({ metric: "Sum of ...", field: "Total" });
       addCustomAggregation({
         formula: "Offset(Sum([Total]), -1)",
         name: OFFSET_SUM_TOTAL_AGGREGATION_NAME,
       });
 
-      addSummaryGroupingField({
+      H.addSummaryGroupingField({
         table: "Products",
         field: "Category",
       });
 
-      addSummaryGroupingField({ field: "Created At", bucketSize: "Year" });
+      H.addSummaryGroupingField({ field: "Created At", bucketSize: "Year" });
 
       addSorting({ field: "Created At" });
-      visualize();
+      H.visualize();
 
       verifyNoQuestionError();
       verifyTableContent([
@@ -654,8 +631,8 @@ describe("scenarios > question > offset", () => {
         ["Widget", "2023", "59,095.56", "12,523.37"],
       ]);
 
-      openNotebook();
-      getNotebookStep("summarize").icon("play").should("be.visible");
+      H.openNotebook();
+      H.getNotebookStep("summarize").icon("play").should("be.visible");
     });
 
     it("offset expression is in the first place in aggregation", () => {
@@ -677,28 +654,28 @@ describe("scenarios > question > offset", () => {
         ],
       };
 
-      createQuestion({ query }, { visitQuestion: true });
-      openNotebook();
+      H.createQuestion({ query }, { visitQuestion: true });
+      H.openNotebook();
 
-      summarize({ mode: "notebook" });
+      H.summarize({ mode: "notebook" });
       addCustomAggregation({
         formula: "Offset(Sum([Total]), -1)",
         name: OFFSET_SUM_TOTAL_AGGREGATION_NAME,
         isOpened: true,
       });
-      addSummaryField({ metric: "Sum of ...", field: "Total" });
+      H.addSummaryField({ metric: "Sum of ...", field: "Total" });
 
-      addSummaryGroupingField({
+      H.addSummaryGroupingField({
         table: "Products",
         field: "Category",
       });
 
-      addSummaryGroupingField({ field: "Created At", bucketSize: "Year" });
+      H.addSummaryGroupingField({ field: "Created At", bucketSize: "Year" });
 
-      startSort();
-      popover().contains("Created At").click();
+      H.startSort();
+      H.popover().contains("Created At").click();
 
-      visualize();
+      H.visualize();
 
       verifyNoQuestionError();
       verifyTableContent([
@@ -712,8 +689,8 @@ describe("scenarios > question > offset", () => {
         ["Widget", "2023", "12,523.37", "59,095.56"],
       ]);
 
-      openNotebook();
-      getNotebookStep("summarize").icon("play").should("be.visible");
+      H.openNotebook();
+      H.getNotebookStep("summarize").icon("play").should("be.visible");
     });
 
     it("offset and avg function applied to custom column", () => {
@@ -737,32 +714,32 @@ describe("scenarios > question > offset", () => {
         ],
       };
 
-      createQuestion({ query }, { visitQuestion: true });
+      H.createQuestion({ query }, { visitQuestion: true });
 
-      openNotebook();
+      H.openNotebook();
       addCustomColumn({
         name: customColumnName,
         formula: "[Products → Rating]",
       });
 
-      summarize({ mode: "notebook" });
-      addSummaryField({ metric: "Average of ...", field: customColumnName });
+      H.summarize({ mode: "notebook" });
+      H.addSummaryField({ metric: "Average of ...", field: customColumnName });
 
       addCustomAggregation({
         formula: `Offset(Average([${customColumnName}]), -1)`,
         name: "offsetted avg product rating",
       });
 
-      addSummaryGroupingField({ field: "Created At", bucketSize: "Year" });
-      addSummaryGroupingField({
+      H.addSummaryGroupingField({ field: "Created At", bucketSize: "Year" });
+      H.addSummaryGroupingField({
         field: customColumnName,
       });
 
-      startSort();
-      popover().contains(customColumnName).click();
-      getNotebookStep("sort").findByText(customColumnName).click();
+      H.startSort();
+      H.popover().contains(customColumnName).click();
+      H.getNotebookStep("sort").findByText(customColumnName).click();
 
-      visualize();
+      H.visualize();
 
       verifyNoQuestionError();
       verifyTableContent([
@@ -777,13 +754,13 @@ describe("scenarios > question > offset", () => {
     describe("when custom column is in the first place of breakout", () => {
       it("works with custom column that contains a function", () => {
         const customColumnName = "CC Product Category";
-        openTable({ table: ORDERS_ID });
+        H.openTable({ table: ORDERS_ID });
 
-        openNotebook();
+        H.openNotebook();
 
-        summarize({ mode: "notebook" });
+        H.summarize({ mode: "notebook" });
 
-        addSummaryField({ metric: "Sum of ...", field: "Total" });
+        H.addSummaryField({ metric: "Sum of ...", field: "Total" });
         addCustomAggregation({
           formula: "Offset(Sum([Total]), -1)",
           name: OFFSET_SUM_TOTAL_AGGREGATION_NAME,
@@ -794,13 +771,13 @@ describe("scenarios > question > offset", () => {
           name: customColumnName,
         });
 
-        addSummaryGroupingField({
+        H.addSummaryGroupingField({
           field: customColumnName,
         });
-        addSummaryGroupingField({ field: "Created At", bucketSize: "Year" });
+        H.addSummaryGroupingField({ field: "Created At", bucketSize: "Year" });
 
         addSorting({ field: "Created At" });
-        visualize();
+        H.visualize();
 
         verifyNoQuestionError();
         verifyTableContent([
@@ -814,19 +791,19 @@ describe("scenarios > question > offset", () => {
           ["Widget from products", "2023", "59,095.56", "12,523.37"],
         ]);
 
-        openNotebook();
-        getNotebookStep("summarize").icon("play").should("be.visible");
+        H.openNotebook();
+        H.getNotebookStep("summarize").icon("play").should("be.visible");
       });
 
       it("works with custom column that contains a column", () => {
         const customColumnName = "CC Product Category";
-        openTable({ table: ORDERS_ID });
+        H.openTable({ table: ORDERS_ID });
 
-        openNotebook();
+        H.openNotebook();
 
-        summarize({ mode: "notebook" });
+        H.summarize({ mode: "notebook" });
 
-        addSummaryField({ metric: "Sum of ...", field: "Total" });
+        H.addSummaryField({ metric: "Sum of ...", field: "Total" });
         addCustomAggregation({
           formula: "Offset(Sum([Total]), -1)",
           name: OFFSET_SUM_TOTAL_AGGREGATION_NAME,
@@ -837,13 +814,13 @@ describe("scenarios > question > offset", () => {
           name: customColumnName,
         });
 
-        addSummaryGroupingField({
+        H.addSummaryGroupingField({
           field: customColumnName,
         });
-        addSummaryGroupingField({ field: "Created At", bucketSize: "Year" });
+        H.addSummaryGroupingField({ field: "Created At", bucketSize: "Year" });
 
         addSorting({ field: "Created At" });
-        visualize();
+        H.visualize();
 
         verifyNoQuestionError();
         verifyTableContent([
@@ -857,8 +834,8 @@ describe("scenarios > question > offset", () => {
           ["Widget", "2023", "59,095.56", "12,523.37"],
         ]);
 
-        openNotebook();
-        getNotebookStep("summarize").icon("play").should("be.visible");
+        H.openNotebook();
+        H.getNotebookStep("summarize").icon("play").should("be.visible");
       });
 
       it("works when custom column is a simple expression (metabase#47870)", () => {
@@ -866,49 +843,49 @@ describe("scenarios > question > offset", () => {
         const customColumnName2 = "constant";
         const customColumnName3 = "string";
 
-        openTable({ table: ORDERS_ID });
+        H.openTable({ table: ORDERS_ID });
 
-        openNotebook();
+        H.openNotebook();
 
         addCustomColumn({
           name: customColumnName,
           formula: "1+1",
         });
-        getNotebookStep("expression").icon("add").click();
-        enterCustomColumnDetails({
+        H.getNotebookStep("expression").icon("add").click();
+        H.enterCustomColumnDetails({
           name: customColumnName2,
           formula: "0+1",
         });
-        popover().findByText("Done").click();
+        H.popover().findByText("Done").click();
 
-        getNotebookStep("expression").icon("add").click();
-        enterCustomColumnDetails({
+        H.getNotebookStep("expression").icon("add").click();
+        H.enterCustomColumnDetails({
           name: customColumnName3,
           formula: "concat('a','b')",
         });
-        popover().findByText("Done").click();
+        H.popover().findByText("Done").click();
 
-        summarize({ mode: "notebook" });
+        H.summarize({ mode: "notebook" });
 
-        addSummaryField({ metric: "Sum of ...", field: "Total" });
+        H.addSummaryField({ metric: "Sum of ...", field: "Total" });
         addCustomAggregation({
           formula: "Offset(Sum([Total]), -1)",
           name: OFFSET_SUM_TOTAL_AGGREGATION_NAME,
         });
 
-        addSummaryGroupingField({
+        H.addSummaryGroupingField({
           field: customColumnName,
         });
-        addSummaryGroupingField({
+        H.addSummaryGroupingField({
           field: customColumnName2,
         });
-        addSummaryGroupingField({
+        H.addSummaryGroupingField({
           field: customColumnName3,
         });
-        addSummaryGroupingField({ field: "Created At", bucketSize: "Year" });
+        H.addSummaryGroupingField({ field: "Created At", bucketSize: "Year" });
         addSorting({ field: "Created At" });
 
-        visualize();
+        H.visualize();
 
         verifyNoQuestionError();
 
@@ -918,8 +895,8 @@ describe("scenarios > question > offset", () => {
           ["2", "1", "ab", "2024", "510,045.03", "205,256.02"],
         ]);
 
-        openNotebook();
-        getNotebookStep("summarize").icon("play").should("be.visible");
+        H.openNotebook();
+        H.getNotebookStep("summarize").icon("play").should("be.visible");
       });
 
       it("works when custom column is a simple expression with CC not in the first place", () => {
@@ -927,49 +904,49 @@ describe("scenarios > question > offset", () => {
         const customColumnName2 = "constant";
         const customColumnName3 = "string";
 
-        openTable({ table: ORDERS_ID });
-        openNotebook();
+        H.openTable({ table: ORDERS_ID });
+        H.openNotebook();
 
         addCustomColumn({
           name: customColumnName,
           formula: "1+1",
         });
 
-        getNotebookStep("expression").icon("add").click();
-        enterCustomColumnDetails({
+        H.getNotebookStep("expression").icon("add").click();
+        H.enterCustomColumnDetails({
           name: customColumnName2,
           formula: "0+1",
         });
-        popover().findByText("Done").click();
+        H.popover().findByText("Done").click();
 
-        getNotebookStep("expression").icon("add").click();
-        enterCustomColumnDetails({
+        H.getNotebookStep("expression").icon("add").click();
+        H.enterCustomColumnDetails({
           name: customColumnName3,
           formula: "concat('a','b')",
         });
-        popover().findByText("Done").click();
+        H.popover().findByText("Done").click();
 
-        summarize({ mode: "notebook" });
+        H.summarize({ mode: "notebook" });
 
-        addSummaryField({ metric: "Sum of ...", field: "Total" });
+        H.addSummaryField({ metric: "Sum of ...", field: "Total" });
         addCustomAggregation({
           formula: "Offset(Sum([Total]), -1)",
           name: OFFSET_SUM_TOTAL_AGGREGATION_NAME,
         });
 
-        addSummaryGroupingField({ field: "Created At", bucketSize: "Year" });
-        addSummaryGroupingField({
+        H.addSummaryGroupingField({ field: "Created At", bucketSize: "Year" });
+        H.addSummaryGroupingField({
           field: customColumnName,
         });
-        addSummaryGroupingField({
+        H.addSummaryGroupingField({
           field: customColumnName2,
         });
-        addSummaryGroupingField({
+        H.addSummaryGroupingField({
           field: customColumnName3,
         });
         addSorting({ field: "Created At" });
 
-        visualize();
+        H.visualize();
 
         verifyNoQuestionError();
 
@@ -979,8 +956,8 @@ describe("scenarios > question > offset", () => {
           ["2024", "2", "1", "ab", "510,045.03", "205,256.02"],
         ]);
 
-        openNotebook();
-        getNotebookStep("summarize").icon("play").should("be.visible");
+        H.openNotebook();
+        H.getNotebookStep("summarize").icon("play").should("be.visible");
       });
     });
 
@@ -988,30 +965,30 @@ describe("scenarios > question > offset", () => {
       it("works with custom column that contains a function", () => {
         const customColumnName = "CC Product Category";
 
-        openTable({ table: ORDERS_ID });
+        H.openTable({ table: ORDERS_ID });
 
-        openNotebook();
+        H.openNotebook();
 
         addCustomColumn({
           name: customColumnName,
           formula: 'concat([Product → Category], " from products")',
         });
 
-        summarize({ mode: "notebook" });
+        H.summarize({ mode: "notebook" });
 
-        addSummaryField({ metric: "Sum of ...", field: "Total" });
+        H.addSummaryField({ metric: "Sum of ...", field: "Total" });
         addCustomAggregation({
           formula: "Offset(Sum([Total]), -1)",
           name: OFFSET_SUM_TOTAL_AGGREGATION_NAME,
         });
 
-        addSummaryGroupingField({ field: "Created At", bucketSize: "Year" });
-        addSummaryGroupingField({
+        H.addSummaryGroupingField({ field: "Created At", bucketSize: "Year" });
+        H.addSummaryGroupingField({
           field: customColumnName,
         });
         addSorting({ field: "Created At" });
 
-        visualize();
+        H.visualize();
 
         verifyNoQuestionError();
         verifyTableContent([
@@ -1020,36 +997,36 @@ describe("scenarios > question > offset", () => {
           ["2022", "Gizmo from products", "9,929.32", ""],
         ]);
 
-        openNotebook();
-        getNotebookStep("summarize").icon("play").should("be.visible");
+        H.openNotebook();
+        H.getNotebookStep("summarize").icon("play").should("be.visible");
       });
 
       it("works with custom column that contains a column", () => {
         const customColumnName = "CC Product Category";
-        openTable({ table: ORDERS_ID });
+        H.openTable({ table: ORDERS_ID });
 
-        openNotebook();
+        H.openNotebook();
 
         addCustomColumn({
           name: customColumnName,
           formula: "[Product → Category]",
         });
 
-        summarize({ mode: "notebook" });
+        H.summarize({ mode: "notebook" });
 
-        addSummaryField({ metric: "Sum of ...", field: "Total" });
+        H.addSummaryField({ metric: "Sum of ...", field: "Total" });
         addCustomAggregation({
           formula: "Offset(Sum([Total]), -1)",
           name: OFFSET_SUM_TOTAL_AGGREGATION_NAME,
         });
 
-        addSummaryGroupingField({ field: "Created At", bucketSize: "Year" });
-        addSummaryGroupingField({
+        H.addSummaryGroupingField({ field: "Created At", bucketSize: "Year" });
+        H.addSummaryGroupingField({
           field: customColumnName,
         });
         addSorting({ field: "Created At" });
 
-        visualize();
+        H.visualize();
 
         verifyNoQuestionError();
         verifyTableContent([
@@ -1058,37 +1035,37 @@ describe("scenarios > question > offset", () => {
           ["2022", "Gizmo", "9,929.32", ""],
         ]);
 
-        openNotebook();
-        getNotebookStep("summarize").icon("play").should("be.visible");
+        H.openNotebook();
+        H.getNotebookStep("summarize").icon("play").should("be.visible");
       });
 
       it("works when custom column is a simple expression", () => {
         const customColumnName = "1 + 1";
 
-        openTable({ table: ORDERS_ID });
+        H.openTable({ table: ORDERS_ID });
 
-        openNotebook();
+        H.openNotebook();
 
         addCustomColumn({
           name: customColumnName,
           formula: "1+1",
         });
 
-        summarize({ mode: "notebook" });
+        H.summarize({ mode: "notebook" });
 
-        addSummaryField({ metric: "Sum of ...", field: "Total" });
+        H.addSummaryField({ metric: "Sum of ...", field: "Total" });
         addCustomAggregation({
           formula: "Offset(Sum([Total]), -1)",
           name: OFFSET_SUM_TOTAL_AGGREGATION_NAME,
         });
 
-        addSummaryGroupingField({ field: "Created At", bucketSize: "Year" });
-        addSummaryGroupingField({
+        H.addSummaryGroupingField({ field: "Created At", bucketSize: "Year" });
+        H.addSummaryGroupingField({
           field: customColumnName,
         });
         addSorting({ field: "Created At" });
 
-        visualize();
+        H.visualize();
 
         verifyNoQuestionError();
         verifyTableContent([
@@ -1097,8 +1074,8 @@ describe("scenarios > question > offset", () => {
           ["2024", "2", "510,045.03", "205,256.02"],
         ]);
 
-        openNotebook();
-        getNotebookStep("summarize").icon("play").should("be.visible");
+        H.openNotebook();
+        H.getNotebookStep("summarize").icon("play").should("be.visible");
       });
     });
   });
@@ -1107,16 +1084,16 @@ describe("scenarios > question > offset", () => {
     it("works with avg", () => {
       const customColumnName = "CC Product Price";
 
-      openTable({ table: ORDERS_ID });
+      H.openTable({ table: ORDERS_ID });
 
-      openNotebook();
+      H.openNotebook();
 
       addCustomColumn({
         name: customColumnName,
         formula: "[Product → Rating]",
       });
 
-      summarize({ mode: "notebook" });
+      H.summarize({ mode: "notebook" });
 
       addCustomAggregation({
         formula: `Average([${customColumnName}])`,
@@ -1128,13 +1105,13 @@ describe("scenarios > question > offset", () => {
         name: "offsetted average product rating",
       });
 
-      addSummaryGroupingField({
+      H.addSummaryGroupingField({
         field: customColumnName,
       });
-      addSummaryGroupingField({ field: "Created At", bucketSize: "Year" });
+      H.addSummaryGroupingField({ field: "Created At", bucketSize: "Year" });
       addSorting({ field: customColumnName, order: "desc" });
 
-      visualize();
+      H.visualize();
 
       verifyNoQuestionError();
       verifyTableContent([
@@ -1154,34 +1131,34 @@ describe("scenarios > question > offset", () => {
     it("works with 3 breakouts", () => {
       const customColumnName = "CC Product Rating";
 
-      openTable({ table: ORDERS_ID });
+      H.openTable({ table: ORDERS_ID });
 
-      openNotebook();
+      H.openNotebook();
 
       addCustomColumn({
         name: customColumnName,
         formula: "[Product → Rating]",
       });
 
-      summarize({ mode: "notebook" });
+      H.summarize({ mode: "notebook" });
 
-      addSummaryField({ metric: "Sum of ...", field: "Total" });
+      H.addSummaryField({ metric: "Sum of ...", field: "Total" });
       addCustomAggregation({
         formula: "Offset(Sum([Total]), -1)",
         name: OFFSET_SUM_TOTAL_AGGREGATION_NAME,
       });
 
-      addSummaryGroupingField({ field: "Created At", bucketSize: "Year" });
-      addSummaryGroupingField({
+      H.addSummaryGroupingField({ field: "Created At", bucketSize: "Year" });
+      H.addSummaryGroupingField({
         field: customColumnName,
       });
-      addSummaryGroupingField({
+      H.addSummaryGroupingField({
         table: "User",
         field: "Source",
       });
       addSorting({ field: "Created At", order: "desc" });
 
-      visualize();
+      H.visualize();
 
       verifyNoQuestionError();
       verifyTableContent([
@@ -1193,7 +1170,7 @@ describe("scenarios > question > offset", () => {
 
   it("works with filtering using segment", () => {
     const segmentName = "Orders < 100";
-    createSegment({
+    H.createSegment({
       name: segmentName,
       // @ts-expect-error convert helper to ts
       description: "All orders with a total under $100.",
@@ -1207,42 +1184,42 @@ describe("scenarios > question > offset", () => {
 
     const customColumnName = "CC Product Rating";
 
-    openTable({ table: ORDERS_ID });
+    H.openTable({ table: ORDERS_ID });
 
-    openNotebook();
+    H.openNotebook();
 
     cy.findAllByTestId("action-buttons").first().icon("filter").click();
-    popover().findByText("Custom Expression").click();
+    H.popover().findByText("Custom Expression").click();
 
-    enterCustomColumnDetails({
+    H.enterCustomColumnDetails({
       formula: `[${segmentName}]`,
     });
-    popover().findByText("Done").click();
+    H.popover().findByText("Done").click();
 
     addCustomColumn({
       name: customColumnName,
       formula: "[Product → Rating]",
     });
 
-    summarize({ mode: "notebook" });
+    H.summarize({ mode: "notebook" });
 
-    addSummaryField({ metric: "Sum of ...", field: "Total" });
+    H.addSummaryField({ metric: "Sum of ...", field: "Total" });
     addCustomAggregation({
       formula: "Offset(Sum([Total]), -1)",
       name: OFFSET_SUM_TOTAL_AGGREGATION_NAME,
     });
 
-    addSummaryGroupingField({ field: "Created At", bucketSize: "Year" });
-    addSummaryGroupingField({
+    H.addSummaryGroupingField({ field: "Created At", bucketSize: "Year" });
+    H.addSummaryGroupingField({
       field: customColumnName,
     });
-    addSummaryGroupingField({
+    H.addSummaryGroupingField({
       table: "User",
       field: "Source",
     });
     addSorting({ field: "Created At", order: "desc" });
 
-    visualize();
+    H.visualize();
 
     verifyNoQuestionError();
     verifyTableContent([
@@ -1253,7 +1230,7 @@ describe("scenarios > question > offset", () => {
 
   it("should work with metrics (metabase#47854)", () => {
     const metricName = "Count of orders";
-    const ORDERS_SCALAR_METRIC: StructuredQuestionDetails = {
+    const ORDERS_SCALAR_METRIC: H.StructuredQuestionDetails = {
       name: metricName,
       type: "metric",
       description: "A metric",
@@ -1271,18 +1248,18 @@ describe("scenarios > question > offset", () => {
       display: "scalar",
     };
 
-    createQuestion(ORDERS_SCALAR_METRIC).then(({ body: card }) =>
-      visitMetric(card.id),
+    H.createQuestion(ORDERS_SCALAR_METRIC).then(({ body: card }) =>
+      H.visitMetric(card.id),
     );
 
-    openNotebook();
+    H.openNotebook();
 
     addCustomAggregation({
       formula: `Offset([${metricName}], -1)`,
       name: "Count of orders (previous month)",
     });
 
-    visualize();
+    H.visualize();
 
     cy.findByTestId("chart-container").should("contain", "January 2024");
   });
@@ -1301,27 +1278,29 @@ function addCustomAggregation({
 }) {
   if (!isOpened) {
     if (isFirst) {
-      getNotebookStep("summarize")
+      H.getNotebookStep("summarize")
         .findByText("Pick a function or metric")
         .click();
     } else {
-      getNotebookStep("summarize").icon("add").first().click();
+      H.getNotebookStep("summarize").icon("add").first().click();
     }
   }
 
-  popover().findByText("Custom Expression").click();
-  enterCustomColumnDetails({ formula, name });
-  popover().button("Done").click();
+  H.popover().findByText("Custom Expression").click();
+  H.enterCustomColumnDetails({ formula, name });
+  H.popover().button("Done").click();
 }
 
 function addBreakout(name: string) {
-  getNotebookStep("summarize").findByText("Pick a column to group by").click();
-  popover().findByText(name).click();
+  H.getNotebookStep("summarize")
+    .findByText("Pick a column to group by")
+    .click();
+  H.popover().findByText(name).click();
 }
 
 function saveQuestion() {
   cy.button("Save").click();
-  modal().button("Save").click();
+  H.modal().button("Save").click();
   return cy.wait("@saveQuestion");
 }
 
@@ -1334,7 +1313,7 @@ function verifyLineChart({
   yAxis?: string;
   legendItems?: string[];
 }) {
-  echartsContainer().within(() => {
+  H.echartsContainer().within(() => {
     cy.findByText(xAxis).should("be.visible");
 
     if (yAxis) {
@@ -1387,12 +1366,12 @@ function verifyInvalidColumnName(
   prefix: string,
   expression: string,
 ) {
-  enterCustomColumnDetails({ formula: prefix });
+  H.enterCustomColumnDetails({ formula: prefix });
   cy.findByTestId("expression-suggestions-list-item").should("not.exist");
 
-  enterCustomColumnDetails({ formula: expression });
+  H.enterCustomColumnDetails({ formula: expression });
   cy.realPress("Tab");
-  popover().within(() => {
+  H.popover().within(() => {
     cy.findByText(`Unknown Field: ${columnName}`).should("be.visible");
     cy.button("Done").should("be.disabled");
   });
@@ -1413,20 +1392,20 @@ function addSorting({
   field: string;
   order?: "asc" | "desc";
 }) {
-  startSort();
-  popover().contains(field).click();
+  H.startSort();
+  H.popover().contains(field).click();
 
   if (order === "desc") {
-    getNotebookStep("sort").contains(field).click();
+    H.getNotebookStep("sort").contains(field).click();
   }
 }
 
 function addCustomColumn({ name, formula }: { name: string; formula: string }) {
   cy.findAllByLabelText("Custom column").last().click();
 
-  enterCustomColumnDetails({
+  H.enterCustomColumnDetails({
     formula,
     name,
   });
-  popover().findByText("Done").click();
+  H.popover().findByText("Done").click();
 }

--- a/e2e/test/scenarios/question/query-external.cy.spec.js
+++ b/e2e/test/scenarios/question/query-external.cy.spec.js
@@ -1,5 +1,5 @@
+import { H } from "e2e/support";
 import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
-import { openTable, restore, visualize } from "e2e/support/helpers";
 
 const supportedDatabases = [
   {
@@ -19,7 +19,7 @@ supportedDatabases.forEach(({ database, snapshotName, dbName }) => {
     beforeEach(() => {
       cy.intercept("POST", "/api/dataset").as("dataset");
 
-      restore(snapshotName);
+      H.restore(snapshotName);
       cy.signInAsAdmin();
 
       cy.request(`/api/database/${WRITABLE_DB_ID}/schema/`).as("schema");
@@ -30,14 +30,14 @@ supportedDatabases.forEach(({ database, snapshotName, dbName }) => {
         const tabelId = body.find(
           table => table.name.toLowerCase() === "orders",
         ).id;
-        openTable({
+        H.openTable({
           database: WRITABLE_DB_ID,
           table: tabelId,
           mode: "notebook",
         });
       });
 
-      visualize();
+      H.visualize();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("37.65");
     });

--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -1,30 +1,13 @@
 import { onlyOn } from "@cypress/skip-test";
 import _ from "underscore";
 
+import { H } from "e2e/support";
 import { USERS, USER_GROUPS } from "e2e/support/cypress_data";
 import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  describeWithSnowplow,
-  enableTracking,
-  entityPickerModal,
-  expectGoodSnowplowEvents,
-  expectNoBadSnowplowEvents,
-  getPersonalCollectionName,
-  modal,
-  navigationSidebar,
-  openNavigationSidebar,
-  openQuestionActions,
-  popover,
-  questionInfoButton,
-  resetSnowplow,
-  restore,
-  visitDashboard,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 const PERMISSIONS = {
   curate: ["admin", "normal", "nodata"],
@@ -37,7 +20,7 @@ describe(
   { tags: "@slow" },
   () => {
     beforeEach(() => {
-      restore();
+      H.restore();
     });
 
     Object.entries(PERMISSIONS).forEach(([permission, userGroup]) => {
@@ -51,7 +34,7 @@ describe(
                 );
 
                 cy.signIn(user);
-                visitQuestion(ORDERS_QUESTION_ID);
+                H.visitQuestion(ORDERS_QUESTION_ID);
               });
 
               it("should be able to edit question details (metabase#11719-1)", () => {
@@ -66,7 +49,7 @@ describe(
               });
 
               it("should be able to edit a question's description", () => {
-                questionInfoButton().click();
+                H.questionInfoButton().click();
 
                 cy.findByPlaceholderText("Add description")
                   .type("foo", { delay: 0 })
@@ -81,8 +64,8 @@ describe(
 
               describe("move", () => {
                 it("should be able to move the question (metabase#11719-2)", () => {
-                  openNavigationSidebar();
-                  navigationSidebar().within(() => {
+                  H.openNavigationSidebar();
+                  H.navigationSidebar().within(() => {
                     // Highlight "Our analytics"
                     cy.findByText("Our analytics")
                       .parents("li")
@@ -97,7 +80,7 @@ describe(
 
                   cy.findAllByRole("status")
                     .contains(
-                      `Question moved to ${getPersonalCollectionName(
+                      `Question moved to ${H.getPersonalCollectionName(
                         USERS[user],
                       )}`,
                     )
@@ -105,7 +88,7 @@ describe(
                   assertNoPermissionsError();
                   cy.findAllByRole("gridcell").contains("37.65");
 
-                  navigationSidebar().within(() => {
+                  H.navigationSidebar().within(() => {
                     // Highlight "Your personal collection" after move
                     cy.findByText("Our analytics")
                       .parents("li")
@@ -119,9 +102,9 @@ describe(
                 it("should be able to move the question to a collection created on the go", () => {
                   const NEW_COLLECTION_NAME = "Foo";
 
-                  openQuestionActions();
+                  H.openQuestionActions();
                   cy.findByTestId("move-button").click();
-                  entityPickerModal().within(() => {
+                  H.entityPickerModal().within(() => {
                     if (user === "admin") {
                       cy.findByRole("tab", { name: /Collections/ }).click();
                     }
@@ -136,7 +119,7 @@ describe(
                     cy.button("Create").click();
                   });
 
-                  entityPickerModal().button("Move").click();
+                  H.entityPickerModal().button("Move").click();
 
                   cy.get("header").findByText(NEW_COLLECTION_NAME);
                 });
@@ -147,8 +130,8 @@ describe(
 
                   turnIntoModel();
 
-                  openNavigationSidebar();
-                  navigationSidebar().within(() => {
+                  H.openNavigationSidebar();
+                  H.navigationSidebar().within(() => {
                     // Highlight "Our analytics"
                     cy.findByText("Our analytics")
                       .parents("li")
@@ -163,7 +146,7 @@ describe(
 
                   cy.findAllByRole("status")
                     .contains(
-                      `Model moved to ${getPersonalCollectionName(
+                      `Model moved to ${H.getPersonalCollectionName(
                         USERS[user],
                       )}`,
                     )
@@ -171,7 +154,7 @@ describe(
                   assertNoPermissionsError();
                   cy.findAllByRole("gridcell").contains("37.65");
 
-                  navigationSidebar().within(() => {
+                  H.navigationSidebar().within(() => {
                     // Highlight "Your personal collection" after move
                     cy.findByText("Our analytics")
                       .parents("li")
@@ -185,10 +168,10 @@ describe(
 
               describe("Add to Dashboard", () => {
                 it("should be able to add question to dashboard", () => {
-                  openQuestionActions();
+                  H.openQuestionActions();
                   cy.findByTestId("add-to-dashboard-button").click();
 
-                  entityPickerModal()
+                  H.entityPickerModal()
                     .as("modal")
                     .within(() => {
                       cy.findByText("Orders in a dashboard").click();
@@ -223,11 +206,11 @@ describe(
                   moveQuestionTo(/Personal Collection/, true);
 
                   cy.log("assert public collections are not visible");
-                  openQuestionActions();
-                  popover().findByText("Add to dashboard").click();
+                  H.openQuestionActions();
+                  H.popover().findByText("Add to dashboard").click();
                   clickTabForUser(user, "Dashboards");
 
-                  entityPickerModal().within(() => {
+                  H.entityPickerModal().within(() => {
                     cy.findByText("Add this question to a dashboard").should(
                       "be.visible",
                     );
@@ -245,9 +228,9 @@ describe(
                   moveQuestionTo("Our analytics", true);
 
                   cy.log("assert all collections are visible");
-                  openQuestionActions();
-                  popover().findByText("Add to dashboard").click();
-                  modal().within(() => {
+                  H.openQuestionActions();
+                  H.popover().findByText("Add to dashboard").click();
+                  H.modal().within(() => {
                     cy.findByText("Add this question to a dashboard").should(
                       "be.visible",
                     );
@@ -262,16 +245,16 @@ describe(
 
                 onlyOn(user === "normal", () => {
                   it("should preselect the most recently visited dashboard", () => {
-                    openQuestionActions();
+                    H.openQuestionActions();
                     cy.findByTestId("add-to-dashboard-button").click();
 
                     findInactivePickerItem("Orders in a dashboard");
 
                     // before visiting the dashboard, we don't have any history
-                    visitDashboard(ORDERS_DASHBOARD_ID);
-                    visitQuestion(ORDERS_COUNT_QUESTION_ID);
+                    H.visitDashboard(ORDERS_DASHBOARD_ID);
+                    H.visitQuestion(ORDERS_COUNT_QUESTION_ID);
 
-                    openQuestionActions();
+                    H.openQuestionActions();
                     cy.findByTestId("add-to-dashboard-button").click();
 
                     findSelectedPickerItem("Orders in a dashboard");
@@ -283,27 +266,27 @@ describe(
                       "/api/activity/most_recently_viewed_dashboard",
                     ).as("mostRecentlyViewedDashboard");
 
-                    openQuestionActions();
+                    H.openQuestionActions();
                     cy.findByTestId("add-to-dashboard-button").click();
 
                     cy.wait("@mostRecentlyViewedDashboard");
                     findInactivePickerItem("Orders in a dashboard");
 
                     // before visiting the dashboard, we don't have any history
-                    visitDashboard(ORDERS_DASHBOARD_ID);
-                    visitQuestion(ORDERS_QUESTION_ID);
+                    H.visitDashboard(ORDERS_DASHBOARD_ID);
+                    H.visitQuestion(ORDERS_QUESTION_ID);
 
-                    openQuestionActions();
+                    H.openQuestionActions();
                     cy.findByTestId("add-to-dashboard-button").click();
 
                     cy.wait("@mostRecentlyViewedDashboard");
-                    entityPickerModal()
+                    H.entityPickerModal()
                       .findByRole("tab", { name: /Dashboards/ })
                       .click();
 
                     findActivePickerItem("Orders in a dashboard");
 
-                    entityPickerModal().findByLabelText("Close").click();
+                    H.entityPickerModal().findByLabelText("Close").click();
 
                     cy.signInAsAdmin();
 
@@ -314,14 +297,14 @@ describe(
                     cy.signOut();
                     cy.reload();
                     cy.signIn(user);
-                    visitQuestion(ORDERS_QUESTION_ID);
+                    H.visitQuestion(ORDERS_QUESTION_ID);
 
-                    openQuestionActions();
+                    H.openQuestionActions();
                     cy.findByTestId("add-to-dashboard-button").click();
 
                     cy.wait("@mostRecentlyViewedDashboard");
 
-                    entityPickerModal()
+                    H.entityPickerModal()
                       .button(/Orders in a dashboard/)
                       .should("be.disabled");
                   });
@@ -334,21 +317,21 @@ describe(
             describe(`${user} user`, () => {
               beforeEach(() => {
                 cy.signIn(user);
-                visitQuestion(ORDERS_QUESTION_ID);
+                H.visitQuestion(ORDERS_QUESTION_ID);
               });
 
               it("should not be offered to add question to dashboard inside a collection they have `read` access to", () => {
-                openQuestionActions();
+                H.openQuestionActions();
                 cy.findByTestId("add-to-dashboard-button").click();
 
-                entityPickerModal()
+                H.entityPickerModal()
                   .findByText("First collection")
                   .should("be.visible");
 
                 findPickerItem("Orders in a dashboard").then($button => {
                   expect($button).to.have.attr("disabled");
                 });
-                entityPickerModal().within(() => {
+                H.entityPickerModal().within(() => {
                   cy.findByPlaceholderText(/Search/).type(
                     "Orders in a dashboard{Enter}",
                     { delay: 0 },
@@ -363,9 +346,9 @@ describe(
                   "not.exist",
                 );
 
-                openQuestionActions();
+                H.openQuestionActions();
 
-                popover().within(() => {
+                H.popover().within(() => {
                   cy.findByTestId("move-button").should("not.exist");
                   cy.findByTestId("clone-button").should("not.exist");
                   cy.findByTestId("archive-button").should("not.exist");
@@ -376,22 +359,22 @@ describe(
               });
 
               it("should not preselect the most recently visited dashboard", () => {
-                openQuestionActions();
+                H.openQuestionActions();
                 cy.findByTestId("add-to-dashboard-button").click();
 
-                entityPickerModal()
+                H.entityPickerModal()
                   .findByText("Orders in a dashboard")
                   .should("not.exist");
 
                 // before visiting the dashboard, we don't have any history
-                visitDashboard(ORDERS_DASHBOARD_ID);
-                visitQuestion(ORDERS_QUESTION_ID);
+                H.visitDashboard(ORDERS_DASHBOARD_ID);
+                H.visitQuestion(ORDERS_QUESTION_ID);
 
-                openQuestionActions();
+                H.openQuestionActions();
                 cy.findByTestId("add-to-dashboard-button").click();
 
                 // still no data
-                entityPickerModal()
+                H.entityPickerModal()
                   .findByText("Orders in a dashboard")
                   .should("not.exist");
               });
@@ -403,30 +386,30 @@ describe(
   },
 );
 
-describeWithSnowplow("send snowplow question events", () => {
+H.describeWithSnowplow("send snowplow question events", () => {
   const NUMBERS_OF_GOOD_SNOWPLOW_EVENTS_BEFORE_MODEL_CONVERSION = 2;
 
   beforeEach(() => {
-    restore();
-    resetSnowplow();
+    H.restore();
+    H.resetSnowplow();
     cy.signInAsAdmin();
-    enableTracking();
+    H.enableTracking();
   });
 
   afterEach(() => {
-    expectNoBadSnowplowEvents();
+    H.expectNoBadSnowplowEvents();
   });
 
   it("should send event when clicking `Turn into a model`", () => {
-    visitQuestion(ORDERS_QUESTION_ID);
-    openQuestionActions();
-    expectGoodSnowplowEvents(
+    H.visitQuestion(ORDERS_QUESTION_ID);
+    H.openQuestionActions();
+    H.expectGoodSnowplowEvents(
       NUMBERS_OF_GOOD_SNOWPLOW_EVENTS_BEFORE_MODEL_CONVERSION,
     );
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Turn into a model").click();
     });
-    expectGoodSnowplowEvents(
+    H.expectGoodSnowplowEvents(
       NUMBERS_OF_GOOD_SNOWPLOW_EVENTS_BEFORE_MODEL_CONVERSION + 1,
     );
   });
@@ -445,7 +428,7 @@ function assertNoPermissionsError() {
 }
 
 function turnIntoModel() {
-  openQuestionActions();
+  H.openQuestionActions();
   cy.findByRole("dialog").contains("Turn into a model").click();
   cy.findByRole("dialog").contains("Turn this into a model").click();
   assertRequestNot403("updateQuestion");
@@ -479,9 +462,9 @@ function findInactivePickerItem(name) {
 }
 
 function moveQuestionTo(newCollectionName, clickTab = false) {
-  openQuestionActions();
+  H.openQuestionActions();
   cy.findByTestId("move-button").click();
-  entityPickerModal().within(() => {
+  H.entityPickerModal().within(() => {
     clickTab && cy.findByRole("tab", { name: /Collections/ }).click();
     cy.findByText(newCollectionName).click();
     cy.button("Move").click();

--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -1,59 +1,30 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_QUESTION_ID,
   SECOND_COLLECTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  WEBHOOK_TEST_DASHBOARD,
-  WEBHOOK_TEST_HOST,
-  WEBHOOK_TEST_SESSION_ID,
-  WEBHOOK_TEST_URL,
-  addSummaryGroupingField,
-  appBar,
-  collectionOnTheGoModal,
-  createQuestion,
-  entityPickerModal,
-  entityPickerModalTab,
-  getAlertChannel,
-  main,
-  modal,
-  openNotebook,
-  openOrdersTable,
-  openQuestionActions,
-  popover,
-  queryBuilderHeader,
-  questionInfoButton,
-  restore,
-  rightSidebar,
-  selectFilterOperator,
-  sidebar,
-  sidesheet,
-  summarize,
-  tableHeaderClick,
-  toggleAlertChannel,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > question > saved", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("POST", "api/card").as("cardCreate");
   });
 
   it("should should correctly display 'Save' modal (metabase#13817)", () => {
-    openOrdersTable();
-    openNotebook();
+    H.openOrdersTable();
+    H.openNotebook();
 
-    summarize({ mode: "notebook" });
-    popover().findByText("Count of rows").click();
-    addSummaryGroupingField({ field: "Total" });
+    H.summarize({ mode: "notebook" });
+    H.popover().findByText("Count of rows").click();
+    H.addSummaryGroupingField({ field: "Total" });
 
     // Save the question
-    queryBuilderHeader().button("Save").click();
+    H.queryBuilderHeader().button("Save").click();
     cy.findByTestId("save-question-modal").within(modal => {
       cy.findByText("Save").click();
     });
@@ -63,15 +34,15 @@ describe("scenarios > question > saved", () => {
     // Add a filter in order to be able to save question again
     cy.findAllByTestId("action-buttons").last().findByText("Filter").click();
 
-    popover().findByText("Total: Auto binned").click();
-    selectFilterOperator("Greater than");
+    H.popover().findByText("Total: Auto binned").click();
+    H.selectFilterOperator("Greater than");
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByPlaceholderText("Enter a number").type("60");
       cy.button("Add filter").click();
     });
 
-    queryBuilderHeader().button("Save").click();
+    H.queryBuilderHeader().button("Save").click();
 
     cy.findByTestId("save-question-modal").within(modal => {
       cy.findByText("Save question").should("be.visible");
@@ -92,14 +63,14 @@ describe("scenarios > question > saved", () => {
   });
 
   it("view and filter saved question", () => {
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
     cy.findAllByText("Orders"); // question and table name appears
 
     // filter to only orders with quantity=100
-    tableHeaderClick("Quantity");
-    popover().findByText("Filter by this column").click();
-    selectFilterOperator("Equal to");
-    popover().within(() => {
+    H.tableHeaderClick("Quantity");
+    H.popover().findByText("Filter by this column").click();
+    H.selectFilterOperator("Equal to");
+    H.popover().within(() => {
       cy.findByPlaceholderText("Search the list").type("100");
       cy.findByText("100").click();
       cy.findByText("Add filter").click();
@@ -132,14 +103,14 @@ describe("scenarios > question > saved", () => {
   it("should duplicate a saved question", () => {
     cy.intercept("POST", "/api/card").as("cardCreate");
 
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
 
-    openQuestionActions();
-    popover().within(() => {
+    H.openQuestionActions();
+    H.popover().within(() => {
       cy.findByText("Duplicate").click();
     });
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByLabelText("Name").should("have.value", "Orders - Duplicate");
       cy.findByText("Duplicate").click();
       cy.wait("@cardCreate");
@@ -155,29 +126,29 @@ describe("scenarios > question > saved", () => {
   it("should duplicate a saved question to a collection created on the go", () => {
     cy.intercept("POST", "/api/card").as("cardCreate");
 
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
 
-    openQuestionActions();
-    popover().within(() => {
+    H.openQuestionActions();
+    H.popover().within(() => {
       cy.findByText("Duplicate").click();
     });
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByLabelText("Name").should("have.value", "Orders - Duplicate");
       cy.findByTestId("collection-picker-button").click();
     });
 
-    entityPickerModal().findByText("Create a new collection").click();
+    H.entityPickerModal().findByText("Create a new collection").click();
 
     const NEW_COLLECTION = "Foo";
-    collectionOnTheGoModal().then(() => {
+    H.collectionOnTheGoModal().then(() => {
       cy.findByPlaceholderText("My new collection").type(NEW_COLLECTION);
       cy.findByText("Create").click();
     });
 
-    entityPickerModal().findByText("Select").click();
+    H.entityPickerModal().findByText("Select").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByLabelText("Name").should("have.value", "Orders - Duplicate");
       cy.findByTestId("collection-picker-button").should(
         "have.text",
@@ -199,10 +170,10 @@ describe("scenarios > question > saved", () => {
   it("should revert a saved question to a previous version", () => {
     cy.intercept("PUT", "/api/card/**").as("updateQuestion");
 
-    visitQuestion(ORDERS_QUESTION_ID);
-    questionInfoButton().click();
+    H.visitQuestion(ORDERS_QUESTION_ID);
+    H.questionInfoButton().click();
 
-    sidesheet().within(() => {
+    H.sidesheet().within(() => {
       cy.findByPlaceholderText("Add description")
         .type("This is a question")
         .blur();
@@ -221,9 +192,9 @@ describe("scenarios > question > saved", () => {
   });
 
   it("should show collection breadcrumbs for a saved question in the root collection", () => {
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    appBar().within(() => cy.findByText("Our analytics").click());
+    H.appBar().within(() => cy.findByText("Our analytics").click());
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders").should("be.visible");
@@ -234,24 +205,24 @@ describe("scenarios > question > saved", () => {
       collection_id: SECOND_COLLECTION_ID,
     });
 
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    appBar().within(() => cy.findByText("Second collection").click());
+    H.appBar().within(() => cy.findByText("Second collection").click());
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders").should("be.visible");
   });
 
   it("should show the question lineage when a saved question is changed", () => {
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
 
-    summarize();
-    rightSidebar().within(() => {
+    H.summarize();
+    H.rightSidebar().within(() => {
       cy.findByText("Quantity").click();
       cy.button("Done").click();
     });
 
-    appBar().within(() => {
+    H.appBar().within(() => {
       cy.findByText("Started from").should("be.visible");
       cy.findByText("Orders").click();
       cy.findByText("Started from").should("not.exist");
@@ -260,7 +231,7 @@ describe("scenarios > question > saved", () => {
 
   it("'read-only' user should be able to resize column width (metabase#9772)", () => {
     cy.signIn("readonly");
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
 
     cy.findAllByTestId("header-cell")
       .filter(":contains(Tax)")
@@ -285,7 +256,7 @@ describe("scenarios > question > saved", () => {
   });
 
   it("should always be possible to view the full title text of the saved question", () => {
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
     const savedQuestionTitle = cy.findByTestId("saved-question-header-title");
     savedQuestionTitle.clear();
     savedQuestionTitle.type(
@@ -308,8 +279,8 @@ describe("scenarios > question > saved", () => {
       .findByText("Use the notebook editor")
       .click();
 
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("Products").click();
     });
 
@@ -334,14 +305,14 @@ describe("scenarios > question > saved", () => {
 
     function hideTable(name, visibilityType) {
       cy.visit("/admin/datamodel");
-      sidebar().findByText(name).click();
-      main().findByText("Hidden").click();
+      H.sidebar().findByText(name).click();
+      H.main().findByText("Hidden").click();
 
       if (visibilityType === "technical") {
-        main().findByText("Technical Data").click();
+        H.main().findByText("Technical Data").click();
       }
       if (visibilityType === "cruft") {
-        main().findByText("Irrelevant/Cruft").click();
+        H.main().findByText("Irrelevant/Cruft").click();
       }
     }
 
@@ -349,13 +320,13 @@ describe("scenarios > question > saved", () => {
       it(`should show a View-only tag when the source table is marked as ${visibilityType}`, () => {
         hideTable("Orders", visibilityType);
 
-        visitQuestion(ORDERS_QUESTION_ID);
+        H.visitQuestion(ORDERS_QUESTION_ID);
 
-        queryBuilderHeader()
+        H.queryBuilderHeader()
           .findByText("View-only")
           .should("be.visible")
           .realHover();
-        popover()
+        H.popover()
           .findByText(
             "One of the administrators hid the source table “Orders”, making this question view-only.",
           )
@@ -365,7 +336,7 @@ describe("scenarios > question > saved", () => {
       it(`should show a View-only tag when a joined table is marked as ${visibilityType}`, () => {
         cy.signInAsAdmin();
         hideTable("Products", visibilityType);
-        createQuestion(
+        H.createQuestion(
           {
             name: "Joined question",
             query: {
@@ -388,11 +359,11 @@ describe("scenarios > question > saved", () => {
             visitQuestion: true,
           },
         );
-        queryBuilderHeader()
+        H.queryBuilderHeader()
           .findByText("View-only")
           .should("be.visible")
           .realHover();
-        popover()
+        H.popover()
           .findByText(
             "One of the administrators hid the source table “Products”, making this question view-only.",
           )
@@ -401,9 +372,9 @@ describe("scenarios > question > saved", () => {
     });
 
     function moveQuestionTo(newCollectionName, clickTab = false) {
-      openQuestionActions();
+      H.openQuestionActions();
       cy.findByTestId("move-button").click();
-      entityPickerModal().within(() => {
+      H.entityPickerModal().within(() => {
         clickTab && cy.findByRole("tab", { name: /Collections/ }).click();
         cy.findByText(newCollectionName).click();
         cy.button("Move").click();
@@ -411,7 +382,7 @@ describe("scenarios > question > saved", () => {
     }
 
     it("should show a View-only tag when one of the source cards is unavailable", () => {
-      createQuestion(
+      H.createQuestion(
         {
           name: "Products Question + Orders",
           query: {
@@ -436,13 +407,13 @@ describe("scenarios > question > saved", () => {
         },
       );
 
-      visitQuestion(ORDERS_QUESTION_ID);
+      H.visitQuestion(ORDERS_QUESTION_ID);
       moveQuestionTo(/Personal Collection/, true);
 
       cy.signInAsNormalUser();
-      cy.get("@questionId").then(visitQuestion);
+      cy.get("@questionId").then(H.visitQuestion);
 
-      queryBuilderHeader().findByText("View-only").should("be.visible");
+      H.queryBuilderHeader().findByText("View-only").should("be.visible");
     });
   });
 });
@@ -460,7 +431,7 @@ describe(
     const secondWebhookName = "Toucan Hook";
 
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
 
       cy.request("POST", "/api/channel", {
@@ -468,7 +439,7 @@ describe(
         description: "All aboard the Metaboat",
         type: "channel/http",
         details: {
-          url: WEBHOOK_TEST_URL,
+          url: H.WEBHOOK_TEST_URL,
           "auth-method": "none",
           "fe-form-type": "none",
         },
@@ -479,7 +450,7 @@ describe(
         description: "Quack!",
         type: "channel/http",
         details: {
-          url: WEBHOOK_TEST_URL,
+          url: H.WEBHOOK_TEST_URL,
           "auth-method": "none",
           "fe-form-type": "none",
         },
@@ -487,51 +458,51 @@ describe(
     });
 
     it("should allow you to enable a webhook alert", () => {
-      visitQuestion(ORDERS_COUNT_QUESTION_ID);
+      H.visitQuestion(ORDERS_COUNT_QUESTION_ID);
       cy.findByTestId("sharing-menu-button").click();
-      popover().findByText("Create alert").click();
-      modal().button("Set up an alert").click();
-      modal().within(() => {
-        toggleAlertChannel("Email");
-        toggleAlertChannel(secondWebhookName);
+      H.popover().findByText("Create alert").click();
+      H.modal().button("Set up an alert").click();
+      H.modal().within(() => {
+        H.toggleAlertChannel("Email");
+        H.toggleAlertChannel(secondWebhookName);
         cy.button("Done").click();
       });
       cy.findByTestId("sharing-menu-button").click();
-      popover().findByText("Edit alerts").click();
-      popover().within(() => {
+      H.popover().findByText("Edit alerts").click();
+      H.popover().within(() => {
         cy.findByText("You set up an alert").should("exist");
         cy.findByText("Edit").click();
       });
 
-      modal().within(() => {
-        getAlertChannel(secondWebhookName).scrollIntoView();
-        getAlertChannel(secondWebhookName)
+      H.modal().within(() => {
+        H.getAlertChannel(secondWebhookName).scrollIntoView();
+        H.getAlertChannel(secondWebhookName)
           .findByRole("checkbox")
           .should("be.checked");
       });
     });
 
     it("should allow you to test a webhook", () => {
-      visitQuestion(ORDERS_COUNT_QUESTION_ID);
+      H.visitQuestion(ORDERS_COUNT_QUESTION_ID);
       cy.findByTestId("sharing-menu-button").click();
-      popover().findByText("Create alert").click();
-      modal().button("Set up an alert").click();
-      modal().within(() => {
-        getAlertChannel(firstWebhookName).scrollIntoView();
+      H.popover().findByText("Create alert").click();
+      H.modal().button("Set up an alert").click();
+      H.modal().within(() => {
+        H.getAlertChannel(firstWebhookName).scrollIntoView();
 
-        getAlertChannel(firstWebhookName)
+        H.getAlertChannel(firstWebhookName)
           .findByRole("checkbox")
           .click({ force: true });
 
-        getAlertChannel(firstWebhookName).button("Send a test").click();
+        H.getAlertChannel(firstWebhookName).button("Send a test").click();
       });
 
-      cy.visit(WEBHOOK_TEST_DASHBOARD);
+      cy.visit(H.WEBHOOK_TEST_DASHBOARD);
 
       cy.findByRole("heading", { name: /Requests 1/ }).should("exist");
 
       cy.request(
-        `${WEBHOOK_TEST_HOST}/api/session/${WEBHOOK_TEST_SESSION_ID}/requests`,
+        `${H.WEBHOOK_TEST_HOST}/api/session/${H.WEBHOOK_TEST_SESSION_ID}/requests`,
       ).then(({ body }) => {
         const payload = cy.wrap(atob(body[0].content_base64));
 

--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -1,24 +1,12 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  browseDatabases,
-  entityPickerModal,
-  modal,
-  moveDnDKitElement,
-  openNavigationSidebar,
-  openOrdersTable,
-  popover,
-  restore,
-  sidebar,
-  tableHeaderClick,
-  visitQuestionAdhoc,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > question > settings", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -29,7 +17,7 @@ describe("scenarios > question > settings", () => {
       // get a really wide window, so we don't need to mess with scrolling the table horizontally
       cy.viewport(1600, 800);
 
-      openOrdersTable();
+      H.openOrdersTable();
       cy.findByTestId("viz-settings-button").click();
 
       // wait for settings sidebar to open
@@ -75,7 +63,7 @@ describe("scenarios > question > settings", () => {
     it("should allow you to re-order columns even when one has been removed (metabase #14238, #29287)", () => {
       cy.viewport(1600, 800);
 
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           database: SAMPLE_DB_ID,
           query: {
@@ -104,7 +92,7 @@ describe("scenarios > question > settings", () => {
 
       getSidebarColumns().eq("5").as("total").contains("Total");
 
-      moveDnDKitElement(cy.get("@total"), { vertical: -100 });
+      H.moveDnDKitElement(cy.get("@total"), { vertical: -100 });
 
       getSidebarColumns().eq("3").should("contain.text", "Total");
 
@@ -118,7 +106,7 @@ describe("scenarios > question > settings", () => {
         expect($el.scrollTop).to.eql(0);
       });
 
-      moveDnDKitElement(cy.get("@title"), { vertical: 15 });
+      H.moveDnDKitElement(cy.get("@title"), { vertical: 15 });
 
       cy.findByTestId("chartsettings-sidebar").should(([$el]) => {
         expect($el.scrollTop).to.be.greaterThan(0);
@@ -128,7 +116,7 @@ describe("scenarios > question > settings", () => {
     it("should preserve correct order of columns after column removal via sidebar (metabase#13455)", () => {
       cy.viewport(2000, 1600);
       // Orders join Products
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           type: "query",
           query: {
@@ -173,7 +161,7 @@ describe("scenarios > question > settings", () => {
         .contains(/Products? → Category/);
 
       // Drag and drop this column between "Tax" and "Discount" (index 5 in @sidebarColumns array)
-      moveDnDKitElement(cy.get("@prod-category"), { vertical: -360 });
+      H.moveDnDKitElement(cy.get("@prod-category"), { vertical: -360 });
 
       refreshResultsInHeader();
 
@@ -204,7 +192,7 @@ describe("scenarios > question > settings", () => {
       findColumnAtIndex("User → Address", -1).as("user-address");
 
       // Move it one place up
-      moveDnDKitElement(cy.get("@user-address"), { vertical: -100 });
+      H.moveDnDKitElement(cy.get("@user-address"), { vertical: -100 });
 
       findColumnAtIndex("User → Address", -3);
 
@@ -219,7 +207,7 @@ describe("scenarios > question > settings", () => {
 
     it("should be okay showing an empty joined table (metabase#29140)", () => {
       // Orders join Products
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           type: "query",
           query: {
@@ -255,7 +243,7 @@ describe("scenarios > question > settings", () => {
     });
 
     it("should change to column formatting when sidebar is already open (metabase#16043)", () => {
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           type: "query",
           query: { "source-table": ORDERS_ID },
@@ -268,9 +256,9 @@ describe("scenarios > question > settings", () => {
       cy.findByText("Conditional Formatting"); // confirm it's open
 
       // cy.get(".test-TableInteractive").findByText("Subtotal").scrollIntoView();
-      tableHeaderClick("Subtotal"); // open subtotal column header actions
+      H.tableHeaderClick("Subtotal"); // open subtotal column header actions
 
-      popover().icon("gear").click(); // open subtotal column settings
+      H.popover().icon("gear").click(); // open subtotal column settings
 
       //cy.findByText("Table options").should("not.exist"); // no longer displaying the top level settings
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -278,9 +266,9 @@ describe("scenarios > question > settings", () => {
 
       cy.findByTestId("head-crumbs-container").findByText("Orders").click(); //Dismiss popover
 
-      tableHeaderClick("Created At"); // open created_at column header actions
+      H.tableHeaderClick("Created At"); // open created_at column header actions
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.icon("gear").click(); // open created_at column settings
       });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -306,18 +294,18 @@ describe("scenarios > question > settings", () => {
         },
       };
 
-      visitQuestionAdhoc(questionDetails);
+      H.visitQuestionAdhoc(questionDetails);
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(newColumnTitle);
 
       cy.findByTestId("viz-settings-button").click();
 
-      sidebar().findByText(newColumnTitle);
+      H.sidebar().findByText(newColumnTitle);
     });
 
     it("should respect symbol settings for all currencies", () => {
-      openOrdersTable();
+      H.openOrdersTable();
       cy.findByTestId("viz-settings-button").click();
 
       getSidebarColumns()
@@ -463,19 +451,19 @@ describe("scenarios > question > settings", () => {
   describe("resetting state", () => {
     it("should reset modal state when navigating away", () => {
       // create a question and add it to a modal
-      openOrdersTable();
+      H.openOrdersTable();
 
       cy.findByTestId("qb-header").contains("Save").click();
       cy.findByTestId("save-question-modal").findByText("Save").click();
-      modal().findByText("Yes please!").click();
-      entityPickerModal().within(() => {
+      H.modal().findByText("Yes please!").click();
+      H.entityPickerModal().within(() => {
         cy.findByText("Orders in a dashboard").click();
         cy.findByText("Cancel").click();
       });
 
       // create a new question to see if the "add to a dashboard" modal is still there
-      openNavigationSidebar();
-      browseDatabases().click();
+      H.openNavigationSidebar();
+      H.browseDatabases().click();
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Sample Database").click();
@@ -485,7 +473,7 @@ describe("scenarios > question > settings", () => {
       // This next assertion might not catch bugs where the modal displays after
       // a quick delay. With the previous presentation of this bug, the modal
       // was immediately visible, so I'm not going to add any waits.
-      modal().should("not.exist");
+      H.modal().should("not.exist");
     });
   });
 });

--- a/e2e/test/scenarios/question/summarization.cy.spec.js
+++ b/e2e/test/scenarios/question/summarization.cy.spec.js
@@ -1,34 +1,18 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  changeBinningForDimension,
-  checkExpressionEditorHelperPopoverPosition,
-  enterCustomColumnDetails,
-  expressionEditorWidget,
-  getDimensionByName,
-  getRemoveDimensionButton,
-  interceptIfNotPreviouslyDefined,
-  openOrdersTable,
-  openReviewsTable,
-  popover,
-  restore,
-  rightSidebar,
-  summarize,
-  visitQuestion,
-  visualize,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > question > summarize sidebar", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    visitQuestion(ORDERS_QUESTION_ID);
-    summarize();
+    H.visitQuestion(ORDERS_QUESTION_ID);
+    H.summarize();
   });
 
   it("removing all aggregations should show add aggregation button with label", () => {
@@ -43,11 +27,11 @@ describe("scenarios > question > summarize sidebar", () => {
   });
 
   it("selected dimensions becomes pinned to the top of the dimensions list", () => {
-    getDimensionByName({ name: "Total" })
+    H.getDimensionByName({ name: "Total" })
       .should("have.attr", "aria-selected", "false")
       .click({ position: "left" });
 
-    getDimensionByName({ name: "Total" }).should(
+    H.getDimensionByName({ name: "Total" }).should(
       "have.attr",
       "aria-selected",
       "true",
@@ -55,7 +39,7 @@ describe("scenarios > question > summarize sidebar", () => {
 
     cy.button("Done").click();
 
-    summarize();
+    H.summarize();
 
     // Removed from the unpinned list
     cy.findByTestId("unpinned-dimensions").within(() => {
@@ -65,14 +49,14 @@ describe("scenarios > question > summarize sidebar", () => {
     // Displayed in the pinned list
     cy.findByTestId("pinned-dimensions").within(() => {
       cy.findByText("Orders → Total").should("not.exist");
-      getDimensionByName({ name: "Total" }).should(
+      H.getDimensionByName({ name: "Total" }).should(
         "have.attr",
         "aria-selected",
         "true",
       );
     });
 
-    getRemoveDimensionButton({ name: "Total" }).click();
+    H.getRemoveDimensionButton({ name: "Total" }).click();
 
     // Becomes visible in the unpinned list again
     cy.findByTestId("unpinned-dimensions").within(() => {
@@ -81,40 +65,40 @@ describe("scenarios > question > summarize sidebar", () => {
   });
 
   it("selected dimensions from another table includes the table alias when becomes pinned to the top", () => {
-    getDimensionByName({ name: "State" }).click();
+    H.getDimensionByName({ name: "State" }).click();
 
     cy.button("Done").click();
 
-    summarize();
+    H.summarize();
 
     cy.findByTestId("pinned-dimensions").within(() => {
-      getDimensionByName({ name: "User → State" }).should(
+      H.getDimensionByName({ name: "User → State" }).should(
         "have.attr",
         "aria-selected",
         "true",
       );
     });
 
-    getRemoveDimensionButton({ name: "User → State" }).click();
+    H.getRemoveDimensionButton({ name: "User → State" }).click();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("User → State").should("not.exist");
   });
 
   it("selecting a binning adds a dimension", () => {
-    getDimensionByName({ name: "Total" }).click({ position: "left" });
+    H.getDimensionByName({ name: "Total" }).click({ position: "left" });
 
-    changeBinningForDimension({
+    H.changeBinningForDimension({
       name: "Quantity",
       toBinning: "10 bins",
     });
 
-    getDimensionByName({ name: "Total" }).should(
+    H.getDimensionByName({ name: "Total" }).should(
       "have.attr",
       "aria-selected",
       "true",
     );
-    getDimensionByName({ name: "Quantity" }).should(
+    H.getDimensionByName({ name: "Quantity" }).should(
       "have.attr",
       "aria-selected",
       "true",
@@ -154,11 +138,11 @@ describe("scenarios > question > summarize sidebar", () => {
   });
 
   it("should allow using `Custom Expression` in orders metrics (metabase#12899)", () => {
-    openOrdersTable({ mode: "notebook" });
-    summarize({ mode: "notebook" });
-    popover().contains("Custom Expression").click();
-    expressionEditorWidget().within(() => {
-      enterCustomColumnDetails({
+    H.openOrdersTable({ mode: "notebook" });
+    H.summarize({ mode: "notebook" });
+    H.popover().contains("Custom Expression").click();
+    H.expressionEditorWidget().within(() => {
+      H.enterCustomColumnDetails({
         formula: "2 * Max([Total])",
         name: "twice max total",
       });
@@ -168,25 +152,25 @@ describe("scenarios > question > summarize sidebar", () => {
       .contains("twice max total")
       .should("exist");
 
-    visualize();
+    H.visualize();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("318.7");
   });
 
   it("should keep manually entered parenthesis intact if they affect the result (metabase#13306)", () => {
-    openOrdersTable({ mode: "notebook" });
-    summarize({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
+    H.summarize({ mode: "notebook" });
 
-    popover().contains("Custom Expression").click();
-    expressionEditorWidget().within(() => {
-      enterCustomColumnDetails({
+    H.popover().contains("Custom Expression").click();
+    H.expressionEditorWidget().within(() => {
+      H.enterCustomColumnDetails({
         formula:
           "sum([Total]) / (sum([Product → Price]) * average([Quantity]))",
       });
     });
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.get(".ace_text-layer").should(
         "have.text",
         "Sum([Total]) / (Sum([Product → Price]) * Average([Quantity]))",
@@ -195,11 +179,11 @@ describe("scenarios > question > summarize sidebar", () => {
   });
 
   it("distinct inside custom expression should suggest non-numeric types (metabase#13469)", () => {
-    openReviewsTable({ mode: "notebook" });
-    summarize({ mode: "notebook" });
-    popover().contains("Custom Expression").click();
+    H.openReviewsTable({ mode: "notebook" });
+    H.summarize({ mode: "notebook" });
+    H.popover().contains("Custom Expression").click();
 
-    enterCustomColumnDetails({ formula: "Distinct([R" });
+    H.enterCustomColumnDetails({ formula: "Distinct([R" });
 
     cy.log(
       "**The point of failure for ANY non-numeric value reported in v0.36.4**",
@@ -211,15 +195,15 @@ describe("scenarios > question > summarize sidebar", () => {
   });
 
   it("summarizing by distinct datetime should allow granular selection (metabase#13098)", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
 
-    summarize({ mode: "notebook" });
-    popover().within(() => {
+    H.summarize({ mode: "notebook" });
+    H.popover().within(() => {
       cy.findByText("Number of distinct values of ...").click();
       cy.findByLabelText("Temporal bucket").click();
     });
 
-    popover()
+    H.popover()
       .last()
       .within(() => {
         cy.button("More…").click();
@@ -245,7 +229,7 @@ describe("scenarios > question > summarize sidebar", () => {
       { visitQuestion: true },
     );
 
-    summarize();
+    H.summarize();
 
     cy.findAllByTestId("header-cell").should("have.length", 4);
     cy.get(".test-TableInteractive-headerCellData--sorted").as("sortedCell");
@@ -271,42 +255,42 @@ describe("scenarios > question > summarize sidebar", () => {
 
   // flaky test (#19454)
   it.skip("should show an info popover when hovering over summarize dimension options", () => {
-    openReviewsTable();
+    H.openReviewsTable();
 
-    summarize();
+    H.summarize();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Group by")
       .parent()
       .findByText("Title")
       .trigger("mouseenter");
 
-    popover().contains("Title");
-    popover().contains("199 distinct values");
+    H.popover().contains("Title");
+    H.popover().contains("199 distinct values");
   });
 
   // TODO: fixme!
   it.skip("should render custom expression helper near the custom expression field", () => {
-    openReviewsTable({ mode: "notebook" });
-    summarize({ mode: "notebook" });
+    H.openReviewsTable({ mode: "notebook" });
+    H.summarize({ mode: "notebook" });
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Custom Expression").click();
 
-      enterCustomColumnDetails({ formula: "floor" });
+      H.enterCustomColumnDetails({ formula: "floor" });
 
-      checkExpressionEditorHelperPopoverPosition();
+      H.checkExpressionEditorHelperPopoverPosition();
     });
   });
 });
 
 function removeMetricFromSidebar(metricName) {
-  interceptIfNotPreviouslyDefined({
+  H.interceptIfNotPreviouslyDefined({
     method: "POST",
     url: "/api/dataset",
     alias: "dataset",
   });
 
-  rightSidebar().within(() => {
+  H.rightSidebar().within(() => {
     cy.findByLabelText(metricName)
       .find(".Icon-close")
       .should("be.visible")

--- a/e2e/test/scenarios/search/recently-viewed.cy.spec.js
+++ b/e2e/test/scenarios/search/recently-viewed.cy.spec.js
@@ -1,35 +1,22 @@
+import { H } from "e2e/support";
 import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  commandPalette,
-  createModerationReview,
-  describeEE,
-  entityPickerModal,
-  openCommandPalette,
-  openPeopleTable,
-  popover,
-  restore,
-  setTokenFeatures,
-  visitDashboard,
-  visitFullAppEmbeddingUrl,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 describe("search > recently viewed", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    openPeopleTable();
+    H.openPeopleTable();
     cy.findByTextEnsureVisible("Address");
 
     // "Orders" question
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
 
     // "Orders in a dashboard" dashboard
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
     cy.findByTextEnsureVisible("Product ID");
 
     // inside the "Orders in a dashboard" dashboard, the order is queried again,
@@ -37,7 +24,10 @@ describe("search > recently viewed", () => {
 
     cy.intercept("/api/activity/recents?*").as("recent");
     //Because this is testing keyboard navigation, these tests can run in embedded mode
-    visitFullAppEmbeddingUrl({ url: "/", qs: { top_nav: true, search: true } });
+    H.visitFullAppEmbeddingUrl({
+      url: "/",
+      qs: { top_nav: true, search: true },
+    });
     cy.wait("@recent");
 
     cy.findByPlaceholderText("Search…").click();
@@ -87,7 +77,7 @@ describe("search > recently viewed", () => {
 
 describe("Recently Viewed > Entity Picker", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.visit("/");
   });
@@ -98,10 +88,10 @@ describe("Recently Viewed > Entity Picker", () => {
     });
 
     cy.findByTestId("app-bar").button(/New/).click();
-    popover().findByText("Dashboard").click();
+    H.popover().findByText("Dashboard").click();
     cy.findByTestId("collection-picker-button").click();
 
-    entityPickerModal().within(() => {
+    H.entityPickerModal().within(() => {
       cy.findByText("Select a collection").click();
       cy.findByRole("tab", { name: /Recents/ });
       cy.findByRole("tab", { name: /Collections/ });
@@ -112,13 +102,13 @@ describe("Recently Viewed > Entity Picker", () => {
   });
 
   it("shows recently visited dashboard in entity picker", () => {
-    visitDashboard(ORDERS_DASHBOARD_ID);
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
 
     cy.findByTestId("qb-header").icon("ellipsis").click();
-    popover().findByText("Add to dashboard").click();
+    H.popover().findByText("Add to dashboard").click();
 
-    entityPickerModal().within(() => {
+    H.entityPickerModal().within(() => {
       cy.findByText("Add this question to a dashboard").click();
       cy.findByRole("tab", { name: /Recents/ });
       cy.findByRole("tab", { name: /Dashboards/ });
@@ -135,27 +125,27 @@ describe("Recently Viewed > Entity Picker", () => {
   });
 });
 
-describeEE("search > recently viewed > enterprise features", () => {
+H.describeEE("search > recently viewed > enterprise features", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
 
-    createModerationReview({
+    H.createModerationReview({
       status: "verified",
       moderated_item_id: ORDERS_QUESTION_ID,
       moderated_item_type: "card",
     });
 
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
 
     cy.findByTestId("qb-header-left-side").find(".Icon-verified");
   });
 
   it("should show verified badge in the 'Recently viewed' list (metabase#18021)", () => {
-    openCommandPalette();
+    H.openCommandPalette();
 
-    commandPalette().within(() => {
+    H.commandPalette().within(() => {
       cy.icon("verified_filled").should("be.visible");
     });
   });

--- a/e2e/test/scenarios/search/search-filters.cy.spec.js
+++ b/e2e/test/scenarios/search/search-filters.cy.spec.js
@@ -1,3 +1,4 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
@@ -6,18 +7,6 @@ import {
   NORMAL_USER_ID,
   ORDERS_COUNT_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  commandPaletteSearch,
-  createAction,
-  createModerationReview,
-  describeEE,
-  expectSearchResultContent,
-  popover,
-  restore,
-  setActionsEnabledForDB,
-  setTokenFeatures,
-  summarize,
-} from "e2e/support/helpers";
 import { createModelIndex } from "e2e/support/helpers/e2e-model-index-helper";
 
 const typeFilters = [
@@ -90,7 +79,7 @@ const TEST_CREATED_AT_FILTERS = [
 
 describe("scenarios > search", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.intercept("GET", "/api/search?q=*").as("search");
     cy.signInAsAdmin();
   });
@@ -108,14 +97,14 @@ describe("scenarios > search", () => {
 
     describe("type filter", () => {
       beforeEach(() => {
-        setActionsEnabledForDB(SAMPLE_DB_ID);
+        H.setActionsEnabledForDB(SAMPLE_DB_ID);
 
         cy.createQuestion({
           name: "Orders Model",
           query: { "source-table": ORDERS_ID },
           type: "model",
         }).then(({ body: { id } }) => {
-          createAction({
+          H.createAction({
             name: "Update orders quantity",
             description: "Set orders quantity to the same value",
             type: "query",
@@ -178,11 +167,11 @@ describe("scenarios > search", () => {
         it(`should filter results by ${label}`, () => {
           cy.visit("/");
 
-          commandPaletteSearch("e");
+          H.commandPaletteSearch("e");
           cy.wait("@search");
 
           cy.findByTestId("type-search-filter").click();
-          popover().within(() => {
+          H.popover().within(() => {
             cy.findByText(label).click();
             cy.findByText("Apply").click();
           });
@@ -224,7 +213,7 @@ describe("scenarios > search", () => {
 
     describe("created_by filter", () => {
       beforeEach(() => {
-        restore();
+        H.restore();
         // create a question from a normal and admin user, then we can query the question
         // created by that user as an admin
         cy.signInAsNormalUser();
@@ -247,7 +236,7 @@ describe("scenarios > search", () => {
           cy.findByLabelText("close icon").should("exist");
         });
 
-        expectSearchResultContent({
+        H.expectSearchResultContent({
           expectedSearchResults: [
             {
               name: NORMAL_USER_TEST_QUESTION.name,
@@ -266,7 +255,7 @@ describe("scenarios > search", () => {
       it("should filter results by one user", () => {
         cy.visit("/");
 
-        commandPaletteSearch("reviews");
+        H.commandPaletteSearch("reviews");
         cy.wait("@search");
 
         expectSearchResultItemNameContent({
@@ -279,13 +268,13 @@ describe("scenarios > search", () => {
 
         cy.findByTestId("created_by-search-filter").click();
 
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findByText("Robert Tableton").click();
           cy.findByText("Apply").click();
         });
         cy.url().should("contain", "created_by");
 
-        expectSearchResultContent({
+        H.expectSearchResultContent({
           expectedSearchResults: [
             {
               name: NORMAL_USER_TEST_QUESTION.name,
@@ -299,7 +288,7 @@ describe("scenarios > search", () => {
       it("should filter results by more than one user", () => {
         cy.visit("/");
 
-        commandPaletteSearch("reviews");
+        H.commandPaletteSearch("reviews");
         cy.wait("@search");
 
         expectSearchResultItemNameContent({
@@ -312,14 +301,14 @@ describe("scenarios > search", () => {
 
         cy.findByTestId("created_by-search-filter").click();
 
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findByText("Robert Tableton").click();
           cy.findByText("Bobby Tables").click();
           cy.findByText("Apply").click();
         });
         cy.url().should("contain", "created_by");
 
-        expectSearchResultContent({
+        H.expectSearchResultContent({
           expectedSearchResults: [
             {
               name: NORMAL_USER_TEST_QUESTION.name,
@@ -342,7 +331,7 @@ describe("scenarios > search", () => {
 
         cy.wait("@search");
 
-        expectSearchResultContent({
+        H.expectSearchResultContent({
           expectedSearchResults: [
             {
               name: NORMAL_USER_TEST_QUESTION.name,
@@ -358,7 +347,7 @@ describe("scenarios > search", () => {
         });
 
         cy.findByTestId("created_by-search-filter").click();
-        popover().within(() => {
+        H.popover().within(() => {
           // remove Robert Tableton from the created_by filter
           cy.findByTestId("search-user-select-box")
             .findByText("Robert Tableton")
@@ -374,7 +363,7 @@ describe("scenarios > search", () => {
       it("should remove created_by filter when `X` is clicked on filter", () => {
         cy.visit(`/search?q=reviews&created_by=${NORMAL_USER_ID}`);
 
-        expectSearchResultContent({
+        H.expectSearchResultContent({
           expectedSearchResults: [
             {
               name: NORMAL_USER_TEST_QUESTION.name,
@@ -403,7 +392,7 @@ describe("scenarios > search", () => {
           cy.signIn(userType);
           cy.visit("/");
 
-          commandPaletteSearch("reviews");
+          H.commandPaletteSearch("reviews");
           cy.wait("@search");
 
           expectSearchResultItemNameContent(
@@ -418,13 +407,13 @@ describe("scenarios > search", () => {
 
           cy.findByTestId("created_by-search-filter").click();
 
-          popover().within(() => {
+          H.popover().within(() => {
             cy.findByText("Bobby Tables").click();
             cy.findByText("Apply").click();
           });
           cy.url().should("contain", "created_by");
 
-          expectSearchResultContent({
+          H.expectSearchResultContent({
             expectedSearchResults: [
               {
                 name: ADMIN_TEST_QUESTION.name,
@@ -446,7 +435,7 @@ describe("scenarios > search", () => {
             cy.signOut();
             cy.signInAsNormalUser();
             cy.visit(`/question/${questionId}`);
-            summarize();
+            H.summarize();
             cy.findByTestId("sidebar-right").findByText("Done").click();
             cy.findByTestId("qb-header-action-panel")
               .findByText("Save")
@@ -462,7 +451,7 @@ describe("scenarios > search", () => {
           ({ body: { id: questionId } }) => {
             cy.signInAsAdmin();
             cy.visit(`/question/${questionId}`);
-            summarize();
+            H.summarize();
             cy.findByTestId("sidebar-right").findByText("Done").click();
             cy.findByTestId("qb-header-action-panel")
               .findByText("Save")
@@ -486,7 +475,7 @@ describe("scenarios > search", () => {
           cy.findByLabelText("close icon").should("exist");
         });
 
-        expectSearchResultContent({
+        H.expectSearchResultContent({
           expectedSearchResults: [
             {
               name: LAST_EDITED_BY_NORMAL_USER_QUESTION.name,
@@ -500,7 +489,7 @@ describe("scenarios > search", () => {
       it("should filter last_edited results by one user", () => {
         cy.visit("/");
 
-        commandPaletteSearch("reviews");
+        H.commandPaletteSearch("reviews");
         cy.wait("@search");
 
         cy.findByTestId("last_edited_by-search-filter").click();
@@ -513,13 +502,13 @@ describe("scenarios > search", () => {
           ],
         });
 
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findByText("Robert Tableton").click();
           cy.findByText("Apply").click();
         });
         cy.url().should("contain", "last_edited_by");
 
-        expectSearchResultContent({
+        H.expectSearchResultContent({
           expectedSearchResults: [
             {
               name: LAST_EDITED_BY_NORMAL_USER_QUESTION.name,
@@ -533,7 +522,7 @@ describe("scenarios > search", () => {
       it("should filter last_edited results by more than user", () => {
         cy.visit("/");
 
-        commandPaletteSearch("reviews");
+        H.commandPaletteSearch("reviews");
         cy.wait("@search");
 
         cy.findByTestId("last_edited_by-search-filter").click();
@@ -546,14 +535,14 @@ describe("scenarios > search", () => {
           ],
         });
 
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findByText("Robert Tableton").click();
           cy.findByText("Bobby Tables").click();
           cy.findByText("Apply").click();
         });
         cy.url().should("contain", "last_edited_by");
 
-        expectSearchResultContent({
+        H.expectSearchResultContent({
           expectedSearchResults: [
             {
               name: LAST_EDITED_BY_NORMAL_USER_QUESTION.name,
@@ -576,7 +565,7 @@ describe("scenarios > search", () => {
 
         cy.wait("@search");
 
-        expectSearchResultContent({
+        H.expectSearchResultContent({
           expectedSearchResults: [
             {
               name: LAST_EDITED_BY_NORMAL_USER_QUESTION.name,
@@ -592,7 +581,7 @@ describe("scenarios > search", () => {
         });
 
         cy.findByTestId("last_edited_by-search-filter").click();
-        popover().within(() => {
+        H.popover().within(() => {
           // remove Robert Tableton from the last_edited_by filter
           cy.findByTestId("search-user-select-box")
             .findByText("Robert Tableton")
@@ -600,7 +589,7 @@ describe("scenarios > search", () => {
           cy.findByText("Apply").click();
         });
 
-        expectSearchResultContent({
+        H.expectSearchResultContent({
           expectedSearchResults: [
             {
               name: LAST_EDITED_BY_ADMIN_QUESTION.name,
@@ -616,7 +605,7 @@ describe("scenarios > search", () => {
           `/search?q=reviews&last_edited_by=${NORMAL_USER_ID}&last_edited_by=${ADMIN_USER_ID}`,
         );
 
-        expectSearchResultContent({
+        H.expectSearchResultContent({
           expectedSearchResults: [
             {
               name: LAST_EDITED_BY_NORMAL_USER_QUESTION.name,
@@ -650,7 +639,7 @@ describe("scenarios > search", () => {
           cy.signIn(userType);
           cy.visit("/");
 
-          commandPaletteSearch("reviews");
+          H.commandPaletteSearch("reviews");
           cy.wait("@search");
 
           expectSearchResultItemNameContent(
@@ -665,13 +654,13 @@ describe("scenarios > search", () => {
 
           cy.findByTestId("last_edited_by-search-filter").click();
 
-          popover().within(() => {
+          H.popover().within(() => {
             cy.findByText("Bobby Tables").click();
             cy.findByText("Apply").click();
           });
           cy.url().should("contain", "last_edited_by");
 
-          expectSearchResultContent({
+          H.expectSearchResultContent({
             expectedSearchResults: [
               {
                 name: LAST_EDITED_BY_ADMIN_QUESTION.name,
@@ -718,11 +707,11 @@ describe("scenarios > search", () => {
         );
 
         cy.findByTestId("created_at-search-filter").click();
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findByText("Today").click();
         });
 
-        expectSearchResultContent({
+        H.expectSearchResultContent({
           expectedSearchResults: [
             {
               name: NORMAL_USER_TEST_QUESTION.name,
@@ -738,7 +727,7 @@ describe("scenarios > search", () => {
         cy.visit("/search?q=Reviews&created_at=thisday");
         cy.wait("@search");
 
-        expectSearchResultContent({
+        H.expectSearchResultContent({
           expectedSearchResults: [
             {
               name: NORMAL_USER_TEST_QUESTION.name,
@@ -778,7 +767,7 @@ describe("scenarios > search", () => {
             cy.signOut();
             cy.signInAsNormalUser();
             cy.visit(`/question/${questionId}`);
-            summarize();
+            H.summarize();
             cy.findByTestId("sidebar-right").findByText("Done").click();
             cy.findByTestId("qb-header-action-panel")
               .findByText("Save")
@@ -818,11 +807,11 @@ describe("scenarios > search", () => {
         });
 
         cy.findByTestId("last_edited_at-search-filter").click();
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findByText("Today").click();
         });
 
-        expectSearchResultContent({
+        H.expectSearchResultContent({
           expectedSearchResults: [
             {
               name: LAST_EDITED_BY_NORMAL_USER_QUESTION.name,
@@ -838,7 +827,7 @@ describe("scenarios > search", () => {
         cy.visit("/search?q=Reviews&last_edited_at=thisday");
         cy.wait("@search");
 
-        expectSearchResultContent({
+        H.expectSearchResultContent({
           expectedSearchResults: [
             {
               name: LAST_EDITED_BY_NORMAL_USER_QUESTION.name,
@@ -869,10 +858,10 @@ describe("scenarios > search", () => {
       });
     });
 
-    describeEE("verified filter", () => {
+    H.describeEE("verified filter", () => {
       beforeEach(() => {
-        setTokenFeatures("all");
-        createModerationReview({
+        H.setTokenFeatures("all");
+        H.createModerationReview({
           status: "verified",
           moderated_item_type: "card",
           moderated_item_id: ORDERS_COUNT_QUESTION_ID,
@@ -897,7 +886,7 @@ describe("scenarios > search", () => {
       it("should filter results by verified items", () => {
         cy.visit("/");
 
-        commandPaletteSearch("e");
+        H.commandPaletteSearch("e");
         cy.wait("@search");
 
         cy.findByTestId("verified-search-filter")
@@ -1042,21 +1031,21 @@ describe("scenarios > search", () => {
 
       // add created_by filter
       cy.findByTestId("created_by-search-filter").click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Bobby Tables").click();
         cy.findByText("Apply").click();
       });
 
       // add last_edited_by filter
       cy.findByTestId("last_edited_by-search-filter").click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Bobby Tables").click();
         cy.findByText("Apply").click();
       });
 
       // add type filter
       cy.findByTestId("type-search-filter").click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Question").click();
         cy.findByText("Apply").click();
       });
@@ -1070,7 +1059,7 @@ describe("scenarios > search", () => {
       });
 
       //getSearchBar().clear().type("count{enter}");
-      commandPaletteSearch("count");
+      H.commandPaletteSearch("count");
 
       expectSearchResultItemNameContent({
         itemNames: [

--- a/e2e/test/scenarios/search/search-pagination.cy.spec.js
+++ b/e2e/test/scenarios/search/search-pagination.cy.spec.js
@@ -1,12 +1,7 @@
 import _ from "underscore";
 
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  commandPaletteSearch,
-  getSearchBar,
-  restore,
-  visitFullAppEmbeddingUrl,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
@@ -15,7 +10,7 @@ const TOTAL_ITEMS = PAGE_SIZE + 1;
 
 describe("scenarios > search", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -23,15 +18,18 @@ describe("scenarios > search", () => {
     cy.intercept("/api/search", req => {
       expect("Unexpected call to /api/search").to.be.false;
     });
-    visitFullAppEmbeddingUrl({ url: "/", qs: { top_nav: true, search: true } });
-    getSearchBar().type(" ");
+    H.visitFullAppEmbeddingUrl({
+      url: "/",
+      qs: { top_nav: true, search: true },
+    });
+    H.getSearchBar().type(" ");
   });
 
   it("should allow users to paginate results", () => {
     generateQuestions(TOTAL_ITEMS);
 
     cy.visit("/");
-    commandPaletteSearch("generated_question");
+    H.commandPaletteSearch("generated_question");
     cy.findByLabelText("Previous page").should("be.disabled");
 
     // First page

--- a/e2e/test/scenarios/search/search-snowplow.cy.spec.js
+++ b/e2e/test/scenarios/search/search-snowplow.cy.spec.js
@@ -1,45 +1,30 @@
-import {
-  commandPalette,
-  commandPaletteSearch,
-  describeEE,
-  describeWithSnowplow,
-  enableTracking,
-  entityPickerModal,
-  expectGoodSnowplowEvent,
-  expectNoBadSnowplowEvents,
-  modal,
-  popover,
-  resetSnowplow,
-  restore,
-  setTokenFeatures,
-  visitFullAppEmbeddingUrl,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 import { commandPaletteInput } from "../../../support/helpers/e2e-command-palette-helpers";
 
-describeWithSnowplow("scenarios > search > snowplow", () => {
+H.describeWithSnowplow("scenarios > search > snowplow", () => {
   const NEW_SEARCH_QUERY_EVENT_NAME = "search_query";
   const SEARCH_CLICK = "search_click";
 
   beforeEach(() => {
-    restore();
-    resetSnowplow();
+    H.restore();
+    H.resetSnowplow();
     cy.signInAsAdmin();
-    enableTracking();
+    H.enableTracking();
     cy.intercept("GET", "/api/search**").as("search");
   });
 
   afterEach(() => {
-    expectNoBadSnowplowEvents();
+    H.expectNoBadSnowplowEvents();
   });
 
   describe("command palette", () => {
     it("should send snowplow events search queries on a click", () => {
       cy.visit("/");
-      commandPaletteSearch("Orders", false);
+      H.commandPaletteSearch("Orders", false);
 
       //Passing a function to ensure that runtime_milliseconds is populated as a number
-      expectGoodSnowplowEvent(data => {
+      H.expectGoodSnowplowEvent(data => {
         if (!data) {
           return false;
         }
@@ -50,8 +35,8 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
         );
       });
 
-      commandPalette().findByRole("option", { name: "Orders Model" }).click();
-      expectGoodSnowplowEvent(
+      H.commandPalette().findByRole("option", { name: "Orders Model" }).click();
+      H.expectGoodSnowplowEvent(
         {
           event: SEARCH_CLICK,
           context: "command-palette",
@@ -63,10 +48,10 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
 
     it("should send snowplow events search queries on keyboard navigation", () => {
       cy.visit("/");
-      commandPaletteSearch("Orders", false);
+      H.commandPaletteSearch("Orders", false);
 
       //Passing a function to ensure that runtime_milliseconds is populated as a number
-      expectGoodSnowplowEvent(data => {
+      H.expectGoodSnowplowEvent(data => {
         if (!data) {
           return false;
         }
@@ -84,7 +69,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
         delay: 200,
       });
 
-      expectGoodSnowplowEvent(
+      H.expectGoodSnowplowEvent(
         {
           event: SEARCH_CLICK,
           context: "command-palette",
@@ -99,22 +84,22 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
     it("should send snowplow events search queries", () => {
       cy.visit("/");
       cy.button("New").click();
-      popover().findByText("Dashboard").click();
-      modal().findByTestId("collection-picker-button").click();
+      H.popover().findByText("Dashboard").click();
+      H.modal().findByTestId("collection-picker-button").click();
 
-      entityPickerModal().findByPlaceholderText("Search…").type("second");
+      H.entityPickerModal().findByPlaceholderText("Search…").type("second");
 
-      expectGoodSnowplowEvent({
+      H.expectGoodSnowplowEvent({
         event: NEW_SEARCH_QUERY_EVENT_NAME,
         context: "entity-picker",
         content_type: ["collection"],
       });
 
-      entityPickerModal()
+      H.entityPickerModal()
         .findByRole("button", { name: /Second/ })
         .click();
 
-      expectGoodSnowplowEvent({
+      H.expectGoodSnowplowEvent({
         event: SEARCH_CLICK,
         context: "entity-picker",
         position: 0,
@@ -124,14 +109,14 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
 
   describe("search bar - embedding only", () => {
     it("should send snowplow events search queries", () => {
-      visitFullAppEmbeddingUrl({
+      H.visitFullAppEmbeddingUrl({
         url: "/",
         qs: { top_nav: true, search: true },
       });
       cy.findByPlaceholderText("Search…").type("coun");
       cy.findByTestId("loading-indicator").should("not.exist");
 
-      expectGoodSnowplowEvent({
+      H.expectGoodSnowplowEvent({
         event: NEW_SEARCH_QUERY_EVENT_NAME,
         context: "search-bar",
       });
@@ -140,7 +125,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
         .findByRole("heading", { name: "PEOPLE" })
         .click();
 
-      expectGoodSnowplowEvent({
+      H.expectGoodSnowplowEvent({
         event: SEARCH_CLICK,
         context: "search-bar",
         position: 2,
@@ -153,13 +138,13 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a new_search_query snowplow event", () => {
         cy.visit("/search?q=orders");
         cy.wait("@search");
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
         });
 
         cy.findByRole("heading", { name: "Orders in a dashboard" }).click();
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: SEARCH_CLICK,
           context: "search-app",
           position: 3,
@@ -172,7 +157,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
         cy.visit("/search?q=orders&type=card");
         cy.wait("@search");
 
-        expectGoodSnowplowEvent(
+        H.expectGoodSnowplowEvent(
           {
             event: NEW_SEARCH_QUERY_EVENT_NAME,
 
@@ -186,20 +171,20 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is applied from the UI", () => {
         cy.visit("/search?q=orders");
         cy.wait("@search");
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
         });
 
         cy.findByTestId("type-search-filter").click();
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findAllByTestId("type-filter-checkbox").each($el => {
             cy.wrap($el).click();
           });
           cy.findByText("Apply").click();
         });
 
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
 
           context: "search-app",
@@ -218,7 +203,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is removed from the UI", () => {
         cy.visit("/search?q=orders&type=card");
         cy.wait("@search");
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -229,7 +214,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
           .findByLabelText("close icon")
           .click();
 
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -242,7 +227,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is used in the URL", () => {
         cy.visit("/search?q=orders&created_by=1");
         cy.wait("@search");
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -253,19 +238,19 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is applied from the UI", () => {
         cy.visit("/search?q=orders");
         cy.wait("@search");
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
           creator: false,
         });
 
         cy.findByTestId("created_by-search-filter").click();
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findByText("Bobby Tables").click();
           cy.findByText("Apply").click();
         });
 
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -276,7 +261,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is removed from the UI", () => {
         cy.visit("/search?q=orders&created_by=1");
         cy.wait("@search");
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -287,7 +272,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
           .findByLabelText("close icon")
           .click();
 
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -300,7 +285,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is used in the URL", () => {
         cy.visit("/search?q=orders&last_edited_by=1");
         cy.wait("@search");
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -311,7 +296,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is applied from the UI", () => {
         cy.visit("/search?q=orders");
         cy.wait("@search");
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -319,12 +304,12 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
         });
 
         cy.findByTestId("last_edited_by-search-filter").click();
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findByText("Bobby Tables").click();
           cy.findByText("Apply").click();
         });
 
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -335,7 +320,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is removed from the UI", () => {
         cy.visit("/search?q=orders&last_edited_by=1");
         cy.wait("@search");
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -346,7 +331,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
           .findByLabelText("close icon")
           .click();
 
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -359,7 +344,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is used in the URL", () => {
         cy.visit("/search?q=orders&created_at=thisday");
         cy.wait("@search");
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -370,7 +355,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is applied from the UI", () => {
         cy.visit("/search?q=orders");
         cy.wait("@search");
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -378,11 +363,11 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
         });
 
         cy.findByTestId("created_at-search-filter").click();
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findByText("Today").click();
         });
 
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -393,7 +378,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is removed from the UI", () => {
         cy.visit("/search?q=orders&created_at=thisday");
         cy.wait("@search");
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -404,7 +389,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
           .findByLabelText("close icon")
           .click();
 
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -417,7 +402,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is used in the URL", () => {
         cy.visit("/search?q=orders&last_edited_at=thisday");
         cy.wait("@search");
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -428,7 +413,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is applied from the UI", () => {
         cy.visit("/search?q=orders");
         cy.wait("@search");
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -436,11 +421,11 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
         });
 
         cy.findByTestId("last_edited_at-search-filter").click();
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findByText("Today").click();
         });
 
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -451,7 +436,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is removed from the UI", () => {
         cy.visit("/search?q=orders&last_edited_at=thisday");
         cy.wait("@search");
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -462,7 +447,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
           .findByLabelText("close icon")
           .click();
 
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -471,15 +456,15 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
       });
     });
 
-    describeEE("verified filter", () => {
+    H.describeEE("verified filter", () => {
       beforeEach(() => {
-        setTokenFeatures("all");
+        H.setTokenFeatures("all");
       });
 
       it("should send a snowplow event when a search filter is used in the URL", () => {
         cy.visit("/search?q=orders&verified=true");
         cy.wait("@search");
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -490,7 +475,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is applied from the UI", () => {
         cy.visit("/search?q=orders");
         cy.wait("@search");
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -501,7 +486,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
           .findByText("Verified items only")
           .click();
 
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -512,7 +497,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is removed from the UI", () => {
         cy.visit("/search?q=orders&verified=true");
         cy.wait("@search");
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -523,7 +508,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
           .findByText("Verified items only")
           .click();
 
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -536,7 +521,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is used in the URL", () => {
         cy.visit("/search?q=orders&search_native_query=true");
         cy.wait("@search");
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -547,7 +532,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is applied from the UI", () => {
         cy.visit("/search?q=orders");
         cy.wait("@search");
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -558,7 +543,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
           .findByText("Search the contents of native queries")
           .click();
 
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -569,7 +554,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is removed from the UI", () => {
         cy.visit("/search?q=orders&search_native_query=true");
         cy.wait("@search");
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -580,7 +565,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
           .findByText("Search the contents of native queries")
           .click();
 
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -593,7 +578,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is used in the URL", () => {
         cy.visit("/search?q=orders&archived=true");
         cy.wait("@search");
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -604,7 +589,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is applied from the UI", () => {
         cy.visit("/search?q=orders");
         cy.wait("@search");
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -615,7 +600,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
           .findByText("Search items in trash")
           .click();
 
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -626,7 +611,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
       it("should send a snowplow event when a search filter is removed from the UI", () => {
         cy.visit("/search?q=orders&archived=true");
         cy.wait("@search");
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 
@@ -637,7 +622,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
           .findByText("Search items in trash")
           .click();
 
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: NEW_SEARCH_QUERY_EVENT_NAME,
           context: "search-app",
 

--- a/e2e/test/scenarios/search/search-typeahead.cy.spec.js
+++ b/e2e/test/scenarios/search/search-typeahead.cy.spec.js
@@ -1,19 +1,12 @@
+import { H } from "e2e/support";
 import { USERS } from "e2e/support/cypress_data";
-import {
-  commandPalette,
-  commandPaletteButton,
-  commandPaletteInput,
-  restore,
-  updateSetting,
-  visitFullAppEmbeddingUrl,
-} from "e2e/support/helpers";
 
 ["admin", "normal"].forEach(user => {
   describe(`search > ${user} user`, () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signIn(user);
-      visitFullAppEmbeddingUrl({
+      H.visitFullAppEmbeddingUrl({
         url: "/",
         qs: { top_nav: true, search: true },
       });
@@ -38,16 +31,16 @@ import {
 
 describe("command palette", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    updateSetting("search-typeahead-enabled", false);
+    H.updateSetting("search-typeahead-enabled", false);
     cy.visit("/");
   });
 
   it("should not display search results in the palette when search-typeahead-enabled is false", () => {
-    commandPaletteButton().click();
-    commandPaletteInput().type("ord");
-    commandPalette()
+    H.commandPaletteButton().click();
+    H.commandPaletteInput().type("ord");
+    H.commandPalette()
       .findByRole("option", { name: /View search results/ })
       .should("exist");
   });

--- a/e2e/test/scenarios/search/search.cy.spec.js
+++ b/e2e/test/scenarios/search/search.cy.spec.js
@@ -1,23 +1,14 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  assertIsEllipsified,
-  expectSearchResultContent,
-  getSearchBar,
-  isScrollableHorizontally,
-  main,
-  restore,
-  updateSetting,
-  visitFullAppEmbeddingUrl,
-} from "e2e/support/helpers";
 
 const { ORDERS_ID, PEOPLE_ID, REVIEWS_ID } = SAMPLE_DATABASE;
 
 const visitEmbeddingWithSearch = (url = "/") => {
-  visitFullAppEmbeddingUrl({
+  H.visitFullAppEmbeddingUrl({
     url: url,
     qs: {
       top_nav: true,
@@ -28,7 +19,7 @@ const visitEmbeddingWithSearch = (url = "/") => {
 
 describe("scenarios > search", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.intercept("GET", "/api/search?q=*").as("search");
     cy.signInAsAdmin();
   });
@@ -36,9 +27,9 @@ describe("scenarios > search", () => {
   describe("universal search", () => {
     it("should work for admin (metabase#20018)", () => {
       visitEmbeddingWithSearch("/");
-      getSearchBar().as("searchBox").clear().type("orders count").blur();
+      H.getSearchBar().as("searchBox").clear().type("orders count").blur();
 
-      expectSearchResultContent({
+      H.expectSearchResultContent({
         expectedSearchResults: [
           {
             name: /Orders, Count, Grouped by/i,
@@ -48,11 +39,11 @@ describe("scenarios > search", () => {
         strict: false,
       });
 
-      getSearchBar().clear().type("product").blur();
+      H.getSearchBar().clear().type("product").blur();
 
       cy.wait("@search");
 
-      expectSearchResultContent({
+      H.expectSearchResultContent({
         expectedSearchResults: [
           {
             name: "Products",
@@ -67,7 +58,7 @@ describe("scenarios > search", () => {
       cy.get("@searchBox").type("{enter}");
       cy.wait("@search");
 
-      expectSearchResultContent({
+      H.expectSearchResultContent({
         expectedSearchResults: [
           {
             name: "Products",
@@ -82,7 +73,7 @@ describe("scenarios > search", () => {
     it("should work for user with permissions (metabase#12332)", () => {
       cy.signInAsNormalUser();
       visitEmbeddingWithSearch("/");
-      getSearchBar().type("product{enter}");
+      H.getSearchBar().type("product{enter}");
       cy.wait("@search");
       cy.findByTestId("search-app").within(() => {
         cy.findByText("Products");
@@ -92,7 +83,7 @@ describe("scenarios > search", () => {
     it("should work for user without data permissions (metabase#16855)", () => {
       cy.signIn("nodata");
       visitEmbeddingWithSearch("/");
-      getSearchBar().type("product{enter}");
+      H.getSearchBar().type("product{enter}");
       cy.wait("@search");
       cy.findByTestId("search-app").within(() => {
         cy.findByText("Didn't find anything");
@@ -102,7 +93,7 @@ describe("scenarios > search", () => {
     it("allows to select a search result using keyboard", () => {
       cy.signInAsNormalUser();
       visitEmbeddingWithSearch("/");
-      getSearchBar().type("ord");
+      H.getSearchBar().type("ord");
 
       cy.wait("@search");
 
@@ -140,13 +131,13 @@ describe("scenarios > search", () => {
       }).then(() => {
         cy.signInAsNormalUser();
         visitEmbeddingWithSearch("/");
-        getSearchBar().type("Test");
+        H.getSearchBar().type("Test");
       });
 
       //Enseure that text is ellipsified
       cy.findByTestId("result-description")
         .findByText(/Lorem ipsum dolor sit amet./)
-        .then(el => assertIsEllipsified(el[0]));
+        .then(el => H.assertIsEllipsified(el[0]));
 
       //Ensure that images are not being rendered in the descriptions
       cy.findByTestId("result-description")
@@ -163,7 +154,7 @@ describe("scenarios > search", () => {
       }).then(() => {
         cy.signInAsNormalUser();
         visitEmbeddingWithSearch("/");
-        getSearchBar().type("Test");
+        H.getSearchBar().type("Test");
       });
 
       const resultDescription = cy.findByTestId("result-description");
@@ -186,16 +177,18 @@ describe("scenarios > search", () => {
       visitEmbeddingWithSearch(`/dashboard/${ORDERS_DASHBOARD_ID}`);
 
       // Type as soon as possible, before the dashboard has finished loading
-      getSearchBar().type("ord");
+      H.getSearchBar().type("ord");
 
       // Once the dashboard is visible, the search results should not be dismissed
-      main().findByRole("heading", { name: "Loading..." }).should("not.exist");
+      H.main()
+        .findByRole("heading", { name: "Loading..." })
+        .should("not.exist");
       cy.findByTestId("search-results-floating-container").should("exist");
     });
 
     it("should not dismiss when the homepage redirects to a dashboard (metabase#34226)", () => {
-      updateSetting("custom-homepage", true);
-      updateSetting("custom-homepage-dashboard", ORDERS_DASHBOARD_ID);
+      H.updateSetting("custom-homepage", true);
+      H.updateSetting("custom-homepage-dashboard", ORDERS_DASHBOARD_ID);
       cy.intercept(
         {
           url: `/api/dashboard/${ORDERS_DASHBOARD_ID}`,
@@ -212,7 +205,7 @@ describe("scenarios > search", () => {
       visitEmbeddingWithSearch("/");
 
       // Type as soon as possible, before the dashboard has finished loading
-      getSearchBar().type("ord");
+      H.getSearchBar().type("ord");
 
       // Once the dashboard is visible, the search results should not be dismissed
       cy.findByTestId("dashboard-parameters-and-cards").should("exist");
@@ -227,7 +220,7 @@ describe("scenarios > search", () => {
 
       visitEmbeddingWithSearch("/");
 
-      getSearchBar().click().type("{enter}");
+      H.getSearchBar().click().type("{enter}");
 
       cy.wait("@getRecentViews");
 
@@ -240,7 +233,7 @@ describe("scenarios > search", () => {
     it("should render full page search when search text is present and user clicks 'Enter'", () => {
       visitEmbeddingWithSearch("/");
 
-      getSearchBar().click().type("orders{enter}");
+      H.getSearchBar().click().type("orders{enter}");
       cy.wait("@search");
 
       cy.findByTestId("search-app").within(() => {
@@ -257,7 +250,7 @@ describe("scenarios > search", () => {
 
 describe.skip("issue 16785", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.request("PUT", "/api/table", {
@@ -280,7 +273,7 @@ describe("issue 28788", () => {
   const LONG_STRING = "01234567890ABCDEFGHIJKLMNOPQRSTUVXYZ0123456789";
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("GET", "/api/search*").as("search");
   });
@@ -304,13 +297,16 @@ describe("issue 28788", () => {
       });
     });
 
-    visitFullAppEmbeddingUrl({ url: "/", qs: { top_nav: true, search: true } });
+    H.visitFullAppEmbeddingUrl({
+      url: "/",
+      qs: { top_nav: true, search: true },
+    });
     cy.findByPlaceholderText("Search…").type(questionDetails.name);
     cy.wait("@search");
     cy.icon("hourglass").should("not.exist");
 
     cy.findByTestId("search-bar-results-container").then($container => {
-      expect(isScrollableHorizontally($container[0])).to.be.false;
+      expect(H.isScrollableHorizontally($container[0])).to.be.false;
     });
   });
 });

--- a/e2e/test/scenarios/sharing/alert/alert-permissions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/alert-permissions.cy.spec.js
@@ -1,20 +1,10 @@
+import { H } from "e2e/support";
 import { USERS } from "e2e/support/cypress_data";
 import {
   ORDERS_BY_YEAR_QUESTION_ID,
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  getFullName,
-  modal,
-  notificationList,
-  openSharingMenu,
-  popover,
-  restore,
-  setupSMTP,
-  sharingMenu,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 const { normal, admin } = USERS;
 
@@ -22,22 +12,22 @@ describe("scenarios > alert > alert permissions", { tags: "@external" }, () => {
   // Intentional use of before (not beforeEach) hook because the setup is quite long.
   // Make sure that all tests are always able to run independently!
   before(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    setupSMTP();
+    H.setupSMTP();
 
     // Create alert as admin
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
     createBasicAlert({ firstAlert: true });
 
     // Create alert as admin that user can see
-    visitQuestion(ORDERS_COUNT_QUESTION_ID);
+    H.visitQuestion(ORDERS_COUNT_QUESTION_ID);
     createBasicAlert({ includeNormal: true });
 
     // Create alert as normal user
     cy.signInAsNormalUser();
-    visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
+    H.visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
     createBasicAlert();
   });
 
@@ -54,15 +44,15 @@ describe("scenarios > alert > alert permissions", { tags: "@external" }, () => {
       cy.intercept("PUT", "/api/alert/*").as("updatedAlert");
 
       // Change alert
-      visitQuestion(ORDERS_QUESTION_ID);
+      H.visitQuestion(ORDERS_QUESTION_ID);
 
-      openSharingMenu("Edit alerts");
+      H.openSharingMenu("Edit alerts");
 
-      popover().findByText("Edit").click();
+      H.popover().findByText("Edit").click();
 
-      modal().findByText("Daily").click();
-      popover().findByText("Weekly").click();
-      modal().button("Save changes").click();
+      H.modal().findByText("Daily").click();
+      H.popover().findByText("Weekly").click();
+      H.modal().button("Save changes").click();
 
       // Check that changes stuck
       cy.wait("@updatedAlert").then(({ response: { body } }) => {
@@ -75,54 +65,56 @@ describe("scenarios > alert > alert permissions", { tags: "@external" }, () => {
     beforeEach(cy.signInAsNormalUser);
 
     it("should not let you see other people's alerts", () => {
-      visitQuestion(ORDERS_QUESTION_ID);
-      openSharingMenu();
+      H.visitQuestion(ORDERS_QUESTION_ID);
+      H.openSharingMenu();
 
-      sharingMenu().findByText("Edit alerts").should("not.exist");
-      sharingMenu().findByText("Create alert").should("be.visible");
+      H.sharingMenu().findByText("Edit alerts").should("not.exist");
+      H.sharingMenu().findByText("Create alert").should("be.visible");
     });
 
     it("should let you see other alerts where you are a recipient", () => {
-      visitQuestion(ORDERS_COUNT_QUESTION_ID);
-      openSharingMenu("Edit alerts");
+      H.visitQuestion(ORDERS_COUNT_QUESTION_ID);
+      H.openSharingMenu("Edit alerts");
 
-      popover().findByText(`You're receiving ${getFullName(admin)}'s alerts`);
-      popover().findByText("Set up your own alert");
+      H.popover().findByText(
+        `You're receiving ${H.getFullName(admin)}'s alerts`,
+      );
+      H.popover().findByText("Set up your own alert");
     });
 
     it("should let you see your own alerts", () => {
-      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
-      openSharingMenu("Edit alerts");
+      H.visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
+      H.openSharingMenu("Edit alerts");
 
-      popover().findByText("You set up an alert");
+      H.popover().findByText("You set up an alert");
     });
 
     it("should let you unsubscribe from both your own and others' alerts", () => {
       // Unsubscribe from your own alert
-      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
-      openSharingMenu("Edit alerts");
-      popover().findByText("Unsubscribe").click();
-      notificationList().findByText("Okay, you're unsubscribed.");
+      H.visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
+      H.openSharingMenu("Edit alerts");
+      H.popover().findByText("Unsubscribe").click();
+      H.notificationList().findByText("Okay, you're unsubscribed.");
 
       // Unsubscribe from others' alerts
-      visitQuestion(ORDERS_COUNT_QUESTION_ID);
-      openSharingMenu("Edit alerts");
-      popover().findByText("Unsubscribe").click();
-      notificationList().findByText("Okay, you're unsubscribed.");
+      H.visitQuestion(ORDERS_COUNT_QUESTION_ID);
+      H.openSharingMenu("Edit alerts");
+      H.popover().findByText("Unsubscribe").click();
+      H.notificationList().findByText("Okay, you're unsubscribed.");
     });
   });
 });
 
 function createBasicAlert({ firstAlert, includeNormal } = {}) {
-  openSharingMenu("Create alert");
+  H.openSharingMenu("Create alert");
 
   if (firstAlert) {
-    modal().findByText("Set up an alert").click();
+    H.modal().findByText("Set up an alert").click();
   }
 
   if (includeNormal) {
     cy.findByText("Email alerts to:").parent().children().last().click();
-    cy.findByText(getFullName(normal)).click();
+    cy.findByText(H.getFullName(normal)).click();
   }
   cy.findByText("Done").click();
   cy.findByText("Let's set up your alert").should("not.exist");

--- a/e2e/test/scenarios/sharing/alert/alert-types.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/alert-types.cy.spec.js
@@ -1,15 +1,9 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_BY_YEAR_QUESTION_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  modal,
-  openSharingMenu,
-  restore,
-  setupSMTP,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 const { PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
 
@@ -50,22 +44,22 @@ describe("scenarios > alert > types", { tags: "@external" }, () => {
     cy.intercept("POST", "/api/alert").as("savedAlert");
     cy.intercept("GET", "/api/channel").as("channel");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.setCookie("metabase.SEEN_ALERT_SPLASH", "true");
 
-    setupSMTP();
+    H.setupSMTP();
   });
 
   describe("rows based alerts", () => {
     rawTestCases.forEach(({ questionType, questionId }) => {
       it(`should be supported for ${questionType}`, () => {
-        visitQuestion(questionId);
+        H.visitQuestion(questionId);
 
-        openSharingMenu("Create alert");
+        H.openSharingMenu("Create alert");
         cy.wait("@channel");
 
-        modal().within(() => {
+        H.modal().within(() => {
           cy.findByText("Let's set up your alert").should("be.visible");
           cy.findByText("Done").click();
         });
@@ -89,10 +83,10 @@ describe("scenarios > alert > types", { tags: "@external" }, () => {
       });
 
       cy.log("Set the goal on timeseries question");
-      visitQuestion(timeSeriesQuestionId);
+      H.visitQuestion(timeSeriesQuestionId);
       cy.findByTestId("chart-container").should("contain", "Goal");
 
-      openSharingMenu("Create alert");
+      H.openSharingMenu("Create alert");
       cy.wait("@channel");
 
       cy.findByTestId("alert-create").within(() => {
@@ -112,7 +106,7 @@ describe("scenarios > alert > types", { tags: "@external" }, () => {
     it("should not be possible to create goal based alert for a multi-series question", () => {
       cy.createQuestion(multiSeriesQuestionWithGoal, { visitQuestion: true });
 
-      openSharingMenu("Create alert");
+      H.openSharingMenu("Create alert");
       cy.wait("@channel");
 
       // *** The warning below is not showing when we try to make an alert (Issue #???)
@@ -120,7 +114,7 @@ describe("scenarios > alert > types", { tags: "@external" }, () => {
       //   "Goal-based alerts aren't yet supported for charts with more than one line",
       // );
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText("Let's set up your alert").should("be.visible");
         cy.findByText("Done").click();
       });

--- a/e2e/test/scenarios/sharing/alert/alert.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/alert.cy.spec.js
@@ -1,47 +1,35 @@
+import { H } from "e2e/support";
 import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_MODEL_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  mockSlackConfigured,
-  modal,
-  openSharingMenu,
-  popover,
-  restore,
-  setupNotificationChannel,
-  setupSMTP,
-  sharingMenuButton,
-  toggleAlertChannel,
-  visitModel,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 const channels = {
   slack: {
-    setup: mockSlackConfigured,
+    setup: H.mockSlackConfigured,
     createAlert: () => {
-      toggleAlertChannel("Email");
-      toggleAlertChannel("Slack");
+      H.toggleAlertChannel("Email");
+      H.toggleAlertChannel("Slack");
       cy.findByPlaceholderText(/Pick a user or channel/).click();
-      popover().findByText("#work").click();
+      H.popover().findByText("#work").click();
     },
   },
-  email: { setup: setupSMTP, createAlert: () => {} },
+  email: { setup: H.setupSMTP, createAlert: () => {} },
 };
 
 describe("scenarios > alert", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   describe("with nothing set", () => {
     it("should prompt you to add email/slack credentials", () => {
-      visitQuestion(ORDERS_QUESTION_ID);
-      openSharingMenu("Create alert");
+      H.visitQuestion(ORDERS_QUESTION_ID);
+      H.openSharingMenu("Create alert");
 
-      modal().within(() => {
+      H.modal().within(() => {
         cy.findByText(
           "To send alerts, you'll need to set up email, Slack or Webhook integration.",
         );
@@ -67,8 +55,8 @@ describe("scenarios > alert", () => {
     it("should say to non-admins that admin must add email credentials", () => {
       cy.signInAsNormalUser();
 
-      visitQuestion(ORDERS_QUESTION_ID);
-      openSharingMenu("Create alert");
+      H.visitQuestion(ORDERS_QUESTION_ID);
+      H.openSharingMenu("Create alert");
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(
@@ -88,8 +76,8 @@ describe("scenarios > alert", () => {
         );
 
         // Open the first alert screen and create an alert
-        visitQuestion(ORDERS_QUESTION_ID);
-        openSharingMenu("Create alert");
+        H.visitQuestion(ORDERS_QUESTION_ID);
+        H.openSharingMenu("Create alert");
 
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("The wide world of alerts");
@@ -113,10 +101,10 @@ describe("scenarios > alert", () => {
         cy.wait("@savedAlert");
 
         // Open the second alert screen
-        visitQuestion(ORDERS_COUNT_QUESTION_ID);
+        H.visitQuestion(ORDERS_COUNT_QUESTION_ID);
         cy.wait("@questionLoaded");
 
-        openSharingMenu("Create alert");
+        H.openSharingMenu("Create alert");
 
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Let's set up your alert");
@@ -128,11 +116,11 @@ describe("scenarios > alert", () => {
 
   describe("with a webhook", { tags: ["@external"] }, () => {
     beforeEach(() => {
-      setupNotificationChannel({
+      H.setupNotificationChannel({
         name: "Foo Hook",
         description: "This is a hook",
       });
-      setupNotificationChannel({
+      H.setupNotificationChannel({
         name: "Bar Hook",
         description: "This is another hook",
       });
@@ -140,19 +128,19 @@ describe("scenarios > alert", () => {
     });
 
     it("should be able to create and delete alerts with webhooks enabled", () => {
-      visitQuestion(ORDERS_QUESTION_ID);
-      openSharingMenu("Create alert");
+      H.visitQuestion(ORDERS_QUESTION_ID);
+      H.openSharingMenu("Create alert");
 
       //Disable Email
-      toggleAlertChannel("Email");
-      toggleAlertChannel("Foo Hook");
-      toggleAlertChannel("Bar Hook");
+      H.toggleAlertChannel("Email");
+      H.toggleAlertChannel("Foo Hook");
+      H.toggleAlertChannel("Bar Hook");
 
       cy.findByRole("button", { name: "Done" }).click();
 
-      openSharingMenu("Edit alerts");
+      H.openSharingMenu("Edit alerts");
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("You set up an alert").should("be.visible");
         cy.findByRole("listitem", { name: "Number of HTTP channels" })
           .should("contain.text", "2")
@@ -174,7 +162,7 @@ describe("scenarios > alert", () => {
   });
 
   it("should not be offered for models (metabase#37893)", () => {
-    visitModel(ORDERS_MODEL_ID);
+    H.visitModel(ORDERS_MODEL_ID);
     cy.findByTestId("view-footer").within(() => {
       cy.findByTestId("question-row-count")
         .should("have.text", "Showing first 2,000 rows")
@@ -182,6 +170,6 @@ describe("scenarios > alert", () => {
       cy.icon("download").should("exist");
     });
 
-    sharingMenuButton().should("not.exist");
+    H.sharingMenuButton().should("not.exist");
   });
 });

--- a/e2e/test/scenarios/sharing/alert/email-alert.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/email-alert.cy.spec.js
@@ -1,18 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  mockSlackConfigured,
-  modal,
-  openSharingMenu,
-  openTable,
-  popover,
-  restore,
-  setupNotificationChannel,
-  setupSMTP,
-  toggleAlertChannel,
-  updateSetting,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 const { PEOPLE_ID } = SAMPLE_DATABASE;
 
@@ -21,11 +9,11 @@ describe("scenarios > alert > email_alert", { tags: "@external" }, () => {
     cy.intercept("POST", "/api/alert").as("savedAlert");
     cy.intercept("POST", "/api/card").as("saveCard");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.setCookie("metabase.SEEN_ALERT_SPLASH", "true");
 
-    setupSMTP();
+    H.setupSMTP();
   });
 
   it("should have no alerts set up initially", () => {
@@ -57,12 +45,12 @@ describe("scenarios > alert > email_alert", { tags: "@external" }, () => {
   });
 
   it("should respect email alerts toggled off (metabase#12349)", () => {
-    updateSetting("report-timezone", "America/New_York");
-    mockSlackConfigured();
+    H.updateSetting("report-timezone", "America/New_York");
+    H.mockSlackConfigured();
 
     //For this test, we need to pretend that slack is set up
-    mockSlackConfigured();
-    setupNotificationChannel({ name: "Webhook" });
+    H.mockSlackConfigured();
+    H.setupNotificationChannel({ name: "Webhook" });
 
     openAlertForQuestion(ORDERS_QUESTION_ID);
 
@@ -70,27 +58,27 @@ describe("scenarios > alert > email_alert", { tags: "@external" }, () => {
       cy.findByText(/Emails will be sent at 12:00 AM ET/).should("exist");
 
       // Turn off email
-      toggleAlertChannel("Email");
+      H.toggleAlertChannel("Email");
       cy.findByText(/Emails will be sent/).should("not.exist");
       cy.findByText(/Slack messages will be sent/).should("not.exist");
 
       // Turn on Slack
-      toggleAlertChannel("Slack");
+      H.toggleAlertChannel("Slack");
       cy.findByPlaceholderText(/Pick a user or channel/).click();
     });
 
-    popover().findByText("#work").click();
+    H.popover().findByText("#work").click();
 
     cy.findByTestId("alert-create").within(() => {
       cy.findByText(/Slack messages will be sent at 12:00 AM ET/).should(
         "exist",
       );
 
-      toggleAlertChannel("Email");
+      H.toggleAlertChannel("Email");
       cy.findByText(
         /Emails and Slack messages will be sent at 12:00 AM ET/,
       ).should("exist");
-      toggleAlertChannel("Email");
+      H.toggleAlertChannel("Email");
 
       cy.button("Done").click();
     });
@@ -104,8 +92,8 @@ describe("scenarios > alert > email_alert", { tags: "@external" }, () => {
     cy.log(
       "ensure that when the alert is deleted, the delete modal is correct metabase#48402",
     );
-    openSharingMenu("Edit alerts");
-    popover().within(() => {
+    H.openSharingMenu("Edit alerts");
+    H.popover().within(() => {
       cy.findByText("You set up an alert").should("be.visible");
       cy.findByText("Edit").click();
     });
@@ -116,7 +104,7 @@ describe("scenarios > alert > email_alert", { tags: "@external" }, () => {
   });
 
   it("should set up an email alert for newly created question", () => {
-    openTable({
+    H.openTable({
       table: PEOPLE_ID,
     });
 
@@ -133,7 +121,7 @@ describe("scenarios > alert > email_alert", { tags: "@external" }, () => {
   });
 
   it("should enable alert to be updated (without updating question) (metabase#36866)", () => {
-    openTable({
+    H.openTable({
       table: PEOPLE_ID,
     });
 
@@ -146,9 +134,9 @@ describe("scenarios > alert > email_alert", { tags: "@external" }, () => {
       .findByText("Your alert is all set up.")
       .should("be.visible");
 
-    openSharingMenu("Edit alerts");
+    H.openSharingMenu("Edit alerts");
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("You set up an alert").should("be.visible");
       cy.findByText("Edit").click();
     });
@@ -175,19 +163,19 @@ describe("scenarios > alert > email_alert", { tags: "@external" }, () => {
 });
 
 function openAlertForQuestion(id) {
-  visitQuestion(id);
-  openSharingMenu("Create alert");
+  H.visitQuestion(id);
+  H.openSharingMenu("Create alert");
 }
 
 function saveAlert() {
-  openSharingMenu();
+  H.openSharingMenu();
 
-  modal().within(() => {
+  H.modal().within(() => {
     cy.findByLabelText("Name").type(" alert");
     cy.button("Save").click();
   });
   cy.wait("@saveCard");
 
-  openSharingMenu("Create alert");
-  modal().button("Done").click();
+  H.openSharingMenu("Create alert");
+  H.modal().button("Done").click();
 }

--- a/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
@@ -1,38 +1,10 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_DASHBOARD_DASHCARD_ID,
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  addOrUpdateDashboardCard,
-  assertSheetRowsCount,
-  createQuestion,
-  describeWithSnowplow,
-  downloadAndAssert,
-  editDashboard,
-  enableTracking,
-  entityPickerModal,
-  entityPickerModalTab,
-  expectGoodSnowplowEvent,
-  expectNoBadSnowplowEvents,
-  exportFromDashcard,
-  filterWidget,
-  getDashboardCard,
-  getDashboardCardMenu,
-  multiAutocompleteInput,
-  openSharingMenu,
-  popover,
-  queryBuilderMain,
-  resetSnowplow,
-  restore,
-  saveDashboard,
-  setFilter,
-  showDashboardCardActions,
-  startNewQuestion,
-  visitDashboard,
-  visualize,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
@@ -63,38 +35,38 @@ const cannotSavePngQuestion = {
 
 describe("scenarios > question > download", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
-  describeWithSnowplow("[snowplow]", () => {
+  H.describeWithSnowplow("[snowplow]", () => {
     beforeEach(() => {
-      resetSnowplow();
-      enableTracking();
+      H.resetSnowplow();
+      H.enableTracking();
     });
 
     afterEach(() => {
-      expectNoBadSnowplowEvents();
+      H.expectNoBadSnowplowEvents();
     });
 
     testCases.forEach(fileType => {
       it(`downloads ${fileType} file`, () => {
-        startNewQuestion();
-        entityPickerModal().within(() => {
-          entityPickerModalTab("Saved questions").click();
+        H.startNewQuestion();
+        H.entityPickerModal().within(() => {
+          H.entityPickerModalTab("Saved questions").click();
           cy.findByText("Orders, Count").click();
         });
 
-        visualize();
+        H.visualize();
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains("18,760");
 
-        downloadAndAssert({ fileType }, sheet => {
+        H.downloadAndAssert({ fileType }, sheet => {
           expect(sheet["A1"].v).to.eq("Count");
           expect(sheet["A2"].v).to.eq(18760);
         });
 
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: "download_results_clicked",
           resource_type: "ad-hoc-question",
           accessed_via: "internal",
@@ -109,7 +81,7 @@ describe("scenarios > question > download", () => {
       const fieldRef = ["field", ORDERS.TOTAL, null];
       const columnKey = `["ref",${JSON.stringify(fieldRef)}]`;
 
-      createQuestion(
+      H.createQuestion(
         {
           query: {
             "source-table": ORDERS_ID,
@@ -129,12 +101,12 @@ describe("scenarios > question > download", () => {
         { visitQuestion: true, wrapId: true },
       );
 
-      queryBuilderMain().findByText("USD 39.72").should("exist");
+      H.queryBuilderMain().findByText("USD 39.72").should("exist");
 
       cy.get("@questionId").then(questionId => {
         const opts = { questionId, fileType };
 
-        downloadAndAssert(
+        H.downloadAndAssert(
           {
             ...opts,
             enableFormatting: true,
@@ -145,7 +117,7 @@ describe("scenarios > question > download", () => {
           },
         );
 
-        downloadAndAssert(
+        H.downloadAndAssert(
           {
             ...opts,
             enableFormatting: false,
@@ -160,7 +132,7 @@ describe("scenarios > question > download", () => {
   });
 
   it("should allow downloading pivoted results", () => {
-    createQuestion(
+    H.createQuestion(
       {
         name: "Pivot Table",
         query: {
@@ -176,7 +148,7 @@ describe("scenarios > question > download", () => {
       { visitQuestion: true },
     );
 
-    downloadAndAssert(
+    H.downloadAndAssert(
       {
         enableFormatting: true,
         fileType: "csv",
@@ -187,7 +159,7 @@ describe("scenarios > question > download", () => {
       },
     );
 
-    downloadAndAssert(
+    H.downloadAndAssert(
       {
         enableFormatting: true,
         pivoting: "non-pivoted",
@@ -235,7 +207,7 @@ describe("scenarios > question > download", () => {
     const totalLeftColumnKey = '["name","TOTAL"]';
     const totalRightColumnKey = '["name","TOTAL_2"]';
 
-    createQuestion(
+    H.createQuestion(
       {
         query: {
           "source-table": ORDERS_ID,
@@ -266,14 +238,14 @@ describe("scenarios > question > download", () => {
       { visitQuestion: true, wrapId: true },
     );
 
-    queryBuilderMain().findByText("Left Total").should("exist");
-    queryBuilderMain().findByText("Right Total").should("exist");
+    H.queryBuilderMain().findByText("Left Total").should("exist");
+    H.queryBuilderMain().findByText("Right Total").should("exist");
 
     cy.get("@questionId").then(questionId => {
       testCases.forEach(fileType => {
         const opts = { questionId, fileType };
 
-        downloadAndAssert(
+        H.downloadAndAssert(
           {
             ...opts,
             enableFormatting: true,
@@ -292,7 +264,7 @@ describe("scenarios > question > download", () => {
   describe("from dashboards", () => {
     it("should allow downloading card data", () => {
       cy.intercept("GET", "/api/dashboard/**").as("dashboard");
-      visitDashboard(ORDERS_DASHBOARD_ID);
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
       cy.findByTestId("dashcard").within(() => {
         cy.findByTestId("legend-caption").realHover();
       });
@@ -300,18 +272,18 @@ describe("scenarios > question > download", () => {
       // In CI agents after downloads Cypress gets stuck for a while so the downloads status gets closed by timeout
       assertOrdersExport(18760);
 
-      editDashboard();
+      H.editDashboard();
 
-      setFilter("ID");
+      H.setFilter("ID");
 
       cy.findByTestId("dashcard-container").contains("Select…").click();
-      popover().contains("ID").eq(0).click();
+      H.popover().contains("ID").eq(0).click();
 
-      saveDashboard();
+      H.saveDashboard();
 
-      filterWidget().contains("ID").click();
+      H.filterWidget().contains("ID").click();
 
-      popover().within(() => multiAutocompleteInput().type("1"));
+      H.popover().within(() => H.multiAutocompleteInput().type("1"));
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add filter").click();
@@ -347,7 +319,7 @@ describe("scenarios > question > download", () => {
             ],
           });
 
-          addOrUpdateDashboardCard({
+          H.addOrUpdateDashboardCard({
             card_id: questionId,
             dashboard_id: dashboardId,
             card: {
@@ -375,15 +347,15 @@ describe("scenarios > question > download", () => {
             },
           }).then(({ body: { id } }) => {
             cy.signIn("nodata");
-            visitDashboard(dashboardId);
+            H.visitDashboard(dashboardId);
 
             cy.findByLabelText("ID").click();
-            popover().findByPlaceholderText("Enter an ID").type("1");
+            H.popover().findByPlaceholderText("Enter an ID").type("1");
             cy.button("Add filter").click();
 
             cy.findByTestId("legend-caption").contains("20868").click();
 
-            downloadAndAssert(
+            H.downloadAndAssert(
               {
                 fileType: "xlsx",
                 questionId,
@@ -394,7 +366,7 @@ describe("scenarios > question > download", () => {
                 expect(sheet["A1"].v).to.eq("ID");
                 expect(sheet["A2"].v).to.eq(1);
 
-                assertSheetRowsCount(1)(sheet);
+                H.assertSheetRowsCount(1)(sheet);
               },
             );
           });
@@ -409,20 +381,22 @@ describe("scenarios > question > download", () => {
         dashboardName: "saving pngs dashboard",
         questions: [canSavePngQuestion, cannotSavePngQuestion],
       }).then(({ dashboard }) => {
-        visitDashboard(dashboard.id);
+        H.visitDashboard(dashboard.id);
       });
 
-      showDashboardCardActions(0);
-      getDashboardCard(0).findByText("Created At: Month").should("be.visible");
-      getDashboardCardMenu(0).click();
+      H.showDashboardCardActions(0);
+      H.getDashboardCard(0)
+        .findByText("Created At: Month")
+        .should("be.visible");
+      H.getDashboardCardMenu(0).click();
 
-      exportFromDashcard(".png");
+      H.exportFromDashcard(".png");
 
-      showDashboardCardActions(1);
-      getDashboardCard(1).findByText("User ID").should("be.visible");
-      getDashboardCardMenu(1).click();
+      H.showDashboardCardActions(1);
+      H.getDashboardCard(1).findByText("User ID").should("be.visible");
+      H.getDashboardCardMenu(1).click();
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Download results").click();
         cy.findByText(".png").should("not.exist");
       });
@@ -435,7 +409,7 @@ describe("scenarios > question > download", () => {
 
       cy.findByTestId("download-button").click();
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText(".png").click();
         cy.findByTestId("download-results-button").click();
       });
@@ -446,7 +420,7 @@ describe("scenarios > question > download", () => {
 
       cy.findByTestId("download-button").click();
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText(".png").should("not.exist");
       });
     });
@@ -455,7 +429,7 @@ describe("scenarios > question > download", () => {
 
 describe("scenarios > dashboard > download pdf", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.deleteDownloadsFolder();
   });
@@ -466,24 +440,24 @@ describe("scenarios > dashboard > download pdf", () => {
       dashboardName: `saving pdf dashboard - ${date}`,
       questions: [canSavePngQuestion, cannotSavePngQuestion],
     }).then(({ dashboard }) => {
-      visitDashboard(dashboard.id);
+      H.visitDashboard(dashboard.id);
     });
 
-    openSharingMenu("Export as PDF");
+    H.openSharingMenu("Export as PDF");
     cy.verifyDownload(`saving pdf dashboard - ${date}.pdf`);
   });
 });
 
-describeWithSnowplow("[snowplow] scenarios > dashboard", () => {
+H.describeWithSnowplow("[snowplow] scenarios > dashboard", () => {
   beforeEach(() => {
-    restore();
-    resetSnowplow();
+    H.restore();
+    H.resetSnowplow();
     cy.signInAsAdmin();
-    enableTracking();
+    H.enableTracking();
   });
 
   afterEach(() => {
-    expectNoBadSnowplowEvents();
+    H.expectNoBadSnowplowEvents();
   });
 
   it("should allow you to download a PDF of a dashboard", () => {
@@ -491,10 +465,10 @@ describeWithSnowplow("[snowplow] scenarios > dashboard", () => {
       dashboardName: "test dashboard",
       questions: [canSavePngQuestion, cannotSavePngQuestion],
     }).then(({ dashboard }) => {
-      visitDashboard(dashboard.id);
-      openSharingMenu("Export as PDF");
+      H.visitDashboard(dashboard.id);
+      H.openSharingMenu("Export as PDF");
 
-      expectGoodSnowplowEvent({
+      H.expectGoodSnowplowEvent({
         event: "dashboard_pdf_exported",
         dashboard_id: dashboard.id,
         dashboard_accessed_via: "internal",
@@ -507,16 +481,16 @@ describeWithSnowplow("[snowplow] scenarios > dashboard", () => {
       dashboardName: "saving pngs dashboard",
       questions: [canSavePngQuestion, cannotSavePngQuestion],
     }).then(({ dashboard }) => {
-      visitDashboard(dashboard.id);
+      H.visitDashboard(dashboard.id);
     });
 
-    showDashboardCardActions(0);
-    getDashboardCard(0).findByText("Created At: Month").should("be.visible");
-    getDashboardCardMenu(0).click();
+    H.showDashboardCardActions(0);
+    H.getDashboardCard(0).findByText("Created At: Month").should("be.visible");
+    H.getDashboardCardMenu(0).click();
 
-    exportFromDashcard(".png");
+    H.exportFromDashcard(".png");
 
-    expectGoodSnowplowEvent({
+    H.expectGoodSnowplowEvent({
       event: "download_results_clicked",
       resource_type: "dashcard",
       accessed_via: "internal",
@@ -526,7 +500,7 @@ describeWithSnowplow("[snowplow] scenarios > dashboard", () => {
 });
 
 function assertOrdersExport(length) {
-  downloadAndAssert(
+  H.downloadAndAssert(
     {
       fileType: "xlsx",
       questionId: ORDERS_QUESTION_ID,
@@ -540,7 +514,7 @@ function assertOrdersExport(length) {
       expect(sheet["B1"].v).to.eq("User ID");
       expect(sheet["B2"].v).to.eq(1);
 
-      assertSheetRowsCount(length)(sheet);
+      H.assertSheetRowsCount(length)(sheet);
     },
   );
 }

--- a/e2e/test/scenarios/sharing/downloads/sharing-download-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/sharing-download-reproductions.cy.spec.js
@@ -1,13 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  downloadAndAssert,
-  focusNativeEditor,
-  restore,
-  runNativeQuery,
-  visitQuestion,
-  visitQuestionAdhoc,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, REVIEWS, REVIEWS_ID, PRODUCTS, PRODUCTS_ID } =
   SAMPLE_DATABASE;
@@ -18,7 +11,7 @@ describe("issue 10803", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestion(
@@ -36,7 +29,7 @@ describe("issue 10803", () => {
   testCases.forEach(fileType => {
     it(`should format the date properly for ${fileType} in saved questions (metabase#10803)`, () => {
       cy.get("@questionId").then(questionId => {
-        downloadAndAssert(
+        H.downloadAndAssert(
           { fileType, questionId, logResults: true, raw: true },
           testWorkbookDatetimes,
         );
@@ -47,10 +40,10 @@ describe("issue 10803", () => {
       // Add a space at the end of the query to make it "dirty"
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains(/open editor/i).click();
-      focusNativeEditor().type("{movetoend} ");
+      H.focusNativeEditor().type("{movetoend} ");
 
-      runNativeQuery();
-      downloadAndAssert({ fileType, raw: true }, testWorkbookDatetimes);
+      H.runNativeQuery();
+      H.downloadAndAssert({ fileType, raw: true }, testWorkbookDatetimes);
     });
 
     function testWorkbookDatetimes(sheet) {
@@ -85,7 +78,7 @@ describe.skip("issue 18219", () => {
   const testCases = ["csv", "xlsx"];
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -93,13 +86,13 @@ describe.skip("issue 18219", () => {
     it("should format temporal units on export (metabase#18219)", () => {
       cy.createQuestion(questionDetails).then(
         ({ body: { id: questionId } }) => {
-          visitQuestion(questionId);
+          H.visitQuestion(questionId);
 
           cy.findByText("Created At: Year");
           cy.findByText("2022");
           cy.findByText("744");
 
-          downloadAndAssert({ fileType, questionId, raw: true }, assertion);
+          H.downloadAndAssert({ fileType, questionId, raw: true }, assertion);
         },
       );
     });
@@ -213,9 +206,9 @@ describe("issue 18382", () => {
   const testCases = ["csv", "xlsx"];
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    visitQuestionAdhoc(questionDetails);
+    H.visitQuestionAdhoc(questionDetails);
   });
 
   testCases.forEach(fileType => {
@@ -223,7 +216,7 @@ describe("issue 18382", () => {
       // TODO: Please remove this line when issue gets fixed
       cy.skipOn(fileType === "csv");
 
-      downloadAndAssert({ fileType }, assertion);
+      H.downloadAndAssert({ fileType }, assertion);
     });
   });
 });
@@ -249,7 +242,7 @@ describe("issue 18440", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/card").as("saveQuestion");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     // Remap Product ID -> Product Title
@@ -262,24 +255,24 @@ describe("issue 18440", () => {
 
   testCases.forEach(fileType => {
     it(`export should include a column with remapped values for ${fileType} (metabase#18440-1)`, () => {
-      visitQuestionAdhoc(questionDetails);
+      H.visitQuestionAdhoc(questionDetails);
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Product ID");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Awesome Concrete Shoes");
 
-      downloadAndAssert({ fileType }, assertion);
+      H.downloadAndAssert({ fileType }, assertion);
     });
 
     it(`export should include a column with remapped values for ${fileType} for a saved question (metabase#18440-2)`, () => {
       cy.createQuestion({ query }).then(({ body: { id } }) => {
-        visitQuestion(id);
+        H.visitQuestion(id);
 
         cy.findByText("Product ID");
         cy.findByText("Awesome Concrete Shoes");
 
-        downloadAndAssert({ fileType, questionId: id }, assertion);
+        H.downloadAndAssert({ fileType, questionId: id }, assertion);
       });
     });
   });
@@ -306,7 +299,7 @@ describe("issue 18573", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     // Remap Product ID -> Product Title
@@ -318,14 +311,14 @@ describe("issue 18573", () => {
   });
 
   it("for the remapped columns, it should preserve renamed column name in exports for xlsx (metabase#18573)", () => {
-    visitQuestionAdhoc(questionDetails);
+    H.visitQuestionAdhoc(questionDetails);
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Foo");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Awesome Concrete Shoes");
 
-    downloadAndAssert({ fileType: "xlsx" }, assertion);
+    H.downloadAndAssert({ fileType: "xlsx" }, assertion);
   });
 });
 
@@ -363,15 +356,15 @@ describe("issue 18729", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   ["csv", "xlsx"].forEach(fileType => {
     it(`should properly format the 'X of Y'dates in ${fileType} exports (metabase#18729)`, () => {
-      visitQuestionAdhoc(questionDetails);
+      H.visitQuestionAdhoc(questionDetails);
 
-      downloadAndAssert({ fileType }, assertion);
+      H.downloadAndAssert({ fileType }, assertion);
     });
   });
 });
@@ -396,7 +389,7 @@ describe("issue 19889", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestion(questionDetails, {
@@ -425,7 +418,7 @@ describe("issue 19889", () => {
 
   testCases.forEach(fileType => {
     it("should order columns correctly in unsaved native query exports", () => {
-      downloadAndAssert({ fileType, raw: true }, sheet => {
+      H.downloadAndAssert({ fileType, raw: true }, sheet => {
         expect(sheet["A1"].v).to.equal("column b");
         expect(sheet["B1"].v).to.equal("column a");
         expect(sheet["C1"].v).to.equal("column c");
@@ -436,7 +429,7 @@ describe("issue 19889", () => {
       saveAndOverwrite();
 
       cy.get("@questionId").then(questionId => {
-        downloadAndAssert({ fileType, questionId, raw: true }, sheet => {
+        H.downloadAndAssert({ fileType, questionId, raw: true }, sheet => {
           expect(sheet["A1"].v).to.equal("column b");
           expect(sheet["B1"].v).to.equal("column a");
           expect(sheet["C1"].v).to.equal("column c");
@@ -447,16 +440,16 @@ describe("issue 19889", () => {
     it("should order columns correctly in saved native query exports when the query was modified but not re-run before save (#19889)", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains(/open editor/i).click();
-      focusNativeEditor().type(
+      H.focusNativeEditor().type(
         '{selectall}select 1 "column x", 2 "column y", 3 "column c"',
       );
 
       saveAndOverwrite();
 
       cy.get("@questionId").then(questionId => {
-        visitQuestion(questionId);
+        H.visitQuestion(questionId);
 
-        downloadAndAssert({ fileType, questionId, raw: true }, sheet => {
+        H.downloadAndAssert({ fileType, questionId, raw: true }, sheet => {
           expect(sheet["A1"].v).to.equal("column x");
           expect(sheet["B1"].v).to.equal("column y");
           expect(sheet["C1"].v).to.equal("column c");
@@ -481,7 +474,7 @@ describe("metabase#28834", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestion(questionDetails, {
@@ -490,12 +483,12 @@ describe("metabase#28834", () => {
     });
 
     cy.findByTestId("query-builder-main").findByText("Open Editor").click();
-    focusNativeEditor().type(', select 2 "column b"');
+    H.focusNativeEditor().type(', select 2 "column b"');
   });
 
   it("should be able to export unsaved native query results as CSV even after the query has changed", () => {
     const fileType = "csv";
-    downloadAndAssert({ fileType, raw: true }, sheet => {
+    H.downloadAndAssert({ fileType, raw: true }, sheet => {
       expect(sheet["A1"].v).to.equal("column a");
       expect(sheet["A2"].v).to.equal("1");
       expect(sheet["A3"]).to.be.undefined;
@@ -504,7 +497,7 @@ describe("metabase#28834", () => {
 
   it("should be able to export unsaved native query results as XLSX even after the query has changed", () => {
     const fileType = "xlsx";
-    downloadAndAssert({ fileType, raw: true }, sheet => {
+    H.downloadAndAssert({ fileType, raw: true }, sheet => {
       expect(sheet["A1"].v).to.equal("column a");
       expect(sheet["A2"].v).to.equal(1);
       expect(sheet["A3"]).to.be.undefined;

--- a/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
@@ -1,23 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  assertDashboardFixedWidth,
-  assertDashboardFullWidth,
-  createDashboardWithQuestions,
-  createPublicDashboardLink,
-  dashboardParametersContainer,
-  describeEE,
-  filterWidget,
-  getDashboardCard,
-  goToTab,
-  openNewPublicLinkDropdown,
-  openSharingMenu,
-  popover,
-  restore,
-  setTokenFeatures,
-  updateSetting,
-  visitDashboard,
-  visitPublicDashboard,
-} from "e2e/support/helpers";
 
 const { PRODUCTS, ORDERS_ID } = SAMPLE_DATABASE;
 
@@ -84,7 +66,7 @@ const USERS = {
 };
 
 const prepareDashboard = () => {
-  updateSetting("enable-public-sharing", true);
+  H.updateSetting("enable-public-sharing", true);
 
   cy.intercept("/api/dashboard/*/public_link").as("publicLink");
 
@@ -125,16 +107,16 @@ const prepareDashboard = () => {
 
 describe("scenarios > public > dashboard", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     prepareDashboard();
   });
 
   it("should allow users to create public dashboards", () => {
-    visitDashboard("@dashboardId");
+    H.visitDashboard("@dashboardId");
 
-    openNewPublicLinkDropdown("dashboard");
+    H.openNewPublicLinkDropdown("dashboard");
 
     cy.wait("@publicLink").then(({ response }) => {
       expect(response.body.uuid).not.to.be.null;
@@ -153,13 +135,13 @@ describe("scenarios > public > dashboard", () => {
 
   it("should only allow non-admin users to see a public link if one has already been created", () => {
     cy.get("@dashboardId").then(id => {
-      createPublicDashboardLink(id);
+      H.createPublicDashboardLink(id);
       cy.signOut();
     });
 
     cy.signInAsNormalUser().then(() => {
-      visitDashboard("@dashboardId");
-      openSharingMenu("Public link");
+      H.visitDashboard("@dashboardId");
+      H.openSharingMenu("Public link");
 
       cy.findByTestId("public-link-popover-content").within(() => {
         cy.findByText("Public link").should("be.visible");
@@ -190,8 +172,8 @@ describe("scenarios > public > dashboard", () => {
 
         cy.findByTestId("scalar-value").should("have.text", COUNT_ALL);
 
-        filterWidget().click();
-        popover().within(() => {
+        H.filterWidget().click();
+        H.popover().within(() => {
           cy.findByText("Doohickey").click();
           cy.button("Add filter").click();
         });
@@ -207,14 +189,14 @@ describe("scenarios > public > dashboard", () => {
         auto_apply_filters: false,
       });
 
-      visitPublicDashboard(id);
+      H.visitPublicDashboard(id);
     });
 
     cy.findByTestId("scalar-value").should("have.text", COUNT_ALL);
     cy.button("Apply").should("not.exist");
 
-    filterWidget().click();
-    popover().within(() => {
+    H.filterWidget().click();
+    H.popover().within(() => {
       cy.findByText("Doohickey").click();
       cy.button("Add filter").click();
     });
@@ -228,17 +210,17 @@ describe("scenarios > public > dashboard", () => {
 
   it("should only display filters mapped to cards on the selected tab", () => {
     cy.get("@dashboardId").then(id => {
-      visitPublicDashboard(id);
+      H.visitPublicDashboard(id);
     });
 
-    dashboardParametersContainer().within(() => {
+    H.dashboardParametersContainer().within(() => {
       cy.findByText(textFilter.name).should("be.visible");
       cy.findByText(unusedFilter.name).should("not.exist");
     });
 
-    goToTab(tab2.name);
+    H.goToTab(tab2.name);
 
-    dashboardParametersContainer().should("not.exist");
+    H.dashboardParametersContainer().should("not.exist");
     cy.findByTestId("embed-frame").within(() => {
       cy.findByText(textFilter.name).should("not.exist");
       cy.findByText(unusedFilter.name).should("not.exist");
@@ -247,11 +229,11 @@ describe("scenarios > public > dashboard", () => {
 
   it("should respect dashboard width setting in a public dashboard", () => {
     cy.get("@dashboardId").then(id => {
-      visitPublicDashboard(id);
+      H.visitPublicDashboard(id);
     });
 
     // new dashboards should default to 'fixed' width
-    assertDashboardFixedWidth();
+    H.assertDashboardFixedWidth();
 
     // toggle full-width
     cy.get("@dashboardId").then(id => {
@@ -259,26 +241,26 @@ describe("scenarios > public > dashboard", () => {
       cy.request("PUT", `/api/dashboard/${id}`, {
         width: "full",
       });
-      visitPublicDashboard(id);
+      H.visitPublicDashboard(id);
     });
 
-    assertDashboardFullWidth();
+    H.assertDashboardFullWidth();
   });
 
   it("should render when a filter passed with value starting from '0' (metabase#41483)", () => {
     cy.get("@dashboardId").then(id => {
-      visitPublicDashboard(id, {
+      H.visitPublicDashboard(id, {
         params: { text: "002" },
       });
     });
 
     cy.url().should("include", "text=002");
 
-    filterWidget().findByText("002").should("be.visible");
+    H.filterWidget().findByText("002").should("be.visible");
   });
 
   it("should respect click behavior", () => {
-    createDashboardWithQuestions({
+    H.createDashboardWithQuestions({
       dashboardName: "test click behavior",
       questions: [
         {
@@ -305,7 +287,7 @@ describe("scenarios > public > dashboard", () => {
         },
       ],
     }).then(({ dashboard }) => {
-      visitPublicDashboard(dashboard.id);
+      H.visitPublicDashboard(dashboard.id);
     });
 
     // This is a hacky way to intercept the link click we create an a element
@@ -314,7 +296,7 @@ describe("scenarios > public > dashboard", () => {
       cy.spy(win.document.body, "appendChild").as("appendChild");
     });
 
-    getDashboardCard().findByText("39.72").click();
+    H.getDashboardCard().findByText("39.72").click();
 
     cy.get("@appendChild").then(appendChild => {
       // last call is a link
@@ -326,21 +308,21 @@ describe("scenarios > public > dashboard", () => {
   });
 });
 
-describeEE("scenarios [EE] > public > dashboard", () => {
+H.describeEE("scenarios [EE] > public > dashboard", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     prepareDashboard();
 
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
   });
 
   it("should set the window title to `{dashboard name} · {application name}`", () => {
-    updateSetting("application-name", "Custom Application Name");
+    H.updateSetting("application-name", "Custom Application Name");
 
     cy.get("@dashboardId").then(id => {
-      visitPublicDashboard(id);
+      H.visitPublicDashboard(id);
 
       cy.title().should("eq", "Test Dashboard · Custom Application Name");
     });
@@ -348,7 +330,7 @@ describeEE("scenarios [EE] > public > dashboard", () => {
 
   it("should allow to set locale from the `#locale` hash parameter (metabase#50182)", () => {
     cy.get("@dashboardId").then(id => {
-      visitPublicDashboard(id, {
+      H.visitPublicDashboard(id, {
         hash: { locale: "de" },
       });
     });

--- a/e2e/test/scenarios/sharing/public-question.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-question.cy.spec.js
@@ -1,23 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  assertSheetRowsCount,
-  createNativeQuestion,
-  createPublicQuestionLink,
-  describeEE,
-  downloadAndAssert,
-  filterWidget,
-  main,
-  modal,
-  openNativeEditor,
-  openNewPublicLinkDropdown,
-  openSharingMenu,
-  restore,
-  saveQuestion,
-  setTokenFeatures,
-  updateSetting,
-  visitPublicQuestion,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 const { PEOPLE } = SAMPLE_DATABASE;
 
@@ -62,20 +44,20 @@ describe("scenarios > public > question", () => {
   beforeEach(() => {
     cy.intercept("GET", "/api/public/card/*/query?*").as("publicQuery");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    updateSetting("enable-public-sharing", true);
+    H.updateSetting("enable-public-sharing", true);
   });
 
   it("adds filters to url as get params and renders the results correctly (metabase#7120, metabase#17033, metabase#21993)", () => {
     cy.createNativeQuestion(questionData).then(({ body: { id } }) => {
-      visitQuestion(id);
+      H.visitQuestion(id);
 
       // Make sure metadata fully loaded before we continue
       cy.get("[data-testid=cell-data]").contains("Winner");
 
-      openNewPublicLinkDropdown("card");
+      H.openNewPublicLinkDropdown("card");
 
       // Although we already have API helper `visitPublicQuestion`,
       // it makes sense to use the UI here in order to check that the
@@ -85,8 +67,8 @@ describe("scenarios > public > question", () => {
       // On page load, query params are added
       cy.location("search").should("eq", EXPECTED_QUERY_PARAMS);
 
-      filterWidget().contains("Previous 30 Years");
-      filterWidget().contains("Affiliate");
+      H.filterWidget().contains("Previous 30 Years");
+      H.filterWidget().contains("Affiliate");
 
       cy.wait("@publicQuery");
       // Name of a city from the expected results
@@ -94,9 +76,9 @@ describe("scenarios > public > question", () => {
 
       // Make sure we can download the public question (metabase#21993)
       cy.get("@uuid").then(publicUuid => {
-        downloadAndAssert(
+        H.downloadAndAssert(
           { fileType: "xlsx", questionId: id, publicUuid },
-          assertSheetRowsCount(5),
+          H.assertSheetRowsCount(5),
         );
       });
     });
@@ -104,12 +86,12 @@ describe("scenarios > public > question", () => {
 
   it("should only allow non-admin users to see a public link if one has already been created", () => {
     cy.createNativeQuestion(questionData).then(({ body: { id } }) => {
-      createPublicQuestionLink(id);
+      H.createPublicQuestionLink(id);
       cy.signOut();
       cy.signInAsNormalUser().then(() => {
-        visitQuestion(id);
+        H.visitQuestion(id);
 
-        openSharingMenu("Public link");
+        H.openSharingMenu("Public link");
 
         cy.findByTestId("public-link-popover-content").within(() => {
           cy.findByText("Public link").should("be.visible");
@@ -133,8 +115,8 @@ describe("scenarios > public > question", () => {
 
               cy.location("search").should("eq", EXPECTED_QUERY_PARAMS);
 
-              filterWidget().contains("Previous 30 Years");
-              filterWidget().contains("Affiliate");
+              H.filterWidget().contains("Previous 30 Years");
+              H.filterWidget().contains("Affiliate");
 
               cy.get("[data-testid=cell-data]").contains("Winner");
             },
@@ -145,13 +127,13 @@ describe("scenarios > public > question", () => {
   );
 
   it("should be able to view public questions with snippets", () => {
-    openNativeEditor();
+    H.openNativeEditor();
 
     // Create a snippet
     cy.icon("snippet").click();
     cy.findByTestId("sidebar-content").findByText("Create a snippet").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByLabelText("Enter some SQL here so you can reuse it later").type(
         "'test'",
       );
@@ -161,10 +143,10 @@ describe("scenarios > public > question", () => {
 
     cy.get("@editor").type("{moveToStart}select ");
 
-    saveQuestion("test question", { wrapId: true });
+    H.saveQuestion("test question", { wrapId: true });
 
     cy.get("@questionId").then(id => {
-      createPublicQuestionLink(id).then(({ body: { uuid } }) => {
+      H.createPublicQuestionLink(id).then(({ body: { uuid } }) => {
         cy.signOut();
         cy.signInAsNormalUser().then(() => {
           cy.visit(`/public/question/${uuid}`);
@@ -181,15 +163,15 @@ describe("scenarios > public > question", () => {
         query: "SELECT * FROM PEOPLE LIMIT 5",
       },
     }).then(({ body: { id } }) => {
-      openNativeEditor();
+      H.openNativeEditor();
 
       cy.get("@editor")
         .type("select * from {{#")
         .type(`{leftarrow}{leftarrow}${id}`);
 
-      saveQuestion("test question", { wrapId: true });
+      H.saveQuestion("test question", { wrapId: true });
       cy.get("@questionId").then(id => {
-        createPublicQuestionLink(id).then(({ body: { uuid } }) => {
+        H.createPublicQuestionLink(id).then(({ body: { uuid } }) => {
           cy.signOut();
           cy.signInAsNormalUser().then(() => {
             cy.visit(`/public/question/${uuid}`);
@@ -202,19 +184,19 @@ describe("scenarios > public > question", () => {
   });
 });
 
-describeEE("scenarios [EE] > public > question", () => {
+H.describeEE("scenarios [EE] > public > question", () => {
   beforeEach(() => {
     cy.intercept("GET", "/api/public/card/*/query?*").as("publicQuery");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
 
-    updateSetting("enable-public-sharing", true);
+    H.updateSetting("enable-public-sharing", true);
   });
 
   it("should allow to set locale from the `#locale` hash parameter (metabase#50182)", () => {
-    createNativeQuestion(
+    H.createNativeQuestion(
       {
         name: "Native question with a parameter",
         native: {
@@ -235,7 +217,7 @@ describeEE("scenarios [EE] > public > question", () => {
     );
 
     cy.get("@questionId").then(id => {
-      visitPublicQuestion(id, {
+      H.visitPublicQuestion(id, {
         params: {
           some_parameter: "some_value",
         },
@@ -245,7 +227,7 @@ describeEE("scenarios [EE] > public > question", () => {
       });
     });
 
-    main().findByText("Februar 11, 2025");
+    H.main().findByText("Februar 11, 2025");
 
     cy.url().should("include", "locale=de");
   });

--- a/e2e/test/scenarios/sharing/public-resource-downloads.cy.spec.ts
+++ b/e2e/test/scenarios/sharing/public-resource-downloads.cy.spec.ts
@@ -1,33 +1,19 @@
+import { H } from "e2e/support";
 import {
   ORDERS_BY_YEAR_QUESTION_ID,
   ORDERS_DASHBOARD_DASHCARD_ID,
   ORDERS_DASHBOARD_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  assertNotEmptyObject,
-  describeWithSnowplowEE,
-  downloadAndAssert,
-  expectGoodSnowplowEvent,
-  expectNoBadSnowplowEvents,
-  getDashboardCardMenu,
-  main,
-  openSharingMenu,
-  popover,
-  resetSnowplow,
-  restore,
-  setTokenFeatures,
-  showDashboardCardActions,
-} from "e2e/support/helpers";
 
 /** These tests are about the `downloads` flag for public dashboards and questions.
  *  Unless the product changes, these should test the same things as `embed-resource-downloads.cy.spec.ts`
  */
 
-describeWithSnowplowEE(
+H.describeWithSnowplowEE(
   "Public dashboards/questions downloads (results and export as pdf)",
   () => {
     beforeEach(() => {
-      resetSnowplow();
+      H.resetSnowplow();
       cy.deleteDownloadsFolder();
     });
 
@@ -35,15 +21,15 @@ describeWithSnowplowEE(
       let publicLink: string;
 
       before(() => {
-        restore("default");
+        H.restore("default");
         cy.signInAsAdmin();
-        setTokenFeatures("all");
+        H.setTokenFeatures("all");
 
         cy.visit(`/dashboard/${ORDERS_DASHBOARD_ID}`);
 
-        openSharingMenu("Create a public link");
+        H.openSharingMenu("Create a public link");
 
-        popover()
+        H.popover()
           .findByTestId("public-link-input")
           .should("contain.value", "/public/")
           .invoke("val")
@@ -55,7 +41,7 @@ describeWithSnowplowEE(
       });
 
       afterEach(() => {
-        expectNoBadSnowplowEvents();
+        H.expectNoBadSnowplowEvents();
       });
 
       it("#downloads=false should disable both PDF downloads and dashcard results downloads", () => {
@@ -66,7 +52,7 @@ describeWithSnowplowEE(
         cy.findByText("Export as PDF").should("not.exist");
 
         // we should not have any dashcard action in a public/embed scenario, so the menu should not be there
-        getDashboardCardMenu().should("not.exist");
+        H.getDashboardCardMenu().should("not.exist");
       });
 
       it("should be able to download a public dashboard as PDF", () => {
@@ -77,7 +63,7 @@ describeWithSnowplowEE(
 
         cy.verifyDownload("Orders in a dashboard.pdf");
 
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: "dashboard_pdf_exported",
           dashboard_id: 0,
           dashboard_accessed_via: "public-link",
@@ -88,11 +74,11 @@ describeWithSnowplowEE(
         cy.visit(`${publicLink}`);
         waitLoading();
 
-        showDashboardCardActions();
+        H.showDashboardCardActions();
 
         const uuid = publicLink.split("/").at(-1);
 
-        downloadAndAssert(
+        H.downloadAndAssert(
           {
             publicUuid: uuid,
             fileType: "csv",
@@ -100,10 +86,10 @@ describeWithSnowplowEE(
             isDashboard: true,
             dashcardId: ORDERS_DASHBOARD_DASHCARD_ID,
           },
-          assertNotEmptyObject,
+          H.assertNotEmptyObject,
         );
 
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: "download_results_clicked",
           resource_type: "dashcard",
           accessed_via: "public-link",
@@ -116,15 +102,15 @@ describeWithSnowplowEE(
       let publicLink: string;
 
       before(() => {
-        restore("default");
+        H.restore("default");
         cy.signInAsAdmin();
-        setTokenFeatures("all");
+        H.setTokenFeatures("all");
 
         cy.visit(`/question/${ORDERS_BY_YEAR_QUESTION_ID}`);
 
-        openSharingMenu("Create a public link");
+        H.openSharingMenu("Create a public link");
 
-        popover()
+        H.popover()
           .findByTestId("public-link-input")
           .should("contain.value", "/public/")
           .invoke("val")
@@ -147,14 +133,14 @@ describeWithSnowplowEE(
         waitLoading();
 
         cy.findByTestId("download-button").click();
-        popover().within(() => {
+        H.popover().within(() => {
           cy.findByText(".png").click();
           cy.findByTestId("download-results-button").click();
         });
 
         cy.verifyDownload(".png", { contains: true });
 
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: "download_results_clicked",
           resource_type: "question",
           accessed_via: "public-link",
@@ -170,17 +156,17 @@ describeWithSnowplowEE(
 
         const uuid = publicLink.split("/").at(-1);
 
-        downloadAndAssert(
+        H.downloadAndAssert(
           {
             publicUuid: uuid,
             fileType: "csv",
             questionId: ORDERS_BY_YEAR_QUESTION_ID,
             isDashboard: false,
           },
-          assertNotEmptyObject,
+          H.assertNotEmptyObject,
         );
 
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: "download_results_clicked",
           resource_type: "question",
           accessed_via: "public-link",
@@ -191,4 +177,4 @@ describeWithSnowplowEE(
   },
 );
 
-const waitLoading = () => main().findByText("Loading...").should("not.exist");
+const waitLoading = () => H.main().findByText("Loading...").should("not.exist");

--- a/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
@@ -1,33 +1,9 @@
-import {
-  createPublicDashboardLink,
-  createPublicQuestionLink,
-  describeEE,
-  describeWithSnowplow,
-  enableTracking,
-  entityPickerModal,
-  entityPickerModalTab,
-  expectGoodSnowplowEvent,
-  expectNoBadSnowplowEvents,
-  getEmbedModalSharingPane,
-  modal,
-  openSharingMenu,
-  openStaticEmbeddingModal,
-  popover,
-  resetSnowplow,
-  restore,
-  setTokenFeatures,
-  sharingMenu,
-  startNewQuestion,
-  updateSetting,
-  visitDashboard,
-  visitQuestion,
-  visualize,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 ["dashboard", "question"].forEach(resource => {
   describe(`embed modal behavior for ${resource}s`, () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
 
       createResource(resource).then(({ body: { id } }) => {
@@ -37,7 +13,7 @@ import {
 
     describe("when embedding is disabled", () => {
       beforeEach(() => {
-        updateSetting("enable-embedding-static", false);
+        H.updateSetting("enable-embedding-static", false);
       });
 
       describe("when user is admin", () => {
@@ -46,8 +22,8 @@ import {
             visitResource(resource, id);
           });
 
-          openSharingMenu();
-          sharingMenu().within(() => {
+          H.openSharingMenu();
+          H.sharingMenu().within(() => {
             cy.findByText("Embedding is off").should("be.visible");
             cy.findByText("Enable it in settings").should("be.visible");
           });
@@ -62,8 +38,8 @@ import {
             visitResource(resource, id);
           });
 
-          openSharingMenu();
-          sharingMenu().findByText(/embed/i).should("not.exist");
+          H.openSharingMenu();
+          H.sharingMenu().findByText(/embed/i).should("not.exist");
         });
       });
     });
@@ -71,8 +47,8 @@ import {
     describe("when embedding is enabled", () => {
       describe("when public sharing is enabled", () => {
         beforeEach(() => {
-          updateSetting("enable-public-sharing", true);
-          updateSetting("enable-embedding-static", true);
+          H.updateSetting("enable-public-sharing", true);
+          H.updateSetting("enable-embedding-static", true);
         });
 
         describe("when user is admin", () => {
@@ -81,8 +57,8 @@ import {
               visitResource(resource, id);
             });
 
-            openSharingMenu("Embed");
-            modal().findByText("Embed Metabase").should("be.visible");
+            H.openSharingMenu("Embed");
+            H.modal().findByText("Embed Metabase").should("be.visible");
           });
 
           it(`should let the user create a public link for ${resource}`, () => {
@@ -91,7 +67,7 @@ import {
               visitResource(resource, id);
             });
 
-            openSharingMenu(/public link/i);
+            H.openSharingMenu(/public link/i);
 
             assertValidPublicLink({ resource, shouldHaveRemoveLink: true });
           });
@@ -105,8 +81,10 @@ import {
               visitResource(resource, id);
             });
 
-            openSharingMenu();
-            sharingMenu().findByText("Ask your admin to create a public link");
+            H.openSharingMenu();
+            H.sharingMenu().findByText(
+              "Ask your admin to create a public link",
+            );
           });
 
           it(`should show the public link button if the ${resource} has a public link`, () => {
@@ -115,7 +93,7 @@ import {
               visitResource(resource, id);
             });
 
-            openSharingMenu(/public link/i);
+            H.openSharingMenu(/public link/i);
 
             assertValidPublicLink({ resource, shouldHaveRemoveLink: true });
 
@@ -125,7 +103,7 @@ import {
               visitResource(resource, id);
             });
 
-            openSharingMenu("Public link");
+            H.openSharingMenu("Public link");
 
             assertValidPublicLink({
               resource,
@@ -137,8 +115,8 @@ import {
 
       describe("when public sharing is disabled", () => {
         beforeEach(() => {
-          updateSetting("enable-public-sharing", false);
-          updateSetting("enable-embedding-static", true);
+          H.updateSetting("enable-public-sharing", false);
+          H.updateSetting("enable-embedding-static", true);
         });
 
         describe("when user is admin", () => {
@@ -147,16 +125,16 @@ import {
               visitResource(resource, id);
             });
 
-            openSharingMenu();
+            H.openSharingMenu();
 
-            sharingMenu().within(() => {
+            H.sharingMenu().within(() => {
               cy.findByText("Public links are off").should("be.visible");
               cy.findByText("Enable them in settings").should("be.visible");
             });
 
             cy.findByTestId("embed-menu-embed-modal-item").click();
 
-            getEmbedModalSharingPane().within(() => {
+            H.getEmbedModalSharingPane().within(() => {
               cy.findByText("Static embedding").should("be.visible");
               cy.findByText(/Use public embedding/).should("not.exist");
               cy.findByText("Public embeds and links are disabled.").should(
@@ -174,8 +152,10 @@ import {
               visitResource(resource, id);
             });
 
-            openSharingMenu();
-            sharingMenu().findByText("Ask your admin to create a public link");
+            H.openSharingMenu();
+            H.sharingMenu().findByText(
+              "Ask your admin to create a public link",
+            );
           });
         });
       });
@@ -185,7 +165,7 @@ import {
 
 describe("embed modal display", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     createResource("dashboard").then(({ body: { id } }) => {
@@ -193,14 +173,14 @@ describe("embed modal display", () => {
     });
   });
 
-  describeEE("when the user has a paid instance", () => {
+  H.describeEE("when the user has a paid instance", () => {
     it("should display a link to the Interactive embedding settings", () => {
-      setTokenFeatures("all");
-      visitDashboard("@dashboardId");
+      H.setTokenFeatures("all");
+      H.visitDashboard("@dashboardId");
 
-      openSharingMenu("Embed");
+      H.openSharingMenu("Embed");
 
-      getEmbedModalSharingPane().within(() => {
+      H.getEmbedModalSharingPane().within(() => {
         cy.findByText("Static embedding").should("be.visible");
         cy.findByText("Interactive embedding").should("be.visible");
 
@@ -218,10 +198,10 @@ describe("embed modal display", () => {
   describe("when the user has an OSS instance", () => {
     it("should display a link to the product page for embedded analytics", () => {
       cy.signInAsAdmin();
-      visitDashboard("@dashboardId");
-      openSharingMenu("Embed");
+      H.visitDashboard("@dashboardId");
+      H.openSharingMenu("Embed");
 
-      getEmbedModalSharingPane().within(() => {
+      H.getEmbedModalSharingPane().within(() => {
         cy.findByText("Static embedding").should("be.visible");
         cy.findByText("Interactive embedding").should("be.visible");
 
@@ -237,39 +217,39 @@ describe("embed modal display", () => {
 
 describe("#39152 sharing an unsaved question", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    updateSetting("enable-public-sharing", true);
+    H.updateSetting("enable-public-sharing", true);
   });
 
   it("should ask the user to save the question before creating a public link", () => {
-    startNewQuestion();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.startNewQuestion();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText("People").click();
     });
-    visualize();
+    H.visualize();
 
-    openSharingMenu();
+    H.openSharingMenu();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("First, save your question").should("be.visible");
       cy.findByText("Save").click();
     });
 
-    openSharingMenu("Create a public link");
+    H.openSharingMenu("Create a public link");
 
     assertValidPublicLink({ resource: "question", shouldHaveRemoveLink: true });
   });
 });
 
 ["dashboard", "question"].forEach(resource => {
-  describeWithSnowplow(`public ${resource} sharing snowplow events`, () => {
+  H.describeWithSnowplow(`public ${resource} sharing snowplow events`, () => {
     beforeEach(() => {
-      restore();
-      resetSnowplow();
+      H.restore();
+      H.resetSnowplow();
       cy.signInAsAdmin();
-      enableTracking();
+      H.enableTracking();
 
       createResource(resource).then(({ body }) => {
         cy.wrap(body).as("resource");
@@ -278,7 +258,7 @@ describe("#39152 sharing an unsaved question", () => {
     });
 
     afterEach(() => {
-      expectNoBadSnowplowEvents();
+      H.expectNoBadSnowplowEvents();
     });
 
     describe(`when embedding ${resource}`, () => {
@@ -288,10 +268,10 @@ describe("#39152 sharing an unsaved question", () => {
             visitResource(resource, id);
           });
 
-          openSharingMenu(/public link/i);
+          H.openSharingMenu(/public link/i);
           cy.findByTestId("copy-button").realClick();
           if (resource === "dashboard") {
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "public_link_copied",
               artifact: "dashboard",
               format: null,
@@ -299,31 +279,31 @@ describe("#39152 sharing an unsaved question", () => {
           }
 
           if (resource === "question") {
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "public_link_copied",
               artifact: "question",
               format: "html",
             });
 
-            popover().findByText("csv").click();
+            H.popover().findByText("csv").click();
             cy.findByTestId("copy-button").realClick();
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "public_link_copied",
               artifact: "question",
               format: "csv",
             });
 
-            popover().findByText("xlsx").click();
+            H.popover().findByText("xlsx").click();
             cy.findByTestId("copy-button").realClick();
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "public_link_copied",
               artifact: "question",
               format: "xlsx",
             });
 
-            popover().findByText("json").click();
+            H.popover().findByText("json").click();
             cy.findByTestId("copy-button").realClick();
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "public_link_copied",
               artifact: "question",
               format: "json",
@@ -336,9 +316,9 @@ describe("#39152 sharing an unsaved question", () => {
             visitResource(resource, id);
           });
 
-          openSharingMenu(/public link/i);
-          popover().button("Remove public link").click();
-          expectGoodSnowplowEvent({
+          H.openSharingMenu(/public link/i);
+          H.popover().button("Remove public link").click();
+          H.expectGoodSnowplowEvent({
             event: "public_link_removed",
             artifact: resource,
             source: "public-share",
@@ -352,9 +332,9 @@ describe("#39152 sharing an unsaved question", () => {
             visitResource(resource, id);
           });
 
-          openSharingMenu("Embed");
+          H.openSharingMenu("Embed");
 
-          modal().findByText("Get embedding code").click();
+          H.modal().findByText("Get embedding code").click();
 
           // mock clipboardData so that copy-to-clipboard doesn't use window.prompt, pausing the tests
           cy.window().then(win => {
@@ -365,9 +345,9 @@ describe("#39152 sharing an unsaved question", () => {
             };
           });
 
-          popover().findByTestId("copy-button").click();
+          H.popover().findByTestId("copy-button").click();
 
-          expectGoodSnowplowEvent({
+          H.expectGoodSnowplowEvent({
             event: "public_embed_code_copied",
             artifact: resource,
             source: "public-embed",
@@ -379,12 +359,12 @@ describe("#39152 sharing an unsaved question", () => {
             visitResource(resource, id);
           });
 
-          openSharingMenu("Embed");
-          modal().findByText("Get embedding code").click();
+          H.openSharingMenu("Embed");
+          H.modal().findByText("Get embedding code").click();
 
-          popover().findByText("Remove public link").click();
+          H.popover().findByText("Remove public link").click();
 
-          expectGoodSnowplowEvent({
+          H.expectGoodSnowplowEvent({
             event: "public_link_removed",
             artifact: resource,
             source: "public-embed",
@@ -397,13 +377,13 @@ describe("#39152 sharing an unsaved question", () => {
           cy.get("@resourceId").then(id => {
             visitResource(resource, id);
           });
-          openStaticEmbeddingModal();
+          H.openStaticEmbeddingModal();
 
           cy.log("Assert copying codes in Overview tab");
           cy.findByTestId("embed-backend")
             .findByTestId("copy-button")
             .realClick();
-          expectGoodSnowplowEvent({
+          H.expectGoodSnowplowEvent({
             event: "static_embed_code_copied",
             artifact: resource,
             language: "node",
@@ -422,7 +402,7 @@ describe("#39152 sharing an unsaved question", () => {
           cy.findByTestId("embed-frontend")
             .findByTestId("copy-button")
             .realClick();
-          expectGoodSnowplowEvent({
+          H.expectGoodSnowplowEvent({
             event: "static_embed_code_copied",
             artifact: resource,
             language: "pug",
@@ -439,16 +419,16 @@ describe("#39152 sharing an unsaved question", () => {
           });
 
           cy.log("Assert copying code in Parameters tab");
-          modal().within(() => {
+          H.modal().within(() => {
             cy.findByRole("tab", { name: "Parameters" }).click();
 
             cy.findByText("Node.js").click();
           });
-          popover().findByText("Ruby").click();
+          H.popover().findByText("Ruby").click();
           cy.findByTestId("embed-backend")
             .findByTestId("copy-button")
             .realClick();
-          expectGoodSnowplowEvent({
+          H.expectGoodSnowplowEvent({
             event: "static_embed_code_copied",
             artifact: resource,
             language: "ruby",
@@ -465,15 +445,15 @@ describe("#39152 sharing an unsaved question", () => {
           });
 
           cy.log("Assert copying code in Appearance tab");
-          modal().within(() => {
+          H.modal().within(() => {
             cy.findByRole("tab", { name: "Look and Feel" }).click();
 
             cy.findByText("Ruby").click();
           });
 
-          popover().findByText("Python").click();
+          H.popover().findByText("Python").click();
 
-          modal().within(() => {
+          H.modal().within(() => {
             cy.findByLabelText("Dark").click({ force: true });
             if (resource === "dashboard") {
               cy.findByLabelText("Dashboard title").click({ force: true });
@@ -488,7 +468,7 @@ describe("#39152 sharing an unsaved question", () => {
           cy.findByTestId("embed-backend")
             .findByTestId("copy-button")
             .realClick();
-          expectGoodSnowplowEvent({
+          H.expectGoodSnowplowEvent({
             event: "static_embed_code_copied",
             artifact: resource,
             language: "python",
@@ -511,7 +491,7 @@ describe("#39152 sharing an unsaved question", () => {
             cy.findByTestId("embed-backend")
               .findByTestId("copy-button")
               .realClick();
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "static_embed_code_copied",
               artifact: resource,
               language: "python",
@@ -529,22 +509,22 @@ describe("#39152 sharing an unsaved question", () => {
           }
         });
 
-        describeEE("Pro/EE instances", () => {
+        H.describeEE("Pro/EE instances", () => {
           beforeEach(() => {
-            setTokenFeatures("all");
+            H.setTokenFeatures("all");
           });
 
           it("should send `static_embed_code_copied` when copying the static embed code", () => {
             cy.get("@resourceId").then(id => {
               visitResource(resource, id);
             });
-            openStaticEmbeddingModal({ acceptTerms: false });
+            H.openStaticEmbeddingModal({ acceptTerms: false });
 
             cy.log("Assert copying codes in Overview tab");
             cy.findByTestId("embed-backend")
               .findByTestId("copy-button")
               .realClick();
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "static_embed_code_copied",
               artifact: resource,
               language: "node",
@@ -563,7 +543,7 @@ describe("#39152 sharing an unsaved question", () => {
             cy.findByTestId("embed-frontend")
               .findByTestId("copy-button")
               .realClick();
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "static_embed_code_copied",
               artifact: resource,
               language: "pug",
@@ -580,16 +560,16 @@ describe("#39152 sharing an unsaved question", () => {
             });
 
             cy.log("Assert copying code in Parameters tab");
-            modal().within(() => {
+            H.modal().within(() => {
               cy.findByRole("tab", { name: "Parameters" }).click();
 
               cy.findByText("Node.js").click();
             });
-            popover().findByText("Ruby").click();
+            H.popover().findByText("Ruby").click();
             cy.findByTestId("embed-backend")
               .findByTestId("copy-button")
               .realClick();
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "static_embed_code_copied",
               artifact: resource,
               language: "ruby",
@@ -606,15 +586,15 @@ describe("#39152 sharing an unsaved question", () => {
             });
 
             cy.log("Assert copying code in Appearance tab");
-            modal().within(() => {
+            H.modal().within(() => {
               cy.findByRole("tab", { name: "Look and Feel" }).click();
 
               cy.findByText("Ruby").click();
             });
 
-            popover().findByText("Python").click();
+            H.popover().findByText("Python").click();
 
-            modal().within(() => {
+            H.modal().within(() => {
               cy.findByLabelText("Dark").click({ force: true });
               if (resource === "dashboard") {
                 cy.findByLabelText("Dashboard title").click({ force: true });
@@ -627,17 +607,19 @@ describe("#39152 sharing an unsaved question", () => {
               cy.findByLabelText("Font").click();
             });
 
-            popover().findByText("Oswald").click();
+            H.popover().findByText("Oswald").click();
 
             cy.log(
               "Assert that it sends `downloads: false` when downloads are disabled",
             );
-            modal().findByLabelText("Download buttons").click({ force: true });
+            H.modal()
+              .findByLabelText("Download buttons")
+              .click({ force: true });
 
             cy.findByTestId("embed-backend")
               .findByTestId("copy-button")
               .realClick();
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "static_embed_code_copied",
               artifact: resource,
               language: "python",
@@ -662,15 +644,15 @@ describe("#39152 sharing an unsaved question", () => {
           });
 
           cy.log("changing parameters, so we could discard changes");
-          openStaticEmbeddingModal({ activeTab: "parameters" });
-          modal().button("Price").click();
-          popover().findByText("Editable").click();
+          H.openStaticEmbeddingModal({ activeTab: "parameters" });
+          H.modal().button("Price").click();
+          H.popover().findByText("Editable").click();
 
           cy.findByTestId("embed-modal-content-status-bar").within(() => {
             cy.findByText("Discard changes").click();
           });
 
-          expectGoodSnowplowEvent({
+          H.expectGoodSnowplowEvent({
             event: "static_embed_discarded",
             artifact: resource,
           });
@@ -683,14 +665,14 @@ describe("#39152 sharing an unsaved question", () => {
           cy.get("@resourceId").then(id => {
             visitResource(resource, id);
           });
-          openStaticEmbeddingModal();
+          H.openStaticEmbeddingModal();
 
           cy.findByTestId("embed-modal-content-status-bar")
             .button("Publish")
             .click();
 
           cy.then(function () {
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "static_embed_published",
               artifact: resource,
               new_embed: true,
@@ -712,12 +694,12 @@ describe("#39152 sharing an unsaved question", () => {
             .button("Unpublish")
             .click();
 
-          modal().findByRole("tab", { name: "Parameters" }).click();
-          modal().button("Price").click();
-          popover().findByText("Editable").click();
+          H.modal().findByRole("tab", { name: "Parameters" }).click();
+          H.modal().button("Price").click();
+          H.popover().findByText("Editable").click();
 
-          modal().button("Category").click();
-          popover().findByText("Locked").click();
+          H.modal().button("Category").click();
+          H.popover().findByText("Locked").click();
 
           cy.then(function () {
             const HOUR = 60 * 60 * 1000;
@@ -728,7 +710,7 @@ describe("#39152 sharing an unsaved question", () => {
               .button("Publish")
               .click();
 
-            expectGoodSnowplowEvent({
+            H.expectGoodSnowplowEvent({
               event: "static_embed_published",
               artifact: resource,
               new_embed: false,
@@ -748,7 +730,7 @@ describe("#39152 sharing an unsaved question", () => {
             enableEmbeddingForResource({ resource, id });
             visitResource(resource, id);
           });
-          openStaticEmbeddingModal();
+          H.openStaticEmbeddingModal();
 
           const HOUR = 60 * 60 * 1000;
           cy.clock(new Date(Date.now() + HOUR));
@@ -756,7 +738,7 @@ describe("#39152 sharing an unsaved question", () => {
             cy.findByText("Unpublish").click();
           });
 
-          expectGoodSnowplowEvent({
+          H.expectGoodSnowplowEvent({
             event: "static_embed_unpublished",
             artifact: resource,
             time_since_creation: closeTo(toSecond(HOUR), 10),
@@ -840,20 +822,20 @@ function createResource(resource) {
 
 function createPublicResourceLink(resource, id) {
   if (resource === "question") {
-    return createPublicQuestionLink(id);
+    return H.createPublicQuestionLink(id);
   }
   if (resource === "dashboard") {
-    return createPublicDashboardLink(id);
+    return H.createPublicDashboardLink(id);
   }
 }
 
 function visitResource(resource, id) {
   if (resource === "question") {
-    visitQuestion(id);
+    H.visitQuestion(id);
   }
 
   if (resource === "dashboard") {
-    visitDashboard(id);
+    H.visitDashboard(id);
   }
 }
 

--- a/e2e/test/scenarios/sharing/public-sharing.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-sharing.cy.spec.js
@@ -1,24 +1,10 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  createAction,
-  describeEE,
-  modal,
-  openSharingMenu,
-  restore,
-  setActionsEnabledForDB,
-  setTokenFeatures,
-  setupSMTP,
-  sidebar,
-  updateSetting,
-  visitDashboard,
-  visitDashboardAndCreateTab,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
 
@@ -73,7 +59,7 @@ const DEFAULT_ACTION_DETAILS = {
 
 describe("scenarios > admin > settings > public sharing", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -109,7 +95,7 @@ describe("scenarios > admin > settings > public sharing", () => {
       });
 
     cy.get("@dashboardId").then(dashboardId =>
-      visitDashboardAndCreateTab({ dashboardId }),
+      H.visitDashboardAndCreateTab({ dashboardId }),
     );
 
     cy.visit("/admin/settings/public-sharing");
@@ -144,7 +130,7 @@ describe("scenarios > admin > settings > public sharing", () => {
     });
 
     cy.button("Revoke link").click();
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Disable this link?").should("be.visible");
       cy.button("Yes").click();
     });
@@ -198,7 +184,7 @@ describe("scenarios > admin > settings > public sharing", () => {
     });
 
     cy.button("Revoke link").click();
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Disable this link?").should("be.visible");
       cy.button("Yes").click();
     });
@@ -209,7 +195,7 @@ describe("scenarios > admin > settings > public sharing", () => {
   });
 
   it("should see public actions", () => {
-    setActionsEnabledForDB(SAMPLE_DB_ID);
+    H.setActionsEnabledForDB(SAMPLE_DB_ID);
     const expectedActionName = "Public action";
 
     cy.createQuestion({
@@ -224,7 +210,7 @@ describe("scenarios > admin > settings > public sharing", () => {
     });
 
     cy.get("@modelId").then(modelId => {
-      createAction({
+      H.createAction({
         ...DEFAULT_ACTION_DETAILS,
         name: expectedActionName,
         model_id: modelId,
@@ -269,7 +255,7 @@ describe("scenarios > admin > settings > public sharing", () => {
     });
 
     cy.button("Revoke link").click();
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Disable this link?").should("be.visible");
       cy.button("Yes").click();
     });
@@ -280,7 +266,7 @@ describe("scenarios > admin > settings > public sharing", () => {
   });
 });
 
-describeEE(
+H.describeEE(
   "scenarios > sharing > approved domains (EE)",
   { tags: "@external" },
   () => {
@@ -295,24 +281,24 @@ describeEE(
     }
 
     function setAllowedDomains() {
-      updateSetting("subscription-allowed-domains", allowedDomain);
+      H.updateSetting("subscription-allowed-domains", allowedDomain);
     }
 
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
-      setTokenFeatures("all");
-      setupSMTP();
+      H.setTokenFeatures("all");
+      H.setupSMTP();
       setAllowedDomains();
     });
 
     it("should validate approved email domains for a question alert", () => {
-      visitQuestion(ORDERS_QUESTION_ID);
+      H.visitQuestion(ORDERS_QUESTION_ID);
 
-      openSharingMenu("Create alert");
-      modal().findByText("Set up an alert").click();
+      H.openSharingMenu("Create alert");
+      H.modal().findByText("Set up an alert").click();
 
-      modal()
+      H.modal()
         .findByRole("heading", { name: "Email" })
         .closest("li")
         .within(() => {
@@ -323,12 +309,12 @@ describeEE(
     });
 
     it("should validate approved email domains for a dashboard subscription (metabase#17977)", () => {
-      visitDashboard(ORDERS_DASHBOARD_ID);
-      openSharingMenu("Subscriptions");
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
+      H.openSharingMenu("Subscriptions");
 
       cy.findByRole("heading", { name: "Email it" }).click();
 
-      sidebar().within(() => {
+      H.sidebar().within(() => {
         addEmailRecipient(deniedEmail);
 
         // Reproduces metabase#17977

--- a/e2e/test/scenarios/sharing/sharing-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/sharing-reproductions.cy.spec.js
@@ -1,3 +1,4 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, USERS, WEBMAIL_CONFIG } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
@@ -6,39 +7,6 @@ import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  chartPathWithFillColor,
-  clickSend,
-  createQuestion,
-  createQuestionAndDashboard,
-  describeEE,
-  editDashboard,
-  filterWidget,
-  getDashboardCard,
-  getFullName,
-  getIframeBody,
-  mockSlackConfigured,
-  modal,
-  openAndAddEmailsToSubscriptions,
-  openNewPublicLinkDropdown,
-  openSharingMenu,
-  openStaticEmbeddingModal,
-  popover,
-  restore,
-  saveDashboard,
-  sendEmailAndAssert,
-  sendEmailAndVisitIt,
-  setFilter,
-  setTokenFeatures,
-  setupSMTP,
-  sharingMenuButton,
-  sidebar,
-  tooltip,
-  visitDashboard,
-  visitEmbeddedPage,
-  visitPublicDashboard,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 const { admin } = USERS;
 const {
@@ -54,23 +22,23 @@ const { WEB_PORT } = WEBMAIL_CONFIG;
 
 describe("issue 18009", { tags: "@external" }, () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    setupSMTP();
+    H.setupSMTP();
 
     cy.signIn("nodata");
   });
 
   it("nodata user should be able to create and receive an email subscription without errors (metabase#18009)", () => {
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
 
-    openSharingMenu("Subscriptions");
+    H.openSharingMenu("Subscriptions");
 
-    sidebar()
+    H.sidebar()
       .findByPlaceholderText("Enter user names or email addresses")
       .click();
-    popover()
+    H.popover()
       .contains(/^No Data/)
       .click();
 
@@ -78,7 +46,7 @@ describe("issue 18009", { tags: "@external" }, () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("To:").click();
 
-    sendEmailAndAssert(email => {
+    H.sendEmailAndAssert(email => {
       expect(email.html).not.to.include(
         "An error occurred while displaying this card.",
       );
@@ -94,34 +62,34 @@ describe("issue 18344", { tags: "@external" }, () => {
   } = USERS;
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    setupSMTP();
+    H.setupSMTP();
 
     // Rename the question
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
 
-    editDashboard();
+    H.editDashboard();
 
     // Open visualization options
     cy.findByTestId("dashcard").realHover();
     cy.icon("palette").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByDisplayValue("Orders").type("Foo").blur();
 
       cy.button("Done").click();
     });
 
-    saveDashboard();
+    H.saveDashboard();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("OrdersFoo");
   });
 
   it("subscription should not include original question name when it's been renamed in the dashboard (metabase#18344)", () => {
     // Send a test email subscription
-    openSharingMenu("Subscriptions");
+    H.openSharingMenu("Subscriptions");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Email it").click();
 
@@ -132,7 +100,7 @@ describe("issue 18344", { tags: "@external" }, () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("To:").click();
 
-    sendEmailAndAssert(email => {
+    H.sendEmailAndAssert(email => {
       expect(email.html).to.include("OrdersFoo");
     });
   });
@@ -151,22 +119,22 @@ describe("issue 18352", { tags: "@external" }, () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    setupSMTP();
+    H.setupSMTP();
 
     cy.createNativeQuestionAndDashboard({ questionDetails }).then(
       ({ body: { card_id, dashboard_id } }) => {
-        visitQuestion(card_id);
+        H.visitQuestion(card_id);
 
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       },
     );
   });
 
   it("should send the card with the INT64 values (metabase#18352)", () => {
-    openSharingMenu("Subscriptions");
+    H.openSharingMenu("Subscriptions");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Email it").click();
@@ -178,7 +146,7 @@ describe("issue 18352", { tags: "@external" }, () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("To:").click();
 
-    sendEmailAndAssert(({ html }) => {
+    H.sendEmailAndAssert(({ html }) => {
       expect(html).not.to.include(
         "An error occurred while displaying this card.",
       );
@@ -189,7 +157,7 @@ describe("issue 18352", { tags: "@external" }, () => {
   });
 });
 
-describeEE("issue 18669", { tags: "@external" }, () => {
+H.describeEE("issue 18669", { tags: "@external" }, () => {
   const questionDetails = {
     name: "Product count",
     database: SAMPLE_DB_ID,
@@ -223,21 +191,21 @@ describeEE("issue 18669", { tags: "@external" }, () => {
   });
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
-    setupSMTP();
+    H.setTokenFeatures("all");
+    H.setupSMTP();
 
     cy.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
       ({ body: card }) => {
         cy.editDashboardCard(card, getFilterMapping(card));
-        visitDashboard(card.dashboard_id);
+        H.visitDashboard(card.dashboard_id);
       },
     );
   });
 
   it("should send a test email with non-default parameters (metabase#18669)", () => {
-    openSharingMenu("Subscriptions");
+    H.openSharingMenu("Subscriptions");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Email it").click();
 
@@ -246,16 +214,16 @@ describeEE("issue 18669", { tags: "@external" }, () => {
       .type(`${admin.first_name} ${admin.last_name}{enter}`)
       .blur();
 
-    sidebar().within(() => {
+    H.sidebar().within(() => {
       cy.findByText("Doohickey").click();
     });
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Gizmo").click();
       cy.button("Update filter").click();
     });
 
-    clickSend();
+    H.clickSend();
   });
 });
 
@@ -275,34 +243,34 @@ describe("issue 20393", () => {
             name: "Q2 in a dashboard",
           },
         })
-        .then(({ body: { dashboard_id } }) => visitDashboard(dashboard_id)),
+        .then(({ body: { dashboard_id } }) => H.visitDashboard(dashboard_id)),
     );
   }
 
   beforeEach(() => {
     cy.intercept("POST", "/api/dashboard/*/public_link").as("publicLink");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should show public dashboards with nested cards mapped to parameters (metabase#20393)", () => {
     createDashboardWithNestedCard();
 
-    editDashboard();
+    H.editDashboard();
 
-    setFilter("Date picker", "All Options");
+    H.setFilter("Date picker", "All Options");
 
     // map the date parameter to the card
     cy.findByTestId("dashcard-container").contains("Select").click();
-    popover().contains("CREATED_AT").click();
+    H.popover().contains("CREATED_AT").click();
 
     // save the dashboard
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
 
     // open the sharing modal and enable sharing
-    openNewPublicLinkDropdown("dashboard");
+    H.openNewPublicLinkDropdown("dashboard");
 
     // navigate to the public dashboard link
     cy.wait("@publicLink").then(({ response: { body } }) => {
@@ -338,19 +306,19 @@ describe("issue 21559", { tags: "@external" }, () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    setupSMTP();
+    H.setupSMTP();
 
-    createQuestionAndDashboard({
+    H.createQuestionAndDashboard({
       questionDetails: q1Details,
     }).then(({ body: { dashboard_id } }) => {
-      createQuestion(q2Details);
+      H.createQuestion(q2Details);
 
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
       cy.findByTestId("scalar-value").should("have.text", "80.52");
-      editDashboard();
+      H.editDashboard();
     });
   });
 
@@ -361,8 +329,8 @@ describe("issue 21559", { tags: "@external" }, () => {
       cy.findByText(q2Details.name).click();
 
       // wait for elements to appear inside modal
-      chartPathWithFillColor("#A989C5").should("have.length", 1);
-      chartPathWithFillColor("#88BF4D").should("have.length", 1);
+      H.chartPathWithFillColor("#A989C5").should("have.length", 1);
+      H.chartPathWithFillColor("#88BF4D").should("have.length", 1);
 
       cy.button("Done").click();
     });
@@ -370,19 +338,21 @@ describe("issue 21559", { tags: "@external" }, () => {
     cy.findByTestId("add-series-modal").should("not.exist");
 
     // Make sure visualization changed to bars
-    getDashboardCard(0).within(() => {
-      chartPathWithFillColor("#A989C5").should("have.length", 1);
-      chartPathWithFillColor("#88BF4D").should("have.length", 1);
+    H.getDashboardCard(0).within(() => {
+      H.chartPathWithFillColor("#A989C5").should("have.length", 1);
+      H.chartPathWithFillColor("#88BF4D").should("have.length", 1);
     });
 
-    saveDashboard();
+    H.saveDashboard();
     // Wait for "Edited a few seconds ago" to disappear because the whole
     // dashboard re-renders after that!
     cy.findByTestId("revision-history-button").should("not.be.visible");
 
-    openAndAddEmailsToSubscriptions([`${admin.first_name} ${admin.last_name}`]);
+    H.openAndAddEmailsToSubscriptions([
+      `${admin.first_name} ${admin.last_name}`,
+    ]);
 
-    sendEmailAndAssert(email => {
+    H.sendEmailAndAssert(email => {
       expect(email.html).to.include("img"); // Bar chart is sent as img (inline attachment)
       expect(email.html).not.to.include("80.52"); // Scalar displays its value in HTML
     });
@@ -406,7 +376,7 @@ describe("issue 22524", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -416,21 +386,21 @@ describe("issue 22524", () => {
         cy.intercept("POST", `/api/dashboard/${dashboard_id}/public_link`).as(
           "publicLink",
         );
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       },
     );
 
-    editDashboard();
-    setFilter("Text or Category", "Is");
+    H.editDashboard();
+    H.setFilter("Text or Category", "Is");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
-    popover().contains("City").click();
+    H.popover().contains("City").click();
 
-    saveDashboard();
+    H.saveDashboard();
 
     // Share dashboard
-    openNewPublicLinkDropdown("dashboard");
+    H.openNewPublicLinkDropdown("dashboard");
 
     cy.wait("@publicLink").then(({ response: { body } }) => {
       const { uuid } = body;
@@ -448,7 +418,7 @@ describe("issue 22524", () => {
   });
 });
 
-describeEE("issue 24223", () => {
+H.describeEE("issue 24223", () => {
   const questionDetails = {
     name: "24223",
     query: {
@@ -515,10 +485,10 @@ describeEE("issue 24223", () => {
   });
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
-    setupSMTP();
+    H.setTokenFeatures("all");
+    H.setupSMTP();
   });
 
   it("should clear default filter (metabase#24223)", () => {
@@ -528,13 +498,15 @@ describeEE("issue 24223", () => {
 
         cy.editDashboardCard(dashboardCard, mapFiltersToCard(card_id));
 
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
         cy.location("search").should("eq", "?category=Doohickey&title=Awesome");
         cy.findByTestId("dashcard").should("contain", "36.37");
       },
     );
 
-    openAndAddEmailsToSubscriptions([`${admin.first_name} ${admin.last_name}`]);
+    H.openAndAddEmailsToSubscriptions([
+      `${admin.first_name} ${admin.last_name}`,
+    ]);
     cy.findByTestId("subscription-parameters-section").within(() => {
       cy.findAllByTestId("field-set-content")
         .filter(":contains(Doohickey)")
@@ -542,14 +514,14 @@ describeEE("issue 24223", () => {
         .click();
     });
 
-    sidebar().button("Done").click();
+    H.sidebar().button("Done").click();
 
     cy.findByLabelText("Pulse Card")
       .should("contain", "Title is Awesome")
       .and("not.contain", "1 more filter")
       .click();
 
-    sendEmailAndVisitIt();
+    H.sendEmailAndVisitIt();
     cy.get("table.header")
       .should("contain", containsFilter.name)
       .and("contain", "Awesome")
@@ -594,7 +566,7 @@ describe("issue 25473", () => {
     cy.findAllByTestId("column-header").last().should("have.text", ccName);
     cy.findAllByText("xavier").should("have.length", 2);
 
-    filterWidget().click();
+    H.filterWidget().click();
     cy.findByPlaceholderText("Enter some text").type("e").blur();
     cy.button("Add filter").click();
 
@@ -604,7 +576,7 @@ describe("issue 25473", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
@@ -638,7 +610,7 @@ describe("issue 25473", () => {
 
   it("public sharing: dashboard text filter on a custom column should accept text input (metabase#25473-1)", () => {
     cy.get("@dashboardId").then(id => {
-      visitPublicDashboard(id);
+      H.visitPublicDashboard(id);
     });
 
     assertOnResults();
@@ -658,22 +630,22 @@ describe("issue 25473", () => {
         params: {},
       };
 
-      visitEmbeddedPage(payload);
+      H.visitEmbeddedPage(payload);
     });
 
     assertOnResults();
   });
 });
 
-describeEE("issue 26988", () => {
+H.describeEE("issue 26988", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.intercept("GET", "/api/preview_embed/dashboard/*").as(
       "previewDashboard",
     );
 
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
   });
 
   it("should apply embedding settings passed in URL on load", () => {
@@ -689,30 +661,30 @@ describeEE("issue 26988", () => {
         enable_embedding: true,
       },
     }).then(({ body: card }) => {
-      visitDashboard(card.dashboard_id);
+      H.visitDashboard(card.dashboard_id);
     });
 
-    openStaticEmbeddingModal({
+    H.openStaticEmbeddingModal({
       activeTab: "lookAndFeel",
       previewMode: "preview",
       acceptTerms: false,
     });
 
     cy.wait("@previewDashboard");
-    getIframeBody().should("have.css", "font-family", "Lato, sans-serif");
+    H.getIframeBody().should("have.css", "font-family", "Lato, sans-serif");
 
     cy.findByLabelText("Customizing look and feel")
       .findByLabelText("Font")
       .as("font-control")
       .click();
-    popover().findByText("Oswald").click();
+    H.popover().findByText("Oswald").click();
 
-    getIframeBody().should("have.css", "font-family", "Oswald, sans-serif");
+    H.getIframeBody().should("have.css", "font-family", "Oswald, sans-serif");
 
     cy.get("@font-control").click();
-    popover().findByText("Slabo 27px").click();
+    H.popover().findByText("Slabo 27px").click();
 
-    getIframeBody().should(
+    H.getIframeBody().should(
       "have.css",
       "font-family",
       '"Slabo 27px", sans-serif',
@@ -722,16 +694,16 @@ describeEE("issue 26988", () => {
 
 describe("issue 30314", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setupSMTP();
+    H.setupSMTP();
   });
 
   it("should clean the new subscription form on cancel (metabase#30314)", () => {
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
 
-    openSharingMenu("Subscriptions");
-    sidebar().within(() => {
+    H.openSharingMenu("Subscriptions");
+    H.sidebar().within(() => {
       cy.findByText("Email it").click();
 
       cy.findByLabelText("Attach results").should("not.be.checked").click();
@@ -792,21 +764,21 @@ describe("issue 17657", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     createSubscriptionWithoutRecipients();
   });
 
   it("frontend should gracefully handle the case of a subscription without a recipient (metabase#17657)", () => {
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
 
-    openSharingMenu("Subscriptions");
+    H.openSharingMenu("Subscriptions");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/^Emailed monthly/).click();
 
-    sidebar().within(() => {
+    H.sidebar().within(() => {
       cy.button("Done").should("be.disabled");
     });
 
@@ -816,7 +788,7 @@ describe("issue 17657", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(`${first_name} ${last_name}`).click();
 
-    sidebar().within(() => {
+    H.sidebar().within(() => {
       cy.button("Done").should("not.be.disabled");
     });
   });
@@ -864,7 +836,7 @@ describe("issue 17658", { tags: "@external" }, () => {
                   email,
                   first_name,
                   last_name,
-                  common_name: getFullName(admin),
+                  common_name: H.getFullName(admin),
                 },
               ],
               details: {},
@@ -885,18 +857,18 @@ describe("issue 17658", { tags: "@external" }, () => {
 
   beforeEach(() => {
     cy.intercept("PUT", "/api/pulse/*").as("deletePulse");
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    setupSMTP();
+    H.setupSMTP();
 
     moveDashboardToCollection("First collection");
   });
 
   it("should delete dashboard subscription from any collection (metabase#17658)", () => {
-    visitDashboard(ORDERS_DASHBOARD_ID);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
 
-    openSharingMenu("Subscriptions");
+    H.openSharingMenu("Subscriptions");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/^Emailed monthly/).click();
@@ -960,20 +932,20 @@ describe("issue 17547", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    mockSlackConfigured();
+    H.mockSlackConfigured();
 
     cy.createQuestion(questionDetails).then(({ body: { id: questionId } }) => {
       setUpAlert(questionId);
 
-      visitQuestion(questionId);
+      H.visitQuestion(questionId);
     });
   });
 
   it("editing an alert should not delete it (metabase#17547)", () => {
-    openSharingMenu("Edit alerts");
-    popover().within(() => {
+    H.openSharingMenu("Edit alerts");
+    H.popover().within(() => {
       cy.findByText("Daily, 12:00 PM");
       cy.findByText("Edit").click();
     });
@@ -984,8 +956,8 @@ describe("issue 17547", () => {
 
     cy.wait("@alertQuery");
 
-    openSharingMenu("Edit alerts");
-    popover().within(() => {
+    H.openSharingMenu("Edit alerts");
+    H.popover().within(() => {
       cy.findByText("Daily, 12:00 AM");
     });
   });
@@ -993,16 +965,16 @@ describe("issue 17547", () => {
 
 describe("issue 16108", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should display a tooltip for CTA icons on an individual question (metabase#16108)", () => {
-    visitQuestion(ORDERS_QUESTION_ID);
+    H.visitQuestion(ORDERS_QUESTION_ID);
     cy.icon("download").realHover();
-    tooltip().findByText("Download full results");
-    sharingMenuButton().realHover();
-    tooltip().findByText("Sharing");
+    H.tooltip().findByText("Download full results");
+    H.sharingMenuButton().realHover();
+    H.tooltip().findByText("Sharing");
   });
 });
 
@@ -1032,29 +1004,29 @@ describe("issue 49525", { tags: "@external" }, () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    setupSMTP();
+    H.setupSMTP();
 
-    createQuestionAndDashboard({
+    H.createQuestionAndDashboard({
       questionDetails: q1Details,
     }).then(({ body: { dashboard_id } }) => {
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
     });
   });
 
   it("Subscriptions with 'Keep data pivoted' checked should work (metabase#49525)", () => {
     // Send a test email subscription
-    openSharingMenu("Subscriptions");
-    sidebar().within(() => {
+    H.openSharingMenu("Subscriptions");
+    H.sidebar().within(() => {
       cy.findByText("Email it").click();
       cy.findByPlaceholderText("Enter user names or email addresses").click();
     });
 
-    popover().findByText(`${first_name} ${last_name}`).click();
+    H.popover().findByText(`${first_name} ${last_name}`).click();
 
-    sidebar().within(() => {
+    H.sidebar().within(() => {
       // Click this just to close the popover that is blocking the "Send email now" button
       cy.findByText("To:").click();
       cy.findByLabelText("Attach results").click();
@@ -1062,7 +1034,7 @@ describe("issue 49525", { tags: "@external" }, () => {
       cy.findByText("Questions to attach").click();
     });
 
-    sendEmailAndAssert(email => {
+    H.sendEmailAndAssert(email => {
       // Get the CSV attachment data
       const csvAttachment = email.attachments.find(
         attachment => attachment.contentType === "text/csv",

--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -1,57 +1,29 @@
+import { H } from "e2e/support";
 import { USERS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  addOrUpdateDashboardCard,
-  addTextBox,
-  clickSend,
-  describeEE,
-  editDashboard,
-  emailSubscriptionRecipients,
-  getEmbedModalSharingPane,
-  mockSlackConfigured,
-  multiAutocompleteInput,
-  onlyOnOSS,
-  openEmailPage,
-  openPulseSubscription,
-  openSharingMenu,
-  popover,
-  removeMultiAutocompleteValue,
-  restore,
-  sendEmailAndAssert,
-  sendEmailAndVisitIt,
-  setFilter,
-  setTokenFeatures,
-  setupSMTP,
-  setupSubscriptionWithRecipients,
-  sharingMenu,
-  sidebar,
-  updateSetting,
-  viewEmailPage,
-  visitDashboard,
-} from "e2e/support/helpers";
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 const { admin, normal } = USERS;
 
 describe("scenarios > dashboard > subscriptions", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should allow sharing if there are no dashboard cards", () => {
     cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
-      visitDashboard(DASHBOARD_ID);
+      H.visitDashboard(DASHBOARD_ID);
     });
 
     cy.findByLabelText("subscriptions").should("not.exist");
 
-    openSharingMenu(/public link/i);
+    H.openSharingMenu(/public link/i);
     cy.findByTestId("public-link-popover-content").should("be.visible");
 
-    openSharingMenu("Embed");
-    getEmbedModalSharingPane().within(() => {
+    H.openSharingMenu("Embed");
+    H.getEmbedModalSharingPane().within(() => {
       cy.findByText("public embedding").should("be.visible");
       cy.findByText("Static embedding").should("be.visible");
     });
@@ -59,18 +31,18 @@ describe("scenarios > dashboard > subscriptions", () => {
 
   it("should allow sharing if dashboard contains only text cards (metabase#15077)", () => {
     cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
-      visitDashboard(DASHBOARD_ID);
+      H.visitDashboard(DASHBOARD_ID);
     });
-    addTextBox("Foo");
+    H.addTextBox("Foo");
     cy.button("Save").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("You're editing this dashboard.").should("not.exist");
-    openSharingMenu();
+    H.openSharingMenu();
     // Dashboard subscriptions are not shown because
     // getting notifications with static text-only cards doesn't make a lot of sense
-    sharingMenu().findByText("subscriptions").should("not.exist");
+    H.sharingMenu().findByText("subscriptions").should("not.exist");
 
-    sharingMenu().within(() => {
+    H.sharingMenu().within(() => {
       cy.findByText("Create a public link").should("be.visible");
       cy.findByText("Embed").should("be.visible");
     });
@@ -81,8 +53,8 @@ describe("scenarios > dashboard > subscriptions", () => {
       openDashboardSubscriptions();
 
       // The sidebar starts open after the method there, so test that clicking the icon closes it
-      openSharingMenu("Subscriptions");
-      sidebar().should("not.exist");
+      H.openSharingMenu("Subscriptions");
+      H.sidebar().should("not.exist");
     });
   });
 
@@ -105,7 +77,7 @@ describe("scenarios > dashboard > subscriptions", () => {
 
   describe("with email set up", { tags: "@external" }, () => {
     beforeEach(() => {
-      setupSMTP();
+      H.setupSMTP();
     });
 
     describe("with no existing subscriptions", () => {
@@ -124,7 +96,7 @@ describe("scenarios > dashboard > subscriptions", () => {
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Monthly").click();
 
-        sidebar().within(() => {
+        H.sidebar().within(() => {
           cy.button("Done").should("be.disabled");
         });
       });
@@ -142,7 +114,7 @@ describe("scenarios > dashboard > subscriptions", () => {
         cy.findByText("Email it").click();
         cy.findByPlaceholderText("Enter user names or email addresses").click();
 
-        popover().isRenderedWithinViewport();
+        H.popover().isRenderedWithinViewport();
       });
 
       it.skip("should not send attachments by default if not explicitly selected (metabase#28673)", () => {
@@ -150,7 +122,7 @@ describe("scenarios > dashboard > subscriptions", () => {
         assignRecipient();
 
         cy.findByLabelText("Attach results").should("not.be.checked");
-        sendEmailAndAssert(
+        H.sendEmailAndAssert(
           ({ attachments }) => expect(attachments).to.be.empty,
         );
       });
@@ -169,7 +141,7 @@ describe("scenarios > dashboard > subscriptions", () => {
 
         openDashboardSubscriptions();
 
-        sidebar().within(() => {
+        H.sidebar().within(() => {
           cy.findByPlaceholderText("Enter user names or email addresses")
             .click()
             .type(`${normal.first_name} ${normal.last_name}{enter}`);
@@ -184,11 +156,11 @@ describe("scenarios > dashboard > subscriptions", () => {
         const ORDERS_DASHBOARD_NAME = "Orders in a dashboard";
 
         assignRecipients();
-        sidebar().within(() => {
-          clickSend();
+        H.sidebar().within(() => {
+          H.clickSend();
         });
 
-        viewEmailPage(ORDERS_DASHBOARD_NAME);
+        H.viewEmailPage(ORDERS_DASHBOARD_NAME);
 
         cy.get(".main-container").within(() => {
           cy.findByText("Bcc:").should("exist");
@@ -207,11 +179,11 @@ describe("scenarios > dashboard > subscriptions", () => {
         const ORDERS_DASHBOARD_NAME = "Orders in a dashboard";
 
         assignRecipients();
-        sidebar().within(() => {
-          clickSend();
+        H.sidebar().within(() => {
+          H.clickSend();
         });
 
-        viewEmailPage(ORDERS_DASHBOARD_NAME);
+        H.viewEmailPage(ORDERS_DASHBOARD_NAME);
 
         cy.get(".main-container").within(() => {
           cy.findByText("Bcc:").should("not.exist");
@@ -226,13 +198,13 @@ describe("scenarios > dashboard > subscriptions", () => {
         const nonUserEmail = "non-user@example.com";
         const dashboardName = "Orders in a dashboard";
 
-        visitDashboard(ORDERS_DASHBOARD_ID);
+        H.visitDashboard(ORDERS_DASHBOARD_ID);
 
-        setupSubscriptionWithRecipients([nonUserEmail]);
+        H.setupSubscriptionWithRecipients([nonUserEmail]);
 
-        emailSubscriptionRecipients();
+        H.emailSubscriptionRecipients();
 
-        openEmailPage(dashboardName).then(() => {
+        H.openEmailPage(dashboardName).then(() => {
           cy.intercept("/api/pulse/unsubscribe").as("unsubscribe");
           cy.findByText("Unsubscribe").click();
           cy.wait("@unsubscribe");
@@ -242,21 +214,21 @@ describe("scenarios > dashboard > subscriptions", () => {
         });
 
         openDashboardSubscriptions();
-        openPulseSubscription();
+        H.openPulseSubscription();
 
-        sidebar().findByText(nonUserEmail).should("not.exist");
+        H.sidebar().findByText(nonUserEmail).should("not.exist");
       });
 
       it("should allow non-user to undo-unsubscribe from subscription", () => {
         const nonUserEmail = "non-user@example.com";
         const dashboardName = "Orders in a dashboard";
-        visitDashboard(ORDERS_DASHBOARD_ID);
+        H.visitDashboard(ORDERS_DASHBOARD_ID);
 
-        setupSubscriptionWithRecipients([nonUserEmail]);
+        H.setupSubscriptionWithRecipients([nonUserEmail]);
 
-        emailSubscriptionRecipients();
+        H.emailSubscriptionRecipients();
 
-        openEmailPage(dashboardName).then(() => {
+        H.openEmailPage(dashboardName).then(() => {
           cy.intercept("/api/pulse/unsubscribe").as("unsubscribe");
           cy.intercept("/api/pulse/unsubscribe/undo").as("resubscribe");
 
@@ -276,9 +248,9 @@ describe("scenarios > dashboard > subscriptions", () => {
         });
 
         openDashboardSubscriptions();
-        openPulseSubscription();
+        H.openPulseSubscription();
 
-        sidebar().findByText(nonUserEmail).should("exist");
+        H.sidebar().findByText(nonUserEmail).should("exist");
       });
 
       it("should show 404 page when missing required parameters", () => {
@@ -391,7 +363,7 @@ describe("scenarios > dashboard > subscriptions", () => {
             });
 
             // Add question to the dashboard
-            addOrUpdateDashboardCard({
+            H.addOrUpdateDashboardCard({
               dashboard_id: DASHBOARD_ID,
               card_id: QUESTION_ID,
               card: {
@@ -412,7 +384,7 @@ describe("scenarios > dashboard > subscriptions", () => {
       // Click anywhere outside to close the popover
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("15705D").click();
-      sendEmailAndAssert(email => {
+      H.sendEmailAndAssert(email => {
         expect(email.html).not.to.include(
           "An error occurred while displaying this card.",
         );
@@ -423,8 +395,8 @@ describe("scenarios > dashboard > subscriptions", () => {
     it("should include text cards (metabase#15744)", () => {
       const TEXT_CARD = "FooBar";
 
-      visitDashboard(ORDERS_DASHBOARD_ID);
-      addTextBox(TEXT_CARD);
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
+      H.addTextBox(TEXT_CARD);
       cy.button("Save").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("You're editing this dashboard.").should("not.exist");
@@ -432,7 +404,7 @@ describe("scenarios > dashboard > subscriptions", () => {
       // Click outside popover to close it and at the same time check that the text card content is shown as expected
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(TEXT_CARD).click();
-      sendEmailAndAssert(email => {
+      H.sendEmailAndAssert(email => {
         expect(email.html).to.include(TEXT_CARD);
       });
     });
@@ -463,7 +435,7 @@ describe("scenarios > dashboard > subscriptions", () => {
         },
       );
 
-      sendEmailAndAssert(email => {
+      H.sendEmailAndAssert(email => {
         expect(email.html).to.include(dashboardDetails.name);
         expect(email.html).to.include(questionDetails.name);
       });
@@ -472,7 +444,7 @@ describe("scenarios > dashboard > subscriptions", () => {
 
   describe("with Slack set up", () => {
     beforeEach(() => {
-      mockSlackConfigured();
+      H.mockSlackConfigured();
     });
 
     it("should not enable 'Done' button before channel is selected (metabase#14494)", () => {
@@ -488,32 +460,34 @@ describe("scenarios > dashboard > subscriptions", () => {
     it("should have 'Send to Slack now' button (metabase#14515)", () => {
       openSlackCreationForm();
 
-      sidebar().within(() => {
+      H.sidebar().within(() => {
         cy.findAllByRole("button", { name: "Send to Slack now" }).should(
           "be.disabled",
         );
         cy.findByPlaceholderText("Pick a user or channel...").click();
       });
 
-      popover().findByText("#work").click();
-      sidebar()
+      H.popover().findByText("#work").click();
+      H.sidebar()
         .findAllByRole("button", { name: "Done" })
         .should("not.be.disabled");
     });
 
     it("should disable subscriptions for non-admin users", () => {
       cy.signInAsNormalUser();
-      visitDashboard(ORDERS_DASHBOARD_ID);
-      openSharingMenu();
-      sharingMenu().findByText("Can't send subscriptions").should("be.visible");
+      H.visitDashboard(ORDERS_DASHBOARD_ID);
+      H.openSharingMenu();
+      H.sharingMenu()
+        .findByText("Can't send subscriptions")
+        .should("be.visible");
     });
   });
 
   describe("OSS email subscriptions", { tags: ["@OSS", "external"] }, () => {
     beforeEach(() => {
-      onlyOnOSS();
+      H.onlyOnOSS();
       cy.visit(`/dashboard/${ORDERS_DASHBOARD_ID}`);
-      setupSMTP();
+      H.setupSMTP();
     });
 
     describe("with parameters", () => {
@@ -534,7 +508,7 @@ describe("scenarios > dashboard > subscriptions", () => {
           .findByText("Text is Corbin Mertz")
           .click();
 
-        sendEmailAndVisitIt();
+        H.sendEmailAndVisitIt();
         cy.get("table.header").within(() => {
           cy.findByText("Text").next().findByText("Corbin Mertz");
           cy.findByText("Text 1").should("not.exist");
@@ -548,16 +522,16 @@ describe("scenarios > dashboard > subscriptions", () => {
           .click();
         cy.get("@subscriptionBar").findByText("Corbin Mertz").click();
 
-        popover().within(() => {
-          removeMultiAutocompleteValue(0);
-          multiAutocompleteInput().type("Sallie");
+        H.popover().within(() => {
+          H.removeMultiAutocompleteValue(0);
+          H.multiAutocompleteInput().type("Sallie");
         });
-        popover().last().findByText("Sallie Flatley").click();
-        popover()
+        H.popover().last().findByText("Sallie Flatley").click();
+        H.popover()
           .first()
           .within(() => {
             // to close the suggestion menu
-            multiAutocompleteInput().blur();
+            H.multiAutocompleteInput().blur();
             cy.button("Update filter").click();
           });
 
@@ -570,7 +544,7 @@ describe("scenarios > dashboard > subscriptions", () => {
           .click();
 
         // verify existing subscription show new default in email
-        sendEmailAndVisitIt();
+        H.sendEmailAndVisitIt();
         cy.get("table.header").within(() => {
           cy.findByText("Text").next().findByText("Sallie Flatley");
           cy.findByText("Text 1").should("not.exist");
@@ -579,29 +553,29 @@ describe("scenarios > dashboard > subscriptions", () => {
     });
   });
 
-  describeEE("EE email subscriptions", { tags: "@external" }, () => {
+  H.describeEE("EE email subscriptions", { tags: "@external" }, () => {
     beforeEach(() => {
-      setTokenFeatures("all");
-      setupSMTP();
+      H.setTokenFeatures("all");
+      H.setupSMTP();
       cy.visit(`/dashboard/${ORDERS_DASHBOARD_ID}`);
     });
 
     it("should only show current user in recipients dropdown if `user-visiblity` setting is `none`", () => {
       openRecipientsWithUserVisibilitySetting("none");
 
-      popover().find("span").should("have.length", 1);
+      H.popover().find("span").should("have.length", 1);
     });
 
     it("should only show users in same group in recipients dropdown if `user-visiblity` setting is `group`", () => {
       openRecipientsWithUserVisibilitySetting("group");
 
-      popover().find("span").should("have.length", 5);
+      H.popover().find("span").should("have.length", 5);
     });
 
     it("should show all users in recipients dropdown if `user-visiblity` setting is `all`", () => {
       openRecipientsWithUserVisibilitySetting("all");
 
-      popover().find("span").should("have.length", 9);
+      H.popover().find("span").should("have.length", 9);
     });
 
     describe("with no parameters", () => {
@@ -632,7 +606,7 @@ describe("scenarios > dashboard > subscriptions", () => {
           .click();
 
         // verify defaults are listed correctly in email
-        sendEmailAndVisitIt();
+        H.sendEmailAndVisitIt();
         cy.get("table.header").within(() => {
           cy.findByText("Text").next().findByText("Corbin Mertz");
           cy.findByText("Text 1").should("not.exist");
@@ -649,13 +623,13 @@ describe("scenarios > dashboard > subscriptions", () => {
           .next("aside")
           .findByText("Corbin Mertz")
           .click();
-        removeMultiAutocompleteValue(0, ":eq(1)");
-        popover().within(() => multiAutocompleteInput().type("Sallie"));
-        popover().last().findByText("Sallie Flatley").click();
-        popover()
+        H.removeMultiAutocompleteValue(0, ":eq(1)");
+        H.popover().within(() => H.multiAutocompleteInput().type("Sallie"));
+        H.popover().last().findByText("Sallie Flatley").click();
+        H.popover()
           .first()
           .within(() => {
-            multiAutocompleteInput().blur();
+            H.multiAutocompleteInput().blur();
             cy.button("Update filter").click();
           });
         cy.button("Save").click();
@@ -667,7 +641,7 @@ describe("scenarios > dashboard > subscriptions", () => {
           .click();
 
         // verify existing subscription show new default in email
-        sendEmailAndVisitIt();
+        H.sendEmailAndVisitIt();
         cy.get("table.header").within(() => {
           cy.findByText("Text").next().findByText("Sallie Flatley");
           cy.findByText("Text 1").should("not.exist");
@@ -682,13 +656,13 @@ describe("scenarios > dashboard > subscriptions", () => {
         cy.findByText("Emailed hourly").click();
 
         cy.findAllByText("Corbin Mertz").last().click();
-        popover().within(() => multiAutocompleteInput().type("Bob"));
-        popover().last().findByText("Bobby Kessler").click();
-        popover().contains("Update filter").click();
+        H.popover().within(() => H.multiAutocompleteInput().type("Bob"));
+        H.popover().last().findByText("Bobby Kessler").click();
+        H.popover().contains("Update filter").click();
 
         cy.findAllByText("Text 1").last().click();
-        popover().findByText("Gizmo").click();
-        popover().contains("Add filter").click();
+        H.popover().findByText("Gizmo").click();
+        H.popover().contains("Add filter").click();
 
         cy.intercept("PUT", "/api/pulse/*").as("pulsePut");
 
@@ -699,7 +673,7 @@ describe("scenarios > dashboard > subscriptions", () => {
           .findByText("Text is 2 selections and 1 more filter")
           .click();
 
-        sendEmailAndVisitIt();
+        H.sendEmailAndVisitIt();
         cy.get("table.header").within(() => {
           cy.findByText("Text")
             .next()
@@ -714,8 +688,8 @@ describe("scenarios > dashboard > subscriptions", () => {
 // Helper functions
 function openDashboardSubscriptions(dashboard_id = ORDERS_DASHBOARD_ID) {
   // Orders in a dashboard
-  visitDashboard(dashboard_id);
-  openSharingMenu("Subscriptions");
+  H.visitDashboard(dashboard_id);
+  H.openSharingMenu("Subscriptions");
 }
 
 function assignRecipient({
@@ -758,44 +732,44 @@ function createEmailSubscription() {
 
 function openSlackCreationForm() {
   openDashboardSubscriptions();
-  sidebar().findByText("Send it to Slack").click();
-  sidebar().findByText("Send this dashboard to Slack");
+  H.sidebar().findByText("Send it to Slack").click();
+  H.sidebar().findByText("Send this dashboard to Slack");
 }
 
 function openRecipientsWithUserVisibilitySetting(setting) {
-  updateSetting("user-visibility", setting);
+  H.updateSetting("user-visibility", setting);
   cy.signInAsNormalUser();
   openDashboardSubscriptions();
 
-  sidebar()
+  H.sidebar()
     .findByPlaceholderText("Enter user names or email addresses")
     .click();
 }
 
 function addParametersToDashboard() {
-  editDashboard();
+  H.editDashboard();
 
-  setFilter("Text or Category", "Is");
+  H.setFilter("Text or Category", "Is");
 
   cy.findByText("Select…").click();
-  popover().within(() => {
+  H.popover().within(() => {
     cy.findByText("Name").click();
   });
 
   // add default value to the above filter
   cy.findByText("No default").click();
-  popover().within(() => {
-    multiAutocompleteInput().type("Corbin");
+  H.popover().within(() => {
+    H.multiAutocompleteInput().type("Corbin");
   });
 
-  popover().last().findByText("Corbin Mertz").click();
+  H.popover().last().findByText("Corbin Mertz").click();
 
-  popover().first().contains("Add filter").click({ force: true });
+  H.popover().first().contains("Add filter").click({ force: true });
 
-  setFilter("Text or Category", "Is");
+  H.setFilter("Text or Category", "Is");
 
   cy.findByText("Select…").click();
-  popover().within(() => {
+  H.popover().within(() => {
     cy.findByText("Category").click();
   });
 

--- a/e2e/test/scenarios/stats/instance-stats-snowplow.cy.spec.js
+++ b/e2e/test/scenarios/stats/instance-stats-snowplow.cy.spec.js
@@ -1,36 +1,28 @@
-import {
-  describeEE,
-  describeWithSnowplow,
-  enableTracking,
-  expectGoodSnowplowEvent,
-  expectNoBadSnowplowEvents,
-  resetSnowplow,
-  restore,
-} from "e2e/support/helpers";
+import { H } from "e2e/support";
 
-describeWithSnowplow("scenarios > stats > snowplow", () => {
+H.describeWithSnowplow("scenarios > stats > snowplow", () => {
   beforeEach(() => {
-    restore();
-    resetSnowplow();
+    H.restore();
+    H.resetSnowplow();
     cy.signInAsAdmin();
-    enableTracking();
+    H.enableTracking();
   });
 
   describe("instance stats", () => {
     it("should send a snowplow event when the stats ping is triggered on OSS", () => {
       cy.request("POST", "api/testing/stats");
-      expectGoodSnowplowEvent();
+      H.expectGoodSnowplowEvent();
     });
   });
 
-  describeEE("instance stats", () => {
+  H.describeEE("instance stats", () => {
     it("should send a snowplow event when the stats ping is triggered on EE", () => {
       cy.request("POST", "api/testing/stats");
-      expectGoodSnowplowEvent();
+      H.expectGoodSnowplowEvent();
     });
   });
 
   afterEach(() => {
-    expectNoBadSnowplowEvents();
+    H.expectNoBadSnowplowEvents();
   });
 });

--- a/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
@@ -1,29 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  assertEChartsTooltip,
-  chartPathWithFillColor,
-  chartPathsWithFillColors,
-  createNativeQuestion,
-  createQuestion,
-  cypressWaitAll,
-  echartsContainer,
-  echartsTooltip,
-  getDraggableElements,
-  getValueLabels,
-  leftSidebar,
-  modal,
-  moveDnDKitElement,
-  openNotebook,
-  otherSeriesChartPaths,
-  popover,
-  queryBuilderHeader,
-  queryBuilderMain,
-  restore,
-  sidebar,
-  visitDashboard,
-  visitQuestionAdhoc,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PEOPLE, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
@@ -45,7 +22,7 @@ const breakoutBarChart = {
 
 describe("scenarios > visualizations > bar chart", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
@@ -70,7 +47,7 @@ describe("scenarios > visualizations > bar chart", () => {
     }
 
     it("should not show a bar for null values (metabase#12138)", () => {
-      visitQuestionAdhoc(
+      H.visitQuestionAdhoc(
         getQuestion({
           "graph.dimensions": ["a"],
           "graph.metrics": ["b"],
@@ -82,7 +59,7 @@ describe("scenarios > visualizations > bar chart", () => {
     });
 
     it("should show an (empty) bar for null values when X axis is ordinal (metabase#12138)", () => {
-      visitQuestionAdhoc(
+      H.visitQuestionAdhoc(
         getQuestion({
           "graph.dimensions": ["a"],
           "graph.metrics": ["b"],
@@ -97,7 +74,7 @@ describe("scenarios > visualizations > bar chart", () => {
 
   describe("with binned dimension (histogram)", () => {
     it("should filter out null values (metabase#16049)", () => {
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           type: "query",
           query: {
@@ -111,7 +88,7 @@ describe("scenarios > visualizations > bar chart", () => {
         },
       });
 
-      chartPathWithFillColor("#509EE3").should("have.length", 5); // there are six bars when null isn't filtered
+      H.chartPathWithFillColor("#509EE3").should("have.length", 5); // there are six bars when null isn't filtered
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("1,800"); // correct data has this on the y-axis
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -121,7 +98,7 @@ describe("scenarios > visualizations > bar chart", () => {
 
   describe("with very low and high values", () => {
     it("should display correct data values", () => {
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         display: "bar",
         dataset_query: {
           type: "native",
@@ -142,7 +119,7 @@ describe("scenarios > visualizations > bar chart", () => {
         },
       });
 
-      echartsContainer()
+      H.echartsContainer()
         .get("text")
         .should("contain", "19")
         .and("contain", "20.0M");
@@ -151,14 +128,14 @@ describe("scenarios > visualizations > bar chart", () => {
 
   describe("with x-axis series", () => {
     beforeEach(() => {
-      visitQuestionAdhoc(breakoutBarChart);
+      H.visitQuestionAdhoc(breakoutBarChart);
 
       cy.findByTestId("viz-settings-button").click();
-      sidebar().findByText("Data").click();
+      H.sidebar().findByText("Data").click();
     });
 
     it("should allow you to show/hide and reorder columns", () => {
-      moveDnDKitElement(getDraggableElements().eq(0), { vertical: 100 });
+      H.moveDnDKitElement(H.getDraggableElements().eq(0), { vertical: 100 });
 
       cy.findAllByTestId("legend-item").eq(0).should("contain.text", "Gadget");
       cy.findAllByTestId("legend-item").eq(1).should("contain.text", "Gizmo");
@@ -167,80 +144,80 @@ describe("scenarios > visualizations > bar chart", () => {
         .should("contain.text", "Doohickey");
       cy.findAllByTestId("legend-item").eq(3).should("contain.text", "Widget");
 
-      getDraggableElements().eq(1).icon("close").click(); // Hide Gizmo
+      H.getDraggableElements().eq(1).icon("close").click(); // Hide Gizmo
 
       cy.findByTestId("query-visualization-root")
         .findByText("Gizmo")
         .should("not.exist");
       cy.findAllByTestId("legend-item").should("have.length", 3);
-      chartPathWithFillColor("#F2A86F").should("be.visible");
-      chartPathWithFillColor("#F9D45C").should("be.visible");
-      chartPathWithFillColor("#88BF4D").should("be.visible");
+      H.chartPathWithFillColor("#F2A86F").should("be.visible");
+      H.chartPathWithFillColor("#F9D45C").should("be.visible");
+      H.chartPathWithFillColor("#88BF4D").should("be.visible");
 
-      leftSidebar().button("Add another series").click();
-      popover().findByText("Gizmo").click();
+      H.leftSidebar().button("Add another series").click();
+      H.popover().findByText("Gizmo").click();
 
       cy.findByTestId("query-visualization-root")
         .findByText("Gizmo")
         .should("exist");
       cy.findAllByTestId("legend-item").should("have.length", 4);
-      chartPathWithFillColor("#F2A86F").should("be.visible");
-      chartPathWithFillColor("#F9D45C").should("be.visible");
-      chartPathWithFillColor("#88BF4D").should("be.visible");
-      chartPathWithFillColor("#A989C5").should("be.visible");
+      H.chartPathWithFillColor("#F2A86F").should("be.visible");
+      H.chartPathWithFillColor("#F9D45C").should("be.visible");
+      H.chartPathWithFillColor("#88BF4D").should("be.visible");
+      H.chartPathWithFillColor("#A989C5").should("be.visible");
 
       cy.findAllByTestId("legend-item").contains("Gadget").click();
-      popover().findByText("See these Orders").click();
+      H.popover().findByText("See these Orders").click();
       cy.findByTestId("qb-filters-panel")
         .findByText("Product → Category is Gadget")
         .should("exist");
     });
 
     it("should gracefully handle removing filtered items, and adding new items to the end of the list", () => {
-      moveDnDKitElement(getDraggableElements().first(), { vertical: 100 });
+      H.moveDnDKitElement(H.getDraggableElements().first(), { vertical: 100 });
 
-      getDraggableElements().eq(1).icon("close").click(); // Hide Gizmo
+      H.getDraggableElements().eq(1).icon("close").click(); // Hide Gizmo
 
-      queryBuilderHeader().button("Filter").click();
-      modal().within(() => {
+      H.queryBuilderHeader().button("Filter").click();
+      H.modal().within(() => {
         cy.findByText("Product").click();
         cy.findByTestId("filter-column-Category")
           .findByLabelText("Filter operator")
           .click();
       });
-      popover().findByText("Is not").click();
-      modal().within(() => {
+      H.popover().findByText("Is not").click();
+      H.modal().within(() => {
         cy.findByText("Product").click();
         cy.findByTestId("filter-column-Category").findByText("Gadget").click();
         cy.button("Apply filters").click();
       });
 
-      getDraggableElements().should("have.length", 2);
-      getDraggableElements().eq(0).should("have.text", "Doohickey");
-      getDraggableElements().eq(1).should("have.text", "Widget");
+      H.getDraggableElements().should("have.length", 2);
+      H.getDraggableElements().eq(0).should("have.text", "Doohickey");
+      H.getDraggableElements().eq(1).should("have.text", "Widget");
 
       cy.findByTestId("qb-filters-panel").icon("close").click();
 
-      getDraggableElements().should("have.length", 3);
-      getDraggableElements().eq(0).should("have.text", "Gadget");
-      getDraggableElements().eq(1).should("have.text", "Doohickey");
-      getDraggableElements().eq(2).should("have.text", "Widget");
+      H.getDraggableElements().should("have.length", 3);
+      H.getDraggableElements().eq(0).should("have.text", "Gadget");
+      H.getDraggableElements().eq(1).should("have.text", "Doohickey");
+      H.getDraggableElements().eq(2).should("have.text", "Widget");
 
-      leftSidebar().button("Add another series").click();
-      popover().findByText("Gizmo").click();
+      H.leftSidebar().button("Add another series").click();
+      H.popover().findByText("Gizmo").click();
 
-      getDraggableElements().should("have.length", 4);
-      getDraggableElements().eq(0).should("have.text", "Gadget");
-      getDraggableElements().eq(1).should("have.text", "Gizmo");
-      getDraggableElements().eq(2).should("have.text", "Doohickey");
-      getDraggableElements().eq(3).should("have.text", "Widget");
+      H.getDraggableElements().should("have.length", 4);
+      H.getDraggableElements().eq(0).should("have.text", "Gadget");
+      H.getDraggableElements().eq(1).should("have.text", "Gizmo");
+      H.getDraggableElements().eq(2).should("have.text", "Doohickey");
+      H.getDraggableElements().eq(3).should("have.text", "Widget");
     });
   });
 
   // Note (EmmadUsmani): see `line_chart.cy.spec.js` for more test cases of this
   describe("with split y-axis (metabase#12939)", () => {
     it("should split the y-axis when column settings differ", () => {
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           type: "query",
           query: {
@@ -264,14 +241,14 @@ describe("scenarios > visualizations > bar chart", () => {
         },
       });
 
-      echartsContainer().within(() => {
+      H.echartsContainer().within(() => {
         cy.get("text").contains("Average of Total").should("be.visible");
         cy.get("text").contains("Min of Total").should("be.visible");
       });
     });
 
     it("should not split the y-axis when semantic_type, column settings are same and values are not far", () => {
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           type: "query",
           query: {
@@ -293,7 +270,7 @@ describe("scenarios > visualizations > bar chart", () => {
     });
 
     it("should split the y-axis on native queries with two numeric columns", () => {
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         display: "bar",
         dataset_query: {
           type: "native",
@@ -312,7 +289,7 @@ describe("scenarios > visualizations > bar chart", () => {
         },
       });
 
-      echartsContainer().within(() => {
+      H.echartsContainer().within(() => {
         cy.get("text").contains("m1").should("exist");
         cy.get("text").contains("m2").should("exist");
       });
@@ -321,7 +298,7 @@ describe("scenarios > visualizations > bar chart", () => {
 
   describe("with stacked bars", () => {
     it("should drill-through correctly when stacking", () => {
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           database: SAMPLE_DB_ID,
           type: "query",
@@ -350,7 +327,7 @@ describe("scenarios > visualizations > bar chart", () => {
   it("supports gray series colors", () => {
     const grayColor = "#F3F3F4";
 
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       ...breakoutBarChart,
       visualization_settings: {
         "graph.dimensions": ["CATEGORY", "SOURCE"],
@@ -359,7 +336,7 @@ describe("scenarios > visualizations > bar chart", () => {
     });
 
     // Ensure the gray color did not get assigned to series
-    chartPathWithFillColor(grayColor).should("not.exist");
+    H.chartPathWithFillColor(grayColor).should("not.exist");
 
     cy.findByTestId("viz-settings-button").click();
 
@@ -369,11 +346,11 @@ describe("scenarios > visualizations > bar chart", () => {
     // Assign gray color to the first series
     cy.findByLabelText(grayColor).click();
 
-    chartPathWithFillColor(grayColor).should("be.visible");
+    H.chartPathWithFillColor(grayColor).should("be.visible");
   });
 
   it("supports up to 100 series (metabase#28796)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       display: "bar",
       dataset_query: {
         database: SAMPLE_DB_ID,
@@ -395,18 +372,18 @@ describe("scenarios > visualizations > bar chart", () => {
     });
 
     cy.findByTestId("viz-settings-button").click();
-    leftSidebar().button("90 more series").click();
+    H.leftSidebar().button("90 more series").click();
     cy.get("[data-testid^=draggable-item]").should("have.length", 100);
 
     cy.findByTestId("qb-filters-panel")
       .findByText("ID is less than 101")
       .click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByDisplayValue("101").type("{backspace}2");
       cy.button("Update filter").click();
     });
 
-    queryBuilderMain().findByText(
+    H.queryBuilderMain().findByText(
       "This chart type doesn't support more than 100 series of data.",
     );
     cy.get("[data-testid^=draggable-item]").should("have.length", 0);
@@ -518,7 +495,7 @@ describe("scenarios > visualizations > bar chart", () => {
     }).then(({ dashboard }) => {
       cy.createQuestion(sumTotalByMonth, { wrapId: true }).then(() => {
         cy.get("@questionId").then(questionId => {
-          cypressWaitAll([
+          H.cypressWaitAll([
             cy.createQuestionAndAddToDashboard(avgTotalByMonth, dashboard.id, {
               series: [
                 {
@@ -537,7 +514,7 @@ describe("scenarios > visualizations > bar chart", () => {
               size_x: 20,
             }),
           ]).then(() => {
-            visitDashboard(dashboard.id);
+            H.visitDashboard(dashboard.id);
           });
         });
       });
@@ -548,21 +525,21 @@ describe("scenarios > visualizations > bar chart", () => {
       .contains("[data-testid=dashcard]", "Should split")
       .within(() => {
         // Verify this axis tick exists twice which verifies there are two y-axes
-        echartsContainer().findAllByText("3.0k").should("have.length", 2);
+        H.echartsContainer().findAllByText("3.0k").should("have.length", 2);
       });
 
     cy.findAllByTestId("dashcard")
       .contains("[data-testid=dashcard]", "Multi Series")
       .within(() => {
-        echartsContainer().findByText("Average Total by Month");
-        echartsContainer().findByText("Sum Total by Month");
+        H.echartsContainer().findByText("Average Total by Month");
+        H.echartsContainer().findByText("Sum Total by Month");
       });
 
     cy.log("Should not produce a split axis graph (#34618)");
     cy.findAllByTestId("dashcard")
       .contains("[data-testid=dashcard]", "Should not Split")
       .within(() => {
-        getValueLabels()
+        H.getValueLabels()
           .should("contain", "6")
           .and("contain", "13")
           .and("contain", "19");
@@ -601,9 +578,9 @@ describe("scenarios > visualizations > bar chart", () => {
       },
     };
 
-    createQuestion(multiMetric, { visitQuestion: true });
+    H.createQuestion(multiMetric, { visitQuestion: true });
 
-    const [firstMetric, secondMetric] = chartPathsWithFillColors([
+    const [firstMetric, secondMetric] = H.chartPathsWithFillColors([
       "#88BF4D",
       "#98D9D9",
     ]);
@@ -620,8 +597,8 @@ describe("scenarios > visualizations > bar chart", () => {
       });
     });
 
-    chartPathWithFillColor("#88BF4D").first().realHover();
-    assertEChartsTooltip({
+    H.chartPathWithFillColor("#88BF4D").first().realHover();
+    H.assertEChartsTooltip({
       header: "2022",
       rows: [
         {
@@ -643,7 +620,7 @@ describe("scenarios > visualizations > bar chart", () => {
   it("should correctly show tool-tips when stacked bar charts contain a total value that is negative (#39012)", () => {
     cy.signInAsAdmin();
 
-    createNativeQuestion(
+    H.createNativeQuestion(
       {
         name: "42948",
         native: {
@@ -661,8 +638,8 @@ describe("scenarios > visualizations > bar chart", () => {
       { visitQuestion: true },
     );
 
-    chartPathWithFillColor("#A989C5").eq(0).realHover();
-    assertEChartsTooltip({
+    H.chartPathWithFillColor("#A989C5").eq(0).realHover();
+    H.assertEChartsTooltip({
       rows: [
         {
           color: "#A989C5",
@@ -685,8 +662,8 @@ describe("scenarios > visualizations > bar chart", () => {
     });
     resetHoverState();
 
-    chartPathWithFillColor("#A989C5").eq(1).realHover();
-    assertEChartsTooltip({
+    H.chartPathWithFillColor("#A989C5").eq(1).realHover();
+    H.assertEChartsTooltip({
       rows: [
         {
           color: "#A989C5",
@@ -709,8 +686,8 @@ describe("scenarios > visualizations > bar chart", () => {
     });
     resetHoverState();
 
-    chartPathWithFillColor("#A989C5").eq(2).realHover();
-    assertEChartsTooltip({
+    H.chartPathWithFillColor("#A989C5").eq(2).realHover();
+    H.assertEChartsTooltip({
       rows: [
         {
           color: "#A989C5",
@@ -733,8 +710,8 @@ describe("scenarios > visualizations > bar chart", () => {
     });
     resetHoverState();
 
-    chartPathWithFillColor("#A989C5").eq(3).realHover();
-    assertEChartsTooltip({
+    H.chartPathWithFillColor("#A989C5").eq(3).realHover();
+    H.assertEChartsTooltip({
       rows: [
         {
           color: "#A989C5",
@@ -757,8 +734,8 @@ describe("scenarios > visualizations > bar chart", () => {
     });
     resetHoverState();
 
-    chartPathWithFillColor("#A989C5").eq(4).realHover();
-    assertEChartsTooltip({
+    H.chartPathWithFillColor("#A989C5").eq(4).realHover();
+    H.assertEChartsTooltip({
       rows: [
         {
           color: "#A989C5",
@@ -798,11 +775,11 @@ describe("scenarios > visualizations > bar chart", () => {
 
     function setMaxCategories(value, { viaBreakoutSettings = false } = {}) {
       if (viaBreakoutSettings) {
-        leftSidebar().findByTestId("settings-STATE").click();
+        H.leftSidebar().findByTestId("settings-STATE").click();
       } else {
-        leftSidebar().findByLabelText("Other series settings").click();
+        H.leftSidebar().findByLabelText("Other series settings").click();
       }
-      popover()
+      H.popover()
         .findByTestId("graph-max-categories-input")
         .type(`{selectAll}${value}`)
         .blur();
@@ -810,14 +787,14 @@ describe("scenarios > visualizations > bar chart", () => {
     }
 
     function setOtherCategoryAggregationFn(fnName) {
-      leftSidebar().findByLabelText("Other series settings").click();
-      popover()
+      H.leftSidebar().findByLabelText("Other series settings").click();
+      H.popover()
         .findByTestId("graph-other-category-aggregation-fn-picker")
         .click();
-      popover().last().findByText(fnName).click();
+      H.popover().last().findByText(fnName).click();
     }
 
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       display: "bar",
       dataset_query: {
         type: "query",
@@ -859,36 +836,36 @@ describe("scenarios > visualizations > bar chart", () => {
 
     // Enable 'Other' series
     cy.findByTestId("viz-settings-button").click();
-    leftSidebar().findByTestId("settings-STATE").click();
-    popover().findByLabelText("Enforce maximum number of series").click();
+    H.leftSidebar().findByTestId("settings-STATE").click();
+    H.popover().findByLabelText("Enforce maximum number of series").click();
 
     // Test 'Other' series renders
-    otherSeriesChartPaths().should("have.length", 6);
+    H.otherSeriesChartPaths().should("have.length", 6);
 
     // Test drill-through is disabled for 'Other' series
-    otherSeriesChartPaths().first().click();
+    H.otherSeriesChartPaths().first().click();
     cy.findByTestId("click-actions-view").should("not.exist");
 
     // Test drill-through is enabled for regular series
-    chartPathWithFillColor(AK_SERIES_COLOR).first().click();
+    H.chartPathWithFillColor(AK_SERIES_COLOR).first().click();
     cy.findByTestId("click-actions-view").should("exist");
 
     // Test legend and series visibility toggling
-    queryBuilderMain()
+    H.queryBuilderMain()
       .findAllByTestId("legend-item")
       .should("have.length", 9)
       .last()
       .as("other-series-legend-item");
     cy.get("@other-series-legend-item").findByLabelText("Hide series").click();
-    otherSeriesChartPaths().should("have.length", 0);
+    H.otherSeriesChartPaths().should("have.length", 0);
     cy.get("@other-series-legend-item").findByLabelText("Show series").click();
-    otherSeriesChartPaths().should("have.length", 6);
+    H.otherSeriesChartPaths().should("have.length", 6);
 
     // Test tooltips
-    chartPathWithFillColor(AK_SERIES_COLOR).first().realHover();
-    assertEChartsTooltip({ rows: [{ name: "Other", value: "9" }] });
-    otherSeriesChartPaths().first().realHover();
-    assertEChartsTooltip({
+    H.chartPathWithFillColor(AK_SERIES_COLOR).first().realHover();
+    H.assertEChartsTooltip({ rows: [{ name: "Other", value: "9" }] });
+    H.otherSeriesChartPaths().first().realHover();
+    H.assertEChartsTooltip({
       header: "September 2022",
       rows: [
         { name: "IA", value: "3" },
@@ -903,50 +880,56 @@ describe("scenarios > visualizations > bar chart", () => {
 
     // Test "graph.max_categories" change
     setMaxCategories(4);
-    queryBuilderMain().click(); // close popover
-    chartPathWithFillColor(AK_SERIES_COLOR).first().realHover();
-    echartsTooltip().find("tr").should("have.length", 5);
-    queryBuilderMain().findAllByTestId("legend-item").should("have.length", 5);
+    H.queryBuilderMain().click(); // close popover
+    H.chartPathWithFillColor(AK_SERIES_COLOR).first().realHover();
+    H.echartsTooltip().find("tr").should("have.length", 5);
+    H.queryBuilderMain()
+      .findAllByTestId("legend-item")
+      .should("have.length", 5);
 
     // Test can move series in/out of "Other" series
-    moveDnDKitElement(getDraggableElements().eq(3), { vertical: 150 }); // Move AZ into "Other"
-    moveDnDKitElement(getDraggableElements().eq(6), { vertical: -150 }); // Move CT out of "Other"
+    H.moveDnDKitElement(H.getDraggableElements().eq(3), { vertical: 150 }); // Move AZ into "Other"
+    H.moveDnDKitElement(H.getDraggableElements().eq(6), { vertical: -150 }); // Move CT out of "Other"
 
-    queryBuilderMain().findAllByTestId("legend-item").should("have.length", 5);
-    queryBuilderMain()
+    H.queryBuilderMain()
+      .findAllByTestId("legend-item")
+      .should("have.length", 5);
+    H.queryBuilderMain()
       .findAllByTestId("legend-item")
       .contains("AZ")
       .should("not.exist");
-    queryBuilderMain()
+    H.queryBuilderMain()
       .findAllByTestId("legend-item")
       .contains("CT")
       .should("exist");
 
     // Test "graph.max_categories" removes "Other" altogether
     setMaxCategories(0);
-    chartPathWithFillColor(AK_SERIES_COLOR).first().realHover();
-    echartsTooltip().find("tr").should("have.length", 14);
-    queryBuilderMain().findAllByTestId("legend-item").should("have.length", 14);
-    otherSeriesChartPaths().should("not.exist");
+    H.chartPathWithFillColor(AK_SERIES_COLOR).first().realHover();
+    H.echartsTooltip().find("tr").should("have.length", 14);
+    H.queryBuilderMain()
+      .findAllByTestId("legend-item")
+      .should("have.length", 14);
+    H.otherSeriesChartPaths().should("not.exist");
     setMaxCategories(8, { viaBreakoutSettings: true });
 
     // Test "graph.other_category_aggregation_fn" for native queries
-    openNotebook();
-    queryBuilderHeader().button("View the SQL").click();
+    H.openNotebook();
+    H.queryBuilderHeader().button("View the SQL").click();
     cy.findByTestId("native-query-preview-sidebar")
       .button("Convert this question to SQL")
       .click();
     cy.wait("@dataset");
-    queryBuilderMain().findByTestId("visibility-toggler").click();
+    H.queryBuilderMain().findByTestId("visibility-toggler").click();
 
     cy.findByTestId("viz-settings-button").click();
     setOtherCategoryAggregationFn("Average");
 
-    chartPathWithFillColor(AK_SERIES_COLOR).first().realHover();
-    assertEChartsTooltip({ rows: [{ name: "Other", value: "1.5" }] });
+    H.chartPathWithFillColor(AK_SERIES_COLOR).first().realHover();
+    H.assertEChartsTooltip({ rows: [{ name: "Other", value: "1.5" }] });
 
-    otherSeriesChartPaths().first().realHover();
-    assertEChartsTooltip({
+    H.otherSeriesChartPaths().first().realHover();
+    H.assertEChartsTooltip({
       header: "September 2022",
       rows: [
         { name: "IA", value: "3" },
@@ -961,19 +944,19 @@ describe("scenarios > visualizations > bar chart", () => {
 
     setOtherCategoryAggregationFn("Min");
 
-    chartPathWithFillColor(AK_SERIES_COLOR).first().realHover();
-    assertEChartsTooltip({ rows: [{ name: "Other", value: "1" }] });
+    H.chartPathWithFillColor(AK_SERIES_COLOR).first().realHover();
+    H.assertEChartsTooltip({ rows: [{ name: "Other", value: "1" }] });
 
-    otherSeriesChartPaths().first().realHover();
-    assertEChartsTooltip({ rows: [{ name: "Min", value: "1" }] });
+    H.otherSeriesChartPaths().first().realHover();
+    H.assertEChartsTooltip({ rows: [{ name: "Min", value: "1" }] });
 
     setOtherCategoryAggregationFn("Max");
 
-    chartPathWithFillColor(AK_SERIES_COLOR).first().realHover();
-    assertEChartsTooltip({ rows: [{ name: "Other", value: "3" }] });
+    H.chartPathWithFillColor(AK_SERIES_COLOR).first().realHover();
+    H.assertEChartsTooltip({ rows: [{ name: "Other", value: "3" }] });
 
-    otherSeriesChartPaths().first().realHover();
-    assertEChartsTooltip({ rows: [{ name: "Max", value: "3" }] });
+    H.otherSeriesChartPaths().first().realHover();
+    H.assertEChartsTooltip({ rows: [{ name: "Max", value: "3" }] });
   });
 });
 

--- a/e2e/test/scenarios/visualizations-charts/combo.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/combo.cy.spec.js
@@ -1,24 +1,17 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  assertEChartsTooltip,
-  cartesianChartCircleWithColor,
-  chartPathWithFillColor,
-  echartsContainer,
-  restore,
-  visitQuestionAdhoc,
-} from "e2e/support/helpers";
 
 const { PRODUCTS, PRODUCTS_ID, ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
 
 describe("scenarios > visualizations > combo", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should render values on data points", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         database: SAMPLE_DB_ID,
         query: {
@@ -47,7 +40,7 @@ describe("scenarios > visualizations > combo", () => {
   });
 
   it("should support stacking", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         database: SAMPLE_DB_ID,
         query: {
@@ -91,8 +84,8 @@ describe("scenarios > visualizations > combo", () => {
     });
 
     // First circle of the line series
-    cartesianChartCircleWithColor("#A989C5").eq(0).trigger("mousemove");
-    assertEChartsTooltip({
+    H.cartesianChartCircleWithColor("#A989C5").eq(0).trigger("mousemove");
+    H.assertEChartsTooltip({
       header: "2022",
       rows: [
         { color: "#A989C5", name: "Average of Total", value: "56.66" },
@@ -105,10 +98,10 @@ describe("scenarios > visualizations > combo", () => {
     });
 
     // First circle of stacked area series
-    cartesianChartCircleWithColor("#98D9D9").eq(0).trigger("mousemove");
+    H.cartesianChartCircleWithColor("#98D9D9").eq(0).trigger("mousemove");
 
     // Check the tooltip shows only stacked areas series
-    assertEChartsTooltip({
+    H.assertEChartsTooltip({
       header: "2022",
       rows: [
         {
@@ -132,8 +125,8 @@ describe("scenarios > visualizations > combo", () => {
     });
 
     // First bar of stacked bar series
-    chartPathWithFillColor("#7172AD").eq(0).realHover();
-    assertEChartsTooltip({
+    H.chartPathWithFillColor("#7172AD").eq(0).realHover();
+    H.assertEChartsTooltip({
       header: "2022",
       rows: [
         {
@@ -166,6 +159,6 @@ describe("scenarios > visualizations > combo", () => {
     cy.findByTestId("chartsettings-sidebar").findByText("Stack - 100%").click();
 
     // Ensure y-axis has 100% tick
-    echartsContainer().findByText("100%");
+    H.echartsContainer().findByText("100%");
   });
 });

--- a/e2e/test/scenarios/visualizations-charts/funnel.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/funnel.cy.spec.js
@@ -1,22 +1,15 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  getDraggableElements,
-  moveDnDKitElement,
-  popover,
-  restore,
-  sidebar,
-  visitQuestionAdhoc,
-} from "e2e/support/helpers";
 
 const { PEOPLE_ID, PEOPLE } = SAMPLE_DATABASE;
 
 describe("scenarios > visualizations > funnel chart", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
 
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "query",
         query: {
@@ -29,14 +22,14 @@ describe("scenarios > visualizations > funnel chart", () => {
       display: "funnel",
     });
     cy.findByTestId("viz-settings-button").click();
-    sidebar().findByText("Data").click();
+    H.sidebar().findByText("Data").click();
   });
 
   it("should allow you to reorder and show/hide rows", () => {
     cy.log("ensure that rows are shown");
-    getDraggableElements().should("have.length", 5);
+    H.getDraggableElements().should("have.length", 5);
 
-    getDraggableElements()
+    H.getDraggableElements()
       .first()
       .invoke("text")
       .then(name => {
@@ -45,9 +38,11 @@ describe("scenarios > visualizations > funnel chart", () => {
           .first()
           .should("have.text", name);
 
-        moveDnDKitElement(getDraggableElements().first(), { vertical: 100 });
+        H.moveDnDKitElement(H.getDraggableElements().first(), {
+          vertical: 100,
+        });
 
-        getDraggableElements().eq(2).should("have.text", name);
+        H.getDraggableElements().eq(2).should("have.text", name);
 
         cy.findAllByTestId("funnel-chart-header")
           .eq(2)
@@ -55,14 +50,14 @@ describe("scenarios > visualizations > funnel chart", () => {
       });
 
     cy.log("toggle row visibility");
-    getDraggableElements()
+    H.getDraggableElements()
       .eq(1)
       .within(() => {
         cy.icon("eye_outline").click();
       });
     cy.findAllByTestId("funnel-chart-header").should("have.length", 4);
 
-    getDraggableElements()
+    H.getDraggableElements()
       .eq(1)
       .within(() => {
         cy.icon("eye_crossed_out").click();
@@ -71,9 +66,9 @@ describe("scenarios > visualizations > funnel chart", () => {
   });
 
   it("should handle row items being filterd out and returned gracefully", () => {
-    moveDnDKitElement(getDraggableElements().first(), { vertical: 100 });
+    H.moveDnDKitElement(H.getDraggableElements().first(), { vertical: 100 });
 
-    getDraggableElements()
+    H.getDraggableElements()
       .eq(1)
       .within(() => {
         cy.icon("eye_outline").click();
@@ -86,7 +81,7 @@ describe("scenarios > visualizations > funnel chart", () => {
       cy.findByLabelText("Filter operator").click();
     });
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Is not").click();
     });
 
@@ -97,10 +92,10 @@ describe("scenarios > visualizations > funnel chart", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Apply filters").click();
 
-    getDraggableElements().should("have.length", 4);
+    H.getDraggableElements().should("have.length", 4);
 
     //Ensures that "Google" is still hidden, so it's state hasn't changed.
-    getDraggableElements()
+    H.getDraggableElements()
       .eq(0)
       .within(() => {
         cy.icon("eye_crossed_out").click();
@@ -112,10 +107,10 @@ describe("scenarios > visualizations > funnel chart", () => {
       cy.icon("close").click();
     });
 
-    getDraggableElements().should("have.length", 5);
+    H.getDraggableElements().should("have.length", 5);
 
     //Re-added items should appear at the end of the list.
-    getDraggableElements().eq(0).should("have.text", "Google");
-    getDraggableElements().eq(4).should("have.text", "Facebook");
+    H.getDraggableElements().eq(0).should("have.text", "Google");
+    H.getDraggableElements().eq(4).should("have.text", "Facebook");
   });
 });

--- a/e2e/test/scenarios/visualizations-charts/gauge.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/gauge.cy.spec.js
@@ -1,11 +1,11 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { restore, visitDashboard } from "e2e/support/helpers";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > visualizations > gauge chart", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -33,7 +33,7 @@ describe("scenarios > visualizations > gauge chart", () => {
           ],
         });
 
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       },
     );
 

--- a/e2e/test/scenarios/visualizations-charts/legend.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/legend.cy.spec.js
@@ -1,22 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  assertEChartsTooltip,
-  chartPathWithFillColor,
-  createQuestion,
-  echartsContainer,
-  editDashboard,
-  getDashboardCard,
-  leftSidebar,
-  modal,
-  pieSlices,
-  popover,
-  restore,
-  scatterBubbleWithColor,
-  showDashboardCardActions,
-  trendLine,
-  visitDashboard,
-  visitPublicDashboard,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PEOPLE, PRODUCTS } = SAMPLE_DATABASE;
 
@@ -120,7 +103,7 @@ const SCATTER_VIZ_QUESTION = {
 
 describe("scenarios > visualizations > legend", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -165,12 +148,12 @@ describe("scenarios > visualizations > legend", () => {
           size_y: 5,
         },
       ],
-    }).then(({ dashboard }) => visitDashboard(dashboard.id));
+    }).then(({ dashboard }) => H.visitDashboard(dashboard.id));
 
-    getDashboardCard(0).within(() =>
-      chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).first().realHover(),
+    H.getDashboardCard(0).within(() =>
+      H.chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).first().realHover(),
     );
-    assertEChartsTooltip({
+    H.assertEChartsTooltip({
       header: "2022",
       rows: [
         { name: "Doohickey", value: "177" },
@@ -180,12 +163,15 @@ describe("scenarios > visualizations > legend", () => {
       ],
     });
 
-    getDashboardCard(0).within(() => {
-      chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should("have.length", 5);
-      chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 5);
-      chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 5);
-      chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 5);
-      echartsContainer().within(() => {
+    H.getDashboardCard(0).within(() => {
+      H.chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should(
+        "have.length",
+        5,
+      );
+      H.chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 5);
+      H.chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 5);
+      H.chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 5);
+      H.echartsContainer().within(() => {
         cy.findByText("Count").should("exist"); // y-axis label
         cy.findByText("Created At: Year").should("exist"); // x-axis label
 
@@ -196,22 +182,28 @@ describe("scenarios > visualizations > legend", () => {
       });
 
       hideSeries(1); // Gadget
-      chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should("have.length", 5);
-      chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 0);
-      chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 5);
-      chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 5);
+      H.chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should(
+        "have.length",
+        5,
+      );
+      H.chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 0);
+      H.chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 5);
+      H.chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 5);
 
       hideSeries(2); // Gizmo
-      chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should("have.length", 5);
-      chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 0);
-      chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 0);
-      chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 5);
+      H.chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should(
+        "have.length",
+        5,
+      );
+      H.chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 0);
+      H.chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 0);
+      H.chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 5);
     });
 
-    getDashboardCard(0).within(() =>
-      chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).first().realHover(),
+    H.getDashboardCard(0).within(() =>
+      H.chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).first().realHover(),
     );
-    assertEChartsTooltip({
+    H.assertEChartsTooltip({
       header: "2022",
       rows: [
         { name: "Doohickey", value: "177" },
@@ -219,21 +211,27 @@ describe("scenarios > visualizations > legend", () => {
       ],
     });
 
-    getDashboardCard(0).within(() => {
+    H.getDashboardCard(0).within(() => {
       hideSeries(3); // Widget
-      chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should("have.length", 5);
-      chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 0);
-      chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 0);
-      chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 0);
+      H.chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should(
+        "have.length",
+        5,
+      );
+      H.chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 0);
+      H.chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 0);
+      H.chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 0);
 
       hideSeries(0);
       // Ensure can't hide the last visible series
-      chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should("have.length", 5);
-      chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 0);
-      chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 0);
-      chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 0);
+      H.chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should(
+        "have.length",
+        5,
+      );
+      H.chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 0);
+      H.chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 0);
+      H.chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 0);
 
-      echartsContainer().within(() => {
+      H.echartsContainer().within(() => {
         cy.findByText("Count").should("exist"); // y-axis label
         cy.findByText("Created At: Year").should("exist"); // x-axis label
 
@@ -244,12 +242,15 @@ describe("scenarios > visualizations > legend", () => {
       });
 
       showSeries(1);
-      chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should("have.length", 5);
-      chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 5);
-      chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 0);
-      chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 0);
+      H.chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should(
+        "have.length",
+        5,
+      );
+      H.chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 5);
+      H.chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 0);
+      H.chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 0);
 
-      echartsContainer().within(() => {
+      H.echartsContainer().within(() => {
         cy.findByText("Count").should("exist"); // y-axis label
         cy.findByText("Created At: Year").should("exist"); // x-axis label
         cy.findByText("1,800").should("exist");
@@ -261,18 +262,18 @@ describe("scenarios > visualizations > legend", () => {
       showSeries(3);
     });
 
-    getDashboardCard(1).within(() => {
-      echartsContainer().findByText("500").should("exist"); // max y-axis value
+    H.getDashboardCard(1).within(() => {
+      H.echartsContainer().findByText("500").should("exist"); // max y-axis value
       cy.findByText("And 39 more").click();
     });
-    popover().within(() => hideSeries(29)); // TX (Texas);
-    getDashboardCard(1).click(); // click outside of popover to close it
-    getDashboardCard(1).within(() =>
-      echartsContainer().findByText("500").should("not.exist"),
+    H.popover().within(() => hideSeries(29)); // TX (Texas);
+    H.getDashboardCard(1).click(); // click outside of popover to close it
+    H.getDashboardCard(1).within(() =>
+      H.echartsContainer().findByText("500").should("not.exist"),
     );
 
-    getDashboardCard(2).within(() => {
-      echartsContainer().within(() => {
+    H.getDashboardCard(2).within(() => {
+      H.echartsContainer().within(() => {
         // left axis
         cy.findByText("Sum of Total").should("exist");
         cy.findByText("600,000").should("exist");
@@ -281,11 +282,11 @@ describe("scenarios > visualizations > legend", () => {
         cy.findByText("Sum of Quantity").should("exist");
         cy.findByText("30,000").should("exist");
       });
-      trendLine().should("have.length", 2);
+      H.trendLine().should("have.length", 2);
 
       hideSeries(0); // Sum of Total
 
-      echartsContainer().within(() => {
+      H.echartsContainer().within(() => {
         // left axis
         cy.findByText("Sum of Total").should("not.exist");
         cy.findByText("600,000").should("not.exist");
@@ -294,12 +295,12 @@ describe("scenarios > visualizations > legend", () => {
         cy.findByText("Sum of Quantity").should("exist");
         cy.findByText("30,000").should("exist");
       });
-      trendLine().should("have.length", 1);
+      H.trendLine().should("have.length", 1);
 
       showSeries(0);
       hideSeries(1);
 
-      echartsContainer().within(() => {
+      H.echartsContainer().within(() => {
         // left axis
         cy.findByText("Sum of Total").should("exist");
         cy.findByText("600,000").should("exist");
@@ -308,47 +309,53 @@ describe("scenarios > visualizations > legend", () => {
         cy.findByText("Sum of Quantity").should("not.exist");
         cy.findByText("30,000").should("not.exist");
       });
-      trendLine().should("have.length", 1);
+      H.trendLine().should("have.length", 1);
     });
 
-    getDashboardCard(3).within(() => {
-      scatterBubbleWithColor(CATEGORY_COLOR.DOOHICKEY).should("have.length", 5);
-      scatterBubbleWithColor(CATEGORY_COLOR.GADGET).should("have.length", 5);
-      scatterBubbleWithColor(CATEGORY_COLOR.GIZMO).should("have.length", 5);
-      scatterBubbleWithColor(CATEGORY_COLOR.WIDGET).should("have.length", 5);
+    H.getDashboardCard(3).within(() => {
+      H.scatterBubbleWithColor(CATEGORY_COLOR.DOOHICKEY).should(
+        "have.length",
+        5,
+      );
+      H.scatterBubbleWithColor(CATEGORY_COLOR.GADGET).should("have.length", 5);
+      H.scatterBubbleWithColor(CATEGORY_COLOR.GIZMO).should("have.length", 5);
+      H.scatterBubbleWithColor(CATEGORY_COLOR.WIDGET).should("have.length", 5);
 
-      echartsContainer().findByText("54").should("exist"); // max y-axis value
+      H.echartsContainer().findByText("54").should("exist"); // max y-axis value
 
       hideSeries(1); // Gadget
       hideSeries(2); // Gizmo
       hideSeries(3); // Widget
 
-      scatterBubbleWithColor(CATEGORY_COLOR.DOOHICKEY).should("have.length", 5);
-      scatterBubbleWithColor(CATEGORY_COLOR.GADGET).should("have.length", 0);
-      scatterBubbleWithColor(CATEGORY_COLOR.GIZMO).should("have.length", 0);
-      scatterBubbleWithColor(CATEGORY_COLOR.WIDGET).should("have.length", 0);
+      H.scatterBubbleWithColor(CATEGORY_COLOR.DOOHICKEY).should(
+        "have.length",
+        5,
+      );
+      H.scatterBubbleWithColor(CATEGORY_COLOR.GADGET).should("have.length", 0);
+      H.scatterBubbleWithColor(CATEGORY_COLOR.GIZMO).should("have.length", 0);
+      H.scatterBubbleWithColor(CATEGORY_COLOR.WIDGET).should("have.length", 0);
 
-      echartsContainer().within(() => {
+      H.echartsContainer().within(() => {
         cy.findByText("54").should("not.exist"); // old max y-axis value
         cy.findByText("42").should("exist"); // new max y-axis value
       });
     });
 
-    getDashboardCard(4).within(() => {
+    H.getDashboardCard(4).within(() => {
       cy.findByText("18,760").should("exist"); // total value
-      pieSlices().should("have.length", 4);
+      H.pieSlices().should("have.length", 4);
       getPieChartLegendItemPercentage("TX").should("have.text", "7.15%");
 
       hideSeries(0); // TX (Texas)
 
-      pieSlices().should("have.length", 3);
+      H.pieSlices().should("have.length", 3);
       cy.findByText("18,760").should("not.exist");
       cy.findByText("17,418").should("exist");
       getPieChartLegendItemPercentage("TX").should("have.text", "");
 
       hideSeries(3); // "Other" slice
 
-      pieSlices().should("have.length", 2);
+      H.pieSlices().should("have.length", 2);
       cy.findByText("17,418").should("not.exist");
       cy.findByText("1,660").should("exist");
       getPieChartLegendItemPercentage("Other").should("have.text", "");
@@ -357,12 +364,12 @@ describe("scenarios > visualizations > legend", () => {
 
       showSeries(0);
 
-      pieSlices().should("have.length", 3);
+      H.pieSlices().should("have.length", 3);
       getPieChartLegendItemPercentage("TX").should("have.text", "44.7%");
     });
 
     // Ensure can't toggle series visibility in edit mode
-    editDashboard();
+    H.editDashboard();
 
     function ensureCanNotToggleSeriesVisibility() {
       cy.findAllByTestId("legend-item").eq(0).as("legend-item");
@@ -372,29 +379,32 @@ describe("scenarios > visualizations > legend", () => {
         .findByTestId("legend-item-dot")
         .click({ force: true });
 
-      chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should("have.length", 5);
-      chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 5);
-      chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 5);
-      chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 5);
+      H.chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should(
+        "have.length",
+        5,
+      );
+      H.chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 5);
+      H.chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 5);
+      H.chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 5);
     }
 
-    showDashboardCardActions(0);
-    getDashboardCard(0).findByLabelText("Show visualization options").click();
+    H.showDashboardCardActions(0);
+    H.getDashboardCard(0).findByLabelText("Show visualization options").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       ensureCanNotToggleSeriesVisibility();
       cy.button("Cancel").click();
     });
 
-    showDashboardCardActions(0);
-    getDashboardCard(0).findByLabelText("Add series").click();
+    H.showDashboardCardActions(0);
+    H.getDashboardCard(0).findByLabelText("Add series").click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       ensureCanNotToggleSeriesVisibility();
       cy.button("Cancel").click();
     });
 
-    getDashboardCard(0).within(() => {
+    H.getDashboardCard(0).within(() => {
       ensureCanNotToggleSeriesVisibility();
     });
   });
@@ -404,14 +414,14 @@ describe("scenarios > visualizations > legend", () => {
       questions: [SINGLE_AGGREGATION_QUESTION],
       cards: [{ col: 0, row: 0, size_x: 24, size_y: 6 }],
     }).then(({ dashboard }) => {
-      visitPublicDashboard(dashboard.id);
+      H.visitPublicDashboard(dashboard.id);
     });
 
-    chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should("have.length", 5);
-    chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 5);
-    chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 5);
-    chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 5);
-    echartsContainer().within(() => {
+    H.chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should("have.length", 5);
+    H.chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 5);
+    H.chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 5);
+    H.chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 5);
+    H.echartsContainer().within(() => {
       cy.findByText("Count").should("exist"); // y-axis label
       cy.findByText("Created At: Year").should("exist"); // x-axis label
 
@@ -422,22 +432,22 @@ describe("scenarios > visualizations > legend", () => {
     });
 
     hideSeries(1); // Gadget
-    chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should("have.length", 5);
-    chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 0);
-    chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 5);
-    chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 5);
+    H.chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should("have.length", 5);
+    H.chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 0);
+    H.chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 5);
+    H.chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 5);
   });
 
   it("should toggle series visibility in the query builder", () => {
-    createQuestion(SINGLE_AGGREGATION_QUESTION, { visitQuestion: true });
+    H.createQuestion(SINGLE_AGGREGATION_QUESTION, { visitQuestion: true });
 
-    chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should("have.length", 5);
-    chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 5);
-    chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 5);
-    chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 5);
+    H.chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should("have.length", 5);
+    H.chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 5);
+    H.chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 5);
+    H.chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 5);
 
-    chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).first().realHover();
-    assertEChartsTooltip({
+    H.chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).first().realHover();
+    H.assertEChartsTooltip({
       header: "2022",
       rows: [
         { name: "Doohickey", value: "177" },
@@ -447,7 +457,7 @@ describe("scenarios > visualizations > legend", () => {
       ],
     });
 
-    echartsContainer().within(() => {
+    H.echartsContainer().within(() => {
       cy.findByText("Count").should("exist"); // y-axis label
       cy.findByText("Created At: Year").should("exist"); // x-axis label
 
@@ -458,19 +468,19 @@ describe("scenarios > visualizations > legend", () => {
     });
 
     hideSeries(1); // Gadget
-    chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should("have.length", 5);
-    chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 0);
-    chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 5);
-    chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 5);
+    H.chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should("have.length", 5);
+    H.chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 0);
+    H.chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 5);
+    H.chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 5);
 
     hideSeries(2); // Gizmo
-    chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should("have.length", 5);
-    chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 0);
-    chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 0);
-    chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 5);
+    H.chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should("have.length", 5);
+    H.chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 0);
+    H.chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 0);
+    H.chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 5);
 
-    chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).first().realHover();
-    assertEChartsTooltip({
+    H.chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).first().realHover();
+    H.assertEChartsTooltip({
       header: "2022",
       rows: [
         { name: "Doohickey", value: "177" },
@@ -479,19 +489,19 @@ describe("scenarios > visualizations > legend", () => {
     });
 
     hideSeries(3); // Widget
-    chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should("have.length", 5);
-    chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 0);
-    chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 0);
-    chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 0);
+    H.chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should("have.length", 5);
+    H.chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 0);
+    H.chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 0);
+    H.chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 0);
 
     hideSeries(0);
     // Ensure can't hide the last visible series
-    chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should("have.length", 5);
-    chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 0);
-    chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 0);
-    chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 0);
+    H.chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should("have.length", 5);
+    H.chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 0);
+    H.chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 0);
+    H.chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 0);
 
-    echartsContainer().within(() => {
+    H.echartsContainer().within(() => {
       cy.findByText("Count").should("exist"); // y-axis label
       cy.findByText("Created At: Year").should("exist"); // x-axis label
 
@@ -502,12 +512,12 @@ describe("scenarios > visualizations > legend", () => {
     });
 
     showSeries(1);
-    chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should("have.length", 5);
-    chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 5);
-    chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 0);
-    chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 0);
+    H.chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).should("have.length", 5);
+    H.chartPathWithFillColor(CATEGORY_COLOR.GADGET).should("have.length", 5);
+    H.chartPathWithFillColor(CATEGORY_COLOR.GIZMO).should("have.length", 0);
+    H.chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 0);
 
-    echartsContainer().within(() => {
+    H.echartsContainer().within(() => {
       cy.findByText("Count").should("exist"); // y-axis label
       cy.findByText("Created At: Year").should("exist"); // x-axis label
       cy.findByText("1,800").should("exist");
@@ -520,14 +530,14 @@ describe("scenarios > visualizations > legend", () => {
 
     cy.findByTestId("viz-settings-button").click();
 
-    leftSidebar().within(() => {
+    H.leftSidebar().within(() => {
       cy.findByText("Display").click();
       cy.findByText("Stack - 100%").click();
     });
     cy.wait(500);
 
-    chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).first().realHover();
-    assertEChartsTooltip({
+    H.chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).first().realHover();
+    H.assertEChartsTooltip({
       header: "2022",
       rows: [
         { name: "Doohickey", value: "177", secondaryValue: "23.79 %" },
@@ -541,8 +551,8 @@ describe("scenarios > visualizations > legend", () => {
     hideSeries(2); // Gizmo
     hideSeries(3); // Widget
 
-    chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).first().realHover();
-    assertEChartsTooltip({
+    H.chartPathWithFillColor(CATEGORY_COLOR.DOOHICKEY).first().realHover();
+    H.assertEChartsTooltip({
       header: "2022",
       rows: [
         { name: "Doohickey", value: "177", secondaryValue: "47.07 %" },

--- a/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
@@ -1,23 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  addOrUpdateDashboardCard,
-  assertEChartsTooltip,
-  assertEChartsTooltipNotContain,
-  assertTooltipRow,
-  cartesianChartCircle,
-  cartesianChartCircleWithColor,
-  chartPathWithFillColor,
-  echartsTooltip,
-  echartsTriggerBlur,
-  leftSidebar,
-  modal,
-  restore,
-  saveDashboard,
-  tooltipHeader,
-  visitDashboard,
-  visitQuestionAdhoc,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
@@ -36,16 +19,16 @@ function testSumTotalChange(
   seriesName = "Sum of Total",
 ) {
   tooltipSelector("#88BF4D", 0);
-  echartsTooltip().within(() => {
-    tooltipHeader("2022");
-    assertTooltipRow(seriesName, { color: "#88BF4D", value: "42,156.87" });
+  H.echartsTooltip().within(() => {
+    H.tooltipHeader("2022");
+    H.assertTooltipRow(seriesName, { color: "#88BF4D", value: "42,156.87" });
   });
 
   tooltipSelector("#88BF4D", 1);
 
-  echartsTooltip().within(() => {
-    tooltipHeader("2023");
-    assertTooltipRow(seriesName, {
+  H.echartsTooltip().within(() => {
+    H.tooltipHeader("2023");
+    H.assertTooltipRow(seriesName, {
       color: "#88BF4D",
       value: "205,256.02",
       secondaryValue: "+386.89%",
@@ -113,18 +96,18 @@ function testAvgTotalChange(
   seriesName = "Average of Total",
 ) {
   tooltipSelector("#A989C5", 0);
-  echartsTooltip().within(() => {
-    tooltipHeader("2022");
-    assertTooltipRow(seriesName, {
+  H.echartsTooltip().within(() => {
+    H.tooltipHeader("2022");
+    H.assertTooltipRow(seriesName, {
       color: "#A989C5",
       value: "56.66",
     });
   });
 
   tooltipSelector("#A989C5", 1);
-  echartsTooltip().within(() => {
-    tooltipHeader("2022");
-    assertTooltipRow(seriesName, {
+  H.echartsTooltip().within(() => {
+    H.tooltipHeader("2022");
+    H.assertTooltipRow(seriesName, {
       color: "#A989C5",
       value: "56.86",
       secondaryValue: "+0.34%",
@@ -154,9 +137,9 @@ function testCumSumChange(
   // specific spec
   if (testFirstTooltip) {
     showTooltipForCircleInSeries("#88BF4D", 0);
-    echartsTooltip().within(() => {
-      tooltipHeader("2022");
-      assertTooltipRow(seriesName, {
+    H.echartsTooltip().within(() => {
+      H.tooltipHeader("2022");
+      H.assertTooltipRow(seriesName, {
         color: "#88BF4D",
         value: "3,236",
       });
@@ -164,9 +147,9 @@ function testCumSumChange(
   }
 
   showTooltipForCircleInSeries("#88BF4D", 1);
-  echartsTooltip().within(() => {
-    tooltipHeader("2023");
-    assertTooltipRow(seriesName, {
+  H.echartsTooltip().within(() => {
+    H.tooltipHeader("2023");
+    H.assertTooltipRow(seriesName, {
       color: "#88BF4D",
       value: "17,587",
       secondaryValue: "+443.48%",
@@ -189,18 +172,18 @@ const AVG_DISCOUNT_SUM_DISCOUNT = {
 
 function testAvgDiscountChange(seriesName = "Average of Discount") {
   showTooltipForCircleInSeries("#509EE3", 0);
-  echartsTooltip().within(() => {
-    tooltipHeader("2022");
-    assertTooltipRow(seriesName, {
+  H.echartsTooltip().within(() => {
+    H.tooltipHeader("2022");
+    H.assertTooltipRow(seriesName, {
       color: "#509EE3",
       value: "5.03",
     });
   });
 
   showTooltipForCircleInSeries("#509EE3", 1);
-  echartsTooltip().within(() => {
-    tooltipHeader("2023");
-    assertTooltipRow(seriesName, {
+  H.echartsTooltip().within(() => {
+    H.tooltipHeader("2023");
+    H.assertTooltipRow(seriesName, {
       color: "#509EE3",
       value: "5.41",
       secondaryValue: "+7.54%",
@@ -210,18 +193,18 @@ function testAvgDiscountChange(seriesName = "Average of Discount") {
 
 function testSumDiscountChange(seriesName = "Sum of Discount") {
   showTooltipForCircleInSeries("#98D9D9", 0);
-  echartsTooltip().within(() => {
-    tooltipHeader("2022");
-    assertTooltipRow(seriesName, {
+  H.echartsTooltip().within(() => {
+    H.tooltipHeader("2022");
+    H.assertTooltipRow(seriesName, {
       color: "#98D9D9",
       value: "342.09",
     });
   });
 
   showTooltipForCircleInSeries("#98D9D9", 1);
-  echartsTooltip().within(() => {
-    tooltipHeader("2023");
-    assertTooltipRow(seriesName, {
+  H.echartsTooltip().within(() => {
+    H.tooltipHeader("2023");
+    H.assertTooltipRow(seriesName, {
       color: "#98D9D9",
       value: "1,953.08",
       secondaryValue: "+470.93%",
@@ -231,7 +214,7 @@ function testSumDiscountChange(seriesName = "Sum of Discount") {
 
 describe("scenarios > visualizations > line/bar chart > tooltips", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -269,15 +252,15 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
     };
 
     it("should allow adding non-series columns from data to the tooltip", () => {
-      visitQuestionAdhoc(testQuestion);
+      H.visitQuestionAdhoc(testQuestion);
 
       // Tooltip by default shows only visible series data
       showTooltipForBarInSeries(COUNT_COLOR);
-      assertEChartsTooltipNotContain([SUM_OF_TOTAL, AVG_OF_QUANTITY]);
+      H.assertEChartsTooltipNotContain([SUM_OF_TOTAL, AVG_OF_QUANTITY]);
 
       // Go to the additional tooltip columns setting
       cy.findByTestId("viz-settings-button").click();
-      leftSidebar().within(() => {
+      H.leftSidebar().within(() => {
         cy.findByText("Display").click();
         cy.findByPlaceholderText("Enter metric names").click();
       });
@@ -292,7 +275,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
 
       // Ensure the tooltip shows additional columns
       showTooltipForBarInSeries(COUNT_COLOR);
-      assertEChartsTooltip({
+      H.assertEChartsTooltip({
         header: "0",
         rows: [
           { name: COUNT, value: "2,308" },
@@ -302,7 +285,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       });
 
       // Add a breakout to the chart
-      leftSidebar().within(() => {
+      H.leftSidebar().within(() => {
         cy.findByText("Data").click();
         cy.findByText("Add series breakout").click();
       });
@@ -310,7 +293,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       // Ensure the tooltip still shows additional columns
       showTooltipForBarInSeries(DOOHICKEY_COLOR);
       const assertBreakoutTooltip = () => {
-        assertEChartsTooltip({
+        H.assertEChartsTooltip({
           header: "0",
           rows: [
             { name: "Doohickey", value: "192" },
@@ -325,7 +308,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       assertBreakoutTooltip();
 
       // Make the chart stacked
-      leftSidebar().within(() => {
+      H.leftSidebar().within(() => {
         cy.findByText("Display").click();
         cy.findByText("Stack").click();
       });
@@ -341,7 +324,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       setup({
         question: SUM_OF_TOTAL,
       }).then(dashboardId => {
-        visitDashboard(dashboardId);
+        H.visitDashboard(dashboardId);
       });
     });
 
@@ -349,8 +332,8 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       const originalName = "Sum of Total";
       const customName = "Custom";
 
-      cartesianChartCircle().first().realHover();
-      assertEChartsTooltip({
+      H.cartesianChartCircle().first().realHover();
+      H.assertEChartsTooltip({
         header: "2022",
         rows: [{ name: originalName, value: "42,156.87" }],
       });
@@ -361,8 +344,8 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
 
       saveDashCardVisualizationOptions();
 
-      cartesianChartCircle().first().realHover();
-      assertEChartsTooltip({
+      H.cartesianChartCircle().first().realHover();
+      H.assertEChartsTooltip({
         header: "2022",
         rows: [{ name: customName, value: "42,156.87" }],
       });
@@ -379,7 +362,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
         question: SUM_OF_TOTAL,
         addedSeriesQuestion: AVG_OF_TOTAL,
       }).then(dashboardId => {
-        visitDashboard(dashboardId);
+        H.visitDashboard(dashboardId);
       });
     });
 
@@ -390,7 +373,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       const updatedAddedSeriesName = "Custom Q2";
 
       showTooltipForCircleInSeries("#88BF4D");
-      assertEChartsTooltip({
+      H.assertEChartsTooltip({
         header: "2022",
         rows: [
           { color: "#88BF4D", name: originalSeriesName, value: "42,156.87" },
@@ -398,7 +381,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       });
 
       showTooltipForCircleInSeries("#A989C5");
-      assertEChartsTooltip({
+      H.assertEChartsTooltip({
         header: "2022",
         rows: [
           {
@@ -417,7 +400,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       saveDashCardVisualizationOptions();
 
       showTooltipForCircleInSeries("#88BF4D");
-      assertEChartsTooltip({
+      H.assertEChartsTooltip({
         header: "2022",
         rows: [
           {
@@ -429,7 +412,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       });
 
       showTooltipForCircleInSeries("#A989C5");
-      assertEChartsTooltip({
+      H.assertEChartsTooltip({
         header: "2022",
         rows: [
           {
@@ -452,7 +435,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       setup({
         question: AVG_OF_TOTAL_CUM_SUM_QUANTITY,
       }).then(dashboardId => {
-        visitDashboard(dashboardId);
+        H.visitDashboard(dashboardId);
       });
     });
 
@@ -462,8 +445,8 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       const customAvgSeriesName = "Custom 1";
       const customCumSumSeriesName = "Custom 2";
 
-      cartesianChartCircle().first().realHover();
-      assertEChartsTooltip({
+      H.cartesianChartCircle().first().realHover();
+      H.assertEChartsTooltip({
         header: "2022",
         rows: [
           {
@@ -486,8 +469,8 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
 
       saveDashCardVisualizationOptions();
 
-      cartesianChartCircle().first().realHover();
-      assertEChartsTooltip({
+      H.cartesianChartCircle().first().realHover();
+      H.assertEChartsTooltip({
         header: "2022",
         rows: [
           {
@@ -519,21 +502,21 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
         y: 4,
       },
     }).then(dashboardId => {
-      visitDashboard(dashboardId);
+      H.visitDashboard(dashboardId);
     });
-    cartesianChartCircleWithColor("#A989C5")
+    H.cartesianChartCircleWithColor("#A989C5")
       .first()
       .as("firstCircle")
       .realHover();
 
     // Ensure the tooltip is visible
-    assertEChartsTooltip({ header: "2022" });
+    H.assertEChartsTooltip({ header: "2022" });
 
     // Ensuring the circle is not covered by the tooltip element
     cy.get("@firstCircle").then($circle => {
       const circleRect = $circle[0].getBoundingClientRect();
 
-      echartsTooltip().then($tooltip => {
+      H.echartsTooltip().then($tooltip => {
         const tooltipRect = $tooltip[0].getBoundingClientRect();
         const isCovered =
           circleRect.top < tooltipRect.bottom &&
@@ -550,20 +533,20 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
     setup({
       question: AVG_OF_TOTAL_CUM_SUM_QUANTITY,
     }).then(dashboardId => {
-      visitDashboard(dashboardId);
+      H.visitDashboard(dashboardId);
     });
 
-    cartesianChartCircleWithColor("#A989C5")
+    H.cartesianChartCircleWithColor("#A989C5")
       .first()
       .as("firstCircle")
       .realHover();
 
     // Ensure the tooltip is visible
-    assertEChartsTooltip({ header: "2022" });
+    H.assertEChartsTooltip({ header: "2022" });
 
     cy.get("@firstCircle").click();
 
-    echartsTooltip().should("not.be.visible");
+    H.echartsTooltip().should("not.be.visible");
   });
 
   describe("> multi series question on dashboard with added question", () => {
@@ -572,7 +555,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
         question: AVG_OF_TOTAL_CUM_SUM_QUANTITY,
         addedSeriesQuestion: AVG_DISCOUNT_SUM_DISCOUNT,
       }).then(dashboardId => {
-        visitDashboard(dashboardId);
+        H.visitDashboard(dashboardId);
       });
     });
 
@@ -593,7 +576,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
 
       [...originalSeriesColors, ...addedSeriesColors].forEach(color => {
         showTooltipForCircleInSeries(color, circleIndex);
-        assertEChartsTooltip({
+        H.assertEChartsTooltip({
           header: "2023",
           rows: [
             {
@@ -635,7 +618,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
 
       [...originalSeriesColors, ...addedSeriesColors].forEach(color => {
         showTooltipForCircleInSeries(color, circleIndex);
-        assertEChartsTooltip({
+        H.assertEChartsTooltip({
           header: "2023",
           rows: [
             {
@@ -676,7 +659,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       setup({
         question: { ...SUM_OF_TOTAL, display: "bar" },
       }).then(dashboardId => {
-        visitDashboard(dashboardId);
+        H.visitDashboard(dashboardId);
       });
     });
 
@@ -684,8 +667,8 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       const originalName = "Sum of Total";
       const updatedName = "Custom";
 
-      chartPathWithFillColor("#88BF4D").first().realHover();
-      assertEChartsTooltip({
+      H.chartPathWithFillColor("#88BF4D").first().realHover();
+      H.assertEChartsTooltip({
         header: "2022",
         rows: [
           {
@@ -702,8 +685,8 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
 
       saveDashCardVisualizationOptions();
 
-      chartPathWithFillColor("#88BF4D").first().realHover();
-      assertEChartsTooltip({
+      H.chartPathWithFillColor("#88BF4D").first().realHover();
+      H.assertEChartsTooltip({
         header: "2022",
         rows: [
           {
@@ -726,7 +709,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
         question: { ...SUM_OF_TOTAL, display: "bar" },
         addedSeriesQuestion: { ...AVG_OF_TOTAL, display: "bar" },
       }).then(dashboardId => {
-        visitDashboard(dashboardId);
+        H.visitDashboard(dashboardId);
       });
     });
 
@@ -739,7 +722,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       const updatedAddedSeriesName = "Custom Q2";
 
       showTooltipForBarInSeries(originalSeriesColor, 0);
-      assertEChartsTooltip({
+      H.assertEChartsTooltip({
         header: "2022",
         rows: [
           {
@@ -751,7 +734,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       });
 
       showTooltipForBarInSeries(addedSeriesColor, 0);
-      assertEChartsTooltip({
+      H.assertEChartsTooltip({
         header: "2022",
         rows: [
           {
@@ -770,7 +753,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       saveDashCardVisualizationOptions();
 
       showTooltipForBarInSeries(originalSeriesColor, 0);
-      assertEChartsTooltip({
+      H.assertEChartsTooltip({
         header: "2022",
         rows: [
           {
@@ -782,7 +765,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       });
 
       showTooltipForBarInSeries(addedSeriesColor, 0);
-      assertEChartsTooltip({
+      H.assertEChartsTooltip({
         header: "2022",
         rows: [
           {
@@ -805,11 +788,11 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       setup({
         question: SUM_OF_TOTAL_MONTH,
       }).then(dashboardId => {
-        visitDashboard(dashboardId);
+        H.visitDashboard(dashboardId);
       });
 
       showTooltipForCircleInSeries("#88BF4D", 0);
-      assertEChartsTooltip({
+      H.assertEChartsTooltip({
         header: "April 2022",
         rows: [
           {
@@ -822,7 +805,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       testTooltipExcludesText("Compared to previous month");
 
       showTooltipForCircleInSeries("#88BF4D", 1);
-      assertEChartsTooltip({
+      H.assertEChartsTooltip({
         header: "May 2022",
         rows: [
           {
@@ -839,11 +822,11 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       setup({
         question: SUM_OF_TOTAL_MONTH_EXCLUDE_MAY_AUG,
       }).then(dashboardId => {
-        visitDashboard(dashboardId);
+        H.visitDashboard(dashboardId);
       });
 
       showTooltipForCircleInSeries("#88BF4D", 0);
-      assertEChartsTooltip({
+      H.assertEChartsTooltip({
         header: "April 2022",
         rows: [
           {
@@ -855,7 +838,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       });
       testTooltipExcludesText("Compared to previous month");
       showTooltipForCircleInSeries("#88BF4D", 1);
-      assertEChartsTooltip({
+      H.assertEChartsTooltip({
         header: "June 2022",
         rows: [
           {
@@ -868,7 +851,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       testTooltipExcludesText("Compared to previous month");
 
       showTooltipForCircleInSeries("#88BF4D", 2);
-      assertEChartsTooltip({
+      H.assertEChartsTooltip({
         header: "July 2022",
         rows: [
           {
@@ -881,7 +864,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       });
 
       showTooltipForCircleInSeries("#88BF4D", 3);
-      assertEChartsTooltip({
+      H.assertEChartsTooltip({
         header: "September 2022",
         rows: [
           {
@@ -898,11 +881,11 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       setup({
         question: SUM_OF_TOTAL_MONTH_ORDINAL,
       }).then(dashboardId => {
-        visitDashboard(dashboardId);
+        H.visitDashboard(dashboardId);
       });
 
       showTooltipForCircleInSeries("#88BF4D", 0);
-      assertEChartsTooltip({
+      H.assertEChartsTooltip({
         header: "April 2022",
         rows: [
           {
@@ -915,7 +898,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       testTooltipExcludesText("Compared to previous month");
 
       showTooltipForCircleInSeries("#88BF4D", 1);
-      assertEChartsTooltip({
+      H.assertEChartsTooltip({
         header: "May 2022",
         rows: [
           {
@@ -987,7 +970,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
 
     it("should not omit percent change on April", () => {
       setup({ question: SUM_OF_TOTAL_APRIL }).then(dashboardId => {
-        visitDashboard(dashboardId);
+        H.visitDashboard(dashboardId);
       });
 
       APRIL_CHANGES.forEach((change, index) => {
@@ -996,7 +979,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
           testTooltipExcludesText("Compared to previous");
           return;
         }
-        assertEChartsTooltip({
+        H.assertEChartsTooltip({
           rows: [
             {
               color: "#88BF4D",
@@ -1010,7 +993,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
 
     it("should not omit percent change the week after DST begins", () => {
       setup({ question: SUM_OF_TOTAL_DST_WEEK }).then(dashboardId => {
-        visitDashboard(dashboardId);
+        H.visitDashboard(dashboardId);
       });
 
       DST_WEEK_CHANGES.forEach((change, index) => {
@@ -1020,7 +1003,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
           return;
         }
 
-        assertEChartsTooltip({
+        H.assertEChartsTooltip({
           rows: [
             {
               color: "#88BF4D",
@@ -1034,7 +1017,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
 
     it("should not omit percent change the day after DST begins", () => {
       setup({ question: SUM_OF_TOTAL_DST_DAY }).then(dashboardId => {
-        visitDashboard(dashboardId);
+        H.visitDashboard(dashboardId);
       });
 
       DST_DAY_CHANGES.forEach((change, index) => {
@@ -1043,7 +1026,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
           testTooltipExcludesText("Compared to previous");
           return;
         }
-        assertEChartsTooltip({
+        H.assertEChartsTooltip({
           rows: [
             {
               color: "#88BF4D",
@@ -1077,7 +1060,7 @@ function setupDashboard(
   cardSize = { x: 24, y: 12 },
 ) {
   return cy.createDashboard().then(({ body: { id: dashboardId } }) => {
-    return addOrUpdateDashboardCard({
+    return H.addOrUpdateDashboardCard({
       dashboard_id: dashboardId,
       card_id: cardId,
       card: {
@@ -1091,22 +1074,22 @@ function setupDashboard(
   });
 }
 function resetHoverState() {
-  echartsTriggerBlur();
+  H.echartsTriggerBlur();
   cy.wait(50);
 }
 
 function showTooltipForCircleInSeries(seriesColor, index = 0) {
   resetHoverState();
-  cartesianChartCircleWithColor(seriesColor).eq(index).realHover();
+  H.cartesianChartCircleWithColor(seriesColor).eq(index).realHover();
 }
 
 function showTooltipForBarInSeries(seriesColor, index = 0) {
   resetHoverState();
-  chartPathWithFillColor(seriesColor).eq(index).realHover();
+  H.chartPathWithFillColor(seriesColor).eq(index).realHover();
 }
 
 function testTooltipExcludesText(text) {
-  echartsTooltip().within(() => {
+  H.echartsTooltip().within(() => {
     cy.contains(text).should("not.exist");
   });
 }
@@ -1122,9 +1105,9 @@ function updateColumnTitle(originalText, updatedText) {
 }
 
 function saveDashCardVisualizationOptions() {
-  modal().within(() => {
+  H.modal().within(() => {
     cy.findByText("Done").click();
   });
 
-  saveDashboard();
+  H.saveDashboard();
 }

--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -1,21 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  addOrUpdateDashboardCard,
-  assertEChartsTooltip,
-  cartesianChartCircle,
-  cartesianChartCircleWithColor,
-  echartsContainer,
-  getXYTransform,
-  modal,
-  openSeriesSettings,
-  popover,
-  queryBuilderMain,
-  restore,
-  trendLine,
-  visitDashboard,
-  visitQuestionAdhoc,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID, PEOPLE, PEOPLE_ID } =
   SAMPLE_DATABASE;
@@ -32,32 +17,32 @@ const testQuery = {
 
 describe("scenarios > visualizations > line chart", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should be able to change y axis position (metabase#13487)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: testQuery,
       display: "line",
     });
 
     cy.findByTestId("viz-settings-button").click();
-    openSeriesSettings("Count");
+    H.openSeriesSettings("Count");
 
-    echartsContainer()
+    H.echartsContainer()
       .findByText("Count")
       .then(label => {
-        const { x, y } = getXYTransform(label);
+        const { x, y } = H.getXYTransform(label);
         cy.wrap({ x, y }).as("leftAxisLabelPosition");
       });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Right").click();
-    echartsContainer()
+    H.echartsContainer()
       .findByText("Count")
       .then(label => {
-        const { x: xRight, y: yRight } = getXYTransform(label);
+        const { x: xRight, y: yRight } = H.getXYTransform(label);
         cy.get("@leftAxisLabelPosition").then(({ x: xLeft, y: yLeft }) => {
           expect(yRight).to.be.eq(yLeft);
           expect(xRight).to.be.greaterThan(xLeft);
@@ -66,15 +51,15 @@ describe("scenarios > visualizations > line chart", () => {
   });
 
   it("should display line settings only for line/area charts", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: testQuery,
       display: "line",
     });
 
     cy.findByTestId("viz-settings-button").click();
-    openSeriesSettings("Count");
+    H.openSeriesSettings("Count");
 
-    popover().within(() => {
+    H.popover().within(() => {
       // For line chart
       cy.findByText("Line shape").should("exist");
       cy.findByText("Line style").should("exist");
@@ -98,32 +83,32 @@ describe("scenarios > visualizations > line chart", () => {
   });
 
   it("should allow changing formatting settings", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: testQuery,
       display: "line",
     });
 
     cy.findByTestId("viz-settings-button").click();
-    openSeriesSettings("Count");
+    H.openSeriesSettings("Count");
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Formatting").click();
 
       cy.findByText("Add a prefix").should("exist");
       cy.findByPlaceholderText("$").type("prefix").blur();
     });
 
-    echartsContainer().findByText("prefix0");
+    H.echartsContainer().findByText("prefix0");
   });
 
   it("should reset series settings when switching to line chart", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: testQuery,
       display: "area",
     });
 
     cy.findByTestId("viz-settings-button").click();
-    openSeriesSettings("Count");
+    H.openSeriesSettings("Count");
     cy.icon("bar").click();
 
     cy.findByTestId("viz-type-button").click();
@@ -131,11 +116,11 @@ describe("scenarios > visualizations > line chart", () => {
     cy.icon("line").click();
 
     // should be a line chart
-    cartesianChartCircleWithColor("#509EE3");
+    H.cartesianChartCircleWithColor("#509EE3");
   });
 
   it("should reset stacking settings when switching to line chart (metabase#43538)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         database: SAMPLE_DB_ID,
         query: {
@@ -158,14 +143,14 @@ describe("scenarios > visualizations > line chart", () => {
 
     cy.icon("line").click();
 
-    cartesianChartCircleWithColor("#A989C5");
+    H.cartesianChartCircleWithColor("#A989C5");
 
     // Y-axis scale should not be normalized
-    echartsContainer().findByText("100%").should("not.exist");
+    H.echartsContainer().findByText("100%").should("not.exist");
   });
 
   it("should be able to format data point values style independently on multi-series chart (metabase#13095)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "query",
         query: {
@@ -193,11 +178,11 @@ describe("scenarios > visualizations > line chart", () => {
       },
     });
 
-    echartsContainer().get("text").contains("39.75%");
+    H.echartsContainer().get("text").contains("39.75%");
   });
 
   it("should let unpin y-axis from zero", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "query",
         query: {
@@ -215,7 +200,7 @@ describe("scenarios > visualizations > line chart", () => {
     });
 
     // The chart is pinned to zero by default: 0 tick should exist
-    echartsContainer().findByText("0");
+    H.echartsContainer().findByText("0");
 
     cy.findByTestId("viz-settings-button").click();
     cy.findByTestId("chartsettings-sidebar").within(() => {
@@ -224,17 +209,17 @@ describe("scenarios > visualizations > line chart", () => {
     });
 
     // Ensure unpinned chart does not have 0 tick
-    echartsContainer().findByText("0").should("not.exist");
+    H.echartsContainer().findByText("0").should("not.exist");
 
     cy.findByTestId("chartsettings-sidebar")
       .findByText("Unpin from zero")
       .click();
 
-    echartsContainer().findByText("0");
+    H.echartsContainer().findByText("0");
   });
 
   it("should display an error message when there are more series than the chart supports", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       display: "line",
       dataset_query: {
         database: SAMPLE_DB_ID,
@@ -261,7 +246,7 @@ describe("scenarios > visualizations > line chart", () => {
   });
 
   it("should correctly display tooltip values when X-axis is numeric and style is 'Ordinal' (metabase#15998)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         database: SAMPLE_DB_ID,
         query: {
@@ -285,8 +270,8 @@ describe("scenarios > visualizations > line chart", () => {
       },
     });
 
-    cartesianChartCircleWithColor("#509EE3").eq(3).realHover();
-    assertEChartsTooltip({
+    H.cartesianChartCircleWithColor("#509EE3").eq(3).realHover();
+    H.assertEChartsTooltip({
       header: "2.7",
       rows: [
         {
@@ -309,7 +294,7 @@ describe("scenarios > visualizations > line chart", () => {
   });
 
   it("should be possible to update/change label for an empty row value (metabase#12128)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "native",
         native: {
@@ -329,15 +314,15 @@ describe("scenarios > visualizations > line chart", () => {
     cy.findByTestId("viz-settings-button").click();
 
     // Make sure we can update input with some existing value
-    openSeriesSettings("cat1", true);
-    popover().within(() => {
+    H.openSeriesSettings("cat1", true);
+    H.popover().within(() => {
       cy.findByDisplayValue("cat1").type(" new").blur();
       cy.findByDisplayValue("cat1 new");
       cy.wait(500);
     });
     // Now do the same for the input with no value
-    openSeriesSettings("(empty)", true);
-    popover().within(() => {
+    H.openSeriesSettings("(empty)", true);
+    H.popover().within(() => {
       cy.findAllByLabelText("series-name-input").clear().type("cat2").blur();
       cy.findByDisplayValue("cat2");
     });
@@ -350,7 +335,7 @@ describe("scenarios > visualizations > line chart", () => {
   });
 
   it("should interpolate null value by not rendering a data point (metabase#4122)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "native",
         native: {
@@ -368,11 +353,11 @@ describe("scenarios > visualizations > line chart", () => {
       display: "line",
     });
 
-    cartesianChartCircle().should("have.length", 2);
+    H.cartesianChartCircle().should("have.length", 2);
   });
 
   it("should show the trend line", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       display: "line",
       dataset_query: {
         database: SAMPLE_DB_ID,
@@ -398,11 +383,11 @@ describe("scenarios > visualizations > line chart", () => {
       },
     });
 
-    trendLine().should("be.visible");
+    H.trendLine().should("be.visible");
   });
 
   it("should show label for empty value series breakout (metabase#32107)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "native",
         native: {
@@ -436,7 +421,7 @@ describe("scenarios > visualizations > line chart", () => {
 
   describe("y-axis splitting (metabase#12939)", () => {
     it("should not split the y-axis when columns are of the same semantic_type and have close values", () => {
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           type: "query",
           query: {
@@ -458,7 +443,7 @@ describe("scenarios > visualizations > line chart", () => {
     });
 
     it("should split the y-axis when columns are of different semantic_type", () => {
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           type: "query",
           query: {
@@ -476,14 +461,14 @@ describe("scenarios > visualizations > line chart", () => {
         display: "line",
       });
 
-      echartsContainer().within(() => {
+      H.echartsContainer().within(() => {
         cy.findByText("Average of Latitude").should("be.visible");
         cy.findByText("Average of Longitude").should("be.visible");
       });
     });
 
     it("should split the y-axis when columns are of the same semantic_type but have far values", () => {
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           type: "query",
           query: {
@@ -501,14 +486,14 @@ describe("scenarios > visualizations > line chart", () => {
         display: "line",
       });
 
-      echartsContainer().within(() => {
+      H.echartsContainer().within(() => {
         cy.findByText("Sum of Total").should("be.visible");
         cy.findByText("Min of Total").should("be.visible");
       });
     });
 
     it("should not split the y-axis when the setting is disabled", () => {
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           type: "query",
           query: {
@@ -564,7 +549,7 @@ describe("scenarios > visualizations > line chart", () => {
               firstCardId: question1Id,
               secondCardId: question2Id,
             });
-            visitDashboard(dashboardId);
+            H.visitDashboard(dashboardId);
 
             // Rename both series
             renameSeries([
@@ -576,7 +561,7 @@ describe("scenarios > visualizations > line chart", () => {
             assertOnYAxisValues();
 
             showTooltipForFirstCircleInSeries("#88BF4D");
-            assertEChartsTooltip({
+            H.assertEChartsTooltip({
               header: "2022",
               rows: [
                 {
@@ -619,7 +604,7 @@ describe("scenarios > visualizations > line chart", () => {
               secondCardId: question2Id,
             });
 
-            visitDashboard(dashboardId);
+            H.visitDashboard(dashboardId);
 
             renameSeries([
               ["16249_Q3", RENAMED_FIRST_SERIES],
@@ -630,7 +615,7 @@ describe("scenarios > visualizations > line chart", () => {
             assertOnYAxisValues();
 
             showTooltipForFirstCircleInSeries("#88BF4D");
-            assertEChartsTooltip({
+            H.assertEChartsTooltip({
               header: "2022",
               rows: [
                 {
@@ -664,7 +649,7 @@ describe("scenarios > visualizations > line chart", () => {
       secondCardId,
     } = {}) {
       // Add the first question to the dashboard
-      addOrUpdateDashboardCard({
+      H.addOrUpdateDashboardCard({
         dashboard_id: dashboardId,
         card_id: firstCardId,
         card: {
@@ -701,7 +686,7 @@ describe("scenarios > visualizations > line chart", () => {
         cy.findByDisplayValue(old_name).clear().type(new_name).blur();
       });
 
-      modal()
+      H.modal()
         .as("modal")
         .within(() => {
           cy.button("Done").click();
@@ -717,7 +702,7 @@ describe("scenarios > visualizations > line chart", () => {
     }
 
     function assertOnYAxisValues() {
-      echartsContainer()
+      H.echartsContainer()
         .get("text")
         .should("contain", RENAMED_FIRST_SERIES)
         .and("contain", RENAMED_SECOND_SERIES);
@@ -726,7 +711,7 @@ describe("scenarios > visualizations > line chart", () => {
 
   describe("problems with the labels when showing only one row in the results (metabase#12782, metabase#4995)", () => {
     beforeEach(() => {
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           database: SAMPLE_DB_ID,
           query: {
@@ -752,15 +737,15 @@ describe("scenarios > visualizations > line chart", () => {
       cy.log("Ensure that legend is hidden when not dealing with multi series");
       cy.findByTestId("viz-settings-button").click();
       cy.findByTestId("remove-CATEGORY").click();
-      queryBuilderMain().should("not.contain", "Doohickey");
+      H.queryBuilderMain().should("not.contain", "Doohickey");
     });
 
     it("should display correct axis labels (metabase#12782)", () => {
-      echartsContainer()
+      H.echartsContainer()
         .get("text")
         .contains("Created At")
         .should("be.visible");
-      echartsContainer()
+      H.echartsContainer()
         .get("text")
         .contains("Average of Price")
         .should("be.visible");
@@ -780,13 +765,13 @@ describe("scenarios > visualizations > line chart", () => {
 
     cy.viewport(1280, 800);
 
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: testQuery,
       display: "line",
     });
 
-    queryBuilderMain().within(() => {
-      echartsContainer().findByText("Quantity").should("exist");
+    H.queryBuilderMain().within(() => {
+      H.echartsContainer().findByText("Quantity").should("exist");
     });
     cy.wait(100); // wait to avoid grabbing the svg before the chart redraws
 
@@ -802,7 +787,7 @@ describe("scenarios > visualizations > line chart", () => {
       "Quantity is between",
     );
     const X_AXIS_VALUE = 8;
-    echartsContainer().within(() => {
+    H.echartsContainer().within(() => {
       cy.get("text").contains("Quantity").should("be.visible");
       cy.findByText(X_AXIS_VALUE);
     });
@@ -810,5 +795,5 @@ describe("scenarios > visualizations > line chart", () => {
 });
 
 function showTooltipForFirstCircleInSeries(seriesColor) {
-  cartesianChartCircleWithColor(seriesColor).eq(0).trigger("mousemove");
+  H.cartesianChartCircleWithColor(seriesColor).eq(0).trigger("mousemove");
 }

--- a/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
@@ -1,24 +1,19 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  openNativeEditor,
-  popover,
-  restore,
-  visitQuestionAdhoc,
-} from "e2e/support/helpers";
 
 const { PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > visualizations > maps", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should display a pin map for a native query", () => {
     cy.signInAsNormalUser();
     // create a native query with lng/lat fields
-    openNativeEditor().type(
+    H.openNativeEditor().type(
       "select -80 as lng, 40 as lat union all select -120 as lng, 40 as lat",
     );
     cy.findByTestId("native-query-editor-container").icon("play").click();
@@ -33,7 +28,7 @@ describe("scenarios > visualizations > maps", () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Map type").next().click();
-    popover().contains("Pin map").click();
+    H.popover().contains("Pin map").click();
 
     // When the settings sidebar opens, both latitude and longitude selects are
     // open. That makes it difficult to select each in Cypress, so we click
@@ -46,11 +41,11 @@ describe("scenarios > visualizations > maps", () => {
     // select both columns
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Latitude field").next().click();
-    popover().contains("LAT").click();
+    H.popover().contains("LAT").click();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Longitude field").next().click();
-    popover().contains("LNG").click();
+    H.popover().contains("LNG").click();
 
     // check that a map appears
     cy.get(".leaflet-container");
@@ -86,7 +81,7 @@ describe("scenarios > visualizations > maps", () => {
 
   it("should not assign the full name of the state as the filter value on a drill-through (metabase#14650)", () => {
     cy.intercept("/app/assets/geojson/**").as("geojson");
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         database: SAMPLE_DB_ID,
         query: {
@@ -134,7 +129,7 @@ describe("scenarios > visualizations > maps", () => {
   });
 
   it("should display a tooltip for a grid map without a metric column (metabase#17940)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       display: "map",
       dataset_query: {
         database: SAMPLE_DB_ID,
@@ -182,7 +177,7 @@ describe("scenarios > visualizations > maps", () => {
   });
 
   it("should render grid map visualization for native questions (metabase#8362)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "native",
         native: {
@@ -220,7 +215,7 @@ describe("scenarios > visualizations > maps", () => {
   it("should apply brush filters by dragging map", () => {
     cy.viewport(1280, 800);
 
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "query",
         database: SAMPLE_DB_ID,

--- a/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
@@ -1,24 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  assertEChartsTooltip,
-  chartPathWithFillColor,
-  createQuestionAndDashboard,
-  echartsContainer,
-  getDraggableElements,
-  getNotebookStep,
-  leftSidebar,
-  main,
-  moveDnDKitElement,
-  openNotebook,
-  pieSlices,
-  popover,
-  restore,
-  tableHeaderClick,
-  visitDashboard,
-  visitQuestionAdhoc,
-  visualize,
-} from "e2e/support/helpers";
 
 const { PRODUCTS, PRODUCTS_ID, ORDERS_ID, ORDERS, PEOPLE } = SAMPLE_DATABASE;
 
@@ -81,12 +63,12 @@ const threeRingQuery = {
 
 describe("scenarios > visualizations > pie chart", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should render a pie chart (metabase#12506) (#35244)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: testQuery,
       display: "pie",
     });
@@ -111,8 +93,8 @@ describe("scenarios > visualizations > pie chart", () => {
 
     cy.log("#35244");
     cy.findByLabelText("Switch to data").click();
-    tableHeaderClick("Count");
-    popover().within(() => {
+    H.tableHeaderClick("Count");
+    H.popover().within(() => {
       cy.findByRole("img", { name: /filter/ }).should("exist");
       cy.findByRole("img", { name: /gear/ }).should("not.exist");
       cy.findByRole("img", { name: /eye_crossed_out/ }).should("not.exist");
@@ -120,7 +102,7 @@ describe("scenarios > visualizations > pie chart", () => {
   });
 
   it("should mute items in legend when hovering (metabase#29224)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: testQuery,
       display: "pie",
     });
@@ -135,7 +117,7 @@ describe("scenarios > visualizations > pie chart", () => {
   });
 
   it("should not truncate legend titles when enabling percentages (metabase#48207)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: testQuery,
       display: "pie",
       visualization_settings: {
@@ -145,7 +127,7 @@ describe("scenarios > visualizations > pie chart", () => {
 
     cy.findByTestId("viz-settings-button").click();
 
-    leftSidebar().within(() => {
+    H.leftSidebar().within(() => {
       cy.findByText("Display").click();
       cy.findByText("In legend").click();
     });
@@ -159,14 +141,14 @@ describe("scenarios > visualizations > pie chart", () => {
   });
 
   it("should instantly toggle the total after changing the setting", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: testQuery,
       display: "pie",
     });
 
     cy.findByTestId("viz-settings-button").click();
 
-    leftSidebar().within(() => {
+    H.leftSidebar().within(() => {
       cy.findByText("Display").click();
       cy.findByText("Show total").click();
     });
@@ -175,7 +157,7 @@ describe("scenarios > visualizations > pie chart", () => {
       cy.findByText("TOTAL").should("not.exist");
     });
 
-    leftSidebar().within(() => {
+    H.leftSidebar().within(() => {
       cy.findByText("Show total").click();
     });
 
@@ -187,7 +169,7 @@ describe("scenarios > visualizations > pie chart", () => {
   // Skipping since the mousemove trigger flakes too often, and there's already a loki
   // test to cover truncation
   it.skip("should truncate the center dimension label if it overflows", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "query",
         query: {
@@ -207,7 +189,7 @@ describe("scenarios > visualizations > pie chart", () => {
       display: "pie",
     });
 
-    chartPathWithFillColor("#A989C5").as("slice");
+    H.chartPathWithFillColor("#A989C5").as("slice");
     cy.get("@slice").trigger("mousemove");
 
     cy.findByTestId("query-visualization-root")
@@ -216,7 +198,7 @@ describe("scenarios > visualizations > pie chart", () => {
   });
 
   it("should add new slices to the chart if they appear in the query result", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: getLimitedQuery(testQuery, 2),
       display: "pie",
     });
@@ -229,7 +211,7 @@ describe("scenarios > visualizations > pie chart", () => {
   });
 
   it("should preserve a slice's settings if its row is removed then reappears in the query result", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: getLimitedQuery(testQuery, 4),
       display: "pie",
     });
@@ -241,7 +223,7 @@ describe("scenarios > visualizations > pie chart", () => {
     // Open color picker
     cy.findByLabelText("#F2A86F").click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       // Change color
       cy.findByLabelText("#509EE3").click();
     });
@@ -250,12 +232,12 @@ describe("scenarios > visualizations > pie chart", () => {
 
     cy.findByDisplayValue("Widget").type("{selectall}Woooget").realPress("Tab");
 
-    moveDnDKitElement(getDraggableElements().contains("Woooget"), {
+    H.moveDnDKitElement(H.getDraggableElements().contains("Woooget"), {
       vertical: 100,
     });
 
     ensurePieChartRendered(["Woooget", "Gadget", "Gizmo", "Doohickey"]);
-    chartPathWithFillColor("#509EE3").should("be.visible");
+    H.chartPathWithFillColor("#509EE3").should("be.visible");
 
     cy.findByTestId("chart-legend").within(() => {
       cy.get("li").eq(2).contains("Woooget");
@@ -266,13 +248,13 @@ describe("scenarios > visualizations > pie chart", () => {
 
     // Ensure row settings should show only two rows
     cy.findByTestId("viz-settings-button").click();
-    getDraggableElements().should("have.length", 2);
-    getDraggableElements().contains("Woooget").should("not.exist");
-    getDraggableElements().contains("Gizmo").should("not.exist");
+    H.getDraggableElements().should("have.length", 2);
+    H.getDraggableElements().contains("Woooget").should("not.exist");
+    H.getDraggableElements().contains("Gizmo").should("not.exist");
 
     cy.findByTestId("Gadget-settings-button").click();
     cy.findByDisplayValue("Gadget").type("{selectall}Katget").realPress("Tab");
-    moveDnDKitElement(getDraggableElements().contains("Katget"), {
+    H.moveDnDKitElement(H.getDraggableElements().contains("Katget"), {
       vertical: 30,
     });
 
@@ -280,7 +262,7 @@ describe("scenarios > visualizations > pie chart", () => {
     ensurePieChartRendered(["Doohickey", "Katget", "Gizmo", "Woooget"]);
 
     cy.findByTestId("chart-legend").findByText("Woooget").realHover();
-    chartPathWithFillColor("#509EE3").should("be.visible");
+    H.chartPathWithFillColor("#509EE3").should("be.visible");
 
     cy.findByTestId("chart-legend").within(() => {
       cy.get("li").eq(1).contains("Katget");
@@ -289,7 +271,7 @@ describe("scenarios > visualizations > pie chart", () => {
   });
 
   it("should automatically map dimension columns in query to rings", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: twoRingQuery,
       display: "pie",
     });
@@ -309,7 +291,7 @@ describe("scenarios > visualizations > pie chart", () => {
   });
 
   it("should allow the user to edit rings", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: threeRingQuery,
       display: "pie",
       visualization_settings: {
@@ -349,7 +331,7 @@ describe("scenarios > visualizations > pie chart", () => {
       ["Doohickey", "Gadget", "Gizmo", "Widget"],
     );
 
-    leftSidebar().within(() => {
+    H.leftSidebar().within(() => {
       cy.findByText("Add Ring").click();
     });
 
@@ -363,7 +345,7 @@ describe("scenarios > visualizations > pie chart", () => {
   });
 
   it("should handle hover and drill throughs correctly", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: twoRingQuery,
       display: "pie",
       visualization_settings: {
@@ -384,11 +366,11 @@ describe("scenarios > visualizations > pie chart", () => {
       ["Doohickey", "Gadget", "Gizmo", "Widget"],
     );
 
-    echartsContainer().within(() => {
+    H.echartsContainer().within(() => {
       cy.findByText("Saturday").as("saturdaySlice").trigger("mousemove");
     });
 
-    assertEChartsTooltip({
+    H.assertEChartsTooltip({
       header: "Created At: Day of week",
       rows: [
         {
@@ -438,7 +420,7 @@ describe("scenarios > visualizations > pie chart", () => {
 
     cy.get("@saturdaySlice").click({ force: true });
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("=").click();
     });
 
@@ -461,14 +443,14 @@ describe("scenarios > visualizations > pie chart", () => {
       ["Doohickey", "Gadget", "Gizmo", "Widget"],
     );
 
-    echartsContainer().within(() => {
+    H.echartsContainer().within(() => {
       cy.findAllByText("Doohickey")
         .first()
         .as("doohickeySlice")
         .trigger("mousemove");
     });
 
-    assertEChartsTooltip({
+    H.assertEChartsTooltip({
       header: "Saturday",
       rows: [
         {
@@ -496,7 +478,7 @@ describe("scenarios > visualizations > pie chart", () => {
 
     cy.get("@doohickeySlice").click({ force: true });
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("=").click();
     });
 
@@ -506,7 +488,7 @@ describe("scenarios > visualizations > pie chart", () => {
   });
 
   it("should handle click behavior correctly", () => {
-    createQuestionAndDashboard({
+    H.createQuestionAndDashboard({
       questionDetails: {
         query: threeRingQuery.query,
         display: "pie",
@@ -523,7 +505,7 @@ describe("scenarios > visualizations > pie chart", () => {
         size_y: 15,
       },
     }).then(({ body: { dashboard_id } }) => {
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
     });
 
     confirmSliceClickBehavior("2025", 6578);
@@ -536,7 +518,7 @@ describe("scenarios > visualizations > pie chart", () => {
   });
 
   it("should handle min percentage setting correctly", () => {
-    createQuestionAndDashboard({
+    H.createQuestionAndDashboard({
       questionDetails: {
         query: threeRingQuery.query,
         display: "pie",
@@ -551,13 +533,13 @@ describe("scenarios > visualizations > pie chart", () => {
         size_y: 15,
       },
     }).then(({ body: { dashboard_id } }) => {
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
     });
 
     // Other slice percentage
-    echartsContainer().findByText("79%").realHover();
+    H.echartsContainer().findByText("79%").realHover();
 
-    assertEChartsTooltip({
+    H.assertEChartsTooltip({
       header: "2024",
       rows: [
         {
@@ -609,7 +591,7 @@ function ensurePieChartRendered(rows, middleRows, outerRows, totalValue) {
     if (hasMiddleRows && hasOuterRows) {
       rowCount += rows.length * middleRows.length * outerRows.length;
     }
-    pieSlices().should("have.length", rowCount);
+    H.pieSlices().should("have.length", rowCount);
 
     // legend
     rows.forEach((name, i) => {
@@ -635,18 +617,18 @@ function getLimitedQuery(query, limit) {
 }
 
 function changeRowLimit(from, to) {
-  openNotebook();
-  getNotebookStep("limit").within(() => {
+  H.openNotebook();
+  H.getNotebookStep("limit").within(() => {
     cy.findByDisplayValue(String(from))
       .type(`{selectall}${String(to)}`)
       .realPress("Tab");
   });
 
-  visualize();
+  H.visualize();
 }
 
 function confirmSliceClickBehavior(sliceLabel, value, elementIndex) {
-  echartsContainer().within(() => {
+  H.echartsContainer().within(() => {
     if (elementIndex == null) {
       cy.findByText(sliceLabel).click({ force: true });
     } else {
@@ -655,7 +637,7 @@ function confirmSliceClickBehavior(sliceLabel, value, elementIndex) {
   });
 
   cy.location("pathname").should("eq", `/question/${value}`);
-  main().within(() => {
+  H.main().within(() => {
     cy.findByText("We're a little lost...");
   });
   cy.go("back");

--- a/e2e/test/scenarios/visualizations-charts/progress-bar.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/progress-bar.cy.spec.js
@@ -1,16 +1,11 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  dashboardCards,
-  queryBuilderMain,
-  restore,
-  visitDashboard,
-} from "e2e/support/helpers";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > visualizations > progress chart", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -40,11 +35,11 @@ describe("scenarios > visualizations > progress chart", () => {
           ],
         });
 
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
       },
     );
 
-    dashboardCards()
+    H.dashboardCards()
       .first()
       .within(() => {
         cy.findByText("18,760").should("be.visible");
@@ -53,8 +48,8 @@ describe("scenarios > visualizations > progress chart", () => {
       });
 
     // check query builder chart render
-    dashboardCards().first().findByText(QUESTION_NAME).click();
-    queryBuilderMain().within(() => {
+    H.dashboardCards().first().findByText(QUESTION_NAME).click();
+    H.queryBuilderMain().within(() => {
       cy.findByText("18,760").should("be.visible");
       cy.findByText("Goal 0").should("be.visible");
       cy.findByText("Goal exceeded").should("be.visible");

--- a/e2e/test/scenarios/visualizations-charts/rows.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/rows.cy.spec.js
@@ -1,8 +1,8 @@
-import { restore } from "e2e/support/helpers";
+import { H } from "e2e/support";
 
 describe("scenarios > visualizations > rows", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 

--- a/e2e/test/scenarios/visualizations-charts/sankey.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/sankey.cy.spec.js
@@ -1,18 +1,5 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
-import {
-  addOrUpdateDashboardCard,
-  assertEChartsTooltip,
-  chartPathWithFillColor,
-  createDashboard,
-  createNativeQuestion,
-  echartsContainer,
-  modal,
-  popover,
-  restore,
-  sankeyEdge,
-  visitDashboard,
-  visitQuestionAdhoc,
-} from "e2e/support/helpers";
 
 const SANKEY_QUERY = `
 SELECT 'Social Media' AS source, 'Landing Page' AS target, 30000 AS metric
@@ -42,12 +29,12 @@ SELECT 'Active Users', 'Cancelled Subscription', 5000;
 
 describe("scenarios > visualizations > sankey", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should render sankey charts in query builder", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       display: "table",
       dataset_query: {
         type: "native",
@@ -63,7 +50,7 @@ describe("scenarios > visualizations > sankey", () => {
     cy.findByTestId("Sankey-button").click();
 
     // Ensure it shows node labels
-    echartsContainer().findByText("Social Media");
+    H.echartsContainer().findByText("Social Media");
 
     // Edit viz settings
     cy.findByTestId("viz-settings-button").click();
@@ -73,32 +60,32 @@ describe("scenarios > visualizations > sankey", () => {
       .click();
 
     // Shows colored edges by default
-    sankeyEdge("#509EE3");
+    H.sankeyEdge("#509EE3");
 
     // Set edge colors to Gray
     cy.get("@settings-sidebar").findByText("Gray").click();
 
     // Ensure it shows gray edges
-    sankeyEdge("#81898e");
+    H.sankeyEdge("#81898e");
 
     // Ensure it does not show edge labels by default
-    echartsContainer().findByText("60,000").should("not.exist");
+    H.echartsContainer().findByText("60,000").should("not.exist");
 
     // Enable edge labels
     cy.get("@settings-sidebar").findByLabelText("Show edge labels").click();
 
     // Ensure it shows edge labels
-    echartsContainer().findByText("60,000");
+    H.echartsContainer().findByText("60,000");
 
     // Apply compact formatting
     cy.get("@settings-sidebar").findByText("Compact").click();
 
     // Ensure it shows compact labels
-    echartsContainer().findByText("60.0k");
+    H.echartsContainer().findByText("60.0k");
 
     // Ensure tooltip shows correct values
-    sankeyEdge("#81898e").eq(0).realHover();
-    assertEChartsTooltip({
+    H.sankeyEdge("#81898e").eq(0).realHover();
+    H.assertEChartsTooltip({
       header: "Social Media → Landing Page",
       rows: [
         {
@@ -108,8 +95,8 @@ describe("scenarios > visualizations > sankey", () => {
       ],
     });
 
-    chartPathWithFillColor("#509EE3").realHover();
-    assertEChartsTooltip({
+    H.chartPathWithFillColor("#509EE3").realHover();
+    H.assertEChartsTooltip({
       header: "Social Media",
       rows: [
         {
@@ -125,14 +112,14 @@ describe("scenarios > visualizations > sankey", () => {
       "My Sankey chart",
     );
     cy.findByTestId("save-question-modal").findByText("Save").click();
-    modal().findByText("Saved! Add this to a dashboard?");
+    H.modal().findByText("Saved! Add this to a dashboard?");
   });
 
   it("should render sankey charts in dashboard context", () => {
-    createDashboard({
+    H.createDashboard({
       name: "Sankey Dashboard",
     }).then(({ body: dashboard }) => {
-      createNativeQuestion({
+      H.createNativeQuestion({
         name: "Sankey Question",
         native: {
           query: SANKEY_QUERY,
@@ -143,7 +130,7 @@ describe("scenarios > visualizations > sankey", () => {
           "graph.label_value_formatting": "compact",
         },
       }).then(({ body: card }) => {
-        addOrUpdateDashboardCard({
+        H.addOrUpdateDashboardCard({
           card_id: card.id,
           dashboard_id: dashboard.id,
           card: {
@@ -152,15 +139,15 @@ describe("scenarios > visualizations > sankey", () => {
           },
         });
 
-        visitDashboard(dashboard.id);
+        H.visitDashboard(dashboard.id);
       });
     });
 
-    echartsContainer().findByText("Social Media");
+    H.echartsContainer().findByText("Social Media");
 
     // Ensure drill-through works
-    chartPathWithFillColor("#ED8535").first().click();
-    popover().within(() => {
+    H.chartPathWithFillColor("#ED8535").first().click();
+    H.popover().within(() => {
       cy.findByText("=").should("be.visible");
       cy.findByText("≠").should("be.visible");
 

--- a/e2e/test/scenarios/visualizations-charts/scatter.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/scatter.cy.spec.js
@@ -1,13 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  assertEChartsTooltip,
-  assertEChartsTooltipNotContain,
-  cartesianChartCircle,
-  leftSidebar,
-  restore,
-  visitQuestionAdhoc,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
@@ -29,12 +22,12 @@ const testQuery = {
 
 describe("scenarios > visualizations > scatter", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should show correct labels in tooltip (metabase#15150)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: testQuery,
       display: "scatter",
       visualization_settings: {
@@ -44,7 +37,7 @@ describe("scenarios > visualizations > scatter", () => {
     });
 
     triggerPopoverForBubble();
-    assertEChartsTooltip({
+    H.assertEChartsTooltip({
       header: "May 2023",
       rows: [
         {
@@ -60,7 +53,7 @@ describe("scenarios > visualizations > scatter", () => {
   });
 
   it("should show correct labels in tooltip when display name has manually set (metabase#11395)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: testQuery,
       display: "scatter",
       visualization_settings: {
@@ -78,7 +71,7 @@ describe("scenarios > visualizations > scatter", () => {
     });
 
     triggerPopoverForBubble();
-    assertEChartsTooltip({
+    H.assertEChartsTooltip({
       header: "May 2023",
       rows: [
         {
@@ -94,7 +87,7 @@ describe("scenarios > visualizations > scatter", () => {
   });
 
   it("should not display data points even when enabled in settings (metabase#13247)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       display: "scatter",
       dataset_query: testQuery,
       visualization_settings: {
@@ -110,7 +103,7 @@ describe("scenarios > visualizations > scatter", () => {
   });
 
   it("should respect circle size in a visualization (metabase#22929)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "native",
         native: {
@@ -127,7 +120,7 @@ select 10 as size, 2 as x, 5 as y`,
       },
     });
 
-    cartesianChartCircle().each(([circle], index) => {
+    H.cartesianChartCircle().each(([circle], index) => {
       const { width, height } = circle.getBoundingClientRect();
       const TOLERANCE = 0.1;
       expect(width).to.be.greaterThan(0);
@@ -143,7 +136,7 @@ select 10 as size, 2 as x, 5 as y`,
   });
 
   it("should allow adding non-series columns to the tooltip", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       display: "scatter",
       dataset_query: {
         type: "query",
@@ -156,24 +149,24 @@ select 10 as size, 2 as x, 5 as y`,
       },
     });
 
-    cartesianChartCircle().first().realHover();
-    assertEChartsTooltip({
+    H.cartesianChartCircle().first().realHover();
+    H.assertEChartsTooltip({
       header: "15.69",
       rows: [{ name: "Tax", value: "0.86" }],
     });
-    assertEChartsTooltipNotContain(["Total", "Discount", "Quantity"]);
+    H.assertEChartsTooltipNotContain(["Total", "Discount", "Quantity"]);
 
     cy.findByTestId("viz-settings-button").click();
 
-    leftSidebar().within(() => {
+    H.leftSidebar().within(() => {
       cy.findByText("Display").click();
       cy.findByPlaceholderText("Enter metric names").click();
     });
     cy.findByRole("option", { name: "Total" }).click();
     cy.findByRole("option", { name: "Discount" }).click();
 
-    cartesianChartCircle().first().realHover();
-    assertEChartsTooltip({
+    H.cartesianChartCircle().first().realHover();
+    H.assertEChartsTooltip({
       header: "15.69",
       rows: [
         { name: "Tax", value: "0.86" },
@@ -181,7 +174,7 @@ select 10 as size, 2 as x, 5 as y`,
         { name: "Discount", value: "(empty)" },
       ],
     });
-    assertEChartsTooltipNotContain(["Quantity"]);
+    H.assertEChartsTooltipNotContain(["Quantity"]);
   });
 });
 
@@ -193,7 +186,7 @@ function triggerPopoverForBubble(index = 13) {
     cy.findByLabelText("Switch to visualization").click(); // ... and then back to the scatter visualization (that now seems to be stable enough to make assertions about)
   });
 
-  cartesianChartCircle()
+  H.cartesianChartCircle()
     .eq(index) // Random bubble
     .trigger("mousemove");
 }

--- a/e2e/test/scenarios/visualizations-charts/trendline.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/trendline.cy.spec.js
@@ -1,11 +1,11 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { leftSidebar, restore, trendLine } from "e2e/support/helpers";
 
 const { ORDERS_ID, ORDERS, PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
 describe("scenarios > question > trendline", () => {
   function setup(questionDetails) {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.createQuestion(questionDetails, { visitQuestion: true });
   }
@@ -26,7 +26,7 @@ describe("scenarios > question > trendline", () => {
 
     // Change settings to trendline
     cy.findByTestId("viz-settings-button").click();
-    leftSidebar().within(() => {
+    H.leftSidebar().within(() => {
       cy.findByText("Display").click();
       cy.findByText("Trend line").click();
     });
@@ -35,7 +35,7 @@ describe("scenarios > question > trendline", () => {
     cy.get("rect");
 
     // Remove sum of total
-    leftSidebar().within(() => {
+    H.leftSidebar().within(() => {
       cy.findByText("Data").click();
       cy.icon("close").last().click();
       cy.findByText("Done").click();
@@ -58,12 +58,12 @@ describe("scenarios > question > trendline", () => {
     });
     cy.findByTestId("viz-settings-button").click();
     // stack 100%, then enable trend line
-    leftSidebar().within(() => {
+    H.leftSidebar().within(() => {
       cy.findByText("Display").click();
       cy.findByText("Stack - 100%").click();
       cy.findByText("Trend line").click();
     });
     // ensure that two trend lines are present
-    trendLine().should("have.length", 2);
+    H.trendLine().should("have.length", 2);
   });
 });

--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
@@ -1,42 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  addSummaryField,
-  addSummaryGroupingField,
-  assertEChartsTooltip,
-  cartesianChartCircle,
-  chartPathWithFillColor,
-  createQuestion,
-  describeEE,
-  echartsContainer,
-  editDashboard,
-  filter,
-  filterField,
-  filterWidget,
-  focusNativeEditor,
-  leftSidebar,
-  openNotebook,
-  openSeriesSettings,
-  popover,
-  queryBuilderHeader,
-  queryBuilderMain,
-  removeSummaryGroupingField,
-  restore,
-  runNativeQuery,
-  saveDashboard,
-  saveSavedQuestion,
-  selectFilterOperator,
-  setTokenFeatures,
-  sidebar,
-  summarize,
-  testPairedTooltipValues,
-  updateSetting,
-  visitAlias,
-  visitDashboard,
-  visitQuestionAdhoc,
-  visualize,
-  withDatabase,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -63,7 +27,7 @@ describe("issue 13504", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
@@ -71,9 +35,9 @@ describe("issue 13504", () => {
   it("should remove post-aggregation filters from a multi-stage query (metabase#13504)", () => {
     cy.createQuestion(questionDetails, { visitQuestion: true });
 
-    cartesianChartCircle().eq(0).click({ force: true });
+    H.cartesianChartCircle().eq(0).click({ force: true });
 
-    popover().findByText("See these Orders").click();
+    H.popover().findByText("See these Orders").click();
     cy.wait("@dataset");
 
     cy.findByTestId("qb-filters-panel").within(() => {
@@ -93,20 +57,20 @@ describe("issue 16170", { tags: "@mongo" }, () => {
         cy.findByTestId("select-button").click();
       });
 
-    popover().contains(value).click();
+    H.popover().contains(value).click();
   }
 
   function assertOnTheYAxis() {
-    echartsContainer().get("text").contains("Count");
+    H.echartsContainer().get("text").contains("Count");
 
-    echartsContainer().get("text").contains("6,000");
+    H.echartsContainer().get("text").contains("6,000");
   }
 
   beforeEach(() => {
-    restore("mongo-5");
+    H.restore("mongo-5");
     cy.signInAsAdmin();
 
-    withDatabase(externalDatabaseId, ({ ORDERS, ORDERS_ID }) => {
+    H.withDatabase(externalDatabaseId, ({ ORDERS, ORDERS_ID }) => {
       const questionDetails = {
         name: "16170",
         query: {
@@ -126,7 +90,7 @@ describe("issue 16170", { tags: "@mongo" }, () => {
     it(`replace missing values with "${replacementValue}" should work on Mongo (metabase#16170)`, () => {
       cy.findByTestId("viz-settings-button").click();
 
-      openSeriesSettings("Count");
+      H.openSeriesSettings("Count");
 
       replaceMissingValuesWith(replacementValue);
 
@@ -135,9 +99,9 @@ describe("issue 16170", { tags: "@mongo" }, () => {
 
       assertOnTheYAxis();
 
-      cartesianChartCircle().eq(-2).trigger("mousemove");
+      H.cartesianChartCircle().eq(-2).trigger("mousemove");
 
-      assertEChartsTooltip({
+      H.assertEChartsTooltip({
         header: "2019",
         rows: [
           {
@@ -186,7 +150,7 @@ describe("issue 17524", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -196,7 +160,7 @@ describe("issue 17524", () => {
     });
 
     it("should not alter visualization type when applying filter on a native question (metabase#17524-1)", () => {
-      filterWidget().type("1");
+      H.filterWidget().type("1");
 
       cy.get("polygon");
 
@@ -216,9 +180,9 @@ describe("issue 17524", () => {
     it("should not alter visualization type when applying filter on a QB question (metabase#17524-2)", () => {
       cy.get("polygon");
 
-      filter();
+      H.filter();
 
-      filterField("ID", {
+      H.filterField("ID", {
         operator: "Greater than",
         value: "1",
       });
@@ -273,13 +237,13 @@ describe("issue 18061", () => {
   const dashboardDetails = { name: "18061D", parameters: [filter] };
 
   function addFilter(filter) {
-    filterWidget().click();
-    popover().contains(filter).click();
+    H.filterWidget().click();
+    H.popover().contains(filter).click();
     cy.button("Add filter").click();
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
@@ -320,23 +284,25 @@ describe("issue 18061", () => {
 
   context("scenario 1: question with a filter", () => {
     it("should handle data sets that contain only null values for longitude/latitude (metabase#18061-1)", () => {
-      visitAlias("@questionUrl");
+      H.visitAlias("@questionUrl");
 
       cy.wait("@getCard");
       cy.wait("@cardQuery");
 
       cy.window().then(w => (w.beforeReload = true));
 
-      queryBuilderHeader().findByTestId("filters-visibility-control").click();
+      H.queryBuilderHeader().findByTestId("filters-visibility-control").click();
       cy.findByTestId("qb-filters-panel")
         .findByText("ID is less than 3")
         .click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByDisplayValue("3").type("{backspace}2");
         cy.button("Update filter").click();
       });
 
-      queryBuilderMain().findByText("Something went wrong").should("not.exist");
+      H.queryBuilderMain()
+        .findByText("Something went wrong")
+        .should("not.exist");
 
       cy.findByTestId("qb-filters-panel")
         .findByText("ID is less than 2")
@@ -349,7 +315,7 @@ describe("issue 18061", () => {
 
   context("scenario 2: dashboard with a filter", () => {
     it("should handle data sets that contain only null values for longitude/latitude (metabase#18061-2)", () => {
-      visitAlias("@dashboardUrl");
+      H.visitAlias("@dashboardUrl");
 
       cy.wait("@dashCardQuery");
 
@@ -365,7 +331,7 @@ describe("issue 18061", () => {
 
   context("scenario 3: publicly shared dashboard with a filter", () => {
     it("should handle data sets that contain only null values for longitude/latitude (metabase#18061-3)", () => {
-      visitAlias("@publicLink");
+      H.visitAlias("@publicLink");
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("18061D");
@@ -399,11 +365,11 @@ describe("issue 18063", () => {
         cy.findByText("Select a field").click();
       });
 
-    popover().findByText(value).click();
+    H.popover().findByText(value).click();
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestion(questionDetails, { visitQuestion: true });
@@ -412,7 +378,7 @@ describe("issue 18063", () => {
     cy.findByTestId("viz-settings-button").click();
     cy.findAllByTestId("select-button").contains("Region map").click();
 
-    popover().contains("Pin map").click();
+    H.popover().contains("Pin map").click();
 
     // Click anywhere to close both popovers that open automatically. Need to click twice to dismiss both popovers
     // Please see: https://github.com/metabase/metabase/issues/18063#issuecomment-927836691
@@ -426,11 +392,11 @@ describe("issue 18063", () => {
 
     cy.get(".leaflet-marker-icon").trigger("mousemove");
 
-    popover().within(() => {
-      testPairedTooltipValues("LATITUDE", "55.68");
-      testPairedTooltipValues("LONGITUDE", "12.57");
-      testPairedTooltipValues("COUNT", "1");
-      testPairedTooltipValues("NAME", "Copenhagen");
+    H.popover().within(() => {
+      H.testPairedTooltipValues("LATITUDE", "55.68");
+      H.testPairedTooltipValues("LONGITUDE", "12.57");
+      H.testPairedTooltipValues("COUNT", "1");
+      H.testPairedTooltipValues("NAME", "Copenhagen");
     });
   });
 });
@@ -456,12 +422,12 @@ describe("issue 18776", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should not freeze when opening a timeseries chart with sparse data and without the X-axis", () => {
-    visitQuestionAdhoc(questionDetails);
+    H.visitQuestionAdhoc(questionDetails);
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Visualization").should("be.visible");
   });
@@ -494,7 +460,7 @@ describe("issue 20548", () => {
 
   function addAggregationItem(item) {
     cy.findByTestId("add-aggregation-button").click();
-    popover().contains(item).click();
+    H.popover().contains(item).click();
 
     cy.wait("@dataset");
   }
@@ -512,23 +478,23 @@ describe("issue 20548", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestion(questionDetails, { visitQuestion: true });
-    summarize();
+    H.summarize();
   });
 
   it("should not display duplicate Y-axis after modifying/reordering metrics (metabase#20548)", () => {
     removeAggregationItem("Count");
     // Ensure bars of only one series exist
-    chartPathWithFillColor("#88BF4D").should("have.length", 4);
-    chartPathWithFillColor("#509EE3").should("not.exist");
+    H.chartPathWithFillColor("#88BF4D").should("have.length", 4);
+    H.chartPathWithFillColor("#509EE3").should("not.exist");
 
     addAggregationItem("Count");
     // Ensure bars of two series exist
-    chartPathWithFillColor("#88BF4D").should("have.length", 4);
-    chartPathWithFillColor("#509EE3").should("have.length", 4);
+    H.chartPathWithFillColor("#88BF4D").should("have.length", 4);
+    H.chartPathWithFillColor("#509EE3").should("have.length", 4);
 
     // Although the test already fails on the previous step, let's add some more assertions to prevent future regressions
     assertOnLegendItemFrequency("Count", 1);
@@ -536,7 +502,7 @@ describe("issue 20548", () => {
 
     cy.findByTestId("viz-settings-button").click();
     // Implicit assertion - it would fail if it finds more than one "Count" in the sidebar
-    sidebar().findAllByText("Count").should("have.length", 1);
+    H.sidebar().findAllByText("Count").should("have.length", 1);
   });
 });
 
@@ -555,16 +521,16 @@ describe("issue 21452", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    visitQuestionAdhoc(questionDetails);
+    H.visitQuestionAdhoc(questionDetails);
 
     cy.findByTestId("viz-settings-button").click();
   });
 
   it("should not fire POST request after every character during display name change (metabase#21452)", () => {
-    openSeriesSettings("Cumulative sum of Quantity");
+    H.openSeriesSettings("Cumulative sum of Quantity");
     cy.findByDisplayValue("Cumulative sum of Quantity").clear().type("Foo");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Display type").click();
@@ -572,9 +538,9 @@ describe("issue 21452", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Done").click();
 
-    cartesianChartCircle().first().realHover();
+    H.cartesianChartCircle().first().realHover();
 
-    assertEChartsTooltip({
+    H.assertEChartsTooltip({
       header: "2022",
       rows: [
         {
@@ -591,12 +557,12 @@ describe("issue 21452", () => {
 
 describe("issue 21504", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should format pie chart settings (metabase#21504)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "query",
         query: {
@@ -613,7 +579,7 @@ describe("issue 21504", () => {
 
     cy.findByTestId("viz-settings-button").click();
 
-    leftSidebar().within(() => {
+    H.leftSidebar().within(() => {
       cy.findByText("January 2025").should("be.visible");
     });
   });
@@ -642,7 +608,7 @@ describe("issue 21665", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestionAndDashboard({
@@ -661,8 +627,8 @@ describe("issue 21665", () => {
 
       cy.createNativeQuestion(Q2);
 
-      visitDashboard(dashboardId);
-      editDashboard();
+      H.visitDashboard(dashboardId);
+      H.editDashboard();
     });
 
     cy.findByTestId("add-series-button").click({ force: true });
@@ -672,7 +638,7 @@ describe("issue 21665", () => {
 
     cy.findByTestId("add-series-modal").button("Done").click();
 
-    saveDashboard();
+    H.saveDashboard();
     cy.wait("@getDashboard");
   });
 
@@ -681,7 +647,7 @@ describe("issue 21665", () => {
       editQ2NativeQuery("select order by --", questionId);
     });
 
-    visitDashboard("@dashboardId");
+    H.visitDashboard("@dashboardId");
 
     cy.get("@dashboardLoaded").should("have.been.calledThrice");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -707,15 +673,15 @@ describe.skip("issue 22527", () => {
   function assertion() {
     cy.get("circle").should("have.length", 5).last().realHover();
 
-    popover().within(() => {
-      testPairedTooltipValues("X", "5");
-      testPairedTooltipValues("Y", "-20");
-      testPairedTooltipValues("SIZE", "70");
+    H.popover().within(() => {
+      H.testPairedTooltipValues("X", "5");
+      H.testPairedTooltipValues("Y", "-20");
+      H.testPairedTooltipValues("SIZE", "70");
     });
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createNativeQuestion(questionDetails, { visitQuestion: true });
@@ -732,7 +698,7 @@ describe.skip("issue 22527", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Bubble size").parent().contains("Select a field").click();
 
-    popover().contains(/size/i).click();
+    H.popover().contains(/size/i).click();
 
     assertion();
   });
@@ -755,18 +721,18 @@ describe("issue 25007", () => {
   };
 
   const clickLineDot = ({ index } = {}) => {
-    cartesianChartCircle().eq(index).click({ force: true });
+    H.cartesianChartCircle().eq(index).click({ force: true });
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should display weeks correctly in tooltips for native questions (metabase#25007)", () => {
     cy.createNativeQuestion(questionDetails, { visitQuestion: true });
     clickLineDot({ index: 1 });
-    popover().findByTextEnsureVisible("May 1–7, 2022");
+    H.popover().findByTextEnsureVisible("May 1–7, 2022");
   });
 });
 
@@ -790,14 +756,14 @@ describe("issue 25156", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should handle invalid x-axis scale (metabase#25156)", () => {
-    createQuestion(questionDetails, { visitQuestion: true });
+    H.createQuestion(questionDetails, { visitQuestion: true });
 
-    echartsContainer()
+    H.echartsContainer()
       .should("contain", "2022")
       .and("contain", "2023")
       .and("contain", "2023")
@@ -826,13 +792,13 @@ describe("issue 27279", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should reflect/apply sorting to the x-axis (metabase#27279)", () => {
     cy.createNativeQuestion(questionDetails).then(({ body: { id } }) => {
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           type: "query",
           query: {
@@ -867,16 +833,16 @@ describe("issue 27279", () => {
       str => ` ${str} `,
     );
     compareValuesInOrder(
-      echartsContainer()
+      H.echartsContainer()
         .get("text")
         .contains(/F2021|V2021|S2022|F2022/),
       xAxisTicks,
     );
 
     // Extra step, just to be overly cautious
-    chartPathWithFillColor("#98D9D9").realHover();
+    H.chartPathWithFillColor("#98D9D9").realHover();
 
-    assertEChartsTooltip({
+    H.assertEChartsTooltip({
       header: "F2021",
       rows: [
         {
@@ -902,8 +868,8 @@ describe("issue 27279", () => {
       ],
     });
 
-    chartPathWithFillColor("#509EE3").realHover();
-    assertEChartsTooltip({
+    H.chartPathWithFillColor("#509EE3").realHover();
+    H.assertEChartsTooltip({
       header: "F2022",
       rows: [
         {
@@ -961,7 +927,7 @@ describe("issue 27427", () => {
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -976,11 +942,11 @@ describe("issue 27427", () => {
 });
 
 const addCountGreaterThan2Filter = () => {
-  openNotebook();
+  H.openNotebook();
   cy.findAllByTestId("action-buttons").last().button("Filter").click();
-  popover().findByText("Count").click();
-  selectFilterOperator("Greater than");
-  popover().within(() => {
+  H.popover().findByText("Count").click();
+  H.selectFilterOperator("Greater than");
+  H.popover().within(() => {
     cy.findByPlaceholderText("Enter a number").type("2");
     cy.button("Add filter").click();
   });
@@ -1011,55 +977,55 @@ describe("issue 32075", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should still display visualization as a map after adding a filter (metabase#32075)", () => {
-    visitQuestionAdhoc({ dataset_query: testQuery }, { mode: "notebook" });
+    H.visitQuestionAdhoc({ dataset_query: testQuery }, { mode: "notebook" });
 
-    visualize();
+    H.visualize();
     addCountGreaterThan2Filter();
-    visualize();
+    H.visualize();
 
     cy.findByTestId("TableInteractive-root").should("not.exist");
     cy.get("[data-element-id=pin-map]").should("exist");
   });
 
   it("should still display visualization as a map after adding another column to group by", () => {
-    visitQuestionAdhoc({ dataset_query: testQuery }, { mode: "notebook" });
+    H.visitQuestionAdhoc({ dataset_query: testQuery }, { mode: "notebook" });
 
-    visualize();
-    openNotebook();
-    addSummaryGroupingField({ field: "Birth Date" });
-    visualize();
+    H.visualize();
+    H.openNotebook();
+    H.addSummaryGroupingField({ field: "Birth Date" });
+    H.visualize();
 
     cy.findByTestId("TableInteractive-root").should("not.exist");
     cy.get("[data-element-id=pin-map]").should("exist");
   });
 
   it("should still display visualization as a map after adding another aggregation", () => {
-    visitQuestionAdhoc({ dataset_query: testQuery }, { mode: "notebook" });
+    H.visitQuestionAdhoc({ dataset_query: testQuery }, { mode: "notebook" });
 
-    visualize();
-    openNotebook();
-    addSummaryField({ metric: "Average of ...", field: "Longitude" });
-    visualize();
+    H.visualize();
+    H.openNotebook();
+    H.addSummaryField({ metric: "Average of ...", field: "Longitude" });
+    H.visualize();
 
     cy.findByTestId("TableInteractive-root").should("not.exist");
     cy.get("[data-element-id=pin-map]").should("exist");
   });
 
   it("should change display to default after removing a column to group by when map is not sensible anymore", () => {
-    visitQuestionAdhoc({ dataset_query: testQuery }, { mode: "notebook" });
+    H.visitQuestionAdhoc({ dataset_query: testQuery }, { mode: "notebook" });
 
-    visualize();
-    openNotebook();
-    removeSummaryGroupingField({ field: "Latitude: Auto binned" });
-    visualize();
+    H.visualize();
+    H.openNotebook();
+    H.removeSummaryGroupingField({ field: "Latitude: Auto binned" });
+    H.visualize();
 
     cy.get("[data-element-id=pin-map]").should("not.exist");
-    echartsContainer().should("exist");
+    H.echartsContainer().should("exist");
   });
 });
 
@@ -1088,19 +1054,19 @@ describe("issue 30058", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should not crash visualization after adding a filter (metabase#30058)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: testQuery,
       display: "map",
       displayIsLocked: true,
     });
 
     addCountGreaterThan2Filter();
-    visualize();
+    H.visualize();
 
     cy.get(".Icon-warning").should("not.exist");
   });
@@ -1108,7 +1074,7 @@ describe("issue 30058", () => {
 
 describe("issue 33208", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.createNativeQuestion(
       {
@@ -1142,16 +1108,16 @@ describe("issue 33208", () => {
 
   it("should not auto-select chart type when saving a native question with parameters that have default values", () => {
     cy.findByTestId("query-builder-main").findByText("Open Editor").click();
-    focusNativeEditor().type(" ");
-    saveSavedQuestion("top category");
-    runNativeQuery({ wait: false });
+    H.focusNativeEditor().type(" ");
+    H.saveSavedQuestion("top category");
+    H.runNativeQuery({ wait: false });
     cy.findByTestId("scalar-value").should("be.visible");
   });
 });
 
 describe("issue 43077", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
@@ -1176,7 +1142,7 @@ describe("issue 43077", () => {
     const cardRequestSpy = cy.spy();
     cy.intercept("/api/card/*", cardRequestSpy);
 
-    visitQuestionAdhoc(cartesianQuestionDetails);
+    H.visitQuestionAdhoc(cartesianQuestionDetails);
 
     cy.findAllByTestId("legend-item").first().click();
 
@@ -1204,7 +1170,7 @@ describe("issue 43077", () => {
     const cardRequestSpy = cy.spy();
     cy.intercept("/api/card/*", cardRequestSpy);
 
-    visitQuestionAdhoc(rowQuestionDetails);
+    H.visitQuestionAdhoc(rowQuestionDetails);
 
     cy.findAllByTestId("legend-item").first().click();
 
@@ -1212,15 +1178,15 @@ describe("issue 43077", () => {
   });
 });
 
-describeEE("issue 49160", () => {
+H.describeEE("issue 49160", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
+    H.setTokenFeatures("all");
   });
 
   it("pie chart should have a placeholder", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "query",
         query: {
@@ -1232,18 +1198,18 @@ describeEE("issue 49160", () => {
     });
 
     // Shows pie placeholder
-    echartsContainer().findByText("18,760").should("be.visible");
+    H.echartsContainer().findByText("18,760").should("be.visible");
     cy.findByTestId("qb-header-action-panel").findByText("Summarize").click();
 
     cy.findByLabelText("Rating").click();
-    echartsContainer().findByText("200").should("be.visible");
-    echartsContainer().findByText("TOTAL").should("be.visible");
+    H.echartsContainer().findByText("200").should("be.visible");
+    H.echartsContainer().findByText("TOTAL").should("be.visible");
   });
 
   it("pie chart should work when instance colors have overrides", () => {
-    updateSetting("application-colors", { "accent0-light": "#98b4ce" });
+    H.updateSetting("application-colors", { "accent0-light": "#98b4ce" });
 
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "query",
         query: {
@@ -1256,10 +1222,10 @@ describeEE("issue 49160", () => {
       display: "pie",
     });
 
-    echartsContainer().findByText("200").should("be.visible");
+    H.echartsContainer().findByText("200").should("be.visible");
 
     cy.findByTestId("viz-settings-button").click();
 
-    leftSidebar().findByText("Gizmo");
+    H.leftSidebar().findByText("Gizmo");
   });
 });

--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
@@ -1,26 +1,11 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  type StructuredQuestionDetails,
-  assertEChartsTooltip,
-  cartesianChartCircleWithColor,
-  chartPathWithFillColor,
-  createQuestion,
-  echartsContainer,
-  getDraggableElements,
-  leftSidebar,
-  modal,
-  moveDnDKitElement,
-  popover,
-  restore,
-  sidebar,
-  visitQuestionAdhoc,
-} from "e2e/support/helpers";
 
 const { PRODUCTS, PRODUCTS_ID, ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
 describe("issue 43075", () => {
-  const questionDetails: StructuredQuestionDetails = {
+  const questionDetails: H.StructuredQuestionDetails = {
     query: {
       "source-table": PRODUCTS_ID,
       aggregation: [["count"]],
@@ -31,16 +16,16 @@ describe("issue 43075", () => {
   beforeEach(() => {
     cy.viewport(1000, 300);
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    createQuestion(questionDetails, { visitQuestion: true });
+    H.createQuestion(questionDetails, { visitQuestion: true });
   });
 
   it("the breakout popover should fit within the window (metabase#43075)", () => {
     cy.findAllByTestId("cell-data").contains("54").click();
-    popover().findByText("Break out by…").click();
-    popover().findByText("Category").click();
+    H.popover().findByText("Break out by…").click();
+    H.popover().findByText("Category").click();
 
     cy.window().then(win => {
       expect(win.document.documentElement.scrollHeight).to.be.lte(
@@ -51,7 +36,7 @@ describe("issue 43075", () => {
 });
 
 describe("issue 41133", () => {
-  const questionDetails: StructuredQuestionDetails = {
+  const questionDetails: H.StructuredQuestionDetails = {
     query: {
       "source-table": PRODUCTS_ID,
     },
@@ -59,15 +44,15 @@ describe("issue 41133", () => {
 
   beforeEach(() => {
     cy.viewport(600, 400);
-    restore();
+    H.restore();
     cy.signInAsAdmin();
-    createQuestion(questionDetails, { visitQuestion: true });
+    H.createQuestion(questionDetails, { visitQuestion: true });
   });
 
   it("object detail view should be scrollable on narrow screens (metabase#41133)", () => {
     cy.findByTestId("detail-shortcut").eq(0).click();
 
-    modal().within(() => {
+    H.modal().within(() => {
       cy.findByText("Created At").scrollIntoView().should("be.visible");
       cy.findByText("is connected to:").scrollIntoView().should("be.visible");
     });
@@ -76,10 +61,10 @@ describe("issue 41133", () => {
 
 describe("issue 45255", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "native",
         native: {
@@ -97,12 +82,12 @@ describe("issue 45255", () => {
     cy.findByTestId("viz-settings-button").click();
 
     // Has (empty) in the settings sidebar
-    sidebar().findByText("(empty)");
+    H.sidebar().findByText("(empty)");
 
     // Can reorder (empty)
-    getDraggableElements().eq(2).should("have.text", "(empty)");
-    moveDnDKitElement(getDraggableElements().first(), { vertical: 100 });
-    getDraggableElements().eq(1).should("have.text", "(empty)");
+    H.getDraggableElements().eq(2).should("have.text", "(empty)");
+    H.moveDnDKitElement(H.getDraggableElements().first(), { vertical: 100 });
+    H.getDraggableElements().eq(1).should("have.text", "(empty)");
 
     // Has (empty) in the chart
     cy.findByTestId("funnel-chart").findByText("(empty)");
@@ -111,7 +96,7 @@ describe("issue 45255", () => {
 
 describe("issue 49874", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -134,23 +119,23 @@ describe("issue 49874", () => {
       display: "bar",
     };
 
-    visitQuestionAdhoc(question);
+    H.visitQuestionAdhoc(question);
 
-    echartsContainer().within(() => {
+    H.echartsContainer().within(() => {
       cy.findByText("Sum of Quantity").should("be.visible");
       cy.findByText("Sum of Total").should("be.visible");
     });
 
-    chartPathWithFillColor("#88BF4D").first().realHover();
+    H.chartPathWithFillColor("#88BF4D").first().realHover();
 
-    echartsContainer().within(() => {
+    H.echartsContainer().within(() => {
       cy.findByText("Sum of Quantity").should("be.visible");
       cy.findByText("Sum of Total").should("not.exist");
     });
 
-    chartPathWithFillColor("#98D9D9").first().realHover();
+    H.chartPathWithFillColor("#98D9D9").first().realHover();
 
-    echartsContainer().within(() => {
+    H.echartsContainer().within(() => {
       cy.findByText("Sum of Quantity").should("not.exist");
       cy.findByText("Sum of Total").should("be.visible");
     });
@@ -159,7 +144,7 @@ describe("issue 49874", () => {
 
 describe("issue 49529", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -175,17 +160,17 @@ describe("issue 49529", () => {
       display: "bar",
     };
 
-    visitQuestionAdhoc(question);
+    H.visitQuestionAdhoc(question);
 
     cy.findByTestId("viz-settings-button").click();
 
     cy.findAllByTestId("select-button").eq(0).as("dimensionSelect").click();
-    popover().findByText("ID").click();
+    H.popover().findByText("ID").click();
 
-    leftSidebar().findByText("Add series breakout").click();
-    popover().findByText("Quantity").click();
+    H.leftSidebar().findByText("Add series breakout").click();
+    H.popover().findByText("Quantity").click();
 
-    leftSidebar().within(() => {
+    H.leftSidebar().within(() => {
       cy.findByText("Y-axis");
       cy.findByText("Nothing to order");
     });
@@ -194,12 +179,12 @@ describe("issue 49529", () => {
 
 describe("issue 47847", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should show chart tooltip on narrow ordinal line charts", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "query",
         query: {
@@ -216,8 +201,8 @@ describe("issue 47847", () => {
       },
     });
 
-    cartesianChartCircleWithColor("#509EE3").eq(0).trigger("mousemove");
-    assertEChartsTooltip({
+    H.cartesianChartCircleWithColor("#509EE3").eq(0).trigger("mousemove");
+    H.assertEChartsTooltip({
       header: "April 24–30, 2022",
       blurAfter: false,
       footer: null,

--- a/e2e/test/scenarios/visualizations-charts/waterfall.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/waterfall.cy.spec.js
@@ -1,44 +1,30 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  assertEChartsTooltip,
-  assertEChartsTooltipNotContain,
-  chartPathWithFillColor,
-  createQuestion,
-  echartsContainer,
-  leftSidebar,
-  openNativeEditor,
-  openOrdersTable,
-  popover,
-  restore,
-  summarize,
-  visitQuestionAdhoc,
-  visualize,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
 describe("scenarios > visualizations > waterfall", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   function verifyWaterfallRendering(xLabel = null, yLabel = null) {
-    chartPathWithFillColor("#88BF4D").should("be.visible");
-    chartPathWithFillColor("#4C5773").should("be.visible");
-    echartsContainer().get("text").contains("Total");
+    H.chartPathWithFillColor("#88BF4D").should("be.visible");
+    H.chartPathWithFillColor("#4C5773").should("be.visible");
+    H.echartsContainer().get("text").contains("Total");
 
     if (xLabel) {
-      echartsContainer().get("text").contains(xLabel);
+      H.echartsContainer().get("text").contains(xLabel);
     }
     if (yLabel) {
-      echartsContainer().get("text").contains(yLabel);
+      H.echartsContainer().get("text").contains(yLabel);
     }
   }
 
   it("should work with ordinal series", () => {
-    openNativeEditor().type(
+    H.openNativeEditor().type(
       "select 'A' as product, 10 as profit union select 'B' as product, -4 as profit",
     );
     cy.findByTestId("native-query-editor-container").icon("play").click();
@@ -50,7 +36,7 @@ describe("scenarios > visualizations > waterfall", () => {
   });
 
   it("should work with ordinal series and numeric X-axis (metabase#15550)", () => {
-    openNativeEditor().type(
+    H.openNativeEditor().type(
       "select 1 as X, 20 as Y union select 2 as X, -10 as Y",
     );
 
@@ -78,7 +64,7 @@ describe("scenarios > visualizations > waterfall", () => {
   });
 
   it("should work with quantitative series", () => {
-    openNativeEditor().type(
+    H.openNativeEditor().type(
       "select 1 as X, 10 as Y union select 2 as X, -2 as Y",
     );
     cy.findByTestId("native-query-editor-container").icon("play").click();
@@ -97,8 +83,8 @@ describe("scenarios > visualizations > waterfall", () => {
   });
 
   it("should work with time-series data", () => {
-    openOrdersTable({ mode: "notebook" });
-    summarize({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
+    H.summarize({ mode: "notebook" });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Count of rows").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -114,7 +100,7 @@ describe("scenarios > visualizations > waterfall", () => {
       .blur();
     cy.button("Done").click();
 
-    visualize();
+    H.visualize();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Visualization").click();
@@ -124,8 +110,8 @@ describe("scenarios > visualizations > waterfall", () => {
   });
 
   it("should hide the Total label if there is no space", () => {
-    openOrdersTable({ mode: "notebook" });
-    summarize({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
+    H.summarize({ mode: "notebook" });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Count of rows").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -133,13 +119,13 @@ describe("scenarios > visualizations > waterfall", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At").click();
 
-    visualize();
+    H.visualize();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Visualization").click();
     switchToWaterfallDisplay();
 
-    echartsContainer().get("text").contains("Total").should("not.exist");
+    H.echartsContainer().get("text").contains("Total").should("not.exist");
   });
 
   describe("multi-series (metabase#15152)", () => {
@@ -157,7 +143,7 @@ describe("scenarios > visualizations > waterfall", () => {
       cy.findByTestId("viz-type-button").click();
       switchToWaterfallDisplay();
 
-      echartsContainer().within(() => {
+      H.echartsContainer().within(() => {
         cy.findByText("Created At: Year").should("exist"); // x-axis
         cy.findByText("Count").should("exist"); // y-axis
         cy.findByText("Sum of Total").should("not.exist");
@@ -173,20 +159,20 @@ describe("scenarios > visualizations > waterfall", () => {
         });
       });
 
-      leftSidebar().within(() => {
+      H.leftSidebar().within(() => {
         cy.findByText("Count").should("exist");
         cy.findByText("Sum of Total").should("not.exist");
         cy.findByText(/Add another/).should("not.exist");
 
         cy.findByText("Count").click();
       });
-      popover().findByText("Sum of Total").click();
-      leftSidebar().within(() => {
+      H.popover().findByText("Sum of Total").click();
+      H.leftSidebar().within(() => {
         cy.findByText("Sum of Total").should("exist");
         cy.findByText("Count").should("not.exist");
       });
 
-      echartsContainer().within(() => {
+      H.echartsContainer().within(() => {
         cy.findByText("Sum of Total").should("exist"); // x-axis
         cy.findByText("Created At: Year").should("exist"); // y-axis
         cy.findByText("Count").should("not.exist");
@@ -204,12 +190,12 @@ describe("scenarios > visualizations > waterfall", () => {
     }
 
     it("should correctly switch into single-series mode for ad-hoc queries", () => {
-      visitQuestionAdhoc({ dataset_query: DATASET_QUERY, display: "line" });
+      H.visitQuestionAdhoc({ dataset_query: DATASET_QUERY, display: "line" });
       testSwitchingToWaterfall();
     });
 
     it("should correctly switch into single-series mode for ad-hoc queries", () => {
-      createQuestion(
+      H.createQuestion(
         { name: "Q1", query: DATASET_QUERY.query, display: "line" },
         { visitQuestion: true },
       );
@@ -218,7 +204,7 @@ describe("scenarios > visualizations > waterfall", () => {
   });
 
   it("should not allow you to choose X-axis breakout", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "query",
         query: {
@@ -245,14 +231,14 @@ describe("scenarios > visualizations > waterfall", () => {
     cy.contains("Select a field").click();
     cy.get("[data-element-id=list-item]").contains("Count").click();
 
-    echartsContainer().should("exist"); // Chart renders after adding a metric
+    H.echartsContainer().should("exist"); // Chart renders after adding a metric
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Add another/).should("not.exist");
   });
 
   it("should work for unaggregated data (metabase#15465)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "native",
         native: {
@@ -265,11 +251,11 @@ describe("scenarios > visualizations > waterfall", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Visualization").click();
     cy.icon("waterfall").click({ force: true });
-    chartPathWithFillColor("#88BF4D").should("be.visible");
+    H.chartPathWithFillColor("#88BF4D").should("be.visible");
   });
 
   it("should display correct values when one of them is 0 (metabase#16246)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "native",
         native: {
@@ -295,7 +281,7 @@ describe("scenarios > visualizations > waterfall", () => {
   });
 
   it("should now display null values (metabase#16246)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "native",
         native: {
@@ -321,7 +307,7 @@ describe("scenarios > visualizations > waterfall", () => {
       .should("eq", "0.1");
 
     // but the x-axis label and area should still be shown for the null data point
-    echartsContainer().findByText("f");
+    H.echartsContainer().findByText("f");
 
     getWaterfallDataLabels()
       .as("labels")
@@ -333,7 +319,7 @@ describe("scenarios > visualizations > waterfall", () => {
   });
 
   it("should correctly apply column value scaling in tool-tips (metabase#44176)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "native",
         native: {
@@ -352,9 +338,9 @@ describe("scenarios > visualizations > waterfall", () => {
 
     getWaterfallDataLabels().first().invoke("text").should("eq", "0.2");
 
-    chartPathWithFillColor("#88BF4D").first().trigger("mousemove");
+    H.chartPathWithFillColor("#88BF4D").first().trigger("mousemove");
 
-    assertEChartsTooltip({
+    H.assertEChartsTooltip({
       rows: [
         {
           name: "C2",
@@ -368,10 +354,12 @@ describe("scenarios > visualizations > waterfall", () => {
     const INCREASE_COLOR = "#00FF00";
 
     function getFirstWaterfallSegment() {
-      return echartsContainer().find(`path[fill='${INCREASE_COLOR}']`).first();
+      return H.echartsContainer()
+        .find(`path[fill='${INCREASE_COLOR}']`)
+        .first();
     }
 
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       display: "waterfall",
       dataset_query: {
         type: "query",
@@ -388,22 +376,22 @@ describe("scenarios > visualizations > waterfall", () => {
     });
 
     getFirstWaterfallSegment().realHover();
-    assertEChartsTooltip({
+    H.assertEChartsTooltip({
       header: "2022",
       rows: [{ name: "Count", value: "744", color: INCREASE_COLOR }],
     });
-    assertEChartsTooltipNotContain(["Sum of Total"]);
+    H.assertEChartsTooltipNotContain(["Sum of Total"]);
 
     cy.findByTestId("viz-settings-button").click();
 
-    leftSidebar().within(() => {
+    H.leftSidebar().within(() => {
       cy.findByText("Display").click();
       cy.findByPlaceholderText("Enter metric names").click();
     });
     cy.findByRole("option", { name: "Sum of Total" }).click();
 
     getFirstWaterfallSegment().realHover();
-    assertEChartsTooltip({
+    H.assertEChartsTooltip({
       header: "2022",
       rows: [
         { name: "Count", value: "744", color: INCREASE_COLOR },
@@ -414,10 +402,10 @@ describe("scenarios > visualizations > waterfall", () => {
 
   describe("scenarios > visualizations > waterfall settings", () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsNormalUser();
 
-      openNativeEditor().type("select 'A' as X, -4.56 as Y");
+      H.openNativeEditor().type("select 'A' as X, -4.56 as Y");
       cy.findByTestId("native-query-editor-container").icon("play").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Visualization").click();
@@ -442,22 +430,22 @@ describe("scenarios > visualizations > waterfall", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Show total").next().click();
 
-      echartsContainer().get("text").contains("Total").should("not.exist");
+      H.echartsContainer().get("text").contains("Total").should("not.exist");
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Show total").next().click();
-      echartsContainer().get("text").contains("Total").should("exist");
+      H.echartsContainer().get("text").contains("Total").should("exist");
     });
 
     it("should allow toggling of value labels", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Display").click();
 
-      echartsContainer().get("text").contains("(4.56)").should("not.exist");
+      H.echartsContainer().get("text").contains("(4.56)").should("not.exist");
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Show values on data points").next().click();
-      echartsContainer().get("text").contains("(4.56)").should("be.visible");
+      H.echartsContainer().get("text").contains("(4.56)").should("be.visible");
     });
   });
 });
@@ -471,5 +459,5 @@ const switchToWaterfallDisplay = () => {
 
 function getWaterfallDataLabels() {
   // paint-order='stroke' targets the waterfall labels only
-  return echartsContainer().get("text[paint-order='stroke']");
+  return H.echartsContainer().get("text[paint-order='stroke']");
 }

--- a/e2e/test/scenarios/visualizations-tabular/column-shortcuts.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-tabular/column-shortcuts.cy.spec.ts
@@ -1,22 +1,8 @@
 import _ from "underscore";
 
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  createQuestion,
-  describeWithSnowplow,
-  enterCustomColumnDetails,
-  expectGoodSnowplowEvent,
-  expectNoBadSnowplowEvents,
-  getNotebookStep,
-  openNotebook,
-  openOrdersTable,
-  popover,
-  resetSnowplow,
-  restore,
-  tableHeaderClick,
-  visualize,
-} from "e2e/support/helpers";
 
 const { PEOPLE, PEOPLE_ID, ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
@@ -95,30 +81,30 @@ const URL_CASES = [
   },
 ];
 
-describeWithSnowplow("extract shortcut", () => {
+H.describeWithSnowplow("extract shortcut", () => {
   beforeEach(() => {
-    restore();
-    resetSnowplow();
+    H.restore();
+    H.resetSnowplow();
 
     cy.signInAsAdmin();
   });
 
   afterEach(() => {
-    expectNoBadSnowplowEvents();
+    H.expectNoBadSnowplowEvents();
   });
 
   describe("date columns", () => {
     describe("should add a date expression for each option", () => {
       DATE_CASES.forEach(({ option, value, example, expressions }) => {
         it(option, () => {
-          openOrdersTable({ limit: 1 });
+          H.openOrdersTable({ limit: 1 });
           extractColumnAndCheck({
             column: "Created At",
             option,
             value,
             example,
           });
-          expectGoodSnowplowEvent({
+          H.expectGoodSnowplowEvent({
             event: "column_extract_via_plus_modal",
             custom_expressions_used: expressions,
             database_id: SAMPLE_DB_ID,
@@ -128,7 +114,7 @@ describeWithSnowplow("extract shortcut", () => {
     });
 
     it("should handle duplicate expression names", () => {
-      openOrdersTable({ limit: 1 });
+      H.openOrdersTable({ limit: 1 });
       extractColumnAndCheck({
         column: "Created At",
         option: "Hour of day",
@@ -142,34 +128,34 @@ describeWithSnowplow("extract shortcut", () => {
     });
 
     it("should be able to modify the expression in the notebook editor", () => {
-      openOrdersTable({ limit: 1 });
+      H.openOrdersTable({ limit: 1 });
       extractColumnAndCheck({
         column: "Created At",
         option: "Year",
         value: "2,025",
       });
-      openNotebook();
-      getNotebookStep("expression").findByText("Year").click();
-      enterCustomColumnDetails({
+      H.openNotebook();
+      H.getNotebookStep("expression").findByText("Year").click();
+      H.enterCustomColumnDetails({
         name: "custom formula",
         formula: "year([Created At]) + 2",
         blur: true,
       });
-      popover().button("Update").click();
-      visualize();
+      H.popover().button("Update").click();
+      H.visualize();
       cy.findByRole("gridcell", { name: "2,027" }).should("be.visible");
     });
   });
 
   describe("email columns", () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
     });
 
     EMAIL_CASES.forEach(({ option, value, example, expressions }) => {
       it(option, () => {
-        createQuestion(
+        H.createQuestion(
           {
             query: {
               "source-table": PEOPLE_ID,
@@ -187,7 +173,7 @@ describeWithSnowplow("extract shortcut", () => {
           value,
           example,
         });
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: "column_extract_via_plus_modal",
           custom_expressions_used: expressions,
           database_id: SAMPLE_DB_ID,
@@ -198,7 +184,7 @@ describeWithSnowplow("extract shortcut", () => {
 
   describe("url columns", () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
 
       // Make the Email column a URL column for these tests, to avoid having to create a new model
@@ -209,7 +195,7 @@ describeWithSnowplow("extract shortcut", () => {
 
     URL_CASES.forEach(({ option, value, example, expressions }) => {
       it(option, () => {
-        createQuestion(
+        H.createQuestion(
           {
             query: {
               "source-table": PEOPLE_ID,
@@ -227,7 +213,7 @@ describeWithSnowplow("extract shortcut", () => {
           value,
           example,
         });
-        expectGoodSnowplowEvent({
+        H.expectGoodSnowplowEvent({
           event: "column_extract_via_plus_modal",
           custom_expressions_used: expressions,
           database_id: SAMPLE_DB_ID,
@@ -237,7 +223,7 @@ describeWithSnowplow("extract shortcut", () => {
   });
 
   it("should disable the scroll behaviour after it has been rendered", () => {
-    createQuestion(
+    H.createQuestion(
       {
         query: {
           "source-table": PEOPLE_ID,
@@ -256,17 +242,17 @@ describeWithSnowplow("extract shortcut", () => {
 
     cy.get("#main-data-grid").scrollTo("left", { duration: 2000 / 60 });
 
-    tableHeaderClick("ID");
+    H.tableHeaderClick("ID");
 
     // Change sort direction
-    popover().findAllByRole("button").first().click();
+    H.popover().findAllByRole("button").first().click();
 
     // ID should still be visible (ie. no scrolling to the end should have happened)
     cy.findAllByRole("columnheader", { name: "ID" }).should("be.visible");
   });
 
   it("should be possible to extract columns from a summarized table", () => {
-    createQuestion(
+    H.createQuestion(
       {
         query: {
           "source-table": ORDERS_ID,
@@ -292,7 +278,7 @@ describeWithSnowplow("extract shortcut", () => {
   });
 
   it("should be possible to extract columns from table with breakouts", () => {
-    createQuestion(
+    H.createQuestion(
       {
         query: {
           "source-table": ORDERS_ID,
@@ -335,14 +321,14 @@ function extractColumnAndCheck({
   cy.intercept("POST", "/api/dataset").as(requestAlias);
   cy.findByLabelText("Add column").click();
 
-  popover().findByText("Extract part of column").click();
-  popover().findAllByText(column).first().click();
+  H.popover().findByText("Extract part of column").click();
+  H.popover().findAllByText(column).first().click();
 
   if (example) {
-    popover().findByText(option).parent().should("contain", example);
+    H.popover().findByText(option).parent().should("contain", example);
   }
 
-  popover().findByText(option).click();
+  H.popover().findByText(option).click();
 
   cy.wait(`@${requestAlias}`);
 
@@ -357,7 +343,7 @@ function extractColumnAndCheck({
   }
 }
 
-describeWithSnowplow("scenarios > visualizations > combine shortcut", () => {
+H.describeWithSnowplow("scenarios > visualizations > combine shortcut", () => {
   function combineColumns({
     columns,
     example,
@@ -373,16 +359,16 @@ describeWithSnowplow("scenarios > visualizations > combine shortcut", () => {
     cy.intercept("POST", "/api/dataset").as(requestAlias);
     cy.findByLabelText("Add column").click();
 
-    popover().findByText("Combine columns").click();
+    H.popover().findByText("Combine columns").click();
     for (const [index, column] of columns.entries()) {
       selectColumn(index, column);
     }
 
     if (example) {
-      popover().findByTestId("combine-example").should("have.text", example);
+      H.popover().findByTestId("combine-example").should("have.text", example);
     }
 
-    popover().button("Done").click();
+    H.popover().button("Done").click();
 
     cy.wait(`@${requestAlias}`);
 
@@ -397,22 +383,22 @@ describeWithSnowplow("scenarios > visualizations > combine shortcut", () => {
   }
 
   function selectColumn(index: number, name: string) {
-    popover().findAllByTestId("column-input").eq(index).click();
-    popover().last().findByText(name).click();
+    H.popover().findAllByTestId("column-input").eq(index).click();
+    H.popover().last().findByText(name).click();
   }
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
-    resetSnowplow();
+    H.resetSnowplow();
   });
 
   afterEach(() => {
-    expectNoBadSnowplowEvents();
+    H.expectNoBadSnowplowEvents();
   });
 
   it("should be possible add a new column through the combine columns shortcut", () => {
-    createQuestion(
+    H.createQuestion(
       {
         query: {
           "source-table": PEOPLE_ID,
@@ -435,7 +421,7 @@ describeWithSnowplow("scenarios > visualizations > combine shortcut", () => {
       newValue: "borer-hudson@yahoo.com1",
     });
 
-    expectGoodSnowplowEvent({
+    H.expectGoodSnowplowEvent({
       event: "column_combine_via_plus_modal",
       custom_expressions_used: ["concat"],
       database_id: SAMPLE_DB_ID,
@@ -443,7 +429,7 @@ describeWithSnowplow("scenarios > visualizations > combine shortcut", () => {
   });
 
   it("should allow combining columns when aggregating", function () {
-    createQuestion(
+    H.createQuestion(
       {
         query: {
           "source-table": ORDERS_ID,
@@ -469,7 +455,7 @@ describeWithSnowplow("scenarios > visualizations > combine shortcut", () => {
   });
 
   it("should allow combining columns on a table with just breakouts", () => {
-    createQuestion(
+    H.createQuestion(
       {
         query: {
           "source-table": ORDERS_ID,

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/chart_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/chart_drill.cy.spec.js
@@ -1,29 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  addOrUpdateDashboardCard,
-  addSummaryField,
-  assertEChartsTooltip,
-  cartesianChartCircle,
-  cartesianChartCircleWithColor,
-  chartPathWithFillColor,
-  echartsContainer,
-  echartsTriggerBlur,
-  entityPickerModal,
-  entityPickerModalTab,
-  openOrdersTable,
-  pieSliceWithColor,
-  popover,
-  queryBuilderMain,
-  restore,
-  startNewQuestion,
-  summarize,
-  tableHeaderClick,
-  visitDashboard,
-  visitQuestion,
-  visitQuestionAdhoc,
-  visualize,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID, PEOPLE, PEOPLE_ID } =
   SAMPLE_DATABASE;
@@ -31,7 +8,7 @@ const { DATA_GROUP } = USER_GROUPS;
 
 describe("scenarios > visualizations > drillthroughs > chart drill", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -56,9 +33,9 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       { visitQuestion: true },
     );
 
-    queryBuilderMain().within(() => {
+    H.queryBuilderMain().within(() => {
       cy.findByLabelText("Legend").findByText("Gadget").should("exist");
-      echartsContainer().findByText("January 2023").should("exist");
+      H.echartsContainer().findByText("January 2023").should("exist");
     });
 
     cy.wait(100); // wait to avoid grabbing the svg before the chart redraws
@@ -74,8 +51,8 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       "Product → Created At is",
     );
 
-    queryBuilderMain().within(() => {
-      echartsContainer().findByText("June 2022"); // more granular axis labels
+    H.queryBuilderMain().within(() => {
+      H.echartsContainer().findByText("June 2022"); // more granular axis labels
 
       // confirm that product category is still broken out
       cy.findByLabelText("Legend").within(() => {
@@ -107,9 +84,9 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
 
       cy.createQuestion(questionDetails, { visitQuestion: true });
 
-      queryBuilderMain().within(() => {
+      H.queryBuilderMain().within(() => {
         cy.findByLabelText("Legend").findByText("Gadget").should("exist");
-        echartsContainer().findByText(/Count/).should("exist");
+        H.echartsContainer().findByText(/Count/).should("exist");
       });
       cy.wait(100); // wait to avoid grabbing the svg before the chart redraws
 
@@ -129,7 +106,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
           .should("exist");
       }
 
-      cartesianChartCircle();
+      H.cartesianChartCircle();
     });
   });
 
@@ -158,7 +135,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
           ({ body: { id: DASHBOARD_ID } }) => {
             cy.log("Add the first question to the dashboard");
 
-            addOrUpdateDashboardCard({
+            H.addOrUpdateDashboardCard({
               card_id: Q1_ID,
               dashboard_id: DASHBOARD_ID,
               card: {
@@ -174,10 +151,10 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
               },
             });
 
-            visitDashboard(DASHBOARD_ID);
+            H.visitDashboard(DASHBOARD_ID);
 
             cy.log("The first series line");
-            cartesianChartCircleWithColor("#509EE3").eq(0).click();
+            H.cartesianChartCircleWithColor("#509EE3").eq(0).click();
             cy.findByText("See this year by quarter");
             cy.findByText("See these Orders");
 
@@ -186,7 +163,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
 
             // Second line from the second question
             cy.log("The second series line");
-            cartesianChartCircleWithColor("#98D9D9").eq(0).click();
+            H.cartesianChartCircleWithColor("#98D9D9").eq(0).click();
             cy.findByText("See this year by quarter");
             cy.findByText("See these Products");
           },
@@ -221,7 +198,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
           ({ body: { id: DASHBOARD_ID } }) => {
             cy.log("Add the first question to the dashboard");
 
-            addOrUpdateDashboardCard({
+            H.addOrUpdateDashboardCard({
               card_id: Q1_ID,
               dashboard_id: DASHBOARD_ID,
               card: {
@@ -237,10 +214,10 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
               },
             });
 
-            visitDashboard(DASHBOARD_ID);
+            H.visitDashboard(DASHBOARD_ID);
 
             cy.log("The first series line");
-            cartesianChartCircleWithColor("#509EE3").eq(0).click();
+            H.cartesianChartCircleWithColor("#509EE3").eq(0).click();
             cy.findByText("See this year by quarter");
             cy.findByText("See these Orders");
 
@@ -249,7 +226,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
 
             // Second line from the second question
             cy.log("The third series line");
-            cartesianChartCircleWithColor("#EF8C8C").eq(0).click();
+            H.cartesianChartCircleWithColor("#EF8C8C").eq(0).click();
             cy.findByText("See this year by quarter");
             cy.findByText("See these Orders");
           },
@@ -266,17 +243,17 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       query: { "source-table": PEOPLE_ID, limit: 5 },
     });
     // Build a new question off that grouping by City
-    startNewQuestion();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Saved questions").click();
+    H.startNewQuestion();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Saved questions").click();
       cy.contains("CA People").click();
     });
 
-    addSummaryField({ metric: "Count of rows" });
+    H.addSummaryField({ metric: "Count of rows" });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("City").click();
     });
 
@@ -287,7 +264,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Count by City");
 
-    chartPathWithFillColor("#509EE3").first().click();
+    H.chartPathWithFillColor("#509EE3").first().click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("See this CA Person").click();
 
@@ -331,8 +308,8 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
   });
 
   it.skip("should drill-through on filtered aggregated results (metabase#13504)", () => {
-    openOrdersTable({ mode: "notebook" });
-    summarize({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
+    H.summarize({ mode: "notebook" });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Count of rows").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -343,7 +320,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     // add filter: Count > 1
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter").click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Count").click();
       cy.findByText("Equal to").click();
     });
@@ -353,7 +330,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add filter").click();
 
-    visualize();
+    H.visualize();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Visualization").click();
@@ -396,8 +373,8 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       { visitQuestion: true },
     );
 
-    cartesianChartCircle().eq(0).realHover();
-    assertEChartsTooltip({
+    H.cartesianChartCircle().eq(0).realHover();
+    H.assertEChartsTooltip({
       header: "January 1, 2026",
       rows: [
         {
@@ -408,10 +385,10 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       ],
     });
 
-    echartsTriggerBlur();
+    H.echartsTriggerBlur();
 
-    cartesianChartCircle().eq(1).realHover();
-    assertEChartsTooltip({
+    H.cartesianChartCircle().eq(1).realHover();
+    H.assertEChartsTooltip({
       header: "January 2, 2026",
       rows: [
         {
@@ -424,7 +401,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
   });
 
   it("should display correct value in a tooltip for unaggregated data with breakouts (metabase#15785)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "native",
         native: {
@@ -440,8 +417,8 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       },
     });
 
-    chartPathWithFillColor("#7172AD").first().trigger("mousemove");
-    assertEChartsTooltip({
+    H.chartPathWithFillColor("#7172AD").first().trigger("mousemove");
+    H.assertEChartsTooltip({
       header: "2",
       rows: [
         {
@@ -515,7 +492,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
 
         // Switch to the normal user who has restricted SQL access
         cy.signInAsNormalUser();
-        visitQuestion(QUESTION_ID);
+        H.visitQuestion(QUESTION_ID);
 
         // Initial visualization has rendered and we can now drill-through
         cy.findByTestId("query-visualization-root")
@@ -534,7 +511,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
   });
 
   it("count of rows from drill-down on binned results should match the number of records (metabase#15324)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       name: "15324",
       dataset_query: {
         database: SAMPLE_DB_ID,
@@ -566,7 +543,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
   });
 
   it("should drill through on a bin of null values (#11345)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       name: "11345",
       dataset_query: {
         database: SAMPLE_DB_ID,
@@ -589,7 +566,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     cy.findByText("See these Orders").click();
 
     // count number of distinct values in the Discount column
-    tableHeaderClick("Discount ($)");
+    H.tableHeaderClick("Discount ($)");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Distinct values").click();
 
@@ -608,7 +585,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       display: "pie",
     }).then(({ body: { id: QUESTION_ID } }) => {
       cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
-        addOrUpdateDashboardCard({
+        H.addOrUpdateDashboardCard({
           card_id: QUESTION_ID,
           dashboard_id: DASHBOARD_ID,
           card: {
@@ -624,16 +601,16 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
           },
         });
 
-        visitDashboard(DASHBOARD_ID);
+        H.visitDashboard(DASHBOARD_ID);
       });
     });
 
-    pieSliceWithColor("#88BF4D")
+    H.pieSliceWithColor("#88BF4D")
       .first()
       .as("doohickeyChart")
       .trigger("mousemove");
 
-    assertEChartsTooltip({
+    H.assertEChartsTooltip({
       header: "Category",
       rows: [
         {
@@ -685,11 +662,11 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
         },
       };
 
-      visitQuestionAdhoc(questionDetails);
+      H.visitQuestionAdhoc(questionDetails);
 
       // Drill-through the last bar (Widget)
-      chartPathWithFillColor("#509EE3").last().click();
-      popover().findByTextEnsureVisible("See these Products").click();
+      H.chartPathWithFillColor("#509EE3").last().click();
+      H.popover().findByTextEnsureVisible("See these Products").click();
     });
 
     it("should result in a correct query result", () => {
@@ -732,8 +709,8 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       { visitQuestion: true },
     );
 
-    cartesianChartCircle().eq(2).click();
-    popover().within(() => {
+    H.cartesianChartCircle().eq(2).click();
+    H.popover().within(() => {
       cy.findByText("See these Orders").should("be.visible");
 
       cy.findByText("See this month by week").should("be.visible");
@@ -778,13 +755,13 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
 
     cy.findAllByTestId("legend-item").first().click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("See these Orders").should("be.visible");
       cy.findByText("Automatic insights…").should("be.visible");
     });
 
-    chartPathWithFillColor("#A989C5").first().click();
-    popover().within(() => {
+    H.chartPathWithFillColor("#A989C5").first().click();
+    H.popover().within(() => {
       cy.findByText("See these Orders").should("be.visible");
 
       cy.findByText("See this month by week").should("be.visible");
@@ -822,7 +799,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
 
     cy.findAllByTestId("choropleth-feature").first().click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("See these People").should("be.visible");
       cy.findByText("Zoom in").should("be.visible");
 

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/column_extract_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/column_extract_drill.cy.spec.js
@@ -1,24 +1,9 @@
 import _ from "underscore";
 
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  describeWithSnowplow,
-  enterCustomColumnDetails,
-  expectGoodSnowplowEvent,
-  expectNoBadSnowplowEvents,
-  getNotebookStep,
-  openNotebook,
-  openOrdersTable,
-  openPeopleTable,
-  popover,
-  resetSnowplow,
-  restore,
-  tableHeaderClick,
-  visitQuestion,
-  visualize,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PEOPLE } = SAMPLE_DATABASE;
 
@@ -103,9 +88,9 @@ const DATE_QUESTION = {
   },
 };
 
-describeWithSnowplow("extract action", () => {
+H.describeWithSnowplow("extract action", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -113,7 +98,7 @@ describeWithSnowplow("extract action", () => {
     describe("should add a date expression for each option", () => {
       DATE_CASES.forEach(({ option, value, example }) => {
         it(option, () => {
-          openOrdersTable({ limit: 1 });
+          H.openOrdersTable({ limit: 1 });
           extractColumnAndCheck({
             column: "Created At",
             option,
@@ -127,7 +112,7 @@ describeWithSnowplow("extract action", () => {
 
     describe("should add a new column after the selected column", () => {
       it("ad-hoc question", () => {
-        openOrdersTable();
+        H.openOrdersTable();
         extractColumnAndCheck({
           column: "Created At",
           option: "Year",
@@ -136,7 +121,7 @@ describeWithSnowplow("extract action", () => {
       });
 
       it("saved question without viz settings", () => {
-        visitQuestion(ORDERS_QUESTION_ID);
+        H.visitQuestion(ORDERS_QUESTION_ID);
         extractColumnAndCheck({
           column: "Created At",
           option: "Year",
@@ -212,7 +197,7 @@ describeWithSnowplow("extract action", () => {
     });
 
     it("should handle duplicate expression names", () => {
-      openOrdersTable({ limit: 1 });
+      H.openOrdersTable({ limit: 1 });
       extractColumnAndCheck({
         column: "Created At",
         option: "Hour of day",
@@ -228,18 +213,18 @@ describeWithSnowplow("extract action", () => {
     });
 
     it("should be able to modify the expression in the notebook editor", () => {
-      openOrdersTable({ limit: 1 });
+      H.openOrdersTable({ limit: 1 });
       extractColumnAndCheck({
         column: "Created At",
         option: "Year",
         value: "2,025",
         extraction: "Extract day, month…",
       });
-      openNotebook();
-      getNotebookStep("expression").findByText("Year").click();
-      enterCustomColumnDetails({ formula: "year([Created At]) + 2" });
-      popover().button("Update").click();
-      visualize();
+      H.openNotebook();
+      H.getNotebookStep("expression").findByText("Year").click();
+      H.enterCustomColumnDetails({ formula: "year([Created At]) + 2" });
+      H.popover().button("Update").click();
+      H.visualize();
       cy.findByRole("gridcell", { name: "2,027" }).should("be.visible");
     });
 
@@ -247,7 +232,7 @@ describeWithSnowplow("extract action", () => {
       cy.request("GET", "/api/user/current").then(({ body: user }) => {
         cy.request("PUT", `/api/user/${user.id}`, { locale: "de" });
       });
-      openOrdersTable({ limit: 1 });
+      H.openOrdersTable({ limit: 1 });
       extractColumnAndCheck({
         column: "Created At",
         option: "Tag der Woche",
@@ -259,13 +244,13 @@ describeWithSnowplow("extract action", () => {
 
   describe("email columns", () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
     });
 
     EMAIL_CASES.forEach(({ option, value, example }) => {
       it(option, () => {
-        openPeopleTable({ limit: 1 });
+        H.openPeopleTable({ limit: 1 });
         extractColumnAndCheck({
           column: "Email",
           option,
@@ -279,7 +264,7 @@ describeWithSnowplow("extract action", () => {
 
   describe("url columns", () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
 
       // Make the Email column a URL column for these tests, to avoid having to create a new model
@@ -290,7 +275,7 @@ describeWithSnowplow("extract action", () => {
 
     URL_CASES.forEach(({ option, value, example }) => {
       it(option, () => {
-        openPeopleTable({ limit: 1 });
+        H.openPeopleTable({ limit: 1 });
 
         extractColumnAndCheck({
           column: "Email",
@@ -314,16 +299,16 @@ function extractColumnAndCheck({
 }) {
   const requestAlias = _.uniqueId("dataset");
   cy.intercept("POST", "/api/dataset").as(requestAlias);
-  tableHeaderClick(column);
+  H.tableHeaderClick(column);
   // cy.findByRole("columnheader", { name: column }).click();
-  popover().findByText(extraction).click();
+  H.popover().findByText(extraction).click();
   cy.wait(1);
 
   if (example) {
-    popover().findByText(option).should("contain", example);
+    H.popover().findByText(option).should("contain", example);
   }
 
-  popover().findByText(option).click();
+  H.popover().findByText(option).click();
   cy.wait(`@${requestAlias}`);
 
   cy.findAllByRole("columnheader")
@@ -336,19 +321,19 @@ function extractColumnAndCheck({
   }
 }
 
-describeWithSnowplow("extract action", () => {
+H.describeWithSnowplow("extract action", () => {
   beforeEach(() => {
-    restore();
-    resetSnowplow();
+    H.restore();
+    H.resetSnowplow();
     cy.signInAsAdmin();
   });
 
   afterEach(() => {
-    expectNoBadSnowplowEvents();
+    H.expectNoBadSnowplowEvents();
   });
 
   it("should create a snowplow event for the column extraction action", () => {
-    openOrdersTable({ limit: 1 });
+    H.openOrdersTable({ limit: 1 });
 
     cy.wait(1);
 
@@ -359,7 +344,7 @@ describeWithSnowplow("extract action", () => {
       extraction: "Extract day, month…",
     });
 
-    expectGoodSnowplowEvent({
+    H.expectGoodSnowplowEvent({
       event: "column_extract_via_column_header",
       custom_expressions_used: ["get-year"],
       database_id: SAMPLE_DB_ID,

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/combine-column.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/combine-column.cy.spec.ts
@@ -1,33 +1,24 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  createQuestion,
-  describeWithSnowplow,
-  expectGoodSnowplowEvent,
-  expectNoBadSnowplowEvents,
-  popover,
-  resetSnowplow,
-  restore,
-  tableHeaderClick,
-} from "e2e/support/helpers";
 
 const { PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
 
-describeWithSnowplow(
+H.describeWithSnowplow(
   "scenarios > visualizations > drillthroughs > table_drills > combine columns",
   () => {
     beforeEach(() => {
-      restore();
-      resetSnowplow();
+      H.restore();
+      H.resetSnowplow();
       cy.signInAsAdmin();
     });
 
     afterEach(() => {
-      expectNoBadSnowplowEvents();
+      H.expectNoBadSnowplowEvents();
     });
 
     it("should be possible to combine columns from the a table header", () => {
-      createQuestion(
+      H.createQuestion(
         {
           query: {
             "source-table": PEOPLE_ID,
@@ -41,10 +32,10 @@ describeWithSnowplow(
         { visitQuestion: true },
       );
 
-      tableHeaderClick("Email");
-      popover().findByText("Combine columns").click();
+      H.tableHeaderClick("Email");
+      H.popover().findByText("Combine columns").click();
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByTestId("combine-example").should(
           "contain",
           "email@example.com12345",
@@ -52,9 +43,9 @@ describeWithSnowplow(
         cy.findByText("ID").click();
       });
 
-      popover().last().findByText("Name").click();
+      H.popover().last().findByText("Name").click();
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Separated by (empty)").click();
         cy.findByLabelText("Separator").type("__");
         cy.findByTestId("combine-example").should(
@@ -87,7 +78,7 @@ describeWithSnowplow(
         .last()
         .should("have.text", "Combined Email, Name, ID");
 
-      expectGoodSnowplowEvent({
+      H.expectGoodSnowplowEvent({
         event: "column_combine_via_column_header",
         custom_expressions_used: ["concat"],
         database_id: SAMPLE_DB_ID,
@@ -95,7 +86,7 @@ describeWithSnowplow(
     });
 
     it("should handle duplicate column names", () => {
-      createQuestion(
+      H.createQuestion(
         {
           query: {
             "source-table": PEOPLE_ID,
@@ -110,14 +101,14 @@ describeWithSnowplow(
       );
 
       // first combine (email + ID)
-      tableHeaderClick("Email");
-      popover().findByText("Combine columns").click();
-      popover().findByText("Done").click();
+      H.tableHeaderClick("Email");
+      H.popover().findByText("Combine columns").click();
+      H.popover().findByText("Done").click();
 
       // second combine (email + ID)
-      tableHeaderClick("Email");
-      popover().findByText("Combine columns").click();
-      popover().findByText("Done").click();
+      H.tableHeaderClick("Email");
+      H.popover().findByText("Combine columns").click();
+      H.popover().findByText("Done").click();
 
       cy.findAllByTestId("header-cell")
         .contains("Combined Email, ID")

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/dash_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/dash_drill.cy.spec.js
@@ -1,13 +1,7 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_COUNT_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  addOrUpdateDashboardCard,
-  cartesianChartCircle,
-  queryBuilderMain,
-  restore,
-  visitDashboard,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
 
@@ -21,7 +15,7 @@ const Q2 = {
 describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
   describe("card title click action", () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
     });
 
@@ -117,7 +111,7 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
             size_y: 12,
           },
         }).then(({ body: { dashboard_id, card_id } }) => {
-          visitDashboard(dashboard_id);
+          H.visitDashboard(dashboard_id);
           cy.findByText(DASHBOARD_NAME);
 
           cy.intercept("POST", `/api/card/${card_id}/query`).as("cardQuery");
@@ -130,7 +124,7 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
       it("should result in a correct query result", () => {
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Affiliate");
-        cartesianChartCircle().should("have.length.of.at.least", 100);
+        H.cartesianChartCircle().should("have.length.of.at.least", 100);
       });
     });
 
@@ -168,7 +162,7 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
           },
         }).then(({ body: { dashboard_id, card_id } }) => {
           // Adding filter parameter mapping to dashcard
-          addOrUpdateDashboardCard({
+          H.addOrUpdateDashboardCard({
             card_id,
             dashboard_id,
             card: {
@@ -190,12 +184,12 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
             },
           });
 
-          visitDashboard(dashboard_id);
+          H.visitDashboard(dashboard_id);
           cy.findByTestId("dashcard").findByText(QUESTION_NAME).click();
           cy.findByTestId("qb-filters-panel")
             .findByText("Product → Category is Doohickey")
             .should("be.visible");
-          queryBuilderMain().findByText("177").should("be.visible"); // Doohickeys for 2022
+          H.queryBuilderMain().findByText("177").should("be.visible"); // Doohickeys for 2022
         });
       });
     });
@@ -211,8 +205,8 @@ function clickScalarCardTitle(card_name) {
 function addCardToNewDashboard(dashboard_name, card_id) {
   cy.createDashboard({ name: dashboard_name }).then(
     ({ body: { id: dashboard_id } }) => {
-      addOrUpdateDashboardCard({ card_id, dashboard_id });
-      visitDashboard(dashboard_id);
+      H.addOrUpdateDashboardCard({ card_id, dashboard_id });
+      H.visitDashboard(dashboard_id);
     },
   );
 }

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/table_drills.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/table_drills.cy.spec.js
@@ -1,34 +1,28 @@
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  openReviewsTable,
-  openTable,
-  popover,
-  restore,
-  tableHeaderClick,
-} from "e2e/support/helpers";
 
 const { REVIEWS, REVIEWS_ID, ACCOUNTS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > visualizations > drillthroughs > table_drills", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.viewport(1500, 800);
   });
 
   it("should display proper drills on cell click for unaggregated query", () => {
-    openReviewsTable({ limit: 3 });
+    H.openReviewsTable({ limit: 3 });
 
     // FK cell drills
     cy.get(".test-Table-FK").findByText("1").first().click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("View this Product's Reviews").should("be.visible");
       cy.findByText("View details").should("be.visible");
     });
 
     // Short text cell drills
     cy.get("[data-testid=cell-data]").contains("christ").click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Is christ").should("be.visible");
       cy.findByText("Is not christ").should("be.visible");
       cy.findByText("View details").should("be.visible");
@@ -36,7 +30,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
 
     // Number cell drills
     cy.get("[data-testid=cell-data]").contains("5").first().click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText(">").should("be.visible");
       cy.findByText("<").should("be.visible");
       cy.findByText("=").should("be.visible");
@@ -45,14 +39,14 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
     });
 
     cy.get("[data-testid=cell-data]").contains("Ad perspiciatis quis").click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Contains…").should("be.visible");
       cy.findByText("Does not contain…").should("be.visible");
       cy.findByText("View details").should("be.visible");
     });
 
     cy.get("[data-testid=cell-data]").contains("May 15, 20").click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Before").should("be.visible");
       cy.findByText("After").should("be.visible");
       cy.findByText("On").should("be.visible");
@@ -60,8 +54,8 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       cy.findByText("View details").should("be.visible");
     });
 
-    tableHeaderClick("ID");
-    popover().within(() => {
+    H.tableHeaderClick("ID");
+    H.popover().within(() => {
       cy.icon("arrow_down").should("be.visible");
       cy.icon("arrow_up").should("be.visible");
       cy.icon("gear").should("be.visible");
@@ -71,8 +65,8 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
     });
 
     //cy.get("[data-testid=cell-data]").contains("Reviewer").click();
-    tableHeaderClick("Reviewer");
-    popover().within(() => {
+    H.tableHeaderClick("Reviewer");
+    H.popover().within(() => {
       cy.icon("arrow_down").should("be.visible");
       cy.icon("arrow_up").should("be.visible");
       cy.icon("gear").should("be.visible");
@@ -83,8 +77,8 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
     });
 
     // cy.get("[data-testid=cell-data]").contains("Rating").click();
-    tableHeaderClick("Rating");
-    popover().within(() => {
+    H.tableHeaderClick("Rating");
+    H.popover().within(() => {
       cy.icon("arrow_down").should("be.visible");
       cy.icon("arrow_up").should("be.visible");
       cy.icon("gear").should("be.visible");
@@ -116,13 +110,13 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       .findByText("abbey-heidenreich")
       .click();
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Is abbey-heidenreich").should("be.visible");
       cy.findByText("Is not abbey-heidenreich").should("be.visible");
     });
 
     cy.get("[data-testid=cell-data]").contains("1").first().click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("See this Review").should("be.visible");
 
       cy.findByText("Automatic insights…").should("be.visible");
@@ -133,8 +127,8 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       cy.findByText("≠").should("be.visible");
     });
 
-    tableHeaderClick("Reviewer");
-    popover().within(() => {
+    H.tableHeaderClick("Reviewer");
+    H.popover().within(() => {
       cy.icon("arrow_down").should("be.visible");
       cy.icon("arrow_up").should("be.visible");
       cy.icon("gear").should("be.visible");
@@ -142,8 +136,8 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       cy.findByText("Filter by this column").should("be.visible");
     });
 
-    tableHeaderClick("Count");
-    popover().within(() => {
+    H.tableHeaderClick("Count");
+    H.popover().within(() => {
       cy.icon("arrow_down").should("be.visible");
       cy.icon("arrow_up").should("be.visible");
       cy.icon("gear").should("be.visible");
@@ -168,7 +162,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
     );
 
     cy.get("[data-testid=cell-data]").contains("June").first().click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Before").should("be.visible");
       cy.findByText("After").should("be.visible");
       cy.findByText("On").should("be.visible");
@@ -176,7 +170,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
     });
 
     cy.get("[data-testid=cell-data]").contains("4").first().click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("See this month by week").should("be.visible");
 
       cy.findByText("Break out by…").should("be.visible");
@@ -208,20 +202,20 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
 
       // FK cell drills
       cy.get("[data-testid=cell-data]").filter(":contains(1)").eq(1).click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Filter by this value").should("be.visible");
       });
 
       // Short text cell drills
       cy.get("[data-testid=cell-data]").contains("christ").click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Is christ").should("be.visible");
         cy.findByText("Is not christ").should("be.visible");
       });
 
       // Number cell drills
       cy.get("[data-testid=cell-data]").contains("5").first().click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText(">").should("be.visible");
         cy.findByText("<").should("be.visible");
         cy.findByText("=").should("be.visible");
@@ -231,21 +225,21 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       cy.get("[data-testid=cell-data]")
         .contains("Ad perspiciatis quis")
         .click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Is this").should("be.visible");
         cy.findByText("Is not this").should("be.visible");
       });
 
       cy.get("[data-testid=cell-data]").contains("May 15, 20").click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Before").should("be.visible");
         cy.findByText("After").should("be.visible");
         cy.findByText("On").should("be.visible");
         cy.findByText("Not on").should("be.visible");
       });
 
-      tableHeaderClick("ID");
-      popover().within(() => {
+      H.tableHeaderClick("ID");
+      H.popover().within(() => {
         cy.icon("arrow_down").should("be.visible");
         cy.icon("arrow_up").should("be.visible");
         cy.icon("gear").should("be.visible");
@@ -254,8 +248,8 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
         cy.findByText("Distinct values").should("be.visible");
       });
 
-      tableHeaderClick("REVIEWER");
-      popover().within(() => {
+      H.tableHeaderClick("REVIEWER");
+      H.popover().within(() => {
         cy.icon("arrow_down").should("be.visible");
         cy.icon("arrow_up").should("be.visible");
         cy.icon("gear").should("be.visible");
@@ -265,8 +259,8 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
         cy.findByText("Distinct values").should("be.visible");
       });
 
-      tableHeaderClick("RATING");
-      popover().within(() => {
+      H.tableHeaderClick("RATING");
+      H.popover().within(() => {
         cy.icon("arrow_down").should("be.visible");
         cy.icon("arrow_up").should("be.visible");
         cy.icon("gear").should("be.visible");
@@ -306,21 +300,21 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
         .findByText("abbey-heidenreich")
         .click();
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Is abbey-heidenreich").should("be.visible");
         cy.findByText("Is not abbey-heidenreich").should("be.visible");
       });
 
       cy.get("[data-testid=cell-data]").contains("1").first().click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText(">").should("be.visible");
         cy.findByText("<").should("be.visible");
         cy.findByText("=").should("be.visible");
         cy.findByText("≠").should("be.visible");
       });
 
-      tableHeaderClick("REVIEWER");
-      popover().within(() => {
+      H.tableHeaderClick("REVIEWER");
+      H.popover().within(() => {
         cy.icon("arrow_down").should("be.visible");
         cy.icon("arrow_up").should("be.visible");
         cy.icon("gear").should("be.visible");
@@ -328,8 +322,8 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
         cy.findByText("Filter by this column").should("be.visible");
       });
 
-      tableHeaderClick("COUNT");
-      popover().within(() => {
+      H.tableHeaderClick("COUNT");
+      H.popover().within(() => {
         cy.icon("arrow_down").should("be.visible");
         cy.icon("arrow_up").should("be.visible");
         cy.icon("gear").should("be.visible");
@@ -360,7 +354,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       );
 
       cy.get("[data-testid=cell-data]").contains("June").first().click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText("Before").should("be.visible");
         cy.findByText("After").should("be.visible");
         cy.findByText("On").should("be.visible");
@@ -368,7 +362,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       });
 
       cy.get("[data-testid=cell-data]").contains("4").first().click();
-      popover().within(() => {
+      H.popover().within(() => {
         cy.findByText(">").should("be.visible");
         cy.findByText("<").should("be.visible");
         cy.findByText("=").should("be.visible");
@@ -381,7 +375,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
 describe("scenarios > visualizations > drillthroughs > table_drills > nulls", () => {
   beforeEach(() => {
     // It's important to restore to the "setup" to have access to "Accounts" table
-    restore("setup");
+    H.restore("setup");
     cy.signInAsAdmin();
     cy.viewport(1500, 800);
   });
@@ -389,13 +383,13 @@ describe("scenarios > visualizations > drillthroughs > table_drills > nulls", ()
   it("should display proper drills on a datetime cell click when there is no value (metabase#44101)", () => {
     const CANCELLED_AT_INDEX = 9;
 
-    openTable({ table: ACCOUNTS_ID, limit: 1 });
+    H.openTable({ table: ACCOUNTS_ID, limit: 1 });
     cy.findAllByRole("gridcell")
       .eq(CANCELLED_AT_INDEX)
       .should("have.text", "")
       .click({ force: true });
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Filter by this date").should("be.visible");
       cy.findByText("Is empty").should("be.visible");
       cy.findByText("Not empty").should("be.visible").click();

--- a/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
@@ -1,20 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  createQuestion,
-  getTableId,
-  openOrdersTable,
-  openPeopleTable,
-  openProductsTable,
-  popover,
-  resetTestTable,
-  restore,
-  resyncDatabase,
-  tableHeaderClick,
-  visitPublicDashboard,
-  visitPublicQuestion,
-  visitQuestionAdhoc,
-} from "e2e/support/helpers";
 
 const {
   ORDERS,
@@ -51,7 +37,7 @@ const TEST_PEOPLE_QUESTION = {
 
 describe("scenarios > question > object details", { tags: "@slow" }, () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -105,7 +91,7 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
       },
     };
 
-    createQuestion(questionDetails, { visitQuestion: true });
+    H.createQuestion(questionDetails, { visitQuestion: true });
     cy.findByTestId("question-row-count").should("have.text", "Showing 2 rows");
 
     cy.log("Check object details for the first row");
@@ -152,7 +138,7 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
       },
     };
 
-    createQuestion(questionDetails, { visitQuestion: true });
+    H.createQuestion(questionDetails, { visitQuestion: true });
 
     cy.findByRole("gridcell", { name: "3" }).should("be.visible").click();
 
@@ -185,7 +171,7 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
   });
 
   it("calculates a row after scrolling correctly (metabase#48323)", () => {
-    openOrdersTable();
+    H.openOrdersTable();
     cy.get(".ReactVirtualized__Grid").eq(1).scrollTo(0, 15000);
     cy.icon("expand").first().click();
     cy.findByRole("dialog")
@@ -195,7 +181,7 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
   });
 
   it("handles browsing records by FKs (metabase#21756)", () => {
-    openOrdersTable();
+    H.openOrdersTable();
 
     drillFK({ id: 1 });
 
@@ -248,7 +234,7 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
     const PRODUCT_ID = 7;
     const EXPECTED_LINKED_ORDERS_COUNT = 92;
     const EXPECTED_LINKED_REVIEWS_COUNT = 8;
-    openProductsTable();
+    H.openProductsTable();
 
     drillPK({ id: 5 });
 
@@ -281,7 +267,7 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
   it("should fetch linked entities data only once per entity type when reopening the modal (metabase#32720)", () => {
     cy.intercept("POST", "/api/dataset", cy.spy().as("fetchDataset"));
 
-    openProductsTable();
+    H.openProductsTable();
     cy.get("@fetchDataset").should("have.callCount", 1);
 
     drillPK({ id: 5 });
@@ -297,7 +283,7 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
   });
 
   it("should not offer drill-through on the object detail records (metabase#20560)", () => {
-    openPeopleTable({ limit: 2 });
+    H.openPeopleTable({ limit: 2 });
 
     drillPK({ id: 2 });
     cy.url().should("contain", "objectId=2");
@@ -320,7 +306,7 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
       semantic_type: "type/PK",
     });
 
-    openProductsTable({ limit: 5 });
+    H.openProductsTable({ limit: 5 });
 
     cy.findByTestId("TableInteractive-root")
       .findByTextEnsureVisible("Rustic Paper Wallet")
@@ -364,7 +350,7 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
         type: "query",
       },
     };
-    visitQuestionAdhoc(questionDetails);
+    H.visitQuestionAdhoc(questionDetails);
 
     cy.findByTestId("object-detail");
 
@@ -382,7 +368,7 @@ function drillPK({ id }) {
 
 function drillFK({ id }) {
   cy.get(".test-Table-FK").contains(id).first().click();
-  popover().findByText("View details").click();
+  H.popover().findByText("View details").click();
 }
 
 function assertDetailView({ id, entityName, byFK = false }) {
@@ -413,8 +399,8 @@ function getNextObjectDetailButton() {
 
 function changeSorting(columnName, direction) {
   const icon = direction === "asc" ? "arrow_up" : "arrow_down";
-  tableHeaderClick(columnName);
-  popover().within(() => {
+  H.tableHeaderClick(columnName);
+  H.popover().within(() => {
     cy.icon(icon).click();
   });
   cy.wait("@dataset");
@@ -428,14 +414,14 @@ function changeSorting(columnName, direction) {
       const TEST_TABLE = "composite_pk_table";
 
       beforeEach(() => {
-        resetTestTable({ type: dialect, table: TEST_TABLE });
-        restore(`${dialect}-writable`);
+        H.resetTestTable({ type: dialect, table: TEST_TABLE });
+        H.restore(`${dialect}-writable`);
         cy.signInAsAdmin();
-        resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: TEST_TABLE });
+        H.resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: TEST_TABLE });
       });
 
       it("can show object detail modal for items with composite keys", () => {
-        getTableId({ name: TEST_TABLE }).then(tableId => {
+        H.getTableId({ name: TEST_TABLE }).then(tableId => {
           cy.visit(`/question#?db=${WRITABLE_DB_ID}&table=${tableId}`);
         });
 
@@ -452,7 +438,7 @@ function changeSorting(columnName, direction) {
         // this bug only manifests on tables without single integer primary keys
         // it is also reproducible on tables with string keys
 
-        getTableId({ name: TEST_TABLE }).then(tableId => {
+        H.getTableId({ name: TEST_TABLE }).then(tableId => {
           cy.visit(`/question#?db=${WRITABLE_DB_ID}&table=${tableId}`);
         });
 
@@ -481,14 +467,14 @@ function changeSorting(columnName, direction) {
       const TEST_TABLE = "no_pk_table";
 
       beforeEach(() => {
-        resetTestTable({ type: dialect, table: TEST_TABLE });
-        restore(`${dialect}-writable`);
+        H.resetTestTable({ type: dialect, table: TEST_TABLE });
+        H.restore(`${dialect}-writable`);
         cy.signInAsAdmin();
-        resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: TEST_TABLE });
+        H.resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: TEST_TABLE });
       });
 
       it("can show object detail modal for items with no primary key", () => {
-        getTableId({ name: TEST_TABLE }).then(tableId => {
+        H.getTableId({ name: TEST_TABLE }).then(tableId => {
           cy.visit(`/question#?db=${WRITABLE_DB_ID}&table=${tableId}`);
         });
 
@@ -506,14 +492,14 @@ function changeSorting(columnName, direction) {
 
 describe("Object Detail > public", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("can view a public object detail question", () => {
     cy.createQuestion({ ...TEST_QUESTION, display: "object" }).then(
       ({ body: { id: questionId } }) => {
-        visitPublicQuestion(questionId);
+        H.visitPublicQuestion(questionId);
       },
     );
     cy.icon("warning").should("not.exist");
@@ -532,7 +518,7 @@ describe("Object Detail > public", () => {
     cy.createQuestionAndDashboard({
       questionDetails: { ...TEST_QUESTION, display: "object" },
     }).then(({ body: { dashboard_id } }) => {
-      visitPublicDashboard(dashboard_id);
+      H.visitPublicDashboard(dashboard_id);
     });
 
     cy.icon("warning").should("not.exist");

--- a/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
@@ -1,26 +1,6 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  createQuestion,
-  dashboardCards,
-  dragField,
-  getIframeBody,
-  getNotebookStep,
-  leftSidebar,
-  main,
-  modal,
-  openNotebook,
-  openSharingMenu,
-  openStaticEmbeddingModal,
-  popover,
-  queryBuilderMain,
-  restore,
-  sidebar,
-  visitDashboard,
-  visitIframe,
-  visitQuestion,
-  visitQuestionAdhoc,
-} from "e2e/support/helpers";
 import { PIVOT_TABLE_BODY_LABEL } from "metabase/visualizations/visualizations/PivotTable/constants";
 
 const {
@@ -43,13 +23,13 @@ const TEST_CASES = [
 
 describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/card").as("createCard");
   });
 
   it("should be created from an ad-hoc question", () => {
-    visitQuestionAdhoc({ dataset_query: testQuery, display: "pivot" });
+    H.visitQuestionAdhoc({ dataset_query: testQuery, display: "pivot" });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Count by Users? → Source and Products? → Category/); // ad-hoc title
@@ -78,7 +58,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
 
     // Switch to "ordinary" table
     cy.findByTestId("view-footer").findByText("Visualization").click();
-    sidebar().icon("table2").should("be.visible").click();
+    H.sidebar().icon("table2").should("be.visible").click();
 
     cy.findByTestId("app-bar").within(() => {
       cy.findByText("Started from");
@@ -122,7 +102,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Doohickey").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    popover().within(() => cy.findByText("=").click());
+    H.popover().within(() => cy.findByText("=").click());
     // filter is applied
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Product → Category is Doohickey");
@@ -130,7 +110,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Affiliate").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    popover().within(() => cy.findByText("≠").click());
+    H.popover().within(() => cy.findByText("≠").click());
     // filter is applied and value is gone from the left header
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("User → Source is not Affiliate");
@@ -150,7 +130,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
     assertOnPivotSettings();
 
     // Drag the second aggregate (Product category) from table columns to table rows
-    dragField(1, 0);
+    H.dragField(1, 0);
 
     // One field should now be empty
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -168,7 +148,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
 
   it("should be able to use binned numeric dimension as a grouping (metabase#14136)", () => {
     // Sample database Orders > Count by Subtotal: Auto binned
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "query",
         query: {
@@ -203,7 +183,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
     ];
     const b3 = ["field", PEOPLE.SOURCE, { "source-field": ORDERS.USER_ID }];
 
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "query",
         query: {
@@ -288,7 +268,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
       },
     };
 
-    visitQuestionAdhoc(questionDetails);
+    H.visitQuestionAdhoc(questionDetails);
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("1162").should("be.visible");
     // Collapse "User ID" column
@@ -307,7 +287,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
   });
 
   it("should allow hiding subtotals", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: testQuery,
       display: "pivot",
       visualization_settings: {
@@ -345,7 +325,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
 
   it("should uncollapse a value when hiding the subtotals", () => {
     const rows = ["SOURCE", "CATEGORY"];
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: testQuery,
       display: "pivot",
       visualization_settings: {
@@ -374,7 +354,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
   });
 
   it("should allow column formatting", () => {
-    visitQuestionAdhoc({ dataset_query: testQuery, display: "pivot" });
+    H.visitQuestionAdhoc({ dataset_query: testQuery, display: "pivot" });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Count by Users? → Source and Products? → Category/); // ad-hoc title
@@ -397,7 +377,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
   });
 
   it("should allow value formatting", () => {
-    visitQuestionAdhoc({ dataset_query: testQuery, display: "pivot" });
+    H.visitQuestionAdhoc({ dataset_query: testQuery, display: "pivot" });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Count by Users? → Source and Products? → Category/); // ad-hoc title
@@ -427,7 +407,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
   });
 
   it("should not allow sorting of value fields", () => {
-    visitQuestionAdhoc({ dataset_query: testQuery, display: "pivot" });
+    H.visitQuestionAdhoc({ dataset_query: testQuery, display: "pivot" });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Count by Users? → Source and Products? → Category/); // ad-hoc title
@@ -444,7 +424,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
     // Pivot by a single column with many values (100 bins).
     // Having many values hides values that are sorted to the end.
     // This lets us assert on presence of a certain value.
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "query",
         query: {
@@ -480,7 +460,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
   });
 
   it("should display an error message for native queries", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "native",
         native: { query: "select 1", "template-tags": {} },
@@ -496,7 +476,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
 
   describe("custom columns (metabase#14604)", () => {
     it("should work with custom columns as values", () => {
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           database: SAMPLE_DB_ID,
           query: {
@@ -537,7 +517,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
     });
 
     it("should work with custom columns as pivoted columns", () => {
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           type: "query",
           query: {
@@ -583,9 +563,9 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
           size_x: 3,
           size_y: 3,
         },
-      }).then(({ body: { dashboard_id } }) => visitDashboard(dashboard_id));
+      }).then(({ body: { dashboard_id } }) => H.visitDashboard(dashboard_id));
 
-      dashboardCards()
+      H.dashboardCards()
         .eq(0)
         .within(() => {
           cy.findByText("Doohickey").scrollIntoView().should("be.visible");
@@ -606,13 +586,13 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
           size_x: 16,
           size_y: 8,
         },
-      }).then(({ body: { dashboard_id } }) => visitDashboard(dashboard_id));
+      }).then(({ body: { dashboard_id } }) => H.visitDashboard(dashboard_id));
 
       assertOnPivotFields();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Google").click(); // open drill-through menu
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      popover().within(() => cy.findByText("=").click()); // drill with additional filter
+      H.popover().within(() => cy.findByText("=").click()); // drill with additional filter
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("User → Source is Google"); // filter was added
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -659,7 +639,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
           enable_embedding: true,
         });
 
-        visitQuestion(card_id);
+        H.visitQuestion(card_id);
       });
     });
 
@@ -674,12 +654,12 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
         it("should display pivot table in a public link", () => {
           cy.findByTestId("pivot-table").should("be.visible");
           if (test.case === "question") {
-            openSharingMenu();
-            modal().within(() => {
+            H.openSharingMenu();
+            H.modal().within(() => {
               cy.findByText("Save").click();
             });
           }
-          openSharingMenu(/public link/i);
+          H.openSharingMenu(/public link/i);
           cy.findByTestId("public-link-popover-content")
             .findByTestId("public-link-input")
             .invoke("val")
@@ -697,25 +677,25 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
           // we use preview endpoints when MB is iframed in itself
           // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText(test.subject);
-          getIframeBody().within(assertOnPivotFields);
+          H.getIframeBody().within(assertOnPivotFields);
         });
 
         it("should display pivot table in an embed URL", () => {
           cy.findByTestId("pivot-table").should("be.visible");
           if (test.case === "question") {
-            openSharingMenu();
-            modal().within(() => {
+            H.openSharingMenu();
+            H.modal().within(() => {
               cy.findByText("Save").click();
             });
           }
 
-          openStaticEmbeddingModal({
+          H.openStaticEmbeddingModal({
             activeTab: "parameters",
             confirmSave: test.confirmSave,
           });
 
           // visit the iframe src directly to ensure it's not sing preview endpoints
-          visitIframe();
+          H.visitIframe();
 
           cy.findByTestId("embed-frame-header").contains(test.subject);
           assertOnPivotFields();
@@ -727,7 +707,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
   it("should open the download popover (metabase#14750)", () => {
     createTestQuestion();
     cy.icon("download").click();
-    popover().within(() =>
+    H.popover().within(() =>
       cy.findAllByText("Download").should("have.length", 2),
     );
   });
@@ -751,7 +731,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
       visualization_settings: {},
     }).then(({ body: { id: QUESTION_ID } }) => {
       cy.signIn("nodata");
-      visitQuestion(QUESTION_ID);
+      H.visitQuestion(QUESTION_ID);
     });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -782,7 +762,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
       ],
     });
 
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         database: SAMPLE_DB_ID,
         query: {
@@ -800,7 +780,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Visualization").click();
-    leftSidebar().within(() => {
+    H.leftSidebar().within(() => {
       // This part is still failing. Uncomment when fixed.
       // cy.findByText("Pivot Table")
       //   .parent()
@@ -817,7 +797,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
   });
 
   it("should show stand-alone row values in grouping when rows are collapsed (metabase#15211)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "query",
         query: {
@@ -874,7 +854,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
   });
 
   it("should not show subtotals for flat tables", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "query",
         query: {
@@ -907,7 +887,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
   });
 
   it("should apply conditional formatting", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "query",
         query: {
@@ -980,18 +960,18 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
       display: "pivot",
     };
 
-    visitQuestionAdhoc(questionDetails);
+    H.visitQuestionAdhoc(questionDetails);
 
     cy.findByTextEnsureVisible("Created At: Year");
     cy.findByTextEnsureVisible("Row totals");
 
     assertTopMostRowTotalValue("149");
 
-    openNotebook();
+    H.openNotebook();
 
     cy.findByTextEnsureVisible("Sort").click();
 
-    popover().contains("Count").click();
+    H.popover().contains("Count").click();
     cy.wait("@pivotDataset");
 
     cy.button("Visualize").click();
@@ -1055,17 +1035,17 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
       },
     }).then(({ body: { dashboard_id }, questionId }) => {
       cy.wrap(questionId).as("questionId");
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
     });
 
-    dashboardCards().within(() => {
+    H.dashboardCards().within(() => {
       cy.findByLabelText(PIVOT_TABLE_BODY_LABEL).scrollTo(10000, 0);
       cy.findByText("Row totals").should("be.visible");
     });
 
-    cy.get("@questionId").then(id => visitQuestion(id));
+    cy.get("@questionId").then(id => H.visitQuestion(id));
 
-    queryBuilderMain().within(() => {
+    H.queryBuilderMain().within(() => {
       cy.findByLabelText(PIVOT_TABLE_BODY_LABEL).scrollTo(10000, 0);
       cy.findByText("Row totals").should("be.visible");
     });
@@ -1076,7 +1056,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
       textEl.closest("[data-testid=pivot-table-cell]").width();
 
     it("should persist column sizes in visualization settings", () => {
-      visitQuestionAdhoc({ dataset_query: testQuery, display: "pivot" });
+      H.visitQuestionAdhoc({ dataset_query: testQuery, display: "pivot" });
       const leftHeaderColHandle = cy
         .findAllByTestId("pivot-table-resize-handle")
         .first();
@@ -1135,15 +1115,15 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
     });
 
     // confirm that it's loading
-    main().findByText("Doing science...").should("be.visible");
+    H.main().findByText("Doing science...").should("be.visible");
 
-    openNotebook();
+    H.openNotebook();
 
-    main().findByText("User → Source").click();
+    H.main().findByText("User → Source").click();
 
-    popover().findByText("Address").click();
+    H.popover().findByText("Address").click();
 
-    main().findByText("User → Address").should("be.visible");
+    H.main().findByText("User → Address").should("be.visible");
   });
 
   it("should return the same number of rows when running as an ad-hoc query vs a saved card (metabase#34278)", () => {
@@ -1160,7 +1140,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
       database: SAMPLE_DB_ID,
     };
 
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: query,
       display: "pivot",
       visualization_settings: {
@@ -1221,7 +1201,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
         },
       });
 
-      createQuestion(
+      H.createQuestion(
         {
           query: {
             "source-table": PRODUCTS_ID,
@@ -1251,7 +1231,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
 
     it("does not allow users with no table access to update pivot questions (metabase#37380)", () => {
       cy.signInAsNormalUser();
-      visitQuestion("@questionId");
+      H.visitQuestion("@questionId");
       cy.findByTestId("viz-settings-button").click();
       cy.findByLabelText("Show row totals").click();
 
@@ -1261,7 +1241,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
 
   describe("issue 38265", () => {
     beforeEach(() => {
-      createQuestion(
+      H.createQuestion(
         {
           query: {
             "source-table": ORDERS_ID,
@@ -1300,7 +1280,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
 
     it("correctly filters the query when zooming in on a **row** header (metabase#38265)", () => {
       cy.findByTestId("pivot-table").findByText("KS").click();
-      popover().findByText("Zoom in").click();
+      H.popover().findByText("Zoom in").click();
 
       cy.log("Filter pills");
       cy.findByTestId("filter-pill").should("have.text", "User → State is KS");
@@ -1314,7 +1294,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
   });
 
   it("should be possible to switch between notebook and simple views when pivot table is the visualization (metabase#39504)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         database: SAMPLE_DB_ID,
         query: {
@@ -1367,14 +1347,14 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
       .and("contain", "Sum of Total")
       .and("contain", "Grand totals");
 
-    openNotebook();
-    getNotebookStep("summarize")
+    H.openNotebook();
+    H.getNotebookStep("summarize")
       .should("be.visible")
       .and("contain", "Sum of Subtotal")
       .and("contain", "Sum of Total");
 
     // Close the notebook editor
-    openNotebook();
+    H.openNotebook();
     cy.findByTestId("pivot-table")
       .should("contain", "User → Source")
       .and("contain", "Sum of Subtotal")
@@ -1389,7 +1369,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
       { "base-type": "type/Text" },
     ];
 
-    createQuestion(
+    H.createQuestion(
       {
         display: "pivot",
         query: {
@@ -1508,7 +1488,7 @@ function dragColumnHeader(el, xDistance = 50) {
 }
 
 function openColumnSettings(columnName) {
-  sidebar()
+  H.sidebar()
     .findByText(columnName)
     .siblings("[data-testid$=settings-button]")
     .click();
@@ -1525,7 +1505,7 @@ function sortColumnResults(column, direction) {
     .findByTestId(`${column}-settings-button`)
     .click();
 
-  popover().icon(iconName).click();
+  H.popover().icon(iconName).click();
   // Click anywhere to dismiss the popover from UI
   cy.get("body").click("topLeft");
 

--- a/e2e/test/scenarios/visualizations-tabular/scalar.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/scalar.cy.spec.js
@@ -1,16 +1,12 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  restore,
-  visitDashboard,
-  visitQuestionAdhoc,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > visualizations > scalar", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -44,14 +40,14 @@ describe("scenarios > visualizations > scalar", () => {
           size_y: 4,
         },
       }).then(({ body: { dashboard_id } }) => {
-        visitDashboard(dashboard_id);
+        H.visitDashboard(dashboard_id);
         cy.findByText("1.5T");
       });
     });
   });
 
   it("should render date without time (metabase#7494)", () => {
-    visitQuestionAdhoc({
+    H.visitQuestionAdhoc({
       dataset_query: {
         type: "native",
         native: {

--- a/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
@@ -1,16 +1,7 @@
 import Color from "color";
 
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  cartesianChartCircle,
-  createNativeQuestion,
-  menu,
-  popover,
-  queryBuilderMain,
-  restore,
-  rightSidebar,
-  summarize,
-} from "e2e/support/helpers";
 import { colors } from "metabase/lib/colors";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -29,7 +20,7 @@ const AGGREGATIONS = [
 
 describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -55,7 +46,7 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
     // primary number
     cy.findByTestId("scalar-container").findByText("344");
     cy.findByTestId("chartsettings-sidebar").findByText("Count").click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findAllByRole("option").should("have.length", AGGREGATIONS.length);
 
       // selected should be highlighted
@@ -82,7 +73,7 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
     cy.findByTestId("chartsettings-sidebar")
       .findByText("Previous month")
       .click();
-    menu().findByText("Previous value").click();
+    H.menu().findByText("Previous value").click();
     cy.findByTestId("scalar-previous-value").within(() => {
       cy.findByText("vs. Mar:");
       cy.findByText("45,683.68");
@@ -92,7 +83,7 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
     cy.findByTestId("chartsettings-sidebar")
       .findByText("Previous value")
       .click();
-    menu().within(() => {
+    H.menu().within(() => {
       // should clamp over input to maxPeriodsAgo
       cy.get("input").click().type("100");
       cy.get("input").should("have.value", 48);
@@ -115,7 +106,7 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
 
     // static number
     cy.findByTestId("chartsettings-sidebar").findByText("3 months ago").click();
-    menu().within(() => {
+    H.menu().within(() => {
       cy.findByText("Custom value…").click();
 
       // Test the back button
@@ -132,7 +123,7 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
       cy.findByText("26.76%").should("exist"); // down percentage
     });
     cy.findByTestId("chartsettings-sidebar").findByText("(My Goal)").click();
-    menu().within(() => {
+    H.menu().within(() => {
       cy.findByLabelText("Back").should("exist");
       cy.findByLabelText("Label").should("have.value", "My Goal");
       cy.findByLabelText("Value").should("have.value", "42000");
@@ -140,9 +131,9 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
     });
 
     // another column
-    menu().findByText("Value from another column…").click();
-    popover().findByText("Mega Count").click();
-    menu().button("Done").click();
+    H.menu().findByText("Value from another column…").click();
+    H.popover().findByText("Mega Count").click();
+    H.menu().button("Done").click();
 
     cy.findByTestId("scalar-previous-value").within(() => {
       cy.findByText("vs. Mega Count:").should("exist");
@@ -151,9 +142,9 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
     });
 
     cy.findByTestId("chartsettings-sidebar").findByText("(Mega Count)").click();
-    menu().findByLabelText("Column").click();
-    popover().findByText("Count").click();
-    menu().button("Done").click();
+    H.menu().findByLabelText("Column").click();
+    H.popover().findByText("Count").click();
+    H.menu().button("Done").click();
 
     cy.findByTestId("scalar-previous-value").within(() => {
       cy.findByText("vs. Count:").should("exist");
@@ -188,7 +179,7 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
 
     cy.button("Add comparison").click();
     cy.findByTestId("comparison-list").children().should("have.length", 2);
-    menu().findByText("months ago").click();
+    H.menu().findByText("months ago").click();
     cy.findAllByTestId("scalar-previous-value")
       .children()
       .should("have.length", 2)
@@ -201,7 +192,7 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
 
     cy.button("Add comparison").click();
     cy.findByTestId("comparison-list").children().should("have.length", 3);
-    menu().findByText("Previous value").click();
+    H.menu().findByText("Previous value").click();
     cy.findAllByTestId("scalar-previous-value")
       .children()
       .should("have.length", 3)
@@ -275,7 +266,7 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
       cy.findByText("(Mega Count)").should("exist");
       cy.findByText("Count").click();
     });
-    popover().findByText("Mega Count").click();
+    H.popover().findByText("Mega Count").click();
 
     cy.findByTestId("scalar-value").should("have.text", "3,440,000");
     cy.findByTestId("scalar-previous-value").within(() => {
@@ -290,13 +281,13 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
     cy.findByTestId("chartsettings-sidebar")
       .findByText(/Custom value/)
       .click();
-    menu().button("Back").click();
-    menu().findByText("Value from another column…").click();
-    popover().findByText("Count").click();
-    popover().button("Done").click();
+    H.menu().button("Back").click();
+    H.menu().findByText("Value from another column…").click();
+    H.popover().findByText("Count").click();
+    H.popover().button("Done").click();
 
     cy.findByTestId("chartsettings-sidebar").findByText("Mega Count").click();
-    popover().findByText("Count").click();
+    H.popover().findByText("Count").click();
 
     cy.findByTestId("scalar-value").should("have.text", "344");
     cy.findByTestId("scalar-previous-value").within(() => {
@@ -308,17 +299,17 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
     cy.findByTestId("chartsettings-sidebar")
       .findByText("Previous month")
       .click();
-    menu().findByText("Value from another column…").click();
-    popover().findByText("Sum of Total").click();
-    popover().button("Done").click();
+    H.menu().findByText("Value from another column…").click();
+    H.popover().findByText("Sum of Total").click();
+    H.popover().button("Done").click();
 
     cy.findByTestId("chartsettings-sidebar").findByText("Count").click();
-    popover().findByText("Mega Count").click();
+    H.popover().findByText("Mega Count").click();
 
     // Removing the comparison column ("Sum of Total") from the query
     // The comparison should be reset to "previous period"
-    summarize();
-    rightSidebar().findByLabelText("Sum of Total").icon("close").click();
+    H.summarize();
+    H.rightSidebar().findByLabelText("Sum of Total").icon("close").click();
     cy.wait("@dataset");
 
     cy.findByTestId("scalar-value").should("have.text", "3,440,000");
@@ -330,7 +321,7 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
 
     // Removing the remaining numeric column, so only Count is left
     // to ensure we no longer offer the "Value from another column…" option
-    rightSidebar().within(() => {
+    H.rightSidebar().within(() => {
       cy.findByLabelText("Count").icon("close").click();
       cy.button("Done").click();
     });
@@ -341,7 +332,7 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
       cy.findByText("Sum of Total").should("not.exist");
       cy.findByText("Previous month").should("exist").click();
     });
-    menu().findByText("Value from another column…").should("not.exist");
+    H.menu().findByText("Value from another column…").should("not.exist");
   });
 
   it("should allow display settings to be changed and display should reflect changes", () => {
@@ -380,12 +371,12 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
     // style
     cy.findByTestId("scalar-container").findByText("344");
     cy.findByLabelText("Style").click();
-    popover().findByText("Percent").click();
+    H.popover().findByText("Percent").click();
     cy.findByTestId("scalar-container").findByText("34,400%");
 
     // separator style
     cy.findByLabelText("Separator style").click();
-    popover().findByText("100’000.00").click();
+    H.popover().findByText("100’000.00").click();
     cy.findByTestId("scalar-container").findByText("34’400%");
 
     // decimal places
@@ -409,7 +400,7 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
       cy.findByText("Data").click();
       cy.findByText("Count").click();
     });
-    popover().findByRole("option", { name: "Mega Count" }).click();
+    H.popover().findByRole("option", { name: "Mega Count" }).click();
     cy.findByTestId("chartsettings-sidebar").findByText("Display").click();
 
     cy.findByTestId("scalar-container").findByText("3,440,000");
@@ -451,7 +442,7 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
   });
 
   it("should gracefully handle errors (metabase#42948)", () => {
-    createNativeQuestion(
+    H.createNativeQuestion(
       {
         name: "42948",
         native: {
@@ -476,13 +467,13 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
 
     // check that error/warning is showing up
     cy.icon("warning").realHover();
-    queryBuilderMain().findByText(
+    H.queryBuilderMain().findByText(
       "No integer value supplied for periods ago comparison.",
     );
 
     // check that we can switch to the table view and the data is shown
     cy.findByLabelText("Switch to data").click();
-    queryBuilderMain().within(() => {
+    H.queryBuilderMain().within(() => {
       cy.findByText("CREATED_AT").should("be.visible");
       cy.findByText("V").should("be.visible");
     });
@@ -491,6 +482,6 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
     cy.findByTestId("viz-type-button").click();
     cy.findByTestId("Line-button").click();
     cy.icon("warning").should("not.exist");
-    cartesianChartCircle().should("have.length", 3);
+    H.cartesianChartCircle().should("have.length", 3);
   });
 });

--- a/e2e/test/scenarios/visualizations-tabular/table-column-settings.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table-column-settings.cy.spec.js
@@ -1,13 +1,7 @@
 import _ from "underscore";
 
+import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  openNotebook,
-  popover,
-  restore,
-  tableHeaderClick,
-  visualize,
-} from "e2e/support/helpers";
 
 const { ORDERS_ID, ORDERS, PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
@@ -221,7 +215,7 @@ const nestedQuestionWithJoinOnQuestion = card => ({
 
 describe("scenarios > visualizations > table column settings", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
@@ -356,9 +350,9 @@ describe("scenarios > visualizations > table column settings", () => {
     it("should be able to rename table columns via popover", () => {
       cy.createQuestion(tableQuestion, { visitQuestion: true });
 
-      tableHeaderClick("Product ID");
+      H.tableHeaderClick("Product ID");
 
-      popover().within(() => {
+      H.popover().within(() => {
         cy.icon("gear").click();
         cy.findByDisplayValue("Product ID").clear().type("prod_id");
       });
@@ -771,10 +765,10 @@ describe("scenarios > visualizations > table column settings", () => {
         cy.createQuestion(nestedQuestion(card), { visitQuestion: true });
       });
 
-      openNotebook();
+      H.openNotebook();
       cy.findByTestId("fields-picker").click();
-      popover().findByText("Tax").click();
-      visualize();
+      H.popover().findByText("Tax").click();
+      H.visualize();
 
       openSettings();
 

--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -1,61 +1,37 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  enterCustomColumnDetails,
-  entityPickerModal,
-  entityPickerModalTab,
-  expressionEditorWidget,
-  getTable,
-  hovercard,
-  isScrollableHorizontally,
-  leftSidebar,
-  moveDnDKitElement,
-  openNativeEditor,
-  openOrdersTable,
-  openPeopleTable,
-  popover,
-  resetTestTable,
-  restore,
-  resyncDatabase,
-  selectFilterOperator,
-  sidebar,
-  startNewNativeQuestion,
-  summarize,
-  tableHeaderClick,
-  visitQuestionAdhoc,
-  visualize,
-} from "e2e/support/helpers";
 
 describe("scenarios > visualizations > table", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("GET", "/api/field/*/search/*").as("findSuggestions");
   });
 
   function joinTable(table) {
     cy.findByText("Join data").click();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
       cy.findByText(table).click();
     });
   }
 
   function selectFromDropdown(option, clickOpts) {
-    popover().last().findByText(option).click(clickOpts);
+    H.popover().last().findByText(option).click(clickOpts);
   }
 
   it("should allow changing column title when the field ref is the same except for the join-alias", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
     joinTable("Orders");
     selectFromDropdown("ID");
     selectFromDropdown("User ID");
-    visualize();
+    H.visualize();
 
     // Rename the first ID column, and make sure the second one is not updated
-    tableHeaderClick("ID");
-    popover().within(() => {
+    H.tableHeaderClick("ID");
+    H.popover().within(() => {
       cy.findByText("Filter by this column");
       cy.icon("gear").click();
       cy.findByLabelText("Column title").type(" updated");
@@ -68,7 +44,7 @@ describe("scenarios > visualizations > table", () => {
   });
 
   it("should allow you to reorder and hide columns in the table header", () => {
-    openNativeEditor().type("select * from orders LIMIT 2");
+    H.openNativeEditor().type("select * from orders LIMIT 2");
     cy.findByTestId("native-query-editor-container").icon("play").click();
 
     cy.findByTestId("viz-settings-button").click();
@@ -90,18 +66,18 @@ describe("scenarios > visualizations > table", () => {
 
     headerCells().eq(1).should("contain.text", "TOTAL");
 
-    tableHeaderClick("QUANTITY");
-    popover().icon("eye_crossed_out").click();
+    H.tableHeaderClick("QUANTITY");
+    H.popover().icon("eye_crossed_out").click();
 
     headerCells().contains("QUANTITY").should("not.exist");
   });
 
   it("should allow to display any column as link with extrapolated url and text", () => {
-    openPeopleTable({ limit: 2 });
+    H.openPeopleTable({ limit: 2 });
 
-    tableHeaderClick("City");
+    H.tableHeaderClick("City");
 
-    popover().within(() => {
+    H.popover().within(() => {
       cy.icon("gear").click();
     });
 
@@ -136,12 +112,12 @@ describe("scenarios > visualizations > table", () => {
   it("should show field metadata in a hovercard when hovering over a table column header", () => {
     const ccName = "Foo";
 
-    openPeopleTable({ mode: "notebook", limit: 2 });
+    H.openPeopleTable({ mode: "notebook", limit: 2 });
 
     cy.findByLabelText("Custom column").click();
 
-    expressionEditorWidget().within(() => {
-      enterCustomColumnDetails({
+    H.expressionEditorWidget().within(() => {
+      H.enterCustomColumnDetails({
         formula: "concat([Name], [Name])",
         name: ccName,
       });
@@ -150,7 +126,7 @@ describe("scenarios > visualizations > table", () => {
     });
 
     cy.findByTestId("fields-picker").click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Select none").click();
       cy.findByText("City").click();
       cy.findByText("State").click();
@@ -161,7 +137,7 @@ describe("scenarios > visualizations > table", () => {
     // Click anywhere else to close the popover which is blocking the Visualize button
     cy.findByTestId("query-builder-root").click(0, 0);
 
-    visualize();
+    H.visualize();
 
     [
       [
@@ -231,21 +207,21 @@ describe("scenarios > visualizations > table", () => {
       // Add a delay here because there can be two popovers active for a very short time.
       cy.wait(250);
 
-      hovercard().within(() => {
+      H.hovercard().within(() => {
         test();
       });
 
       cy.get("[data-testid=cell-data]").contains(column).trigger("mouseout");
     });
 
-    summarize();
+    H.summarize();
 
     cy.findAllByTestId("dimension-list-item-name").contains(ccName).click();
 
     cy.wait("@dataset");
 
     cy.get("[data-testid=cell-data]").contains("Count").trigger("mouseover");
-    hovercard().within(() => {
+    H.hovercard().within(() => {
       cy.contains("Quantity");
       cy.findByText("No description");
     });
@@ -255,29 +231,29 @@ describe("scenarios > visualizations > table", () => {
     cy.get("[data-testid=cell-data]").contains(ccName).trigger("mouseover");
     cy.wait(250);
 
-    hovercard().within(() => {
+    H.hovercard().within(() => {
       cy.contains("No special type");
       cy.findByText("No description");
     });
   });
 
   it("should show the field metadata popover for a foreign key field (metabase#19577)", () => {
-    openOrdersTable({ limit: 2 });
+    H.openOrdersTable({ limit: 2 });
 
     cy.get("[data-testid=cell-data]")
       .contains("Product ID")
       .trigger("mouseover");
 
-    hovercard().within(() => {
+    H.hovercard().within(() => {
       cy.contains("Foreign Key");
       cy.contains("The product ID.");
     });
   });
 
   it("should show field metadata in a hovercard when hovering over a table column in the summarize sidebar", () => {
-    openOrdersTable({ limit: 2 });
+    H.openOrdersTable({ limit: 2 });
 
-    summarize();
+    H.summarize();
 
     cy.findAllByTestId("dimension-list-item")
       .contains("ID")
@@ -286,13 +262,13 @@ describe("scenarios > visualizations > table", () => {
         cy.findByLabelText("More info").realHover();
       });
 
-    hovercard().within(() => {
+    H.hovercard().within(() => {
       cy.contains("Entity Key");
     });
   });
 
   it("should show field metadata hovercards for native query tables", () => {
-    startNewNativeQuestion({ query: "select * from products limit 1" });
+    H.startNewNativeQuestion({ query: "select * from products limit 1" });
     cy.findByTestId("native-query-editor-container").icon("play").click();
 
     cy.log("Wait for the table to load");
@@ -302,17 +278,17 @@ describe("scenarios > visualizations > table", () => {
 
     cy.log("Assert");
     cy.findAllByTestId("header-cell").filter(":contains(CATEGORY)").realHover();
-    hovercard()
+    H.hovercard()
       .should("contain", "No special type")
       .and("contain", "No description");
   });
 
   it.skip("should close the colum popover on subsequent click (metabase#16789)", () => {
-    openPeopleTable({ limit: 2 });
+    H.openPeopleTable({ limit: 2 });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("City").click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.icon("arrow_up");
       cy.icon("arrow_down");
       cy.icon("gear");
@@ -326,28 +302,28 @@ describe("scenarios > visualizations > table", () => {
     // Although arbitrary waiting is considered an anti-pattern and a really bad practice, I couldn't find any other way to reproduce this issue.
     // Cypress is too fast and is doing the assertions in that split second while popover is reloading which results in a false positive result.
     cy.wait(100);
-    popover().should("not.exist");
+    H.popover().should("not.exist");
   });
 
   it("popover should not be scrollable horizontally (metabase#31339)", () => {
-    openPeopleTable();
-    tableHeaderClick("Password");
+    H.openPeopleTable();
+    H.tableHeaderClick("Password");
 
-    popover().findByText("Filter by this column").click();
-    selectFilterOperator("Is");
-    popover().within(() => {
+    H.popover().findByText("Filter by this column").click();
+    H.selectFilterOperator("Is");
+    H.popover().within(() => {
       cy.findByPlaceholderText("Search by Password").type("e");
       cy.wait("@findSuggestions");
       cy.findByPlaceholderText("Search by Password").blur();
     });
 
-    popover().then($popover => {
-      expect(isScrollableHorizontally($popover[0])).to.be.false;
+    H.popover().then($popover => {
+      expect(H.isScrollableHorizontally($popover[0])).to.be.false;
     });
   });
 
   it("should show the slow loading text when the query is taking too long", () => {
-    openOrdersTable({ mode: "notebook" });
+    H.openOrdersTable({ mode: "notebook" });
 
     cy.intercept("POST", "/api/dataset", req => {
       req.on("response", res => {
@@ -369,10 +345,10 @@ describe("scenarios > visualizations > table", () => {
 describe("scenarios > visualizations > table > conditional formatting", () => {
   describe("rules", () => {
     beforeEach(() => {
-      restore();
+      H.restore();
       cy.signInAsAdmin();
 
-      visitQuestionAdhoc({
+      H.visitQuestionAdhoc({
         dataset_query: {
           database: SAMPLE_DB_ID,
           query: {
@@ -414,7 +390,7 @@ describe("scenarios > visualizations > table > conditional formatting", () => {
       });
 
       cy.findByTestId("viz-settings-button").click();
-      sidebar().findByText("Conditional Formatting").click();
+      H.sidebar().findByText("Conditional Formatting").click();
     });
 
     it("should be able to remove, add, and re-order rows", () => {
@@ -432,15 +408,15 @@ describe("scenarios > visualizations > table > conditional formatting", () => {
 
       cy.findByRole("button", { name: /add a rule/i }).click();
       // popover should open automatically
-      popover().findByText("Subtotal").click();
+      H.popover().findByText("Subtotal").click();
       cy.realPress("Escape");
       cy.findByRole("button", { name: /is equal to/i }).click();
-      popover().findByText("is less than").click();
+      H.popover().findByText("is less than").click();
 
       cy.findByTestId("conditional-formatting-value-input").type("20");
       cy.findByTestId("conditional-formatting-color-selector").click();
 
-      popover()
+      H.popover()
         .findByRole("generic", { name: /#F2A86F/i })
         .click();
 
@@ -450,7 +426,7 @@ describe("scenarios > visualizations > table > conditional formatting", () => {
         .first()
         .should("contain.text", "is less than 20");
 
-      moveDnDKitElement(cy.findAllByTestId("formatting-rule-preview").eq(2), {
+      H.moveDnDKitElement(cy.findAllByTestId("formatting-rule-preview").eq(2), {
         vertical: -300,
       });
 
@@ -462,54 +438,56 @@ describe("scenarios > visualizations > table > conditional formatting", () => {
 
   describe("operators", () => {
     beforeEach(() => {
-      resetTestTable({ type: "postgres", table: "many_data_types" });
-      restore("postgres-writable");
+      H.resetTestTable({ type: "postgres", table: "many_data_types" });
+      H.restore("postgres-writable");
       cy.signInAsAdmin();
-      resyncDatabase({
+      H.resyncDatabase({
         dbId: WRITABLE_DB_ID,
         tableName: "many_data_types",
       });
 
-      getTable({ name: "many_data_types" }).then(({ id: tableId, fields }) => {
-        const booleanField = fields.find(field => field.name === "boolean");
-        const stringField = fields.find(field => field.name === "string");
-        const idField = fields.find(field => field.name === "id");
+      H.getTable({ name: "many_data_types" }).then(
+        ({ id: tableId, fields }) => {
+          const booleanField = fields.find(field => field.name === "boolean");
+          const stringField = fields.find(field => field.name === "string");
+          const idField = fields.find(field => field.name === "id");
 
-        visitQuestionAdhoc({
-          dataset_query: {
-            database: WRITABLE_DB_ID,
-            query: {
-              "source-table": tableId,
-              fields: [
-                ["field", idField.id, { "base-type": idField["base_type"] }],
-                [
-                  "field",
-                  stringField.id,
-                  { "base-type": stringField["base_type"] },
+          H.visitQuestionAdhoc({
+            dataset_query: {
+              database: WRITABLE_DB_ID,
+              query: {
+                "source-table": tableId,
+                fields: [
+                  ["field", idField.id, { "base-type": idField["base_type"] }],
+                  [
+                    "field",
+                    stringField.id,
+                    { "base-type": stringField["base_type"] },
+                  ],
+                  [
+                    "field",
+                    booleanField.id,
+                    { "base-type": booleanField["base_type"] },
+                  ],
                 ],
-                [
-                  "field",
-                  booleanField.id,
-                  { "base-type": booleanField["base_type"] },
-                ],
-              ],
+              },
+              type: "query",
             },
-            type: "query",
-          },
-          display: "table",
-        });
-      });
+            display: "table",
+          });
+        },
+      );
     });
 
     it("should work with boolean columns", { tags: ["@external"] }, () => {
       cy.findByTestId("viz-settings-button").click();
-      leftSidebar().findByText("Conditional Formatting").click();
+      H.leftSidebar().findByText("Conditional Formatting").click();
       cy.findByRole("button", { name: /add a rule/i }).click();
 
-      popover().findByRole("option", { name: "Boolean" }).click();
+      H.popover().findByRole("option", { name: "Boolean" }).click();
 
       //Dismiss popover
-      leftSidebar().findByText("Which columns should be affected?").click();
+      H.leftSidebar().findByText("Which columns should be affected?").click();
 
       //Check that is-true was applied by default to boolean field rule
       cy.findByTestId("conditional-formatting-value-operator-button").should(
@@ -536,7 +514,7 @@ describe("scenarios > visualizations > table > time formatting (#11398)", () => 
   `;
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
@@ -552,9 +530,9 @@ describe("scenarios > visualizations > table > time formatting (#11398)", () => 
     );
 
     // Open the formatting menu
-    tableHeaderClick("CREATION_TIME");
+    H.tableHeaderClick("CREATION_TIME");
 
-    popover().icon("gear").click();
+    H.popover().icon("gear").click();
 
     cy.findByTestId("column-formatting-settings").within(() => {
       // Set to hours, minutes, seconds, 24-hour clock

--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -1,36 +1,7 @@
+import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ADMIN_USER_ID } from "e2e/support/cypress_sample_instance_data";
-import {
-  assertEChartsTooltip,
-  cartesianChartCircle,
-  createNativeQuestion,
-  createQuestion,
-  focusNativeEditor,
-  getDashboardCard,
-  getDraggableElements,
-  getNotebookStep,
-  leftSidebar,
-  main,
-  modal,
-  moveDnDKitElement,
-  openNotebook,
-  openOrdersTable,
-  popover,
-  queryBuilderHeader,
-  restore,
-  rightSidebar,
-  runNativeQuery,
-  sidebar,
-  startNewNativeQuestion,
-  summarize,
-  tableInteractive,
-  visitDashboard,
-  visitQuestion,
-  visitQuestionAdhoc,
-  visualize,
-  withDatabase,
-} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PEOPLE, PEOPLE_ID, PRODUCTS, PRODUCTS_ID } =
   SAMPLE_DATABASE;
@@ -66,7 +37,7 @@ describe("issue 6010", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
@@ -74,11 +45,11 @@ describe("issue 6010", () => {
   it("should apply the filter from a metric when drilling through (metabase#6010)", () => {
     createMetric()
       .then(({ body: { id } }) => createQuestion(id))
-      .then(({ body: { id } }) => visitQuestion(id));
+      .then(({ body: { id } }) => H.visitQuestion(id));
 
-    cartesianChartCircle().eq(0).click();
+    H.cartesianChartCircle().eq(0).click();
 
-    popover().findByText("See these Orders").click();
+    H.popover().findByText("See these Orders").click();
     cy.wait("@dataset");
 
     cy.findByTestId("qb-filters-panel").within(() => {
@@ -108,12 +79,12 @@ describe("issue 11249", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should not allow adding more series when all columns are used (metabase#11249)", () => {
-    visitQuestionAdhoc(questionDetails);
+    H.visitQuestionAdhoc(questionDetails);
 
     cy.findByTestId("viz-settings-button").click();
 
@@ -151,18 +122,18 @@ describe("issue 11435", () => {
     },
   };
   const hoverLineDot = ({ index } = {}) => {
-    cartesianChartCircle().eq(index).realHover();
+    H.cartesianChartCircle().eq(index).realHover();
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should use time formatting settings in tooltips for native questions (metabase#11435)", () => {
     cy.createNativeQuestion(questionDetails, { visitQuestion: true });
     hoverLineDot({ index: 1 });
-    assertEChartsTooltip({
+    H.assertEChartsTooltip({
       header: "March 11, 2025, 8:45:17.010 PM",
       rows: [
         {
@@ -189,7 +160,7 @@ describe("issue 15353", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset/pivot").as("pivotDataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestion(questionDetails, { visitQuestion: true });
@@ -197,7 +168,7 @@ describe("issue 15353", () => {
 
   it("should be able to change field name used for values (metabase#15353)", () => {
     cy.findByTestId("viz-settings-button").click();
-    sidebar()
+    H.sidebar()
       .contains("Count")
       .siblings("[data-testid$=settings-button]")
       .click();
@@ -232,12 +203,12 @@ describe("issue 18976, 18817", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should display a pivot table as regular one when pivot columns are missing (metabase#18976)", () => {
-    visitQuestionAdhoc(questionDetails);
+    H.visitQuestionAdhoc(questionDetails);
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 1 row");
@@ -262,7 +233,7 @@ describe("issue 18976, 18817", () => {
     );
 
     cy.findByTestId("qb-header").button("Summarize").click();
-    rightSidebar()
+    H.rightSidebar()
       .findByLabelText("Source")
       .findByRole("button", { name: "Remove dimension" })
       .click();
@@ -304,7 +275,7 @@ describe("issue 18996", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -312,10 +283,10 @@ describe("issue 18996", () => {
     cy.createNativeQuestionAndDashboard({
       questionDetails,
     }).then(({ body: { dashboard_id } }) => {
-      visitDashboard(dashboard_id);
+      H.visitDashboard(dashboard_id);
     });
 
-    getDashboardCard().within(() => {
+    H.getDashboardCard().within(() => {
       cy.findByText(/Rows \d+-\d+ of 10/).should("be.visible");
       cy.icon("chevronright").click();
       cy.findByText(/Rows \d+-\d+ of 10/).should("be.visible");
@@ -342,7 +313,7 @@ describe.skip("issue 19373", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset/pivot").as("pivotDataset");
 
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.createQuestion(questiondDetails, { visitQuestion: true });
@@ -399,12 +370,12 @@ describe("issue 21392", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
   it("should render a chart with many columns without freezing (metabase#21392)", () => {
-    visitQuestionAdhoc({ dataset_query: TEST_QUERY, display: "line" });
+    H.visitQuestionAdhoc({ dataset_query: TEST_QUERY, display: "line" });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Visualization").should("be.visible");
   });
@@ -412,9 +383,9 @@ describe("issue 21392", () => {
 
 describe("#22206 adding and removing columns doesn't duplicate columns", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
-    openOrdersTable();
+    H.openOrdersTable();
 
     cy.findByTestId("loading-indicator").should("not.exist");
   });
@@ -472,7 +443,7 @@ describe("issue 23076", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
     cy.request("PUT", `/api/user/${ADMIN_USER_ID}`, {
@@ -538,10 +509,10 @@ describe("issue 28304", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    visitQuestionAdhoc(questionDetails);
+    H.visitQuestionAdhoc(questionDetails);
   });
 
   it("table should should generate default columns when table.columns entries do not match data.cols (metabase#28304)", () => {
@@ -549,11 +520,11 @@ describe("issue 28304", () => {
     cy.findByText("Count by Created At: Month").should("be.visible");
 
     cy.findByTestId("viz-settings-button").click();
-    leftSidebar().should("not.contain", "[Unknown]");
-    leftSidebar().should("contain", "Created At");
-    leftSidebar().should("contain", "Count");
+    H.leftSidebar().should("not.contain", "[Unknown]");
+    H.leftSidebar().should("contain", "Created At");
+    H.leftSidebar().should("contain", "Count");
     cy.findAllByTestId("mini-bar").should("have.length.greaterThan", 0);
-    getDraggableElements().should("have.length", 2);
+    H.getDraggableElements().should("have.length", 2);
   });
 });
 
@@ -599,10 +570,10 @@ describe("issue 25250", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
 
-    visitQuestionAdhoc(questionDetails);
+    H.visitQuestionAdhoc(questionDetails);
   });
 
   it("pivot table should show standalone values when collapsed to the sub-level grouping (metabase#25250)", () => {
@@ -610,23 +581,23 @@ describe("issue 25250", () => {
     cy.findByText("Product ID").should("be.visible");
 
     cy.findByTestId("viz-settings-button").click();
-    moveDnDKitElement(getDraggableElements().contains("Product ID"), {
+    H.moveDnDKitElement(H.getDraggableElements().contains("Product ID"), {
       vertical: -100,
     });
-    getDraggableElements().eq(0).should("contain", "Product ID");
+    H.getDraggableElements().eq(0).should("contain", "Product ID");
   });
 });
 
 describe("issue 30039", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should not trigger object detail navigation after the modal was closed (metabase#30039)", () => {
-    startNewNativeQuestion();
-    focusNativeEditor().as("editor").type("select * from ORDERS LIMIT 2");
-    runNativeQuery();
+    H.startNewNativeQuestion();
+    H.focusNativeEditor().as("editor").type("select * from ORDERS LIMIT 2");
+    H.runNativeQuery();
     cy.findAllByTestId("detail-shortcut").first().click();
     cy.findByTestId("object-detail").should("be.visible");
 
@@ -634,7 +605,7 @@ describe("issue 30039", () => {
     cy.findByTestId("object-detail").should("not.exist");
 
     cy.get("@editor").type("{downArrow};");
-    runNativeQuery();
+    H.runNativeQuery();
     cy.findByTestId("object-detail").should("not.exist");
   });
 });
@@ -671,7 +642,7 @@ describe("issue 37726", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
@@ -700,7 +671,7 @@ describe("issue 37726", () => {
     // Note that before this fix, the page would error out and this elements,
     // along with the rest of the pivot table, would not appear.
     // Instead, you got a nice ⚠️ icon and a "Something's gone wrong" tooltip.
-    main().within(() => {
+    H.main().within(() => {
       cy.findByText("Product → Category");
     });
   });
@@ -709,7 +680,7 @@ describe("issue 37726", () => {
 // unskip once metabase#42049 is addressed
 describe.skip("issue 42049", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -724,7 +695,7 @@ describe.skip("issue 42049", () => {
       });
     }).as("cardQuery");
 
-    createQuestion(
+    H.createQuestion(
       {
         query: {
           "source-table": ORDERS_ID,
@@ -826,24 +797,24 @@ describe("issue 42697", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("PUT", "/api/card/*").as("updateCard");
   });
 
   it("should display a pivot table when a new breakout is added to the query (metabase#42697)", () => {
-    createQuestion(PIVOT_QUESTION, { visitQuestion: true });
-    openNotebook();
-    getNotebookStep("summarize")
+    H.createQuestion(PIVOT_QUESTION, { visitQuestion: true });
+    H.openNotebook();
+    H.getNotebookStep("summarize")
       .findByTestId("breakout-step")
       .icon("add")
       .click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Product").click();
       cy.findByText("Category").click();
     });
-    queryBuilderHeader().findByText("Save").click();
-    modal().button("Save").click();
+    H.queryBuilderHeader().findByText("Save").click();
+    H.modal().button("Save").click();
     cy.wait("@updateCard");
     cy.button("Visualize").click();
     cy.findByTestId("pivot-table")
@@ -856,13 +827,13 @@ describe("issue 14148", { tags: "@external" }, () => {
   const PG_DB_ID = 2;
 
   beforeEach(() => {
-    restore("postgres-12");
+    H.restore("postgres-12");
     cy.signInAsAdmin();
   });
 
   it("postgres should display pivot tables (metabase#14148)", () => {
-    withDatabase(PG_DB_ID, ({ PEOPLE, PEOPLE_ID }) =>
-      visitQuestionAdhoc(
+    H.withDatabase(PG_DB_ID, ({ PEOPLE, PEOPLE_ID }) =>
+      H.visitQuestionAdhoc(
         {
           display: "pivot",
           dataset_query: {
@@ -898,7 +869,7 @@ describe("issue 14148", { tags: "@external" }, () => {
 
 describe.skip("issue 25415", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
   });
 
@@ -934,7 +905,7 @@ describe.skip("issue 25415", () => {
 
     cy.get(".dc-tooltip-list").get(".dot").first().click({ force: true });
 
-    popover().findByText("See these Orders").click();
+    H.popover().findByText("See these Orders").click();
 
     // filter gets applied
     cy.findByTestId("qb-filters-panel").should("contain", "Product ID is 1");
@@ -972,14 +943,14 @@ describe("issue 7884", () => {
   });
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should not reset the column order after one of the columns is removed from data source (metabase#7884)", () => {
-    createNativeQuestion(oldSourceQuestionDetails).then(
+    H.createNativeQuestion(oldSourceQuestionDetails).then(
       ({ body: sourceQuestion }) =>
-        createQuestion(getNestedQuestionDetails(sourceQuestion.id)).then(
+        H.createQuestion(getNestedQuestionDetails(sourceQuestion.id)).then(
           ({ body: nestedQuestion }) => {
             cy.request("PUT", `/api/card/${sourceQuestion.id}`, {
               ...sourceQuestion,
@@ -988,7 +959,7 @@ describe("issue 7884", () => {
                 native: newSourceQuestionDetails.native,
               },
             });
-            visitQuestion(nestedQuestion.id);
+            H.visitQuestion(nestedQuestion.id);
           },
         ),
     );
@@ -999,35 +970,35 @@ describe("issue 7884", () => {
 
     cy.log("verify column order in viz settings");
     cy.findByTestId("viz-settings-button").click();
-    getDraggableElements().eq(0).should("contain.text", "C3");
-    getDraggableElements().eq(1).should("contain.text", "C1");
+    H.getDraggableElements().eq(0).should("contain.text", "C3");
+    H.getDraggableElements().eq(1).should("contain.text", "C1");
   });
 });
 
 describe("issue 45481", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should not crash when the table viz gets automatically pivoted (metabase#45481)", () => {
-    openOrdersTable({ mode: "notebook" });
-    summarize({ mode: "notebook" });
-    popover().findByText("Count of rows").click();
-    getNotebookStep("summarize")
+    H.openOrdersTable({ mode: "notebook" });
+    H.summarize({ mode: "notebook" });
+    H.popover().findByText("Count of rows").click();
+    H.getNotebookStep("summarize")
       .findByText("Pick a column to group by")
       .click();
-    popover().findByText("User ID").click();
-    getNotebookStep("summarize")
+    H.popover().findByText("User ID").click();
+    H.getNotebookStep("summarize")
       .findByTestId("breakout-step")
       .icon("add")
       .click();
-    popover().within(() => {
+    H.popover().within(() => {
       cy.findByText("Product").click();
       cy.findByText("Category").click();
     });
-    visualize();
-    tableInteractive().should("be.visible");
+    H.visualize();
+    H.tableInteractive().should("be.visible");
   });
 });
 
@@ -1055,18 +1026,18 @@ describe("issue 12368", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
   });
 
   it("should clear pivot settings when doing underlying records drill from a pivot table (metabase#12368)", () => {
     cy.log("drill thru from a pivot table");
-    createQuestion(questionDetails, { visitQuestion: true });
+    H.createQuestion(questionDetails, { visitQuestion: true });
     cy.findAllByTestId("cell-data").contains("1").first().click();
-    popover().findByText("See this Product").click();
+    H.popover().findByText("See this Product").click();
 
     cy.log("pivot flag should be cleared but other viz settings are preserved");
-    tableInteractive().within(() => {
+    H.tableInteractive().within(() => {
       cy.findByText("Ean").should("be.visible");
       cy.findByText("Vendor2").should("be.visible");
     });
@@ -1103,7 +1074,7 @@ describe("issue 32718", () => {
   };
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.request("PUT", `/api/field/${PRODUCTS.CATEGORY}`, {
       visibility_type: "details-only",
@@ -1111,8 +1082,8 @@ describe("issue 32718", () => {
   });
 
   it("should honor visibility_type of the field when the question has viz settings (metabase#32718)", () => {
-    createQuestion(questionDetails, { visitQuestion: true });
-    tableInteractive().within(() => {
+    H.createQuestion(questionDetails, { visitQuestion: true });
+    H.tableInteractive().within(() => {
       cy.findByText("ID").should("be.visible");
       cy.findByText("Ean").should("not.exist");
       cy.findByText("Category").should("not.exist");
@@ -1193,13 +1164,13 @@ describe("issue 50346", () => {
   const totalValue = "1,217.76";
 
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("PUT", "/api/card/*").as("updateCard");
   });
 
   it("should be able to collapse rows for questions with legacy pivot settings (metabase#50346)", () => {
-    createQuestion(questionDetails, { visitQuestion: true, wrapId: true });
+    H.createQuestion(questionDetails, { visitQuestion: true, wrapId: true });
 
     cy.log("collapse one of the sections");
     cy.findByTestId("pivot-table").within(() => {
@@ -1209,10 +1180,10 @@ describe("issue 50346", () => {
     });
 
     cy.log("save and make sure the setting is preserved on reload");
-    queryBuilderHeader().button("Save").click();
-    modal().button("Save").click();
+    H.queryBuilderHeader().button("Save").click();
+    H.modal().button("Save").click();
     cy.wait("@updateCard");
-    visitQuestion("@questionId");
+    H.visitQuestion("@questionId");
     cy.findByTestId("pivot-table").within(() => {
       cy.findByText(totalValue).should("not.exist");
     });


### PR DESCRIPTION
In re Frontend RFC [No 114](https://www.notion.so/metabase/114-Don-t-use-named-imports-for-e2e-helpers-13f69354c90180b6b33adddbe5e6e0f0)

## Description

Replaces big named imports list with a single Global Helper namespace, which has 2 big advantages
1) Makes our helper functions much more discoverable via editor hints
2) Makes moving e2e tests around trivial - in most cases the hardest part of moving tests around is adjusting imports.

[jscodeshift](https://www.npmjs.com/package/jscodeshift) codemod used:
`jscodeshift --parser=ts -t codemod.js e2e/**/*.cy.spec.(js|ts)`
```js
module.exports = function (fileInfo, api) {
  const j = api.jscodeshift;

  // problematic values to exclude
  const excludedValues = new Set([
    "visitQuestion",
    "filter",
    "duplicateTab",
    "sidebar",
    "saveDashboard",
  ]);

  // Parse the source code
  const root = j(fileInfo.source);

  // Find all `import` declarations from "e2e/support/helpers"
  root.find(j.ImportDeclaration, { source: { value: "e2e/support/helpers" } }).forEach((path) => {
    const importDeclaration = path.node;

    // Collect all imported specifiers
    const specifiersToReplace = importDeclaration.specifiers.filter(
      (spec) => spec.type === "ImportSpecifier"
    );

    if (specifiersToReplace.length > 0) {
      // Replace the import
      const newImport = j.importDeclaration(
        [j.importSpecifier(j.identifier("H"))], // import with alias "H"
        j.literal("e2e/support")
      );

      // Replace the old import with the new one
      j(path).replaceWith(newImport);

      // Update references to use the namespace
      specifiersToReplace.forEach((specifier) => {
        const importedName = specifier.imported.name;
        const localName = specifier.local.name;

        root
          .find(j.Identifier, { name: localName })
          .filter((idPath) => {
            const parent = idPath.parent.node;

            // Skip identifiers used as keys in object properties
            if (j.Property.check(parent) && parent.key === idPath.node) {
              return false;
            }

            // Skip variable declarations
            if (
              j.VariableDeclarator.check(parent) &&
              parent.id === idPath.node
            ) {
              return false;
            }

            // Skip identifiers used as keys in object literal properties
            if (
              j.Property.check(parent) &&
              parent.key === idPath.node &&
              !parent.computed &&
              parent.shorthand
            ) {
              return false;
            }

            // Skip object key names (e.g., { key: value })
            if (
              j.Property.check(parent) &&
              parent.key === idPath.node
            ) {
              return false;
            }

            // Skip function parameters (callback arguments) like in map(), filter(), or event handlers
            if (
              j.FunctionExpression.check(parent) ||
              j.ArrowFunctionExpression.check(parent)
            ) {
              // Skip if the identifier is part of the function's parameter list
              if (parent.params && parent.params.includes(idPath.node)) {
                return false;
              }
            }

            // Skip member expressions like `cy.<name>`
            if (
              j.MemberExpression.check(parent) &&
              parent.property === idPath.node
            ) {
              return false;
            }

            // only specific values
            // return targetValues.has(importedName);

            return !excludedValues.has(importedName);
          })
          .replaceWith(() => {
            return j.memberExpression(j.identifier("H"), j.identifier(importedName));
          });

        // Update function calls
        root
          .find(j.CallExpression, { callee: { name: localName } })
          .replaceWith((callPath) =>
            j.callExpression(
              j.memberExpression(j.identifier("H"), j.identifier(importedName)),
              callPath.node.arguments
            )
          );
      });
    }
  });

  // Return the transformed source code
  return root.toSource();
};
```


