### PR TITLE
do not show chart settings button in result

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewFooter/LeftViewFooterButtonGroup.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter/LeftViewFooterButtonGroup.tsx
@@ -7,7 +7,6 @@ import {
 } from "metabase/query_builder/actions";
 import {
   getIsShowingRawTable,
-  getIsVisualized,
   getUiControls,
 } from "metabase/query_builder/selectors";
 import { Button, Flex, rem } from "metabase/ui";
@@ -35,12 +34,8 @@ export const LeftViewFooterButtonGroup = ({
 
   const dispatch = useDispatch();
 
-  const isVisualized = useSelector(getIsVisualized);
   const shouldShowChartSettingsButton =
-    !isNotebook &&
-    !hideChartSettings &&
-    (!isShowingRawTable || isVisualized) &&
-    isResultLoaded;
+    !isNotebook && !hideChartSettings && !isShowingRawTable && isResultLoaded;
 
   return (
     <Flex gap="0.75rem">

--- a/frontend/src/metabase/query_builder/components/view/ViewFooter/LeftViewFooterButtonGroup.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter/LeftViewFooterButtonGroup.tsx
@@ -35,7 +35,10 @@ export const LeftViewFooterButtonGroup = ({
   const dispatch = useDispatch();
 
   const shouldShowChartSettingsButton =
-    !isNotebook && !hideChartSettings && !isShowingRawTable && isResultLoaded;
+    !isNotebook &&
+    !hideChartSettings &&
+    (!isShowingRawTable || isShowingChartSettingsSidebar) &&
+    isResultLoaded;
 
   return (
     <Flex gap="0.75rem">

--- a/frontend/src/metabase/query_builder/components/view/ViewFooter/LeftViewFooterButtonGroup.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter/LeftViewFooterButtonGroup.unit.spec.tsx
@@ -99,7 +99,12 @@ describe("LeftViewFooterButtonGroup", () => {
     expect(screen.queryByTestId("viz-settings-button")).not.toBeInTheDocument();
   });
 
-  it("should not show chart settings button when showing raw table", () => {
+  it("should show chart settings button when showing raw table and sidebar is open", () => {
+    setup({ isShowingRawTable: true, isShowingChartSettingsSidebar: true });
+    expect(screen.getByTestId("viz-settings-button")).toBeInTheDocument();
+  });
+
+  it("should not show chart settings button when showing raw table and sidebar is closed", () => {
     setup({ isShowingRawTable: true });
     expect(screen.queryByTestId("viz-settings-button")).not.toBeInTheDocument();
   });

--- a/frontend/src/metabase/query_builder/components/view/ViewFooter/LeftViewFooterButtonGroup.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter/LeftViewFooterButtonGroup.unit.spec.tsx
@@ -56,6 +56,7 @@ const setup = ({
   isResultLoaded = true,
   isNotebook = false,
   hideChartSettings = false,
+  isRunning = false,
 } = {}) => {
   const qbState = createMockQueryBuilderState({
     uiControls: createMockQueryBuilderUIControlsState({
@@ -77,6 +78,7 @@ const setup = ({
       isResultLoaded={isResultLoaded}
       isNotebook={isNotebook}
       hideChartSettings={hideChartSettings}
+      isRunning={isRunning}
     />,
     { storeInitialState: state },
   );

--- a/frontend/src/metabase/query_builder/components/view/ViewFooter/LeftViewFooterButtonGroup.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter/LeftViewFooterButtonGroup.unit.spec.tsx
@@ -1,0 +1,111 @@
+import { screen } from "@testing-library/react";
+
+import { createMockEntitiesState } from "__support__/store";
+import { renderWithProviders } from "__support__/ui";
+import { getMetadata } from "metabase/selectors/metadata";
+import type Question from "metabase-lib/v1/Question";
+import type { Card, DashCardId, DashboardId } from "metabase-types/api";
+import {
+  createMockCard,
+  createMockStructuredDatasetQuery,
+} from "metabase-types/api/mocks";
+import {
+  ORDERS_ID,
+  SAMPLE_DB_ID,
+  createSampleDatabase,
+} from "metabase-types/api/mocks/presets";
+import {
+  createMockQueryBuilderState,
+  createMockQueryBuilderUIControlsState,
+  createMockState,
+} from "metabase-types/store/mocks";
+
+import { LeftViewFooterButtonGroup } from "./LeftViewFooterButtonGroup";
+
+const MOCK_QUERY = createMockStructuredDatasetQuery({
+  database: SAMPLE_DB_ID,
+  query: {
+    "source-table": ORDERS_ID,
+  },
+});
+
+type DashboardAwareCard = Card & {
+  dashboardId?: DashboardId;
+  dashcardId?: DashCardId;
+};
+
+function createMockMetadata(card?: Card) {
+  const database = createSampleDatabase();
+  const state = createMockState({
+    entities: createMockEntitiesState({
+      databases: [database],
+      questions: card ? [card] : [],
+    }),
+  });
+  return getMetadata(state);
+}
+
+function createMockSavedQuestion(card?: Partial<DashboardAwareCard>) {
+  const savedCard = createMockCard({ dataset_query: MOCK_QUERY, ...card });
+  return createMockMetadata(savedCard).question(savedCard.id) as Question;
+}
+
+const setup = ({
+  isShowingChartSettingsSidebar = false,
+  isShowingRawTable = false,
+  isResultLoaded = true,
+  isNotebook = false,
+  hideChartSettings = false,
+} = {}) => {
+  const qbState = createMockQueryBuilderState({
+    uiControls: createMockQueryBuilderUIControlsState({
+      isShowingChartSettingsSidebar,
+      isShowingRawTable,
+    }),
+  });
+
+  const state = {
+    ...createMockState(),
+    qb: qbState,
+  };
+
+  const question = createMockSavedQuestion();
+
+  return renderWithProviders(
+    <LeftViewFooterButtonGroup
+      question={question}
+      isResultLoaded={isResultLoaded}
+      isNotebook={isNotebook}
+      hideChartSettings={hideChartSettings}
+    />,
+    { storeInitialState: state },
+  );
+};
+
+describe("LeftViewFooterButtonGroup", () => {
+  it("should show chart settings button when conditions are met", () => {
+    setup();
+    expect(screen.getByTestId("viz-settings-button")).toBeInTheDocument();
+    expect(screen.getByText("Chart settings")).toBeInTheDocument();
+  });
+
+  it("should not show chart settings button in notebook mode", () => {
+    setup({ isNotebook: true });
+    expect(screen.queryByTestId("viz-settings-button")).not.toBeInTheDocument();
+  });
+
+  it("should not show chart settings button when hideChartSettings is true", () => {
+    setup({ hideChartSettings: true });
+    expect(screen.queryByTestId("viz-settings-button")).not.toBeInTheDocument();
+  });
+
+  it("should not show chart settings button when showing raw table", () => {
+    setup({ isShowingRawTable: true });
+    expect(screen.queryByTestId("viz-settings-button")).not.toBeInTheDocument();
+  });
+
+  it("should not show chart settings button when results are not loaded", () => {
+    setup({ isResultLoaded: false });
+    expect(screen.queryByTestId("viz-settings-button")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Feedback from Maz - do not show chart settings button in results (raw table) mode

https://github.com/user-attachments/assets/28248fad-e650-46f5-a4da-c54ef1c61b78

