### PR TITLE
[serdes] do not require prefix when passing entity ids to export

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/api.clj
@@ -170,7 +170,10 @@
    collection        (mu/with [:maybe (ms/QueryVectorOf
                                        [:or
                                         ms/PositiveInt
-                                        [:re {:error/message "value must be string with `eid:<...>` prefix"} "^eid:.{21}$"]])]
+                                        [:re {:error/message "if you are passing entity_id, it should be exactly 21 chars long"}
+                                         "^.{21}$"]
+                                        [:re {:error/message "value must be string with `eid:<...>` prefix"}
+                                         "^eid:.{21}$"]])]
                               {:description "collections' db ids/entity-ids to serialize"})
    all_collections   (mu/with [:maybe ms/BooleanValue]
                               {:default     true

--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -98,7 +98,14 @@
 
               (testing "We can export that collection using entity id"
                 (let [f (mt/user-http-request :crowberto :post 200 "ee/serialization/export" {}
+                                              ;; eid:... syntax is kept for backward compat
                                               :collection (str "eid:" (:entity_id coll)) :data_model false :settings false)]
+                  (is (= #{:log :dir :dashboard :card :collection}
+                         (tar-file-types f)))))
+
+              (testing "We can export that collection using entity id"
+                (let [f (mt/user-http-request :crowberto :post 200 "ee/serialization/export" {}
+                                              :collection (:entity_id coll) :data_model false :settings false)]
                   (is (= #{:log :dir :dashboard :card :collection}
                          (tar-file-types f)))))
 

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -207,14 +207,15 @@
   (call-enterprise 'metabase-enterprise.serialization.cmd/v1-dump! path (get-parsed-options #'dump options)))
 
 (defn ^:command export
-  {:doc "Serialize Metabase instance into directory at `path`."
-   :arg-spec [["-c" "--collection ID"            "Export only specified ID(s). Use commas to separate multiple IDs. You can pass entity ids with `eid:<...>` as a prefix."
+  {:doc      "Serialize Metabase instance into directory at `path`."
+   :arg-spec [["-c" "--collection ID"            "Export only specified ID(s). Use commas to separate multiple IDs. Pass either PKs or entity IDs."
                :id        :collection-ids
                :parse-fn  (fn [raw-string] (->> (str/split raw-string #"\s*,\s*")
                                                 (map (fn [v]
-                                                       (if (str/starts-with? v "eid:")
-                                                         v
-                                                         (parse-long v))))))]
+                                                       (cond
+                                                         (str/starts-with? v "eid:") v
+                                                         (= (count v) 21)            v
+                                                         :else                       (parse-long v))))))]
               ["-C" "--no-collections"           "Do not export any content in collections."]
               ["-S" "--no-settings"              "Do not export settings.yaml"]
               ["-D" "--no-data-model"            "Do not export any data model entities; useful for subsequent exports."]


### PR DESCRIPTION
Refs #45224 