### PR TITLE
perf: Make registered? and initialized? checks faster for already initialized drivers

### DIFF
--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -33,10 +33,11 @@
        (driver/database-supports? ::test-driver :some-made-up-thing "dummy"))))
 
 (deftest the-driver-test
-  (testing (str "calling `the-driver` should set the context classloader, important because driver plugin code exists "
-                "there but not elsewhere")
+  (testing (str "calling `the-driver` should set the context classloader if the driver is not registered yet,"
+                "important because driver plugin code exists there but not elsewhere")
     (.setContextClassLoader (Thread/currentThread) (ClassLoader/getSystemClassLoader))
-    (driver/the-driver :h2)
+    (with-redefs [driver.impl/hierarchy (make-hierarchy)] ;; To simulate :h2 not being registed yet.
+      (driver/the-driver :h2))
     (is (= @@#'classloader/shared-context-classloader
            (.getContextClassLoader (Thread/currentThread))))))
 


### PR DESCRIPTION
The functions affected turn out to be quite hot when the query processor is working. This PR does 3 things:

1. Makes `initialized?` faster by hiding the initialization of parent drivers behind the initialization of child driver. The logic is this: initializing a driver requires first initializing its parents. So, if the child driver is marked as initialized, then parents are surely initialized too.
2. Makes `the-initialized-driver` check if the driver is already `initialized?`, and only otherwise it proceeds to register and initialize it. This is done because `registered?` predicate is comparatively expensive, performing lookups in the hierarchy. And `isa?` is sloppy peformance-wise in general.
3. Buries the initialization of the classloader into a place where we really start loading stuff. This is less important after **2*.* but still makes sense to do it like this. The current access of the classloader (in fact, replacing it inside) looks out of place here.
