### PR TITLE
Track which search models are affected by deletes

### DIFF
--- a/src/metabase/util/connection.clj
+++ b/src/metabase/util/connection.clj
@@ -28,21 +28,16 @@
                                         [(.getString pks "COLUMN_NAME") true]))
                 fks (consume-rset fks (fn [^ResultSet fks]
                                         [(.getString fks "FKCOLUMN_NAME")
-                                         {:table   (.getString fks "PKTABLE_NAME")
-                                          :column  (.getString fks "PKCOLUMN_NAME")
-                                          :cascade (= (.getInt fks "DELETE_RULE")
-                                                      DatabaseMetaData/importedKeyCascade)}]))]
+                                         (str (.getString fks "PKTABLE_NAME")
+                                              "."
+                                              (.getString fks "PKCOLUMN_NAME"))]))]
             (consume-rset cols (fn [^ResultSet cols]
                                  (let [col (.getString cols "COLUMN_NAME")]
                                    [col {:type    (.getString cols "TYPE_NAME")
                                          :notnull (= (.getInt cols "NULLABLE")
                                                      ResultSetMetaData/columnNoNulls)
                                          :pk      (get pks col)
-                                         :fk      (qualified-name (get fks col))
-                                         :fk-data (get fks col)}])))))))))
-
-(defn- qualified-name [{:keys [table column]}]
-  (str table "." column))
+                                         :fk      (get fks col)}])))))))))
 
 (defn- group-rset [^ResultSet rset cb]
   (u/group-by first some? second (constantly true) conj #{}

--- a/test/metabase/search/appdb/index_test.clj
+++ b/test/metabase/search/appdb/index_test.clj
@@ -2,13 +2,16 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [java-time.api :as t]
+   [metabase.db :as mdb]
    [metabase.search.appdb.index :as search.index]
    [metabase.search.core :as search]
    [metabase.search.engine :as search.engine]
    [metabase.search.ingestion :as search.ingestion]
+   [metabase.search.spec :as search.spec]
    [metabase.search.test-util :as search.tu]
    [metabase.test :as mt]
    [metabase.util :as u]
+   [metabase.util.connection :as u.conn]
    [metabase.util.json :as json]
    [toucan2.core :as t2]))
 
@@ -490,3 +493,47 @@
           (is (not (#'search.index/exists? (#'search.index/pending-table)))))
         (finally
           (#'search.index/drop-table! related-table))))))
+
+;; We don't currently track database deletes in realtime in the search index.
+;; To do so, we would make use of the following mechanism to find downstream elements deleted by a cascade.
+;; For now, as we lack a low-impact way to decorate toucan2 to do such a thing, we simply track the relations as a test.
+;; This way we will at least be aware of the implication for staleness in the index whenever we change the specs.
+
+(def ^:private model->deleted-descendants
+  ;; Note that these refer to the table names, not the search-model names.
+  {"core_user"         #{"action" "collection" "model_index_value" "report_card" "report_dashboard" "segment"}
+   "model_index"       #{"model_index_value"}
+   "metabase_database" #{"action" "metabase_table" "model_index_value" "report_card" "segment"}
+   "metabase_table"    #{"action" "model_index_value" "report_card" "segment"}
+   "report_card"       #{"action" "model_index_value" "report_card"}})
+
+(defn- transitive*
+  "Borrows heavily from clojure.core/derive. Notably, however, this intentionally permits circular dependencies."
+  [h child parent]
+  (let [td (:descendants h {})
+        ta (:ancestors h {})
+        tf (fn [source sources target targets]
+             (reduce (fn [ret k]
+                       (assoc ret k
+                              (reduce conj (get targets k #{}) (cons target (targets target)))))
+                     targets (cons source (sources source))))]
+    {:ancestors   (tf child td parent ta)
+     :descendants (tf parent ta child td)}))
+
+(defn transitive
+  "Given a mapping from (say) parents to children, return the corresponding mapping from parents to descendants."
+  [adj-map]
+  (:descendants (reduce-kv (fn [h p children] (reduce #(transitive* %1 %2 p) h children)) nil adj-map)))
+
+(deftest search-model-cascade-text
+  (is (= model->deleted-descendants
+         (mt/with-empty-h2-app-db
+           (let [table->children    (u.conn/app-db-cascading-deletes (mdb/app-db) (map t2/table-name (descendants :metabase/model)))
+                 table->sub-tables  (into {} (for [[t cs] table->children] [t (map :child-table cs)]))
+                 table->descendants (transitive table->sub-tables)
+                 search-model?      (into #{} (map (comp name t2/table-name :model val)) (search.spec/specifications))]
+             (into {}
+                   (keep (fn [[p ds]]
+                           (when-let [ds (not-empty (into (sorted-set) (filter search-model? ds)))]
+                             [p ds])))
+                   table->descendants))))))


### PR DESCRIPTION
For now, we've decided not to trigger index updates when elements are deleted, due to the overhead that toucan2 would add.

We have the code to calculate what *should* be done, so we might as well keep it around in a test that documents these relationships. 

It's good to be mindful of the implications, and we could even use this information to do manual calls from the relevant deletion call sites.