### PR TITLE
Add metrics support in diagnostics dialog

### DIFF
--- a/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.unit.spec.tsx
+++ b/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.unit.spec.tsx
@@ -88,6 +88,7 @@ describe("ErrorDiagnosticsModal", () => {
     "question",
     "dashboard",
     "collection",
+    "metric",
     "model",
   ];
 
@@ -138,6 +139,15 @@ describe("ErrorDiagnosticsModal", () => {
       localizedEntityName: "Dashboard",
     });
     expect(screen.queryByText(/query results/i)).not.toBeInTheDocument();
+  });
+
+  it("should show query results checkbox for metrics", () => {
+    setup({
+      ...defaultErrorPayload,
+      entityName: "metric",
+      localizedEntityName: "Metric",
+    });
+    expect(screen.getByText(/query results/i)).toBeInTheDocument();
   });
 
   it("should not show backend logs checkboxes when we don't have any logs", () => {

--- a/frontend/src/metabase/components/ErrorPages/types.ts
+++ b/frontend/src/metabase/components/ErrorPages/types.ts
@@ -10,6 +10,7 @@ import type {
 export type ReportableEntityName =
   | "question"
   | "model"
+  | "metric"
   | "dashboard"
   | "collection";
 

--- a/frontend/src/metabase/components/ErrorPages/use-error-info.ts
+++ b/frontend/src/metabase/components/ErrorPages/use-error-info.ts
@@ -34,7 +34,7 @@ export const useErrorInfo = (
     }
     // https://regexr.com/7ra8o
     const matches = location.match(
-      /(question|model|dashboard|collection)[[\/\#]([\d\w]+)/,
+      /(question|model|dashboard|collection|metric)[[\/\#]([\d\w]+)/,
     );
 
     const entity = (matches?.[1] ?? undefined) as

--- a/frontend/src/metabase/components/ErrorPages/utils.ts
+++ b/frontend/src/metabase/components/ErrorPages/utils.ts
@@ -33,6 +33,7 @@ export const getEntityDetails = ({
   }
 
   switch (entity) {
+    case "metric":
     case "question":
     case "model":
       if (isAdHoc) {
@@ -55,6 +56,7 @@ export const getEntityDetails = ({
 
 export const hasQueryData = (
   entityName?: ReportableEntityName | null,
-): boolean => !!entityName && ["question", "model"].includes(entityName);
+): boolean =>
+  !!entityName && ["question", "model", "metric"].includes(entityName);
 
 const nullOnCatch = () => null;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50328

### Description

Adds diagnostics information about metrics.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Open a metric
2. Do Cmd/Ctrl + F1 to pop the diagnostics modal
3. Verify that the entity is available