### PR TITLE
Always send a context when calling the search endpoint

### DIFF
--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -111,7 +111,7 @@ export type SearchRequest = {
   models?: SearchModel[];
   ids?: SearchResultId[];
   filter_items_in_personal_collection?: "only" | "exclude";
-  context?: SearchContext;
+  context: SearchContext;
   created_at?: string | null;
   created_by?: UserId[] | null;
   last_edited_at?: string | null;


### PR DESCRIPTION
My thinking is that I can just lean on the typescript checker to smoke out all the usages 😏 