### PR TITLE
[Notification] Rename notification types

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/dashboard_subscription_filters/parameter_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dashboard_subscription_filters/parameter_test.clj
@@ -1,7 +1,7 @@
 (ns ^:mb/once metabase-enterprise.dashboard-subscription-filters.parameter-test
   (:require
    [clojure.test :refer :all]
-   [metabase.notification.payload.impl.dashboard-subscription :as notification.dashboard-subscription]
+   [metabase.notification.payload.impl.dashboard :as notification.dashboard]
    [metabase.test :as mt]))
 
 (deftest parameters-test
@@ -10,7 +10,7 @@
       (is (= [{:id "1" :v "a"}
               {:id "2" :v "b"}
               {:id "3" :v "yes"}]
-             (notification.dashboard-subscription/the-parameters
+             (notification.dashboard/the-parameters
               [{:id "1" :v "a"} {:id "2" :v "b"}]
               [{:id "1" :v "no, since it's trumped by the pulse"} {:id "3" :v "yes"}])))))
 
@@ -18,6 +18,6 @@
     (mt/with-premium-features #{}
       (is (= [{:id "1" :v "no, since it's trumped by the pulse"}
               {:id "3" :v "yes"}]
-             (notification.dashboard-subscription/the-parameters
+             (notification.dashboard/the-parameters
               [{:id "1" :v "a"} {:id "2" :v "b"}]
               [{:id "1" :v "no, since it's trumped by the pulse"} {:id "3" :v "yes"}]))))))

--- a/src/metabase/channel/impl/email.clj
+++ b/src/metabase/channel/impl/email.clj
@@ -162,7 +162,7 @@
 ;;                                           Alerts                                                ;;
 ;; ------------------------------------------------------------------------------------------------;;
 
-(mu/defmethod channel/render-notification [:channel/email :notification/alert] :- [:sequential EmailMessage]
+(mu/defmethod channel/render-notification [:channel/email :notification/card] :- [:sequential EmailMessage]
   [_channel-type {:keys [payload] :as notification-payload} template recipients]
   (let [{:keys [card_part
                 alert
@@ -235,7 +235,7 @@
       (for [row rows]
         [:tr {} row])])))
 
-(mu/defmethod channel/render-notification [:channel/email :notification/dashboard-subscription] :- [:sequential EmailMessage]
+(mu/defmethod channel/render-notification [:channel/email :notification/dashboard] :- [:sequential EmailMessage]
   [_channel-type {:keys [payload] :as notification-payload} template recipients]
   (let [{:keys [dashboard_parts
                 dashboard_subscription

--- a/src/metabase/channel/impl/http.clj
+++ b/src/metabase/channel/impl/http.clj
@@ -76,7 +76,7 @@
     {:cols (map :name (:cols data))
      :rows (:rows data)}))
 
-(mu/defmethod channel/render-notification [:channel/http :notification/alert]
+(mu/defmethod channel/render-notification [:channel/http :notification/card]
   [_channel-type {:keys [payload creator]} _template _recipients]
   (let [{:keys [card alert card_part]} payload
         request-body {:type               "alert"

--- a/src/metabase/channel/impl/slack.clj
+++ b/src/metabase/channel/impl/slack.clj
@@ -94,7 +94,7 @@
 ;;                                           Alerts                                                ;;
 ;; ------------------------------------------------------------------------------------------------;;
 
-(mu/defmethod channel/render-notification [:channel/slack :notification/alert] :- [:sequential SlackMessage]
+(mu/defmethod channel/render-notification [:channel/slack :notification/card] :- [:sequential SlackMessage]
   [_channel-type {:keys [payload]} _template channel-ids]
   (let [attachments [{:blocks [{:type "header"
                                 :text {:type "plain_text"
@@ -146,7 +146,7 @@
           :when attachment]
       attachment)))
 
-(mu/defmethod channel/render-notification [:channel/slack :notification/dashboard-subscription] :- [:sequential SlackMessage]
+(mu/defmethod channel/render-notification [:channel/slack :notification/dashboard] :- [:sequential SlackMessage]
   [_channel-type {:keys [payload creator]} _template channel-ids]
   (let [parameters (:parameters payload)
         dashboard  (:dashboard payload)]

--- a/src/metabase/models/notification.clj
+++ b/src/metabase/models/notification.clj
@@ -36,8 +36,8 @@
 (def notification-types
   "Set of valid notification types."
   #{:notification/system-event
-    :notification/dashboard-subscription
-    :notification/alert
+    :notification/dashboard
+    :notification/card
     ;; for testing only
     :notification/testing})
 

--- a/src/metabase/notification/payload/core.clj
+++ b/src/metabase/notification/payload/core.clj
@@ -34,7 +34,7 @@
         ;; TODO: event-info schema for each event type
         [:event_topic [:fn #(= "event" (-> % keyword namespace))]]
         [:event_info  [:maybe :map]]]]]]
-    [:notification/alert
+    [:notification/card
      [:map
       ;; replacement of pulse
       [:alert      [:map
@@ -48,7 +48,7 @@
                     [:format_rows      {:optional true} [:maybe ms/BooleanValue]]
                     [:pivot_results    {:optional true} [:maybe ms/BooleanValue]]]]
       [:creator_id ms/PositiveInt]]]
-    [:notification/dashboard-subscription
+    [:notification/dashboard
      [:map
       [:creator_id ms/PositiveInt]
       ;; replacement of pulse
@@ -83,7 +83,7 @@
         [:event_topic                   [:fn #(= "event" (-> % keyword namespace))]]
         [:event_info                    [:maybe :map]]
         [:custom       {:optional true} [:maybe :map]]]]]]
-    [:notification/dashboard-subscription
+    [:notification/dashboard
      [:map
       [:payload [:map
                  [:dashboard_parts             [:sequential notification.payload.execute/Part]]
@@ -91,7 +91,7 @@
                  [:dashboard_subscription      :map]
                  [:style                       :map]
                  [:parameters {:optional true} [:maybe [:sequential :map]]]]]]]
-    [:notification/alert
+    [:notification/card
      [:map
       [:payload [:map
                  [:card_part [:maybe notification.payload.execute/Part]]

--- a/src/metabase/notification/payload/impl/card.clj
+++ b/src/metabase/notification/payload/impl/card.clj
@@ -1,4 +1,4 @@
-(ns metabase.notification.payload.impl.alert
+(ns metabase.notification.payload.impl.card
   (:require
    [metabase.channel.render.core :as channel.render]
    [metabase.notification.payload.core :as notification.payload]
@@ -7,7 +7,7 @@
    [metabase.util.ui-logic :as ui-logic]
    [toucan2.core :as t2]))
 
-(mu/defmethod notification.payload/payload :notification/alert
+(mu/defmethod notification.payload/payload :notification/card
   [{:keys [creator_id alert] :as _notification-info} :- notification.payload/Notification]
   (let [card_id (:card_id alert)]
     {:card_part   (notification.execute/execute-card creator_id card_id
@@ -35,7 +35,7 @@
              (goal-comparison (comparison-col-rowfn row) goal-val))
            (get-in card_part [:result :data :rows])))))
 
-(mu/defmethod notification.payload/should-send-notification? :notification/alert
+(mu/defmethod notification.payload/should-send-notification? :notification/card
   [{:keys [payload]}]
   (let [{:keys [alert card_part]} payload
         alert_condition        (:alert_condition alert)]

--- a/src/metabase/notification/payload/impl/dashboard.clj
+++ b/src/metabase/notification/payload/impl/dashboard.clj
@@ -1,4 +1,4 @@
-(ns metabase.notification.payload.impl.dashboard-subscription
+(ns metabase.notification.payload.impl.dashboard
   (:require
    [metabase.channel.render.core :as channel.render]
    [metabase.models.params.shared :as shared.params]
@@ -22,7 +22,7 @@
    shared.params/param-val-or-default
    (the-parameters dashboard-subscription-params dashboard-params)))
 
-(mu/defmethod notification.payload/payload :notification/dashboard-subscription
+(mu/defmethod notification.payload/payload :notification/dashboard
   [{:keys [creator_id dashboard_subscription] :as _notification-info} :- notification.payload/Notification]
   (let [dashboard-id (:dashboard_id dashboard_subscription)
         dashboard    (t2/hydrate (t2/select-one :model/Dashboard dashboard-id) :tabs)
@@ -40,7 +40,7 @@
      :parameters             parameters
      :dashboard_subscription dashboard_subscription}))
 
-(mu/defmethod notification.payload/should-send-notification? :notification/dashboard-subscription
+(mu/defmethod notification.payload/should-send-notification? :notification/dashboard
   [{:keys [payload] :as _noti-payload}]
   (let [{:keys [dashboard_parts dashboard_subscription]} payload]
     (if (:skip_if_empty dashboard_subscription)

--- a/src/metabase/notification/send.clj
+++ b/src/metabase/notification/send.clj
@@ -145,23 +145,23 @@
            {:task          "notification-send"
             :task_details {:notification_id       (:id notification-info)
                            :notification_handlers (map #(select-keys % [:id :channel_type :channel_id :template_id]) handlers)}}
-           (doseq [handler handlers]
-             (let [channel-type (:channel_type handler)
-                   messages     (channel/render-notification
-                                 channel-type
-                                 notification-payload
-                                 (:template handler)
-                                 (:recipients handler))]
-               (log/debugf "[Notification %d] Got %d messages for channel %s with template %d"
-                           (:id notification-info) (count messages)
-                           (handler->channel-name handler)
-                           (-> handler :template :id))
-               (doseq [message messages]
-                 (log/infof "[Notification %d] Sending message to channel %s"
-                            (:id notification-info) (:channel_type handler))
-                 (channel-send-retrying! (:id notification-info) (:payload_type notification-info) handler message))))
-           (do-after-notification-sent notification-info)
-           (log/infof "[Notification %d] Sent successfully" (:id notification-info))))
+            (doseq [handler handlers]
+              (let [channel-type (:channel_type handler)
+                    messages     (channel/render-notification
+                                  channel-type
+                                  notification-payload
+                                  (:template handler)
+                                  (:recipients handler))]
+                (log/debugf "[Notification %d] Got %d messages for channel %s with template %d"
+                            (:id notification-info) (count messages)
+                            (handler->channel-name handler)
+                            (-> handler :template :id))
+                (doseq [message messages]
+                  (log/infof "[Notification %d] Sending message to channel %s"
+                             (:id notification-info) (:channel_type handler))
+                  (channel-send-retrying! (:id notification-info) (:payload_type notification-info) handler message))))
+            (do-after-notification-sent notification-info)
+            (log/infof "[Notification %d] Sent successfully" (:id notification-info))))
         (log/infof "[Notification %d] Skipping" (:id notification-info))))
     (catch Exception e
       (log/errorf e "[Notification %d] Failed to send" (:id notification-info))

--- a/src/metabase/notification/send.clj
+++ b/src/metabase/notification/send.clj
@@ -114,19 +114,19 @@
 (defn- do-after-notification-sent
   [{:keys [payload_type] :as notification-info}]
   (u/ignore-exceptions
-    (when (and (= :notification/alert payload_type)
+    (when (and (= :notification/card payload_type)
                (-> notification-info :alert :alert_first_only))
       (t2/delete! :model/Pulse (-> notification-info :alert :id)))
     ;; TODO check how this is used, maybe we need to rework this
-    (when (#{:notification/alert :notification/dashboard-subscription} payload_type)
-      (let [event-type (if (= :notification/dashboard-subscription payload_type)
+    (when (#{:notification/card :notification/dashboard} payload_type)
+      (let [event-type (if (= :notification/dashboard payload_type)
                          :event/subscription-send
                          :event/alert-send)]
         (events/publish-event! event-type {:id      (:id notification-info)
                                            :user-id (:creator_id notification-info)
                                            :object  {:recipients (->> notification-info :handlers (mapcat :recipients) (map #(or (:user %)
                                                                                                                                  (:email %))))
-                                                     :filters    (-> notification-info #((if (= :notification/dashboard-subscription payload_type)
+                                                     :filters    (-> notification-info #((if (= :notification/dashboard payload_type)
                                                                                            :dashboard_subscription
                                                                                            :alert)
                                                                                          %)
@@ -145,23 +145,23 @@
            {:task          "notification-send"
             :task_details {:notification_id       (:id notification-info)
                            :notification_handlers (map #(select-keys % [:id :channel_type :channel_id :template_id]) handlers)}}
-            (doseq [handler handlers]
-              (let [channel-type (:channel_type handler)
-                    messages     (channel/render-notification
-                                  channel-type
-                                  notification-payload
-                                  (:template handler)
-                                  (:recipients handler))]
-                (log/debugf "[Notification %d] Got %d messages for channel %s with template %d"
-                            (:id notification-info) (count messages)
-                            (handler->channel-name handler)
-                            (-> handler :template :id))
-                (doseq [message messages]
-                  (log/infof "[Notification %d] Sending message to channel %s"
-                             (:id notification-info) (:channel_type handler))
-                  (channel-send-retrying! (:id notification-info) (:payload_type notification-info) handler message))))
-            (do-after-notification-sent notification-info)
-            (log/infof "[Notification %d] Sent successfully" (:id notification-info))))
+           (doseq [handler handlers]
+             (let [channel-type (:channel_type handler)
+                   messages     (channel/render-notification
+                                 channel-type
+                                 notification-payload
+                                 (:template handler)
+                                 (:recipients handler))]
+               (log/debugf "[Notification %d] Got %d messages for channel %s with template %d"
+                           (:id notification-info) (count messages)
+                           (handler->channel-name handler)
+                           (-> handler :template :id))
+               (doseq [message messages]
+                 (log/infof "[Notification %d] Sending message to channel %s"
+                            (:id notification-info) (:channel_type handler))
+                 (channel-send-retrying! (:id notification-info) (:payload_type notification-info) handler message))))
+           (do-after-notification-sent notification-info)
+           (log/infof "[Notification %d] Sent successfully" (:id notification-info))))
         (log/infof "[Notification %d] Skipping" (:id notification-info))))
     (catch Exception e
       (log/errorf e "[Notification %d] Failed to send" (:id notification-info))

--- a/src/metabase/pulse/send.clj
+++ b/src/metabase/pulse/send.clj
@@ -47,13 +47,13 @@
 (defn- get-template
   [channel-type payload-type]
   (case [channel-type payload-type]
-    [:channel/email :notification/dashboard-subscription]
+    [:channel/email :notification/dashboard]
     {:channel_type :channel/email
      :details      {:type    :email/handlebars-resource
                     :subject "{{payload.dashboard.name}}"
                     :path    "metabase/email/dashboard_subscription.hbs"}}
 
-    [:channel/email :notification/alert]
+    [:channel/email :notification/card]
     {:channel_type :channel/email
      :details      {:type    :email/handlebars-resource
                     :subject "{{computed.subject}}"
@@ -73,7 +73,7 @@
   [pulse dashboard pulse-channel]
   (if (= :pulse (alert-or-pulse pulse))
     {:id                     (:id pulse)
-     :payload_type           :notification/dashboard-subscription
+     :payload_type           :notification/dashboard
      :creator_id             (:creator_id pulse)
      :dashboard_subscription {:id                               (:id pulse)
                               :dashboard_id                     (:id dashboard)
@@ -83,15 +83,15 @@
                                                                  #(merge {:card_id (:id %)}
                                                                          (select-keys % [:include_xls :include_csv :pivot_results :format_rows]))
                                                                  (:cards pulse))}
-     :handlers               [(get-notification-handler pulse-channel :notification/dashboard-subscription)]}
+     :handlers               [(get-notification-handler pulse-channel :notification/dashboard)]}
     {:id           (:id pulse)
-     :payload_type :notification/alert
+     :payload_type :notification/card
      :creator_id   (:creator_id pulse)
      :alert        (merge (assoc (select-keys pulse [:id :alert_condition :alert_above_goal :alert_first_only])
                                  :card_id (some :id (:cards pulse))
                                  :schedule (select-keys pulse-channel [:schedule_type :schedule_hour :schedule_day :schedule_frame]))
                           (select-keys (-> pulse :cards first) [:include_xls :include_csv :pivot_results :format_rows]))
-     :handlers     [(get-notification-handler pulse-channel :notification/alert)]}))
+     :handlers     [(get-notification-handler pulse-channel :notification/card)]}))
 
 (def ^:private send-notification! (requiring-resolve 'metabase.notification.core/send-notification!))
 

--- a/test/metabase/pulse/send_test.clj
+++ b/test/metabase/pulse/send_test.clj
@@ -842,12 +842,12 @@
         (testing "channel send task history task details include retry config"
           (with-redefs
            [channel/send! (constantly true)]
-           (send!)
-           (is (=? {:task         "channel-send"
-                    :db_id        nil
-                    :status       :success
-                    :task_details default-task-details}
-                   (latest-task-history-entry :channel-send)))))
+            (send!)
+            (is (=? {:task         "channel-send"
+                     :db_id        nil
+                     :status       :success
+                     :task_details default-task-details}
+                    (latest-task-history-entry :channel-send)))))
 
         (testing "retry errors are recorded when the task eventually succeeds"
           (with-redefs [channel/send! (tu/works-after 2 (constantly nil))]

--- a/test/metabase/pulse/send_test.clj
+++ b/test/metabase/pulse/send_test.clj
@@ -622,7 +622,7 @@
                                                              :effective-type :type/Integer
                                                              :semantic_type  :type/Quantity}]
                                                      :rows [["2021-01-01T00:00:00Z" val]]}}})
-        goal-met?           (requiring-resolve 'metabase.notification.payload.impl.alert/goal-met?)]
+        goal-met?           (requiring-resolve 'metabase.notification.payload.impl.card/goal-met?)]
     (testing "Progress bar"
       (testing "alert above"
         (testing "value below goal"  (is (= false (goal-met? alert-above-pulse (progress-result 4)))))
@@ -734,7 +734,7 @@
         (mt/with-temporary-setting-values [email-smtp-host "fake_smtp_host"
                                            email-smtp-port 587]
           (mt/reset-inbox!)
-          (#'notification.send/channel-send-retrying! 1 :notification/alert {:channel_type :channel/email} fake-email-notification)
+          (#'notification.send/channel-send-retrying! 1 :notification/card {:channel_type :channel/email} fake-email-notification)
           (is (= {:numberOfSuccessfulCallsWithoutRetryAttempt 1}
                  (get-positive-retry-metrics test-retry)))
           (is (= 1 (count @mt/inbox)))))))
@@ -745,7 +745,7 @@
         (mt/with-temporary-setting-values [email-smtp-host "fake_smtp_host"
                                            email-smtp-port 587]
           (mt/reset-inbox!)
-          (#'notification.send/channel-send-retrying! 1 :notification/alert {:channel_type :channel/email} fake-email-notification)
+          (#'notification.send/channel-send-retrying! 1 :notification/card {:channel_type :channel/email} fake-email-notification)
           (is (= {:numberOfSuccessfulCallsWithoutRetryAttempt 1}
                  (get-positive-retry-metrics test-retry)))
           (is (= 0 (count @mt/inbox)))))))
@@ -757,7 +757,7 @@
         (mt/with-temporary-setting-values [email-smtp-host "fake_smtp_host"
                                            email-smtp-port 587]
           (mt/reset-inbox!)
-          (#'notification.send/channel-send-retrying! 1 :notification/alert {:channel_type :channel/email} fake-email-notification)
+          (#'notification.send/channel-send-retrying! 1 :notification/card {:channel_type :channel/email} fake-email-notification)
           (is (= {:numberOfFailedCallsWithRetryAttempt 1}
                  (get-positive-retry-metrics test-retry)))
           (is (= 0 (count @mt/inbox)))))))
@@ -769,7 +769,7 @@
         (mt/with-temporary-setting-values [email-smtp-host "fake_smtp_host"
                                            email-smtp-port 587]
           (mt/reset-inbox!)
-          (#'notification.send/channel-send-retrying! 1 :notification/alert {:channel_type :channel/email} fake-email-notification)
+          (#'notification.send/channel-send-retrying! 1 :notification/card {:channel_type :channel/email} fake-email-notification)
           (is (= {:numberOfSuccessfulCallsWithRetryAttempt 1}
                  (get-positive-retry-metrics test-retry)))
           (is (= 1 (count @mt/inbox))))))))
@@ -785,7 +785,7 @@
       (let [test-retry (retry/random-exponential-backoff-retry "test-retry" (test-retry-configuration))]
         (with-redefs [retry/random-exponential-backoff-retry (constantly test-retry)
                       slack/post-chat-message!               (constantly nil)]
-          (#'notification.send/channel-send-retrying! 1 :notification/alert {:channel_type :channel/slack} fake-slack-notification)
+          (#'notification.send/channel-send-retrying! 1 :notification/card {:channel_type :channel/slack} fake-slack-notification)
           (is (= {:numberOfSuccessfulCallsWithoutRetryAttempt 1}
                  (get-positive-retry-metrics test-retry))))))
     (testing "post slack message succeeds hiding token error"
@@ -794,7 +794,7 @@
                       slack/post-chat-message!               (fn [& _]
                                                                (throw (ex-info "Invalid token"
                                                                                {:errors {:slack-token "Invalid token"}})))]
-          (#'notification.send/channel-send-retrying! 1 :notification/alert {:channel_type :channel/slack} fake-slack-notification)
+          (#'notification.send/channel-send-retrying! 1 :notification/card {:channel_type :channel/slack} fake-slack-notification)
           (is (= {:numberOfSuccessfulCallsWithoutRetryAttempt 1}
                  (get-positive-retry-metrics test-retry))))))
     (testing "post slack message fails b/c retry limit"
@@ -802,7 +802,7 @@
             test-retry   (retry/random-exponential-backoff-retry "test-retry" retry-config)]
         (with-redefs [slack/post-chat-message!               (tu/works-after 1 (constantly nil))
                       retry/random-exponential-backoff-retry (constantly test-retry)]
-          (#'notification.send/channel-send-retrying! 1 :notification/alert {:channel_type :channel/slack} fake-slack-notification)
+          (#'notification.send/channel-send-retrying! 1 :notification/card {:channel_type :channel/slack} fake-slack-notification)
           (is (= {:numberOfFailedCallsWithRetryAttempt 1}
                  (get-positive-retry-metrics test-retry))))))
     (testing "post slack message succeeds with retry"
@@ -810,7 +810,7 @@
             test-retry   (retry/random-exponential-backoff-retry "test-retry" retry-config)]
         (with-redefs [slack/post-chat-message!               (tu/works-after 1 (constantly nil))
                       retry/random-exponential-backoff-retry (constantly test-retry)]
-          (#'notification.send/channel-send-retrying! 1 :notification/alert {:channel_type :channel/slack} fake-slack-notification)
+          (#'notification.send/channel-send-retrying! 1 :notification/card {:channel_type :channel/slack} fake-slack-notification)
           (is (= {:numberOfSuccessfulCallsWithRetryAttempt 1}
                  (get-positive-retry-metrics test-retry))))))))
 
@@ -830,7 +830,7 @@
     (mt/with-model-cleanup [:model/TaskHistory]
       (let [pulse-id             (rand-int 10000)
             default-task-details {:notification_id pulse-id
-                                  :notification_type "notification/alert"
+                                  :notification_type "notification/card"
                                   :channel_type "channel/slack"
                                   :channel_id   nil
                                   :retry_config {:max-attempts            4
@@ -838,16 +838,16 @@
                                                  :multiplier              2.0
                                                  :randomization-factor    0.1
                                                  :max-interval-millis     30000}}
-            send!                #(#'notification.send/channel-send-retrying! pulse-id :notification/alert {:channel_type :channel/slack} fake-slack-notification)]
+            send!                #(#'notification.send/channel-send-retrying! pulse-id :notification/card {:channel_type :channel/slack} fake-slack-notification)]
         (testing "channel send task history task details include retry config"
           (with-redefs
            [channel/send! (constantly true)]
-            (send!)
-            (is (=? {:task         "channel-send"
-                     :db_id        nil
-                     :status       :success
-                     :task_details default-task-details}
-                    (latest-task-history-entry :channel-send)))))
+           (send!)
+           (is (=? {:task         "channel-send"
+                    :db_id        nil
+                    :status       :success
+                    :task_details default-task-details}
+                   (latest-task-history-entry :channel-send)))))
 
         (testing "retry errors are recorded when the task eventually succeeds"
           (with-redefs [channel/send! (tu/works-after 2 (constantly nil))]


### PR DESCRIPTION
- notification/alert -> notification/card
- notification/dashboard-subscription -> notification/dashboard

renaming now is fine because none of these notifications are persisted