### PR TITLE
Old data picker in notebook for embedding 

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
@@ -38,6 +38,7 @@ describeEE("scenarios > embedding-sdk > create-question", () => {
     getSdkRoot().contains("Pick your starting data");
 
     popover().within(() => {
+      cy.findByText("Raw Data").click();
       cy.findByText("Orders").click();
     });
 

--- a/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
@@ -1,6 +1,6 @@
 import { CreateQuestion } from "@metabase/embedding-sdk-react";
 
-import { describeEE, entityPickerModal, modal } from "e2e/support/helpers";
+import { describeEE, modal, popover } from "e2e/support/helpers";
 import {
   mockAuthProviderAndJwtSignIn,
   mountSdkContent,
@@ -37,8 +37,7 @@ describeEE("scenarios > embedding-sdk > create-question", () => {
     // Wait until the entity picker modal is visible
     getSdkRoot().contains("Pick your starting data");
 
-    entityPickerModal().within(() => {
-      cy.findByText("Tables").click();
+    popover().within(() => {
       cy.findByText("Orders").click();
     });
 

--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -374,6 +374,35 @@ describeEE("scenarios > embedding > full app", () => {
           });
         },
       );
+
+      it(
+        "should select a table in a schema-less database",
+        { tags: "@external" },
+        () => {
+          restore("mysql-8");
+          cy.signInAsAdmin();
+
+          cy.log("select a table");
+          startNewEmbeddingQuestion();
+          popover().within(() => {
+            cy.findByText("Raw Data").click();
+            cy.findByText("QA MySQL8").click();
+            cy.findByText("Reviews").click();
+          });
+          getNotebookStep("data").findByText("Reviews").should("be.visible");
+
+          cy.log("make sure it is selected in the picker when opened again");
+          getNotebookStep("data").findByText("Reviews").click();
+          popover().within(() => {
+            cy.findByText("QA MySQL8").should("be.visible");
+            cy.findByLabelText("Reviews").should(
+              "have.attr",
+              "aria-selected",
+              "true",
+            );
+          });
+        },
+      );
     });
   });
 

--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -9,8 +9,6 @@ import {
   createDashboardWithTabs,
   dashboardGrid,
   describeEE,
-  entityPickerModal,
-  entityPickerModalTab,
   exportFromDashcard,
   getDashboardCard,
   getDashboardCardMenu,
@@ -254,8 +252,8 @@ describeEE("scenarios > embedding > full app", () => {
 
         cy.button("New").click();
         popover().findByText("Question").click();
-        entityPickerModal().within(() => {
-          entityPickerModalTab("Tables").click();
+        popover().within(() => {
+          cy.findByText("Raw Data").click();
           cy.findByText("Orders").click();
         });
       });

--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -467,7 +467,7 @@ describeEE("scenarios > embedding > full app", () => {
       );
     });
 
-    describe("cards", () => {
+    describe("questions", () => {
       it("should select a question in the root collection", () => {
         const questionDetails = {
           ...cardDetails,

--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -326,13 +326,54 @@ describeEE("scenarios > embedding > full app", () => {
 
     describe("tables", () => {
       it("should select a table in the only database", () => {
+        cy.log("select a table");
         startNewEmbeddingQuestion();
         popover().within(() => {
           cy.findByText("Raw Data").click();
           cy.findByText("Products").click();
         });
         getNotebookStep("data").findByText("Products").should("be.visible");
+
+        cy.log("make sure it is selected in the picker when opened again");
+        getNotebookStep("data").findByText("Products").click();
+        popover().within(() => {
+          cy.findByText("Sample Database").should("be.visible");
+          cy.findByLabelText("Products").should(
+            "have.attr",
+            "aria-selected",
+            "true",
+          );
+        });
       });
+
+      it(
+        "should select a table when there are multiple databases",
+        { tags: "@external" },
+        () => {
+          restore("postgres-12");
+          cy.signInAsAdmin();
+
+          cy.log("select a table");
+          startNewEmbeddingQuestion();
+          popover().within(() => {
+            cy.findByText("Raw Data").click();
+            cy.findByText("QA Postgres12").click();
+            cy.findByText("Orders").click();
+          });
+          getNotebookStep("data").findByText("Orders").should("be.visible");
+
+          cy.log("make sure it is selected in the picker when opened again");
+          getNotebookStep("data").findByText("Orders").click();
+          popover().within(() => {
+            cy.findByText("QA Postgres12").should("be.visible");
+            cy.findByLabelText("Orders").should(
+              "have.attr",
+              "aria-selected",
+              "true",
+            );
+          });
+        },
+      );
     });
   });
 

--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -485,7 +485,7 @@ describeEE("scenarios > embedding > full app", () => {
           resetTestTable({ type: "postgres", table: "multi_schema" });
           restore("postgres-writable");
           cy.signInAsAdmin();
-          resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: "multi_schema" });
+          resyncDatabase({ dbId: WRITABLE_DB_ID });
           startNewEmbeddingQuestion();
           selectTable({
             tableName: "Animals",

--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -810,6 +810,28 @@ describeEE("scenarios > embedding > full app", () => {
           databaseName: "Sample Database",
         });
       });
+
+      it("should not be able to join a metric", () => {
+        const cardDetails = {
+          ...ordersCardDetails,
+          type: "metric",
+          collection_id: null,
+        };
+        createQuestion(cardDetails);
+        startNewEmbeddingQuestion();
+        selectTable({
+          tableName: "Orders",
+        });
+        getNotebookStep("data").button("Join data").click();
+        popover().within(() => {
+          cy.icon("chevronleft").click();
+          cy.icon("chevronleft").click();
+          cy.findByText("Raw Data").should("be.visible");
+          cy.findByText("Saved Questions").should("be.visible");
+          cy.findByText("Models").should("be.visible");
+          cy.findByText("Metrics").should("not.exist");
+        });
+      });
     });
   });
 

--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -324,13 +324,11 @@ describeEE("scenarios > embedding > full app", () => {
   });
 
   describe("notebook", () => {
-    const cardTypes = ["question", "model", "metric"];
     const baseCardDetails = {
       name: "Card",
       type: "question",
       query: {
         "source-table": ORDERS_ID,
-        aggregation: [["count"]],
       },
     };
 
@@ -411,7 +409,7 @@ describeEE("scenarios > embedding > full app", () => {
       cy.signInAsNormalUser();
     });
 
-    describe("tables", () => {
+    describe("table", () => {
       it("should select a table in the only database", () => {
         startNewEmbeddingQuestion();
         selectTable({ tableName: "Products" });
@@ -494,6 +492,7 @@ describeEE("scenarios > embedding > full app", () => {
         startNewEmbeddingQuestion();
         selectCard({
           cardName: "Orders",
+          collectionNames: [],
         });
         getNotebookStep("data").button("Join data").click();
         popover().within(() => {
@@ -511,9 +510,9 @@ describeEE("scenarios > embedding > full app", () => {
       });
     });
 
-    describe("cards", () => {
-      cardTypes.forEach(cardType => {
-        it(`should select a ${cardType} in the root collection`, () => {
+    ["question", "model"].forEach(cardType => {
+      describe(cardType, () => {
+        it("should select a data source in the root collection", () => {
           const cardDetails = {
             ...baseCardDetails,
             type: cardType,
@@ -523,7 +522,7 @@ describeEE("scenarios > embedding > full app", () => {
           startNewEmbeddingQuestion();
           selectCard({
             cardName: cardDetails.name,
-            cardType: cardDetails.type,
+            cardType,
             collectionNames: [],
           });
           clickOnDataSource(baseCardDetails.name);
@@ -533,7 +532,7 @@ describeEE("scenarios > embedding > full app", () => {
           });
         });
 
-        it(`should select a ${cardType} in a regular collection`, () => {
+        it("should select a data source in a regular collection", () => {
           const cardDetails = {
             ...baseCardDetails,
             type: cardType,
@@ -543,7 +542,7 @@ describeEE("scenarios > embedding > full app", () => {
           startNewEmbeddingQuestion();
           selectCard({
             cardName: cardDetails.name,
-            cardType: cardDetails.type,
+            cardType,
             collectionNames: ["First collection"],
           });
           clickOnDataSource(baseCardDetails.name);
@@ -553,7 +552,7 @@ describeEE("scenarios > embedding > full app", () => {
           });
         });
 
-        it(`should select a ${cardType} in a nested collection`, () => {
+        it("should select a data source in a nested collection", () => {
           const cardDetails = {
             ...baseCardDetails,
             type: cardType,
@@ -563,7 +562,7 @@ describeEE("scenarios > embedding > full app", () => {
           startNewEmbeddingQuestion();
           selectCard({
             cardName: cardDetails.name,
-            cardType: cardDetails.type,
+            cardType,
             collectionNames: ["First collection", "Second collection"],
           });
           clickOnDataSource(baseCardDetails.name);
@@ -573,7 +572,7 @@ describeEE("scenarios > embedding > full app", () => {
           });
         });
 
-        it(`should select a ${cardType} in a personal collection`, () => {
+        it("should select a data source in a personal collection", () => {
           const cardDetails = {
             ...baseCardDetails,
             type: cardType,
@@ -583,7 +582,7 @@ describeEE("scenarios > embedding > full app", () => {
           startNewEmbeddingQuestion();
           selectCard({
             cardName: cardDetails.name,
-            cardType: cardDetails.type,
+            cardType,
             collectionNames: ["Your personal collection"],
           });
           clickOnDataSource(baseCardDetails.name);
@@ -593,7 +592,7 @@ describeEE("scenarios > embedding > full app", () => {
           });
         });
 
-        it(`should select a ${cardType} in another user personal collection`, () => {
+        it("should select a data source in another user personal collection", () => {
           cy.signInAsAdmin();
           const cardDetails = {
             ...baseCardDetails,
@@ -604,7 +603,7 @@ describeEE("scenarios > embedding > full app", () => {
           startNewEmbeddingQuestion();
           selectCard({
             cardName: cardDetails.name,
-            cardType: cardDetails.type,
+            cardType,
             collectionNames: [
               "All personal collections",
               "Robert Tableton's Personal Collection",
@@ -614,6 +613,66 @@ describeEE("scenarios > embedding > full app", () => {
           verifyCardSelected({
             cardName: cardDetails.name,
             collectionName: "Robert Tableton's Personal Collection",
+          });
+        });
+
+        it("should be able to join a card when the data source is a table", () => {
+          const cardDetails = {
+            ...baseCardDetails,
+            type: cardType,
+            collection_id: FIRST_COLLECTION_ID,
+          };
+          createQuestion(cardDetails);
+          startNewEmbeddingQuestion();
+          selectTable({
+            tableName: "Products",
+          });
+          getNotebookStep("data").button("Join data").click();
+          popover().within(() => {
+            cy.icon("chevronleft").click();
+            cy.icon("chevronleft").click();
+          });
+          selectCard({
+            cardName: cardDetails.name,
+            cardType,
+            collectionNames: ["First collection"],
+          });
+          clickOnJoinDataSource(cardDetails.name);
+          verifyCardSelected({
+            cardName: cardDetails.name,
+            collectionName: "First collection",
+          });
+        });
+
+        it("should be able to join a card when the data source is a question", () => {
+          const cardDetails = {
+            ...baseCardDetails,
+            type: cardType,
+            collection_id: FIRST_COLLECTION_ID,
+          };
+          createQuestion(cardDetails);
+          startNewEmbeddingQuestion();
+          selectCard({
+            cardName: "Orders",
+            cardType: "question",
+            collectionNames: [],
+          });
+          getNotebookStep("data").button("Join data").click();
+          popover().within(() => {
+            cy.icon("chevronleft").click();
+            cy.icon("chevronleft").click();
+          });
+          selectCard({
+            cardName: cardDetails.name,
+            cardType,
+            collectionNames: ["First collection"],
+          });
+          popover().findByText("ID").click();
+          popover().findByText("ID").click();
+          clickOnJoinDataSource(cardDetails.name);
+          verifyCardSelected({
+            cardName: cardDetails.name,
+            collectionName: "First collection",
           });
         });
       });

--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -19,6 +19,7 @@ import {
   navigationSidebar,
   popover,
   restore,
+  resyncDatabase,
   setTokenFeatures,
   updateDashboardCards,
   visitFullAppEmbeddingUrl,
@@ -27,6 +28,7 @@ import {
   createMockDashboardCard,
   createMockTextDashboardCard,
 } from "metabase-types/api/mocks";
+import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
 
 const { ORDERS } = SAMPLE_DATABASE;
 
@@ -396,6 +398,38 @@ describeEE("scenarios > embedding > full app", () => {
           popover().within(() => {
             cy.findByText("QA MySQL8").should("be.visible");
             cy.findByLabelText("Reviews").should(
+              "have.attr",
+              "aria-selected",
+              "true",
+            );
+          });
+        },
+      );
+
+      it(
+        "should select a table when there are multiple schemas",
+        { tags: "@external" },
+        () => {
+          restore("postgres-writable");
+          cy.signInAsAdmin();
+          resyncDatabase({ dbId: WRITABLE_DB_ID });
+
+          cy.log("select a table");
+          startNewEmbeddingQuestion();
+          popover().within(() => {
+            cy.findByText("Raw Data").click();
+            cy.findByText("Writable Postgres12").click();
+            cy.findByText("Domestic").click();
+            cy.findByText("Animals").click();
+          });
+          getNotebookStep("data").findByText("Animals").should("be.visible");
+
+          cy.log("make sure it is selected in the picker when opened again");
+          getNotebookStep("data").findByText("Animals").click();
+          popover().within(() => {
+            cy.findByText("Writable Postgres12").should("be.visible");
+            cy.findByText("Domestic").should("be.visible");
+            cy.findByLabelText("Animals").should(
               "have.attr",
               "aria-selected",
               "true",

--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -24,6 +24,7 @@ import {
   goToTab,
   navigationSidebar,
   popover,
+  resetTestTable,
   restore,
   resyncDatabase,
   setTokenFeatures,
@@ -481,9 +482,10 @@ describeEE("scenarios > embedding > full app", () => {
         "should select a table when there are multiple schemas",
         { tags: "@external" },
         () => {
+          resetTestTable({ type: "postgres", table: "multi_schema" });
           restore("postgres-writable");
           cy.signInAsAdmin();
-          resyncDatabase({ dbId: WRITABLE_DB_ID });
+          resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: "multi_schema" });
           startNewEmbeddingQuestion();
           selectTable({
             tableName: "Animals",

--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -370,6 +370,13 @@ describeEE("scenarios > embedding > full app", () => {
       getNotebookStep("data").findByText(sourceName).click();
     }
 
+    function clickOnJoinDataSource(sourceName) {
+      getNotebookStep("join")
+        .findByLabelText("Right table")
+        .findByText(sourceName)
+        .click();
+    }
+
     function verifyTableSelected({ tableName, schemaName, databaseName }) {
       popover().within(() => {
         cy.findByLabelText(tableName).should(
@@ -465,6 +472,42 @@ describeEE("scenarios > embedding > full app", () => {
           });
         },
       );
+
+      it("should be able to join a table", () => {
+        startNewEmbeddingQuestion();
+        selectTable({
+          tableName: "Orders",
+        });
+        getNotebookStep("data").button("Join data").click();
+        popover().findByText("Products").click();
+        clickOnJoinDataSource("Products");
+        verifyTableSelected({
+          tableName: "Products",
+          databaseName: "Sample Database",
+        });
+      });
+
+      it("should be able to join a question", () => {
+        startNewEmbeddingQuestion();
+        selectTable({
+          tableName: "Products",
+        });
+        getNotebookStep("data").button("Join data").click();
+        popover().within(() => {
+          cy.icon("chevronleft").click();
+          cy.icon("chevronleft").click();
+        });
+        selectCard({
+          cardName: "Orders",
+          cardType: "question",
+          collectionNames: [],
+        });
+        clickOnJoinDataSource("Orders");
+        verifyCardSelected({
+          cardName: "Orders",
+          collectionName: "Our analytics",
+        });
+      });
     });
 
     describe("questions", () => {

--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -547,6 +547,30 @@ describeEE("scenarios > embedding > full app", () => {
           collectionName: "Your personal collection",
         });
       });
+
+      it("should select a question in another user personal collection", () => {
+        cy.signInAsAdmin();
+        const questionDetails = {
+          ...cardDetails,
+          type: "question",
+          collection_id: NORMAL_PERSONAL_COLLECTION_ID,
+        };
+        createQuestion(questionDetails);
+        startNewEmbeddingQuestion();
+        selectCard({
+          cardName: questionDetails.name,
+          cardType: questionDetails.type,
+          collectionNames: [
+            "All personal collections",
+            "Robert Tableton's Personal Collection",
+          ],
+        });
+        clickOnDataSource(cardDetails.name);
+        verifyCardSelected({
+          cardName: questionDetails.name,
+          collectionName: "Robert Tableton's Personal Collection",
+        });
+      });
     });
   });
 

--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -324,7 +324,8 @@ describeEE("scenarios > embedding > full app", () => {
   });
 
   describe("notebook", () => {
-    const cardDetails = {
+    const cardTypes = ["question", "model", "metric"];
+    const baseCardDetails = {
       name: "Card",
       type: "question",
       query: {
@@ -335,6 +336,8 @@ describeEE("scenarios > embedding > full app", () => {
 
     const cardTypeToLabel = {
       question: "Saved Questions",
+      model: "Models",
+      metric: "Metrics",
     };
 
     function startNewEmbeddingQuestion() {
@@ -473,7 +476,7 @@ describeEE("scenarios > embedding > full app", () => {
         },
       );
 
-      it("should be able to join a table", () => {
+      it("should be able to join a table when the data source is a table", () => {
         startNewEmbeddingQuestion();
         selectTable({
           tableName: "Orders",
@@ -487,131 +490,131 @@ describeEE("scenarios > embedding > full app", () => {
         });
       });
 
-      it("should be able to join a question", () => {
+      it("should be able to join a table when the data source is a question", () => {
         startNewEmbeddingQuestion();
-        selectTable({
-          tableName: "Products",
+        selectCard({
+          cardName: "Orders",
         });
         getNotebookStep("data").button("Join data").click();
         popover().within(() => {
           cy.icon("chevronleft").click();
           cy.icon("chevronleft").click();
         });
-        selectCard({
-          cardName: "Orders",
-          cardType: "question",
-          collectionNames: [],
+        selectTable({
+          tableName: "Products",
         });
-        clickOnJoinDataSource("Orders");
-        verifyCardSelected({
-          cardName: "Orders",
-          collectionName: "Our analytics",
+        clickOnJoinDataSource("Products");
+        verifyTableSelected({
+          tableName: "Products",
+          databaseName: "Sample Database",
         });
       });
     });
 
-    describe("questions", () => {
-      it("should select a question in the root collection", () => {
-        const questionDetails = {
-          ...cardDetails,
-          type: "question",
-          collection_id: null,
-        };
-        createQuestion(questionDetails);
-        startNewEmbeddingQuestion();
-        selectCard({
-          cardName: questionDetails.name,
-          cardType: questionDetails.type,
-          collectionNames: [],
+    describe("cards", () => {
+      cardTypes.forEach(cardType => {
+        it(`should select a ${cardType} in the root collection`, () => {
+          const cardDetails = {
+            ...baseCardDetails,
+            type: cardType,
+            collection_id: null,
+          };
+          createQuestion(cardDetails);
+          startNewEmbeddingQuestion();
+          selectCard({
+            cardName: cardDetails.name,
+            cardType: cardDetails.type,
+            collectionNames: [],
+          });
+          clickOnDataSource(baseCardDetails.name);
+          verifyCardSelected({
+            cardName: cardDetails.name,
+            collectionName: "Our analytics",
+          });
         });
-        clickOnDataSource(cardDetails.name);
-        verifyCardSelected({
-          cardName: questionDetails.name,
-          collectionName: "Our analytics",
-        });
-      });
 
-      it("should select a question in a regular collection", () => {
-        const questionDetails = {
-          ...cardDetails,
-          type: "question",
-          collection_id: FIRST_COLLECTION_ID,
-        };
-        createQuestion(questionDetails);
-        startNewEmbeddingQuestion();
-        selectCard({
-          cardName: questionDetails.name,
-          cardType: questionDetails.type,
-          collectionNames: ["First collection"],
+        it(`should select a ${cardType} in a regular collection`, () => {
+          const cardDetails = {
+            ...baseCardDetails,
+            type: cardType,
+            collection_id: FIRST_COLLECTION_ID,
+          };
+          createQuestion(cardDetails);
+          startNewEmbeddingQuestion();
+          selectCard({
+            cardName: cardDetails.name,
+            cardType: cardDetails.type,
+            collectionNames: ["First collection"],
+          });
+          clickOnDataSource(baseCardDetails.name);
+          verifyCardSelected({
+            cardName: cardDetails.name,
+            collectionName: "First collection",
+          });
         });
-        clickOnDataSource(cardDetails.name);
-        verifyCardSelected({
-          cardName: questionDetails.name,
-          collectionName: "First collection",
-        });
-      });
 
-      it("should select a question in a nested collection", () => {
-        const questionDetails = {
-          ...cardDetails,
-          type: "question",
-          collection_id: SECOND_COLLECTION_ID,
-        };
-        createQuestion(questionDetails);
-        startNewEmbeddingQuestion();
-        selectCard({
-          cardName: questionDetails.name,
-          cardType: questionDetails.type,
-          collectionNames: ["First collection", "Second collection"],
+        it(`should select a ${cardType} in a nested collection`, () => {
+          const cardDetails = {
+            ...baseCardDetails,
+            type: cardType,
+            collection_id: SECOND_COLLECTION_ID,
+          };
+          createQuestion(cardDetails);
+          startNewEmbeddingQuestion();
+          selectCard({
+            cardName: cardDetails.name,
+            cardType: cardDetails.type,
+            collectionNames: ["First collection", "Second collection"],
+          });
+          clickOnDataSource(baseCardDetails.name);
+          verifyCardSelected({
+            cardName: cardDetails.name,
+            collectionName: "Second collection",
+          });
         });
-        clickOnDataSource(cardDetails.name);
-        verifyCardSelected({
-          cardName: questionDetails.name,
-          collectionName: "Second collection",
-        });
-      });
 
-      it("should select a question in a personal collection", () => {
-        const questionDetails = {
-          ...cardDetails,
-          type: "question",
-          collection_id: NORMAL_PERSONAL_COLLECTION_ID,
-        };
-        createQuestion(questionDetails);
-        startNewEmbeddingQuestion();
-        selectCard({
-          cardName: questionDetails.name,
-          cardType: questionDetails.type,
-          collectionNames: ["Your personal collection"],
+        it(`should select a ${cardType} in a personal collection`, () => {
+          const cardDetails = {
+            ...baseCardDetails,
+            type: cardType,
+            collection_id: NORMAL_PERSONAL_COLLECTION_ID,
+          };
+          createQuestion(cardDetails);
+          startNewEmbeddingQuestion();
+          selectCard({
+            cardName: cardDetails.name,
+            cardType: cardDetails.type,
+            collectionNames: ["Your personal collection"],
+          });
+          clickOnDataSource(baseCardDetails.name);
+          verifyCardSelected({
+            cardName: cardDetails.name,
+            collectionName: "Your personal collection",
+          });
         });
-        clickOnDataSource(cardDetails.name);
-        verifyCardSelected({
-          cardName: questionDetails.name,
-          collectionName: "Your personal collection",
-        });
-      });
 
-      it("should select a question in another user personal collection", () => {
-        cy.signInAsAdmin();
-        const questionDetails = {
-          ...cardDetails,
-          type: "question",
-          collection_id: NORMAL_PERSONAL_COLLECTION_ID,
-        };
-        createQuestion(questionDetails);
-        startNewEmbeddingQuestion();
-        selectCard({
-          cardName: questionDetails.name,
-          cardType: questionDetails.type,
-          collectionNames: [
-            "All personal collections",
-            "Robert Tableton's Personal Collection",
-          ],
-        });
-        clickOnDataSource(cardDetails.name);
-        verifyCardSelected({
-          cardName: questionDetails.name,
-          collectionName: "Robert Tableton's Personal Collection",
+        it(`should select a ${cardType} in another user personal collection`, () => {
+          cy.signInAsAdmin();
+          const cardDetails = {
+            ...baseCardDetails,
+            type: cardType,
+            collection_id: NORMAL_PERSONAL_COLLECTION_ID,
+          };
+          createQuestion(cardDetails);
+          startNewEmbeddingQuestion();
+          selectCard({
+            cardName: cardDetails.name,
+            cardType: cardDetails.type,
+            collectionNames: [
+              "All personal collections",
+              "Robert Tableton's Personal Collection",
+            ],
+          });
+          clickOnDataSource(baseCardDetails.name);
+          verifyCardSelected({
+            cardName: cardDetails.name,
+            collectionName: "Robert Tableton's Personal Collection",
+          });
         });
       });
     });

--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -13,6 +13,7 @@ import {
   getDashboardCard,
   getDashboardCardMenu,
   getNextUnsavedDashboardCardId,
+  getNotebookStep,
   getTextCardDetails,
   goToTab,
   navigationSidebar,
@@ -312,6 +313,25 @@ describeEE("scenarios > embedding > full app", () => {
         cy.findByTestId("main-logo").should("not.exist");
         cy.icon("sidebar_closed").should("not.exist");
         cy.button("Toggle sidebar").should("not.exist");
+      });
+    });
+  });
+
+  describe("notebook", () => {
+    function startNewEmbeddingQuestion() {
+      visitFullAppEmbeddingUrl({ url: "/", qs: { new_button: true } });
+      cy.button("New").click();
+      popover().findByText("Question").click();
+    }
+
+    describe("tables", () => {
+      it("should select a table in the only database", () => {
+        startNewEmbeddingQuestion();
+        popover().within(() => {
+          cy.findByText("Raw Data").click();
+          cy.findByText("Products").click();
+        });
+        getNotebookStep("data").findByText("Products").should("be.visible");
       });
     });
   });

--- a/e2e/test/scenarios/native/native_subquery.cy.spec.js
+++ b/e2e/test/scenarios/native/native_subquery.cy.spec.js
@@ -1,11 +1,12 @@
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  ADMIN_PERSONAL_COLLECTION_ID,
+  ORDERS_QUESTION_ID,
+} from "e2e/support/cypress_sample_instance_data";
 import {
   createNativeQuestion,
   createQuestion,
-  entityPickerModal,
   focusNativeEditor,
   openNativeEditor,
-  openQuestionActions,
   restore,
   runNativeQuery,
   startNewNativeQuestion,
@@ -73,20 +74,10 @@ describe("scenarios > question > native subquery", () => {
           query: "SELECT id FROM PEOPLE",
         },
         type: "model",
+        collection_id: ADMIN_PERSONAL_COLLECTION_ID,
       }).then(({ body: { id: questionId2 } }) => {
-        // Move question 2 to personal collection
-        cy.visit(`/question/${questionId2}`);
-        openQuestionActions();
-        cy.findByTestId("move-button").click();
-        entityPickerModal().within(() => {
-          cy.findByRole("tab", { name: /Collections/ }).click();
-          cy.findByText("Bobby Tables's Personal Collection").click();
-          cy.button("Move").click();
-        });
-
         openNativeEditor();
-        cy.reload(); // Refresh the state, so previously created questions need to be loaded again.
-        cy.get(".ace_editor").should("be.visible").type(" ").type("{{#people");
+        cy.get(".ace_editor").should("be.visible").realType("{{#people");
 
         // Wait until another explicit autocomplete is triggered
         // (slightly longer than AUTOCOMPLETE_DEBOUNCE_DURATION)

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -953,7 +953,7 @@ export class UnconnectedDataSelector extends Component {
   handleClose = () => {
     const { onClose } = this.props;
     this.setState({ searchText: "" });
-    if (typeof onProps === "function") {
+    if (typeof onClose === "function") {
       onClose();
     }
   };

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -168,6 +168,8 @@ export class UnconnectedDataSelector extends Component {
     hasTableSearch: PropTypes.bool,
     canChangeDatabase: PropTypes.bool,
     containerClassName: PropTypes.string,
+    canSelectQuestion: PropTypes.bool,
+    canSelectModel: PropTypes.bool,
     canSelectMetric: PropTypes.bool,
 
     // from search entity list loader
@@ -200,6 +202,8 @@ export class UnconnectedDataSelector extends Component {
     hasTriggerExpandControl: true,
     isPopover: true,
     isMantine: false,
+    canSelectQuestion: true,
+    canSelectModel: true,
     canSelectMetric: false,
   };
 
@@ -445,8 +449,8 @@ export class UnconnectedDataSelector extends Component {
   }
 
   hasModels = () => {
-    const { models, loaded } = this.props;
-    return loaded && models && models.length > 0;
+    const { models, loaded, canSelectModel } = this.props;
+    return loaded && models && models.length > 0 && canSelectModel;
   };
 
   hasUsableModels = () => {
@@ -469,7 +473,12 @@ export class UnconnectedDataSelector extends Component {
   };
 
   hasSavedQuestions = () => {
-    return this.state.databases.some(database => database.is_saved_questions);
+    const { canSelectQuestion } = this.props;
+    const { databases } = this.state;
+    return (
+      databases.some(database => database.is_saved_questions) &&
+      canSelectQuestion
+    );
   };
 
   getDatabases = () => {

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -427,7 +427,7 @@ export class UnconnectedDataSelector extends Component {
     }
   }
 
-  isLoadingDatasets = () => this.props.loading;
+  isLoadingDatasets = () => this.props.allLoading;
 
   getCardType() {
     const { selectedDataBucketId, savedEntityType } = this.state;

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -345,7 +345,7 @@ export class UnconnectedDataSelector extends Component {
       selectedTableId: sourceId,
     } = this.props;
 
-    if (!this.isLoadingDatasets() && !activeStep) {
+    if (!this.isSearchLoading() && !activeStep) {
       await this.hydrateActiveStep();
     }
 
@@ -427,7 +427,10 @@ export class UnconnectedDataSelector extends Component {
     }
   }
 
-  isLoadingDatasets = () => this.props.allLoading;
+  isSearchLoading = () => {
+    const { models, metrics, allLoading } = this.props;
+    return models == null || metrics == null || allLoading;
+  };
 
   getCardType() {
     const { selectedDataBucketId, savedEntityType } = this.state;
@@ -555,7 +558,7 @@ export class UnconnectedDataSelector extends Component {
   getPreviousStep() {
     const { steps } = this.props;
     const { activeStep } = this.state;
-    if (this.isLoadingDatasets() || activeStep === null) {
+    if (this.isSearchLoading() || activeStep === null) {
       return null;
     }
 
@@ -1017,7 +1020,7 @@ export class UnconnectedDataSelector extends Component {
     const isPickerOpen =
       isSavedEntityPickerShown || selectedDataBucketId === DATA_BUCKET.MODELS;
 
-    if (this.isLoadingDatasets()) {
+    if (this.isSearchLoading()) {
       return <LoadingAndErrorWrapper loading />;
     }
 

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -168,8 +168,6 @@ export class UnconnectedDataSelector extends Component {
     hasTableSearch: PropTypes.bool,
     canChangeDatabase: PropTypes.bool,
     containerClassName: PropTypes.string,
-    canSelectQuestion: PropTypes.bool,
-    canSelectModel: PropTypes.bool,
     canSelectMetric: PropTypes.bool,
 
     // from search entity list loader
@@ -202,8 +200,6 @@ export class UnconnectedDataSelector extends Component {
     hasTriggerExpandControl: true,
     isPopover: true,
     isMantine: false,
-    canSelectQuestion: true,
-    canSelectModel: true,
     canSelectMetric: false,
   };
 
@@ -449,8 +445,8 @@ export class UnconnectedDataSelector extends Component {
   }
 
   hasModels = () => {
-    const { models, loaded, canSelectModel } = this.props;
-    return loaded && models && models.length > 0 && canSelectModel;
+    const { models, loaded } = this.props;
+    return loaded && models && models.length > 0;
   };
 
   hasUsableModels = () => {
@@ -473,12 +469,7 @@ export class UnconnectedDataSelector extends Component {
   };
 
   hasSavedQuestions = () => {
-    const { canSelectQuestion } = this.props;
-    const { databases } = this.state;
-    return (
-      databases.some(database => database.is_saved_questions) &&
-      canSelectQuestion
-    );
+    return this.state.databases.some(database => database.is_saved_questions);
   };
 
   getDatabases = () => {

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -24,7 +24,6 @@ import {
   getQuestionIdFromVirtualTableId,
   isVirtualCardId,
 } from "metabase-lib/v1/metadata/utils/saved-questions";
-import { getSchemaName } from "metabase-lib/v1/metadata/utils/schema";
 
 import {
   EmptyStateContainer,
@@ -1008,7 +1007,8 @@ export class UnconnectedDataSelector extends Component {
       selectedDataBucketId,
       selectedTable,
     } = this.state;
-    const { canChangeDatabase, selectedDatabaseId } = this.props;
+    const { canChangeDatabase, selectedDatabaseId, selectedCollectionId } =
+      this.props;
 
     const currentDatabaseId = canChangeDatabase ? null : selectedDatabaseId;
 
@@ -1047,11 +1047,7 @@ export class UnconnectedDataSelector extends Component {
           {!isSearchActive &&
             (isPickerOpen ? (
               <SavedEntityPicker
-                collectionName={
-                  selectedTable &&
-                  selectedTable.schema &&
-                  getSchemaName(selectedTable.schema.id)
-                }
+                collectionId={selectedCollectionId}
                 type={this.getCardType()}
                 tableId={selectedTable?.id}
                 databaseId={currentDatabaseId}

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.unit.spec.js
@@ -186,7 +186,7 @@ describe("DataSelector", () => {
     // on initial load, we fetch databases
     await delay(1);
     expect(fetchDatabases).toHaveBeenCalled();
-    rerender(<DataSelector {...props} loading />);
+    rerender(<DataSelector {...props} allLoading />);
     expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
 
     // select a db

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.unit.spec.js
@@ -113,6 +113,8 @@ describe("DataSelector", () => {
         combineDatabaseSchemaSteps
         triggerElement={<div />}
         databases={[MULTI_SCHEMA_DATABASE, SAMPLE_DATABASE, ANOTHER_DATABASE]}
+        models={[]}
+        metrics={[]}
         metadata={metadata}
         isOpen={true}
         setSourceTableFn={setTable}
@@ -163,6 +165,8 @@ describe("DataSelector", () => {
       combineDatabaseSchemaSteps: true,
       triggerElement: <div />,
       databases: [],
+      models: [],
+      metrics: [],
       metadata: emptyMetadata,
       isOpen: true,
       fetchDatabases,
@@ -229,6 +233,8 @@ describe("DataSelector", () => {
         combineDatabaseSchemaSteps
         triggerElement={<div />}
         databases={[SAMPLE_DATABASE]}
+        models={[]}
+        metrics={[]}
         metadata={metadata}
         isOpen={true}
       />,
@@ -245,6 +251,8 @@ describe("DataSelector", () => {
         triggerElement={<div>button</div>}
         metadata={emptyMetadata}
         databases={[]}
+        models={[]}
+        metrics={[]}
         fetchDatabases={fetchDatabases}
       />,
     );
@@ -261,6 +269,8 @@ describe("DataSelector", () => {
         combineDatabaseSchemaSteps
         triggerElement={<div />}
         databases={[MULTI_SCHEMA_DATABASE, SAMPLE_DATABASE]}
+        models={[]}
+        metrics={[]}
         metadata={metadata}
         isOpen={true}
       />,
@@ -280,6 +290,8 @@ describe("DataSelector", () => {
         combineDatabaseSchemaSteps
         triggerElement={<div />}
         databases={[MULTI_SCHEMA_DATABASE, SAMPLE_DATABASE]}
+        models={[]}
+        metrics={[]}
         metadata={metadata}
         isOpen={true}
       />,
@@ -309,6 +321,8 @@ describe("DataSelector", () => {
         combineDatabaseSchemaSteps
         triggerElement={<div />}
         databases={[MULTI_SCHEMA_DATABASE, SAMPLE_DATABASE]}
+        models={[]}
+        metrics={[]}
         metadata={metadata}
         isOpen={true}
       />,
@@ -340,6 +354,8 @@ describe("DataSelector", () => {
         combineDatabaseSchemaSteps
         triggerElement={<div />}
         databases={[MULTI_SCHEMA_DATABASE, SAMPLE_DATABASE]}
+        models={[]}
+        metrics={[]}
         metadata={metadata}
         isOpen={true}
       />,
@@ -370,6 +386,8 @@ describe("DataSelector", () => {
         steps={["SCHEMA", "TABLE", "FIELD"]}
         selectedDatabaseId={SAMPLE_DATABASE.id}
         databases={[SAMPLE_DATABASE]}
+        models={[]}
+        metrics={[]}
         triggerElement={<div />}
         metadata={metadata}
         isOpen={true}
@@ -386,6 +404,8 @@ describe("DataSelector", () => {
         steps={["SCHEMA", "TABLE", "FIELD"]}
         selectedDatabaseId={MULTI_SCHEMA_DATABASE.id}
         databases={[MULTI_SCHEMA_DATABASE]}
+        models={[]}
+        metrics={[]}
         triggerElement={<div />}
         metadata={metadata}
         isOpen={true}
@@ -402,6 +422,8 @@ describe("DataSelector", () => {
         steps={["DATABASE"]}
         databases={[SAMPLE_DATABASE, MULTI_SCHEMA_DATABASE]}
         selectedDatabaseId={SAMPLE_DATABASE.id}
+        models={[]}
+        metrics={[]}
         triggerElement={<div />}
         metadata={metadata}
         isOpen={true}
@@ -420,6 +442,8 @@ describe("DataSelector", () => {
       <DataSelector
         steps={["DATABASE", "SCHEMA", "TABLE"]}
         databases={[MULTI_SCHEMA_DATABASE, OTHER_MULTI_SCHEMA_DATABASE]}
+        models={[]}
+        metrics={[]}
         combineDatabaseSchemaSteps
         triggerElement={<div />}
         metadata={metadata}
@@ -441,6 +465,8 @@ describe("DataSelector", () => {
       <DataSelector
         steps={["DATABASE", "SCHEMA", "TABLE"]}
         databases={[SAMPLE_DATABASE, ANOTHER_DATABASE]}
+        models={[]}
+        metrics={[]}
         combineDatabaseSchemaSteps
         triggerElement={<div />}
         metadata={metadata}
@@ -468,6 +494,8 @@ describe("DataSelector", () => {
       <DataSelector
         steps={["DATABASE", "SCHEMA", "TABLE"]}
         databases={[]}
+        models={[]}
+        metrics={[]}
         triggerElement={<div />}
         isOpen={true}
       />,
@@ -484,6 +512,8 @@ describe("DataSelector", () => {
         steps={["BUCKET", "DATABASE", "SCHEMA", "TABLE"]}
         combineDatabaseSchemaSteps
         databases={[SAMPLE_DATABASE, SAVED_QUESTIONS_DATABASE]}
+        models={[]}
+        metrics={[]}
         hasNestedQueriesEnabled
         hasTableSearch
         loaded
@@ -503,6 +533,8 @@ describe("DataSelector", () => {
         steps={["BUCKET", "DATABASE", "SCHEMA", "TABLE"]}
         combineDatabaseSchemaSteps
         databases={[SAMPLE_DATABASE]}
+        models={[]}
+        metrics={[]}
         hasNestedQueriesEnabled
         hasTableSearch
         loaded

--- a/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityPicker.jsx
@@ -34,7 +34,7 @@ const propTypes = {
   currentUser: PropTypes.object.isRequired,
   databaseId: PropTypes.string,
   tableId: PropTypes.string,
-  collectionName: PropTypes.string,
+  collectionId: PropTypes.number,
   rootCollection: PropTypes.object,
 };
 
@@ -58,7 +58,7 @@ function SavedEntityPicker({
   currentUser,
   databaseId,
   tableId,
-  collectionName,
+  collectionId,
   rootCollection,
 }) {
   const collectionTree = useMemo(() => {
@@ -99,7 +99,7 @@ function SavedEntityPicker({
 
   const initialCollection = useMemo(
     () =>
-      findCollectionByName(collectionTree, collectionName) ?? collectionTree[0],
+      findCollectionByName(collectionTree, collectionId) ?? collectionTree[0],
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );

--- a/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityPicker.jsx
@@ -24,7 +24,7 @@ import {
   TreeContainer,
 } from "./SavedEntityPicker.styled";
 import { CARD_INFO } from "./constants";
-import { findCollectionByName } from "./utils";
+import { findCollectionById } from "./utils";
 
 const propTypes = {
   type: PropTypes.string,
@@ -98,8 +98,7 @@ function SavedEntityPicker({
   }, [collections, rootCollection, currentUser, type]);
 
   const initialCollection = useMemo(
-    () =>
-      findCollectionByName(collectionTree, collectionId) ?? collectionTree[0],
+    () => findCollectionById(collectionTree, collectionId) ?? collectionTree[0],
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );

--- a/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/utils.js
+++ b/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/utils.js
@@ -1,4 +1,4 @@
-export const findCollectionByName = (collections, collectionId) => {
+export const findCollectionById = (collections, collectionId) => {
   if (!collections || collections.length === 0) {
     return null;
   }
@@ -9,7 +9,7 @@ export const findCollectionByName = (collections, collectionId) => {
     return collection;
   }
 
-  return findCollectionByName(
+  return findCollectionById(
     collections
       .map(c => c.children)
       .filter(Boolean)

--- a/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/utils.js
+++ b/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/utils.js
@@ -1,9 +1,9 @@
-export const findCollectionByName = (collections, name) => {
+export const findCollectionByName = (collections, collectionId) => {
   if (!collections || collections.length === 0) {
     return null;
   }
 
-  const collection = collections.find(c => c.schemaName === name);
+  const collection = collections.find(c => c.id === collectionId);
 
   if (collection) {
     return collection;
@@ -14,6 +14,6 @@ export const findCollectionByName = (collections, name) => {
       .map(c => c.children)
       .filter(Boolean)
       .flat(),
-    name,
+    collectionId,
   );
 };

--- a/frontend/src/metabase/querying/notebook/components/DataStep/DataStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/DataStep/DataStep.tsx
@@ -14,7 +14,7 @@ import { DataStepIconButton } from "./DataStep.styled";
 export const DataStep = ({
   query,
   step,
-  readOnly,
+  readOnly = false,
   color,
   updateQuery,
 }: NotebookStepProps) => {
@@ -64,11 +64,13 @@ export const DataStep = ({
         data-testid="data-step-cell"
       >
         <NotebookDataPicker
-          title={t`Pick your starting data`}
           query={query}
           stageIndex={stageIndex}
           table={table}
+          title={t`Pick your starting data`}
+          canChangeDatabase
           hasMetrics
+          isDisabled={readOnly}
           onChange={handleTableChange}
         />
       </NotebookCellItem>

--- a/frontend/src/metabase/querying/notebook/components/DataStep/DataStep.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/DataStep/DataStep.unit.spec.tsx
@@ -403,9 +403,7 @@ describe("DataStep", () => {
           const dataSource = screen.getByText("Orders");
           fireEvent.click(dataSource, clickConfig);
 
-          expect(
-            await screen.findByTestId("entity-picker-modal"),
-          ).toBeInTheDocument();
+          expect(await screen.findByText("Products")).toBeInTheDocument();
           expect(mockWindowOpen).not.toHaveBeenCalled();
           mockWindowOpen.mockClear();
         },
@@ -421,12 +419,8 @@ describe("DataStep", () => {
           bubbles: true,
           button: 1,
         });
-
         fireEvent(dataSource, middleClick);
 
-        expect(
-          await screen.findByTestId("entity-picker-modal"),
-        ).toBeInTheDocument();
         expect(mockWindowOpen).not.toHaveBeenCalled();
         mockWindowOpen.mockClear();
       });

--- a/frontend/src/metabase/querying/notebook/components/JoinStep/JoinTablePicker/JoinTablePicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/JoinStep/JoinTablePicker/JoinTablePicker.tsx
@@ -1,9 +1,9 @@
 import type { ReactNode } from "react";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { t } from "ttag";
 
 import { Icon, Popover, Tooltip } from "metabase/ui";
-import * as Lib from "metabase-lib";
+import type * as Lib from "metabase-lib";
 
 import { NotebookCellItem } from "../../NotebookCell";
 import { NotebookDataPicker } from "../../NotebookDataPicker";
@@ -29,7 +29,6 @@ export function JoinTablePicker({
   columnPicker,
   onChange,
 }: JoinTablePickerProps) {
-  const databaseId = useMemo(() => Lib.databaseID(query), [query]);
   const isDisabled = isReadOnly;
 
   return (
@@ -52,8 +51,9 @@ export function JoinTablePicker({
         query={query}
         stageIndex={stageIndex}
         table={table}
-        databaseId={databaseId ?? undefined}
         placeholder={t`Pick data…`}
+        canChangeDatabase={false}
+        hasMetrics={false}
         isDisabled={isDisabled}
         onChange={onChange}
       />

--- a/frontend/src/metabase/querying/notebook/components/Notebook/context.tsx
+++ b/frontend/src/metabase/querying/notebook/components/Notebook/context.tsx
@@ -2,7 +2,7 @@ import { type PropsWithChildren, createContext, useContext } from "react";
 
 import type { DataPickerValue } from "metabase/common/components/DataPicker";
 
-type NotebookContextType = {
+export type NotebookContextType = {
   modelsFilterList: DataPickerValue["model"][];
 };
 

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
@@ -219,6 +219,7 @@ function LegacyDataPicker({
 
   return (
     <DataSourceSelector
+      key={pickerInfo?.tableId}
       isInitiallyOpen={!table}
       selectedDatabaseId={databaseId}
       selectedTableId={pickerInfo?.tableId}

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
@@ -63,6 +63,7 @@ export function NotebookDataPicker({
 
   const isEmbeddingSdk = useSelector(getIsEmbeddingSdk);
   const isEmbeddingIframe = useSelector(getIsEmbedded);
+  const isEmbedding = isEmbeddingSdk || isEmbeddingIframe;
 
   const tableInfo = useMemo(
     () => table && Lib.displayInfo(query, stageIndex, table),
@@ -96,7 +97,7 @@ export function NotebookDataPicker({
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
     const isCtrlOrMetaClick =
       (event.ctrlKey || event.metaKey) && event.button === 0;
-    if (isCtrlOrMetaClick) {
+    if (isCtrlOrMetaClick && !isEmbedding) {
       openDataSourceInNewTab();
     } else {
       setIsOpen(true);
@@ -105,27 +106,34 @@ export function NotebookDataPicker({
 
   const handleAuxClick = (event: MouseEvent<HTMLButtonElement>) => {
     const isMiddleClick = event.button === 1;
-    if (isMiddleClick) {
+    if (isMiddleClick && !isEmbedding) {
       openDataSourceInNewTab();
     } else {
       setIsOpen(true);
     }
   };
 
-  if (isEmbeddingSdk || isEmbeddingIframe) {
+  const handleClose = () => {
+    setIsOpen(false);
+  };
+
+  if (isEmbedding) {
     return (
       <DataSourceSelector
         selectedDatabase={metadata.databases}
         selectedDatabaseId={Lib.databaseID(query)}
         selectedTableId={Lib.sourceTableOrCardId(query)}
-        setSourceTableFn={handleChange}
+        isInitiallyOpen={isOpen}
         triggerElement={
           <DataPickerTarget
             tableInfo={tableInfo}
             placeholder={placeholder}
             isDisabled={isDisabled}
+            onClick={handleClick}
+            onAuxClick={handleAuxClick}
           />
         }
+        setSourceTableFn={handleChange}
       />
     );
   }
@@ -156,7 +164,7 @@ export function NotebookDataPicker({
           databaseId={databaseId}
           models={filterList}
           onChange={handleChange}
-          onClose={() => setIsOpen(false)}
+          onClose={handleClose}
         />
       )}
     </>

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
@@ -1,4 +1,4 @@
-import { type MouseEvent, useState } from "react";
+import { type MouseEvent, type Ref, forwardRef, useState } from "react";
 import { useLatest } from "react-use";
 import { t } from "ttag";
 
@@ -246,15 +246,19 @@ type DataPickerTargetProps = {
   onAuxClick?: (event: MouseEvent<HTMLButtonElement>) => void;
 };
 
-function DataPickerTarget({
-  tableInfo,
-  placeholder,
-  isDisabled,
-  onClick,
-  onAuxClick,
-}: DataPickerTargetProps) {
+const DataPickerTarget = forwardRef(function DataPickerTarget(
+  {
+    tableInfo,
+    placeholder,
+    isDisabled,
+    onClick,
+    onAuxClick,
+  }: DataPickerTargetProps,
+  ref: Ref<HTMLButtonElement>,
+) {
   return (
     <UnstyledButton
+      ref={ref}
       c="inherit"
       fz="inherit"
       fw="inherit"
@@ -271,7 +275,7 @@ function DataPickerTarget({
       </Flex>
     </UnstyledButton>
   );
-}
+});
 
 function getTableIcon(tableInfo: Lib.TableDisplayInfo): IconName {
   switch (true) {

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
@@ -220,8 +220,6 @@ function LegacyDataPicker({
       isInitiallyOpen={!table}
       selectedDatabaseId={databaseId}
       selectedTableId={pickerInfo?.tableId}
-      canSelectQuestion={modelList.includes("card")}
-      canSelectModel={modelList.includes("dataset")}
       canSelectMetric={modelList.includes("metric")}
       triggerElement={
         <DataPickerTarget

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
@@ -77,7 +77,6 @@ export function NotebookDataPicker({
         stageIndex={stageIndex}
         table={table}
         placeholder={placeholder}
-        canChangeDatabase={canChangeDatabase}
         hasMetrics={hasMetrics}
         isDisabled={isDisabled}
         onChange={handleChange}
@@ -194,7 +193,6 @@ type LegacyDataPickerProps = {
   stageIndex: number;
   table: Lib.TableMetadata | Lib.CardMetadata | undefined;
   placeholder: string;
-  canChangeDatabase: boolean;
   hasMetrics: boolean;
   isDisabled: boolean;
   onChange: (tableId: TableId) => void;
@@ -205,15 +203,11 @@ function LegacyDataPicker({
   stageIndex,
   table,
   placeholder,
-  canChangeDatabase,
   hasMetrics,
   isDisabled,
   onChange,
 }: LegacyDataPickerProps) {
-  const metadata = useSelector(getMetadata);
   const databaseId = Lib.databaseID(query);
-  const database =
-    databaseId != null ? metadata.database(databaseId) : undefined;
   const tableInfo =
     table != null ? Lib.displayInfo(query, stageIndex, table) : undefined;
   const pickerInfo = table != null ? Lib.pickerInfo(query, table) : undefined;
@@ -226,10 +220,10 @@ function LegacyDataPicker({
   return (
     <DataSourceSelector
       isInitiallyOpen={!table}
-      databases={canChangeDatabase ? undefined : [database]}
       selectedDatabaseId={databaseId}
       selectedTableId={pickerInfo?.tableId}
       selectedCollectionId={card?.collection_id}
+      databaseQuery={{ saved: true }}
       canSelectMetric={modelList.includes("metric")}
       triggerElement={
         <DataPickerTarget


### PR DESCRIPTION
Demo https://www.loom.com/share/175d961bfc8d4bca8948bb5ea17c238d

Uses the `DataSelector` component for data source selection in the notebook editor for embedding cases - both full app embedding and the sdk. In other cases the existing `EntityPicker` is used without changes. 

**The old component doesn't support some newer features introduced in the `EntityPicker`:**
- Hiding specific data source types,
- Hiding data sources for different databases (used for joins).

There are e2e tests for all interesting data selection cases I'm aware of. If there is some case missing please let me know.

How to verify:
- Run EE
- Enable interactive embedding in admin settings. Use `http://localhost:3001` for the allowed iframe host.
- Add a html page `iframe.html` with the following contents
```html
<!DOCTYPE html>
<html>
<head>
  <title>Full app embedding</title>
</head>
<body>
<iframe src="http://localhost:3000?new_button=true" width="1000" height="800"></iframe>
</body>
</html>
```
- Run some simple http server like `npx http-server -p 3001` and open `http://localhost:3001/iframe.html`
- Make sure that you can pick a data source in the notebook editor using the old picker
- Make sure that the main app itself is not affected 

<img width="1032" alt="Screenshot 2024-11-28 at 10 42 17" src="https://github.com/user-attachments/assets/c98796a0-a959-4228-8ef5-72d3528e5db5">
<img width="1100" alt="Screenshot 2024-11-28 at 10 42 28" src="https://github.com/user-attachments/assets/26926cb0-ece9-4925-9a24-d8c8b1370e41">

