### PR TITLE
Fix NPE on search model calculation, and improve testing story

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -128,10 +128,12 @@
      clojure.core.async/to-chan!
      clojure.core.async/to-chan!!
      metabase.channel.core/send!
-     metabase.models.notification/create-notification!
      metabase.driver.sql-jdbc.execute/execute-prepared-statement!
+     metabase.models.notification/create-notification!
      metabase.pulse.send/send-pulse!
      metabase.query-processor.store/store-database!
+     ;; Safe in tests, where we typically use a private, temporary index per thread.
+     metabase.search.core/reindex!
      metabase.util/run-count!
      next.jdbc/execute!}}
 

--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -78,7 +78,9 @@
 (defmethod search.engine/model-set :search.engine/fulltext
   [search-ctx]
   ;; We ignore any current models filter
-  (let [search-ctx (assoc search-ctx :models search.config/all-models)]
+  (let [unfiltered-context (assoc search-ctx :models search.config/all-models)
+        applicable-models  (search.filter/search-context->applicable-models unfiltered-context)
+        search-ctx         (assoc search-ctx :models applicable-models)]
     (->> (search.index/search-query (:search-string search-ctx) search-ctx [[[:distinct :model] :model]])
          (add-collection-join-and-where-clauses search-ctx)
          (search.filter/with-filters search-ctx)

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -150,7 +150,7 @@
   ([table-name]
    (boolean
     (when (exists? table-name)
-      (update-metadata! {:active-table table-name})))))
+      (update-metadata! {:active-table table-name :pending-table nil})))))
 
 (defn- document->entry [entity]
   (-> entity

--- a/src/metabase/search/appdb/scoring.clj
+++ b/src/metabase/search/appdb/scoring.clj
@@ -156,7 +156,7 @@
 (defn base-scorers
   "The default constituents of the search ranking scores."
   [{:keys [search-string limit-int] :as search-ctx}]
-  (if (or (nil? limit-int) (<= limit-int 1))
+  (if (and limit-int (zero? limit-int))
     {:model       [:inline 1]}
     ;; NOTE: we calculate scores even if the weight is zero, so that it's easy to consider how we could affect any
     ;; given set of results. At some point, we should optimize away the irrelevant scores for any given context.

--- a/src/metabase/search/appdb/scoring.clj
+++ b/src/metabase/search/appdb/scoring.clj
@@ -155,20 +155,28 @@
 
 (defn base-scorers
   "The default constituents of the search ranking scores."
-  [search-ctx]
-  ;; NOTE: we calculate scores even if the weight is zero, so that it's easy to consider how we could affect any
-  ;; given set of results. At some point, we should optimize away the irrelevant scores for any given context.
-  {:text         [:ts_rank :search_vector :query [:inline ts-rank-normalization]]
-   :view-count   (view-count-expr search.config/view-count-scaling-percentile)
-   :pinned       (truthy :pinned)
-   :bookmarked   bookmark-score-expr
-   :recency      (inverse-duration [:coalesce :last_viewed_at :model_updated_at] [:now] search.config/stale-time-in-days)
-   :user-recency (inverse-duration (user-recency-expr search-ctx) [:now] search.config/stale-time-in-days)
-   :dashboard    (size :dashboardcard_count search.config/dashboard-count-ceiling)
-   :model        (model-rank-exp search-ctx)
-   :mine         (equal :search_index.creator_id (:current-user-id search-ctx))
-   :exact        (equal [:lower :search_index.name] [:lower (:search-string search-ctx)])
-   :prefix       (prefix [:lower :search_index.name] (u/lower-case-en (:search-string search-ctx)))})
+  [{:keys [search-string limit-int] :as search-ctx}]
+  (if (or (nil? limit-int) (<= limit-int 1))
+    {:model       [:inline 1]}
+    ;; NOTE: we calculate scores even if the weight is zero, so that it's easy to consider how we could affect any
+    ;; given set of results. At some point, we should optimize away the irrelevant scores for any given context.
+    {:text         [:ts_rank :search_vector :query [:inline ts-rank-normalization]]
+     :view-count   (view-count-expr search.config/view-count-scaling-percentile)
+     :pinned       (truthy :pinned)
+     :bookmarked   bookmark-score-expr
+     :recency      (inverse-duration [:coalesce :last_viewed_at :model_updated_at] [:now] search.config/stale-time-in-days)
+     :user-recency (inverse-duration (user-recency-expr search-ctx) [:now] search.config/stale-time-in-days)
+     :dashboard    (size :dashboardcard_count search.config/dashboard-count-ceiling)
+     :model        (model-rank-exp search-ctx)
+     :mine         (equal :search_index.creator_id (:current-user-id search-ctx))
+     :exact        (if search-string
+                     ;; perform the lower casing within the database, in case it behaves differently to our helper
+                     (equal [:lower :search_index.name] [:lower search-string])
+                     [:inline 0])
+     :prefix       (if search-string
+                     ;; in this case, we need to transform the string into a pattern in code, so forced to use helper
+                     (prefix [:lower :search_index.name] (u/lower-case-en search-string))
+                     [:inline 0])}))
 
 (defenterprise scorers
   "Return the select-item expressions used to calculate the score for each search result."

--- a/src/metabase/search/filter.clj
+++ b/src/metabase/search/filter.clj
@@ -67,7 +67,7 @@
       :else
       [:and [:>= dt-col start] [:< dt-col end]])))
 
-(defmulti ^:private where-clause* (fn [context-key _column _v] context-key))
+(defmulti ^:private where-clause* (fn [filter-type _column _v] filter-type))
 
 (defmethod where-clause* ::single-value [_ k v] [:= k v])
 

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -150,8 +150,6 @@
                                           :type nil})
                    (default-search-results)))
 
-;; It is safe to call `search/reindex!` when we are in a `with-temp-index-table` scope.
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn- do-with-search-items [search-string in-root-collection? f]
   (let [data-map      (fn [instance-name]
                         {:name (format instance-name search-string)})
@@ -180,7 +178,6 @@
                      Card        metric         (assoc (coll-data-map "metric %s metric" coll)
                                                        :type :metric)
                      Segment     segment        (data-map "segment %s segment")]
-        (search/reindex!)
         (f {:action     action
             :collection coll
             :card       card

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -150,6 +150,7 @@
                                           :type nil})
                    (default-search-results)))
 
+#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn- do-with-search-items [search-string in-root-collection? f]
   (let [data-map      (fn [instance-name]
                         {:name (format instance-name search-string)})
@@ -157,35 +158,37 @@
                         (merge (data-map instance-name)
                                (when-not in-root-collection?
                                  {:collection_id (u/the-id collection)})))]
-    (mt/with-temp [Collection  coll           (data-map "collection %s collection")
-                   Card        action-model   (if in-root-collection?
-                                                action-model-params
-                                                (assoc action-model-params :collection_id (u/the-id coll)))
-                   Action      {action-id :id
-                                :as action}   (merge (data-map "action %s action")
-                                                     {:type :query, :model_id (u/the-id action-model)})
-                   Database    {db-id :id
-                                :as db}       (data-map "database %s database")
-                   Table       table          (merge (data-map "database %s database")
-                                                     {:db_id db-id})
+    (search.tu/with-temp-index-table
+      (mt/with-temp [Collection  coll           (data-map "collection %s collection")
+                     Card        action-model   (if in-root-collection?
+                                                  action-model-params
+                                                  (assoc action-model-params :collection_id (u/the-id coll)))
+                     Action      {action-id :id
+                                  :as action}   (merge (data-map "action %s action")
+                                                       {:type :query, :model_id (u/the-id action-model)})
+                     Database    {db-id :id
+                                  :as db}       (data-map "database %s database")
+                     Table       table          (merge (data-map "database %s database")
+                                                       {:db_id db-id})
 
-                   QueryAction _qa (query-action action-id)
-                   Card        card           (coll-data-map "card %s card" coll)
-                   Card        dataset        (assoc (coll-data-map "dataset %s dataset" coll)
-                                                     :type :model)
-                   Dashboard   dashboard      (coll-data-map "dashboard %s dashboard" coll)
-                   Card        metric         (assoc (coll-data-map "metric %s metric" coll)
-                                                     :type :metric)
-                   Segment     segment        (data-map "segment %s segment")]
-      (f {:action     action
-          :collection coll
-          :card       card
-          :database   db
-          :dataset    dataset
-          :dashboard  dashboard
-          :metric     metric
-          :table      table
-          :segment    segment}))))
+                     QueryAction _qa (query-action action-id)
+                     Card        card           (coll-data-map "card %s card" coll)
+                     Card        dataset        (assoc (coll-data-map "dataset %s dataset" coll)
+                                                       :type :model)
+                     Dashboard   dashboard      (coll-data-map "dashboard %s dashboard" coll)
+                     Card        metric         (assoc (coll-data-map "metric %s metric" coll)
+                                                       :type :metric)
+                     Segment     segment        (data-map "segment %s segment")]
+        (search/reindex!)
+        (f {:action     action
+            :collection coll
+            :card       card
+            :database   db
+            :dataset    dataset
+            :dashboard  dashboard
+            :metric     metric
+            :table      table
+            :segment    segment})))))
 
 (defmacro ^:private with-search-items-in-root-collection [search-string & body]
   `(do-with-search-items ~search-string true (fn [~'_] ~@body)))
@@ -336,37 +339,42 @@
       (is (= #{} (get-available-models :q "noresults"))))))
 
 (deftest available-models-test
-  (let [search-term "query-model-set"]
-    (with-search-items-in-root-collection search-term
-      (testing "should returns a list of models that search result will return"
-        (is (= #{"dashboard" "table" "dataset" "segment" "collection" "database" "action" "metric" "card"}
-               (get-available-models :q search-term))))
-      (testing "return a subset of model for created-by filter"
-        (is (= #{"dashboard" "dataset" "card" "metric" "action"}
-               (get-available-models :q search-term :created_by (mt/user->id :rasta)))))
-      (testing "return a subset of model for verified filter"
-        (t2.with-temp/with-temp
-          [:model/Card       {v-card-id :id}   {:name (format "%s Verified Card" search-term)}
-           :model/Card       {v-model-id :id}  {:name (format "%s Verified Model" search-term) :type :model}
-           :model/Card       {v-metric-id :id} {:name (format "%s Verified Metric" search-term) :type :metric}
-           :model/Collection {_v-coll-id :id}  {:name (format "%s Verified Collection" search-term) :authority_level "official"}]
-          (testing "when has both :content-verification features"
-            (mt/with-premium-features #{:content-verification}
-              (mt/with-verified-cards! [v-card-id v-model-id v-metric-id]
-                (is (= #{"card" "dataset" "metric"}
-                       (get-available-models :q search-term :verified true))))))
-          (testing "when has :content-verification feature only"
-            (mt/with-premium-features #{:content-verification}
-              (mt/with-verified-cards! [v-card-id]
-                (is (= #{"card"}
-                       (get-available-models :q search-term :verified true))))))))
-      (testing "return a subset of model for created_at filter"
-        (is (= #{"dashboard" "table" "dataset" "collection" "database" "action" "card" "metric"}
-               (get-available-models :q search-term :created_at "today"))))
+  ;; Porting these tests over earlier
+  (doseq [engine ["in-place" "fulltext"]]
+    (let [search-term "query-model-set"
+          get-available-models #(apply get-available-models :search_engine engine %&)]
+      (with-search-items-in-root-collection search-term
+        (testing "should returns a list of models that search result will return"
+          (is (= #{"dashboard" "table" "dataset" "segment" "collection" "database" "action" "metric" "card"}
+                 (get-available-models)))
+          (is (= #{"dashboard" "table" "dataset" "segment" "collection" "database" "action" "metric" "card"}
+                 (get-available-models :q search-term))))
+        (testing "return a subset of model for created-by filter"
+          (is (= #{"dashboard" "dataset" "card" "metric" "action"}
+                 (get-available-models :q search-term :created_by (mt/user->id :rasta)))))
+        (testing "return a subset of model for verified filter"
+          (t2.with-temp/with-temp
+            [:model/Card       {v-card-id :id}   {:name (format "%s Verified Card" search-term)}
+             :model/Card       {v-model-id :id}  {:name (format "%s Verified Model" search-term) :type :model}
+             :model/Card       {v-metric-id :id} {:name (format "%s Verified Metric" search-term) :type :metric}
+             :model/Collection {_v-coll-id :id}  {:name (format "%s Verified Collection" search-term) :authority_level "official"}]
+            (testing "when has both :content-verification features"
+              (mt/with-premium-features #{:content-verification}
+                (mt/with-verified-cards! [v-card-id v-model-id v-metric-id]
+                  (is (= #{"card" "dataset" "metric"}
+                         (get-available-models :q search-term :verified true))))))
+            (testing "when has :content-verification feature only"
+              (mt/with-premium-features #{:content-verification}
+                (mt/with-verified-cards! [v-card-id]
+                  (is (= #{"card"}
+                         (get-available-models :q search-term :verified true))))))))
+        (testing "return a subset of model for created_at filter"
+          (is (= #{"dashboard" "table" "dataset" "collection" "database" "action" "card" "metric"}
+                 (get-available-models :q search-term :created_at "today"))))
 
-      (testing "return a subset of model for search_native_query filter"
-        (is (= #{"dataset" "action" "card" "metric"}
-               (get-available-models :q search-term :search_native_query true)))))))
+        (testing "return a subset of model for search_native_query filter"
+          (is (= #{"dataset" "action" "card" "metric"}
+                 (get-available-models :q search-term :search_native_query true))))))))
 
 (def ^:private dashboard-count-results
   (letfn [(make-card [dashboard-count]

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -150,6 +150,7 @@
                                           :type nil})
                    (default-search-results)))
 
+;; It is safe to call `search/reindex!` when we are in a `with-temp-index-table` scope.
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn- do-with-search-items [search-string in-root-collection? f]
   (let [data-map      (fn [instance-name]

--- a/test/metabase/search/appdb/index_test.clj
+++ b/test/metabase/search/appdb/index_test.clj
@@ -480,11 +480,13 @@
         (testing "Given various obsolete search indexes"
           (is (every? #'search.index/exists? (cons related-table obsolete-tables))))
         (search.index/reset-index!)
-        (testing "We can create new one"
+        (testing "We can create new index"
           (is (#'search.index/exists? (search.index/active-table))))
         (testing "... without destroying any related non-index tables"
           (is (#'search.index/exists? related-table)))
         (testing "... and we clear out all the obsolete tables"
           (is (every? (comp not #'search.index/exists?) obsolete-tables)))
+        (testing "... and there is no more pending table"
+          (is (not (#'search.index/exists? (#'search.index/pending-table)))))
         (finally
           (#'search.index/drop-table! related-table))))))

--- a/test/metabase/search/appdb/scoring_test.clj
+++ b/test/metabase/search/appdb/scoring_test.clj
@@ -58,6 +58,12 @@
 ;; ---- index-ony rankers ----
 ;; These are the easiest to test, as they don't depend on other appdb state.
 
+(deftest ^:parallel no-search-string-test
+  (with-index-contents
+    [{:model "card" :id 1 :name "orders"}]
+    (testing "For better or worse, we can omit a search query"
+      (is [{:model "card" 1 "orders"}] (search-results* nil)))))
+
 (deftest ^:parallel text-test
   (with-index-contents
     [{:model "card" :id 1 :name "orders"}

--- a/test/metabase/search/test_util.clj
+++ b/test/metabase/search/test_util.clj
@@ -20,7 +20,10 @@
   "Create a temporary index table for the duration of the body."
   [& body]
   `(when (search/supports-index?)
-     (search.index/with-temp-index-table ~@body)))
+     (search.index/with-temp-index-table
+      ;; We need ingestion to happen on the same thread so that it uses the right search index.
+      (binding [metabase.search.ingestion/*force-sync* true]
+        ~@body))))
 
 (defmacro with-api-user [raw-ctx & body]
   `(let [raw-ctx# ~raw-ctx]

--- a/test/metabase/search/test_util.clj
+++ b/test/metabase/search/test_util.clj
@@ -22,8 +22,8 @@
   `(when (search/supports-index?)
      (search.index/with-temp-index-table
       ;; We need ingestion to happen on the same thread so that it uses the right search index.
-      (binding [metabase.search.ingestion/*force-sync* true]
-        ~@body))))
+       (binding [metabase.search.ingestion/*force-sync* true]
+         ~@body))))
 
 (defmacro with-api-user [raw-ctx & body]
   `(let [raw-ctx# ~raw-ctx]

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -35,6 +35,7 @@
    [metabase.permissions.test-util :as perms.test-util]
    [metabase.plugins.classloader :as classloader]
    [metabase.query-processor.util :as qp.util]
+   [metabase.search.core :as search]
    [metabase.task :as task]
    [metabase.test-runner.assert-exprs :as test-runner.assert-exprs]
    [metabase.test.data :as data]
@@ -840,6 +841,8 @@
           :moderated_item_type "card"
           :moderator_id        ((requiring-resolve 'metabase.test.data.users/user->id) :rasta)
           :status              status})))
+    ;; This is only needed when running tests as dev, where index hooks are async
+    (search/reindex!)
     (thunk)))
 
 (defmacro with-verified-cards!


### PR DESCRIPTION
Since we are going to ship with "classic" search in the final 52, our integration tests are still using that variant.

This allowed a NPE to slip through recently in the Friday build, breaking stats and the nightly beta.

As a stop-gap I've switched over some of the relevant API tests to loop over both engine flavors, but we still need more comprehensive solution.

Backlog item for migrating the test suite is here: https://github.com/metabase/metabase/issues/50261