### PR TITLE
feat: allow ionic scheme-source in frame-ancestors CSP directive

### DIFF
--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -173,7 +173,7 @@
   [allow-iframes? nonce]
   (update (content-security-policy-header nonce)
           "Content-Security-Policy"
-          #(format "%s frame-ancestors %s;" % (if allow-iframes? "*"
+          #(format "%s frame-ancestors %s;" % (if allow-iframes? "* ionic:"
                                                   (if-let [eao (and (embed.settings/enable-embedding-interactive)
                                                                     (embed.settings/embedding-app-origins-interactive))]
                                                     eao


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

PR following a discussion with Metabase support by email - ticket number: 31976.

### Description

This PR allows the scheme-source `ionic:` in the frame-ancestors directive. Allowing Ionic mobile apps (https://ionicframework.com/) to embed static Metabase dashboards.

#### Problem it solves
Static embedded Metabase dashboards currently refuses to be loaded as an iframe in mobile iOS apps using Ionic Cordova. 
The problem comes from the CSP (Content Security Policy) header in the HTTP response.
The directive `frame-ancestors: *;` allows only http and https schema. It is not compatible with iOS and Ionic because it uses `ionic:` schema.

### How to verify

Describe the steps to verify that the changes are working as expected.

- Embed a dashboard into an Ionic mobile app.
- Build and open the app on an iOS device.
- The dashboard should be visible.
