### PR TITLE
Do not match inner clauses with -filter-parts

### DIFF
--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -164,7 +164,11 @@
 
       ;; multiple arguments with options
       [(op :guard #{:contains :does-not-contain :starts-with :ends-with}) opts (col-ref :guard string-col?) & (args :guard #(every? string? %))]
-      {:operator op, :column (ref->col col-ref), :values args, :options {:case-sensitive (get opts :case-sensitive true)}})))
+      {:operator op, :column (ref->col col-ref), :values args, :options {:case-sensitive (get opts :case-sensitive true)}}
+
+      ;; do not match inner clauses
+      _
+      nil)))
 
 (def ^:private NumberFilterParts
   [:map
@@ -203,7 +207,11 @@
 
       ;; exactly 2 arguments
       [(op :guard #{:between}) _ (col-ref :guard number-col?) (start :guard number?) (end :guard number?)]
-      {:operator op, :column (ref->col col-ref), :values [start end]})))
+      {:operator op, :column (ref->col col-ref), :values [start end]}
+
+      ;; do not match inner clauses
+      _
+      nil)))
 
 (def ^:private CoordinateFilterParts
   [:map
@@ -255,7 +263,11 @@
        (lat-col-ref :guard coordinate-col?)
        (lon-col-ref :guard coordinate-col?)
        & (args :guard #(and (every? number? %) (= (count %) 4)))]
-      {:operator op, :column (ref->col lat-col-ref), :longitude-column (ref->col lon-col-ref), :values args})))
+      {:operator op, :column (ref->col lat-col-ref), :longitude-column (ref->col lon-col-ref), :values args}
+
+      ;; do not match inner clauses
+      _
+      nil)))
 
 (def ^:private BooleanFilterParts
   [:map
@@ -286,7 +298,11 @@
 
       ;; exactly 1 argument
       [(op :guard #{:=}) _ (col-ref :guard boolean-col?) (arg :guard boolean?)]
-      {:operator op, :column (ref->col col-ref), :values [arg]})))
+      {:operator op, :column (ref->col col-ref), :values [arg]}
+
+      ;; do not match inner clauses
+      _
+      nil)))
 
 (def ^:private SpecificDateFilterParts
   [:map
@@ -329,7 +345,11 @@
             start (u.time/coerce-to-timestamp start)
             end   (u.time/coerce-to-timestamp end)]
         (when (and (u.time/valid? start) (u.time/valid? end))
-          {:operator op, :column (ref->col col-ref), :values [start end], :with-time? (not date?)})))))
+          {:operator op, :column (ref->col col-ref), :values [start end], :with-time? (not date?)}))
+
+      ;; do not match inner clauses
+      _
+      nil)))
 
 (def ^:private RelativeDateFilterParts
   [:map
@@ -403,7 +423,11 @@
        :unit         start-unit
        :offset-value (- offset-value)
        :offset-unit  offset-unit
-       :options      {}})))
+       :options      {}}
+
+      ;; do not match inner clauses
+      _
+      nil)))
 
 (def ^:private ExcludeDateFilterParts
   [:map
@@ -449,7 +473,11 @@
 
       ;; with `:mode`
       [:!= _ [:get-day-of-week _ (col-ref :guard date-col?) :iso] & (args :guard #(every? int? %))]
-      {:operator :!=, :column (ref->col col-ref), :unit :day-of-week, :values args})))
+      {:operator :!=, :column (ref->col col-ref), :unit :day-of-week, :values args}
+
+      ;; do not match inner clauses
+      _
+      nil)))
 
 (def ^:private TimeFilterParts
   [:map
@@ -490,7 +518,11 @@
       (let [start (u.time/coerce-to-time start)
             end   (u.time/coerce-to-time end)]
         (when (and (u.time/valid? start) (u.time/valid? end))
-          {:operator op, :column (ref->col col-ref), :values [start end]})))))
+          {:operator op, :column (ref->col col-ref), :values [start end]}))
+
+      ;; do not match inner clauses
+      _
+      nil)))
 
 (mu/defn filter-args-display-name :- :string
   "Provides a reasonable display name for the `filter-clause` excluding the column-name.

--- a/test/metabase/lib/fe_util_test.cljc
+++ b/test/metabase/lib/fe_util_test.cljc
@@ -176,7 +176,8 @@
       (are [clause] (nil? (lib.fe-util/string-filter-parts query -1 clause))
         (lib.filter/= "A" column)
         (lib.filter/is-null column)
-        (lib.expression/concat column "A")))))
+        (lib.expression/concat column "A")
+        (lib.filter/and (lib.filter/= column "A") true)))))
 
 (deftest ^:parallel number-filter-parts-test
   (let [query  lib.tu/venues-query
@@ -202,7 +203,8 @@
       (are [clause] (nil? (lib.fe-util/number-filter-parts query -1 clause))
         (lib.filter/= 10 column)
         (lib.filter/is-null (meta/field-metadata :venues :name))
-        (lib.expression/+ column 10)))))
+        (lib.expression/+ column 10)
+        (lib.filter/and (lib.filter/= column 10) true)))))
 
 (deftest ^:parallel coordinate-filter-parts-test
   (let [query      (lib.query/query meta/metadata-provider (meta/table-metadata :orders))
@@ -246,7 +248,8 @@
         (lib.filter/= 10 lat-column)
         (lib.filter/is-null lat-column)
         (lib.filter/= (meta/field-metadata :orders :total) 10)
-        (lib.expression/+ lat-column 10)))))
+        (lib.expression/+ lat-column 10)
+        (lib.filter/and (lib.filter/= lat-column 10) true)))))
 
 (deftest ^:parallel boolean-filter-parts-test
   (let [query  (-> lib.tu/venues-query
@@ -268,7 +271,8 @@
       (are [clause] (nil? (lib.fe-util/boolean-filter-parts query -1 clause))
         (lib.filter/= true column)
         (lib.filter/!= column true)
-        (lib.filter/is-null (meta/field-metadata :venues :name))))))
+        (lib.filter/is-null (meta/field-metadata :venues :name))
+        (lib.filter/and (lib.filter/= column true) true)))))
 
 (defn- format-date-filter-parts
   [{:keys [with-time?], :as parts}]
@@ -337,7 +341,8 @@
       (are [clause] (nil? (lib.fe-util/specific-date-filter-parts query -1 clause))
         (lib.filter/is-null column)
         (lib.filter/< "2024-11-28" column)
-        (lib.filter/> (meta/field-metadata :venues :price) 10)))))
+        (lib.filter/> (meta/field-metadata :venues :price) 10)
+        (lib.filter/and (lib.filter/< column "2024-11-28") true)))))
 
 (deftest ^:parallel relative-date-filter-parts-test
   (let [query  lib.tu/venues-query
@@ -388,7 +393,8 @@
                                                                            options)))))))
     (testing "unsupported clauses"
       (are [clause] (nil? (lib.fe-util/relative-date-filter-parts query -1 clause))
-        (lib.filter/is-null column)))))
+        (lib.filter/is-null column)
+        (lib.filter/and (lib.filter/time-interval column -10 :month) true)))))
 
 (deftest ^:parallel exclude-date-filter-parts-test
   (let [query  lib.tu/venues-query
@@ -445,7 +451,8 @@
       (are [clause] (nil? (lib.fe-util/exclude-date-filter-parts query -1 clause))
         (lib.filter/between column "2020-01-01" "2021-01-01")
         (lib.filter/!= (lib.expression/get-day-of-week column) 1)
-        (lib.filter/!= (lib.expression/get-year column) 2024)))))
+        (lib.filter/!= (lib.expression/get-year column) 2024)
+        (lib.filter/and (lib.filter/!= (lib.expression/get-hour column) 0) true)))))
 
 (defn- format-time-filter-parts
   [parts]
@@ -495,7 +502,8 @@
       (are [clause] (nil? (lib.fe-util/time-filter-parts query -1 clause))
         (lib.filter/= column "10:20")
         (lib.filter/> "10:20" column)
-        (lib.filter/is-null (meta/field-metadata :venues :name))))))
+        (lib.filter/is-null (meta/field-metadata :venues :name))
+        (lib.filter/and (lib.filter/> column "10:20") true)))))
 
 (deftest ^:parallel date-parts-display-name-test
   (let [created-at (meta/field-metadata :products :created-at)


### PR DESCRIPTION
Fixes a regression (master-only) introduced by new `-filter-parts` functions. They should not match inner clauses. This PR fixes the issue and adds tests.

How to verify:
- New -> Question -> Products
- Filter -> Custom expression -> `case([Price] > 50, 1, 2) = 1` -> Done
- Click on the newly added filter. It should not open a filter widget for `[Price] > 50` part.