### PR TITLE
[Cards in Dashboards] Fix no items appearing in personal collection

### DIFF
--- a/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
+++ b/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
@@ -747,6 +747,29 @@ describe("scenarios > organization > entity picker", () => {
         );
       });
     });
+
+    it("should show dashboards in personal collections when apropriate, even if there are no sub collections", () => {
+      cy.signInAsAdmin();
+      H.createDashboard({
+        collection_id: ADMIN_PERSONAL_COLLECTION_ID,
+      });
+
+      H.openTable({ table: ORDERS_ID });
+      cy.button("Save").click();
+      H.modal().findByLabelText("Where do you want to save this?").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Browse").click();
+        H.entityPickerModalItem(
+          0,
+          "Bobby Tables's Personal Collection",
+        ).click();
+        H.entityPickerModalItem(1, "Test Dashboard").should("exist").click();
+        cy.button("Select this dashboard").click();
+      });
+      H.modal()
+        .findByLabelText("Where do you want to save this?")
+        .should("contain.text", "Test Dashboard");
+    });
   });
 
   describe("dashboard picker", () => {

--- a/frontend/src/metabase/common/components/CollectionPicker/hooks.ts
+++ b/frontend/src/metabase/common/components/CollectionPicker/hooks.ts
@@ -51,10 +51,12 @@ export const useRootCollectionPickerItems = (
     currentUser?.personal_collection_id
       ? {
           id: currentUser?.personal_collection_id,
-          models: ["collection"],
+          models: ["collection", "dashboard"],
+          limit: 0, // we only want total number of items
         }
       : skipToken,
   );
+  const totalPersonalCollectionItems = personalCollectionItems?.total ?? 0;
 
   const {
     data: rootCollection,
@@ -98,7 +100,7 @@ export const useRootCollectionPickerItems = (
     ) {
       collectionItems.push({
         ...personalCollection,
-        here: personalCollectionItems?.data.length ? ["collection"] : [],
+        here: totalPersonalCollectionItems ? ["collection"] : [],
         model: "collection",
         can_write: true,
       });
@@ -116,7 +118,7 @@ export const useRootCollectionPickerItems = (
     isAdmin,
     options,
     rootCollectionError,
-    personalCollectionItems,
+    totalPersonalCollectionItems,
   ]);
 
   const isLoading =


### PR DESCRIPTION
### Description

Bug flagged internally here: https://metaboat.slack.com/archives/C064EB1UE5P/p1733864029661029
![Captura de ecrã 2024-12-10, às 20 51 17](https://github.com/user-attachments/assets/98e6e5a5-3ee7-438f-9df3-6e60ca73d59f)
It appears the issue only arises for users with a personal collection with no sub-collections but they have dashboards.

This PR adjusts our logic to account for dashboards being containers too and makes the query more efficient by not fetching any collection/dashboard data, just the number of items we have available.

### How to verify

1. Adjust your personal collection to have only one dashboard in it
2. Create a new question, open up the picker to save
3. Click on some other collection than your personal collection
4. Click on your personal collection from the root collections
5. You should see your dashboard now where you wouldn't before

### Demo

TODO

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
