### PR TITLE
Partially fix flaky native e2e tests

### DIFF
--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.js
@@ -135,8 +135,17 @@ describe("issue 16914", () => {
       FAILING_PIECE.length,
     );
 
-    openNativeEditor().type("SELECT 'a' as hidden, 'b' as visible");
-    runNativeQuery();
+    visitQuestionAdhoc({
+      display: "table",
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        type: "native",
+        native: {
+          query: "SELECT 'a' as hidden, 'b' as visible",
+        },
+      },
+      visualization_settings: {},
+    });
 
     cy.findByTestId("viz-settings-button").click();
     cy.findByTestId("sidebar-left")
@@ -145,10 +154,10 @@ describe("issue 16914", () => {
       .click();
     cy.button("Done").click();
 
-    cy.get("@editor").type(FAILING_PIECE);
+    focusNativeEditor().type(FAILING_PIECE);
     runNativeQuery();
 
-    cy.get("@editor").type(
+    focusNativeEditor().type(
       "{movetoend}" + highlightSelectedText + "{backspace}",
     );
     runNativeQuery();
@@ -189,20 +198,26 @@ describe("issue 17060", () => {
 
     restore();
     cy.signInAsAdmin();
-
-    openNativeEditor().type(ORIGINAL_QUERY);
-
-    runQuery();
+    visitQuestionAdhoc({
+      display: "table",
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        type: "native",
+        native: {
+          query: ORIGINAL_QUERY,
+        },
+      },
+      visualization_settings: {},
+    });
 
     cy.findByTestId("viz-settings-button").click();
-
     cy.findByTestId("sidebar-left").within(() => {
       rearrangeColumns();
     });
   });
 
   it("should not render duplicated columns (metabase#17060)", () => {
-    cy.get("@editor").type(
+    focusNativeEditor().type(
       moveCursorToBeginning +
         moveCursorAfterSection +
         highlightSelectedText +

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.js
@@ -25,6 +25,10 @@ import {
 
 const { PRODUCTS, ORDERS_ID } = SAMPLE_DATABASE;
 
+// cy.realType does not have an option to not parse special characters
+const LEFT_BRACKET = "{{}";
+const DOUBLE_LEFT_BRACKET = `${LEFT_BRACKET}${LEFT_BRACKET}`;
+
 describe("issue 12439", () => {
   const nativeQuery = `
   SELECT "PRODUCTS__via__PRODUCT_ID"."CATEGORY" AS "CATEGORY",
@@ -83,8 +87,9 @@ describe("issue 15029", () => {
   });
 
   it("should allow dots in the variable reference (metabase#15029)", () => {
-    openNativeEditor().type(
-      "select * from products where RATING = {{number.of.stars}}",
+    openNativeEditor();
+    cy.realType(
+      `select * from products where RATING = ${DOUBLE_LEFT_BRACKET}number.of.stars}}`,
       {
         parseSpecialCharSequences: false,
       },
@@ -98,20 +103,17 @@ describe("issue 16886", () => {
   const ORIGINAL_QUERY = "select 1 from orders";
   const SELECTED_TEXT = "select 1";
 
-  const moveCursorToBeginning = "{selectall}{leftarrow}";
-  const highlightSelectedText = "{shift}{rightarrow}".repeat(
-    SELECTED_TEXT.length,
-  );
-
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
   });
 
   it("shouldn't remove parts of the query when choosing 'Run selected text' (metabase#16886)", () => {
-    openNativeEditor().type(
-      ORIGINAL_QUERY + moveCursorToBeginning + highlightSelectedText,
-      { delay: 50 },
+    openNativeEditor();
+    cy.realType(ORIGINAL_QUERY);
+    cy.realPress("Home");
+    Cypress._.range(SELECTED_TEXT.length).forEach(() =>
+      cy.realPress(["Shift", "ArrowRight"]),
     );
 
     cy.findByTestId("native-query-editor-container").icon("play").click();
@@ -131,9 +133,6 @@ describe("issue 16914", () => {
 
   it("should recover visualization settings after a failed query (metabase#16914)", () => {
     const FAILING_PIECE = " foo";
-    const highlightSelectedText = "{shift}{leftarrow}".repeat(
-      FAILING_PIECE.length,
-    );
 
     visitQuestionAdhoc({
       display: "table",
@@ -154,12 +153,16 @@ describe("issue 16914", () => {
       .click();
     cy.button("Done").click();
 
-    focusNativeEditor().type(FAILING_PIECE);
+    focusNativeEditor();
+    cy.realType(FAILING_PIECE);
     runNativeQuery();
 
-    focusNativeEditor().type(
-      "{movetoend}" + highlightSelectedText + "{backspace}",
+    focusNativeEditor();
+    cy.realPress("End");
+    Cypress._.range(FAILING_PIECE.length).forEach(() =>
+      cy.realPress(["Shift", "ArrowLeft"]),
     );
+    cy.realPress("Backspace");
     runNativeQuery();
 
     cy.findByTestId("query-visualization-root").within(() => {
@@ -175,14 +178,6 @@ describe("issue 17060", () => {
     'select ID as "num", CATEGORY as "text" from PRODUCTS limit 1';
   const SECTION = "select ";
   const SELECTED_TEXT = "ID";
-
-  const moveCursorToBeginning = "{selectall}{leftarrow}";
-
-  const highlightSelectedText = "{shift}{rightarrow}".repeat(
-    SELECTED_TEXT.length,
-  );
-
-  const moveCursorAfterSection = "{rightarrow}".repeat(SECTION.length);
 
   function rearrangeColumns() {
     cy.findAllByTestId(/draggable-item/)
@@ -217,14 +212,13 @@ describe("issue 17060", () => {
   });
 
   it("should not render duplicated columns (metabase#17060)", () => {
-    focusNativeEditor().type(
-      moveCursorToBeginning +
-        moveCursorAfterSection +
-        highlightSelectedText +
-        "RATING",
-      { delay: 50 },
+    focusNativeEditor();
+    cy.realPress("Home");
+    Cypress._.range(SECTION.length).forEach(() => cy.realPress("ArrowRight"));
+    Cypress._.range(SELECTED_TEXT.length).forEach(() =>
+      cy.realPress(["Shift", "ArrowRight"]),
     );
-
+    cy.realType("RATING");
     runQuery();
 
     cy.findByTestId("query-visualization-root").within(() => {
@@ -260,7 +254,8 @@ describe("issue 18148", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(dbName).click();
 
-    cy.get(".ace_content").should("be.visible").type("select foo");
+    focusNativeEditor();
+    cy.realType("select foo");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
@@ -389,7 +384,8 @@ describe("issue 20625", { tags: "@quarantine" }, () => {
 
   // realpress messes with cypress 13
   it("should continue to request more prefix matches (metabase#20625)", () => {
-    openNativeEditor().type("s");
+    openNativeEditor();
+    cy.realType("s");
 
     // autocomplete_suggestions?prefix=s
     cy.wait("@autocomplete");
@@ -415,7 +411,8 @@ describe("issue 21034", () => {
   });
 
   it("should not invoke API calls for autocomplete twice in a row (metabase#18148)", () => {
-    cy.get(".ace_content").should("be.visible").type("p");
+    focusNativeEditor();
+    cy.realType("p");
 
     // Wait until another explicit autocomplete is triggered
     // (slightly longer than AUTOCOMPLETE_DEBOUNCE_DURATION)
@@ -484,10 +481,10 @@ describe("issue 21597", { tags: "@external" }, () => {
     // Create a native query and run it
     openNativeEditor({
       databaseName,
-    }).type("SELECT COUNT(*) FROM PRODUCTS WHERE {{FILTER}}", {
-      delay: 0,
-      parseSpecialCharSequences: false,
     });
+    cy.realType(
+      `SELECT COUNT(*) FROM PRODUCTS WHERE ${DOUBLE_LEFT_BRACKET}FILTER}}`,
+    );
 
     cy.findByTestId("variable-type-select").click();
     popover().within(() => {
@@ -603,15 +600,12 @@ describe("issue 34330", () => {
   });
 
   it("should only call the autocompleter with all text typed (metabase#34330)", () => {
-    const editor = openNativeEditor();
-
-    // can't use cy.type because it does not simulate the bug
-    // Delay needed for React 18. TODO: fix shame
-    editor.type("USER").type("_", { delay: 1000 });
+    openNativeEditor();
+    cy.realType("USER");
 
     cy.wait("@autocomplete").then(({ request }) => {
       const url = new URL(request.url);
-      expect(url.searchParams.get("substring")).to.equal("USER_");
+      expect(url.searchParams.get("substring")).to.equal("USER");
     });
 
     // only one call to the autocompleter should have been made
@@ -619,10 +613,8 @@ describe("issue 34330", () => {
   });
 
   it("should call the autocompleter eventually, even when only 1 character was typed (metabase#34330)", () => {
-    const editor = openNativeEditor();
-
-    // can't use cy.type because it does not simulate the bug
-    editor.type("U");
+    openNativeEditor();
+    cy.realType("U");
 
     cy.wait("@autocomplete").then(({ request }) => {
       const url = new URL(request.url);
@@ -634,10 +626,8 @@ describe("issue 34330", () => {
   });
 
   it("should call the autocompleter when backspacing to a 1-character prefix(metabase#34330)", () => {
-    const editor = openNativeEditor();
-
-    // can't use cy.type because it does not simulate the bug
-    editor.type("SE{backspace}");
+    openNativeEditor();
+    cy.realType("SE{backspace}");
 
     cy.wait("@autocomplete").then(({ request }) => {
       const url = new URL(request.url);
@@ -666,14 +656,17 @@ describe("issue 35344", () => {
     cy.findByTestId("query-builder-main").findByText("Open Editor").click();
 
     // make sure normal undo still works
-    focusNativeEditor().type("--");
+    focusNativeEditor();
+    cy.realType("--");
     expect(focusNativeEditor().findByText("--")).to.exist;
 
-    focusNativeEditor().type("{meta}z");
+    focusNativeEditor();
+    cy.realPress(["Meta", "z"]);
     focusNativeEditor().findByText("--").should("not.exist");
 
     // more undoing does not change to empty editor
-    focusNativeEditor().type("{meta}z");
+    focusNativeEditor();
+    cy.realPress(["Meta", "z"]);
     expect(focusNativeEditor().findByText("select")).to.exist;
   });
 });
@@ -719,7 +712,8 @@ describe("issue 35785", () => {
     cy.findByTestId("native-query-editor-container")
       .findByTestId("visibility-toggler")
       .click();
-    cy.findByTestId("native-query-editor").type("{backspace}4");
+    focusNativeEditor();
+    cy.realType("{backspace}4");
 
     cy.findByTestId("qb-header").findByRole("button", { name: "Save" }).click();
 
@@ -769,11 +763,10 @@ describe("issue 22991", () => {
     cy.signOut();
     cy.signInAsNormalUser();
 
-    const editor = openNativeEditor();
-
+    openNativeEditor();
     cy.get("@questionId").then(questionId => {
       // can't use cy.type because it does not simulate the bug
-      editor.type(`select * from {{#${questionId}`);
+      cy.realType(`select * from ${DOUBLE_LEFT_BRACKET}#${questionId}`);
     });
 
     cy.get("main").should(

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -33,6 +33,7 @@ const ORDERS_SCALAR_METRIC = {
   display: "scalar",
 };
 
+// cy.realType does not have an option to not parse special characters
 const LEFT_BRACKET = "{{}";
 const DOUBLE_LEFT_BRACKET = `${LEFT_BRACKET}${LEFT_BRACKET}`;
 

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -33,6 +33,9 @@ const ORDERS_SCALAR_METRIC = {
   display: "scalar",
 };
 
+const LEFT_BRACKET = "{{}";
+const DOUBLE_LEFT_BRACKET = `${LEFT_BRACKET}${LEFT_BRACKET}`;
+
 describe("scenarios > question > native", () => {
   beforeEach(() => {
     cy.intercept("POST", "api/card").as("card");
@@ -43,7 +46,8 @@ describe("scenarios > question > native", () => {
   });
 
   it("lets you create and run a SQL question", () => {
-    openNativeEditor().type("select count(*) from orders");
+    openNativeEditor();
+    cy.realType("select count(*) from orders");
     runQuery();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("18,760");
@@ -52,9 +56,8 @@ describe("scenarios > question > native", () => {
   it("should suggest the currently viewed collection when saving question", () => {
     visitCollection(THIRD_COLLECTION_ID);
 
-    openNativeEditor({ fromCurrentPage: true }).type(
-      "select count(*) from orders",
-    );
+    openNativeEditor({ fromCurrentPage: true });
+    cy.realType("select count(*) from orders");
 
     cy.findByTestId("qb-header").within(() => {
       cy.findByText("Save").click();
@@ -68,36 +71,30 @@ describe("scenarios > question > native", () => {
   });
 
   it("displays an error", () => {
-    visitQuestionAdhoc({
-      display: "table",
-      dataset_query: {
-        database: SAMPLE_DB_ID,
-        type: "native",
-        native: {
-          query: "select * from not_a_table",
-        },
-      },
-      visualization_settings: {},
-    });
+    openNativeEditor();
+    cy.realType("select * from not_a_table");
+    runQuery();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains('Table "NOT_A_TABLE" not found');
   });
 
   it("displays an error when running selected text", () => {
-    openNativeEditor().type(
-      "select * from orders" +
-        "{leftarrow}".repeat(3) + // move left three
-        "{shift}{leftarrow}".repeat(19), // highlight back to the front
-    );
+    openNativeEditor();
+    cy.realType("select * from orders");
+    // move left three
+    Cypress._.range(3).forEach(() => cy.realPress("ArrowLeft"));
+    // highlight back to the front
+    Cypress._.range(19).forEach(() => cy.realPress(["Shift", "ArrowLeft"]));
     runQuery();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains('Table "ORD" not found');
   });
 
   it("should handle template tags", () => {
-    openNativeEditor().type("select * from PRODUCTS where RATING > {{Stars}}", {
-      parseSpecialCharSequences: false,
-    });
+    openNativeEditor();
+    cy.realType(
+      `select * from PRODUCTS where RATING > ${DOUBLE_LEFT_BRACKET}Stars}}`,
+    );
     cy.get("input[placeholder*='Stars']").type("3");
     runQuery();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -105,9 +102,10 @@ describe("scenarios > question > native", () => {
   });
 
   it("should modify parameters accordingly when tags are modified", () => {
-    openNativeEditor().type("select * from PRODUCTS where CATEGORY = {{cat}}", {
-      parseSpecialCharSequences: false,
-    });
+    openNativeEditor();
+    cy.realType(
+      `select * from PRODUCTS where CATEGORY = ${DOUBLE_LEFT_BRACKET}cat}}`,
+    );
     cy.findByTestId("sidebar-right")
       .findByText("Always require a value")
       .click();
@@ -134,7 +132,8 @@ describe("scenarios > question > native", () => {
   });
 
   it("can save a question with no rows", () => {
-    openNativeEditor().type("select * from people where false");
+    openNativeEditor();
+    cy.realType("select * from people where false");
     runQuery();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("No results!");
@@ -214,7 +213,8 @@ describe("scenarios > question > native", () => {
   });
 
   it("should be able to add new columns after hiding some (metabase#15393)", () => {
-    openNativeEditor().type("select 1 as visible, 2 as hidden");
+    openNativeEditor();
+    cy.realType("select 1 as visible, 2 as hidden");
     cy.findByTestId("native-query-editor-container")
       .icon("play")
       .as("runQuery")
@@ -232,11 +232,9 @@ describe("scenarios > question > native", () => {
   });
 
   it("should recognize template tags and save them as parameters", () => {
-    openNativeEditor().type(
-      "select * from PRODUCTS where CATEGORY={{cat}} and RATING >= {{stars}}",
-      {
-        parseSpecialCharSequences: false,
-      },
+    openNativeEditor();
+    cy.realType(
+      `select * from PRODUCTS where CATEGORY=${DOUBLE_LEFT_BRACKET}cat}} and RATING >= ${DOUBLE_LEFT_BRACKET}stars}}`,
     );
     cy.get("input[placeholder*='Cat']").type("Gizmo");
     cy.get("input[placeholder*='Stars']").type("3");
@@ -291,9 +289,9 @@ describe("scenarios > question > native", () => {
   });
 
   it("should allow to preview a fully parameterized query", () => {
-    openNativeEditor().type(
-      "select * from PRODUCTS where CATEGORY={{category}}",
-      { parseSpecialCharSequences: false },
+    openNativeEditor();
+    cy.realType(
+      `select * from PRODUCTS where CATEGORY=${DOUBLE_LEFT_BRACKET}category}}`,
     );
     cy.findByPlaceholderText("Category").type("Gadget");
     cy.button("Preview the query").click();
@@ -304,9 +302,9 @@ describe("scenarios > question > native", () => {
   });
 
   it("should show errors when previewing a query", () => {
-    openNativeEditor().type(
-      "select * from PRODUCTS where CATEGORY={{category}}",
-      { parseSpecialCharSequences: false },
+    openNativeEditor();
+    cy.realType(
+      `select * from PRODUCTS where CATEGORY=${DOUBLE_LEFT_BRACKET}category}}`,
     );
     cy.button("Preview the query").click();
     cy.wait("@datasetNative");

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -68,8 +68,17 @@ describe("scenarios > question > native", () => {
   });
 
   it("displays an error", () => {
-    openNativeEditor().type("select * from not_a_table");
-    runQuery();
+    visitQuestionAdhoc({
+      display: "table",
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        type: "native",
+        native: {
+          query: "select * from not_a_table",
+        },
+      },
+      visualization_settings: {},
+    });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains('Table "NOT_A_TABLE" not found');
   });


### PR DESCRIPTION
Uses `realType` and `realPress` which are much less flaky. Still, it doesn't pass stress test; but the previous implementation fails 10-20x more often.

- native https://github.com/metabase/metabase/actions/runs/12092518185
- native reproductions https://github.com/metabase/metabase/actions/runs/12092522549

