### PR TITLE
Keep support for the old search engine name

### DIFF
--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -24,6 +24,9 @@
 
 (set! *warn-on-reflection* true)
 
+;; Make sure the legacy cookies still work.
+(derive :search.engine/fulltext :search.engine/appdb)
+
 (defmethod search.engine/supported-engine? :search.engine/appdb [_]
   (and (or (not config/is-prod?)
            (= "appdb" (some-> (public-settings/search-engine) name)))

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -319,7 +319,21 @@
       (with-search-items-in-root-collection "test"
         (let [resp (search-request :crowberto :q "test" :search_engine "appdb" :limit 1)]
           ;; The index is not populated here, so there's not much interesting to assert.
-          (is (= "search.engine/appdb" (:engine resp))))))))
+          (is (= "search.engine/appdb" (:engine resp))))))
+
+    (testing "It can use the old search engine name, e.g. for old cookies"
+      (search/init-index! {:force-reset? false :re-populate? false})
+      (with-search-items-in-root-collection "test"
+        (let [resp (search-request :crowberto :q "test" :search_engine "fulltext" :limit 1)]
+          (is (= "search.engine/fulltext" (:engine resp))))))
+
+    (testing "It will not use an unknown search engine"
+      (search/init-index! {:force-reset? false :re-populate? false})
+      (with-search-items-in-root-collection "test"
+        (let [resp (search-request :crowberto :q "test" :search_engine "wut" :limit 1)]
+          (is (#{"search.engine/in-place"
+                 "search.engine/appdb"}
+               (:engine resp))))))))
 
 (defn- get-available-models [& args]
   (set

--- a/test/metabase/search/impl_test.clj
+++ b/test/metabase/search/impl_test.clj
@@ -25,7 +25,10 @@
   (testing "Registered engines"
     (is (= :search.engine/in-place (#'search.impl/parse-engine "in-place")))
     (when (search/supports-index?)
-      (is (= :search.engine/appdb (#'search.impl/parse-engine "appdb")))))
+      (is (= :search.engine/appdb (#'search.impl/parse-engine "appdb"))))
+    (testing "Legacy engine name"
+      (when (search/supports-index?)
+        (is (= :search.engine/fulltext (#'search.impl/parse-engine "fulltext"))))))
   ;; We don't currently leverage subclasses.
   #_(when (search/supports-index?)
       (testing "Subclasses"


### PR DESCRIPTION
I realize there are still cookies and bookmarked "magic links" floating around, so this makes sure those keep working.