### PR TITLE
perf: Don't compile MBQL query into native query twice

### DIFF
--- a/src/metabase/query_processor/execute.clj
+++ b/src/metabase/query_processor/execute.clj
@@ -21,7 +21,7 @@
               {:pre [(map? metadata)]}
               (rff (cond-> metadata
                      (not (:native_form metadata))
-                     (assoc :native_form ((some-fn :qp/compiled-inline :qp/compiled :native) query)))))]
+                     (assoc :native_form ((some-fn :qp/compiled :native) query)))))]
       (qp query rff*))))
 
 (defn- add-preprocessed-query-to-result-metadata-for-userland-query [qp]


### PR DESCRIPTION
This PR is more of a question of whether the current approach is required. I'm sorry if it is intentional, and there is no way to do it differently.

So, while rendering the results, we compile the MBQL query twice – once in the normal mode and once with inline parameters. I understand the intent of the inline mode for converting the native query to human-readable SQL. But does it need to happen on every data visualization? Can't it be compiled on-demand when the user actually requests the SQL?