### PR TITLE
Include explicit require to c.t.build.tasks.uber

### DIFF
--- a/bin/build/src/build_drivers/create_uberjar.clj
+++ b/bin/build/src/build_drivers/create_uberjar.clj
@@ -4,6 +4,7 @@
    [build-drivers.common :as c]
    [clojure.java.io :as io]
    [clojure.tools.build.api :as b]
+   [clojure.tools.build.tasks.uber] ;; workaround for (#50940)
    [clojure.tools.deps.alpha :as deps]
    [clojure.tools.deps.alpha.util.dir :as deps.dir]
    [colorize.core :as colorize]


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/50940

Build sometimes fails with

```clojure
      Compiling namespaces [metabase.driver.sqlserver]
{:via
 [{:type clojure.lang.ExceptionInfo,
   :message
   "Running build steps for Enterprise Edition version UNKNOWN: version, translations, frontend, licenses, drivers, uberjar",
   :data {},
   :at [metabuild_common.steps$do_step invokeStatic "steps.clj" 90]}
  {:type clojure.lang.ExceptionInfo,
   :message "Building all drivers in parallel (:ee edition)",
   :data {},
   :at [metabuild_common.steps$do_step invokeStatic "steps.clj" 90]}
  {:type java.util.concurrent.ExecutionException,
   :message "clojure.lang.ExceptionInfo: Build driver :databricks (edition = :ee, options = nil) {}",
   :at [java.util.concurrent.FutureTask report "FutureTask.java" 122]}
  {:type clojure.lang.ExceptionInfo,
   :message "Build driver :databricks (edition = :ee, options = nil)",
   :data {},
   :at [metabuild_common.steps$do_step invokeStatic "steps.clj" 90]}
  {:type clojure.lang.ExceptionInfo,
   :message
   "Write :databricks :ee uberjar -> /home/runner/work/metabase/metabase/resources/modules/databricks.metabase-driver.jar",
   :data {},
   :at [metabuild_common.steps$do_step invokeStatic "steps.clj" 90]}
  {:type java.lang.IllegalStateException,
   :message "Attempting to call unbound fn: #'clojure.tools.build.tasks.uber/uber",
   :at [clojure.lang.Var$Unbound throwArity "Var.java" 47]}],
 :trace
 [[clojure.lang.Var$Unbound throwArity "Var.java" 47]
  [clojure.lang.AFn invoke "AFn.java" 32]
  [clojure.lang.Var invoke "Var.java" 386]
  [clojure.tools.build.api$uber invokeStatic "api.clj" 511]
  [clojure.tools.build.api$uber invoke "api.clj" 439]
  [build_drivers.create_uberjar$create_uberjar_BANG_$fn__4951 invoke "create_uberjar.clj" 82]
  [metabuild_common.steps$do_step invokeStatic "steps.clj" 87]
  [metabuild_common.steps$do_step invoke "steps.clj" 81]
  [build_drivers.create_uberjar$create_uberjar_BANG_ invokeStatic "create_uberjar.clj" 80]
  [build_drivers.create_uberjar$create_uberjar_BANG_ invoke "create_uberjar.clj" 77]
  [build_drivers.build_driver$build_driver_BANG_$fn__6636 invoke "build_driver.clj" 37]
  [metabuild_common.steps$do_step invokeStatic "steps.clj" 87]
  [metabuild_common.steps$do_step invoke "steps.clj" 81]
  [build_drivers.build_driver$build_driver_BANG_ invokeStatic "build_driver.clj" 33]
  [build_drivers.build_driver$build_driver_BANG_ invoke "build_driver.clj" 17]
  [build_drivers.build_driver$build_driver_BANG_ invokeStatic "build_driver.clj" 24]
  [build_drivers.build_driver$build_driver_BANG_ invoke "build_driver.clj" 17]
  [build_drivers$build_drivers_BANG_$fn__6657$fn__6658 invoke "build_drivers.clj" 31]
  [clojure.core$pmap$fn__8582$fn__8583 invoke "core.clj" 7169]
  [clojure.core$binding_conveyor_fn$fn__5842 invoke "core.clj" 2047]
  [clojure.lang.AFn call "AFn.java" 18]
  [java.util.concurrent.FutureTask run "FutureTask.java" 264]
  [java.util.concurrent.ThreadPoolExecutor runWorker "ThreadPoolExecutor.java" 1128]
  [java.util.concurrent.ThreadPoolExecutor$Worker run "ThreadPoolExecutor.java" 628]
  [java.lang.Thread run "Thread.java" 829]],
 :cause "Attempting to call unbound fn: #'clojure.tools.build.tasks.uber/uber"}
```

Seems that pmap-ing over the tasks hits a race condition with how the api works

```clojure
(defn uber
  [params]
  (assert-required "uber" params [:class-dir :uber-file])
  (assert-specs "uber" params
    :class-dir ::specs/path
    :uber-file ::specs/path)
  ((requiring-resolve 'clojure.tools.build.tasks.uber/uber) params))
```

So we just require `clojure.tools.build.tasks.uber` so that the namespace is compiled and ready.
