### PR TITLE
Fix custom expressions with multiple arguments - contains, does-not-contain, starts-with, ends-with

### DIFF
--- a/frontend/src/metabase-lib/filter.ts
+++ b/frontend/src/metabase-lib/filter.ts
@@ -615,7 +615,7 @@ function getStringFilterOptions(
 ): StringFilterOptions {
   const operators: ReadonlyArray<string> = STRING_FILTER_OPERATORS_WITH_OPTIONS;
   const supportsOptions = operators.includes(operator);
-  return supportsOptions ? { "case-sensitive": false, ...options } : {};
+  return supportsOptions ? { "case-sensitive": true, ...options } : {};
 }
 
 function isNumberOperator(

--- a/frontend/src/metabase-lib/filter.unit.spec.ts
+++ b/frontend/src/metabase-lib/filter.unit.spec.ts
@@ -273,7 +273,7 @@ describe("filter", () => {
           operator: "starts-with",
           column: expect.anything(),
           values: ["Gadget"],
-          options: { "case-sensitive": false },
+          options: { "case-sensitive": true },
         });
         expect(columnInfo?.name).toBe(columnName);
       },
@@ -291,7 +291,7 @@ describe("filter", () => {
           operator: "starts-with",
           column,
           values: ["Gadget"],
-          options: { "case-sensitive": true },
+          options: { "case-sensitive": false },
         }),
       );
 
@@ -299,7 +299,7 @@ describe("filter", () => {
         operator: "starts-with",
         column: expect.anything(),
         values: ["Gadget"],
-        options: { "case-sensitive": true },
+        options: { "case-sensitive": false },
       });
       expect(columnInfo?.name).toBe(columnName);
     });

--- a/frontend/src/metabase-lib/v1/expressions/__support__/shared.ts
+++ b/frontend/src/metabase-lib/v1/expressions/__support__/shared.ts
@@ -195,6 +195,30 @@ const expression = [
     ],
     "should handle priority for addition and subtraction with parenthesis",
   ],
+
+  [
+    'contains([Product → Ean], "A", "B")',
+    [
+      "contains",
+      {},
+      ["field", PRODUCTS.EAN, { "source-field": ORDERS.PRODUCT_ID }],
+      "A",
+      "B",
+    ],
+    "should handle contains with multiple arguments and empty options",
+  ],
+
+  [
+    'contains([Product → Ean], "A", "B", "case-insensitive")',
+    [
+      "contains",
+      { "case-sensitive": false },
+      ["field", PRODUCTS.EAN, { "source-field": ORDERS.PRODUCT_ID }],
+      "A",
+      "B",
+    ],
+    "should handle contains with multiple arguments and non-empty options",
+  ],
 ];
 
 const aggregation = [

--- a/frontend/src/metabase-lib/v1/expressions/__support__/shared.ts
+++ b/frontend/src/metabase-lib/v1/expressions/__support__/shared.ts
@@ -219,6 +219,84 @@ const expression = [
     ],
     "should handle contains with multiple arguments and non-empty options",
   ],
+
+  [
+    'doesNotContain([User → Name], "A", "B", "C")',
+    [
+      "does-not-contain",
+      {},
+      ["field", PEOPLE.NAME, { "source-field": ORDERS.USER_ID }],
+      "A",
+      "B",
+      "C",
+    ],
+    "should handle doesNotContain with multiple arguments and empty options",
+  ],
+
+  [
+    'doesNotContain([User → Name], "A", "B", "C", "case-insensitive")',
+    [
+      "does-not-contain",
+      { "case-sensitive": false },
+      ["field", PEOPLE.NAME, { "source-field": ORDERS.USER_ID }],
+      "A",
+      "B",
+      "C",
+    ],
+    "should handle doesNotContain with multiple arguments and empty options",
+  ],
+
+  [
+    'startsWith([Product → Category], "A", "B")',
+    [
+      "starts-with",
+      {},
+      ["field", PRODUCTS.CATEGORY, { "source-field": ORDERS.PRODUCT_ID }],
+      "A",
+      "B",
+    ],
+    "should handle startsWith with multiple arguments and empty options",
+  ],
+
+  [
+    'startsWith([Product → Category], "A", "B", "case-insensitive")',
+    [
+      "starts-with",
+      { "case-sensitive": false },
+      ["field", PRODUCTS.CATEGORY, { "source-field": ORDERS.PRODUCT_ID }],
+      "A",
+      "B",
+    ],
+    "should handle startsWith with multiple arguments and non-empty options",
+  ],
+
+  [
+    'endsWith([User → Email], "A", "B", "C", "D")',
+    [
+      "ends-with",
+      {},
+      ["field", PEOPLE.EMAIL, { "source-field": ORDERS.USER_ID }],
+      "A",
+      "B",
+      "C",
+      "D",
+    ],
+    "should handle endsWith with multiple arguments and empty options",
+  ],
+
+  [
+    'endsWith([User → Email], "A", "B", "C", "D", "case-insensitive")',
+    [
+      "ends-with",
+      { "case-sensitive": false },
+      ["field", PEOPLE.EMAIL, { "source-field": ORDERS.USER_ID }],
+      "A",
+      "B",
+      "C",
+      "D",
+    ],
+    "should handle endsWith with multiple arguments and non-empty options",
+  ],
 ];
 
 const aggregation = [

--- a/frontend/src/metabase-lib/v1/expressions/config.ts
+++ b/frontend/src/metabase-lib/v1/expressions/config.ts
@@ -217,24 +217,28 @@ export const MBQL_CLAUSES: MBQLClauseMap = {
     displayName: `contains`,
     type: "boolean",
     args: ["string", "string"],
+    multiple: true,
     hasOptions: true,
   },
   "does-not-contain": {
     displayName: `doesNotContain`,
     type: "boolean",
     args: ["string", "string"],
+    multiple: true,
     hasOptions: true,
   },
   "starts-with": {
     displayName: `startsWith`,
     type: "boolean",
     args: ["string", "string"],
+    multiple: true,
     hasOptions: true,
   },
   "ends-with": {
     displayName: `endsWith`,
     type: "boolean",
     args: ["string", "string"],
+    multiple: true,
     hasOptions: true,
   },
   between: {

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics.ts
@@ -13,6 +13,7 @@ import type Metadata from "metabase-lib/v1/metadata/Metadata";
 
 import {
   adjustCase,
+  adjustMultiArgOptions,
   adjustOffset,
   adjustOptions,
   useShorthands,
@@ -231,6 +232,7 @@ function prattCompiler({
       useShorthands,
       adjustOffset,
       adjustCase,
+      adjustMultiArgOptions,
       expression =>
         resolve({
           expression,

--- a/frontend/src/metabase-lib/v1/expressions/format.ts
+++ b/frontend/src/metabase-lib/v1/expressions/format.ts
@@ -12,7 +12,6 @@ import {
   formatSegmentName,
   formatStringLiteral,
   getExpressionName,
-  hasOptions,
   isBooleanLiteral,
   isCase,
   isDimension,
@@ -21,6 +20,7 @@ import {
   isNumberLiteral,
   isOffset,
   isOperator,
+  isOptionsObject,
   isSegment,
   isStringLiteral,
 } from "./index";
@@ -159,11 +159,13 @@ function formatFunctionOptions(fnOptions: Record<string, any>) {
   }
 }
 
-function formatFunction([fn, ...args]: any[], options: Options) {
-  if (hasOptions(args)) {
-    const fnOptions = formatFunctionOptions(args.pop());
-    if (fnOptions) {
-      args = [...args, fnOptions];
+function formatFunction([fn, ...operands]: any[], options: Options) {
+  const args = operands.filter(arg => !isOptionsObject(arg));
+  const fnOptions = operands.find(isOptionsObject);
+  if (fnOptions) {
+    const formattedOptions = formatFunctionOptions(fnOptions);
+    if (formattedOptions) {
+      args.push(formattedOptions);
     }
   }
   const formattedName = getExpressionName(fn) ?? "";
@@ -173,12 +175,8 @@ function formatFunction([fn, ...args]: any[], options: Options) {
     : `${formattedName}(${formattedArgs.join(", ")})`;
 }
 
-function formatOperator([op, ...args]: any[], options: Options) {
-  if (hasOptions(args)) {
-    // FIXME: how should we format args?
-    args = args.slice(0, -1);
-  }
-
+function formatOperator([op, ...operands]: any[], options: Options) {
+  const args = operands.filter(arg => !isOptionsObject(arg));
   const formattedOperator = getExpressionName(op) || op;
   const formattedArgs = args.map((arg, index) => {
     const argOp = isOperator(arg) && arg[0];

--- a/frontend/src/metabase-lib/v1/expressions/format.ts
+++ b/frontend/src/metabase-lib/v1/expressions/format.ts
@@ -159,17 +159,17 @@ function formatFunctionOptions(fnOptions: Record<string, any>) {
   }
 }
 
-function formatFunction([fn, ...operands]: any[], options: Options) {
+function formatFunction([fn, ...operands]: any[], formatOptions: Options) {
   const args = operands.filter(arg => !isOptionsObject(arg));
-  const fnOptions = operands.find(isOptionsObject);
-  if (fnOptions) {
-    const formattedOptions = formatFunctionOptions(fnOptions);
+  const options = operands.find(isOptionsObject);
+  if (options) {
+    const formattedOptions = formatFunctionOptions(options);
     if (formattedOptions) {
       args.push(formattedOptions);
     }
   }
   const formattedName = getExpressionName(fn) ?? "";
-  const formattedArgs = args.map(arg => format(arg, options));
+  const formattedArgs = args.map(arg => format(arg, formatOptions));
   return args.length === 0
     ? formattedName
     : `${formattedName}(${formattedArgs.join(", ")})`;

--- a/frontend/src/metabase-lib/v1/expressions/index.ts
+++ b/frontend/src/metabase-lib/v1/expressions/index.ts
@@ -331,7 +331,9 @@ export function isDimension(expr: unknown): boolean {
 }
 
 export function isMetric(expr: unknown): boolean {
-  return Array.isArray(expr) && expr[0] === "metric";
+  return (
+    Array.isArray(expr) && expr[0] === "metric" && typeof expr[1] === "number"
+  );
 }
 
 export function isSegment(expr: unknown): boolean {

--- a/frontend/src/metabase-lib/v1/expressions/index.ts
+++ b/frontend/src/metabase-lib/v1/expressions/index.ts
@@ -2,7 +2,6 @@ export * from "./config";
 
 import { FK_SYMBOL } from "metabase/lib/formatting";
 import * as Lib from "metabase-lib";
-import Dimension from "metabase-lib/v1/Dimension";
 import type { Expression } from "metabase-types/api";
 
 import {
@@ -309,50 +308,35 @@ export function isOperator(expr: unknown): boolean {
   return (
     Array.isArray(expr) &&
     OPERATORS.has(expr[0]) &&
-    expr
-      .slice(1, hasOptions(expr) ? -1 : 0) // skip options object at the end
-      .every(isExpression)
+    expr.slice(1).every(arg => isExpression(arg) || isOptionsObject(arg))
   );
 }
 
-function isPlainObject(obj: unknown): boolean {
+export function isOptionsObject(obj: unknown): boolean {
   return obj ? Object.getPrototypeOf(obj) === Object.prototype : false;
-}
-
-export function hasOptions(expr: unknown): boolean {
-  return Array.isArray(expr) && isPlainObject(expr[expr.length - 1]);
 }
 
 export function isFunction(expr: unknown): boolean {
   return (
     Array.isArray(expr) &&
     FUNCTIONS.has(expr[0]) &&
-    expr
-      .slice(1, hasOptions(expr) ? -1 : 0) // skip options object at the end
-      .every(isExpression)
+    expr.slice(1).every(arg => isExpression(arg) || isOptionsObject(arg))
   );
 }
 
 export function isDimension(expr: unknown): boolean {
-  // @ts-expect-error parseMBQL doesn't accept Expr
-  return !!Dimension.parseMBQL(expr);
+  return (
+    Array.isArray(expr) && (expr[0] === "field" || expr[0] === "expression")
+  );
 }
 
 export function isMetric(expr: unknown): boolean {
-  return (
-    Array.isArray(expr) &&
-    expr[0] === "metric" &&
-    (expr.length === 2 || expr.length === 3) &&
-    typeof expr[1] === "number"
-  );
+  return Array.isArray(expr) && expr[0] === "metric";
 }
 
 export function isSegment(expr: unknown): boolean {
   return (
-    Array.isArray(expr) &&
-    expr[0] === "segment" &&
-    expr.length === 2 &&
-    typeof expr[1] === "number"
+    Array.isArray(expr) && expr[0] === "segment" && typeof expr[1] === "number"
   );
 }
 

--- a/frontend/src/metabase-lib/v1/expressions/recursive-parser.js
+++ b/frontend/src/metabase-lib/v1/expressions/recursive-parser.js
@@ -324,6 +324,19 @@ export const adjustOffset = tree =>
     return node;
   });
 
+/*
+ MBQL clause for an operator that supports multiple arguments *requires* an
+ option object after the operator when there are more than 2 arguments. Compare:
+
+ ["contains", ["field", 1, null], "A"]
+ ["contains", ["field", 1, null], "A", {"case-sensitive": false}]
+ ["contains", {}, ["field", 1, null], "A", "B"]
+ ["contains", {"case-sensitive": false}, ["field", 1, null], "A", "B"]
+
+ By default, the expression parser adds the options object as the last operand,
+ so we need to adjust its position here or insert an empty options object if
+ there is none.
+*/
 export const adjustMultiArgOptions = tree =>
   modify(tree, node => {
     if (Array.isArray(node)) {

--- a/frontend/src/metabase-lib/v1/expressions/recursive-parser.js
+++ b/frontend/src/metabase-lib/v1/expressions/recursive-parser.js
@@ -269,7 +269,7 @@ export const adjustOptions = tree =>
       if (operands.length > 0) {
         const clause = MBQL_CLAUSES[operator];
         if (clause && clause.hasOptions) {
-          if (operands.length === clause.args.length + 1) {
+          if (operands.length === clause.args.length + 1 || clause.multiple) {
             // the last one holds the function options
             const options = operands[operands.length - 1];
 

--- a/frontend/src/metabase-lib/v1/expressions/recursive-parser.js
+++ b/frontend/src/metabase-lib/v1/expressions/recursive-parser.js
@@ -2,7 +2,12 @@ import { t } from "ttag";
 
 import { OPERATOR as OP, TOKEN, tokenize } from "./tokenizer";
 
-import { MBQL_CLAUSES, getMBQLName, hasOptions, unescapeString } from "./index";
+import {
+  MBQL_CLAUSES,
+  getMBQLName,
+  isOptionsObject,
+  unescapeString,
+} from "./index";
 
 const COMPARISON_OPS = [
   OP.Equal,
@@ -322,14 +327,14 @@ export const adjustOffset = tree =>
 export const adjustMultiArgOptions = tree =>
   modify(tree, node => {
     if (Array.isArray(node)) {
-      const [operator] = node;
+      const [operator, ...args] = node;
       const clause = MBQL_CLAUSES[operator];
       if (clause != null && clause.multiple && clause.hasOptions) {
-        if (hasOptions(node) && node.length > 4) {
-          return withAST([operator, node.at(-1), ...node.slice(1, -1)], node);
+        if (isOptionsObject(args.at(-1)) && args.length > 3) {
+          return withAST([operator, args.at(-1), ...args.slice(0, -1)], node);
         }
-        if (node.length > 3) {
-          return withAST([operator, {}, ...node.slice(1)], node);
+        if (args.length > 2) {
+          return withAST([operator, {}, ...args], node);
         }
       }
     }

--- a/frontend/src/metabase-lib/v1/expressions/recursive-parser.js
+++ b/frontend/src/metabase-lib/v1/expressions/recursive-parser.js
@@ -346,7 +346,7 @@ export const adjustMultiArgOptions = tree =>
         if (isOptionsObject(args.at(-1)) && args.length > 3) {
           return withAST([operator, args.at(-1), ...args.slice(0, -1)], node);
         }
-        if (args.length > 2) {
+        if (args.length > 2 && !isOptionsObject(args.at(-1))) {
           return withAST([operator, {}, ...args], node);
         }
       }

--- a/frontend/src/metabase-lib/v1/expressions/recursive-parser.js
+++ b/frontend/src/metabase-lib/v1/expressions/recursive-parser.js
@@ -2,7 +2,7 @@ import { t } from "ttag";
 
 import { OPERATOR as OP, TOKEN, tokenize } from "./tokenizer";
 
-import { MBQL_CLAUSES, getMBQLName, unescapeString } from "./index";
+import { MBQL_CLAUSES, getMBQLName, hasOptions, unescapeString } from "./index";
 
 const COMPARISON_OPS = [
   OP.Equal,
@@ -319,6 +319,23 @@ export const adjustOffset = tree =>
     return node;
   });
 
+export const adjustMultiArgOptions = tree =>
+  modify(tree, node => {
+    if (Array.isArray(node)) {
+      const [operator] = node;
+      const clause = MBQL_CLAUSES[operator];
+      if (clause != null && clause.multiple && clause.hasOptions) {
+        if (hasOptions(node) && node.length > 4) {
+          return withAST([operator, node.at(-1), ...node.slice(1, -1)], node);
+        }
+        if (node.length > 3) {
+          return withAST([operator, {}, ...node.slice(1)], node);
+        }
+      }
+    }
+    return node;
+  });
+
 export const adjustBooleans = tree =>
   modify(tree, node => {
     if (Array.isArray(node)) {
@@ -374,4 +391,5 @@ export const parse = pipe(
   useShorthands,
   adjustOffset,
   adjustCase,
+  adjustMultiArgOptions,
 );

--- a/frontend/src/metabase-lib/v1/expressions/resolver.js
+++ b/frontend/src/metabase-lib/v1/expressions/resolver.js
@@ -4,7 +4,7 @@ import { ResolverError } from "metabase-lib/v1/expressions/pratt/types";
 
 import { OPERATOR as OP } from "./tokenizer";
 
-import { MBQL_CLAUSES, getMBQLName } from "./index";
+import { MBQL_CLAUSES, getMBQLName, isOptionsObject } from "./index";
 
 const FIELD_MARKERS = ["dimension", "segment", "metric"];
 export const LOGICAL_OPS = [OP.Not, OP.And, OP.Or];
@@ -203,7 +203,7 @@ export function resolve({
       }
     }
     const resolvedOperands = operands.map((operand, i) => {
-      if (i >= args.length) {
+      if (i >= args.length || isOptionsObject(operand)) {
         // as-is, optional object for e.g. ends-with, time-interval, etc
         return operand;
       }

--- a/frontend/src/metabase/querying/filters/hooks/use-string-filter/use-string-filter.ts
+++ b/frontend/src/metabase/querying/filters/hooks/use-string-filter/use-string-filter.ts
@@ -45,7 +45,7 @@ export function useStringFilter({
   );
 
   const [options, setOptions] = useState(
-    filterParts ? filterParts.options : {},
+    filterParts ? filterParts.options : { "case-sensitive": false },
   );
 
   const { type } = getOptionByOperator(operator);

--- a/frontend/test/metabase/lib/expressions/diagnostics.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/diagnostics.unit.spec.js
@@ -53,8 +53,7 @@ describe("metabase-lib/v1/expressions/diagnostics", () => {
 
   it("should show the correct number of function arguments in a custom expression", () => {
     expect(
-      diagnose({ source: "contains([Category])", startRule: "boolean" })
-        .message,
-    ).toEqual("Function contains expects 2 arguments");
+      diagnose({ source: "between([Tax])", startRule: "boolean" }).message,
+    ).toEqual("Function between expects 3 arguments");
   });
 });

--- a/frontend/test/metabase/lib/expressions/pratt/common.ts
+++ b/frontend/test/metabase/lib/expressions/pratt/common.ts
@@ -7,6 +7,7 @@ import {
 } from "metabase-lib/v1/expressions/pratt";
 import {
   adjustCase,
+  adjustMultiArgOptions,
   adjustOffset,
   adjustOptions,
   parse as oldParser,
@@ -25,7 +26,13 @@ interface Opts {
 
 export function compile(source: string, type: Type, opts: Opts = {}) {
   const { throwOnError } = opts;
-  const passes = [adjustOptions, useShorthands, adjustOffset, adjustCase];
+  const passes = [
+    adjustOptions,
+    useShorthands,
+    adjustOffset,
+    adjustCase,
+    adjustMultiArgOptions,
+  ];
   return newCompile(
     parse(lexify(source), {
       throwOnError,

--- a/frontend/test/metabase/lib/expressions/recursive-parser.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/recursive-parser.unit.spec.js
@@ -126,6 +126,18 @@ describe("metabase-lib/v1/expressions/recursive-parser", () => {
       expression: ["contains", { "case-sensitive": false }, B, C, D],
     },
     {
+      source: "doesNotContain(B, C, D, 'case-insensitive')",
+      expression: ["does-not-contain", { "case-sensitive": false }, B, C, D],
+    },
+    {
+      source: "startsWith(B, C, D, 'case-insensitive')",
+      expression: ["starts-with", { "case-sensitive": false }, B, C, D],
+    },
+    {
+      source: "endsWith(B, C, D, 'case-insensitive')",
+      expression: ["ends-with", { "case-sensitive": false }, B, C, D],
+    },
+    {
       source: "interval(B, -1, 'days', 'include-current')",
       expression: ["time-interval", B, -1, "days", { "include-current": true }],
     },

--- a/frontend/test/metabase/lib/expressions/recursive-parser.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/recursive-parser.unit.spec.js
@@ -13,6 +13,7 @@ describe("metabase-lib/v1/expressions/recursive-parser", () => {
   const A = ["segment", "A"];
   const B = ["dimension", "B"];
   const C = ["dimension", "C"];
+  const D = ["dimension", "D"];
 
   it("should parse numeric literals", () => {
     expect(process("0")).toEqual(0);
@@ -117,6 +118,14 @@ describe("metabase-lib/v1/expressions/recursive-parser", () => {
       B,
       C,
       { "case-sensitive": false },
+    ]);
+    expect(filter("contains(B, C, D)")).toEqual(["contains", {}, B, C, D]);
+    expect(filter("contains(B, C, D, 'case-insensitive')")).toEqual([
+      "contains",
+      { "case-sensitive": false },
+      B,
+      C,
+      D,
     ]);
     expect(filter("interval(B, -1, 'days', 'include-current')")).toEqual([
       "time-interval",

--- a/frontend/test/metabase/lib/expressions/recursive-parser.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/recursive-parser.unit.spec.js
@@ -112,28 +112,25 @@ describe("metabase-lib/v1/expressions/recursive-parser", () => {
     expect(process("regexextract(B,C)")).toEqual(["regex-match-first", B, C]);
   });
 
-  it("should handle function options", () => {
-    expect(filter("contains(B, C, 'case-insensitive')")).toEqual([
-      "contains",
-      B,
-      C,
-      { "case-sensitive": false },
-    ]);
-    expect(filter("contains(B, C, D)")).toEqual(["contains", {}, B, C, D]);
-    expect(filter("contains(B, C, D, 'case-insensitive')")).toEqual([
-      "contains",
-      { "case-sensitive": false },
-      B,
-      C,
-      D,
-    ]);
-    expect(filter("interval(B, -1, 'days', 'include-current')")).toEqual([
-      "time-interval",
-      B,
-      -1,
-      "days",
-      { "include-current": true },
-    ]);
+  it.each([
+    {
+      source: "contains(B, C, 'case-insensitive')",
+      expression: ["contains", B, C, { "case-sensitive": false }],
+    },
+    {
+      source: "contains(B, C, D)",
+      expression: ["contains", {}, B, C, D],
+    },
+    {
+      source: "contains(B, C, D, 'case-insensitive')",
+      expression: ["contains", { "case-sensitive": false }, B, C, D],
+    },
+    {
+      source: "interval(B, -1, 'days', 'include-current')",
+      expression: ["time-interval", B, -1, "days", { "include-current": true }],
+    },
+  ])("should handle function options: $source", ({ source, expression }) => {
+    expect(filter(source)).toEqual(expression);
   });
 
   it("should use MBQL negative shorthands", () => {

--- a/frontend/test/metabase/lib/expressions/resolver.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/resolver.unit.spec.js
@@ -81,15 +81,9 @@ describe("metabase-lib/v1/expressions/resolve", () => {
     });
 
     it("should catch mismatched number of function parameters", () => {
-      expect(() => filter(["contains"])).toThrow();
-      expect(() => filter(["contains", Y])).toThrow();
-      expect(() => filter(["contains", Y, "A", "B", "C"])).toThrow();
-      expect(() => filter(["starts-with"])).toThrow();
-      expect(() => filter(["starts-with", A])).toThrow();
-      expect(() => filter(["starts-with", A, "P", "Q", "R"])).toThrow();
-      expect(() => filter(["ends-with"])).toThrow();
-      expect(() => filter(["ends-with", B])).toThrow();
-      expect(() => filter(["ends-with", B, "P", "Q", "R"])).toThrow();
+      expect(() => filter(["between"])).toThrow();
+      expect(() => filter(["between", Y])).toThrow();
+      expect(() => filter(["between", Y, "A", "B", "C"])).toThrow();
     });
 
     it("should allow a comparison (lexicographically) on strings", () => {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/49304

How to verify:
- New -> Question -> Products -> Filter -> Custom expression. Try:
- `contains([Ean], "A", "B")`
- `contains([Ean], "A", "B", "C")`
- `contains([Ean], "A", "B", "case-insensitive")`
- `contains([Ean], "A", "B", "C", "case-insensitive")`
- These clauses should be picked by the widget; try changing them both via the widget and the expression editor and see if options are picked up correctly.