### PR TITLE
[xlsx-export] Refactor postprocess namespace with perf/concat

### DIFF
--- a/src/metabase/util/performance.clj
+++ b/src/metabase/util/performance.clj
@@ -1,6 +1,6 @@
 (ns metabase.util.performance
   "Functions and utilities for faster processing."
-  (:refer-clojure :exclude [reduce mapv some])
+  (:refer-clojure :exclude [reduce mapv some concat])
   (:import (clojure.lang LazilyPersistentVector RT)))
 
 (set! *warn-on-reflection* true)
@@ -131,3 +131,43 @@
   "Like `clojure.core/some` but uses our custom `reduce` which in turn uses iterators."
   [f coll]
   (unreduced (reduce #(when-let [match (f %2)] (reduced match)) nil coll)))
+
+(defn concat
+  "Like `clojure.core/concat` but accumulates the result into a vector."
+  ([a b]
+   (into (vec a) b))
+  ([a b c]
+   (as-> (transient (vec a)) res
+     (reduce conj! res b)
+     (reduce conj! res c)
+     (persistent! res)))
+  ([a b c d]
+   (as-> (transient (vec a)) res
+     (reduce conj! res b)
+     (reduce conj! res c)
+     (reduce conj! res d)
+     (persistent! res)))
+  ([a b c d e]
+   (as-> (transient (vec a)) res
+     (reduce conj! res b)
+     (reduce conj! res c)
+     (reduce conj! res d)
+     (reduce conj! res e)
+     (persistent! res)))
+  ([a b c d e f]
+   (as-> (transient (vec a)) res
+     (reduce conj! res b)
+     (reduce conj! res c)
+     (reduce conj! res d)
+     (reduce conj! res e)
+     (reduce conj! res f)
+     (persistent! res)))
+  ([a b c d e f & more]
+   (as-> (transient (vec a)) res
+     (reduce conj! res b)
+     (reduce conj! res c)
+     (reduce conj! res d)
+     (reduce conj! res e)
+     (reduce conj! res f)
+     (reduce (fn [res l] (reduce conj! res l)) res more)
+     (persistent! res))))

--- a/test/metabase/util/performance_test.clj
+++ b/test/metabase/util/performance_test.clj
@@ -1,0 +1,17 @@
+(ns ^:mb/once metabase.util.performance-test
+  (:require [clojure.test :refer :all]
+            [metabase.util.performance :as perf]))
+
+(deftest concat-test
+  (is (= [1 2 3 4 5] (perf/concat [1] [] [2] [3 4] nil '(5))))
+  (is (= [] (perf/concat [] [])))
+  (is (= [] (perf/concat [] [])))
+  ;; Pseudo-generative testing.
+  (dotimes [n 20]
+    (let [inputs (repeatedly (+ n 2)
+                             (fn []
+                               (let [r (rand-int 3)]
+                                 (when (> r 0)
+                                   (cond-> (repeatedly (rand-int 10) #(rand-int 1000))
+                                     (= r 2) vec)))))]
+      (is (= (apply concat inputs) (apply perf/concat inputs))))))


### PR DESCRIPTION
This is a follow-up to #50117. Here I introduce a replacement for regular `concat` in the form of `metabase.util.performance/concat`. The main difference is that the latter ensures the first argument to be a transient vector, appends elements of the other passed sequences with `conj!` and persists it. Using this `concat` replacement retains readability while avoiding the performance drawback and also makes the code less prone to mistakes  (like where one forgets to cast the target of `into` to vector).