### PR TITLE
Make iframe dashcards more permissive

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1619,7 +1619,7 @@ function validateIFrame(src, index = 0) {
     .and(
       "have.attr",
       "sandbox",
-      "allow-scripts allow-same-origin allow-forms allow-popups",
+      "allow-forms allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts",
     )
     .and("not.have.attr", "onload");
 }

--- a/frontend/src/metabase/visualizations/visualizations/IFrameViz/IFrameViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/IFrameViz/IFrameViz.tsx
@@ -22,7 +22,7 @@ import {
   StyledInput,
 } from "./IFrameViz.styled";
 import { settings } from "./IFrameVizSettings";
-import { getIframeUrl, isAllowedIframeUrl } from "./utils";
+import { getAllowedIframeAttributes, isAllowedIframeUrl } from "./utils";
 
 export interface IFrameVizProps {
   dashcard: VirtualDashboardCard;
@@ -56,7 +56,10 @@ export function IFrameViz({
   const isNew = !!dashcard?.justAdded;
 
   const allowedHosts = useSetting("allowed-iframe-hosts");
-  const iframeUrl = useMemo(() => getIframeUrl(iframeOrUrl), [iframeOrUrl]);
+  const allowedIframeAttributes = useMemo(
+    () => getAllowedIframeAttributes(iframeOrUrl),
+    [iframeOrUrl],
+  );
 
   const handleIFrameChange = useCallback(
     (newIFrame: string) => {
@@ -105,15 +108,14 @@ export function IFrameViz({
       </IFrameEditWrapper>
     );
   }
+  const src = allowedIframeAttributes?.src;
 
-  const hasAllowedIFrameUrl =
-    iframeUrl && isAllowedIframeUrl(iframeUrl, allowedHosts);
-  const hasForbiddenIFrameUrl =
-    iframeUrl && !isAllowedIframeUrl(iframeUrl, allowedHosts);
+  const hasAllowedIFrameUrl = src && isAllowedIframeUrl(src, allowedHosts);
+  const hasForbiddenIFrameUrl = src && !isAllowedIframeUrl(src, allowedHosts);
 
   const renderError = () => {
     if (hasForbiddenIFrameUrl && isEditing) {
-      return <ForbiddenDomainError url={iframeUrl} />;
+      return <ForbiddenDomainError url={src} />;
     }
     return <GenericError />;
   };
@@ -123,11 +125,11 @@ export function IFrameViz({
       {hasAllowedIFrameUrl ? (
         <iframe
           data-testid="iframe-visualization"
-          src={iframeUrl}
           width={width}
           height={height}
           frameBorder={0}
           sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+          {...allowedIframeAttributes}
         />
       ) : (
         renderError()

--- a/frontend/src/metabase/visualizations/visualizations/IFrameViz/IFrameViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/IFrameViz/IFrameViz.tsx
@@ -128,7 +128,8 @@ export function IFrameViz({
           width={width}
           height={height}
           frameBorder={0}
-          sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+          sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts"
+          referrerPolicy="strict-origin-when-cross-origin"
           {...allowedIframeAttributes}
         />
       ) : (

--- a/frontend/src/metabase/visualizations/visualizations/IFrameViz/IFrameViz.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/IFrameViz/IFrameViz.unit.spec.tsx
@@ -144,6 +144,22 @@ describe("IFrameViz", () => {
     );
   });
 
+  it("should preserve allow and allowfullscreen attributes from iframe", () => {
+    setup({
+      isEditing: false,
+      isPreviewing: true,
+      settings: {
+        iframe:
+          "<iframe src='https://example.com' allow='camera; microphone' allowfullscreen='true'></iframe>",
+      },
+    });
+
+    const iframe = screen.getByTestId("iframe-visualization");
+    expect(iframe).toHaveAttribute("src", "https://example.com");
+    expect(iframe).toHaveAttribute("allow", "camera; microphone");
+    expect(iframe).toHaveAttribute("allowfullscreen", "true");
+  });
+
   it("should not render iframe for unsafe URLs", () => {
     setup({
       isEditing: false,
@@ -159,19 +175,21 @@ describe("IFrameViz", () => {
     ).toBeInTheDocument();
   });
 
-  it("should sanitize iframe with onload attribute", () => {
+  it("should sanitize iframe with onload attribute while preserving allowed attributes", () => {
     setup({
       isEditing: false,
       isPreviewing: true,
       settings: {
         iframe:
-          "<iframe src='https://example.com' onload=\"alert('XSS')\"></iframe>",
+          "<iframe src='https://example.com' allow='camera' allowfullscreen='true' onload=\"alert('XSS')\"></iframe>",
       },
     });
 
     const iframe = screen.getByTestId("iframe-visualization");
     expect(iframe).toBeInTheDocument();
     expect(iframe).toHaveAttribute("src", "https://example.com");
+    expect(iframe).toHaveAttribute("allow", "camera");
+    expect(iframe).toHaveAttribute("allowfullscreen", "true");
     expect(iframe).not.toHaveAttribute("onload");
     expect(iframe).toHaveAttribute(
       "sandbox",

--- a/frontend/src/metabase/visualizations/visualizations/IFrameViz/IFrameViz.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/IFrameViz/IFrameViz.unit.spec.tsx
@@ -58,7 +58,11 @@ describe("IFrameViz", () => {
     const iframe = screen.getByTestId("iframe-visualization");
     expect(iframe).toHaveAttribute(
       "sandbox",
-      "allow-scripts allow-same-origin allow-forms allow-popups",
+      "allow-forms allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts",
+    );
+    expect(iframe).toHaveAttribute(
+      "referrerPolicy",
+      "strict-origin-when-cross-origin",
     );
   });
 
@@ -193,7 +197,11 @@ describe("IFrameViz", () => {
     expect(iframe).not.toHaveAttribute("onload");
     expect(iframe).toHaveAttribute(
       "sandbox",
-      "allow-scripts allow-same-origin allow-forms allow-popups",
+      "allow-forms allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts",
+    );
+    expect(iframe).toHaveAttribute(
+      "referrerPolicy",
+      "strict-origin-when-cross-origin",
     );
   });
 

--- a/frontend/src/metabase/visualizations/visualizations/IFrameViz/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/IFrameViz/utils.ts
@@ -101,10 +101,10 @@ const parseAllowedAttribuesFromIframe = (
   const allow = iframeEl.getAttribute("allow");
   const allowFullscreen = iframeEl.getAttribute("allowfullscreen");
 
-  if (allow) {
+  if (allow != null) {
     result.allow = allow;
   }
-  if (allowFullscreen) {
+  if (allowFullscreen != null) {
     result.allowFullscreen = allowFullscreen;
   }
 

--- a/frontend/src/metabase/visualizations/visualizations/IFrameViz/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/IFrameViz/utils.ts
@@ -83,6 +83,34 @@ const parseUrlFromIframe = (iframeHtml: string) => {
   return "";
 };
 
+const parseAllowedAttribuesFromIframe = (
+  iframeHtml: string,
+): AllowedIframeAttributes | null => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(iframeHtml, "text/html");
+  const iframeEl = doc.querySelector("iframe");
+  const src = iframeEl?.getAttribute("src");
+
+  if (!iframeEl || !src) {
+    return null;
+  }
+
+  const result: AllowedIframeAttributes = {};
+  result.src = src;
+
+  const allow = iframeEl.getAttribute("allow");
+  const allowFullscreen = iframeEl.getAttribute("allowfullscreen");
+
+  if (allow) {
+    result.allow = allow;
+  }
+  if (allowFullscreen) {
+    result.allowFullscreen = allowFullscreen;
+  }
+
+  return result;
+};
+
 const DEFAULT_PROTOCOL = "https://";
 
 const normalizeUrl = (trimmedUrl: string) => {
@@ -122,9 +150,15 @@ export const getIframeDomainName = (
   }
 };
 
-export const getIframeUrl = (
+export type AllowedIframeAttributes = {
+  src?: string;
+  allow?: string;
+  allowFullscreen?: string;
+};
+
+export const getAllowedIframeAttributes = (
   iframeOrUrl: string | undefined,
-): string | null => {
+): AllowedIframeAttributes | null => {
   if (!iframeOrUrl) {
     return null;
   }
@@ -132,12 +166,15 @@ export const getIframeUrl = (
   const trimmedInput = iframeOrUrl.trim();
 
   if (isIframeString(trimmedInput)) {
-    return parseUrlFromIframe(trimmedInput);
+    return parseAllowedAttribuesFromIframe(trimmedInput);
   }
 
   const normalizedUrl = normalizeUrl(trimmedInput);
   if (isSafeUrl(normalizedUrl)) {
-    return replaceSharingLinkWithEmbedLink(normalizedUrl);
+    const src = replaceSharingLinkWithEmbedLink(normalizedUrl);
+    if (src) {
+      return { src };
+    }
   }
 
   return null;

--- a/frontend/src/metabase/visualizations/visualizations/IFrameViz/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/IFrameViz/utils.unit.spec.ts
@@ -1,86 +1,102 @@
-import { getIframeDomainName, getIframeUrl, isAllowedIframeUrl } from "./utils";
+import {
+  getAllowedIframeAttributes,
+  getIframeDomainName,
+  isAllowedIframeUrl,
+} from "./utils";
 
-describe("getIframeUrl", () => {
+describe("getAllowedIframeAttributes", () => {
   describe("share to embed link transformation", () => {
     it("should transform YouTube watch link to embed link", () => {
       const input = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
-      const result = getIframeUrl(input);
-      expect(result).toBe("https://www.youtube.com/embed/dQw4w9WgXcQ");
+      const result = getAllowedIframeAttributes(input);
+      expect(result).toStrictEqual({
+        src: "https://www.youtube.com/embed/dQw4w9WgXcQ",
+      });
     });
 
     it("should transform YouTube short link to embed link", () => {
       const input = "https://youtu.be/dQw4w9WgXcQ";
-      const result = getIframeUrl(input);
-      expect(result).toBe("https://www.youtube.com/embed/dQw4w9WgXcQ");
+      const result = getAllowedIframeAttributes(input);
+      expect(result).toStrictEqual({
+        src: "https://www.youtube.com/embed/dQw4w9WgXcQ",
+      });
     });
 
     it("should transform YouTube playlist link to embed link", () => {
       const input = "https://www.youtube.com/playlist?list=123";
-      const result = getIframeUrl(input);
-      expect(result).toBe("https://www.youtube.com/embed/videoseries?list=123");
+      const result = getAllowedIframeAttributes(input);
+      expect(result).toStrictEqual({
+        src: "https://www.youtube.com/embed/videoseries?list=123",
+      });
     });
 
     it("should transform YouTube link with both video ID and playlist ID", () => {
       const input = "https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=123";
-      const result = getIframeUrl(input);
-      expect(result).toBe("https://www.youtube.com/embed/dQw4w9WgXcQ?list=123");
+      const result = getAllowedIframeAttributes(input);
+      expect(result).toStrictEqual({
+        src: "https://www.youtube.com/embed/dQw4w9WgXcQ?list=123",
+      });
     });
 
     it("should transform Loom share link to embed link", () => {
       const input = "https://www.loom.com/share/1234567890abcdef";
-      const result = getIframeUrl(input);
-      expect(result).toBe("https://www.loom.com/embed/1234567890abcdef");
+      const result = getAllowedIframeAttributes(input);
+      expect(result).toStrictEqual({
+        src: "https://www.loom.com/embed/1234567890abcdef",
+      });
     });
 
     it("should transform Vimeo link to embed link", () => {
       const input = "https://vimeo.com/123456789";
-      const result = getIframeUrl(input);
-      expect(result).toBe("https://player.vimeo.com/video/123456789");
+      const result = getAllowedIframeAttributes(input);
+      expect(result).toStrictEqual({
+        src: "https://player.vimeo.com/video/123456789",
+      });
     });
   });
 
   describe("URL handling", () => {
     it("should return an https URL as is", () => {
       const input = "https://example.com";
-      const result = getIframeUrl(input);
-      expect(result).toBe("https://example.com");
+      const result = getAllowedIframeAttributes(input);
+      expect(result).toStrictEqual({ src: "https://example.com" });
     });
 
     it("should return an http URL as is", () => {
       const input = "http://example.com";
-      const result = getIframeUrl(input);
-      expect(result).toBe("http://example.com");
+      const result = getAllowedIframeAttributes(input);
+      expect(result).toStrictEqual({ src: "http://example.com" });
     });
 
     it("should trim whitespace around the URL", () => {
       const input = "  https://example.com  ";
-      const result = getIframeUrl(input);
-      expect(result).toBe("https://example.com");
+      const result = getAllowedIframeAttributes(input);
+      expect(result).toStrictEqual({ src: "https://example.com" });
     });
 
     it("should add https:// protocol if missing", () => {
       const input = "example.com";
-      const result = getIframeUrl(input);
-      expect(result).toBe("https://example.com");
+      const result = getAllowedIframeAttributes(input);
+      expect(result).toStrictEqual({ src: "https://example.com" });
     });
 
     it("should add https:// protocol if starts with //", () => {
       const input = "//example.com";
-      const result = getIframeUrl(input);
-      expect(result).toBe("https://example.com");
+      const result = getAllowedIframeAttributes(input);
+      expect(result).toStrictEqual({ src: "https://example.com" });
     });
   });
 
   describe("iframe handling", () => {
     it("should extract URL from iframe", () => {
       const input = '<iframe src="https://example.com"></iframe>';
-      const result = getIframeUrl(input);
-      expect(result).toBe("https://example.com");
+      const result = getAllowedIframeAttributes(input);
+      expect(result).toStrictEqual({ src: "https://example.com" });
     });
 
     it("should return null for iframe without src", () => {
       const input = "<iframe></iframe>";
-      const result = getIframeUrl(input);
+      const result = getAllowedIframeAttributes(input);
       expect(result).toBeNull();
     });
   });
@@ -89,36 +105,36 @@ describe("getIframeUrl", () => {
     it("should ignore existing onload handler", () => {
       const input =
         '<iframe src="https://example.com" onload="alert(\'XSS\')"></iframe>';
-      const result = getIframeUrl(input);
-      expect(result).toBe("https://example.com");
+      const result = getAllowedIframeAttributes(input);
+      expect(result).toStrictEqual({ src: "https://example.com" });
     });
 
     it("should return null for unsafe URLs", () => {
       const input = "javascript:alert('XSS')";
-      const result = getIframeUrl(input);
+      const result = getAllowedIframeAttributes(input);
       expect(result).toBeNull();
     });
 
     it("should return null for data URLs", () => {
       const input = "data:text/html,<script>alert('XSS')</script>";
-      const result = getIframeUrl(input);
+      const result = getAllowedIframeAttributes(input);
       expect(result).toBeNull();
     });
   });
 
   it("should return null for undefined input", () => {
-    const result = getIframeUrl(undefined);
+    const result = getAllowedIframeAttributes(undefined);
     expect(result).toBeNull();
   });
 
   it("should return null for empty string input", () => {
-    const result = getIframeUrl("");
+    const result = getAllowedIframeAttributes("");
     expect(result).toBeNull();
   });
 
   it("should return null for HTML without an iframe", () => {
     const input = "<div>hello world</div>";
-    const result = getIframeUrl(input);
+    const result = getAllowedIframeAttributes(input);
     expect(result).toBeNull();
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50020

### Description

While we added iframe dashboard cards in v51 they are excessive limiting which prevents using them for certain usecases like embedding sites that require accessing camera, microphone, and so on. It did make some sense before we introduced the allowed iframe hosts setting but now since admins can limit hosts to only safe ones, we can allow more attributes for a richer UX.

1. Allows adding `allow` [attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#allow) with any values.
2. Allows adding `allowfullscreen` [attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#allowfullscreen).
3. Explicitly sets `referrerpolicy` [attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#referrerpolicy) to its default `strict-origin-when-cross-origin` that prevents from sending full url since old versions of browser use `no-referrer-when-downgrade` as default.
4. Updates [sandbox](https://github.com/metabase/metabase/pull/50177/files#diff-bf073d51166097d37234b5d8ce649f462acbd812f252672c50260b232bce8eceR131) value which allows opening embedded videos such as youtube in a new tab by clicking on the title.

### How to verify

Create an iframe dashboard card:
```
<iframe
  width="560"
  height="315"
  src="https://www.youtube.com/embed/W-i9E5_Wjmw?si=qWeMGxEymVOIHiXo"
  title="YouTube video player"
  frameborder="0"
  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
  referrerpolicy="strict-origin-when-cross-origin"
  allowfullscreen
></iframe>
```
- Ensure you can open the link in a new tab by clicking on the video title
- Ensure you can watch it in fullscreen mode
- Ensure "allow" attribute values present in DOM

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
