### PR TITLE
Fix embedding test build

### DIFF
--- a/.github/workflows/e2e-component-tests-embedding-sdk.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk.yml
@@ -53,7 +53,7 @@ jobs:
               getBuildRequirements,
               getVersionFromReleaseBranch,
             } = require('${{ github.workspace }}/release/dist/index.cjs');
-            const targetBranchName = '${{ github.base_ref }}';
+            const targetBranchName = '${{ github.ref_name }}';
 
             const version = getVersionFromReleaseBranch(targetBranchName);
             const requirements = getBuildRequirements(version);

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -108,6 +108,7 @@ export const versionRequirements: Record<
   49: { java: 11, node: 18 },
   50: { java: 11, node: 18 },
   51: { java: 11, node: 18 },
+  52: { java: 11, node: 18 },
 };
 
 export const getBuildRequirements = (version: string) => {


### PR DESCRIPTION

### Description

A recent change to the embedding test workflow broke tests in our release branches. It was a small error, but `github.base_ref` only exists for pull request runs, not for tests that run on push to a branch, like the release branches. Since this workflow step only runs on release branches, this should be an uncontroversial fix.