### PR TITLE
ci(sdk): remove unreliable loading indicator e2e for create question

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
@@ -20,14 +20,6 @@ describeEE("scenarios > embedding-sdk > create-question", () => {
   it("can create a question via the CreateQuestion component", () => {
     cy.intercept("POST", "/api/card").as("createCard");
 
-    cy.intercept("POST", "/api/dataset", req => {
-      // throttling to 500 Kbps (slow 3G) makes the loading indicator
-      // shows up reliably when we click on visualize.
-      req.on("response", res => {
-        res.setThrottle(500);
-      });
-    });
-
     mountSdkContent(
       <Flex p="xl">
         <CreateQuestion />
@@ -47,9 +39,6 @@ describeEE("scenarios > embedding-sdk > create-question", () => {
       cy.contains("New question");
 
       cy.findByRole("button", { name: "Visualize" }).click();
-
-      // Should show a loading indicator (metabase#47564)
-      cy.findByTestId("loading-indicator").should("exist");
 
       // Should be able to go back to the editor view
       cy.findByRole("button", { name: "Show editor" }).click();


### PR DESCRIPTION
Removes the loading indicator checks as it is unreliable in a CI environment, even with setThrottle. This is blocking CI for release. I'll replace this with a more reliable unit test.

PS. I'll create a separate PR targeting `master`, but this is to unblock the CI first.