### PR TITLE
Search Index: allow weight overrides per context

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/search/scoring.clj
+++ b/enterprise/backend/src/metabase_enterprise/search/scoring.clj
@@ -56,7 +56,7 @@
   {:name   (legacy-name k)
    :score  (let [f (get legacy-scorers k)]
              (f result))
-   :weight (search.config/weight k)})
+   :weight (search.config/weight :default k)})
 
 (defenterprise score-result
   "Scoring implementation that adds score for items in official collections."

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -80,10 +80,11 @@
   (when (= context :all)
     (throw (ex-info (str "Cannot set weights for all context")
                     {:status-code 400})))
-  (let [allowed-key?    (set (keys (:default @#'search.config/static-weights)))
-        unknown-weights (seq (remove allowed-key? (keys overrides)))]
-    (when unknown-weights
-      (throw (ex-info (str "Unknown weights: " (str/join ", " (map name (sort unknown-weights))))
+  (let [known-ranker?   (set (keys (:default @#'search.config/static-weights)))
+        rankers         (into #{} (map (fn [k] (keyword (first (str/split (name k) #"/"))))) (keys overrides))
+        unknown-rankers (seq (remove known-ranker? rankers))]
+    (when unknown-rankers
+      (throw (ex-info (str "Unknown rankers: " (str/join ", " (map name (sort unknown-rankers))))
                       {:status-code 400})))
     (public-settings/experimental-search-weight-overrides!
      (merge-with merge (public-settings/experimental-search-weight-overrides) {context overrides}))))

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -81,17 +81,18 @@
 
 (assert (= all-models (set models-search-order)) "The models search order has to include all models")
 
-(def ^:private default-weights
-  {:pinned              0
-   :bookmarked          2
-   :recency             1.5
-   :user-recency        1.5
-   :dashboard           0.5
-   :model               2
-   :official-collection 2
-   :verified            2
-   :view-count          2
-   :text                10})
+(def ^:private static-weights
+  {:default
+   {:pinned              0
+    :bookmarked          2
+    :recency             1.5
+    :user-recency        1.5
+    :dashboard           0.5
+    :model               2
+    :official-collection 2
+    :verified            2
+    :view-count          2
+    :text                10}})
 
 (def ^:private FilterDef
   "A relaxed definition, capturing how we can write the filter - with some fields omitted."
@@ -144,18 +145,25 @@
 
 (defn weights
   "Strength of the various scorers. Copied from metabase.search.in-place.scoring, but allowing divergence."
-  []
-  (merge default-weights (public-settings/experimental-search-weight-overrides)))
+  [context]
+  (let [context   (or context :default)
+        overrides (public-settings/experimental-search-weight-overrides)]
+    (if (= :all context)
+      (merge-with merge static-weights overrides)
+      (merge {}
+             (get static-weights context)
+             (get overrides context)))))
 
 (defn weight
   "The relative strength the corresponding score has in influencing the total score."
-  [scorer-key]
-  (get (weights) scorer-key 0))
+  [context scorer-key]
+  (get (weights context) scorer-key (when-not (namespace scorer-key) 0)))
 
 (defn scorer-param
   "Get a nested parameter scoped to the given scorer"
-  [scorer-key param-key]
-  (get (weights) (keyword (name scorer-key) (name param-key))))
+  [context scorer-key param-key]
+  (let [flat-key (keyword (name scorer-key) (name param-key))]
+    (weight context flat-key)))
 
 (defn model->alias
   "Given a model string returns the model alias"

--- a/src/metabase/search/postgres/core.clj
+++ b/src/metabase/search/postgres/core.clj
@@ -71,7 +71,7 @@
   (when s
     (OffsetDateTime/parse s)))
 
-(defn- rehydrate [index-row]
+(defn- rehydrate [context index-row]
   ;; Useful for debugging scoring
   #_(dissoc index-row :legacy_input :created_at :updated_at :last_edited_at)
   (-> (merge
@@ -80,7 +80,7 @@
       (assoc :scores (mapv (fn [k]
                              ;; we shouldn't get null scores, but just in case (i.e., because there are bugs)
                              (let [score  (or (get index-row k) 0)
-                                   weight (search.config/weight k)]
+                                   weight (search.config/weight context k)]
                                {:score        score
                                 :name         k
                                 :weight       weight
@@ -113,7 +113,7 @@
        (search.scoring/with-scores search-ctx)
        (search.filter/with-filters search-ctx)
        t2/query
-       (map rehydrate)))
+       (map (partial rehydrate (:context search-ctx)))))
 
 (def ^:private default-engine fulltext)
 

--- a/src/metabase/search/postgres/ingestion.clj
+++ b/src/metabase/search/postgres/ingestion.clj
@@ -3,7 +3,7 @@
    [clojure.string :as str]
    [honey.sql.helpers :as sql.helpers]
    [medley.core :as m]
-  [metabase.search.postgres.index :as search.index]
+   [metabase.search.postgres.index :as search.index]
    [metabase.search.spec :as search.spec]
    [metabase.task :as task]
    [metabase.util :as u]

--- a/src/metabase/search/postgres/scoring.clj
+++ b/src/metabase/search/postgres/scoring.clj
@@ -74,7 +74,7 @@
   (concat
    (for [[column-alias expr] scorers]
      [expr column-alias])
-   [[(sum-columns (map weighted-score context scorers))
+   [[(sum-columns (map (partial weighted-score context) scorers))
      :total_score]]))
 
 ;; See https://www.postgresql.org/docs/current/textsearch-controls.html#TEXTSEARCH-RANKING

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -1596,7 +1596,15 @@
   ([]
    "search/weights")
   ([params]
-   (str (weights-url) (when (seq params) "?") (str/join "&" (map (fn [[k v]] (str (name k) "=" v)) params))))
+   (str (weights-url)
+        (when (seq params) "?")
+        (str/join "&" (map (fn [[k v]]
+                             (str
+                              (namespace k)
+                              (when (namespace k) "/")
+                              (name k)
+                              "=" v))
+                           params))))
   ([context params]
    (weights-url (assoc params :context (name context)))))
 
@@ -1613,32 +1621,39 @@
         (is (= (assoc original-weights :recency 4.0 :text 30.0)
                (mt/user-http-request :crowberto :get 200 (weights-url {:text 30}))))
         (is (= (assoc original-weights :recency 4.0 :text 30.0)
-               (mt/user-http-request :crowberto :get 200 base-url)))
+               (mt/user-http-request :crowberto :get 200 base-url))))
 
-        (testing "custom context"
-          (let [context          :none-given
-                context-url      (weights-url context {})
-                original-weights (search.config/weights context)]
-            (is (= original-weights (mt/user-http-request :crowberto :get 200 context-url)))
-            (is (mt/user-http-request :rasta :get 403 (weights-url context {:recency 5})))
-            (is (= (assoc original-weights :recency 5.0)
-                   (mt/user-http-request :crowberto :get 200 (weights-url context {:recency 5}))))
-            (is (= (assoc original-weights :recency 5.0 :text 40.0)
-                   (mt/user-http-request :crowberto :get 200 (weights-url context {:text 40}))))
-            (is (= (assoc original-weights :recency 5.0 :text 40.0)
-                   (mt/user-http-request :crowberto :get 200 context-url)))))
+      (testing "custom context"
+        (let [context          :none-given
+              context-url      (weights-url context {})
+              original-weights (search.config/weights context)]
+          (is (= original-weights (mt/user-http-request :crowberto :get 200 context-url)))
+          (is (mt/user-http-request :rasta :get 403 (weights-url context {:recency 5})))
+          (is (= (assoc original-weights :recency 5.0)
+                 (mt/user-http-request :crowberto :get 200 (weights-url context {:recency 5}))))
+          (is (= (assoc original-weights :recency 5.0 :text 40.0)
+                 (mt/user-http-request :crowberto :get 200 (weights-url context {:text 40}))))
+          (is (= (assoc original-weights :recency 5.0 :text 40.0)
+                 (mt/user-http-request :crowberto :get 200 context-url)))))
 
-        (testing "all weights (nested)"
-          (let [context     :all
-                context-url (weights-url context {})
-                all-weights (search.config/weights context)]
-            (is (= all-weights (mt/user-http-request :crowberto :get 200 context-url)))
-            (is (= (mt/user-http-request :crowberto :get 200 base-url)
-                   (:default (mt/user-http-request :crowberto :get 200 context-url))))
-            (is (mt/user-http-request :rasta :get 403 (weights-url context {:recency 4})))
-            (is (mt/user-http-request :crowberto :get 400 (weights-url context {:recency 4})))
-            (is (mt/user-http-request :crowberto :get 400 (weights-url context {:text 30})))
-            (is (= all-weights (mt/user-http-request :crowberto :get 200 context-url))))))
+      (testing "all weights (nested)"
+        (let [context     :all
+              context-url (weights-url context {})
+              all-weights (search.config/weights context)]
+          (is (= all-weights (mt/user-http-request :crowberto :get 200 context-url)))
+          (is (= (mt/user-http-request :crowberto :get 200 base-url)
+                 (:default (mt/user-http-request :crowberto :get 200 context-url))))
+          (is (mt/user-http-request :rasta :get 403 (weights-url context {:recency 4})))
+          (is (mt/user-http-request :crowberto :get 400 (weights-url context {:recency 4})))
+          (is (mt/user-http-request :crowberto :get 400 (weights-url context {:text 30})))
+          (is (= all-weights (mt/user-http-request :crowberto :get 200 context-url)))))
+
+      (testing "ranker parameters"
+        (let [context :just-for-fun]
+          (is (mt/user-http-request :crowberto :get 200 (weights-url context {:model/dataset 10})))
+          (is (= 10.0 (search.config/scorer-param context :model :dataset)))
+          (is (mt/user-http-request :crowberto :get 200 (weights-url context {:model/dataset 5})))
+          (is (= 5.0 (search.config/scorer-param context :model :dataset)))))
 
       (finally
         (public-settings/experimental-search-weight-overrides! original-overrides)))))

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -1592,19 +1592,53 @@
                   (Thread/sleep 200)
                   (recur (dec attempts-left))))))))))
 
+(defn- weights-url
+  ([]
+   "search/weights")
+  ([params]
+   (str (weights-url) (when (seq params) "?") (str/join "&" (map (fn [[k v]] (str (name k) "=" v)) params))))
+  ([context params]
+   (weights-url (assoc params :context (name context)))))
+
 (deftest weights-test
-  (let [original-weights   (search.config/weights)
+  (let [base-url           (weights-url)
+        original-weights   (search.config/weights :default)
         original-overrides (public-settings/experimental-search-weight-overrides)]
     (try
-      (is (= original-weights (mt/user-http-request :crowberto :get 200 "search/weights")))
-      (is (mt/user-http-request :rasta :put 403 "search/weights"))
-      (is (= original-weights (mt/user-http-request :crowberto :put 200 "search/weights")))
-      (is (= (assoc original-weights :recency 4 :text 20)
-             (mt/user-http-request :crowberto :put 200 "search/weights" {:recency 4, :text 20})))
-      (is (= (assoc original-weights :recency 4 :text 30.0)
-             (mt/user-http-request :crowberto :get 200 "search/weights?text=30")))
-      (is (mt/user-http-request :crowberto :put 400 "search/weights" {:bad-spelling 2}))
-      (is (= (assoc original-weights :recency 4 :text 30.0)
-             (mt/user-http-request :crowberto :get 200 "search/weights")))
+      (testing "default weights"
+        (is (= original-weights (mt/user-http-request :crowberto :get 200 base-url)))
+        (is (mt/user-http-request :rasta :get 403 (weights-url {:recency 4})))
+        (is (= (assoc original-weights :recency 4.0)
+               (mt/user-http-request :crowberto :get 200 (weights-url {:recency 4}))))
+        (is (= (assoc original-weights :recency 4.0 :text 30.0)
+               (mt/user-http-request :crowberto :get 200 (weights-url {:text 30}))))
+        (is (= (assoc original-weights :recency 4.0 :text 30.0)
+               (mt/user-http-request :crowberto :get 200 base-url)))
+
+        (testing "custom context"
+          (let [context          :none-given
+                context-url      (weights-url context {})
+                original-weights (search.config/weights context)]
+            (is (= original-weights (mt/user-http-request :crowberto :get 200 context-url)))
+            (is (mt/user-http-request :rasta :get 403 (weights-url context {:recency 5})))
+            (is (= (assoc original-weights :recency 5.0)
+                   (mt/user-http-request :crowberto :get 200 (weights-url context {:recency 5}))))
+            (is (= (assoc original-weights :recency 5.0 :text 40.0)
+                   (mt/user-http-request :crowberto :get 200 (weights-url context {:text 40}))))
+            (is (= (assoc original-weights :recency 5.0 :text 40.0)
+                   (mt/user-http-request :crowberto :get 200 context-url)))))
+
+        (testing "all weights (nested)"
+          (let [context     :all
+                context-url (weights-url context {})
+                all-weights (search.config/weights context)]
+            (is (= all-weights (mt/user-http-request :crowberto :get 200 context-url)))
+            (is (= (mt/user-http-request :crowberto :get 200 base-url)
+                   (:default (mt/user-http-request :crowberto :get 200 context-url))))
+            (is (mt/user-http-request :rasta :get 403 (weights-url context {:recency 4})))
+            (is (mt/user-http-request :crowberto :get 400 (weights-url context {:recency 4})))
+            (is (mt/user-http-request :crowberto :get 400 (weights-url context {:text 30})))
+            (is (= all-weights (mt/user-http-request :crowberto :get 200 context-url))))))
+
       (finally
         (public-settings/experimental-search-weight-overrides! original-overrides)))))

--- a/test/metabase/search/fulltext/scoring_test.clj
+++ b/test/metabase/search/fulltext/scoring_test.clj
@@ -79,7 +79,7 @@
 (defn- search-no-weights
   "Like search but with all weights set to 0."
   [ranker-key & args]
-  (mt/with-dynamic-redefs [search.config/weights #(assoc @#'search.config/default-weights ranker-key 0)]
+  (mt/with-dynamic-redefs [search.config/weights #(assoc @#'search.config/static-weights ranker-key 0)]
     (apply search* ranker-key args)))
 
 (defn- search [& args]

--- a/test/metabase/search/fulltext/scoring_test.clj
+++ b/test/metabase/search/fulltext/scoring_test.clj
@@ -79,7 +79,7 @@
 (defn- search-no-weights
   "Like search but with all weights set to 0."
   [ranker-key & args]
-  (mt/with-dynamic-redefs [search.config/weights #(assoc @#'search.config/static-weights ranker-key 0)]
+  (mt/with-dynamic-redefs [search.config/weights #(assoc (:default @#'search.config/static-weights) ranker-key 0)]
     (apply search* ranker-key args)))
 
 (defn- search [& args]


### PR DESCRIPTION
Combined with dynamic model ranking, this lets us specify the precedence order of the different models for each context.