### PR TITLE
fix(sdk): introduce `.mb-wrapper` to scope down our css

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -42,15 +42,20 @@ const globalStyles = css`
 export const decorators = isEmbeddingSDK
   ? [] // No decorators for Embedding SDK stories, as we want to simulate real use cases
   : [
-      renderStory => (
-        <EmotionCacheProvider>
-          <ThemeProvider>
-            <Global styles={globalStyles} />
-            <CssVariables />
-            {renderStory()}
-          </ThemeProvider>
-        </EmotionCacheProvider>
-      ),
+      renderStory => {
+        if (!document.body.classList.contains("mb-wrapper")) {
+          document.body.classList.add("mb-wrapper");
+        }
+        return (
+          <EmotionCacheProvider>
+            <ThemeProvider>
+              <Global styles={globalStyles} />
+              <CssVariables />
+              {renderStory()}
+            </ThemeProvider>
+          </EmotionCacheProvider>
+        );
+      },
     ];
 
 function CssVariables() {

--- a/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
@@ -271,7 +271,67 @@ describeEE("scenarios > embedding-sdk > styles", () => {
       // TODO: good place for a visual regression test
     });
   });
+
+  describe("styles should not leak outside of the provider", () => {
+    const elements = [
+      { tag: "body", jsx: undefined }, // no need to render anything specific, the body tag is rendered by cypress
+      { tag: "h1", jsx: <h1>h1 tag text</h1> },
+      { tag: "h2", jsx: <h2>h2 tag text</h2> },
+      { tag: "h3", jsx: <h3>h3 tag text</h3> },
+      { tag: "p", jsx: <p>p tag text</p> },
+      { tag: "button", jsx: <button>button tag text</button> },
+      { tag: "input", jsx: <input placeholder="input tag" type="text" /> },
+      { tag: "div", jsx: <div>div tag text</div> },
+      { tag: "span", jsx: <span>span tag text</span> },
+      { tag: "label", jsx: <label>label tag text</label> },
+      { tag: "select", jsx: <select>select tag text</select> },
+      { tag: "textarea", jsx: <textarea>textarea tag text</textarea> },
+    ];
+
+    it(`no css rule should match affect ${elements.map(e => e.tag).join(", ")} outside of the provider`, () => {
+      cy.mount(
+        <div>
+          {elements.map(({ jsx }) => jsx)}
+          <MetabaseProvider config={DEFAULT_SDK_PROVIDER_CONFIG}>
+            <StaticQuestion questionId={ORDERS_QUESTION_ID} />
+          </MetabaseProvider>
+        </div>,
+      );
+
+      // wait for the question to load, to make sure our bundle and styles have loaded
+      getSdkRoot().findByText("Product ID").should("exist");
+
+      for (const { tag } of elements) {
+        expectElementToHaveNoAppliedCssRules(tag);
+      }
+    });
+  });
 });
+
+const expectElementToHaveNoAppliedCssRules = (selector: string) => {
+  cy.get(selector).then($el => {
+    const rules = getCssRulesThatApplyToElement($el);
+    if (rules.length > 0) {
+      console.warn("rules matching", selector, rules);
+    }
+    expect(rules, `No css rules should match ${selector}`).to.be.empty;
+  });
+};
+
+const getCssRulesThatApplyToElement = ($element: JQuery<HTMLElement>) => {
+  const element = $element[0];
+  const rulesThatMatch: CSSStyleRule[] = Array.from(
+    document.styleSheets,
+  ).flatMap(sheet => {
+    const cssRules = Array.from(sheet.cssRules).filter(
+      rule => rule instanceof CSSStyleRule,
+    ) as CSSStyleRule[];
+
+    return cssRules.filter(rule => element.matches(rule.selectorText));
+  });
+
+  return rulesThatMatch;
+};
 
 function wrapBrowserDefaultFont() {
   cy.mount(<p>paragraph with default browser font</p>);

--- a/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
@@ -288,7 +288,7 @@ describeEE("scenarios > embedding-sdk > styles", () => {
       { tag: "textarea", jsx: <textarea>textarea tag text</textarea> },
     ];
 
-    it(`no css rule should match affect ${elements.map(e => e.tag).join(", ")} outside of the provider`, () => {
+    it(`no css rule should match ${elements.map(e => e.tag).join(", ")} outside of the provider`, () => {
       cy.mount(
         <div>
           {elements.map(({ jsx }) => jsx)}

--- a/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentStylesWrapper.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentStylesWrapper.tsx
@@ -1,5 +1,6 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
+import type React from "react";
 
 import { aceEditorStyles } from "metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.styled";
 import { saveDomImageStyles } from "metabase/visualizations/lib/save-chart-image";
@@ -9,7 +10,7 @@ import { saveDomImageStyles } from "metabase/visualizations/lib/save-chart-image
  * This is to ensure that the SDK components are styled correctly,
  * even when rendered under a React portal.
  */
-export const PublicComponentStylesWrapper = styled.div`
+const PublicComponentStylesWrapperInner = styled.div`
   // Try to reset as much as possible to avoid css leaking from host app to our components
   all: initial;
   text-decoration: none;
@@ -37,6 +38,18 @@ export const PublicComponentStylesWrapper = styled.div`
     display: inline;
   }
 `;
+
+export const PublicComponentStylesWrapper = (
+  props: React.ComponentProps<"div">,
+) => {
+  return (
+    <PublicComponentStylesWrapperInner
+      {...props}
+      // eslint-disable-next-line react/prop-types -- className is in div props :shrugs:
+      className={`mb-wrapper ${props.className}`}
+    />
+  );
+};
 /**
  * We can't apply a global css reset as it would leak into the host app but we
  * can't also apply our entire css reset scoped to this container, as it would
@@ -48,7 +61,7 @@ export const PublicComponentStylesWrapper = styled.div`
  * - -> our other code with specificity (0,1,0) will override this as they're loaded after
  */
 export const SCOPED_CSS_RESET = css`
-  ${PublicComponentStylesWrapper} *:where(button) {
+  ${PublicComponentStylesWrapperInner} *:where(button) {
     border: 0;
     background-color: transparent;
   }

--- a/frontend/src/metabase/css/core/box_sizing.module.css
+++ b/frontend/src/metabase/css/core/box_sizing.module.css
@@ -1,19 +1,24 @@
 /* set main elements to box-sizing border-box for more reliable box model calc */
-body,
-div,
-nav,
-article,
-section,
-main,
-header,
-footer,
-input,
-form,
-table,
-fieldset,
-textarea,
-ul,
-li,
-span {
+body:where(:global(.mb-wrapper)) {
   box-sizing: border-box;
+}
+
+:where(:global(.mb-wrapper)) {
+  div,
+  nav,
+  article,
+  section,
+  main,
+  header,
+  footer,
+  input,
+  form,
+  table,
+  fieldset,
+  textarea,
+  ul,
+  li,
+  span {
+    box-sizing: border-box;
+  }
 }

--- a/frontend/src/metabase/css/core/headings.module.css
+++ b/frontend/src/metabase/css/core/headings.module.css
@@ -2,51 +2,53 @@
   --default-header-margin: 0;
 }
 
-h1,
-.h1,
-h2,
-.h2,
-h3,
-.h3,
-h4,
-.h4,
-h5,
-.h5,
-h6,
-.h6 {
-  font-weight: 700;
-  margin-top: var(--default-header-margin);
-  margin-bottom: var(--default-header-margin);
-}
+:where(:global(.mb-wrapper)) {
+  h1,
+  .h1,
+  h2,
+  .h2,
+  h3,
+  .h3,
+  h4,
+  .h4,
+  h5,
+  .h5,
+  h6,
+  .h6 {
+    font-weight: 700;
+    margin-top: var(--default-header-margin);
+    margin-bottom: var(--default-header-margin);
+  }
 
-/**
- * Correct the font size on `h1` elements within `section` and
- * `article` contexts in Chrome, Firefox, and Safari.
- * https://github.com/necolas/normalize.css/blob/fc091cc/normalize.css#L40
- */
-h1,
-.h1 {
-  font-size: 2em;
-}
+  /**
+  * Correct the font size on `h1` elements within `section` and
+  * `article` contexts in Chrome, Firefox, and Safari.
+  * https://github.com/necolas/normalize.css/blob/fc091cc/normalize.css#L40
+  */
+  h1,
+  .h1 {
+    font-size: 2em;
+  }
 
-.h2 {
-  font-size: 1.5em;
-}
+  .h2 {
+    font-size: 1.5em;
+  }
 
-.h3 {
-  font-size: 1.17em;
-}
+  .h3 {
+    font-size: 1.17em;
+  }
 
-.h4 {
-  font-size: 1.12em;
-}
+  .h4 {
+    font-size: 1.12em;
+  }
 
-.h5 {
-  font-size: 0.83em;
-}
+  .h5 {
+    font-size: 0.83em;
+  }
 
-.h6 {
-  font-size: 0.75em;
+  .h6 {
+    font-size: 0.75em;
+  }
 }
 
 @media screen and (--breakpoint-min-sm) {

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.module.css
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.module.css
@@ -1,4 +1,4 @@
-body {
+body:where(:global(.mb-wrapper)) {
   background-color: transparent;
 }
 

--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -44,7 +44,7 @@
     <script type="text/javascript">{{{assetOnErrorJS}}}</script>
   </head>
 
-  <body>
+  <body class="mb-wrapper">
     <div id="root"></div>
   </body>
 </html>


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/50279

# Context
When the embedding sdk is imported on a project, all the css used by the app is loaded.
Even though we use a mix of emotion and css modules, both can "leak" styles in the host app if they target plain tags, such as `button`, `div`, `body` etc 

# Description

This PR adds a `mb-wrapper` class to the body (in the core app) and to the "public component wrapper" (for the sdk) so that our styles can be scoped to that class.

## Problem 

We can't _simply_ do `button` -> `.mb-wrapper button`, as that will increase the specificity from (0,0,1) to (0,1,1) and will break stuff:
<img width="360" alt="image" src="https://github.com/user-attachments/assets/b59a3008-ade2-40ac-9250-d6fc3d760792">
<img width="278" alt="image" src="https://github.com/user-attachments/assets/349ab210-f509-4d8d-baa0-0a0cf2135f14">

## Solution
Use `:where()`:
> The difference between :where() and [:is()](https://developer.mozilla.org/en-US/docs/Web/CSS/:is) is that :where() always has 0 [specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity), whereas :is() takes on the specificity of the most specific selector in its arguments.

([from mdn](https://developer.mozilla.org/en-US/docs/Web/CSS/:where))

`:where` can be used to add selectors without increasing specificity:
<img width="281" alt="image" src="https://github.com/user-attachments/assets/dac3f95f-e72d-4660-8273-7b15617016c6">


# Note about scope and backporting

We need to backport the sdk changes up to the v51 release branch in order to make it go out in sdk version that's compatible with version 51 (see the [docs about sdk versions](https://www.metabase.com/docs/latest/embedding/sdk/version)).
For this reason, even though there are more places that use "unscoped" plain tags selectors in our css files, I find it safer to address them one-by-one as we find them, as changing a css file has a potentially huge blast radius.


# Open questions
- is `mb-wrapper` a unique enough name or do we think customers may use that? if so, what name should be use?
- will this break anything? Do we have visual regression tests on the core app? It seems we don't have percy anymore