### PR TITLE
Make e2e tests of embedding and sql filters date-invariant

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -1157,8 +1157,8 @@ describeEE("issue 8490", () => {
 
       cy.log("assert the line chart");
       getDashboardCard(0).within(() => {
-        // X-axis labels: Jan 2024
-        cy.findByText("1월 2024").should("be.visible");
+        // X-axis labels: Jan 2024 (or some other year)
+        cy.findByText(/1월 20\d\d\b/).should("be.visible");
         // Aggregation "count"
         cy.findByText("카운트").should("be.visible");
       });
@@ -1200,8 +1200,8 @@ describeEE("issue 8490", () => {
     });
 
     cy.findByTestId("embed-frame").within(() => {
-      // X-axis labels: Jan 2023
-      cy.findByText("11월 2023").should("be.visible");
+      // X-axis labels: Jan 2023 (or some other year)
+      cy.findByText(/11월 20\d\d\b/).should("be.visible");
       // Aggregation "count"
       cy.findByText("카운트").should("be.visible");
     });

--- a/e2e/test/scenarios/native-filters/helpers/e2e-field-filter-data-objects.js
+++ b/e2e/test/scenarios/native-filters/helpers/e2e-field-filter-data-objects.js
@@ -1,3 +1,5 @@
+import dayjs from "dayjs";
+
 export const STRING_FILTER_SUBTYPES = {
   String: {
     searchTerm: "Synerg",
@@ -85,6 +87,12 @@ export const DATE_FILTER_SUBTYPES = {
   "All Options": {
     value: {
       timeBucket: "month",
+      quantity:
+        // When the filter is "Previous N months", we must ensure that N is large
+        // enough that the representative result appears. For this filter, the
+        // representative result is Synergistic Steel Chair, created on May 24,
+        // 2022.
+        dayjs().diff(dayjs("2022-05-24"), "month") + 2,
     },
     representativeResult: "Synergistic Steel Chair",
   },

--- a/e2e/test/scenarios/native-filters/helpers/e2e-sql-filter-helpers.js
+++ b/e2e/test/scenarios/native-filters/helpers/e2e-sql-filter-helpers.js
@@ -93,7 +93,7 @@ export function runQuery(xhrAlias = "dataset") {
  */
 export function enterParameterizedQuery(query, options = {}) {
   focusNativeEditor();
-  cy.get("@editor").realType(query, {
+  cy.get("@editor").type(query, {
     parseSpecialCharSequences: false,
     ...options,
   });

--- a/e2e/test/scenarios/native-filters/helpers/e2e-sql-filter-helpers.js
+++ b/e2e/test/scenarios/native-filters/helpers/e2e-sql-filter-helpers.js
@@ -93,7 +93,7 @@ export function runQuery(xhrAlias = "dataset") {
  */
 export function enterParameterizedQuery(query, options = {}) {
   focusNativeEditor();
-  cy.get("@editor").type(query, {
+  cy.get("@editor").realType(query, {
     parseSpecialCharSequences: false,
     ...options,
   });

--- a/e2e/test/scenarios/native-filters/sql-field-filter-types.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-field-filter-types.cy.spec.js
@@ -68,11 +68,7 @@ describe("scenarios > filters > sql filters > field filter > Date", () => {
 
     openNativeEditor();
 
-    const LEFT_BRACKET = "{{}";
-    const DOUBLE_LEFT_BRACKET = `${LEFT_BRACKET}${LEFT_BRACKET}`;
-    SQLFilter.enterParameterizedQuery(
-      `SELECT * FROM products WHERE ${DOUBLE_LEFT_BRACKET}f}}`,
-    );
+    SQLFilter.enterParameterizedQuery("SELECT * FROM products WHERE {{f}}");
 
     SQLFilter.openTypePickerFromDefaultFilterType();
     SQLFilter.chooseType("Field Filter");

--- a/e2e/test/scenarios/native-filters/sql-field-filter-types.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-field-filter-types.cy.spec.js
@@ -89,25 +89,6 @@ describe("scenarios > filters > sql filters > field filter > Date", () => {
         filterValue: value,
       });
 
-      // When the filter is "Previous N months", ensure that N is large enough
-      // that the representative result appears. For this filter, the
-      // representative result is Synergistic Steel Chair, created on May 24,
-      // 2022.
-      if (subType === "All Options" && value.timeBucket === "month") {
-        cy.findAllByTestId("parameter-value-widget-target")
-          .filter(':contains("Previous 30")')
-          .click();
-        const representativeResultDate = new Date(2022, 5, 24);
-        const monthsAgo = Math.floor(
-          (new Date() - representativeResultDate) / (1000 * 60 * 60 * 24 * 30),
-        );
-        cy.findByTestId("relative-datetime-value")
-          .clear()
-          .type(`${monthsAgo + 2}`)
-          .blur();
-        cy.button("Update filter").click();
-      }
-
       SQLFilter.runQuery();
 
       cy.findByTestId("query-visualization-root").within(() => {


### PR DESCRIPTION
This fixes an e2e test that was failing because November 2024 is now in the past. The test now does not assert which particular year appears in the x-axis. Note that this is a test of whether the year displays correctly when the locale is set to Korean, not a test that the user can control which specific year appears in the x-axis.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/03b382b9-6cd8-4c21-abfa-d701efb98f53.png)

This PR also fixes an e2e test that was failing because May 24, 2022 is now more than 30 months ago.

