### PR TITLE
Ignore interpolated expressions in query analysis

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -79,7 +79,7 @@
   io.github.eerohele/pp                     {#_#_:git/tag "2024-11-13.77"       ; super fast pretty-printing library
                                              :git/sha "7ac1bc56de95520ff4938df05e3518e9b051415d"
                                              :git/url "https://github.com/eerohele/pp"}
-  io.github.metabase/macaw                  {:mvn/version "0.2.24"}             ; Parse native SQL queries
+  io.github.metabase/macaw                  {:mvn/version "0.2.25"}             ; Parse native SQL queries
   io.github.resilience4j/resilience4j-retry ^:antq/exclude                      ; 2.x do not support Java 8
                                             {:mvn/version "1.7.1"}              ; Support for retrying operations
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector

--- a/src/metabase/query_analysis.clj
+++ b/src/metabase/query_analysis.clj
@@ -116,6 +116,11 @@
      :query      (explicit-references (mbql.u/referenced-field-ids query))
      :mbql/query (explicit-references (lib.util/referenced-field-ids query)))))
 
+(defn- truncate-string [x]
+  (if (and (string? x) (> (count x) 254))
+    (subs x 0 254)
+    x))
+
 (defn- update-query-analysis-for-card!
   "Clears QueryFields associated with this card and creates fresh, up-to-date-ones.
 
@@ -127,22 +132,24 @@
       (t2/with-transaction [_conn]
         (let [analysis-id (t2/insert-returning-pk! :model/QueryAnalysis {:card_id card-id :status "running"})
               result      (query-references query query-type)
-              table->row  (fn [{:keys [schema table table-id]}]
-                            {:card_id     card-id
-                             :analysis_id analysis-id
-                             :schema      schema
-                             :table       table
-                             :table_id    table-id})
-              field->row  (fn [{:keys [schema table column table-id field-id explicit-reference]}]
-                            {:card_id            card-id
-                             :analysis_id        analysis-id
-                             :schema             schema
-                             :table              table
-                             :column             column
-                             :table_id           table-id
-                             :field_id           field-id
-                             :explicit_reference explicit-reference})]
-
+              safely      (fn [f] (fn [m] (update-vals (f m) truncate-string)))
+              table->row  (safely
+                           (fn [{:keys [schema table table-id]}]
+                             {:card_id     card-id
+                              :analysis_id analysis-id
+                              :schema      schema
+                              :table       table
+                              :table_id    table-id}))
+              field->row  (safely
+                           (fn [{:keys [schema table column table-id field-id explicit-reference]}]
+                             {:card_id            card-id
+                              :analysis_id        analysis-id
+                              :schema             schema
+                              :table              table
+                              :column             column
+                              :table_id           table-id
+                              :field_id           field-id
+                              :explicit_reference explicit-reference}))]
           (if (contains? result :error)
             ;; TODO we should track cases where the driver is disabled or not-supported differently.
             (t2/update! :model/QueryAnalysis analysis-id {:status "failed"})
@@ -258,7 +265,11 @@
   "Assuming analysis is enabled, analyze the card immediately (and in the current thread)."
   [card-or-id]
   (when-not (= ::disabled (execution))
-    (analyze!* card-or-id)))
+    (try
+      (analyze!* card-or-id)
+      ;; Don't throw exceptions on the main thread path, analysis is best-effort.
+      (catch Exception e
+        (log/errorf e "Failure analysing card %s" (u/the-id card-or-id))))))
 
 (defn queue-analysis!
   "Synchronously hand off the given card for analysis, at a low priority. May block indefinitely, relies on consumer.

--- a/test/metabase/query_analysis_test.clj
+++ b/test/metabase/query_analysis_test.clj
@@ -116,7 +116,8 @@
 
 (defmacro with-analysis-on [& body]
   `(mt/with-dynamic-redefs [query-analysis/enabled-type? (constantly true)]
-     ~@body))
+     (query-analysis/with-immediate-analysis
+      ~@body)))
 
 (deftest parse-crosstab-test
   (with-analysis-on

--- a/test/metabase/query_analysis_test.clj
+++ b/test/metabase/query_analysis_test.clj
@@ -117,7 +117,7 @@
 (defmacro with-analysis-on [& body]
   `(mt/with-dynamic-redefs [query-analysis/enabled-type? (constantly true)]
      (query-analysis/with-immediate-analysis
-      ~@body)))
+       ~@body)))
 
 (deftest parse-crosstab-test
   (with-analysis-on

--- a/test/metabase/query_analysis_test.clj
+++ b/test/metabase/query_analysis_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.query-analysis-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -109,3 +110,53 @@
                           :tables {(mt/id :orders) (mt/id :people)}}]
         (is (= "SELECT NAME FROM PEOPLE"
                (query-analysis/replace-fields-and-tables card replacements)))))))
+
+(defn- monstrous-name []
+  (str/replace (apply str (repeatedly 10 random-uuid)) "-" "_"))
+
+(defmacro with-analysis-on [& body]
+  `(mt/with-dynamic-redefs [query-analysis/enabled-type? (constantly true)]
+     ~@body))
+
+(deftest parse-crosstab-test
+  (with-analysis-on
+    (testing "Nested queries within crosstab expressions are ignored"
+      (let [sql "SELECT * FROM CROSSTAB($$ wat $$, $$ wut $$) AS ct(page INTEGER, \"foo\" FLOAT)"]
+        (mt/with-temp [Card {c-id :id} {:dataset_query (mt/native-query {:query sql})}]
+          (testing "We record that analysis was successful"
+            (is (t2/exists? :model/QueryAnalysis :card_id c-id)))
+          (testing "But there are no identifiers saved to the database"
+            (is (not (t2/exists? :model/QueryField :card_id c-id)))
+            (is (not (t2/exists? :model/QueryTable :card_id c-id)))))))))
+
+(deftest parse-long-column-test
+  (with-analysis-on
+    (testing "Long identifiers are truncated"
+      (let [long-column (monstrous-name)
+            long-table  (monstrous-name)]
+        (mt/with-temp [Card {c-id :id} {:dataset_query (mt/native-query {:query (format "SELECT c, %s FROM t, %s"
+                                                                                        long-column
+                                                                                        long-table)})}]
+          (let [columns (t2/select-fn-set :column :model/QueryField :card_id c-id)
+                tables  (t2/select-fn-set :table :model/QueryTable :card_id c-id)]
+            (is (= 2 (count columns)))
+            (is (contains? columns "c"))
+            (is (some (partial str/starts-with? long-column) columns))
+            (is (= 2 (count tables)))
+            (is (contains? tables "t"))
+            (is (some (partial str/starts-with? long-table) tables))))))))
+
+(deftest analysis-error-test
+  (with-analysis-on
+    (testing "Errors analyzing queries will not prevent cards being created or updated"
+      (mt/with-dynamic-redefs [query-analysis/update-query-analysis-for-card! (fn [& _] (throw (ex-info "Oh no!" {})))]
+        (mt/with-temp [Card {c-id :id} {:dataset_query (mt/native-query {:query "SELECT c FROM t"})}]
+          (testing "The card was created"
+            (is (t2/exists? :model/Card c-id)))
+          (testing "The analysis was not"
+            (is (not (t2/exists? :model/QueryAnalysis :card_id c-id)))
+            (is (not (t2/exists? :model/QueryField :card_id c-id)))
+            (is (not (t2/exists? :model/QueryTable :card_id c-id))))
+          (testing "We can also update it"
+            (t2/update! :model/Card c-id {:name "Spiffy"})
+            (is (= "Spiffy" (t2/select-one-fn :name :model/Card c-id)))))))))


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/51131

There are 3 layers of defense being added:

1. Macaw will [no longer](https://github.com/metabase/macaw/pull/115) return interpolated strings as identifiers.
2. We ensure that identifiers that are actually just super long are truncated.
3. If there is some unexpected exception, we catch it on the model hook path.

This will need to be backported twice, to 51