### PR TITLE
Fix Quartz rescheduling with multiple triggers

### DIFF
--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -86,11 +86,13 @@
                              (keyword table-name)))
           to-drop     (remove keep-table? (existing-indexes))]
       (when (seq to-drop)
-        (try
-          (t2/query (apply sql.helpers/drop-table to-drop))
-          ;; Deletion could fail if it races with other instances
-          (catch ExceptionInfo _))
-        (log/infof "Dropped %d stale indexes" (count to-drop))))))
+        (let [dropped (volatile! 0)]
+          (try
+            (t2/query (apply sql.helpers/drop-table to-drop))
+            (vswap! dropped inc)
+            ;; Deletion could fail if it races with other instances
+            (catch ExceptionInfo _))
+          (log/infof "Dropped %d stale indexes" @dropped))))))
 
 (defsetting search-engine-appdb-index-state
   "Internation state used to maintain the AppDb Search Index"

--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -209,6 +209,8 @@
                          (.getName new-trigger-key)
                          (when (> (count triggers) 1)
                            ;; We probably want more intuitive rescheduling semantics for multi-trigger jobs...
+                           ;; Ideally we would pass *all* the new triggers at once, so we can match them up atomically.
+                           ;; The current behavior is especially confounding if replacing N triggers with M ones.
                            (str " (chosen randomly from " (count triggers) " existing ones)")))
               matching-trigger)
             (.rescheduleJob scheduler (.getKey ^Trigger matching-trigger) new-trigger)))))

--- a/src/metabase/task/sweep_query_analysis.clj
+++ b/src/metabase/task/sweep_query_analysis.clj
@@ -101,11 +101,11 @@
                  (jobs/store-durably))
         trigger (triggers/build
                  (triggers/with-identity (triggers/key "metabase.task.backfill-query-fields.trigger"))
-                 (triggers/start-now)
                  (triggers/with-schedule
                   (cron/schedule
                    (cron/cron-schedule
-                       ;; run every 4 hours at a random minute:
+                    ;; run every 4 hours at a random minute:
                     (format "0 %d 0/4 1/1 * ? *" (rand-int 60)))
                    (cron/with-misfire-handling-instruction-ignore-misfires))))]
-    (task/schedule-task! job trigger)))
+    (task/schedule-task! job trigger)
+    (task/trigger-now! job-key)))

--- a/src/metabase/task/sweep_query_analysis.clj
+++ b/src/metabase/task/sweep_query_analysis.clj
@@ -106,6 +106,6 @@
                    (cron/cron-schedule
                     ;; run every 4 hours at a random minute:
                     (format "0 %d 0/4 1/1 * ? *" (rand-int 60)))
-                   (cron/with-misfire-handling-instruction-ignore-misfires))))]
+                   (cron/with-misfire-handling-instruction-do-nothing))))]
     (task/schedule-task! job trigger)
     (task/trigger-now! job-key)))

--- a/src/metabase/task/sweep_query_analysis.clj
+++ b/src/metabase/task/sweep_query_analysis.clj
@@ -98,8 +98,7 @@
         job     (jobs/build
                  (jobs/of-type SweepQueryAnalysis)
                  (jobs/with-identity job-key)
-                 (jobs/store-durably)
-                 (jobs/request-recovery))
+                 (jobs/store-durably))
         trigger (triggers/build
                  (triggers/with-identity (triggers/key "metabase.task.backfill-query-fields.trigger"))
                  (triggers/start-now)
@@ -109,7 +108,4 @@
                        ;; run every 4 hours at a random minute:
                     (format "0 %d 0/4 1/1 * ? *" (rand-int 60)))
                    (cron/with-misfire-handling-instruction-ignore-misfires))))]
-    ;; Schedule the repeats
-    (task/schedule-task! job trigger)
-    ;; Don't wait, try to kick it off immediately
-    (task/trigger-now! job-key)))
+    (task/schedule-task! job trigger)))


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/50063

Stats is having a sad where the first trigger we pull out from Quartz is *not* the one with the conflicting trigger, and then we get another conflict exception when trying to swap them out.

This updated behavior is strictly better than before, but it's still not perfect. Ideally we'd have one method that takes *all* the triggers in one go, atomically swaps out all the matching entries, and deletes the other obsolete records. I don't think we make enough use of multi-trigger jobs right now that this is important.

This also fixes how we handle misfires for the query analysis sweeper - I think it's safer to skip a firing than to run non-stop.

I also snuck in a little change to make Sanya happy about honesty in log messages.

See: [registration failure logs](https://grafana.monitoring.metabase.com/d/Zjw_nJX7k/metabase-logs?orgId=1&refresh=5m&var-cluster=staging-1&var-filter=Unable%20to%20store%20Trigger%20with%20name&var-namespace=All&var-dns_host=stats.metabase.com&var-pod=All&from=now-1h&to=now)