### PR TITLE
simplify use-license

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/license/components/LicenseAndBillingSettings/LicenseAndBillingSettings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/license/components/LicenseAndBillingSettings/LicenseAndBillingSettings.tsx
@@ -1,4 +1,4 @@
-import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
+import dayjs from "dayjs";
 import { connect } from "react-redux";
 import { jt, t } from "ttag";
 
@@ -44,16 +44,13 @@ const getDescription = (tokenStatus?: TokenStatus, hasToken?: boolean) => {
     );
   }
 
-  const daysRemaining = moment(tokenStatus["valid-thru"]).diff(
-    moment(),
-    "days",
-  );
+  const daysRemaining = dayjs(tokenStatus["valid-thru"]).diff(dayjs(), "days");
 
   if (tokenStatus.valid && tokenStatus.trial) {
     return t`Your trial ends in ${daysRemaining} days. If you already have a license, please enter it below.`;
   }
 
-  const validUntil = moment(tokenStatus["valid-thru"]).format("MMM D, YYYY");
+  const validUntil = dayjs(tokenStatus["valid-thru"]).format("MMM D, YYYY");
   return t`Your license is active until ${validUntil}! Hope you’re enjoying it.`;
 };
 
@@ -137,9 +134,7 @@ const LicenseAndBillingSettings = ({
       {shouldShowLicenseInput && (
         <>
           <SectionHeader>{t`License`}</SectionHeader>
-
           <SectionDescription>{description}</SectionDescription>
-
           <LicenseInput
             disabled={is_env_setting}
             placeholder={is_env_setting ? t`Using ${env_name}` : undefined}

--- a/enterprise/frontend/src/metabase-enterprise/settings/hooks/use-license.ts
+++ b/enterprise/frontend/src/metabase-enterprise/settings/hooks/use-license.ts
@@ -2,20 +2,13 @@ import { useCallback, useEffect, useState } from "react";
 import { t } from "ttag";
 
 import { SettingsApi, StoreApi } from "metabase/services";
+import type { TokenStatus } from "metabase-types/api";
 
 export const LICENSE_ACCEPTED_URL_HASH = "#activated";
 
 const INVALID_TOKEN_ERROR = t`This token doesn't seem to be valid. Double-check it, then contact support if you think it should be working.`;
 // eslint-disable-next-line no-literal-metabase-strings -- Metabase settings
 const UNABLE_TO_VALIDATE_TOKEN = t`We're having trouble validating your token. Please double-check that your instance can connect to Metabase's servers.`;
-
-export type TokenStatus = {
-  validUntil: Date;
-  isValid: boolean;
-  isTrial: boolean;
-  features: Set<string>;
-  status: string;
-};
 
 export const useLicense = (onActivated?: () => void) => {
   const [tokenStatus, setTokenStatus] = useState<TokenStatus>();
@@ -55,14 +48,7 @@ export const useLicense = (onActivated?: () => void) => {
   useEffect(() => {
     const fetchStatus = async () => {
       try {
-        const response = await StoreApi.tokenStatus();
-        setTokenStatus({
-          validUntil: new Date(response["valid-thru"]),
-          isValid: response.valid,
-          isTrial: response.trial,
-          features: new Set(response.features),
-          status: response.status,
-        });
+        setTokenStatus(await StoreApi.tokenStatus());
       } catch (e) {
         if ((e as any).status !== 404) {
           setError(UNABLE_TO_VALIDATE_TOKEN);

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -96,6 +96,7 @@ export const createMockTokenStatus = (
   valid: true,
   trial: false,
   "valid-thru": "2022-12-30T23:00:00Z",
+  features: [],
   ...opts,
 });
 

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -129,12 +129,52 @@ export type LoadingMessage =
 
 export type TokenStatusStatus = "unpaid" | "past-due" | "invalid" | string;
 
+const tokenStatusFeatures = [
+  "advanced-config",
+  "advanced-permissions",
+  "audit-app",
+  "cache-granular-controls",
+  "collection-cleanup",
+  "config-text-file",
+  "content-management",
+  "content-verification",
+  "dashboard-subscription-filters",
+  "database-auth-providers",
+  "disable-password-login",
+  "email-allow-list",
+  "email-restrict-recipients",
+  "embedding-sdk",
+  "embedding",
+  "hosting",
+  "metabase-store-managed",
+  "metabot-v3",
+  "no-upsell",
+  "official-collections",
+  "query-reference-validation",
+  "question-error-logs",
+  "sandboxes",
+  "scim",
+  "serialization",
+  "session-timeout-config",
+  "snippet-collections",
+  "sso-google",
+  "sso-jwt",
+  "sso-ldap",
+  "sso-saml",
+  "sso",
+  "upload-management",
+  "whitelabel",
+] as const;
+
+export type TokenStatusFeature = (typeof tokenStatusFeatures)[number];
+
 export interface TokenStatus {
   status?: TokenStatusStatus;
   valid: boolean;
   "valid-thru"?: string;
   "error-details"?: string;
   trial: boolean;
+  features: TokenStatusFeature[];
 }
 
 export type DayOfWeekId =


### PR DESCRIPTION
### Description

- Drops unnecessary response [mapping](https://github.com/metabase/metabase/compare/simplify-use-license?expand=1#diff-427e0894f2a7ee5be71cde0952bf078b25117fb83e980d704959ac2eaaffd55bL58) to another shape in the `use-license` hook. 
- Extends TokenStatus API type with list of features

### How to verify

No functional changes. When running Metabase EE [adding](http://localhost:3000/admin/settings/license) a license key and its verification should work as before.

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
