### PR TITLE
docs(sdk): Manually update chaneglog for master

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/CHANGELOG.md
+++ b/enterprise/frontend/src/embedding-sdk/CHANGELOG.md
@@ -77,7 +77,7 @@
 
 
 
-# [1.51.0](https://github.com/metabase/metabase/compare/embedding-sdk-0.1.37...embedding-sdk-1.51.0) (2024-10-08)
+# [0.51.0](https://github.com/metabase/metabase/compare/embedding-sdk-0.1.37...embedding-sdk-0.51.0) (2024-10-08)
 
 
 ### Bug Fixes

--- a/enterprise/frontend/src/embedding-sdk/CHANGELOG.md
+++ b/enterprise/frontend/src/embedding-sdk/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.52.2-nightly](https://github.com/metabase/metabase/compare/embedding-sdk-1.52.1...embedding-sdk-0.52.2-nightly) (2024-11-21)
+## [0.52.2-nightly](https://github.com/metabase/metabase/compare/embedding-sdk-0.52.1-nightly...embedding-sdk-0.52.2-nightly) (2024-11-21)
 
 
 ### Bug Fixes
@@ -30,7 +30,7 @@
 
 
 
-## [1.52.1](https://github.com/metabase/metabase/compare/embedding-sdk-0.1.38...embedding-sdk-1.52.1) (2024-11-07)
+## [0.52.1](https://github.com/metabase/metabase/compare/embedding-sdk-0.1.38...embedding-sdk-0.52.1-nightly) (2024-11-07)
 
 
 ### Bug Fixes


### PR DESCRIPTION
[Slack discussion](https://metaboat.slack.com/archives/C063Q3F1HPF/p1732286276909939?thread_ts=1731680130.243949&cid=C063Q3F1HPF)

### Description

After we've redeployed version 0 for 1.52.x, we should fix the changelog accordingly to prevent confusion.

