### PR TITLE
feat(sdk): use string types for specifying entity ids instead of internal nanoid type

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/types.ts
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/types.ts
@@ -7,7 +7,7 @@ import type { SaveQuestionProps } from "metabase/components/SaveQuestionForm/typ
 import type { NotebookProps as QBNotebookProps } from "metabase/querying/notebook/components/Notebook";
 import type { Mode } from "metabase/visualizations/click-actions/Mode";
 import type Question from "metabase-lib/v1/Question";
-import type { CardEntityId, CardId } from "metabase-types/api";
+import type { CardId } from "metabase-types/api";
 
 export type EntityTypeFilterKeys = "table" | "question" | "model" | "metric";
 
@@ -39,7 +39,7 @@ export type InteractiveQuestionProviderWithLocationProps = PropsWithChildren<
 
 export type InteractiveQuestionProviderProps = PropsWithChildren<
   InteractiveQuestionConfig &
-    Omit<LoadSdkQuestionParams, "cardId"> & { cardId?: CardId | CardEntityId }
+    Omit<LoadSdkQuestionParams, "cardId"> & { cardId?: CardId | string }
 >;
 
 export type InteractiveQuestionContextType = Omit<

--- a/enterprise/frontend/src/embedding-sdk/components/public/StaticQuestion/StaticQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/StaticQuestion/StaticQuestion.tsx
@@ -21,10 +21,10 @@ import { getMetadata } from "metabase/selectors/metadata";
 import { Box, Group } from "metabase/ui";
 import { PublicMode } from "metabase/visualizations/click-actions/modes/PublicMode";
 import Question from "metabase-lib/v1/Question";
-import type { CardEntityId, CardId, Dataset } from "metabase-types/api";
+import type { CardId, Dataset } from "metabase-types/api";
 
 export type StaticQuestionProps = {
-  questionId: CardId | CardEntityId;
+  questionId: CardId | string;
   showVisualizationSelector?: boolean;
   height?: string | number;
   parameterValues?: Record<string, string | number>;

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -26,7 +26,7 @@ type CreatorInfo = Pick<
 export interface Card<Q extends DatasetQuery = DatasetQuery>
   extends UnsavedCard<Q> {
   id: CardId;
-  entity_id: CardEntityId;
+  entity_id: BaseEntityId;
   created_at: string;
   updated_at: string;
   name: string;
@@ -286,7 +286,6 @@ export type EmbedVisualizationSettings = {
 export type VisualizationSettingKey = keyof VisualizationSettings;
 
 export type CardId = number;
-export type CardEntityId = BaseEntityId;
 
 export type CardFilterOption =
   | "all"

--- a/frontend/src/metabase-types/api/entity-id.ts
+++ b/frontend/src/metabase-types/api/entity-id.ts
@@ -33,10 +33,3 @@ export const isBaseEntityID = (id: unknown): id is BaseEntityId => {
     NANOID_ALPHABET.test(id)
   );
 };
-
-export const asBaseEntityID = (id: string): BaseEntityId => {
-  if (!isBaseEntityID(id)) {
-    throw new Error("Invalid BaseEntityId");
-  }
-  return id as BaseEntityId;
-};


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50563

### Description

SDK users cannot use entity IDs in question components today because they cannot construct the NanoID-based type. This PR updates the types to use plain strings for specifying entity ids in question components.

Note that the dashboard components already uses the `DashboardId` type which is already defined as `number | string`, so SDK users can already pass in entity ids there.

Also, the docs are already correct that we can use "number or string", so no doc changes needed.