### PR TITLE
docs - locale params

### DIFF
--- a/docs/configuring-metabase/localization.md
+++ b/docs/configuring-metabase/localization.md
@@ -18,36 +18,43 @@ Thanks to our amazing user community, Metabase has been translated into many dif
 
 Supported languages include:
 
-| Language         | Code |
-| ---------------- | ---- |
-| English          | `en` |
-| Albanian         | `sq` |
-| Arabic           | `ar` |
-| Bulgarian        | `bg` |
-| Catalan          | `ca` |
-| Chinese          | `zh` |
-| Czech            | `cs` |
-| Dutch            | `nl` |
-| Farsi/Persian    | `fa` |
-| Finnish          | `fi` |
-| French           | `fr` |
-| German           | `de` |
-| Indonesian       | `id` |
-| Italian          | `it` |
-| Japanese         | `ja` |
-| Korean           | `ko` |
-| Latvian          | `lv` |
-| Norwegian Bokmål | `nb` |
-| Polish           | `pl` |
-| Portuguese       | `pt` |
-| Russian          | `ru` |
-| Serbian          | `sr` |
-| Slovak           | `sk` |
-| Spanish          | `es` |
-| Swedish          | `sv` |
-| Turkish          | `tr` |
-| Ukrainian        | `uk` |
-| Vietnamese       | `vi` |
+| Language               | Code    |
+| ---------------------- | ------- |
+| English                | `en`    |
+| Albanian               | `sq`    |
+| Arabic                 | `ar`    |
+| Arabic (Saudi Arabia)  | `ar-SA` |
+| Bulgarian              | `bg`    |
+| Catalan                | `ca`    |
+| Chinese (Traditional)  | `zh`    |
+| Chinese (Taiwanese)    | `zh-TW` |
+| Chinese (Hong Kong)    | `zh-HK` |
+| Chinese (Simplified)   | `zh-CN` |
+| Czech                  | `cs`    |
+| Dutch                  | `nl`    |
+| Farsi/Persian          | `fa`    |
+| Finnish                | `fi`    |
+| French                 | `fr`    |
+| German                 | `de`    |
+| Hebrew                 | `he`    |
+| Hungarian              | `hu`    |
+| Indonesian             | `id`    |
+| Malay                  | `ms`    |
+| Italian                | `it`    |
+| Japanese               | `ja`    |
+| Korean                 | `ko`    |
+| Latvian                | `lv`    |
+| Norwegian Bokmål       | `nb`    |
+| Polish                 | `pl`    |
+| Portuguese (Brazilian) | `pt-BR` |
+| Russian                | `ru`    |
+| Serbian                | `sr`    |
+| Slovak                 | `sk`    |
+| Spanish                | `es`    |
+| Swedish                | `sv`    |
+| Turkish                | `tr`    |
+| Ukrainian              | `uk`    |
+| Vietnamese             | `vi`    |
 
 The locale codes are relevant for setting the language in [static embeds](../embedding/static-embedding-parameters.md#setting-the-language-for-a-static-embed).
 

--- a/docs/configuring-metabase/localization.md
+++ b/docs/configuring-metabase/localization.md
@@ -18,36 +18,36 @@ Thanks to our amazing user community, Metabase has been translated into many dif
 
 Supported languages include:
 
-| Language              | Code      |
-| --------------------- | --------- |
-| English               | `en`      |
-| Albanian              | `sq`      |
-| Arabic                | `ar`      |
-| Bulgarian             | `bg`      |
-| Catalan               | `ca`      |
-| Chinese               | `zh` |
-| Czech                 | `cs`      |
-| Dutch                 | `nl`      |
-| Farsi/Persian         | `fa`      |
-| Finnish               | `fi`      |
-| French                | `fr`      |
-| German                | `de`      |
-| Indonesian            | `id`      |
-| Italian               | `it`      |
-| Japanese              | `ja`      |
-| Korean                | `ko`      |
-| Latvian               | `lv`      |
-| Norwegian Bokmål      | `nb`      |
-| Polish                | `pl`      |
-| Portuguese            | `pt`      |
-| Russian               | `ru`      |
-| Serbian               | `sr`      |
-| Slovak                | `sk`      |
-| Spanish               | `es`      |
-| Swedish               | `sv`      |
-| Turkish               | `tr`      |
-| Ukrainian             | `uk`      |
-| Vietnamese            | `vi`      |
+| Language         | Code |
+| ---------------- | ---- |
+| English          | `en` |
+| Albanian         | `sq` |
+| Arabic           | `ar` |
+| Bulgarian        | `bg` |
+| Catalan          | `ca` |
+| Chinese          | `zh` |
+| Czech            | `cs` |
+| Dutch            | `nl` |
+| Farsi/Persian    | `fa` |
+| Finnish          | `fi` |
+| French           | `fr` |
+| German           | `de` |
+| Indonesian       | `id` |
+| Italian          | `it` |
+| Japanese         | `ja` |
+| Korean           | `ko` |
+| Latvian          | `lv` |
+| Norwegian Bokmål | `nb` |
+| Polish           | `pl` |
+| Portuguese       | `pt` |
+| Russian          | `ru` |
+| Serbian          | `sr` |
+| Slovak           | `sk` |
+| Spanish          | `es` |
+| Swedish          | `sv` |
+| Turkish          | `tr` |
+| Ukrainian        | `uk` |
+| Vietnamese       | `vi` |
 
 The locale codes are relevant for setting the language in [static embeds](../embedding/static-embedding-parameters.md#setting-the-language-for-a-static-embed).
 

--- a/docs/configuring-metabase/localization.md
+++ b/docs/configuring-metabase/localization.md
@@ -16,37 +16,40 @@ Here you can set the default language (also called the "instance language") acro
 
 Thanks to our amazing user community, Metabase has been translated into many different languages. Due to [the way we collect translations](#translations), languages may be added or removed during major releases depending on translation coverage.
 
-The languages you can currently pick from are:
+Supported languages include:
 
-- English (default)
-- Albanian
-- Arabic
-- Bulgarian
-- Catalan
-- Chinese (simplified)
-- Chinese (traditional)
-- Czech
-- Dutch
-- Farsi/Persian
-- Finnish
-- French
-- German
-- Indonesian
-- Italian
-- Japanese
-- Korean
-- Latvian
-- Norwegian Bokmål
-- Polish
-- Portuguese
-- Russian
-- Serbian
-- Slovak
-- Spanish
-- Swedish
-- Turkish
-- Ukrainian
-- Vietnamese
+| Language              | Code      |
+| --------------------- | --------- |
+| English               | `en`      |
+| Albanian              | `sq`      |
+| Arabic                | `ar`      |
+| Bulgarian             | `bg`      |
+| Catalan               | `ca`      |
+| Chinese               | `zh` |
+| Czech                 | `cs`      |
+| Dutch                 | `nl`      |
+| Farsi/Persian         | `fa`      |
+| Finnish               | `fi`      |
+| French                | `fr`      |
+| German                | `de`      |
+| Indonesian            | `id`      |
+| Italian               | `it`      |
+| Japanese              | `ja`      |
+| Korean                | `ko`      |
+| Latvian               | `lv`      |
+| Norwegian Bokmål      | `nb`      |
+| Polish                | `pl`      |
+| Portuguese            | `pt`      |
+| Russian               | `ru`      |
+| Serbian               | `sr`      |
+| Slovak                | `sk`      |
+| Spanish               | `es`      |
+| Swedish               | `sv`      |
+| Turkish               | `tr`      |
+| Ukrainian             | `uk`      |
+| Vietnamese            | `vi`      |
+
+The locale codes are relevant for setting the language in [static embeds](../embedding/static-embedding-parameters.md#setting-the-language-for-a-static-embed).
 
 > While Metabase can support languages that read right to left, the Metabase UI is designed around languages that read left to right.
 

--- a/docs/embedding/interactive-embedding.md
+++ b/docs/embedding/interactive-embedding.md
@@ -275,13 +275,13 @@ To hide a question or dashboard's title, [additional info](#additional_info), an
 
 ### `locale`
 
-You can localize the user interface via a parameter. For example, to set the locale to Spanish:
+You can change the language of the user interface via a parameter. For example, to set the locale to Spanish:
 
 ```
-locale=es-ES
+locale=es
 ```
 
-Check out the [locales Metabase supports](https://github.com/metabase/metabase/tree/master/locales). And read more about [localization](../configuring-metabase/localization.md).
+Read more about [localization](../configuring-metabase/localization.md).
 
 ### `logo`
 

--- a/docs/embedding/static-embedding-parameters.md
+++ b/docs/embedding/static-embedding-parameters.md
@@ -213,7 +213,7 @@ If you have multiple params, separated them with an ampersand `&`:
 category=Gadget&state=Vermont#theme=night&locale=ko
 ```
 
-See a [list of supported locales](../configuring-metabase/localization.md#supported-languages)
+The `locale` param only changes the language for Metabase UI elements. The _content_'s language is defined by whomever created the item. So for example Metabase wouldn't translate the name of a question, but Metabase _would_ translate the UI text "Export to PDF".
 
 ## Transparent backgrounds for embeds
 

--- a/docs/embedding/static-embedding-parameters.md
+++ b/docs/embedding/static-embedding-parameters.md
@@ -172,7 +172,7 @@ Because Metabase doesn't display locked parameters as filter widgets, you can us
 
 ![Look and feel: appearance settings on static embed](./images/04-preview.png)
 
-You can change the appearance of an embedded item by adding hash parameters to the end of the URL in your iframe's `src` attribute.
+You can change the appearance of an embedded item by adding hash parameters (e.g., `#theme=night`) to the end of the URL in your iframe's `src` attribute.
 
 For example, the following embedding URL will display an embedded item in dark mode, without a border, and with its original title:
 
@@ -186,6 +186,7 @@ You can preview appearance settings from your question or dashboard's embedded a
 | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | `background`               | true (default), false. Dashboards only.                                                                                                        |
 | `bordered`                 | true (default), false.                                                                                                                         |
+| `locale`                   | E.g., `locale=ko`. See [list of locales](../configuring-metabase/localization.md#supported-languages)                                          |
 | `titled`                   | true (default), false.                                                                                                                         |
 | `theme`                    | null (default), night. `theme=transparent` should work, but is deprecated (see [Transparent backgrounds](#transparent-backgrounds-for-embeds)) |
 | `refresh` (dashboard only) | integer (seconds, e.g., `refresh=60`).                                                                                                         |
@@ -197,6 +198,22 @@ You can preview appearance settings from your question or dashboard's embedded a
 \*\* Disabling downloads is available on [Pro](https://www.metabase.com/product/pro) and [Enterprise](https://www.metabase.com/product/enterprise) plans.
 
 For global appearance settings, such as the colors and fonts used across your entire Metabase instance, see [Customizing Metabase's appearance](../configuring-metabase/appearance.md).
+
+## Setting the language for a static embed
+
+To change the UI language for a static embed, you can set its [locale](../configuring-metabase/localization.md#supported-languages). For example, to set a public link's language to Korean, you could append `#locale=ko`.
+
+```
+https://metabase.example.com/public/dashboard/7b6e347b-6928-4aff-a56f-6cfa5b718c6b?category=&city=&state=#locale=ko
+```
+
+If you have multiple params, separated them with an ampersand `&`:
+
+```
+category=Gadget&state=Vermont#theme=night&locale=ko
+```
+
+See a [list of supported locales](../configuring-metabase/localization.md#supported-languages)
 
 ## Transparent backgrounds for embeds
 

--- a/docs/embedding/static-embedding-parameters.md
+++ b/docs/embedding/static-embedding-parameters.md
@@ -201,6 +201,8 @@ For global appearance settings, such as the colors and fonts used across your en
 
 ## Setting the language for a static embed
 
+{% include plans-blockquote.html feature="Locales for static embeds" %}
+
 To change the UI language for a static embed, you can set its [locale](../configuring-metabase/localization.md#supported-languages). For example, to set a public link's language to Korean, you could append `#locale=ko`.
 
 ```

--- a/docs/embedding/static-embedding-parameters.md
+++ b/docs/embedding/static-embedding-parameters.md
@@ -186,7 +186,7 @@ You can preview appearance settings from your question or dashboard's embedded a
 | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | `background`               | true (default), false. Dashboards only.                                                                                                        |
 | `bordered`                 | true (default), false.                                                                                                                         |
-| `locale`                   | E.g., `locale=ko`. See [list of locales](../configuring-metabase/localization.md#supported-languages)                                          |
+| `locale\*`                 | E.g., `locale=ko`. See [list of locales](../configuring-metabase/localization.md#supported-languages)                                          |
 | `titled`                   | true (default), false.                                                                                                                         |
 | `theme`                    | null (default), night. `theme=transparent` should work, but is deprecated (see [Transparent backgrounds](#transparent-backgrounds-for-embeds)) |
 | `refresh` (dashboard only) | integer (seconds, e.g., `refresh=60`).                                                                                                         |


### PR DESCRIPTION
- Adds list of codes to supported languages
- `locale` hash param