### PR TITLE
Enable underlying-records drill in table viz for multi-stage queries

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -255,7 +255,8 @@ describe("issue 18770", () => {
     popover().within(() => {
       cy.findByText("Filter by this value").should("be.visible");
       cy.findAllByRole("button")
-        .should("have.length", 4)
+        .should("have.length", 5)
+        .and("contain", "See these Orders")
         .and("contain", "<")
         .and("contain", ">")
         .and("contain", "=")

--- a/frontend/src/metabase/visualizations/lib/table.js
+++ b/frontend/src/metabase/visualizations/lib/table.js
@@ -65,6 +65,11 @@ export function getTableCellClickedObject(
       data: clickedRowData,
     };
   } else {
+    // Clicks on aggregation columns can wind up here if the query has stages after the aggregation / breakout
+    // stage. In that case, column.source will be something like "fields", and it's up to the drill to check
+    // the underlying column and construct the dimensions from the passed in clickedRowData. Currently, only
+    // the underlying_records drill handles this, but other drills should be updated if they care about the
+    // column's underlying source.
     return {
       value,
       column,

--- a/src/metabase/lib/drill_thru/underlying_records.cljc
+++ b/src/metabase/lib/drill_thru/underlying_records.cljc
@@ -104,31 +104,31 @@
                  (and (nil? column) (nil? value)))
              ;; If the column exists, it must not be a structured column like JSON.
              (not (and column (lib.types.isa/structured? column))))
-    {:lib/type   :metabase.lib.drill-thru/drill-thru
-     :type       :drill-thru/underlying-records
-     ;; TODO: This is a bit confused for non-COUNT aggregations. Perhaps it should just always be 10 or something?
-     ;; Note that some languages have different plurals for exactly 2, or for 1, 2-5, and 6+.
-     :row-count  (if (and (number? value)
-                          (not (neg? value)))
-                   value
-                   2)
-     :table-name (when-let [table-or-card (or (some->> query lib.util/source-table-id (lib.metadata/table query))
-                                              (some->> query lib.util/source-card-id  (lib.metadata/card  query)))]
-                   (lib.metadata.calculation/display-name query stage-number table-or-card))
-     ;; If no dimensions were provided but the underlying column comes from an aggregation, then construct the
-     ;; dimensions from the row data.
-     :dimensions (or (not-empty dimensions)
-                     (when (and (not (aggregation-sourced? column))
-                                (aggregation-sourced? query column))
-                       (into [] (filter #(breakout-sourced? query (:column %))
-                                        row))))
-     ;; If the underlying column comes from an aggregation, then the column-ref needs to be updated as well to the
-     ;; corresponding aggregation ref so that [[drill-underlying-records]] knows to extract the filter implied by
-     ;; aggregations like sum-where.
-     :column-ref (if (and (not (aggregation-sourced? column))
-                          (aggregation-sourced? query column))
-                   (lib.aggregation/column-metadata->aggregation-ref (lib.underlying/top-level-column query column))
-                   column-ref)}))
+    (let [underlying-aggregation? (and (not (aggregation-sourced? column))
+                                       (aggregation-sourced? query column))]
+      {:lib/type   :metabase.lib.drill-thru/drill-thru
+       :type       :drill-thru/underlying-records
+       ;; TODO: This is a bit confused for non-COUNT aggregations. Perhaps it should just always be 10 or something?
+       ;; Note that some languages have different plurals for exactly 2, or for 1, 2-5, and 6+.
+       :row-count  (if (and (number? value)
+                            (not (neg? value)))
+                     value
+                     2)
+       :table-name (when-let [table-or-card (or (some->> query lib.util/source-table-id (lib.metadata/table query))
+                                                (some->> query lib.util/source-card-id  (lib.metadata/card  query)))]
+                     (lib.metadata.calculation/display-name query stage-number table-or-card))
+       ;; If no dimensions were provided but the underlying column comes from an aggregation, then construct the
+       ;; dimensions from the row data.
+       :dimensions (or (not-empty dimensions)
+                       (when underlying-aggregation?
+                         (not-empty (filterv #(breakout-sourced? query (:column %))
+                                             row))))
+       ;; If the underlying column comes from an aggregation, then the column-ref needs to be updated as well to the
+       ;; corresponding aggregation ref so that [[drill-underlying-records]] knows to extract the filter implied by
+       ;; aggregations like sum-where.
+       :column-ref (if underlying-aggregation?
+                     (lib.aggregation/column-metadata->aggregation-ref (lib.underlying/top-level-column query column))
+                     column-ref)})))
 
 (defmethod lib.drill-thru.common/drill-thru-info-method :drill-thru/underlying-records
   [_query _stage-number {:keys [row-count table-name]}]

--- a/src/metabase/lib/drill_thru/underlying_records.cljc
+++ b/src/metabase/lib/drill_thru/underlying_records.cljc
@@ -46,6 +46,20 @@
    [metabase.lib.util :as lib.util]
    [metabase.util.malli :as mu]))
 
+(defn- has-source-or-underyling-source-fn
+  [source]
+  (fn has-source?
+    ([column]
+     (= (:lib/source column) source))
+    ([query column]
+     (and
+      (seq column)
+      (or (has-source? column)
+          (has-source? (lib.underlying/top-level-column query column)))))))
+
+(def ^:private aggregation-sourced? (has-source-or-underyling-source-fn :source/aggregations))
+(def ^:private breakout-sourced?    (has-source-or-underyling-source-fn :source/breakouts))
+
 (mu/defn underlying-records-drill :- [:maybe ::lib.schema.drill-thru/drill-thru.underlying-records]
   "When clicking on a particular broken-out group, offer a look at the details of all the rows that went into this
   bucket. Eg. distribution of People by State, then click New York and see the table of all People filtered by
@@ -53,9 +67,9 @@
 
   There is another quite different case: clicking the legend of a chart with multiple bars or lines broken out by
   category. Then `column` is nil!"
-  [query                                                      :- ::lib.schema/query
-   stage-number                                               :- :int
-   {:keys [column column-ref dimensions value], :as _context} :- ::lib.schema.drill-thru/context]
+  [query                                                          :- ::lib.schema/query
+   stage-number                                                   :- :int
+   {:keys [column column-ref dimensions row value], :as _context} :- ::lib.schema.drill-thru/context]
   ;; Clicking on breakouts is weird. Clicking on Count(People) by State: Minnesota yields a FE `clicked` with:
   ;; - column is COUNT
   ;; - row[0] has col: STATE, value: "Minnesota"
@@ -63,18 +77,27 @@
   ;; - dimensions which is [{column: STATE, value: "MN"}]
   ;; - value: the aggregated value (the count, the sum, etc.)
   ;; So dimensions is exactly what we want.
-  ;; It returns the table name and row count, since that's used for pluralization of the name.
 
   ;; Clicking on a single-row aggregation, there's no dimensions, but we should support underlying records.
+
+  ;; Clicking on a table cell for an aggregated column when there are additional query stages (e.g. filters) after the
+  ;; underyling breakouts/aggregations stage results in a context like:
+  ;; - (:lib/source column) is NOT :source/aggregations
+  ;; - (:lib/source (lib.underlying/top-level-column query column) IS :source/aggregations
+  ;; - column-ref is similarly NOT an :aggregation ref
+  ;; - dimensions is nil
+  ;; - rows is not nil and can be used to construct the breakout dimensions
 
   ;; Clicking on a chart legend for eg. COUNT(Orders) by Products.CATEGORY and Orders.CREATED_AT has a context like:
   ;; - column is nil
   ;; - value is nil
   ;; - dimensions holds only the legend's column, eg. Products.CATEGORY.
+
+  ;; This function returns the table name and row count, since that's used for pluralization of the name.
   (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
              (lib.underlying/has-aggregation-or-breakout? query)
              ;; Either we clicked the aggregation, or there are dimensions.
-             (or (= (:lib/source column) :source/aggregations)
+             (or (aggregation-sourced? query column)
                  (not-empty dimensions))
              ;; Either we need both column and value (cell/map/data point click) or neither (chart legend click).
              (or (and column (some? value))
@@ -92,8 +115,20 @@
      :table-name (when-let [table-or-card (or (some->> query lib.util/source-table-id (lib.metadata/table query))
                                               (some->> query lib.util/source-card-id  (lib.metadata/card  query)))]
                    (lib.metadata.calculation/display-name query stage-number table-or-card))
-     :dimensions dimensions
-     :column-ref column-ref}))
+     ;; If no dimensions were provided but the underlying column comes from an aggregation, then construct the
+     ;; dimensions from the row data.
+     :dimensions (or (not-empty dimensions)
+                     (when (and (not (aggregation-sourced? column))
+                                (aggregation-sourced? query column))
+                       (into [] (filter #(breakout-sourced? query (:column %))
+                                        row))))
+     ;; If the underlying column comes from an aggregation, then the column-ref needs to be updated as well to the
+     ;; corresponding aggregation ref so that [[drill-underlying-records]] knows to extract the filter implied by
+     ;; aggregations like sum-where.
+     :column-ref (if (and (not (aggregation-sourced? column))
+                          (aggregation-sourced? query column))
+                   (lib.aggregation/column-metadata->aggregation-ref (lib.underlying/top-level-column query column))
+                   column-ref)}))
 
 (defmethod lib.drill-thru.common/drill-thru-info-method :drill-thru/underlying-records
   [_query _stage-number {:keys [row-count table-name]}]

--- a/test/metabase/lib/drill_thru/test_util/canned.cljc
+++ b/test/metabase/lib/drill_thru/test_util/canned.cljc
@@ -109,6 +109,14 @@
      :breakouts      0
      :default-column "count"}
 
+    :test.query/orders-by-product-id
+    {:query          (-> (lib/query metadata-provider (meta/table-metadata :orders))
+                         (lib/breakout (meta/field-metadata :orders :product-id)))
+     :row            {"PRODUCT_ID" 77}
+     :aggregations   0
+     :breakouts      1
+     :default-column "PRODUCT_ID"}
+
     :test.query/orders-count-by-product-id
     {:query          (-> (lib/query metadata-provider (meta/table-metadata :orders))
                          (lib/aggregate (lib/count))
@@ -270,6 +278,12 @@
 
          ;; Singular aggregation for Orders, just clicking that single cell.
          [(click (test-case metadata-provider :test.query/orders-count) :cell "count" :aggregation :number)]
+
+         ;; Breakout-only for Orders by Product ID - click both cell and header.
+         (let [tc (test-case metadata-provider :test.query/orders-by-product-id)]
+           [(click tc :cell "PRODUCT_ID" :breakout    :fk)
+
+            (click tc :header "PRODUCT_ID" :breakout    :fk)])
 
          ;; Count broken out by Product ID - click both count and Product ID, both the cells and headers; also a pivot.
          (let [tc (test-case metadata-provider :test.query/orders-count-by-product-id)]


### PR DESCRIPTION
### Description

Enable the underlying-records drill in table visualizations for multi-stage queries by having the drill look up the underlying "top-level-column" to determine if it comes from an aggregation, and, if so, construct `dimensions` for the drill from the `row` data.

Unfortunately, I just realized that this same bug exists in multiple other drills. This PR only fixes the underlying_records drill. At a minimum, this same bug seems to also affect the zoom-in-timeseries, pivot, and automatic-insight drills, but possibly others as well.

update: per slack thread [here](https://metaboat.slack.com/archives/C0645JP1W81/p1732738034864339) this fix can land first and I'll work on these other drills in a follow-on PR(s)

Partial fix for: https://github.com/metabase/metabase/issues/46932

Previous slack discussions

https://metaboat.slack.com/archives/C0645JP1W81/p1732567276393749

https://metaboat.slack.com/archives/C0643FZ5E83/p1732208207975959?thread_ts=1732200887.449339&cid=C0643FZ5E83

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> Orders
2. Summarize: count by Created At: month
3. Add a filter stage after the summarization, e.g. Count > 1
4. Visualize
5. Click on the Count column in the resulting Table viz
6. Observe "See these Orders" in the context menu

### Demo

<img width="544" alt="Screenshot 2024-11-27 at 11 51 53 AM" src="https://github.com/user-attachments/assets/933af02a-bc67-4e04-9b34-d30390531101">

<img width="727" alt="Screenshot 2024-11-27 at 11 50 36 AM" src="https://github.com/user-attachments/assets/33622957-9e9b-4cd0-bdef-d77710a73589">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
