### PR TITLE
Manual backport of 50813

### DIFF
--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -112,16 +112,16 @@
   "Amount of time to cache the status of a valid enterprise token before forcing a re-check."
   (u/hours->ms 12))
 
-(def ^{:arglists '([token base-url site-uuid active-users-count])} fetch-token-and-parse-body*
+(def ^{:arglists '([token base-url site-uuid])} fetch-token-and-parse-body*
   "Caches successful and 4XX API responses for 24 hours. 5XX errors, timeouts, etc. may be transient and will NOT be
   cached, but may trigger the *store-circuit-breaker*."
   (memoize/ttl
-   ^{::memoize/args-fn (fn [[token base-url site-uuid _active-users-count]]
+   ^{::memoize/args-fn (fn [[token base-url site-uuid]]
                          [token base-url site-uuid])}
-   (fn [token base-url site-uuid active-users-count]
+   (fn [token base-url site-uuid]
      (log/infof "Checking with the MetaStore to see whether token '%s' is valid..." (u.str/mask token))
      (let [{:keys [body status] :as resp} (some-> (token-status-url token base-url)
-                                                  (http/get {:query-params     {:users      active-users-count
+                                                  (http/get {:query-params     {:users      (active-users-count)
                                                                                 :site-uuid  site-uuid
                                                                                 :mb-version (:tag config/mb-version-info)}
                                                              :throw-exceptions false}))]
@@ -163,7 +163,7 @@
     (dh/with-circuit-breaker *store-circuit-breaker*
       (dh/with-timeout {:timeout-ms fetch-token-status-timeout-ms
                         :interrupt? true}
-        (try (fetch-token-and-parse-body* token base-url site-uuid (active-users-count))
+        (try (fetch-token-and-parse-body* token base-url site-uuid)
              (catch Exception e
                (throw e)))))
     (catch dev.failsafe.TimeoutExceededException _e

--- a/test/metabase/public_settings/premium_features_test.clj
+++ b/test/metabase/public_settings/premium_features_test.clj
@@ -151,6 +151,18 @@
     (is (partial= {:valid false, :status "Token does not exist."}
                   (#'premium-features/fetch-token-status* (random-token))))))
 
+(deftest fetch-token-does-not-call-db-when-cached
+  (testing "No DB calls are made for the user count when checking token status if the status is cached"
+    (let [token (random-token)]
+      (t2/with-call-count [call-count]
+        ;; First fetch, should trigger a DB call to fetch user count
+        (premium-features/fetch-token-status token)
+        (is (= 1 (call-count)))
+
+        ;; Subsequent fetches with the same token should not trigger additional DB calls
+        (premium-features/fetch-token-status token)
+        (is (= 1 (call-count)))))))
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                          Defenterprise Macro Tests                                             |
 ;;; +----------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
Manual backport of https://github.com/metabase/metabase/pull/50813 to 51 (opening preemptively to allow CI to run)