### PR TITLE
Disable `?locale` on static embeds/public links

### DIFF
--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -343,22 +343,46 @@ export function saveSavedQuestion() {
   cy.wait("@updateQuestion");
 }
 
-export function visitPublicQuestion(id) {
+/**
+ *
+ * @param {number} id
+ * @param {object} options
+ * @param {Record<string, string>} options.params
+ * @param {Record<string, string>} options.hash
+ */
+export function visitPublicQuestion(id, { params = {}, hash = {} } = {}) {
+  const searchParams = new URLSearchParams(params).toString();
+  const searchSection = searchParams ? `?${searchParams}` : "";
+  const hashParams = new URLSearchParams(hash).toString();
+  const hashSection = hashParams ? `#${hashParams}` : "";
   cy.request("POST", `/api/card/${id}/public_link`).then(
     ({ body: { uuid } }) => {
       cy.signOut();
-      cy.visit(`/public/question/${uuid}`);
+      cy.visit({
+        url: `/public/question/${uuid}` + searchSection + hashSection,
+      });
     },
   );
 }
 
-export function visitPublicDashboard(id, { params = {} } = {}) {
+/**
+ *
+ * @param {number} id
+ * @param {object} options
+ * @param {Record<string, string>} options.params
+ * @param {Record<string, string>} options.hash
+ */
+export function visitPublicDashboard(id, { params = {}, hash = {} } = {}) {
+  const searchParams = new URLSearchParams(params).toString();
+  const searchSection = searchParams ? `?${searchParams}` : "";
+  const hashParams = new URLSearchParams(hash).toString();
+  const hashSection = hashParams ? `#${hashParams}` : "";
+
   cy.request("POST", `/api/dashboard/${id}/public_link`).then(
     ({ body: { uuid } }) => {
       cy.signOut();
       cy.visit({
-        url: `/public/dashboard/${uuid}`,
-        qs: params,
+        url: `/public/dashboard/${uuid}` + searchSection + hashSection,
       });
     },
   );

--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -355,6 +355,7 @@ export function visitPublicQuestion(id, { params = {}, hash = {} } = {}) {
   const searchSection = searchParams ? `?${searchParams}` : "";
   const hashParams = new URLSearchParams(hash).toString();
   const hashSection = hashParams ? `#${hashParams}` : "";
+
   cy.request("POST", `/api/card/${id}/public_link`).then(
     ({ body: { uuid } }) => {
       cy.signOut();

--- a/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -1009,7 +1009,7 @@ describeEE("scenarios > embedding > dashboard appearance", () => {
     });
   });
 
-  it("should allow to set locale from the `locale` query parameter", () => {
+  it("should allow to set locale from the `#locale` hash parameter (metabase#50182)", () => {
     cy.request("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}`, {
       enable_embedding: true,
     });
@@ -1020,7 +1020,11 @@ describeEE("scenarios > embedding > dashboard appearance", () => {
         resource: { dashboard: ORDERS_DASHBOARD_ID },
         params: {},
       },
-      { qs: { locale: "de" } },
+      {
+        additionalHashOptions: {
+          locale: "de",
+        },
+      },
     );
 
     main().findByText("Februar 11, 2025, 9:40 PM");

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -1138,7 +1138,7 @@ describeEE("issue 8490", () => {
     });
   });
 
-  it("static embeddings should respect `#locale` hash in the URL (metabase#8490)", () => {
+  it("static embeddings should respect `#locale` hash parameter (metabase#8490, metabase#50182)", () => {
     cy.log("test a static embedded dashboard");
     cy.get("@dashboardId").then(dashboardId => {
       visitEmbeddedPage(

--- a/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
@@ -277,18 +277,6 @@ describe("scenarios > public > dashboard", () => {
     filterWidget().findByText("002").should("be.visible");
   });
 
-  it("should allow to set locale from the `locale` query parameter", () => {
-    cy.get("@dashboardId").then(id => {
-      visitPublicDashboard(id, {
-        params: { locale: "de" },
-      });
-    });
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- we don't care where the text is
-    cy.findByText("Registerkarte als PDF exportieren").should("be.visible");
-    cy.url().should("include", "locale=de");
-  });
-
   it("should respect click behavior", () => {
     createDashboardWithQuestions({
       dashboardName: "test click behavior",
@@ -356,5 +344,17 @@ describeEE("scenarios [EE] > public > dashboard", () => {
 
       cy.title().should("eq", "Test Dashboard · Custom Application Name");
     });
+  });
+
+  it("should allow to set locale from the `#locale` hash parameter (metabase#50182)", () => {
+    cy.get("@dashboardId").then(id => {
+      visitPublicDashboard(id, {
+        hash: { locale: "de" },
+      });
+    });
+
+    // eslint-disable-next-line no-unscoped-text-selectors -- we don't care where the text is
+    cy.findByText("Registerkarte als PDF exportieren").should("be.visible");
+    cy.url().should("include", "locale=de");
   });
 });

--- a/src/metabase/server/routes/index.clj
+++ b/src/metabase/server/routes/index.clj
@@ -78,11 +78,13 @@
 (defn- load-entrypoint-template [entrypoint-name embeddable? {:keys [uri params nonce]}]
   (load-template
    (str "frontend_client/" entrypoint-name ".html")
-   (let [{:keys [anon-tracking-enabled google-auth-client-id], :as public-settings} (setting/user-readable-values-map #{:public})]
+   (let [{:keys [anon-tracking-enabled google-auth-client-id], :as public-settings} (setting/user-readable-values-map #{:public})
+         ;; We disable `locale` parameter on static embeds/public links (metabase#50313)
+         should-load-locale-params? (not embeddable?)]
      {:bootstrapJS          (load-inline-js "index_bootstrap")
       :bootstrapJSON        (escape-script (json/generate-string public-settings))
       :assetOnErrorJS       (load-inline-js "asset_loading_error")
-      :userLocalizationJSON (escape-script (load-localization (:locale params)))
+      :userLocalizationJSON (escape-script (load-localization (when should-load-locale-params? (:locale params))))
       :siteLocalizationJSON (escape-script (load-localization (public-settings/site-locale)))
       :nonceJSON            (escape-script (json/generate-string nonce))
       :language             (hiccup.util/escape-html (public-settings/site-locale))


### PR DESCRIPTION
> [!note]
> Do not backport this PR because it targets 52

Closes https://github.com/metabase/metabase/issues/50313

### Description

Since we have the new hash option `#locale` on static embeds/public links. We want to avoid confusion on the undocumented `?locale` parameter by removing it and opt for `#locale` instead.

### How to verify

1. Try setting the search param `?locale=xx` with the locale of your choice e.g. `?locale=ko` in either a static embed or a public link on either a dashboard or a question. And none of it should work
1. Try setting `?locale=xx` with the locale of your choice on normal Metabase and it should work. This means the interactive embed would work as well.
1. Now test the static embed/public link again with `#locale`, and it should only work when you have a Pro license (https://github.com/metabase/metabase/issues/50199).

### Demo
#### with `?locale=en`, it doesn't work anymore
![image](https://github.com/user-attachments/assets/1679d7db-a1e6-4c29-a700-0566e64c5bc4)

#### with `#localo=en`, only when we use the hash locale, then it would work

![image](https://github.com/user-attachments/assets/af82f080-f078-4aa8-82fc-692fefbf29e8)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
