### PR TITLE
refactor(sdk): use relative paths when fixing d.ts files

### DIFF
--- a/bin/embedding-sdk/fixup-types-after-compilation.js
+++ b/bin/embedding-sdk/fixup-types-after-compilation.js
@@ -5,7 +5,6 @@ const fs = require("fs");
 const path = require("path");
 
 const SDK_DIST_DIR_PATH = path.resolve("./resources/embedding-sdk/dist");
-const SDK_PACKAGE_NAME = "@metabase/embedding-sdk-react";
 
 /*
  * This script replaces all custom aliases in Embedding SDK generated ".d.ts" files so that this imports could be resolved
@@ -14,12 +13,12 @@ const SDK_PACKAGE_NAME = "@metabase/embedding-sdk-react";
 
 // this map should be synced with "tsconfig.sdk.json"
 const REPLACES_MAP = {
-  "metabase-enterprise": `${SDK_PACKAGE_NAME}/dist/enterprise/frontend/src/metabase-enterprise`,
-  "metabase-lib": `${SDK_PACKAGE_NAME}/dist/frontend/src/metabase-lib`,
-  "metabase-types": `${SDK_PACKAGE_NAME}/dist/frontend/src/metabase-types`,
-  metabase: `${SDK_PACKAGE_NAME}/dist/frontend/src/metabase`,
-  "embedding-sdk": `${SDK_PACKAGE_NAME}/dist/enterprise/frontend/src/embedding-sdk`,
-  cljs: `${SDK_PACKAGE_NAME}/dist/target/cljs_release`,
+  "metabase-enterprise": "enterprise/frontend/src/metabase-enterprise",
+  "metabase-lib": "frontend/src/metabase-lib",
+  "metabase-types": "frontend/src/metabase-types",
+  metabase: "frontend/src/metabase",
+  "embedding-sdk": "enterprise/frontend/src/embedding-sdk",
+  cljs: "target/cljs_release",
 };
 
 const traverseFilesTree = dir => {
@@ -42,24 +41,30 @@ const traverseFilesTree = dir => {
   }
 };
 
+const getRelativePath = (fromPath, toPath) => {
+  const relativePath = path.relative(path.dirname(fromPath), toPath);
+  return relativePath.startsWith(".") ? relativePath : "./" + relativePath;
+};
+
 const replaceAliasedImports = filePath => {
   let fileContent = fs.readFileSync(filePath, { encoding: "utf8" });
 
-  Object.entries(REPLACES_MAP).forEach(([alias, replacement]) => {
+  Object.entries(REPLACES_MAP).forEach(([alias, targetPath]) => {
+    const relativePath = getRelativePath(
+      filePath,
+      path.join(SDK_DIST_DIR_PATH, targetPath),
+    );
+
     fileContent = fileContent
-      // replaces "metabase-lib/foo" with "<sdk>/metabase-lib/foo"
-      .replaceAll(`from "${alias}/`, `from "${replacement}/`)
-      // replaces "metabase-lib" with "<sdk>/metabase-lib"
-      .replaceAll(`from "${alias}"`, `from "${replacement}"`)
-      .replaceAll(`import("${alias}`, `import("${replacement}`)
+      .replaceAll(`from "${alias}/`, `from "${relativePath}/`)
+      .replaceAll(`from "${alias}"`, `from "${relativePath}"`)
+      .replaceAll(`import("${alias}`, `import("${relativePath}`)
       .replace(
-        // replace dynamic imports using alias, with possible relative paths - "../../" and "frontend/src/"
-        // import("(../)*(frontend/src/)*<alias>
         new RegExp(
           `import\\("(\\.\\.\/)*(frontend\/src\/)*${alias.replace("/", "\\/")}`,
           "gi",
         ),
-        `import("${replacement}`,
+        `import("${relativePath}`,
       );
   });
 


### PR DESCRIPTION
### Description

This is mostly to make types work on https://github.com/metabase/metabase/pull/50230, which are currently broken.

In that branch, the types are resolving correctly to the first "layer" of the sdk, but then it wasn't resolving types from `@metabase/embedding-sdk-react` from inside the sdk itself. I tried to change the package.json to make that work, but I couldn't find anything that worked and even if it worked I'm afraid it would have made typescript autocomplete folders like `@metabase/embedding-sdk-react/dist` etc which we don't want.

The only solution I found was to make the d.ts not use the package name but instead use relative paths.

I think this makes sense on its own so I'm opening a PR with just this change, also to keep the prs smaller

###

Before:
<img width="1156" alt="image" src="https://github.com/user-attachments/assets/70e356ed-9fc9-40b7-a939-154705fd659b">

After:
<img width="1341" alt="image" src="https://github.com/user-attachments/assets/6f9df9c6-d649-4aa5-9140-68e1864873c5">

