### PR TITLE
docs - update env var docs

### DIFF
--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -567,13 +567,6 @@ Allow users to explore data using X-rays.
 
 Enumerated field values with cardinality at or below this point are treated as enums in the pseudo-ddl used in some model prompts.
 
-### `MB_EXPERIMENTAL_FULLTEXT_SEARCH_ENABLED`
-
-- Type: boolean
-- Default: `false`
-
-Enables search engines which are still in the experimental stage.
-
 ### `MB_FOLLOW_UP_EMAIL_SENT`
 
 - Type: boolean
@@ -1410,6 +1403,13 @@ don't have one.
 - [Configuration file name](./config-file.md): `scim-enabled`
 
 Is SCIM currently enabled?
+
+### `MB_SEARCH_ENGINE`
+
+- Type: keyword
+- Default: `:in-place`
+
+Which engine to use when performing search. Supported values are :in-place and :appdb.
 
 ### `MB_SEARCH_TYPEAHEAD_ENABLED`
 

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -101,7 +101,8 @@
   :export?    false
   :default    nil
   :type       :json
-  :on-change sync-metadata)
+  :on-change sync-metadata
+  :doc false)
 
 (defn- update-metadata! [new-metadata]
   (if *mocking-tables*


### PR DESCRIPTION
- Updates env var docs for 52.
- Adds `:doc false` to `defsetting` that's only used internally.