### PR TITLE
Lock revisions before adding more

### DIFF
--- a/src/metabase/models/revision.clj
+++ b/src/metabase/models/revision.clj
@@ -83,7 +83,13 @@
   {:object mi/transform-json})
 
 (t2/define-before-insert :model/Revision
-  [revision]
+  [{:keys [model model_id] :as revision}]
+  (t2/query {:select [:id]
+             :from [:revision]
+             :where [:and
+                     [:= :model model]
+                     [:= :model_id model_id]]
+             :for :update})
   (assoc revision
          :timestamp (or (:timestamp revision) :%now)
          :metabase_version config/mb-version-string

--- a/src/metabase/models/revision.clj
+++ b/src/metabase/models/revision.clj
@@ -84,6 +84,7 @@
 
 (t2/define-before-insert :model/Revision
   [{:keys [model model_id] :as revision}]
+  ;; obtain a lock on the existing revisions for this entity to prevent concurrent inserts of new revisions
   (t2/query {:select [:id]
              :from [:revision]
              :where [:and


### PR DESCRIPTION
Our revision system has a race condition in the case of two concurrent requests to modify the same object. You can reproduce the exact issue here by opening two `psql` shells. In each one, run

```
begin;
insert into revision (model, model_id, user_id, timestamp, object, most_recent, metabase_version) values ('Dashboard', 1, 1, '2024-01-01T00:00:00Z', '{}', true, 'v1.0.0') returning id;
update revision set most_recent = false where model='Dashboard' and model_id = 10 and id != [[the id from above]];
```

after running all of the above, `commit` the transaction and note that **two** revisions are now marked as `most_recent`.

This is the way our revision system works: `t2/before-insert` sets `most_recent=true`, while `t2/after-insert` updates all the *other* revisions with `most_recent=false`.

The issue here is that when each transaction is running, it doesn't see the uncommitted result of the other transaction (the new revision), so the UPDATE does not set `most_recent` to `false` for either new revision.

The solution here is to just select all existing `revision`s for this model `FOR UPDATE`. This effectively locks the revisions for a single entity, so we can't concurrently update revisions for the same entity. Note that this only works if we already have at least one revision for the entity! But we create a revision when the entity is created, and it won't be possible to do *that* concurrently, so I think it's ok.