### PR TITLE
Update links for SDK npm so they actually point to the npm page

### DIFF
--- a/docs/embedding/sdk/introduction.md
+++ b/docs/embedding/sdk/introduction.md
@@ -27,7 +27,7 @@ To give you and idea of what's possible with the SDK, we've put together example
 
 ## Embedded analytics SDK on NPM
 
-Check out the Metabase Embedded analytics SDK on NPM: [metaba.se/sdk](https://metaba.se/sdk).
+Check out the Metabase Embedded analytics SDK on NPM: [https://www.npmjs.com/package/@metabase/embedding-sdk-react](https://www.npmjs.com/package/@metabase/embedding-sdk-react).
 
 ## Quickstart with CLI
 

--- a/docs/embedding/sdk/quickstart.md
+++ b/docs/embedding/sdk/quickstart.md
@@ -162,7 +162,7 @@ Install packages:
 npm install
 ```
 
-This command will install the [Metabase embedded analytics SDK](https://metaba.se/sdk), in addition to the application's other dependencies.
+This command will install the [Metabase embedded analytics SDK](https://www.npmjs.com/package/@metabase/embedding-sdk-react), in addition to the application's other dependencies.
 
 ## Start the client
 


### PR DESCRIPTION
metaba.se/sdk is now pointing to the docs.