### PR TITLE
[Clean Up] Show alert with 3 month stale content rather than 6

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/clean_up/CollectionCleanupAlert/CollectionCleanupAlert.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/CollectionCleanupAlert/CollectionCleanupAlert.tsx
@@ -10,6 +10,8 @@ import { Alert, Box, Icon } from "metabase/ui";
 import { useListStaleCollectionItemsQuery } from "metabase-enterprise/api/collection";
 import type { Collection } from "metabase-types/api";
 
+import { getDateFilterValue } from "../CleanupCollectionModal/utils";
+
 const TEXT = {
   CLEAN_THINGS_UP: c(
     "This is the heading of a banner that invites the user to clean up a collection.",
@@ -35,6 +37,7 @@ export const CollectionCleanupAlert = ({
       ? {
           id: collection.id,
           limit: 0, // only fetch pagination info
+          before_date: getDateFilterValue("three-months"), // set to 3 months ago
         }
       : skipToken,
   );


### PR DESCRIPTION
### Description

Product feedback to make the clean up alert more sensitive to stale content. Decreased from the default 6 months to 3 months.

![CleanShot 2024-11-21 at 16 03 38@2x](https://github.com/user-attachments/assets/46f1a5e6-8d0b-4b2b-812a-8419adef69de)
