### PR TITLE
Add more logs for sending notification

### DIFF
--- a/src/metabase/notification/send.clj
+++ b/src/metabase/notification/send.clj
@@ -137,32 +137,32 @@
   [notification-info :- notification.payload/Notification]
   (try
     (log/infof "[Notification %d] Sending" (:id notification-info))
-    (let [handlers             (noti-handlers notification-info)
-          notification-payload (notification.payload/notification-payload notification-info)]
-      (if (notification.payload/should-send-notification? notification-payload)
-        (do
-          (log/debugf "[Notification %d] Found %d handlers" (:id notification-info) (count handlers))
-          (task-history/with-task-history {:task          "notification-send"
-                                           :task_details {:notification_id       (:id notification-info)
-                                                          :notification_handlers (map #(select-keys % [:id :channel_type :channel_id :template_id]) handlers)}}
-            (doseq [handler handlers]
-              (let [channel-type (:channel_type handler)
-                    messages     (channel/render-notification
-                                  channel-type
-                                  notification-payload
-                                  (:template handler)
-                                  (:recipients handler))]
-                (log/debugf "[Notification %d] Got %d messages for channel %s with template %d"
-                            (:id notification-info) (count messages)
-                            (handler->channel-name handler)
-                            (-> handler :template :id))
-                (doseq [message messages]
-                  (log/infof "[Notification %d] Sending message to channel %s"
-                             (:id notification-info) (:channel_type handler))
-                  (channel-send-retrying! (:id notification-info) (:payload_type notification-info) handler message))))
-            (do-after-notification-sent notification-info)
-            (log/infof "[Notification %d] Sent successfully" (:id notification-info))))
-        (log/infof "[Notification %d] Skipping" (:id notification-info))))
+    (let [handlers (noti-handlers notification-info)]
+      (task-history/with-task-history {:task          "notification-send"
+                                       :task_details {:notification_id       (:id notification-info)
+                                                      :notification_handlers (map #(select-keys % [:id :channel_type :channel_id :template_id]) handlers)}}
+        (let [notification-payload (notification.payload/notification-payload notification-info)]
+          (if (notification.payload/should-send-notification? notification-payload)
+            (do
+              (log/debugf "[Notification %d] Found %d handlers" (:id notification-info) (count handlers))
+              (doseq [handler handlers]
+                (let [channel-type (:channel_type handler)
+                      messages     (channel/render-notification
+                                    channel-type
+                                    notification-payload
+                                    (:template handler)
+                                    (:recipients handler))]
+                  (log/debugf "[Notification %d] Got %d messages for channel %s with template %d"
+                              (:id notification-info) (count messages)
+                              (handler->channel-name handler)
+                              (-> handler :template :id))
+                  (doseq [message messages]
+                    (log/infof "[Notification %d] Sending message to channel %s"
+                               (:id notification-info) (:channel_type handler))
+                    (channel-send-retrying! (:id notification-info) (:payload_type notification-info) handler message))))
+              (do-after-notification-sent notification-info)
+              (log/infof "[Notification %d] Sent successfully" (:id notification-info)))
+            (log/infof "[Notification %d] Skipping" (:id notification-info))))))
     (catch Exception e
       (log/errorf e "[Notification %d] Failed to send" (:id notification-info))
       (throw e)))


### PR DESCRIPTION
Context: https://metaboat.slack.com/archives/C010L1Z4F9S/p1733236472322129

- Add more logs around sending notification
- the task history `notification-send` now also tracks the execution of `notification-payload` => it should be like this from the beginning.