### PR TITLE
Introduce the non-admin Onboarding Checklist

### DIFF
--- a/e2e/test/scenarios/onboarding/onboarding-checklist.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/onboarding-checklist.cy.spec.ts
@@ -13,7 +13,35 @@ import {
 } from "e2e/support/helpers";
 import type { ChecklistItemValue } from "metabase/home/components/Onboarding/types";
 
-describeEE("Onboarding checklist page", () => {
+describe("Onboarding checklist page", () => {
+  beforeEach(() => {
+    restore();
+  });
+
+  it("should let non-admins access this page", () => {
+    cy.signInAsNormalUser();
+    cy.visit("/getting-started");
+
+    cy.get("[data-accordion=true]").within(() => {
+      cy.findByRole("heading", { name: "Start visualizing your data" }).should(
+        "be.visible",
+      );
+      cy.contains(
+        "Hover over a table and click the yellow lightning bolt",
+      ).should("be.visible");
+
+      cy.findByText("Make an interactive chart with the query builder").click();
+      cy.contains(
+        "Filter and summarize data, add custom columns, join data from other tables, and more",
+      ).should("be.visible");
+      cy.contains(
+        "Hover over a table and click the yellow lightning bolt",
+      ).should("not.exist");
+    });
+  });
+});
+
+describeEE("Onboarding checklist main sidebar link", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/onboarding/onboarding-checklist.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/onboarding-checklist.cy.spec.ts
@@ -41,7 +41,7 @@ describe("Onboarding checklist page", () => {
   });
 });
 
-describeEE("Onboarding checklist main sidebar link", () => {
+describeEE("Inaccessible Onboarding checklist", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
@@ -57,7 +57,14 @@ describeEE("Onboarding checklist main sidebar link", () => {
       );
     });
 
+    cy.log("Redirects to the home page");
+    visitFullAppEmbeddingUrl({ url: "/getting-started", qs: {} });
+    cy.location("pathname").should("eq", "/");
+  });
+
+  it("should not render when the instance is whitelabelled", () => {
     updateSetting("application-name", "Acme, corp.");
+
     cy.visit("/");
     cy.findByTestId("main-navbar-root").within(() => {
       cy.findByRole("listitem", { name: "Home" }).should("be.visible");
@@ -65,6 +72,10 @@ describeEE("Onboarding checklist main sidebar link", () => {
         "not.exist",
       );
     });
+
+    cy.log("Redirects to the home page");
+    cy.visit("/getting-started");
+    cy.location("pathname").should("eq", "/");
   });
 });
 

--- a/frontend/src/metabase/home/components/Onboarding/Onboarding.tsx
+++ b/frontend/src/metabase/home/components/Onboarding/Onboarding.tsx
@@ -232,7 +232,7 @@ export const Onboarding = () => {
                 <Accordion.Panel>
                   <Stack spacing="lg">
                     <img
-                      alt={`${applicationName} data stack`}
+                      alt={`${applicationName} ${t`data stack`}`}
                       className={S.image}
                       loading="lazy"
                       src="app/assets/img/onboarding_data_diagram.png"

--- a/frontend/src/metabase/home/components/Onboarding/Onboarding.tsx
+++ b/frontend/src/metabase/home/components/Onboarding/Onboarding.tsx
@@ -261,7 +261,7 @@ export const Onboarding = () => {
                 <Accordion.Panel>
                   <Stack spacing="lg">
                     <img
-                      alt={`Admin panel with the "Invite someone" button`}
+                      alt={t`Admin panel with the "Invite someone" button`}
                       className={S.image}
                       loading="lazy"
                       src="app/assets/img/onboarding_invite.png"

--- a/frontend/src/metabase/home/components/Onboarding/Onboarding.tsx
+++ b/frontend/src/metabase/home/components/Onboarding/Onboarding.tsx
@@ -20,6 +20,7 @@ import {
   getIsPaidPlan,
   getSetting,
 } from "metabase/selectors/settings";
+import { getUserIsAdmin } from "metabase/selectors/user";
 import {
   getApplicationName,
   getShowMetabaseLinks,
@@ -48,9 +49,10 @@ export const Onboarding = () => {
   const applicationName = useSelector(getApplicationName);
   const showMetabaseLinks = useSelector(getShowMetabaseLinks);
   const isPaidPlan = useSelector(getIsPaidPlan);
+  const isAdmin = useSelector(getUserIsAdmin);
 
   const isHosted = useSelector(getIsHosted);
-  const shouldConfigureCommunicationChannels = !isHosted;
+  const shouldConfigureCommunicationChannels = isAdmin && !isHosted;
 
   const isXrayEnabled = useSelector(getIsXrayEnabled);
 
@@ -78,7 +80,7 @@ export const Onboarding = () => {
 
   const [itemValue, setItemValue] = useState<ChecklistItemValue | null>(null);
 
-  const DEFAULT_ITEM = "database";
+  const DEFAULT_ITEM = isAdmin ? "database" : "x-ray";
 
   const newQuestionUrl = Urls.newQuestion({
     mode: "notebook",
@@ -189,6 +191,11 @@ export const Onboarding = () => {
     }),
   );
 
+  const disabledXrayCopy = (isAdmin: boolean) =>
+    isAdmin
+      ? t`You need to enable this feature first.`
+      : t`An admin needs to enable this feature first.`;
+
   return (
     <Box
       mih="100%"
@@ -212,81 +219,86 @@ export const Onboarding = () => {
             handleValueChange(value)
           }
         >
-          <Box mb={64}>
-            <Title order={2} mb="lg">{t`Set up your ${applicationName}`}</Title>
-            <Accordion.Item value="database" data-testid="database-item">
-              <Accordion.Control icon={<Icon name="add_data" />}>
-                {t`Connect to your database`}
-              </Accordion.Control>
-              <Accordion.Panel>
-                <Stack spacing="lg">
-                  <img
-                    alt={`${applicationName} data stack`}
-                    className={S.image}
-                    loading="lazy"
-                    src="app/assets/img/onboarding_data_diagram.png"
-                    srcSet="app/assets/img/onboarding_data_diagram@2x.png 2x"
-                    width="100%"
-                  />
+          {isAdmin && (
+            <Box mb={64}>
+              <Title
+                order={2}
+                mb="lg"
+              >{t`Set up your ${applicationName}`}</Title>
+              <Accordion.Item value="database" data-testid="database-item">
+                <Accordion.Control icon={<Icon name="add_data" />}>
+                  {t`Connect to your database`}
+                </Accordion.Control>
+                <Accordion.Panel>
+                  <Stack spacing="lg">
+                    <img
+                      alt={`${applicationName} data stack`}
+                      className={S.image}
+                      loading="lazy"
+                      src="app/assets/img/onboarding_data_diagram.png"
+                      srcSet="app/assets/img/onboarding_data_diagram@2x.png 2x"
+                      width="100%"
+                    />
 
-                  <Text>
-                    {t`You can connect multiple databases, and query them directly with the query builder or the Native/SQL editor. ${applicationName} connects to more than 15 popular databases.`}
-                  </Text>
-                  <Box data-testid="database-cta">
-                    <Link
-                      to="/admin/databases/create"
-                      onClick={() => trackChecklistItemCTAClicked("database")}
-                    >
-                      <Button variant="outline">{t`Add Database`}</Button>
-                    </Link>
-                  </Box>
-                </Stack>
-              </Accordion.Panel>
-            </Accordion.Item>
-            <Accordion.Item value="invite" data-testid="invite-item">
-              <Accordion.Control icon={<Icon name="group" />}>
-                {t`Invite people`}
-              </Accordion.Control>
-              <Accordion.Panel>
-                <Stack spacing="lg">
-                  <img
-                    alt={`Admin panel with the "Invite someone" button`}
-                    className={S.image}
-                    loading="lazy"
-                    src="app/assets/img/onboarding_invite.png"
-                    srcSet="app/assets/img/onboarding_invite@2x.png 2x"
-                    width="100%"
-                  />
-                  {!isPaidPlan ? (
-                    // eslint-disable-next-line no-literal-metabase-strings -- OSS doesn't have whitelabeling option
-                    <Text>{t`Don't be shy with invites. Metabase makes self-service analytics easy.`}</Text>
-                  ) : (
-                    // eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins
-                    <Text>{t`Don't be shy with invites. Metabase Starter plan includes 5 users, and Pro includes 10 users without the need to pay additionally.`}</Text>
-                  )}
+                    <Text>
+                      {t`You can connect multiple databases, and query them directly with the query builder or the Native/SQL editor. ${applicationName} connects to more than 15 popular databases.`}
+                    </Text>
+                    <Box data-testid="database-cta">
+                      <Link
+                        to="/admin/databases/create"
+                        onClick={() => trackChecklistItemCTAClicked("database")}
+                      >
+                        <Button variant="outline">{t`Add Database`}</Button>
+                      </Link>
+                    </Box>
+                  </Stack>
+                </Accordion.Panel>
+              </Accordion.Item>
+              <Accordion.Item value="invite" data-testid="invite-item">
+                <Accordion.Control icon={<Icon name="group" />}>
+                  {t`Invite people`}
+                </Accordion.Control>
+                <Accordion.Panel>
+                  <Stack spacing="lg">
+                    <img
+                      alt={`Admin panel with the "Invite someone" button`}
+                      className={S.image}
+                      loading="lazy"
+                      src="app/assets/img/onboarding_invite.png"
+                      srcSet="app/assets/img/onboarding_invite@2x.png 2x"
+                      width="100%"
+                    />
+                    {!isPaidPlan ? (
+                      // eslint-disable-next-line no-literal-metabase-strings -- OSS doesn't have whitelabeling option
+                      <Text>{t`Don't be shy with invites. Metabase makes self-service analytics easy.`}</Text>
+                    ) : (
+                      // eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins
+                      <Text>{t`Don't be shy with invites. Metabase Starter plan includes 5 users, and Pro includes 10 users without the need to pay additionally.`}</Text>
+                    )}
 
-                  <Group spacing={0} data-testid="invite-cta">
-                    <Link
-                      to="/admin/people"
-                      onClick={() =>
-                        trackChecklistItemCTAClicked("invite", "primary")
-                      }
-                    >
-                      <Button variant="outline">{t`Invite people`}</Button>
-                    </Link>
-                    <Link
-                      to="/admin/settings/authentication"
-                      onClick={() =>
-                        trackChecklistItemCTAClicked("invite", "secondary")
-                      }
-                    >
-                      <Button variant="subtle">{t`Set up Single Sign-on`}</Button>
-                    </Link>
-                  </Group>
-                </Stack>
-              </Accordion.Panel>
-            </Accordion.Item>
-          </Box>
+                    <Group spacing={0} data-testid="invite-cta">
+                      <Link
+                        to="/admin/people"
+                        onClick={() =>
+                          trackChecklistItemCTAClicked("invite", "primary")
+                        }
+                      >
+                        <Button variant="outline">{t`Invite people`}</Button>
+                      </Link>
+                      <Link
+                        to="/admin/settings/authentication"
+                        onClick={() =>
+                          trackChecklistItemCTAClicked("invite", "secondary")
+                        }
+                      >
+                        <Button variant="subtle">{t`Set up Single Sign-on`}</Button>
+                      </Link>
+                    </Group>
+                  </Stack>
+                </Accordion.Panel>
+              </Accordion.Item>
+            </Box>
+          )}
 
           <Box mb={64}>
             <Title order={2} mb="lg">{t`Start visualizing your data`}</Title>
@@ -315,17 +327,21 @@ export const Onboarding = () => {
                           />
                         )}. ${applicationName} will create a bunch of charts based on that data and arrange them on a dashboard.`}
                       </Text>
-                      <Box data-testid="x-ray-cta">
-                        <Link
-                          to="/browse/databases"
-                          onClick={() => trackChecklistItemCTAClicked("x-ray")}
-                        >
-                          <Button variant="outline">{t`Browse data`}</Button>
-                        </Link>
-                      </Box>
+                      {isAdmin && (
+                        <Box data-testid="x-ray-cta">
+                          <Link
+                            to="/browse/databases"
+                            onClick={() =>
+                              trackChecklistItemCTAClicked("x-ray")
+                            }
+                          >
+                            <Button variant="outline">{t`Browse data`}</Button>
+                          </Link>
+                        </Box>
+                      )}
                     </>
                   ) : (
-                    <Text>{t`You need to enable this feature first.`}</Text>
+                    <Text>{disabledXrayCopy(isAdmin)}</Text>
                   )}
                 </Stack>
               </Accordion.Panel>
@@ -349,14 +365,16 @@ export const Onboarding = () => {
                       <b key="drill-through">{t`drill-through the chart`}</b>
                     )} to explore the data further.`}
                   </Text>
-                  <Box data-testid="notebook-cta">
-                    <Link
-                      to={newQuestionUrl}
-                      onClick={() => trackChecklistItemCTAClicked("notebook")}
-                    >
-                      <Button variant="outline">{t`New question`}</Button>
-                    </Link>
-                  </Box>
+                  {isAdmin && (
+                    <Box data-testid="notebook-cta">
+                      <Link
+                        to={newQuestionUrl}
+                        onClick={() => trackChecklistItemCTAClicked("notebook")}
+                      >
+                        <Button variant="outline">{t`New question`}</Button>
+                      </Link>
+                    </Box>
+                  )}
                 </Stack>
               </Accordion.Panel>
             </Accordion.Item>
@@ -389,14 +407,16 @@ export const Onboarding = () => {
                       )
                     }, and reference the results of models or other saved question in your code.`}
                   </Text>
-                  <Box data-testid="sql-cta">
-                    <Link
-                      to={newNativeQuestionUrl}
-                      onClick={() => trackChecklistItemCTAClicked("sql")}
-                    >
-                      <Button variant="outline">{t`New native query`}</Button>
-                    </Link>
-                  </Box>
+                  {isAdmin && (
+                    <Box data-testid="sql-cta">
+                      <Link
+                        to={newNativeQuestionUrl}
+                        onClick={() => trackChecklistItemCTAClicked("sql")}
+                      >
+                        <Button variant="outline">{t`New native query`}</Button>
+                      </Link>
+                    </Box>
+                  )}
                 </Stack>
               </Accordion.Panel>
             </Accordion.Item>
@@ -429,7 +449,7 @@ export const Onboarding = () => {
                     </ul>
                   </Text>
 
-                  {exampleDashboardId && (
+                  {isAdmin && exampleDashboardId && (
                     <Box data-testid="dashboard-cta">
                       <Link
                         to={`/dashboard/${exampleDashboardId}`}
@@ -494,7 +514,7 @@ export const Onboarding = () => {
                       />
                     )} ${(<b key="subscriptions">{t`Subscriptions`}</b>)}.`}
                   </Text>
-                  {exampleDashboardId && (
+                  {isAdmin && exampleDashboardId && (
                     <Box data-testid="subscription-cta">
                       <Link
                         to="/dashboard/1"
@@ -589,7 +609,7 @@ export const Onboarding = () => {
                     </ul>
                   </Text>
                   {/* If the example dashboard is not available, there's a high chance that this question isn't either */}
-                  {exampleDashboardId && (
+                  {isAdmin && exampleDashboardId && (
                     <Box data-testid="alert-cta">
                       <Link
                         // The product decision was to hard code this question id, since we don't have the
@@ -624,7 +644,7 @@ export const Onboarding = () => {
                 </Text>
               </Box>
             )}
-            {isPaidPlan && (
+            {isAdmin && isPaidPlan && (
               <Box className={S.support} data-testid="help-section" p="lg">
                 <Stack spacing="xs">
                   <Title order={4}>{t`Need to talk with someone?`}</Title>

--- a/frontend/src/metabase/home/components/Onboarding/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/Onboarding/tests/common.unit.spec.tsx
@@ -22,7 +22,7 @@ describe("Onboarding", () => {
     jest.clearAllMocks();
   });
 
-  it("should have four sections by default", () => {
+  it("should have four sections by default for admins", () => {
     setup();
 
     [
@@ -37,7 +37,28 @@ describe("Onboarding", () => {
     });
   });
 
-  it("'database' accordion item should be open by default", () => {
+  it("should not render the 'Set up' section for non-admins", () => {
+    setup({ isAdmin: false });
+
+    [
+      "Start visualizing your data",
+      "Get email updates and alerts",
+      "Get the most out of Metabase",
+    ].forEach(section => {
+      expect(
+        screen.getByRole("heading", { name: section }),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole("heading", { name: "Set up your Metabase" }),
+    ).not.toBeInTheDocument();
+
+    expect(screen.queryByTestId("database-item")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("invite-item")).not.toBeInTheDocument();
+  });
+
+  it("'database' accordion item should be open by default for admins", () => {
     const { scrollIntoViewMock } = setup();
 
     const databaseItem = getItem("database");
@@ -58,6 +79,19 @@ describe("Onboarding", () => {
     expect(
       within(cta).getByRole("button", { name: "Add Database" }),
     ).toBeInTheDocument();
+
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+  });
+
+  it("'x-ray' accordion item should be open by default for non-admins", () => {
+    const { scrollIntoViewMock } = setup({ isAdmin: false });
+
+    const xRayItem = getItem("x-ray");
+    const xRayItemControl = getItemControl("Create automatic dashboards");
+
+    expect(xRayItem).toHaveAttribute("data-active", "true");
+    expect(xRayItemControl).toHaveAttribute("data-active", "true");
+    expect(xRayItemControl).toHaveAttribute("aria-expanded", "true");
 
     expect(scrollIntoViewMock).not.toHaveBeenCalled();
   });
@@ -84,6 +118,23 @@ describe("Onboarding", () => {
 
     expect(databaseItemControl).toHaveAttribute("aria-expanded", "false");
     expect(sqlItemControl).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it.each<ChecklistItemValue>([
+    "x-ray",
+    "notebook",
+    "sql",
+    "dashboard",
+    "subscription",
+    "alert",
+  ])("%s CTA should not be visible to non-admins", item => {
+    setup({ isAdmin: false, openItem: item });
+
+    expect(screen.getByTestId(`${item}-item`)).toHaveAttribute(
+      "data-active",
+      "true",
+    );
+    expect(screen.queryByTestId(`${item}-cta`)).not.toBeInTheDocument();
   });
 
   describe("'Set up your Metabase' section", () => {
@@ -173,6 +224,20 @@ describe("Onboarding", () => {
       expect(
         within(getItem("x-ray")).queryByTestId("x-ray-cta"),
       ).not.toBeInTheDocument();
+    });
+
+    it("copy for disabled x-rays should be slightly different for non-admins", () => {
+      setup({ openItem: "x-ray", enableXrays: false, isAdmin: false });
+      expect(
+        within(getItem("x-ray")).queryByText(
+          /Hover over a table and click the yellow lightning bolt/,
+        ),
+      ).not.toBeInTheDocument();
+      expect(
+        within(getItem("x-ray")).getByText(
+          /An admin needs to enable this feature first./,
+        ),
+      ).toBeInTheDocument();
     });
 
     it("'notebook' item should render properly", () => {

--- a/frontend/src/metabase/home/components/Onboarding/tests/setup.tsx
+++ b/frontend/src/metabase/home/components/Onboarding/tests/setup.tsx
@@ -7,6 +7,7 @@ import type { TokenFeatures } from "metabase-types/api";
 import {
   createMockTokenFeatures,
   createMockTokenStatus,
+  createMockUser,
 } from "metabase-types/api/mocks";
 import {
   createMockAppState,
@@ -17,6 +18,7 @@ import { Onboarding } from "../Onboarding";
 import type { ChecklistItemValue } from "../types";
 
 export type SetupProps = {
+  isAdmin?: boolean;
   applicationName?: string;
   enableXrays?: boolean;
   hasEnterprisePlugins?: boolean;
@@ -28,6 +30,7 @@ export type SetupProps = {
 };
 
 export const setup = ({
+  isAdmin = true,
   applicationName,
   enableXrays = true,
   hasEnterprisePlugins = false,
@@ -48,6 +51,7 @@ export const setup = ({
         "last-opened-onboarding-checklist-item": openItem,
       },
     }),
+    currentUser: createMockUser({ is_superuser: isAdmin }),
     settings: mockSettings({
       "application-name": applicationName,
       "enable-xrays": enableXrays,

--- a/frontend/src/metabase/home/selectors.ts
+++ b/frontend/src/metabase/home/selectors.ts
@@ -1,4 +1,9 @@
+import { createSelector } from "@reduxjs/toolkit";
+import dayjs from "dayjs";
+
+import { getIsEmbedded } from "metabase/selectors/embed";
 import { getSetting } from "metabase/selectors/settings";
+import { getIsWhiteLabeling } from "metabase/selectors/whitelabel";
 import type { State } from "metabase-types/store";
 
 export const getIsXrayEnabled = (state: State) => {
@@ -8,3 +13,16 @@ export const getIsXrayEnabled = (state: State) => {
 export const getHasMetabotLogo = (state: State) => {
   return getSetting(state, "show-metabot");
 };
+
+const getIsNewInstance = (state: State) => {
+  const instanceCreated = getSetting(state, "instance-creation");
+  const daysSinceCreation = dayjs().diff(dayjs(instanceCreated), "days");
+  return daysSinceCreation <= 30;
+};
+
+export const getShouldShowOnboardingLink = createSelector(
+  [getIsNewInstance, getIsEmbedded, getIsWhiteLabeling],
+  (isNewInstance, isEmbedded, isWhiteLabelled) => {
+    return isNewInstance && !isEmbedded && !isWhiteLabelled;
+  },
+);

--- a/frontend/src/metabase/home/selectors.ts
+++ b/frontend/src/metabase/home/selectors.ts
@@ -14,15 +14,15 @@ export const getHasMetabotLogo = (state: State) => {
   return getSetting(state, "show-metabot");
 };
 
-const getIsNewInstance = (state: State) => {
+export const getIsNewInstance = (state: State) => {
   const instanceCreated = getSetting(state, "instance-creation");
   const daysSinceCreation = dayjs().diff(dayjs(instanceCreated), "days");
   return daysSinceCreation <= 30;
 };
 
-export const getShouldShowOnboardingLink = createSelector(
-  [getIsNewInstance, getIsEmbedded, getIsWhiteLabeling],
-  (isNewInstance, isEmbedded, isWhiteLabelled) => {
-    return isNewInstance && !isEmbedded && !isWhiteLabelled;
+export const getCanAccessOnboardingPage = createSelector(
+  [getIsEmbedded, getIsWhiteLabeling],
+  (isEmbedded, isWhiteLabelled) => {
+    return !isEmbedded && !isWhiteLabelled;
   },
 );

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -1,15 +1,10 @@
-import dayjs from "dayjs";
 import type { MouseEvent } from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
-import {
-  useHasTokenFeature,
-  useSetting,
-  useUserSetting,
-} from "metabase/common/hooks";
+import { useHasTokenFeature, useUserSetting } from "metabase/common/hooks";
 import { useIsAtHomepageDashboard } from "metabase/common/hooks/use-is-at-homepage-dashboard";
 import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import { Tree } from "metabase/components/tree";
@@ -17,14 +12,13 @@ import {
   PERSONAL_COLLECTIONS,
   getCollectionIcon,
 } from "metabase/entities/collections";
+import { getShouldShowOnboardingLink } from "metabase/home/selectors";
 import { isSmallScreen } from "metabase/lib/dom";
 import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { WhatsNewNotification } from "metabase/nav/components/WhatsNewNotification";
 import { getHasOwnDatabase } from "metabase/selectors/data";
-import { getIsEmbedded } from "metabase/selectors/embed";
 import { getSetting } from "metabase/selectors/settings";
-import { getIsWhiteLabeling } from "metabase/selectors/whitelabel";
 import type { IconName, IconProps } from "metabase/ui";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type { Bookmark, Collection, User } from "metabase-types/api";
@@ -124,24 +118,7 @@ export function MainNavbarView({
   );
 
   const ONBOARDING_URL = "/getting-started";
-
-  const [showOnboarding, setShowOnboarding] = useState(false);
-  const instanceCreated = useSetting("instance-creation");
-
-  useEffect(() => {
-    const daysSinceCreation = dayjs().diff(dayjs(instanceCreated), "days");
-    const isNewInstance = daysSinceCreation <= 30;
-
-    if (isNewInstance) {
-      setShowOnboarding(true);
-    }
-  }, [instanceCreated]);
-
-  const isEmbedded = useSelector(getIsEmbedded);
-  const isWhiteLabelled = useSelector(getIsWhiteLabeling);
-
-  const showOnboardingChecklist =
-    isAdmin && showOnboarding && !isEmbedded && !isWhiteLabelled;
+  const showOnboardingCheckLink = useSelector(getShouldShowOnboardingLink);
 
   // Instances with DWH enabled already have uploads enabled by default.
   // It is not possible to turn the uploads off, nor to delete the attached database.
@@ -183,7 +160,7 @@ export function MainNavbarView({
             >
               {t`Home`}
             </PaddedSidebarLink>
-            {showOnboardingChecklist && (
+            {showOnboardingCheckLink && (
               <PaddedSidebarLink
                 icon="learn"
                 url={ONBOARDING_URL}

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -118,7 +118,7 @@ export function MainNavbarView({
   );
 
   const ONBOARDING_URL = "/getting-started";
-  const showOnboardingCheckLink = useSelector(getShouldShowOnboardingLink);
+  const showOnboardingLink = useSelector(getShouldShowOnboardingLink);
 
   // Instances with DWH enabled already have uploads enabled by default.
   // It is not possible to turn the uploads off, nor to delete the attached database.
@@ -160,7 +160,7 @@ export function MainNavbarView({
             >
               {t`Home`}
             </PaddedSidebarLink>
-            {showOnboardingCheckLink && (
+            {showOnboardingLink && (
               <PaddedSidebarLink
                 icon="learn"
                 url={ONBOARDING_URL}

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -12,7 +12,10 @@ import {
   PERSONAL_COLLECTIONS,
   getCollectionIcon,
 } from "metabase/entities/collections";
-import { getShouldShowOnboardingLink } from "metabase/home/selectors";
+import {
+  getCanAccessOnboardingPage,
+  getIsNewInstance,
+} from "metabase/home/selectors";
 import { isSmallScreen } from "metabase/lib/dom";
 import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
@@ -118,7 +121,9 @@ export function MainNavbarView({
   );
 
   const ONBOARDING_URL = "/getting-started";
-  const showOnboardingLink = useSelector(getShouldShowOnboardingLink);
+  const isNewInstance = useSelector(getIsNewInstance);
+  const canAccessOnboarding = useSelector(getCanAccessOnboardingPage);
+  const showOnboardingLink = isNewInstance && canAccessOnboarding;
 
   // Instances with DWH enabled already have uploads enabled by default.
   // It is not possible to turn the uploads off, nor to delete the attached database.

--- a/frontend/src/metabase/nav/containers/MainNavbar/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/tests/common.unit.spec.tsx
@@ -34,17 +34,11 @@ describe("nav > containers > MainNavbar", () => {
   });
 
   describe("how to use Metabase", () => {
-    it("should render for admins", async () => {
-      await setup({ user: createMockUser({ is_superuser: true }) });
+    it.each(["admin", "non-admin"])("should render for %s", async user => {
+      await setup({ user: createMockUser({ is_superuser: user === "admin" }) });
       const link = screen.getByRole("link", { name: /How to use Metabase/i });
       expect(link).toBeInTheDocument();
       expect(link).toHaveAttribute("href", "/getting-started");
-    });
-
-    it("should not render for non-admins", async () => {
-      await setup({ user: createMockUser({ is_superuser: false }) });
-      const link = screen.queryByRole("link", { name: /How to use Metabase/i });
-      expect(link).not.toBeInTheDocument();
     });
 
     it("should be highlighted if selected", async () => {

--- a/frontend/src/metabase/route-guards.tsx
+++ b/frontend/src/metabase/route-guards.tsx
@@ -6,6 +6,8 @@ import { isSameOrSiteUrlOrigin } from "metabase/lib/dom";
 import { getSetting } from "metabase/selectors/settings";
 import type { State } from "metabase-types/store";
 
+import { getCanAccessOnboardingPage } from "./home/selectors";
+
 type Props = { children: React.ReactElement };
 
 const getRedirectUrl = () => {
@@ -60,6 +62,14 @@ const UserCanAccessSettings = connectedReduxRedirect<Props, State>({
   redirectAction: routerActions.replace,
 });
 
+export const UserCanAccessOnboarding = connectedReduxRedirect<Props, State>({
+  wrapperDisplayName: "UserCanAccessOnboarding",
+  redirectPath: "/",
+  allowRedirectBack: false,
+  authenticatedSelector: state => getCanAccessOnboardingPage(state),
+  redirectAction: routerActions.replace,
+});
+
 export const IsAuthenticated = MetabaseIsSetup(
   UserIsAuthenticated(({ children }) => children),
 );
@@ -73,4 +83,8 @@ export const IsNotAuthenticated = MetabaseIsSetup(
 
 export const CanAccessSettings = MetabaseIsSetup(
   UserIsAuthenticated(UserCanAccessSettings(({ children }) => children)),
+);
+
+export const CanAccessOnboarding = UserCanAccessOnboarding(
+  ({ children }) => children,
 );

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -57,6 +57,7 @@ import { Setup } from "metabase/setup/components/Setup";
 import getCollectionTimelineRoutes from "metabase/timelines/collections/routes";
 
 import {
+  CanAccessOnboarding,
   CanAccessSettings,
   IsAdmin,
   IsAuthenticated,
@@ -131,8 +132,10 @@ export const getRoutes = store => {
           <Route
             path="getting-started"
             title={t`Getting Started`}
-            component={Onboarding}
-          />
+            component={CanAccessOnboarding}
+          >
+            <IndexRoute component={Onboarding} />
+          </Route>
 
           <Route path="search" title={t`Search`} component={SearchApp} />
           {/* Send historical /archive route to trash - can remove in v52 */}

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -131,10 +131,8 @@ export const getRoutes = store => {
           <Route
             path="getting-started"
             title={t`Getting Started`}
-            component={IsAdmin}
-          >
-            <IndexRoute component={Onboarding} />
-          </Route>
+            component={Onboarding}
+          />
 
           <Route path="search" title={t`Search`} component={SearchApp} />
           {/* Send historical /archive route to trash - can remove in v52 */}


### PR DESCRIPTION
### What does this PR accomplish?
- It opens up an onboarding checklist for non-admins!
- It improves the route guards so that now even people who navigate directly to this route (`/gettting-started`) are redirected to the home page if they are not supposed to see the page (whitelabelled instances or embedding context)

Resolves #50576

> [!IMPORTANT]
> Other than opening this up to non-admins, all other conditions that determine whether or not to display the link to this page still apply.
