### PR TITLE
Pivot Exports Can Handle `nil` in Breakout Col, and Multiple Cols of the Same Aggregation Type

### DIFF
--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -362,7 +362,7 @@
         returned-columns   (lib/returned-columns query)
         {:source/keys [aggregations breakouts]} (group-by :lib/source returned-columns)
         column-name->index (into {}
-                                 (map-indexed (fn [i column] [(:name column) i]))
+                                 (map-indexed (fn [i column] [(:lib/desired-column-alias column) i]))
                                  (concat breakouts aggregations))
         process-columns    (fn process-columns [column-names]
                              (when (seq column-names)

--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -361,12 +361,16 @@
         query              (lib/query metadata-provider query)
         returned-columns   (lib/returned-columns query)
         {:source/keys [aggregations breakouts]} (group-by :lib/source returned-columns)
+        column-alias->index (into {}
+                                  (map-indexed (fn [i column] [(:lib/desired-column-alias column) i]))
+                                  (concat breakouts aggregations))
         column-name->index (into {}
-                                 (map-indexed (fn [i column] [(:lib/desired-column-alias column) i]))
+                                 (map-indexed (fn [i column] [(:name column) i]))
                                  (concat breakouts aggregations))
         process-columns    (fn process-columns [column-names]
                              (when (seq column-names)
-                               (into [] (keep column-name->index) column-names)))
+                               (into [] (keep (fn [n] (or (column-alias->index n)
+                                                          (column-name->index n)))) column-names)))
         pivot-opts         {:pivot-rows     (process-columns rows)
                             :pivot-cols     (process-columns columns)
                             :pivot-measures (process-columns values)}]

--- a/src/metabase/query_processor/pivot/postprocess.clj
+++ b/src/metabase/query_processor/pivot/postprocess.clj
@@ -129,15 +129,19 @@
     :min
     (fn [prev v]
       (if (number? v)
-        (-> (merge {:min 0} prev)
-            (update :min #(min % v)))
+        (update prev :min
+                (fn [x] (if x
+                          (min x v)
+                          v)))
         v))
 
     :max
     (fn [prev v]
       (if (number? v)
-        (-> (merge {:min 0} prev)
-            (update :min #(max % v)))
+        (update prev :max
+                (fn [x] (if x
+                          (max x v)
+                          v)))
         v))
 
     ;; else

--- a/src/metabase/query_processor/pivot/postprocess.clj
+++ b/src/metabase/query_processor/pivot/postprocess.clj
@@ -442,10 +442,11 @@
                             ;; filtering out any rows that begin with "Totals ..."
                             (mapv
                              (fn [row]
-                               (let [[row-part vals-part] (split-at (count pivot-rows) row)]
+                               (let [[row-part vals-part] (split-at (count pivot-rows) row)
+                                     first-entry (first row-part)]
                                  (if (or
                                       (not (seq row-part))
-                                      (str/starts-with? (first row-part) "Totals"))
+                                      (and (string? first-entry) (str/starts-with? first-entry "Totals")))
                                    row
                                    (into (mapv fmt row-formatters row-part) vals-part)))))))
                          sections-rows))))

--- a/src/metabase/query_processor/streaming/csv.clj
+++ b/src/metabase/query_processor/streaming/csv.clj
@@ -116,7 +116,7 @@
                    (mapv #(formatter/create-formatter results_timezone % viz-settings format-rows?) ordered-cols))
 
           ;; write the column names for non-pivot tables
-          (when (not opts)
+          (when (or (not opts) (not (public-settings/enable-pivoted-exports)))
             (let [header (m/remove-nth (or pivot-grouping-key (inc (count col-names))) col-names)]
               (write-csv writer [header])
               (.flush writer)))))


### PR DESCRIPTION
Fixes #50551
Fixes #50685 

If a pivot table has several measures configured, they might both use the same kind of aggregation (eg. 'sum'). Previously, this would lead to columns with the same name preventing the pivot-measures from properly making it through the export post processing. Now, the correct aliased/deduped name is used and all columns can be properly included in the pivot export.

Also fixes the case where a breakout column (pivot-row) contains `nil` values, which caused the pivot export to fail. Now, all nil values are grouped and handled appropriately.
