### PR TITLE
Extend milestone setter timeout

### DIFF
--- a/.github/workflows/check-milestone.yml
+++ b/.github/workflows/check-milestone.yml
@@ -16,7 +16,7 @@ jobs:
   set-milestone:
     name: Automatically set milestone
     runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    timeout-minutes: 30
     env:
       isNewReleaseBranch: ${{ github.event_name == 'workflow_dispatch' }}
     permissions:


### PR DESCRIPTION
Last time I tried to run this action in CI it [timed out](https://metaboat.slack.com/archives/C864UT5CZ/p1728406041776849), this simply extends the job timeout from 15 to 30 minutes in CI.