### PR TITLE
hide pivoted exports under env var

### DIFF
--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -183,6 +183,7 @@ export const createMockSettings = (
   "enable-embedding-interactive": false,
   "enable-enhancements?": false,
   "enable-nested-queries": true,
+  "enable-pivoted-exports": true,
   "expand-browse-in-nav": true,
   "expand-bookmarks-in-nav": true,
   "query-caching-ttl-ratio": 10,

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -307,6 +307,7 @@ interface PublicSettings {
   "embedding-app-origins-interactive": string | null;
   "enable-enhancements?": boolean;
   "enable-password-login": boolean;
+  "enable-pivoted-exports": boolean;
   engines: Record<string, Engine>;
   "google-auth-client-id": string | null;
   "google-auth-enabled": boolean;

--- a/frontend/src/metabase/common/components/ExportSettingsWidget/ExportSettingsWidget.tsx
+++ b/frontend/src/metabase/common/components/ExportSettingsWidget/ExportSettingsWidget.tsx
@@ -1,5 +1,6 @@
 import { t } from "ttag";
 
+import { useSetting } from "metabase/common/hooks";
 import type { ExportFormat } from "metabase/common/types/export";
 import { useSelector } from "metabase/lib/redux";
 import { getApplicationName } from "metabase/selectors/whitelabel";
@@ -28,6 +29,7 @@ export const ExportSettingsWidget = ({
   onToggleFormatting,
   onTogglePivoting,
 }: ExportSettingsWidgetProps) => {
+  const arePivotedExportsEnabled = useSetting("enable-pivoted-exports") ?? true;
   const applicationName = useSelector(getApplicationName);
   return (
     <Stack>
@@ -65,7 +67,7 @@ export const ExportSettingsWidget = ({
           </Text>
         </Stack>
       ) : null}
-      {canConfigurePivoting ? (
+      {arePivotedExportsEnabled && canConfigurePivoting ? (
         <Checkbox
           data-testid="keep-data-pivoted"
           label={t`Keep data pivoted`}

--- a/frontend/src/metabase/query_builder/components/QueryDownloadPopover/QueryDownloadPopover.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadPopover/QueryDownloadPopover.unit.spec.tsx
@@ -1,6 +1,7 @@
 import userEvent from "@testing-library/user-event";
 
 import { setupCardQueryDownloadEndpoint } from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
 import { createMockEntitiesState } from "__support__/store";
 import { act, renderWithProviders, screen } from "__support__/ui";
 import { checkNotNull } from "metabase/lib/types";
@@ -33,15 +34,21 @@ const TEST_RESULT = createMockDataset();
 interface SetupOpts {
   card?: Card;
   result?: Dataset;
+  settings?: Record<string, unknown>;
 }
 
-const setup = ({ card = TEST_CARD, result = TEST_RESULT }: SetupOpts = {}) => {
+const setup = ({
+  card = TEST_CARD,
+  result = TEST_RESULT,
+  settings = { "enable-pivoted-exports": true },
+}: SetupOpts = {}) => {
   const onDownload = jest.fn();
 
   const state = createMockState({
     entities: createMockEntitiesState({
       questions: [card],
     }),
+    settings: mockSettings(settings),
   });
 
   const metadata = getMetadata(state);
@@ -55,6 +62,9 @@ const setup = ({ card = TEST_CARD, result = TEST_RESULT }: SetupOpts = {}) => {
       result={result}
       onDownload={onDownload}
     />,
+    {
+      storeInitialState: state,
+    },
   );
 
   return { onDownload };
@@ -181,4 +191,16 @@ describe("QueryDownloadPopover", () => {
       });
     },
   );
+
+  it("should hide 'Keep data pivoted' option when enable-pivoted-exports setting is false", async () => {
+    setup({
+      card: { ...TEST_CARD, display: "pivot" },
+      settings: { "enable-pivoted-exports": false },
+    });
+
+    await userEvent.click(screen.getByLabelText(".csv"));
+    expect(
+      screen.queryByLabelText("Keep data pivoted"),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -359,7 +359,7 @@ x.com")
   :type       :boolean
   :default    true
   :export?    true
-  :visibility :internal
+  :visibility :authenticated
   :audit      :getter)
 
 (defsetting enable-public-sharing

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -358,6 +358,7 @@ x.com")
   (deferred-tru "Enable pivoted exports and pivoted subscriptions")
   :type       :boolean
   :default    true
+  :export?    true
   :visibility :authenticated
   :audit      :getter)
 

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -354,6 +354,13 @@ x.com")
                     (throw (ex-info (tru "This field must be a relative URL.") {:status-code 400}))))
                 (setting/set-value-of-type! :string :landing-page (coerce-to-relative-url new-landing-page))))
 
+(defsetting enable-pivoted-exports
+  (deferred-tru "Enable pivoted exports and pivoted subscriptions")
+  :type       :boolean
+  :default    true
+  :visibility :authenticated
+  :audit      :getter)
+
 (defsetting enable-public-sharing
   (deferred-tru "Enable admins to create publicly viewable links (and embeddable iframes) for Questions and Dashboards?")
   :type       :boolean

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -359,7 +359,7 @@ x.com")
   :type       :boolean
   :default    true
   :export?    true
-  :visibility :authenticated
+  :visibility :internal
   :audit      :getter)
 
 (defsetting enable-public-sharing

--- a/src/metabase/query_processor/streaming/csv.clj
+++ b/src/metabase/query_processor/streaming/csv.clj
@@ -5,6 +5,7 @@
    [medley.core :as m]
    [metabase.formatter :as formatter]
    [metabase.models.visualization-settings :as mb.viz]
+   [metabase.public-settings :as public-settings]
    [metabase.query-processor.pivot.postprocess :as qp.pivot.postprocess]
    [metabase.query-processor.streaming.common :as common]
    [metabase.query-processor.streaming.interface :as qp.si]
@@ -112,7 +113,7 @@
                                          row)
               {:keys [pivot-grouping]} (or (:config @pivot-data) @pivot-data)
               group                    (get ordered-row pivot-grouping)]
-          (if (contains? @pivot-data :config)
+          (if (and (contains? @pivot-data :config) (public-settings/enable-pivoted-exports))
             ;; if we're processing a pivot result, we don't write it out yet, just aggregate it
             ;; so that we can post process the data in finish!
             (when (= qp.pivot.postprocess/NON_PIVOT_ROW_GROUP (int group))
@@ -134,7 +135,7 @@
 
       (finish! [_ _]
         ;; TODO -- not sure we need to flush both
-        (when (contains? @pivot-data :config)
+        (when (and (contains? @pivot-data :config) (public-settings/enable-pivoted-exports))
           (doseq [xf-row (qp.pivot.postprocess/build-pivot-output @pivot-data @ordered-formatters)]
             (write-csv writer [xf-row])))
         (.flush writer)

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -10,6 +10,7 @@
    [metabase.formatter :as formatter]
    [metabase.lib.schema.temporal-bucketing :as lib.schema.temporal-bucketing]
    [metabase.models.visualization-settings :as mb.viz]
+   [metabase.public-settings :as public-settings]
    [metabase.query-processor.pivot.postprocess :as qp.pivot.postprocess]
    [metabase.query-processor.streaming.common :as common]
    [metabase.query-processor.streaming.interface :as qp.si]
@@ -668,7 +669,7 @@
                    :or   {format-rows? true
                           pivot?       false}} :data}
                {col-settings ::mb.viz/column-settings :as viz-settings}]
-        (let [opts               (when (and pivot? pivot-export-options)
+        (let [opts               (when (and pivot? pivot-export-options (public-settings/enable-pivoted-exports))
                                    (pivot-opts->pivot-spec (merge {:pivot-cols []
                                                                    :pivot-rows []}
                                                                   pivot-export-options) ordered-cols))

--- a/test_resources/serialization_baseline/settings.yaml
+++ b/test_resources/serialization_baseline/settings.yaml
@@ -20,6 +20,7 @@ enable-embedding: null
 enable-nested-queries: null
 enable-sandboxes?: null
 enable-whitelabeling?: null
+enable-pivoted-exports: null
 enable-xrays: null
 hide-embed-branding?: null
 humanization-strategy: null


### PR DESCRIPTION
[Slack convo](https://metaboat.slack.com/archives/C064QMXEV9N/p1732199147716249)

### Description

Adds a setting that hides the ability to pivot export results. Can be configured via `MB_ENABLE_PIVOTED_EXPORTS` env variable.

### How to verify

- Run your instance with `MB_ENABLE_PIVOTED_EXPORTS=false`
- Create a pivot table
- Try download results
- Ensure there is no "Keep data pivoted" checkbox and it exports only non-pivoted results

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
