### PR TITLE
Namespace native editor e2e helpers

### DIFF
--- a/e2e/support/helpers/e2e-action-helpers.js
+++ b/e2e/support/helpers/e2e-action-helpers.js
@@ -1,6 +1,6 @@
 import { capitalize } from "inflection";
 
-import { nativeEditorType } from "./e2e-native-editor-helpers";
+import { NativeEditor } from "./e2e-native-editor-helpers";
 
 export function setActionsEnabledForDB(dbId, enabled = true) {
   return cy.request("PUT", `/api/database/${dbId}`, {
@@ -11,7 +11,7 @@ export function setActionsEnabledForDB(dbId, enabled = true) {
 }
 
 export function fillActionQuery(query) {
-  nativeEditorType(query);
+  NativeEditor.type(query);
 }
 /**
  *

--- a/e2e/support/helpers/e2e-ad-hoc-question-helpers.js
+++ b/e2e/support/helpers/e2e-ad-hoc-question-helpers.js
@@ -1,7 +1,7 @@
 import { SAMPLE_DB_ID, SAMPLE_DB_TABLES } from "e2e/support/cypress_data";
 
 import { runNativeQuery } from "./e2e-misc-helpers";
-import { nativeEditor } from "./e2e-native-editor-helpers";
+import { NativeEditor } from "./e2e-native-editor-helpers";
 
 const {
   STATIC_ORDERS_ID,
@@ -96,7 +96,7 @@ export function startNewNativeQuestion(config) {
 
   cy.visit("/question#" + hash);
 
-  return nativeEditor();
+  return NativeEditor.get();
 }
 
 /**
@@ -107,7 +107,7 @@ export function startNewNativeModel(config) {
 
   cy.visit("/model/query#" + hash);
 
-  return nativeEditor();
+  return NativeEditor.get();
 }
 
 /**

--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -1,5 +1,5 @@
 import { pickEntity } from "./e2e-collection-helpers";
-import { focusNativeEditor } from "./e2e-native-editor-helpers";
+import { NativeEditor } from "./e2e-native-editor-helpers";
 
 // Find a text field by label text, type it in, then blur the field.
 // Commonly used in our Admin section as we auto-save settings.
@@ -43,7 +43,7 @@ export function openNativeEditor({
   // database selector or simply display the previously selected database
   cy.findAllByTestId("loading-indicator").should("not.exist");
 
-  return focusNativeEditor().as(alias);
+  return NativeEditor.focus().get().as(alias);
 }
 
 /**

--- a/e2e/support/helpers/e2e-native-editor-helpers.ts
+++ b/e2e/support/helpers/e2e-native-editor-helpers.ts
@@ -79,6 +79,9 @@ function nativeEditorType(
       case "{movetoend}":
         return cy.realPress(["Control", "E"]);
 
+      case "{backspace}":
+        return cy.realPress(["Backspace"]);
+
       case "{{}":
         return cy.realType("{");
     }

--- a/e2e/support/helpers/e2e-native-editor-helpers.ts
+++ b/e2e/support/helpers/e2e-native-editor-helpers.ts
@@ -1,4 +1,4 @@
-export function nativeEditor() {
+function nativeEditor() {
   cy.findAllByTestId("loading-indicator").should("not.exist");
   return cy.get("[data-testid=native-query-editor] .cm-content");
 }

--- a/e2e/support/helpers/e2e-native-editor-helpers.ts
+++ b/e2e/support/helpers/e2e-native-editor-helpers.ts
@@ -3,7 +3,7 @@ function nativeEditor() {
   return cy.get("[data-testid=native-query-editor] .cm-content");
 }
 
-export function focusNativeEditor() {
+function focusNativeEditor() {
   nativeEditor().should("be.visible").click();
 
   nativeEditor().get(".cm-editor").should("have.class", "cm-focused");

--- a/e2e/support/helpers/e2e-native-editor-helpers.ts
+++ b/e2e/support/helpers/e2e-native-editor-helpers.ts
@@ -35,7 +35,7 @@ function clearNativeEditor() {
   cy.realPress(["Backspace"]);
 }
 
-export function nativeEditorType(
+function nativeEditorType(
   text: string,
   { delay = 10 }: { delay?: number } = {},
 ) {

--- a/e2e/support/helpers/e2e-native-editor-helpers.ts
+++ b/e2e/support/helpers/e2e-native-editor-helpers.ts
@@ -35,11 +35,18 @@ function clearNativeEditor() {
   cy.realPress(["Backspace"]);
 }
 
+type TypeOptions = {
+  delay?: number;
+  focus?: boolean;
+};
+
 function nativeEditorType(
   text: string,
-  { delay = 10 }: { delay?: number } = {},
+  { delay = 10, focus = true }: TypeOptions = {},
 ) {
-  focusNativeEditor();
+  if (focus) {
+    focusNativeEditor();
+  }
 
   const parts = text.replaceAll("{{", "{{}{{}").split(/(\{[^}]+\})/);
 
@@ -101,8 +108,8 @@ function nativeEditorType(
 
 export const NativeEditor = {
   get: nativeEditor,
-  type(text: string) {
-    nativeEditorType(text);
+  type(text: string, options: TypeOptions) {
+    nativeEditorType(text, options);
     return NativeEditor;
   },
   focus() {

--- a/e2e/support/helpers/e2e-native-editor-helpers.ts
+++ b/e2e/support/helpers/e2e-native-editor-helpers.ts
@@ -59,7 +59,7 @@ function nativeEditorType(
       case "{clear}":
         return clearNativeEditor();
 
-      case "{selectAll}":
+      case "{selectall}":
         return nativeEditorSelectAll();
 
       case "{leftarrow}":

--- a/e2e/support/helpers/e2e-native-editor-helpers.ts
+++ b/e2e/support/helpers/e2e-native-editor-helpers.ts
@@ -30,7 +30,7 @@ function nativeEditorSelectAll() {
   cy.get(".cm-selectionBackground").should("exist");
 }
 
-export function clearNativeEditor() {
+function clearNativeEditor() {
   nativeEditorSelectAll();
   cy.realPress(["Backspace"]);
 }

--- a/e2e/support/helpers/e2e-native-editor-helpers.ts
+++ b/e2e/support/helpers/e2e-native-editor-helpers.ts
@@ -23,7 +23,7 @@ function nativeEditorCompletion(label: string) {
   return cy.get(".cm-completionLabel").contains(label).parent();
 }
 
-export function nativeEditorSelectAll() {
+function nativeEditorSelectAll() {
   const isMac = Cypress.platform === "darwin";
   const metaKey = isMac ? "Meta" : "Control";
   focusNativeEditor().realPress([metaKey, "A"]);

--- a/e2e/support/helpers/e2e-native-editor-helpers.ts
+++ b/e2e/support/helpers/e2e-native-editor-helpers.ts
@@ -11,15 +11,15 @@ function focusNativeEditor() {
   return nativeEditor();
 }
 
-export function blurNativeEditor() {
+function blurNativeEditor() {
   nativeEditor().get(".cm-editor").blur();
 }
 
-export function nativeEditorCompletions() {
+function nativeEditorCompletions() {
   return cy.get(".cm-tooltip-autocomplete").should("be.visible");
 }
 
-export function nativeEditorCompletion(label: string) {
+function nativeEditorCompletion(label: string) {
   return cy.get(".cm-completionLabel").contains(label).parent();
 }
 

--- a/e2e/support/helpers/e2e-native-editor-helpers.ts
+++ b/e2e/support/helpers/e2e-native-editor-helpers.ts
@@ -95,3 +95,29 @@ export function nativeEditorType(
 
   return nativeEditor();
 }
+
+export const NativeEditor = {
+  get: nativeEditor,
+  type(text: string) {
+    nativeEditorType(text);
+    return NativeEditor;
+  },
+  focus() {
+    focusNativeEditor();
+    return NativeEditor;
+  },
+  blur() {
+    blurNativeEditor();
+    return NativeEditor;
+  },
+  selectAll() {
+    nativeEditorSelectAll();
+    return NativeEditor;
+  },
+  clear() {
+    clearNativeEditor();
+    return NativeEditor;
+  },
+  completions: nativeEditorCompletions,
+  completion: nativeEditorCompletion,
+};

--- a/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
@@ -984,7 +984,7 @@ const MODEL_NAME = "Test Action Model";
           });
 
           actionEditorModal().within(() => {
-            H.NativeEditor.focus().type("{home}{shift+end}{backspace}");
+            H.NativeEditor.clear();
             const TEST_COLUMNS_QUERY = `UPDATE ${TEST_COLUMNS_TABLE} SET timestamp = {{ Timestamp }} WHERE id = {{ ID }}`;
             H.NativeEditor.focus().type(TEST_COLUMNS_QUERY, {
               delay: 0,

--- a/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
@@ -984,9 +984,9 @@ const MODEL_NAME = "Test Action Model";
           });
 
           actionEditorModal().within(() => {
-            H.focusNativeEditor().type("{home}{shift+end}{backspace}");
+            H.NativeEditor.focus().type("{home}{shift+end}{backspace}");
             const TEST_COLUMNS_QUERY = `UPDATE ${TEST_COLUMNS_TABLE} SET timestamp = {{ Timestamp }} WHERE id = {{ ID }}`;
-            H.focusNativeEditor().type(TEST_COLUMNS_QUERY, {
+            H.NativeEditor.focus().type(TEST_COLUMNS_QUERY, {
               delay: 0,
               parseSpecialCharSequences: false,
             });

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
@@ -1802,7 +1802,7 @@ describe("issue 48878", () => {
     cy.findByTestId("model-actions-header").findByText("New action").click();
 
     H.modal().within(() => {
-      H.focusNativeEditor().type("UPDATE orders SET plan = {{ plan ", {
+      H.NativeEditor.focus().type("UPDATE orders SET plan = {{ plan ", {
         parseSpecialCharSequences: false,
       });
       cy.button("Save").click();
@@ -1848,7 +1848,7 @@ describe("issue 48878", () => {
       .findByText("Use a native query")
       .click();
 
-    H.focusNativeEditor().type(query);
+    H.NativeEditor.focus().type(query);
     cy.findByTestId("native-query-editor-sidebar")
       .findByTestId("run-button")
       .click();

--- a/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
@@ -68,14 +68,14 @@ describe("scenarios > dashboard > dashboard back navigation", () => {
     H.getDashboardCard().realHover();
     H.getDashboardCardMenu().click();
     H.popover().findByText("Edit question").click();
-    H.nativeEditor().should("be.visible");
+    H.NativeEditor.get().should("be.visible");
 
     H.queryBuilderHeader().findByLabelText("Back to Test Dashboard").click();
     H.getDashboardCard().findByText("Orders SQL").click();
     cy.findByTestId("native-query-top-bar")
       .findByText("This question is written in SQL.")
       .should("be.visible");
-    H.nativeEditor().should("not.be.visible");
+    H.NativeEditor.get().should("not.be.visible");
   });
 
   it("should display a back to the dashboard button in table x-ray dashboards", () => {

--- a/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
@@ -372,8 +372,7 @@ describe("Dashboard > Dashboard Questions", () => {
       cy.visit("/");
       H.newButton("SQL query").click();
 
-      H.focusNativeEditor();
-      cy.realType("SELECT COUNT(*) / 2 as half_count FROM ORDERS");
+      H.NativeEditor.type("SELECT COUNT(*) / 2 as half_count FROM ORDERS");
 
       H.queryBuilderHeader().button("Save").click();
       H.modal().within(() => {

--- a/e2e/test/scenarios/models/create.cy.spec.js
+++ b/e2e/test/scenarios/models/create.cy.spec.js
@@ -25,7 +25,7 @@ describe("scenarios > models > create", () => {
     // Clicking on metadata should not work until we run a query
     cy.findByTestId("editor-tabs-metadata").should("be.disabled");
 
-    H.focusNativeEditor().type("select * from ORDERS");
+    H.NativeEditor.focus().type("select * from ORDERS");
 
     cy.findByTestId("native-query-editor-container").icon("play").click();
     cy.wait("@dataset");
@@ -47,7 +47,7 @@ describe("scenarios > models > create", () => {
     H.visitCollection(THIRD_COLLECTION_ID);
 
     navigateToNewModelPage();
-    H.focusNativeEditor().type("select * from ORDERS");
+    H.NativeEditor.focus().type("select * from ORDERS");
     cy.findByTestId("native-query-editor-container").icon("play").click();
     cy.wait("@dataset");
 

--- a/e2e/test/scenarios/models/helpers/e2e-models-helpers.js
+++ b/e2e/test/scenarios/models/helpers/e2e-models-helpers.js
@@ -1,9 +1,9 @@
 import {
+  NativeEditor,
   entityPickerModal,
   entityPickerModalTab,
   interceptIfNotPreviouslyDefined,
   modal,
-  nativeEditor,
   openQuestionActions,
   popover,
 } from "e2e/support/helpers";
@@ -74,7 +74,7 @@ export function assertIsModel() {
 
   // For native
   cy.findByText("This question is written in SQL.").should("not.exist");
-  nativeEditor().should("not.exist");
+  NativeEditor().get.should("not.exist");
 }
 
 // Requires question actions to be open

--- a/e2e/test/scenarios/models/helpers/e2e-models-helpers.js
+++ b/e2e/test/scenarios/models/helpers/e2e-models-helpers.js
@@ -74,7 +74,7 @@ export function assertIsModel() {
 
   // For native
   cy.findByText("This question is written in SQL.").should("not.exist");
-  NativeEditor.get.should("not.exist");
+  NativeEditor.get().should("not.exist");
 }
 
 // Requires question actions to be open

--- a/e2e/test/scenarios/models/helpers/e2e-models-helpers.js
+++ b/e2e/test/scenarios/models/helpers/e2e-models-helpers.js
@@ -74,7 +74,7 @@ export function assertIsModel() {
 
   // For native
   cy.findByText("This question is written in SQL.").should("not.exist");
-  NativeEditor().get.should("not.exist");
+  NativeEditor.get.should("not.exist");
 }
 
 // Requires question actions to be open

--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -197,7 +197,7 @@ describe("scenarios > models metadata", () => {
     H.popover().findByTextEnsureVisible("Edit query definition").click();
 
     H.NativeEditor.clear();
-    H.nativeEditorType("SELECT TOTAL FROM ORDERS LIMIT 5");
+    H.NativeEditor.type("SELECT TOTAL FROM ORDERS LIMIT 5");
 
     cy.findByTestId("editor-tabs-metadata-name").click();
     cy.wait("@dataset");

--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -196,7 +196,7 @@ describe("scenarios > models metadata", () => {
     H.openQuestionActions();
     H.popover().findByTextEnsureVisible("Edit query definition").click();
 
-    H.clearNativeEditor();
+    H.NativeEditor.clear();
     H.nativeEditorType("SELECT TOTAL FROM ORDERS LIMIT 5");
 
     cy.findByTestId("editor-tabs-metadata-name").click();

--- a/e2e/test/scenarios/models/models-query-editor.cy.spec.js
+++ b/e2e/test/scenarios/models/models-query-editor.cy.spec.js
@@ -144,7 +144,7 @@ describe("scenarios > models query editor", () => {
       cy.url().should("include", "/query");
       cy.button("Save changes").should("be.disabled");
 
-      H.focusNativeEditor().type("{backspace}2");
+      H.NativeEditor.focus().type("{backspace}2");
 
       H.runNativeQuery();
 
@@ -185,7 +185,7 @@ describe("scenarios > models query editor", () => {
       cy.url().should("include", "/query");
       cy.button("Save changes").should("be.disabled");
 
-      H.focusNativeEditor().type("{backspace}2");
+      H.NativeEditor.focus().type("{backspace}2");
 
       H.runNativeQuery();
 
@@ -230,7 +230,7 @@ describe("scenarios > models query editor", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Syntax error in SQL/).should("be.visible");
 
-      H.focusNativeEditor().type("{backspace}".repeat(" FROM".length));
+      H.NativeEditor.focus().type("{backspace}".repeat(" FROM".length));
       H.runNativeQuery();
 
       cy.get("[data-testid=cell-data]").contains(1);

--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -549,7 +549,7 @@ describe("scenarios > models", () => {
     // Check card tags are supported by models
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Open editor/i).click();
-    H.focusNativeEditor().type(
+    H.NativeEditor.focus().type(
       "{leftarrow}{leftarrow}{backspace}{backspace}#1-orders",
     );
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -570,7 +570,7 @@ describe("scenarios > models", () => {
     }).then(({ body: { id: modelId } }) => {
       cy.request("PUT", `/api/card/${modelId}`, { type: "model" }).then(() => {
         cy.visit(`/model/${modelId}/query`);
-        H.focusNativeEditor().type("{movetoend}").type(" WHERE {{F", {
+        H.NativeEditor.focus().type("{movetoend}").type(" WHERE {{F", {
           parseSpecialCharSequences: false,
         });
         cy.findByTestId("tag-editor-sidebar").should("not.exist");

--- a/e2e/test/scenarios/models/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.js
@@ -431,7 +431,7 @@ describe("issue 22517", () => {
 
     // This will edit the original query and add the `SIZE` column
     // Updated query: `select *, case when quantity > 4 then 'large' else 'small' end size from orders`
-    H.focusNativeEditor().type(
+    H.NativeEditor.focus().type(
       "{leftarrow}".repeat(" from orders".length) +
         ", case when quantity > 4 then 'large' else 'small' end size ",
     );
@@ -471,7 +471,7 @@ describe("issue 22518", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Edit query definition").click();
 
-    H.focusNativeEditor().type(", 'b' bar");
+    H.NativeEditor.focus().type(", 'b' bar");
     cy.findByTestId("native-query-editor-container").icon("play").click();
     cy.wait("@dataset");
 
@@ -1606,7 +1606,7 @@ describe("issues 35039 and 37009", () => {
   it("should show columns available in the model (metabase#35039) (metabase#37009)", () => {
     // The repro requires that we update the query in a minor, non-impactful way.
     cy.log("Update the query and save");
-    H.focusNativeEditor().type("{backspace}");
+    H.NativeEditor.focus().type("{backspace}");
     cy.findByTestId("native-query-editor-container").icon("play").click();
     cy.wait("@dataset");
 
@@ -1677,7 +1677,7 @@ describe("issue 37009", () => {
 
     H.openQuestionActions();
     H.popover().findByText("Edit query definition").click();
-    H.focusNativeEditor().type(" WHERE CATEGORY = 'Gadget'");
+    H.NativeEditor.focus().type(" WHERE CATEGORY = 'Gadget'");
     cy.findByTestId("dataset-edit-bar")
       .button("Save changes")
       .should("be.disabled")

--- a/e2e/test/scenarios/models/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.js
@@ -736,7 +736,7 @@ describe("issue 23421", () => {
     H.openQuestionActions();
     H.popover().findByText("Edit query definition").click();
 
-    H.nativeEditor().should("be.visible").and("contain", query);
+    H.NativeEditor.get().should("be.visible").and("contain", query);
     cy.findByRole("columnheader", { name: "id" }).should("be.visible");
     cy.findByRole("columnheader", { name: "created_at" }).should("be.visible");
     cy.button("Save changes").should("be.visible");
@@ -749,7 +749,7 @@ describe("issue 23421", () => {
     H.openQuestionActions();
     H.popover().findByText("Edit query definition").click();
 
-    H.nativeEditor().should("be.visible").and("contain", query);
+    H.NativeEditor.get().should("be.visible").and("contain", query);
     cy.findByTestId("visualization-root")
       .findByText("Every field is hidden right now")
       .should("be.visible");

--- a/e2e/test/scenarios/native-filters/helpers/e2e-sql-filter-helpers.js
+++ b/e2e/test/scenarios/native-filters/helpers/e2e-sql-filter-helpers.js
@@ -1,7 +1,6 @@
 import {
+  NativeEditor,
   filterWidget,
-  focusNativeEditor,
-  nativeEditor,
   selectDropdown,
 } from "e2e/support/helpers";
 
@@ -97,9 +96,7 @@ export function runQuery(xhrAlias = "dataset") {
  * @param {string} query
  */
 export function enterParameterizedQuery(query, options = {}) {
-  focusNativeEditor();
-  nativeEditor().type(query, {
-    parseSpecialCharSequences: false,
+  NativeEditor.focus().type(query, {
     ...options,
   });
 }

--- a/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
@@ -191,12 +191,7 @@ describe("issue 12581", () => {
 
     // Both delay and a repeated sequence of `{selectall}{backspace}` are there to prevent typing flakes
     // Without them at least 1 in 10 test runs locally didn't fully clear the field or type correctly
-    H.NativeEditor.focus()
-      .as("editor")
-      .click()
-      .type("{selectall}{backspace}", { delay: 50 })
-      .click()
-      .type("{selectall}{backspace}SELECT 1");
+    H.NativeEditor.clear().type("SELECT 1");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
@@ -228,7 +223,7 @@ describe("issue 12581", () => {
       .click();
 
     cy.log("Reported failing on v0.35.3");
-    H.NativeEditor.focus().should("be.visible").and("contain", ORIGINAL_QUERY);
+    H.NativeEditor.get().should("be.visible").and("contain", ORIGINAL_QUERY);
 
     H.tableInteractive().findByText("37.65");
 

--- a/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
@@ -433,7 +433,7 @@ describe("issue 14302", () => {
         expect(xhr.response.body.error).not.to.exist;
       });
 
-      H.nativeEditor().should("not.be.visible");
+      H.NativeEditor.get().should("not.be.visible");
       cy.get("[data-testid=cell-data]").should("contain", "51");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 1 row");

--- a/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
@@ -191,7 +191,7 @@ describe("issue 12581", () => {
 
     // Both delay and a repeated sequence of `{selectall}{backspace}` are there to prevent typing flakes
     // Without them at least 1 in 10 test runs locally didn't fully clear the field or type correctly
-    H.focusNativeEditor()
+    H.NativeEditor.focus()
       .as("editor")
       .click()
       .type("{selectall}{backspace}", { delay: 50 })
@@ -228,7 +228,7 @@ describe("issue 12581", () => {
       .click();
 
     cy.log("Reported failing on v0.35.3");
-    H.focusNativeEditor().should("be.visible").and("contain", ORIGINAL_QUERY);
+    H.NativeEditor.focus().should("be.visible").and("contain", ORIGINAL_QUERY);
 
     H.tableInteractive().findByText("37.65");
 

--- a/e2e/test/scenarios/native/native-database-source.cy.spec.js
+++ b/e2e/test/scenarios/native/native-database-source.cy.spec.js
@@ -326,7 +326,7 @@ describe("scenarios > question > native > mongo", { tags: "@mongo" }, () => {
   });
 
   it("can save a native MongoDB query", () => {
-    H.focusNativeEditor().type('[ { $count: "Total" } ]', {
+    H.NativeEditor.focus().type('[ { $count: "Total" } ]', {
       parseSpecialCharSequences: false,
     });
     cy.findByTestId("native-query-editor-container").icon("play").click();

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.js
@@ -651,7 +651,7 @@ describe("issue 34330", () => {
 
   it("should only call the autocompleter with all text typed (metabase#34330)", () => {
     H.openNativeEditor();
-    H.NativeEditor.type("USER", { delay: 0 });
+    H.NativeEditor.type("USER", { delay: 10 });
 
     cy.wait("@autocomplete").then(({ request }) => {
       const url = new URL(request.url);

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.js
@@ -709,16 +709,16 @@ describe("issue 35344", () => {
 
     // make sure normal undo still works
     H.NativeEditor.type("--");
-    expect(H.NativeEditor.focus().findByText("--")).to.exist;
+    expect(H.NativeEditor.get().findByText("--")).to.exist;
 
     H.NativeEditor.focus();
     cy.realPress(["Meta", "z"]);
-    H.NativeEditor.focus().findByText("--").should("not.exist");
+    H.NativeEditor.get().findByText("--").should("not.exist");
 
     // more undoing does not change to empty editor
     H.NativeEditor.focus();
     cy.realPress(["Meta", "z"]);
-    expect(H.NativeEditor.focus().findByText("select")).to.exist;
+    expect(H.NativeEditor.get().findByText("select")).to.exist;
   });
 });
 

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.js
@@ -130,7 +130,7 @@ describe("issue 16914", () => {
       .click();
     cy.button("Done").click();
 
-    H.NativeEditor.type(FAILING_PIECE);
+    H.NativeEditor.focus().type(FAILING_PIECE);
     H.runNativeQuery();
 
     H.NativeEditor.focus();

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.js
@@ -87,7 +87,7 @@ describe("issue 16886", () => {
 
   it("shouldn't remove parts of the query when choosing 'Run selected text' (metabase#16886)", () => {
     H.openNativeEditor();
-    cy.realType(ORIGINAL_QUERY);
+    H.NativeEditor.type(ORIGINAL_QUERY);
     cy.realPress("Home");
     Cypress._.range(SELECTED_TEXT.length).forEach(() =>
       cy.realPress(["Shift", "ArrowRight"]),
@@ -130,8 +130,7 @@ describe("issue 16914", () => {
       .click();
     cy.button("Done").click();
 
-    H.NativeEditor.focus();
-    cy.realType(FAILING_PIECE);
+    H.NativeEditor.focus().type(FAILING_PIECE);
     H.runNativeQuery();
 
     H.NativeEditor.focus();
@@ -195,7 +194,7 @@ describe("issue 17060", () => {
     Cypress._.range(SELECTED_TEXT.length).forEach(() =>
       cy.realPress(["Shift", "ArrowRight"]),
     );
-    cy.realType("RATING");
+    H.NativeEditor.type("RATING");
     runQuery();
 
     cy.findByTestId("query-visualization-root").within(() => {
@@ -231,8 +230,7 @@ describe("issue 18148", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(dbName).click();
 
-    H.NativeEditor.focus();
-    cy.realType("select foo");
+    H.NativeEditor.focus().type("select foo");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
@@ -414,12 +412,12 @@ describe("issue 20625", { tags: "@quarantine" }, () => {
     }).as("autocomplete");
 
     H.openNativeEditor();
-    cy.realType("e");
+    H.NativeEditor.type("e");
 
     // autocomplete_suggestions?prefix=s
     cy.wait("@autocomplete");
 
-    cy.realType("o");
+    H.NativeEditor.type("o");
 
     // autocomplete_suggestions?prefix=so
     cy.wait("@autocomplete");
@@ -441,12 +439,12 @@ describe("issue 20625", { tags: "@quarantine" }, () => {
     }).as("autocomplete");
 
     H.openNativeEditor();
-    cy.realType("e");
+    H.NativeEditor.type("e");
 
     // autocomplete_suggestions?prefix=s
     cy.wait("@autocomplete");
 
-    cy.realType("o");
+    H.NativeEditor.type("o");
 
     cy.get("@autocomplete.all").should("have.length", 1);
   });
@@ -465,8 +463,7 @@ describe("issue 21034", () => {
   });
 
   it("should not invoke API calls for autocomplete twice in a row (metabase#18148)", () => {
-    H.NativeEditor.focus();
-    cy.realType("p");
+    H.NativeEditor.type("p");
 
     // Wait until another explicit autocomplete is triggered
     // (slightly longer than AUTOCOMPLETE_DEBOUNCE_DURATION)
@@ -682,7 +679,7 @@ describe("issue 34330", () => {
 
   it("should call the autocompleter when backspacing to a 1-character prefix (metabase#34330)", () => {
     H.openNativeEditor();
-    cy.realType("SE{backspace}");
+    H.NativeEditor.type("SE{backspace}");
 
     cy.wait("@autocomplete").then(({ request }) => {
       const url = new URL(request.url);
@@ -711,8 +708,7 @@ describe("issue 35344", () => {
     cy.findByTestId("query-builder-main").findByText("Open Editor").click();
 
     // make sure normal undo still works
-    H.NativeEditor.focus();
-    cy.realType("--");
+    H.NativeEditor.focus().type("--");
     expect(H.NativeEditor.focus().findByText("--")).to.exist;
 
     H.NativeEditor.focus();

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.js
@@ -194,7 +194,7 @@ describe("issue 17060", () => {
     Cypress._.range(SELECTED_TEXT.length).forEach(() =>
       cy.realPress(["Shift", "ArrowRight"]),
     );
-    H.NativeEditor.type("RATING");
+    H.NativeEditor.type("RATING", { focus: false });
     runQuery();
 
     cy.findByTestId("query-visualization-root").within(() => {

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.js
@@ -130,7 +130,7 @@ describe("issue 16914", () => {
       .click();
     cy.button("Done").click();
 
-    H.NativeEditor.focus().type(FAILING_PIECE);
+    H.NativeEditor.type(FAILING_PIECE);
     H.runNativeQuery();
 
     H.NativeEditor.focus();
@@ -708,7 +708,7 @@ describe("issue 35344", () => {
     cy.findByTestId("query-builder-main").findByText("Open Editor").click();
 
     // make sure normal undo still works
-    H.NativeEditor.focus().type("--");
+    H.NativeEditor.type("--");
     expect(H.NativeEditor.focus().findByText("--")).to.exist;
 
     H.NativeEditor.focus();

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.js
@@ -68,7 +68,7 @@ describe("issue 15029", () => {
 
   it("should allow dots in the variable reference (metabase#15029)", () => {
     H.openNativeEditor();
-    H.nativeEditorType(
+    H.NativeEditor.type(
       "select * from products where RATING = {{number.of.stars}}",
     );
 
@@ -537,7 +537,7 @@ describe("issue 21597", { tags: "@external" }, () => {
       databaseName,
     });
 
-    H.nativeEditorType("SELECT COUNT(*) FROM PRODUCTS WHERE {{FILTER}}");
+    H.NativeEditor.type("SELECT COUNT(*) FROM PRODUCTS WHERE {{FILTER}}");
 
     cy.findByTestId("variable-type-select").click();
     H.popover().within(() => {
@@ -654,7 +654,7 @@ describe("issue 34330", () => {
 
   it("should only call the autocompleter with all text typed (metabase#34330)", () => {
     H.openNativeEditor();
-    H.nativeEditorType("USER", { delay: 0 });
+    H.NativeEditor.type("USER", { delay: 0 });
 
     cy.wait("@autocomplete").then(({ request }) => {
       const url = new URL(request.url);
@@ -669,7 +669,7 @@ describe("issue 34330", () => {
 
   it("should call the autocompleter eventually, even when only 1 character was typed (metabase#34330)", () => {
     H.openNativeEditor();
-    H.nativeEditorType("U");
+    H.NativeEditor.type("U");
 
     cy.wait("@autocomplete").then(({ request }) => {
       const url = new URL(request.url);
@@ -820,7 +820,7 @@ describe("issue 22991", () => {
     H.openNativeEditor();
     cy.get("@questionId").then(questionId => {
       // can't use cy.type because it does not simulate the bug
-      H.nativeEditorType(`select * from {{${questionId}}}`);
+      H.NativeEditor.type(`select * from {{${questionId}}}`);
     });
 
     cy.get("main").should(

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.js
@@ -130,11 +130,11 @@ describe("issue 16914", () => {
       .click();
     cy.button("Done").click();
 
-    H.focusNativeEditor();
+    H.NativeEditor.focus();
     cy.realType(FAILING_PIECE);
     H.runNativeQuery();
 
-    H.focusNativeEditor();
+    H.NativeEditor.focus();
     cy.realPress("End");
     Cypress._.range(FAILING_PIECE.length).forEach(() =>
       cy.realPress(["Shift", "ArrowLeft"]),
@@ -189,7 +189,7 @@ describe("issue 17060", () => {
   });
 
   it("should not render duplicated columns (metabase#17060)", () => {
-    H.focusNativeEditor();
+    H.NativeEditor.focus();
     cy.realPress("Home");
     Cypress._.range(SECTION.length).forEach(() => cy.realPress("ArrowRight"));
     Cypress._.range(SELECTED_TEXT.length).forEach(() =>
@@ -231,7 +231,7 @@ describe("issue 18148", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(dbName).click();
 
-    H.focusNativeEditor();
+    H.NativeEditor.focus();
     cy.realType("select foo");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -465,7 +465,7 @@ describe("issue 21034", () => {
   });
 
   it("should not invoke API calls for autocomplete twice in a row (metabase#18148)", () => {
-    H.focusNativeEditor();
+    H.NativeEditor.focus();
     cy.realType("p");
 
     // Wait until another explicit autocomplete is triggered
@@ -711,18 +711,18 @@ describe("issue 35344", () => {
     cy.findByTestId("query-builder-main").findByText("Open Editor").click();
 
     // make sure normal undo still works
-    H.focusNativeEditor();
+    H.NativeEditor.focus();
     cy.realType("--");
-    expect(H.focusNativeEditor().findByText("--")).to.exist;
+    expect(H.NativeEditor.focus().findByText("--")).to.exist;
 
-    H.focusNativeEditor();
+    H.NativeEditor.focus();
     cy.realPress(["Meta", "z"]);
-    H.focusNativeEditor().findByText("--").should("not.exist");
+    H.NativeEditor.focus().findByText("--").should("not.exist");
 
     // more undoing does not change to empty editor
-    H.focusNativeEditor();
+    H.NativeEditor.focus();
     cy.realPress(["Meta", "z"]);
-    expect(H.focusNativeEditor().findByText("select")).to.exist;
+    expect(H.NativeEditor.focus().findByText("select")).to.exist;
   });
 });
 
@@ -767,8 +767,7 @@ describe("issue 35785", () => {
     cy.findByTestId("native-query-editor-container")
       .findByTestId("visibility-toggler")
       .click();
-    H.focusNativeEditor();
-    cy.realType("{backspace}4");
+    H.NativeEditor.type("{backspace}4");
 
     cy.findByTestId("qb-header").findByRole("button", { name: "Save" }).click();
 

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -133,9 +133,8 @@ describe("issue 33327", () => {
     cy.findByTestId("visualization-root").icon("warning").should("be.visible");
     cy.findByTestId("scalar-value").should("not.exist");
 
-    H.NativeEditor.focus()
-      .should("contain", "SELECT --1")
-      .realType("{leftarrow}{backspace}{backspace}");
+    H.NativeEditor.get().should("contain", "SELECT --1");
+    H.NativeEditor.type("{leftarrow}{backspace}{backspace}");
 
     H.NativeEditor.get().should("contain", query);
 
@@ -171,7 +170,8 @@ describe("issue 49454", () => {
   });
 
   it("should be possible to use metrics in native queries (metabase#49454)", () => {
-    H.openNativeEditor().realType("select * from {{ #test");
+    H.openNativeEditor();
+    H.NativeEditor.type("select * from {{ #test");
 
     H.NativeEditor.completions().within(() => {
       H.NativeEditor.completion("-question-49454").should("be.visible");

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -122,7 +122,8 @@ describe("issue 33327", () => {
     cy.findByTestId("scalar-value").should("have.text", "1");
 
     cy.findByTestId("visibility-toggler").click();
-    H.focusNativeEditor().should("contain", query).realType("{leftarrow}--");
+    H.NativeEditor.get().should("contain", query);
+    H.NativeEditor.type("{leftarrow}--");
 
     cy.intercept("POST", "/api/dataset").as("dataset");
     H.NativeEditor.get().should("be.visible").and("contain", "SELECT --1");
@@ -132,7 +133,7 @@ describe("issue 33327", () => {
     cy.findByTestId("visualization-root").icon("warning").should("be.visible");
     cy.findByTestId("scalar-value").should("not.exist");
 
-    H.focusNativeEditor()
+    H.NativeEditor.focus()
       .should("contain", "SELECT --1")
       .realType("{leftarrow}{backspace}{backspace}");
 

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -57,7 +57,7 @@ describe("issue 16584", () => {
 
     cy.findByPlaceholderText("Country").type("NL", { delay: 0 });
 
-    H.nativeEditorSelectAll();
+    H.NativeEditor.selectAll();
     H.runNativeQuery();
 
     cy.findByTestId("query-visualization-root")

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -51,7 +51,7 @@ describe("issue 16584", () => {
     // - the issue is unrelated to whether or not the parameter is required or if default value is set
     // - the space at the end of the query is not needed to reproduce this issue
     H.openNativeEditor();
-    H.nativeEditorType(
+    H.NativeEditor.type(
       "SELECT COUNTRY FROM ACCOUNTS WHERE COUNTRY = {{ country }} LIMIT 1",
     );
 

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -125,7 +125,7 @@ describe("issue 33327", () => {
     H.focusNativeEditor().should("contain", query).realType("{leftarrow}--");
 
     cy.intercept("POST", "/api/dataset").as("dataset");
-    H.nativeEditor().should("be.visible").and("contain", "SELECT --1");
+    H.NativeEditor.get().should("be.visible").and("contain", "SELECT --1");
     getRunQueryButton().click();
     cy.wait("@dataset");
 
@@ -136,7 +136,7 @@ describe("issue 33327", () => {
       .should("contain", "SELECT --1")
       .realType("{leftarrow}{backspace}{backspace}");
 
-    H.nativeEditor().should("contain", query);
+    H.NativeEditor.get().should("contain", query);
 
     getRunQueryButton().click();
     cy.wait("@dataset");

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -173,9 +173,9 @@ describe("issue 49454", () => {
   it("should be possible to use metrics in native queries (metabase#49454)", () => {
     H.openNativeEditor().realType("select * from {{ #test");
 
-    H.nativeEditorCompletions().within(() => {
-      H.nativeEditorCompletion("-question-49454").should("be.visible");
-      H.nativeEditorCompletion("-metric-49454").should("be.visible");
+    H.NativeEditor.completions().within(() => {
+      H.NativeEditor.completion("-question-49454").should("be.visible");
+      H.NativeEditor.completion("-metric-49454").should("be.visible");
     });
   });
 });

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -424,7 +424,7 @@ describe("no native access", { tags: ["@external", "@quarantine"] }, () => {
 
       cy.wait("@sqlFormatter");
 
-      H.nativeEditor().should("be.visible").get(".ace_line").as("lines");
+      H.NativeEditor.get().should("be.visible").get(".ace_line").as("lines");
 
       cy.get("@lines").eq(0).should("have.text", "SELECT");
       cy.get("@lines").eq(1).should("have.text", "  *");

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -413,7 +413,7 @@ describe("no native access", { tags: ["@external", "@quarantine"] }, () => {
       // Switch to SQL engine which is supported by the formatter
       H.popover().findByText("Sample Database").click();
 
-      H.focusNativeEditor().type("select * from orders", {
+      H.NativeEditor.focus().type("select * from orders", {
         parseSpecialCharSequences: false,
       });
 

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -23,10 +23,6 @@ const ORDERS_SCALAR_METRIC = {
   display: "scalar",
 };
 
-// cy.realType does not have an option to not parse special characters
-const LEFT_BRACKET = "{{}";
-const DOUBLE_LEFT_BRACKET = `${LEFT_BRACKET}${LEFT_BRACKET}`;
-
 describe("scenarios > question > native", () => {
   beforeEach(() => {
     cy.intercept("POST", "api/card").as("card");
@@ -38,7 +34,7 @@ describe("scenarios > question > native", () => {
 
   it("lets you create and run a SQL question", () => {
     H.openNativeEditor();
-    cy.realType("select count(*) from orders");
+    H.NativeEditor.type("select count(*) from orders");
     runQuery();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("18,760");
@@ -48,7 +44,7 @@ describe("scenarios > question > native", () => {
     H.visitCollection(THIRD_COLLECTION_ID);
 
     H.openNativeEditor({ fromCurrentPage: true });
-    cy.realType("select count(*) from orders");
+    H.NativeEditor.type("select count(*) from orders");
 
     cy.findByTestId("qb-header").within(() => {
       cy.findByText("Save").click();
@@ -82,7 +78,7 @@ describe("scenarios > question > native", () => {
 
   it("displays an error", () => {
     H.openNativeEditor();
-    cy.realType("select * from not_a_table");
+    H.NativeEditor.type("select * from not_a_table");
     runQuery();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains('Table "NOT_A_TABLE" not found');
@@ -90,7 +86,7 @@ describe("scenarios > question > native", () => {
 
   it("displays an error when running selected text", () => {
     H.openNativeEditor();
-    cy.realType("select * from orders");
+    H.NativeEditor.type("select * from orders");
     // move left three
     Cypress._.range(3).forEach(() => cy.realPress("ArrowLeft"));
     // highlight back to the front
@@ -102,9 +98,7 @@ describe("scenarios > question > native", () => {
 
   it("should handle template tags", () => {
     H.openNativeEditor();
-    cy.realType(
-      `select * from PRODUCTS where RATING > ${DOUBLE_LEFT_BRACKET}Stars}}`,
-    );
+    H.NativeEditor.type("select * from PRODUCTS where RATING > {{Stars}}");
     cy.get("input[placeholder*='Stars']").type("3");
     runQuery();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -113,9 +107,7 @@ describe("scenarios > question > native", () => {
 
   it("should modify parameters accordingly when tags are modified", () => {
     H.openNativeEditor();
-    cy.realType(
-      `select * from PRODUCTS where CATEGORY = ${DOUBLE_LEFT_BRACKET}cat}}`,
-    );
+    H.NativeEditor.type("select * from PRODUCTS where CATEGORY = {{cat}}");
     cy.findByTestId("sidebar-right")
       .findByText("Always require a value")
       .click();
@@ -143,7 +135,7 @@ describe("scenarios > question > native", () => {
 
   it("can save a question with no rows", () => {
     H.openNativeEditor();
-    cy.realType("select * from people where false");
+    H.NativeEditor.type("select * from people where false");
     runQuery();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("No results!");
@@ -224,7 +216,8 @@ describe("scenarios > question > native", () => {
 
   it("should be able to add new columns after hiding some (metabase#15393)", () => {
     H.openNativeEditor();
-    cy.realType("select 1 as visible, 2 as hidden");
+
+    H.NativeEditor.type("select 1 as visible, 2 as hidden");
     cy.findByTestId("native-query-editor-container")
       .icon("play")
       .as("runQuery")
@@ -243,8 +236,8 @@ describe("scenarios > question > native", () => {
 
   it("should recognize template tags and save them as parameters", () => {
     H.openNativeEditor();
-    cy.realType(
-      `select * from PRODUCTS where CATEGORY=${DOUBLE_LEFT_BRACKET}cat}} and RATING >= ${DOUBLE_LEFT_BRACKET}stars}}`,
+    H.NativeEditor.type(
+      "select * from PRODUCTS where CATEGORY={{cat}} and RATING >= {{stars}}",
     );
     cy.get("input[placeholder*='Cat']").type("Gizmo");
     cy.get("input[placeholder*='Stars']").type("3");
@@ -300,9 +293,7 @@ describe("scenarios > question > native", () => {
 
   it("should allow to preview a fully parameterized query", () => {
     H.openNativeEditor();
-    cy.realType(
-      `select * from PRODUCTS where CATEGORY=${DOUBLE_LEFT_BRACKET}category}}`,
-    );
+    H.NativeEditor.type("select * from PRODUCTS where CATEGORY={{category}}");
     cy.findByPlaceholderText("Category").type("Gadget");
     cy.button("Preview the query").click();
     cy.wait("@datasetNative");
@@ -313,9 +304,7 @@ describe("scenarios > question > native", () => {
 
   it("should show errors when previewing a query", () => {
     H.openNativeEditor();
-    cy.realType(
-      `select * from PRODUCTS where CATEGORY=${DOUBLE_LEFT_BRACKET}category}}`,
-    );
+    H.NativeEditor.type("select * from PRODUCTS where CATEGORY={{category}}");
     cy.button("Preview the query").click();
     cy.wait("@datasetNative");
 

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -61,7 +61,7 @@ describe("scenarios > question > native", () => {
     cy.log("after visiting a dashboard, it should be the new suggestion");
     H.visitDashboard(ORDERS_DASHBOARD_ID);
     H.openNativeEditor({ fromCurrentPage: true });
-    cy.realType("select count(*) from orders");
+    H.NativeEditor.type("select count(*) from orders");
 
     cy.findByTestId("qb-header").within(() => {
       cy.findByText("Save").click();

--- a/e2e/test/scenarios/native/native_subquery.cy.spec.js
+++ b/e2e/test/scenarios/native/native_subquery.cy.spec.js
@@ -87,13 +87,13 @@ describe("scenarios > question > native subquery", () => {
         // See https://github.com/metabase/metabase/pull/20970
         cy.wait(1000);
 
-        H.nativeEditorCompletions().within(() => {
-          H.nativeEditorCompletion(`${questionId2}-a-`)
+        H.NativeEditor.completions().within(() => {
+          H.NativeEditor.completion(`${questionId2}-a-`)
             .should("be.visible")
             .findByText("Model in Bobby Tables's Personal Collection")
             .should("be.visible");
 
-          H.nativeEditorCompletion(`${questionId1}-a-`)
+          H.NativeEditor.completion(`${questionId1}-a-`)
             .should("be.visible")
             .findByText("Question in Our analytics")
             .should("be.visible");
@@ -142,7 +142,9 @@ describe("scenarios > question > native subquery", () => {
           cy.findByText("Open Editor").click();
           H.nativeEditorType(" a_");
 
-          H.nativeEditorCompletion("A_UNIQUE_COLUMN_NAME").should("be.visible");
+          H.NativeEditor.completion("A_UNIQUE_COLUMN_NAME").should(
+            "be.visible",
+          );
 
           // For some reason, typing `{{#${questionId2}}}` in one go isn't deterministic,
           // so type it in two parts
@@ -152,7 +154,7 @@ describe("scenarios > question > native subquery", () => {
           // so type it in two parts
           H.nativeEditorType(" another");
 
-          H.nativeEditorCompletion("ANOTHER_UNIQUE_COLUMN_NAME").should(
+          H.NativeEditor.completion("ANOTHER_UNIQUE_COLUMN_NAME").should(
             "be.visible",
           );
         });

--- a/e2e/test/scenarios/native/native_subquery.cy.spec.js
+++ b/e2e/test/scenarios/native/native_subquery.cy.spec.js
@@ -35,15 +35,15 @@ describe("scenarios > question > native subquery", () => {
           cy.reload();
           cy.findByText("Open Editor").click();
           // placing the cursor inside an existing template tag should open the data reference
-          H.focusNativeEditor().type("{leftarrow}{leftarrow}");
+          H.NativeEditor.focus().type("{leftarrow}{leftarrow}");
           cy.findByText("A People Question");
           // subsequently moving the cursor out from the tag should keep the data reference open
-          H.focusNativeEditor().type("{rightarrow}");
+          H.NativeEditor.focus().type("{rightarrow}");
           cy.findByText("A People Question");
           // typing a template tag id should open the editor
-          H.focusNativeEditor().type(" ").realType("{{#");
+          H.NativeEditor.focus().type(" ").realType("{{#");
 
-          H.focusNativeEditor()
+          H.NativeEditor.focus()
             .type("{leftarrow}{leftarrow}")
             .realType(questionId2.toString());
           cy.findByText("A People Model");
@@ -80,7 +80,7 @@ describe("scenarios > question > native subquery", () => {
 
         H.openNativeEditor();
         cy.reload(); // Refresh the state, so previously created questions need to be loaded again.
-        H.focusNativeEditor().realType(" {{#people");
+        H.NativeEditor.focus().realType(" {{#people");
 
         // Wait until another explicit autocomplete is triggered
         // (slightly longer than AUTOCOMPLETE_DEBOUNCE_DURATION)
@@ -275,7 +275,7 @@ describe("scenarios > question > native subquery", () => {
         cy.intercept("GET", `/api/card/${nestedQuestionId}`).as("loadQuestion");
 
         H.startNewNativeQuestion();
-        H.focusNativeEditor().realType(`SELECT * FROM {{${tagID}`);
+        H.NativeEditor.focus().realType(`SELECT * FROM {{${tagID}`);
         cy.wait("@loadQuestion");
         cy.findByTestId("sidebar-header-title").should(
           "have.text",
@@ -299,7 +299,7 @@ describe("scenarios > question > native subquery", () => {
         const tagID = `#${baseQuestionId}`;
 
         H.startNewNativeQuestion();
-        H.focusNativeEditor().realType(`SELECT * FROM {{${tagID}`);
+        H.NativeEditor.focus().realType(`SELECT * FROM {{${tagID}`);
 
         H.runNativeQuery();
         cy.findAllByTestId("cell-data").should("contain", "1");

--- a/e2e/test/scenarios/native/native_subquery.cy.spec.js
+++ b/e2e/test/scenarios/native/native_subquery.cy.spec.js
@@ -188,7 +188,7 @@ describe("scenarios > question > native subquery", () => {
         cy.visit(`/question/${questionId2}`);
         cy.findByText("Open Editor").click();
         cy.get("@questionId").then(questionId => {
-          H.nativeEditor()
+          H.NativeEditor.get()
             .should("be.visible")
             .and("contain", `{{#${questionId}-a-people-question-1}}`);
         });
@@ -203,7 +203,7 @@ describe("scenarios > question > native subquery", () => {
         cy.visit(`/question/${questionId2}`);
         cy.findByText("Open Editor").click();
         cy.get("@questionId").then(questionId => {
-          H.nativeEditor()
+          H.NativeEditor.get()
             .should("be.visible")
             .and("contain", `{{#${questionId}-a-people-question-1-changed}}`);
         });

--- a/e2e/test/scenarios/native/native_subquery.cy.spec.js
+++ b/e2e/test/scenarios/native/native_subquery.cy.spec.js
@@ -40,12 +40,9 @@ describe("scenarios > question > native subquery", () => {
           // subsequently moving the cursor out from the tag should keep the data reference open
           H.NativeEditor.focus().type("{rightarrow}");
           cy.findByText("A People Question");
-          // typing a template tag id should open the editor
-          H.NativeEditor.focus().type(" ").type("{{#");
 
-          H.NativeEditor.focus()
-            .type("{leftarrow}{leftarrow}")
-            .type(questionId2.toString());
+          // typing a template tag id should open the editor
+          H.NativeEditor.focus().type(" ").type(`{{#${questionId2.toString()}`);
           cy.findByText("A People Model");
         });
       });

--- a/e2e/test/scenarios/native/native_subquery.cy.spec.js
+++ b/e2e/test/scenarios/native/native_subquery.cy.spec.js
@@ -41,11 +41,11 @@ describe("scenarios > question > native subquery", () => {
           H.NativeEditor.focus().type("{rightarrow}");
           cy.findByText("A People Question");
           // typing a template tag id should open the editor
-          H.NativeEditor.focus().type(" ").realType("{{#");
+          H.NativeEditor.focus().type(" ").type("{{#");
 
           H.NativeEditor.focus()
             .type("{leftarrow}{leftarrow}")
-            .realType(questionId2.toString());
+            .type(questionId2.toString());
           cy.findByText("A People Model");
         });
       });
@@ -80,7 +80,7 @@ describe("scenarios > question > native subquery", () => {
 
         H.openNativeEditor();
         cy.reload(); // Refresh the state, so previously created questions need to be loaded again.
-        H.NativeEditor.focus().realType(" {{#people");
+        H.NativeEditor.focus().type(" {{#people");
 
         // Wait until another explicit autocomplete is triggered
         // (slightly longer than AUTOCOMPLETE_DEBOUNCE_DURATION)
@@ -277,7 +277,7 @@ describe("scenarios > question > native subquery", () => {
         cy.intercept("GET", `/api/card/${nestedQuestionId}`).as("loadQuestion");
 
         H.startNewNativeQuestion();
-        H.NativeEditor.focus().realType(`SELECT * FROM {{${tagID}`);
+        H.NativeEditor.focus().type(`SELECT * FROM {{${tagID}`);
         cy.wait("@loadQuestion");
         cy.findByTestId("sidebar-header-title").should(
           "have.text",
@@ -301,7 +301,7 @@ describe("scenarios > question > native subquery", () => {
         const tagID = `#${baseQuestionId}`;
 
         H.startNewNativeQuestion();
-        H.NativeEditor.focus().realType(`SELECT * FROM {{${tagID}`);
+        H.NativeEditor.focus().type(`SELECT * FROM {{${tagID}`);
 
         H.runNativeQuery();
         cy.findAllByTestId("cell-data").should("contain", "1");

--- a/e2e/test/scenarios/native/native_subquery.cy.spec.js
+++ b/e2e/test/scenarios/native/native_subquery.cy.spec.js
@@ -140,7 +140,7 @@ describe("scenarios > question > native subquery", () => {
           // Refresh the state, so previously created questions need to be loaded again.
           cy.reload();
           cy.findByText("Open Editor").click();
-          H.nativeEditorType(" a_");
+          H.NativeEditor.type(" a_");
 
           H.NativeEditor.completion("A_UNIQUE_COLUMN_NAME").should(
             "be.visible",
@@ -148,11 +148,11 @@ describe("scenarios > question > native subquery", () => {
 
           // For some reason, typing `{{#${questionId2}}}` in one go isn't deterministic,
           // so type it in two parts
-          H.nativeEditorType(` {{#${questionId2}}}`);
+          H.NativeEditor.type(` {{#${questionId2}}}`);
 
           // Again, typing in in one go doesn't always work
           // so type it in two parts
-          H.nativeEditorType(" another");
+          H.NativeEditor.type(" another");
 
           H.NativeEditor.completion("ANOTHER_UNIQUE_COLUMN_NAME").should(
             "be.visible",

--- a/e2e/test/scenarios/native/snippets.cy.spec.js
+++ b/e2e/test/scenarios/native/snippets.cy.spec.js
@@ -128,7 +128,7 @@ describe("scenarios > question > snippets", () => {
     cy.findByText(/Open Editor/i).click();
     // We need these mid-point checks to make sure Cypress typed the sequence/query correctly
     // Check 1
-    H.nativeEditor()
+    H.NativeEditor.get()
       .should("be.visible")
       .and("have.text", "select * from {{snippet: Table: Orders}} limit 1");
     // Replace "Orders" with "Reviews"
@@ -139,7 +139,7 @@ describe("scenarios > question > snippets", () => {
         "Reviews",
     );
     // Check 2
-    H.nativeEditor()
+    H.NativeEditor.get()
       .should("be.visible")
       .and("have.text", "select * from {{snippet: Table: Reviews}} limit 1");
     // Rerun the query
@@ -197,7 +197,7 @@ H.describeEE("scenarios > question > snippets (EE)", () => {
 
       cy.wait("@snippetCreated");
 
-      H.nativeEditor().should("have.text", "{{snippet: one}}");
+      H.NativeEditor.get().should("have.text", "{{snippet: one}}");
 
       cy.icon("play").first().click();
       cy.findByTestId("scalar-value").contains(1);

--- a/e2e/test/scenarios/native/snippets.cy.spec.js
+++ b/e2e/test/scenarios/native/snippets.cy.spec.js
@@ -132,7 +132,7 @@ describe("scenarios > question > snippets", () => {
       .should("be.visible")
       .and("have.text", "select * from {{snippet: Table: Orders}} limit 1");
     // Replace "Orders" with "Reviews"
-    H.focusNativeEditor().realType(
+    H.NativeEditor.focus().type(
       "{end}" +
         "{leftarrow}".repeat("}} limit 1".length) + // move left to "reach" the "Orders"
         "{backspace}".repeat("Orders".length) + // Delete orders character by character

--- a/e2e/test/scenarios/native/snippets.cy.spec.js
+++ b/e2e/test/scenarios/native/snippets.cy.spec.js
@@ -21,7 +21,8 @@ describe("scenarios > question > snippets", () => {
 
   it("should let you create and use a snippet", () => {
     cy.log("Type a query and highlight some of the text");
-    H.openNativeEditor().realType("select 'stuff'");
+    H.openNativeEditor();
+    H.NativeEditor.type("select 'stuff'");
 
     for (let i = 0; i < "'stuff'".length; i++) {
       cy.realPress(["Shift", "ArrowLeft"]);
@@ -53,7 +54,8 @@ describe("scenarios > question > snippets", () => {
 
     // Populate the native editor first
     // 1. select
-    H.openNativeEditor().realType("select ");
+    H.openNativeEditor();
+    H.NativeEditor.type("select ");
     // 2. snippet
     cy.icon("snippet").click();
     cy.findByTestId("sidebar-right").within(() => {

--- a/e2e/test/scenarios/onboarding/navbar/new-menu.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/navbar/new-menu.cy.spec.js
@@ -24,7 +24,7 @@ describe("metabase > scenarios > navbar > new menu", () => {
     });
 
     cy.url("should.contain", "/question#");
-    H.nativeEditor().should("be.visible");
+    H.NativeEditor.get().should("be.visible");
   });
 
   it("collection opens modal and redirects to a created collection after saving", () => {

--- a/e2e/test/scenarios/question-reproductions/reproductions-1.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-1.cy.spec.js
@@ -137,7 +137,7 @@ describe("issue 9027", () => {
 
     H.openNativeEditor({ fromCurrentPage: true });
 
-    H.focusNativeEditor().type("select 0");
+    H.NativeEditor.focus().type("select 0");
     cy.findByTestId("native-query-editor-container").icon("play").click();
 
     H.saveQuestion(QUESTION_NAME, undefined, {

--- a/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
@@ -480,17 +480,17 @@ describe("issue 30165", () => {
 
   it("should not autorun native queries after updating a question (metabase#30165)", () => {
     H.openNativeEditor();
-    cy.findByTestId("native-query-editor").type("SELECT * FROM ORDERS");
+    H.NativeEditor.type("SELECT * FROM ORDERS");
     H.saveQuestionToCollection("Q1");
 
-    H.focusNativeEditor().type(" WHERE TOTAL < 20");
+    H.NativeEditor.focus().type(" WHERE TOTAL < 20");
     H.queryBuilderHeader().findByText("Save").click();
     cy.findByTestId("save-question-modal").within(modal => {
       cy.findByText("Save").click();
     });
     cy.wait("@updateQuestion");
 
-    H.focusNativeEditor().type(" LIMIT 10");
+    H.NativeEditor.focus().type(" LIMIT 10");
     H.queryBuilderHeader().findByText("Save").click();
     cy.findByTestId("save-question-modal").within(modal => {
       cy.findByText("Save").click();
@@ -650,7 +650,7 @@ describe("issue 43216", () => {
     cy.findByTestId("native-query-editor-container")
       .findByText("Open Editor")
       .click();
-    H.focusNativeEditor().should("be.visible").type(" , 4 as D");
+    H.NativeEditor.focus().type(" , 4 as D");
     H.saveSavedQuestion();
 
     cy.log("Assert updated metadata in target question");

--- a/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
@@ -33,7 +33,7 @@ describe("scenarios > question > notebook > native query preview sidebar", () =>
 
     cy.findByTestId("native-query-preview-sidebar").within(() => {
       cy.findByText("SQL for this question").should("exist");
-      H.nativeEditor().should("not.exist");
+      H.NativeEditor.get().should("not.exist");
       cy.button("Convert this question to SQL").should("be.disabled");
     });
   });
@@ -49,7 +49,7 @@ describe("scenarios > question > notebook > native query preview sidebar", () =>
     cy.wait("@nativeDataset");
     cy.findByTestId("native-query-preview-sidebar").within(() => {
       cy.findByText("SQL for this question").should("exist");
-      H.nativeEditor()
+      H.NativeEditor.get()
         .should("be.visible")
         .and("contain", "SELECT")
         .and("contain", queryLimit);
@@ -71,7 +71,7 @@ describe("scenarios > question > notebook > native query preview sidebar", () =>
     cy.log("Modifying GUI query should update the SQL preview");
     cy.findByTestId("step-limit-0-0").icon("close").click({ force: true });
     cy.wait("@nativeDataset");
-    H.nativeEditor()
+    H.NativeEditor.get()
       .should("be.visible")
       .and("contain", "SELECT")
       .and("contain", defaultRowLimit)
@@ -278,7 +278,7 @@ describe(
       cy.findByLabelText("View the native query").click();
       cy.findByTestId("native-query-preview-sidebar").within(() => {
         cy.findByText("Native query for this question").should("exist");
-        H.nativeEditor()
+        H.NativeEditor.get()
           .should("be.visible")
           .and("contain", "$project")
           .and("contain", "$limit");
@@ -306,7 +306,7 @@ describe(
       H.openNotebook(); // SQL sidebar state was persisted so it's already open now
       cy.findByTestId("native-query-preview-sidebar").within(() => {
         cy.findByText("Native query for this question").should("exist");
-        H.nativeEditor()
+        H.NativeEditor.get()
           .should("be.visible")
           .and("contain", "$project")
           .and("contain", "$limit")
@@ -362,7 +362,7 @@ describe(
 
       cy.findByTestId("native-query-preview-sidebar").within(() => {
         cy.findByText("Native query for this question").should("exist");
-        H.nativeEditor()
+        H.NativeEditor.get()
           .should("be.visible")
           .and("contain", "$project")
           .and("contain", "$limit")
@@ -425,7 +425,7 @@ function convertToSql() {
   cy.intercept("POST", "/api/dataset").as("dataset");
   cy.button("Convert this question to SQL").click();
   cy.wait("@dataset");
-  H.nativeEditor().should("be.visible");
+  H.NativeEditor.get().should("be.visible");
 }
 
 type ResizeSidebarCallback = (

--- a/e2e/test/scenarios/sharing/downloads/sharing-download-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/sharing-download-reproductions.cy.spec.js
@@ -40,7 +40,7 @@ describe("issue 10803", () => {
       // Add a space at the end of the query to make it "dirty"
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains(/open editor/i).click();
-      H.focusNativeEditor().type("{movetoend} ");
+      H.NativeEditor.focus().type("{movetoend} ");
 
       H.runNativeQuery();
       H.downloadAndAssert({ fileType, raw: true }, testWorkbookDatetimes);
@@ -440,7 +440,7 @@ describe("issue 19889", () => {
     it("should order columns correctly in saved native query exports when the query was modified but not re-run before save (#19889)", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains(/open editor/i).click();
-      H.focusNativeEditor().type(
+      H.NativeEditor.focus().type(
         '{selectall}select 1 "column x", 2 "column y", 3 "column c"',
       );
 
@@ -483,7 +483,7 @@ describe("metabase#28834", () => {
     });
 
     cy.findByTestId("query-builder-main").findByText("Open Editor").click();
-    H.focusNativeEditor().type(', select 2 "column b"');
+    H.NativeEditor.focus().type(', select 2 "column b"');
   });
 
   it("should be able to export unsaved native query results as CSV even after the query has changed", () => {

--- a/e2e/test/scenarios/sharing/public-question.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-question.cy.spec.js
@@ -172,7 +172,7 @@ describe("scenarios > public > question", () => {
     }).then(({ body: { id } }) => {
       H.openNativeEditor();
 
-      H.nativeEditorType(`select * from {{#${id}`);
+      H.NativeEditor.type(`select * from {{#${id}`);
 
       H.saveQuestion(
         "test question",

--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
@@ -1107,7 +1107,7 @@ describe("issue 33208", () => {
 
   it("should not auto-select chart type when saving a native question with parameters that have default values", () => {
     cy.findByTestId("query-builder-main").findByText("Open Editor").click();
-    H.focusNativeEditor().type(" ");
+    H.NativeEditor.focus().type(" ");
     H.saveSavedQuestion("top category");
     H.runNativeQuery({ wait: false });
     cy.findByTestId("scalar-value").should("be.visible");

--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -596,7 +596,7 @@ describe("issue 30039", () => {
 
   it("should not trigger object detail navigation after the modal was closed (metabase#30039)", () => {
     H.startNewNativeQuestion();
-    H.focusNativeEditor().as("editor").type("select * from ORDERS LIMIT 2");
+    H.NativeEditor.focus().as("editor").type("select * from ORDERS LIMIT 2");
     H.runNativeQuery();
     cy.findAllByTestId("detail-shortcut").first().click();
     cy.findByTestId("object-detail").should("be.visible");

--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -596,7 +596,7 @@ describe("issue 30039", () => {
 
   it("should not trigger object detail navigation after the modal was closed (metabase#30039)", () => {
     H.startNewNativeQuestion();
-    H.NativeEditor.focus().as("editor").type("select * from ORDERS LIMIT 2");
+    H.NativeEditor.type("select * from ORDERS LIMIT 2");
     H.runNativeQuery();
     cy.findAllByTestId("detail-shortcut").first().click();
     cy.findByTestId("object-detail").should("be.visible");
@@ -604,7 +604,7 @@ describe("issue 30039", () => {
     cy.realPress("{esc}");
     cy.findByTestId("object-detail").should("not.exist");
 
-    cy.get("@editor").type("{downArrow};");
+    H.NativeEditor.type("{downArrow};");
     H.runNativeQuery();
     cy.findByTestId("object-detail").should("not.exist");
   });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/51493

As part of https://github.com/metabase/metabase/issues/50249 we want to replace all native editor test helpers with namespaced alternatives which are more robust.