### PR TITLE
Deprecate alert and pulse apis

### DIFF
--- a/docs/developers-guide/api-changelog.md
+++ b/docs/developers-guide/api-changelog.md
@@ -9,7 +9,7 @@ title: API changelog
 - `POST /api/user/:id/send_invite` has been removed.
 - `GET /:id/fields` now includes the Table ID.
 
-- APIs under `/api/pulse` and `/api/alert` are deprecated and will be removed in a future version as we're tranitioning to a new architecture.
+- APIs under `/api/pulse` and `/api/alert` will be removed in a future version as we're tranitioning to a new architecture.
 
 ## Metabase 0.51.0
 

--- a/docs/developers-guide/api-changelog.md
+++ b/docs/developers-guide/api-changelog.md
@@ -9,6 +9,8 @@ title: API changelog
 - `POST /api/user/:id/send_invite` has been removed.
 - `GET /:id/fields` now includes the Table ID.
 
+- APIs under `/api/pulse` and `/api/alert` are deprecated and will be removed in a future version as we're tranitioning to a new architecture.
+
 ## Metabase 0.51.0
 
 - `GET /api/dashboard/:id/query_metadata`

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/subscription_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/subscription_test.clj
@@ -1,5 +1,6 @@
 (ns ^:mb/once metabase-enterprise.advanced-permissions.api.subscription-test
-  "Permisisons tests for API that needs to be enforced by Application Permissions to create and edit alerts/subscriptions."
+   "Permisisons tests for API that needs to be enforced by Application Permissions to create and edit alerts/subscriptions."
+  #_{:clj-kondo/ignore [:deprecated-namespace]}
   (:require
    [clojure.test :refer :all]
    [metabase.api.alert :as api.alert]

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/subscription_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/subscription_test.clj
@@ -1,5 +1,5 @@
 (ns ^:mb/once metabase-enterprise.advanced-permissions.api.subscription-test
-   "Permisisons tests for API that needs to be enforced by Application Permissions to create and edit alerts/subscriptions."
+  "Permisisons tests for API that needs to be enforced by Application Permissions to create and edit alerts/subscriptions."
   #_{:clj-kondo/ignore [:deprecated-namespace]}
   (:require
    [clojure.test :refer :all]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/pulse_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/pulse_test.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.sandbox.pulse-test
+  #_{:clj-kondo/ignore [:deprecated-namespace]}
   (:require
    [clojure.data.csv :as csv]
    [clojure.java.io :as io]

--- a/src/metabase/api/alert.clj
+++ b/src/metabase/api/alert.clj
@@ -1,5 +1,7 @@
-(ns metabase.api.alert
-  "/api/alert endpoints"
+(ns ^:deprecated metabase.api.alert
+  "/api/alert endpoints.
+
+  Deprecated: will soon be migrated to notification APIs."
   (:require
    [clojure.data :as data]
    [clojure.set :refer [difference]]

--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -1,6 +1,8 @@
-(ns metabase.api.pulse
+(ns ^:deprecated metabase.api.pulse
   "`/api/pulse` endpoints. These are all authenticated. For unauthenticated `/api/pulse/unsubscribe` endpoints,
-  see [[metabase.api.pulse.unsubscribe]]."
+  see [[metabase.api.pulse.unsubscribe]].
+
+  Deprecated: will soon be migrated to notification APIs."
   #_{:clj-kondo/ignore [:deprecated-namespace]}
   (:require
    [clojure.set :refer [difference]]

--- a/src/metabase/api/routes.clj
+++ b/src/metabase/api/routes.clj
@@ -1,4 +1,5 @@
 (ns metabase.api.routes
+  #_{:clj-kondo/ignore [:deprecated-namespace]}
   (:require
    [compojure.core :refer [GET]]
    [compojure.route :as route]

--- a/test/metabase/api/pulse_test.clj
+++ b/test/metabase/api/pulse_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.api.pulse-test
   "Tests for /api/pulse endpoints."
+  #_{:clj-kondo/ignore [:deprecated-namespace]}
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]


### PR DESCRIPTION
Notification APIs are coming soon, so deprecate the alert and pulse API for 52.