### PR TITLE
Quiet snowflake logging

### DIFF
--- a/resources/log4j2.xml
+++ b/resources/log4j2.xml
@@ -32,6 +32,7 @@
     <Logger name="metabase.server.middleware" level="DEBUG"/>
     <Logger name="org.quartz" level="INFO"/>
     <Logger name="net.snowflake.client.jdbc.SnowflakeConnectString" level="ERROR"/>
+    <Logger name="net.snowflake.client.core.SessionUtil" level="FATAL"/>
 
     <Root level="WARN">
       <AppenderRef ref="STDOUT"/>


### PR DESCRIPTION
It looks like snowflake introduced some very noisy logging in their code.

https://github.com/snowflakedb/snowflake-jdbc/commit/9b7c9eb3e02c93cf7788c9866e1a483fe978e1be#diff-7859cac7243b3b9668df0770c96e264a1be2be06eefbbf7bba63904104028495L743

This should reduce the noise and allow our code to handle and log the exceptions.

Further context here:
https://metaboat.slack.com/archives/C010L1Z4F9S/p1733861342280199