### PR TITLE
Fix edge cases in New Search around model filtering

### DIFF
--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -60,11 +60,13 @@
   [search-ctx qry]
   (let [collection-id-col :search_index.collection_id
         permitted-clause  (search.permissions/permitted-collections-clause search-ctx collection-id-col)
-        personal-clause   (search.filter/personal-collections-where-clause search-ctx collection-id-col)]
+        personal-clause   (search.filter/personal-collections-where-clause search-ctx collection-id-col)
+        excluded-models   (search.filter/models-without-collection)
+        or-null           #(vector :or [:in :search_index.model excluded-models] %)]
     (cond-> qry
       true (sql.helpers/left-join [:collection :collection] [:= collection-id-col :collection.id])
-      true (sql.helpers/where permitted-clause)
-      personal-clause (sql.helpers/where personal-clause))))
+      true (sql.helpers/where (or-null permitted-clause))
+      personal-clause (sql.helpers/where (or-null personal-clause)))))
 
 (defmethod search.engine/results :search.engine/appdb
   [{:keys [search-string] :as search-ctx}]

--- a/test/metabase/search/filter_test.clj
+++ b/test/metabase/search/filter_test.clj
@@ -62,10 +62,17 @@
 (deftest with-filters-test
   (testing "The kitchen sink context is complete"
     (is (empty? (remove kitchen-sink-filter-context (filter-keys)))))
-  (testing "We leave the query alone if there are no filters"
+
+  (testing "In the general case, we simply filter by models"
     (is (= {:select [:some :stuff]
-            :from   :somewhere}
-           (search.filter/with-filters {} {:select [:some :stuff], :from :somewhere}))))
+            :from   :somewhere
+            :where [:= 1 2]}
+           (search.filter/with-filters {:models []} {:select [:some :stuff], :from :somewhere})))
+    (is (= {:select [:some :stuff]
+            :from   :somewhere
+            :where [:in :search_index.model ["a"]]}
+           (search.filter/with-filters {:models ["a"]} {:select [:some :stuff], :from :somewhere}))))
+
   (testing "We can insert appropriate constraints for all the filters"
     (is (= {:select [:some :stuff]
             :from   :somewhere


### PR DESCRIPTION
- We were incorrectly filtering out some models for restricted users.
- We were not filtering by models in the case where none were viable for our filters.

Found both of these while porting over the integration tests, but want to bring these fixes in separately so that its safe to backport.