### PR TITLE
Search Index refactor: calculate model rank on the fly

### DIFF
--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -152,6 +152,11 @@
   [scorer-key]
   (get (weights) scorer-key 0))
 
+(defn scorer-param
+  "Get a nested parameter scoped to the given scorer"
+  [scorer-key param-key]
+  (get (weights) (keyword (name scorer-key) (name param-key))))
+
 (defn model->alias
   "Given a model string returns the model alias"
   [model]

--- a/src/metabase/search/postgres/index.clj
+++ b/src/metabase/search/postgres/index.clj
@@ -62,7 +62,6 @@
         ;; scoring related
          [:dashboardcard_count :int]
          [:last_viewed_at :timestamp]
-         [:model_rank :int :not-null]
          [:official_collection :boolean]
          [:pinned :boolean]
          [:verified :boolean]
@@ -121,9 +120,7 @@
       (select-keys
        ;; remove attrs that get aliased
        (remove #{:id :created_at :updated_at :native_query}
-               (conj search.spec/attr-columns
-                     :model :model_rank
-                     :display_data :legacy_input)))
+               (conj search.spec/attr-columns :model :display_data :legacy_input)))
       (update :display_data json/generate-string)
       (update :legacy_input json/generate-string)
       (assoc

--- a/src/metabase/search/postgres/ingestion.clj
+++ b/src/metabase/search/postgres/ingestion.clj
@@ -3,8 +3,7 @@
    [clojure.string :as str]
    [honey.sql.helpers :as sql.helpers]
    [medley.core :as m]
-   [metabase.search.config :as search.config]
-   [metabase.search.postgres.index :as search.index]
+  [metabase.search.postgres.index :as search.index]
    [metabase.search.spec :as search.spec]
    [metabase.task :as task]
    [metabase.util :as u]
@@ -21,13 +20,6 @@
 (def ^:private batch-max 50)
 
 (def ^:private insert-batch-size 150)
-
-(def ^:private model-rankings
-  (zipmap search.config/models-search-order (range)))
-
-(defn- model-rank [model]
-  ;; Give unknown models the lowest priority
-  (model-rankings model (count model-rankings)))
 
 (defn- searchable-text [m]
   ;; For now, we never index the native query content
@@ -48,8 +40,7 @@
       (assoc
        :display_data (display-data m)
        :legacy_input m
-       :searchable_text (searchable-text m)
-       :model_rank (model-rank (:model m)))))
+       :searchable_text (searchable-text m))))
 
 (defn- attrs->select-items [attrs]
   (for [[k v] attrs :when v]

--- a/src/metabase/search/postgres/scoring.clj
+++ b/src/metabase/search/postgres/scoring.clj
@@ -130,6 +130,17 @@
                         1))
     #_(atan-size :view_count [:* 0.1 [:greatest 1 (into [:case] cat cases)]])))
 
+;; TODO make this context dependent + dynamic + non-linear
+(def ^:private model-rank-exp
+  (let [search-order search.config/models-search-order
+        n            (double (count search-order))
+        cases        (map-indexed (fn [i sm]
+                                    [[:= :search_index.model sm] [:inline (/ (- n i) n)]])
+                                  search-order)]
+    (-> (into [:case] cat (concat cases))
+        ;; if you're not listed, get a very poor score
+        (into [:else [:inline 0.01]]))))
+
 (defn base-scorers
   "The default constituents of the search ranking scores."
   [search-ctx]
@@ -140,7 +151,7 @@
    :recency      (inverse-duration [:coalesce :last_viewed_at :model_updated_at] [:now] search.config/stale-time-in-days)
    :user-recency (inverse-duration (user-recency-expr search-ctx) [:now] search.config/stale-time-in-days)
    :dashboard    (size :dashboardcard_count search.config/dashboard-count-ceiling)
-   :model        (idx-rank :model_rank (count search.config/all-models))})
+   :model        model-rank-exp})
 
 (defenterprise scorers
   "Return the select-item expressions used to calculate the score for each search result."

--- a/test/metabase/search/fulltext/scoring_test.clj
+++ b/test/metabase/search/fulltext/scoring_test.clj
@@ -109,7 +109,13 @@
       (is (= [["metric"  3 "card old"]
               ["card"    2 "card recent"]
               ["dataset" 1 "card ancient"]]
-             (search :model "card"))))))
+             (search :model "card"))))
+    (testing "We can override this order with weights"
+      (is (= [["dataset" 1 "card ancient"]
+              ["metric"  3 "card old"]
+              ["card"    2 "card recent"]]
+             (mt/with-dynamic-redefs [search.config/weights (constantly {:model 1.0 :model/dataset 1.0})]
+               (search :model "card")))))))
 
 (deftest ^:parallel recency-test
   (let [right-now   (Instant/now)


### PR DESCRIPTION
Make model ranking dynamic, so that:

1. We can experiment with it on-the-fly in Stats.
2. We can make it context dependent in future.