### PR TITLE
docs(sdk): Manually update changelog for release 51

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/CHANGELOG.md
+++ b/enterprise/frontend/src/embedding-sdk/CHANGELOG.md
@@ -40,7 +40,7 @@
 
 
 
-## [0.51.5](https://github.com/metabase/metabase/compare/embedding-sdk-1.51.4...embedding-sdk-0.51.5) (2024-11-20)
+## [0.51.5](https://github.com/metabase/metabase/compare/embedding-sdk-0.51.4...embedding-sdk-0.51.5) (2024-11-20)
 
 
 ### Bug Fixes
@@ -62,7 +62,7 @@
 
 
 
-## [1.51.4](https://github.com/metabase/metabase/compare/embedding-sdk-1.51.3...embedding-sdk-1.51.4) (2024-11-12)
+## [0.51.4](https://github.com/metabase/metabase/compare/embedding-sdk-0.51.3...embedding-sdk-0.51.4) (2024-11-12)
 
 
 ### Bug Fixes
@@ -82,7 +82,7 @@
 
 
 
-## [1.51.3](https://github.com/metabase/metabase/compare/embedding-sdk-1.51.2...embedding-sdk-1.51.3) (2024-11-06)
+## [0.51.3](https://github.com/metabase/metabase/compare/embedding-sdk-0.51.2...embedding-sdk-0.51.3) (2024-11-06)
 
 
 ### Bug Fixes
@@ -104,7 +104,7 @@
 
 
 
-## [1.51.2](https://github.com/metabase/metabase/compare/embedding-sdk-0.1.40...embedding-sdk-1.51.2) (2024-10-24)
+## [0.51.2](https://github.com/metabase/metabase/compare/embedding-sdk-0.1.40...embedding-sdk-0.51.2) (2024-10-24)
 
 
 ### Bug Fixes
@@ -130,7 +130,7 @@
 
 
 
-## [0.1.39](https://github.com/metabase/metabase/compare/embedding-sdk-1.51.0...embedding-sdk-0.1.39) (2024-10-16)
+## [0.1.39](https://github.com/metabase/metabase/compare/embedding-sdk-0.51.0...embedding-sdk-0.1.39) (2024-10-16)
 
 
 ### Bug Fixes


### PR DESCRIPTION
> [!note]
> I reopen #50448, as it seems the original branch name got restricted in some kind of branch protection configurations.

[Slack discussion](https://metaboat.slack.com/archives/C063Q3F1HPF/p1732286276909939?thread_ts=1731680130.243949&cid=C063Q3F1HPF)

### Description

After we've redeployed version 0 for 1.51.x, we should fix the changelog accordingly to prevent confusion.

### How to verify
1. The diff for each version should look the same
2. The new chaneglog shouldn't contain any reference to v1.51.x

