### PR TITLE
Fix auto-translate locales file path

### DIFF
--- a/release/src/auto-translate.ts
+++ b/release/src/auto-translate.ts
@@ -82,7 +82,7 @@ const autoTranslate = async (language: string) => {
 }
 
 function getExistingLanguages() {
-  const localeFiles = fs.readdirSync("../locales");
+  const localeFiles = fs.readdirSync("./locales");
 
   return localeFiles.filter(f => /\.po$/.test(f))
     .map(f => f.replace(/\.po$/, ""));


### PR DESCRIPTION


### Description

The auto-translate + translation download action has never worked properly - I finally figured out that it was just a file path issue - github actions script can only run from the root directory of the repo, and when testing locally, I had always run it from within the `releases/` directory. This led to [errors like this](https://github.com/metabase/metabase/actions/runs/10118157302).


![Screen Shot 2024-11-18 at 12 44 10 PM](https://github.com/user-attachments/assets/7344d97b-2751-4b5d-a374-677a52822715)
