### PR TITLE
updating @reduxjs/toolkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@mantine/dates": "^6.0.13",
     "@mantine/hooks": "^6.0.13",
     "@react-oauth/google": "^0.11.1",
-    "@reduxjs/toolkit": "^2.2.5",
+    "@reduxjs/toolkit": "^2.3.0",
     "@snowplow/browser-tracker": "^3.1.6",
     "@tanstack/react-virtual": "^3.1.2",
     "@tippyjs/react": "^4.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3046,10 +3046,10 @@
   resolved "https://registry.yarnpkg.com/@react-oauth/google/-/google-0.11.1.tgz#f937c8d02bd37e3a6be7713b8212e9b9b9b3f914"
   integrity sha512-tywZisXbsdaRBVbEu0VX6dRbOSL2I6DgY97woq5NMOOOz+xtDsm418vqq+Vx10KMtra3kdHMRMf0hXLWrk2RMg==
 
-"@reduxjs/toolkit@^2.2.5":
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-2.2.5.tgz#c0d2d8482ef80722bebe015ff05b06c34bfb6e0d"
-  integrity sha512-aeFA/s5NCG7NoJe/MhmwREJxRkDs0ZaSqt0MxhWUrwCf1UQXpwR87RROJEql0uAkLI6U7snBOYOcKw83ew3FPg==
+"@reduxjs/toolkit@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-2.3.0.tgz#d00134634d6c1678e8563ac50026e429e3b64420"
+  integrity sha512-WC7Yd6cNGfHx8zf+iu+Q1UPTfEcXhQ+ATi7CV1hlrSAaQBdlPzg7Ww/wJHNQem7qG9rxmWoFCDCPubSvFObGzA==
   dependencies:
     immer "^10.0.3"
     redux "^5.0.1"


### PR DESCRIPTION
### Description

This PR updates @reduxjs/toolkit to the latest version, bringing us from `2.2.5` to `2.3.0`. The main drive for this is to resolve a bug around calling awaiting a dispatched call to `initiate()` to an endpoint that currently has a pending request, and something in the cache (this happens for us when we verify an item, and then dispatch the `SOFT_RELOAD` action. In our current version, the awaited promise will resolve with cached data, but starting with `2.2.8`, the promise will wait until the current request is done to resolve.

This is something that came up while working on Cards in Dashboards, and doesn't appear to be showing up in stats / master.
