### PR TITLE
Use separate indexes for different versions

### DIFF
--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -56,7 +56,7 @@
     (throw (ex-info "Search index is not enabled." {:status-code 501}))
 
     (search.core/supports-index?)
-    (do (search.core/init-index! {:force-reset? true}) {:message "done"})
+    {:message (search.core/init-index! {:force-reset? true})}
 
     :else
     (throw (ex-info "Search index is not supported for this installation." {:status-code 501}))))

--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -86,10 +86,10 @@
          (into #{} (map :model)))))
 
 (defmethod search.engine/init! :search.engine/fulltext
-  [& {:keys [force-reset? populate?] :or {populate? true}}]
-  (search.index/ensure-ready! force-reset?)
-  (when populate?
-    (search.ingestion/populate-index! :search.engine/fulltext)))
+  [_ {:keys [force-reset? re-populate?]}]
+  (let [created? (search.index/ensure-ready! force-reset?)]
+    (when (or created? re-populate?)
+      (search.ingestion/populate-index! :search.engine/fulltext))))
 
 (defmethod search.engine/reindex! :search.engine/fulltext
   [_]

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -183,10 +183,12 @@
 (defn- batch-update!
   "Create the given search index entries in bulk"
   [documents]
-  (when (and config/is-test?
-             (and (active-table) (not (exists? (active-table))))
-             (and (pending-table) (not (exists? (pending-table)))))
-    (search.engine/reset-tracking! :search.engine/fulltext))
+  ;; Protect against tests that nuke the appdb
+  (when config/is-test?
+    (when (and (active-table) (not (exists? (active-table))))
+      (reset! *active-table* nil))
+    (when (and (pending-table) (not (exists? (pending-table))))
+      (reset! *pending-table* nil)))
 
   (let [entries          (map document->entry documents)
         ;; Optimization idea: if the updates are coming from the re-indexing worker, skip updating the active table.

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -13,7 +13,7 @@
    [metabase.util.log :as log]
    [toucan2.core :as t2])
   (:import
-   (org.postgresql.util PSQLException ServerErrorMessage)))
+   (org.postgresql.util PSQLException)))
 
 (comment
   postgres/keep-me)
@@ -175,10 +175,8 @@
       (specialization/batch-upsert! table-name entries)
       (catch Exception e
         ;; ignore database errors, the table likely doesn't exist, or has a stale schema.
-        (let [cause (ex-cause e)]
-          (when-not (or (instance? PSQLException cause)
-                        (instance? ServerErrorMessage cause))
-            (throw e)))))))
+        (when-not (instance? PSQLException (ex-cause e))
+          (throw e))))))
 
 (defn- batch-update!
   "Create the given search index entries in bulk"

--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -24,7 +24,7 @@
 (defn init-index!
   "Ensure there is an index ready to be populated."
   [& {:as opts}]
-  ;; If there are multiple indexes, return the peak inserted for each type. In practice they should all be the same.
+  ;; If there are multiple indexes, return the peak inserted for each type. In practice, they should all be the same.
   (reduce (partial merge-with max)
           nil
           (for [e (search.engine/active-engines)]
@@ -33,8 +33,11 @@
 (defn reindex!
   "Populate a new index, and make it active. Simultaneously updates the current index."
   []
-  (doseq [e (search.engine/active-engines)]
-    (search.engine/reindex! e)))
+  ;; If there are multiple indexes, return the peak inserted for each type. In practice, they should all be the same.
+  (reduce (partial merge-with max)
+          nil
+          (for [e (search.engine/active-engines)]
+            (search.engine/reindex! e))))
 
 (defn reset-tracking!
   "Stop tracking the current indexes. Used when resetting the appdb."

--- a/src/metabase/search/util.clj
+++ b/src/metabase/search/util.clj
@@ -12,3 +12,12 @@
       :and (boolean (some impossible-condition? (rest where)))
       :or  (every? impossible-condition? (rest where))
       false)))
+
+(defn cycle-recent-versions
+  "Given a list of recently used index versions, from most recent to least recent, and an index that's just been used,
+  update the list to reflect its usage, and drop stale entries."
+  [previous-ids active-id]
+  ;; consider the 2 most recently used indexes to be active, to handle rolling upgrades and downgrades smoothly.
+  (->> (remove #{active-id} previous-ids)
+       (cons active-id)
+       (take 2)))

--- a/src/metabase/task/search_index.clj
+++ b/src/metabase/task/search_index.clj
@@ -43,7 +43,6 @@
           report (search/init-index! {:force-reset? false, :re-populate? false})]
       (if (seq report)
         (do (report->prometheus! report)
-            (log/info "Recreated search index from the latest schema")
             (log/infof "Done indexing in %.0fms %s" (u/since-ms timer) (sort-by (comp - val) report))
             true)
         (log/info "Found existing search index, and using it.")))))

--- a/src/metabase/task/search_index.clj
+++ b/src/metabase/task/search_index.clj
@@ -92,6 +92,7 @@
 (defmethod task/init! ::SearchIndexInit [_]
   (let [job (jobs/build
              (jobs/of-type SearchIndexInit)
+             (jobs/store-durably)
              (jobs/with-identity init-job-key))]
     (task/add-job! job)
     (task/trigger-now! init-job-key)))

--- a/src/metabase/task/search_index.clj
+++ b/src/metabase/task/search_index.clj
@@ -13,11 +13,13 @@
 
 (set! *warn-on-reflection* true)
 
-;; This is problematic multi-instance deployments, see below.
-(def ^:private recreated? (atom false))
-
+(def ^:private init-stem "metabase.task.search-index.init")
 (def ^:private reindex-stem "metabase.task.search-index.reindex")
 (def ^:private update-stem "metabase.task.search-index.update")
+
+(def init-job-key
+  "Key used to define and trigger a job that ensures there is an active index."
+  (jobs/key (str init-stem ".job")))
 
 (def reindex-job-key
   "Key used to define and trigger a job that rebuilds the entire index from scratch."
@@ -33,27 +35,29 @@
   (doseq [[model cnt] report]
     (prometheus/inc! :metabase-search/index {:model model} cnt)))
 
+(defn init!
+  "Create a new index, if necessary"
+  []
+  (when (search/supports-index?)
+    (let [timer  (u/start-timer)
+          report (search/init-index! {:force-reset? false, :re-populate? false})]
+      (if (seq report)
+        (do (report->prometheus! report)
+            (log/info "Recreated search index from the latest schema")
+            (log/infof "Done indexing in %.0fms %s" (u/since-ms timer) (sort-by (comp - val) report))
+            true)
+        (log/info "Found existing search index, and using it.")))))
+
 (defn reindex!
   "Reindex the whole AppDB"
-  ([]
-   (let [recreate? (not @recreated?)]
-     (u/prog1 (reindex! recreate?)
-       (when recreate?
-         (reset! recreated? true)))))
-  ([recreate?]
-   (when (search/supports-index?)
-     (let [timer  (u/start-timer)
-           report (if recreate?
-                    (do (log/info "Recreating search index from the latest schema")
-                        ;; Each instance in a multi-instance deployment will recreate the table the first time it is
-                        ;; selected to run the job, resulting in a momentary lack of search results.  One solution to
-                        ;; this would be to store metadata about the index in another table, which we can use to
-                        ;; determine whether it was built by another version of Metabase and should be rebuilt.
-                        (search/init-index! {:force-reset? recreate?}))
-                    (do (log/info "Reindexing searchable entities")
-                        (search/reindex!)))]
-       (report->prometheus! report)
-       (log/infof "Done indexing in %.0fms %s" (u/since-ms timer) (sort-by (comp - val) report))))))
+  []
+  (when (search/supports-index?)
+    (log/info "Reindexing searchable entities")
+    (let [timer  (u/start-timer)
+          report (search/reindex!)]
+      (report->prometheus! report)
+      (log/infof "Done reindexing in %.0fms %s" (u/since-ms timer) (sort-by (comp - val) report))
+      report)))
 
 (defn- update-index! []
   (when (search/supports-index?)
@@ -71,8 +75,12 @@
   (task/add-job! job)
   (task/add-trigger! trigger))
 
+(jobs/defjob ^{:doc "Ensure a Search Index exists"}
+  SearchIndexInit [_ctx]
+  (init!))
+
 (jobs/defjob ^{DisallowConcurrentExecution true
-               :doc                        "Populate Search Index"}
+               :doc                        "Populate a new Search Index"}
   SearchIndexReindex [_ctx]
   (reindex!))
 
@@ -80,6 +88,13 @@
                :doc                        "Keep Search Index updated"}
   SearchIndexUpdate [_ctx]
   (update-index!))
+
+(defmethod task/init! ::SearchIndexInit [_]
+  (let [job (jobs/build
+             (jobs/of-type SearchIndexInit)
+             (jobs/with-identity init-job-key))]
+    (task/add-job! job)
+    (task/trigger-now! init-job-key)))
 
 (defmethod task/init! ::SearchIndexReindex [_]
   (let [job         (jobs/build
@@ -90,10 +105,9 @@
         trigger     (triggers/build
                      (triggers/with-identity trigger-key)
                      (triggers/for-job reindex-job-key)
-                     (triggers/start-now)
                      (triggers/with-schedule
                       (simple/schedule (simple/with-interval-in-hours 1))))]
-    (force-scheduled-task! job trigger)))
+    (task/schedule-task! job trigger)))
 
 (defmethod task/init! ::SearchIndexUpdate [_]
   (let [job         (jobs/build

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -314,7 +314,7 @@
 (deftest custom-engine-test
   (when (search/supports-index?)
     (testing "It can use an alternate search engine"
-      (is (search/init-index! {:force-reset? false :populate? false}))
+      (search/init-index! {:force-reset? false :re-populate? false})
       (with-search-items-in-root-collection "test"
         (let [resp (search-request :crowberto :q "test" :search_engine "fulltext" :limit 1)]
           ;; The index is not populated here, so there's not much interesting to assert.

--- a/test/metabase/search/postgres/index_test.clj
+++ b/test/metabase/search/postgres/index_test.clj
@@ -437,3 +437,29 @@
                   :database_id      (mt/id)
                   :collection_id    coll-id})
                 (ingest-then-fetch! "indexed-entity" entity-name)))))))
+
+(deftest ^:synchronized update-metadata!-test
+  (mt/with-temporary-setting-values [search-engine-appdb-index-state nil]
+    (testing "Clearing the setting clears the tracking atoms"
+      (is (nil? (search.index/active-table)))
+      (is (nil? (#'search.index/pending-table))))
+    (testing "Updating the setting updates the tracking atoms"
+      (#'search.index/update-metadata! {:active-table :active, :pending-table :pending})
+      (is (= :active (search.index/active-table)))
+      (is (= :pending (#'search.index/pending-table))))
+    (testing "We can update to a newer version"
+      (binding [search.index/*index-version-id* "newer-version"]
+        (#'search.index/update-metadata! {:active-table :activer, :pending-table :pendinger})
+        (is (= :activer (search.index/active-table)))
+        (is (= :pendinger (#'search.index/pending-table)))))
+    (testing "We keep the previous version around"
+      (is (= #{:newer-version (keyword @#'search.index/*index-version-id*)}
+             (set (keys (:versions (search.index/search-engine-appdb-index-state)))))))
+    (testing "We can update to an ever newer version"
+      (binding [search.index/*index-version-id* "newest-version"]
+        (#'search.index/update-metadata! {:active-table :activest, :pending-table :pendingest})
+        (is (= :activest (search.index/active-table)))
+        (is (= :pendingest (#'search.index/pending-table)))))
+    (testing "We only keep the two most recent versions around"
+      (is (= #{:newer-version :newest-version}
+             (set (keys (:versions (search.index/search-engine-appdb-index-state)))))))))

--- a/test/metabase/search/util_test.clj
+++ b/test/metabase/search/util_test.clj
@@ -17,3 +17,12 @@
   (is (not (impossible? [:and [:= 1 :this.id] [:!= "card" "dashboard"]])))
   (is (not (impossible? [:or [:= 1 :this.id] [:!= "card" "dashboard"]])))
   (is (impossible? [:or [:= "oh" "no"] [:= "card" "dashboard"]])))
+
+(deftest cycle-recent-indexes-test
+  (is (= (search.util/cycle-recent-versions nil "a") ["a"]))
+  (is (= (search.util/cycle-recent-versions ["a"] "a") ["a"]))
+  (is (= (search.util/cycle-recent-versions ["b"] "a") ["a" "b"]))
+  (is (= (search.util/cycle-recent-versions '("b" "a") "a") ["a" "b"]))
+  (is (= (search.util/cycle-recent-versions '("a" "b") "a") ["a" "b"]))
+  (is (= (search.util/cycle-recent-versions '("b" "c") "a") ["a" "b"]))
+  (is (= (search.util/cycle-recent-versions '("b" "c" "d") "a") ["a" "b"])))

--- a/test/metabase/task/search_index_test.clj
+++ b/test/metabase/task/search_index_test.clj
@@ -1,24 +1,38 @@
 (ns metabase.task.search-index-test
   (:require
    [clojure.test :refer :all]
+   [honey.sql.helpers :as sql.helpers]
    [metabase.search.appdb.index :as search.index]
    [metabase.search.test-util :as search.tu]
    [metabase.task.search-index :as task]
    [toucan2.core :as t2]))
 
+;; TODO this is coupled to appdb engines at the moment
 (defn- index-size []
   (t2/count (search.index/active-table)))
 
-;; TODO this is coupled to appdb engines at the moment
+(deftest index!-test
+  (search.tu/with-temp-index-table
+   ;; TODO this is coupled to appdb engines at the moment
+    (t2/query (sql.helpers/drop-table (search.index/active-table)))
+    (testing "It can recreate the index from scratch"
+     ;; May return falsey if there is nothing to index.
+      (is (task/init!))
+      (is (pos? (index-size))))
+    (testing "It will reuse an existing index"
+      (is (not (task/init!))))))
+
 (deftest reindex!-test
   (search.tu/with-temp-index-table
-    (is (zero? (index-size)))
+   ;; TODO this is coupled to appdb engines at the moment
+    (t2/query (sql.helpers/drop-table (search.index/active-table)))
     (testing "It can recreate the index from scratch"
-      (task/reindex! true)
-      (let [initial-size (index-size)]
+      (is (task/reindex!))
+      (let [initial-size (index-size)
+            table-name (search.index/active-table)]
         (is (pos? initial-size))
-        (t2/delete! (search.index/active-table) (t2/select-one-pk (search.index/active-table)))
+        (t2/delete! table-name (t2/select-one-pk table-name))
         (is (= (dec initial-size) (index-size)))
         (testing "It can cycle the index gracefully"
-          (task/reindex! false)
+          (is (task/reindex!))
           (is (= initial-size (index-size))))))))


### PR DESCRIPTION
This protects against us trying to read or write from an incompatible search index. In particular it prevents existing instances from being switched over to an incompatible table during an HA upgrade or downgrade.

~~It doesn't yet get rid of the needless re-initialization, but that will be a fast follow.~~ It breaks up the jobs so that we won't reindex on startup unless necessary.