### PR TITLE
Allow questions to run if there's an invalid `loading-message` setting value

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/settings/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/settings/selectors.ts
@@ -24,7 +24,10 @@ export const getLogoUrl = (state: EnterpriseState) =>
   getCustomLogoUrl(getSettings(state));
 
 export const getLoadingMessage = (state: EnterpriseState) => {
-  return LOADING_MESSAGE_BY_SETTING[getSetting(state, "loading-message")].value;
+  const setting = getSetting(state, "loading-message");
+  // default to empty string to account for a historical bug where the
+  // setting could be set via MB_LOADING_MESSAGE to a value not in our enum
+  return LOADING_MESSAGE_BY_SETTING[setting]?.value ?? (() => "");
 };
 
 // eslint-disable-next-line no-literal-metabase-strings -- This is a Metabase string we want to keep. It's used for comparison.

--- a/enterprise/frontend/src/metabase-enterprise/settings/selectors.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/settings/selectors.unit.spec.ts
@@ -77,6 +77,18 @@ describe("getLoadingMessage", () => {
 
     expect(getLoadingMessage(states)(false)).toBe(expectedLoadingMessage);
   });
+
+  it('should show no loading message when "loading-message" is set to an invalid enum value', () => {
+    const states = createMockState({
+      settings: createMockSettingsState({
+        "loading-message": "bad-enum-bad" as any,
+      }),
+    });
+
+    const expectedLoadingMessage = "";
+
+    expect(getLoadingMessage(states)(false)).toBe(expectedLoadingMessage);
+  });
 });
 
 describe("getIsWhiteLabeling", () => {

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -472,7 +472,7 @@ x.com")
                                 (throw (ex-info "Loading message set to an unsupported value"
                                                 {:value   new-value
                                                  :options (seq loading-message-values)})))]
-                  (setting/set-value-of-type! value)))
+                  (setting/set-value-of-type! :keyword :loading-message value)))
   :getter     (fn []
                 (let [value (setting/get-value-of-type :keyword :loading-message)]
                   (or (loading-message-values value)

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -455,14 +455,28 @@ x.com")
   :doc        false
   :audit      :never)
 
+(def ^:private loading-message-values
+  #{:doing-science :running-query :loading-results})
+
 (defsetting loading-message
-  (deferred-tru "Choose the message to show while a query is running.")
+  (deferred-tru (str "Choose the message to show while a query is running. Possible values are \"doing-science\", "
+                     "\"running-query\", or \"loading-results\""))
   :encryption :no
   :visibility :public
   :export?    true
   :feature    :whitelabel
   :type       :keyword
   :default    :doing-science
+  :setter     (fn [new-value]
+                (let [value (or (loading-message-values (keyword new-value))
+                                (throw (ex-info "Loading message set to an unsupported value"
+                                                {:value   new-value
+                                                 :options (seq loading-message-values)})))]
+                  (setting/set-value-of-type! value)))
+  :getter     (fn []
+                (let [value (setting/get-value-of-type :keyword :loading-message)]
+                  (or (loading-message-values value)
+                      :doing-science)))
   :audit      :getter)
 
 (defsetting application-colors

--- a/test/metabase/public_settings_test.clj
+++ b/test/metabase/public_settings_test.clj
@@ -449,3 +449,18 @@
       (is (thrown?
            IllegalArgumentException
            (public-settings/update-channel! "millennially"))))))
+
+(deftest loading-message-test
+  (mt/with-premium-features #{:whitelabel}
+    (testing "Loading message can be set by env var"
+      (mt/with-temp-env-var-value! [mb-loading-message "running-query"]
+        (is (= :running-query (public-settings/loading-message)))))
+
+    (testing "Default value is returned if loading message set via env var to an unsupported keyword value"
+      (mt/with-temp-env-var-value! [mb-loading-message "unsupported enum value"]
+        (is (= :doing-science (public-settings/loading-message)))))
+
+    (testing "Setter blocks unsupported values set at runtime"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"Loading message set to an unsupported value"
+                            (public-settings/loading-message! :unsupported-value))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50414

### Description

The `loading-message` setting value could be set to an invalid enum value via the `MB_LOADING_MESSAGE` env variable. This prevented being able to run questions and cause the UI to break, this PR resolves this issue in two places:
1. Prevents the UI from breaking when if it gets an invalid setting value by showing no message.
2. Validates that `MB_LOADING_MESSAGE` is a valid enum value and defaults "Doing science"

### How to verify

See issue for repro steps.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR