### PR TITLE
Improve Search Index clean-up and re-enable some tests

### DIFF
--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -13,6 +13,7 @@
    [metabase.util.log :as log]
    [toucan2.core :as t2])
   (:import
+   (clojure.lang ExceptionInfo)
    (org.postgresql.util PSQLException)))
 
 (comment
@@ -63,7 +64,10 @@
   (map (comp keyword :table_name)
        (t2/query {:select [:table_name]
                   :from   :information_schema.tables
-                  :where  [:like :table_name "search_index__%"]})))
+                  :where  [:or
+                           [:like :table_name "search\\_index\\_\\_%"]
+                           ;; legacy table names
+                           [:in :table_name ["search_index" "search_index_next" "search_index_retired"]]]})))
 
 (defn- sync-metadata [_old-setting-raw new-setting-raw]
   ;; Oh dear, we get the raw setting. Save a little bit of overhead by no keywordizing the keys.
@@ -82,8 +86,11 @@
                              (keyword table-name)))
           to-drop     (remove keep-table? (existing-indexes))]
       (when (seq to-drop)
-        (log/infof "Dropping %d stale indexes" (count to-drop))
-        (t2/query (apply sql.helpers/drop-table to-drop))))))
+        (try
+          (t2/query (apply sql.helpers/drop-table to-drop))
+          ;; Deletion could fail if it races with other instances
+          (catch ExceptionInfo _))
+        (log/infof "Dropped %d stale indexes" (count to-drop))))))
 
 (defsetting search-engine-appdb-index-state
   "Internation state used to maintain the AppDb Search Index"

--- a/test/metabase/search/appdb/index_test.clj
+++ b/test/metabase/search/appdb/index_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.search.appdb.index-test
   (:require
-   [cheshire.core :as json]
    [clojure.test :refer [deftest is testing]]
    [java-time.api :as t]
    [metabase.search.appdb.index :as search.index]
@@ -9,7 +8,7 @@
    [metabase.search.test-util :as search.tu]
    [metabase.test :as mt]
    [metabase.util :as u]
-   ;;[metabase.util.json :as json]
+   [metabase.util.json :as json]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -49,35 +48,35 @@
 
 ;; Disabled due to CI issue
 (deftest incremental-update-test
-    (with-index
-     (testing "The index is updated when models change"
+  (with-index
+    (testing "The index is updated when models change"
        ;; Has a second entry is "Revenue Project(ions)", when using English dictionary
-       (is (= 2 (count (search.index/search "Projected Revenue"))))
-       (is (= 0 (count (search.index/search "Protected Avenue"))))
-       (t2/update! :model/Card {:name "Projected Revenue"} {:name "Protected Avenue"})
-       (is (= 1 (count (search.index/search "Projected Revenue"))))
-        (is (= 1 (count (search.index/search "Protected Avenue"))))
+      (is (= 2 (count (search.index/search "Projected Revenue"))))
+      (is (= 0 (count (search.index/search "Protected Avenue"))))
+      (t2/update! :model/Card {:name "Projected Revenue"} {:name "Protected Avenue"})
+      (is (= 1 (count (search.index/search "Projected Revenue"))))
+      (is (= 1 (count (search.index/search "Protected Avenue"))))
 
        ;; Delete hooks are remove for now, over performance concerns.
        ;(t2/delete! :model/Card :name "Protected Avenue")
-        #_(is (= 0 #_1 (count (search.index/search "Projected Revenue"))))
-        #_(is (= 0 (count (search.index/search "Protected Avenue")))))))
+      #_(is (= 0 #_1 (count (search.index/search "Projected Revenue"))))
+      #_(is (= 0 (count (search.index/search "Protected Avenue")))))))
 
 ;; Disabled due to CI issue
 (deftest related-update-test
-    (with-index
-      (testing "The index is updated when model dependencies change"
-        (let [index-table    (search.index/active-table)
-              table-id       (t2/select-one-pk :model/Table :name "Indexed Table")
-              legacy-input   #(-> (t2/select-one [index-table :legacy_input] :model "table" :model_id table-id)
-                                  :legacy_input
-                                  json/decode+kw)
-              db-id          (t2/select-one-fn :db_id :model/Table table-id)
-              db-name-fn     (comp :database_name legacy-input)
-              alternate-name (str (random-uuid))]
-          (is (= "Indexed Database" (db-name-fn)))
-          (t2/update! :model/Database db-id {:name alternate-name})
-          (is (= alternate-name (db-name-fn)))))))
+  (with-index
+    (testing "The index is updated when model dependencies change"
+      (let [index-table    (search.index/active-table)
+            table-id       (t2/select-one-pk :model/Table :name "Indexed Table")
+            legacy-input   #(-> (t2/select-one [index-table :legacy_input] :model "table" :model_id table-id)
+                                :legacy_input
+                                json/decode+kw)
+            db-id          (t2/select-one-fn :db_id :model/Table table-id)
+            db-name-fn     (comp :database_name legacy-input)
+            alternate-name (str (random-uuid))]
+        (is (= "Indexed Database" (db-name-fn)))
+        (t2/update! :model/Database db-id {:name alternate-name})
+        (is (= alternate-name (db-name-fn)))))))
 
 (deftest partial-word-test
   (with-index


### PR DESCRIPTION
Maybe sure we clean up the old `:search_index` table. Learned something new about Postgres LIKE patterns today. 

Also, I think these old hook tests will work now, at least they do locally, so re-enabled them.