### PR TITLE
Test that we can go back from the notebook editor

### DIFF
--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -993,6 +993,31 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       cy.findByLabelText("close icon").invoke("outerHeight").should("eq", 16);
     }
   });
+
+  it("should let the user navigate back (metabase#50971)", () => {
+    cy.visit("/");
+    H.newButton("Model").click();
+    cy.findByTestId("new-model-options")
+      .findByText("Use the notebook editor")
+      .click();
+
+    H.entityPickerModal().should("be.visible");
+
+    // Cypress can emulate the browser's back button with cy.go('back'), but
+    // this does not trigger a confirmation modal, so we need to perform a
+    // similar action that also triggers the confirmation modal: clicking the
+    // cancel button in the edit bar.
+    cy.log('Triggering a "Discard your changes?" confirmation modal');
+    cy.findByTestId("dataset-edit-bar")
+      .findByRole("button", { name: "Cancel", hidden: true })
+      .click({ force: true });
+
+    cy.log(
+      'Clicking "Discard changes" in the confirmation modal to verify that this modal is above the data picker modal',
+    );
+    H.modal().should("be.visible").contains("Discard changes").click();
+    cy.findByTestId("greeting-message").should("be.visible");
+  });
 });
 
 function assertTableRowCount(expectedCount) {


### PR DESCRIPTION
This PR builds on #50420 by adding an e2e test that the user can press the back button to return from the notebook editor to the homepage. Previously this was impossible due to a pop-under bug (#50971).