### PR TITLE
WIP: allow underlying_records drill thru on questions with filter after aggregation

### DIFF
--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -235,3 +235,10 @@ export function tableOrCardDependentMetadata(
 export function columnKey(column: ColumnMetadata): string {
   return ML.column_key(column);
 }
+
+export function topLevelColumnSource(
+  query: Query,
+  column: ColumnMetadata,
+): string {
+  return ML.top_level_column_source(query, column);
+}

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -466,10 +466,32 @@ class TableInteractive extends Component {
     }
   }
 
+  resolveTopLevelColumnSources(question, data) {
+    const query = question?.query();
+    const stageIndex = -1;
+
+    if (!query) {
+      return data;
+    }
+
+    const colsWithTopLevelSources = data.cols.map(col => {
+      const topLevelColumnSource = Lib.topLevelColumnSource(
+        query,
+        Lib.fromLegacyColumn(query, stageIndex, col),
+      );
+      if (topLevelColumnSource && topLevelColumnSource !== col.source) {
+        return { ...col, source: topLevelColumnSource };
+      }
+      return col;
+    });
+
+    return { ...data, cols: colsWithTopLevelSources };
+  }
+
   getCellClickedObject(rowIndex, columnIndex) {
     try {
       return this._getCellClickedObjectCached(
-        this.props.data,
+        this.resolveTopLevelColumnSources(this.props.question, this.props.data),
         this.props.settings,
         rowIndex,
         columnIndex,

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -79,6 +79,7 @@
    [metabase.lib.query :as lib.query]
    [metabase.lib.stage :as lib.stage]
    [metabase.lib.types.isa :as lib.types.isa]
+   [metabase.lib.underlying :as lib.underlying]
    [metabase.lib.util :as lib.util]
    [metabase.util :as u]
    [metabase.util.log :as log]
@@ -2358,3 +2359,16 @@
   > **Code health:** Healthy"
   [a-query]
   (lib.core/ensure-filter-stage a-query))
+
+(defn ^:export top-level-column-source
+  "Return the legacy-formatted source of the top-level column corresponding to `column` in `a-query`.
+
+  For example, if `column` originally came from an aggregation, but the `query` then had filter stages added after the
+  aggregation stage, then the `column` source might be `:source/fields`, but the source of the top-level column would
+  be `:source/aggregations`, and this function will return the legacy equivalent \"aggregation\".
+
+  > **Code health:** Legacy, Single use. Used to enable underlying_records drill thru in Table visualizations."
+  [a-query column]
+  (some-> (lib.underlying/top-level-column a-query column)
+          :lib/source
+          (js.metadata/unparse-column-source)))


### PR DESCRIPTION
Fixes #46932

### Description

WIP

Modify the column's `source` property to reflect the original source of the "top-level" column before passing the data into `getTableCellClickedObject`. `getTableCellClickedObject` will inspect the column source to determine whether to add dimensions to the returned click object.

This gets the underyling_records drill thru working for TableInteractive visualizations (TableSimple TBD) in cases where the "top-level" source of the column is from an aggregation, but additional stages have since been added after the aggregations, so that the column's source is no longer `"aggregation"`.

Alternatively we could

- Fix it in the BE by instead adding some new key to the column metadata like `:lib/original-source` or some such, in which case we modify `getTableCellClickedObject` in `table.js` to check both `col.source` and `col.original_source` to see if either is `=== "aggregation"`.
- Port all consumers of click objects returned by `getTableCellClickedObject` to handle MLv2 `ColumnMetadata` columns rather than `DatasetColumn`s and then replace the full column with the corresponding top-level column, rather than just modifying the source. (unclear how big of a change this would be)

Remaining TODOs, assuming we move forward with this approach

- [ ] Port to TableSimple.jsx, probably by moving implementation up out of TableInteractive.jsx and into Table.jsx
- [ ] Add tests

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> Orders
2. Summarize Count, by: Created At: Month
3. Add filter on aggregated column, e.g. Count > 1
4. Visualize
5. Click on a cell value for the Count column and select "See these Orders" from the context menu

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
