### PR TITLE
removing the 'can_write' requirement for selecting things via the question picker

### DIFF
--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPickerModal.tsx
@@ -35,7 +35,6 @@ const canSelectItem = (
 ): item is QuestionPickerValueItem => {
   return (
     item != null &&
-    item.can_write !== false &&
     (item.model === "card" ||
       item.model === "dataset" ||
       item.model === "metric")


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50602

### Description
The question picker had a requirement in it that only made things selectable if you had write access to the item. This meant that when replacing a question in a dashboard (or using the add sections flow) you weren't able to add things from read only collections. This is likely a mistake, as selecting a question from the picker doesn't generally involve editing the item, but selecting it as the source for a dashcard / filter / sandbox data. This PR removes that condition and adds a test to ensure that we can select items we only have read access to.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a new dashboard, and click add section
2. Click one of the "Select a question" buttons and navigate to a question or model you only have read access to
3. You should be able to select the item, and it should appear in the appropriate dash card

### Demo
![chrome_Xv1u56Zavb](https://github.com/user-attachments/assets/0c070c14-5a0a-4573-9343-2d6003367c28)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
