### PR TITLE
adjusting webhook test response ui

### DIFF
--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -7,12 +7,6 @@ import {
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
-import {
-  WEBHOOK_TEST_DASHBOARD,
-  WEBHOOK_TEST_HOST,
-  WEBHOOK_TEST_SESSION_ID,
-} from "../../../support/helpers/e2e-notification-helpers";
-
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 const { SMTP_PORT, WEB_PORT } = WEBMAIL_CONFIG;
 
@@ -1122,19 +1116,16 @@ describe("notifications", { tags: "@external" }, () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
+    cy.request({
+      failOnStatusCode: false,
+      url: `${H.WEBHOOK_TEST_HOST}/api/session/${H.WEBHOOK_TEST_SESSION_ID}/requests`,
+      method: "DELETE",
+    }).then(response => {
+      cy.log("Deleted requests.");
+    });
   });
 
   describe("Auth", () => {
-    afterEach(() => {
-      cy.request(
-        "DELETE",
-        `${WEBHOOK_TEST_HOST}/api/session/${WEBHOOK_TEST_SESSION_ID}/requests`,
-        { failOnStatusCode: false },
-      ).then(response => {
-        cy.log("Deleted requests.");
-      });
-    });
-
     const COMMON_FIELDS = [
       {
         label: "Webhook URL",
@@ -1214,7 +1205,7 @@ describe("notifications", { tags: "@external" }, () => {
 
         cy.findByRole("heading", { name: "Awesome Hook" }).should("exist");
 
-        cy.visit(WEBHOOK_TEST_DASHBOARD);
+        cy.visit(H.WEBHOOK_TEST_DASHBOARD);
         cy.findByRole("heading", { name: /Requests 1/ }).should("exist");
 
         auth.validate();
@@ -1234,10 +1225,24 @@ describe("notifications", { tags: "@external" }, () => {
 
       cy.findByLabelText("Give it a name").type("Awesome Hook");
       cy.findByLabelText("Description").type("The best hook ever");
+
+      cy.log("should show error responses when testing");
+
+      cy.findByLabelText("Webhook URL").clear().type(H.WEBHOOK_TEST_HOST);
+      cy.button("Send a test").click();
+      cy.findByText("Test response").should("exist");
+      cy.findByTestId("notification-test-response").should(
+        "contain.text",
+        "request-status",
+      );
+      cy.findByTestId("notification-test-response").should(
+        "contain.text",
+        "request-body",
+      );
+
       cy.findByLabelText("Webhook URL").clear().type(H.WEBHOOK_TEST_URL);
       cy.button("Send a test").click();
-
-      cy.findByText("Test response").should("exist");
+      cy.findByText("Test response").should("not.exist");
 
       cy.button("Create destination").click();
     });

--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -1235,6 +1235,10 @@ describe("notifications", { tags: "@external" }, () => {
       cy.findByLabelText("Give it a name").type("Awesome Hook");
       cy.findByLabelText("Description").type("The best hook ever");
       cy.findByLabelText("Webhook URL").clear().type(H.WEBHOOK_TEST_URL);
+      cy.button("Send a test").click();
+
+      cy.findByText("Test response").should("exist");
+
       cy.button("Create destination").click();
     });
 

--- a/frontend/src/metabase-types/api/notifications.ts
+++ b/frontend/src/metabase-types/api/notifications.ts
@@ -2,6 +2,7 @@ import type {
   ScheduleSettings,
   ScheduleType,
 } from "metabase-types/api/settings";
+import { isObject } from "metabase-types/guards";
 
 import type { Card } from "./card";
 import type { User } from "./user";
@@ -83,6 +84,26 @@ export type NotificationChannel<Details = ChannelDetails> = {
   id: number;
   name: string;
   description: string;
+};
+
+type NotificationChannelTestErrorResponse = {
+  data: {
+    "request-body": string;
+    "request-status": number;
+  };
+  message: string;
+};
+
+export const isNotificationChannelTestErrorResponse = (
+  response: unknown,
+): response is { data: NotificationChannelTestErrorResponse } => {
+  return (
+    isObject(response) &&
+    isObject(response.data) &&
+    isObject(response.data.data) &&
+    "request-body" in response.data.data &&
+    "request-status" in response.data.data
+  );
 };
 
 export type SlackChannelSpec = ChannelSpec & {

--- a/frontend/src/metabase/admin/settings/notifications/WebhookForm.tsx
+++ b/frontend/src/metabase/admin/settings/notifications/WebhookForm.tsx
@@ -226,39 +226,49 @@ export const WebhookForm = ({
               </ExternalLink>
             )}`}</Text>
           </Alert>
-          <Flex align="end" mb="1.5rem" gap="1rem">
-            <FormTextInput
-              name="url"
-              label={t`Webhook URL`}
-              placeholder="http://hooks.example.com/hooks/catch/"
-              style={{ flexGrow: 1 }}
-              {...styles}
-              maw="21rem"
-            />
-            <Button
-              h="2.5rem"
-              onClick={() => handleTest(values, setFieldError)}
-            >
-              {testButtonLabel}
-            </Button>
-          </Flex>
-          {testData && (
-            //@ts-expect-error - I think the typing for ScrollArea.Autosize is wrong. It seems to want every single style prop for Box
-            <ScrollArea.Autosize
-              mah={300}
-              pt="0.75rem"
-              px="0.5rem"
-              bg="bg-light"
-              mb="0.75rem"
-            >
-              <Title order={5}>Test Response</Title>
-              <Box py="1rem">
-                <pre style={{ margin: 0 }}>
-                  {JSON.stringify(testData, null, 2)}
-                </pre>
-              </Box>
-            </ScrollArea.Autosize>
-          )}
+          <Box mb="1.5rem">
+            <Flex align="end" gap="1rem">
+              <FormTextInput
+                name="url"
+                label={t`Webhook URL`}
+                placeholder="http://hooks.example.com/hooks/catch/"
+                style={{ flexGrow: 1 }}
+                {...styles}
+                maw="21rem"
+              />
+              <Button
+                h="2.5rem"
+                onClick={() => handleTest(values, setFieldError)}
+              >
+                {testButtonLabel}
+              </Button>
+            </Flex>
+            {testData && (
+              //@ts-expect-error - I think the typing for ScrollArea.Autosize is wrong. It seems to want every single style prop for Box
+              <ScrollArea.Autosize mah={300} mt="0.75rem">
+                <Title order={6} mb="0.75rem" lh="1rem">
+                  Test Response
+                </Title>
+                <Box
+                  py="0.5rem"
+                  px="1.5rem"
+                  bg="bg-light"
+                  style={{ borderRadius: "0.5rem" }}
+                >
+                  <pre
+                    style={{
+                      margin: 0,
+                      fontSize: "0.75rem",
+                      lineHeight: "1rem",
+                    }}
+                  >
+                    {JSON.stringify(testData, null, 2)}
+                  </pre>
+                </Box>
+              </ScrollArea.Autosize>
+            )}
+          </Box>
+
           <FormTextInput
             name="name"
             label={t`Give it a name`}

--- a/frontend/src/metabase/admin/settings/notifications/WebhookForm.tsx
+++ b/frontend/src/metabase/admin/settings/notifications/WebhookForm.tsx
@@ -1,5 +1,5 @@
 import type { FormikHelpers } from "formik";
-import { jt, t } from "ttag";
+import { c, jt, t } from "ttag";
 import * as Yup from "yup";
 
 import { useTestChannelMutation } from "metabase/api/channel";
@@ -247,7 +247,8 @@ export const WebhookForm = ({
               //@ts-expect-error - I think the typing for ScrollArea.Autosize is wrong. It seems to want every single style prop for Box
               <ScrollArea.Autosize mah={300} mt="0.75rem">
                 <Title order={6} mb="0.75rem" lh="1rem">
-                  Test Response
+                  {c("The response returned by an API Request")
+                    .t`Test response`}
                 </Title>
                 <Box
                   py="0.5rem"

--- a/src/metabase/channel/impl/http.clj
+++ b/src/metabase/channel/impl/http.clj
@@ -52,6 +52,15 @@
                     (or (map? (:body req))
                         (sequential? (:body req))) (update :body json/encode)))))
 
+(defn- maybe-parse-json
+  [x]
+  (if (string? x)
+    (try
+      (json/decode x)
+      (catch Exception _e
+        x))
+    x))
+
 (defmethod channel/can-connect? :channel/http
   [_channel-type details]
   (channel.shared/validate-channel-details HTTPDetails details)
@@ -63,7 +72,7 @@
         ;; throw an appriopriate error if it's a connection error
         (if (= ::http/unexceptional-status (:type data))
           (throw (ex-info (tru "Failed to connect to channel") {:request-status (:status data)
-                                                                :request-body   (:body data)}))
+                                                                :request-body   (maybe-parse-json (:body data))}))
           (throw e))))))
 
 ;; ------------------------------------------------------------------------------------------------;;

--- a/test/metabase/channel/impl/http_test.clj
+++ b/test/metabase/channel/impl/http_test.clj
@@ -254,7 +254,18 @@
               :request-status 400}
              (exception-data (can-connect? {:url         (str url (:path get-400))
                                             :method      "get"
-                                            :auth-method "none"})))))))
+                                            :auth-method "none"})))))
+
+    (with-server [url [(make-route :get "/test_http_channel_400"
+                                   (fn [_]
+                                     {:status 400
+                                      :body   {:message "too bad"}}))]]
+      (testing "attempt to json parse the response body if it's a string"
+        (is (= {:request-body   {"message" "too bad"}
+                :request-status 400}
+               (exception-data (can-connect? {:url         (str url (:path get-400))
+                                              :method      "get"
+                                              :auth-method "none"}))))))))
 
 (deftest ^:parallel send!-test
   (testing "basic send"


### PR DESCRIPTION
Fixes #51114 

### Description
This change makes it so that only non-success responses get a test response section in the webhook form

### How to verify
- Go to an existing webhook (or set up a new one) and provide an valid URL, but that returns a 400 or 500 response.
- hit "Send Test".
- The box with the background should not contain the header, and the padding should be in line with the rest of the form. Also, the response should be scrollable.
- Replace with a valid url and hit send test. Test response should go away

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
