### PR TITLE
Fix a (native-ace-editor) flake 30039

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -6,6 +6,7 @@ import {
   cartesianChartCircle,
   createNativeQuestion,
   createQuestion,
+  focusNativeEditor,
   getDashboardCard,
   getDraggableElements,
   getNotebookStep,
@@ -13,7 +14,6 @@ import {
   main,
   modal,
   moveDnDKitElement,
-  openNativeEditor,
   openNotebook,
   openOrdersTable,
   popover,
@@ -22,6 +22,7 @@ import {
   rightSidebar,
   runNativeQuery,
   sidebar,
+  startNewNativeQuestion,
   summarize,
   tableInteractive,
   visitDashboard,
@@ -623,7 +624,8 @@ describe("issue 30039", () => {
   });
 
   it("should not trigger object detail navigation after the modal was closed (metabase#30039)", () => {
-    openNativeEditor().type("select * from ORDERS LIMIT 2");
+    startNewNativeQuestion();
+    focusNativeEditor().as("editor").type("select * from ORDERS LIMIT 2");
     runNativeQuery();
     cy.findAllByTestId("detail-shortcut").first().click();
     cy.findByTestId("object-detail").should("be.visible");


### PR DESCRIPTION
### What does this PR accomplish?
Fixes yet another flake related to the native (ace) editor.

The flakiness is exacerbated by using the UI flow to open the native editor. It is (1) slow, and (2) it triggers page rerenders. If we switch to using the `startNewNativeQuestion` that is generating a base64 hash and then navigating to the native editor directly, a lot of these nastiness can be avoided.

![image](https://github.com/user-attachments/assets/f31fbf50-1475-4ef9-95e6-08fd55048c87)

![image](https://github.com/user-attachments/assets/f769df49-6b8a-4582-8bf8-4b5b48e18c23)

### Stress-test
50/50 ✅ https://github.com/metabase/metabase/actions/runs/12139480495/job/33847197758#step:9:185