### PR TITLE
Fix the zoom-in.timeseries drill for multi-stage queries

### DIFF
--- a/src/metabase/lib/drill_thru/common.cljc
+++ b/src/metabase/lib/drill_thru/common.cljc
@@ -2,6 +2,7 @@
   (:require
    [metabase.lib.hierarchy :as lib.hierarchy]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
+   [metabase.lib.underlying :as lib.underlying]
    [metabase.lib.util :as lib.util]))
 
 (defn mbql-stage?
@@ -46,3 +47,35 @@
   "Convert a drill value to a JS value"
   [value]
   (if (= value :null) nil value))
+
+(defn- has-source-or-underyling-source-fn
+  [source]
+  (fn has-source?
+    ([column]
+     (= (:lib/source column) source))
+    ([query column]
+     (and
+      (seq column)
+      (or (has-source? column)
+          (has-source? (lib.underlying/top-level-column query column)))))))
+
+(def aggregation-sourced?
+  "Does column or top-level-column have :source/aggregations?"
+  (has-source-or-underyling-source-fn :source/aggregations))
+
+(def breakout-sourced?
+  "Does column or top-level-column have :source/breakouts?"
+  (has-source-or-underyling-source-fn :source/breakouts))
+
+(defn strictly-underyling-aggregation?
+  "Does the top-level-column for `column` in `query` have :source/aggregations?"
+  [query column]
+  (and (not (aggregation-sourced? column))
+       (aggregation-sourced? query column)))
+
+(defn dimensions-from-breakout-columns
+  "Convert `row` data into dimensions for `column`s that come from an aggregation in a previous stage."
+  [query column row]
+  (when (strictly-underyling-aggregation? query column)
+    (not-empty (filterv #(breakout-sourced? query (:column %))
+                        row))))

--- a/src/metabase/lib/drill_thru/zoom_in_timeseries.cljc
+++ b/src/metabase/lib/drill_thru/zoom_in_timeseries.cljc
@@ -14,7 +14,8 @@
   - `dimensions` have a date or datetime column with `year`, `quarter`, `month`, `week`, `day`, `hour` temporal unit.
     For other units, or when there is no temporal bucketing, this drill cannot be applied. Changing `hour` to `minute`
     ends the sequence for datetime columns (`week` to `day` for date columns). Only the first matching column would be
-    used in query transformation.
+    used in query transformation. If `dimensions` are not provided, `row` data will instead be used to try to find a
+    `matching-breakout-dimension`.
 
   - `displayInfo` returns `displayName` with `See this {0} by {1}` string using the current and the next available
     temporal unit.
@@ -45,6 +46,7 @@
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
    [metabase.lib.schema.temporal-bucketing :as lib.schema.temporal-bucketing]
    [metabase.lib.temporal-bucket :as lib.temporal-bucket]
+   [metabase.lib.underlying :as lib.underlying]
    [metabase.lib.util :as lib.util]
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]))
@@ -62,14 +64,22 @@
   [query        :- ::lib.schema/query
    stage-number :- :int
    dimensions   :- [:sequential ::lib.schema.drill-thru/context.row.value]]
-  (first (for [breakout (lib.breakout/breakouts query stage-number)
-               :when (and (lib.util/clause-of-type? breakout :field)
-                          (lib.temporal-bucket/temporal-bucket breakout))
+  (first (for [[breakout-ref breakout-col] (map vector
+                                                (lib.breakout/breakouts query stage-number)
+                                                (lib.breakout/breakouts-metadata query stage-number))
+               :when (and (lib.util/clause-of-type? breakout-ref :field)
+                          (lib.temporal-bucket/temporal-bucket breakout-ref))
                {:keys [column] :as dimension} dimensions
-               :when (and (lib.equality/find-matching-column breakout [column])
-                          (= (lib.temporal-bucket/temporal-bucket breakout)
-                             (lib.temporal-bucket/temporal-bucket column)))]
-           (assoc dimension :column-ref breakout))))
+               :when (and (lib.equality/find-matching-column breakout-ref [column])
+                          (= (lib.temporal-bucket/raw-temporal-bucket breakout-ref)
+                             (or (lib.temporal-bucket/raw-temporal-bucket column)
+                                 ;; If query is multi-stage and column comes from a call
+                                 ;; to [[lib.calculation/returned-columns]], then it may have an
+                                 ;; :inherited-temporal-unit instead of a :temporal-unit.
+                                 (:inherited-temporal-unit column))))]
+           ;; If stage-number is not -1, then the column from the input dimension will be from the last stage,
+           ;; whereas breakout-col will be the corresponding breakout column from [[lib.underlying/top-level-stage]].
+           (assoc dimension :column breakout-col :column-ref breakout-ref))))
 
 (mu/defn- next-breakout-unit :- [:maybe ::lib.schema.drill-thru/drill-thru.zoom-in.timeseries.next-unit]
   [query :- ::lib.schema/query
@@ -96,27 +106,33 @@
   For example: The month of a year, days or weeks of a quarter, smaller lat/long regions, etc.
 
   This is different from the `:drill-thru/zoom` type, which is for showing the details of a single object."
-  [query                              :- ::lib.schema/query
-   stage-number                       :- :int
-   {:keys [dimensions], :as _context} :- ::lib.schema.drill-thru/context]
-  (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
-             (not-empty dimensions))
-    (when-let [{:keys [value column-ref], :as dimension} (matching-breakout-dimension query stage-number dimensions)]
-      (when value
-        (when-let [next-unit (next-breakout-unit query stage-number column-ref)]
-          {:lib/type     :metabase.lib.drill-thru/drill-thru
-           :display-name (describe-next-unit next-unit)
-           :type         :drill-thru/zoom-in.timeseries
-           :dimension    dimension
-           :next-unit    next-unit})))))
+  [query                                         :- ::lib.schema/query
+   _stage-number                                 :- :int
+   {:keys [dimensions row], :as _context} :- ::lib.schema.drill-thru/context]
+  ;; For multi-stage queries, we want the stage-number of the underlying stage with breakouts or aggregations.
+  ;; In such cases, the FE will not pass dimensions, so use the row data instead, if available.
+  (let [stage-number      (lib.underlying/top-level-stage-number query)
+        dimensions-or-row ((some-fn not-empty) dimensions row)]
+    (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
+               dimensions-or-row)
+      (when-let [{:keys [value column-ref], :as dimension}
+                 (matching-breakout-dimension query stage-number dimensions-or-row)]
+        (when value
+          (when-let [next-unit (next-breakout-unit query stage-number column-ref)]
+            {:lib/type     :metabase.lib.drill-thru/drill-thru
+             :display-name (describe-next-unit next-unit)
+             :type         :drill-thru/zoom-in.timeseries
+             :dimension    dimension
+             :next-unit    next-unit}))))))
 
 (mu/defmethod lib.drill-thru.common/drill-thru-method :drill-thru/zoom-in.timeseries
   [query                         :- ::lib.schema/query
-   stage-number                  :- :int
+   _stage-number                 :- :int
    {:keys [dimension next-unit]} :- ::lib.schema.drill-thru/drill-thru.zoom-in.timeseries]
   (let [{:keys [column value]} dimension
         old-breakout           (:column-ref dimension)
-        new-breakout           (lib.temporal-bucket/with-temporal-bucket old-breakout next-unit)]
+        new-breakout           (lib.temporal-bucket/with-temporal-bucket old-breakout next-unit)
+        stage-number           (lib.underlying/top-level-stage-number query)]
     (-> query
         (lib.filter/filter stage-number (lib.filter/= column value))
         (lib.remove-replace/replace-clause stage-number old-breakout new-breakout))))

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -100,8 +100,8 @@
                   ;; the [[lib.metadata.calculation/*propagate-binning-and-bucketing*]] is thruthy, ie. bound. Intent
                   ;; is to pass it from ref to column only during [[returned-columns]] call. Otherwise eg.
                   ;; [[orderable-columns]] would contain that too. That could be problematic, because original ref that
-                  ;; contained `:temporal-unit` contains no `:inherent-temporal-unit`. If the column like this was used
-                  ;; to generate ref for eg. order by it would contain the `:inherent-temporal-unit`, while
+                  ;; contained `:temporal-unit` contains no `:inherited-temporal-unit`. If the column like this was used
+                  ;; to generate ref for eg. order by it would contain the `:inherited-temporal-unit`, while
                   ;; the original column (eg. in breakout) would not.
                   (let [inherited-temporal-unit-keys (cond-> (list :inherited-temporal-unit)
                                                        lib.metadata.calculation/*propagate-binning-and-bucketing*

--- a/test/metabase/lib/drill_thru_test.cljc
+++ b/test/metabase/lib/drill_thru_test.cljc
@@ -456,7 +456,7 @@
         (let [context (merge (basic-context count-column 123)
                              {:row row})]
           (testing (str "\ncontext =\n" (u/pprint-to-str context))
-            (is (=? (map expected-drills [:pivot :underlying-records :zoom-in.timeseries])
+            (is (=? (map expected-drills [:pivot :underlying-records])
                     (lib/available-drill-thrus query -1 context)))
             (test-drill-applications query context)))
         (testing "with :dimensions"

--- a/test/metabase/lib/drill_thru_test.cljc
+++ b/test/metabase/lib/drill_thru_test.cljc
@@ -456,7 +456,7 @@
         (let [context (merge (basic-context count-column 123)
                              {:row row})]
           (testing (str "\ncontext =\n" (u/pprint-to-str context))
-            (is (=? (map expected-drills [:pivot :underlying-records])
+            (is (=? (map expected-drills [:pivot :underlying-records :zoom-in.timeseries])
                     (lib/available-drill-thrus query -1 context)))
             (test-drill-applications query context)))
         (testing "with :dimensions"
@@ -554,11 +554,10 @@
                                              :month)))
             columns      (lib/returned-columns query)
             sum          (by-name columns "sum")
-            breakout     (by-name columns "CREATED_AT")
             sum-dim      {:column     sum
                           :column-ref (lib/ref sum)
                           :value      42295.12}
-            breakout-dim {:column     breakout
+            breakout-dim {:column     (first (lib/breakouts-metadata query))
                           :column-ref (first (lib/breakouts query))
                           :value      "2024-11-01T00:00:00Z"}
             context      (merge sum-dim


### PR DESCRIPTION
### Description

If no dimensions are provided to the zoom-in.timeseries drill, then attempt to find the matching dimension from the FE-provided row data instead, if present.

Related to https://github.com/metabase/metabase/issues/46932

### How to verify

- New question: Orders
- summarize: Count by Created At: Month
- Add filter stage after summarize, e.g. Count > 1
- Visualize
- Select Table viz
- Click on a cell
- "See this month by week" drill through should appear in the context menu

### Demo


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
