### PR TITLE
fix(sdk): cli suggests a relative import path with reminder message

### DIFF
--- a/docs/embedding/sdk/quickstart-cli.md
+++ b/docs/embedding/sdk/quickstart-cli.md
@@ -61,7 +61,7 @@ npm run start
 
 ## Generates React components that you'll import into your app
 
-Generates example React components files. By default, it will save them in `./components/metabase` in your React app, though the tool will prompt you to save them to a different directory (e.g., `./src/components/metabase`).
+Generates example React components files. By default, it will save them in `./src/components/metabase` in your React app, though the tool will prompt you to save them to a different directory (e.g., `./src/analytics`).
 
 ## Add the Metabase/React components to your app
 
@@ -70,7 +70,7 @@ Once the mock server is running, go back to the tool's terminal session and pres
 Prompts you to add the following `import` in your client app:
 
 ```sh
-import { AnalyticsPage } from "../metabase/components";
+import { AnalyticsPage } from "./metabase";
 ```
 
 Make sure the `from` path is valid (depending on your app, you may need to move the components to a new directory).

--- a/enterprise/frontend/src/embedding-sdk/cli/constants/config.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/constants/config.ts
@@ -19,3 +19,5 @@ export const HARDCODED_JWT_SHARED_SECRET =
 
 // Name of the permission groups and collections to create.
 export const SANDBOXED_GROUP_NAMES = ["Customer A", "Customer B", "Customer C"];
+
+export const GENERATED_COMPONENTS_DEFAULT_PATH = "./src/components/metabase";

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/generate-component-files.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/generate-component-files.ts
@@ -2,6 +2,7 @@ import fs from "fs/promises";
 
 import { input } from "@inquirer/prompts";
 
+import { GENERATED_COMPONENTS_DEFAULT_PATH } from "../constants/config";
 import { getGeneratedComponentFilesMessage } from "../constants/messages";
 import { ANALYTICS_CSS_SNIPPET } from "../snippets/analytics-css-snippet";
 import type { CliStepMethod } from "../types/cli";
@@ -24,7 +25,7 @@ export const generateReactComponentFiles: CliStepMethod = async state => {
   while (true) {
     path = await input({
       message: "Where do you want to save the example React components?",
-      default: "./components/metabase",
+      default: GENERATED_COMPONENTS_DEFAULT_PATH,
     });
 
     // Create a directory if it doesn't already exist.

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/show-post-setup-steps.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/show-post-setup-steps.ts
@@ -25,7 +25,7 @@ export const showPostSetupSteps: CliStepMethod = async state => {
   ${green(`import { AnalyticsPage } from "${importPath}";`)}
 
   Make sure the import path is valid.
-  Depending on your app, you may need to move the components to a new directory.
+  Depending on your app's directory structure, you may need to move the components to a new directory.
 
   Then, add the component to your page.
   ${green(`<AnalyticsPage />`)}

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/show-post-setup-steps.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/show-post-setup-steps.ts
@@ -1,6 +1,8 @@
 import { select } from "@inquirer/prompts";
 import { green } from "chalk";
+import path from "path";
 
+import { GENERATED_COMPONENTS_DEFAULT_PATH } from "../constants/config";
 import {
   SDK_LEARN_MORE_MESSAGE,
   getMetabaseInstanceSetupCompleteMessage,
@@ -17,11 +19,22 @@ export const showPostSetupSteps: CliStepMethod = async state => {
   ${green("npm run start")}
 `;
 
-  const STEP_2 = `
-  Import the component in your React frontend.
-  ${green(`import { AnalyticsPage } from "./${state.reactComponentDir}";`)}
+  // We don't actually know which path the user will import the component from,
+  // so the suggested import path is the last directory in the path.
+  // e.g. "./src/components/metabase" -> "./metabase".
+  const importPath = path.join(
+    "./",
+    path.basename(state.reactComponentDir ?? GENERATED_COMPONENTS_DEFAULT_PATH),
+  );
 
-  Add the component to your page.
+  const STEP_2 = `
+  Import the component in your React frontend. For example:
+  ${green(`import { AnalyticsPage } from "${importPath}";`)}
+
+  Make sure the import path is valid.
+  Depending on your app, you may need to move the components to a new directory.
+
+  Then, add the component to your page.
   ${green(`<AnalyticsPage />`)}
 `;
 

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/show-post-setup-steps.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/show-post-setup-steps.ts
@@ -19,17 +19,17 @@ export const showPostSetupSteps: CliStepMethod = async state => {
   ${green("npm run start")}
 `;
 
-  // We don't actually know which path the user will import the component from,
-  // so the suggested import path is the last directory in the path.
+  // We don't actually know which path the user will import the component from.
+  // We assume they will import from their components directory,
+  // so we use the last directory in the path as an example.
   // e.g. "./src/components/metabase" -> "./metabase".
-  const importPath = path.join(
-    "./",
-    path.basename(state.reactComponentDir ?? GENERATED_COMPONENTS_DEFAULT_PATH),
+  const exampleImportPath = path.basename(
+    state.reactComponentDir ?? GENERATED_COMPONENTS_DEFAULT_PATH,
   );
 
   const STEP_2 = `
   Import the component in your React frontend. For example:
-  ${green(`import { AnalyticsPage } from "${importPath}";`)}
+  ${green(`import { AnalyticsPage } from "./${exampleImportPath}";`)}
 
   Make sure the import path is valid.
   Depending on your app, you may need to move the components to a new directory.

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/show-post-setup-steps.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/show-post-setup-steps.ts
@@ -1,13 +1,12 @@
 import { select } from "@inquirer/prompts";
 import { green } from "chalk";
-import path from "path";
 
-import { GENERATED_COMPONENTS_DEFAULT_PATH } from "../constants/config";
 import {
   SDK_LEARN_MORE_MESSAGE,
   getMetabaseInstanceSetupCompleteMessage,
 } from "../constants/messages";
 import type { CliStepMethod } from "../types/cli";
+import { getSuggestedImportPath } from "../utils/get-suggested-import-path";
 import { printEmptyLines, printWithPadding } from "../utils/print";
 
 export const showPostSetupSteps: CliStepMethod = async state => {
@@ -19,17 +18,11 @@ export const showPostSetupSteps: CliStepMethod = async state => {
   ${green("npm run start")}
 `;
 
-  // We don't actually know which path the user will import the component from.
-  // We assume they will import from their components directory,
-  // so we use the last directory in the path as an example.
-  // e.g. "./src/components/metabase" -> "./metabase".
-  const exampleImportPath = path.basename(
-    state.reactComponentDir ?? GENERATED_COMPONENTS_DEFAULT_PATH,
-  );
+  const importPath = getSuggestedImportPath(state.reactComponentDir);
 
   const STEP_2 = `
   Import the component in your React frontend. For example:
-  ${green(`import { AnalyticsPage } from "./${exampleImportPath}";`)}
+  ${green(`import { AnalyticsPage } from "${importPath}";`)}
 
   Make sure the import path is valid.
   Depending on your app, you may need to move the components to a new directory.

--- a/enterprise/frontend/src/embedding-sdk/cli/utils/get-suggested-import-path.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/utils/get-suggested-import-path.ts
@@ -1,0 +1,15 @@
+import path from "path";
+
+// We don't actually know which path the user will import the component from.
+// We assume they will import from their components directory,
+// so we use the last directory in the path as an example.
+// e.g. "./src/components/metabase" -> "./metabase".
+import { GENERATED_COMPONENTS_DEFAULT_PATH } from "../constants/config";
+
+export const getSuggestedImportPath = (componentDir?: string): string => {
+  const importPath = path.basename(
+    componentDir || GENERATED_COMPONENTS_DEFAULT_PATH,
+  );
+
+  return importPath.startsWith(".") ? importPath : `./${importPath}`;
+};

--- a/enterprise/frontend/src/embedding-sdk/cli/utils/get-suggested-import-path.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/utils/get-suggested-import-path.ts
@@ -1,12 +1,12 @@
 import path from "path";
 
-// We don't actually know which path the user will import the component from.
-// We assume they will import from their components directory,
-// so we use the last directory in the path as an example.
-// e.g. "./src/components/metabase" -> "./metabase".
 import { GENERATED_COMPONENTS_DEFAULT_PATH } from "../constants/config";
 
 export const getSuggestedImportPath = (componentDir?: string): string => {
+  // We don't know where the user will import the component from.
+  // We assume they will import from their components directory,
+  // so we use the last directory in the path as an example.
+  // e.g. "./src/components/metabase" -> "./metabase".
   const importPath = path.basename(
     componentDir || GENERATED_COMPONENTS_DEFAULT_PATH,
   );

--- a/enterprise/frontend/src/embedding-sdk/cli/utils/get-suggested-import-path.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/utils/get-suggested-import-path.unit.spec.ts
@@ -1,0 +1,11 @@
+import { getSuggestedImportPath } from "../utils/get-suggested-import-path";
+
+describe("CLI > getSuggestedImportPath", () => {
+  it.each([
+    ["", "./metabase"],
+    [".", "."],
+    ["./src/components", "./components"],
+  ])("suggests a reasonable import path", (input, suggestion) => {
+    expect(getSuggestedImportPath(input)).toBe(suggestion);
+  });
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50093

### Description

Uses the last path segment as an [import path](https://www.loom.com/share/a3177f2a91c1404a83ead516effbd436) (e.g. `./src/components/metabase` -> `./metabase`), and print a message to remind users to update the import path to match their app. It also updates the default import path to `./src/components/metabase` to be a more reasonable default.

### Demo

![CleanShot 2567-11-20 at 20 38 45@2x](https://github.com/user-attachments/assets/d1fd7a0d-c49a-46b4-924c-4c39bd1dde2f)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - Unit
