### PR TITLE
Take default Search weights from Stats

### DIFF
--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -84,15 +84,29 @@
 (def ^:private static-weights
   {:default
    {:pinned              0
-    :bookmarked          2
-    :recency             1.5
-    :user-recency        1.5
-    :dashboard           0.5
+    :bookmarked          1
+    :recency             1
+    :user-recency        5
+    :dashboard           0
     :model               2
-    :official-collection 2
-    :verified            2
+    :official-collection 1
+    :verified            1
     :view-count          2
-    :text                10}})
+    :text                5}
+   :command-palette
+   {:model/collection     1
+    :model/dashboard      1
+    :model/metric         1
+    :model/dataset        0.8
+    :model/table          0.8
+    :model/indexed-entity 0.5
+    :model/database       0.5
+    :model/question       0}
+   :entity-picker
+   {:model/table    1
+    :model/dataset  1
+    :model/metric   1
+    :model/question 0}})
 
 (def ^:private FilterDef
   "A relaxed definition, capturing how we can write the filter - with some fields omitted."


### PR DESCRIPTION
Updates our default weights to those chosen experimentally in Stats, to go out in the next beta.

See: https://stats.metabase.com/api/search/weights?context=all

```
{
  "default": {
    "recency": 1,
    "pinned": 0,
    "bookmarked": 1,
    "official-collection": 1,
    "dashboard": 0,
    "view-count": 2,
    "user-recency": 5,
    "verified": 1,
    "text": 5,
    "model": 2
  },
  "pinned": 0,
  "recency": 2,
  "command-palette": {
    "model/indexed-entity": 0.5,
    "model/dashboard": 1,
    "model/dataset": 0.8,
    "model/database": 0.5,
    "model/question": 0,
    "model/table": 0.8,
    "model/collection": 1,
    "model/metric": 1
  },
  "entity-picker": {
    "model/question": 0,
    "model/table": 1,
    "model/dataset": 1,
    "model/metric": 1
  }
}
```

