### PR TITLE
Introduce metabase.util.json to encapsulate usage of the underlying JSON library

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -249,6 +249,7 @@
 
   :discouraged-namespace
   {camel-snake-kebab.core {:message "CSK is not Turkish-safe, use the versions in metabase.util instead."}
+   cheshire.core          {:message "Use metabase.util.json instead of cheshire.core directly."}
    clojure.tools.logging  {:message "Use metabase.util.log instead of clojure.tools.logging directly"}
    grouper.core           {:message "Use metabase.util.grouper instead of grouper.core"}
    honeysql.core          {:message "Use Honey SQL 2. Honey SQL 1 is removed as a dependency in Metabase 49+."}

--- a/bin/build/src/i18n/create_artifacts/frontend.clj
+++ b/bin/build/src/i18n/create_artifacts/frontend.clj
@@ -1,5 +1,6 @@
 (ns i18n.create-artifacts.frontend
   (:require
+   #_{:clj-kondo/ignore [:discouraged-namespace]}
    [cheshire.core :as json]
    [clojure.java.io :as io]
    [clojure.string :as str]

--- a/enterprise/backend/src/metabase_enterprise/billing/billing.clj
+++ b/enterprise/backend/src/metabase_enterprise/billing/billing.clj
@@ -1,7 +1,6 @@
 (ns metabase-enterprise.billing.billing
   "`/api/ee/billing/` endpoint(s)"
   (:require
-   [cheshire.core :as json]
    [clj-http.client :as http]
    [clojure.core.memoize :as memoize]
    [clojure.string :as str]
@@ -12,6 +11,7 @@
    [metabase.util :as u]
    [metabase.util.date-2.parse :as u.date.parse]
    [metabase.util.i18n :as i18n]
+   [metabase.util.json :as json]
    [toucan2.core :as t2])
   (:import
    [com.fasterxml.jackson.core JsonParseException]))
@@ -29,7 +29,7 @@
                              :language     language
                              :content-type :json})
                   :body
-                  (json/parse-string keyword))
+                  json/decode+kw)
           (catch JsonParseException _
             {:content nil})))
    :ttl/threshold (u/minutes->ms 5)))

--- a/enterprise/backend/src/metabase_enterprise/llm/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/llm/client.clj
@@ -19,9 +19,9 @@
   [OpenAI Client](https://platform.openai.com/docs/libraries) with [Llama API](https://docs.llama-api.com/essentials/chat).
   "
   (:require
-   [cheshire.core :as json]
    [metabase-enterprise.llm.settings :as llm-settings]
    [metabase.analytics.snowplow :as snowplow]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [wkok.openai-clojure.api :as openai.api]))
 
@@ -58,7 +58,7 @@
            ;; If we have ex-data, we'll assume were intercepting an openai.api/create-chat-completion response
           (if-some [status (:status (ex-data e))]
             (let [{:keys [body]} (ex-data e)
-                  {:keys [error]} (json/parse-string body keyword)
+                  {:keys [error]} (json/decode+kw body)
                   {error-type :type :keys [message code]} error]
               (case (int status)
                 400 (do
@@ -144,7 +144,7 @@
                   response (or
                             (second (re-matches md-regex response))
                             response)]
-              (postprocess-fn (json/parse-string response true)))
+              (postprocess-fn (json/decode+kw response)))
             (catch Exception e
               (throw
                (do

--- a/enterprise/backend/src/metabase_enterprise/llm/tasks/describe_dashboard.clj
+++ b/enterprise/backend/src/metabase_enterprise/llm/tasks/describe_dashboard.clj
@@ -1,11 +1,11 @@
 (ns metabase-enterprise.llm.tasks.describe-dashboard
   "LLM task(s) for generating dashboard descriptions"
   (:require
-   [cheshire.core :as json]
    [clojure.set :refer [rename-keys]]
    [clojure.walk :as walk]
    [metabase-enterprise.llm.client :as llm-client]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [toucan2.core :as t2]))
 
 (defn- dashboard->prompt-data
@@ -61,7 +61,7 @@
                                     {:description "%%FILL_THIS_DESCRIPTION_IN%%"
                                      :keywords    "%%FILL_THESE_KEYWORDS_IN%%"
                                      :questions   "%%FILL_THESE_QUESTIONS_IN%%"})
-        json-str             (json/generate-string summary-with-prompts)
+        json-str             (json/encode summary-with-prompts)
         client               (-> (llm-client/create-chat-completion)
                                  (llm-client/wrap-parse-json
                                   (fn [{:keys [description keywords questions]}]

--- a/enterprise/backend/src/metabase_enterprise/llm/tasks/describe_question.clj
+++ b/enterprise/backend/src/metabase_enterprise/llm/tasks/describe_question.clj
@@ -1,11 +1,11 @@
 (ns metabase-enterprise.llm.tasks.describe-question
   "LLM task(s) for generating question descriptions"
   (:require
-   [cheshire.core :as json]
    [clojure.set :refer [rename-keys]]
    [metabase-enterprise.llm.client :as llm-client]
    [metabase.query-processor.compile :as qp.compile]
-   [metabase.util :as u]))
+   [metabase.util :as u]
+   [metabase.util.json :as json]))
 
 (defn- question->prompt-data
   "Create a data-oriented summary of a question as input to an LLM for summarization."
@@ -30,7 +30,7 @@
         summary-with-prompts (merge description
                                     {:friendly_title   "%%FILL_THIS_TITLE_IN%%"
                                      :friendly_summary "%%FILL_THIS_SUMMARY_IN%%"})
-        json-str             (json/generate-string summary-with-prompts)
+        json-str             (json/encode summary-with-prompts)
         client               (-> (llm-client/create-chat-completion)
                                  (llm-client/wrap-parse-json
                                   (fn [rsp] (rename-keys rsp {:friendly_title   :title

--- a/enterprise/backend/src/metabase_enterprise/serialization/upsert.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/upsert.clj
@@ -1,7 +1,6 @@
 (ns metabase-enterprise.serialization.upsert
   "Upsert-or-skip functionality for our models."
   (:require
-   [cheshire.core :as json]
    [clojure.data :as data]
    [medley.core :as m]
    [metabase-enterprise.serialization.names :refer [name-for-logging]]
@@ -24,6 +23,7 @@
    [metabase.models.user :refer [User]]
    [metabase.util :as u]
    [metabase.util.i18n :as i18n :refer [trs]]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [methodical.core :as methodical]
    [toucan2.core :as t2]

--- a/enterprise/backend/test/metabase_enterprise/auth_provider_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/auth_provider_test.clj
@@ -1,6 +1,5 @@
 (ns metabase-enterprise.auth-provider-test
   (:require
-   [cheshire.core :as json]
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [metabase.auth-provider :as auth-provider]
@@ -9,7 +8,8 @@
    [metabase.http-client :as client]
    [metabase.test :as mt]
    [metabase.test.data.interface :as tx]
-   [metabase.util.http :as u.http])
+   [metabase.util.http :as u.http]
+   [metabase.util.json :as json])
   (:import
    [java.util Properties]))
 

--- a/enterprise/backend/test/metabase_enterprise/llm/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/llm/api_test.clj
@@ -1,10 +1,10 @@
 (ns metabase-enterprise.llm.api-test
   (:require
-   [cheshire.core :as json]
    [clojure.test :refer :all]
    [metabase-enterprise.llm.client :as llm-client]
    [metabase.models :refer [Card Dashboard DashboardCard]]
    [metabase.test :as mt]
+   [metabase.util.json :as json]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
 (deftest summarize-card-test
@@ -16,7 +16,7 @@
                                            :type     :query
                                            :query    {:source-table (mt/id :orders)}}}]
         (let [fake-response {:title "Title" :description "Description"}
-              json-response (json/generate-string fake-response)
+              json-response (json/encode fake-response)
               expected {:summary fake-response}]
           (testing "Card summarization works in the happy path"
             (mt/with-premium-features #{:llm-autodescription}
@@ -67,7 +67,7 @@
               fake-response {:description "Description"
                              :keywords    "awesome, amazing"
                              :questions   "- What is this?"}
-              json-response (json/generate-string fake-response)
+              json-response (json/encode fake-response)
               expected      {:summary {:description "Keywords: awesome, amazing\n\nDescription: Description\n\nQuestions:\n- What is this?"}}]
           (testing "Card summarization works in the happy path"
             (mt/with-premium-features #{:llm-autodescription}

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/permissions_test.clj
@@ -1,6 +1,5 @@
 (ns metabase-enterprise.sandbox.api.permissions-test
   (:require
-   [cheshire.core :as json]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase-enterprise.sandbox.models.group-table-access-policy
@@ -13,6 +12,7 @@
    [metabase.query-processor.compile :as qp.compile]
    [metabase.test :as mt]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp]))

--- a/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
@@ -1,6 +1,5 @@
 (ns metabase-enterprise.search.scoring-test
   (:require
-   [cheshire.core :as json]
    [clojure.math.combinatorics :as math.combo]
    [clojure.set :as set]
    [clojure.string :as str]
@@ -9,7 +8,8 @@
    [metabase-enterprise.search.scoring :as ee-scoring]
    [metabase.search.appdb.scoring-test :as appdb.scoring-test]
    [metabase.search.in-place.scoring :as scoring]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util.json :as json]))
 
 (deftest ^:parallel verified-score-test
   (let [score #'ee-scoring/verified-score
@@ -114,7 +114,7 @@
                     all-permutations-all-orders
                     (mapv #(str/join " " %))
                     (remove #{""}))
-        the-query (json/generate-string {:type :query :query {:source-table 1}})
+        the-query (json/encode {:type :query :query {:source-table 1}})
         ->query (fn [n] {:name n :dataset_query the-query})
         results (map ->query corpus)]
     (doseq [search-string corpus]

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -1,6 +1,5 @@
 (ns ^:mb/once metabase-enterprise.serialization.v2.extract-test
   (:require
-   [cheshire.core :as json]
    [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
@@ -31,6 +30,7 @@
    [metabase.query-processor :as qp]
    [metabase.test :as mt]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [toucan2.core :as t2]))
 
 (comment
@@ -1238,7 +1238,7 @@
                                                                  :visualization_settings
                                                                  ;; Top-level click behavior for the card.
                                                                  (let [dimension  [:dimension [:field "something" {:base-type "type/Text"}]]
-                                                                       mapping-id (json/generate-string dimension)]
+                                                                       mapping-id (json/encode dimension)]
                                                                    {:click_behavior {:type     "link"
                                                                                      :linkType "question"
                                                                                      :targetId c3-2-id

--- a/modules/drivers/athena/src/metabase/driver/athena/hive_parser.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena/hive_parser.clj
@@ -1,8 +1,8 @@
 (ns metabase.driver.athena.hive-parser
   (:require
-   [cheshire.core :as json]
    [clojure.string :as str]
-   [clojure.walk :as walk]))
+   [clojure.walk :as walk]
+   [metabase.util.json :as json]))
 
 (set! *warn-on-reflection* true)
 
@@ -58,5 +58,5 @@
   [schema]
   (-> schema
       parse-to-json-string
-      json/parse-string
+      json/decode
       walk/keywordize-keys))

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -1,6 +1,5 @@
 (ns ^:mb/driver-tests metabase.driver.bigquery-cloud-sdk-test
   (:require
-   [cheshire.core :as json]
    [clojure.core.async :as a]
    [clojure.string :as str]
    [clojure.test :refer :all]
@@ -19,6 +18,7 @@
    [metabase.test.data.bigquery-cloud-sdk :as bigquery.tx]
    [metabase.test.data.interface :as tx]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]
@@ -534,7 +534,7 @@
                                        :join   [[:metabase_fieldvalues :fv] [:= :field.id :fv.field_id]]
                                        :where  [:and [:in :field.table_id table-ids]
                                                 [:in :field.name ["customer_id" "vip_customer" "name" "is_awesome" "is_opensource" "company" "ev_company"]]]})
-                            (map #(update % :values (comp set json/parse-string)))
+                            (map #(update % :values (comp set json/decode)))
                             (map (juxt :field-name :values))
                             (into {}))))))
 

--- a/modules/drivers/druid-jdbc/src/metabase/driver/druid_jdbc.clj
+++ b/modules/drivers/druid-jdbc/src/metabase/driver/druid_jdbc.clj
@@ -1,6 +1,5 @@
 (ns metabase.driver.druid-jdbc
   (:require
-   [cheshire.core :as json]
    [clj-http.client :as http]
    [clojure.string :as str]
    [clojure.walk :as walk]
@@ -17,6 +16,7 @@
    [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.util.add-alias-info :as add]
    [metabase.util.honey-sql-2 :as h2x]
+   [metabase.util.json :as json]
    [metabase.util.log :as log])
   (:import
    (java.sql ResultSet Types)
@@ -174,7 +174,7 @@
   (let [{:keys [host port]} (:details database)]
     (try (let [version (-> (http/get (format "%s:%s/status" host port))
                            :body
-                           json/parse-string
+                           json/decode
                            (get "version"))
                [maj-min maj min] (re-find #"^(\d+)\.(\d+)" version)
                semantic (mapv #(Integer/parseInt %) [maj min])]

--- a/modules/drivers/druid-jdbc/test/metabase/test/data/druid_jdbc.clj
+++ b/modules/drivers/druid-jdbc/test/metabase/test/data/druid_jdbc.clj
@@ -1,9 +1,9 @@
 (ns metabase.test.data.druid-jdbc
   (:require
-   [cheshire.core :as json]
    [clj-http.client :as http]
    [metabase.test.data.dataset-definitions :as defs]
-   [metabase.test.data.interface :as tx]))
+   [metabase.test.data.interface :as tx]
+   [metabase.util.json :as json]))
 
 (tx/add-test-extensions! :druid-jdbc)
 
@@ -14,7 +14,7 @@
 
 (defn- already-loaded []
   (let [{:keys [host port]} (tx/dbdef->connection-details :druid-jdbc)]
-    (set (json/parse-string (:body (http/get (format "%s:%s/druid/v2/datasources" host port)))))))
+    (set (json/decode (:body (http/get (format "%s:%s/druid/v2/datasources" host port)))))))
 
 (def built-in-datasets #{"checkins" "json"})
 

--- a/modules/drivers/druid/src/metabase/driver/druid.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid.clj
@@ -1,7 +1,6 @@
 (ns metabase.driver.druid
   "Druid driver."
   (:require
-   [cheshire.core :as json]
    [clj-http.client :as http]
    [metabase.driver :as driver]
    [metabase.driver.druid.client :as druid.client]
@@ -9,6 +8,7 @@
    [metabase.driver.druid.query-processor :as druid.qp]
    [metabase.driver.druid.sync :as druid.sync]
    [metabase.query-processor.pipeline :as qp.pipeline]
+   [metabase.util.json :as json]
    [metabase.util.ssh :as ssh]))
 
 (driver/register! :druid)
@@ -46,7 +46,7 @@
 
 (defn- add-timeout-to-query [query timeout]
   (let [parsed (if (string? query)
-                 (json/parse-string query keyword)
+                 (json/decode+kw query)
                  query)]
     (assoc-in parsed [:context :timeout] timeout)))
 

--- a/modules/drivers/druid/src/metabase/driver/druid/execute.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/execute.clj
@@ -1,6 +1,5 @@
 (ns metabase.driver.druid.execute
   (:require
-   [cheshire.core :as json]
    [clojure.math.numeric-tower :as math]
    [java-time.api :as t]
    [medley.core :as m]
@@ -13,6 +12,7 @@
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
    [metabase.util.i18n :refer [tru]]
+   [metabase.util.json :as json]
    [metabase.util.malli :as mu]))
 
 (set! *warn-on-reflection* true)
@@ -155,7 +155,7 @@
   {:pre [query]}
   (let [details    (:details (lib.metadata/database (qp.store/metadata-provider)))
         query      (if (string? query)
-                     (json/parse-string query keyword)
+                     (json/decode+kw query)
                      query)
         query-type (or query-type
                        (keyword (namespace ::druid.qp/query) (name (:queryType query))))

--- a/modules/drivers/druid/test/metabase/driver/druid/execute_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid/execute_test.clj
@@ -1,11 +1,11 @@
 (ns ^:mb/driver-tests metabase.driver.druid.execute-test
-  (:require [cheshire.core :as json]
-            [clojure.java.io :as io]
+  (:require [clojure.java.io :as io]
             [clojure.test :refer :all]
             [metabase.driver.druid.execute :as druid.execute]
             [metabase.test :as mt]
             [metabase.timeseries-query-processor-test.util :as tqpt]
-            [metabase.util :as u]))
+            [metabase.util :as u]
+            [metabase.util.json :as json]))
 
 (deftest results-order-test
   (mt/test-driver :druid
@@ -47,7 +47,7 @@
   (testing "Test that we can still return results from native :select queries, even if we no longer generate them"
     ;; example results adapted from https://github.com/apache/druid/blob/d00747774208dbbfcb272ee7d1c30cf879887838/docs/querying/select-query.md
     (let [results (with-open [r (io/reader "modules/drivers/druid/test/metabase/driver/druid/execute_test/select_results.json")]
-                    (json/parse-stream r true))]
+                    (json/decode+kw r))]
       (is (= {:projections [:a :b :c]
               :results     [{:timestamp #t "2013-01-01T00:00Z[UTC]", :robot "1", :namespace "article", :page "11._korpus_(NOVJ)"}
                             {:timestamp #t "2013-01-01T00:00Z[UTC]", :robot "0", :namespace "article", :page "112_U.S._580"}

--- a/modules/drivers/druid/test/metabase/driver/druid/query_processor_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid/query_processor_test.clj
@@ -1,7 +1,6 @@
 (ns ^:mb/driver-tests metabase.driver.druid.query-processor-test
   "Some tests to make sure the Druid Query Processor is generating sane Druid queries when compiling MBQL."
   (:require
-   [cheshire.core :as json]
    [clojure.test :refer :all]
    [clojure.tools.macro :as tools.macro]
    [java-time.api :as t]
@@ -15,6 +14,7 @@
    [metabase.test :as mt]
    [metabase.timeseries-query-processor-test.util :as tqpt]
    [metabase.util.date-2 :as u.date]
+   [metabase.util.json :as json]
    [toucan2.core :as t2]))
 
 (defn- str->absolute-dt [s]
@@ -263,7 +263,7 @@
                    (table-rows-sample)))))))))
 
 (def ^:private native-query-1
-  (json/generate-string
+  (json/encode
    {:queryType   :scan
     :dataSource  :checkins
     :intervals   ["1900-01-01/2100-01-01"]
@@ -326,7 +326,7 @@
              (m/dissoc-in [:data :insights]))))))
 
 (def ^:private native-query-2
-  (json/generate-string
+  (json/encode
    {:intervals    ["1900-01-01/2100-01-01"]
     :granularity  {:type     :period
                    :period   :P1M

--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -1,8 +1,6 @@
 (ns metabase.driver.mongo
   "MongoDB Driver."
   (:require
-   [cheshire.core :as json]
-   [cheshire.generate :as json.generate]
    [clojure.string :as str]
    [clojure.walk :as walk]
    [medley.core :as m]
@@ -22,6 +20,7 @@
    [metabase.query-processor :as qp]
    [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [taoensso.nippy :as nippy])
@@ -36,7 +35,7 @@
 ;; JSON Encoding (etc.)
 
 ;; Encode BSON undefined like `nil`
-(json.generate/add-encoder org.bson.BsonUndefined json.generate/encode-nil)
+(json/add-encoder org.bson.BsonUndefined json/generate-nil)
 
 (nippy/extend-freeze ObjectId :mongodb/ObjectId
   [^ObjectId oid data-output]
@@ -302,7 +301,7 @@
         data  (:data (qp/process-query {:database (:id db)
                                         :type     "native"
                                         :native   {:collection (:name table)
-                                                   :query      (json/generate-string query)}}))
+                                                   :query      (json/encode query)}}))
         cols  (map (comp keyword :name) (:cols data))]
     (map #(zipmap cols %) (:rows data))))
 

--- a/modules/drivers/mongo/src/metabase/driver/mongo/json.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/json.clj
@@ -6,15 +6,15 @@
          encoders yield no failures. Unfortunately I was unable to prove it is not needed yet, hence I'm leaving it
          in just to be safe. Removal should be considered during follow-up of monger removal."
   (:require
-   [cheshire.generate])
+   [metabase.util.json :as json])
   (:import
    (org.bson.types BSONTimestamp ObjectId)))
 
 (set! *warn-on-reflection* true)
 
-(cheshire.generate/add-encoder ObjectId
-                               (fn [^ObjectId oid ^com.fasterxml.jackson.core.json.WriterBasedJsonGenerator generator]
-                                 (.writeString generator (.toString oid))))
-(cheshire.generate/add-encoder BSONTimestamp
-                               (fn [^BSONTimestamp ts ^com.fasterxml.jackson.core.json.WriterBasedJsonGenerator generator]
-                                 (cheshire.generate/encode-map {:time (.getTime ts) :inc (.getInc ts)} generator)))
+(json/add-encoder ObjectId
+                  (fn [^ObjectId oid ^com.fasterxml.jackson.core.json.WriterBasedJsonGenerator generator]
+                    (.writeString generator (.toString oid))))
+(json/add-encoder BSONTimestamp
+                  (fn [^BSONTimestamp ts ^com.fasterxml.jackson.core.json.WriterBasedJsonGenerator generator]
+                    (json/generate-map {:time (.getTime ts) :inc (.getInc ts)} generator)))

--- a/modules/drivers/mongo/src/metabase/driver/mongo/parameters.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/parameters.clj
@@ -1,6 +1,5 @@
 (ns metabase.driver.mongo.parameters
   (:require
-   [cheshire.core :as json]
    [clojure.string :as str]
    [clojure.walk :as walk]
    [java-time.api :as t]
@@ -17,6 +16,7 @@
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
    [metabase.util.i18n :refer [tru]]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu])
   (:import
@@ -144,7 +144,7 @@
                                     mbql.u/desugar-filter-clause
                                     qp.wrap-value-literals/wrap-value-literals-in-mbql
                                     mongo.qp/compile-filter
-                                    json/generate-string)]
+                                    json/encode)]
             [(conj acc compiled-clause) missing])
           ;; no-value field filters inside optional clauses are ignored and omitted entirely
           (and no-value? in-optional?) [acc (conj missing k)]

--- a/modules/drivers/mongo/test/metabase/driver/mongo/parameters_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/parameters_test.clj
@@ -1,7 +1,5 @@
 (ns ^:mb/driver-tests metabase.driver.mongo.parameters-test
   (:require
-   [cheshire.core :as json]
-   [cheshire.generate :as json.generate]
    [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
@@ -11,9 +9,8 @@
    [metabase.models :refer [NativeQuerySnippet]]
    [metabase.query-processor :as qp]
    [metabase.test :as mt]
-   [toucan2.tools.with-temp :as t2.with-temp])
-  (:import
-   (com.fasterxml.jackson.core JsonGenerator)))
+   [metabase.util.json :as json]
+   [toucan2.tools.with-temp :as t2.with-temp]))
 
 (set! *warn-on-reflection* true)
 
@@ -254,12 +251,6 @@
     (is (= (strip (to-bson [{:$match {"price" {:$gt 2}}}]))
            (strip (substitute {"snippet: high price" (params/->ReferencedQuerySnippet 123 (to-bson {"price" {:$gt 2}}))}
                               ["[{$match: " (param "snippet: high price") "}]"]))))))
-(defn- json-raw
-  "Wrap a string so it will be spliced directly into resulting JSON as-is. Analogous to HoneySQL `raw`."
-  [^String s]
-  (reify json.generate/JSONable
-    (to-json [_ generator]
-      (.writeRawValue ^JsonGenerator generator s))))
 
 (deftest ^:parallel e2e-field-filter-test
   (mt/test-driver :mongo
@@ -271,8 +262,8 @@
               (qp/process-query
                (mt/query checkins
                  {:type       :native
-                  :native     {:query         (json/generate-string
-                                               [{:$match (json-raw "{{date}}")}
+                  :native     {:query         (json/encode
+                                               [{:$match (json/raw-json-generator "{{date}}")}
                                                 {:$sort {:_id 1}}])
                                :collection    "checkins"
                                :template-tags {"date" {:name         "date"
@@ -291,8 +282,8 @@
               (qp/process-query
                (mt/query categories
                  {:type       :native
-                  :native     {:query         (json/generate-string [{:$match (json-raw "{{id}}")}
-                                                                     {:$sort {:_id 1}}])
+                  :native     {:query         (json/encode [{:$match (json/raw-json-generator "{{id}}")}
+                                                            {:$sort {:_id 1}}])
                                :collection    "categories"
                                :template-tags {"id" {:name         "id"
                                                      :display-name "ID"
@@ -308,8 +299,8 @@
               (qp/process-query
                (mt/query checkins
                  {:type   :native
-                  :native {:query         (json/generate-string
-                                           [{:$match (json-raw "{{date}}")}
+                  :native {:query         (json/encode
+                                           [{:$match (json/raw-json-generator "{{date}}")}
                                             {:$sort {:_id 1}}
                                             {:$limit 1}])
                            :collection    "checkins"
@@ -326,8 +317,8 @@
                   (qp/process-query
                    (mt/query tips
                      {:type       :native
-                      :native     {:query         (json/generate-string
-                                                   [{:$match (json-raw "{{username}}")}
+                      :native     {:query         (json/encode
+                                                   [{:$match (json/raw-json-generator "{{username}}")}
                                                     {:$sort {:_id 1}}
                                                     {:$project {"username" "$source.username"
                                                                 "_id" 1}}
@@ -353,8 +344,8 @@
                       (qp/process-query
                        (mt/query tips
                          {:type       :native
-                          :native     {:query         (json/generate-string
-                                                       [{:$match (json-raw "{{username}}")}
+                          :native     {:query         (json/encode
+                                                       [{:$match (json/raw-json-generator "{{username}}")}
                                                         {:$sort {:_id 1}}
                                                         {:$project {"username" "$source.username"}}
                                                         {:$limit 1}])
@@ -378,8 +369,8 @@
                          (qp/process-query
                           (mt/query venues
                             {:type       :native
-                             :native     {:query         (json/generate-string
-                                                          [{:$match (json-raw "{{price}}")}
+                             :native     {:query         (json/encode
+                                                          [{:$match (json/raw-json-generator "{{price}}")}
                                                            {:$project {"price" "$price"}}
                                                            {:$sort {:_id 1}}
                                                            {:$limit 10}])
@@ -399,8 +390,8 @@
                                (qp/process-query
                                 (mt/query tips
                                   {:type       :native
-                                   :native     {:query         (json/generate-string
-                                                                [{:$match (json-raw "{{username}}")}
+                                   :native     {:query         (json/encode
+                                                                [{:$match (json/raw-json-generator "{{username}}")}
                                                                  {:$sort {:_id 1}}
                                                                  {:$project {"username" "$source.username"}}
                                                                  {:$limit 20}])
@@ -419,8 +410,8 @@
             (is (= #{}
                    (set/intersection
                     #{"bob" "tupac"}
-                     ;; most of these are nil as most records don't have a username. not equal is a bit ambiguous in
-                     ;; mongo. maybe they might want present but not equal semantics
+                    ;; most of these are nil as most records don't have a username. not equal is a bit ambiguous in
+                    ;; mongo. maybe they might want present but not equal semantics
                     (into #{} (map second)
                           (run-query :string/!=)))))))))))
 
@@ -435,7 +426,7 @@
               (qp/process-query
                (mt/query categories
                  {:type       :native
-                  :native     {:query         (json/generate-string [{:$match (json-raw "{{snippet: first 3 checkins}}")}])
+                  :native     {:query         (json/encode [{:$match (json/raw-json-generator "{{snippet: first 3 checkins}}")}])
                                :collection    "categories"
                                :template-tags {"snippet: first 3 checkins" {:name         "snippet: first 3 checkins"
                                                                             :display-name "Snippet: First 3 checkins"

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -1,7 +1,6 @@
 (ns ^:mb/driver-tests metabase.driver.mongo-test
   "Tests for Mongo driver."
   (:require
-   [cheshire.core :as json]
    [clojure.test :refer :all]
    [medley.core :as m]
    [metabase.api.downloads-exports-test :as downloads-test]
@@ -25,6 +24,7 @@
    [metabase.test :as mt]
    [metabase.test.data.interface :as tx]
    [metabase.test.data.mongo :as tdm]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.xrays.automagic-dashboards.core :as magic]
    [taoensso.nippy :as nippy]
@@ -764,7 +764,7 @@
 
 (defn- json-from-file [^String filename]
   (with-open [rdr (java.io.FileReader. (java.io.File. filename))]
-    (json/parse-stream rdr true)))
+    (json/decode+kw rdr)))
 
 (defn- missing-fields-db []
   (create-database-from-row-maps!

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -1,7 +1,6 @@
 (ns metabase.driver.redshift
   "Amazon Redshift Driver."
   (:require
-   [cheshire.core :as json]
    [clojure.string :as str]
    [honey.sql :as sql]
    [java-time.api :as t]
@@ -25,6 +24,7 @@
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
    [metabase.util.honey-sql-2 :as h2x]
+   [metabase.util.json :as json]
    [metabase.util.log :as log])
   (:import
    (com.amazon.redshift.util RedshiftInterval)
@@ -447,11 +447,11 @@
 (defmethod qp.util/query->remark :redshift
   [_ {{:keys [executed-by card-id dashboard-id]} :info, :as query}]
   (str "/* partner: \"metabase\", "
-       (json/generate-string {:dashboard_id        dashboard-id
-                              :chart_id            card-id
-                              :optional_user_id    executed-by
-                              :optional_account_id (public-settings/site-uuid)
-                              :filter_values       (field->parameter-value query)})
+       (json/encode {:dashboard_id        dashboard-id
+                     :chart_id            card-id
+                     :optional_user_id    executed-by
+                     :optional_account_id (public-settings/site-uuid)
+                     :filter_values       (field->parameter-value query)})
        " */ "
        (qp.util/default-query->remark query)))
 

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -2,7 +2,6 @@
   "Snowflake Driver."
   (:require
    [buddy.core.codecs :as codecs]
-   [cheshire.core :as json]
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]
    [clojure.string :as str]
@@ -37,6 +36,7 @@
    [metabase.util.date-2 :as u.date]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [tru]]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [ring.util.codec :as codec])
   (:import
@@ -724,16 +724,16 @@
   [_ {{:keys [context executed-by card-id pulse-id dashboard-id query-hash]} :info,
       query-type :type,
       database-id :database}]
-  (json/generate-string {:client      "Metabase"
-                         :context     context
-                         :queryType   query-type
-                         :userId      executed-by
-                         :pulseId     pulse-id
-                         :cardId      card-id
-                         :dashboardId dashboard-id
-                         :databaseId  database-id
-                         :queryHash   (when (bytes? query-hash) (codecs/bytes->hex query-hash))
-                         :serverId    (public-settings/site-uuid)}))
+  (json/encode {:client      "Metabase"
+                :context     context
+                :queryType   query-type
+                :userId      executed-by
+                :pulseId     pulse-id
+                :cardId      card-id
+                :dashboardId dashboard-id
+                :databaseId  database-id
+                :queryHash   (when (bytes? query-hash) (codecs/bytes->hex query-hash))
+                :serverId    (public-settings/site-uuid)}))
 
 ;;; ------------------------------------------------- User Impersonation --------------------------------------------------
 

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -1,7 +1,6 @@
 (ns metabase.analytics.stats
   "Functions which summarize the usage of an instance"
   (:require
-   [cheshire.core :as json]
    [clj-http.client :as http]
    [clojure.java.io :as io]
    [clojure.string :as str]
@@ -30,6 +29,7 @@
    [metabase.public-settings.premium-features :as premium-features :refer [defenterprise]]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [toucan2.core :as t2]))
@@ -326,7 +326,7 @@
                                         (-> db
                                             :dbms_version
                                             (assoc :engine (:engine db))
-                                            json/generate-string))
+                                            json/encode))
                                       databases))}))
 
 (defn- table-metrics

--- a/src/metabase/api/action.clj
+++ b/src/metabase/api/action.clj
@@ -1,7 +1,6 @@
 (ns metabase.api.action
   "`/api/action/` endpoints."
   (:require
-   [cheshire.core :as json]
    [compojure.core :as compojure :refer [POST]]
    [metabase.actions.core :as actions]
    [metabase.analytics.snowplow :as snowplow]
@@ -13,6 +12,7 @@
    [metabase.models.collection :as collection]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru tru]]
+   [metabase.util.json :as json]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
@@ -208,7 +208,7 @@
   (actions/check-actions-enabled! action-id)
   (-> (action/select-action :id action-id :archived false)
       api/read-check
-      (actions/fetch-values (json/parse-string parameters))))
+      (actions/fetch-values (json/decode parameters))))
 
 (api/defendpoint POST "/:id/execute"
   "Execute the Action.

--- a/src/metabase/api/automagic_dashboards.clj
+++ b/src/metabase/api/automagic_dashboards.clj
@@ -1,7 +1,6 @@
 (ns metabase.api.automagic-dashboards
   (:require
    [buddy.core.codecs :as codecs]
-   [cheshire.core :as json]
    [compojure.core :refer [GET]]
    [metabase.api.common :as api]
    [metabase.api.query-metadata :as api.query-metadata]
@@ -16,6 +15,7 @@
    [metabase.models.segment :refer [Segment]]
    [metabase.models.table :refer [Table]]
    [metabase.util.i18n :refer [deferred-tru]]
+   [metabase.util.json :as json]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
    [metabase.xrays :as xrays]
@@ -48,7 +48,7 @@
    (deferred-tru "invalid value for dashboard template name")))
 
 (def ^:private ^{:arglists '([s])} decode-base64-json
-  (comp #(json/decode % keyword) codecs/bytes->str codec/base64-decode))
+  (comp json/decode+kw codecs/bytes->str codec/base64-decode))
 
 (def ^:private Base64EncodedJSON
   (mu/with-api-error-message

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -1,7 +1,6 @@
 (ns metabase.api.card
   "/api/card endpoints."
   (:require
-   [cheshire.core :as json]
    [clojure.java.io :as io]
    [compojure.core :refer [DELETE GET POST PUT]]
    [medley.core :as m]
@@ -43,6 +42,7 @@
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
    [metabase.util.i18n :refer [deferred-tru trs tru]]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
@@ -713,7 +713,7 @@
    export-format (into [:enum] api.dataset/export-formats)}
   (qp.card/process-query-for-card
    card-id export-format
-   :parameters  (json/parse-string parameters keyword)
+   :parameters  (json/decode+kw parameters)
    :constraints nil
    :context     (api.dataset/export-format->context export-format)
    :middleware  {:process-viz-settings?  true

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -1,7 +1,6 @@
 (ns metabase.api.dashboard
   "/api/dashboard endpoints."
   (:require
-   [cheshire.core :as json]
    [clojure.core.cache :as cache]
    [clojure.core.memoize :as memoize]
    [clojure.set :as set]
@@ -49,6 +48,7 @@
    [metabase.related :as related]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru tru]]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
@@ -1224,7 +1224,7 @@
   (api/read-check :model/Dashboard dashboard-id)
   (actions/fetch-values
    (api/check-404 (action/dashcard->action dashcard-id))
-   (json/parse-string parameters)))
+   (json/decode parameters)))
 
 (api/defendpoint POST "/:dashboard-id/dashcard/:dashcard-id/execute"
   "Execute the associated Action in the context of a `Dashboard` and `DashboardCard` that includes it.
@@ -1279,7 +1279,7 @@
               :card-id       card-id
               :dashcard-id   dashcard-id
               :export-format export-format
-              :parameters    (json/parse-string parameters keyword)
+              :parameters    (json/decode+kw parameters)
               :context       (api.dataset/export-format->context export-format)
               :constraints   nil
               ;; TODO -- passing this `:middleware` map is a little repetitive, need to think of a way to not have to

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -1,7 +1,6 @@
 (ns metabase.api.dataset
   "/api/dataset endpoints."
   (:require
-   [cheshire.core :as json]
    [clojure.string :as str]
    [compojure.core :refer [POST]]
    [metabase.api.common :as api]
@@ -28,6 +27,7 @@
    [metabase.query-processor.util :as qp.util]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
@@ -136,9 +136,9 @@
    format_rows            [:maybe ms/BooleanValue]
    pivot_results          [:maybe ms/BooleanValue]
    export-format          ExportFormat}
-  (let [{:keys [was-pivot] :as query} (json/parse-string query keyword)
+  (let [{:keys [was-pivot] :as query} (json/decode+kw query)
         query                         (dissoc query :was-pivot)
-        viz-settings                  (-> (json/parse-string visualization_settings viz-setting-key-fn)
+        viz-settings                  (-> (json/decode visualization_settings viz-setting-key-fn)
                                           (update :table.columns mbql.normalize/normalize)
                                           mb.viz/norm->db)
         query                         (-> query

--- a/src/metabase/api/embed/common.clj
+++ b/src/metabase/api/embed/common.clj
@@ -1,6 +1,5 @@
 (ns metabase.api.embed.common
   (:require
-   [cheshire.core :as json]
    [clojure.set :as set]
    [clojure.string :as str]
    [malli.core :as mc]
@@ -24,6 +23,7 @@
    [metabase.util.i18n
     :as i18n
     :refer [deferred-tru tru]]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
@@ -134,7 +134,7 @@
   [query-params]
   (or (try
         (when-let [parameters (:parameters query-params)]
-          (json/parse-string parameters keyword))
+          (json/decode+kw parameters))
         (catch Throwable _
           nil))
       query-params))

--- a/src/metabase/api/slack.clj
+++ b/src/metabase/api/slack.clj
@@ -1,7 +1,6 @@
 (ns metabase.api.slack
   "/api/slack endpoints"
   (:require
-   [cheshire.core :as json]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [compojure.core :refer [PUT]]
@@ -10,6 +9,7 @@
    [metabase.config :as config]
    [metabase.integrations.slack :as slack]
    [metabase.util.i18n :refer [tru]]
+   [metabase.util.json :as json]
    [metabase.util.malli.schema :as ms]))
 
 (set! *warn-on-reflection* true)
@@ -46,7 +46,7 @@
                            (get system-info :os.version "N/A"))}
                {:type "mrkdwn"
                 :text (str "*Version info:*\n```"
-                           (json/generate-string version-info {:pretty true})
+                           (json/encode version-info {:pretty true})
                            "```")}]}
      {:type "divider"}
      {:type "actions"
@@ -141,7 +141,7 @@
   (try
     (let [files-channel (slack/files-channel)
           bug-report-channel (slack/bug-report-channel)
-          file-content (.getBytes (json/generate-string diagnosticInfo {:pretty true}))
+          file-content (.getBytes (json/encode diagnosticInfo {:pretty true}))
           file-info (slack/upload-file! file-content
                                         "diagnostic-info.json"
                                         files-channel)]

--- a/src/metabase/api/testing.clj
+++ b/src/metabase/api/testing.clj
@@ -1,7 +1,6 @@
 (ns metabase.api.testing
   "Endpoints for testing."
   (:require
-   [cheshire.core :as json]
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [compojure.core :refer [POST]]
@@ -13,6 +12,7 @@
    [metabase.db :as mdb]
    [metabase.util.date-2 :as u.date]
    [metabase.util.files :as u.files]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2])
@@ -155,7 +155,7 @@
     {:status 400
      :body {:error-code "oops"}}
     {:status 200
-     :body (json/decode body true)}))
+     :body (json/decode+kw body)}))
 
 (api/defendpoint POST "/mark-stale"
   "Mark the card or dashboard as stale"

--- a/src/metabase/api/tiles.clj
+++ b/src/metabase/api/tiles.clj
@@ -1,7 +1,6 @@
 (ns metabase.api.tiles
   "`/api/tiles` endpoints."
   (:require
-   [cheshire.core :as json]
    [clojure.set :as set]
    [compojure.core :refer [GET]]
    [metabase.api.common :as api]
@@ -11,6 +10,7 @@
    [metabase.query-processor.util :as qp.util]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
+   [metabase.util.json :as json]
    [metabase.util.malli.schema :as ms])
   (:import
    (java.awt Color)
@@ -179,7 +179,7 @@
         lon-field-ref (field-ref lon-field)
 
         query
-        (mbql.normalize/normalize (json/parse-string query keyword))
+        (mbql.normalize/normalize (json/decode+kw query))
 
         updated-query (query->tiles-query query {:zoom zoom :x x :y y
                                                  :lat-field lat-field-ref

--- a/src/metabase/api/util.clj
+++ b/src/metabase/api/util.clj
@@ -2,7 +2,6 @@
   "Random utilty endpoints for things that don't belong anywhere else in particular, e.g. endpoints for certain admin
   page tasks."
   (:require
-   [cheshire.core :as json]
    [clj-http.client :as http]
    [compojure.core :refer [GET POST]]
    [crypto.random :as crypto-random]
@@ -16,6 +15,7 @@
    [metabase.logger :as logger]
    [metabase.public-settings.premium-features :as premium-features]
    [metabase.troubleshooting :as troubleshooting]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
@@ -61,9 +61,9 @@
    email :- [:maybe ms/NonBlankString]]
   (try (http/post (product-feedback-url)
                   {:content-type :json
-                   :body         (json/generate-string {:comments comments
-                                                        :source   source
-                                                        :email    email})})
+                   :body         (json/encode {:comments comments
+                                               :source   source
+                                               :email    email})})
        (catch Exception e
          (log/warn e)
          (throw e))))

--- a/src/metabase/async/streaming_response.clj
+++ b/src/metabase/async/streaming_response.clj
@@ -1,6 +1,5 @@
 (ns metabase.async.streaming-response
   (:require
-   [cheshire.core :as json]
    [clojure.core.async :as a]
    [clojure.walk :as walk]
    [compojure.response]
@@ -8,6 +7,7 @@
    [metabase.async.util :as async.u]
    [metabase.server.protocols :as server.protocols]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [potemkin.types :as p.types]
    [pretty.core :as pretty]
@@ -68,7 +68,7 @@
                         obj)
                       (dissoc :export-format))]
           (with-open [writer (BufferedWriter. (OutputStreamWriter. os StandardCharsets/UTF_8))]
-            (json/generate-stream obj writer)))
+            (json/encode-to obj writer {})))
         (catch EofException _)
         (catch Throwable e
           (log/error e "Error writing error to output stream" obj))))))

--- a/src/metabase/channel/impl/email.clj
+++ b/src/metabase/channel/impl/email.clj
@@ -1,7 +1,6 @@
 (ns metabase.channel.impl.email
   (:require
    [buddy.core.codecs :as codecs]
-   [cheshire.core :as json]
    [hiccup.core :refer [html]]
    [medley.core :as m]
    [metabase.channel.core :as channel]
@@ -18,6 +17,7 @@
    [metabase.util :as u]
    [metabase.util.encryption :as encryption]
    [metabase.util.i18n :refer [trs]]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
@@ -52,9 +52,9 @@
   [pulse-id email]
   (codecs/bytes->hex
    (encryption/validate-and-hash-secret-key
-    (json/generate-string {:salt     (public-settings/site-uuid-for-unsubscribing-url)
-                           :email    email
-                           :pulse-id pulse-id}))))
+    (json/encode {:salt     (public-settings/site-uuid-for-unsubscribing-url)
+                  :email    email
+                  :pulse-id pulse-id}))))
 
 (defn- unsubscribe-url-for-non-user
   [dashboard-subscription-id non-user-email]

--- a/src/metabase/channel/impl/http.clj
+++ b/src/metabase/channel/impl/http.clj
@@ -1,12 +1,12 @@
 (ns metabase.channel.impl.http
   (:require
-   [cheshire.core :as json]
    [clj-http.client :as http]
    [java-time.api :as t]
    [metabase.channel.core :as channel]
    [metabase.channel.render.core :as channel.render]
    [metabase.channel.shared :as channel.shared]
    [metabase.util.i18n :refer [tru]]
+   [metabase.util.json :as json]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
    [metabase.util.urls :as urls]))
@@ -50,7 +50,7 @@
                (= "query-param" auth-method)  (update :query-params merge auth-info)))]
     (http/request (cond-> req
                     (or (map? (:body req))
-                        (sequential? (:body req))) (update :body json/generate-string)))))
+                        (sequential? (:body req))) (update :body json/encode)))))
 
 (defmethod channel/can-connect? :channel/http
   [_channel-type details]

--- a/src/metabase/channel/render/js/color.clj
+++ b/src/metabase/channel/render/js/color.clj
@@ -2,11 +2,11 @@
   "Namespaces that uses the Nashorn javascript engine to invoke some shared javascript code that we use to determine
   the background color of pulse table cells"
   (:require
-   [cheshire.core :as json]
    [clojure.java.io :as io]
    [metabase.channel.render.js.engine :as js.engine]
    [metabase.formatter]
    [metabase.util.i18n :refer [trs]]
+   [metabase.util.json :as json]
    [metabase.util.malli :as mu])
   (:import
    (metabase.formatter NumericWrapper)))
@@ -48,8 +48,8 @@
   ;; code
   (js.engine/execute-fn-name (js-engine) "makeCellBackgroundGetter"
                              rows
-                             (json/generate-string cols)
-                             (json/generate-string viz-settings)))
+                             (json/encode cols)
+                             (json/encode viz-settings)))
 
 (defn get-background-color
   "Get the correct color for a cell in a pulse table. Returns color as string suitable for use CSS, e.g. a hex string or

--- a/src/metabase/cmd/rotate_encryption_key.clj
+++ b/src/metabase/cmd/rotate_encryption_key.clj
@@ -1,11 +1,11 @@
 (ns metabase.cmd.rotate-encryption-key
   (:require
-   [cheshire.core :as json]
    [metabase.db :as mdb]
    [metabase.models :refer [Database Secret Setting]]
    [metabase.models.setting.cache :as setting.cache]
    [metabase.util.encryption :as encryption]
    [metabase.util.i18n :refer [trs]]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [toucan2.core :as t2]))
 

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -1,5 +1,6 @@
 (ns metabase.config
   (:require
+   #_{:clj-kondo/ignore [:discouraged-namespace]}
    [cheshire.core :as json]
    [clojure.java.io :as io]
    [clojure.string :as str]

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -8,7 +8,6 @@
 
    If you need to use code from elsewhere, consider copying it into this namespace to minimize risk of the code changing behaviour."
   (:require
-   [cheshire.core :as json]
    [clojure.core.match :refer [match]]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
@@ -27,6 +26,7 @@
    [metabase.util.date-2 :as u.date]
    [metabase.util.encryption :as encryption]
    [metabase.util.honey-sql-2 :as h2x]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [toucan2.core :as t2]
    [toucan2.execute :as t2.execute])
@@ -112,12 +112,12 @@
   [obj]
   (if (string? obj)
     obj
-    (json/generate-string obj)))
+    (json/encode obj)))
 
 (defn- json-out [s keywordize-keys?]
   (if (string? s)
     (try
-      (json/parse-string s keywordize-keys?)
+      (json/decode s keywordize-keys?)
       (catch Throwable e
         (log/error e "Error parsing JSON")
         s))
@@ -132,7 +132,7 @@
   [v]
   (let [decrypted (encryption/maybe-decrypt v)]
     (try
-      (json/parse-string decrypted true)
+      (json/decode+kw decrypted)
       (catch Throwable e
         (if (or (encryption/possibly-encrypted-string? decrypted)
                 (encryption/possibly-encrypted-bytes? decrypted))
@@ -232,7 +232,7 @@
                                   ;; so we need to remove databases that have it set to false
                                   (filter (fn [{:keys [details]}]
                                             (when details
-                                              (false? (:json-unfolding (json/parse-string details true))))))
+                                              (false? (:json-unfolding (json/decode+kw details))))))
                                   (map :id))
         field-ids-to-update  (->> (t2/query {:select [:f.id]
                                              :from   [[:metabase_field :f]]
@@ -266,10 +266,10 @@
     (m/update-existing viz-settings "column_settings" update-keys
                        (fn [k]
                          (-> k
-                             json/parse-string
+                             json/decode
                              vec
                              old-to-new
-                             json/generate-string)))))
+                             json/encode)))))
 
 (define-migration MigrateLegacyColumnSettingsFieldRefs
   (let [update! (fn [{:keys [id visualization_settings]}]
@@ -277,11 +277,11 @@
                                  :set    {:visualization_settings visualization_settings}
                                  :where  [:= :id id]}))]
     (run! update! (eduction (keep (fn [{:keys [id visualization_settings]}]
-                                    (let [parsed  (json/parse-string visualization_settings)
+                                    (let [parsed  (json/decode visualization_settings)
                                           updated (update-legacy-field-refs-in-viz-settings parsed)]
                                       (when (not= parsed updated)
                                         {:id                     id
-                                         :visualization_settings (json/generate-string updated)}))))
+                                         :visualization_settings (json/encode updated)}))))
                             (t2/reducible-query {:select [:id :visualization_settings]
                                                  :from   [:report_card]
                                                  :where  [:or
@@ -308,9 +308,9 @@
                                       ["field" y {:source-field x}])
                        _ ref))]
     (->> result-metadata
-         json/parse-string
+         json/decode
          (map #(m/update-existing % "field_ref" old-to-new))
-         json/generate-string)))
+         json/encode)))
 
 (define-migration MigrateLegacyResultMetadataFieldRefs
   (let [update! (fn [{:keys [id result_metadata]}]
@@ -341,33 +341,33 @@
           (fn [column_settings]
             (into {}
                   (map (fn [[k v]]
-                         (match (vec (json/parse-string k))
+                         (match (vec (json/decode k))
                            ["ref" ["field" id opts]]
-                           [(json/generate-string ["ref" (remove-opts ["field" id opts] "join-alias")]) v]
+                           [(json/encode ["ref" (remove-opts ["field" id opts] "join-alias")]) v]
                            _ [k v]))
                        column_settings)))))
 
 (defn- add-join-alias-to-column-settings-refs [{:keys [visualization_settings result_metadata]}]
-  (let [result_metadata        (json/parse-string result_metadata)
-        visualization_settings (json/parse-string visualization_settings)
+  (let [result_metadata        (json/decode result_metadata)
+        visualization_settings (json/decode visualization_settings)
         column-key->metadata   (group-by #(-> (get % "field_ref")
                                               ;; like the FE's `getColumnKey` function, remove "join-alias",
                                               ;; "temporal-unit" and "binning" options from the field_ref
                                               (remove-opts "join-alias" "temporal-unit" "binning"))
                                          result_metadata)]
-    (json/generate-string
+    (json/encode
      (update visualization_settings "column_settings"
              (fn [column_settings]
                (into {}
                      (mapcat (fn [[k v]]
-                               (match (vec (json/parse-string k))
+                               (match (vec (json/decode k))
                                  ["ref" ["field" id opts]]
                                  (for [column-metadata (column-key->metadata ["field" id opts])
                                        ;; remove "temporal-unit" and "binning" options from the matching field refs,
                                        ;; but not "join-alias" as before.
                                        :let [field-ref (-> (get column-metadata "field_ref")
                                                            (remove-opts "temporal-unit" "binning"))]]
-                                   [(json/generate-string ["ref" field-ref]) v])
+                                   [(json/encode ["ref" field-ref]) v])
                                  _ [[k v]]))
                              column_settings)))))))
 
@@ -391,9 +391,9 @@
                                                     [:like :result_metadata "%join-alias%"]]})))
   (let [update! (fn [{:keys [id visualization_settings]}]
                   (let [updated (-> visualization_settings
-                                    json/parse-string
+                                    json/decode
                                     remove-join-alias-from-column-settings-field-refs
-                                    json/generate-string)]
+                                    json/encode)]
                     (when (not= visualization_settings updated)
                       (t2/query-one {:update :report_card
                                      :set    {:visualization_settings updated}
@@ -492,19 +492,19 @@
 
 (define-reversible-migration RevisionDashboardMigrateGridFrom18To24
   (let [migrate! (fn [revision]
-                   (let [object (json/parse-string (:object revision) keyword)]
+                   (let [object (json/decode+kw (:object revision))]
                      (when (seq (:cards object))
                        (t2/query {:update :revision
-                                  :set {:object (json/generate-string (update object :cards #(map migrate-dashboard-grid-from-18-to-24 %)))}
+                                  :set {:object (json/encode (update object :cards #(map migrate-dashboard-grid-from-18-to-24 %)))}
                                   :where [:= :id (:id revision)]}))))]
     (run! migrate! (t2/reducible-query {:select [:*]
                                         :from   [:revision]
                                         :where  [:= :model "Dashboard"]})))
   (let [roll-back! (fn [revision]
-                     (let [object (json/parse-string (:object revision) keyword)]
+                     (let [object (json/decode+kw (:object revision))]
                        (when (seq (:cards object))
                          (t2/query {:update :revision
-                                    :set {:object (json/generate-string (update object :cards #(map migrate-dashboard-grid-from-24-to-18 %)))}
+                                    :set {:object (json/encode (update object :cards #(map migrate-dashboard-grid-from-24-to-18 %)))}
                                     :where [:= :id (:id revision)]}))))]
     (run! roll-back! (t2/reducible-query {:select [:*]
                                           :from   [:revision]
@@ -512,11 +512,11 @@
 
 (define-migration RevisionMigrateLegacyColumnSettingsFieldRefs
   (let [update-one! (fn [{:keys [id object]}]
-                      (let [object  (json/parse-string object)
+                      (let [object  (json/decode object)
                             updated (update object "visualization_settings" update-legacy-field-refs-in-viz-settings)]
                         (when (not= updated object)
                           (t2/query-one {:update :revision
-                                         :set    {:object (json/generate-string updated)}
+                                         :set    {:object (json/encode updated)}
                                          :where  [:= :id id]}))))]
     (run! update-one! (t2/reducible-query {:select [:id :object]
                                            :from   [:revision]
@@ -547,10 +547,10 @@
                       (fn [column_settings]
                         (let [copies-with-join-alias (into {}
                                                            (mapcat (fn [[k v]]
-                                                                     (match (vec (json/parse-string k))
+                                                                     (match (vec (json/decode k))
                                                                        ["ref" ["field" id opts]]
                                                                        (for [alias join-aliases]
-                                                                         [(json/generate-string ["ref" ["field" id (assoc opts "join-alias" alias)]]) v])
+                                                                         [(json/encode ["ref" ["field" id (assoc opts "join-alias" alias)]]) v])
                                                                        _ '()))
                                                                    column_settings))]
                           ;; existing column settings should take precedence over the copies in case there is a conflict
@@ -558,12 +558,12 @@
               card)))
         update-one!
         (fn [revision]
-          (let [card (json/parse-string (:object revision))]
+          (let [card (json/decode (:object revision))]
             (when (not= (get card "query_type") "native") ; native queries won't have join aliases, so we can exclude them straight away
               (let [updated (add-join-aliases card)]
                 (when (not= updated (get "visualization_settings" card))
                   (t2/query {:update :revision
-                             :set {:object (json/generate-string (assoc card "visualization_settings" updated))}
+                             :set {:object (json/encode (assoc card "visualization_settings" updated))}
                              :where [:= :id (:id revision)]}))))))]
     (run! update-one! (t2/reducible-query {:select [:*]
                                            :from   [:revision]
@@ -578,13 +578,13 @@
   ;; Reverse migration
   (let [update-one!
         (fn [revision]
-          (let [card (json/parse-string (:object revision))]
+          (let [card (json/decode (:object revision))]
             (when (not= (get card "query_type") "native")
               (let [viz-settings (get card "visualization_settings")
                     updated      (remove-join-alias-from-column-settings-field-refs viz-settings)]
                 (when (not= updated viz-settings)
                   (t2/query {:update :revision
-                             :set {:object (json/generate-string (assoc card "visualization_settings" updated))}
+                             :set {:object (json/encode (assoc card "visualization_settings" updated))}
                              :where [:= :id (:id revision)]}))))))]
     (run! update-one! (t2/reducible-query {:select [:*]
                                            :from   [:revision]
@@ -597,11 +597,11 @@
 
 (define-migration MigrateLegacyDashboardCardColumnSettingsFieldRefs
   (let [update-one! (fn [{:keys [id visualization_settings]}]
-                      (let [parsed  (json/parse-string visualization_settings)
+                      (let [parsed  (json/decode visualization_settings)
                             updated (update-legacy-field-refs-in-viz-settings parsed)]
                         (when (not= parsed updated)
                           (t2/query-one {:update :report_dashboardcard
-                                         :set    {:visualization_settings (json/generate-string updated)}
+                                         :set    {:visualization_settings (json/encode updated)}
                                          :where  [:= :id id]}))))]
     (run! update-one! (t2/reducible-query
                        {:select [:id :visualization_settings]
@@ -639,11 +639,11 @@
                                                      [:like :dc.visualization_settings "%ref\\\\\\\",[\\\\\\\"field%"]]
                                                     [:like :c.result_metadata "%join-alias%"]]})))
   (let [update! (fn [{:keys [id visualization_settings]}]
-                  (let [parsed  (json/parse-string visualization_settings)
+                  (let [parsed  (json/decode visualization_settings)
                         updated (remove-join-alias-from-column-settings-field-refs parsed)]
                     (when (not= parsed updated)
                       (t2/query-one {:update :report_dashboardcard
-                                     :set    {:visualization_settings (json/generate-string updated)}
+                                     :set    {:visualization_settings (json/encode updated)}
                                      :where  [:= :id id]}))))]
     (run! update! (t2/reducible-query {:select [:dc.id :dc.visualization_settings]
                                        :from   [[:report_card :c]]
@@ -659,12 +659,12 @@
 
 (define-migration RevisionMigrateLegacyDashboardCardColumnSettingsFieldRefs
   (let [update-one! (fn [{:keys [id object]}]
-                      (let [object  (json/parse-string object)
+                      (let [object  (json/decode object)
                             updated (update object "cards" (fn [cards]
                                                              (map #(update % "visualization_settings" update-legacy-field-refs-in-viz-settings) cards)))]
                         (when (not= updated object)
                           (t2/query-one {:update :revision
-                                         :set    {:object (json/generate-string updated)}
+                                         :set    {:object (json/encode updated)}
                                          :where  [:= :id id]}))))]
     (run! update-one! (t2/reducible-query {:select [:id :object]
                                            :from   [:revision]
@@ -693,7 +693,7 @@
                                                                    [:= :id (get dashcard "card_id")]
                                                                    ;; only include cards with joins
                                                                    [:like :dataset_query "%joins%"]]})]
-            (if-let [join-aliases (->> (get-in (json/parse-string dataset_query) ["query" "joins"])
+            (if-let [join-aliases (->> (get-in (json/decode dataset_query) ["query" "joins"])
                                        (map #(get % "alias"))
                                        set
                                        seq)]
@@ -701,10 +701,10 @@
                                     (fn [column_settings]
                                       (let [copies-with-join-alias (into {}
                                                                          (mapcat (fn [[k v]]
-                                                                                   (match (vec (json/parse-string k))
+                                                                                   (match (vec (json/decode k))
                                                                                      ["ref" ["field" id opts]]
                                                                                      (for [alias join-aliases]
-                                                                                       [(json/generate-string ["ref" ["field" id (assoc opts "join-alias" alias)]]) v])
+                                                                                       [(json/encode ["ref" ["field" id (assoc opts "join-alias" alias)]]) v])
                                                                                      _ '()))
                                                                                  column_settings))]
                                         ;; existing column settings should take precedence over the copies in case there is a conflict
@@ -713,12 +713,12 @@
             dashcard))
         update-one!
         (fn [revision]
-          (let [dashboard (json/parse-string (:object revision))
+          (let [dashboard (json/decode (:object revision))
                 updated   (update dashboard "cards" (fn [dashcards]
                                                       (map add-join-aliases dashcards)))]
             (when (not= updated dashboard)
               (t2/query {:update :revision
-                         :set    {:object (json/generate-string updated)}
+                         :set    {:object (json/encode updated)}
                          :where  [:= :id (:id revision)]}))))]
     (run! update-one! (t2/reducible-query {:select [:*]
                                            :from   [:revision]
@@ -731,14 +731,14 @@
   ;; Reverse migration
   (let [update-one!
         (fn [revision]
-          (let [dashboard (json/parse-string (:object revision))
+          (let [dashboard (json/decode (:object revision))
                 updated   (update dashboard "cards"
                                   (fn [dashcards]
                                     (map #(update % "visualization_settings" remove-join-alias-from-column-settings-field-refs)
                                          dashcards)))]
             (when (not= updated dashboard)
               (t2/query {:update :revision
-                         :set    {:object (json/generate-string updated)}
+                         :set    {:object (json/encode updated)}
                          :where  [:= :id (:id revision)]}))))]
     (run! update-one! (t2/reducible-query {:select [:*]
                                            :from   [:revision]
@@ -768,7 +768,7 @@
                               options  (json-out options true)]
                           (when (some? (:persist-models-enabled settings))
                             (t2/query {:update :metabase_database
-                                       :set    {:options (json/generate-string (select-keys settings [:persist-models-enabled]))
+                                       :set    {:options (json/encode (select-keys settings [:persist-models-enabled]))
                                                 :settings (encrypted-json-in (dissoc settings :persist-models-enabled))}
                                        :where  [:= :id id]}))))]
     (run! rollback-one! (t2/reducible-query {:select [:id :settings :options]
@@ -863,7 +863,7 @@
 
 (defn- parse-to-json [& ks]
   (fn [x]
-    (reduce #(update %1 %2 json/parse-string)
+    (reduce #(update %1 %2 json/decode)
             x
             ks)))
 
@@ -880,7 +880,7 @@
              (completing
               (fn [_ {:keys [id visualization_settings]}]
                 (t2/update! :report_dashboardcard id
-                            {:visualization_settings (json/generate-string visualization_settings)})))
+                            {:visualization_settings (json/encode visualization_settings)})))
              nil
              ;; flamber wrote a manual postgres migration that this faithfully recreates: see
              ;; https://github.com/metabase/metabase/issues/15014
@@ -915,7 +915,7 @@
   [mapping-setting-key]
   (let [admin-group-id (t2/select-one-pk :permissions_group :name "Administrators")
         mapping        (try
-                         (json/parse-string (raw-setting mapping-setting-key))
+                         (json/decode (raw-setting mapping-setting-key))
                          (catch Exception _e
                            {}))]
     (when-not (empty? mapping)
@@ -924,7 +924,7 @@
                    (->> mapping
                         (map (fn [[k v]] [k (filter #(not= admin-group-id %) v)]))
                         (into {})
-                        json/generate-string)}))))
+                        json/encode)}))))
 
 (defn- migrate-remove-admin-from-group-mapping-if-needed
   {:author "qnkhuat"
@@ -1076,12 +1076,12 @@
     ;; So we do this in clojure land for mariadb
     (:h2 :mariadb)
     (let [migrate! (fn [revision]
-                     (let [object     (json/parse-string (:object revision) keyword)
+                     (let [object     (json/decode+kw (:object revision))
                            new-object (assoc object :type (if (:dataset object)
                                                             "model"
                                                             "question"))]
                        (t2/query {:update :revision
-                                  :set    {:object (json/generate-string new-object)}
+                                  :set    {:object (json/encode new-object)}
                                   :where  [:= :id (:id revision)]})))]
       (run! migrate! (t2/reducible-query {:select [:*]
                                           :from   [:revision]
@@ -1117,12 +1117,12 @@
 
     (:h2 :mariadb)
     (let [rollback! (fn [revision]
-                      (let [object     (json/parse-string (:object revision) keyword)
+                      (let [object     (json/decode+kw (:object revision))
                             new-object (-> object
                                            (assoc :dataset (= (:type object) "model"))
                                            (dissoc :type))]
                         (t2/query {:update :revision
-                                   :set    {:object (json/generate-string new-object)}
+                                   :set    {:object (json/encode new-object)}
                                    :where  [:= :id (:id revision)]})))]
       (run! rollback! (t2/reducible-query {:select [:*]
                                            :from   [:revision]
@@ -1415,7 +1415,7 @@
                                           :display                display}
                                  :where  [:= :id id]}))]
     (run! update! (eduction (keep (fn [{:keys [id display visualization_settings]}]
-                                    (let [parsed-viz           (json/parse-string visualization_settings keyword)
+                                    (let [parsed-viz           (json/decode+kw visualization_settings)
                                           partial-card         {:display display :visualization_settings parsed-viz}
                                           updated-partial-card (update-stacked-viz-cards partial-card)]
                                       (when (not= partial-card updated-partial-card)
@@ -1423,7 +1423,7 @@
                                                updated-viz     :visualization_settings} updated-partial-card]
                                           {:id                     id
                                            :display                (name updated-display)
-                                           :visualization_settings (json/generate-string updated-viz)})))))
+                                           :visualization_settings (json/encode updated-viz)})))))
                             (t2/reducible-query {:select [:id :display :visualization_settings]
                                                  :from   [:report_card]
                                                  :where  [:like :visualization_settings "%stackable%"]})))))
@@ -1472,7 +1472,7 @@
   "Computes a modern viz setting column key for a `column`. The modern format is [\"name\",`name`]."
   [{name "name"}]
   (when name
-    (json/generate-string ["name" name])))
+    (json/encode ["name" name])))
 
 (defn- column->legacy-column-key
   "Computes a legacy viz setting column key for a `column`.
@@ -1491,7 +1491,7 @@
       (column->column-key column)
 
       field-ref
-      (json/generate-string ["ref" field-ref]))))
+      (json/encode ["ref" field-ref]))))
 
 (defn- update-legacy-column-keys-in-viz-settings
   "Updates `:column_settings` keys. Unmatched keys are retained."
@@ -1527,12 +1527,12 @@
   to find the deduplicated column name by the field reference and compute the new column key."
   [column-key-tag update-viz-settings-fn]
   (let [update-one! (fn [{id :id viz-settings :visualization_settings result-metadata :result_metadata}]
-                      (let [viz-settings         (json/parse-string viz-settings)
-                            result-metadata      (json/parse-string result-metadata)
+                      (let [viz-settings         (json/decode viz-settings)
+                            result-metadata      (json/decode result-metadata)
                             updated-viz-settings (update-viz-settings-fn viz-settings result-metadata)]
                         (when (not= viz-settings updated-viz-settings)
                           (t2/query-one {:update :report_card
-                                         :set    {:visualization_settings (json/generate-string updated-viz-settings)}
+                                         :set    {:visualization_settings (json/encode updated-viz-settings)}
                                          :where  [:= :id id]}))))]
     (run! update-one! (t2/reducible-query {:select [:id :visualization_settings :result_metadata]
                                            :from   [:report_card]
@@ -1551,12 +1551,12 @@
   key."
   [column-key-tag update-viz-settings-fn]
   (let [update-one! (fn [{id :id viz-settings :visualization_settings result-metadata :result_metadata}]
-                      (let [viz-settings         (json/parse-string viz-settings)
-                            result-metadata      (json/parse-string result-metadata)
+                      (let [viz-settings         (json/decode viz-settings)
+                            result-metadata      (json/decode result-metadata)
                             updated-viz-settings (update-viz-settings-fn viz-settings result-metadata)]
                         (when (not= viz-settings updated-viz-settings)
                           (t2/query-one {:update :report_dashboardcard
-                                         :set    {:visualization_settings (json/generate-string updated-viz-settings)}
+                                         :set    {:visualization_settings (json/encode updated-viz-settings)}
                                          :where  [:= :id id]}))))]
     (run! update-one! (t2/reducible-query {:select [:dc.id :dc.visualization_settings :c.result_metadata]
                                            :from   [[:report_card :c]]
@@ -1586,7 +1586,7 @@
 
 (defn- set-parameter-stage-numbers
   [record last-stage]
-  (when-let [orig-pmappings (some-> record :parameter_mappings (json/parse-string true))]
+  (when-let [orig-pmappings (some-> record :parameter_mappings json/decode+kw)]
     (let [pmappings (map #(set-target-stage-number % last-stage) orig-pmappings)]
       (when (not= pmappings orig-pmappings)
         pmappings))))
@@ -1599,7 +1599,7 @@
     ;; questions and metrics are
     (-> record
         :dataset_query
-        (json/parse-string true)
+        json/decode+kw
         last-stage-number)))
 
 (defn- add-stage-numbers-to-parameter-mapping-targets
@@ -1616,7 +1616,7 @@
                             ls))]
          (when-let [new-mappings (set-parameter-stage-numbers record last-stage)]
            (t2/query {:update :report_dashboardcard
-                      :set    {:parameter_mappings (json/generate-string new-mappings)}
+                      :set    {:parameter_mappings (json/encode new-mappings)}
                       :where  [:= :id (:dc_id record)]}))))
      (t2/reducible-query {:select     [[:c.id :c_id] [:c.type :c_type] :c.dataset_query
                                        [:dc.id :dc_id] :dc.parameter_mappings]
@@ -1635,7 +1635,7 @@
 
 (defn- remove-parameter-stage-numbers
   [record]
-  (when-let [orig-pmappings (some-> record :parameter_mappings (json/parse-string true))]
+  (when-let [orig-pmappings (some-> record :parameter_mappings json/decode+kw)]
     (let [pmappings (map remove-target-stage-number orig-pmappings)]
       (when (not= pmappings orig-pmappings)
         pmappings))))
@@ -1646,7 +1646,7 @@
    (fn [record]
      (when-let [new-mappings (remove-parameter-stage-numbers record)]
        (t2/query {:update :report_dashboardcard
-                  :set    {:parameter_mappings (json/generate-string new-mappings)}
+                  :set    {:parameter_mappings (json/encode new-mappings)}
                   :where  [:= :id (:id record)]})))
    (t2/reducible-query {:select [:id :parameter_mappings]
                         :from   [:report_dashboardcard]
@@ -1672,7 +1672,7 @@
                              (dimension? dimension))
                         update-fn)]
     (if (not= new-dimension dimension)
-      (let [new-dimension-str (json/generate-string new-dimension)
+      (let [new-dimension-str (json/encode new-dimension)
             new-dimension-key (keyword new-dimension-str)]
         [new-dimension-key (-> parameter-mapping
                                (assoc :id new-dimension-str)
@@ -1726,7 +1726,7 @@
   []
   (let [id-viz-settings                 ; based on Hosting Insights, a few hundred records are expected
         (into []
-              (map (juxt :id (comp #(json/parse-string % true) :visualization_settings)))
+              (map (juxt :id (comp json/decode+kw :visualization_settings)))
               (t2/reducible-query {:select [:id :visualization_settings]
                                    :from   [:report_dashboardcard]
                                    :where  [:and
@@ -1752,13 +1752,13 @@
      (fn [[id viz-settings]]
        (when-let [new-viz-settings (set-viz-settings-parameter-stage-numbers viz-settings card-id->last-stage)]
          (t2/query {:update :report_dashboardcard
-                    :set    {:visualization_settings (json/generate-string new-viz-settings)}
+                    :set    {:visualization_settings (json/encode new-viz-settings)}
                     :where  [:= :id id]})))
      id-viz-settings)))
 
 (defn- remove-viz-settings-parameter-stage-numbers
   [record]
-  (let [orig-viz-settings (some-> record :visualization_settings (json/parse-string true))
+  (let [orig-viz-settings (some-> record :visualization_settings json/decode+kw)
         remove-stage-numbers (constantly #(subvec % 0 2))
         viz-settings (-> orig-viz-settings
                          (update-viz-settings-target-dimensions remove-stage-numbers)
@@ -1772,7 +1772,7 @@
    (fn [record]
      (when-let [new-mappings (remove-viz-settings-parameter-stage-numbers record)]
        (t2/query {:update :report_dashboardcard
-                  :set    {:visualization_settings (json/generate-string new-mappings)}
+                  :set    {:visualization_settings (json/encode new-mappings)}
                   :where  [:= :id (:id record)]})))
    (t2/reducible-query {:select [:id :visualization_settings]
                         :from   [:report_dashboardcard]

--- a/src/metabase/db/custom_migrations/metrics_v2.clj
+++ b/src/metabase/db/custom_migrations/metrics_v2.clj
@@ -1,7 +1,7 @@
 (ns metabase.db.custom-migrations.metrics-v2
   (:require
-   [cheshire.core :as json]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [toucan2.core :as t2])
   (:import (java.time Instant)))
 
@@ -41,7 +41,7 @@
   database with ID `db-id`.
   The :collection_id property is not set and the question is not persisted."
   [metric-v1 db-id]
-  (let [definition (json/parse-string (:definition metric-v1) true)
+  (let [definition (json/decode+kw (:definition metric-v1))
         dataset-query {:type :query
                        :database db-id
                        :query definition}]
@@ -49,7 +49,7 @@
         (select-keys [:archived :created_at :creator_id :database_id
                       :description :name :table_id])
         (update :description add-metric-id (:id metric-v1))
-        (assoc :dataset_query (json/generate-string dataset-query)
+        (assoc :dataset_query (json/encode dataset-query)
                :enable_embedding false
                :query_type "query"
                :type "metric"
@@ -105,13 +105,13 @@
   "Rewrite `outer-query` replacing references to v1 metrics with references
   to the corresponding v2 metric question as specified by the mapping `metric-id->metric-card-id`."
   [outer-query metric-id->metric-card-id]
-  (let [dataset-query (json/parse-string outer-query true)
+  (let [dataset-query (json/decode+kw outer-query)
         inner-query (:query dataset-query)
         rewritten (rewrite-metric-consuming-query inner-query metric-id->metric-card-id)]
     (when (not= rewritten inner-query)
       (-> dataset-query
           (assoc :query rewritten)
-          json/generate-string))))
+          json/encode))))
 
 (defn migrate-up!
   "Migrate metrics and the cards consuming them to metrics v2. This involves

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -5,7 +5,6 @@
   NOTE: This namespace is deprecated, all of these emails will soon be converted to System Email Notifications."
   (:require
    [buddy.core.codecs :as codecs]
-   [cheshire.core :as json]
    [java-time.api :as t]
    [medley.core :as m]
    [metabase.channel.render.core :as channel.render]
@@ -25,6 +24,7 @@
    [metabase.util.date-2 :as u.date]
    [metabase.util.encryption :as encryption]
    [metabase.util.i18n :as i18n :refer [trs tru]]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.urls :as urls]
@@ -250,7 +250,7 @@
   {:pre [(u/email? email)]}
   (let [encoded-info    (when blob
                           (-> blob
-                              json/generate-string
+                              json/encode
                               .getBytes
                               codecs/bytes->b64-str))
         context (merge (common-context)
@@ -272,9 +272,9 @@
   [pulse-id email]
   (codecs/bytes->hex
    (encryption/validate-and-hash-secret-key
-    (json/generate-string {:salt     (public-settings/site-uuid-for-unsubscribing-url)
-                           :email    email
-                           :pulse-id pulse-id}))))
+    (json/encode {:salt     (public-settings/site-uuid-for-unsubscribing-url)
+                  :email    email
+                  :pulse-id pulse-id}))))
 
 (defn pulse->alert-condition-kwd
   "Given an `alert` return a keyword representing what kind of goal needs to be met."

--- a/src/metabase/formatter.clj
+++ b/src/metabase/formatter.clj
@@ -3,7 +3,6 @@
    column metadata, and visualization-settings are known. These functions can be used for uniform rendering of all
    artifacts such as generated CSV or image files that need consistent formatting across the board."
   (:require
-   [cheshire.core :as json]
    [clojure.pprint :refer [cl-format]]
    [clojure.string :as str]
    [hiccup.util]
@@ -13,6 +12,7 @@
    [metabase.query-processor.streaming.common :as common]
    [metabase.types :as types]
    [metabase.util.currency :as currency]
+   [metabase.util.json :as json]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
    [metabase.util.ui-logic :as ui-logic]

--- a/src/metabase/integrations/google.clj
+++ b/src/metabase/integrations/google.clj
@@ -1,6 +1,5 @@
 (ns metabase.integrations.google
   (:require
-   [cheshire.core :as json]
    [clj-http.client :as http]
    [clojure.string :as str]
    [metabase.api.common :as api]
@@ -13,6 +12,7 @@
    [metabase.plugins.classloader :as classloader]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru tru]]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
@@ -81,7 +81,7 @@
    (let [{:keys [status body]} token-info-response]
      (when-not (= status 200)
        (throw (ex-info (tru "Invalid Google Sign-In token.") {:status-code 400})))
-     (u/prog1 (json/parse-string body keyword)
+     (u/prog1 (json/decode+kw body)
        (let [audience (:aud <>)
              audience (if (string? audience) [audience] audience)]
          (when-not (contains? (set audience) client-id)

--- a/src/metabase/integrations/ldap.clj
+++ b/src/metabase/integrations/ldap.clj
@@ -1,6 +1,5 @@
 (ns metabase.integrations.ldap
   (:require
-   [cheshire.core :as json]
    [clj-ldap.client :as ldap]
    [metabase.config :as config]
    [metabase.integrations.ldap.default-implementation :as default-impl]
@@ -9,6 +8,7 @@
    [metabase.plugins.classloader :as classloader]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru tru]]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms])
@@ -108,11 +108,11 @@
   :default    {}
   :audit      :getter
   :getter     (fn []
-                (json/parse-string (setting/get-value-of-type :string :ldap-group-mappings) #(DN. (str %))))
+                (json/decode (setting/get-value-of-type :string :ldap-group-mappings) #(DN. (str %))))
   :setter     (fn [new-value]
                 (cond
                   (string? new-value)
-                  (recur (json/parse-string new-value))
+                  (recur (json/decode new-value))
 
                   (map? new-value)
                   (do (doseq [k (keys new-value)]

--- a/src/metabase/metabot.clj
+++ b/src/metabase/metabot.clj
@@ -2,7 +2,6 @@
   "The core metabot namespace. Consists primarily of functions named infer-X,
   where X is the thing we want to extract from the bot response."
   (:require
-   [cheshire.core :as json]
    [metabase.lib.native :as lib-native]
    [metabase.metabot.client :as metabot-client]
    [metabase.metabot.feedback :as metabot-feedback]
@@ -10,6 +9,7 @@
    [metabase.metabot.util :as metabot-util]
    [metabase.models :refer [Table]]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [potemkin :as p]
    [toucan2.core :as t2]))
@@ -39,7 +39,7 @@
         {:template                (metabot-util/find-result
                                    (fn [message]
                                      (metabot-util/response->viz
-                                      (json/parse-string message keyword)))
+                                      (json/decode+kw message)))
                                    (metabot-client/invoke-metabot prompt))
          :prompt_template_version (format "%s:%s" prompt_template version)}))
     (log/warn "Metabot is not enabled")))

--- a/src/metabase/metabot/client.clj
+++ b/src/metabase/metabot/client.clj
@@ -1,7 +1,7 @@
 (ns metabase.metabot.client
   (:require
-   [cheshire.core :as json]
    [metabase.metabot.settings :as metabot-settings]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [wkok.openai-clojure.api :as openai.api]))
 
@@ -19,7 +19,7 @@
           ;; If we have ex-data, we'll assume were intercepting an openai.api/create-chat-completion response
          (if-some [status (:status (ex-data e))]
            (let [{:keys [body]} (ex-data e)
-                 {:keys [error]} (json/parse-string body keyword)
+                 {:keys [error]} (json/decode+kw body)
                  {error-type :type :keys [message code]} error]
              (case (int status)
                400 (do

--- a/src/metabase/metabot/feedback.clj
+++ b/src/metabase/metabot/feedback.clj
@@ -1,9 +1,9 @@
 (ns metabase.metabot.feedback
   (:require
-   [cheshire.core :as json]
    [clj-http.client :as http]
    [metabase.analytics.snowplow :as snowplow]
-   [metabase.metabot.settings :as metabot-settings]))
+   [metabase.metabot.settings :as metabot-settings]
+   [metabase.util.json :as json]))
 
 (def ^:private snowplow-keys [:entity_type :prompt_template_versions :feedback_type])
 (def ^:private feedback-keys (into snowplow-keys [:prompt :sql]))
@@ -15,9 +15,7 @@
         {:keys [status body]} (http/request
                                {:url              (metabot-settings/metabot-feedback-url)
                                 :method           :post
-                                :body             (json/generate-string
-                                                   feedback
-                                                   {:pretty true})
+                                :body             (json/encode feedback {:pretty true})
                                 :throw-exceptions false
                                 :as               :json
                                 :accept           :json

--- a/src/metabase/metabot/util.clj
+++ b/src/metabase/metabot/util.clj
@@ -2,7 +2,6 @@
   "Functions for denormalizing input, prompt input generation, and sql handing.
   If this grows much, we might want to split these out into separate nses."
   (:require
-   [cheshire.core :as json]
    [clojure.core.memoize :as memoize]
    [clojure.string :as str]
    [honey.sql :as sql]
@@ -16,6 +15,7 @@
    [metabase.query-processor.setup :as qp.setup]
    [metabase.query-processor.util.add-alias-info :as add]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [toucan2.core :as t2]))
 
@@ -198,7 +198,7 @@
   "Convert a map of {:models ...} to a json string summary of these models.
   This is used as a summary of the database in prompt engineering."
   [{:keys [models]}]
-  (let [json-str (json/generate-string
+  (let [json-str (json/encode
                   {:tables
                    (for [{model-name :name model-id :id :keys [result_metadata] :as _model} models]
                      {:table-id     model-id
@@ -416,7 +416,7 @@
   (log/info "Refreshing metabot prompt templates.")
   (let [all-templates (-> (metabot-settings/metabot-get-prompt-templates-url)
                           slurp
-                          (json/parse-string keyword))]
+                          json/decode+kw)]
     (-> (group-by (comp keyword :prompt_template) all-templates)
         (update-vals
          (fn [templates]

--- a/src/metabase/models/action.clj
+++ b/src/metabase/models/action.clj
@@ -1,6 +1,5 @@
 (ns metabase.models.action
   (:require
-   [cheshire.core :as json]
    [medley.core :as m]
    [metabase.models.card :refer [Card]]
    [metabase.models.interface :as mi]
@@ -9,6 +8,7 @@
    [metabase.search :as search]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
+   [metabase.util.json :as json]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 

--- a/src/metabase/models/cloud_migration.clj
+++ b/src/metabase/models/cloud_migration.clj
@@ -1,7 +1,6 @@
 (ns metabase.models.cloud-migration
   "A model representing a migration to cloud."
   (:require
-   [cheshire.core :as json]
    [clj-http.client :as http]
    [clojure.java.io :as io]
    [clojure.set :as set]
@@ -14,6 +13,7 @@
    [metabase.models.setting.cache :as setting.cache]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru tru]]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [methodical.core :as methodical]
    [toucan2.core :as t2]
@@ -222,7 +222,7 @@
                           {:form-params  {:part_count (count parts)}
                            :content-type :json})
                 :body
-                (json/parse-string keyword))
+                json/decode+kw)
 
             etags
             (->> (map (fn [[start end] [part-number url]]
@@ -294,7 +294,7 @@
                                                        (config/mb-version-info :tag))}
                   :content-type :json})
       :body
-      (json/parse-string keyword)
+      json/decode+kw
       (select-keys [:id :upload_url])
       (set/rename-keys {:id :external_id})))
 

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -62,8 +62,8 @@
    For example:
    ```
    (= dashcard ;; from toucan select, excluding :created_at and :updated_at
-      (-> (json/generate-string dashcard)
-          (json/parse-string true)
+      (-> (json/encode dashcard)
+          json/decode+kw
           from-parsed-json))
    =>
    true

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -1,8 +1,6 @@
 (ns metabase.models.interface
   (:require
    [buddy.core.codecs :as codecs]
-   [cheshire.core :as json]
-   [cheshire.generate :as json.generate]
    [clojure.core.memoize :as memoize]
    [clojure.spec.alpha :as s]
    [clojure.string :as str]
@@ -22,6 +20,7 @@
    [metabase.util.cron :as u.cron]
    [metabase.util.encryption :as encryption]
    [metabase.util.i18n :refer [tru]]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
@@ -135,12 +134,12 @@
   [obj]
   (if (string? obj)
     obj
-    (json/generate-string obj)))
+    (json/encode obj)))
 
 (defn- json-out [s keywordize-keys?]
   (if (string? s)
     (try
-      (json/parse-string s keywordize-keys?)
+      (json/decode s keywordize-keys?)
       (catch Throwable e
         (log/error e "Error parsing JSON")
         s))
@@ -319,7 +318,7 @@
   [v]
   (let [decrypted (encryption/maybe-decrypt v)]
     (try
-      (json/parse-string decrypted true)
+      (json/decode+kw decrypted)
       (catch Throwable e
         (if (or (encryption/possibly-encrypted-string? decrypted)
                 (encryption/possibly-encrypted-bytes? decrypted))
@@ -341,7 +340,7 @@
    to modern MBQL clauses so things work correctly."
   [viz-settings]
   (letfn [(normalize-column-settings-key [k]
-            (some-> k u/qualified-name json/parse-string mbql.normalize/normalize json/generate-string))
+            (some-> k u/qualified-name json/decode mbql.normalize/normalize json/encode))
           (normalize-column-settings [column-settings]
             (into {} (for [[k v] column-settings]
                        [(normalize-column-settings-key k) (walk/keywordize-keys v)])))
@@ -745,9 +744,9 @@
 (methodical/defmethod to-json :default
   "Default method for encoding instances of a Toucan model to JSON."
   [instance json-generator]
-  (json.generate/encode-map instance json-generator))
+  (json/generate-map instance json-generator))
 
-(json.generate/add-encoder
+(json/add-encoder
  Instance
  #'to-json)
 

--- a/src/metabase/models/query.clj
+++ b/src/metabase/models/query.clj
@@ -1,7 +1,6 @@
 (ns metabase.models.query
   "Functions related to the 'Query' model, which records stuff such as average query execution time."
   (:require
-   [cheshire.core :as json]
    [clojure.walk :as walk]
    [metabase.db :as mdb]
    [metabase.lib.core :as lib]
@@ -10,6 +9,7 @@
    [metabase.lib.util :as lib.util]
    [metabase.models.interface :as mi]
    [metabase.util.honey-sql-2 :as h2x]
+   [metabase.util.json :as json]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
@@ -63,7 +63,7 @@
      ;; new entries, so at some point in the future we can take this out, and save a DB call.
      (pos? (t2/update! Query
                        {:query_hash query-hash, :query nil}
-                       {:query                 (json/generate-string query)
+                       {:query                 (json/encode query)
                         :average_execution_time avg-execution-time}))
      ;; if query is already set then just update average_execution_time. (We're doing this separate call to avoid
      ;; updating query on every single UPDATE)

--- a/src/metabase/models/revision.clj
+++ b/src/metabase/models/revision.clj
@@ -1,12 +1,12 @@
 (ns metabase.models.revision
   (:require
-   [cheshire.core :as json]
    [clojure.data :as data]
    [metabase.config :as config]
    [metabase.models.interface :as mi]
    [metabase.models.revision.diff :refer [diff-strings*]]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru tru]]
+   [metabase.util.json :as json]
    [metabase.util.malli :as mu]
    [methodical.core :as methodical]
    [toucan2.core :as t2]
@@ -202,8 +202,8 @@
     ;; even though we call `post-select` on the `object`, the nested object might not be transformed correctly
     ;; E.g: Cards inside Dashboard will not be transformed
     ;; so to be safe, we'll just compare them as string
-    (when-not (= (json/generate-string serialized-object)
-                 (json/generate-string last-object))
+    (when-not (= (json/encode serialized-object)
+                 (json/encode last-object))
       (t2/insert! Revision
                   :model        entity-name
                   :model_id     id

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -53,7 +53,6 @@
     format distinguishes between `nil` and absence)"
   (:refer-clojure :exclude [descendants])
   (:require
-   [cheshire.core :as json]
    [clojure.core.match :refer [match]]
    [clojure.set :as set]
    [clojure.string :as str]
@@ -65,6 +64,7 @@
    [metabase.models.visualization-settings :as mb.viz]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [toucan2.core :as t2]
    [toucan2.model :as t2.model]
@@ -1325,18 +1325,18 @@
   Returns a new JSON string with the IDs converted inside."
   [json-str]
   (-> json-str
-      (json/parse-string true)
+      json/decode+kw
       ids->fully-qualified-names
-      json/generate-string))
+      json/encode))
 
 (defn- json-mbql-fully-qualified-names->ids
   "Converts fully qualified names to IDs in MBQL embedded inside a JSON string.
   Returns a new JSON string with teh IDs converted inside."
   [json-str]
   (-> json-str
-      (json/parse-string true)
+      json/decode+kw
       mbql-fully-qualified-names->ids
-      json/generate-string))
+      json/encode))
 
 (defn- export-viz-click-behavior-link
   [{:keys [linkType type] old-target-id :targetId :as click-behavior}]
@@ -1447,7 +1447,7 @@
   [settings]
   (when settings
     (-> settings
-        (update-keys #(-> % json/parse-string export-visualizations json/generate-string))
+        (update-keys #(-> % json/decode export-visualizations json/encode))
         (update-vals export-viz-click-behavior))))
 
 (defn export-visualization-settings
@@ -1495,7 +1495,7 @@
 (defn- import-column-settings [settings]
   (when settings
     (-> settings
-        (update-keys #(-> % name json/parse-string import-visualizations json/generate-string))
+        (update-keys #(-> % name json/decode import-visualizations json/encode))
         (update-vals import-viz-click-behavior))))
 
 (defn import-visualization-settings
@@ -1536,7 +1536,7 @@
   (let [column-settings-keys-deps (some->> viz
                                            :column_settings
                                            keys
-                                           (map (comp mbql-deps json/parse-string name)))
+                                           (map (comp mbql-deps json/decode name)))
         column-settings-vals-deps (some->> viz
                                            :column_settings
                                            vals

--- a/src/metabase/models/task_history.clj
+++ b/src/metabase/models/task_history.clj
@@ -1,11 +1,11 @@
 (ns metabase.models.task-history
   (:require
-   [cheshire.generate :refer [add-encoder encode-map]]
    [java-time.api :as t]
    [metabase.models.interface :as mi]
    [metabase.models.permissions :as perms]
    [metabase.public-settings.premium-features :as premium-features]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
    [methodical.core :as methodical]
@@ -156,7 +156,7 @@
 
 ;; TaskHistory can contain an exception for logging purposes, so use the built-in
 ;; serialization of a `Throwable->map` to make this something that can be JSON encoded.
-(add-encoder
+(json/add-encoder
  Throwable
  (fn [throwable json-generator]
-   (encode-map (Throwable->map throwable) json-generator)))
+   (json/generate-map (Throwable->map throwable) json-generator)))

--- a/src/metabase/models/user_parameter_value.clj
+++ b/src/metabase/models/user_parameter_value.clj
@@ -1,10 +1,10 @@
 (ns metabase.models.user-parameter-value
   (:require
-   [cheshire.core :as json]
    [medley.core :as m]
    [metabase.api.common :as api]
    [metabase.models.interface :as mi]
    [metabase.util.grouper :as grouper]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
@@ -24,7 +24,7 @@
   [s]
   (if (string? s)
     (try
-      (json/parse-string s true)
+      (json/decode+kw s)
       (catch Throwable _e
         s))
     s))

--- a/src/metabase/models/visualization_settings.cljc
+++ b/src/metabase/models/visualization_settings.cljc
@@ -22,11 +22,11 @@
   #?@
    (:clj
     [(:require
-      [cheshire.core :as json]
       [clojure.set :as set]
       [clojure.spec.alpha :as s]
       [medley.core :as m]
-      [metabase.legacy-mbql.normalize :as mbql.normalize])]
+      [metabase.legacy-mbql.normalize :as mbql.normalize]
+      [metabase.util.json :as json])]
     :cljs
     [(:require
       [clojure.set :as set]
@@ -165,7 +165,7 @@
   "Parse the given `json-str` to a map. In Clojure, this uses Cheshire. In Clojurescript, it calls `.parse` with
   `js/JSON` and threads that to `js->clj`."
   [json-str]
-  #?(:clj  (json/parse-string json-str)
+  #?(:clj  (json/decode json-str)
      :cljs (-> (.parse js/JSON json-str)
                js->clj)))
 

--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -4,7 +4,6 @@
   dumb, right? It's not just me? Why don't we just generate a big ol' UNION query so we can run one single query
   instead of running like 10 separate queries? -- Cam"
   (:require
-   [cheshire.core :as json]
    [medley.core :as m]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
@@ -28,6 +27,7 @@
    [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]))
@@ -390,7 +390,7 @@
             (::mb.viz/column-settings viz-settings))
         (update-keys (fn [k]
                        (if (string? k)
-                         (-> k json/parse-string last index-in-breakouts)
+                         (-> k json/decode last index-in-breakouts)
                          (->> k ::mb.viz/column-name index-in-breakouts))))
         (update-vals (comp keyword :pivot_table.column_sort_order)))))
 

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -1,7 +1,5 @@
 (ns metabase.query-processor.streaming.xlsx
   (:require
-   [cheshire.core :as json]
-   [cheshire.generate :as json.generate]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [dk.ative.docjure.spreadsheet :as spreadsheet]
@@ -17,7 +15,8 @@
    [metabase.util :as u]
    [metabase.util.currency :as currency]
    [metabase.util.date-2 :as u.date]
-   [metabase.util.i18n :refer [tru]])
+   [metabase.util.i18n :refer [tru]]
+   [metabase.util.json :as json])
   (:import
    (java.io OutputStream)
    (java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime)
@@ -379,7 +378,7 @@
   ;; For simplicity, we'll assume objects are exported as some kind of string, and the value can be parsed
   ;; by the user later somehow
   (let [encoded-obj (cond-> (json/encode value)
-                      (contains? (:impls json.generate/JSONable) (type value)) json/parse-string)]
+                      (json/has-custom-encoder? value) json/decode)]
     (.setCellValue cell (str encoded-obj))))
 
 (defmethod set-cell! nil [^Cell cell _value _styles _typed-styles]

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -3,7 +3,6 @@
   (:require
    [buddy.core.codecs :as codecs]
    [buddy.core.hash :as buddy-hash]
-   [cheshire.core :as json]
    [clojure.string :as str]
    [clojure.walk :as walk]
    [medley.core :as m]
@@ -14,6 +13,7 @@
    [metabase.lib.schema.util :as lib.schema.util]
    [metabase.query-processor.schema :as qp.schema]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [metabase.util.malli :as mu]))
 
 (set! *warn-on-reflection* true)
@@ -114,7 +114,7 @@
                   (throw (ex-info "Error hashing query. Is this a valid query?"
                                   {:query query}
                                   e))))]
-    (buddy-hash/sha3-256 (json/generate-string (select-keys-for-hashing query)))))
+    (buddy-hash/sha3-256 (json/encode (select-keys-for-hashing query)))))
 
 ;;; --------------------------------------------- Query Source Card IDs ----------------------------------------------
 

--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -1,6 +1,5 @@
 (ns metabase.search.appdb.core
   (:require
-   [cheshire.core :as json]
    [honey.sql.helpers :as sql.helpers]
    [metabase.db :as mdb]
    [metabase.public-settings :as public-settings]
@@ -13,6 +12,7 @@
    [metabase.search.ingestion :as search.ingestion]
    [metabase.search.permissions :as search.permissions]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [toucan2.core :as t2])
   (:import
    (java.time OffsetDateTime)))
@@ -32,7 +32,7 @@
 
 (defn- rehydrate [weights active-scorers index-row]
   (-> (merge
-       (json/parse-string (:legacy_input index-row) keyword)
+       (json/decode+kw (:legacy_input index-row))
        (select-keys index-row [:pinned]))
       (assoc
        :score      (:total_score index-row 1)

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -1,6 +1,5 @@
 (ns metabase.search.appdb.index
   (:require
-   [cheshire.core :as json]
    [clojure.string :as str]
    [honey.sql.helpers :as sql.helpers]
    [metabase.config :as config]
@@ -10,6 +9,7 @@
    [metabase.search.engine :as search.engine]
    [metabase.search.spec :as search.spec]
    [metabase.search.util :as search.util]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [toucan2.core :as t2])
   (:import
@@ -67,7 +67,7 @@
 
 (defn- sync-metadata [_old-setting-raw new-setting-raw]
   ;; Oh dear, we get the raw setting. Save a little bit of overhead by no keywordizing the keys.
-  (let [new-setting                          (json/parse-string new-setting-raw)
+  (let [new-setting                          (json/decode new-setting-raw)
         this-index-metadata                  #(get-in % ["versions" *index-version-id*])
         {:strs [active-table pending-table]} (this-index-metadata new-setting)
         ;; implicitly clear the pending table if we just activated it
@@ -151,8 +151,8 @@
        ;; remove attrs that get aliased
        (remove #{:id :created_at :updated_at :native_query}
                (conj search.spec/attr-columns :model :display_data :legacy_input)))
-      (update :display_data json/generate-string)
-      (update :legacy_input json/generate-string)
+      (update :display_data json/encode)
+      (update :legacy_input json/encode)
       (assoc
        :updated_at       :%now
        :model_id         (:id entity)

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -1,12 +1,12 @@
 (ns metabase.search.config
   (:require
-   [cheshire.core :as json]
    [metabase.api.common :as api]
    [metabase.models.setting :refer [defsetting]]
    [metabase.permissions.util :as perms.u]
    [metabase.public-settings :as public-settings]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru]]
+   [metabase.util.json :as json]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]))
 
@@ -263,7 +263,7 @@
 
 (defmethod column->string [:card :dataset_query]
   [value _ _]
-  (let [query (json/parse-string value true)]
+  (let [query (json/decode+kw value)]
     (if (= "native" (:type query))
       (-> query :native :query)
       "")))

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -1,6 +1,5 @@
 (ns metabase.search.impl
   (:require
-   [cheshire.core :as json]
    [clojure.string :as str]
    [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.lib.core :as lib]
@@ -19,6 +18,7 @@
    [metabase.search.in-place.filter :as search.in-place.filter]
    [metabase.search.in-place.scoring :as scoring]
    [metabase.util.i18n :refer [tru deferred-tru]]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
@@ -181,7 +181,7 @@
                                     {:effective_ancestors collection_effective_ancestors})))
          :scores          (remove-thunks all-scores))
         (update :dataset_query (fn [dataset-query]
-                                 (when-let [query (some-> dataset-query json/parse-string)]
+                                 (when-let [query (some-> dataset-query json/decode)]
                                    (if (get query "type")
                                      (mbql.normalize/normalize query)
                                      (not-empty (lib/normalize query))))))
@@ -359,7 +359,7 @@
 (defn- normalize-result-more
   "Additional normalization that is done after we've filtered by permissions, as its more expensive."
   [search-ctx result]
-  (->> (update result :pk_ref json/parse-string)
+  (->> (update result :pk_ref json/decode)
        (add-can-write search-ctx)))
 
 (defn- search-results [search-ctx model-set-fn total-results]

--- a/src/metabase/server/request/util.clj
+++ b/src/metabase/server/request/util.clj
@@ -1,7 +1,6 @@
 (ns metabase.server.request.util
   "Utility functions for Ring requests."
   (:require
-   [cheshire.core :as json]
    [clj-http.client :as http]
    [clojure.string :as str]
    [java-time.api :as t]
@@ -9,6 +8,7 @@
    [metabase.public-settings :as public-settings]
    [metabase.util :as u]
    [metabase.util.i18n :refer [trs tru]]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
@@ -167,7 +167,7 @@
                                             :socket-timeout     gecode-ip-address-timeout-ms
                                             :connection-timeout gecode-ip-address-timeout-ms})
                              :body
-                             (json/parse-string true))]
+                             json/decode+kw)]
             (into {} (for [info response]
                        [(:ip info) {:description (or (describe-location info)
                                                      "Unknown location")

--- a/src/metabase/server/routes/index.clj
+++ b/src/metabase/server/routes/index.clj
@@ -3,7 +3,6 @@
   `resources/frontend_client/index_template.html`; when the frontend is built (e.g. via `./bin/build.sh frontend`)
   different versions that include the FE app are created as `index.html`, `public.html`, and `embed.html`."
   (:require
-   [cheshire.core :as json]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [hiccup.util]
@@ -12,6 +11,7 @@
    [metabase.public-settings :as public-settings]
    [metabase.util.embed :as embed]
    [metabase.util.i18n :as i18n :refer [trs]]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [ring.util.response :as response]
    [stencil.core :as stencil])
@@ -30,7 +30,7 @@
   (str/replace s #"(?i)</script" "</scr\\\\ipt"))
 
 (defn- fallback-localization [locale-or-name]
-  (json/generate-string
+  (json/encode
    {"headers"
     {"language"     (str locale-or-name)
      "plural-forms" "nplurals=2; plural=(n != 1);"}
@@ -82,11 +82,11 @@
          ;; We disable `locale` parameter on static embeds/public links (metabase#50313)
          should-load-locale-params? (not embeddable?)]
      {:bootstrapJS          (load-inline-js "index_bootstrap")
-      :bootstrapJSON        (escape-script (json/generate-string public-settings))
+      :bootstrapJSON        (escape-script (json/encode public-settings))
       :assetOnErrorJS       (load-inline-js "asset_loading_error")
       :userLocalizationJSON (escape-script (load-localization (when should-load-locale-params? (:locale params))))
       :siteLocalizationJSON (escape-script (load-localization (public-settings/site-locale)))
-      :nonceJSON            (escape-script (json/generate-string nonce))
+      :nonceJSON            (escape-script (json/encode nonce))
       :language             (hiccup.util/escape-html (public-settings/site-locale))
       :favicon              (hiccup.util/escape-html (public-settings/application-favicon-url))
       :applicationName      (hiccup.util/escape-html (public-settings/application-name))

--- a/src/metabase/task/upgrade_checks.clj
+++ b/src/metabase/task/upgrade_checks.clj
@@ -1,7 +1,6 @@
 (ns metabase.task.upgrade-checks
   "Contains a Metabase task which periodically checks for the availability of new Metabase versions."
   (:require
-   [cheshire.core :as json]
    [clj-http.client :as http]
    [clojure.string :as str]
    [clojurewerkz.quartzite.jobs :as jobs]
@@ -12,6 +11,7 @@
    [metabase.config :as config]
    [metabase.public-settings :as public-settings]
    [metabase.task :as task]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]))
 
 (set! *warn-on-reflection* true)
@@ -29,7 +29,7 @@
                                                                              "channel" (public-settings/update-channel)})})))]
     (when (not= status 200)
       (throw (Exception. (format "[%d]: %s" status body))))
-    (json/parse-string body keyword)))
+    (json/decode+kw body)))
 
 (jobs/defjob ^{:doc "Simple job which looks up all databases and runs a sync on them"} CheckForNewVersions [_]
   (when (public-settings/check-for-updates)

--- a/src/metabase/util/embed.clj
+++ b/src/metabase/util/embed.clj
@@ -3,7 +3,6 @@
   (:require
    [buddy.core.codecs :as codecs]
    [buddy.sign.jwt :as jwt]
-   [cheshire.core :as json]
    [clojure.string :as str]
    [hiccup.core :refer [html]]
    [metabase.config :as config]
@@ -12,6 +11,7 @@
    [metabase.public-settings.premium-features :as premium-features]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru trs tru]]
+   [metabase.util.json :as json]
    [ring.util.codec :as codec]))
 
 (set! *warn-on-reflection* true)
@@ -71,7 +71,7 @@
   "Parse a JWT `message` and return the header portion."
   [^String message]
   (let [[header] (str/split message #"\.")]
-    (json/parse-string (codecs/bytes->str (codec/base64-decode header)) keyword)))
+    (json/decode+kw (codecs/bytes->str (codec/base64-decode header)))))
 
 (defn- check-valid-alg
   "Check that the JWT `alg` isn't `none`. `none` is valid per the standard, but for obvious reasons we want to make sure

--- a/src/metabase/util/http.clj
+++ b/src/metabase/util/http.clj
@@ -1,11 +1,11 @@
 (ns metabase.util.http
   (:require
-   [cheshire.core :as json]
    [clj-http.client :as http]
-   [medley.core :as m]))
+   [medley.core :as m]
+   [metabase.util.json :as json]))
 
 (defn- parse-http-headers [headers]
-  (json/parse-string headers))
+  (json/decode headers))
 
 (defn ^:dynamic *fetch-as-json*
   "Fetches url and parses body as json, returning it."

--- a/src/metabase/util/i18n.clj
+++ b/src/metabase/util/i18n.clj
@@ -1,10 +1,10 @@
 (ns metabase.util.i18n
   "i18n functionality."
   (:require
-   [cheshire.generate :as json.generate]
    [clojure.string :as str]
    [clojure.walk :as walk]
    [metabase.util.i18n.impl :as i18n.impl]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [net.cgrand.macrovich :as macros]
    [potemkin :as p]
@@ -96,13 +96,13 @@
 
 (defn- localized-to-json
   "Write a UserLocalizedString or SiteLocalizedString to the `json-generator`. This is intended for
-  `json.generate/add-encoder`. Ideally we'd implement those protocols directly as it's faster, but currently that doesn't
+  `json/add-encoder`. Ideally we'd implement those protocols directly as it's faster, but currently that doesn't
   work with Cheshire"
   [localized-string json-generator]
-  (json.generate/write-string json-generator (str localized-string)))
+  (json/write-string json-generator (str localized-string)))
 
-(json.generate/add-encoder UserLocalizedString localized-to-json)
-(json.generate/add-encoder SiteLocalizedString localized-to-json)
+(json/add-encoder UserLocalizedString localized-to-json)
+(json/add-encoder SiteLocalizedString localized-to-json)
 
 (def LocalizedString
   "Schema for user and system localized string instances"

--- a/src/metabase/util/json.clj
+++ b/src/metabase/util/json.clj
@@ -1,6 +1,7 @@
 (ns metabase.util.json
   "Functions for encoding and decoding JSON that abstract away the underlying implementation."
   (:require
+   #_{:clj-kondo/ignore [:discouraged-namespace]}
    [cheshire.core :as cheshire]
    [cheshire.factory]
    [cheshire.generate :as json.generate]

--- a/src/metabase/util/json.clj
+++ b/src/metabase/util/json.clj
@@ -1,0 +1,87 @@
+(ns metabase.util.json
+  "Functions for encoding and decoding JSON that abstract away the underlying implementation."
+  (:require
+   [cheshire.core :as cheshire]
+   [cheshire.factory]
+   [cheshire.generate :as json.generate]
+   [clojure.java.io :as io])
+  (:import
+   (com.fasterxml.jackson.core JsonGenerator)
+   (java.io InputStream Reader)))
+
+(set! *warn-on-reflection* true)
+
+(defn add-encoder
+  "Register a custom `encoder` for `class`."
+  [class encoder]
+  (json.generate/add-encoder class encoder))
+
+(defn create-generator
+  "Returns JsonGenerator for given writer."
+  [writer]
+  (cheshire/create-generator writer))
+
+;; Tell the JSON middleware to use a date format that includes milliseconds (why?)
+(def default-date-format "Default date formatter for JSON serialization." "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+
+(alter-var-root #'cheshire.factory/default-date-format (constantly default-date-format))
+(alter-var-root #'json.generate/*date-format* (constantly default-date-format))
+
+(defn generate
+  "Call `cheshire.generate/generate`."
+  [jg obj date-format ex key-fn]
+  (json.generate/generate jg obj date-format ex key-fn))
+
+(defn generate-map
+  "Encode a clojure map to the json generator."
+  [m jg]
+  (json.generate/encode-map m jg))
+
+(defn generate-nil
+  "Encode null to the json generator."
+  [_ ^JsonGenerator jg]
+  (.writeNull jg))
+
+(defn raw-json-generator
+  "Wrap a string so it will be spliced directly into resulting JSON as-is. Analogous to HoneySQL `raw`."
+  [^String s]
+  (reify json.generate/JSONable
+    (to-json [_ generator]
+      (.writeRawValue ^JsonGenerator generator s))))
+
+(defn has-custom-encoder?
+  "Return true if the type of the given value has a registered custom implementation of JSONable."
+  [value]
+  (contains? (:impls json.generate/JSONable) (type value)))
+
+(defn write-string
+  "Encode string to the json generator."
+  [^JsonGenerator jg ^String str]
+  (json.generate/write-string jg str))
+
+(defn encode
+  "Return a JSON-encoding String for the given object."
+  (^String [obj]
+   (cheshire/generate-string obj))
+  (^String [obj opt-map]
+   (cheshire/generate-string obj opt-map)))
+
+(defn encode-to
+  "Encode a value as JSON and write to the given Writer object."
+  [obj writer opt-map]
+  (cheshire/generate-stream obj writer opt-map))
+
+(defn decode
+  "Decode a value from a JSON from a string, InputStream, or Reader."
+  ([source] (decode source nil))
+  ([source key-fn]
+   (cond (string? source) (cheshire/parse-string source key-fn)
+         (instance? Reader source) (cheshire/parse-stream source key-fn)
+         (instance? InputStream source) (cheshire/parse-stream (io/reader source) key-fn)
+         (nil? source) nil
+         :else (throw (ex-info (str "Unsupported source type: " (type source)) {})))))
+
+(defn decode+kw
+  "Decode a value from a JSON from a string, InputStream, or Reader, keywordizing map keys."
+  [source]
+  (decode source true))

--- a/src/metabase/util/malli/schema.clj
+++ b/src/metabase/util/malli/schema.clj
@@ -4,7 +4,6 @@
   For example the PositiveInt can be defined as (mr/def ::positive-int pos-int?)
   "
   (:require
-   [cheshire.core :as json]
    [clojure.string :as str]
    [malli.core :as mc]
    [metabase.legacy-mbql.normalize :as mbql.normalize]
@@ -15,6 +14,7 @@
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
    [metabase.util.i18n :as i18n :refer [deferred-tru]]
+   [metabase.util.json :as json]
    [metabase.util.malli :as mu]
    [metabase.util.password :as u.password]))
 
@@ -261,7 +261,7 @@
    [:and
     :string
     [:fn #(try
-            (json/parse-string %)
+            (json/decode %)
             true
             (catch Throwable _
               false))]]

--- a/src/metabase/xrays/automagic_dashboards/util.clj
+++ b/src/metabase/xrays/automagic_dashboards/util.clj
@@ -1,7 +1,6 @@
 (ns metabase.xrays.automagic-dashboards.util
   (:require
    [buddy.core.codecs :as codecs]
-   [cheshire.core :as json]
    [clojure.string :as str]
    [medley.core :as m]
    [metabase.analyze :as analyze]
@@ -12,6 +11,7 @@
    [metabase.models.field :refer [Field]]
    [metabase.models.interface :as mi]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]

--- a/test/metabase/analytics/snowplow_test.clj
+++ b/test/metabase/analytics/snowplow_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.analytics.snowplow-test
   (:require
-   [cheshire.core :as json]
    [clojure.test :refer :all]
    [clojure.walk :as walk]
    [metabase.analytics.snowplow :as snowplow]
@@ -10,6 +9,7 @@
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
+   [metabase.util.json :as json]
    [toucan2.core :as t2])
   (:import
    (com.snowplowanalytics.snowplow.tracker.events SelfDescribing)
@@ -38,7 +38,7 @@
         ;; cases
         properties                         (-> (or (:ue_pr payload)
                                                    (u/decode-base64 (:ue_px payload)))
-                                               json/parse-string)
+                                               json/decode)
         subject                            (when-let [subject (.getSubject event)]
                                              (-> subject .getSubject normalize-map))
         [^SelfDescribingJson context-json] (.getContext event)

--- a/test/metabase/analyze/fingerprint/fingerprinters_test.clj
+++ b/test/metabase/analyze/fingerprint/fingerprinters_test.clj
@@ -1,6 +1,5 @@
 (ns ^:mb/driver-tests metabase.analyze.fingerprint.fingerprinters-test
   (:require
-   [cheshire.core :as json]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.analyze.fingerprint.fingerprinters :as fingerprinters]
@@ -8,6 +7,7 @@
    [metabase.models.field :as field :refer [Field]]
    [metabase.models.interface :as mi]
    [metabase.test :as mt]
+   [metabase.util.json :as json]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -124,7 +124,7 @@
          (transduce identity
                     (fingerprinters/fingerprinter (mi/instance Field {:base_type :type/Text}))
                     ["metabase" "more" "like" "metabae" "[1, 2, 3]"])))
-  (let [truncated-json (subs (json/generate-string (vec (range 50))) 0 30)]
+  (let [truncated-json (subs (json/encode (vec (range 50))) 0 30)]
     (is (= {:global {:distinct-count 5
                      :nil%           0.0}
             :type   {:type/Text {:percent-json   0.2
@@ -178,7 +178,7 @@
 (deftest ^:parallel valid-serialized-json?-test
   (testing "recognizes substrings of json"
     (letfn [(partial-json [x]
-              (let [json (json/generate-string x)]
+              (let [json (json/encode x)]
                 (subs json 0 (/ (count json) 2))))]
       (are [x] (#'fingerprinters/valid-serialized-json? (partial-json x))
         [1 2 3]

--- a/test/metabase/api/action_test.clj
+++ b/test/metabase/api/action_test.clj
@@ -1,6 +1,5 @@
 (ns ^:mb/driver-tests metabase.api.action-test
   (:require
-   [cheshire.core :as json]
    [clojure.set :as set]
    [clojure.test :refer :all]
    [metabase.analytics.snowplow-test :as snowplow-test]
@@ -10,6 +9,7 @@
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp]))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -1,7 +1,6 @@
 (ns ^:mb/driver-tests metabase.api.card-test
   "Tests for /api/card endpoints."
   (:require
-   [cheshire.core :as json]
    [clojure.data.csv :as csv]
    [clojure.set :as set]
    [clojure.string :as str]
@@ -44,6 +43,7 @@
    [metabase.test.data.users :as test.users]
    [metabase.upload-test :as upload-test]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp])
   (:import
@@ -2041,9 +2041,9 @@
 
 ;;; Test GET /api/card/:id/query/csv & GET /api/card/:id/json & GET /api/card/:id/query/xlsx **WITH PARAMETERS**
 (def ^:private ^:const ^String encoded-params
-  (json/generate-string [{:type   :number
-                          :target [:variable [:template-tag :category]]
-                          :value  2}]))
+  (json/encode [{:type   :number
+                 :target [:variable [:template-tag :category]]
+                 :value  2}]))
 
 (deftest csv-download-test
   (testing "no parameters"
@@ -2462,7 +2462,7 @@
   [url]
   (-> (client/client-full-response (test.users/username->token :rasta)
                                    :post 200 url
-                                   :query (json/generate-string (mt/mbql-query checkins {:limit 1})))
+                                   :query (json/encode (mt/mbql-query checkins {:limit 1})))
       :headers
       (select-keys ["Cache-Control" "Content-Disposition" "Content-Type" "Expires" "X-Accel-Buffering"])
       (update "Content-Disposition" #(some-> % (str/replace #"my_awesome_card_.+(\.\w+)"

--- a/test/metabase/api/common/internal_test.clj
+++ b/test/metabase/api/common/internal_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.api.common.internal-test
   (:require
-   [cheshire.core :as json]
    [clj-http.client :as http]
    [clojure.string :as str]
    [clojure.test :refer :all]
@@ -14,6 +13,7 @@
    [metabase.server.middleware.exceptions :as mw.exceptions]
    [metabase.test :as mt]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
    [ring.adapter.jetty :as jetty]
@@ -127,9 +127,9 @@
 (defn- json-mw [handler]
   (fn [req]
     (-> req
-        (update :body #(-> % slurp (json/parse-string true)))
+        (update :body #(-> % slurp json/decode+kw))
         handler
-        (update :body json/generate-string))))
+        (update :body json/encode))))
 
 (defn exception-mw [handler]
   (fn [req] (try
@@ -153,7 +153,7 @@
                            :accept           :json
                            :as               :json
                            :coerce           :always
-                           :body             (json/generate-string body)}))]
+                           :body             (json/encode body)}))]
     (try
       (testing (format "With temp Jetty server on port %d" port)
         (f {:get get, :post! post}))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1,7 +1,6 @@
 (ns ^:mb/driver-tests metabase.api.dashboard-test
   "Tests for /api/dashboard endpoints."
   (:require
-   [cheshire.core :as json]
    [clojure.data.csv :as csv]
    [clojure.set :as set]
    [clojure.string :as str]
@@ -59,6 +58,7 @@
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [ring.util.codec :as codec]
    [toucan2.core :as t2]
    [toucan2.protocols :as t2.protocols]
@@ -3108,7 +3108,7 @@
                            :data :results_metadata :columns)]
           (is (seq metadata) "Did not get metadata")
           (t2/update! 'Card {:id model-id}
-                      {:result_metadata (json/generate-string
+                      {:result_metadata (json/encode
                                          (assoc-in metadata [0 :id]
                                                    (mt/id :products :category)))}))
         ;; ...so instead we create a question on top of this model (note that
@@ -3679,8 +3679,8 @@
                       (mt/user-real-request :rasta :post 200 url
                                             {:request-options {:as :byte-array}}
                                             :format_rows true
-                                            :parameters (json/generate-string [{:id    "_PRICE_"
-                                                                                :value 4}]))
+                                            :parameters (json/encode [{:id    "_PRICE_"
+                                                                       :value 4}]))
                       export-format))))))))))
 
 (defn- dashcard-pivot-query-endpoint [dashboard-id card-id dashcard-id]

--- a/test/metabase/api/downloads_exports_test.clj
+++ b/test/metabase/api/downloads_exports_test.clj
@@ -11,7 +11,6 @@
   - Alert attachments"
   #_{:clj-kondo/ignore [:deprecated-namespace]}
   (:require
-   [cheshire.core :as json]
    [clojure.data :as data]
    [clojure.data.csv :as csv]
    [clojure.java.io :as io]
@@ -24,7 +23,8 @@
    [metabase.public-settings :as public-settings]
    [metabase.pulse.core :as pulse]
    [metabase.pulse.test-util :as pulse.test-util]
-   [metabase.test :as mt])
+   [metabase.test :as mt]
+   [metabase.util.json :as json])
   (:import
    (org.apache.poi.ss.usermodel DataFormatter)
    (org.apache.poi.xssf.usermodel XSSFSheet)))
@@ -73,9 +73,9 @@
   [card {:keys [export-format format-rows pivot]}]
   (->> (mt/user-http-request :crowberto :post 200
                              (format "dataset/%s" (name export-format))
-                             :visualization_settings (json/generate-string
+                             :visualization_settings (json/encode
                                                       (:visualization_settings card))
-                             :query (json/generate-string
+                             :query (json/encode
                                      (assoc (:dataset_query card)
                                             :was-pivot (boolean pivot)
                                             :info {:visualization-settings (:visualization_settings card)}

--- a/test/metabase/api/geojson_test.clj
+++ b/test/metabase/api/geojson_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.api.geojson-test
   (:require
-   [cheshire.core :as json]
    [clj-http.fake :as fake]
    [clojure.test :refer :all]
    [metabase.api.geojson :as api.geojson]
@@ -9,6 +8,7 @@
    [metabase.models.setting :as setting]
    [metabase.test :as mt]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [metabase.util.malli.schema :as ms]
    [ring.adapter.jetty :as ring-jetty])
   (:import
@@ -256,7 +256,7 @@
                              :region_name "NAME"}}
             expected-value (merge (@#'api.geojson/builtin-geojson) custom-geojson)]
         (mt/with-temporary-setting-values [custom-geojson nil]
-          (mt/with-temp-env-var-value! [mb-custom-geojson (json/generate-string custom-geojson)]
+          (mt/with-temp-env-var-value! [mb-custom-geojson (json/encode custom-geojson)]
             (binding [config/*disable-setting-cache* true]
               (testing "Should parse env var custom GeoJSON and merge in"
                 (is (= expected-value

--- a/test/metabase/api/metabot_test.clj
+++ b/test/metabase/api/metabot_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.api.metabot-test
   (:require
-   [cheshire.core :as json]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.db.query :as mdb.query]
@@ -9,6 +8,7 @@
    [metabase.metabot.util :as metabot-util]
    [metabase.models :refer [Card]]
    [metabase.test :as mt]
+   [metabase.util.json :as json]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
 (deftest metabot-only-works-on-models-test
@@ -204,7 +204,7 @@
             (with-redefs [metabot-client/*create-chat-completion-endpoint* (fn [_ _]
                                                                              (throw (ex-info
                                                                                      error-message
-                                                                                     {:body   (json/generate-string
+                                                                                     {:body   (json/encode
                                                                                                {:error {:message error-message
                                                                                                         :code    error-code}})
                                                                                       :status 400})))

--- a/test/metabase/api/preview_embed_test.clj
+++ b/test/metabase/api/preview_embed_test.clj
@@ -1,7 +1,6 @@
 (ns ^:mb/driver-tests metabase.api.preview-embed-test
   (:require
    [buddy.sign.jwt :as jwt]
-   [cheshire.core :as json]
    [clojure.test :refer :all]
    [crypto.random :as crypto-random]
    [metabase.api.dashboard-test :as api.dashboard-test]
@@ -13,6 +12,7 @@
    [metabase.models.dashboard-card :refer [DashboardCard]]
    [metabase.test :as mt]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
@@ -616,26 +616,26 @@
             (let [url (card-query-url card {:_embedding_params {:LIKED "enabled"}})]
               (is (= [[3 "The Dentist" false]]
                      (-> (mt/user-http-request :crowberto :get 202 url
-                                               :parameters (json/generate-string {:LIKED false}))
+                                               :parameters (json/encode {:LIKED false}))
                          :data
                          :rows)))
               (is (= [[1 "Tempest" true]
                       [2 "Bullit" true]]
                      (-> (mt/user-http-request :crowberto :get 202 url
-                                               :parameters (json/generate-string {:LIKED true}))
+                                               :parameters (json/encode {:LIKED true}))
                          :data
                          :rows)))))
           (testing "for dashboard embeds"
             (let [url (dashcard-url dashcard {:_embedding_params {:LIKED "enabled"}})]
               (is (= [[3 "The Dentist" false]]
                      (-> (mt/user-http-request :crowberto :get 202 url
-                                               :parameters (json/generate-string {:LIKED false}))
+                                               :parameters (json/encode {:LIKED false}))
                          :data
                          :rows)))
               (is (= [[1 "Tempest" true]
                       [2 "Bullit" true]]
                      (-> (mt/user-http-request :crowberto :get 202 url
-                                               :parameters (json/generate-string {:LIKED true}))
+                                               :parameters (json/encode {:LIKED true}))
                          :data
                          :rows))))))))))
 
@@ -665,6 +665,6 @@
             (let [url (dashcard-url dashcard {:_embedding_params {:NAME "enabled"}})]
               (is (= [["Cheongju International Airport/Cheongju Air Base (K-59/G-513)"]]
                      (-> (mt/user-http-request :crowberto :get 202 url
-                                               :parameters (json/generate-string {:NAME "513"}))
+                                               :parameters (json/encode {:NAME "513"}))
                          :data
                          :rows))))))))))

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -1,7 +1,6 @@
 (ns ^:mb/driver-tests metabase.api.public-test
   "Tests for `api/public/` (public links) endpoints."
   (:require
-   [cheshire.core :as json]
    [clojure.data.csv :as csv]
    [clojure.set :as set]
    [clojure.string :as str]
@@ -26,6 +25,7 @@
    [metabase.query-processor.middleware.process-userland-query-test :as process-userland-query-test]
    [metabase.test :as mt]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [throttle.core :as throttle]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp])
@@ -818,7 +818,7 @@
                 (is (= [[50]]
                        (-> (mt/user-http-request :crowberto
                                                  :get (dashcard-url dash card dashcard)
-                                                 :parameters (json/generate-string
+                                                 :parameters (json/encode
                                                               [{:type   :category
                                                                 :target [:variable [:template-tag :num]]
                                                                 :value  "50"
@@ -844,7 +844,7 @@
                   (is (= [[1]]
                          (-> (mt/user-http-request :crowberto
                                                    :get (dashcard-url dash card dashcard)
-                                                   :parameters (json/generate-string
+                                                   :parameters (json/encode
                                                                 [{:type   :id
                                                                   :target [:dimension [:field (mt/id :venues :id) nil]]
                                                                   :value  "50"
@@ -872,7 +872,7 @@
                     (is (= [[733]]
                            (-> (mt/user-http-request :crowberto
                                                      :get (dashcard-url dash card dashcard)
-                                                     :parameters (json/generate-string
+                                                     :parameters (json/encode
                                                                   [{:type   "date/all-options"
                                                                     :target [:dimension [:field (mt/id :checkins :date) nil]]
                                                                     :value  "~2015-01-01"
@@ -905,7 +905,7 @@
               (is (= [["World"]]
                      (-> (mt/user-http-request :crowberto
                                                :get (dashcard-url dash card dashcard)
-                                               :parameters (json/generate-string
+                                               :parameters (json/encode
                                                             [{:type    :category
                                                               :target  [:variable [:template-tag :msg]]
                                                               :value   "World"

--- a/test/metabase/api/tiles_test.clj
+++ b/test/metabase/api/tiles_test.clj
@@ -1,12 +1,12 @@
 (ns metabase.api.tiles-test
   "Tests for `/api/tiles` endpoints."
   (:require
-   [cheshire.core :as json]
    [clojure.set :as set]
    [clojure.test :refer :all]
    [metabase.api.tiles :as api.tiles]
    [metabase.query-processor.compile :as qp.compile]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util.json :as json]))
 
 (defn- png? [s]
   (= [\P \N \G]
@@ -24,14 +24,14 @@
                  :crowberto :get 200 (format "tiles/1/1/1/%d/%d"
                                              (mt/id :venues :latitude)
                                              (mt/id :venues :longitude))
-                 :query (json/generate-string venues-query)))))
+                 :query (json/encode venues-query)))))
     (testing "Works on native queries"
       (let [native-query {:query (:query (qp.compile/compile venues-query))
                           :template-tags {}}]
         (is (png? (mt/user-http-request
                    :crowberto :get 200 (format "tiles/1/1/1/%s/%s"
                                                "LATITUDE" "LONGITUDE")
-                   :query (json/generate-string
+                   :query (json/encode
                            {:database (mt/id)
                             :type :native
                             :native native-query}))))))))
@@ -90,7 +90,7 @@
                       :crowberto :get 200 (format "tiles/7/30/49/%d/%d"
                                                   (mt/id :people :latitude)
                                                   (mt/id :people :longitude))
-                      :query (json/generate-string
+                      :query (json/encode
                               {:database (mt/id)
                                :type :query
                                :query {:source-table (mt/id :people)

--- a/test/metabase/auth_provider_test.clj
+++ b/test/metabase/auth_provider_test.clj
@@ -1,13 +1,13 @@
 (ns metabase.auth-provider-test
   (:require
-   [cheshire.core :as json]
    [clojure.test :refer [deftest is testing]]
    [metabase.api.database :as api.database]
    [metabase.auth-provider :as auth-provider]
    [metabase.http-client :as client]
    [metabase.sync :as sync]
    [metabase.test :as mt]
-   [metabase.test.data.interface :as tx]))
+   [metabase.test.data.interface :as tx]
+   [metabase.util.json :as json]))
 
 (deftest auth-integration-test
   (mt/test-drivers #{:postgres :mysql}

--- a/test/metabase/channel/render/js/svg_test.clj
+++ b/test/metabase/channel/render/js/svg_test.clj
@@ -6,11 +6,11 @@
   the svg png renderer does not understand nested html elements so we ensure that there are no divs, spans, etc in the
   resulting svg."
   (:require
-   [cheshire.core :as json]
    [clojure.set :as set]
    [clojure.test :refer :all]
    [metabase.channel.render.js.engine :as js.engine]
-   [metabase.channel.render.js.svg :as js.svg])
+   [metabase.channel.render.js.svg :as js.svg]
+   [metabase.util.json :as json])
   (:import
    (org.apache.batik.anim.dom SVGOMDocument)
    (org.graalvm.polyglot Context Value)
@@ -89,9 +89,9 @@
                       (js.engine/execute-fn-name
                        context
                        "progress"
-                       (json/generate-string {:value value :goal goal})
-                       (json/generate-string settings)
-                       (json/generate-string {})))]
+                       (json/encode {:value value :goal goal})
+                       (json/encode settings)
+                       (json/encode {})))]
       (validate-svg-string :progress svg-string))))
 
 (deftest parse-svg-sanitizes-characters-test

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -1,6 +1,5 @@
 (ns ^:mb/driver-tests metabase.driver-test
   (:require
-   [cheshire.core :as json]
    [clojure.set :as set]
    [clojure.test :refer :all]
    [metabase.driver :as driver]
@@ -15,6 +14,7 @@
    [metabase.test.data.env :as tx.env]
    [metabase.test.data.interface :as tx]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -186,14 +186,14 @@
         ;; TODO(qnkhuat): do we really need to handle case where wrong driver is passed?
         (let [;; This is a mongodb query, but if you pass in the wrong driver it will attempt the format
               ;; This is a corner case since the system should always be using the right driver
-              weird-formatted-query (driver/prettify-native-form :postgres (json/generate-string query))]
+              weird-formatted-query (driver/prettify-native-form :postgres (json/encode query))]
           (testing "The wrong formatter will change the format..."
             (is (not= query weird-formatted-query)))
           (testing "...but the resulting data is still the same"
             ;; Bottom line - Use the right driver, but if you use the wrong
             ;; one it should be harmless but annoying
             (is (= query
-                   (json/parse-string weird-formatted-query)))))))))
+                   (json/decode weird-formatted-query)))))))))
 
 (deftest ^:parallel prettify-native-form-executable-test
   (mt/test-drivers

--- a/test/metabase/integrations/slack_test.clj
+++ b/test/metabase/integrations/slack_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.integrations.slack-test
   (:require
-   [cheshire.core :as json]
    [clj-http.fake :as http-fake]
    [clojure.test :refer :all]
    [medley.core :as m]
@@ -9,6 +8,7 @@
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.test.util :as tu]
+   [metabase.util.json :as json]
    [toucan2.core :as t2])
   (:import
    (java.nio.charset Charset)
@@ -25,7 +25,7 @@
 
 (defn- mock-paged-response-body [{:keys [query-string], :as request} response-body]
   (if (string? response-body)
-    (recur request (json/parse-string response-body true))
+    (recur request (json/decode+kw response-body))
     (let [{:keys [cursor]} (parse-query-string query-string)]
       ;; if the mock handler is called without a `cursor` param, return response with a `next_cursor`; if passed that
       ;; `cursor`, remove the `next_cursor`. That way we should get two pages total for testing paging
@@ -45,7 +45,7 @@
   {:status 200
    :body   (if (string? body)
              body
-             (json/generate-string body))})
+             (json/encode body))})
 
 (defn- test-no-auth-token!
   "Test that a Slack API endpoint function returns `nil` if a Slack API token isn't configured."
@@ -228,7 +228,7 @@
                                        (case endpoint
                                          "files.completeUploadExternal"
                                          (if @joined?
-                                           (json/parse-string (slurp "./test_resources/slack_upload_file_response.json") keyword)
+                                           (json/decode+kw (slurp "./test_resources/slack_upload_file_response.json"))
                                            (throw (ex-info "Not in that channel"
                                                            {:error-code "not_in_channel"})))
                                          "conversations.join"

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.models.card-test
   (:require
-   [cheshire.core :as json]
    [clojure.set :as set]
    [clojure.test :refer :all]
    [java-time.api :as t]
@@ -19,6 +18,7 @@
    [metabase.test :as mt]
    [metabase.test.util :as tu]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
@@ -302,8 +302,8 @@
               ;; also check that normalization of already-normalized refs is idempotent
               original [original expected]
               ;; frontend uses JSON-serialized versions of the MBQL clauses as keys
-              :let     [original (json/generate-string original)
-                        expected (json/generate-string expected)]]
+              :let     [original (json/encode original)
+                        expected (json/encode expected)]]
         (testing (format "Viz settings field ref key %s should get normalized to %s"
                          (pr-str original)
                          (pr-str expected))
@@ -728,7 +728,7 @@
               :pie.percent_visibility "inside"}
              (-> (t2/select-one (t2/table-name :model/Card) {:where [:= :id card-id]})
                  :visualization_settings
-                 (json/parse-string keyword)))))))
+                 json/decode+kw))))))
 
 ;;; -------------------------------------------- Revision tests  --------------------------------------------
 
@@ -985,7 +985,7 @@
                   "database" (mt/id)
                   "stages"   [{"lib/type"     "mbql.stage/mbql"
                                "source-table" (mt/id :venues)}]}
-                 (json/parse-string (t2/select-one-fn :dataset_query (t2/table-name :model/Card) :id (u/the-id card))))))
+                 (json/decode (t2/select-one-fn :dataset_query (t2/table-name :model/Card) :id (u/the-id card))))))
         (testing "fetch from app DB"
           (is (=? {:dataset_query {:lib/type     :mbql/query
                                    :database     (mt/id)

--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -1,6 +1,5 @@
 (ns ^:mb/driver-tests metabase.models.database-test
   (:require
-   [cheshire.core :refer [decode encode]]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.api.common :as api]
@@ -19,6 +18,7 @@
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
@@ -59,7 +59,7 @@
                  (trigger-for-db db-id))))))))
 
 (deftest can-read-database-setting-test
-  (let [encode-decode (fn [obj] (decode (encode obj)))
+  (let [encode-decode (comp json/decode json/encode)
         pg-db         (mi/instance
                        Database
                        {:description nil
@@ -102,7 +102,7 @@
              (t2/update! Database (:id database) {:engine :sqlite})))))))
 
 (deftest ^:parallel sensitive-data-redacted-test
-  (let [encode-decode (fn [obj] (decode (encode obj)))
+  (let [encode-decode (comp json/decode json/encode)
         project-id    "random-project-id" ; the actual value here doesn't seem to matter
         ;; this is trimmed for the parts we care about in the test
         pg-db         (mi/instance

--- a/test/metabase/models/field_values_test.clj
+++ b/test/metabase/models/field_values_test.clj
@@ -1,7 +1,6 @@
 (ns metabase.models.field-values-test
   "Tests for specific behavior related to FieldValues and functions in the [[metabase.models.field-values]] namespace."
   (:require
-   [cheshire.core :as json]
    [clojure.java.jdbc :as jdbc]
    [clojure.test :refer :all]
    [java-time.api :as t]
@@ -15,6 +14,7 @@
    [metabase.sync :as sync]
    [metabase.test :as mt]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [next.jdbc :as next.jdbc]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp])
@@ -263,9 +263,9 @@
 (deftest normalize-human-readable-values-test
   (testing "If FieldValues were saved as a map, normalize them to a sequence on the way out"
     (t2.with-temp/with-temp [FieldValues fv {:field_id (mt/id :venues :id)
-                                             :values   (json/generate-string ["1" "2" "3"])}]
+                                             :values   (json/encode ["1" "2" "3"])}]
       (is (t2/query-one {:update :metabase_fieldvalues
-                         :set    {:human_readable_values (json/generate-string {"1" "a", "2" "b", "3" "c"})}
+                         :set    {:human_readable_values (json/encode {"1" "a", "2" "b", "3" "c"})}
                          :where  [:= :id (:id fv)]}))
       (is (= ["a" "b" "c"]
              (:human_readable_values (t2/select-one FieldValues :id (:id fv))))))))

--- a/test/metabase/models/interface_test.clj
+++ b/test/metabase/models/interface_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.models.interface-test
   (:require
-   [cheshire.core :as json]
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.legacy-mbql.normalize :as mbql.normalize]
@@ -11,6 +10,7 @@
    [metabase.util :as u]
    [metabase.util.encryption :as encryption]
    [metabase.util.encryption-test :as encryption-test]
+   [metabase.util.json :as json]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp])
   (:import (com.fasterxml.jackson.core JsonParseException)))
@@ -23,7 +23,7 @@
                 "response because of one malformed Card, dump the error to the logs and return nil.")
     (is (= nil
            ((:out mi/transform-metabase-query)
-            (json/generate-string
+            (json/encode
              {:database 1
               :type     :native
               :native   {:template-tags 1000}}))))))
@@ -46,14 +46,14 @@
   (testing "Legacy Metric/Segment definitions should get normalized"
     (is (= {:filter [:= [:field 1 nil] [:field 2 {:temporal-unit :month}]]}
            ((:out mi/transform-legacy-metric-segment-definition)
-            (json/generate-string
+            (json/encode
              {:filter [:= [:field-id 1] [:datetime-field [:field-id 2] :month]]}))))))
 
 (deftest ^:parallel dont-explode-on-way-out-from-db-test
   (testing "`metric-segment-definition`s should avoid explosions coming out of the DB..."
     (is (= nil
            ((:out mi/transform-legacy-metric-segment-definition)
-            (json/generate-string
+            (json/encode
              {:filter 1000}))))
 
     (testing "...but should still throw them coming in"
@@ -68,7 +68,7 @@
     (with-redefs [mbql.normalize/normalize-tokens (fn [& _] (throw (Exception. "BARF")))]
       (is (= nil
              ((:out mi/transform-parameters-list)
-              (json/generate-string
+              (json/encode
                [{:target [:dimension [:field "ABC" nil]]}])))))))
 
 (deftest do-not-eat-exceptions-test

--- a/test/metabase/models/params/chain_filter_test.clj
+++ b/test/metabase/models/params/chain_filter_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.models.params.chain-filter-test
   (:require
-   [cheshire.core :as json]
    [clojure.test :refer :all]
    [metabase.models :refer [Field FieldValues]]
    [metabase.models.field-values :as field-values]
@@ -8,6 +7,7 @@
    [metabase.models.params.field-values :as params.field-values]
    [metabase.test :as mt]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
@@ -521,7 +521,7 @@
           (testing "should search for the values of linked-filter FieldValues"
             (t2/update! FieldValues {:field_id field-id
                                      :type     "linked-filter"}
-                        {:values (json/generate-string ["Good" "Bad"])
+                        {:values (json/encode ["Good" "Bad"])
                          ;; HACK: currently this is hardcoded to true for linked-filter
                          ;; in [[params.field-values/fetch-advanced-field-values]]
                          ;; we want this to false to test this case

--- a/test/metabase/public_settings/premium_features_test.clj
+++ b/test/metabase/public_settings/premium_features_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.public-settings.premium-features-test
   (:require
-   [cheshire.core :as json]
    [clj-http.client :as http]
    [clj-http.fake :as http-fake]
    [clojure.test :refer :all]
@@ -14,6 +13,7 @@
     :as premium-features
     :refer [defenterprise defenterprise-schema]]
    [metabase.test :as mt]
+   [metabase.util.json :as json]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp]))
 

--- a/test/metabase/query_processor/card_test.clj
+++ b/test/metabase/query_processor/card_test.clj
@@ -1,7 +1,6 @@
 (ns metabase.query-processor.card-test
   "There are more e2e tests in [[metabase.api.card-test]]."
   (:require
-   [cheshire.core :as json]
    [clojure.test :refer :all]
    [metabase.models :refer [Card]]
    [metabase.models.data-permissions :as data-perms]
@@ -12,6 +11,7 @@
    [metabase.query-processor.card :as qp.card]
    [metabase.test :as mt]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
 (defn run-query-for-card
@@ -164,7 +164,7 @@
                                                           {:aggregation [[:count]]})
 
                                                         :visualization_settings
-                                                        {:column_settings {(json/generate-string
+                                                        {:column_settings {(json/encode
                                                                             [:ref [:field Integer/MAX_VALUE {:base-type :type/DateTime, :temporal-unit :month}]])
                                                                            {:date_abbreviate true
                                                                             :some_other_key  [:ref [:field Integer/MAX_VALUE {:base-type :type/DateTime, :temporal-unit :month}]]}}}}]

--- a/test/metabase/query_processor/streaming/csv_test.clj
+++ b/test/metabase/query_processor/streaming/csv_test.clj
@@ -1,6 +1,5 @@
 (ns ^:mb/driver-tests metabase.query-processor.streaming.csv-test
   (:require
-   [cheshire.core :as json]
    [clojure.data.csv :as csv]
    [clojure.string :as str]
    [clojure.test :refer :all]
@@ -11,7 +10,8 @@
    [metabase.query-processor.streaming.interface :as qp.si]
    [metabase.test :as mt]
    [metabase.test.data.dataset-definitions :as defs]
-   [metabase.util :as u])
+   [metabase.util :as u]
+   [metabase.util.json :as json])
   (:import
    (java.io BufferedOutputStream ByteArrayOutputStream)))
 
@@ -52,7 +52,7 @@
             ["4" "March 11, 2014"     "5" "4"]
             ["5" "May 5, 2013"        "3" "49"]]
            (let [result (mt/user-http-request :crowberto :post 200 "dataset/csv" :query
-                                              (json/generate-string (mt/mbql-query checkins {:order-by [[:asc $id]], :limit 5}))
+                                              (json/encode (mt/mbql-query checkins {:order-by [[:asc $id]], :limit 5}))
                                               :format_rows true)]
              (take 5 (parse-and-sort-csv result)))))))
 
@@ -77,7 +77,7 @@
   (testing "NULL values should be written correctly"
     (mt/dataset defs/test-data-null-date
       (let [result (mt/user-http-request :crowberto :post 200 "dataset/csv" :query
-                                         (json/generate-string (mt/mbql-query checkins {:order-by [[:asc $id]], :limit 5}))
+                                         (json/encode (mt/mbql-query checkins {:order-by [[:asc $id]], :limit 5}))
                                          :format_rows true)]
         (is (= [["1" "April 7, 2014"      "" "5" "12"]
                 ["2" "September 18, 2014" "" "1" "31"]
@@ -88,7 +88,7 @@
 
 (deftest datetime-fields-are-untouched-when-exported
   (let [result (mt/user-http-request :crowberto :post 200 "dataset/csv" :query
-                                     (json/generate-string (mt/mbql-query users {:order-by [[:asc $id]], :limit 5}))
+                                     (json/encode (mt/mbql-query users {:order-by [[:asc $id]], :limit 5}))
                                      :format_rows true)]
     (is (= [["1" "Plato Yeshua" "April 1, 2014, 8:30 AM"]
             ["2" "Felipinho Asklepios" "December 5, 2014, 3:15 PM"]
@@ -101,7 +101,7 @@
   (testing "Ensure CSV longitude and latitude values are correctly exported"
     (let [result (mt/user-http-request
                   :rasta :post 200 "dataset/csv" :query
-                  (json/generate-string
+                  (json/encode
                    {:database (mt/id)
                     :type     :query
                     :query    {:source-table (mt/id :venues)

--- a/test/metabase/query_processor/streaming/json_test.clj
+++ b/test/metabase/query_processor/streaming/json_test.clj
@@ -1,10 +1,10 @@
 (ns metabase.query-processor.streaming.json-test
   (:require
-   [cheshire.core :as json]
    [clojure.test :refer :all]
    [metabase.query-processor :as qp]
    [metabase.query-processor.streaming :as qp.streaming]
-   [metabase.test :as mt])
+   [metabase.test :as mt]
+   [metabase.util.json :as json])
   (:import
    [java.io ByteArrayOutputStream OutputStream]))
 
@@ -14,7 +14,7 @@
   (testing "Ensure JSON longitude and latitude values are correctly exported"
     (let [result (mt/user-http-request
                   :rasta :post 200 "dataset/json" :query
-                  (json/generate-string
+                  (json/encode
                    {:database (mt/id)
                     :type     :query
                     :query    {:source-table (mt/id :venues)

--- a/test/metabase/query_processor/streaming/test_util.clj
+++ b/test/metabase/query_processor/streaming/test_util.clj
@@ -1,7 +1,6 @@
 (ns metabase.query-processor.streaming.test-util
   "Utility functions for testing QP streaming (download) functionality."
   (:require
-   [cheshire.core :as json]
    [clojure.data.csv :as csv]
    [clojure.test :refer :all]
    [dk.ative.docjure.spreadsheet :as spreadsheet]
@@ -9,7 +8,8 @@
    [metabase.query-processor.pipeline :as qp.pipeline]
    [metabase.query-processor.streaming :as qp.streaming]
    [metabase.test :as mt]
-   [metabase.util :as u])
+   [metabase.util :as u]
+   [metabase.util.json :as json])
   (:import
    (java.io BufferedInputStream BufferedOutputStream ByteArrayInputStream ByteArrayOutputStream InputStream InputStreamReader)))
 
@@ -22,7 +22,7 @@
 (defmethod parse-result* :api
   [_ ^InputStream is _]
   (with-open [reader (InputStreamReader. is)]
-    (let [response (json/parse-stream reader true)]
+    (let [response (json/decode+kw reader)]
       (cond-> response
         (map? response) (dissoc :database_id :started_at :json_query :average_execution_time :context :running_time)))))
 
@@ -78,7 +78,7 @@
                                        (assoc-in query [:middleware :js-int-to-string?] false))
                  (mt/user-real-request :crowberto :post (format "dataset/%s" (name export-format))
                                        {:request-options {:as :byte-array}}
-                                       :query (json/generate-string query)
+                                       :query (json/encode query)
                                        :format_rows true))]
     (with-open [is (ByteArrayInputStream. byytes)]
       (apply parse-result export-format is args))))

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.query-processor.streaming.xlsx-test
   (:require
-   [cheshire.generate :as json.generate]
    [clojure.java.io :as io]
    [clojure.test :refer :all]
    [dk.ative.docjure.spreadsheet :as spreadsheet]
@@ -9,7 +8,8 @@
    [metabase.query-processor.streaming.common :as common]
    [metabase.query-processor.streaming.interface :as qp.si]
    [metabase.query-processor.streaming.xlsx :as qp.xlsx]
-   [metabase.test :as mt])
+   [metabase.test :as mt]
+   [metabase.util.json :as json])
   (:import
    (com.fasterxml.jackson.core JsonGenerator)
    com.sun.management.ThreadMXBean
@@ -638,14 +638,14 @@
 
 (defrecord ^:private SampleNastyClass [^String v])
 
-(json.generate/add-encoder
+(json/add-encoder
  SampleNastyClass
  (fn [obj, ^JsonGenerator json-generator]
    (.writeString json-generator (str (:v obj)))))
 
 (defrecord ^:private SampleNastyClass2 [^Number v])
 
-(json.generate/add-encoder
+(json/add-encoder
  SampleNastyClass2
  (fn [obj, ^JsonGenerator json-generator]
    (.writeNumber json-generator (long (:v obj)))))

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.query-processor.streaming-test
   (:require
-   [cheshire.core :as json]
    [clojure.data.csv :as csv]
    [clojure.string :as str]
    [clojure.test :refer :all]
@@ -16,6 +15,7 @@
    [metabase.server.protocols :as server.protocols]
    [metabase.test :as mt]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [toucan2.pipeline :as t2.pipeline]
    [toucan2.tools.with-temp :as t2.with-temp])
   (:import
@@ -178,7 +178,7 @@
           (is (= "[{\"num_cans\":\"2\"}]"
                  (str/replace response-str #"\n+" "")))
           (is (= [{:num_cans "2"}]
-                 (json/parse-string response-str true))))))))
+                 (json/decode+kw response-str))))))))
 
 (defmulti ^:private first-row-map
   "Return the first row in `results` as a map with `col-names` as the keys."
@@ -312,8 +312,8 @@
   "Test helper to enable writing API-level export tests across multiple export endpoints and formats."
   [message {:keys [query viz-settings assertions endpoints user]}]
   (testing message
-    (let [query-json        (json/generate-string query)
-          viz-settings-json (json/generate-string viz-settings)
+    (let [query-json        (json/encode query)
+          viz-settings-json (json/encode viz-settings)
           public-uuid       (str (random-uuid))
           card-defaults     {:dataset_query query, :public_uuid public-uuid, :enable_embedding true}
           user              (or user :rasta)]

--- a/test/metabase/search/impl_test.clj
+++ b/test/metabase/search/impl_test.clj
@@ -2,7 +2,6 @@
   "There are a lot more tests around search in [[metabase.api.search-test]]. TODO: we should move more of those tests
   into this namespace."
   (:require
-   [cheshire.core :as json]
    [clojure.set :as set]
    [clojure.test :refer :all]
    [java-time.api :as t]
@@ -13,6 +12,7 @@
    [metabase.search.impl :as search.impl]
    [metabase.search.in-place.legacy :as search.legacy]
    [metabase.test :as mt]
+   [metabase.util.json :as json]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
@@ -281,7 +281,7 @@
                   :database 1}
           result {:name          "card"
                   :model         "card"
-                  :dataset_query (json/generate-string query)
+                  :dataset_query (json/encode query)
                   :all-scores {}
                   :relevant-scores {}}]
       (is (= query (-> result search.impl/serialize :dataset_query)))))

--- a/test/metabase/search/postgres/index_test.clj
+++ b/test/metabase/search/postgres/index_test.clj
@@ -8,6 +8,7 @@
    [metabase.search.test-util :as search.tu]
    [metabase.test :as mt]
    [metabase.util :as u]
+   ;;[metabase.util.json :as json]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -69,7 +70,7 @@
               table-id       (t2/select-one-pk :model/Table :name "Indexed Table")
               legacy-input   #(-> (t2/select-one [index-table :legacy_input] :model "table" :model_id table-id)
                                   :legacy_input
-                                  (json/parse-string true))
+                                  json/decode+kw)
               db-id          (t2/select-one-fn :db_id :model/Table table-id)
               db-name-fn     (comp :database_name legacy-input)
               alternate-name (str (random-uuid))]

--- a/test/metabase/server/middleware/json_test.clj
+++ b/test/metabase/server/middleware/json_test.clj
@@ -1,14 +1,14 @@
 (ns metabase.server.middleware.json-test
   (:require
-   [cheshire.core :as json]
    [clojure.test :refer :all]
-   [metabase.server.middleware.json :as mw.json]))
+   [metabase.server.middleware.json :as mw.json]
+   [metabase.util.json :as json]))
 
 (comment mw.json/keep-me) ; so custom Cheshire encoders are loaded
 
 (deftest encode-byte-arrays-test
   (testing "Check that we encode byte arrays as the hex values of their first four bytes"
     (is (= "{\"my-bytes\":\"0xC42360D7\"}"
-           (json/generate-string
+           (json/encode
             {:my-bytes (byte-array [196 35  96 215  8 106 108 248 183 215 244 143  17 160 53 186
                                     213 30 116  25 87  31 123 172 207 108  47 107 191 215 76  92])})))))

--- a/test/metabase/server/middleware/offset_paging_test.clj
+++ b/test/metabase/server/middleware/offset_paging_test.clj
@@ -1,10 +1,10 @@
 (ns metabase.server.middleware.offset-paging-test
   (:require
-   [cheshire.core :as json]
    [clojure.java.io :as io]
    [clojure.test :refer :all]
    [metabase.server.handler :as handler]
    [metabase.server.middleware.offset-paging :as mw.offset-paging]
+   [metabase.util.json :as json]
    [ring.mock.request :as ring.mock]
    [ring.util.response :as response])
   (:import
@@ -28,7 +28,7 @@
           (fn [body]
             (if (instance? PipedInputStream body)
               (with-open [r (io/reader body)]
-                (json/parse-stream r))
+                (json/decode r))
               body))))
 
 (deftest paging-test

--- a/test/metabase/server/middleware/security_test.clj
+++ b/test/metabase/server/middleware/security_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.server.middleware.security-test
   (:require
-   [cheshire.core :as json]
    [clj-http.client :as http]
    [clojure.string :as str]
    [clojure.test :refer :all]
@@ -10,6 +9,7 @@
    [metabase.server.middleware.security :as mw.security]
    [metabase.test :as mt]
    [metabase.test.util :as tu]
+   [metabase.util.json :as json]
    [stencil.core :as stencil]))
 
 (defn- csp-directive
@@ -94,7 +94,7 @@
                                           (assert (= path "frontend_client/index.html"))
                                           (render-file "frontend_client/index_template.html" variables))]
         (let [response  (http/get (str "http://localhost:" (config/config-str :mb-jetty-port)))
-              nonce     (json/parse-string @nonceJSON)
+              nonce     (json/decode @nonceJSON)
               csp       (get-in response [:headers "Content-Security-Policy"])
               style-src (->> (str/split csp #"; *")
                              (filter #(str/starts-with? % "style-src "))

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.server.middleware.session-test
   (:require
-   [cheshire.core :as json]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [environ.core :as env]
@@ -21,6 +20,7 @@
    [metabase.server.middleware.session :as mw.session]
    [metabase.test :as mt]
    [metabase.util.i18n :as i18n]
+   [metabase.util.json :as json]
    [metabase.util.secret :as u.secret]
    [ring.mock.request :as ring.mock]
    [toucan2.core :as t2]
@@ -553,7 +553,7 @@
 
 (deftest session-timeout-env-var-validation-test
   (let [set-and-get! (fn [timeout]
-                       (mt/with-temp-env-var-value! [mb-session-timeout (json/generate-string timeout)]
+                       (mt/with-temp-env-var-value! [mb-session-timeout (json/encode timeout)]
                          (mw.session/session-timeout)))]
     (testing "Setting the session timeout with env var should work with valid timeouts"
       (doseq [timeout [{:unit "hours", :amount 1}

--- a/test/metabase/server/routes/index_test.clj
+++ b/test/metabase/server/routes/index_test.clj
@@ -1,9 +1,9 @@
 (ns metabase.server.routes.index-test
   (:require
-   [cheshire.core :as json]
    [clojure.test :refer :all]
    [metabase.server.routes.index :as index]
-   [metabase.util.i18n :as i18n]))
+   [metabase.util.i18n :as i18n]
+   [metabase.util.json :as json]))
 
 (deftest ^:parallel localization-json-file-name-test
   (is (= "frontend_client/app/locales/es.json"
@@ -25,7 +25,7 @@
            (some->
             (binding [i18n/*user-locale* "es"]
               (#'index/load-localization nil))
-            json/parse-string
+            json/decode
             (update "translations" select-keys [""])
             (update-in ["translations" ""] select-keys ["Your database has been added!"]))))))
 
@@ -36,7 +36,7 @@
            (some->
             (binding [i18n/*user-locale* "xx"]
               (#'index/load-localization nil))
-            json/parse-string)))))
+            json/decode)))))
 
 (deftest ^:parallel english-test
   (testing "english should return the fallback localization (english)"
@@ -45,7 +45,7 @@
            (some->
             (binding [i18n/*user-locale* "en"]
               (#'index/load-localization nil))
-            json/parse-string)))))
+            json/decode)))))
 
 (deftest ^:parallel override-localization-test
   (testing "a valid override is honored no matter what the user locale is"
@@ -61,7 +61,7 @@
            (some->
             (binding [i18n/*user-locale* "xx"]
               (#'index/load-localization "es"))
-            json/parse-string
+            json/decode
             (update "translations" select-keys [""])
             (update-in ["translations" ""] select-keys ["Your database has been added!"])))))
 
@@ -71,4 +71,4 @@
            (some->
             (binding [i18n/*user-locale* "xx"]
               (#'index/load-localization "yy"))
-            json/parse-string)))))
+            json/decode)))))

--- a/test/metabase/task/creator_sentiment_emails_test.clj
+++ b/test/metabase/task/creator_sentiment_emails_test.clj
@@ -1,7 +1,6 @@
 (ns ^:mb/once metabase.task.creator-sentiment-emails-test
   (:require
    [buddy.core.codecs :as codecs]
-   [cheshire.core :as json]
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.email-test :as et :refer [inbox]]
@@ -9,6 +8,7 @@
    [metabase.public-settings.premium-features :as premium-features]
    [metabase.task.creator-sentiment-emails :as creator-sentiment-emails]
    [metabase.test :as mt]
+   [metabase.util.json :as json]
    [metabase.util.malli.schema :as ms]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
@@ -53,7 +53,7 @@
               (let [email-body (-> @inbox vals first first :body first :content)]
                 (is (string? email-body))
                 (let [[_ query-params] (re-find #"creator\?context=(.*)\"" email-body)
-                      decoded          (some-> query-params codecs/b64->str json/parse-string)]
+                      decoded          (some-> query-params codecs/b64->str json/decode)]
                   (is (=? {"instance" {"created_at"     (mt/malli=? ms/TemporalString)
                                        "plan"           (mt/malli=? :string)
                                        "version"        (mt/malli=? :string)

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -1,7 +1,6 @@
 (ns metabase.test.util
   "Helper functions and macros for writing unit tests."
   (:require
-   [cheshire.core :as json]
    [clojure.java.io :as io]
    [clojure.set :as set]
    [clojure.string :as str]
@@ -45,6 +44,7 @@
    [metabase.test.util.public-settings]
    [metabase.util :as u]
    [metabase.util.files :as u.files]
+   [metabase.util.json :as json]
    [metabase.util.random :as u.random]
    [methodical.core :as methodical]
    [toucan2.core :as t2]
@@ -326,7 +326,7 @@
 
      (obj->json->obj {:type :query}) -> {:type \"query\"}"
   [obj]
-  (json/parse-string (json/generate-string obj) keyword))
+  (json/decode+kw (json/encode obj)))
 
 (defn- ->lisp-case-keyword [s]
   (-> (name s)

--- a/test/metabase/xrays/automagic_dashboards/core_test.clj
+++ b/test/metabase/xrays/automagic_dashboards/core_test.clj
@@ -1,6 +1,5 @@
 (ns ^:mb/once metabase.xrays.automagic-dashboards.core-test
   (:require
-   [cheshire.core :as json]
    [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
@@ -16,6 +15,7 @@
    [metabase.sync :as sync]
    [metabase.test :as mt]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [metabase.util.malli :as mu]
    [metabase.xrays.automagic-dashboards.combination :as combination]
    [metabase.xrays.automagic-dashboards.comparison :as comparison]
@@ -1166,7 +1166,7 @@
                            [:field (mt/id :products :created_at) {:temporal-unit "year"}]
                            "2017-01-01T00:00:00Z"]
                 ->base-64 (fn [x]
-                            (codec/base64-encode (.getBytes (json/generate-string x) "UTF-8")))]
+                            (codec/base64-encode (.getBytes (json/encode x) "UTF-8")))]
             (is (=? {:description "A closer look at the metrics and dimensions used in this saved question."}
                     (mt/user-http-request
                      :crowberto :get 200


### PR DESCRIPTION
This rather voluminous change has two goals in mind:

1. Add a facade around Metabase's usage of Cheshire, the JSON serdes library. My original intent was to eventually try to replace Cheshire with Jsonista for performance reasons and since the latter is more actively maintained. Now, it is unclear if the move will ever happen. Still, hiding all interactions behind the facade will make it easier to do the swap if it is ever deemed beneficial.
2. Unify the usage of some actions that can be done and are done with Cheshire in several ways:
- `metabase.util.json/encode` to instead of `cheshire.core/encode` and `cheshire.core/generate-string`.
- `metabase.util.json/decode` instead of `cheshire.core/decode` and `cheshire.core/parse-string`.
- A new function `metabase.util.json/decode+kw` that performs a very common action of parsing the JSON string and keywordizing the keys. Using this function is more convenient than making ad-hoc closures and fixes inconsistency of passing either `true` or `keyword` as an argument.