### PR TITLE
fix(sdk): remove Error.captureStackTrace as it errors on firefox

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/store/auth.ts
+++ b/enterprise/frontend/src/embedding-sdk/store/auth.ts
@@ -129,10 +129,6 @@ export const refreshTokenAsync = createAsyncThunk(
       }
       return session;
     } catch (exception: unknown) {
-      if (exception instanceof Error) {
-        Error.captureStackTrace(exception, refreshTokenAsync);
-      }
-
       // The host app may have a lot of logs (and the sdk logs a lot too), so we
       // make a big red error message to make it visible as this is 90% a blocking error
       console.error(...bigErrorHeader("Failed to get auth session"), exception);


### PR DESCRIPTION
Firefox doesn't have Error.captureStackTrace so I removed it

It also seems like without it the stack track is actually better on chrome too, I forgot why I even put it, maybe something changed and we don't need it anymore?

The error this fixes:

![image](https://github.com/user-attachments/assets/b68d2f46-54b9-4983-9933-b1a6d96ac442)

Stack trace after, on chrome:
<img width="656" alt="image" src="https://github.com/user-attachments/assets/0140dbd8-eaed-44e9-aead-f9caba044b0e">

