### PR TITLE
Manual backport of: Make e2e tests of embedding and sql filters date-invariant (#50737)

### DIFF
--- a/e2e/test/scenarios/native-filters/helpers/e2e-field-filter-data-objects.js
+++ b/e2e/test/scenarios/native-filters/helpers/e2e-field-filter-data-objects.js
@@ -1,3 +1,5 @@
+import dayjs from "dayjs";
+
 export const STRING_FILTER_SUBTYPES = {
   String: {
     searchTerm: "Synerg",
@@ -85,6 +87,12 @@ export const DATE_FILTER_SUBTYPES = {
   "All Options": {
     value: {
       timeBucket: "month",
+      quantity:
+        // When the filter is "Previous N months", we must ensure that N is large
+        // enough that the representative result appears. For this filter, the
+        // representative result is Synergistic Steel Chair, created on May 24,
+        // 2022.
+        dayjs().diff(dayjs("2022-05-24"), "month") + 2,
     },
     representativeResult: "Synergistic Steel Chair",
   },

--- a/e2e/test/scenarios/native-filters/sql-field-filter-types.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-field-filter-types.cy.spec.js
@@ -66,6 +66,7 @@ describe("scenarios > filters > sql filters > field filter > Date", () => {
     cy.signInAsAdmin();
 
     openNativeEditor();
+
     SQLFilter.enterParameterizedQuery("SELECT * FROM products WHERE {{f}}");
 
     SQLFilter.openTypePickerFromDefaultFilterType();


### PR DESCRIPTION
#50737 

This only backports the sql filter test fix because I don't think the embedding one is needed. CI will confirm.