### PR TITLE
Include in-page promo banner in embedding docs pages

### DIFF
--- a/docs/embedding/interactive-embedding-quick-start-guide.md
+++ b/docs/embedding/interactive-embedding-quick-start-guide.md
@@ -8,6 +8,8 @@ redirect_from:
 
 You'll embed the full Metabase application in your app. Once logged in, people can view a Metabase dashboard in your web app, and be able to use the full Metabase application to explore their data, and only their data.
 
+{% include shared/in-page-promo.html %}
+
 ## Prerequisites
 
 - You have an app that you can embed Metabase in.

--- a/docs/embedding/interactive-embedding.md
+++ b/docs/embedding/interactive-embedding.md
@@ -9,6 +9,8 @@ redirect_from:
 
 {% include plans-blockquote.html feature="Interactive embedding" %}
 
+{% include shared/in-page-promo.html %}
+
 **Interactive embedding** is what you want if you want to offer [multi-tenant, self-service analytics](https://www.metabase.com/learn/metabase-basics/embedding/multi-tenant-self-service-analytics).
 
 Interactive embedding is the only type of embedding that integrates with your [permissions](../permissions/introduction.md) and [SSO](../people-and-groups/start.md#authentication) to give people the right level of access to [query](https://www.metabase.com/glossary/query_builder) and [drill-down](https://www.metabase.com/learn/metabase-basics/querying-and-dashboards/questions/drill-through) into your data.

--- a/docs/embedding/introduction.md
+++ b/docs/embedding/introduction.md
@@ -10,6 +10,8 @@ You can embed Metabase tables, charts, and dashboards—even Metabase's query bu
 
 Here are the different ways you can embed Metabase.
 
+{% include shared/in-page-promo.html %}
+
 ## Embedding SDK with React (BETA)
 
 With the [Embedding SDK](./sdk/introduction.md), you can embed individual Metabase components with React (like standalone charts, dashboards, the query builder, and more). You can manage access and interactivity per component, and you have advanced customization for seamless styling.

--- a/docs/embedding/static-embedding-parameters.md
+++ b/docs/embedding/static-embedding-parameters.md
@@ -10,6 +10,8 @@ Also known as: parameters for signed embeds, or standalone embeds.
 
 Parameters are pieces of information that are passed between Metabase and your website via the [embedding URL](./static-embedding.md#adding-the-embedding-url-to-your-website). You can use parameters to specify how Metabase items should look and behave inside the iframe on your website.
 
+{% include shared/in-page-promo.html %}
+
 ## Types of parameters
 
 Parameters can be signed or unsigned.

--- a/docs/embedding/static-embedding.md
+++ b/docs/embedding/static-embedding.md
@@ -8,6 +8,8 @@ redirect_from:
 
 Also known as: standalone embedding, or signed embedding.
 
+{% include shared/in-page-promo.html %}
+
 In general, embedding works by displaying a Metabase URL inside an iframe in your website. A **static embed** (or signed embed) is an iframe that's loading a Metabase URL secured with a signed JSON Web Token (JWT). Metabase will only load the URL if the request supplies a JWT signed with the secret shared between your app and your Metabase. The JWT also includes a reference to the resource to load, e.g., the dashboard ID, and any values for locked parameters.
 
 You can can't use static embeds with [data sandboxes](../permissions/data-sandboxes.md), [drill-through](https://www.metabase.com/learn/metabase-basics/querying-and-dashboards/questions/drill-through), and user-specific data isn't captured in [usage analytics](../usage-and-performance-tools/usage-analytics.md) because signed JWTs don't create user sessions (server-side sessions). For those features, check out [interactive embedding](./interactive-embedding.md).


### PR DESCRIPTION
Part of [Create a flexible block we can use to promote webinars](https://www.notion.so/metabase/13969354c901804eaa41e2d779914e2f?v=13a69354c901800fa30a000c3b643666&p=11869354c90180a99c92e8f92d029548&pm=s)

Adds the component shown in the screenshot below (this one is from https://www.metabase.com/learn/metabase-basics/embedding/overview).

<img width="1075" alt="image" src="https://github.com/user-attachments/assets/bacfb926-029f-4c6b-ac3d-eafdb3b25df5">
