### PR TITLE
Replace postcss-nesting with postcss-nested

### DIFF
--- a/package.json
+++ b/package.json
@@ -292,6 +292,7 @@
     "postcss-discard-comments": "^7.0.1",
     "postcss-import": "15.1.0",
     "postcss-loader": "7.0.2",
+    "postcss-nested": "^7.0.2",
     "postcss-preset-env": "^6.7.0",
     "postcss-styled-syntax": "^0.6.4",
     "postcss-url": "^10.1.3",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -20,6 +20,6 @@ module.exports = {
       },
     },
     "postcss-discard-comments": {},
-    "postcss-nesting": {},
+    "postcss-nested": {},
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -19113,6 +19113,13 @@ postcss-modules-values@^4.0.0:
   dependencies:
     icss-utils "^5.0.0"
 
+postcss-nested@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-nested/-/postcss-nested-7.0.2.tgz#863d83a6b5df0a2894560394be93d5383ea37a65"
+  integrity sha512-5osppouFc0VR9/VYzYxO03VaDa3e8F23Kfd6/9qcZTUI8P58GIYlArOET2Wq0ywSl2o2PjELhYOFI4W7l5QHKw==
+  dependencies:
+    postcss-selector-parser "^7.0.0"
+
 postcss-nesting@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/postcss-nesting/-/postcss-nesting-7.0.1.tgz#b50ad7b7f0173e5b5e3880c3501344703e04c052"
@@ -19255,6 +19262,14 @@ postcss-selector-parser@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.1.0.tgz#49694cb4e7c649299fea510a29fa6577104bcf53"
   integrity sha512-UMz42UD0UY0EApS0ZL9o1XnLhSTtvvvLe5Dc2H2O56fvRZi+KulDyf5ctDhhtYJBGKStV2FL1fy6253cmLgqVQ==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
+
+postcss-selector-parser@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz#41bd8b56f177c093ca49435f65731befe25d6b9c"
+  integrity sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==
   dependencies:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"


### PR DESCRIPTION
### Description 

I was debugging some CSS issues in CI and I'm seeing that our production CSS files contain nested css rules a la:
```css
button.UgFcU{
  .pMUGl {
    width:100%;
  }
  .vbRlx {
    display:flex;
    justify-content:space-between;
    width:100%;
  }
}
```

For example open our [production css](https://stats.metabase.com/app/dist/app-main.73a2f03294b8530c.css) and search for `pMUGl` (which is where the example above is taken from).

While this feature [is gaining browser support (currently at 85%)](https://caniuse.com/css-nesting), it's also trivial to compile out.
Given the fact our `postcss.config.json` contains the `postcss-nesting` plugin, I get the feeling that it is also the intention for this to be compiled away.

However, `postcss-nesting` seems to not work in all cases and ignores some, leading to non-unnested css in our production css.

This PR proposed to swap out [`postcss-nesting`](https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-nesting) with [`postcss-nested`](https://github.com/postcss/postcss-nested) (which is maintained by `postcss` itself), which seems to lead to more consistent results.