### PR TITLE
Use relative-time-interval in the QP for parameters

### DIFF
--- a/frontend/src/metabase-lib/v1/parameters/utils/mbql.js
+++ b/frontend/src/metabase-lib/v1/parameters/utils/mbql.js
@@ -48,21 +48,16 @@ const timeParameterValueDeserializers = [
   {
     testRegex: /^past([0-9]+)([a-z]+)s-from-([0-9]+)([a-z]+)s$/,
     deserialize: (matches, fieldRef) => {
-      const base = [
-        "time-interval",
-        fieldRef,
-        -parseInt(matches[0]),
-        matches[1],
-      ];
-      return setStartingFrom(base, parseInt(matches[2]), matches[3]);
+      const base = ["time-interval", fieldRef, -Number(matches[0]), matches[1]];
+      return setStartingFrom(base, Number(matches[2]), matches[3]);
     },
     deserializeMBQL: (matches, fieldRef) => {
       return [
         "relative-time-interval",
         fieldRef,
-        -parseInt(matches[0]),
+        -Number(matches[0]),
         matches[1],
-        -parseInt(matches[2]),
+        -Number(matches[2]),
         matches[3],
       ];
     },
@@ -70,28 +65,23 @@ const timeParameterValueDeserializers = [
   {
     testRegex: /^past([0-9]+)([a-z]+)s(~)?$/,
     deserialize: (matches, fieldRef) =>
-      ["time-interval", fieldRef, -parseInt(matches[0]), matches[1]].concat(
+      ["time-interval", fieldRef, -Number(matches[0]), matches[1]].concat(
         matches[2] ? [{ "include-current": true }] : [],
       ),
   },
   {
     testRegex: /^next([0-9]+)([a-z]+)s-from-([0-9]+)([a-z]+)s$/,
     deserialize: (matches, fieldRef) => {
-      const base = [
-        "time-interval",
-        fieldRef,
-        parseInt(matches[0]),
-        matches[1],
-      ];
-      return setStartingFrom(base, -parseInt(matches[2]), matches[3]);
+      const base = ["time-interval", fieldRef, Number(matches[0]), matches[1]];
+      return setStartingFrom(base, -Number(matches[2]), matches[3]);
     },
     deserializeMBQL: (matches, fieldRef) => {
       return [
         "relative-time-interval",
         fieldRef,
-        parseInt(matches[0]),
+        Number(matches[0]),
         matches[1],
-        parseInt(matches[2]),
+        Number(matches[2]),
         matches[3],
       ];
     },
@@ -99,7 +89,7 @@ const timeParameterValueDeserializers = [
   {
     testRegex: /^next([0-9]+)([a-z]+)s(~)?$/,
     deserialize: (matches, fieldRef) =>
-      ["time-interval", fieldRef, parseInt(matches[0]), matches[1]].concat(
+      ["time-interval", fieldRef, Number(matches[0]), matches[1]].concat(
         matches[2] ? [{ "include-current": true }] : [],
       ),
   },

--- a/frontend/src/metabase-lib/v1/parameters/utils/mbql.unit.spec.js
+++ b/frontend/src/metabase-lib/v1/parameters/utils/mbql.unit.spec.js
@@ -295,7 +295,7 @@ describe("parameters/utils/mbql", () => {
       ).toBe(query);
     });
 
-    it("should add a filter fora  date parameter", () => {
+    it("should add a filter for a date parameter", () => {
       const newQuery = applyFilterParameter(query, stageIndex, {
         target: ["dimension", ["field", PRODUCTS.CREATED_AT, null]],
         type: "date/single",
@@ -304,6 +304,22 @@ describe("parameters/utils/mbql", () => {
       const [filter] = Lib.filters(newQuery, -1);
       expect(Lib.displayInfo(query, stageIndex, filter)).toMatchObject({
         displayName: "Created At is on 01-01-2020",
+      });
+    });
+
+    it("should add a relative date filter with an offset for a date parameter with a correct operator (metabase#49853)", () => {
+      const newQuery = applyFilterParameter(query, stageIndex, {
+        target: ["dimension", ["field", PRODUCTS.CREATED_AT, null]],
+        type: "date/all-options",
+        value: "past3months-from-9months",
+      });
+      const [filter] = Lib.filters(newQuery, stageIndex);
+      expect(Lib.expressionParts(query, stageIndex, filter)).toMatchObject({
+        operator: "relative-time-interval",
+      });
+      expect(Lib.displayInfo(query, stageIndex, filter)).toMatchObject({
+        displayName:
+          "Created At is in the previous 3 months, starting 9 months ago",
       });
     });
 

--- a/src/metabase/driver/common/parameters/dates.clj
+++ b/src/metabase/driver/common/parameters/dates.clj
@@ -215,10 +215,12 @@
 
     :filter (fn [{:keys [unit int-value relative-suffix unit-1 int-value-1]} field-clause]
               (if unit-1
-                [:between
-                 [:+ field-clause [:interval int-value-1 (keyword unit-1)]]
-                 [:relative-datetime (- int-value) (keyword unit)]
-                 [:relative-datetime 0 (keyword unit)]]
+                [:relative-time-interval
+                 field-clause
+                 (- int-value)
+                 (keyword unit)
+                 (- int-value-1)
+                 (keyword unit-1)]
                 [:time-interval field-clause (- int-value) (keyword unit) {:include-current (include-current? relative-suffix)}]))}
 
    {:parser (regex->parser (re-pattern (str #"next([0-9]+)" temporal-units-regex #"s" relative-suffix-regex))
@@ -231,10 +233,12 @@
                             (t/plus dt-resolution (to-period int-value)))))
     :filter (fn [{:keys [unit int-value relative-suffix unit-1 int-value-1]} field-clause]
               (if unit-1
-                [:between
-                 [:+ field-clause [:interval (- int-value-1) (keyword unit-1)]]
-                 [:relative-datetime 0 (keyword unit)]
-                 [:relative-datetime int-value (keyword unit)]]
+                [:relative-time-interval
+                 field-clause
+                 int-value
+                 (keyword unit)
+                 int-value-1
+                 (keyword unit-1)]
                 [:time-interval field-clause int-value (keyword unit) {:include-current (include-current? relative-suffix)}]))}
 
    {:parser (regex->parser (re-pattern (str #"last" temporal-units-regex))

--- a/test/metabase/driver/common/parameters/dates_test.clj
+++ b/test/metabase/driver/common/parameters/dates_test.clj
@@ -71,16 +71,20 @@
     (is (= [:time-interval [:field "field" {:base-type :type/DateTime}] -30 :quarter {:include-current false}]
            (params.dates/date-string->filter "past30quarters" [:field "field" {:base-type :type/DateTime}]))))
   (testing "relative (past) with starting from "
-    (is (= [:between
-            [:+ [:field "field" {:base-type :type/DateTime}] [:interval 3 :year]]
-            [:relative-datetime -3 :day]
-            [:relative-datetime 0 :day]]
+    (is (= [:relative-time-interval
+            [:field "field" {:base-type :type/DateTime}]
+            -3
+            :day
+            -3
+            :year]
            (params.dates/date-string->filter "past3days-from-3years" [:field "field" {:base-type :type/DateTime}]))))
   (testing "relative (next) with starting from"
-    (is (= [:between
-            [:+ [:field "field" {:base-type :type/DateTime}] [:interval -13 :month]]
-            [:relative-datetime 0 :hour]
-            [:relative-datetime 7 :hour]]
+    (is (= [:relative-time-interval
+            [:field "field" {:base-type :type/DateTime}]
+            7
+            :hour
+            13
+            :month]
            (params.dates/date-string->filter "next7hours-from-13months" [:field "field" {:base-type :type/DateTime}]))))
   (testing "exclusions"
     (mt/with-clock #t "2016-06-07T12:13:55Z"


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/49853

**BE**
We previously added a new `relative-time-interval` MBQL lib function to fix relative date filters with offset but it's used by new QB filters only on the FE. Let's use it in the QP as well.

**FE**
We need to use `relative-time-interval` when converting date parameter values to MBQL filters. This is legacy code that works with MBQL directly. Furthermore, this MBQL is used internally by the legacy `DatePicker` for the UI state (!) and updating the clause for all cases is very hard due to how this code is written. I have plans to completely drop the legacy `DatePicker`, so for now I introduce a new function to create an actual MBQL clause and leave whatever is generated for the component untouched. 

If anyone has a good idea how write a stable E2E test (without simply checking for filter operators) I'm all ears. 

How to verify:
- Make sure that `relative-time-interval` is used when drilling thru from a dashboard with a relative date filter with an offset.