### PR TITLE
Improve SDK release job title

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -1,4 +1,5 @@
 name: Release Metabase Embedding SDK for React
+run-name: Release SDK from ${{ inputs.branch }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
### Description

It's not clear what branch we're deploying the SDK from. Now we can deploy from 2 branches, `master` or `release-x.51.x`.

This PR surfaces this info in the title for easy troubleshooting.

### Demo

[See the run here](https://github.com/metabase/metabase/actions/workflows/release-embedding-sdk.yml). I manually triggered this with `branch=master`

![image](https://github.com/user-attachments/assets/8b293982-90be-47be-b639-eb51769b56d6)
