### PR TITLE
feat(sdk): add style and className to static dashboards

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/InteractiveDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/InteractiveDashboard.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, ReactNode } from "react";
+import type { ReactNode } from "react";
 import _ from "underscore";
 
 import type { SdkPluginsConfig } from "embedding-sdk";
@@ -23,10 +23,7 @@ import type { PublicOrEmbeddedDashboardEventHandlersProps } from "metabase/publi
 import { InteractiveDashboardProvider } from "./context";
 
 export type InteractiveDashboardProps = {
-  drillThroughQuestionHeight?: number;
   plugins?: SdkPluginsConfig;
-  className?: string;
-  style?: CSSProperties;
 
   /**
    * A custom React component to render the question layout.
@@ -36,6 +33,7 @@ export type InteractiveDashboardProps = {
    *       once we have a public-facing question context.
    */
   renderDrillThroughQuestion?: () => ReactNode;
+  drillThroughQuestionHeight?: number;
 } & SdkDashboardDisplayProps &
   PublicOrEmbeddedDashboardEventHandlersProps;
 

--- a/enterprise/frontend/src/embedding-sdk/components/public/StaticDashboard/StaticDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/StaticDashboard/StaticDashboard.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type { CSSProperties } from "react";
 import _ from "underscore";
 
 import {
@@ -21,11 +20,7 @@ import type { PublicOrEmbeddedDashboardEventHandlersProps } from "metabase/publi
 import { Box } from "metabase/ui";
 
 export type StaticDashboardProps = SdkDashboardDisplayProps &
-  PublicOrEmbeddedDashboardEventHandlersProps & {
-    withCardTitle?: boolean;
-    className?: string;
-    style?: CSSProperties;
-  };
+  PublicOrEmbeddedDashboardEventHandlersProps;
 
 export const StaticDashboardInner = ({
   dashboardId,

--- a/enterprise/frontend/src/embedding-sdk/components/public/StaticDashboard/StaticDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/StaticDashboard/StaticDashboard.tsx
@@ -1,3 +1,5 @@
+import cx from "classnames";
+import type { CSSProperties } from "react";
 import _ from "underscore";
 
 import {
@@ -19,7 +21,11 @@ import type { PublicOrEmbeddedDashboardEventHandlersProps } from "metabase/publi
 import { Box } from "metabase/ui";
 
 export type StaticDashboardProps = SdkDashboardDisplayProps &
-  PublicOrEmbeddedDashboardEventHandlersProps;
+  PublicOrEmbeddedDashboardEventHandlersProps & {
+    withCardTitle?: boolean;
+    className?: string;
+    style?: CSSProperties;
+  };
 
 export const StaticDashboardInner = ({
   dashboardId,
@@ -30,6 +36,8 @@ export const StaticDashboardInner = ({
   hiddenParameters = [],
   onLoad,
   onLoadWithoutCards,
+  style,
+  className,
 }: StaticDashboardProps) => {
   const {
     displayOptions,
@@ -52,7 +60,12 @@ export const StaticDashboardInner = ({
   const { font } = useEmbedFont();
 
   return (
-    <Box w="100%" ref={ref} className={CS.overflowAuto}>
+    <Box
+      w="100%"
+      ref={ref}
+      className={cx(CS.overflowAuto, className)}
+      style={style}
+    >
       <PublicOrEmbeddedDashboard
         dashboardId={dashboardId}
         parameterQueryParams={initialParameters}

--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-sdk-dashboard-params.ts
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-sdk-dashboard-params.ts
@@ -15,7 +15,6 @@ export type SdkDashboardDisplayProps = {
   dashboardId: DashboardId;
   initialParameters?: Query;
   withTitle?: boolean;
-  withCardTitle?: boolean;
   withDownloads?: boolean;
   hiddenParameters?: string[];
 };

--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-sdk-dashboard-params.ts
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-sdk-dashboard-params.ts
@@ -1,4 +1,5 @@
 import type { Query } from "history";
+import type { CSSProperties } from "react";
 import { pick } from "underscore";
 
 import { DEFAULT_DASHBOARD_DISPLAY_OPTIONS } from "metabase/dashboard/constants";
@@ -15,8 +16,11 @@ export type SdkDashboardDisplayProps = {
   dashboardId: DashboardId;
   initialParameters?: Query;
   withTitle?: boolean;
+  withCardTitle?: boolean;
   withDownloads?: boolean;
   hiddenParameters?: string[];
+  className?: string;
+  style?: CSSProperties;
 };
 
 export const useSdkDashboardParams = ({


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50490

Adds `style` and `className` to static dashboard to be consistent with interactive dashboards.