### PR TITLE
Normalize :temporal_units in action, card, and dashboard entries

### DIFF
--- a/src/metabase/models/action.clj
+++ b/src/metabase/models/action.clj
@@ -55,7 +55,7 @@
 (t2/deftransforms :model/Action
   {:type                   mi/transform-keyword
    :parameter_mappings     mi/transform-parameters-list
-   :parameters             mi/transform-parameters-list
+   :parameters             mi/transform-card-parameters-list
    :visualization_settings transform-action-visualization-settings})
 
 (t2/deftransforms :model/QueryAction

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -70,7 +70,7 @@
    :query_type             mi/transform-keyword
    :result_metadata        mi/transform-result-metadata
    :visualization_settings mi/transform-visualization-settings
-   :parameters             mi/transform-parameters-list
+   :parameters             mi/transform-card-parameters-list
    :parameter_mappings     mi/transform-parameters-list
    :type                   mi/transform-keyword})
 

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -73,7 +73,7 @@
    (mi/can-read? (t2/select-one :model/Dashboard :id pk))))
 
 (t2/deftransforms :model/Dashboard
-  {:parameters       mi/transform-parameters-list
+  {:parameters       mi/transform-card-parameters-list
    :embedding_params mi/transform-json})
 
 (t2/define-before-delete :model/Dashboard

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -9,6 +9,7 @@
    [clojure.walk :as walk]
    [malli.core :as mc]
    [malli.error :as me]
+   [medley.core :as m]
    [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.lib.core :as lib]
@@ -216,6 +217,17 @@
   (or (mbql.normalize/normalize-fragment [:parameters] parameters)
       []))
 
+(defn- keywordize-temporal_units
+  [parameter]
+  (m/update-existing parameter :temporal_units (fn [units] (mapv keyword units))))
+
+(defn normalize-card-parameters-list
+  "Normalize `parameters` of actions, cards, and dashboards when coming out of the application database."
+  [parameters]
+  (->> parameters
+       normalize-parameters-list
+       (mapv keywordize-temporal_units)))
+
 (def transform-metabase-query
   "Transform for metabase-query."
   {:in  (comp json-in (partial maybe-normalize-query :in))
@@ -225,6 +237,11 @@
   "Transform for parameters list."
   {:in  (comp json-in normalize-parameters-list)
    :out (comp (catch-normalization-exceptions normalize-parameters-list) json-out-with-keywordization)})
+
+(def transform-card-parameters-list
+  "Transform for parameters list."
+  {:in  (comp json-in normalize-card-parameters-list)
+   :out (comp (catch-normalization-exceptions normalize-card-parameters-list) json-out-with-keywordization)})
 
 (def transform-field-ref
   "Transform field refs"

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -905,10 +905,23 @@
                            :id        "927e929"
                            :type      :temporal-unit
                            :sectionId "temporal-unit"
-                           :temporal_units ["week" "month"]}]]
+                           :temporal_units [:week :month]}]]
               (mt/user-http-request :rasta :put 200 (str "dashboard/" (u/the-id dashboard)) {:parameters params})
               (is (= params
-                     (t2/select-one-fn :parameters Dashboard :id (u/the-id dashboard)))))))))))
+                     (t2/select-one-fn :parameters Dashboard :id (u/the-id dashboard))))))
+
+          (testing "Update dashboard with parameters works (#50371)"
+            (let [put-response (mt/user-http-request :rasta :put 200 (str "dashboard/" (u/the-id dashboard))
+                                                     {:archived :true})]
+              (is (=? {:archived true
+                       :parameters
+                       [{:name      "Time Unit"
+                         :slug      "time_unit"
+                         :id        "927e929"
+                         :type      "temporal-unit"
+                         :sectionId "temporal-unit"
+                         :temporal_units ["week" "month"]}]}
+                      put-response)))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                    UPDATING DASHBOARD CARD IN DASHCARD                                         |

--- a/test/metabase/models/dashboard_card_test.clj
+++ b/test/metabase/models/dashboard_card_test.clj
@@ -34,7 +34,7 @@
                              (= :updated_at k))
                  [k (f v)])))))
 
-(deftest retrieve-dashboard-card-test
+(deftest ^:parallel retrieve-dashboard-card-test
   (testing "retrieve-dashboard-card basic dashcard (no additional series)"
     (mt/with-temp [Dashboard     {dashboard-id :id} {}
                    Card          {card-id :id}      {}
@@ -48,7 +48,7 @@
               :series                 []}
              (remove-ids-and-timestamps (dashboard-card/retrieve-dashboard-card dashcard-id)))))))
 
-(deftest retrieve-dashboard-card-with-additional-series-test
+(deftest ^:parallel retrieve-dashboard-card-with-additional-series-test
   (testing "retrieve-dashboard-card dashcard w/ additional series"
     (mt/with-temp [Dashboard           {dashboard-id :id} {}
                    Card                {card-id :id} {}
@@ -77,7 +77,7 @@
                                         :visualization_settings {}}]}
              (remove-ids-and-timestamps (dashboard-card/retrieve-dashboard-card dashcard-id)))))))
 
-(deftest dashcard->multi-card-test
+(deftest ^:parallel dashcard->multi-card-test
   (testing "Check that the multi-cards are returned"
     (mt/with-temp [Card                card1 {}
                    Card                card2 {}
@@ -251,7 +251,7 @@
             ;; this is usually 10, but it can be 11 sometimes in CI for some reason
             (is (contains? #{10 11} (call-count)))))))))
 
-(deftest normalize-parameter-mappings-test
+(deftest ^:parallel normalize-parameter-mappings-test
   (testing "DashboardCard parameter mappings should get normalized when coming out of the DB"
     (mt/with-temp [Dashboard     dashboard {:parameters [{:name "Venue ID"
                                                           :slug "venue_id"
@@ -268,7 +268,7 @@
                :target       [:dimension [:field (mt/id :venues :id) nil]]}]
              (t2/select-one-fn :parameter_mappings DashboardCard :id (u/the-id dashcard)))))))
 
-(deftest normalize-visualization-settings-test
+(deftest ^:parallel normalize-visualization-settings-test
   (testing "DashboardCard visualization settings should get normalized to use modern MBQL syntax"
     (mt/with-temp [Card      card      {}
                    Dashboard dashboard {}]
@@ -280,7 +280,7 @@
            (is (= expected
                   (t2/select-one-fn :visualization_settings DashboardCard :id (u/the-id dashcard))))))))))
 
-(deftest normalize-parameter-mappings-test-2
+(deftest ^:parallel normalize-parameter-mappings-test-2
   (testing "make sure parameter mappings correctly normalize things like legacy MBQL clauses"
     (is (= [{:target [:dimension [:field 30 {:source-field 23}]]}]
            ((:out mi/transform-parameters-list)
@@ -293,14 +293,14 @@
               (json/generate-string
                [{:card-id 123, :hash "abc", :target "foo"}])))))))
 
-(deftest keep-empty-parameter-mappings-empty-test
+(deftest ^:parallel keep-empty-parameter-mappings-empty-test
   (testing (str "we should keep empty parameter mappings as empty instead of making them nil (if `normalize` removes "
                 "them because they are empty) (I think this is to prevent NPEs on the FE? Not sure why we do this)")
     (is (= []
            ((:out mi/transform-parameters-list)
             (json/generate-string []))))))
 
-(deftest identity-hash-test
+(deftest ^:parallel identity-hash-test
   (testing "Dashboard card hashes are composed of the card hash, dashboard hash, and visualization settings"
     (let [now (LocalDateTime/of 2022 9 1 12 34 56)]
       (mt/with-temp [Collection    c1       {:name "top level" :location "/" :created_at now}
@@ -316,7 +316,7 @@
                (serdes/raw-hash [(serdes/identity-hash card) (serdes/identity-hash dash) {} 6 3 now])
                (serdes/identity-hash dashcard)))))))
 
-(deftest from-decoded-json-test
+(deftest ^:parallel from-decoded-json-test
   (testing "Dashboard Cards should remain the same if they are serialized to JSON,
             deserialized, and finally transformed with `from-parsed-json`."
     (mt/with-temp [Dashboard     dash     {:name "my dashboard"}

--- a/test/metabase/models/dashboard_card_test.clj
+++ b/test/metabase/models/dashboard_card_test.clj
@@ -300,6 +300,18 @@
            ((:out mi/transform-parameters-list)
             (json/generate-string []))))))
 
+(deftest ^:parallel normalize-card-parameter-mappings-test
+  (doseq [parameters [[]
+                      [{:name "Time grouping"
+                        :slug "time_grouping"
+                        :id "8e366c15"
+                        :type :temporal-unit
+                        :sectionId "temporal-unit"
+                        :temporal_units [:minute :quarter-of-year]}]]]
+    (is (= parameters
+           ((:out mi/transform-card-parameters-list)
+            (json/generate-string parameters))))))
+
 (deftest ^:parallel identity-hash-test
   (testing "Dashboard card hashes are composed of the card hash, dashboard hash, and visualization settings"
     (let [now (LocalDateTime/of 2022 9 1 12 34 56)]


### PR DESCRIPTION
Fixes #50371

### Description

The `:parameters` field was normalized according to the legacy parameters schema, which resulted in `:temporal_units` not getting converted to keywords.

I've marked a few tests as `:^parallel`. This is not really relevant for the bug fix.

### How to verify

Use the steps from #50371 and check out the new test in `test/metabase/api/dashboard_test.clj`.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
