### PR TITLE
Fix weight fallback for new Search

### DIFF
--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -143,6 +143,7 @@
     :native-query   {:type :native-query, :context-key :search-native-query}
     :verified       {:type :single-value, :supported-value? #{true}, :required-feature :content-verification}}))
 
+;; This gets called *a lot* during a search request, so we'll almost certainly need to optimize it. Maybe just TTL.
 (defn weights
   "Strength of the various scorers. Copied from metabase.search.in-place.scoring, but allowing divergence."
   [context]
@@ -150,7 +151,9 @@
         overrides (public-settings/experimental-search-weight-overrides)]
     (if (= :all context)
       (merge-with merge static-weights overrides)
-      (merge {}
+      (merge (get static-weights :default)
+             ;; Not sure which of the next two should have precedence, arguments for both "¯\_(ツ)_/¯"
+             (get overrides :default)
              (get static-weights context)
              (get overrides context)))))
 

--- a/src/metabase/search/fulltext.clj
+++ b/src/metabase/search/fulltext.clj
@@ -1,6 +1,5 @@
 (ns metabase.search.fulltext
   (:require
-   [metabase.config :as config]
    [metabase.public-settings :as public-settings]
    [metabase.search.api :as search.api]
    [metabase.search.postgres.core :as search.postgres]))
@@ -14,7 +13,7 @@
 (defmethod supported-db? :default [_] false)
 
 (defmethod supported-db? :postgres [_]
-  (or (public-settings/experimental-fulltext-search-enabled) config/is-test?))
+  (public-settings/experimental-fulltext-search-enabled))
 
 ;; For now, we know that the app db is postgres. We can extract multimethods if this changes.
 

--- a/src/metabase/search/fulltext.clj
+++ b/src/metabase/search/fulltext.clj
@@ -1,5 +1,6 @@
 (ns metabase.search.fulltext
   (:require
+   [metabase.config :as config]
    [metabase.public-settings :as public-settings]
    [metabase.search.api :as search.api]
    [metabase.search.postgres.core :as search.postgres]))
@@ -13,7 +14,7 @@
 (defmethod supported-db? :default [_] false)
 
 (defmethod supported-db? :postgres [_]
-  (public-settings/experimental-fulltext-search-enabled))
+  (or (public-settings/experimental-fulltext-search-enabled) config/is-test?))
 
 ;; For now, we know that the app db is postgres. We can extract multimethods if this changes.
 

--- a/test/metabase/search/fulltext/scoring_test.clj
+++ b/test/metabase/search/fulltext/scoring_test.clj
@@ -217,37 +217,37 @@
                    :model/Card {c2 :id} {}]
       (testing "bookmarked items are ranker higher"
         (with-index-contents
-         [{:model "card" :id c1 :name "card normal"}
-          {:model "card" :id c2 :name "card crowberto loved"}]
-         (mt/with-temp [:model/CardBookmark _ {:card_id c2 :user_id crowberto}
-                        :model/CardBookmark _ {:card_id c1 :user_id rasta}]
-           (is (= [["card" c2 "card crowberto loved"]
-                   ["card" c1 "card normal"]]
-                  (search :bookmarked "card" {:current-user-id crowberto})))))))
+          [{:model "card" :id c1 :name "card normal"}
+           {:model "card" :id c2 :name "card crowberto loved"}]
+          (mt/with-temp [:model/CardBookmark _ {:card_id c2 :user_id crowberto}
+                         :model/CardBookmark _ {:card_id c1 :user_id rasta}]
+            (is (= [["card" c2 "card crowberto loved"]
+                    ["card" c1 "card normal"]]
+                   (search :bookmarked "card" {:current-user-id crowberto})))))))
 
     (mt/with-temp [:model/Dashboard {d1 :id} {}
                    :model/Dashboard {d2 :id} {}]
       (testing "bookmarked dashboard"
         (with-index-contents
-         [{:model "dashboard" :id d1 :name "dashboard normal"}
-          {:model "dashboard" :id d2 :name "dashboard crowberto loved"}]
-         (mt/with-temp [:model/DashboardBookmark _ {:dashboard_id d2 :user_id crowberto}
-                        :model/DashboardBookmark _ {:dashboard_id d1 :user_id rasta}]
-           (is (= [["dashboard" d2 "dashboard crowberto loved"]
-                   ["dashboard" d1 "dashboard normal"]]
-                  (search :bookmarked "dashboard" {:current-user-id crowberto})))))))
+          [{:model "dashboard" :id d1 :name "dashboard normal"}
+           {:model "dashboard" :id d2 :name "dashboard crowberto loved"}]
+          (mt/with-temp [:model/DashboardBookmark _ {:dashboard_id d2 :user_id crowberto}
+                         :model/DashboardBookmark _ {:dashboard_id d1 :user_id rasta}]
+            (is (= [["dashboard" d2 "dashboard crowberto loved"]
+                    ["dashboard" d1 "dashboard normal"]]
+                   (search :bookmarked "dashboard" {:current-user-id crowberto})))))))
 
     (mt/with-temp [:model/Collection {c1 :id} {}
                    :model/Collection {c2 :id} {}]
       (testing "bookmarked collection"
         (with-index-contents
-         [{:model "collection" :id c1 :name "collection normal"}
-          {:model "collection" :id c2 :name "collection crowberto loved"}]
-         (mt/with-temp [:model/CollectionBookmark _ {:collection_id c2 :user_id crowberto}
-                        :model/CollectionBookmark _ {:collection_id c1 :user_id rasta}]
-           (is (= [["collection" c2 "collection crowberto loved"]
-                   ["collection" c1 "collection normal"]]
-                  (search :bookmarked "collection" {:current-user-id crowberto})))))))))
+          [{:model "collection" :id c1 :name "collection normal"}
+           {:model "collection" :id c2 :name "collection crowberto loved"}]
+          (mt/with-temp [:model/CollectionBookmark _ {:collection_id c2 :user_id crowberto}
+                         :model/CollectionBookmark _ {:collection_id c1 :user_id rasta}]
+            (is (= [["collection" c2 "collection crowberto loved"]
+                    ["collection" c1 "collection normal"]]
+                   (search :bookmarked "collection" {:current-user-id crowberto})))))))))
 
 (deftest ^:parallel user-recency-test
   (let [user-id     (mt/user->id :crowberto)
@@ -268,11 +268,11 @@
                    :model/RecentViews _ (recent-view c2 forever-ago)
                    :model/RecentViews _ (recent-view c4 forever-ago)
                    :model/RecentViews _ (recent-view c4 long-ago)]
-        (with-index-contents
-         [{:model "card"    :id c1 :name "card ancient"}
-          {:model "metric"  :id c2 :name "card recent"}
-          {:model "dataset" :id c3 :name "card unseen"}
-          {:model "dataset" :id c4 :name "card old"}]
+      (with-index-contents
+        [{:model "card"    :id c1 :name "card ancient"}
+         {:model "metric"  :id c2 :name "card recent"}
+         {:model "dataset" :id c3 :name "card unseen"}
+         {:model "dataset" :id c4 :name "card old"}]
         (testing "We prefer results more recently viewed by the current user"
           (is (= [["metric"  c2 "card recent"]
                   ["dataset" c4 "card old"]

--- a/test/metabase/search/fulltext/scoring_test.clj
+++ b/test/metabase/search/fulltext/scoring_test.clj
@@ -69,6 +69,7 @@
                             :is-impersonated-user? (premium-features/impersonated-user?)
                             :is-sandboxed-user?    (premium-features/impersonated-user?)})
                        {:archived         false
+                        :context          :command-palette
                         :search-string    search-string
                         :models           search.config/all-models
                         :model-ancestors? false}
@@ -79,8 +80,9 @@
 (defn- search-no-weights
   "Like search but with all weights set to 0."
   [ranker-key & args]
-  (mt/with-dynamic-redefs [search.config/weights #(assoc (:default @#'search.config/static-weights) ranker-key 0)]
-    (apply search* ranker-key args)))
+  (let [orig-weights (or (mt/dynamic-value search.config/weights) search.config/weights)]
+    (mt/with-dynamic-redefs [search.config/weights #(assoc (orig-weights %) ranker-key 0)]
+      (apply search* ranker-key args))))
 
 (defn- search [& args]
   (let [result (apply search* args)]
@@ -211,35 +213,41 @@
 (deftest ^:parallel bookmark-test
   (let [crowberto (mt/user->id :crowberto)
         rasta     (mt/user->id :rasta)]
-    (testing "bookmarked items are ranker higher"
-      (with-index-contents
-        [{:model "card" :id 1 :name "card normal"}
-         {:model "card" :id 2 :name "card crowberto loved"}]
-        (mt/with-temp [:model/CardBookmark _ {:card_id 2 :user_id crowberto}
-                       :model/CardBookmark _ {:card_id 1 :user_id rasta}]
-          (is (= [["card" 2 "card crowberto loved"]
-                  ["card" 1 "card normal"]]
-                 (search :bookmarked "card" {:current-user-id crowberto}))))))
+    (mt/with-temp [:model/Card {c1 :id} {}
+                   :model/Card {c2 :id} {}]
+      (testing "bookmarked items are ranker higher"
+        (with-index-contents
+         [{:model "card" :id c1 :name "card normal"}
+          {:model "card" :id c2 :name "card crowberto loved"}]
+         (mt/with-temp [:model/CardBookmark _ {:card_id c2 :user_id crowberto}
+                        :model/CardBookmark _ {:card_id c1 :user_id rasta}]
+           (is (= [["card" c2 "card crowberto loved"]
+                   ["card" c1 "card normal"]]
+                  (search :bookmarked "card" {:current-user-id crowberto})))))))
 
-    (testing "bookmarked dashboard"
-      (with-index-contents
-        [{:model "dashboard" :id 1 :name "dashboard normal"}
-         {:model "dashboard" :id 2 :name "dashboard crowberto loved"}]
-        (mt/with-temp [:model/DashboardBookmark _ {:dashboard_id 2 :user_id crowberto}
-                       :model/DashboardBookmark _ {:dashboard_id 1 :user_id rasta}]
-          (is (= [["dashboard" 2 "dashboard crowberto loved"]
-                  ["dashboard" 1 "dashboard normal"]]
-                 (search :bookmarked "dashboard" {:current-user-id crowberto}))))))
+    (mt/with-temp [:model/Dashboard {d1 :id} {}
+                   :model/Dashboard {d2 :id} {}]
+      (testing "bookmarked dashboard"
+        (with-index-contents
+         [{:model "dashboard" :id d1 :name "dashboard normal"}
+          {:model "dashboard" :id d2 :name "dashboard crowberto loved"}]
+         (mt/with-temp [:model/DashboardBookmark _ {:dashboard_id d2 :user_id crowberto}
+                        :model/DashboardBookmark _ {:dashboard_id d1 :user_id rasta}]
+           (is (= [["dashboard" d2 "dashboard crowberto loved"]
+                   ["dashboard" d1 "dashboard normal"]]
+                  (search :bookmarked "dashboard" {:current-user-id crowberto})))))))
 
-    (testing "bookmarked collection"
-      (with-index-contents
-        [{:model "collection" :id 1 :name "collection normal"}
-         {:model "collection" :id 2 :name "collection crowberto loved"}]
-        (mt/with-temp [:model/CollectionBookmark _ {:collection_id 2 :user_id crowberto}
-                       :model/CollectionBookmark _ {:collection_id 1 :user_id rasta}]
-          (is (= [["collection" 2 "collection crowberto loved"]
-                  ["collection" 1 "collection normal"]]
-                 (search :bookmarked "collection" {:current-user-id crowberto}))))))))
+    (mt/with-temp [:model/Collection {c1 :id} {}
+                   :model/Collection {c2 :id} {}]
+      (testing "bookmarked collection"
+        (with-index-contents
+         [{:model "collection" :id c1 :name "collection normal"}
+          {:model "collection" :id c2 :name "collection crowberto loved"}]
+         (mt/with-temp [:model/CollectionBookmark _ {:collection_id c2 :user_id crowberto}
+                        :model/CollectionBookmark _ {:collection_id c1 :user_id rasta}]
+           (is (= [["collection" c2 "collection crowberto loved"]
+                   ["collection" c1 "collection normal"]]
+                  (search :bookmarked "collection" {:current-user-id crowberto})))))))))
 
 (deftest ^:parallel user-recency-test
   (let [user-id     (mt/user->id :crowberto)
@@ -251,19 +259,23 @@
                        :model_id  model-id
                        :user_id   user-id
                        :timestamp timestamp})]
-    (with-index-contents
-      [{:model "card"    :id 1 :name "card ancient"}
-       {:model "metric"  :id 2 :name "card recent"}
-       {:model "dataset" :id 3 :name "card unseen"}
-       {:model "dataset" :id 4 :name "card old"}]
-      (mt/with-temp [:model/RecentViews _ (recent-view 1 forever-ago)
-                     :model/RecentViews _ (recent-view 2 right-now)
-                     :model/RecentViews _ (recent-view 2 forever-ago)
-                     :model/RecentViews _ (recent-view 4 forever-ago)
-                     :model/RecentViews _ (recent-view 4 long-ago)]
+    (mt/with-temp [:model/Card        {c1 :id} {}
+                   :model/Card        {c2 :id} {}
+                   :model/Card        {c3 :id} {}
+                   :model/Card        {c4 :id} {}
+                   :model/RecentViews _ (recent-view c1 forever-ago)
+                   :model/RecentViews _ (recent-view c2 right-now)
+                   :model/RecentViews _ (recent-view c2 forever-ago)
+                   :model/RecentViews _ (recent-view c4 forever-ago)
+                   :model/RecentViews _ (recent-view c4 long-ago)]
+        (with-index-contents
+         [{:model "card"    :id c1 :name "card ancient"}
+          {:model "metric"  :id c2 :name "card recent"}
+          {:model "dataset" :id c3 :name "card unseen"}
+          {:model "dataset" :id c4 :name "card old"}]
         (testing "We prefer results more recently viewed by the current user"
-          (is (= [["metric"  2 "card recent"]
-                  ["dataset" 4 "card old"]
-                  ["card"    1 "card ancient"]
-                  ["dataset" 3 "card unseen"]]
+          (is (= [["metric"  c2 "card recent"]
+                  ["dataset" c4 "card old"]
+                  ["card"    c1 "card ancient"]
+                  ["dataset" c3 "card unseen"]]
                  (search :user-recency "card" {:current-user-id user-id}))))))))

--- a/test/metabase/search/impl_test.clj
+++ b/test/metabase/search/impl_test.clj
@@ -18,7 +18,7 @@
 
 (deftest ^:parallel parse-engine-test
   (testing "Default engine"
-    (is (= :search.engine/in-place (#'search.impl/parse-engine nil))))
+    (is (= "search.engine" (namespace (#'search.impl/parse-engine nil)))))
   (testing "Unknown engine resolves to the default"
     (is (=  (#'search.impl/parse-engine nil)
             (#'search.impl/parse-engine "vespa"))))


### PR DESCRIPTION
Double whammy. 

Broke the fallback when refactoring the shape of the setting, local tests weren't running anymore, assumed they'd block CI as well, but then they didn't run on there!

This fixes 3 things:

1. The default weights apply to all contexts (unless they know better)
2. ~~The ranker tests which exercise the weights run on CI, even though it doesn't have the experimental flag.~~ 
	Done in next PR
4. The tests are fixed to work with empty databases.

The last one is annoying. When we insert stuff straight into the index, it saves us polluting the appdb *but* it also means we can't create joins to them to use for personalized ranking. This PR works around this clumsily, by using dummy temp items to generate the ids.