### PR TITLE
fix padding on published embeds list

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing/PublicLinksListing.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing/PublicLinksListing.tsx
@@ -2,6 +2,7 @@ import cx from "classnames";
 import { t } from "ttag";
 
 import Confirm from "metabase/components/Confirm";
+import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import Link from "metabase/core/components/Link";
 import AdminS from "metabase/css/admin.module.css";
@@ -32,7 +33,7 @@ export const PublicLinksListing = <
   }
 
   if (data.length === 0) {
-    return noLinksMessage;
+    return <LoadingAndErrorWrapper error={noLinksMessage} />;
   }
 
   return (

--- a/frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing/PublicResources.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing/PublicResources.tsx
@@ -1,3 +1,4 @@
+import cx from "classnames";
 import { t } from "ttag";
 
 import {
@@ -9,6 +10,7 @@ import {
   useListPublicDashboardsQuery,
 } from "metabase/api";
 import { useSetting } from "metabase/common/hooks";
+import CS from "metabase/css/core/index.css";
 import * as Urls from "metabase/lib/urls";
 import type {
   GetPublicAction,
@@ -22,18 +24,20 @@ export const PublicLinksDashboardListing = () => {
   const query = useListPublicDashboardsQuery();
   const [revoke] = useDeleteDashboardPublicLinkMutation();
   return (
-    <PublicLinksListing<GetPublicDashboard>
-      revoke={revoke}
-      getUrl={dashboard => Urls.dashboard(dashboard)}
-      getPublicUrl={({ public_uuid }: GetPublicDashboard) => {
-        if (public_uuid) {
-          return Urls.publicDashboard(public_uuid);
-        }
-        return null;
-      }}
-      noLinksMessage={t`No dashboards have been publicly shared yet.`}
-      {...query}
-    />
+    <div className={cx(CS.bordered, CS.rounded, CS.full)}>
+      <PublicLinksListing<GetPublicDashboard>
+        revoke={revoke}
+        getUrl={dashboard => Urls.dashboard(dashboard)}
+        getPublicUrl={({ public_uuid }: GetPublicDashboard) => {
+          if (public_uuid) {
+            return Urls.publicDashboard(public_uuid);
+          }
+          return null;
+        }}
+        noLinksMessage={t`No dashboards have been publicly shared yet.`}
+        {...query}
+      />
+    </div>
   );
 };
 
@@ -41,18 +45,20 @@ export const PublicLinksQuestionListing = () => {
   const query = useListPublicCardsQuery();
   const [revoke] = useDeleteCardPublicLinkMutation();
   return (
-    <PublicLinksListing<GetPublicCard>
-      revoke={revoke}
-      getUrl={question => Urls.question(question)}
-      getPublicUrl={({ public_uuid }) => {
-        if (public_uuid) {
-          return Urls.publicQuestion({ uuid: public_uuid });
-        }
-        return null;
-      }}
-      noLinksMessage={t`No questions have been publicly shared yet.`}
-      {...query}
-    />
+    <div className={cx(CS.bordered, CS.rounded, CS.full)}>
+      <PublicLinksListing<GetPublicCard>
+        revoke={revoke}
+        getUrl={question => Urls.question(question)}
+        getPublicUrl={({ public_uuid }) => {
+          if (public_uuid) {
+            return Urls.publicQuestion({ uuid: public_uuid });
+          }
+          return null;
+        }}
+        noLinksMessage={t`No questions have been publicly shared yet.`}
+        {...query}
+      />
+    </div>
   );
 };
 
@@ -62,17 +68,19 @@ export const PublicLinksActionListing = () => {
   const [revoke] = useDeleteActionPublicLinkMutation();
 
   return (
-    <PublicLinksListing<GetPublicAction>
-      revoke={revoke}
-      getUrl={action => Urls.action({ id: action.model_id }, action.id)}
-      getPublicUrl={({ public_uuid }) => {
-        if (public_uuid) {
-          return Urls.publicAction(siteUrl, public_uuid);
-        }
-        return null;
-      }}
-      noLinksMessage={t`No actions have been publicly shared yet.`}
-      {...query}
-    />
+    <div className={cx(CS.bordered, CS.rounded, CS.full)}>
+      <PublicLinksListing<GetPublicAction>
+        revoke={revoke}
+        getUrl={action => Urls.action({ id: action.model_id }, action.id)}
+        getPublicUrl={({ public_uuid }) => {
+          if (public_uuid) {
+            return Urls.publicAction(siteUrl, public_uuid);
+          }
+          return null;
+        }}
+        noLinksMessage={t`No actions have been publicly shared yet.`}
+        {...query}
+      />
+    </div>
   );
 };


### PR DESCRIPTION

Closes the issue reported here: https://metaboat.slack.com/archives/C063Q3F1HPF/p1732048755464569

### Description

Commit 1 fixes the missing padding by adding back the same component used originally: https://github.com/metabase/metabase/commit/3c16a1bdb0e1c032d7e347c955c20f4725b20531#diff-cf7f65b354d04f8fb18deb685341cc334dbb8a4f42ba93f5200546e4037c5b57L58-L63

Commit 2 adds the border to the public links to make them consistent with the list of embeds. I didn't add the maxWidth as it was not present and public links tends to be long.


### How to verify

Open http://localhost:3000/admin/settings/public-sharing and http://localhost:3000/admin/settings/embedding-in-other-applications/standalone without any public links/embeds shared



### Demo
Before
Embeds:
<img width="2183" alt="image" src="https://github.com/user-attachments/assets/f421d213-eaa0-4363-818e-7548888f3162">


Public:
<img width="2180" alt="image" src="https://github.com/user-attachments/assets/9b9610f0-70a7-485f-94f1-1d514ecbab8a">


After:
Embeds:
<img width="1578" alt="image" src="https://github.com/user-attachments/assets/2902362e-fc49-428a-9e07-c1ec24bfba51">


Public:

<img width="2180" alt="image" src="https://github.com/user-attachments/assets/faf8f795-6d5a-4ad5-acab-f8e82fdc1594">
