### PR TITLE
Fix broken migration on MySQL 8.0.17

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8313,6 +8313,7 @@ databaseChangeLog:
       id: v50.2024-05-29T18:42:14
       author: johnswanson
       comment: Populate `archived_directly` and `archive_operation_id` (MySQL)
+      validCheckSum: ANY
       changes:
         - sqlFile:
             dbms: mysql

--- a/resources/migrations/trash/mysql.sql
+++ b/resources/migrations/trash/mysql.sql
@@ -87,8 +87,8 @@ WITH RECURSIVE Ancestors (id, archived, archived_directly, archive_operation_id,
     collection.archived_directly,
     parent.archive_operation_id,
     collection.location
-    FROM collection
-    JOIN Ancestors parent ON collection.location = concat(parent.location, parent.id, '/')
+    FROM Ancestors parent
+    JOIN collection ON collection.location = concat(parent.location, parent.id, '/')
   WHERE collection.archived = true
 )
 UPDATE collection


### PR DESCRIPTION
On MySQL 8.0.17, the following is prohibited:

```
WITH RECURSIVE MyRecursiveCTE (...) AS
(
  SELECT ... FROM bar UNION ALL
  SELECT ... FROM bar JOIN MyRecursiveCTE ON ...
)
```

Instead, you need to do:

```
WITH RECURSIVE MyRecursiveCTE (...) AS
(
  SELECT ... FROM bar UNION ALL
  SELECT ... FROM MyRecursiveCTE JOIN bar ON ...
)
```

Basically, just putting the CTE on the left vs. the right side of the join (which is exactly equivalent under the hood) fixes the issue.

I can't actually find any documentation of this change, but it seems that sometime between MySQL 8.0.17 and MySQL 8.0.33, MySQL started allowing this, perhaps just an optimization where it now notices the equivalence and does the right thing.

I originally tested this on what I believed was the oldest version of MySQL we supported, but didn't read carefully enough. We recommend 8.0.33 or higher here:

https://www.metabase.com/docs/latest/databases/connections/mysql

But that's not for the AppDB - for that, we recommend 8.0.17 or higher.

Fixes #49497 