### PR TITLE
Update test to use revert icon

### DIFF
--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -103,7 +103,7 @@ describe("issue 38083", () => {
       .contains(QUESTION.native["template-tags"].state["display-name"])
       .parent("fieldset")
       .within(() => {
-        cy.icon("time_history").should("not.exist");
+        cy.icon("revert").should("not.exist");
       });
   });
 });


### PR DESCRIPTION
We changed the time_history icon in this context to a revert icon in #46050 but never updated this test. This PR fixes that.