### PR TITLE
Pin webhook tester to v1

### DIFF
--- a/.github/actions/e2e-prepare-containers/action.yml
+++ b/.github/actions/e2e-prepare-containers/action.yml
@@ -90,7 +90,7 @@ runs:
 
         if ${{ inputs.webhook }}; then
           echo -e "${Y}Starting webhook test container..." &&
-          docker run -d -p 9080:8080/tcp tarampampam/webhook-tester serve --create-session 00000000-0000-0000-0000-000000000000 &&
+          docker run -d -p 9080:8080/tcp tarampampam/webhook-tester:1.1.0 serve --create-session 00000000-0000-0000-0000-000000000000 &&
           while ! nc -z localhost 9080; do sleep 1; done &&
           echo -e "${G}Webhook tester is up and running!"
         fi

--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -1117,7 +1117,7 @@ describe("scenarios > admin > settings > map settings", () => {
 });
 
 // Ensure the webhook tester docker container is running
-// docker run -p 9080:8080/tcp tarampampam/webhook-tester serve --create-session 00000000-0000-0000-0000-000000000000
+// docker run -p 9080:8080/tcp tarampampam/webhook-tester:1.1.0 serve --create-session 00000000-0000-0000-0000-000000000000
 describe("notifications", { tags: "@external" }, () => {
   beforeEach(() => {
     H.restore();

--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -421,7 +421,7 @@ describe("scenarios > question > saved", () => {
 //http://127.0.0.1:9080/api/session/00000000-0000-0000-0000-000000000000/requests
 
 // Ensure the webhook tester docker container is running
-// docker run -p 9080:8080/tcp tarampampam/webhook-tester serve --create-session 00000000-0000-0000-0000-000000000000
+// docker run -p 9080:8080/tcp tarampampam/webhook-tester:1.1.0 serve --create-session 00000000-0000-0000-0000-000000000000
 describe(
   "scenarios > question > saved > alerts",
   { tags: ["@external"] },


### PR DESCRIPTION
Our webhook testing docker container just moved to v2 which had some breaking changes which broke some of our e2e tests

https://github.com/tarampampam/webhook-tester/releases/tag/v2.0.0

Lesson: always use a version tag on docker containers like this.

This pins CI to the version 1.1 so it continues to work consistently