### PR TITLE
Provide a generic (static) way to override search filter defaults

### DIFF
--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -143,6 +143,21 @@
     :native-query   {:type :native-query, :context-key :search-native-query}
     :verified       {:type :single-value, :supported-value? #{true}, :required-feature :content-verification}}))
 
+(def ^:private filter-defaults-by-context
+  {:default         {:archived               false
+                     ;; keys will typically those in [[filters]], but this is an atypical filter.
+                     ;; we plan to generify it, by precalculating it on the index.
+                     :personal-collection-id "all"}
+   :command-palette {:personal-collection-id "exclude-others"}})
+
+(defn filter-default
+  "Get the default value for the given filter in the given context. Is non-contextual for legacy search."
+  [engine context filter-key]
+  (let [fetch (fn [ctx] (when ctx (-> filter-defaults-by-context (get ctx) (get filter-key))))]
+    (if (= engine :search.engine/in-place)
+      (fetch :default)
+      (or (fetch context) (fetch :default)))))
+
 ;; This gets called *a lot* during a search request, so we'll almost certainly need to optimize it. Maybe just TTL.
 (defn weights
   "Strength of the various scorers. Copied from metabase.search.in-place.scoring, but allowing divergence."

--- a/src/metabase/search/config_test.clj
+++ b/src/metabase/search/config_test.clj
@@ -1,0 +1,20 @@
+(ns metabase.search.config-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.search.config :as search.config]))
+
+;; All that matters is that this is not legacy search.
+(def ^:private search-engine :search.engine/fulltext)
+
+(deftest filter-default-test
+  (testing "Default values"
+    (is (= false (search.config/filter-default search-engine nil :archived)))
+    (is (= "all" (search.config/filter-default search-engine nil :personal-collection-id))))
+  (testing "No overrides"
+    (is (= false (search.config/filter-default search-engine :command-palette :archived))))
+  (testing "Overrides"
+    (is (= "exclude-others"
+           (search.config/filter-default search-engine :command-palette :personal-collection-id))))
+  (testing "Legacy search does not support overrides"
+    (is (= "all"
+           (search.config/filter-default :search.engine/in-place :command-palette :personal-collection-id)))))

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -311,16 +311,14 @@
      (deferred-tru "Content Management or Official Collections")))
   (let [models (if (string? models) [models] models)
         engine (parse-engine search-engine)
-        ctx    (cond-> {:archived?                           (boolean archived)
+        fvalue (fn [filter-key] (search.config/filter-default engine context filter-key))
+        ctx    (cond-> {:archived?                           (boolean (or archived (fvalue :archived)))
                         :context                             (or context :unknown)
                         :calculate-available-models?         (boolean calculate-available-models?)
                         :current-user-id                     current-user-id
                         :current-user-perms                  current-user-perms
                         :filter-items-in-personal-collection (or filter-items-in-personal-collection
-                                                                 (if (and (not= engine :search.engine/in-place)
-                                                                          (#{:search-app :command-palette} context))
-                                                                   "exclude-others"
-                                                                   "all"))
+                                                                 (fvalue :personal-collection-id))
                         :is-impersonated-user?               is-impersonated-user?
                         :is-sandboxed-user?                  is-sandboxed-user?
                         :is-superuser?                       is-superuser?


### PR DESCRIPTION
Refs https://github.com/metabase/metabase/issues/50206

I don't think it's necessary to make this dynamic.