### PR TITLE
Fix light theme embeddings has different text colors

### DIFF
--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.module.css
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.module.css
@@ -19,12 +19,6 @@ body {
   border-color: var(--mb-color-border);
 }
 
-/* A temporary solution until we migrated all colors in visualization to use semantic colors
-   e.g. `text-primary`, `text-secondary`, `text-tertiary`. */
-.EmbedFrame svg text {
-  fill: var(--mb-color-text-primary);
-}
-
 .EmbedFrameHeader,
 .EmbedFrameFooter {
   color: var(--mb-color-text-primary);
@@ -77,7 +71,10 @@ body {
     transition: color 1s linear;
   }
 
+  /* A temporary solution until we migrated all colors in visualization to use semantic colors
+   e.g. `text-primary`, `text-secondary`, `text-tertiary`. */
   .EmbedFrame svg text {
+    fill: var(--mb-color-text-primary);
     stroke: none !important;
   }
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50677

### Description

This happened because of https://github.com/metabase/metabase/pull/45633. I believe I incorrectly implemented one of the lines.
https://github.com/metabase/metabase/blob/dd00df1a06ae729d9641e147a0fc91bf54349923/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.module.css#L32-L35

This `fill` property was inside the dark theme selector, but currently, we apply this style everywhere.

https://github.com/metabase/metabase/blob/8f41692cb09c41ad3734943422b585acd56e3dee/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.module.css#L22-L26
### How to verify

1. Create a dashboard with a pie chart. (I tested with a pie with outer and inner rings, but one ring also exhibited the same bug)
    - Set the label to show inside the slices.
    - Ensure at least one of the chart labels inside a slice is white color.
1. Visit a public link.
1. The text color should stay the same.

### Demo

#### Before
![image](https://github.com/user-attachments/assets/69dc7708-47f0-4f8e-ba19-b1eb358faa76)

#### After
![image](https://github.com/user-attachments/assets/bfbe313d-df09-4a18-8f11-d1753b8773ed)



### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~ All loki tests for #45633 still pass, so I didn't add any more tests.
