### PR TITLE
Enable New Search by default

### DIFF
--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -1068,7 +1068,8 @@ See [fonts](../configuring-metabase/fonts.md).")
   (deferred-tru "Enables search engines which are still in the experimental stage")
   :visibility :internal
   :export?    false
-  :default    (not config/is-prod?)
+  ;; TODO disable by default again in the 52 Gold release
+  :default    true #_(not config/is-prod?)
   :type       :boolean)
 
 (defsetting experimental-search-weight-overrides


### PR DESCRIPTION
For the Beta it will be good to get feedback on the new search engine.

This is just a extraction of [this commit](https://github.com/metabase/metabase/pull/50471/commits/fce7f0a2d28d0d9ee15dc1dae037d213ad5f19ef) from a larger PR.