### PR TITLE
[Notification] insert and replace instead of truncate

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10083,7 +10083,7 @@ databaseChangeLog:
       id: v52.2024-12-10T10:00:00
       author: qnkhuat
       comment: Truncate the notification tables
-      rollback: # not needed)
+      rollback: # not needed
       changes:
         - sql:
             dbms: postgresql

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10100,6 +10100,10 @@ databaseChangeLog:
                     nullable: true
                     unique: true
 
+  # Prior to this, we used to truncate then insert notifications on startup (#50127)
+  # But we can't do that anymore because pulses are migated to notificaiton, so moving forward
+  # we'll insert/replace notifications on startup (see metabase.notification.seed)
+  # We need to do another truncate here so we have a clean slate for the new notifications
   - changeSet:
       id: v52.2024-12-10T10:00:10
       author: qnkhuat
@@ -10131,6 +10135,11 @@ databaseChangeLog:
         - sql:
             dbms: h2
             sql: >-
+              DELETE FROM notification;
+              DELETE FROM notification_handler;
+              DELETE FROM notification_subscription;
+              DELETE FROM notification_recipient;
+              DELETE FROM channel_template;
               ALTER TABLE notification ALTER COLUMN id RESTART WITH 1;
               ALTER TABLE notification_handler ALTER COLUMN id RESTART WITH 1;
               ALTER TABLE notification_subscription ALTER COLUMN id RESTART WITH 1;

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10082,6 +10082,27 @@ databaseChangeLog:
   - changeSet:
       id: v52.2024-12-10T10:00:00
       author: qnkhuat
+      comment: add notification.internal_id
+      preConditions:
+        - not:
+          - columnExists:
+              tableName: notification
+              columnName: internal_id
+      changes:
+        - addColumn:
+            tableName: notification
+            columns:
+              - column:
+                  name: internal_id
+                  type: varchar(254)
+                  remarks: the internal id of the notification
+                  constraints:
+                    nullable: true
+                    unique: true
+
+  - changeSet:
+      id: v52.2024-12-10T10:00:10
+      author: qnkhuat
       comment: Truncate the notification tables
       rollback: # not needed
       changes:

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10101,7 +10101,7 @@ databaseChangeLog:
                     unique: true
 
   # Prior to this, we used to truncate then insert notifications on startup (#50127)
-  # But we can't do that anymore because pulses are migated to notificaiton, so moving forward
+  # But we can't do that anymore because pulses are migated to notification, so moving forward
   # we'll insert/replace notifications on startup (see metabase.notification.seed)
   # We need to do another truncate here so we have a clean slate for the new notifications
   - changeSet:

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10079,6 +10079,43 @@ databaseChangeLog:
         - customChange:
             class: "metabase.db.custom_migrations.CreateSampleContentV2"
 
+  - changeSet:
+      id: v52.2024-12-10T10:00:00
+      author: qnkhuat
+      comment: Truncate the notification tables
+      rollback: # not needed)
+      changes:
+        - sql:
+            dbms: postgresql
+            sql: >-
+              TRUNCATE TABLE notification RESTART IDENTITY CASCADE;
+              TRUNCATE TABLE notification_handler RESTART IDENTITY CASCADE;
+              TRUNCATE TABLE notification_subscription RESTART IDENTITY CASCADE;
+              TRUNCATE TABLE notification_recipient RESTART IDENTITY CASCADE;
+              TRUNCATE TABLE channel_template RESTART IDENTITY CASCADE;
+        - sql:
+            dbms: mysql,mariadb
+            sql: >-
+              DELETE FROM notification;
+              ALTER TABLE notification AUTO_INCREMENT = 1;
+              DELETE FROM notification_handler;
+              ALTER TABLE notification_handler AUTO_INCREMENT = 1;
+              DELETE FROM notification_subscription;
+              ALTER TABLE notification_subscription AUTO_INCREMENT = 1;
+              DELETE FROM notification_recipient;
+              ALTER TABLE notification_recipient AUTO_INCREMENT = 1;
+              DELETE FROM channel_template;
+              ALTER TABLE channel_template AUTO_INCREMENT = 1;
+
+        - sql:
+            dbms: h2
+            sql: >-
+              ALTER TABLE notification ALTER COLUMN id RESTART WITH 1;
+              ALTER TABLE notification_handler ALTER COLUMN id RESTART WITH 1;
+              ALTER TABLE notification_subscription ALTER COLUMN id RESTART WITH 1;
+              ALTER TABLE notification_recipient ALTER COLUMN id RESTART WITH 1;
+              ALTER TABLE channel_template ALTER COLUMN id RESTART WITH 1;
+
  # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -153,7 +153,7 @@
     (init-status/set-progress! 0.8))
 
   (ensure-audit-db-installed!)
-  (notification/truncate-then-seed-notification!)
+  (notification/seed-notification!)
   (init-status/set-progress! 0.9)
 
   (embed.settings/check-and-sync-settings-on-startup! env/env)

--- a/src/metabase/models/notification.clj
+++ b/src/metabase/models/notification.clj
@@ -44,6 +44,10 @@
 (t2/deftransforms :model/Notification
   {:payload_type (mi/transform-validator mi/transform-keyword (partial mi/assert-enum notification-types))})
 
+(t2/define-after-select :model/Notification
+  [notification]
+  (dissoc notification :internal_id))
+
 (methodical/defmethod t2/batched-hydrate [:model/Notification :subscriptions]
   "Batch hydration NotificationSubscriptions for a list of Notifications."
   [_model k notifications]

--- a/src/metabase/notification/core.clj
+++ b/src/metabase/notification/core.clj
@@ -17,7 +17,7 @@
   Notification
   NotificationPayload]
  [notification.seed
-  truncate-then-seed-notification!])
+  seed-notification!])
 
 (def ^:private Options
   [:map

--- a/src/metabase/notification/seed.clj
+++ b/src/metabase/notification/seed.clj
@@ -1,98 +1,115 @@
 (ns metabase.notification.seed
   "Seed default notifications on startup.
-  Will truncate al notifications related tables then reinsert the default notifications."
+  No-op if none of the notifications are changed.
+  If a notification is changed, it will be replaced with the new one."
   (:require
-   [metabase.db :as db]
    [metabase.models.notification :as models.notification]
    [metabase.models.permissions-group :as perms-group]
+   [metabase.util :as u]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [toucan2.core :as t2]))
 
+(def ^:private model->compare-keys
+  "A mapping of model to the keys that are used to check if a row is the same."
+  {:model/Notification             [:payload_type :active]
+   :model/NotificationSubscription [:type :event_name :cron_schedule]
+   :model/NotificationHandler      [:channel_type :active]
+   :model/NotificationRecipient    [:type :user_id :permissions_group_id :details]
+   :model/Channel                  [:channel_type :details]
+   :model/ChannelTemplate          [:channel_type :name :details]})
+
+(defn- select-keys-nil-vals
+  "Select keys from a map, missing keys are included with value = nil."
+  [m ks]
+  (merge (into {} (zipmap ks (repeat nil)))
+         (select-keys m ks)))
+
+(defn- sanitize-model
+  [model data]
+  (select-keys-nil-vals data (get model->compare-keys model)))
+
+(defn- sanitize-notification
+  [{:keys [subscriptions handlers] :as notification}]
+  (assoc (sanitize-model :model/Notification notification)
+         :subscriptions (set (mapv #(sanitize-model :model/NotificationSubscription %) subscriptions))
+         :handlers      (set (mapv (fn [{:keys [channel template recipients] :as handler}]
+                                     (assoc (sanitize-model :model/NotificationHandler handler)
+                                            :channel    (sanitize-model :model/Channel channel)
+                                            :template   (sanitize-model :model/ChannelTemplate template)
+                                            :recipients (set (mapv #(sanitize-model :model/NotificationRecipient %) recipients))))
+                                   handlers))))
+
 (def ^:private default-notifications
+  "List of notifications that are seeded into the database on startup.
+  This list should only be modified or appended, never removed.
+  In order to remove a notification, it should be marked as inactive."
   (delay [;; user invited
-          {:notification  {:payload_type :notification/system-event}
-           :subscriptions [{:type            :notification-subscription/system-event
-                            :event_name      :event/user-invited}]
-           :handlers      [{:channel_type :channel/email
+          {:internal_id   "system-event/user-invited"
+           :active        true
+           :payload_type  :notification/system-event
+           :subscriptions [{:type       :notification-subscription/system-event
+                            :event_name :event/user-invited}]
+           :handlers      [{:active       true
+                            :channel_type :channel/email
                             :channel_id   nil
                             :template     {:name         "User joined Email template"
                                            :channel_type :channel/email
                                            :details      {:type           "email/handlebars-resource"
                                                           :subject        "{{payload.custom.user_invited_email_subject}}"
                                                           :path           "metabase/email/new_user_invite.hbs"
-                                                          :recipient-type :cc}
-                                           :created_at   :%now
-                                           :updated_at   :%now}
+                                                          :recipient-type "cc"}}
                             :recipients   [{:type    :notification-recipient/template
                                             :details {:pattern "{{payload.event_info.object.email}}"}}]}]}
-          ;; alert created
-          {:notification  {:payload_type :notification/system-event}
-           :subscriptions [{:type            :notification-subscription/system-event
-                            :event_name      :event/alert-create}]
-           :handlers      [{:channel_type :channel/email
+
+          ;; alert new confirmation
+          {:internal_id   "system-event/alert-new-confirmation"
+           :active        true
+           :payload_type  :notification/system-event
+           :subscriptions [{:type       :notification-subscription/system-event
+                            :event_name :event/alert-create}]
+           :handlers      [{:active       true
+                            :channel_type :channel/email
                             :channel_id   nil
                             :template     {:name         "Alert Created Email template"
                                            :channel_type "channel/email"
-                                           :details      {:type           "email/handlebars-resource"
-                                                          :subject        "You set up an alert"
-                                                          :path           "metabase/email/alert_new_confirmation.hbs"
-                                                          :recipient-type :cc}
-                                           :created_at   :%now
-                                           :updated_at   :%now}
-                            :recipients   [{:type    :notification-recipient/template
-                                            :details {:pattern "{{payload.event_info.user.email}}"}}]}]}
+                                           :details      {:type "email/handlebars-resource"
+                                                          :subject "You set up an alert"
+                                                          :path "metabase/email/alert_new_confirmation.hbs"
+                                                          :recipient-type "cc"}}
+                            :recipients  [{:type    :notification-recipient/template
+                                           :details {:pattern "{{payload.event_info.user.email}}"}}]}]}
 
           ;; slack token invalid
-          {:notification  {:payload_type :notification/system-event}
-           :subscriptions [{:type            :notification-subscription/system-event
-                            :event_name      :event/slack-token-invalid}]
-           :handlers      [{:channel_type    :channel/email
-                            :channel_id      nil
-                            :template        {:name         "Slack Token Error Email template"
-                                              :channel_type "channel/email"
-                                              :details      {:type           "email/handlebars-resource"
-                                                             :subject        "Your Slack connection stopped working"
-                                                             :path           "metabase/email/slack_token_error.hbs"
-                                                             :recipient-type :cc}
-                                              :created_at   :%now
-                                              :updated_at   :%now}
-                            :recipients      [{:type    :notification-recipient/template
-                                               :details {:pattern     "{{context.admin_email}}"
-                                                         :is_optional true}}
-                                              {:type                 :notification-recipient/group
-                                               :permissions_group_id (:id (perms-group/admin))}]}]}]))
+          {:internal_id   "system-event/slack-token-error"
+           :active        true
+           :payload_type  :notification/system-event
+           :subscriptions [{:type       :notification-subscription/system-event
+                            :event_name :event/slack-token-invalid}]
+           :handlers      [{:active       true
+                            :channel_type :channel/email
+                            :channel_id   nil
+                            :template     {:name         "Slack Token Error Email template"
+                                           :channel_type "channel/email"
+                                           :details      {:type "email/handlebars-resource"
+                                                          :subject "Your Slack connection stopped working"
+                                                          :path "metabase/email/slack_token_error.hbs"
+                                                          :recipient-type "cc"}}
+                            :recipients   [{:type    :notification-recipient/template
+                                            :details {:pattern "{{context.admin_email}}" :is_optional true}}
+                                           {:type                 :notification-recipient/group
+                                            :permissions_group_id (:id (perms-group/admin))}]}]}]))
 
-(def ^:private notification-related-models
-  [:model/Notification
-   :model/NotificationHandler
-   :model/NotificationSubscription
-   :model/NotificationRecipient
-   :model/ChannelTemplate])
 
-(defn- truncate-table!
-  "Truncate a table and restart the identity column."
-  [table-name]
-  (case (db/db-type)
-    :postgres
-    (t2/query {:truncate [table-name :restart :identity :cascade]})
-    :mysql
-    (do
-      (t2/delete! table-name)
-      (t2/query (format "ALTER TABLE `%s` AUTO_INCREMENT = 1" (name table-name))))
-    (do
-      (t2/delete! table-name)
-      (t2/query {:alter-table [table-name {:alter-column [:id :restart :with 1]}]}))))
-
-(defn- truncate-notification-related-tables!
-  []
-  (doseq [model notification-related-models
-          :let [table (t2/table-name model)]]
-    (log/infof "Truncating table %s" table)
-    (truncate-table! table)))
+(defn- cleanup-notification!
+  [internal-id existing-row]
+  (t2/delete! :model/Notification :internal_id internal-id)
+  (when-let [template-ids (->> existing-row :handlers (map (comp :id :template)) (filter some?) not-empty)]
+    (t2/delete! :model/ChannelTemplate :id [:in template-ids])))
 
 (defn- create-notification!
-  [{:keys [notification subscriptions handlers]}]
-  (let [handlers (for [handler handlers]
+  [notification]
+  (let [handlers (for [handler (:handlers notification)]
                    (if-let [template (:template handler)]
                      (-> handler
                          (dissoc :template)
@@ -100,25 +117,55 @@
                                               :model/ChannelTemplate
                                               template)))
                      handler))]
-    (models.notification/create-notification! notification subscriptions handlers)))
+    (models.notification/create-notification!
+     (dissoc notification :handlers :subscriptions)
+     (:subscriptions notification)
+     handlers)))
 
-(defn- seed-notification!
-  "Seed default notifications"
+(defn- replace-notification!
+  "Replace an existing notification with a new one"
+  [existing-row {:keys [internal_id] :as new-row}]
+  (cleanup-notification! internal_id existing-row)
+  (create-notification! new-row))
+
+(defn- action
+  [existing-row new-row]
+  (cond
+    (nil? existing-row)
+    :create
+    ;; use json to compare to avoid any difference like keyword vs string
+    (not= (json/encode (sanitize-notification existing-row)) (json/encode (sanitize-notification new-row)))
+    :replace
+    :else
+    :skip))
+
+(defn- sync-notification!
+  [{:keys [internal_id] :as row}]
+  (let [existing-notification (some-> (t2/select-one :model/Notification :internal_id internal_id)
+                                      models.notification/hydrate-notification)]
+    (u/prog1 (action existing-notification row)
+      (case <>
+        :create
+        (do
+          (log/debugf "Creating notification %s" internal_id)
+          (create-notification! row))
+        :replace
+        (do
+          (log/debugf "Replacing notification %s" internal_id)
+          (replace-notification! existing-notification row))
+        :skip
+        (do
+          (log/debugf "Skipping notification %s" internal_id)
+          nil)))))
+
+(defn seed-notification!
+  "Seed default notifications into the database.
+  If a notification already exists, it'll be replaced if it's changed, otherwise it'll be skipped."
   []
   (log/info "Seeding default notifications")
-  (doseq [row @default-notifications]
-    (create-notification! row))
-  (log/infof "Seeded %d notifications" (count @default-notifications)))
-
-(defn truncate-then-seed-notification!
-  "Truncate all notifications related tables then seed it with the default notifications.
-  Runs on every deployment by metabase.task.seed_notification.
-
-  We do this instead of migrations because we want to be able to modify the default notifications
-  without having to write migrations.
-
-  This is possible because as of now users can't modify notifications or channel template."
-  []
-  (t2/with-transaction []
-    (truncate-notification-related-tables!)
-    (seed-notification!)))
+  (let [actions (t2/with-transaction []
+                  (doall (for [row @default-notifications]
+                           (sync-notification! row))))
+        summary (frequencies actions)]
+    (log/infof "Seeded notifications: %s" summary)
+    summary))

--- a/src/metabase/notification/seed.clj
+++ b/src/metabase/notification/seed.clj
@@ -103,7 +103,6 @@
                                            {:type                 :notification-recipient/group
                                             :permissions_group_id (:id (perms-group/admin))}]}]}]))
 
-
 (defn- cleanup-notification!
   [internal-id existing-row]
   (t2/delete! :model/Notification :internal_id internal-id)

--- a/src/metabase/notification/seed.clj
+++ b/src/metabase/notification/seed.clj
@@ -1,7 +1,7 @@
 (ns metabase.notification.seed
   "Seed default notifications on startup.
   No-op if none of the notifications are changed.
-  If a notification is changed, it will be replaced with the new one."
+  If a notification is changed, it will be replaced with a new one."
   (:require
    [metabase.models.notification :as models.notification]
    [metabase.models.permissions-group :as perms-group]

--- a/src/metabase/notification/seed.clj
+++ b/src/metabase/notification/seed.clj
@@ -139,10 +139,17 @@
     :else
     :skip))
 
+(defn- hydrate-notification
+  [notification]
+  (t2/hydrate notification
+              :subscriptions
+              [:handlers :channel :template :recipients]))
+
 (defn- sync-notification!
   [{:keys [internal_id] :as row}]
   (let [existing-notification (some-> (t2/select-one :model/Notification :internal_id internal_id)
-                                      models.notification/hydrate-notification)]
+                                      hydrate-notification)]
+
     (u/prog1 (action existing-notification row)
       (case <>
         :create

--- a/src/metabase/notification/seed.clj
+++ b/src/metabase/notification/seed.clj
@@ -107,7 +107,7 @@
 (defn- cleanup-notification!
   [internal-id existing-row]
   (t2/delete! :model/Notification :internal_id internal-id)
-  (when-let [template-ids (->> existing-row :handlers (map (comp :id :template)) (filter some?) not-empty)]
+  (when-let [template-ids (->> existing-row :handlers (keep (comp :id :template)) seq)]
     (t2/delete! :model/ChannelTemplate :id [:in template-ids])))
 
 (defn- create-notification!

--- a/test/metabase/notification/seed_test.clj
+++ b/test/metabase/notification/seed_test.clj
@@ -3,7 +3,6 @@
    [clojure.test :refer :all]
    [clojure.walk :as walk]
    [medley.core :as m]
-   [metabase.models.notification :as models.notification]
    [metabase.notification.seed :as notification.seed]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
@@ -23,7 +22,7 @@
 (deftest seed-notification!-is-idempotent
   (mt/with-empty-h2-app-db
     (let [get-notifications-data #(-> (t2/select :model/Notification)
-                                      (models.notification/hydrate-notification)
+                                      @#'notification.seed/hydrate-notification
                                       nullify-timestamp)
           default-notifications-cnt (count @@#'notification.seed/default-notifications)]
       (testing "seed the first time will insert all default notifications"

--- a/test/metabase/notification/seed_test.clj
+++ b/test/metabase/notification/seed_test.clj
@@ -22,7 +22,7 @@
 (deftest seed-notification!-is-idempotent
   (mt/with-empty-h2-app-db
     (let [get-notifications-data #(-> (t2/select :model/Notification)
-                                      @#'notification.seed/hydrate-notification
+                                      (#'notification.seed/hydrate-notification)
                                       nullify-timestamp)
           default-notifications-cnt (count @@#'notification.seed/default-notifications)]
       (testing "seed the first time will insert all default notifications"
@@ -34,7 +34,6 @@
                  (notification.seed/seed-notification!))))
         (testing "it equals to the data before "
           (is (= before (get-notifications-data))))))))
-
 
 (deftest sync-notification!-test
   (let [internal-id       (mt/random-name)

--- a/test/metabase/notification/seed_test.clj
+++ b/test/metabase/notification/seed_test.clj
@@ -3,7 +3,9 @@
    [clojure.test :refer :all]
    [clojure.walk :as walk]
    [medley.core :as m]
+   [metabase.models.notification :as models.notification]
    [metabase.notification.seed :as notification.seed]
+   [metabase.test :as mt]
    [toucan2.core :as t2]))
 
 (defn- nullify-timestamp
@@ -18,11 +20,76 @@
        x))
    data))
 
-(deftest truncate-then-seed-notification!-is-idempotent
-  (let [get-notifications-data #(-> (t2/select :model/Notification)
-                                    (t2/hydrate [:handlers :channel :template :recipients])
-                                    nullify-timestamp)]
-    (notification.seed/truncate-then-seed-notification!)
-    (let [before (get-notifications-data)]
-      (notification.seed/truncate-then-seed-notification!)
-      (is (= before (get-notifications-data))))))
+(deftest seed-notification!-is-idempotent
+  (mt/with-empty-h2-app-db
+    (let [get-notifications-data #(-> (t2/select :model/Notification)
+                                      (models.notification/hydrate-notification)
+                                      nullify-timestamp)
+          default-notifications-cnt (count @@#'notification.seed/default-notifications)]
+      (testing "seed the first time will insert all default notifications"
+        (is (= {:create default-notifications-cnt}
+               (notification.seed/seed-notification!))))
+      (let [before (get-notifications-data)]
+        (testing "skip all since none of the notifications were changed"
+          (is (= {:skip 3}
+                 (notification.seed/seed-notification!))))
+        (testing "it equals to the data before "
+          (is (= before (get-notifications-data))))))))
+
+
+(deftest sync-notification!-test
+  (let [internal-id       (mt/random-name)
+        template-name     (mt/random-name)
+        test-notification {:internal_id   internal-id
+                           :active        true
+                           :payload_type  :notification/system-event
+                           :subscriptions [{:type       :notification-subscription/system-event
+                                            :event_name :event/user-invited}]
+                           :handlers      [{:active       true
+                                            :channel_type :channel/metabase-test
+                                            :channel_id   nil
+                                            :template     {:name         template-name
+                                                           :channel_type :channel/metabase-test}
+                                            :recipients   []}]}]
+    (mt/with-model-cleanup [:model/Notification]
+      (is (= :create (#'notification.seed/sync-notification! test-notification)))
+      (testing "skip if the notification is unchanged"
+        (is (= :skip (#'notification.seed/sync-notification! test-notification))))
+      (let [notification-id (t2/select-one-pk :model/Notification :internal_id internal-id)
+            template-id     (t2/select-one-pk :model/ChannelTemplate :name template-name)]
+        (testing "If the notification is changed, delete the old one and replace it with a new one"
+          (is (= :replace (#'notification.seed/sync-notification! (assoc test-notification :active false))))
+          (testing "both notification and template are deleted"
+            (is (false? (t2/exists? :model/Notification :id notification-id)))
+            (is (false? (t2/exists? :model/ChannelTemplate :id template-id)))))))))
+
+
+(def ^:private test-notification
+  {:internal_id   "metabase-testing"
+   :active        true
+   :payload_type  :notification/system-event
+   :subscriptions [{:type       :notification-subscription/system-event
+                    :event_name :event/user-invited}]
+   :handlers      [{:active       true
+                    :channel_type :channel/email
+                    :channel_id   nil
+                    :template     {:name         "Template name"
+                                   :channel_type :channel/metabase-test}
+                    :recipients   [{:type    :notification-recipient/user
+                                    :user_id 1}]}]})
+
+(deftest action-test
+  (let [check-change (fn [new-notification]
+                       (#'notification.seed/action test-notification new-notification))]
+    (testing ":skip if nothing changed"
+      (is (= :skip (check-change test-notification))))
+    (testing ":replace if notification.active changes"
+      (is (= :replace (check-change (update test-notification :active not)))))
+    (testing ":replace if notification.subscriptions changes"
+      (is (= :replace (check-change (assoc-in test-notification [:subscriptions 0 :event_name] :event/user-uninvited)))))
+    (testing ":replace if template changed"
+      (is (= :replace (check-change (assoc-in test-notification [:handlers 0 :template :name] "new name")))))
+    (testing ":replace if handlers.active changed"
+      (is (= :replace (check-change (assoc-in test-notification [:handlers 0 :active] not)))))
+    (testing ":replace if recipients changed"
+      (is (= :replace (check-change (update-in test-notification [:handlers 0 :recipients] conj {:type :notification-recipient/user :user_id 2})))))))

--- a/test/metabase/notification/seed_test.clj
+++ b/test/metabase/notification/seed_test.clj
@@ -61,7 +61,6 @@
             (is (false? (t2/exists? :model/Notification :id notification-id)))
             (is (false? (t2/exists? :model/ChannelTemplate :id template-id)))))))))
 
-
 (def ^:private test-notification
   {:internal_id   "metabase-testing"
    :active        true

--- a/test/metabase/test/initialize.clj
+++ b/test/metabase/test/initialize.clj
@@ -116,7 +116,7 @@
 
 (define-initialization :notifications
   (initialize-if-needed! :db)
-  (notification/truncate-then-seed-notification!))
+  (notification/seed-notification!))
 
 (defn- all-components
   "Set of all components/initialization steps that are defined."


### PR DESCRIPTION
In https://github.com/metabase/metabase/pull/50127 we introduced truncate then insert mechanism for default notifications, as we're going to migrate pulse to notification this no longer viable.

So instead we're going to insert the first time, for subsequent startups: we'll check if the notification are changed and replace them if they are.

We do this by adding a `notification.internal_id` column for the default notifications, we'll use this key to ID them and hydrate all sub-resources to check for changes.