### PR TITLE
fix(sdk): summarize sdk component crashes with stage index errors

### DIFF
--- a/e2e/test/scenarios/embedding-sdk/interactive-question.cy.spec.ts
+++ b/e2e/test/scenarios/embedding-sdk/interactive-question.cy.spec.ts
@@ -185,8 +185,8 @@ describeSDK("scenarios > embedding-sdk > interactive-question", () => {
       // Open the default summarization view in the sdk
       cy.findByText("Summarize").click();
 
-      // Expect the text from the default summarization view to be there.
-      cy.contains("Group by");
+      // Expect the default summarization view to be there.
+      cy.findByTestId("summarize-aggregation-item-list").should("be.visible");
     });
 
     cy.on("uncaught:exception", error => {

--- a/e2e/test/scenarios/embedding-sdk/interactive-question.cy.spec.ts
+++ b/e2e/test/scenarios/embedding-sdk/interactive-question.cy.spec.ts
@@ -174,7 +174,7 @@ describeSDK("scenarios > embedding-sdk > interactive-question", () => {
     getSdkRoot().contains("question saved as Sample Orders 4");
   });
 
-  it("should not crash when clicking on Summarize", () => {
+  it("should not crash when clicking on Summarize (metabase#50398)", () => {
     visitInteractiveQuestionStory();
 
     cy.wait("@cardQuery").then(({ response }) => {

--- a/e2e/test/scenarios/embedding-sdk/interactive-question.cy.spec.ts
+++ b/e2e/test/scenarios/embedding-sdk/interactive-question.cy.spec.ts
@@ -173,4 +173,25 @@ describeSDK("scenarios > embedding-sdk > interactive-question", () => {
     getSdkRoot().contains("onBeforeSave is called");
     getSdkRoot().contains("question saved as Sample Orders 4");
   });
+
+  it("should not crash when clicking on Summarize", () => {
+    visitInteractiveQuestionStory();
+
+    cy.wait("@cardQuery").then(({ response }) => {
+      expect(response?.statusCode).to.equal(202);
+    });
+
+    getSdkRoot().within(() => {
+      // Open the default summarization view in the sdk
+      cy.findByText("Summarize").click();
+
+      // Expect the text from the default summarization view to be there.
+      cy.contains("Group by");
+      cy.contains("Sum of Total");
+    });
+
+    cy.on("uncaught:exception", error => {
+      expect(error.message.includes("Stage 1 does not exist")).to.be.false;
+    });
+  });
 });

--- a/e2e/test/scenarios/embedding-sdk/interactive-question.cy.spec.ts
+++ b/e2e/test/scenarios/embedding-sdk/interactive-question.cy.spec.ts
@@ -187,7 +187,6 @@ describeSDK("scenarios > embedding-sdk > interactive-question", () => {
 
       // Expect the text from the default summarization view to be there.
       cy.contains("Group by");
-      cy.contains("Sum of Total");
     });
 
     cy.on("uncaught:exception", error => {

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Summarize.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Summarize.tsx
@@ -52,7 +52,7 @@ const SummarizeInner = ({
     onClose();
   };
 
-  const hasAggregations = Lib.aggregations(currentQuery, stageIndex).length > 0;
+  const hasAggregations = Lib.aggregations(currentQuery, -1).length > 0;
 
   return (
     <Stack className={CS.overflowHidden} h="100%" w="100%">

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Summarize.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Summarize.tsx
@@ -38,9 +38,6 @@ const SummarizeInner = ({
 
   const [currentQuery, setCurrentQuery] = useState<Lib.Query>(question.query());
 
-  // yeah we need to change this
-  const stageIndex = Lib.stageCount(currentQuery);
-
   const onApplyFilter = () => {
     if (currentQuery) {
       onQueryChange(currentQuery);
@@ -63,14 +60,14 @@ const SummarizeInner = ({
         <SummarizeAggregationItemList
           query={currentQuery}
           onQueryChange={setCurrentQuery}
-          stageIndex={stageIndex}
+          stageIndex={-1}
         />
         <Divider my="lg" />
         {hasAggregations && (
           <SummarizeBreakoutColumnList
             query={currentQuery}
             onQueryChange={setCurrentQuery}
-            stageIndex={stageIndex}
+            stageIndex={-1}
           />
         )}
       </Stack>

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Summarize.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Summarize.tsx
@@ -52,7 +52,8 @@ const SummarizeInner = ({
     onClose();
   };
 
-  const hasAggregations = Lib.aggregations(currentQuery, -1).length > 0;
+  const stageIndex = -1;
+  const hasAggregations = Lib.aggregations(currentQuery, stageIndex).length > 0;
 
   return (
     <Stack className={CS.overflowHidden} h="100%" w="100%">
@@ -60,14 +61,14 @@ const SummarizeInner = ({
         <SummarizeAggregationItemList
           query={currentQuery}
           onQueryChange={setCurrentQuery}
-          stageIndex={-1}
+          stageIndex={stageIndex}
         />
         <Divider my="lg" />
         {hasAggregations && (
           <SummarizeBreakoutColumnList
             query={currentQuery}
             onQueryChange={setCurrentQuery}
-            stageIndex={-1}
+            stageIndex={stageIndex}
           />
         )}
       </Stack>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50398

### Description

Fixes the stage index error thrown when rendering the [Summarize](https://github.com/metabase/metabase/pull/49901) sdk component. The only consumers of `SummarizeAggregationItemList` and `SummarizeBreakoutColumnList` used in the SDK's `Summarize` component is `SummarizeSidebar`, which is only used by `StructuredQueryRightSidebar` which only passes `stageIndex={-1}`. This makes sense as we only want to work with the latest stages in this case.

### How to verify

- Go to an interactive question's default view (or a view with the Summarize view)
- Click on the Summarize button
- It should not crash. The layout does look weird but this will be fixed in https://github.com/metabase/metabase/issues/49719

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - E2E
