### PR TITLE
[refs] Adding `:ident` to columns returned by `MetadataProvider`s

### DIFF
--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -457,6 +457,7 @@
              :schema           (get-in card [:collection :name] (root-collection-schema-name))
              :moderated_status (:moderated_status card)
              :description      (:description card)
+             :entity_id        (:entity_id card)
              :metrics          (:metrics card)
              :type             card-type}
       (and (= card-type :metric)

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -221,6 +221,7 @@
   [query stage-number x]
   (try
     {:lib/type     :metadata/column
+     :ident        (lib.options/ident x)
      ;; TODO -- effective-type
      :base-type    (type-of query stage-number x)
      :name         (column-name query stage-number x)

--- a/src/metabase/lib/metadata/ident.cljc
+++ b/src/metabase/lib/metadata/ident.cljc
@@ -1,0 +1,50 @@
+(ns metabase.lib.metadata.ident
+  "Helpers for working with `:ident` fields on columns."
+  (:require
+   [clojure.string :as str]))
+
+(defn table-prefix
+  "Given the DB name and a `table` with `:name` and optional `:schema`, returns a string prefix for the `:ident`s
+  of fields in this table."
+  [db-name {tbl-name :name, :keys [schema] :as _table}]
+  (str/join "__" ["field"
+                  db-name
+                  (or schema "!noschema!")
+                  tbl-name]))
+
+(defn ident-for-field
+  "Given a database name, table with `:name` and optional `:schema`, and column with `:name`, construct the `:ident`
+  for Fields from the user's DWH. (Other kinds of columns get randomly generated NanoIDs as `:ident`s.)"
+  ([prefix {col-name :name :as _column}]
+   (str prefix "__" col-name))
+  ([db-name table column]
+   (ident-for-field (table-prefix db-name table) column)))
+
+(defn attach-ident
+  "Generates and attaches an `:ident` to a column, if it doesn't already have one.
+
+  Either takes a prefix for the database, schema and table, or the DB name and table."
+  ([prefix-or-fn column]
+   (if (:ident column)
+     column
+     (let [prefix (if (ifn? prefix-or-fn)
+                    (prefix-or-fn column)
+                    prefix-or-fn)]
+       (assoc column :ident (ident-for-field prefix column)))))
+  ([db-name table column]
+   (cond-> column
+     (not (:ident column)) (assoc :ident (ident-for-field db-name table column)))))
+
+(defn attach-idents
+  "Generates and attaches an `:ident` to each of the `columns`, if it doesn't have one already.
+
+  2-arity version takes a function from table IDs to the `:ident` prefix for that table.
+
+  1-arity version takes the same function and returns a transducer.
+
+  If you want to memoize or cache the calls to `prefix-fn`, you need to handle that externally! Some callers just have
+  a map or constant value, so caching inside this function is redundant and wasteful."
+  ([prefix-fn]
+   (map #(attach-ident (prefix-fn (:table-id %)) %)))
+  ([prefix-fn columns]
+   (sequence (attach-idents prefix-fn) columns)))

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -299,7 +299,7 @@
        field-cols
        (do (doall field-cols)           ; force generation of unique names before join columns
            (into []
-                 (m/distinct-by #(dissoc % :source-alias :lib/source :lib/source-uuid :lib/desired-column-alias))
+                 (m/distinct-by #(dissoc % :source-alias :ident :lib/source :lib/source-uuid :lib/desired-column-alias))
                  (concat field-cols
                          (lib.join/all-joins-expected-columns query stage-number options))))
 

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -542,7 +542,7 @@
 
 (mu/defn add-summary-clause :- ::lib.schema/query
   "If the given stage has no summary, it will drop :fields, :order-by, and :join :fields from it,
-   as well as any subsequent stages."
+   as well as dropping any subsequent stages."
   [query :- ::lib.schema/query
    stage-number :- :int
    location :- [:enum :breakout :aggregation]
@@ -567,8 +567,7 @@
              (-> stage
                  (dissoc :order-by :fields)
                  (m/update-existing :joins (fn [joins] (mapv #(dissoc % :fields) joins))))))
-          ;; subvec holds onto references, so create a new vector
-          (update :stages (comp #(into [] %) subvec) 0 (inc (canonical-stage-index query stage-number))))
+          (update :stages #(into [] (take (inc (canonical-stage-index query stage-number))) %)))
       new-query)))
 
 (defn fresh-uuids

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -260,7 +260,9 @@
                                                     opts))]
     ;; TODO -- I think we actually need two `:field_ref` columns -- one for referring to the Field at the SAME
     ;; level, and one for referring to the Field from the PARENT level.
-    (cond-> {:field_ref (mbql.u/remove-namespaced-options clause)}
+    (cond-> {:field_ref (-> clause
+                            mbql.u/remove-namespaced-options
+                            (mbql.u/update-field-options dissoc :ident))}
       (:base-type opts)
       (assoc :base_type (:base-type opts))
 

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -129,6 +129,7 @@
   (merge
    {:id               (format "card__%d" (u/the-id card))
     :db_id            (:database_id card)
+    :entity_id        nil
     :display_name     (:name card)
     :schema           "Everything else"
     :moderated_status nil
@@ -1680,6 +1681,7 @@
         (testing "Should be able to get saved questions in a specific collection"
           (is (= [{:id               (format "card__%d" (:id card-1))
                    :db_id            (mt/id)
+                   :entity_id        nil
                    :metrics          nil
                    :moderated_status nil
                    :display_name     "Card 1"
@@ -1706,6 +1708,7 @@
             (is (contains? (set response)
                            {:id               (format "card__%d" (:id card-2))
                             :db_id            (mt/id)
+                            :entity_id        nil
                             :display_name     "Card 2"
                             :metrics          nil
                             :moderated_status nil
@@ -1772,6 +1775,7 @@
             (is (contains? (set response)
                            {:id               (format "card__%d" (:id card-2))
                             :db_id            (mt/id)
+                            :entity_id        nil
                             :display_name     "Card 2"
                             :metrics          nil
                             :moderated_status nil

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -659,6 +659,7 @@
                   :schema            "Everything else"
                   :db_id             (:database_id card)
                   :id                card-virtual-table-id
+                  :entity_id         (:entity_id card)
                   :type              "question"
                   :moderated_status  nil
                   :metrics           nil
@@ -741,6 +742,7 @@
                     :schema            "Everything else"
                     :db_id             (:database_id card)
                     :id                card-virtual-table-id
+                    :entity_id         (:entity_id card)
                     :type              "question"
                     :description       nil
                     :moderated_status  nil

--- a/test/metabase/lib/js/metadata_test.cljs
+++ b/test/metabase/lib/js/metadata_test.cljs
@@ -31,6 +31,9 @@
         metadata-provider (lib.js.metadata/metadata-provider 1 metadata)]
     (is (= {:lib/type           :metadata/column
             :id                 36
+            ;; This is a bit busted because of the partial metadata, but it's still there.
+            ;; No DB or table names, so those are blank.
+            :ident              "field____!noschema!____CATEGORY_ID"
             :name               "CATEGORY_ID"
             :has-field-values   :none
             :lib/external-remap {:lib/type :metadata.column.remapping/external
@@ -54,9 +57,38 @@
         metadata-provider (lib.js.metadata/metadata-provider 1 metadata)]
     (is (= {:lib/type           :metadata/column
             :id                 33
+            ;; This is a bit busted because of the partial metadata, but it's still there.
+            ;; No DB or table names, so those are blank.
+            :ident              "field____!noschema!____ID"
             :name               "ID"
             :has-field-values   :none
             :lib/internal-remap {:lib/type :metadata.column.remapping/internal
                                  :id       66
                                  :name     "ID [internal remap]"}}
            (lib.metadata/field metadata-provider 33)))))
+
+(def ^:private mock-metadata-with-generic-tables-and-fields
+  #js {:databases #js {"1" #js {:id 1
+                                :name "fake DB"}}
+       :tables    #js {"6" #js {:id     6
+                                :name   "basic_table"
+                                :db_id  1
+                                :fields #js {}}
+                       "7" #js {:id     7
+                                :name   "another_table"
+                                :schema "SomeSchema"
+                                :db_id  1
+                                :fields #js {}}}
+       :fields    #js {"600" #js {:id   600
+                                  :table_id 6
+                                  :name "one_field"}
+                       "700" #js {:id   700
+                                  :table_id 7
+                                  :name "two_field"}}})
+
+(deftest ^:parallel idents-test
+  (let [mp (lib.js.metadata/metadata-provider 1 mock-metadata-with-generic-tables-and-fields)]
+    (is (= "field__fake DB__!noschema!__basic_table__one_field"
+           (:ident (lib.metadata/field mp 600))))
+    (is (= "field__fake DB__SomeSchema__another_table__two_field"
+           (:ident (lib.metadata/field mp 700))))))

--- a/test/metabase/lib/metadata_test.cljc
+++ b/test/metabase/lib/metadata_test.cljc
@@ -86,3 +86,11 @@
         restritcted-query (assoc query :lib/metadata restricted-provider)]
     (is (lib.metadata/editable? query))
     (is (not (lib.metadata/editable? restritcted-query)))))
+
+(deftest ^:parallel idents-test
+  (doseq [table-key (meta/tables)
+          field-key (meta/fields table-key)]
+    (let [table    (meta/table-metadata table-key)
+          field    (meta/field-metadata table-key field-key)]
+      (is (= (str "field__" (:name meta/database) "__" (:schema table) "__" (:name table) "__" (:name field))
+             (:ident (lib.metadata/field meta/metadata-provider (:id field))))))))

--- a/test/metabase/lib/test_metadata/graph_provider.cljc
+++ b/test/metabase/lib/test_metadata/graph_provider.cljc
@@ -5,6 +5,7 @@
    [clojure.core.protocols]
    [clojure.test :refer [deftest is]]
    [medley.core :as m]
+   [metabase.lib.metadata.ident :as lib.metadata.ident]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]))
 
 (defn- graph-database [metadata-graph]
@@ -33,6 +34,13 @@
   ;; not implemented for the simple graph metadata provider.
   nil)
 
+(defn- graph->prefix-fn [metadata-graph]
+  (let [db-name (:name (graph-database metadata-graph))]
+    (memoize
+     (fn [table-id]
+       (let [table (graph-table metadata-graph table-id)]
+         (lib.metadata.ident/table-prefix db-name table))))))
+
 (defn- graph-metadatas [metadata-graph metadata-type ids]
   (let [f (case metadata-type
             :metadata/table         graph-table
@@ -40,8 +48,11 @@
             :metadata/segment       graph-segment
             :metadata/card          graph-card)]
     (into []
-          (keep (fn [id]
-                  (f metadata-graph id)))
+          (comp (keep (fn [id]
+                        (f metadata-graph id)))
+                (if (= metadata-type :metadata/column)
+                  (lib.metadata.ident/attach-idents (graph->prefix-fn metadata-graph))
+                  identity))
           ids)))
 
 (defn- graph-tables [metadata-graph]
@@ -57,7 +68,9 @@
     (cond->> (get table k)
       (= metadata-type :metadata/metric)
       (filterv #(and (= (:type %) :metric)
-                     (not (:archived %)))))))
+                     (not (:archived %))))
+      (= metadata-type :metadata/column)
+      (lib.metadata.ident/attach-idents (graph->prefix-fn metadata-graph)))))
 
 (defn- graph-setting [metadata-graph setting-name]
   (get-in metadata-graph [:settings (keyword setting-name)]))

--- a/test/metabase/query_processor/middleware/add_implicit_clauses_test.clj
+++ b/test/metabase/query_processor/middleware/add_implicit_clauses_test.clj
@@ -51,51 +51,45 @@
   (testing "we should add order-bys for breakout clauses"
     (testing "Add Field to existing order-by"
       (mt/with-metadata-provider meta/metadata-provider
-        (is (= {:source-table 1
-                :breakout     [[:field 2 nil]]
-                :order-by     [[:asc [:field 1 nil]]
-                               [:asc [:field 2 nil]]]}
-               (#'qp.add-implicit-clauses/add-implicit-breakout-order-by
-                {:source-table 1
-                 :breakout     [[:field 2 nil]]
-                 :order-by     [[:asc [:field 1 nil]]]})))))))
+        (is (=? (lib.tu.macros/mbql-query orders
+                  {:breakout [$product-id->products.category]
+                   :order-by [[:asc $created-at]
+                              [:asc $product-id->products.category]]})
+                (update (lib.tu.macros/mbql-query orders
+                          {:breakout [$product-id->products.category]
+                           :order-by [[:asc $created-at]]})
+                        :query #'qp.add-implicit-clauses/add-implicit-breakout-order-by)))))))
 
 (deftest ^:parallel add-order-bys-for-breakouts-test-3
   (testing "we should add order-bys for breakout clauses"
     (testing "...but not if the Field is already in an order-by"
       (mt/with-metadata-provider meta/metadata-provider
-        (is (= {:source-table 1
-                :breakout     [[:field 1 nil]]
-                :order-by     [[:asc [:field 1 nil]]]}
-               (#'qp.add-implicit-clauses/add-implicit-breakout-order-by
-                {:source-table 1
-                 :breakout     [[:field 1 nil]]
-                 :order-by     [[:asc [:field 1 nil]]]})))))))
+        (let [{:keys [query]} (lib.tu.macros/mbql-query orders
+                                {:breakout [$product-id->products.category]
+                                 :order-by [[:asc $product-id->products.category]]})]
+          (is (= query
+                 (#'qp.add-implicit-clauses/add-implicit-breakout-order-by query))))))))
 
 (deftest ^:parallel add-order-bys-for-breakouts-test-4
   (testing "we should add order-bys for breakout clauses"
     (testing "...but not if the Field is already in an order-by"
       (mt/with-metadata-provider meta/metadata-provider
-        (is (= {:source-table 1
-                :breakout     [[:field 1 nil]]
-                :order-by     [[:desc [:field 1 nil]]]}
-               (#'qp.add-implicit-clauses/add-implicit-breakout-order-by
-                {:source-table 1
-                 :breakout     [[:field 1 nil]]
-                 :order-by     [[:desc [:field 1 nil]]]})))))))
+        (let [{:keys [query]} (lib.tu.macros/mbql-query orders
+                                {:breakout [$product-id->products.category]
+                                 :order-by [[:desc $product-id->products.category]]})]
+          (is (= query
+                 (#'qp.add-implicit-clauses/add-implicit-breakout-order-by query))))))))
 
 (deftest ^:parallel add-order-bys-for-breakouts-test-5
   (testing "we should add order-bys for breakout clauses"
     (testing "...but not if the Field is already in an order-by"
       (testing "With a datetime-field"
         (mt/with-metadata-provider meta/metadata-provider
-          (is (= {:source-table 1
-                  :breakout     [[:field 1 {:temporal-unit :day}]]
-                  :order-by     [[:asc [:field 1 {:temporal-unit :day}]]]}
-                 (#'qp.add-implicit-clauses/add-implicit-breakout-order-by
-                  {:source-table 1
-                   :breakout     [[:field 1 {:temporal-unit :day}]]
-                   :order-by     [[:asc [:field 1 {:temporal-unit :day}]]]}))))))))
+          (let [{:keys [query]} (lib.tu.macros/mbql-query orders
+                                  {:breakout [!day.created-at]
+                                   :order-by [[:asc !day.created-at]]})]
+            (is (= query
+                   (#'qp.add-implicit-clauses/add-implicit-breakout-order-by query)))))))))
 
 (defn- add-implicit-fields [inner-query]
   (if (qp.store/initialized?)

--- a/test/metabase/query_processor/middleware/auto_bucket_datetimes_test.clj
+++ b/test/metabase/query_processor/middleware/auto_bucket_datetimes_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer :all]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.normalize :as lib.normalize]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
@@ -273,10 +274,11 @@
     (is (= {:source-table 1
             :breakout     [[:field Integer/MAX_VALUE nil]]
             :breakout-idents {0 "ZT7n35j6KY0m_NPIEa7Ut"}}
-           (auto-bucket-mbql
-            {:source-table 1
-             :breakout     [[:field Integer/MAX_VALUE nil]]
-             :breakout-idents {0 "ZT7n35j6KY0m_NPIEa7Ut"}})))))
+           (binding [lib.metadata/*enforce-idents* false]
+             (auto-bucket-mbql
+              {:source-table 1
+               :breakout     [[:field Integer/MAX_VALUE nil]]
+               :breakout-idents {0 "ZT7n35j6KY0m_NPIEa7Ut"}}))))))
 
 (deftest ^:parallel do-not-auto-bucket-relative-time-interval-test
   (testing "does a :type/DateTime breakout Field that is already bucketed pass thru unchanged?"

--- a/test/metabase/query_processor/middleware/desugar_test.clj
+++ b/test/metabase/query_processor/middleware/desugar_test.clj
@@ -2,55 +2,52 @@
   (:require
    [clojure.test :refer :all]
    [metabase.lib.test-metadata :as meta]
+   [metabase.lib.test-util.macros :as lib.tu.macros]
    [metabase.query-processor.middleware.desugar :as desugar]
    [metabase.test :as mt]))
 
 ;; actual desugaring logic and tests are in [[metabase.legacy-mbql.util-test]]
 (deftest ^:parallel e2e-test
-  (is (= {:database 1
-          :type     :query
-          :query    {:source-table 1
-                     :filter       [:and
-                                    [:= [:field 1 nil] "Run Query"]
-                                    [:between
-                                     [:field 2 {:temporal-unit :day}]
-                                     [:relative-datetime -30 :day]
-                                     [:relative-datetime -1 :day]]
-                                    [:>=
-                                     [:field 2 {:temporal-unit :default}]
-                                     [:+ [:relative-datetime -30 :day] [:interval -30 :day]]]
-                                    [:<
-                                     [:field 2 {:temporal-unit :default}]
-                                     [:+ [:relative-datetime 0 :day] [:interval -30 :day]]]
-                                    [:!= [:field 3 nil] "(not set)"]
-                                    [:!= [:field 3 nil] "url"]
-                                    [:> [:temporal-extract [:field 4 nil] :year-of-era] [:/ [:/ 1 2] 3]]]
-                     :expressions  {"year" [:+
-                                            [:temporal-extract [:field 4 nil] :year-of-era]
-                                            [:/ [:/ [:/ 1 2] 3] 4]]}
-                     :aggregation  [[:share [:and
-                                             [:= [:field 1 nil] "Run Query"]
-                                             [:between
-                                              [:field 2 {:temporal-unit :day}]
-                                              [:relative-datetime -30 :day]
-                                              [:relative-datetime -1 :day]]
-                                             [:!= [:field 3 nil] "(not set)"]
-                                             [:!= [:field 3 nil] "url"]]]]}}
-         (mt/with-metadata-provider meta/metadata-provider
-           (desugar/desugar
-            {:database 1
-             :type     :query
-             :query    {:source-table 1
-                        :filter       [:and
-                                       [:= [:field 1 nil] "Run Query"]
-                                       [:time-interval [:field 2 nil] -30 :day]
-                                       [:relative-time-interval [:field 2 nil] -30 :day -30 :day]
-                                       [:!= [:field 3 nil] "(not set)" "url"]
-                                       [:> [:get-year [:field 4 nil]] [:/ 1 2 3]]]
-                        :expressions  {"year" [:+
-                                               [:get-year [:field 4 nil]]
-                                               [:/ 1 2 3 4]]}
-                        :aggregation  [[:share [:and
-                                                [:= [:field 1 nil] "Run Query"]
-                                                [:time-interval [:field 2 nil] -30 :day]
-                                                [:!= [:field 3 nil] "(not set)" "url"]]]]}})))))
+  (is (=? (lib.tu.macros/mbql-query orders
+            {:filter       [:and
+                            [:= $user-id->people.name "Run Query"]
+                            [:between
+                             !day.created-at
+                             [:relative-datetime -30 :day]
+                             [:relative-datetime -1 :day]]
+                            [:>=
+                             !default.created-at
+                             [:+ [:relative-datetime -30 :day] [:interval -30 :day]]]
+                            [:<
+                             !default.created-at
+                             [:+ [:relative-datetime 0 :day] [:interval -30 :day]]]
+                            [:!= $user-id->people.source "(not set)"]
+                            [:!= $user-id->people.source "Twitter"]
+                            [:> [:temporal-extract $user-id->people.birth-date :year-of-era] [:/ [:/ 1 2] 3]]]
+             :expressions  {"year" [:+
+                                    [:temporal-extract $user-id->people.birth-date :year-of-era]
+                                    [:/ [:/ [:/ 1 2] 3] 4]]}
+             :aggregation  [[:share [:and
+                                     [:= $user-id->people.name "Run Query"]
+                                     [:between
+                                      !day.created-at
+                                      [:relative-datetime -30 :day]
+                                      [:relative-datetime -1 :day]]
+                                     [:!= $user-id->people.source "(not set)"]
+                                     [:!= $user-id->people.source "Twitter"]]]]})
+          (mt/with-metadata-provider meta/metadata-provider
+            (desugar/desugar
+             (lib.tu.macros/mbql-query orders
+               {:filter       [:and
+                               [:= $user-id->people.name "Run Query"]
+                               [:time-interval !day.created-at -30 :day]
+                               [:relative-time-interval $created-at -30 :day -30 :day]
+                               [:!= $user-id->people.source "(not set)" "Twitter"]
+                               [:> [:get-year $user-id->people.birth-date] [:/ 1 2 3]]]
+                :expressions  {"year" [:+
+                                       [:get-year $user-id->people.birth-date]
+                                       [:/ 1 2 3 4]]}
+                :aggregation  [[:share [:and
+                                        [:= $user-id->people.name "Run Query"]
+                                        [:time-interval $created-at -30 :day]
+                                        [:!= $user-id->people.source "(not set)" "Twitter"]]]]}))))))

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -651,12 +651,13 @@
       (testing "inside :joins inside :source-query"
         (is (=? (lib.tu.macros/mbql-query nil
                   {:source-query {:source-table (meta/id :checkins)
-                                  :joins        [{:condition    [:= [:field 1 nil] 2]
+                                  :joins        [{:condition    [:= [:field (meta/id :checkins :venue-id) nil] 2]
                                                   :source-query after}]}})
                 (expand-macros (lib.tu.macros/mbql-query nil
                                  {:source-query {:source-table (meta/id :checkins)
-                                                 :joins        [{:condition    [:= [:field 1 nil] 2]
-                                                                 :source-query before}]}}))))))))
+                                                 :joins
+                                                 [{:condition    [:= [:field (meta/id :checkins :venue-id) nil] 2]
+                                                   :source-query before}]}}))))))))
 
 (deftest ^:parallel model-based-metric-use-test
   (let [model {:lib/type :metadata/card

--- a/test/metabase/query_processor/middleware/pre_alias_aggregations_test.clj
+++ b/test/metabase/query_processor/middleware/pre_alias_aggregations_test.clj
@@ -108,14 +108,16 @@
                 "drivers need to tweak the default names we generate."))
   (is (= {:database 1
           :type     :query
-          :query    {:source-table 1
-                     :aggregation  [[:aggregation-options [:+ 20 [:sum [:field 2 nil]]] {:name "_expression"}]
+          :query    {:source-table (meta/id :orders)
+                     :aggregation  [[:aggregation-options
+                                     [:+ 20 [:sum [:field (meta/id :orders :subtotal) nil]]]
+                                     {:name "_expression"}]
                                     [:aggregation-options [:count] {:name "_count"}]]}}
          (driver/with-driver ::test-driver
            (qp.store/with-metadata-provider meta/metadata-provider
              (qp.pre-alias-aggregations/pre-alias-aggregations
               {:database 1
                :type     :query
-               :query    {:source-table 1
-                          :aggregation  [[:+ 20 [:sum [:field 2 nil]]]
+               :query    {:source-table (meta/id :orders)
+                          :aggregation  [[:+ 20 [:sum [:field (meta/id :orders :subtotal) nil]]]
                                          [:count]]}}))))))

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -671,7 +671,7 @@
                                                    :data :cols)]
                                        (-> (into {} col)
                                            (assoc :source :fields)
-                                           (dissoc :position :aggregation_index)))]
+                                           (dissoc :position :aggregation_index :ident)))]
             ;; since the bucketing is happening in the source query rather than at this level, the field ref should
             ;; return temporal unit `:default` rather than the upstream bucketing unit. You wouldn't want to re-apply
             ;; the `:year` bucketing if you used this query in another subsequent query, so the field ref doesn't


### PR DESCRIPTION
Closes #49686

### Description

Updates JVM, JS and unit test `MetadataProvider` implementations to include `:ident` fields for all columns.

These idents need to be globally unique and serdes portable; therefore they are not randomized.
Instead they are built from the database, schema, table and field names, eg.

```clojure
{:ident "field__Sample Database__PUBLIC__Orders__CREATED_AT"
 #_...}
```

**Note:** These `:ident` fields are not included on `/query_metadata` and other such API calls (currently).
They could be, but they can just as easily be synthesized from the DB, table and field in the JS metadata
implementation.

### How to verify

`lib.metadata` surface APIs that return columns now have checks for `:ident` on returned columns and throw if it
is not found. I have not encountered any cases where it throws, but perhaps the e2e tests will find something.

- No visible changes, but you can verify that the app is working.
- New unit tests verify that the idents we expect are returned for each `MetadataProvider` implementation

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
