### PR TITLE
fix inability to select breakout dimension before metric

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
@@ -6,6 +6,7 @@ import {
   createQuestion,
   echartsContainer,
   getDraggableElements,
+  leftSidebar,
   modal,
   moveDnDKitElement,
   popover,
@@ -150,6 +151,41 @@ describe("issue 49874", () => {
     echartsContainer().within(() => {
       cy.findByText("Sum of Quantity").should("not.exist");
       cy.findByText("Sum of Total").should("be.visible");
+    });
+  });
+});
+
+describe("issue 49529", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should allow selecting breakout dimension before metrics", () => {
+    const question = {
+      dataset_query: {
+        type: "query",
+        query: {
+          "source-table": ORDERS_ID,
+        },
+        database: 1,
+      },
+      display: "bar",
+    };
+
+    visitQuestionAdhoc(question);
+
+    cy.findByTestId("viz-settings-button").click();
+
+    cy.findAllByTestId("select-button").eq(0).as("dimensionSelect").click();
+    popover().findByText("ID").click();
+
+    leftSidebar().findByText("Add series breakout").click();
+    popover().findByText("Quantity").click();
+
+    leftSidebar().within(() => {
+      cy.findByText("Y-axis");
+      cy.findByText("Nothing to order");
     });
   });
 });

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSeriesOrder.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSeriesOrder.tsx
@@ -59,7 +59,7 @@ interface ChartSettingSeriesOrderProps {
 
 export const ChartSettingSeriesOrder = ({
   onChange,
-  value: orderedItems,
+  value: orderedItems = [],
   addButtonLabel = t`Add another series`,
   searchPickerPlaceholder = t`Select a series`,
   onShowWidget,

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -169,10 +169,10 @@ export const GRAPH_DATA_SETTINGS = {
         truncateAfter: 10,
       };
     },
-    getHidden: (series, settings, { transformedSeries }) => {
+    getHidden: (_series, settings, extra) => {
+      const seriesCount = extra.transformedSeries?.length ?? 0;
       return (
-        settings["graph.dimensions"]?.length < 2 ||
-        transformedSeries.length > MAX_SERIES
+        settings["graph.dimensions"]?.length < 2 || seriesCount > MAX_SERIES
       );
     },
     dashboard: false,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/49529

### Description

Fixes viz settings sidebar crash when selecting second dimension before choosing any metrics.

### How to verify

- New > Question > Orders > Visualize
- Change viz type to Bar
- Open viz settings sidebar
- Select X-axis dimension
- Click "Add series breakout" and select select another dimension
- Ensure it works

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
