### PR TITLE
fix scatter chart tooltip

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -304,39 +304,45 @@ export const LEGEND_SETTINGS = {
 
 export const TOOLTIP_SETTINGS = {
   "graph.tooltip_type": {
-    getDefault: () => "series_comparison",
+    getDefault: ([{ card }]) => {
+      const shouldShowComparisonTooltip = !["scatter", "waterfall"].includes(
+        card.display,
+      );
+      return shouldShowComparisonTooltip ? "series_comparison" : "default";
+    },
     hidden: true,
   },
   "graph.tooltip_columns": {
     section: t`Display`,
+
     title: t`Additional tooltip metrics`,
     placeholder: t`Enter metric names`,
     widget: "multiselect",
     useRawSeries: true,
     getValue: getComputedAdditionalColumnsValue,
     getHidden: (rawSeries, vizSettings) => {
-      // Default tooltip shows all columns
-      if (vizSettings["graph.tooltip_type"] === "default") {
-        return true;
-      }
-      return getAvailableAdditionalColumns(rawSeries, vizSettings).length === 0;
+      const isAggregatedChart = rawSeries[0].card.display !== "scatter";
+      return (
+        getAvailableAdditionalColumns(rawSeries, vizSettings, isAggregatedChart)
+          .length === 0
+      );
     },
     getProps: (rawSeries, vizSettings) => {
-      const options = getAvailableAdditionalColumns(rawSeries, vizSettings).map(
-        col => ({
-          label: col.display_name,
-          value: getColumnKey(col),
-        }),
-      );
+      const isAggregatedChart = rawSeries[0].card.display !== "scatter";
+      const options = getAvailableAdditionalColumns(
+        rawSeries,
+        vizSettings,
+        isAggregatedChart,
+      ).map(col => ({
+        label: col.display_name,
+        value: getColumnKey(col),
+      }));
+
       return {
         options,
       };
     },
-    readDependencies: [
-      "graph.metrics",
-      "graph.dimensions",
-      "graph.tooltip_type",
-    ],
+    readDependencies: ["graph.metrics", "graph.dimensions"],
   },
 };
 

--- a/frontend/src/metabase/visualizations/lib/settings/graph.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.unit.spec.js
@@ -439,14 +439,6 @@ describe("graph.tooltip_columns", () => {
   const tooltipColumnsSetting = TOOLTIP_SETTINGS["graph.tooltip_columns"];
 
   describe("getHidden", () => {
-    it("should be hidden when tooltip type is default", () => {
-      const isHidden = tooltipColumnsSetting.getHidden([], {
-        "graph.tooltip_type": "default",
-      });
-
-      expect(isHidden).toBe(true);
-    });
-
     it("should be hidden when there are no available additional columns", () => {
       const mockSeries = [
         createMockSingleSeries(

--- a/frontend/src/metabase/visualizations/lib/settings/graph.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.unit.spec.js
@@ -463,7 +463,7 @@ describe("graph.tooltip_columns", () => {
       ];
 
       const isHidden = tooltipColumnsSetting.getHidden(mockSeries, {
-        "graph.tooltip_type": "customized",
+        "graph.tooltip_type": "series_comparison",
         "graph.dimensions": ["dim"],
         "graph.metrics": ["metric"],
       });
@@ -488,7 +488,7 @@ describe("graph.tooltip_columns", () => {
       ];
 
       const isHidden = tooltipColumnsSetting.getHidden(mockSeries, {
-        "graph.tooltip_type": "customized",
+        "graph.tooltip_type": "series_comparison",
         "graph.dimensions": ["dim"],
         "graph.metrics": ["metric1"],
       });

--- a/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
@@ -392,6 +392,7 @@ function getDefaultLineAreaBarColumns(series: RawSeries) {
 export function getAvailableAdditionalColumns(
   rawSeries: RawSeries,
   settings: ComputedVisualizationSettings,
+  metricsOnly: boolean,
 ): DatasetColumn[] {
   const alreadyIncludedColumns = new Set<DatasetColumn>();
 
@@ -418,16 +419,22 @@ export function getAvailableAdditionalColumns(
     .flatMap(singleSeries => {
       return singleSeries.data.cols;
     })
-    .filter(column => isMetric(column) && !alreadyIncludedColumns.has(column));
+    .filter(
+      column =>
+        (isMetric(column) || !metricsOnly) &&
+        !alreadyIncludedColumns.has(column),
+    );
 }
 
 export function getComputedAdditionalColumnsValue(
   rawSeries: RawSeries,
   settings: ComputedVisualizationSettings,
 ) {
+  const isAggregatedChart = rawSeries[0].card.display !== "scatter";
+
   const availableAdditionalColumnKeys = new Set(
-    getAvailableAdditionalColumns(rawSeries, settings).map(column =>
-      getColumnKey(column),
+    getAvailableAdditionalColumns(rawSeries, settings, isAggregatedChart).map(
+      column => getColumnKey(column),
     ),
   );
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50630

### Description

Scatter charts display unaggregated data which means each series can have multiple values for a single x-axis value.
In case of breakouts (2 dimensions) each bubble represents a single row of ones with a given breakout value:
<img width="643" alt="Screenshot 2024-12-04 at 11 03 25 PM" src="https://github.com/user-attachments/assets/33467498-1724-47d9-88a1-31009e88e669">

There are multiple rows for `x = Q2 2022` and various breakout values so the series comparison tooltip does not make sense and in this case it showed just empty values:
<img width="368" alt="Screenshot 2024-12-04 at 11 00 54 PM" src="https://github.com/user-attachments/assets/8c599409-12b4-4344-860e-3eb3d877f64f">

This PR hides other breakout series from the tooltip on scatter charts. 

In addition to that, since the data is not aggregated it also makes sense to allow adding categorical columns to tooltips like "Product -> Category" here:

<video src="https://github.com/user-attachments/assets/b33fdb2d-fb44-48a6-9a68-4270d33c556a" />

### How to verify

- New -> Orders group by [Created At, Product.Category, User.Source] 
- Make it a Scatter chart with two dimensions: Created At and Product.Category
- Hover bubbles
- Ensure it does not show other empty breakout series in the tooltip

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
