### PR TITLE
return better errors when request contains malformed JSON

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -185,7 +185,6 @@
   ring/ring-jetty-adapter                   {:mvn/version "1.13.0"              ; Jetty adapter
                                              :exclusions [org.eclipse.jetty/jetty-server
                                                           org.eclipse.jetty.websocket/websocket-jetty-server]}
-  ring/ring-json                            {:mvn/version "0.5.1"}              ; Ring middleware for reading/writing JSON automatically
   slingshot/slingshot                       {:mvn/version "0.12.2"}             ; enhanced throw/catch, used by other deps
   stencil/stencil                           {:mvn/version "0.5.0"}              ; Mustache templates for Clojure
   user-agent/user-agent                     {:mvn/version "0.1.1"}              ; User-Agent string parser, for Login History page & elsewhere

--- a/src/metabase/server/handler.clj
+++ b/src/metabase/server/handler.clj
@@ -19,7 +19,6 @@
    [ring.core.protocols :as ring.protocols]
    [ring.middleware.cookies :refer [wrap-cookies]]
    [ring.middleware.gzip :refer [wrap-gzip]]
-   [ring.middleware.json :as ring.json]
    [ring.middleware.keyword-params :refer [wrap-keyword-params]]
    [ring.middleware.params :refer [wrap-params]]))
 
@@ -49,7 +48,7 @@
    #'mw.log/log-api-call
    #'mw.browser-cookie/ensure-browser-id-cookie ; add cookie to identify browser; add `:browser-id` to the request
    #'mw.security/add-security-headers           ; Add HTTP headers to API responses to prevent them from being cached
-   #(ring.json/wrap-json-body % {:keywords? true}) ; extracts json POST body and makes it available on request
+   #'mw.json/wrap-json-body                     ; extracts json POST/PUT body and makes it available on request
    #'mw.offset-paging/handle-paging             ; binds per-request parameters to handle paging
    #'mw.json/wrap-streamed-json-response        ; middleware to automatically serialize suitable objects as JSON in responses
    #'wrap-keyword-params                        ; converts string keys in :params to keyword keys

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -3785,7 +3785,8 @@
                        (mt/user-http-request :crowberto :post 200 execute-path
                                              {:parameters {"id" 1}}))))
               (testing "Should handle errors"
-                (is (= {:remote-status 400}
+                (is (= {:remote-status 400
+                        :message       "oops"}
                        (mt/user-http-request :crowberto :post 400 execute-path
                                              {:parameters {"id" 1 "fail" "true"}}))))
               (testing "Extra parameter should fail gracefully"
@@ -3794,11 +3795,11 @@
                                                     {:parameters {"extra" 1}}))))
               (testing "Missing parameter should fail gracefully"
                 (is (has-valid-action-execution-error-message?
-                     (mt/user-http-request :crowberto :post 500 execute-path
+                     (mt/user-http-request :crowberto :post 400 execute-path
                                            {:parameters {}}))))
               (testing "Sending an invalid number should fail gracefully"
                 (is (has-valid-action-execution-error-message?
-                     (mt/user-http-request :crowberto :post 500 execute-path
+                     (mt/user-http-request :crowberto :post 400 execute-path
                                            {:parameters {"id" "BAD"}})))))))))))
 
 (deftest dashcard-implicit-action-execution-insert-test

--- a/test/metabase/channel/impl/http_test.clj
+++ b/test/metabase/channel/impl/http_test.clj
@@ -8,11 +8,11 @@
    [metabase.channel.core :as channel]
    [metabase.notification.test-util :as notification.tu]
    [metabase.server.handler :as server.handler]
+   [metabase.server.middleware.json :as mw.json]
    [metabase.task.send-pulses :as task.send-pulses]
    [metabase.test :as mt]
    [metabase.util.i18n :refer [deferred-tru]]
    [ring.adapter.jetty :as jetty]
-   [ring.middleware.json :refer [wrap-json-body wrap-json-response]]
    [ring.middleware.params :refer [wrap-params]]
    [toucan2.core :as t2])
   (:import
@@ -49,8 +49,8 @@
    handler
    middlewares))
 
-(def middlewares [#(wrap-json-body % {:keywords? true})
-                  wrap-json-response
+(def middlewares [mw.json/wrap-json-body
+                  mw.json/wrap-streamed-json-response
                   wrap-params])
 
 (defn do-with-server

--- a/test/metabase/server/middleware/json_test.clj
+++ b/test/metabase/server/middleware/json_test.clj
@@ -1,10 +1,15 @@
 (ns metabase.server.middleware.json-test
   (:require
+   [clojure.java.io :as io]
    [clojure.test :refer :all]
+   [metabase.http-client]
+   [metabase.server.handler :as handler]
    [metabase.server.middleware.json :as mw.json]
    [metabase.util.json :as json]))
 
 (comment mw.json/keep-me) ; so custom Cheshire encoders are loaded
+
+(set! *warn-on-reflection* true)
 
 (deftest encode-byte-arrays-test
   (testing "Check that we encode byte arrays as the hex values of their first four bytes"
@@ -12,3 +17,21 @@
            (json/encode
             {:my-bytes (byte-array [196 35  96 215  8 106 108 248 183 215 244 143  17 160 53 186
                                     213 30 116  25 87  31 123 172 207 108  47 107 191 215 76  92])})))))
+
+(defn- raw-json-req
+  "Kind of `mt/http-request`, but is less picky about body :)"
+  [method url ^String body]
+  (handler/app {:method method
+                :uri     (str metabase.http-client/*url-prefix* url)
+                :headers {"content-type" "application/json"}
+                :body    (io/input-stream (.getBytes body))}
+               #(-> (:body %)
+                    io/reader
+                    json/decode+kw)
+               (fn raise [e] (throw e))))
+
+(deftest json-error-test
+  (testing "Parsing invalid JSON returns messages with some details"
+    (is (= {:error
+            "Unrecognized token 'ture': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false') at 1:17"}
+           (raw-json-req :post "/alert/" "{\"archive\": ture}")))))


### PR DESCRIPTION
before this change, Metabase would always return `Malformed JSON in request body.` as an error, which could be confusing if your request is big enough.