### PR TITLE
Hacky multi-tool chain

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
@@ -31,7 +31,7 @@
 (defn- request [message context history session-id]
   (let [env (metabot-v3.handle-envelope/handle-envelope
              (metabot-v3.envelope/add-user-message
-              (metabot-v3.envelope/create context history session-id)
+              (metabot-v3.envelope/create (metabot-v3.context/create-context context) history session-id)
               message))]
     {:reactions (encode-reactions (metabot-v3.envelope/reactions env))
      :history (metabot-v3.envelope/history env)}))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
@@ -49,12 +49,12 @@
                                                                                         (u/->snake_case_en k)))}))))
 
 (mu/defn- build-request-body
-  [context :- [:maybe ::metabot-v3.context/context]
+  [context :- [:maybe :map]
    messages :- [:maybe ::metabot-v3.client.schema/messages]
    session-id :- :string]
   (encode-request-body
    {:messages      messages
-    :context       (metabot-v3.context/hydrate-context (or context {}))
+    :context       (metabot-v3.context/describe-context context)
     :tools         (metabot-v3.tools/applicable-tools (metabot-v3.tools/*tools-metadata*) context)
     :session-id    session-id
     :user-id       api/*current-user-id*
@@ -109,7 +109,7 @@
 
 (mu/defn ^:dynamic *request* :- ::metabot-v3.client.schema/ai-proxy.response
   "Make a request to the AI Proxy."
-  [context :- [:maybe ::metabot-v3.context/context]
+  [context :- [:maybe :map]
    messages :- [:maybe ::metabot-v3.client.schema/messages]
    session-id :- :string]
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client/schema.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client/schema.clj
@@ -1,7 +1,6 @@
 (ns metabase-enterprise.metabot-v3.client.schema
   (:require
    [cheshire.core :as json]
-   [metabase-enterprise.metabot-v3.context :as metabot-v3.context]
    [metabase-enterprise.metabot-v3.tools.interface :as metabot-v3.tools.interface]
    [metabase.util :as u]
    [metabase.util.malli.registry :as mr]))
@@ -54,7 +53,7 @@
    {:encode/api-request #(update-keys % u/->snake_case_en)}
    [:messages      ::messages]
    [:tools         ::request.tools]
-   [:context       {:default {}} ::metabot-v3.context/context]
+   [:context       {:default {}} :map]
    [:instance-info ::request.instance-info]
    [:user-id       integer?]])
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/context.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/context.clj
@@ -35,11 +35,11 @@
         (.newLine w)))))
 
 (mr/def ::context
-        [:map-of
-         ;; TODO -- should this be recursive?
-          {:encode/api-request #(update-keys % u/->snake_case_en)}
-         :keyword
-          :any])
+  [:map-of
+   ;; TODO -- should this be recursive?
+   {:encode/api-request #(update-keys % u/->snake_case_en)}
+   :keyword
+   :any])
 
 (mu/defn create-context
   "Create a tool context."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/context.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/context.clj
@@ -34,26 +34,26 @@
         (.newLine w)
         (.newLine w)))))
 
-;;; TODO
 (mr/def ::context
-  [:map-of
-   ;; TODO -- should this be recursive?
-   {:encode/api-request #(update-keys % u/->snake_case_en)}
-   :keyword
-   :any])
+        [:map-of
+         ;; TODO -- should this be recursive?
+          {:encode/api-request #(update-keys % u/->snake_case_en)}
+         :keyword
+          :any])
 
-(mu/defn hydrate-context
-  "Hydrate context (about what the current user is currently looking at in the FE app), for example
-
-    {:current_dashboard_id 1}
-
-  With enough information that the LLM will be able to make meaningful decisions with it, e.g.
-
-    {:current_dashboard {:name \"Car Dashboard\", :id 1, :cards [{:name \"Credit Card\", :id 2}}
-
-  This should be a 'sparse' hydration rather than `SELECT * FROM dashboard WHERE id = 1` -- we should only include
-  information needed for the LLM to do its thing rather than everything in the world."
-  [{:keys [dataset_query]}]
+(mu/defn create-context
+  "Create a tool context."
+  [context]
   (merge {}
-         (when dataset_query
-           (metabot-v3.tools.query/query-context dataset_query))))
+         (metabot-v3.tools.query/create-context context)))
+
+(mu/defn describe-context
+  "Transforms the tool context into LLM context."
+  [context]
+  (merge {}
+         (metabot-v3.tools.query/describe-context context)))
+
+(mu/defn create-reactions
+  "Extracts reactions based on the current context."
+  [context]
+  (into [] (concat (metabot-v3.tools.query/create-reactions context))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/handle_envelope.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/handle_envelope.clj
@@ -10,11 +10,11 @@
 (defn- invoke-all-tool-calls! [{:keys [context] :as e}]
   (reduce (fn [e {tool-name :name, tool-call-id :id, :keys [arguments]}]
             (let [result (promise)
-                  {:keys [reactions output]}
+                  {:keys [output context]}
                   (o11y/with-span :info {:name tool-name}
                     (u/prog1 (metabot-v3.tools.interface/*invoke-tool* tool-name arguments context)
                       (deliver result <>)))]
-              (envelope/add-tool-response e tool-call-id output reactions)))
+              (envelope/add-tool-response e tool-call-id output context)))
           e
           (envelope/tool-calls-requiring-invocation e)))
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/reactions.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/reactions.clj
@@ -74,7 +74,7 @@
    [:type    [:= :metabot.reaction/message]]
    [:message :string]])
 
-(defreaction :metabot.reaction/filter-data
+(defreaction :metabot.reaction/run-query
   [:map
-   [:type [:= :metabot.reaction/filter-data]]
+   [:type [:= :metabot.reaction/run-query]]
    [:dataset_query :map]])

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/who_is_your_favorite.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/who_is_your_favorite.clj
@@ -4,5 +4,6 @@
    [metabase.util.malli :as mu]))
 
 (mu/defmethod metabot-v3.tools.interface/*invoke-tool* :metabot.tool/who-is-your-favorite
-  [_tool-name _arg-map _context]
-  {:output "You are... but don't tell anyone!"})
+  [_tool-name _arg-map context]
+  {:output  "You are... but don't tell anyone!"
+   :context context})

--- a/enterprise/frontend/src/metabase-enterprise/metabot/reactions/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/reactions/index.ts
@@ -3,7 +3,7 @@ import type { MetabotReaction } from "metabase-types/api";
 import { apiCall } from "./api";
 import { requireUserConfirmation, showMessage } from "./messages";
 import { writeBack } from "./metabot";
-import { aggregateData, filterData } from "./queries";
+import { runQuery } from "./queries";
 import type { ReactionHandler } from "./types";
 import {
   changeChartAppearance,
@@ -32,6 +32,5 @@ export const reactionHandlers: ReactionHandlers = {
   "metabot.reaction/message": showMessage,
   "metabot.reaction/api-call": apiCall,
   "metabot.reaction/writeback": writeBack,
-  "metabot.reaction/filter-data": filterData,
-  "metabot.reaction/aggregate-data": aggregateData,
+  "metabot.reaction/run-query": runQuery,
 };

--- a/enterprise/frontend/src/metabase-enterprise/metabot/reactions/queries.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/reactions/queries.ts
@@ -1,25 +1,10 @@
 import { updateQuestion } from "metabase/query_builder/actions";
 import { getQuestion } from "metabase/query_builder/selectors";
-import type {
-  MetabotAggregateDataReaction,
-  MetabotFilterDataReaction,
-} from "metabase-types/api";
+import type { MetabotRunQueryReaction } from "metabase-types/api";
 
 import type { ReactionHandler } from "./types";
 
-export const filterData: ReactionHandler<MetabotFilterDataReaction> =
-  reaction =>
-  async ({ dispatch, getState }) => {
-    const question = getQuestion(getState());
-    if (!question) {
-      return;
-    }
-
-    const newQuestion = question.setDatasetQuery(reaction.dataset_query);
-    await dispatch(updateQuestion(newQuestion, { run: true }));
-  };
-
-export const aggregateData: ReactionHandler<MetabotAggregateDataReaction> =
+export const runQuery: ReactionHandler<MetabotRunQueryReaction> =
   reaction =>
   async ({ dispatch, getState }) => {
     const question = getQuestion(getState());

--- a/frontend/src/metabase-types/api/metabot.ts
+++ b/frontend/src/metabase-types/api/metabot.ts
@@ -79,13 +79,8 @@ export type MetabotApiCallReaction = {
   };
 };
 
-export type MetabotFilterDataReaction = {
-  type: "metabot.reaction/filter-data";
-  dataset_query: DatasetQuery;
-};
-
-export type MetabotAggregateDataReaction = {
-  type: "metabot.reaction/aggregate-data";
+export type MetabotRunQueryReaction = {
+  type: "metabot.reaction/run-query";
   dataset_query: DatasetQuery;
 };
 
@@ -140,8 +135,7 @@ export type MetabotReaction =
   | MetabotConfirmationReaction
   | MetabotWriteBackReaction
   | MetabotApiCallReaction
-  | MetabotFilterDataReaction
-  | MetabotAggregateDataReaction;
+  | MetabotRunQueryReaction;
 
 /* Metabot v3 - API Request Types */
 


### PR DESCRIPTION
There are 3 contexts now (previously we had 2):
- FE->BE context, which is what the FE sends
- Tool context, which is passed to each tool and the tool can update it <-- this is new
- BE->LLM context, which is derived from the tool context

Tools do not output reactions now, instead they only update context. There is separate mechanism that checks the context and computes the list of reactions after all tools have been invoked. Currently, in this branch, there are 2 main tools - `filter-data` and `aggregate-data` and they update the passed `query` and `run-query?` property. When all tool calls are made, we check `run-query?` and send a `run-query` reaction to the FE with the provided `query`.