### PR TITLE
Fix logging with conflict handlers

### DIFF
--- a/bin/build/src/build/uberjar.clj
+++ b/bin/build/src/build/uberjar.clj
@@ -6,7 +6,8 @@
    [clojure.tools.namespace.dependency :as ns.deps]
    [clojure.tools.namespace.find :as ns.find]
    [clojure.tools.namespace.parse :as ns.parse]
-   [metabuild-common.core :as u])
+   [metabuild-common.core :as u]
+   [org.corfield.log4j2-conflict-handler :refer [log4j2-conflict-handler]])
   (:import
    (java.io OutputStream)
    (java.nio.file Files OpenOption StandardOpenOption)
@@ -133,10 +134,12 @@
 (defn- create-uberjar! [basis]
   (u/step "Create uberjar"
     (with-duration-ms [duration-ms]
-      (b/uber {:class-dir class-dir
-               :uber-file uberjar-filename
-               :basis     basis
-               :exclude   dependency-ignore-patterns})
+      (b/uber {:class-dir         class-dir
+               :uber-file         uberjar-filename
+               ;; merge Log4j2Plugins.dat files. (#50721)
+               :conflict-handlers log4j2-conflict-handler
+               :basis             basis
+               :exclude           dependency-ignore-patterns})
       (u/announce "Created uberjar in %.1f seconds." (/ duration-ms 1000.0)))))
 
 (def ^:private manifest-entries

--- a/bin/build/src/build_drivers/create_uberjar.clj
+++ b/bin/build/src/build_drivers/create_uberjar.clj
@@ -78,7 +78,7 @@
   "Build a driver jar for `driver`, either an `:oss` or `:ee` `edition`."
   [driver edition]
   (u/step (format "Write %s %s uberjar -> %s" driver edition (c/driver-jar-destination-path driver))
-          (let [start-time-ms (System/currentTimeMillis)]
+    (let [start-time-ms (System/currentTimeMillis)]
       (b/uber
        {:class-dir         (c/compiled-source-target-dir driver)
         :uber-file         (c/driver-jar-destination-path driver)

--- a/bin/build/src/build_drivers/create_uberjar.clj
+++ b/bin/build/src/build_drivers/create_uberjar.clj
@@ -7,7 +7,8 @@
    [clojure.tools.deps.alpha :as deps]
    [clojure.tools.deps.alpha.util.dir :as deps.dir]
    [colorize.core :as colorize]
-   [metabuild-common.core :as u]))
+   [metabuild-common.core :as u]
+   [org.corfield.log4j2-conflict-handler :refer [log4j2-conflict-handler]]))
 
 (set! *warn-on-reflection* true)
 
@@ -77,12 +78,14 @@
   "Build a driver jar for `driver`, either an `:oss` or `:ee` `edition`."
   [driver edition]
   (u/step (format "Write %s %s uberjar -> %s" driver edition (c/driver-jar-destination-path driver))
-    (let [start-time-ms (System/currentTimeMillis)]
+          (let [start-time-ms (System/currentTimeMillis)]
       (b/uber
-       {:class-dir (c/compiled-source-target-dir driver)
-        :uber-file (c/driver-jar-destination-path driver)
-        :basis     (uberjar-basis driver edition)
+       {:class-dir         (c/compiled-source-target-dir driver)
+        :uber-file         (c/driver-jar-destination-path driver)
+        :basis             (uberjar-basis driver edition)
+        ;; merge Log4j2Plugins.dat files. (#50721)
+        :conflict-handlers log4j2-conflict-handler
         ;; we need to skip this file since on MacOS it conflicts with other licenses, see:
         ;; https://ask.clojure.org/index.php/13231/switch-tools-build-pull-from-jars-rather-than-exploding-onto
-        :exclude   ["META-INF/LICENSE"]})
+        :exclude           ["META-INF/LICENSE"]})
       (u/announce "Created uberjar in %d ms." (- (System/currentTimeMillis) start-time-ms)))))

--- a/deps.edn
+++ b/deps.edn
@@ -667,7 +667,9 @@
     io.github.clojure/tools.build     {:mvn/version "0.10.6"}
     org.clojure/data.xml              {:mvn/version "0.2.0-alpha9"}
     org.clojure/tools.deps.alpha      {:mvn/version "0.15.1254"}
-    org.fedorahosted.tennera/jgettext {:mvn/version "0.15.1"}}
+    org.fedorahosted.tennera/jgettext {:mvn/version "0.15.1"}
+
+    io.github.seancorfield/build-uber-log4j2-handler {:git/tag "v2.24.0" :git/sha "de93f51"}} ; collect binary files for log4j2
 
    :jvm-opts
    ["-Dclojure.main.report=stderr"


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/50721

Information:
https://github.com/seancorfield/depstar
https://github.com/seancorfield/build-uber-log4j2-handler

Gist is that log4j needs all of it's plugin files merged into one file. Lots of
`META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat` files become one.

In our jar currently it is 3247 bytes. In older good jars it is 28463 bytes.

Before:

```
❯ MB_JETTY_PORT=3006 java -jar before.jar
Warning: environ value /Users/dan/.sdkman/candidates/java/current for key :java-home has been overwritten with /Users/dan/.sdkman/candidates/java/21.0.2-tem
2024-12-02T03:58:45.591114Z main ERROR Unrecognized format specifier [d]
2024-12-02T03:58:45.592271Z main ERROR Unrecognized conversion specifier [d] starting at position 16 in conversion pattern.
2024-12-02T03:58:45.592893Z main ERROR Unrecognized format specifier [thread]
2024-12-02T03:58:45.592989Z main ERROR Unrecognized conversion specifier [thread] starting at position 25 in conversion pattern.
2024-12-02T03:58:45.593101Z main ERROR Unrecognized format specifier [level]
2024-12-02T03:58:45.593187Z main ERROR Unrecognized conversion specifier [level] starting at position 35 in conversion pattern.
2024-12-02T03:58:45.593291Z main ERROR Unrecognized format specifier [logger]
2024-12-02T03:58:45.593375Z main ERROR Unrecognized conversion specifier [logger] starting at position 47 in conversion pattern.
2024-12-02T03:58:45.593459Z main ERROR Unrecognized format specifier [msg]
2024-12-02T03:58:45.593541Z main ERROR Unrecognized conversion specifier [msg] starting at position 54 in conversion pattern.
2024-12-02T03:58:45.593628Z main ERROR Unrecognized format specifier [n]
2024-12-02T03:58:45.593710Z main ERROR Unrecognized conversion specifier [n] starting at position 56 in conversion pattern.
2024-12-02T03:58:45.603389Z main ERROR Reconfiguration failed: No configuration found for 'Default' at 'null' in 'null'
WARNING: infinite? already refers to: #'clojure.core/infinite? in namespace: kixi.stats.core, being replaced by: #'kixi.stats.math/infinite?

UPDATE SUMMARY
Run:                        436
Previously run:               0
Filtered out:                52
-------------------------------
Total change sets:          488

FILTERED CHANGE SETS SUMMARY
DBMS mismatch:               52
```

And now after:

```
❯ MB_JETTY_PORT=3007 java -jar after.jar
Warning: environ value /Users/dan/.sdkman/candidates/java/current for key :java-home has been overwritten with /Users/dan/.sdkman/candidates/java/21.0.2-tem
2024-12-01 21:58:49,892 INFO metabase.util :: Maximum memory available to JVM: 8.0 GB
2024-12-01 21:58:51,121 INFO util.encryption :: Saved credentials encryption is DISABLED for this Metabase instance. 🔓
 For more information, see https://metabase.com/docs/latest/operations-guide/encrypting-database-details-at-rest.html
2024-12-01 21:58:51,591 WARN db.env :: WARNING: Using Metabase with an H2 application database is not recommended for production deployments. For production deployments, we highly recommend using Postgres, MySQL, or MariaDB instead. If you decide to continue to use H2, please be sure to back up the database file regularly. For more information, see https://metabase.com/docs/latest/operations-guide/migrating-from-h2.html
WARNING: infinite? already refers to: #'clojure.core/infinite? in namespace: kixi.stats.core, being replaced by: #'kixi.stats.math/infinite?
2024-12-01 21:58:54,353 INFO driver.impl :: Registered abstract driver :sql  🚚
2024-12-01 21:58:54,375 INFO driver.impl :: Registered abstract driver :sql-jdbc (parents: [:sql]) 🚚
2024-12-01 21:58:54,379 INFO metabase.util :: Load driver :sql-jdbc took 7.3 ms
2024-12-01 21:58:54,379 INFO driver.impl :: Registered driver :h2 (parents: [:sql-jdbc]) 🚚
2024-12-01 21:58:54,525 INFO driver.impl :: Registered driver :mysql (parents: [:sql-jdbc]) 🚚
2024-12-01 21:58:54,543 INFO driver.impl :: Registered driver :postgres (parents: [:sql-jdbc]) 🚚
2024-12-01 21:58:54,642 INFO util.namespaces :: Loading namespace: metabase.notification.payload.impl.alert
2024-12-01 21:58:54,646 INFO util.namespaces :: Loading namespace: metabase.notification.payload.impl.dashboard-subscription
2024-12-01 21:58:54,648 INFO util.namespaces :: Loading namespace: metabase.notification.payload.impl.system-event
2024-12-01 21:58:54,655 INFO util.namespaces :: Loading namespace: metabase.channel.impl.email
2024-12-01 21:58:54,663 INFO util.namespaces :: Loading namespace: metabase.channel.impl.http
2024-12-01 21:58:54,667 INFO util.namespaces :: Loading namespace: metabase.channel.impl.slack
2024-12-01 21:58:55,520 INFO metabase.core ::
Metabase v0.52.1-SNAPSHOT (3e7a8a4)

Copyright © 2024 Metabase, Inc.

Metabase Enterprise Edition extensions are NOT PRESENT.
2024-12-01 21:58:55,522 INFO metabase.core :: Starting Metabase in STANDALONE mode
2024-12-01 21:58:55,550 INFO metabase.server :: Launching Embedded Jetty Webserver with config:
 {:port 3007}
```
