### PR TITLE
Sdk e2e tests release x.51.x

### DIFF
--- a/.github/workflows/e2e-tests-embedding-sdk.yml
+++ b/.github/workflows/e2e-tests-embedding-sdk.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - "master"
       - "release-**"
-      - "sdk-e2e-tests-fix-release-ci"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
@@ -51,7 +50,7 @@ jobs:
         with:
           script: | # js
             const { getBuildRequirements, getMajorVersionNumberFromReleaseBranch, getVersionFromReleaseBranch } = require('${{ github.workspace }}/release/dist/index.cjs');
-            const targetBranchName = '${{ github.base_ref || github.ref_name }}'; // base_ref for PRs, ref_name for branch itself
+            const targetBranchName = '${{ github.base_ref || github.ref }}'; // base_ref for PRs, ref_name for branch itself
 
             if (targetBranchName === 'master' || !targetBranchName.startsWith('release-x.')) {
               return {

--- a/.github/workflows/e2e-tests-embedding-sdk.yml
+++ b/.github/workflows/e2e-tests-embedding-sdk.yml
@@ -51,9 +51,9 @@ jobs:
         with:
           script: | # js
             const { getBuildRequirements, getMajorVersionNumberFromReleaseBranch, getVersionFromReleaseBranch } = require('${{ github.workspace }}/release/dist/index.cjs');
-            const targetBranchName = '${{ github.ref_name }}'; // base_ref for PRs, ref_name for branch itself
+            const targetBranchName = '${{ github.base_ref || github.ref_name }}'; // base_ref for PRs, ref_name for branch itself
 
-            if (targetBranchName === 'master') {
+            if (targetBranchName === 'master' || !targetBranchName.startsWith('release-x.')) {
               return {
                 sdk_version: 'latest'
               };

--- a/.github/workflows/e2e-tests-embedding-sdk.yml
+++ b/.github/workflows/e2e-tests-embedding-sdk.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "master"
       - "release-**"
+      - "sdk-e2e-tests-fix-release-ci"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
@@ -50,7 +51,7 @@ jobs:
         with:
           script: | # js
             const { getBuildRequirements, getMajorVersionNumberFromReleaseBranch, getVersionFromReleaseBranch } = require('${{ github.workspace }}/release/dist/index.cjs');
-            const targetBranchName = '${{ github.base_ref || github.ref_name }}'; // base_ref for PRs, ref_name for branch itself
+            const targetBranchName = '${{ github.ref_name }}'; // base_ref for PRs, ref_name for branch itself
 
             if (targetBranchName === 'master') {
               return {

--- a/.github/workflows/e2e-tests-embedding-sdk.yml
+++ b/.github/workflows/e2e-tests-embedding-sdk.yml
@@ -50,9 +50,9 @@ jobs:
         with:
           script: | # js
             const { getBuildRequirements, getMajorVersionNumberFromReleaseBranch, getVersionFromReleaseBranch } = require('${{ github.workspace }}/release/dist/index.cjs');
-            const targetBranchName = '${{ github.base_ref || github.ref }}'; // base_ref for PRs, ref_name for branch itself
+            const targetBranchName = '${{ github.ref }}'; // base_ref for PRs, ref for release branch / master
 
-            if (targetBranchName === 'master' || !targetBranchName.startsWith('release-x.')) {
+            if (targetBranchName === 'master') {
               return {
                 sdk_version: 'latest'
               };

--- a/.github/workflows/e2e-tests-embedding-sdk.yml
+++ b/.github/workflows/e2e-tests-embedding-sdk.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           script: | # js
             const { getBuildRequirements, getMajorVersionNumberFromReleaseBranch, getVersionFromReleaseBranch } = require('${{ github.workspace }}/release/dist/index.cjs');
-            const targetBranchName = '${{ github.base_ref }}';
+            const targetBranchName = '${{ github.base_ref || github.ref_name }}'; // base_ref for PRs, ref_name for branch itself
 
             if (targetBranchName === 'master') {
               return {

--- a/.github/workflows/e2e-tests-embedding-sdk.yml
+++ b/.github/workflows/e2e-tests-embedding-sdk.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           script: | # js
             const { getBuildRequirements, getMajorVersionNumberFromReleaseBranch, getVersionFromReleaseBranch } = require('${{ github.workspace }}/release/dist/index.cjs');
-            const targetBranchName = '${{ github.ref }}'; // base_ref for PRs, ref for release branch / master
+            const targetBranchName = '${{ github.base_ref || github.ref }}'; // base_ref for PRs, ref for release branch / master
 
             if (targetBranchName === 'master') {
               return {


### PR DESCRIPTION
Relates to https://github.com/metabase/metabase/issues/50113

### Description

This fixes CI failures on release branch, which is caused by branch name parameter.

### How to verify

I haven't managed to validate this for sure, but it _should_ work

