### PR TITLE
Add basic auth on druid JDBC driver

### DIFF
--- a/modules/drivers/druid-jdbc/resources/metabase-plugin.yaml
+++ b/modules/drivers/druid-jdbc/resources/metabase-plugin.yaml
@@ -24,6 +24,28 @@ driver:
         advanced-options: true
       description: This enables unfolding JSON columns into their component fields.
       default: true
+    - name: auth-enabled
+      display-name: Authentication
+      description: This enables the connection with basic authentication.
+      default: false
+      type: boolean
+      visible-if:
+        advanced-options: true
+    - name: auth-username
+      display-name: Username
+      description: Basic authentication username.
+      type: string
+      placeholder: ingestuser
+      visible-if:
+        auth-enabled: true
+    - name: auth-password
+      display-name: Password
+      description: Basic authentication password.
+      placeholder: '**********'
+      type: secret
+      secret-kind: password
+      visible-if:
+        auth-enabled: true
     - default-advanced-options
 init:
   - step: load-namespace

--- a/modules/drivers/druid-jdbc/src/metabase/driver/druid_jdbc.clj
+++ b/modules/drivers/druid-jdbc/src/metabase/driver/druid_jdbc.clj
@@ -13,6 +13,7 @@
    [metabase.driver.sql.query-processor.util :as sql.qp.u]
    [metabase.lib.field :as lib.field]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.models.secret :as secret]
    [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.util.add-alias-info :as add]
    [metabase.util.honey-sql-2 :as h2x]
@@ -31,10 +32,13 @@
   (defmethod driver/database-supports? [:druid-jdbc feature] [_driver _feature _db] supported?))
 
 (defmethod sql-jdbc.conn/connection-details->spec :druid-jdbc
-  [_driver {:keys [host port] :as _db-details}]
+  [_driver {:keys [host port auth-enabled auth-username] :as db-details}]
   (merge {:classname   "org.apache.calcite.avatica.remote.Driver"
           :subprotocol "avatica:remote"
           :subname     (str "url=" host ":" port "/druid/v2/sql/avatica/;transparent_reconnection=true")}
+         (when auth-enabled
+           {:user auth-username
+            :password (secret/get-secret-string db-details "auth-password")})
          (when (some? (driver/report-timezone))
            {:sqlTimeZone (driver/report-timezone)
             :timeZone (driver/report-timezone)})))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/45728

### Description

Add basic auth capabilities to Druid JDBC.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Databases -> Add Database -> Database type -> Druid JDBC
2. Fill host data
3. Show advanced options -> Enable flag "Authentication"
4. Fill basic auth credentials

Note: A Druid database with basic authentication enabled is required to perform the full connection test. Ref: [druid-basic-security](https://druid.apache.org/docs/latest/development/extensions-core/druid-basic-security/)

### Demo

- Database properties, basic auth enabled

![image](https://github.com/user-attachments/assets/2516fab0-4e92-41af-9bb8-d6e2eaf8b2e7)

- Database properties, basic auth enabled with data

![image](https://github.com/user-attachments/assets/b17a0cd5-8228-420f-9b96-a21cacf47060)

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
