### PR TITLE
Experimental search tweaks v2

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/search/scoring.clj
+++ b/enterprise/backend/src/metabase_enterprise/search/scoring.clj
@@ -25,7 +25,7 @@
   "Return the select-item expressions used to calculate the score for each search result."
   :feature :none
   []
-  (merge (fulltext.scoring/base-scorers) (select-keys enterprise-scorers (additional-scorers))))
+  (merge (fulltext.scoring/base-scorers) (additional-scorers)))
 
 ;; ------------ LEGACY ----------
 

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -40,11 +40,6 @@
   "Results in more dashboards than this are all considered to be equally popular."
   10)
 
-(def ^:const view-count-scaling
-  "A constant factor influencing how quickly the incremental score grows with view count for a given search model.
-  The larger this value, the longer it will take for the score to approach 1.0. It will never quite reach it."
-  0.2)
-
 (def ^:const view-count-scaling-percentile
   "The percentile of the given search model's view counts, to be multiplied by [[view-count-scaling]].
   The larger this value, the longer it will take for the score to approach 1.0. It will never quite reach it."

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -156,12 +156,16 @@
                       archived_directly model]}]
   (let [matching-columns    (into #{} (keep :column relevant-scores))
         match-context-thunk (some :match-context-thunk relevant-scores)
-        remove-thunks       (partial mapv #(dissoc % :match-context-thunk))]
+        remove-thunks       (partial mapv #(dissoc % :match-context-thunk))
+        use-display-name?   (and display_name
+                                 ;; This collection will be empty unless we used in-place matching.
+                                 ;; For now, for simplicity and performance reasons, we are not bothering to check
+                                 ;; *where* the matches in the tsvector came from.
+                                 (or (empty? matching-columns)
+                                     (contains? matching-columns :display_name)))]
     (-> result
         (assoc
-         :name           (if (and (contains? matching-columns :display_name) display_name)
-                           display_name
-                           name)
+         :name           (if use-display-name? display_name name)
          :context        (when (and match-context-thunk
                                     (empty?
                                      (remove matching-columns displayed-columns)))

--- a/src/metabase/search/postgres/scoring.clj
+++ b/src/metabase/search/postgres/scoring.clj
@@ -17,7 +17,13 @@
 (defn size
   "Prefer items whose value is larger, up to some saturation point. Items beyond that point are equivalent."
   [column ceiling]
-  [:least [:/ [:coalesce column [:inline 0]] [:inline (double ceiling)]] [:inline 1]])
+  [:least
+   [:inline 1]
+   [:/
+    [:coalesce column [:inline 0]]
+    (if (number? ceiling)
+      [:inline (double ceiling)]
+      [:cast ceiling :float])]])
 
 (defn atan-size
   "Prefer items whose value is larger, with diminishing gains."

--- a/src/metabase/search/postgres/scoring.clj
+++ b/src/metabase/search/postgres/scoring.clj
@@ -65,9 +65,15 @@
    [[(sum-columns (map weighted-score scorers))
      :total_score]]))
 
-;; Divides rank by log(len(doc))
 ;; See https://www.postgresql.org/docs/current/textsearch-controls.html#TEXTSEARCH-RANKING
-(def ^:private ts-rank-normalization 1)
+;;  0 (the default) ignores the document length
+;;  1 divides the rank by 1 + the logarithm of the document length
+;;  2 divides the rank by the document length
+;;  4 divides the rank by the mean harmonic distance between extents (this is implemented only by ts_rank_cd)
+;;  8 divides the rank by the number of unique words in document
+;; 16 divides the rank by 1 + the logarithm of the number of unique words in document
+;; 32 divides the rank by itself + 1
+(def ^:private ts-rank-normalization 0)
 
 ;; TODO move these to the spec definitions
 (def ^:private bookmarked-models [:card :collection :dashboard])


### PR DESCRIPTION
- Disabled non-linear curve for view-count scoring. Just hit 1 at the p99.
- Disabled text rank normalization - this de-prioritized entities with long descriptions too much.
- Always uses the `display_name` for tables.
- Fixes the enterprise rankers.