### PR TITLE
Implement dashboard subscription using dummy tools

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
@@ -7,6 +7,7 @@
    [malli.transform :as mtx]
    [metabase-enterprise.metabot-v3.client.schema :as metabot-v3.client.schema]
    [metabase-enterprise.metabot-v3.context :as metabot-v3.context]
+   [metabase-enterprise.metabot-v3.dummy-tools :as metabot-v3.dummy-tools]
    [metabase-enterprise.metabot-v3.tools :as metabot-v3.tools]
    [metabase.analytics.snowplow :as snowplow]
    [metabase.api.common :as api]
@@ -40,21 +41,24 @@
    :metabase-version (public-settings/version)})
 
 (defn- encode-request-body [body]
-  (mc/encode ::metabot-v3.client.schema/request body (mtx/transformer
-                                                      (mtx/default-value-transformer)
-                                                      {:name :api-request}
-                                                      (mtx/key-transformer {:encode (fn [k]
-                                                                                      (if (#{:additionalProperties :additional-properties} k)
-                                                                                        :additionalProperties
-                                                                                        (u/->snake_case_en k)))}))))
+  (mc/encode ::metabot-v3.client.schema/request
+             body
+             (mtx/transformer
+              (mtx/default-value-transformer)
+              {:name :api-request}
+              (mtx/key-transformer {:encode (fn [k]
+                                              (case k
+                                                (:additionalProperties :additional-properties) :additionalProperties
+                                                :anyOf :anyOf
+                                                (u/->snake_case_en k)))}))))
 
 (mu/defn- build-request-body
   [context :- [:maybe :map]
    messages :- [:maybe ::metabot-v3.client.schema/messages]
    session-id :- :string]
   (encode-request-body
-   {:messages      messages
-    :context       (metabot-v3.context/describe-context context)
+   {:messages      (into messages (metabot-v3.dummy-tools/invoke-dummy-tools context))
+    :context       context
     :tools         (metabot-v3.tools/applicable-tools (metabot-v3.tools/*tools-metadata*) context)
     :session-id    session-id
     :user-id       api/*current-user-id*

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
@@ -57,7 +57,7 @@
    messages :- [:maybe ::metabot-v3.client.schema/messages]
    session-id :- :string]
   (encode-request-body
-   {:messages      (into messages (metabot-v3.dummy-tools/invoke-dummy-tools context))
+   {:messages      (into (metabot-v3.dummy-tools/invoke-dummy-tools context) messages)
     :context       context
     :tools         (metabot-v3.tools/applicable-tools (metabot-v3.tools/*tools-metadata*) context)
     :session-id    session-id

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
@@ -56,7 +56,6 @@
           (:user-is-viewing context)))
 
 (def ^:private dummy-tool-registry
-  "Get metadata about the available dummy tools. "
   [dummy-get-current-user
    dummy-get-dashboard-details])
 
@@ -64,7 +63,7 @@
   "Invoke `tool` with `context` if applicable and return the resulting context."
   [context]
   (let [context (or (not-empty context)
-                    ;; hallucinate the user is viewing dashboard with ID 14
+                    ;; for testing purposes, pretend the user is viewing dashboard with ID 14
                     {:user-is-viewing [{:type :dashboard
                                         :ref 14
                                         :parameters []

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
@@ -1,0 +1,75 @@
+(ns metabase-enterprise.metabot-v3.dummy-tools
+  (:require
+   [cheshire.core :as json]
+   [metabase-enterprise.metabot-v3.tools.create-dashboard-subscription]
+   [metabase-enterprise.metabot-v3.tools.query]
+   [metabase-enterprise.metabot-v3.tools.who-is-your-favorite]
+   [metabase.api.common :as api]
+   [toucan2.core :as t2]))
+
+(defn- get-current-user
+  [_ _ context]
+  {:output (if-let [{:keys [id email first_name last_name]}
+                    (or (some-> api/*current-user* deref)
+                        (t2/select-one [:model/User :id :email :first_name :last_name] api/*current-user-id*))]
+             {:user_id id
+              :name (str first_name " " last_name)
+              :email_address email}
+             {:error "current user not found"})
+   :context context})
+
+(defn- get-dashboard-details
+  [_ {:keys [dashboard_id]} context]
+  {:output (or (t2/select-one [:model/Dashboard :id :description :name] dashboard_id)
+               {:error "dashboard not found"})
+   :context context})
+
+(defn- dummy-tool-messages
+  [tool-id arguments content]
+  (let [call-id (random-uuid)]
+    [{:content    nil
+      :role       :assistant,
+      :tool_calls [{:id        call-id
+                    :name      tool-id
+                    :arguments (json/generate-string arguments)}]}
+
+     {:content      (json/generate-string content)
+      :role         :tool,
+      :tool_call_id call-id}]))
+
+(defn- dummy-get-current-user
+  [context]
+  (let [content (:output (get-current-user :get-current-user {} context))]
+    (dummy-tool-messages :get-current-user {} content)))
+
+(defn- dummy-get-dashboard-details
+  [context]
+  (reduce (fn [messages viewed]
+            (if-let [dashboard-id (when (= (:type viewed) :dashboard)
+                                    (:ref viewed))]
+              (let [arguments {:dashboard_id dashboard-id}
+                    content (-> (get-dashboard-details :get-dashboard-details arguments context)
+                                :output)]
+                (into messages (dummy-tool-messages :get-dashboard-details arguments content)))
+              messages))
+          []
+          (:user-is-viewing context)))
+
+(def ^:private dummy-tool-registry
+  "Get metadata about the available dummy tools. "
+  [dummy-get-current-user
+   dummy-get-dashboard-details])
+
+(defn invoke-dummy-tools
+  "Invoke `tool` with `context` if applicable and return the resulting context."
+  [context]
+  (let [context (or (not-empty context)
+                    ;; hallucinate the user is viewing dashboard with ID 14
+                    {:user-is-viewing [{:type :dashboard
+                                        :ref 14
+                                        :parameters []
+                                        :is-embedded false}]})]
+    (reduce (fn [messages tool]
+              (into messages (tool context)))
+            []
+            dummy-tool-registry)))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
@@ -12,7 +12,7 @@
   {:output (if-let [{:keys [id email first_name last_name]}
                     (or (some-> api/*current-user* deref)
                         (t2/select-one [:model/User :id :email :first_name :last_name] api/*current-user-id*))]
-             {:user_id id
+             {:id id
               :name (str first_name " " last_name)
               :email_address email}
              {:error "current user not found"})

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools.clj
@@ -4,6 +4,7 @@
    [clojure.string :as str]
    [malli.core :as mc]
    [malli.transform :as mtx]
+   [metabase-enterprise.metabot-v3.tools.create-dashboard-subscription]
    [metabase-enterprise.metabot-v3.tools.interface :as metabot-v3.tools.interface]
    [metabase-enterprise.metabot-v3.tools.query]
    [metabase-enterprise.metabot-v3.tools.who-is-your-favorite]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/create-dashboard-subscription.json
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/create-dashboard-subscription.json
@@ -1,0 +1,145 @@
+{
+    "name": "create-dashboard-subscription",
+    "description": "Dashboards can be sent to via email on a regular schedule. This is helpful when a user wants to be kept up to date on the contents of a dashboard. Requirements to use the tool: 1.) You have a valid and complete email address for the recipient (username + @ + domain + TLD) like 'peter.pan@neverland.com'(cannot be used with incomplete emails e.g. 'peter.pan@neverland').  2.) The user provided a valid schedule (**Only full-hour schedules are supported (e.g., 14:00, not 14:30 or 14:15) - non-full-hour requests cannot be fulfilled.**). If the requirements are not met, ask the user for clarification before proceeding.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "dashboard_id": {
+                "type": "integer",
+                "description": "The ID of the dashboard to subscribe to."
+            },
+            "email": {
+                "type": "string",
+                "description": "A valid and complete email address of the user to whom the dashboard should be sent."
+            },
+            "schedule": {
+                "description": "The schedule at which the dashboard should be sent.",
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "frequency": {
+                                "type": "string",
+                                "enum": [
+                                    "hourly"
+                                ],
+                                "description": "Frequency at which the dashboard should be sent"
+                            }
+                        },
+                        "required": [
+                            "frequency"
+                        ],
+                        "additionalProperties": false
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "frequency": {
+                                "type": "string",
+                                "enum": [
+                                    "daily"
+                                ],
+                                "description": "Frequency at which the dashboard should be sent"
+                            },
+                            "hour": {
+                                "type": "integer",
+                                "description": "Hour at which the dashboard should be sent. Must be between 0 and 23. Can only be a full hour."
+                            }
+                        },
+                        "required": [
+                            "frequency",
+                            "hour"
+                        ],
+                        "additionalProperties": false
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "frequency": {
+                                "type": "string",
+                                "enum": [
+                                    "weekly"
+                                ],
+                                "description": "Frequency at which the dashboard should be sent"
+                            },
+                            "day_of_week": {
+                                "type": "string",
+                                "enum": [
+                                    "sunday",
+                                    "monday",
+                                    "tuesday",
+                                    "wednesday",
+                                    "thursday",
+                                    "friday",
+                                    "saturday"
+                                ],
+                                "description": "Day of the week at which the dashboard should be sent"
+                            },
+                            "hour": {
+                                "type": "integer",
+                                "description": "Hour at which the dashboard should be sent. Must be between 0 and 23. Can only be a full hour."
+                            }
+                        },
+                        "required": [
+                            "frequency",
+                            "day_of_week",
+                            "hour"
+                        ],
+                        "additionalProperties": false
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "frequency": {
+                                "type": "string",
+                                "enum": [
+                                    "monthly"
+                                ],
+                                "description": "Frequency at which the dashboard should be sent"
+                            },
+                            "day_of_month": {
+                                "type": "string",
+                                "enum": [
+                                    "first-calendar-day",
+                                    "first-sunday",
+                                    "first-monday",
+                                    "first-tuesday",
+                                    "first-wednesday",
+                                    "first-thursday",
+                                    "first-friday",
+                                    "first-saturday",
+                                    "middle-of-month",
+                                    "last-calendar-day",
+                                    "last-sunday",
+                                    "last-monday",
+                                    "last-tuesday",
+                                    "last-wednesday",
+                                    "last-thursday",
+                                    "last-friday",
+                                    "last-saturday"
+                                ],
+                                "description": "Day of the month at which the dashboard should be sent"
+                            },
+                            "hour": {
+                                "type": "integer",
+                                "description": "Hour at which the dashboard should be sent. Must be between 0 and 23. Can only be a full hour."
+                            }
+                        },
+                        "required": [
+                            "frequency",
+                            "day_of_month",
+                            "hour"
+                        ],
+                        "additionalProperties": false
+                    }
+                ]
+            }
+        },
+        "required": [
+            "dashboard_id",
+            "email",
+            "schedule"
+        ],
+        "additionalProperties": false
+    }
+}

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/create_dashboard_subscription.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/create_dashboard_subscription.clj
@@ -1,0 +1,38 @@
+(ns metabase-enterprise.metabot-v3.tools.create-dashboard-subscription
+  (:require
+   [metabase-enterprise.metabot-v3.tools.interface :as metabot-v3.tools.interface]
+   [metabase.api.common :as api]
+   [metabase.models.pulse :as models.pulse]
+   [metabase.util :as u]
+   [metabase.util.malli :as mu]
+   [toucan2.core :as t2]))
+
+(mu/defmethod metabot-v3.tools.interface/*invoke-tool* :metabot.tool/create-dashboard-subscription
+  [_tool-name {:keys [dashboard-id email schedule] :as _arguments} context]
+  (let [dashboard (-> (t2/select-one :model/Dashboard :id dashboard-id)
+                      (t2/hydrate [:dashcards :card]))
+        cards (for [{:keys [id card]} (:dashcards dashboard)]
+                (-> card
+                    (select-keys [:id :name :collection_id :description :display :parameter_mappings])
+                    (assoc :dashboard_card_id id :dashboard_id dashboard-id)))
+        recipient {:id (t2/select-one-fn :id :model/User :email email)} ; the real input is not the email address, but the user
+        {:keys [frequency hour day_of_week day_of_month]} schedule
+        channel {:channel_type :email
+                 :enabled true
+                 :recipients [recipient]
+                 :schedule_day (or (some-> day_of_week (subs 0 3) u/lower-case-en)
+                                   (some->> day_of_month
+                                            u/lower-case-en
+                                            (re-find #"^(?:first|last)-(mon|tue|wed|thu|fri|sat|sun)")
+                                            second))
+                 :schedule_frame (some->> day_of_month (re-find #"^(?:first|mid|last)"))
+                 :schedule_hour hour
+                 :schedule_type frequency}
+        pulse-data (-> dashboard
+                       (select-keys [:collection_id :collection_position :name :parameters])
+                       (assoc :dashboard_id  dashboard-id
+                              :creator_id    api/*current-user-id*
+                              :skip_if_empty false))]
+    (models.pulse/create-pulse! (map models.pulse/card->ref cards) [channel] pulse-data))
+  {:output "success"
+   :context context})

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/create_dashboard_subscription.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/create_dashboard_subscription.clj
@@ -15,7 +15,7 @@
                 (-> card
                     (select-keys [:id :name :collection_id :description :display :parameter_mappings])
                     (assoc :dashboard_card_id id :dashboard_id dashboard-id)))
-        recipient {:id (t2/select-one-fn :id :model/User :email email)} ; the real input is not the email address, but the user
+        recipient {:id (t2/select-one-fn :id :model/User :email email)}
         {:keys [frequency hour day_of_week day_of_month]} schedule
         channel {:channel_type :email
                  :enabled true
@@ -33,6 +33,9 @@
                        (assoc :dashboard_id  dashboard-id
                               :creator_id    api/*current-user-id*
                               :skip_if_empty false))]
-    (models.pulse/create-pulse! (map models.pulse/card->ref cards) [channel] pulse-data))
-  {:output "success"
-   :context context})
+    (if recipient
+      (do (models.pulse/create-pulse! (map models.pulse/card->ref cards) [channel] pulse-data)
+          {:output "success"
+           :context context})
+      {:output "no user with this email found"
+       :context context})))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/interface.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/interface.clj
@@ -24,11 +24,17 @@
     #(= (u/->kebab-case-en %) %)]])
 
 (mr/def ::metadata.parameter
-  [:map
-   [:type [:or
-           ::metadata.parameter.type
-           [:set ::metadata.parameter.type]]]
-   [:description {:optional true} [:maybe ::lib.schema.common/non-blank-string]]])
+  [:and
+   [:map
+    [:type {:optional true} [:or
+                             ::metadata.parameter.type
+                             [:set ::metadata.parameter.type]]]
+    [:anyOf {:optional true} [:sequential [:ref ::metadata.parameter]]]
+    [:description {:optional true} [:maybe ::lib.schema.common/non-blank-string]]]
+   [:fn
+    {:error/message "metadata.parameter must specify either `:type`` or `:anyOf`, but not both."}
+    (fn [query]
+      (= (count (select-keys query [:type :anyOf])) 1))]])
 
 (mr/def ::metadata.parameters.properties
   [:map-of ::metadata.parameter.name ::metadata.parameter])

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/handle_envelope_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/handle_envelope_test.clj
@@ -16,7 +16,7 @@
         e (create-env response)
         e* (#'metabot-v3.handle-envelope/handle-envelope e)]
     (testing "No reactions were created"
-      (is (= [] (:reactions e*))))
+      (is (empty? (:reactions e*))))
     (testing "The history is unchanged"
       (is (= [response] (:history e*))))
     (testing "We can get a reaction from the last message in the history"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/change_table_visualization_settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/change_table_visualization_settings_test.clj
@@ -6,7 +6,7 @@
   (is (= {:output "success",
           :reactions [{:visible-columns ["meow" "mix"]
                        :type :metabot.reaction/change-table-visualization-settings}]}
-         (tools.interface/*invoke-tool* :metabot.tool/change-table-visualization-settings {:visible-columns ["meow" "mix"]}))))
+         (tools.interface/*invoke-tool* :metabot.tool/change-table-visualization-settings {:visible-columns ["meow" "mix"]} {}))))
 
 (deftest it-is-only-applicable-for-tables
   (is (tools.interface/*tool-applicable?* :metabot.tool/change-table-visualization-settings


### PR DESCRIPTION
Fixes #50879 

### Description

Implements dashboard subscription for the current user to the currently visible dashboard. Assumes a generic context provided by the FE describing the objects currently visible to the user. (For testing purposes, If the FE provides no context, it puts dashboard 14 into the context.)

