### PR TITLE
fix: Qualify postgres enums outside public schema

### DIFF
--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -285,7 +285,12 @@
   (sql/format
    {:union-all
     [{:select [[:c.column_name :name]
-               [:c.udt_name :database-type]
+               [[:case
+                 [:in :c.udt_schema [[:inline "public"] [:inline "pg_catalog"]]]
+                 [:format [:inline "%s"] :c.udt_name]
+                 :else
+                 [:format [:inline "\"%s\".\"%s\""] :c.udt_schema :c.udt_name]]
+                :database-type]
                [[:- :c.ordinal_position [:inline 1]] :database-position]
                [:c.table_schema :table-schema]
                [:c.table_name :table-name]
@@ -327,7 +332,12 @@
               (when schema-names [:in :c.table_schema schema-names])
               (when table-names [:in :c.table_name table-names])]}
      {:select [[:pa.attname :name]
-               [:pt.typname :database-type]
+               [[:case
+                 [:in :ptn.nspname [[:inline "public"] [:inline "pg_catalog"]]]
+                 [:format [:inline "%s"] :pt.typname]
+                 :else
+                 [:format [:inline "\"%s\".\"%s\""] :ptn.nspname :pt.typname]]
+                :database-type]
                [[:- :pa.attnum [:inline 1]] :database-position]
                [:pn.nspname :table-schema]
                [:pc.relname :table-name]
@@ -338,10 +348,11 @@
       :from [[:pg_catalog.pg_class :pc]]
       :join [[:pg_catalog.pg_namespace :pn] [:= :pn.oid :pc.relnamespace]
              [:pg_catalog.pg_attribute :pa] [:= :pa.attrelid :pc.oid]
-             [:pg_catalog.pg_type :pt] [:= :pt.oid :pa.atttypid]]
+             [:pg_catalog.pg_type :pt] [:= :pt.oid :pa.atttypid]
+             [:pg_catalog.pg_namespace :ptn] [:= :ptn.oid :pt.typnamespace]]
       :where [:and
               [:= :pc.relkind [:inline "m"]]
-              [:>= :pa.attnum 1]
+              [:>= :pa.attnum [:inline 1]]
               (when schema-names [:in :pn.nspname schema-names])
               (when table-names [:in :pc.relname table-names])]}]
     :order-by [:table-schema :table-name :database-position]}

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -792,19 +792,22 @@
 (def ^:private enums-db-sql
   (str/join
    \newline
-   ["CREATE TYPE \"bird type\" AS ENUM ('toucan', 'pigeon', 'turkey');"
+   ["CREATE SCHEMA bird_schema;"
+    "CREATE TYPE \"bird type\" AS ENUM ('toucan', 'pigeon', 'turkey');"
     "CREATE TYPE bird_status AS ENUM ('good bird', 'angry bird', 'delicious bird');"
+    "CREATE TYPE bird_schema.bird_status AS ENUM ('sad bird', 'baby bird', 'big bird');"
     "CREATE TABLE birds ("
     "  name varchar PRIMARY KEY NOT NULL,"
     "  status bird_status NOT NULL,"
+    "  other_status bird_schema.bird_status NOT NULL,"
     "  type \"bird type\" NOT NULL"
     ");"
     "INSERT INTO"
-    "  birds (\"name\", status, \"type\")"
+    "  birds (\"name\", status, other_status, \"type\")"
     "VALUES"
-    "  ('Rasta', 'good bird', 'toucan'),"
-    "  ('Lucky', 'angry bird', 'pigeon'),"
-    "  ('Theodore', 'delicious bird', 'turkey');"]))
+    "  ('Rasta', 'good bird', 'sad bird', 'toucan'),"
+    "  ('Lucky', 'angry bird', 'baby bird', 'pigeon'),"
+    "  ('Theodore', 'delicious bird', 'big bird', 'turkey');"]))
 
 (defn- create-enums-db!
   "Create a Postgres database called `enums_test` that has a couple of enum types and a couple columns of those types.
@@ -834,7 +837,7 @@
     (do-with-enums-db!
      (fn [db]
        (testing "check that we can actually fetch the enum types from a DB"
-         (is (= #{"bird type" "bird_status"}
+         (is (= #{"\"bird_schema\".\"bird_status\"" "bird type" "bird_status"}
                 (#'postgres/enum-types db))))
 
        (testing "check that describe-table properly describes the database & base types of the enum fields"
@@ -859,10 +862,19 @@
                    :json-unfolding             false}
                   {:table-schema               "public"
                    :table-name                 "birds"
+                   :name                       "other_status"
+                   :database-type              "\"bird_schema\".\"bird_status\""
+                   :base-type                  :type/PostgresEnum
+                   :database-position          2
+                   :database-required          true
+                   :database-is-auto-increment false
+                   :json-unfolding             false}
+                  {:table-schema               "public"
+                   :table-name                 "birds"
                    :name                       "type"
                    :database-type              "bird type"
                    :base-type                  :type/PostgresEnum
-                   :database-position          2
+                   :database-position          3
                    :database-required          true
                    :database-is-auto-increment false
                    :json-unfolding             false}]
@@ -874,16 +886,18 @@
          (let [table-id (t2/select-one-pk Table :db_id (u/the-id db), :name "birds")]
            (is (= #{{:name "name", :database_type "varchar", :base_type :type/Text}
                     {:name "type", :database_type "bird type", :base_type :type/PostgresEnum}
-                    {:name "status", :database_type "bird_status", :base_type :type/PostgresEnum}}
+                    {:name "status", :database_type "bird_status", :base_type :type/PostgresEnum}
+                    {:name "other_status", :database_type "\"bird_schema\".\"bird_status\"", :base_type :type/PostgresEnum}}
                   (set (map (partial into {})
                             (t2/select [Field :name :database_type :base_type] :table_id table-id)))))))
 
        (testing "End-to-end check: make sure everything works as expected when we run an actual query"
          (let [table-id           (t2/select-one-pk Table :db_id (u/the-id db), :name "birds")
                bird-type-field-id (t2/select-one-pk Field :table_id table-id, :name "type")]
-           (is (= {:rows        [["Rasta" "good bird" "toucan"]]
+           (is (= {:rows        [["Rasta" "good bird" "sad bird" "toucan"]]
                    :native_form {:query  (str "SELECT \"public\".\"birds\".\"name\" AS \"name\","
                                               " \"public\".\"birds\".\"status\" AS \"status\","
+                                              " \"public\".\"birds\".\"other_status\" AS \"other_status\","
                                               " \"public\".\"birds\".\"type\" AS \"type\" "
                                               "FROM \"public\".\"birds\" "
                                               "WHERE \"public\".\"birds\".\"type\" = CAST('toucan' AS \"bird type\") "
@@ -928,10 +942,19 @@
                    :json-unfolding             false}
                   {:table-schema               "public"
                    :table-name                 "birds_m"
+                   :name                       "other_status"
+                   :database-type              "\"bird_schema\".\"bird_status\""
+                   :base-type                  :type/PostgresEnum
+                   :database-position          2
+                   :database-required          false
+                   :database-is-auto-increment false
+                   :json-unfolding             false}
+                  {:table-schema               "public"
+                   :table-name                 "birds_m"
                    :name                       "type"
                    :database-type              "bird type"
                    :base-type                  :type/PostgresEnum
-                   :database-position          2
+                   :database-position          3
                    :database-required          false
                    :database-is-auto-increment false
                    :json-unfolding             false}]
@@ -943,6 +966,7 @@
          (let [table-id (t2/select-one-pk Table :db_id (u/the-id db), :name "birds_m")]
            (is (= #{{:name "name", :database_type "varchar", :base_type :type/Text}
                     {:name "type", :database_type "bird type", :base_type :type/PostgresEnum}
+                    {:name "other_status", :database_type "\"bird_schema\".\"bird_status\"", :base_type :type/PostgresEnum}
                     {:name "status", :database_type "bird_status", :base_type :type/PostgresEnum}}
                   (set (map (partial into {})
                             (t2/select [Field :name :database_type :base_type] :table_id table-id)))))))
@@ -950,9 +974,10 @@
        (testing "End-to-end check: make sure everything works as expected when we run an actual query"
          (let [table-id           (t2/select-one-pk Table :db_id (u/the-id db), :name "birds_m")
                bird-type-field-id (t2/select-one-pk Field :table_id table-id, :name "type")]
-           (is (= {:rows        [["Rasta" "good bird" "toucan"]]
+           (is (= {:rows        [["Rasta" "good bird" "sad bird" "toucan"]]
                    :native_form {:query  (str "SELECT \"public\".\"birds_m\".\"name\" AS \"name\","
                                               " \"public\".\"birds_m\".\"status\" AS \"status\","
+                                              " \"public\".\"birds_m\".\"other_status\" AS \"other_status\","
                                               " \"public\".\"birds_m\".\"type\" AS \"type\" "
                                               "FROM \"public\".\"birds_m\" "
                                               "WHERE \"public\".\"birds_m\".\"type\" = CAST('toucan' AS \"bird type\") "
@@ -988,13 +1013,14 @@
                    (is (= columns action-targets))))
                (testing "Can create new records with an enum value"
                  (is (= {:created-row
-                         {:name "new bird", :status "good bird", :type "turkey"}}
+                         {:name "new bird", :status "good bird", :other_status "sad bird" :type "turkey"}}
                         (mt/user-http-request :crowberto
                                               :post 200
                                               (format "action/%s/execute" action-id)
-                                              {:parameters {"name"   "new bird"
-                                                            "status" "good bird"
-                                                            "type"   "turkey"}}))))))))))))
+                                              {:parameters {"name"         "new bird"
+                                                            "status"       "good bird"
+                                                            "other_status" "sad bird"
+                                                            "type"         "turkey"}}))))))))))))
 
 ;; API tests are in [[metabase.api.action-test]]
 (deftest ^:parallel actions-maybe-parse-sql-violate-not-null-constraint-test


### PR DESCRIPTION
Fixes: #50771

The new sync process failed to qualify enums outside public and therefore failed to properly type them in database_type. This could either result in matching the wrong type if there was a conflict or not being typed as an enum.

@metabase-bot backport release-x.51.x
