### PR TITLE
Allow config files to have literal values enclosed in {{{ ... }}}

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file.clj
@@ -219,10 +219,8 @@
       (str/join parts))))
 
 (defn- expand-templates-in-str [s]
-  (if (and (str/starts-with? s "{{{") (str/ends-with? s "}}}"))
-    (-> s
-        (subs 3 (- (count s) 3))
-        str/trim)
+  (if-let [[_, raw-string] (re-matches #"\{\{\{(.+)\}\}\}" s)]
+    (str/trim raw-string)
     (str/join (map expand-template-str-part (params.parse/parse s)))))
 
 (defn- expand-templates [m]

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file.clj
@@ -219,12 +219,11 @@
       (str/join parts))))
 
 (defn- expand-templates-in-str [s]
-  (if (and (str/starts-with? s "{{{" ) (str/ends-with? s "}}}"))
+  (if (and (str/starts-with? s "{{{") (str/ends-with? s "}}}"))
     (-> s
         (subs 3 (- (count s) 3))
         str/trim)
     (str/join (map expand-template-str-part (params.parse/parse s)))))
-
 
 (defn- expand-templates [m]
   (walk/postwalk

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file.clj
@@ -219,7 +219,12 @@
       (str/join parts))))
 
 (defn- expand-templates-in-str [s]
-  (str/join (map expand-template-str-part (params.parse/parse s))))
+  (if (and (str/starts-with? s "{{{" ) (str/ends-with? s "}}}"))
+    (-> s
+        (subs 3 (- (count s) 3))
+        str/trim)
+    (str/join (map expand-template-str-part (params.parse/parse s)))))
+
 
 (defn- expand-templates [m]
   (walk/postwalk

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file_test.clj
@@ -82,6 +82,21 @@
       "{}}"
       "{ {}}")))
 
+(deftest ^:parallel literal-value-test
+  (testing "Can specify literal values with {{{'s"
+    (are [input output] (= (mock-config-with-setting output)
+                           (binding [advanced-config.file/*config* (mock-config-with-setting input)]
+                             (#'advanced-config.file/config)))
+                        "{{{asdf}}}" "asdf"
+                        "{{{ asdf }}}" "asdf"
+                        "{{{ {{ asdf }}  }}}" "{{ asdf }}"
+                        "{{{ {{ asdf }}}" "{{ asdf"
+                        )))
+    ;(are [input output] (= output
+    ;            (binding [advanced-config.file/*config* (mock-config-with-setting input)]
+    ;              (#'advanced-config.file/config)))
+    ;         "{{{asdf}}}" "asdf")))
+
 (deftest ^:parallel expand-template-forms-test-2
   (testing "Invalid template forms"
     (are [template error-pattern] (thrown-with-msg?

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file_test.clj
@@ -87,15 +87,10 @@
     (are [input output] (= (mock-config-with-setting output)
                            (binding [advanced-config.file/*config* (mock-config-with-setting input)]
                              (#'advanced-config.file/config)))
-                        "{{{asdf}}}" "asdf"
-                        "{{{ asdf }}}" "asdf"
-                        "{{{ {{ asdf }}  }}}" "{{ asdf }}"
-                        "{{{ {{ asdf }}}" "{{ asdf"
-                        )))
-    ;(are [input output] (= output
-    ;            (binding [advanced-config.file/*config* (mock-config-with-setting input)]
-    ;              (#'advanced-config.file/config)))
-    ;         "{{{asdf}}}" "asdf")))
+      "{{{asdf}}}" "asdf"
+      "{{{ asdf }}}" "asdf"
+      "{{{ {{ asdf }}  }}}" "{{ asdf }}"
+      "{{{ {{ asdf }}}" "{{ asdf")))
 
 (deftest ^:parallel expand-template-forms-test-2
   (testing "Invalid template forms"


### PR DESCRIPTION
Closes #31562

### Description

Adds support to the config parser to use values surrounded by `{{{ ... }}}` as literals.

Whitespace around the value inside the brackets are trimmed for easier reading.

### How to verify

Create a config like in the issue, but surround the problem "password" value:

```
version: 1
config:
  users:
    - first_name: Luiz
      last_name: Arakaki
      password: {{{ MetaPa$$123{{> }}}
      email: luiz.arakaki@metabase.com
```


### Checklist

- [X] Tests have been added/updated to cover changes in this PR
