### PR TITLE
Unify (app) banners

### DIFF
--- a/frontend/src/metabase/components/Banner/Banner.tsx
+++ b/frontend/src/metabase/components/Banner/Banner.tsx
@@ -1,19 +1,48 @@
-import Markdown from "metabase/core/components/Markdown";
-import { Flex, type FlexProps } from "metabase/ui";
+import type { ReactNode } from "react";
 
-export const Banner = ({ children, ...props }: FlexProps) => {
-  const content =
-    typeof children === "string" ? <Markdown>{children}</Markdown> : children;
+import CS from "metabase/css/core/index.css";
+import type { FlexProps, IconName } from "metabase/ui";
+import { Flex, Group, Icon } from "metabase/ui";
 
+interface BaseBannerProps extends FlexProps {
+  icon?: IconName;
+  body: ReactNode;
+}
+
+type BannerProps =
+  | (BaseBannerProps & { closable: true; onClose: () => void })
+  | (BaseBannerProps & { closable?: false; onClose?: never });
+
+export const Banner = ({
+  icon,
+  body,
+  closable,
+  onClose,
+  bg,
+  ...flexProps
+}: BannerProps) => {
   return (
     <Flex
-      bg="bg-light"
-      c="text-medium"
-      data-testid="app-banner"
-      p="0.75rem"
-      {...props}
+      align="center"
+      bg={bg || "bg-medium"}
+      py="sm"
+      justify="space-between"
+      pl="1.325rem"
+      pr="md"
+      {...flexProps}
     >
-      {content}
+      <Group spacing="xs">
+        {icon && <Icon name={icon} w={36} />}
+        {body}
+      </Group>
+      {closable && (
+        <Icon
+          className={CS.cursorPointer}
+          name="close"
+          onClick={onClose}
+          w={36}
+        />
+      )}
     </Flex>
   );
 };

--- a/frontend/src/metabase/components/Banner/Banner.tsx
+++ b/frontend/src/metabase/components/Banner/Banner.tsx
@@ -23,6 +23,7 @@ export const Banner = ({
 }: BannerProps) => {
   return (
     <Flex
+      data-testid="app-banner"
       align="center"
       bg={bg || "bg-medium"}
       py="sm"

--- a/frontend/src/metabase/components/Banner/Banner.unit.spec.tsx
+++ b/frontend/src/metabase/components/Banner/Banner.unit.spec.tsx
@@ -1,12 +1,27 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 
 import { Banner } from "./Banner";
 
 describe("Banner", () => {
-  it("should render banner with content", () => {
-    render(<Banner>Content</Banner>);
+  it("should render non-closable banner with content", () => {
+    render(<Banner icon="warning" body="Foobar" />);
 
     expect(screen.getByTestId("app-banner")).toBeInTheDocument();
-    expect(screen.getByText("Content")).toBeInTheDocument();
+    expect(screen.getByLabelText("warning icon")).toBeInTheDocument();
+    expect(screen.queryByLabelText("close icon")).not.toBeInTheDocument();
+    expect(screen.getByText("Foobar")).toBeInTheDocument();
+  });
+
+  it("should render closable banner with content", () => {
+    const closeMock = jest.fn();
+    render(
+      <Banner icon="warning" body="Foobar" closable onClose={closeMock} />,
+    );
+
+    expect(screen.getByTestId("app-banner")).toBeInTheDocument();
+    expect(screen.getByLabelText("warning icon")).toBeInTheDocument();
+    expect(screen.getByText("Foobar")).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("close icon"));
+    expect(closeMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/metabase/nav/components/PaymentBanner/PaymentBanner.tsx
+++ b/frontend/src/metabase/nav/components/PaymentBanner/PaymentBanner.tsx
@@ -5,6 +5,7 @@ import { Banner } from "metabase/components/Banner";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import CS from "metabase/css/core/index.css";
 import { getStoreUrl } from "metabase/selectors/settings";
+import { Text } from "metabase/ui";
 import type { TokenStatus } from "metabase-types/api";
 
 interface PaymentBannerProps {
@@ -14,35 +15,48 @@ interface PaymentBannerProps {
 export const PaymentBanner = ({ tokenStatus }: PaymentBannerProps) => {
   return match(tokenStatus.status)
     .with("past-due", () => (
-      <Banner>
-        {jt`⚠️ We couldn't process payment for your account. Please ${(
-          <ExternalLink
-            key="payment-past-due"
-            className={CS.link}
-            href={getStoreUrl()}
-          >
-            {t`review your payment settings`}
-          </ExternalLink>
-        )} to avoid service interruptions.`}
-      </Banner>
+      <Banner
+        icon="warning"
+        body={
+          <Text>
+            {jt`We couldn't process payment for your account. Please ${(
+              <ExternalLink
+                key="payment-past-due"
+                className={CS.link}
+                href={getStoreUrl()}
+              >
+                {t`review your payment settings`}
+              </ExternalLink>
+            )} to avoid service interruptions.`}
+          </Text>
+        }
+      ></Banner>
     ))
     .with("unpaid", () => (
-      <Banner>
-        {jt`⚠️ Pro features won't work right now due to lack of payment. ${(
-          <ExternalLink
-            key="payment-unpaid"
-            className={CS.link}
-            href={getStoreUrl()}
-          >
-            {t`Review your payment settings`}
-          </ExternalLink>
-        )} to restore Pro functionality.`}
-      </Banner>
+      <Banner
+        icon="warning"
+        body={
+          <Text>{jt`Pro features won't work right now due to lack of payment. ${(
+            <ExternalLink
+              key="payment-unpaid"
+              className={CS.link}
+              href={getStoreUrl()}
+            >
+              {t`Review your payment settings`}
+            </ExternalLink>
+          )} to restore Pro functionality.`}</Text>
+        }
+      ></Banner>
     ))
     .with("invalid", () => (
-      <Banner>
-        {jt`⚠️ Pro features error. ` + (tokenStatus["error-details"] || "")}
-      </Banner>
+      <Banner
+        icon="warning"
+        body={
+          <Text>
+            {jt`Pro features error. ` + (tokenStatus["error-details"] || "")}
+          </Text>
+        }
+      ></Banner>
     ))
     .otherwise(() => null);
 };

--- a/frontend/src/metabase/nav/components/ReadOnlyBanner/ReadOnlyBanner.tsx
+++ b/frontend/src/metabase/nav/components/ReadOnlyBanner/ReadOnlyBanner.tsx
@@ -1,23 +1,19 @@
 import { t } from "ttag";
 
 import { Banner } from "metabase/components/Banner";
-import { Icon, Text, useMantineTheme } from "metabase/ui";
+import { Text } from "metabase/ui";
 
 export const ReadOnlyBanner = () => {
-  const theme = useMantineTheme();
   return (
     <Banner
-      py="0.75rem"
-      px="1rem"
-      bg={theme.fn.themeColor("accent4")}
-      gap="md"
-      align="center"
-    >
-      <Icon color="text-dark" name="info_filled" />
-      <Text fw="bold" color="text-dark">
-        {/* eslint-disable-next-line no-literal-metabase-strings -- correct usage */}
-        {t`Metabase is under maintenance and is operating in read-only mode. It should only take up to 30 minutes.`}
-      </Text>
-    </Banner>
+      bg="warning"
+      body={
+        <Text fw="bold" color="text-dark">
+          {/* eslint-disable-next-line no-literal-metabase-strings -- correct usage */}
+          {t`Metabase is under maintenance and is operating in read-only mode. It should only take up to 30 minutes.`}
+        </Text>
+      }
+      icon="info_filled"
+    />
   );
 };


### PR DESCRIPTION
> [!IMPORTANT]
> Prerequisite for #49344


### What does this PR accomplish?
- It introduces some order in the components that rely on the `Banner` component.
- It uses the icons defined in our design system, and not emojis like before
- It aligns the icon and the beginning of text with the hamburger menu and the rest of the icons in sidebar
- Slightly increases the contrast of the Payment banner by using a bit darker shade of the background color

## Before
![Screenshot 2024-11-21 at 19 39 09](https://github.com/user-attachments/assets/0cdca88a-a3a6-415f-8f48-f2bed6cd9ef6)
![Screenshot 2024-11-21 at 19 38 50](https://github.com/user-attachments/assets/23bbe5f9-7cb9-44f9-8466-2f70a1dc0880)
![Screenshot 2024-11-21 at 19 38 38](https://github.com/user-attachments/assets/462152f5-4eab-4e73-90c4-080c12a1ef8e)
![Screenshot 2024-11-21 at 19 38 06](https://github.com/user-attachments/assets/7070a6fd-d5ba-4ddb-9a80-de820a95b9d4)


## Now
![Screenshot 2024-11-21 at 19 36 07](https://github.com/user-attachments/assets/86ec83a8-f9fd-474a-8954-c23880d04617)
![Screenshot 2024-11-21 at 19 36 36](https://github.com/user-attachments/assets/83c5e7ae-282f-4b30-abca-ec0765c43f90)
![Screenshot 2024-11-21 at 19 36 58](https://github.com/user-attachments/assets/ee6e2c2b-826b-419d-8136-d9af72e5ce39)
![Screenshot 2024-11-21 at 19 37 44](https://github.com/user-attachments/assets/f2920d4c-c2af-4cf9-ab38-9491e0b97640)


