### PR TITLE
If multiple limit or offset arguments are passed, only use the 1st one

### DIFF
--- a/src/metabase/server/middleware/offset_paging.clj
+++ b/src/metabase/server/middleware/offset_paging.clj
@@ -17,7 +17,7 @@
 (defn- ensure-single-value
   "For parameters that should have a single value, only return the 1st if multiple values were passed in the request"
   [v]
-  (if (vector? v)
+  (if (sequential? v)
     (first v)
     v))
 

--- a/src/metabase/server/middleware/offset_paging.clj
+++ b/src/metabase/server/middleware/offset_paging.clj
@@ -14,9 +14,16 @@
 (def ^:private default-limit 50)
 (def ^:private default-offset 0)
 
+(defn- ensure-single-value
+  "For parameters that should have a single value, only return the 1st if multiple values were passed in the request"
+  [v]
+  (if (vector? v)
+    (first v)
+    v))
+
 (defn- parse-paging-params [{{:strs [limit offset]} :query-params}]
-  (let [limit  (some-> limit parse-long)
-        offset (some-> offset parse-long)]
+  (let [limit  (some-> limit ensure-single-value parse-long)
+        offset (some-> offset ensure-single-value parse-long)]
     (when (or limit offset)
       {:limit (or limit default-limit), :offset (or offset default-offset)})))
 

--- a/test/metabase/query_processor_test/offset_test.clj
+++ b/test/metabase/query_processor_test/offset_test.clj
@@ -312,10 +312,9 @@
                   (qp/process-query query)))))))))
 
 (deftest multiple-limits
-  (let [total_count (-> (mt/user-real-request :crowberto :get 200 "search?q=product")
+  (let [total-count (-> (mt/user-real-request :crowberto :get 200 "search?q=product")
                         :data count)
-        result_count (-> (mt/user-real-request :crowberto :get 200 "search?q=product&limit=2&limit=3")
+        result-count (-> (mt/user-real-request :crowberto :get 200 "search?q=product&limit=2&limit=3")
                          :data count)]
-    (is (and
-           (> total_count result_count)
-           (= 2 result_count)))))
+    (is (> total-count result-count))
+    (is (= 2 result-count))))

--- a/test/metabase/query_processor_test/offset_test.clj
+++ b/test/metabase/query_processor_test/offset_test.clj
@@ -314,7 +314,7 @@
 (deftest multiple-limits
   (let [total-count (-> (mt/user-real-request :crowberto :get 200 "search?q=product")
                         :data count)
-        result-count (-> (mt/user-real-request :crowberto :get 200 "search?q=product&limit=2&limit=3")
+        result-count (-> (mt/user-real-request :crowberto :get 200 "search?q=product&limit=1&limit=3")
                          :data count)]
-    (is (> total-count result-count))
-    (is (= 2 result-count))))
+    (is (>= total-count result-count))
+    (is (= 1 result-count))))

--- a/test/metabase/query_processor_test/offset_test.clj
+++ b/test/metabase/query_processor_test/offset_test.clj
@@ -310,3 +310,12 @@
                  (mt/formatted-rows
                   [->local-date 2.0]
                   (qp/process-query query)))))))))
+
+(deftest multiple-limits
+  (let [total_count (-> (mt/user-real-request :crowberto :get 200 "search?q=product")
+                        :data count)
+        result_count (-> (mt/user-real-request :crowberto :get 200 "search?q=product&limit=2&limit=3")
+                         :data count)]
+    (is (and
+           (> total_count result_count)
+           (= 2 result_count)))))

--- a/test/metabase/server/middleware/offset_paging_test.clj
+++ b/test/metabase/server/middleware/offset_paging_test.clj
@@ -46,6 +46,13 @@
                        "paged?" true
                        "params" {"whatever" "true"}}}
             (read-response (handler (ring.mock/request :get "/" {:offset "200", :limit "100", :whatever "true"}))))))
+  (testing "w/duplicate paging params"
+    (is (=? {:status 200
+             :body {"limit" 100
+                    "offset" 200
+                    "paged?" true
+                    "params" {"whatever", "true"}}}
+            (read-response (handler (ring.mock/request :get  "/" {:offset ["200", "250"], :limit ["100" "150"], :whatever "true"}))))))
   (testing "w/ non-numeric paging params, paging is disabled"
     (is (=? {:status 200
              :body {"limit"  nil


### PR DESCRIPTION
### Description

Fixes #45345 based closed PR #48650

Did not end up using Malli as the change was well isolated already and simple

### How to verify

Adding an extra &limit or &offset to a question loads the page and strips off the extra limit/offset like in PR 48650

![image](https://github.com/user-attachments/assets/cd43d098-5cd8-4618-b835-2a7a8a645ef3)


### Checklist

- [X] Tests have been added/updated to cover changes in this PR
