### PR TITLE
Remove memoization of active user counts setting

### DIFF
--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -164,8 +164,8 @@
       (dh/with-timeout {:timeout-ms fetch-token-status-timeout-ms
                         :interrupt? true}
         (try (fetch-token-and-parse-body* token base-url site-uuid (active-users-count))
-          (catch Exception e
-            (throw e)))))
+             (catch Exception e
+               (throw e)))))
     (catch dev.failsafe.TimeoutExceededException _e
       {:valid         false
        :status        (tru "Unable to validate token")

--- a/src/metabase/troubleshooting.clj
+++ b/src/metabase/troubleshooting.clj
@@ -47,5 +47,5 @@
    (when (premium-features/airgap-enabled)
      {:airgap-token       :enabled
       :max-users          (premium-features/max-users-allowed)
-      :current-user-count (premium-features/cached-active-users-count)
+      :current-user-count (premium-features/active-users-count)
       :valid-thru         (some-> (premium-features/premium-embedding-token) premium-features/fetch-token-status :valid-thru)})))

--- a/test/metabase/public_settings/premium_features_test.clj
+++ b/test/metabase/public_settings/premium_features_test.clj
@@ -276,7 +276,7 @@
   (t2.with-temp/with-temp
     [User _ {:is_active false}]
     (testing "returns the number of active users"
-      (is (= (t2/count :core_user :is_active true)
+      (is (= (t2/count :model/User :is_active true :type :personal)
              (premium-features/active-users-count))))
 
     (testing "Default to 0 if db is not setup yet"

--- a/test/metabase/public_settings/premium_features_test.clj
+++ b/test/metabase/public_settings/premium_features_test.clj
@@ -275,13 +275,9 @@
 (deftest active-users-count-setting-test
   (t2.with-temp/with-temp
     [User _ {:is_active false}]
-    ;; premium-features/active-users-count is cached so it could be make the test flaky
-    ;; rebinding to avoid caching
     (testing "returns the number of active users"
-      (with-redefs [premium-features/active-users-count (fn []
-                                                          (t2/count :core_user :is_active true))]
-        (is (= (t2/count :core_user :is_active true)
-               (premium-features/active-users-count)))))
+      (is (= (t2/count :core_user :is_active true)
+             (premium-features/active-users-count))))
 
     (testing "Default to 0 if db is not setup yet"
       (binding [mdb.connection/*application-db* {:status (atom nil)}]

--- a/test/metabase/public_settings/premium_features_test.clj
+++ b/test/metabase/public_settings/premium_features_test.clj
@@ -39,7 +39,7 @@
   [token premium-features-response]
   (http-fake/with-fake-routes-in-isolation
     {{:address      (#'premium-features/token-status-url token @#'premium-features/token-check-url)
-      :query-params {:users      (str (#'premium-features/cached-active-users-count))
+      :query-params {:users      (str (#'premium-features/active-users-count))
                      :site-uuid  (public-settings/site-uuid-for-premium-features-token-checks)
                      :mb-version (:tag config/mb-version-info)}}
      (constantly premium-features-response)}
@@ -278,11 +278,11 @@
     ;; premium-features/active-users-count is cached so it could be make the test flaky
     ;; rebinding to avoid caching
     (testing "returns the number of active users"
-      (with-redefs [premium-features/cached-active-users-count (fn []
-                                                                 (t2/count :core_user :is_active true))]
+      (with-redefs [premium-features/active-users-count (fn []
+                                                          (t2/count :core_user :is_active true))]
         (is (= (t2/count :core_user :is_active true)
-               (premium-features/cached-active-users-count)))))
+               (premium-features/active-users-count)))))
 
     (testing "Default to 0 if db is not setup yet"
       (binding [mdb.connection/*application-db* {:status (atom nil)}]
-        (is (zero? (premium-features/cached-active-users-count)))))))
+        (is (zero? (premium-features/active-users-count)))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50777

Removes memoization layer for the `active-users-count` setting. This resolves an issue introduced by https://github.com/metabase/metabase/pull/49916 in which the TTL for this cache was accidentally converted to milliseconds twice, inflating its value.