### PR TITLE
[Databricks] Add catalog validation into `can-connect?` implementation

### DIFF
--- a/modules/drivers/databricks/src/metabase/driver/databricks.clj
+++ b/modules/drivers/databricks/src/metabase/driver/databricks.clj
@@ -49,7 +49,7 @@
 
 (defn- catalog-present?
   [jdbc-spec catalog]
-  (let [sql "select * from `system`.`information_schema`.`catalogs` where catalog_name = ?"]
+  (let [sql "select 0 from `system`.`information_schema`.`catalogs` where catalog_name = ?"]
     (= 1 (count (jdbc/query jdbc-spec [sql catalog])))))
 
 (defmethod driver/can-connect? :databricks

--- a/modules/drivers/databricks/src/metabase/driver/databricks.clj
+++ b/modules/drivers/databricks/src/metabase/driver/databricks.clj
@@ -1,5 +1,6 @@
 (ns metabase.driver.databricks
   (:require
+   [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [honey.sql :as sql]
    [java-time.api :as t]
@@ -45,6 +46,18 @@
     #"timestamp_ntz" :type/DateTime
     ((get-method sql-jdbc.sync/database-type->base-type :hive-like)
      driver database-type)))
+
+(defn- catalog-present?
+  [jdbc-spec catalog]
+  (let [sql "select * from `system`.`information_schema`.`catalogs` where catalog_name = ?"]
+    (= 1 (count (jdbc/query jdbc-spec [sql catalog])))))
+
+(defmethod driver/can-connect? :databricks
+  [driver details]
+  (let [catalog (:catalog details)]
+    (sql-jdbc.conn/with-connection-spec-for-testing-connection [jdbc-spec [driver details]]
+      (and (catalog-present? jdbc-spec catalog)
+           (sql-jdbc.conn/can-connect-with-spec? jdbc-spec)))))
 
 (defn- get-tables-sql
   [catalog]

--- a/modules/drivers/databricks/src/metabase/driver/databricks.clj
+++ b/modules/drivers/databricks/src/metabase/driver/databricks.clj
@@ -54,10 +54,9 @@
 
 (defmethod driver/can-connect? :databricks
   [driver details]
-  (let [catalog (:catalog details)]
-    (sql-jdbc.conn/with-connection-spec-for-testing-connection [jdbc-spec [driver details]]
-      (and (catalog-present? jdbc-spec catalog)
-           (sql-jdbc.conn/can-connect-with-spec? jdbc-spec)))))
+  (sql-jdbc.conn/with-connection-spec-for-testing-connection [jdbc-spec [driver details]]
+    (and (catalog-present? jdbc-spec (:catalog details))
+         (sql-jdbc.conn/can-connect-with-spec? jdbc-spec))))
 
 (defn- get-tables-sql
   [catalog]

--- a/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
+++ b/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
@@ -283,7 +283,7 @@
 (deftest can-connect-test
   (mt/test-driver
     :databricks
-    (testing "Can connect returns true for correct catalog name"
+    (testing "Can connect returns true for catalog that is present on the instance"
       (is (true? (driver/can-connect? :databricks (:details (mt/db))))))
-    (testing "Can connect returns false for INcorrect catalog name (#49444)"
+    (testing "Can connect returns false for catalog that is NOT present on the instance (#49444)"
       (is (false? (driver/can-connect? :databricks (assoc (:details (mt/db)) :catalog "xixixix")))))))

--- a/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
+++ b/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
@@ -279,3 +279,11 @@
                          :additional-options "IgnoreTransactions=0;bla=1"}
                         (sql-jdbc.conn/connection-details->spec :databricks)
                         :subname))))))
+
+(deftest can-connect-test
+  (mt/test-driver
+    :databricks
+    (testing "Can connect returns true for correct catalog name"
+      (is (true? (driver/can-connect? :databricks (:details (mt/db))))))
+    (testing "Can connect returns false for INcorrect catalog name (#49444)"
+      (is (false? (driver/can-connect? :databricks (assoc (:details (mt/db)) :catalog "xixixix")))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/49444

### Description

This PR adds catalog name validation into `can-connect? :databricks` implementation.

### How to verify

Either run new test or try to add new database connection with catalog name not present on the Databricks instance.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
