### PR TITLE
[search] track average entry index time as histogram

### DIFF
--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -213,7 +213,9 @@
                        {:description "Number of errors when processing metrics in the metrics adjust middleware."})
    (prometheus/counter :metabase-search/index
                        {:description "Number of entries indexed for search"
-                        :labels      [:model]})])
+                        :labels      [:model]})
+   (prometheus/counter :metabase-search/index-ms
+                       {:description "Total number of ms indexing took"})])
 
 (defn- setup-metrics!
   "Instrument the application. Conditionally done when some setting is set. If [[prometheus-server-port]] is not set it

--- a/src/metabase/server/middleware/log.clj
+++ b/src/metabase/server/middleware/log.clj
@@ -48,11 +48,11 @@
 
 (defn- format-performance-info
   [{:keys [start-time call-count-fn _diag-info-fn]
-    :or {start-time    (System/nanoTime)
+    :or {start-time    (u/start-timer)
          call-count-fn (constantly -1)}}]
-  (let [elapsed-time (u/format-nanoseconds (- (System/nanoTime) start-time))
+  (let [elapsed-time (u/since-ms start-time)
         db-calls     (call-count-fn)]
-    (format "%s (%s DB calls)" elapsed-time db-calls)))
+    (format "%.0fms (%s DB calls)" elapsed-time db-calls)))
 
 (defn- stats [diag-info-fn]
   (str
@@ -222,7 +222,7 @@
       (t2/with-call-count [call-count-fn]
         (sql-jdbc.execute.diagnostic/capturing-diagnostic-info [diag-info-fn]
           (let [info           {:request       request
-                                :start-time    (System/nanoTime)
+                                :start-time    (u/start-timer)
                                 :call-count-fn call-count-fn
                                 :diag-info-fn  diag-info-fn
                                 :log-context   {:metabase-user-id api/*current-user-id*}}


### PR DESCRIPTION
Also I've changed format of middleware.log to always log milliseconds so the logs are easier to parse in our infra.