### PR TITLE
fix(sdk): make modals use the correct portal

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
@@ -1,10 +1,12 @@
 import {
+  CreateDashboardModal,
+  InteractiveQuestion,
   MetabaseProvider,
   StaticQuestion,
 } from "@metabase/embedding-sdk-react";
 
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
-import { describeEE, updateSetting } from "e2e/support/helpers";
+import { describeEE, modal, updateSetting } from "e2e/support/helpers";
 import {
   DEFAULT_SDK_PROVIDER_CONFIG,
   mockAuthProviderAndJwtSignIn,
@@ -12,7 +14,7 @@ import {
 } from "e2e/support/helpers/component-testing-sdk";
 import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 
-describeEE("scenarios > embedding-sdk > static-dashboard", () => {
+describeEE("scenarios > embedding-sdk > styles", () => {
   beforeEach(() => {
     signInAsAdminAndEnableEmbeddingSdk();
 
@@ -218,6 +220,55 @@ describeEE("scenarios > embedding-sdk > static-dashboard", () => {
       getSdkRoot()
         .findByText("Product ID")
         .should("have.css", "font-family", "Custom, sans-serif");
+    });
+  });
+
+  describe("modals and tooltips", () => {
+    it("legacy WindowModal modals should render with our styles", () => {
+      // this test renders a create dashboard modal that, at this time, is using the legacy WindowModal
+      cy.mount(
+        <MetabaseProvider config={DEFAULT_SDK_PROVIDER_CONFIG}>
+          <CreateDashboardModal />
+        </MetabaseProvider>,
+      );
+
+      modal()
+        .findByText("New dashboard")
+        .should("exist")
+        .and("have.css", "font-family", "Lato, sans-serif");
+
+      // TODO: good place for a visual regression test
+    });
+
+    it("mantine modals should render with our styles", () => {
+      cy.mount(
+        <MetabaseProvider config={DEFAULT_SDK_PROVIDER_CONFIG}>
+          <InteractiveQuestion questionId={ORDERS_QUESTION_ID} />
+        </MetabaseProvider>,
+      );
+
+      getSdkRoot().findByText("Summarize").click();
+      getSdkRoot().findByText("Add a function or metric").click();
+      getSdkRoot().findByText("Count of rows").click();
+      getSdkRoot().findByText("Apply").click();
+      getSdkRoot().findByText("Save").click();
+
+      getSdkRoot()
+        .findByText("Save question")
+        .should("exist")
+        .and("have.css", "font-family", "Lato, sans-serif");
+
+      // TODO: good place for a visual regression test
+
+      getSdkRoot().findByText("Save as new question").click();
+      getSdkRoot().findByText("Our analytics").click();
+
+      getSdkRoot()
+        .findByText("Select a collection")
+        .should("exist")
+        .and("have.css", "font-family", "Lato, sans-serif");
+
+      // TODO: good place for a visual regression test
     });
   });
 });

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkThemeProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkThemeProvider.tsx
@@ -30,7 +30,7 @@ export const SdkThemeProvider = ({ theme, children }: Props) => {
     // This must be done before ThemeProvider calls getThemeOverrides.
     setGlobalEmbeddingColors(theme?.colors, appColors);
 
-    return theme && getEmbeddingThemeOverride(theme, font);
+    return getEmbeddingThemeOverride(theme || {}, font);
   }, [appColors, theme, font]);
 
   return (

--- a/frontend/src/metabase/components/Modal/WindowModal.tsx
+++ b/frontend/src/metabase/components/Modal/WindowModal.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties } from "react";
 import { Component } from "react";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 
+import { EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID } from "embedding-sdk/config";
 import { MaybeOnClickOutsideWrapper } from "metabase/components/Modal/MaybeOnClickOutsideWrapper";
 import type {
   BaseModalProps,
@@ -53,7 +54,13 @@ export class WindowModal extends Component<WindowModalProps> {
     if (props.zIndex != null) {
       this._modalElement.style.zIndex = String(props.zIndex);
     }
-    document.body.appendChild(this._modalElement);
+
+    const modalContainer =
+      window.document.querySelector(
+        `#${EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID}`,
+      ) || document.body;
+
+    modalContainer.appendChild(this._modalElement);
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50521

This fixes two issues:
- when theme was not passed the mantine modals were not using the portal container correctly (fixes #50521), fixed in `SdkThemeProvider.tsx`
- "legacy modals" were being added to the body, not to our modal container, fixed in WindowModal