### PR TITLE
Address feedback on Sankey

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/sankey.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/sankey.cy.spec.js
@@ -114,7 +114,7 @@ describe("scenarios > visualizations > sankey", () => {
       rows: [
         {
           name: "METRIC",
-          value: "0",
+          value: "30,000",
         },
       ],
     });

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
@@ -29,6 +29,7 @@ const ChartSettingFieldPicker = ({
   colors,
   series,
   onChangeSeriesColor,
+  autoOpenWhenUnset = true,
   fieldSettingWidget = null,
 }) => {
   let columnKey;
@@ -91,6 +92,7 @@ const ChartSettingFieldPicker = ({
         onChange={onChange}
         placeholder={t`Select a field`}
         placeholderNoOptions={t`No valid fields`}
+        isInitiallyOpen={autoOpenWhenUnset && value === undefined}
         hiddenIcons
       />
       {menuWidgetInfo && (

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
@@ -91,7 +91,6 @@ const ChartSettingFieldPicker = ({
         onChange={onChange}
         placeholder={t`Select a field`}
         placeholderNoOptions={t`No valid fields`}
-        isInitiallyOpen={value === undefined}
         hiddenIcons
       />
       {menuWidgetInfo && (

--- a/frontend/src/metabase/visualizations/echarts/graph/sankey/layout/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/sankey/layout/index.ts
@@ -97,7 +97,7 @@ export const getSankeyLayout = (
   );
   const maxRightLabelWidth = Math.max(
     ...mostRightNodes
-      .map(({ node }) => chartModel.formatters.node(node.rawName))
+      .map(({ node }) => chartModel.formatters.node(node))
       .map(formattedNode =>
         renderingContext.measureText(formattedNode, {
           ...SANKEY_CHART_STYLE.nodeLabels,

--- a/frontend/src/metabase/visualizations/echarts/graph/sankey/layout/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/sankey/layout/index.ts
@@ -97,7 +97,7 @@ export const getSankeyLayout = (
   );
   const maxRightLabelWidth = Math.max(
     ...mostRightNodes
-      .map(({ node }) => chartModel.formatters.node(node.value))
+      .map(({ node }) => chartModel.formatters.node(node.rawName))
       .map(formattedNode =>
         renderingContext.measureText(formattedNode, {
           ...SANKEY_CHART_STYLE.nodeLabels,

--- a/frontend/src/metabase/visualizations/echarts/graph/sankey/model/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/sankey/model/dataset.ts
@@ -69,7 +69,7 @@ export const getSankeyData = (
     row: RowValue[],
   ): SankeyNode {
     const node = valueToNode.get(value) ?? {
-      value,
+      rawName: value,
       level,
       hasInputs: false,
       hasOutputs: false,

--- a/frontend/src/metabase/visualizations/echarts/graph/sankey/model/dataset.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/sankey/model/dataset.unit.spec.ts
@@ -118,7 +118,7 @@ describe("getSankeyData", () => {
     expect(result).toEqual({
       nodes: [
         {
-          value: "A",
+          rawName: "A",
           level: 0,
           hasInputs: false,
           hasOutputs: true,
@@ -131,7 +131,7 @@ describe("getSankeyData", () => {
           },
         },
         {
-          value: "B",
+          rawName: "B",
           level: 1,
           hasInputs: true,
           hasOutputs: true,
@@ -149,7 +149,7 @@ describe("getSankeyData", () => {
           },
         },
         {
-          value: "C",
+          rawName: "C",
           level: 2,
           hasInputs: true,
           hasOutputs: false,
@@ -166,7 +166,7 @@ describe("getSankeyData", () => {
         {
           source: "A",
           target: "B",
-          value: 11,
+          rawName: 11,
           columnValues: {
             [getColumnKey(columns[0])]: "A",
             [getColumnKey(columns[1])]: "B",
@@ -177,7 +177,7 @@ describe("getSankeyData", () => {
         {
           source: "B",
           target: "C",
-          value: 20,
+          rawName: 20,
           columnValues: {
             [getColumnKey(columns[0])]: "B",
             [getColumnKey(columns[1])]: "C",
@@ -188,7 +188,7 @@ describe("getSankeyData", () => {
         {
           source: "A",
           target: "C",
-          value: 2,
+          rawName: 2,
           columnValues: {
             [getColumnKey(columns[0])]: "A",
             [getColumnKey(columns[1])]: "C",

--- a/frontend/src/metabase/visualizations/echarts/graph/sankey/model/dataset.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/sankey/model/dataset.unit.spec.ts
@@ -166,7 +166,7 @@ describe("getSankeyData", () => {
         {
           source: "A",
           target: "B",
-          rawName: 11,
+          value: 11,
           columnValues: {
             [getColumnKey(columns[0])]: "A",
             [getColumnKey(columns[1])]: "B",
@@ -177,7 +177,7 @@ describe("getSankeyData", () => {
         {
           source: "B",
           target: "C",
-          rawName: 20,
+          value: 20,
           columnValues: {
             [getColumnKey(columns[0])]: "B",
             [getColumnKey(columns[1])]: "C",
@@ -188,7 +188,7 @@ describe("getSankeyData", () => {
         {
           source: "A",
           target: "C",
-          rawName: 2,
+          value: 2,
           columnValues: {
             [getColumnKey(columns[0])]: "A",
             [getColumnKey(columns[1])]: "C",

--- a/frontend/src/metabase/visualizations/echarts/graph/sankey/model/formatters.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/sankey/model/formatters.ts
@@ -4,13 +4,30 @@ import type { RowValue } from "metabase-types/api";
 
 import { cachedFormatter } from "../../../cartesian/utils/formatter";
 
-import type { SankeyChartColumns, SankeyFormatters } from "./types";
+import type { SankeyChartColumns, SankeyFormatters, SankeyNode } from "./types";
 
 export const getSankeyFormatters = (
   columns: SankeyChartColumns,
   settings: ComputedVisualizationSettings,
 ): SankeyFormatters => {
+  const source = cachedFormatter((value: RowValue) => {
+    return String(
+      formatValue(value, settings.column?.(columns.source.column) ?? {}),
+    );
+  });
+  const target = cachedFormatter((value: RowValue) => {
+    return String(
+      formatValue(value, settings.column?.(columns.target.column) ?? {}),
+    );
+  });
+
+  const node = (node: SankeyNode) =>
+    !node.hasOutputs ? target(node.rawName) : source(node.rawName);
+
   return {
+    node,
+    source,
+    target,
     value: cachedFormatter((value: RowValue) => {
       if (typeof value !== "number") {
         return "";
@@ -30,11 +47,6 @@ export const getSankeyFormatters = (
           ...(settings.column?.(columns.value.column) ?? {}),
           compact: true,
         }),
-      );
-    }),
-    node: cachedFormatter((value: RowValue) => {
-      return String(
-        formatValue(value, settings.column?.(columns.source.column) ?? {}),
       );
     }),
   };

--- a/frontend/src/metabase/visualizations/echarts/graph/sankey/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/sankey/model/index.ts
@@ -27,7 +27,7 @@ export const getSankeyChartModel = (
   const data = getSankeyData(rawSeries, sankeyColumns);
 
   const nodeColors = getColorsForValues(
-    data.nodes.map(node => String(node.value)),
+    data.nodes.map(node => String(node.rawName)),
   );
 
   return {

--- a/frontend/src/metabase/visualizations/echarts/graph/sankey/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/sankey/model/types.ts
@@ -10,7 +10,7 @@ export interface SankeyChartColumns {
 }
 
 export interface SankeyNode {
-  value: RowValue;
+  rawName: RowValue;
   level: number;
   hasInputs: boolean;
   hasOutputs: boolean;

--- a/frontend/src/metabase/visualizations/echarts/graph/sankey/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/sankey/model/types.ts
@@ -37,9 +37,11 @@ export interface SankeyDataModel {
 export type Formatter = (value: RowValue) => string;
 
 export interface SankeyFormatters {
-  node: Formatter;
   value: Formatter;
   valueCompact: Formatter;
+  source: Formatter;
+  target: Formatter;
+  node: (node: SankeyNode) => string;
 }
 
 export interface SankeyChartModel {

--- a/frontend/src/metabase/visualizations/echarts/graph/sankey/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/sankey/option/index.ts
@@ -20,10 +20,10 @@ export const getSankeyChartOption = (
   const { data, formatters } = chartModel;
   const nodes = data.nodes.map(node => ({
     ...node,
-    name: formatters.node(node.value),
-    value: formatters.node(node.value),
+    name: formatters.node(node.rawName),
+    value: formatters.node(node.rawName),
     itemStyle: {
-      color: chartModel.nodeColors[String(node.value)],
+      color: chartModel.nodeColors[String(node.rawName)],
     },
   }));
   const links = data.links.map(link => ({

--- a/frontend/src/metabase/visualizations/echarts/graph/sankey/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/sankey/option/index.ts
@@ -18,18 +18,22 @@ export const getSankeyChartOption = (
   renderingContext: RenderingContext,
 ): EChartsCoreOption => {
   const { data, formatters } = chartModel;
-  const nodes = data.nodes.map(node => ({
-    ...node,
-    name: formatters.node(node.rawName),
-    value: formatters.node(node.rawName),
-    itemStyle: {
-      color: chartModel.nodeColors[String(node.rawName)],
-    },
-  }));
+  const nodes = data.nodes.map(node => {
+    const formattedName = formatters.node(node);
+
+    return {
+      ...node,
+      name: formattedName,
+      value: formattedName,
+      itemStyle: {
+        color: chartModel.nodeColors[String(node.rawName)],
+      },
+    };
+  });
   const links = data.links.map(link => ({
     ...link,
-    source: formatters.node(link.source),
-    target: formatters.node(link.target),
+    source: formatters.source(link.source),
+    target: formatters.target(link.target),
     value: typeof link.value === "number" ? link.value : undefined,
   }));
 

--- a/frontend/src/metabase/visualizations/echarts/graph/sankey/option/tooltip.tsx
+++ b/frontend/src/metabase/visualizations/echarts/graph/sankey/option/tooltip.tsx
@@ -26,10 +26,10 @@ const ChartItemTooltip = ({
   let header = "";
   let value = null;
   if (params.dataType === "edge") {
-    header = `${formatters.node(data.source)} → ${formatters.node(data.target)}`;
+    header = `${formatters.source(data.source)} → ${formatters.target(data.target)}`;
     value = params.value;
   } else if (params.dataType === "node") {
-    header = formatters.node(data.name);
+    header = formatters.node(data);
     value = Math.max(
       data.inputColumnValues[metricColumnKey] ?? 0,
       data.outputColumnValues[metricColumnKey] ?? 0,

--- a/frontend/src/metabase/visualizations/echarts/graph/sankey/option/tooltip.tsx
+++ b/frontend/src/metabase/visualizations/echarts/graph/sankey/option/tooltip.tsx
@@ -22,21 +22,19 @@ const ChartItemTooltip = ({
   params,
 }: ChartItemTooltipProps) => {
   const data = params.data;
-  let header = "";
-  if (data.name) {
-    header = formatters.node(data.name);
-  } else if (data.source == null) {
-    header = formatters.node(data.target);
-  } else if (data.target == null) {
-    header = formatters.node(data.source);
-  } else {
-    header = `${formatters.node(data.source)} → ${formatters.node(data.target)}`;
-  }
 
-  const value =
-    params.dataType === "node"
-      ? (data.inputColumnValues[metricColumnKey] ?? 0)
-      : params.value;
+  let header = "";
+  let value = null;
+  if (params.dataType === "edge") {
+    header = `${formatters.node(data.source)} → ${formatters.node(data.target)}`;
+    value = params.value;
+  } else if (params.dataType === "node") {
+    header = formatters.node(data.name);
+    value = Math.max(
+      data.inputColumnValues[metricColumnKey] ?? 0,
+      data.outputColumnValues[metricColumnKey] ?? 0,
+    );
+  }
 
   return (
     <EChartsTooltip

--- a/frontend/src/metabase/visualizations/echarts/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/types.ts
@@ -8,7 +8,7 @@ import type { ElementEvent } from "echarts/core";
 import type { BrushAreaParam } from "echarts/types/src/component/brush/BrushModel";
 import type { ZRRawMouseEvent } from "zrender/lib/core/types";
 
-export type EChartsSeriesMouseEvent<TDatum = unknown> = ElementEvent & {
+export type EChartsSeriesMouseEvent<TDatum = unknown> = {
   event: ElementEvent["event"] & {
     event: ZRRawMouseEvent;
   };

--- a/frontend/src/metabase/visualizations/lib/settings/utils.js
+++ b/frontend/src/metabase/visualizations/lib/settings/utils.js
@@ -54,7 +54,7 @@ export function fieldSetting(
       getProps: ([{ card, data }], vizSettings) => ({
         options: data.cols.filter(fieldFilter).map(getOptionFromColumn),
         columns: data.cols,
-        showColumnSetting: showColumnSetting,
+        showColumnSetting,
       }),
       ...def,
     },

--- a/frontend/src/metabase/visualizations/lib/settings/utils.js
+++ b/frontend/src/metabase/visualizations/lib/settings/utils.js
@@ -42,7 +42,12 @@ export function getDefaultColumn(
 
 export function fieldSetting(
   id,
-  { fieldFilter = DEFAULT_FIELD_FILTER, showColumnSetting, ...def } = {},
+  {
+    fieldFilter = DEFAULT_FIELD_FILTER,
+    showColumnSetting,
+    autoOpenWhenUnset,
+    ...def
+  } = {},
 ) {
   return {
     [id]: {
@@ -55,6 +60,7 @@ export function fieldSetting(
         options: data.cols.filter(fieldFilter).map(getOptionFromColumn),
         columns: data.cols,
         showColumnSetting,
+        autoOpenWhenUnset,
       }),
       ...def,
     },

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -140,9 +140,6 @@ export interface VisualizationProps {
   onDeselectTimelineEvents?: () => void;
   onOpenTimelines?: () => void;
 
-  "graph.dimensions"?: string[];
-  "graph.metrics"?: string[];
-
   canRemoveSeries?: (seriesIndex: number) => boolean;
   canToggleSeriesVisibility?: boolean;
   onRemoveSeries?: (event: React.MouseEvent, seriesIndex: number) => void;

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/SankeyChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/SankeyChart.tsx
@@ -58,7 +58,7 @@ export const SankeyChart = ({
 
   const { eventHandlers } = useChartEvents(
     chartRef,
-    chartModel,
+    chartModel.sankeyColumns,
     rawSeriesWithRemappings,
     settings,
     onVisualizationClick,

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/SankeyChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/SankeyChart.tsx
@@ -8,6 +8,7 @@ import { getSankeyLayout } from "metabase/visualizations/echarts/graph/sankey/la
 import { getSankeyChartModel } from "metabase/visualizations/echarts/graph/sankey/model";
 import { getSankeyChartOption } from "metabase/visualizations/echarts/graph/sankey/option";
 import { getTooltipOption } from "metabase/visualizations/echarts/graph/sankey/option/tooltip";
+import { useCloseTooltipOnScroll } from "metabase/visualizations/echarts/tooltip";
 import { useBrowserRenderingContext } from "metabase/visualizations/hooks/use-browser-rendering-context";
 import type { VisualizationProps } from "metabase/visualizations/types";
 
@@ -64,6 +65,8 @@ export const SankeyChart = ({
     onVisualizationClick,
     clicked,
   );
+
+  useCloseTooltipOnScroll(chartRef);
 
   return (
     <ResponsiveEChartsRenderer

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.ts
@@ -202,7 +202,7 @@ export const SANKEY_CHART_DEFINITION = {
 
     if (nodesCount > MAX_SANKEY_NODES) {
       throw new ChartSettingsError(
-        t`This chart type doesn't support more than ${MAX_SANKEY_NODES} sankey nodes.`,
+        t`Sankey chart doesn't support more than ${MAX_SANKEY_NODES} unique nodes.`,
       );
     }
   },

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.ts
@@ -31,6 +31,7 @@ export const SETTINGS_DEFINITIONS = {
     showColumnSetting: true,
     persistDefault: true,
     dashboard: false,
+    autoOpenWhenUnset: false,
     getDefault: ([series]: RawSeries) =>
       findSensibleSankeyColumns(series.data)?.source,
   }),
@@ -40,6 +41,7 @@ export const SETTINGS_DEFINITIONS = {
     showColumnSetting: true,
     persistDefault: true,
     dashboard: false,
+    autoOpenWhenUnset: false,
     getDefault: ([series]: RawSeries) =>
       findSensibleSankeyColumns(series.data)?.target,
   }),
@@ -49,6 +51,7 @@ export const SETTINGS_DEFINITIONS = {
     showColumnSetting: true,
     persistDefault: true,
     dashboard: false,
+    autoOpenWhenUnset: false,
     getDefault: ([series]: RawSeries) =>
       findSensibleSankeyColumns(series.data)?.metric,
   }),

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.ts
@@ -21,6 +21,8 @@ import type { DatasetData, RawSeries, Series } from "metabase-types/api";
 
 import { hasCyclicFlow } from "./utils/cycle-detection";
 
+const MAX_SANKEY_NODES = 150;
+
 export const SETTINGS_DEFINITIONS = {
   ...columnSettings({ hidden: true }),
   ...dimensionSetting("sankey.source", {
@@ -188,6 +190,19 @@ export const SANKEY_CHART_DEFINITION = {
       throw new ChartSettingsError(
         t`Selected columns create circular flows. Try picking different columns that flow in one direction.`,
         { section: "Data" },
+      );
+    }
+
+    const nodesCount = new Set(
+      rows.flatMap(row => [
+        row[sankeyColumns.source.index],
+        row[sankeyColumns.target.index],
+      ]),
+    ).size;
+
+    if (nodesCount > MAX_SANKEY_NODES) {
+      throw new ChartSettingsError(
+        t`This chart type doesn't support more than ${MAX_SANKEY_NODES} sankey nodes.`,
       );
     }
   },

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.ts
@@ -28,6 +28,7 @@ export const SETTINGS_DEFINITIONS = {
     title: t`Source`,
     showColumnSetting: true,
     persistDefault: true,
+    dashboard: false,
     getDefault: ([series]: RawSeries) =>
       findSensibleSankeyColumns(series.data)?.source,
   }),
@@ -36,6 +37,7 @@ export const SETTINGS_DEFINITIONS = {
     title: t`Target`,
     showColumnSetting: true,
     persistDefault: true,
+    dashboard: false,
     getDefault: ([series]: RawSeries) =>
       findSensibleSankeyColumns(series.data)?.target,
   }),
@@ -44,6 +46,7 @@ export const SETTINGS_DEFINITIONS = {
     title: t`Value`,
     showColumnSetting: true,
     persistDefault: true,
+    dashboard: false,
     getDefault: ([series]: RawSeries) =>
       findSensibleSankeyColumns(series.data)?.metric,
   }),

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.unit.spec.ts
@@ -22,7 +22,6 @@ const columns = [
     name: "Amount",
     display_name: "Amount",
     base_type: "type/Number",
-    semantic_type: "type/Number",
   }),
 ];
 

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.unit.spec.ts
@@ -266,5 +266,67 @@ describe("SANKEY_CHART_DEFINITION", () => {
         ),
       );
     });
+
+    it("should throw error when there are too many nodes", () => {
+      // Create 152 unique nodes
+      const rows = Array.from({ length: 76 }, (_, i) => [
+        `Source${i}`,
+        `Target${i}`,
+        10,
+      ]);
+
+      const rawSeries = [
+        {
+          card: createMockCard(),
+          data: createMockDatasetData({
+            rows,
+            cols: columns,
+          }),
+        },
+      ];
+
+      const settings = {
+        "sankey.source": "Source",
+        "sankey.target": "Target",
+        "sankey.value": "Amount",
+      };
+
+      expect(() =>
+        SANKEY_CHART_DEFINITION.checkRenderable(rawSeries, settings),
+      ).toThrow(
+        new ChartSettingsError(
+          "This chart type doesn't support more than 150 sankey nodes.",
+        ),
+      );
+    });
+
+    it("should not throw error when node count is at the limit", () => {
+      // Create 150 unique nodes
+      const rows = Array.from({ length: 75 }, (_, i) => [
+        `Source${i}`,
+        `Target${i}`,
+        10,
+      ]);
+
+      const rawSeries = [
+        {
+          card: createMockCard(),
+          data: createMockDatasetData({
+            rows,
+            cols: columns,
+          }),
+        },
+      ];
+
+      const settings = {
+        "sankey.source": "Source",
+        "sankey.target": "Target",
+        "sankey.value": "Amount",
+      };
+
+      expect(() =>
+        SANKEY_CHART_DEFINITION.checkRenderable(rawSeries, settings),
+      ).not.toThrow();
+    });
   });
 });

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.unit.spec.ts
@@ -22,6 +22,7 @@ const columns = [
     name: "Amount",
     display_name: "Amount",
     base_type: "type/Number",
+    semantic_type: "type/Number",
   }),
 ];
 

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/chart-definition.unit.spec.ts
@@ -295,7 +295,7 @@ describe("SANKEY_CHART_DEFINITION", () => {
         SANKEY_CHART_DEFINITION.checkRenderable(rawSeries, settings),
       ).toThrow(
         new ChartSettingsError(
-          "This chart type doesn't support more than 150 sankey nodes.",
+          "Sankey chart doesn't support more than 150 unique nodes.",
         ),
       );
     });

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/events.ts
@@ -56,7 +56,7 @@ export const createSankeyClickData = (
   sankeyColumns: SankeyChartColumns,
   rawSeries: RawSeries,
   settings: ComputedVisualizationSettings,
-): ClickObject | null => {
+): ClickObject | undefined => {
   const clickData: ClickObject = {
     event: event.event.event,
     settings,
@@ -76,7 +76,7 @@ export const createSankeyClickData = (
     );
   } else if (isSankeyEdgeEvent(event)) {
     if (isNativeQuery(rawSeries[0].card)) {
-      return null;
+      return;
     }
 
     clickData.data = getSankeyClickData(rawSeries, event.data.columnValues);

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/events.ts
@@ -16,7 +16,12 @@ import type {
 } from "metabase/visualizations/types";
 import type { EChartsEventHandler } from "metabase/visualizations/types/echarts";
 import { getColumnKey } from "metabase-lib/v1/queries/utils/column-key";
-import type { DatasetColumn, RawSeries, RowValue } from "metabase-types/api";
+import type {
+  Card,
+  DatasetColumn,
+  RawSeries,
+  RowValue,
+} from "metabase-types/api";
 
 const getSankeyClickData = (
   [
@@ -44,12 +49,14 @@ const isSankeyNodeEvent = (
   event: EChartsSeriesMouseEvent<SankeyLink | SankeyNode>,
 ): event is EChartsSeriesMouseEvent<SankeyNode> => event.dataType === "node";
 
+const isNativeQuery = (card: Card) => card.dataset_query?.type === "native";
+
 export const createSankeyClickData = (
   event: EChartsSeriesMouseEvent<SankeyLink | SankeyNode>,
   sankeyColumns: SankeyChartColumns,
   rawSeries: RawSeries,
   settings: ComputedVisualizationSettings,
-): ClickObject => {
+): ClickObject | null => {
   const clickData: ClickObject = {
     event: event.event.event,
     settings,
@@ -68,6 +75,10 @@ export const createSankeyClickData = (
       (_col, index) => index === source.index || index === target.index,
     );
   } else if (isSankeyEdgeEvent(event)) {
+    if (isNativeQuery(rawSeries[0].card)) {
+      return null;
+    }
+
     clickData.data = getSankeyClickData(rawSeries, event.data.columnValues);
     clickData.dimensions = [
       {

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/events.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/events.unit.spec.ts
@@ -58,6 +58,7 @@ describe("createSankeyClickData", () => {
         level: 0,
         hasInputs: false,
         hasOutputs: true,
+        origin: "both" as const,
         inputColumnValues: {
           [getColumnKey(columns[0])]: "A",
           [getColumnKey(columns[1])]: "B",
@@ -97,6 +98,7 @@ describe("createSankeyClickData", () => {
         level: 1,
         hasInputs: true,
         hasOutputs: false,
+        origin: "target" as const,
         inputColumnValues: {
           [getColumnKey(columns[0])]: "A",
           [getColumnKey(columns[1])]: "B",

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/events.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/events.unit.spec.ts
@@ -1,0 +1,170 @@
+import type { EChartsSeriesMouseEvent } from "metabase/visualizations/echarts/types";
+import { getColumnKey } from "metabase-lib/v1/queries/utils/column-key";
+import { createMockCard } from "metabase-types/api/mocks/card";
+import {
+  createMockColumn,
+  createMockDatasetData,
+} from "metabase-types/api/mocks/dataset";
+
+import { createSankeyClickData } from "./events";
+
+describe("createSankeyClickData", () => {
+  const columns = [
+    createMockColumn({
+      name: "Source",
+      display_name: "Source",
+      base_type: "type/Text",
+    }),
+    createMockColumn({
+      name: "Target",
+      display_name: "Target",
+      base_type: "type/Text",
+    }),
+    createMockColumn({
+      name: "Amount",
+      display_name: "Amount",
+      base_type: "type/Number",
+    }),
+  ];
+
+  const rawSeries = [
+    {
+      card: createMockCard(),
+      data: createMockDatasetData({
+        rows: [["A", "B", 10]],
+        cols: columns,
+      }),
+    },
+  ];
+
+  const sankeyColumns = {
+    source: { index: 0, column: columns[0] },
+    target: { index: 1, column: columns[1] },
+    value: { index: 2, column: columns[2] },
+  };
+
+  const settings = {};
+  const mockEvent = {
+    event: {
+      event: new MouseEvent("click"),
+    },
+  } as unknown as EChartsSeriesMouseEvent["event"];
+
+  it("should create click data for node events without inputs", () => {
+    const nodeEvent = {
+      dataType: "node",
+      data: {
+        rawName: "A",
+        level: 0,
+        hasInputs: false,
+        hasOutputs: true,
+        inputColumnValues: {
+          [getColumnKey(columns[0])]: "A",
+          [getColumnKey(columns[1])]: "B",
+          [getColumnKey(columns[2])]: 10,
+        },
+        outputColumnValues: {},
+      },
+      event: mockEvent,
+      value: "A",
+      seriesType: "sankey",
+    };
+
+    const clickData = createSankeyClickData(
+      nodeEvent,
+      sankeyColumns,
+      rawSeries,
+      settings,
+    );
+
+    expect(clickData).toEqual({
+      event: mockEvent.event,
+      settings,
+      column: columns[0], // Use source column since node has no inputs
+      value: "A",
+      data: expect.arrayContaining([
+        expect.objectContaining({ col: columns[0], value: "A" }),
+        expect.objectContaining({ col: columns[1], value: "B" }),
+      ]),
+    });
+  });
+
+  it("should create click data for node events with inputs", () => {
+    const nodeEvent = {
+      dataType: "node",
+      data: {
+        rawName: "B",
+        level: 1,
+        hasInputs: true,
+        hasOutputs: false,
+        inputColumnValues: {
+          [getColumnKey(columns[0])]: "A",
+          [getColumnKey(columns[1])]: "B",
+          [getColumnKey(columns[2])]: 10,
+        },
+        outputColumnValues: {},
+      },
+      event: mockEvent,
+      value: "B",
+      seriesType: "sankey",
+    };
+
+    const clickData = createSankeyClickData(
+      nodeEvent,
+      sankeyColumns,
+      rawSeries,
+      settings,
+    );
+
+    expect(clickData).toEqual({
+      event: mockEvent.event,
+      settings,
+      column: columns[1],
+      value: "B",
+      data: expect.arrayContaining([
+        expect.objectContaining({ col: columns[0], value: "A" }),
+        expect.objectContaining({ col: columns[1], value: "B" }),
+      ]),
+    });
+  });
+
+  it("should create click data for edge events", () => {
+    const edgeEvent = {
+      dataType: "edge",
+      data: {
+        source: "A",
+        target: "B",
+        value: 10,
+        columnValues: {
+          [getColumnKey(columns[0])]: "A",
+          [getColumnKey(columns[1])]: "B",
+          [getColumnKey(columns[2])]: 10,
+        },
+      },
+      event: mockEvent,
+      value: 10,
+      seriesType: "sankey",
+    };
+
+    const clickData = createSankeyClickData(
+      edgeEvent,
+      sankeyColumns,
+      rawSeries,
+      settings,
+    );
+
+    expect(clickData).toEqual({
+      event: mockEvent.event,
+      settings,
+      dimensions: [
+        { column: columns[0], value: "A" },
+        { column: columns[1], value: "B" },
+      ],
+      data: expect.arrayContaining([
+        expect.objectContaining({ col: columns[0], value: "A" }),
+        expect.objectContaining({ col: columns[1], value: "B" }),
+        expect.objectContaining({ col: columns[2], value: 10 }),
+      ]),
+    });
+  });
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50657
Addresses [[Slack thread]](https://metaboat.slack.com/archives/C064QMXEV9N/p1732676292039259)

### Description

1. Previously source and target values were formatted using source column formatting options because of an assumption that both columns represent the same type of values. However, it is possible to use two entirely different types of values, for example `Product.Category` for source and `Created At` which creates a two level Sankey diagram but values of these column different types should still be formatted correctly.

<img width="637" alt="Screenshot 2024-11-29 at 5 15 40 PM" src="https://github.com/user-attachments/assets/376730e0-637b-4559-9878-c5217507acd4">

2. Sets limit max number of Sankey nodes like we limit cartesian charts to 100 series max.
<img width="534" alt="Screenshot 2024-11-29 at 5 16 40 PM" src="https://github.com/user-attachments/assets/ebd8b8e7-299d-450f-a93b-df6e898a66d6">

3. Drill-throughs for nodes without any inputs work correctly now, same as all other nodes.

4. On structured queries now it is possible to drill-through "See these records" on Sankey edges

5. When settings logic does not find two suitable columns it shows "Edit settings" button  (repro on raw orders table). Clicking on this button opens viz settings data tab. Previously clicking on "Edit settings" initially opened all 3 select components for sankey columns.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
