### PR TITLE
Avoid renaming Search Index tables

### DIFF
--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -63,7 +63,7 @@
 
 (defmethod search.engine/results :search.engine/fulltext
   [{:keys [search-string] :as search-ctx}]
-  (when-not @#'search.index/initialized?
+  (when-not (search.index/active-table)
     (throw (ex-info "Search index is not initialized. Use [[init!]] to ensure it exists."
                     {:search-engine :postgres})))
   (let [weights (search.config/weights search-ctx)
@@ -96,4 +96,4 @@
   (search.index/ensure-ready! false)
   (search.index/maybe-create-pending!)
   (u/prog1 (search.ingestion/populate-index! :search.engine/fulltext)
-    (search.index/activate-pending!)))
+    (search.index/activate-table!)))

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -13,36 +13,36 @@
 (comment
   postgres/keep-me)
 
+(set! *warn-on-reflection* true)
+
 (def ^:private insert-batch-size 150)
 
-(def ^:dynamic *active-table*
-  "The table against which we should currently make search queries. Dynamic for testing."
-  :search_index)
+(def ^:dynamic ^:private *active-table* (atom nil))
 
-(def ^:private pending-table :search_index_next)
+(def ^:dynamic ^:private *pending-table* (atom nil))
 
-(def ^:private retired-table :search_index_retired)
+(defn gen-table-name
+  "Generate a unique table name to use as a search index table."
+  []
+  (keyword (str/replace (str "search_index_" (random-uuid)) #"-" "_")))
 
-(defonce ^:private initialized? (atom false))
+(defn active-table
+  "The table against which we should currently make search queries."
+  []
+  @*active-table*)
 
-(defonce ^:private reindexing? (atom false))
-
-(defn- random-prefix []
-  (str/replace (str (name *active-table*) "_" (random-uuid)) #"-" "_"))
+(defn pending-table
+  "A partially populated table that will take over from [[active-table]] when it is done."
+  []
+  @*pending-table*)
 
 (defn- exists? [table-name]
   (t2/exists? :information_schema.tables :table_name (name table-name)))
 
 (defn- drop-table! [table-name]
   (boolean
-   (when (exists? table-name)
+   (when (and table-name (exists? table-name))
      (t2/query (sql.helpers/drop-table table-name)))))
-
-(defn- rename-table! [old new]
-  (when (and (exists? old) (not (exists? new)))
-    (-> (sql.helpers/alter-table old)
-        (sql.helpers/rename-table new)
-        t2/query)))
 
 (defn create-table!
   "Create an index table with the given name. Should fail if it already exists."
@@ -50,33 +50,38 @@
   (-> (sql.helpers/create-table table-name)
       (sql.helpers/with-columns (specialization/table-schema))
       t2/query)
-  (let [idx-prefix (random-prefix)
-        table-name (name table-name)]
-    (doseq [stmt (specialization/post-create-statements idx-prefix table-name)]
+  (let [table-name (name table-name)]
+    (doseq [stmt (specialization/post-create-statements table-name table-name)]
       (t2/query stmt))))
 
 (defn maybe-create-pending!
   "Create a search index table."
   ([]
-   (when (not @reindexing?)
-     (maybe-create-pending! pending-table)
-     (reset! reindexing? true)))
+   (when (not (pending-table))
+     (let [tn (gen-table-name)]
+       (maybe-create-pending! tn)
+       (reset! *pending-table* tn))))
   ([table-name]
    (when-not (exists? table-name)
      (create-table! table-name))))
 
-(defn activate-pending!
+(defn activate-table!
   "Make the pending index active if it exists. Returns true if it did so."
-  []
-  ;; ... just in case it wasn't cleaned up last time.
-  (drop-table! retired-table)
-  (when (exists? pending-table)
-    (t2/with-transaction [_conn]
-      (rename-table! *active-table* retired-table)
-      (rename-table! pending-table *active-table*))
-    (reset! reindexing? false)
-    (drop-table! retired-table)
-    true))
+  ([]
+   (activate-table! (pending-table)))
+  ([table-name]
+   (boolean
+    (when (exists? table-name)
+      (let [active (active-table)]
+        (when (not= active table-name)
+          (reset! *active-table* table-name)
+          (swap! *pending-table* #(when (not= % table-name) %))
+          (when active
+            ;; TODO we need more graceful way to drop these
+            (-> (Thread. (fn []
+                           (Thread/sleep 1000)
+                           (drop-table! active)))
+                (.run)))))))))
 
 (defn- document->entry [entity]
   (-> entity
@@ -98,36 +103,33 @@
   [id search-models]
   ;; In practice, we expect this to be 1-1, but the data model does not preclude it.
   (when (seq search-models)
-    (when @initialized?
-      (t2/delete! *active-table* :model_id id :model [:in search-models]))
-    (when @reindexing?
-      (t2/delete! pending-table :model_id id :model [:in search-models]))))
+    (doseq [table-name [(active-table) (pending-table)] :when table-name]
+      (t2/delete! table-name :model_id id :model [:in search-models]))))
 
 (defn- safe-batch-upsert! [table-name entries]
-  (try
-    (specialization/batch-upsert! table-name entries)
-    (catch Exception e
-      ;; ignore database errors, the table likely doesn't exist, or has a stale schema.
-      (when-not (instance? PSQLException (ex-cause e))
-        (throw e)))))
+  ;; For convenience, if we're given a non-existing table, gracefully no-op.
+  (when table-name
+    (try
+      (specialization/batch-upsert! table-name entries)
+      (catch Exception e
+        ;; ignore database errors, the table likely doesn't exist, or has a stale schema.
+        (when-not (instance? PSQLException (ex-cause e))
+          (throw e))))))
 
 (defn- batch-update!
   "Create the given search index entries in bulk"
   [documents]
   (let [entries          (map document->entry documents)
-        ;; When stubbing the table in tests, always treat it as active
-        active?          (or @initialized? (not= :search_index *active-table*))
         ;; Ideally, we would reset these atoms if the corresponding tables don't exist.
         ;; We're about to rework this area, so just leaving this as a note for now.
-        active-updated?  (when active? (safe-batch-upsert! *active-table* entries))
-        pending-updated? (when @reindexing?  (safe-batch-upsert! pending-table entries))]
+        active-updated?  (safe-batch-upsert! (active-table) entries)
+        pending-updated? (safe-batch-upsert! (pending-table) entries)]
     (when (or active-updated? pending-updated?)
       (->> entries (map :model) frequencies))))
 
 (defmethod search.engine/reset-tracking! :search.engine/fulltext [_]
-  ;; TODO we'll make this safe when we switch to the metadata table.
-  (reset! initialized? false)
-  (reset! reindexing? false))
+  (reset! *active-table* nil)
+  (reset! *pending-table* nil))
 
 (defmethod search.engine/consume! :search.engine/fulltext [_engine document-reducible]
   (transduce (comp (partition-all insert-batch-size)
@@ -140,7 +142,8 @@
   ([search-term search-ctx]
    (search-query search-term search-ctx [:model_id :model]))
   ([search-term search-ctx select-items]
-   (specialization/base-query *active-table* search-term search-ctx select-items)))
+   (when-let [index-table (active-table)]
+     (specialization/base-query index-table search-term search-ctx select-items))))
 
 (defn search
   "Use the index table to search for records."
@@ -151,21 +154,26 @@
 (defn reset-index!
   "Ensure we have a blank slate; in case the table schema or stored data format has changed."
   []
-  ;; Moving to random tables will clean this up
-  (let [testing?   (not= *active-table* :search_index)
-        table-name (if testing? *active-table* pending-table)]
-    (when-not testing?
-      (reset! reindexing? false))
-    (drop-table! table-name)
-    (maybe-create-pending! table-name)
-    (when-not testing?
-      (activate-pending!)
-      (reset! initialized? true))
-    true))
+  (drop-table! (pending-table))
+  (maybe-create-pending!)
+  (activate-table!))
 
 (defn ensure-ready!
   "Ensure the index is ready to be populated. Return false if it was already ready."
   [force-recreation?]
-  (if (or force-recreation? (not (exists? *active-table*)))
+  (if (or force-recreation? (not (exists? (active-table))))
     (reset-index!)
-    (reset! initialized? true)))
+    true))
+
+#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
+(defmacro with-temp-index-table
+  "Create a temporary index table for the duration of the body."
+  [& body]
+  `(let [table-name# (gen-table-name)]
+     (binding [*pending-table* (atom nil)
+               *active-table*  (atom table-name#)]
+       (try
+         (create-table! table-name#)
+         ~@body
+         (finally
+           (#'drop-table! table-name#))))))

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -37,7 +37,8 @@
   (keyword (str/replace (str "search_index_" (random-uuid)) #"-" "_")))
 
 (defn- exists? [table-name]
-  (t2/exists? :information_schema.tables :table_name (name table-name)))
+  (when table-name
+    (t2/exists? :information_schema.tables :table_name (name table-name))))
 
 (defn- drop-table! [table-name]
   (boolean

--- a/src/metabase/search/appdb/scoring.clj
+++ b/src/metabase/search/appdb/scoring.clj
@@ -105,7 +105,7 @@
 (defn- view-count-percentile-query [p-value]
   (let [expr [:raw "percentile_cont(" [:lift p-value] ") WITHIN GROUP (ORDER BY view_count)"]]
     {:select   [:search_index.model [expr :vcp]]
-     :from     [[search.index/*active-table* :search_index]]
+     :from     [[(search.index/active-table) :search_index]]
      :group-by [:search_index.model]
      :having   [:is-not expr nil]}))
 

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -22,9 +22,11 @@
    [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features :as premium-features]
    [metabase.search.appdb.core :as search.engines.appdb]
+   [metabase.search.appdb.index :as search.index]
    [metabase.search.config :as search.config]
    [metabase.search.core :as search]
    [metabase.search.in-place.scoring :as scoring]
+   [metabase.search.test-util :as search.tu]
    [metabase.test :as mt]
    [metabase.util :as u]
    [toucan2.core :as t2]
@@ -1579,22 +1581,20 @@
 
 (deftest force-reindex-test
   (when (search/supports-index?)
-    (mt/with-temp [Card {id :id} {:name "It boggles the mind!"}]
-      (mt/user-http-request :crowberto :post 200 "search/re-init")
-      (let [search-results #(:data (mt/user-http-request :rasta :get % "search" :q "boggle" :search_engine "fulltext"))]
-        (is (try
-              (t2/delete! :search_index)
-              (catch Exception _
-                :already-deleted)))
-        (is (empty? (search-results 200)))
-        (mt/user-http-request :crowberto :post 200 "search/force-reindex")
-        (is (loop [attempts-left 5]
-              (if (and (pos? (try (t2/count :search_index) (catch Exception _ 0)))
-                       (some (comp #{id} :id) (search-results 200)))
-                ::success
-                (when (pos? attempts-left)
-                  (Thread/sleep 200)
-                  (recur (dec attempts-left))))))))))
+    (search.tu/with-temp-index-table
+      (mt/with-temp [Card {id :id} {:name "It boggles the mind!"}]
+        (mt/user-http-request :crowberto :post 200 "search/re-init")
+        (let [search-results #(:data (mt/user-http-request :rasta :get % "search" :q "boggle" :search_engine "fulltext"))]
+          (is (try (t2/delete! (search.index/active-table)) (catch Exception _ :already-deleted)))
+          (is (empty? (search-results 200)))
+          (mt/user-http-request :crowberto :post 200 "search/force-reindex")
+          (is (loop [attempts-left 5]
+                (if (and (pos? (try (t2/count (search.index/active-table)) (catch Exception _ 0)))
+                         (some (comp #{id} :id) (search-results 200)))
+                  ::success
+                  (when (pos? attempts-left)
+                    (Thread/sleep 200)
+                    (recur (dec attempts-left)))))))))))
 
 (defn- weights-url
   ([]

--- a/test/metabase/search/test_util.clj
+++ b/test/metabase/search/test_util.clj
@@ -1,6 +1,5 @@
 (ns metabase.search.test-util
   (:require
-   [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.api.common :as api]
    [metabase.public-settings.premium-features :as premium-features]
@@ -16,26 +15,12 @@
 
 (def ^:dynamic *user-ctx* nil)
 
-(defn- random-prefix []
-  (str/replace (str (name search.index/*active-table*) "_" (random-uuid)) #"-" "_"))
-
-(defn random-table-name
-  "Generate a random name for a search index table."
-  []
-  (keyword (random-prefix)))
-
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro with-temp-index-table
   "Create a temporary index table for the duration of the body."
   [& body]
   `(when (search/supports-index?)
-     (let [table-name# (random-table-name)]
-       (binding [search.index/*active-table* table-name#]
-         (try
-           (search.index/create-table! search.index/*active-table*)
-           ~@body
-           (finally
-             (#'search.index/drop-table! search.index/*active-table*)))))))
+     (search.index/with-temp-index-table ~@body)))
 
 (defmacro with-api-user [raw-ctx & body]
   `(let [raw-ctx# ~raw-ctx]

--- a/test/metabase/task/search_index_test.clj
+++ b/test/metabase/task/search_index_test.clj
@@ -7,17 +7,17 @@
    [toucan2.core :as t2]))
 
 (defn- index-size []
-  (t2/count search.index/*active-table*))
+  (t2/count (search.index/active-table)))
 
 ;; TODO this is coupled to appdb engines at the moment
 (deftest reindex!-test
   (search.tu/with-temp-index-table
-    (is (zero? (t2/count search.index/*active-table*)))
+    (is (zero? (index-size)))
     (testing "It can recreate the index from scratch"
       (task/reindex! true)
       (let [initial-size (index-size)]
         (is (pos? initial-size))
-        (t2/delete! search.index/*active-table* (t2/select-one-pk search.index/*active-table*))
+        (t2/delete! (search.index/active-table) (t2/select-one-pk (search.index/active-table)))
         (is (= (dec initial-size) (index-size)))
         (testing "It can cycle the index gracefully"
           (task/reindex! false)


### PR DESCRIPTION
This also avoids a brittle song and dance with non-authoritative atoms in the background. Now we juggle authoritative atoms all the time 😄 
