### PR TITLE
Fix race between jobs accessing the search index

### DIFF
--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -70,7 +70,7 @@
                            [:in :table_name ["search_index" "search_index_next" "search_index_retired"]]]})))
 
 (defn- sync-metadata [_old-setting-raw new-setting-raw]
-  ;; Oh dear, we get the raw setting. Save a little bit of overhead by no keywordizing the keys.
+  ;; Oh dear, we get the raw setting. Save a little bit of overhead by not converting keys
   (let [new-setting                          (json/decode new-setting-raw)
         this-index-metadata                  #(get-in % ["versions" *index-version-id*])
         {:strs [active-table pending-table]} (this-index-metadata new-setting)
@@ -236,14 +236,16 @@
 (defn ensure-ready!
   "Ensure the index is ready to be populated. Return false if it was already ready."
   [force-recreation?]
-  (when-not *mocking-tables*
-    (when (nil? (active-table))
-      ;; double check that we're initialized from the current shared metadata
-      (when-let [raw-state (settings/get-raw-value :search-engine-appdb-index-state)]
-        (sync-metadata raw-state raw-state))))
+  ;; Be extra careful against races on initializing the setting
+  (locking *active-table*
+    (when-not *mocking-tables*
+      (when (nil? (active-table))
+        ;; double check that we're initialized from the current shared metadata
+        (when-let [raw-state (settings/get-raw-value :search-engine-appdb-index-state)]
+          (sync-metadata raw-state raw-state))))
 
-  (when (or force-recreation? (not (exists? (active-table))))
-    (reset-index!)))
+    (when (or force-recreation? (not (exists? (active-table))))
+      (reset-index!))))
 
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro with-temp-index-table

--- a/src/metabase/task/search_index.clj
+++ b/src/metabase/task/search_index.clj
@@ -9,6 +9,8 @@
    [metabase.util :as u]
    [metabase.util.log :as log])
   (:import
+   (java.time Instant)
+   (java.util Date)
    (org.quartz DisallowConcurrentExecution JobDetail Trigger)))
 
 (set! *warn-on-reflection* true)
@@ -105,8 +107,11 @@
         trigger     (triggers/build
                      (triggers/with-identity trigger-key)
                      (triggers/for-job reindex-job-key)
+                     (triggers/start-at (Date/from (.plusSeconds (Instant/now) 3600)))
                      (triggers/with-schedule
-                      (simple/schedule (simple/with-interval-in-hours 1))))]
+                      (simple/schedule
+                       (simple/with-interval-in-hours 1)
+                       (simple/repeat-forever))))]
     (task/schedule-task! job trigger)))
 
 (defmethod task/init! ::SearchIndexUpdate [_]


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/50978

TIL that simple jobs run immediately the first time they're scheduled.