### PR TITLE
Update Interactive Embedding Admin Settings page

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettings.tsx
@@ -7,7 +7,10 @@ import { SwitchWithSetByEnvVar } from "metabase/admin/settings/components/widget
 import { SettingTextInput } from "metabase/admin/settings/components/widgets/SettingTextInput";
 import { useMergeSetting } from "metabase/common/hooks";
 import Breadcrumbs from "metabase/components/Breadcrumbs";
-import { Box, Stack } from "metabase/ui";
+import ExternalLink from "metabase/core/components/ExternalLink";
+import { useSelector } from "metabase/lib/redux";
+import { getDocsUrl } from "metabase/selectors/settings";
+import { Box, Button, Stack } from "metabase/ui";
 import type { SessionCookieSameSite } from "metabase-types/api";
 
 import { EmbeddingAppOriginDescription } from "./EmbeddingAppOriginDescription";
@@ -30,12 +33,27 @@ const SAME_SITE_SETTING = {
   widget: SameSiteSelectWidget,
 } as const;
 
+const utmTags = {
+  utm_source: "product",
+  utm_medium: "docs",
+  utm_campaign: "embedding-interactive",
+  utm_content: "embedding-interactive-admin",
+};
+
 export function InteractiveEmbeddingSettings({
   updateSetting,
 }: AdminSettingComponentProps) {
   function handleToggleInteractiveEmbedding(value: boolean) {
     updateSetting({ key: "enable-embedding-interactive" }, value);
   }
+
+  const quickStartUrl = useSelector(state =>
+    // eslint-disable-next-line no-unconditional-metabase-links-render -- This is used in admin settings
+    getDocsUrl(state, {
+      page: "embedding/interactive-embedding-quick-start-guide",
+      utm: utmTags,
+    }),
+  );
 
   const interactiveEmbeddingOriginsSetting = useMergeSetting(
     INTERACTIVE_EMBEDDING_ORIGINS_SETTING,
@@ -66,6 +84,21 @@ export function InteractiveEmbeddingSettings({
           onChange={handleToggleInteractiveEmbedding}
           label={t`Enable Interactive embedding`}
         />
+
+        <Box>
+          <SettingHeader
+            id="get-started"
+            setting={{
+              display_name: t`Get started`,
+            }}
+          />
+          <Button
+            variant="outline"
+            component={ExternalLink}
+            href={quickStartUrl}
+          >{t`Check out the Quick Start`}</Button>
+        </Box>
+
         <Box>
           <SettingHeader
             id={interactiveEmbeddingOriginsSetting.key}
@@ -80,6 +113,7 @@ export function InteractiveEmbeddingSettings({
             />
           </SetByEnvVarWrapper>
         </Box>
+
         <Box>
           <SettingHeader id={sameSiteSetting.key} setting={sameSiteSetting} />
           <SetByEnvVarWrapper setting={sameSiteSetting}>

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/common.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/common.embedding.unit.spec.tsx
@@ -460,7 +460,7 @@ describe("[OSS] embedding settings", () => {
     expect(getInteractiveEmbeddingQuickStartLink()).toBeInTheDocument();
     expect(getInteractiveEmbeddingQuickStartLink()).toHaveProperty(
       "href",
-      "https://www.metabase.com/docs/v0.49/embedding/interactive-embedding-quick-start-guide.html?utm_source=oss&utm_media=embed-settings",
+      "https://www.metabase.com/docs/v0.49/embedding/interactive-embedding-quick-start-guide.html?utm_source=product&utm_medium=docs&utm_campaign=embedding-interactive&utm_content=embedding-admin&source_plan=oss",
     );
   });
 

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/enterprise.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/enterprise.embedding.unit.spec.tsx
@@ -467,7 +467,7 @@ describe("[EE, no token] embedding settings", () => {
     expect(getInteractiveEmbeddingQuickStartLink()).toBeInTheDocument();
     expect(getInteractiveEmbeddingQuickStartLink()).toHaveProperty(
       "href",
-      "https://www.metabase.com/docs/v0.49/embedding/interactive-embedding-quick-start-guide.html?utm_source=oss&utm_media=embed-settings",
+      "https://www.metabase.com/docs/v0.49/embedding/interactive-embedding-quick-start-guide.html?utm_source=product&utm_medium=docs&utm_campaign=embedding-interactive&utm_content=embedding-admin&source_plan=oss",
     );
   });
 

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
@@ -499,7 +499,7 @@ describe("[EE, with token] embedding settings", () => {
     expect(getInteractiveEmbeddingQuickStartLink()).toBeInTheDocument();
     expect(getInteractiveEmbeddingQuickStartLink()).toHaveProperty(
       "href",
-      "https://www.metabase.com/docs/v0.49/embedding/interactive-embedding-quick-start-guide.html?utm_source=pro-self-hosted&utm_media=embed-settings",
+      "https://www.metabase.com/docs/v0.49/embedding/interactive-embedding-quick-start-guide.html?utm_source=product&utm_medium=docs&utm_campaign=embedding-interactive&utm_content=embedding-admin&source_plan=pro-self-hosted",
     );
   });
 

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
@@ -462,6 +462,7 @@ describe("[EE, with token] embedding settings", () => {
           }),
         );
 
+        // Interactive embedding settings page
         expect(
           screen.getByLabelText("Enable Interactive embedding"),
         ).toBeEnabled();
@@ -470,6 +471,21 @@ describe("[EE, with token] embedding settings", () => {
         ).toBeChecked();
         await userEvent.click(
           screen.getByLabelText("Enable Interactive embedding"),
+        );
+
+        expect(
+          screen.getByRole("link", { name: "Check out the Quick Start" }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole("link", { name: "Check out the Quick Start" }),
+        ).toHaveProperty(
+          "href",
+          /**
+           * The link is almost the same as the test "should link to quickstart for interactive embedding", but with different version
+           * since we're not passing the version in the `setupPremium` function here, and with different `utm_content` because this link
+           * is in the interactive admin settings page rather than the embedding settings page in the aforementioned test.
+           */
+          "https://www.metabase.com/docs/latest/embedding/interactive-embedding-quick-start-guide.html?utm_source=product&utm_medium=docs&utm_campaign=embedding-interactive&utm_content=embedding-interactive-admin&source_plan=pro-self-hosted",
         );
 
         expect(screen.getByLabelText("Authorized origins")).toBeEnabled();

--- a/frontend/src/metabase/admin/settings/components/widgets/EmbeddingOption/InteractiveEmbeddingOptionCard/InteractiveEmbeddingOptionCard.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/EmbeddingOption/InteractiveEmbeddingOptionCard/InteractiveEmbeddingOptionCard.tsx
@@ -16,6 +16,13 @@ import type { EmbeddingOptionCardProps } from "../types";
 
 import { InteractiveEmbeddingIcon } from "./InteractiveEmbeddingIcon";
 
+const interactiveEmbeddingUtmTags = {
+  utm_source: "product",
+  utm_medium: "docs",
+  utm_campaign: "embedding-interactive",
+  utm_content: "embedding-admin",
+};
+
 export const InteractiveEmbeddingOptionCard = ({
   onToggle,
 }: EmbeddingOptionCardProps) => {
@@ -29,10 +36,9 @@ export const InteractiveEmbeddingOptionCard = ({
   const quickStartUrl = useSelector(state =>
     getDocsUrl(state, {
       page: "embedding/interactive-embedding-quick-start-guide",
+      utm: interactiveEmbeddingUtmTags,
     }),
   );
-
-  const quickStartLinkWithUtm = `${quickStartUrl}?utm_source=${plan}&utm_media=embed-settings`;
 
   return (
     <EmbeddingOption
@@ -65,7 +71,7 @@ export const InteractiveEmbeddingOptionCard = ({
         color="brand"
         component="a"
         pos="relative"
-        href={quickStartLinkWithUtm}
+        href={quickStartUrl}
         target="_blank"
       >
         {t`Check out our Quick Start`}{" "}

--- a/frontend/src/metabase/admin/settings/components/widgets/EmbeddingOption/InteractiveEmbeddingOptionCard/InteractiveEmbeddingOptionCard.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/EmbeddingOption/InteractiveEmbeddingOptionCard/InteractiveEmbeddingOptionCard.tsx
@@ -44,7 +44,7 @@ export const InteractiveEmbeddingOptionCard = ({
     <EmbeddingOption
       icon={
         <InteractiveEmbeddingIcon
-          disabled={isEE && !isInteractiveEmbeddingEnabled}
+          disabled={!isEE || !isInteractiveEmbeddingEnabled}
         />
       }
       title={t`Interactive embedding`}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50616

### Description

This PR does 2 things:
1. [Add a quick start link to the Interactive Embedding admin settings page.](https://www.notion.so/metabase/Streamline-embed-flow-when-embedding-features-are-off-13869354c90180b4bc02ca29ebf61ad2?pvs=4#14269354c901807ebcf8ff557a875aba)
1. [Make the Interactive Embedding card on admin settings grey when on OSS (unavailable)](https://www.notion.so/metabase/Streamline-embed-flow-when-embedding-features-are-off-13869354c90180b4bc02ca29ebf61ad2?pvs=4#14c69354c90180f3adb8ddbd0886642e)

Note: The [links are confirmed here.](https://metaboat.slack.com/archives/C063Q3F1HPF/p1732892823162379)

### How to verify
For 1), check that the interactive embedding settings page has a quick start guide following the [confirmed new links](https://metaboat.slack.com/archives/C063Q3F1HPF/p1732892823162379) here.

For 2) check that on OSS, the interactive setting icon should look disabled, it used to always be enabled on OSS when the feature is not available.


### Demo
![Screenshot 2024-12-03 at 9 03 17 PM](https://github.com/user-attachments/assets/2cf83ac1-db1a-4fe4-bfcf-77a828b29d0d)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
