### PR TITLE
Fix incorrect labelling for "IS NULL" and "IS NOT NULL" clauses in Date Picker

### DIFF
--- a/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/constants.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/constants.ts
@@ -23,11 +23,11 @@ export const EXCLUDE_UNIT_OPTIONS: ExcludeUnitOption[] = [
 
 export const EXCLUDE_OPERATOR_OPTIONS: ExcludeOperatorOption[] = [
   {
-    operator: "not-null",
+    operator: "is-null",
     label: t`Is empty`,
   },
   {
-    operator: "is-null",
+    operator: "not-null",
     label: t`Is not empty`,
   },
 ];


### PR DESCRIPTION
<!--
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/[issue_number]
-->

### Description

On the Query Builder UI for a question, when adding filter on a Date column, adding an "Is empty" filter actually added a "IS NOT NULL" to the query and vice-versa for "Is not empty".
This change fixes it.
### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> Select date column -> Click on "Exclude" -> Select "Is empty" 
2. Verify SQL has correct generated clause

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
