### PR TITLE
Simplify epic template to allow for easier editing

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -12,7 +12,7 @@ labels: ".Epic"
 - [product doc](LINK_TO_PRODUCT_DOC)
 - [technical design doc](LINK_TO_TECHNICAL_DESIGN_DOC)
 - [testing plan](LINK_TO_TESTING_PLAN)
-- feature branch: `BRANCH_NAME` _this should be the feature branch where this work will be done in. PRs will be delivered against this branch_
+- feature branch: `BRANCH_NAME`
 - issue links: _related issues, if any_
 
 ### Implementation Plan

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -11,7 +11,7 @@ labels: ".Epic"
 
 - [product doc](LINK_TO_PRODUCT_DOC)
 - [engineering doc](LINK_TO_ENGINEERING_DOC)
-- feature branch: `BRANCH_NAME` _this should be the feature branch where this work will be done in. PRs will be delivered against this branch, if any_
+- feature branch: `BRANCH_NAME` _this should be the feature branch where this work will be done in. PRs will be delivered against this branch_
 - issue links: _related issues, if any_
 
 ### Implementation Plan

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -5,20 +5,18 @@ about: This issue is used to track a feature/project that may span several days
   and manage work.
 title: "[Epic] Title"
 labels: ".Epic"
-
 ---
 
-**Links**
-- product doc: _link to product doc_
-- eng doc: _link to technical design doc, if any_
-- feature branch: `branch-name` _this should be the feature branch where this work will be done in. PRs will be delivered against this branch_
-- issue links: _related issues if any_
+### Links
 
-**Implementation Plan**
+- [product doc](LINK_TO_PRODUCT_DOC)
+- [engineering doc](LINK_TO_ENGINEERING_DOC)
+- feature branch: `BRANCH_NAME` _this should be the feature branch where this work will be done in. PRs will be delivered against this branch, if any_
+- issue links: _related issues, if any_
 
+### Implementation Plan
 
-***Milestone 1***
-_insert tasklist here_
-
-***Milestone 2***
-
+```[tasklist]
+#### Milestone 1
+- [ ] _Add tasks here_
+```

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -10,7 +10,7 @@ labels: ".Epic"
 ### Links
 
 - [product doc](LINK_TO_PRODUCT_DOC)
-- [engineering doc](LINK_TO_ENGINEERING_DOC)
+- [technical design doc](LINK_TO_TECHNICAL_DESIGN_DOC)
 - feature branch: `BRANCH_NAME` _this should be the feature branch where this work will be done in. PRs will be delivered against this branch_
 - issue links: _related issues, if any_
 

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -11,6 +11,7 @@ labels: ".Epic"
 
 - [product doc](LINK_TO_PRODUCT_DOC)
 - [technical design doc](LINK_TO_TECHNICAL_DESIGN_DOC)
+- [testing plan](LINK_TO_TESTING_PLAN)
 - feature branch: `BRANCH_NAME` _this should be the feature branch where this work will be done in. PRs will be delivered against this branch_
 - issue links: _related issues, if any_
 


### PR DESCRIPTION
### Description

Every time I create a new epic I feel a bit of friction with the epic template. This PR attempts to fix these isssues:
- the template does not use github formatted links for links to the product/engineering docs
  - This PR replaces them with properly formatted markdown links
- the template does not use easy-to-select text for items that need to be replaced, so I have to use my mouse to select the text
  - This PR replaces most of the finicky text with `ALL_CAPS_SNAKE_CASE`, which is easy to triple click to select
- the template does not use proper headings for sections, using bold text instead
  - This PR rectifies that
- the epic template does not use GitHub's `[tasklist]` syntax for milestones so I have to remember how to use the syntax and edit the the epic accordingly
  - This PR adds an actual template milestone with tasklist using the proper syntax