### PR TITLE
Show /api/search errors in Browse models and Browse metrics

### DIFF
--- a/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
@@ -110,6 +110,28 @@ describeWithSnowplow("scenarios > browse", () => {
       "not.exist",
     );
   });
+
+  it("The Browse models page shows an error message if the search endpoint throws an error", () => {
+    cy.visit("/");
+    cy.intercept("GET", "/api/search*", req => {
+      req.reply({ statusCode: 400 });
+    });
+    navigationSidebar().findByLabelText("Browse models").click();
+    cy.findByLabelText("Models")
+      .findAllByText("An error occurred")
+      .should("have.length", 2);
+  });
+
+  it("The Browse metrics page shows an error message if the search endpoint throws an error", () => {
+    cy.visit("/");
+    cy.intercept("GET", "/api/search*", req => {
+      req.reply({ statusCode: 400 });
+    });
+    navigationSidebar().findByLabelText("Browse metrics").click();
+    cy.findByLabelText("Metrics")
+      .findByText("An error occurred")
+      .should("be.visible");
+  });
 });
 
 describeWithSnowplowEE("scenarios > browse (EE)", () => {

--- a/frontend/src/metabase/browse/metrics/BrowseMetrics.tsx
+++ b/frontend/src/metabase/browse/metrics/BrowseMetrics.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { t } from "ttag";
+import _ from "underscore";
 
 import NoResults from "assets/img/metrics_bot.svg";
 import { getCurrentUser } from "metabase/admin/datamodel/selectors";
@@ -45,10 +46,11 @@ export function BrowseMetrics() {
   const { isLoading, error, metrics, hasVerifiedMetrics } =
     useFilteredMetrics(metricFilters);
 
-  const isEmpty = !isLoading && !metrics?.length;
+  const isEmpty = !isLoading && !error && !metrics?.length;
+  const titleId = useMemo(() => _.uniqueId("browse-metrics"), []);
 
   return (
-    <BrowseContainer>
+    <BrowseContainer aria-labelledby={titleId}>
       <BrowseHeader role="heading" data-testid="browse-metrics-header">
         <BrowseSection>
           <Flex
@@ -58,7 +60,7 @@ export function BrowseMetrics() {
             justify="space-between"
             align="center"
           >
-            <Title order={1} color="text-dark">
+            <Title order={1} color="text-dark" id={titleId}>
               <Group spacing="sm">
                 <Icon
                   size={24}

--- a/frontend/src/metabase/browse/models/BrowseModels.tsx
+++ b/frontend/src/metabase/browse/models/BrowseModels.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { t } from "ttag";
+import _ from "underscore";
 
 import NoResults from "assets/img/no_results.svg";
 import { skipToken, useListRecentsQuery } from "metabase/api";
@@ -37,10 +38,11 @@ export const BrowseModels = () => {
   const { isLoading, error, models, recentModels, hasVerifiedModels } =
     useFilteredModels(modelFilters);
 
-  const isEmpty = !isLoading && models.length === 0;
+  const isEmpty = !isLoading && !error && models.length === 0;
+  const titleId = useMemo(() => _.uniqueId("browse-models"), []);
 
   return (
-    <BrowseContainer>
+    <BrowseContainer aria-labelledby={titleId}>
       <BrowseHeader role="heading" data-testid="browse-models-header">
         <BrowseSection>
           <Flex
@@ -50,7 +52,7 @@ export const BrowseModels = () => {
             justify="space-between"
             align="center"
           >
-            <Title order={1} color="text-dark">
+            <Title order={1} color="text-dark" id={titleId}>
               <Group spacing="sm">
                 <Icon
                   size={24}


### PR DESCRIPTION
### Description

On master, if /api/search returns an error, the Browse models and Browse metrics pages will both show "No models/metrics found" rather than an error message.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
