### PR TITLE
Make Loki's embedding scroll stories more resilient

### DIFF
--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardView.stories.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardView.stories.tsx
@@ -427,13 +427,21 @@ export const CardVisualizationsDarkTheme = {
   },
 };
 
-const EXPLICIT_SIZE_WAIT_TIME = 300;
 function ScrollDecorator(Story: StoryFn) {
+  const asyncCallback = createAsyncCallback();
+
   useEffect(() => {
-    setTimeout(() => {
-      document.querySelector("[data-testid=embed-frame]")?.scrollBy(0, 9999);
-    }, EXPLICIT_SIZE_WAIT_TIME);
-  }, []);
+    const scrollContainer = document.querySelector("[data-testid=embed-frame]");
+    const intervalId = setInterval(() => {
+      const contentHeight = scrollContainer?.scrollHeight ?? 0;
+      if (contentHeight > 1000) {
+        scrollContainer?.scrollBy(0, 9999);
+        clearInterval(intervalId);
+        asyncCallback();
+      }
+    }, 100);
+  }, [asyncCallback]);
+
   return <Story />;
 }
 


### PR DESCRIPTION
Reported [on Slack](https://metaboat.slack.com/archives/C063Q3F1HPF/p1733417902850549), [example failure](https://github.com/metabase/metabase/actions/runs/12163691229/job/33984446227?pr=50792)

### Description.

I previously wait for 300ms before scroll the embed container, it seems this isn't enough in some cases on CI. So, the fix should be to try to attempt this until it succeed.

### How to verify

The Loki visual regression CI check should pass


### Checklist

- [] ~Tests have been added/updated to cover changes in this PR~ tests already covered by Loki
