### PR TITLE
Migrate legacy & broken relative date time filters

### DIFF
--- a/src/metabase/legacy_mbql/normalize.cljc
+++ b/src/metabase/legacy_mbql/normalize.cljc
@@ -928,6 +928,39 @@
   [field]
   (mbql.u/update-field-options field dissoc :temporal-unit :original-temporal-unit))
 
+(mu/defn ^:private replace-relative-date-filters :- mbql.s/Filter
+  "Replaces broken relative date filter clauses with `:relative-time-interval` calls.
+
+  Previously we generated a complex expression for relative date filters with an offset on the FE. It turned out that
+  the expression was wrong by 1 offset unit, e.g. if the offset was by months, it was wrong by 1 month. To fix the issue
+  we introduced a new `:relative-time-interval` function that surved several purposes. It captured the user intent
+  clearly while hiding the implementation details; it also fixed the underlying expression. Here we match the old
+  expression and convert it to a `:relative-time-interval` call, honoring the original user intent. See #46211 and
+  #46438 for details."
+  [filter-clause :- mbql.s/Filter]
+  (lib.util.match/replace filter-clause
+    [:between
+     [:+
+      field
+      [:internal (offset-value :guard integer?) (offset-unit :guard keyword?)]]
+     [:relative-datetime
+      (start-value :guard integer?)
+      (start-unit :guard keyword?)]
+     [:relative-datetime
+      (end-value :guard integer?)
+      (end-unit :guard keyword?)]]
+    (let [offset-value (- offset-value)]
+      (if (and (= start-unit end-unit)
+               (or (and (pos? offset-value) (zero? start-value) (pos? end-value))
+                   (and (neg? offset-value) (neg? start-value) (zero? end-value))))
+        [:relative-time-interval
+         field
+         (if (neg? offset-value) start-value end-value)
+         start-unit
+         offset-value
+         offset-unit]
+        &match))))
+
 (mu/defn ^:private replace-exclude-date-filters :- mbql.s/Filter
   "Replaces legacy exclude date filter clauses that rely on temporal bucketing with `:temporal-extract` function calls."
   [filter-clause :- mbql.s/Filter]
@@ -960,7 +993,9 @@
   (try
     (lib.util.match/replace query
       (filter-clause :guard mbql.preds/Filter?)
-      (replace-exclude-date-filters filter-clause))
+      (-> filter-clause
+          replace-relative-date-filters
+          replace-exclude-date-filters))
     (catch #?(:clj Throwable :cljs :default) e
       (throw (ex-info (i18n/tru "Error replacing legacy filters")
                       {:query query}

--- a/src/metabase/legacy_mbql/normalize.cljc
+++ b/src/metabase/legacy_mbql/normalize.cljc
@@ -933,7 +933,7 @@
 
   Previously we generated a complex expression for relative date filters with an offset on the FE. It turned out that
   the expression was wrong by 1 offset unit, e.g. if the offset was by months, it was wrong by 1 month. To fix the issue
-  we introduced a new `:relative-time-interval` function that surved several purposes. It captured the user intent
+  we introduced a new `:relative-time-interval` function that served several purposes. It captured the user intent
   clearly while hiding the implementation details; it also fixed the underlying expression. Here we match the old
   expression and convert it to a `:relative-time-interval` call, honoring the original user intent. See #46211 and
   #46438 for details."

--- a/src/metabase/legacy_mbql/normalize.cljc
+++ b/src/metabase/legacy_mbql/normalize.cljc
@@ -942,7 +942,7 @@
     [:between
      [:+
       field
-      [:internal (offset-value :guard integer?) (offset-unit :guard keyword?)]]
+      [:interval (offset-value :guard integer?) (offset-unit :guard keyword?)]]
      [:relative-datetime
       (start-value :guard integer?)
       (start-unit :guard keyword?)]

--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -385,24 +385,6 @@
        :unit         unit
        :offset-value offset-value
        :offset-unit  offset-unit
-       :options      {}}
-
-      ;; legacy expression; replaced by :relative-time-interval; supported for backward compatibility
-      [:between _
-       [:+ _
-        (col-ref :guard date-col?)
-        [:internal _ (offset-value :guard number?) (offset-unit :guard keyword?)]]
-       [:relative-datetime _
-        (start-value :guard number?)
-        (start-unit :guard keyword?)]
-       [:relative-datetime _
-        (end-value :guard number?)
-        (end-unit :guard keyword?)]]
-      {:column       (ref->col col-ref)
-       :value        (if (pos? offset-value) start-value end-value)
-       :unit         start-unit
-       :offset-value (- offset-value)
-       :offset-unit  offset-unit
        :options      {}})))
 
 (def ^:private ExcludeDateFilterParts

--- a/test/metabase/legacy_mbql/normalize_test.cljc
+++ b/test/metabase/legacy_mbql/normalize_test.cljc
@@ -1026,6 +1026,42 @@
 ;;; |                                              REPLACE LEGACY FILTERS                                            |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+(t/deftest ^:parallel replace-relative-date-filters-test
+  (tests 'replace-relative-date-filters #'mbql.normalize/replace-relative-date-filters
+         {"date range in the past"
+          {[:between
+            [:+ [:field 1 nil] [:interval 7 :year]]
+            [:relative-datetime -30 :day]
+            [:relative-datetime 0 :day]]
+           [:relative-time-interval [:field 1 nil] -30 :day -7 :year]}
+
+          "date range in the future"
+          {[:between
+            [:+ [:field 1 nil] [:interval -7 :year]]
+            [:relative-datetime 0 :day]
+            [:relative-datetime 30 :day]]
+           [:relative-time-interval [:field 1 nil] 30 :day 7 :year]}
+
+          "date range that is not entirely in the past or in the future should be skipped"
+          {[:between
+            [:+ [:field 1 nil] [:interval -7 :year]]
+            [:relative-datetime -5 :day]
+            [:relative-datetime 30 :day]]
+           [:between
+            [:+ [:field 1 nil] [:interval -7 :year]]
+            [:relative-datetime -5 :day]
+            [:relative-datetime 30 :day]]}
+
+          "date range with different units for start and end of the interval should be skipped"
+          {[:between
+            [:+ [:field 1 nil] [:interval -7 :year]]
+            [:relative-datetime 0 :day]
+            [:relative-datetime 30 :quarter]]
+           [:between
+            [:+ [:field 1 nil] [:interval -7 :year]]
+            [:relative-datetime 0 :day]
+            [:relative-datetime 30 :quarter]]}}))
+
 (t/deftest ^:parallel replace-exclude-date-filters-test
   (tests 'replace-exclude-date-filters #'mbql.normalize/replace-exclude-date-filters
          {"`:hour-of-day`"

--- a/test/metabase/query_processor/middleware/auto_bucket_datetimes_test.clj
+++ b/test/metabase/query_processor/middleware/auto_bucket_datetimes_test.clj
@@ -262,18 +262,14 @@
             {:source-table 1
              :breakout     [[:field Integer/MAX_VALUE nil]]})))))
 
-(deftest ^:parallel do-not-auto-bucket-time-interval-test
+(deftest ^:parallel do-not-auto-bucket-relative-time-interval-test
   (testing "does a :type/DateTime breakout Field that is already bucketed pass thru unchanged?"
     (qp.store/with-metadata-provider meta/metadata-provider
       (is (= {:source-table (meta/id :orders)
-              :filter       [:between [:+ [:field (meta/id :orders :created-at) nil] [:interval 1 :minute]]
-                             [:relative-datetime -10 :minute]
-                             [:relative-datetime 0 :minute]]}
+              :filter       [:relative-time-interval [:field (meta/id :orders :created-at) nil] 1 :day 2 :month]}
              (auto-bucket-mbql
               {:source-table (meta/id :orders)
-               :filter       [:between [:+ [:field (meta/id :orders :created-at) nil] [:interval 1 :minute]]
-                              [:relative-datetime -10 :minute]
-                              [:relative-datetime 0 :minute]]}))))))
+               :filter      [:relative-time-interval [:field (meta/id :orders :created-at) nil] 1 :day 2 :month]}))))))
 
 (deftest ^:parallel auto-bucket-unix-timestamp-fields-test
   (testing "do UNIX TIMESTAMP fields get auto-bucketed?"


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/50238

Previously we generated a complex expression for relative date filters with an offset on the FE. It turned out that the expression was wrong by 1 offset unit, e.g. if the offset was by months, it was wrong by 1 month. To fix the issue we introduced a new `:relative-time-interval` function that served several purposes. It captured the user intent clearly while hiding the implementation details; it also fixed the underlying expression. Here we match the old expression and convert it to a `:relative-time-interval` call, honoring the original user intent. See #46211 and #46438 for details.