### PR TITLE
[Cards in Dashboards] Fix bulk move runtime error

### DIFF
--- a/frontend/src/metabase/ErrorBoundary.tsx
+++ b/frontend/src/metabase/ErrorBoundary.tsx
@@ -42,7 +42,12 @@ export default class ErrorBoundary extends Component<
       const ErrorComponent = this.props.errorComponent
         ? this.props.errorComponent
         : SmallGenericError;
-      return <ErrorComponent message={this.props.message} />;
+      return (
+        <ErrorComponent
+          message={this.props.message}
+          data-testid="error-boundary"
+        />
+      );
     }
 
     return this.props.children;

--- a/frontend/src/metabase/collections/components/CollectionBulkActions/QuestionMoveConfirmModal.tsx
+++ b/frontend/src/metabase/collections/components/CollectionBulkActions/QuestionMoveConfirmModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from "react";
 import { useLatest } from "react-use";
 import { jt, msgid, ngettext, t } from "ttag";
+import { first } from "underscore";
 
 import { useGetMultipleCardsDashboardsQuery } from "metabase/api";
 import { Button, Flex, List, Loader, Modal, Text, Title } from "metabase/ui";
@@ -47,10 +48,10 @@ export const QuestionMoveConfirmModal = ({
 
   const cardsThatAppearInOtherDashboards = useMemo(
     () =>
-      cardDashboards?.filter(
-        cd =>
-          cd.dashboards.length > 1 || cd.dashboards[0].id !== destination?.id,
-      ),
+      cardDashboards?.filter(cd => {
+        cd.dashboards.length !== 1 ||
+          first(cd.dashboards)?.id !== destination?.id;
+      }),
     [destination, cardDashboards],
   );
 

--- a/frontend/src/metabase/collections/components/CollectionBulkActions/QuestionMoveConfirmModal.tsx
+++ b/frontend/src/metabase/collections/components/CollectionBulkActions/QuestionMoveConfirmModal.tsx
@@ -49,8 +49,15 @@ export const QuestionMoveConfirmModal = ({
   const cardsThatAppearInOtherDashboards = useMemo(
     () =>
       cardDashboards?.filter(cd => {
-        cd.dashboards.length !== 1 ||
-          first(cd.dashboards)?.id !== destination?.id;
+        if (cd.dashboards.length === 0) {
+          return false;
+        }
+
+        if (cd.dashboards.length > 1) {
+          return true;
+        }
+
+        return first(cd.dashboards)?.id !== destination?.id;
       }),
     [destination, cardDashboards],
   );

--- a/frontend/src/metabase/components/ErrorPages/ErrorPages.tsx
+++ b/frontend/src/metabase/components/ErrorPages/ErrorPages.tsx
@@ -89,6 +89,7 @@ export const Archived = ({
 export const SmallGenericError = ({
   message = t`Something’s gone wrong.`,
   bordered = true,
+  ...props
 }: {
   message?: string;
   bordered?: boolean;
@@ -103,7 +104,7 @@ export const SmallGenericError = ({
     : message + t` Click for more information`;
 
   return (
-    <ErrorPageRoot bordered={bordered}>
+    <ErrorPageRoot bordered={bordered} {...props}>
       <Tooltip label={tooltipMessage}>
         {isEmbedded ? (
           <Icon name="warning" size={32} color={color("text-light")} />


### PR DESCRIPTION
### Description

Fixes this internal error: https://metaboat.slack.com/archives/C0834B8DXKK/p1733867611819779

https://github.com/user-attachments/assets/a793ceaa-7c4e-4575-ace7-0c71af4eb046

### How to verify

- Create a dashboard, save to a collection
- Create a new question, save to the same collection (not the dashboard) and add it to the dashboard
- Create another collection, save it to the same collection, do not save to any dashboard in any way
- From the collection items view, bulk move both questions into the dashboard
- Should be successful now, but fail previously

### Demo

https://github.com/user-attachments/assets/649be76a-0fda-4fa4-82e8-d388a2c925d3

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
