### PR TITLE
Properly handle other users personal collections in collection picker

### DIFF
--- a/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
+++ b/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
@@ -16,6 +16,7 @@ import {
   createQuestion,
   editDashboard,
   entityPickerModal,
+  entityPickerModalItem,
   entityPickerModalTab,
   getDashboardCard,
   getNotebookStep,
@@ -31,6 +32,7 @@ import {
   visitQuestion,
   visualize,
 } from "e2e/support/helpers";
+import * as H from "e2e/support/helpers";
 import type { DashboardCard } from "metabase-types/api";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
@@ -719,6 +721,53 @@ describe("scenarios > organization > entity picker", () => {
             "Normal personal collection 2",
           ],
         });
+      });
+    });
+
+    it("Should properly render a path from other users personal collections", () => {
+      cy.signInAsAdmin();
+      createTestCollections();
+      cy.visit("/");
+      H.newButton("Dashboard").click();
+
+      H.modal().within(() => {
+        cy.findByLabelText("Which collection should this go in?").click();
+      });
+
+      entityPickerModal().within(() => {
+        entityPickerModalTab("Collections").click();
+        entityPickerModalItem(0, "All personal collections").click();
+        entityPickerModalItem(
+          1,
+          "Robert Tableton's Personal Collection",
+        ).click();
+        entityPickerModalItem(2, "Normal personal collection 2").click();
+        cy.button("Select").click();
+      });
+
+      cy.log(
+        "Re-open the collection picker to ensure that the path is generated properly",
+      );
+      H.modal().within(() => {
+        cy.findByLabelText("Which collection should this go in?").click();
+      });
+
+      entityPickerModal().within(() => {
+        entityPickerModalTab("Collections").click();
+        entityPickerModalItem(0, "All personal collections").should(
+          "have.attr",
+          "data-active",
+          "true",
+        );
+        entityPickerModalItem(
+          1,
+          "Robert Tableton's Personal Collection",
+        ).should("have.attr", "data-active", "true");
+        entityPickerModalItem(2, "Normal personal collection 2").should(
+          "have.attr",
+          "data-active",
+          "true",
+        );
       });
     });
   });

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPicker.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPicker.tsx
@@ -73,28 +73,14 @@ export const CollectionPickerInner = (
 
   const onFolderSelect = useCallback(
     ({ folder }: { folder: CollectionPickerItem }) => {
-      const isUserPersonalCollection = folder?.id === userPersonalCollectionId;
-      const isUserSubfolder =
-        path?.[1]?.query?.id === "personal" && !isUserPersonalCollection;
-
       const newPath = getStateFromIdPath({
-        idPath: getCollectionIdPath(
-          folder,
-          userPersonalCollectionId,
-          isUserSubfolder,
-        ),
+        idPath: getCollectionIdPath(folder, userPersonalCollectionId),
         namespace: options.namespace,
       });
       onItemSelect(folder);
       onPathChange(newPath);
     },
-    [
-      onItemSelect,
-      onPathChange,
-      options.namespace,
-      userPersonalCollectionId,
-      path,
-    ],
+    [onItemSelect, onPathChange, options.namespace, userPersonalCollectionId],
   );
 
   const handleItemSelect = useCallback(

--- a/frontend/src/metabase/common/components/CollectionPicker/utils.ts
+++ b/frontend/src/metabase/common/components/CollectionPicker/utils.ts
@@ -15,7 +15,6 @@ export const getCollectionIdPath = (
     "id" | "location" | "is_personal" | "effective_location"
   >,
   userPersonalCollectionId?: CollectionId,
-  isPersonal?: boolean,
 ): CollectionId[] => {
   if (collection.id === null || collection.id === "root") {
     return ["root"];
@@ -39,10 +38,10 @@ export const getCollectionIdPath = (
     (collection.id === userPersonalCollectionId ||
       pathFromRoot.includes(userPersonalCollectionId));
 
-  if (isPersonal) {
-    return ["personal", ...pathFromRoot, collection.id];
-  } else if (isInUserPersonalCollection) {
+  if (isInUserPersonalCollection) {
     return [...pathFromRoot, collection.id];
+  } else if (collection.is_personal) {
+    return ["personal", ...pathFromRoot, collection.id];
   } else {
     return ["root", ...pathFromRoot, collection.id];
   }

--- a/frontend/src/metabase/common/components/CollectionPicker/utils.unit.spec.ts
+++ b/frontend/src/metabase/common/components/CollectionPicker/utils.unit.spec.ts
@@ -11,7 +11,6 @@ describe("CollectionPicker > utils", () => {
           is_personal: true,
         },
         1337,
-        false,
       );
 
       expect(path).toEqual([1337]);
@@ -26,7 +25,6 @@ describe("CollectionPicker > utils", () => {
           is_personal: true,
         },
         1337,
-        false,
       );
 
       expect(path).toEqual([1337, 1339]);
@@ -40,7 +38,6 @@ describe("CollectionPicker > utils", () => {
           effective_location: "/",
         },
         1337,
-        false,
       );
 
       expect(path).toEqual(["personal"]);
@@ -52,9 +49,9 @@ describe("CollectionPicker > utils", () => {
           id: 8675309,
           location: "/1400/",
           effective_location: "/1400/",
+          is_personal: true,
         },
         1337,
-        true,
       );
 
       expect(path).toEqual(["personal", 1400, 8675309]);
@@ -69,10 +66,9 @@ describe("CollectionPicker > utils", () => {
           is_personal: true,
         },
         1337,
-        true,
       );
 
-      expect(path).toEqual(["personal", 1337]);
+      expect(path).toEqual([1337]);
     });
 
     it("should handle subcollections of the current user's personal collection within all users' personal collections 🥴", () => {
@@ -84,10 +80,9 @@ describe("CollectionPicker > utils", () => {
           is_personal: true,
         },
         1337,
-        true,
       );
 
-      expect(path).toEqual(["personal", 1337, 1339]);
+      expect(path).toEqual([1337, 1339]);
     });
 
     it("should handle root collection", () => {
@@ -98,7 +93,6 @@ describe("CollectionPicker > utils", () => {
           effective_location: "/",
         },
         1337,
-        false,
       );
 
       expect(path).toEqual(["root"]);
@@ -112,7 +106,6 @@ describe("CollectionPicker > utils", () => {
           effective_location: "/6/7/8/",
         },
         1337,
-        false,
       );
 
       expect(path).toEqual(["root", 6, 7, 8, 9]);
@@ -126,7 +119,6 @@ describe("CollectionPicker > utils", () => {
           effective_location: "/6/7/8/",
         },
         1337,
-        false,
       );
 
       expect(path).toEqual(["root", 6, 7, 8, 9]);


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50604

### Description
Properly detects collections in other users personal collections when generating an initial path

### How to verify

1. New -> Dashboard -> Open collection picker
2. Pick a collection in another users personal collection. Hit Select
3. Re-open the collection picker. It should render a correct path

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
