### PR TITLE
Fix missing tooltip on waterfall total bar

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/waterfall.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/waterfall.cy.spec.js
@@ -400,6 +400,30 @@ describe("scenarios > visualizations > waterfall", () => {
     });
   });
 
+  it("should show tooltip when hovering the total bar (metabase#48118)", () => {
+    H.visitQuestionAdhoc({
+      display: "waterfall",
+      dataset_query: {
+        type: "query",
+        database: SAMPLE_DB_ID,
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"], ["sum", ["field-id", ORDERS.TOTAL]]],
+          breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }]],
+        },
+      },
+    });
+
+    const totalBarColor = "#4C5773";
+
+    H.chartPathWithFillColor(totalBarColor).realHover();
+
+    H.assertEChartsTooltip({
+      header: "Total",
+      rows: [{ name: "Count", value: "18,760", color: totalBarColor }],
+    });
+  });
+
   describe("scenarios > visualizations > waterfall settings", () => {
     beforeEach(() => {
       H.restore();

--- a/frontend/src/metabase/visualizations/echarts/cartesian/constants/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/constants/dataset.ts
@@ -12,6 +12,8 @@ export const NEGATIVE_STACK_TOTAL_DATA_KEY =
 export const POSITIVE_BAR_DATA_LABEL_KEY_SUFFIX = `${NULL_CHAR}_positive_bar_data_label`;
 export const NEGATIVE_BAR_DATA_LABEL_KEY_SUFFIX = `${NULL_CHAR}_negative_bar_data_label`;
 
+export const IS_WATERFALL_TOTAL_DATA_KEY = `${NULL_CHAR}_is_total` as const;
+
 // Key of x-axis values
 export const X_AXIS_DATA_KEY = `${NULL_CHAR}_x` as const;
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/dataset.ts
@@ -1,7 +1,10 @@
 import { t } from "ttag";
 
 import { NULL_DISPLAY_VALUE } from "metabase/lib/constants";
-import { X_AXIS_DATA_KEY } from "metabase/visualizations/echarts/cartesian/constants/dataset";
+import {
+  IS_WATERFALL_TOTAL_DATA_KEY,
+  X_AXIS_DATA_KEY,
+} from "metabase/visualizations/echarts/cartesian/constants/dataset";
 import {
   replaceValues,
   replaceZeroesForLogScale,
@@ -119,6 +122,7 @@ export const extendOriginalDatasetWithTotalDatum = (
   const totalDatum: Datum = {
     [seriesDataKey]: waterfallDatasetTotalDatum[WATERFALL_TOTAL_KEY],
     [X_AXIS_DATA_KEY]: t`Total`,
+    [IS_WATERFALL_TOTAL_DATA_KEY]: true,
   };
 
   return [...dataset, totalDatum];

--- a/frontend/src/metabase/visualizations/echarts/tooltip/index.tsx
+++ b/frontend/src/metabase/visualizations/echarts/tooltip/index.tsx
@@ -142,6 +142,7 @@ export const useCartesianChartSeriesColorsClasses = (
     const settingColors = [
       settings["waterfall.increase_color"],
       settings["waterfall.decrease_color"],
+      settings["waterfall.total_color"],
     ].filter(isNotNull);
 
     return [...seriesColors, ...settingColors];

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -304,39 +304,45 @@ export const LEGEND_SETTINGS = {
 
 export const TOOLTIP_SETTINGS = {
   "graph.tooltip_type": {
-    getDefault: () => "series_comparison",
+    getDefault: ([{ card }]) => {
+      const shouldShowComparisonTooltip = !["scatter", "waterfall"].includes(
+        card.display,
+      );
+      return shouldShowComparisonTooltip ? "series_comparison" : "default";
+    },
     hidden: true,
   },
   "graph.tooltip_columns": {
     section: t`Display`,
+
     title: t`Additional tooltip metrics`,
     placeholder: t`Enter metric names`,
     widget: "multiselect",
     useRawSeries: true,
     getValue: getComputedAdditionalColumnsValue,
     getHidden: (rawSeries, vizSettings) => {
-      // Default tooltip shows all columns
-      if (vizSettings["graph.tooltip_type"] === "default") {
-        return true;
-      }
-      return getAvailableAdditionalColumns(rawSeries, vizSettings).length === 0;
+      const isAggregatedChart = rawSeries[0].card.display !== "scatter";
+      return (
+        getAvailableAdditionalColumns(rawSeries, vizSettings, isAggregatedChart)
+          .length === 0
+      );
     },
     getProps: (rawSeries, vizSettings) => {
-      const options = getAvailableAdditionalColumns(rawSeries, vizSettings).map(
-        col => ({
-          label: col.display_name,
-          value: getColumnKey(col),
-        }),
-      );
+      const isAggregatedChart = rawSeries[0].card.display !== "scatter";
+      const options = getAvailableAdditionalColumns(
+        rawSeries,
+        vizSettings,
+        isAggregatedChart,
+      ).map(col => ({
+        label: col.display_name,
+        value: getColumnKey(col),
+      }));
+
       return {
         options,
       };
     },
-    readDependencies: [
-      "graph.metrics",
-      "graph.dimensions",
-      "graph.tooltip_type",
-    ],
+    readDependencies: ["graph.metrics", "graph.dimensions"],
   },
 };
 

--- a/frontend/src/metabase/visualizations/lib/settings/graph.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.unit.spec.js
@@ -439,14 +439,6 @@ describe("graph.tooltip_columns", () => {
   const tooltipColumnsSetting = TOOLTIP_SETTINGS["graph.tooltip_columns"];
 
   describe("getHidden", () => {
-    it("should be hidden when tooltip type is default", () => {
-      const isHidden = tooltipColumnsSetting.getHidden([], {
-        "graph.tooltip_type": "default",
-      });
-
-      expect(isHidden).toBe(true);
-    });
-
     it("should be hidden when there are no available additional columns", () => {
       const mockSeries = [
         createMockSingleSeries(

--- a/frontend/src/metabase/visualizations/lib/settings/graph.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.unit.spec.js
@@ -463,7 +463,7 @@ describe("graph.tooltip_columns", () => {
       ];
 
       const isHidden = tooltipColumnsSetting.getHidden(mockSeries, {
-        "graph.tooltip_type": "customized",
+        "graph.tooltip_type": "series_comparison",
         "graph.dimensions": ["dim"],
         "graph.metrics": ["metric"],
       });
@@ -488,7 +488,7 @@ describe("graph.tooltip_columns", () => {
       ];
 
       const isHidden = tooltipColumnsSetting.getHidden(mockSeries, {
-        "graph.tooltip_type": "customized",
+        "graph.tooltip_type": "series_comparison",
         "graph.dimensions": ["dim"],
         "graph.metrics": ["metric1"],
       });

--- a/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
@@ -392,6 +392,7 @@ function getDefaultLineAreaBarColumns(series: RawSeries) {
 export function getAvailableAdditionalColumns(
   rawSeries: RawSeries,
   settings: ComputedVisualizationSettings,
+  metricsOnly: boolean,
 ): DatasetColumn[] {
   const alreadyIncludedColumns = new Set<DatasetColumn>();
 
@@ -418,16 +419,22 @@ export function getAvailableAdditionalColumns(
     .flatMap(singleSeries => {
       return singleSeries.data.cols;
     })
-    .filter(column => isMetric(column) && !alreadyIncludedColumns.has(column));
+    .filter(
+      column =>
+        (isMetric(column) || !metricsOnly) &&
+        !alreadyIncludedColumns.has(column),
+    );
 }
 
 export function getComputedAdditionalColumnsValue(
   rawSeries: RawSeries,
   settings: ComputedVisualizationSettings,
 ) {
+  const isAggregatedChart = rawSeries[0].card.display !== "scatter";
+
   const availableAdditionalColumnKeys = new Set(
-    getAvailableAdditionalColumns(rawSeries, settings).map(column =>
-      getColumnKey(column),
+    getAvailableAdditionalColumns(rawSeries, settings, isAggregatedChart).map(
+      column => getColumnKey(column),
     ),
   );
 

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -20,6 +20,7 @@ import {
 } from "metabase/visualizations/components/ChartTooltip/StackedDataTooltip/utils";
 import { formatValueForTooltip } from "metabase/visualizations/components/ChartTooltip/utils";
 import {
+  IS_WATERFALL_TOTAL_DATA_KEY,
   ORIGINAL_INDEX_DATA_KEY,
   OTHER_DATA_KEY,
   X_AXIS_DATA_KEY,
@@ -367,9 +368,8 @@ export const getTooltipModel = (
     return getOtherSeriesTooltipModel(chartModel, settings, dataIndex, datum);
   }
 
-  const hoveredSeries = chartModel.seriesModels.find(
-    s => s.dataKey === seriesDataKey,
-  );
+  const seriesIndex = findSeriesModelIndexById(chartModel, seriesDataKey);
+  const hoveredSeries = chartModel.seriesModels[seriesIndex];
 
   if (!hoveredSeries) {
     return null;
@@ -560,14 +560,18 @@ const getSeriesOnlyTooltipRowColor = (
   display: CardDisplayType,
 ) => {
   const value = datum[seriesModel.dataKey];
+  let color;
   if (display === "waterfall" && typeof value === "number") {
-    const color =
-      value >= 0
-        ? settings["waterfall.increase_color"]
-        : settings["waterfall.decrease_color"];
-    return color ?? seriesModel.color;
+    if (datum[IS_WATERFALL_TOTAL_DATA_KEY]) {
+      color = settings["waterfall.total_color"];
+    } else {
+      color =
+        value >= 0
+          ? settings["waterfall.increase_color"]
+          : settings["waterfall.decrease_color"];
+    }
   }
-  return seriesModel.color;
+  return color ?? seriesModel.color;
 };
 
 export const getStackedTooltipModel = (


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/48118

### Description

Fixes missing tooltip on the Total bar of Waterfall charts.

### How to verify

- Create a waterfall chart
- Hover the Total bar
- Ensure the tooltip appears

### Demo

<img width="441" alt="Screenshot 2024-12-05 at 5 45 23 PM" src="https://github.com/user-attachments/assets/14f48e52-28d5-4629-9ddb-acab932a6e8d">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
