### PR TITLE
add file id to to the upload-file method

### DIFF
--- a/src/metabase/api/slack.clj
+++ b/src/metabase/api/slack.clj
@@ -22,7 +22,7 @@
         version-info (get-in diagnostic-info [:bugReportDetails :metabase-info :version])
         file-url (if (string? file-info)
                    file-info
-                   (get file-info :url_private))]
+                   (:url file-info))]
     [{:type "section"
       :text {:type "mrkdwn"
              :text "A new bug report has been submitted. Please check it out!"}}
@@ -57,7 +57,7 @@
                   :url (str "https://metabase-debugger.vercel.app/?fileId="
                             (if (string? file-info)
                               (last (str/split file-info #"/"))  ; Extract file ID from URL
-                              (get file-info :id)))
+                              (:id file-info)))
                   :style "primary"}
                  {:type "button"
                   :text {:type "plain_text"

--- a/src/metabase/channel/impl/slack.clj
+++ b/src/metabase/channel/impl/slack.clj
@@ -72,9 +72,9 @@
                                   (-> (f attachment-data)
                                       (assoc :text (:render/text rendered-info)))
                                   (let [image-bytes (channel.render/png-from-render-info rendered-info slack-width)
-                                        image-url   (slack/upload-file! image-bytes attachment-name channel-id)]
+                                        {:keys [url]} (slack/upload-file! image-bytes attachment-name channel-id)]
                                     (-> (f attachment-data)
-                                        (assoc :image_url image-url)))))))
+                                        (assoc :image_url url)))))))
             []
             attachments)))
 

--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -428,9 +428,9 @@
         file-url (complete! {:channel-id (maybe-lookup-id channel-id (slack-cached-channels-and-usernames))
                              :file-id    file_id
                              :filename   filename})]
-    (u/prog1 file-url
-      (log/debug "Uploaded image" <>))))
-
+    (u/prog1 {:url file-url
+              :id file_id}
+      (log/debug "Uploaded image" (:url <>)))))
 (mu/defn post-chat-message!
   "Calls Slack API `chat.postMessage` endpoint and posts a message to a channel. `attachments` can be either serialized JSON for notification attachments or a map containing blocks."
   [channel-id  :- ms/NonBlankString

--- a/test/metabase/channel/impl/slack_test.clj
+++ b/test/metabase/channel/impl/slack_test.clj
@@ -8,7 +8,8 @@
   (let [slack-uploader (fn [storage]
                          (fn [_bytes attachment-name _channel-id]
                            (swap! storage conj attachment-name)
-                           (str "http://uploaded/" attachment-name)))]
+                           {:url (str "http://uploaded/" attachment-name)
+                            :id (str "ID_" attachment-name)}))]
     (testing "Uploads files"
       (let [titles         (atom [])
             attachments    [{:title           "a"

--- a/test/metabase/integrations/slack_test.clj
+++ b/test/metabase/integrations/slack_test.clj
@@ -193,7 +193,8 @@
       (http-fake/with-fake-routes fake-upload-routes
         (tu/with-temporary-setting-values [slack-token "test-token"
                                            slack-app-token nil]
-          (is (= "https://files.slack.com/files-pri/DDDDDDDDD-EEEEEEEEE/wow.gif"
+          (is (= {:url "https://files.slack.com/files-pri/DDDDDDDDD-EEEEEEEEE/wow.gif"
+                  :id "DDDDDDDDD-EEEEEEEEE"}
                  (slack/upload-file! image-bytes filename channel-id)))))
       ;; Slack app token requires joining the `metabase_files` channel before uploading a file
       (http-fake/with-fake-routes
@@ -202,7 +203,8 @@
                (fn [_] (mock-200-response (slurp "./test_resources/slack_conversations_join_response.json"))))
         (tu/with-temporary-setting-values [slack-token nil
                                            slack-app-token "test-token"]
-          (is (= "https://files.slack.com/files-pri/DDDDDDDDD-EEEEEEEEE/wow.gif"
+          (is (= {:url "https://files.slack.com/files-pri/DDDDDDDDD-EEEEEEEEE/wow.gif"
+                  :id "DDDDDDDDD-EEEEEEEEE"}
                  (slack/upload-file! image-bytes filename channel-id))))
         (testing (str "upload-file! will attempt to join channels by internal slack id"
                       " but we can continue to use the channel name for posting")


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50732

### Description

Debugger shows a button "jump to debugger". This stopped working after integrating bug reporting into metabase’s codebase, because debugger relies on a file id. This wasn’t being passed from the upload_file method. This PR fixes that while keeping the original functionality as it was.

### How to verify

You can press F1 to report a bug to slack and then click "jump to debugger" button.

- [x] Tests have been added/updated to cover changes in this PR
