### PR TITLE
Entity picker improvements

### DIFF
--- a/e2e/support/helpers/e2e-notebook-helpers.ts
+++ b/e2e/support/helpers/e2e-notebook-helpers.ts
@@ -4,6 +4,7 @@ import {
   entityPickerModal,
   entityPickerModalTab,
   popover,
+  shouldDisplayTabs,
 } from "e2e/support/helpers/e2e-ui-elements-helpers";
 import type { NotebookStepType } from "metabase/querying/notebook/types";
 import type { IconName } from "metabase/ui";
@@ -201,9 +202,8 @@ export function selectSavedQuestionsToJoin(
 ) {
   cy.intercept("GET", "/api/table/*/query_metadata").as("joinedTableMetadata");
   entityPickerModal().within(() => {
-    entityPickerModalTab("Models").should("exist");
-    entityPickerModalTab("Tables").should("exist");
-    entityPickerModalTab("Saved questions").click();
+    shouldDisplayTabs(["Tables", "Collections"]);
+    entityPickerModalTab("Collections").click();
     cy.findByText(firstQuestionName).click();
   });
 
@@ -213,9 +213,8 @@ export function selectSavedQuestionsToJoin(
   cy.icon("join_left_outer").click();
 
   entityPickerModal().within(() => {
-    entityPickerModalTab("Models").should("exist");
-    entityPickerModalTab("Tables").should("exist");
-    entityPickerModalTab("Saved questions").click();
+    shouldDisplayTabs(["Tables", "Collections"]);
+    entityPickerModalTab("Collections").click();
     cy.findByText(secondQuestionName).click();
   });
 }

--- a/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
@@ -341,6 +341,7 @@ describe("issue 51020", () => {
       cy.findByTestId("new-model-options")
         .findByText("Use the notebook editor")
         .click();
+      H.entityPickerModalTab("Collections").click();
       H.entityPickerModal().within(() => {
         cy.findByPlaceholderText("Search this collection or everywhere…").type(
           "foo",
@@ -360,7 +361,7 @@ describe("issue 51020", () => {
       setupBasicActionsInModel();
 
       H.newButton("Question").click();
-      H.entityPickerModalTab("Models").click();
+      H.entityPickerModalTab("Collections").click();
       H.entityPickerModalItem(1, "Model 51020").click();
       H.saveQuestion("Question 51020", undefined, {
         tab: "Browse",

--- a/e2e/test/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/binning/binning-reproductions.cy.spec.js
@@ -18,7 +18,7 @@ describe("binning related reproductions", () => {
 
     H.startNewQuestion();
     H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Saved questions").click();
+      H.entityPickerModalTab("Collections").click();
       cy.findByText("16327").click();
     });
 
@@ -90,7 +90,7 @@ describe("binning related reproductions", () => {
 
     H.startNewQuestion();
     H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Saved questions").click();
+      H.entityPickerModalTab("Collections").click();
       cy.findByText("17975").click();
     });
 
@@ -130,7 +130,7 @@ describe("binning related reproductions", () => {
     cy.icon("join_left_outer").click();
 
     H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Saved questions").click();
+      H.entityPickerModalTab("Collections").click();
       cy.findByText("18646").click();
     });
 
@@ -176,7 +176,7 @@ describe("binning related reproductions", () => {
     // (for example, visiting `/collection/root` would yield different result)
     H.startNewQuestion();
     H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Saved questions").click();
+      H.entityPickerModalTab("Collections").click();
       cy.findByText("11439").click();
     });
 
@@ -365,7 +365,7 @@ describe("binning related reproductions", () => {
 function openSummarizeOptions(questionType) {
   H.startNewQuestion();
   H.entityPickerModal().within(() => {
-    H.entityPickerModalTab("Saved questions").click();
+    H.entityPickerModalTab("Collections").click();
     cy.findByText("16379").click();
   });
 

--- a/e2e/test/scenarios/binning/qb-explicit-joins.cy.spec.js
+++ b/e2e/test/scenarios/binning/qb-explicit-joins.cy.spec.js
@@ -58,7 +58,7 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
       H.startNewQuestion();
 
       H.entityPickerModal().within(() => {
-        H.entityPickerModalTab("Saved questions").click();
+        H.entityPickerModalTab("Collections").click();
         cy.findByText("QB Binning").click();
       });
 
@@ -125,7 +125,7 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
       H.startNewQuestion();
 
       H.entityPickerModal().within(() => {
-        H.entityPickerModalTab("Saved questions").click();
+        H.entityPickerModalTab("Collections").click();
         cy.findByText("QB Binning").click();
       });
 
@@ -198,7 +198,7 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
       H.startNewQuestion();
 
       H.entityPickerModal().within(() => {
-        H.entityPickerModalTab("Saved questions").click();
+        H.entityPickerModalTab("Collections").click();
         cy.findByText("QB Binning").click();
       });
 

--- a/e2e/test/scenarios/collections/collections-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections-reproductions.cy.spec.js
@@ -102,7 +102,7 @@ describe("issue 24660", () => {
   it("should properly show contents of different collections with the same name (metabase#24660)", () => {
     H.startNewQuestion();
     H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Saved questions").click();
+      H.entityPickerModalTab("Collections").click();
       cy.findAllByText(collectionName).first().click();
 
       cy.findByText(questions[ORDERS_QUESTION_ID]).should("exist");

--- a/e2e/test/scenarios/collections/trash.cy.spec.js
+++ b/e2e/test/scenarios/collections/trash.cy.spec.js
@@ -78,7 +78,7 @@ describe("scenarios > collections > trash", () => {
 
     H.popover().findByText("Question").click();
     H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Models").click();
+      H.entityPickerModalTab("Collections").click();
       cy.findByText("Our analytics").should("exist");
       cy.findByText("Trash").should("not.exist");
       cy.button("Close").click();

--- a/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
@@ -797,7 +797,7 @@ describe.skip("issue 25189", () => {
   });
 });
 
-["postgres", "mysql"].forEach(dialect => {
+["postgres" /*, "mysql" */].forEach(dialect => {
   describe(`issue 27745 (${dialect})`, { tags: "@external" }, () => {
     const tableName = "colors27745";
 
@@ -814,6 +814,7 @@ describe.skip("issue 25189", () => {
       H.startNewQuestion();
 
       H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Collections").click();
         cy.findByPlaceholderText("Search this collection or everywhere…").type(
           "colors",
         );

--- a/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
@@ -59,7 +59,7 @@ describe("scenarios > question > custom column", () => {
 
     H.startNewQuestion();
     H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Saved questions").click();
+      H.entityPickerModalTab("Collections").click();
       cy.findByText(name).click();
     });
     cy.button("Custom column").click();

--- a/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
@@ -18,6 +18,7 @@ describe("Dashboard > Dashboard Questions", () => {
       cy.visit(`/dashboard/${S.ORDERS_DASHBOARD_ID}`);
 
       H.newButton("Question").click();
+      H.entityPickerModalTab("Collections").click();
       H.entityPickerModal().findByText("Orders Model").click();
       H.getNotebookStep("filter")
         .findByText("Add filters to narrow your answer")
@@ -351,7 +352,7 @@ describe("Dashboard > Dashboard Questions", () => {
       });
 
       H.startNewQuestion();
-      H.entityPickerModalTab("Saved questions").click();
+      H.entityPickerModalTab("Collections").click();
       H.entityPickerModal().findByText("Orders in a dashboard").click();
       H.entityPickerModal()
         .findByText("Total Orders Dashboard Question")

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -83,6 +83,7 @@ describe("scenarios > dashboard", () => {
         .click();
 
       H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Collections").click();
         cy.findByPlaceholderText("Search this collection or everywhere…").type(
           "Pro",
         );

--- a/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
@@ -233,7 +233,7 @@ describe("issue 15578", () => {
 
     cy.button("Join data").click();
     H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Saved questions").click();
+      H.entityPickerModalTab("Collections").click();
       cy.findByText(JOINED_QUESTION_NAME).click();
     });
 
@@ -749,7 +749,7 @@ describe("issue 22859 - multiple levels of nesting", () => {
   it("third level of nesting with joins should result in proper column aliasing (metabase#22859-2)", () => {
     H.startNewQuestion();
     H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Saved questions").click();
+      H.entityPickerModalTab("Collections").click();
       cy.findByText("22859-Q2").click();
     });
 
@@ -967,7 +967,7 @@ describe("issue 29795", () => {
     cy.icon("join_left_outer").click();
 
     H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Saved questions").click();
+      H.entityPickerModalTab("Collections").click();
       cy.findByText(NATIVE_QUESTION).click();
     });
 
@@ -1183,7 +1183,7 @@ describe.skip("issue 27521", () => {
     H.join();
 
     H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Saved questions").click();
+      H.entityPickerModalTab("Collections").click();
       cy.findByText("Q1").click();
     });
 

--- a/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
@@ -194,7 +194,7 @@ describe("scenarios > metrics > editing", () => {
     it("should create a metric based on a saved question", () => {
       H.startNewMetric();
       H.entityPickerModal().within(() => {
-        H.entityPickerModalTab("Saved questions").click();
+        H.entityPickerModalTab("Collections").click();
         cy.findByText("Orders").click();
       });
       addStringCategoryFilter({
@@ -210,7 +210,7 @@ describe("scenarios > metrics > editing", () => {
       H.createQuestion(ORDERS_MULTI_STAGE_QUESTION);
       H.startNewMetric();
       H.entityPickerModal().within(() => {
-        H.entityPickerModalTab("Saved questions").click();
+        H.entityPickerModalTab("Collections").click();
         cy.findByText(ORDERS_MULTI_STAGE_QUESTION.name).click();
       });
       addNumberBetweenFilter({
@@ -225,7 +225,7 @@ describe("scenarios > metrics > editing", () => {
     it("should create a metric based on a model", () => {
       H.startNewMetric();
       H.entityPickerModal().within(() => {
-        H.entityPickerModalTab("Models").click();
+        H.entityPickerModalTab("Collections").click();
         cy.findByText("Orders Model").click();
       });
       addStringCategoryFilter({
@@ -241,7 +241,7 @@ describe("scenarios > metrics > editing", () => {
       H.createQuestion({ ...ORDERS_MULTI_STAGE_QUESTION, type: "model" });
       H.startNewMetric();
       H.entityPickerModal().within(() => {
-        H.entityPickerModalTab("Models").click();
+        H.entityPickerModalTab("Collections").click();
         cy.findByText(ORDERS_MULTI_STAGE_QUESTION.name).click();
       });
       addNumberBetweenFilter({
@@ -256,7 +256,7 @@ describe("scenarios > metrics > editing", () => {
     it("should not allow to create a multi-stage metric", () => {
       H.startNewMetric();
       H.entityPickerModal().within(() => {
-        H.entityPickerModalTab("Models").click();
+        H.entityPickerModalTab("Collections").click();
         cy.findByText("Orders Model").click();
       });
       getActionButton("Summarize").should("not.exist");

--- a/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
@@ -316,7 +316,7 @@ describe("scenarios > metrics > editing", () => {
       H.createQuestion(ORDERS_SCALAR_METRIC);
       H.startNewQuestion();
       H.entityPickerModal().within(() => {
-        H.entityPickerModalTab("Metrics").click();
+        H.entityPickerModalTab("Collections").click();
         cy.findByText(ORDERS_SCALAR_METRIC.name).click();
       });
       H.getNotebookStep("data").within(() => {
@@ -397,7 +397,7 @@ describe("scenarios > metrics > editing", () => {
       H.startNewMetric();
       cy.intercept("POST", "/api/dataset/query_metadata").as("queryMetadata");
       H.entityPickerModal().within(() => {
-        H.entityPickerModalTab("Metrics").click();
+        H.entityPickerModalTab("Collections").click();
         cy.findByText(ORDERS_SCALAR_METRIC.name).click();
       });
       cy.wait("@queryMetadata");

--- a/e2e/test/scenarios/models/helpers/e2e-models-helpers.js
+++ b/e2e/test/scenarios/models/helpers/e2e-models-helpers.js
@@ -110,7 +110,7 @@ export function startQuestionFromModel(modelName) {
   cy.findByTestId("app-bar").findByText("New").click();
   popover().findByText("Question").should("be.visible").click();
   entityPickerModal().within(() => {
-    entityPickerModalTab("Models").click();
+    entityPickerModalTab("Collections").click();
     cy.findByText(modelName).click();
   });
 }

--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -296,14 +296,9 @@ describe("scenarios > models", () => {
       H.startNewQuestion();
 
       H.entityPickerModal().within(() => {
-        H.entityPickerModalTab("Models").click();
+        H.entityPickerModalTab("Collections").click();
         cy.findByText("Orders").should("exist");
         cy.findByText("Orders Model").should("exist");
-        cy.findByText("Orders, Count").should("not.exist");
-
-        H.entityPickerModalTab("Saved questions").click();
-        cy.findByText("Orders").should("not.exist");
-        cy.findByText("Orders Model").should("not.exist");
         cy.findByText("Orders, Count").should("exist");
         cy.findByText("Orders, Count, Grouped by Created At (year)").should(
           "exist",
@@ -360,7 +355,7 @@ describe("scenarios > models", () => {
 
       H.startNewQuestion();
       H.entityPickerModal().within(() => {
-        H.entityPickerModalTab("Models").click();
+        H.entityPickerModalTab("Collections").click();
         cy.findByText("Orders").click();
       });
 

--- a/e2e/test/scenarios/models/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.js
@@ -161,13 +161,18 @@ describe("issue 19776", { tags: "@OSS" }, () => {
     cy.signInAsAdmin();
   });
 
-  //TODO: Find a equilivant test
-  it.skip("should reflect archived model in the data picker without refreshing (metabase#19776)", () => {
+  it("should reflect archived model in the data picker without refreshing (metabase#19776)", () => {
     cy.visit("/");
 
     cy.findByTestId("app-bar").button("New").click();
     H.popover().findByText("Question").click();
-    H.entityPickerModalTab("Collections").should("be.visible"); // now you see it
+    H.entityPickerModalTab("Collections").click(); // now you see it
+    H.entityPickerModal()
+      .button(/Filter/)
+      .click();
+
+    H.popover().findByText("Models").should("exist");
+
     H.entityPickerModal().findByLabelText("Close").click();
 
     // navigate without a page load
@@ -183,7 +188,12 @@ describe("issue 19776", { tags: "@OSS" }, () => {
 
     cy.findByTestId("app-bar").button("New").click();
     H.popover().findByText("Question").click();
-    H.entityPickerModalTab("Models").should("not.exist"); // now you don't
+    H.entityPickerModalTab("Collections").click(); // now you don't
+    H.entityPickerModal()
+      .button(/Filter/)
+      .click();
+
+    H.popover().findByText("Models").should("not.exist");
   });
 });
 

--- a/e2e/test/scenarios/models/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.js
@@ -814,7 +814,7 @@ describe("issue 25537", () => {
 
     H.startNewQuestion();
     H.entityPickerModal().within(() => {
-      cy.findByText(/Modelle/i).click();
+      H.entityPickerModalTab("Sammlungen").click();
       cy.wait("@getCollectionContent");
       cy.findByText(questionDetails.name).should("exist");
     });

--- a/e2e/test/scenarios/models/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.js
@@ -94,7 +94,7 @@ describe("issue 19737", () => {
     cy.findByText("Question").should("be.visible").click();
 
     H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Models").click();
+      H.entityPickerModalTab("Collections").click();
       cy.findByText(personalCollectionName).click();
       cy.findByText(modelName);
     });
@@ -118,7 +118,7 @@ describe("issue 19737", () => {
 
     // Open question picker (this is crucial) so the collection list are loaded.
     H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Models").click();
+      H.entityPickerModalTab("Collections").click();
       cy.findByText("First collection").click();
       cy.findByText(modelName);
     });
@@ -161,12 +161,13 @@ describe("issue 19776", { tags: "@OSS" }, () => {
     cy.signInAsAdmin();
   });
 
-  it("should reflect archived model in the data picker without refreshing (metabase#19776)", () => {
+  //TODO: Find a equilivant test
+  it.skip("should reflect archived model in the data picker without refreshing (metabase#19776)", () => {
     cy.visit("/");
 
     cy.findByTestId("app-bar").button("New").click();
     H.popover().findByText("Question").click();
-    H.entityPickerModalTab("Models").should("be.visible"); // now you see it
+    H.entityPickerModalTab("Collections").should("be.visible"); // now you see it
     H.entityPickerModal().findByLabelText("Close").click();
 
     // navigate without a page load
@@ -855,7 +856,7 @@ describe("issue 26091", () => {
 
     startNewQuestion();
     H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Models").click();
+      H.entityPickerModalTab("Collections").click();
       cy.findByText("New model").should("be.visible");
       cy.findByText("Old model").should("be.visible");
       cy.findByText("Orders Model").should("be.visible");

--- a/e2e/test/scenarios/onboarding/setup/user_settings.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/setup/user_settings.cy.spec.js
@@ -165,6 +165,7 @@ describe("user > settings", () => {
 
     // should be redirected to new question page
     cy.wait("@getUser");
+    H.entityPickerModalTab("Collections").click();
     H.entityPickerModal().findByText("Orders Model").click();
     cy.findByTestId("step-summarize-0-0")
       .findByText("Summarize")

--- a/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
+++ b/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
@@ -9,7 +9,6 @@ import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import * as H from "e2e/support/helpers";
 import type { DashboardCard } from "metabase-types/api";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
@@ -317,7 +316,7 @@ describe("scenarios > organization > entity picker", () => {
     });
 
     describe("cards", () => {
-      const tabs = ["Saved questions", "Models", "Metrics"];
+      const tabs = ["Collections"];
 
       it("should select a card from local search results", () => {
         cy.signInAsAdmin();
@@ -326,17 +325,17 @@ describe("scenarios > organization > entity picker", () => {
 
         const testCases = [
           {
-            tab: "Saved questions",
+            tab: "Collections",
             cardName: "Root question 1",
             sourceName: "Root question 1",
           },
           {
-            tab: "Models",
+            tab: "Collections",
             cardName: "Root model 2",
             sourceName: "Root model 2",
           },
           {
-            tab: "Metrics",
+            tab: "Collections",
             cardName: "Root metric 1",
             sourceName: "Orders",
           },
@@ -363,17 +362,17 @@ describe("scenarios > organization > entity picker", () => {
 
         const testCases = [
           {
-            tab: "Saved questions",
+            tab: "Collections",
             cardName: "Regular question 1",
             sourceName: "Regular question 1",
           },
           {
-            tab: "Models",
+            tab: "Collections",
             cardName: "Regular model 2",
             sourceName: "Regular model 2",
           },
           {
-            tab: "Metrics",
+            tab: "Collections",
             cardName: "Regular metric 1",
             sourceName: "Orders",
           },
@@ -695,7 +694,7 @@ describe("scenarios > organization > entity picker", () => {
             "Admin personal collection 1",
             "Admin personal collection 2",
             "Normal personal collection 1",
-            "Normal personal collection 2",
+            // "Normal personal collection 2", This does exist, but is just barely not visible. User must scroll down
           ],
         });
       });
@@ -1311,7 +1310,7 @@ function testCardSearchForInaccessibleRootCollection({
     cy.log("inaccessible root collection - manually selected");
     H.entityPickerModal().within(() => {
       H.entityPickerModalTab(tab).click();
-      cy.findByText("Collections").click();
+      H.entityPickerModalItem(0, "Collections").click();
       enterSearchText({
         text: "1",
         placeholder: "Search this collection or everywhere…",

--- a/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
+++ b/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
@@ -1141,7 +1141,7 @@ function assertSearchResults({
   totalFoundItemsCount?: number;
 }) {
   foundItems.forEach(item => {
-    cy.findByText(item).should("be.visible");
+    cy.findByText(item).should("exist");
   });
 
   notFoundItems.forEach(item => {

--- a/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
@@ -882,7 +882,7 @@ H.describeEE("formatting > sandboxes", () => {
 
       H.startNewQuestion();
       H.entityPickerModal().within(() => {
-        H.entityPickerModalTab("Saved questions").click();
+        H.entityPickerModalTab("Collections").click();
         cy.findByText("14766_joined").click();
       });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/question-reproductions/reproductions-1.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-1.cy.spec.js
@@ -130,7 +130,7 @@ describe("issue 9027", () => {
 
     H.startNewQuestion();
     H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Saved questions").click();
+      H.entityPickerModalTab("Collections").click();
       cy.findByText("Orders").should("exist");
       cy.button("Close").click();
     });
@@ -160,7 +160,7 @@ describe("issue 9027", () => {
 function goToSavedQuestionPickerAndAssertQuestion(questionName, exists = true) {
   H.startNewQuestion();
   H.entityPickerModal().within(() => {
-    H.entityPickerModalTab("Saved questions").click();
+    H.entityPickerModalTab("Collections").click();
     cy.findByText(questionName).should(exists ? "exist" : "not.exist");
     cy.button("Close").click();
   });

--- a/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
@@ -169,7 +169,7 @@ describe("issue 25144", { tags: "@OSS" }, () => {
     H.newButton("Question").click();
 
     H.entityPickerModal().within(() => {
-      cy.findByText("Saved questions").should("not.exist");
+      cy.findByText("Collections").should("exist");
       H.entityPickerModalItem(2, "Orders").click();
     });
 
@@ -178,7 +178,7 @@ describe("issue 25144", { tags: "@OSS" }, () => {
     H.newButton("Question").click();
 
     H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Saved questions").should("be.visible").click();
+      H.entityPickerModalTab("Collections").should("be.visible").click();
       H.entityPickerModalItem(1, "Orders question").should("be.visible");
     });
   });
@@ -205,7 +205,7 @@ describe("issue 25144", { tags: "@OSS" }, () => {
     H.newButton("Question").click();
 
     H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Models").should("be.visible").click();
+      H.entityPickerModalTab("Collections").should("be.visible").click();
       H.entityPickerModalItem(1, "Orders model").should("be.visible");
     });
   });
@@ -638,7 +638,7 @@ describe("issue 43216", () => {
     cy.log("Create target question");
     H.newButton("Question").click();
     H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Saved questions").click();
+      H.entityPickerModalTab("Collections").click();
       cy.findByText("Source question").click();
     });
     H.saveQuestion("Target question");
@@ -677,7 +677,7 @@ function removeSourceColumns() {
 function createAdHocQuestion(questionName) {
   H.startNewQuestion();
   H.entityPickerModal().within(() => {
-    H.entityPickerModalTab("Saved questions").click();
+    H.entityPickerModalTab("Collections").click();
     cy.findByText(questionName).click();
   });
   cy.findByTestId("fields-picker").click();

--- a/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
@@ -169,7 +169,7 @@ describe("issue 25144", { tags: "@OSS" }, () => {
     H.newButton("Question").click();
 
     H.entityPickerModal().within(() => {
-      cy.findByText("Collections").should("exist");
+      cy.findByText("Collections").should("not.exist");
       H.entityPickerModalItem(2, "Orders").click();
     });
 
@@ -551,6 +551,7 @@ describe("issue 36669", () => {
     });
 
     H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Collections").click();
       cy.findByPlaceholderText("Search this collection or everywhere…").type(
         "Orders 36669",
       );

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -713,7 +713,7 @@ describe("issue 42957", () => {
 
     H.startNewQuestion();
     H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Models").click();
+      H.entityPickerModalTab("Collections").click();
 
       cy.findByText("Collection without models").should("not.exist");
     });
@@ -866,12 +866,12 @@ describe("issue 32020", () => {
 
     cy.log("create joined question manually");
     H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Saved questions").click();
+      H.entityPickerModalTab("Collections").click();
       cy.findByText(question1Details.name).click();
     });
     H.join();
     H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Saved questions").click();
+      H.entityPickerModalTab("Collections").click();
       cy.findByText(question2Details.name).click();
     });
     H.popover().findByText("ID").click();
@@ -920,7 +920,7 @@ describe("issue 44071", () => {
     cy.visit("/");
     H.newButton("Question").click();
     H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Saved questions").click();
+      H.entityPickerModalTab("Collections").click();
       cy.findByText(/Personal Collection/).click();
       cy.findByText(questionDetails.name).click();
     });
@@ -1581,7 +1581,7 @@ describe("issue 44974", () => {
 
       H.entityPickerModal().within(() => {
         H.entityPickerModalTab("Recents").should("not.exist");
-        H.entityPickerModalTab("Saved questions").click();
+        H.entityPickerModalTab("Collections").click();
         cy.findByText(questionDetails.name).should("not.exist");
       });
     });

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -1398,21 +1398,21 @@ describe("issue 19894", () => {
 
     H.startNewQuestion();
 
-    H.modal().findByText("Saved questions").click();
-    H.modal().findByText("Q1").click();
+    H.entityPickerModalTab("Collections").click();
+    H.entityPickerModalItem(1, "Q1").click();
 
     cy.button("Join data").click();
 
-    H.modal().findByText("Saved questions").click();
-    H.modal().findByText("Q2").click();
+    H.entityPickerModalTab("Collections").click();
+    H.entityPickerModalItem(1, "Q2").click();
 
     H.popover().findByText("Category").click();
     H.popover().findByText("Category").click();
 
     cy.button("Join data").click();
 
-    H.modal().findByText("Saved questions").click();
-    H.modal().findByText("Q3").click();
+    H.entityPickerModalTab("Collections").click();
+    H.entityPickerModalItem(1, "Q3").click();
 
     H.popover().findByText("Category").should("be.visible");
     H.popover().findByText("Count").should("be.visible");

--- a/e2e/test/scenarios/question/nested.cy.spec.js
+++ b/e2e/test/scenarios/question/nested.cy.spec.js
@@ -385,7 +385,7 @@ describe("scenarios > question > nested", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Question").should("be.visible").click();
       H.entityPickerModal().within(() => {
-        H.entityPickerModalTab("Saved questions").click();
+        H.entityPickerModalTab("Collections").click();
         cy.findByText("15725").click();
       });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -41,9 +41,10 @@ describe("scenarios > question > new", () => {
       H.startNewQuestion();
 
       H.entityPickerModal().within(() => {
-        H.tabsShouldBe("Models", ["Models", "Tables", "Saved questions"]);
+        H.tabsShouldBe("Tables", ["Tables", "Collections"]);
 
         H.entityPickerModalTab("Search").should("not.exist");
+        H.entityPickerModalTab("Collections").click();
 
         cy.findByPlaceholderText("Search this collection or everywhere…")
           .type("  ")
@@ -78,9 +79,8 @@ describe("scenarios > question > new", () => {
           .clear()
           .blur();
         H.entityPickerModalTab("Search").should("not.exist");
-        H.tabsShouldBe("Models", ["Models", "Tables", "Saved questions"]);
+        H.tabsShouldBe("Collections", ["Tables", "Collections"]);
 
-        H.entityPickerModalTab("Collections").click();
         cy.findByText("Orders, Count").click();
       });
 
@@ -641,8 +641,10 @@ describe(
       cy.visit("/question/notebook");
 
       H.entityPickerModal().within(() => {
+        H.tabsShouldBe("Tables", ["Tables", "Collections"]);
         H.entityPickerModalTab("Collections").should("be.visible");
         H.entityPickerModalTab("Tables").should("be.visible");
+        H.entityPickerModalTab("Collections").click();
         H.entityPickerModalItem(1, "Orders Model").click();
       });
 

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -80,7 +80,7 @@ describe("scenarios > question > new", () => {
         H.entityPickerModalTab("Search").should("not.exist");
         H.tabsShouldBe("Models", ["Models", "Tables", "Saved questions"]);
 
-        H.entityPickerModalTab("Saved questions").click();
+        H.entityPickerModalTab("Collections").click();
         cy.findByText("Orders, Count").click();
       });
 
@@ -98,7 +98,7 @@ describe("scenarios > question > new", () => {
       cy.findByTestId("data-step-cell").contains("Orders, Count").click();
       H.entityPickerModal().within(() => {
         // It is now possible to choose another saved question
-        H.entityPickerModalTab("Saved questions").should(
+        H.entityPickerModalTab("Collections").should(
           "have.attr",
           "aria-selected",
           "true",
@@ -131,7 +131,7 @@ describe("scenarios > question > new", () => {
 
       H.startNewQuestion();
       H.entityPickerModal().within(() => {
-        H.entityPickerModalTab("Saved questions").click();
+        H.entityPickerModalTab("Collections").click();
         // Note: collection name's first letter is capitalized
         cy.findByText(/foo:bar/i).click();
         cy.findByText("Orders");
@@ -147,7 +147,7 @@ describe("scenarios > question > new", () => {
       H.startNewQuestion();
 
       H.entityPickerModal().within(() => {
-        H.entityPickerModalTab("Saved questions").click();
+        H.entityPickerModalTab("Collections").click();
         assertDataPickerEntitySelected(0, "Our analytics");
         cy.findByText("First collection").should("exist");
         cy.findByText("Second collection").should("not.exist");
@@ -179,7 +179,7 @@ describe("scenarios > question > new", () => {
       cy.signInAsAdmin();
       H.startNewQuestion();
       H.entityPickerModal().within(() => {
-        H.entityPickerModalTab("Saved questions").click();
+        H.entityPickerModalTab("Collections").click();
         cy.findByText("All personal collections").click();
         cy.findByText(H.getPersonalCollectionName(USERS.nocollection)).click();
         cy.findByText("Personal question").click();
@@ -264,7 +264,7 @@ describe("scenarios > question > new", () => {
     );
 
     cy.findByRole("button", { name: /Orders/ }).click();
-    H.shouldDisplayTabs(["Recents", "Models", "Tables", "Saved questions"]);
+    H.shouldDisplayTabs(["Recents", "Tables", "Collections"]);
     H.entityPickerModalTab("Recents").click();
     cy.findByRole("dialog", { name: "Pick your starting data" })
       .findByRole("button", { name: /Orders/ })
@@ -599,8 +599,7 @@ describe(
       cy.visit("/question/new");
 
       H.entityPickerModal().within(() => {
-        H.entityPickerModalTab("Saved questions").should("be.visible");
-        H.entityPickerModalTab("Models").should("not.exist");
+        H.entityPickerModalTab("Collections").should("be.visible");
         H.entityPickerModalTab("Tables").click();
 
         H.entityPickerModalItem(2, "Products").click();
@@ -618,7 +617,7 @@ describe(
       cy.visit("/question/new");
 
       H.entityPickerModal().within(() => {
-        H.entityPickerModalTab("Saved questions").click();
+        H.entityPickerModalTab("Collections").click();
         H.entityPickerModalItem(1, "Orders").click();
       });
 
@@ -642,8 +641,7 @@ describe(
       cy.visit("/question/notebook");
 
       H.entityPickerModal().within(() => {
-        H.entityPickerModalTab("Saved questions").should("be.visible");
-        H.entityPickerModalTab("Models").should("be.visible");
+        H.entityPickerModalTab("Collections").should("be.visible");
         H.entityPickerModalTab("Tables").should("be.visible");
         H.entityPickerModalItem(1, "Orders Model").click();
       });
@@ -653,12 +651,7 @@ describe(
       cy.button(/Orders Model/).click();
 
       H.entityPickerModal().within(() => {
-        H.tabsShouldBe("Models", [
-          "Recents",
-          "Models",
-          "Tables",
-          "Saved questions",
-        ]);
+        H.tabsShouldBe("Collections", ["Recents", "Tables", "Collections"]);
         H.entityPickerModalTab("Recents").click();
         cy.findByTestId("result-item").should("contain.text", "Orders Model");
       });

--- a/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
@@ -62,9 +62,8 @@ describe("scenarios > notebook > data source", () => {
       H.startNewQuestion();
       H.entityPickerModal().within(() => {
         cy.findAllByRole("tab").should("have.length", 2);
-        H.entityPickerModalTab("Models").should("exist");
         H.entityPickerModalTab("Tables").should("exist");
-        H.entityPickerModalTab("Saved questions").should("not.exist");
+        H.entityPickerModalTab("Collections").should("exist");
       });
     });
 
@@ -78,8 +77,7 @@ describe("scenarios > notebook > data source", () => {
       H.startNewQuestion();
 
       H.entityPickerModal().within(() => {
-        H.shouldDisplayTabs(["Tables", "Saved questions"]);
-        H.entityPickerModalTab("Models").should("not.exist");
+        H.shouldDisplayTabs(["Tables", "Collections"]);
       });
     });
   });
@@ -232,7 +230,7 @@ describe("scenarios > notebook > data source", () => {
         .click();
 
       H.entityPickerModal().within(() => {
-        H.shouldDisplayTabs(["Models", "Tables", "Saved questions"]);
+        H.shouldDisplayTabs(["Models", "Tables", "Collections"]);
 
         assertDataPickerEntitySelected(0, "Our analytics");
         assertDataPickerEntitySelected(1, "First collection");
@@ -251,7 +249,7 @@ describe("scenarios > notebook > data source", () => {
 
       openDataSelector();
       H.entityPickerModal().within(() => {
-        H.entityPickerModalTab("Models").should(
+        H.entityPickerModalTab("Collections").should(
           "have.attr",
           "aria-selected",
           "true",
@@ -266,7 +264,7 @@ describe("scenarios > notebook > data source", () => {
 
       openDataSelector();
       H.entityPickerModal().within(() => {
-        H.entityPickerModalTab("Models").should(
+        H.entityPickerModalTab("Collections").should(
           "have.attr",
           "aria-selected",
           "true",
@@ -301,7 +299,7 @@ describe("scenarios > notebook > data source", () => {
       H.openNotebook();
       openDataSelector();
       H.entityPickerModal().within(() => {
-        H.entityPickerModalTab("Saved questions").should(
+        H.entityPickerModalTab("Collections").should(
           "have.attr",
           "aria-selected",
           "true",
@@ -323,7 +321,7 @@ describe("scenarios > notebook > data source", () => {
 
       openDataSelector();
       H.entityPickerModal().within(() => {
-        H.entityPickerModalTab("Saved questions").should(
+        H.entityPickerModalTab("Collections").should(
           "have.attr",
           "aria-selected",
           "true",
@@ -354,8 +352,7 @@ describe("scenarios > notebook > data source", { tags: "@OSS" }, () => {
     H.entityPickerModal().within(() => {
       cy.findAllByRole("tab").should("have.length", 2);
       H.entityPickerModalTab("Tables").should("be.visible");
-      H.entityPickerModalTab("Models").should("be.visible");
-      H.entityPickerModalTab("Saved questions").should("not.exist");
+      H.entityPickerModalTab("Collections").should("be.visible");
     });
   });
 });

--- a/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
@@ -93,7 +93,7 @@ describe("scenarios > notebook > data source", () => {
       H.openNotebook();
       cy.findByTestId("data-step-cell").should("have.text", "Reviews").click();
       H.entityPickerModal().within(() => {
-        H.tabsShouldBe("Tables", ["Models", "Tables", "Saved questions"]);
+        H.tabsShouldBe("Tables", ["Tables", "Collections"]);
         // should not show databases step if there's only 1 database
         H.entityPickerModalLevel(0).should("not.exist");
         // should not show schema step if there's only 1 schema
@@ -107,7 +107,7 @@ describe("scenarios > notebook > data source", () => {
       H.openNotebook();
       cy.findByTestId("data-step-cell").should("have.text", "Orders").click();
       H.entityPickerModal().within(() => {
-        H.tabsShouldBe("Tables", ["Models", "Tables", "Saved questions"]);
+        H.tabsShouldBe("Tables", ["Tables", "Collections"]);
         // should not show databases step if there's only 1 database
         H.entityPickerModalLevel(0).should("not.exist");
         // should not show schema step if there's only 1 schema
@@ -230,7 +230,7 @@ describe("scenarios > notebook > data source", () => {
         .click();
 
       H.entityPickerModal().within(() => {
-        H.shouldDisplayTabs(["Models", "Tables", "Collections"]);
+        H.shouldDisplayTabs(["Tables", "Collections"]);
 
         assertDataPickerEntitySelected(0, "Our analytics");
         assertDataPickerEntitySelected(1, "First collection");
@@ -447,8 +447,10 @@ describe("issue 28106", () => {
   }
 });
 
-describe("issue 32252", () => {
+// Needs to be OSS because EE will always have models due to instance analytics
+describe("issue 32252", { tags: "@OSS" }, () => {
   beforeEach(() => {
+    H.onlyOnOSS();
     H.restore("setup");
     cy.signInAsAdmin();
 
@@ -476,7 +478,7 @@ describe("issue 32252", () => {
     H.entityPickerModal().within(() => {
       cy.findByTestId("loading-indicator").should("not.exist");
       cy.findByText("Recents").should("not.exist");
-      cy.findByText("Saved questions").should("be.visible");
+      cy.findByText("Collections").should("be.visible");
       cy.button("Close").click();
     });
 
@@ -493,7 +495,7 @@ describe("issue 32252", () => {
     H.entityPickerModal().within(() => {
       cy.findByTestId("loading-indicator").should("not.exist");
       cy.findByText("Recents").should("not.exist");
-      cy.findByText("Saved questions").should("not.exist");
+      cy.findByText("Collections").should("not.exist");
       cy.findByText("Orders").should("be.visible");
     });
   });
@@ -505,7 +507,7 @@ describe("issue 32252", () => {
     H.entityPickerModal().within(() => {
       cy.findByTestId("loading-indicator").should("not.exist");
       cy.findByText("Recents").should("not.exist");
-      cy.findByText("Saved questions").should("be.visible");
+      cy.findByText("Collections").should("be.visible");
       cy.button("Close").click();
     });
 
@@ -523,7 +525,7 @@ describe("issue 32252", () => {
     H.entityPickerModal().within(() => {
       cy.findByTestId("loading-indicator").should("not.exist");
       cy.findByText("Recents").should("not.exist");
-      cy.findByText("Saved questions").should("not.exist");
+      cy.findByText("Collections").should("not.exist");
       cy.findByText("Orders").should("be.visible");
     });
   });

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -495,7 +495,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
     H.join();
     H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Models").click();
+      H.entityPickerModalTab("Collections").click();
       cy.findByText("Products model").click();
     });
 
@@ -552,7 +552,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     H.startNewQuestion();
 
     H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Saved questions").click();
+      H.entityPickerModalTab("Collections").click();
       cy.findByText("Orders, Count").click();
     });
 

--- a/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
@@ -53,7 +53,7 @@ describe("scenarios > question > download", () => {
       it(`downloads ${fileType} file`, () => {
         H.startNewQuestion();
         H.entityPickerModal().within(() => {
-          H.entityPickerModalTab("Saved questions").click();
+          H.entityPickerModalTab("Collections").click();
           cy.findByText("Orders, Count").click();
         });
 

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/chart_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/chart_drill.cy.spec.js
@@ -245,7 +245,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     // Build a new question off that grouping by City
     H.startNewQuestion();
     H.entityPickerModal().within(() => {
-      H.entityPickerModalTab("Saved questions").click();
+      H.entityPickerModalTab("Collections").click();
       cy.contains("CA People").click();
     });
 

--- a/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPickerModal.tsx
@@ -163,9 +163,8 @@ export const DashboardPickerModal = ({
   >[] = [
     {
       id: "dashboards-tab",
-      displayName: canSelectCollection ? t`Browse` : t`Dashboards`,
+      displayName: t`Dashboards`,
       models: ["dashboard" as const],
-      additionalModels: canSelectCollection ? ["collection"] : undefined,
       folderModels: ["collection" as const],
       icon: "dashboard",
       render: ({ onItemSelect }) => (

--- a/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from "react";
-import { t } from "ttag";
+import { c, t } from "ttag";
 
 import { useSetting } from "metabase/common/hooks";
 import { Button, Checkbox, Icon, Popover } from "metabase/ui";
@@ -48,25 +48,12 @@ interface Props {
   onClose: () => void;
 }
 
+type FilterOption = { label: string; value: CollectionItemModel };
+
 const QUESTION_PICKER_MODELS: CollectionItemModel[] = [
   "card",
   "dataset",
   "metric",
-];
-
-const QUESITON_PICKER_MODEL_FILTER_OPTIONS = [
-  {
-    label: t`Metrics`,
-    value: "metric" as const,
-  },
-  {
-    label: t`Models`,
-    value: "dataset" as const,
-  },
-  {
-    label: t`Saved questions`,
-    value: "card" as const,
-  },
 ];
 
 const RECENTS_CONTEXT: RecentContexts[] = ["selections"];
@@ -99,6 +86,30 @@ export const DataPickerModal = ({
   } = useAvailableData({
     databaseId,
   });
+
+  const QUESITON_PICKER_MODEL_FILTER_OPTIONS = useMemo(() => {
+    const filterOptions: FilterOption[] = [];
+
+    if (hasQuestions) {
+      filterOptions.push({
+        label: t`Saved questions`,
+        value: "card" as const,
+      });
+    }
+    if (hasModels) {
+      filterOptions.push({
+        label: t`Models`,
+        value: "dataset" as const,
+      });
+    }
+    if (hasMetrics) {
+      filterOptions.push({
+        label: t`Metrics`,
+        value: "metric" as const,
+      });
+    }
+    return filterOptions;
+  }, [hasQuestions, hasModels, hasMetrics]);
 
   const { tryLogRecentItem } = useLogRecentItem();
 
@@ -138,8 +149,6 @@ export const DataPickerModal = ({
     [onChange, onClose, tryLogRecentItem],
   );
 
-  // const [modelsPath, setModelsPath] = useState<QuestionPickerStatePath>();
-  // const [metricsPath, setMetricsPath] = useState<QuestionPickerStatePath>();
   const [questionsPath, setQuestionsPath] = useState<QuestionPickerStatePath>();
   const [tablesPath, setTablesPath] = useState<TablePickerStatePath>();
 
@@ -236,15 +245,14 @@ const FilterButton = ({
 }: {
   value: CollectionItemModel[];
   onChange: (value: CollectionItemModel[]) => void;
-  options: { label: string; value: CollectionItemModel }[];
+  options: FilterOption[];
 }) => {
   return (
     <Popover zIndex={1000}>
       <Popover.Target>
-        <Button
-          leftIcon={<Icon name="filter" />}
-          variant="subtle"
-        >{t`Filter`}</Button>
+        <Button leftIcon={<Icon name="filter" />} variant="subtle">{c(
+          "A verb, not a noun",
+        ).t`Filter`}</Button>
       </Popover.Target>
       <Popover.Dropdown>
         <Checkbox.Group value={value} onChange={onChange} px="1rem" py="0.5rem">

--- a/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
@@ -231,14 +231,14 @@ export const DataPickerModal = ({
       computedTabs.push({
         id: "questions-tab",
         displayName: t`Collections`,
-        models: ["card" as const],
+        models: ["card" as const, "dataset" as const, "metric" as const],
         folderModels: ["collection" as const],
         icon: "folder",
         extraButtons: [filterButton],
         render: ({ onItemSelect }) => (
           <QuestionPicker
             initialValue={isQuestionItem(value) ? value : undefined}
-            models={modelFilter}
+            models={QUESTION_PICKER_MODELS}
             options={options}
             path={questionsPath}
             shouldShowItem={shouldShowItem}
@@ -268,6 +268,8 @@ export const DataPickerModal = ({
       onClose={onClose}
       onItemSelect={handleItemSelect}
       isLoadingTabs={isLoadingAvailableData}
+      searchExtraButtons={[filterButton]}
+      searchResultFilter={items => items.filter(shouldShowItem)}
     />
   );
 };

--- a/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
@@ -29,7 +29,7 @@ import type {
 import {
   createQuestionPickerItemSelectHandler,
   createShouldShowItem,
-  isQuestionItem,
+  isCollectionItem,
   isTableItem,
   isValueItem,
 } from "../utils";
@@ -191,7 +191,7 @@ export const DataPickerModal = ({
         extraButtons: [filterButton],
         render: ({ onItemSelect }) => (
           <QuestionPicker
-            initialValue={isQuestionItem(value) ? value : undefined}
+            initialValue={isCollectionItem(value) ? value : undefined}
             models={QUESTION_PICKER_MODELS}
             options={options}
             path={questionsPath}

--- a/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
@@ -29,8 +29,6 @@ import type {
 import {
   createQuestionPickerItemSelectHandler,
   createShouldShowItem,
-  // isMetricItem,
-  // isModelItem,
   isQuestionItem,
   isTableItem,
   isValueItem,
@@ -160,50 +158,6 @@ export const DataPickerModal = ({
       DataPickerItem
     >[] = [];
 
-    // if (hasModels && hasNestedQueriesEnabled && models.includes("dataset")) {
-    //   computedTabs.push({
-    //     id: "models-tab",
-    //     displayName: t`Models`,
-    //     model: "dataset" as const,
-    //     folderModels: ["collection" as const],
-    //     icon: "model",
-    //     render: ({ onItemSelect }) => (
-    //       <QuestionPicker
-    //         initialValue={isModelItem(value) ? value : undefined}
-    //         models={MODEL_PICKER_MODELS}
-    //         options={options}
-    //         path={modelsPath}
-    //         shouldShowItem={modelsShouldShowItem}
-    //         onInit={createQuestionPickerItemSelectHandler(onItemSelect)}
-    //         onItemSelect={createQuestionPickerItemSelectHandler(onItemSelect)}
-    //         onPathChange={setModelsPath}
-    //       />
-    //     ),
-    //   });
-    // }
-
-    // if (hasMetrics && hasNestedQueriesEnabled && models.includes("metric")) {
-    //   computedTabs.push({
-    //     id: "metrics-tab",
-    //     displayName: t`Metrics`,
-    //     model: "metric" as const,
-    //     folderModels: ["collection" as const],
-    //     icon: "metric",
-    //     render: ({ onItemSelect }) => (
-    //       <QuestionPicker
-    //         initialValue={isMetricItem(value) ? value : undefined}
-    //         models={METRIC_PICKER_MODELS}
-    //         options={options}
-    //         path={metricsPath}
-    //         shouldShowItem={metricsShouldShowItem}
-    //         onInit={createQuestionPickerItemSelectHandler(onItemSelect)}
-    //         onItemSelect={createQuestionPickerItemSelectHandler(onItemSelect)}
-    //         onPathChange={setMetricsPath}
-    //       />
-    //     ),
-    //   });
-    // }
-
     if (models.includes("table")) {
       computedTabs.push({
         id: "tables-tab",
@@ -269,7 +223,6 @@ export const DataPickerModal = ({
       onItemSelect={handleItemSelect}
       isLoadingTabs={isLoadingAvailableData}
       searchExtraButtons={[filterButton]}
-      searchResultFilter={items => items.filter(shouldShowItem)}
     />
   );
 };

--- a/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 
 import { useSetting } from "metabase/common/hooks";
+import { Button, Checkbox, Icon, Popover } from "metabase/ui";
 import { getQuestionVirtualTableId } from "metabase-lib/v1/metadata/utils/saved-questions";
 import type {
   CollectionItemModel,
@@ -28,8 +29,8 @@ import type {
 import {
   createQuestionPickerItemSelectHandler,
   createShouldShowItem,
-  isMetricItem,
-  isModelItem,
+  // isMetricItem,
+  // isModelItem,
   isQuestionItem,
   isTableItem,
   isValueItem,
@@ -49,11 +50,26 @@ interface Props {
   onClose: () => void;
 }
 
-const QUESTION_PICKER_MODELS: CollectionItemModel[] = ["card", "dashboard"];
+const QUESTION_PICKER_MODELS: CollectionItemModel[] = [
+  "card",
+  "dataset",
+  "metric",
+];
 
-const MODEL_PICKER_MODELS: CollectionItemModel[] = ["dataset"];
-
-const METRIC_PICKER_MODELS: CollectionItemModel[] = ["metric"];
+const QUESITON_PICKER_MODEL_FILTER_OPTIONS = [
+  {
+    label: t`Metrics`,
+    value: "metric" as const,
+  },
+  {
+    label: t`Models`,
+    value: "dataset" as const,
+  },
+  {
+    label: t`Saved questions`,
+    value: "card" as const,
+  },
+];
 
 const RECENTS_CONTEXT: RecentContexts[] = ["selections"];
 
@@ -73,6 +89,9 @@ export const DataPickerModal = ({
   onChange,
   onClose,
 }: Props) => {
+  const [modelFilter, setModelFilter] = useState<CollectionItemModel[]>(
+    QUESTION_PICKER_MODELS,
+  );
   const hasNestedQueriesEnabled = useSetting("enable-nested-queries");
   const {
     hasQuestions,
@@ -85,17 +104,9 @@ export const DataPickerModal = ({
 
   const { tryLogRecentItem } = useLogRecentItem();
 
-  const modelsShouldShowItem = useMemo(() => {
-    return createShouldShowItem(["dataset"], databaseId);
-  }, [databaseId]);
-
-  const metricsShouldShowItem = useMemo(() => {
-    return createShouldShowItem(["metric"], databaseId);
-  }, [databaseId]);
-
-  const questionsShouldShowItem = useMemo(() => {
-    return createShouldShowItem(["card"], databaseId);
-  }, [databaseId]);
+  const shouldShowItem = useMemo(() => {
+    return createShouldShowItem(modelFilter, databaseId);
+  }, [databaseId, modelFilter]);
 
   const recentFilter = useCallback(
     (recentItems: RecentItem[]) => {
@@ -129,10 +140,18 @@ export const DataPickerModal = ({
     [onChange, onClose, tryLogRecentItem],
   );
 
-  const [modelsPath, setModelsPath] = useState<QuestionPickerStatePath>();
-  const [metricsPath, setMetricsPath] = useState<QuestionPickerStatePath>();
+  // const [modelsPath, setModelsPath] = useState<QuestionPickerStatePath>();
+  // const [metricsPath, setMetricsPath] = useState<QuestionPickerStatePath>();
   const [questionsPath, setQuestionsPath] = useState<QuestionPickerStatePath>();
   const [tablesPath, setTablesPath] = useState<TablePickerStatePath>();
+
+  const filterButton = (
+    <FilterButton
+      value={modelFilter}
+      onChange={setModelFilter}
+      options={QUESITON_PICKER_MODEL_FILTER_OPTIONS}
+    />
+  );
 
   const tabs = (function getTabs() {
     const computedTabs: EntityPickerTab<
@@ -141,49 +160,49 @@ export const DataPickerModal = ({
       DataPickerItem
     >[] = [];
 
-    if (hasModels && hasNestedQueriesEnabled && models.includes("dataset")) {
-      computedTabs.push({
-        id: "models-tab",
-        displayName: t`Models`,
-        models: ["dataset" as const],
-        folderModels: ["collection" as const],
-        icon: "model",
-        render: ({ onItemSelect }) => (
-          <QuestionPicker
-            initialValue={isModelItem(value) ? value : undefined}
-            models={MODEL_PICKER_MODELS}
-            options={options}
-            path={modelsPath}
-            shouldShowItem={modelsShouldShowItem}
-            onInit={createQuestionPickerItemSelectHandler(onItemSelect)}
-            onItemSelect={createQuestionPickerItemSelectHandler(onItemSelect)}
-            onPathChange={setModelsPath}
-          />
-        ),
-      });
-    }
+    // if (hasModels && hasNestedQueriesEnabled && models.includes("dataset")) {
+    //   computedTabs.push({
+    //     id: "models-tab",
+    //     displayName: t`Models`,
+    //     model: "dataset" as const,
+    //     folderModels: ["collection" as const],
+    //     icon: "model",
+    //     render: ({ onItemSelect }) => (
+    //       <QuestionPicker
+    //         initialValue={isModelItem(value) ? value : undefined}
+    //         models={MODEL_PICKER_MODELS}
+    //         options={options}
+    //         path={modelsPath}
+    //         shouldShowItem={modelsShouldShowItem}
+    //         onInit={createQuestionPickerItemSelectHandler(onItemSelect)}
+    //         onItemSelect={createQuestionPickerItemSelectHandler(onItemSelect)}
+    //         onPathChange={setModelsPath}
+    //       />
+    //     ),
+    //   });
+    // }
 
-    if (hasMetrics && hasNestedQueriesEnabled && models.includes("metric")) {
-      computedTabs.push({
-        id: "metrics-tab",
-        displayName: t`Metrics`,
-        models: ["metric" as const],
-        folderModels: ["collection" as const],
-        icon: "metric",
-        render: ({ onItemSelect }) => (
-          <QuestionPicker
-            initialValue={isMetricItem(value) ? value : undefined}
-            models={METRIC_PICKER_MODELS}
-            options={options}
-            path={metricsPath}
-            shouldShowItem={metricsShouldShowItem}
-            onInit={createQuestionPickerItemSelectHandler(onItemSelect)}
-            onItemSelect={createQuestionPickerItemSelectHandler(onItemSelect)}
-            onPathChange={setMetricsPath}
-          />
-        ),
-      });
-    }
+    // if (hasMetrics && hasNestedQueriesEnabled && models.includes("metric")) {
+    //   computedTabs.push({
+    //     id: "metrics-tab",
+    //     displayName: t`Metrics`,
+    //     model: "metric" as const,
+    //     folderModels: ["collection" as const],
+    //     icon: "metric",
+    //     render: ({ onItemSelect }) => (
+    //       <QuestionPicker
+    //         initialValue={isMetricItem(value) ? value : undefined}
+    //         models={METRIC_PICKER_MODELS}
+    //         options={options}
+    //         path={metricsPath}
+    //         shouldShowItem={metricsShouldShowItem}
+    //         onInit={createQuestionPickerItemSelectHandler(onItemSelect)}
+    //         onItemSelect={createQuestionPickerItemSelectHandler(onItemSelect)}
+    //         onPathChange={setMetricsPath}
+    //       />
+    //     ),
+    //   });
+    // }
 
     if (models.includes("table")) {
       computedTabs.push({
@@ -204,20 +223,25 @@ export const DataPickerModal = ({
       });
     }
 
-    if (hasQuestions && hasNestedQueriesEnabled && models.includes("card")) {
+    if (
+      (hasQuestions || hasMetrics || hasModels) &&
+      hasNestedQueriesEnabled &&
+      models.includes("card")
+    ) {
       computedTabs.push({
         id: "questions-tab",
-        displayName: t`Saved questions`,
+        displayName: t`Collections`,
         models: ["card" as const],
         folderModels: ["collection" as const],
         icon: "folder",
+        extraButtons: [filterButton],
         render: ({ onItemSelect }) => (
           <QuestionPicker
             initialValue={isQuestionItem(value) ? value : undefined}
-            models={QUESTION_PICKER_MODELS}
+            models={modelFilter}
             options={options}
             path={questionsPath}
-            shouldShowItem={questionsShouldShowItem}
+            shouldShowItem={shouldShowItem}
             onInit={createQuestionPickerItemSelectHandler(onItemSelect)}
             onItemSelect={createQuestionPickerItemSelectHandler(onItemSelect)}
             onPathChange={setQuestionsPath}
@@ -245,5 +269,38 @@ export const DataPickerModal = ({
       onItemSelect={handleItemSelect}
       isLoadingTabs={isLoadingAvailableData}
     />
+  );
+};
+
+const FilterButton = ({
+  value,
+  onChange,
+  options,
+}: {
+  value: CollectionItemModel[];
+  onChange: (value: CollectionItemModel[]) => void;
+  options: { label: string; value: CollectionItemModel }[];
+}) => {
+  return (
+    <Popover zIndex={1000}>
+      <Popover.Target>
+        <Button
+          leftIcon={<Icon name="filter" />}
+          variant="subtle"
+        >{t`Filter`}</Button>
+      </Popover.Target>
+      <Popover.Dropdown>
+        <Checkbox.Group value={value} onChange={onChange} px="1rem" py="0.5rem">
+          {options.map(option => (
+            <Checkbox
+              key={`filter-${value}`}
+              label={option.label}
+              value={option.value}
+              my="1rem"
+            />
+          ))}
+        </Checkbox.Group>
+      </Popover.Dropdown>
+    </Popover>
   );
 };

--- a/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
@@ -180,7 +180,9 @@ export const DataPickerModal = ({
     if (
       (hasQuestions || hasMetrics || hasModels) &&
       hasNestedQueriesEnabled &&
-      models.includes("card")
+      (models.includes("card") ||
+        models.includes("dataset") ||
+        models.includes("metric"))
     ) {
       computedTabs.push({
         id: "questions-tab",

--- a/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
@@ -54,6 +54,7 @@ const QUESTION_PICKER_MODELS: CollectionItemModel[] = [
   "card",
   "dataset",
   "metric",
+  "dashboard",
 ];
 
 const RECENTS_CONTEXT: RecentContexts[] = ["selections"];

--- a/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
@@ -293,7 +293,7 @@ const FilterButton = ({
         <Checkbox.Group value={value} onChange={onChange} px="1rem" py="0.5rem">
           {options.map(option => (
             <Checkbox
-              key={`filter-${value}`}
+              key={`filter-${option.value}`}
               label={option.label}
               value={option.value}
               my="1rem"

--- a/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
@@ -87,7 +87,7 @@ export const DataPickerModal = ({
     databaseId,
   });
 
-  const QUESITON_PICKER_MODEL_FILTER_OPTIONS = useMemo(() => {
+  const questionPickerModalFilterOptions = useMemo(() => {
     const filterOptions: FilterOption[] = [];
 
     if (hasQuestions) {
@@ -156,7 +156,7 @@ export const DataPickerModal = ({
     <FilterButton
       value={modelFilter}
       onChange={setModelFilter}
-      options={QUESITON_PICKER_MODEL_FILTER_OPTIONS}
+      options={questionPickerModalFilterOptions}
     />
   );
 
@@ -186,13 +186,14 @@ export const DataPickerModal = ({
       });
     }
 
-    if (
+    const shouldShowCollectionsTab =
       (hasQuestions || hasMetrics || hasModels) &&
       hasNestedQueriesEnabled &&
       (models.includes("card") ||
         models.includes("dataset") ||
-        models.includes("metric"))
-    ) {
+        models.includes("metric"));
+
+    if (shouldShowCollectionsTab) {
       computedTabs.push({
         id: "questions-tab",
         displayName: t`Collections`,
@@ -248,7 +249,7 @@ const FilterButton = ({
   options: FilterOption[];
 }) => {
   return (
-    <Popover zIndex={1000}>
+    <Popover zIndex={450}>
       <Popover.Target>
         <Button leftIcon={<Icon name="filter" />} variant="subtle">{c(
           "A verb, not a noun",

--- a/frontend/src/metabase/common/components/DataPicker/components/DatabaseList.tsx
+++ b/frontend/src/metabase/common/components/DataPicker/components/DatabaseList.tsx
@@ -48,6 +48,15 @@ export const DatabaseList = ({
         items={items}
         selectedItem={selectedItem}
         onClick={onClick}
+        navLinkProps={isSelected => ({
+          px: "1.5rem",
+          py: "1.25rem",
+          mb: "1rem",
+          rightSection: null,
+          style: {
+            border: isSelected ? undefined : "1px solid var(--mb-color-border)",
+          },
+        })}
       />
     </ListBox>
   );

--- a/frontend/src/metabase/common/components/DataPicker/utils.ts
+++ b/frontend/src/metabase/common/components/DataPicker/utils.ts
@@ -165,6 +165,10 @@ export const createShouldShowItem = (
 ) => {
   return (item: QuestionPickerItem & { database_id?: DatabaseId }) => {
     if (item.model === "collection") {
+      if (item.id === "root" || item.is_personal) {
+        return true;
+      }
+
       const below = item.below ?? [];
       const here = item.here ?? [];
       const contents = [...below, ...here];
@@ -172,7 +176,7 @@ export const createShouldShowItem = (
         contents.includes(model as CollectionItemModel),
       );
 
-      return item.id === "root" && !!item.is_personal && hasCards;
+      return hasCards;
     }
     if (
       (isNullOrUndefined(databaseId) ||

--- a/frontend/src/metabase/common/components/DataPicker/utils.ts
+++ b/frontend/src/metabase/common/components/DataPicker/utils.ts
@@ -116,6 +116,10 @@ export const getSchemaDisplayName = (schemaName: SchemaName | undefined) => {
   return titleize(humanize(schemaName));
 };
 
+export const isCollectionItem = (value: DataPickerValue | undefined) => {
+  return isQuestionItem(value) || isModelItem(value) || isMetricItem(value);
+};
+
 export const isQuestionItem = (
   value: DataPickerValue | undefined,
 ): value is QuestionItem => {

--- a/frontend/src/metabase/common/components/DataPicker/utils.ts
+++ b/frontend/src/metabase/common/components/DataPicker/utils.ts
@@ -172,11 +172,7 @@ export const createShouldShowItem = (
         contents.includes(model as CollectionItemModel),
       );
 
-      if (item.id !== "root" && !item.is_personal && !hasCards) {
-        return false;
-      } else {
-        return true;
-      }
+      return item.id === "root" && !!item.is_personal && hasCards;
     }
     if (
       (isNullOrUndefined(databaseId) ||

--- a/frontend/src/metabase/common/components/DataPicker/utils.ts
+++ b/frontend/src/metabase/common/components/DataPicker/utils.ts
@@ -19,6 +19,7 @@ import type {
   DataPickerItem,
   DataPickerValue,
   DataPickerValueItem,
+  MetricItem,
   ModelItem,
   QuestionItem,
   TablePickerValue,
@@ -116,7 +117,9 @@ export const getSchemaDisplayName = (schemaName: SchemaName | undefined) => {
   return titleize(humanize(schemaName));
 };
 
-export const isCollectionItem = (value: DataPickerValue | undefined) => {
+export const isCollectionItem = (
+  value: DataPickerValue | undefined,
+): value is QuestionItem | ModelItem | MetricItem => {
   return isQuestionItem(value) || isModelItem(value) || isMetricItem(value);
 };
 
@@ -134,7 +137,7 @@ export const isModelItem = (
 
 export const isMetricItem = (
   value: DataPickerValue | undefined,
-): value is ModelItem => {
+): value is MetricItem => {
   return value?.model === "metric";
 };
 

--- a/frontend/src/metabase/common/components/DataPicker/utils.ts
+++ b/frontend/src/metabase/common/components/DataPicker/utils.ts
@@ -8,6 +8,8 @@ import type {
   Database,
   DatabaseId,
   SchemaName,
+  SearchModel,
+  SearchResult,
   Table,
   TableId,
 } from "metabase-types/api";
@@ -153,25 +155,29 @@ export const isFolderItem = (
 };
 
 export const createShouldShowItem = (
-  models: CollectionItemModel[],
+  models: (CollectionItemModel | SearchModel)[],
   databaseId?: DatabaseId,
 ) => {
-  return (item: QuestionPickerItem) => {
+  return (item: QuestionPickerItem | SearchResult) => {
     if (item.model === "collection") {
       const below = item.below ?? [];
       const here = item.here ?? [];
       const contents = [...below, ...here];
-      const hasCards = models.some(model => contents.includes(model));
+      const hasCards = models.some(model =>
+        contents.includes(model as CollectionItemModel),
+      );
 
       if (item.id !== "root" && !item.is_personal && !hasCards) {
         return false;
+      } else {
+        return true;
       }
     }
-
     if (
-      isNullOrUndefined(databaseId) ||
-      !hasDatabaseId(item) ||
-      isNullOrUndefined(item.database_id)
+      (isNullOrUndefined(databaseId) ||
+        !hasDatabaseId(item) ||
+        isNullOrUndefined(item.database_id)) &&
+      models.includes(item.model)
     ) {
       return true;
     }

--- a/frontend/src/metabase/common/components/DataPicker/utils.ts
+++ b/frontend/src/metabase/common/components/DataPicker/utils.ts
@@ -8,8 +8,6 @@ import type {
   Database,
   DatabaseId,
   SchemaName,
-  SearchModel,
-  SearchResult,
   Table,
   TableId,
 } from "metabase-types/api";
@@ -155,10 +153,10 @@ export const isFolderItem = (
 };
 
 export const createShouldShowItem = (
-  models: (CollectionItemModel | SearchModel)[],
+  models: CollectionItemModel[],
   databaseId?: DatabaseId,
 ) => {
-  return (item: QuestionPickerItem | SearchResult) => {
+  return (item: QuestionPickerItem & { database_id?: DatabaseId }) => {
     if (item.model === "collection") {
       const below = item.below ?? [];
       const here = item.here ?? [];

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -128,7 +128,6 @@ export function EntityPickerModal<
   onConfirm,
   onItemSelect,
   isLoadingTabs = false,
-  searchExtraButtons = [],
 }: EntityPickerModalProps<Id, Model, Item>) {
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [searchScope, setSearchScope] =
@@ -250,7 +249,6 @@ export function EntityPickerModal<
         folderModels: [],
         displayName: getSearchTabText(finalSearchResults, searchQuery),
         icon: "search",
-        extraButtons: searchExtraButtons,
         render: ({ onItemSelect }) => (
           <SearchTab
             folder={selectedFolder}
@@ -381,6 +379,7 @@ export function EntityPickerModal<
           {hydratedOptions.showSearch && (
             <Box px="2.5rem" mb="1.5rem">
               <TextInput
+                data-autofocus
                 type="search"
                 icon={<Icon name="search" size={16} />}
                 miw={400}

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -1,5 +1,11 @@
 import { useWindowEvent } from "@mantine/hooks";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { useDebounce, usePreviousDistinct } from "react-use";
 import { t } from "ttag";
 
@@ -97,6 +103,7 @@ export interface EntityPickerModalProps<
   onConfirm?: () => void;
   onItemSelect: (item: Item) => void;
   isLoadingTabs?: boolean;
+  searchExtraButtons?: ReactNode[];
 }
 
 export function EntityPickerModal<
@@ -121,6 +128,7 @@ export function EntityPickerModal<
   onConfirm,
   onItemSelect,
   isLoadingTabs = false,
+  searchExtraButtons = [],
 }: EntityPickerModalProps<Id, Model, Item>) {
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [searchScope, setSearchScope] =
@@ -133,6 +141,7 @@ export function EntityPickerModal<
       },
     );
   const searchModels = useMemo(() => getSearchModels(passedTabs), [passedTabs]);
+
   const folderModels = useMemo(
     () => getSearchFolderModels(passedTabs),
     [passedTabs],
@@ -217,7 +226,7 @@ export function EntityPickerModal<
     if (hasRecentsTab || shouldOptimisticallyAddRecentsTabWhileLoading) {
       computedTabs.push({
         id: RECENTS_TAB_ID,
-        models: null,
+        models: [],
         folderModels: [],
         displayName: t`Recents`,
         icon: "clock",
@@ -237,10 +246,11 @@ export function EntityPickerModal<
     if (hasSearchTab) {
       computedTabs.push({
         id: SEARCH_TAB_ID,
-        models: null,
+        models: [],
         folderModels: [],
         displayName: getSearchTabText(finalSearchResults, searchQuery),
         icon: "search",
+        extraButtons: searchExtraButtons,
         render: ({ onItemSelect }) => (
           <SearchTab
             folder={selectedFolder}

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -360,12 +360,11 @@ export function EntityPickerModal<
       h="100vh"
       trapFocus={trapFocus}
       closeOnEscape={false} // we're doing this manually in useWindowEvent
-      xOffset="10vw"
       yOffset="10dvh"
       zIndex={ENTITY_PICKER_Z_INDEX} // needs to be above popovers and bulk actions
     >
       <Modal.Overlay />
-      <ModalContent h="100%" maw="57.5rem">
+      <ModalContent h="100%" maw="57.5rem" mah="40rem">
         <Modal.Header
           px="2.5rem"
           pt="1rem"

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -40,7 +40,6 @@ import { SearchTab } from "../SearchTab";
 
 import { ButtonBar } from "./ButtonBar";
 import {
-  GrowFlex,
   ModalBody,
   ModalContent,
   SinglePickerView,
@@ -358,30 +357,29 @@ export function EntityPickerModal<
       zIndex={ENTITY_PICKER_Z_INDEX} // needs to be above popovers and bulk actions
     >
       <Modal.Overlay />
-      <ModalContent h="100%">
+      <ModalContent h="100%" maw="920px">
         <Modal.Header
-          px="1.5rem"
+          px="2.5rem"
           pt="1rem"
           pb={hasTabs ? "1rem" : "1.5rem"}
           bg="var(--mb-color-background)"
         >
-          <GrowFlex justify="space-between">
-            <Modal.Title lh="2.5rem">{title}</Modal.Title>
-            {hydratedOptions.showSearch && (
+          <Modal.Title lh="2.5rem">{title}</Modal.Title>
+          <Modal.CloseButton size={21} pos="relative" top="1px" />
+        </Modal.Header>
+        <ModalBody p="0">
+          {hydratedOptions.showSearch && (
+            <Box px="2.5rem" mb="1.5rem">
               <TextInput
                 type="search"
                 icon={<Icon name="search" size={16} />}
                 miw={400}
-                mr="2rem"
                 placeholder={getSearchInputPlaceholder(selectedFolder)}
                 value={searchQuery}
                 onChange={e => handleQueryChange(e.target.value ?? "")}
               />
-            )}
-          </GrowFlex>
-          <Modal.CloseButton size={21} pos="relative" top="1px" />
-        </Modal.Header>
-        <ModalBody p="0">
+            </Box>
+          )}
           {!isLoadingTabs && !isLoadingRecentItems ? (
             <ErrorBoundary>
               {hasTabs ? (

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -365,7 +365,7 @@ export function EntityPickerModal<
       zIndex={ENTITY_PICKER_Z_INDEX} // needs to be above popovers and bulk actions
     >
       <Modal.Overlay />
-      <ModalContent h="100%" maw="920px">
+      <ModalContent h="100%" maw="57.5rem">
         <Modal.Header
           px="2.5rem"
           pt="1rem"

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/TabsView.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/TabsView.tsx
@@ -1,4 +1,4 @@
-import { Icon, Tabs } from "metabase/ui";
+import { Flex, Icon, Tabs } from "metabase/ui";
 import type { SearchResultId } from "metabase-types/api";
 
 import type {
@@ -39,22 +39,38 @@ export const TabsView = <
       }}
       data-testid="tabs-view"
     >
-      <Tabs.List px="2.5rem">
-        {tabs.map(tab => {
-          const { id, icon, displayName } = tab;
+      <Flex
+        justify="space-between"
+        align="center"
+        px="2.5rem"
+        style={{
+          borderBottom: "1px solid var(--mb-color-border)",
+        }}
+        pb="1px" // Keeps the selected tab underline above the border
+      >
+        <Tabs.List
+          h="2.5rem"
+          style={{
+            borderBottom: "none",
+          }}
+        >
+          {tabs.map(tab => {
+            const { id, icon, displayName } = tab;
 
-          return (
-            <Tabs.Tab
-              key={id}
-              value={id}
-              icon={<Icon name={icon} />}
-              onClick={() => onTabChange(id)}
-            >
-              {displayName}
-            </Tabs.Tab>
-          );
-        })}
-      </Tabs.List>
+            return (
+              <Tabs.Tab
+                key={id}
+                value={id}
+                icon={<Icon name={icon} />}
+                onClick={() => onTabChange(id)}
+              >
+                {displayName}
+              </Tabs.Tab>
+            );
+          })}
+        </Tabs.List>
+        {tabs.find(tab => tab.id === selectedTabId)?.extraButtons || null}
+      </Flex>
 
       {tabs.map(tab => {
         const { id } = tab;

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/TabsView.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/TabsView.tsx
@@ -39,7 +39,7 @@ export const TabsView = <
       }}
       data-testid="tabs-view"
     >
-      <Tabs.List px="1rem">
+      <Tabs.List px="2.5rem">
         {tabs.map(tab => {
           const { id, icon, displayName } = tab;
 

--- a/frontend/src/metabase/common/components/EntityPicker/components/ItemList/ItemList.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/ItemList/ItemList.tsx
@@ -5,7 +5,14 @@ import { t } from "ttag";
 import { VirtualizedList } from "metabase/components/VirtualizedList";
 import { PLUGIN_MODERATION } from "metabase/plugins";
 import { LoadingAndErrorWrapper } from "metabase/public/containers/PublicAction/PublicAction.styled";
-import { Box, Center, Flex, Icon, NavLink } from "metabase/ui";
+import {
+  Box,
+  Center,
+  Flex,
+  Icon,
+  NavLink,
+  type NavLinkProps,
+} from "metabase/ui";
 
 import type { TypeWithModel } from "../../types";
 import { getEntityPickerIcon, isSelectedItem } from "../../utils";
@@ -27,6 +34,7 @@ interface ItemListProps<
   isCurrentLevel: boolean;
   shouldDisableItem?: (item: Item) => boolean;
   shouldShowItem?: (item: Item) => boolean;
+  navLinkProps?: (isSelected?: boolean) => NavLinkProps;
 }
 
 export const ItemList = <
@@ -43,6 +51,7 @@ export const ItemList = <
   isCurrentLevel,
   shouldDisableItem,
   shouldShowItem,
+  navLinkProps,
 }: ItemListProps<Id, Model, Item>) => {
   const filteredItems =
     items && shouldShowItem ? items.filter(shouldShowItem) : items;
@@ -105,6 +114,7 @@ export const ItemList = <
               }}
               variant={isCurrentLevel ? "default" : "mb-light"}
               mb="xs"
+              {...navLinkProps?.(isSelected)}
             />
           </div>
         );

--- a/frontend/src/metabase/common/components/EntityPicker/types.ts
+++ b/frontend/src/metabase/common/components/EntityPicker/types.ts
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 import type { IconName } from "metabase/ui";
 import type { SearchResult, SearchResultId } from "metabase-types/api";
 
@@ -50,9 +52,9 @@ export type EntityPickerTab<
    * Recents & Search tabs don't have models associated with them - hence null
    * (they provide the same models as the other tabs combined).
    */
-  models: Model[] | null;
-  additionalModels?: Model[];
+  models: Model[];
   folderModels: Model[];
+  extraButtons?: ReactNode[];
 };
 
 export type EntityPickerSearchScope = "everywhere" | "folder";

--- a/frontend/src/metabase/common/components/EntityPicker/utils.ts
+++ b/frontend/src/metabase/common/components/EntityPicker/utils.ts
@@ -74,7 +74,7 @@ export const computeInitialTabId = <
 
   const initialValueTab =
     initialValue?.model &&
-    tabs.find(tab => tab.models?.includes(initialValue.model as Model));
+    tabs.find(tab => tab.models.includes(initialValue.model as Model));
 
   if (initialValueTab) {
     return initialValueTab.id;

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.tsx
@@ -211,6 +211,7 @@ export const QuestionPicker = ({
       currentCollection,
       userPersonalCollectionId,
       onPathChange,
+      models,
     ],
   );
 

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPickerModal.tsx
@@ -155,7 +155,7 @@ export const QuestionPickerModal = ({
   ];
 
   const filteredTabs = tabs.filter(tab =>
-    models.some(model => tab.models?.includes(model)),
+    tab.models.every(m => models.includes(m as QuestionPickerModel)),
   );
 
   return (

--- a/frontend/src/metabase/querying/notebook/components/Notebook/Notebook.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/Notebook/Notebook.unit.spec.tsx
@@ -309,6 +309,7 @@ describe("Notebook", () => {
         });
       });
 
+      /* eslint-disable jest/expect-expect */
       it("should show tabs if more than one type is chosen", async () => {
         const models: DataPickerValue["model"][] = ["dataset", "card"];
 
@@ -331,9 +332,6 @@ describe("Notebook", () => {
             data: itemPickerData,
           });
         }
-
-        // Stupid assertion to make linter happy. Assertions are made in convenience functions above
-        expect(true).toBe(true);
       });
 
       it("should show all tabs if no filter is selected", async () => {

--- a/frontend/src/metabase/querying/notebook/components/Notebook/Notebook.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/Notebook/Notebook.unit.spec.tsx
@@ -309,7 +309,6 @@ describe("Notebook", () => {
         });
       });
 
-      /* eslint-disable jest/expect-expect */
       it("should show tabs if more than one type is chosen", async () => {
         const models: DataPickerValue["model"][] = ["dataset", "card"];
 

--- a/frontend/src/metabase/querying/notebook/components/Notebook/Notebook.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/Notebook/Notebook.unit.spec.tsx
@@ -309,6 +309,7 @@ describe("Notebook", () => {
         });
       });
 
+      // eslint-disable-next-line jest/expect-expect
       it("should show tabs if more than one type is chosen", async () => {
         const models: DataPickerValue["model"][] = ["dataset", "card"];
 

--- a/frontend/src/metabase/querying/notebook/components/Notebook/Notebook.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/Notebook/Notebook.unit.spec.tsx
@@ -73,11 +73,13 @@ const TEST_RECENT_TABLE = createMockRecentTableItem();
 const TEST_RECENT_METRIC = createMockRecentMetric(
   createMockMetricResult({
     collection: TEST_COLLECTION,
+    name: "Metric",
   }) as unknown as RecentMetric,
 );
 const TEST_RECENT_MODEL = createMockRecentModel(
   createMockModelResult({
     collection: TEST_COLLECTION,
+    name: "Model",
   }) as unknown as RecentModel,
 );
 
@@ -108,19 +110,19 @@ const dataPickerValueMap: Record<
   },
   card: {
     tabIcon: "folder",
-    tabDisplayName: "Saved questions",
+    tabDisplayName: "Collections",
     recentItem: TEST_RECENT_CARD,
     itemPickerData: ["card"],
   },
   dataset: {
-    tabIcon: "model",
-    tabDisplayName: "Models",
+    tabIcon: "folder",
+    tabDisplayName: "Collections",
     recentItem: TEST_RECENT_MODEL,
     itemPickerData: ["dataset"],
   },
   metric: {
-    tabIcon: "metric",
-    tabDisplayName: "Metrics",
+    tabIcon: "folder",
+    tabDisplayName: "Collections",
     recentItem: TEST_RECENT_METRIC,
     itemPickerData: ["metric"],
   },
@@ -318,20 +320,9 @@ describe("Notebook", () => {
 
         await goToEntityModal();
 
-        expect(await screen.findByTestId("tabs-view")).toBeInTheDocument();
-
         for (const model of models) {
-          const {
-            tabDisplayName,
-            tabIcon,
-            pickerColIdx = 1,
-            itemPickerData,
-          } = dataPickerValueMap[model];
-
-          await goToDataPickerTab({
-            name: tabDisplayName,
-            iconName: tabIcon,
-          });
+          const { pickerColIdx = 1, itemPickerData } =
+            dataPickerValueMap[model];
 
           await userEvent.click(screen.getByText("Our analytics"));
 
@@ -340,6 +331,9 @@ describe("Notebook", () => {
             data: itemPickerData,
           });
         }
+
+        // Stupid assertion to make linter happy. Assertions are made in convenience functions above
+        expect(true).toBe(true);
       });
 
       it("should show all tabs if no filter is selected", async () => {
@@ -366,7 +360,7 @@ describe("Notebook", () => {
       "when filtering with %s",
       entityType => {
         // eslint-disable-next-line jest/expect-expect
-        it(`should only show the ${entityType} picker when modelsFilterList=[${entityType}]`, async () => {
+        it(`should show the Collection item picker when modelsFilterList=[${entityType}]`, async () => {
           setup({
             question: createSummarizedQuestion("question"),
             modelsFilterList: [entityType],
@@ -447,21 +441,19 @@ const assertDataInPickerColumn = ({
   columnIndex: number;
   data: string[];
 }) => {
-  const pickerItems = within(
-    screen.getByTestId(`item-picker-level-${columnIndex}`),
-  ).getAllByTestId("picker-item");
-
-  // Need to figure out this one for the nested items
-  for (let i = 0; i < data.length; i++) {
-    expect(within(pickerItems[i]).getByText(data[i])).toBeInTheDocument();
-  }
+  data.forEach(d => {
+    expect(
+      within(screen.getByTestId(`item-picker-level-${columnIndex}`)).getByText(
+        d,
+      ),
+    ).toBeInTheDocument();
+  });
 };
 
 const assertDataInRecents = ({ data }: { data: string[] }) => {
-  const pickerItems = screen.getAllByTestId("result-item");
-
-  // Need to figure out this one for the nested items
-  for (let i = 0; i < data.length; i++) {
-    expect(within(pickerItems[i]).getByText(data[i])).toBeInTheDocument();
-  }
+  data.forEach(d => {
+    expect(
+      within(screen.getByRole("tabpanel", { name: /Recents/ })).getByText(d),
+    ).toBeInTheDocument();
+  });
 };

--- a/frontend/src/metabase/ui/components/navigation/NavLink/index.ts
+++ b/frontend/src/metabase/ui/components/navigation/NavLink/index.ts
@@ -1,3 +1,3 @@
-export { NavLink } from "@mantine/core";
+export { NavLink, type NavLinkProps } from "@mantine/core";
 
 export { getNavLinkOverrides } from "./NavLink.styled";


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50526

### Description
Makes some UI adjustments to the Entity Picker Modal, `<DatabaseList>` component, and adds a concept of tabs working with multiple modals at a time, while being able to filter what is seen. Filtering is all done on the FE.

### How to verify

1. New question -> Collections
2. Try out the new filtering button to restrict what models are returned
3. Search for something. The filter should carry over and you should only see what is returned

### Demo
![image](https://github.com/user-attachments/assets/b569b47f-df88-42f0-89be-6ace82ac01f0)

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
