### PR TITLE
[Cards in Dashboards] Reduce requests made for dashboards

### DIFF
--- a/frontend/src/metabase-lib/v1/Question.ts
+++ b/frontend/src/metabase-lib/v1/Question.ts
@@ -495,6 +495,10 @@ class Question {
     return this.setCard(assoc(this.card(), "collection_id", collectionId));
   }
 
+  dashboard(): Dashboard | undefined {
+    return this._card.dashboard;
+  }
+
   dashboardId(): DashboardId | null {
     return this._card.dashboard_id;
   }

--- a/frontend/src/metabase/nav/components/AppBar/AppBar.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBar.tsx
@@ -20,7 +20,6 @@ export interface AppBarProps {
   isProfileLinkVisible?: boolean;
   isCollectionPathVisible?: boolean;
   isQuestionLineageVisible?: boolean;
-  isContainingDashboardPathVisible?: boolean;
   onToggleNavbar: () => void;
   onCloseNavbar: () => void;
   onLogout: () => void;

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLarge.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLarge.tsx
@@ -30,7 +30,6 @@ export interface AppBarLargeProps {
   isProfileLinkVisible?: boolean;
   isCollectionPathVisible?: boolean;
   isQuestionLineageVisible?: boolean;
-  isContainingDashboardPathVisible?: boolean;
   onToggleNavbar: () => void;
   onLogout: () => void;
 }
@@ -46,7 +45,6 @@ const AppBarLarge = ({
   isProfileLinkVisible,
   isCollectionPathVisible,
   isQuestionLineageVisible,
-  isContainingDashboardPathVisible,
   onToggleNavbar,
   onLogout,
 }: AppBarLargeProps): JSX.Element => {
@@ -70,9 +68,7 @@ const AppBarLarge = ({
           {isQuestionLineageVisible ? (
             <QuestionLineage />
           ) : isCollectionPathVisible ? (
-            <CollectionBreadcrumbs
-              showContainingDashboard={isContainingDashboardPathVisible}
-            />
+            <CollectionBreadcrumbs />
           ) : null}
         </AppBarInfoContainer>
       </AppBarLeftContainer>

--- a/frontend/src/metabase/nav/components/AppBar/AppBarSmall.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarSmall.tsx
@@ -30,7 +30,6 @@ export interface AppBarSmallProps {
   isProfileLinkVisible?: boolean;
   isCollectionPathVisible?: boolean;
   isQuestionLineageVisible?: boolean;
-  isContainingDashboardPathVisible?: boolean;
   onToggleNavbar: () => void;
   onCloseNavbar: () => void;
   onLogout: () => void;
@@ -45,7 +44,6 @@ const AppBarSmall = ({
   isProfileLinkVisible,
   isCollectionPathVisible,
   isQuestionLineageVisible,
-  isContainingDashboardPathVisible,
   onToggleNavbar,
   onCloseNavbar,
   onLogout,
@@ -114,9 +112,7 @@ const AppBarSmall = ({
           {isQuestionLineageVisible ? (
             <QuestionLineage />
           ) : isCollectionPathVisible ? (
-            <CollectionBreadcrumbs
-              showContainingDashboard={isContainingDashboardPathVisible}
-            />
+            <CollectionBreadcrumbs />
           ) : null}
         </AppBarSubheader>
       )}

--- a/frontend/src/metabase/nav/containers/AppBar/AppBar.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar/AppBar.tsx
@@ -8,7 +8,6 @@ import { closeNavbar, toggleNavbar } from "metabase/redux/app";
 import type { RouterProps } from "metabase/selectors/app";
 import {
   getIsCollectionPathVisible,
-  getIsContainingDashboardPathVisible,
   getIsLogoVisible,
   getIsNavBarEnabled,
   getIsNavbarOpen,
@@ -34,10 +33,6 @@ const mapStateToProps = (state: State, props: RouterProps) => ({
   isNewButtonVisible: getIsNewButtonVisible(state),
   isProfileLinkVisible: getIsProfileLinkVisible(state),
   isCollectionPathVisible: getIsCollectionPathVisible(state, props),
-  isContainingDashboardPathVisible: getIsContainingDashboardPathVisible(
-    state,
-    props,
-  ),
   isQuestionLineageVisible: getIsQuestionLineageVisible(state, props),
 });
 

--- a/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
@@ -44,6 +44,7 @@ const CARD_IN_DASHBOARD = createMockCard({
   id: 3,
   collection_id: 3,
   dashboard_id: 4,
+  dashboard: BAR_DASHBOARD,
 });
 
 describe("AppBar", () => {

--- a/frontend/src/metabase/nav/containers/CollectionBreadcrumbs/CollectionBreadcrumbs.tsx
+++ b/frontend/src/metabase/nav/containers/CollectionBreadcrumbs/CollectionBreadcrumbs.tsx
@@ -1,10 +1,6 @@
 import _ from "underscore";
 
-import {
-  skipToken,
-  useGetCollectionQuery,
-  useGetDashboardQuery,
-} from "metabase/api";
+import { useGetCollectionQuery } from "metabase/api";
 import { useSelector } from "metabase/lib/redux";
 import { getQuestion } from "metabase/query_builder/selectors";
 import { getCollectionId } from "metabase/selectors/app";
@@ -21,7 +17,6 @@ type CollectionBreadcrumbsProps = Omit<
 > & {
   collectionId?: CollectionId;
   baseCollectionId?: CollectionId | null;
-  showContainingDashboard?: boolean;
 };
 
 export const CollectionBreadcrumbs = (props: CollectionBreadcrumbsProps) => {
@@ -31,20 +26,12 @@ export const CollectionBreadcrumbs = (props: CollectionBreadcrumbsProps) => {
   const { data: collection } = useGetCollectionQuery({ id: collectionId });
 
   const question = useSelector(getQuestion);
-  const dashboardId = question?.dashboardId();
-  const isDashboardQuestion = _.isNumber(dashboardId);
-  const shouldShowDashboard =
-    props.showContainingDashboard && isDashboardQuestion;
-  const dashboardReq = useGetDashboardQuery(
-    shouldShowDashboard ? { id: dashboardId } : skipToken,
-  );
-  const dashboard = shouldShowDashboard ? dashboardReq?.data : undefined;
 
   return (
     <Breadcrumbs
       {...props}
       collection={collection}
-      dashboard={dashboard}
+      dashboard={question?.dashboard()}
       baseCollectionId={props.baseCollectionId ?? null}
     />
   );

--- a/frontend/src/metabase/selectors/app.ts
+++ b/frontend/src/metabase/selectors/app.ts
@@ -68,23 +68,6 @@ export const getIsCollectionPathVisible = createSelector(
   },
 );
 
-export const getIsContainingDashboardPathVisible = createSelector(
-  [getIsCollectionPathVisible, getQuestion, getRouterPath],
-  (isCollectionPathVisible, question, path) => {
-    if (!isCollectionPathVisible) {
-      return false;
-    }
-
-    const isOnQuestionPage = /\/question\//.test(path);
-    const isSavedDashboardQuestion =
-      question != null &&
-      question.isSaved() &&
-      typeof question?.dashboardId() === "number";
-
-    return isSavedDashboardQuestion && isOnQuestionPage;
-  },
-);
-
 export const getIsQuestionLineageVisible = createSelector(
   [getIsSavedQuestionChanged, getRouterPath],
   (isSavedQuestionChanged, path) =>


### PR DESCRIPTION
Related to #50173

### Description

Reduces the number of requests for a dashboard question's dashboard by using the `dashboard` property that is now populated on dashboard questions.

### How to verify

- Open the network tab in the browser developer tools
- Visit a dedicated dashboard question page
- See that there is no longer a request for the dashboard the question is contained in

### Demo

Before

https://github.com/user-attachments/assets/b765038f-ab80-4801-9680-73841b763078

After

https://github.com/user-attachments/assets/b2845985-b07b-46ec-bc56-3a03f7a6d80d


### Checklist

- [x] Tests have been added/updated to cover changes in this PR