### PR TITLE
Convert ChartSettingToggle to Mantine

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/visualization-options.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/visualization-options.cy.spec.js
@@ -58,13 +58,13 @@ describe("scenarios > dashboard cards > visualization options", () => {
     H.modal().findAllByTestId("column-header").first().contains("User ID");
   });
 
-  it("should refelct column settings accurately when changing (metabase#30966)", () => {
+  it("should reflect column settings accurately when changing (metabase#30966)", () => {
     H.visitDashboard(ORDERS_DASHBOARD_ID);
     cy.findByLabelText("Edit dashboard").click();
     H.getDashboardCard().realHover();
     cy.findByLabelText("Show visualization options").click();
     cy.findByTestId("Subtotal-settings-button").click();
-    H.popover().findByLabelText("Show a mini bar chart").click();
+    H.popover().findByLabelText("Show a mini bar chart").click({ force: true });
     cy.findAllByTestId("mini-bar").should("have.length.above", 0);
   });
 });

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1108,7 +1108,7 @@ describe("scenarios > dashboard", () => {
     cy.findByRole("dialog").within(() => {
       cy.findByRole("switch", {
         name: "Hide this card if there are no results",
-      }).click();
+      }).click({ force: true });
       cy.button("Done").click();
     });
 
@@ -1231,9 +1231,9 @@ H.describeWithSnowplow("scenarios > dashboard", () => {
       cy.findByRole("switch", {
         name: "Hide this card if there are no results",
       })
-        .click() // enable
-        .click() // disable
-        .click(); // enable
+        .click({ force: true }) // enable
+        .click({ force: true }) // disable
+        .click({ force: true }); // enable
 
       H.expectGoodSnowplowEvent(
         {

--- a/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
@@ -722,7 +722,7 @@ describe("Custom columns visualization settings", () => {
     goToExpressionSidebarVisualizationSettings();
     H.popover().within(() => {
       const miniBarSwitch = cy.findByLabelText("Show a mini bar chart");
-      miniBarSwitch.click();
+      miniBarSwitch.click({ force: true });
       miniBarSwitch.should("be.checked");
     });
     saveModifiedQuestion();
@@ -752,7 +752,7 @@ describe("Custom columns visualization settings", () => {
     });
     H.popover().within(() => {
       const miniBarSwitch = cy.findByLabelText("Show a mini bar chart");
-      miniBarSwitch.click();
+      miniBarSwitch.click({ force: true });
       miniBarSwitch.should("be.checked");
     });
 

--- a/e2e/test/scenarios/visualizations-charts/sankey.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/sankey.cy.spec.js
@@ -72,7 +72,9 @@ describe("scenarios > visualizations > sankey", () => {
     H.echartsContainer().findByText("60,000").should("not.exist");
 
     // Enable edge labels
-    cy.get("@settings-sidebar").findByLabelText("Show edge labels").click();
+    cy.get("@settings-sidebar")
+      .findByLabelText("Show edge labels")
+      .click({ force: true });
 
     // Ensure it shows edge labels
     H.echartsContainer().findByText("60,000");

--- a/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
@@ -317,7 +317,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
     // turn off subtotals for User -> Source
     openColumnSettings(/Users? → Source/);
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Show totals").parent().find("input").click();
+    cy.findByText("Show totals").parent().find("input").click({ force: true });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("3,520").should("not.exist"); // the subtotal has disappeared!
@@ -345,7 +345,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
     // turn off subtotals for User -> Source
     openColumnSettings(/Users? → Source/);
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Show totals").parent().find("input").click();
+    cy.findByText("Show totals").parent().find("input").click({ force: true });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("3,520").should("not.exist"); // the subtotal isn't there
@@ -1228,7 +1228,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
       cy.signInAsNormalUser();
       H.visitQuestion("@questionId");
       cy.findByTestId("viz-settings-button").click();
-      cy.findByLabelText("Show row totals").click();
+      cy.findByLabelText("Show row totals").click({ force: true });
 
       cy.findByTestId("qb-save-button").should("have.attr", "data-disabled");
     });

--- a/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
@@ -410,13 +410,13 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
 
     cy.findByTestId("chartsettings-sidebar")
       .findByLabelText("Compact number")
-      .click();
+      .click({ force: true });
     cy.findByTestId("scalar-container").findByText("3.4M");
     cy.findByTestId("scalar-previous-value").findByText("5.3M");
 
     cy.findByTestId("chartsettings-sidebar")
       .findByLabelText("Compact number")
-      .click();
+      .click({ force: true });
     cy.findByTestId("scalar-container").findByText("3,440,000");
     cy.findByTestId("scalar-previous-value").findByText("5,270,000");
   });

--- a/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
@@ -360,7 +360,9 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
     cy.findByTestId("viz-settings-button").click();
     cy.findByTestId("chartsettings-sidebar").within(() => {
       cy.findByText("Display").click();
-      cy.findByLabelText("Switch positive / negative colors?").click();
+      cy.findByLabelText("Switch positive / negative colors?").click({
+        force: true,
+      });
     });
     cy.icon("arrow_down").should(
       "have.css",

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingToggle.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingToggle.jsx
@@ -1,8 +1,0 @@
-/* eslint-disable react/prop-types */
-import Toggle from "metabase/core/components/Toggle";
-
-const ChartSettingToggle = ({ value, onChange, id }) => (
-  <Toggle value={value} onChange={onChange} id={id} />
-);
-
-export default ChartSettingToggle;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingToggle.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingToggle.tsx
@@ -1,12 +1,22 @@
 /* eslint-disable react/prop-types */
-import { Switch } from "metabase/ui";
+import CS from "metabase/css/core/index.css";
+import { Switch, Text } from "metabase/ui";
 
 export const ChartSettingToggle = ({ value, onChange, id, title }) => (
   <Switch
-    label={title}
+    label={
+      <Text truncate fw="bold">
+        {title}
+      </Text>
+    }
     labelPosition="left"
     checked={value}
     onChange={e => onChange(e.currentTarget.checked)}
     id={id}
+    w="100%"
+    size="sm"
+    classNames={{
+      labelWrapper: CS.fullWidth,
+    }}
   />
 );

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingToggle.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingToggle.tsx
@@ -1,22 +1,19 @@
-/* eslint-disable react/prop-types */
-import CS from "metabase/css/core/index.css";
-import { Switch, Text } from "metabase/ui";
+import { Switch } from "metabase/ui";
 
-export const ChartSettingToggle = ({ value, onChange, id, label }) => (
+export const ChartSettingToggle = ({
+  value,
+  onChange,
+  id,
+}: {
+  value: boolean;
+  onChange: (value: boolean) => void;
+  id: string;
+}) => (
   <Switch
-    label={
-      <Text truncate fw="bold">
-        {label}
-      </Text>
-    }
     labelPosition="left"
     checked={value}
     onChange={e => onChange(e.currentTarget.checked)}
     id={id}
-    w="100%"
     size="sm"
-    classNames={{
-      labelWrapper: CS.fullWidth,
-    }}
   />
 );

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingToggle.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingToggle.tsx
@@ -1,0 +1,12 @@
+/* eslint-disable react/prop-types */
+import { Switch } from "metabase/ui";
+
+export const ChartSettingToggle = ({ value, onChange, id, title }) => (
+  <Switch
+    label={title}
+    labelPosition="left"
+    checked={value}
+    onChange={e => onChange(e.currentTarget.checked)}
+    id={id}
+  />
+);

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingToggle.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingToggle.tsx
@@ -14,6 +14,7 @@ export const ChartSettingToggle = ({
     checked={value}
     onChange={e => onChange(e.currentTarget.checked)}
     id={id}
+    role="switch"
     size="sm"
   />
 );

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingToggle.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingToggle.tsx
@@ -2,11 +2,11 @@
 import CS from "metabase/css/core/index.css";
 import { Switch, Text } from "metabase/ui";
 
-export const ChartSettingToggle = ({ value, onChange, id, title }) => (
+export const ChartSettingToggle = ({ value, onChange, id, label }) => (
   <Switch
     label={
       <Text truncate fw="bold">
-        {title}
+        {label}
       </Text>
     }
     labelPosition="left"

--- a/frontend/src/metabase/visualizations/lib/settings.js
+++ b/frontend/src/metabase/visualizations/lib/settings.js
@@ -6,17 +6,15 @@ import ChartSettingFieldPicker from "metabase/visualizations/components/settings
 import ChartSettingFieldsPartition from "metabase/visualizations/components/settings/ChartSettingFieldsPartition";
 import ChartSettingFieldsPicker from "metabase/visualizations/components/settings/ChartSettingFieldsPicker";
 import ChartSettingInput from "metabase/visualizations/components/settings/ChartSettingInput";
-import ChartSettingInputGroup from "metabase/visualizations/components/settings/ChartSettingInputGroup";
 import { ChartSettingInputNumeric } from "metabase/visualizations/components/settings/ChartSettingInputNumeric";
 import { ChartSettingMultiSelect } from "metabase/visualizations/components/settings/ChartSettingMultiSelect";
 import ChartSettingRadio from "metabase/visualizations/components/settings/ChartSettingRadio";
 import { ChartSettingSegmentedControl } from "metabase/visualizations/components/settings/ChartSettingSegmentedControl";
 import ChartSettingSelect from "metabase/visualizations/components/settings/ChartSettingSelect";
-import ChartSettingToggle from "metabase/visualizations/components/settings/ChartSettingToggle";
+import { ChartSettingToggle } from "metabase/visualizations/components/settings/ChartSettingToggle";
 
 const WIDGETS = {
   input: ChartSettingInput,
-  inputGroup: ChartSettingInputGroup,
   number: ChartSettingInputNumeric,
   radio: ChartSettingRadio,
   select: ChartSettingSelect,

--- a/frontend/src/metabase/visualizations/lib/settings.js
+++ b/frontend/src/metabase/visualizations/lib/settings.js
@@ -6,6 +6,7 @@ import ChartSettingFieldPicker from "metabase/visualizations/components/settings
 import ChartSettingFieldsPartition from "metabase/visualizations/components/settings/ChartSettingFieldsPartition";
 import ChartSettingFieldsPicker from "metabase/visualizations/components/settings/ChartSettingFieldsPicker";
 import ChartSettingInput from "metabase/visualizations/components/settings/ChartSettingInput";
+import ChartSettingInputGroup from "metabase/visualizations/components/settings/ChartSettingInputGroup";
 import { ChartSettingInputNumeric } from "metabase/visualizations/components/settings/ChartSettingInputNumeric";
 import { ChartSettingMultiSelect } from "metabase/visualizations/components/settings/ChartSettingMultiSelect";
 import ChartSettingRadio from "metabase/visualizations/components/settings/ChartSettingRadio";
@@ -15,6 +16,7 @@ import { ChartSettingToggle } from "metabase/visualizations/components/settings/
 
 const WIDGETS = {
   input: ChartSettingInput,
+  inputGroup: ChartSettingInputGroup,
   number: ChartSettingInputNumeric,
   radio: ChartSettingRadio,
   select: ChartSettingSelect,


### PR DESCRIPTION
Converts the `ChartSettingToggle` component to the Mantine component. This supports the SDK's ability to have uniform theming for all of the chart setting components.

Before:

<img width="301" alt="image" src="https://github.com/user-attachments/assets/2a255720-1470-4bb7-83b9-f38227c4af57" />
<img width="308" alt="image" src="https://github.com/user-attachments/assets/174e2153-8523-414f-8410-e6b67bdf126e" />


After:

<img width="310" alt="image" src="https://github.com/user-attachments/assets/8fff74b5-cfb4-4a57-a53f-a316d90c3244" />

<img width="315" alt="image" src="https://github.com/user-attachments/assets/7d399711-7244-4e47-b4e9-87d36b8c59b5" />
