### PR TITLE
Fix Embedding SDK cross-version e2e tests for release 51 branch

### DIFF
--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Checkout SDK release commit
         uses: actions/checkout@v4
         with:
-          ref: embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }} -- e2e
+          ref: embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }}
           sparse-checkout: |
             e2e/support/helpers
             e2e/test-component

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -156,10 +156,12 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Needed to omit newly added tests for functionality that is not yet released
-      - name: Checkout tests from SDK release commit
-        run: |
-          git fetch --all --tags --prune
-          git checkout tags/embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }} -- e2e/support/helpers e2e/test-component
+      - name: Checkout tests from SDK release commit - 1
+        run: git fetch origin refs/tags/embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }}
+        shell: bash
+
+      - name: Checkout tests from SDK release commit - 2
+        run: git checkout tags/embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }} -- e2e/support/helpers e2e/test-component
         shell: bash
 
       - name: Retrieve uberjar artifact for ee

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -159,8 +159,7 @@ jobs:
       - name: Checkout SDK release commit
         uses: actions/checkout@v4
         with:
-          ref: embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }}
-          filter: 'e2e/*'
+          ref: embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }} -- e2e
 
       - name: Retrieve uberjar artifact for ee
         uses: actions/download-artifact@v4

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -194,8 +194,11 @@ jobs:
         id: cypress-prep
         uses: ./.github/actions/prepare-cypress
 
-      - name: Install Embedding SDK package v${{ needs.resolve-sdk-version.outputs.sdk_version }} and Run E2E tests for Embedding SDK
-        run: yarn add @metabase/embedding-sdk-react@${{ needs.resolve-sdk-version.outputs.sdk_version }} && yarn why @metabase/embedding-sdk-react && yarn run test-cypress-run-component-sdk --browser ${{ steps.cypress-prep.outputs.chrome-path }}
+      - name: Install Embedding SDK package v${{ needs.resolve-sdk-version.outputs.sdk_version }}
+        run: yarn add @metabase/embedding-sdk-react@${{ needs.resolve-sdk-version.outputs.sdk_version }}
+
+      - name: Run E2E tests for Embedding SDK
+        run: yarn run test-cypress-run-component-sdk --browser ${{ steps.cypress-prep.outputs.chrome-path }}
 
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -165,11 +165,10 @@ jobs:
 
       - name: Move tests from the release commit into the repo
         run: |
-          ls -lah
           rm -rf e2e/support/helpers
-          mv sdk-release-e2e/e2e/support/helpers/* e2e/support/helpers
+          mv sdk-release-e2e/e2e/support/helpers/* ./e2e/support/helpers
           rm -rf e2e/test-component
-          mv sdk-release-e2e/e2e/test-component/* e2e/test-component
+          mv sdk-release-e2e/e2e/test-component/* ./e2e/test-component
         shell: bash
 
       - name: Retrieve uberjar artifact for ee

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -157,7 +157,9 @@ jobs:
 
       # Needed to omit newly added tests for functionality that is not yet released
       - name: Checkout tests from SDK release commit
-        run: git checkout tags/embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }} -- e2e/support/helpers e2e/test-component
+        run: |
+          git fetch --all --tags --prune
+          git checkout tags/embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }} -- e2e/support/helpers e2e/test-component
         shell: bash
 
       - name: Retrieve uberjar artifact for ee

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -156,12 +156,19 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Needed to omit newly added tests for functionality that is not yet released
-      - name: Checkout tests from SDK release commit - 1
-        run: git fetch origin refs/tags/embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }}
-        shell: bash
+      - name: Sparse checkout tests from SDK release commit
+        uses: actions/checkout@v4
+        with:
+          ref: embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }}
+          path: sdk-release-e2e
+          sparse-checkout: e2e
 
-      - name: Checkout tests from SDK release commit - 2
-        run: git checkout tags/embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }} -- e2e/support/helpers e2e/test-component
+      - name: Move tests from the release commit into the repo
+        run: |
+          rm -rf e2e/support/helpers
+          mv sdk-release-e2e/support/helpers/* e2e/support/helpers
+          rm -rf e2e/test-component
+          mv sdk-release-e2e/test-component/* e2e/test-component
         shell: bash
 
       - name: Retrieve uberjar artifact for ee

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -156,10 +156,11 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Needed to omit newly added tests for functionality that is not yet released
-#      - name: Checkout SDK release commit
-#        uses: actions/checkout@v4
-#        with:
-#          ref: embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }}
+      - name: Checkout SDK release commit
+        uses: actions/checkout@v4
+        with:
+          ref: embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }}
+          filter: 'e2e/*'
 
       - name: Retrieve uberjar artifact for ee
         uses: actions/download-artifact@v4

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -165,10 +165,11 @@ jobs:
 
       - name: Move tests from the release commit into the repo
         run: |
+          ls -lah
           rm -rf e2e/support/helpers
-          mv sdk-release-e2e/support/helpers/* e2e/support/helpers
+          mv sdk-release-e2e/e2e/support/helpers/* e2e/support/helpers
           rm -rf e2e/test-component
-          mv sdk-release-e2e/test-component/* e2e/test-component
+          mv sdk-release-e2e/e2e/test-component/* e2e/test-component
         shell: bash
 
       - name: Retrieve uberjar artifact for ee

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -156,10 +156,10 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Needed to omit newly added tests for functionality that is not yet released
-#      - name: Checkout SDK release commit
-#        uses: actions/checkout@v4
-#        with:
-#          ref: embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }}
+      - name: Checkout SDK release commit
+        uses: actions/checkout@v4
+        with:
+          ref: embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }}
 
       - name: Retrieve uberjar artifact for ee
         uses: actions/download-artifact@v4

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -165,10 +165,10 @@ jobs:
 
       - name: Move tests from the release commit into the repo
         run: |
-          rm -rf e2e/support/helpers
-          mv sdk-release-e2e/e2e/support/helpers/* ./e2e/support/helpers
-          rm -rf e2e/test-component
-          mv sdk-release-e2e/e2e/test-component/* ./e2e/test-component
+          rm -rf ./e2e/support/helpers/*
+          mv ./sdk-release-e2e/e2e/support/helpers/* ./e2e/support/helpers
+          rm -rf ./e2e/test-component/*
+          mv ./sdk-release-e2e/e2e/test-component/* ./e2e/test-component
         shell: bash
 
       - name: Retrieve uberjar artifact for ee

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -160,6 +160,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }} -- e2e
+          sparse-checkout: |
+            e2e/support/helpers
+            e2e/test-component
 
       - name: Retrieve uberjar artifact for ee
         uses: actions/download-artifact@v4

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -156,10 +156,10 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Needed to omit newly added tests for functionality that is not yet released
-      - name: Checkout SDK release commit
-        uses: actions/checkout@v4
-        with:
-          ref: embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }}
+#      - name: Checkout SDK release commit
+#        uses: actions/checkout@v4
+#        with:
+#          ref: embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }}
 
       - name: Retrieve uberjar artifact for ee
         uses: actions/download-artifact@v4

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -184,11 +184,8 @@ jobs:
         id: cypress-prep
         uses: ./.github/actions/prepare-cypress
 
-      - name: Install Embedding SDK package v${{ needs.resolve-sdk-version.outputs.sdk_version }}
-        run: yarn add @metabase/embedding-sdk-react@${{ needs.resolve-sdk-version.outputs.sdk_version }}
-
-      - name: Run E2E tests for Embedding SDK
-        run: yarn run test-cypress-run-component-sdk --browser ${{ steps.cypress-prep.outputs.chrome-path }}
+      - name: Install Embedding SDK package v${{ needs.resolve-sdk-version.outputs.sdk_version }} and Run E2E tests for Embedding SDK
+        run: yarn add @metabase/embedding-sdk-react@${{ needs.resolve-sdk-version.outputs.sdk_version }} && yarn why @metabase/embedding-sdk-react && yarn run test-cypress-run-component-sdk --browser ${{ steps.cypress-prep.outputs.chrome-path }}
 
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -156,13 +156,9 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Needed to omit newly added tests for functionality that is not yet released
-      - name: Checkout SDK release commit
-        uses: actions/checkout@v4
-        with:
-          ref: embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }}
-          sparse-checkout: |
-            e2e/support/helpers
-            e2e/test-component
+      - name: Checkout tests from SDK release commit
+        run: git checkout embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }} -- e2e/support/helpers e2e/test-component
+        shell: bash
 
       - name: Retrieve uberjar artifact for ee
         uses: actions/download-artifact@v4

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -157,7 +157,7 @@ jobs:
 
       # Needed to omit newly added tests for functionality that is not yet released
       - name: Checkout tests from SDK release commit
-        run: git checkout embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }} -- e2e/support/helpers e2e/test-component
+        run: git checkout tags/embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }} -- e2e/support/helpers e2e/test-component
         shell: bash
 
       - name: Retrieve uberjar artifact for ee

--- a/e2e/support/component-webpack.config.js
+++ b/e2e/support/component-webpack.config.js
@@ -19,14 +19,14 @@ module.exports = {
     extensions: [".ts", ".tsx", ".js", ".jsx", ".css", ".svg"],
     alias: {
       ...mainConfig.resolve.alias,
-      // ...(!isEmbeddingSdkPackageInstalled
-      //   ? {
-      //       "@metabase/embedding-sdk-react": path.resolve(
-      //         __dirname,
-      //         "../../resources/embedding-sdk/dist/main.bundle.js",
-      //       ),
-      //     }
-      //   : null),
+      ...(!isEmbeddingSdkPackageInstalled
+        ? {
+            "@metabase/embedding-sdk-react": path.resolve(
+              __dirname,
+              "../../resources/embedding-sdk/dist/main.bundle.js",
+            ),
+          }
+        : null),
     },
     fallback: { path: false, fs: false }, // FIXME: this might break file download tests, we might need to implement this properly
   },

--- a/e2e/support/component-webpack.config.js
+++ b/e2e/support/component-webpack.config.js
@@ -1,15 +1,12 @@
-const fs = require("fs");
-
 const path = require("path");
 const webpack = require("webpack");
 
 const mainConfig = require("../../webpack.config");
 
-const { isEmbeddingSdkPackageInstalled, embeddingSdkVersion } =
-  resolveEmbeddingSdkPackage();
+const { isEmbeddingSdkPackageInstalled } = resolveEmbeddingSdkPackage();
 
 console.log(
-  `Embedding SDK is ${isEmbeddingSdkPackageInstalled ? `installed, using "${embeddingSdkVersion}"` : 'NOT installed, using locally built version from "resources/embedding-sdk"'}`,
+  `Embedding SDK is ${isEmbeddingSdkPackageInstalled ? "installed" : 'NOT installed, using locally built version from "resources/embedding-sdk"'}`,
 );
 
 module.exports = {
@@ -85,25 +82,13 @@ module.exports = {
 
 function resolveEmbeddingSdkPackage() {
   let isEmbeddingSdkPackageInstalled = false;
-  let embeddingSdkVersion;
 
   try {
-    embeddingSdkVersion =
-      require("@metabase/embedding-sdk-react/package.json").version;
+    require.resolve("@metabase/embedding-sdk-react");
     isEmbeddingSdkPackageInstalled = true;
-  } catch (err) {
-    const sdkPackageTemplateJson = fs.readFileSync(
-      path.resolve(
-        "../../enterprise/frontend/src/embedding-sdk/package.template.json",
-      ),
-      "utf-8",
-    );
-    const sdkPackageTemplateJsonContent = JSON.parse(sdkPackageTemplateJson);
-    embeddingSdkVersion = JSON.stringify(sdkPackageTemplateJsonContent.version);
-  }
+  } catch (err) {}
 
   return {
     isEmbeddingSdkPackageInstalled,
-    embeddingSdkVersion,
   };
 }

--- a/e2e/support/component-webpack.config.js
+++ b/e2e/support/component-webpack.config.js
@@ -5,7 +5,12 @@ const webpack = require("webpack");
 
 const mainConfig = require("../../webpack.config");
 
-const { isEmbeddingSdkPackageInstalled } = resolveEmbeddingSdkPackage();
+const { isEmbeddingSdkPackageInstalled, embeddingSdkVersion } =
+  resolveEmbeddingSdkPackage();
+
+console.log(
+  `Embedding SDK is ${isEmbeddingSdkPackageInstalled ? `installed, using "${embeddingSdkVersion}"` : 'NOT installed, using locally built version from "resources/embedding-sdk"'}`,
+);
 
 module.exports = {
   mode: "development",

--- a/e2e/support/component-webpack.config.js
+++ b/e2e/support/component-webpack.config.js
@@ -19,14 +19,14 @@ module.exports = {
     extensions: [".ts", ".tsx", ".js", ".jsx", ".css", ".svg"],
     alias: {
       ...mainConfig.resolve.alias,
-      ...(!isEmbeddingSdkPackageInstalled
-        ? {
-            "@metabase/embedding-sdk-react": path.resolve(
-              __dirname,
-              "../../resources/embedding-sdk/dist/main.bundle.js",
-            ),
-          }
-        : null),
+      // ...(!isEmbeddingSdkPackageInstalled
+      //   ? {
+      //       "@metabase/embedding-sdk-react": path.resolve(
+      //         __dirname,
+      //         "../../resources/embedding-sdk/dist/main.bundle.js",
+      //       ),
+      //     }
+      //   : null),
     },
     fallback: { path: false, fs: false }, // FIXME: this might break file download tests, we might need to implement this properly
   },


### PR DESCRIPTION
### Description

Fixes issues with Embedding SDK cross-version e2e tests for release 51 branch.

Issue happens because we cannot resolve `@metabase/embedding-sdk-react/package.json`, which is most likely happens because we added "exports" block to the `package.json`, and it takes priority.

We don't need version for e2e tests so we can remove it. 

Then , the second issue is that we checkout FE files to get stable set of tests and this overrides webpack config file. SO, I had to refactor this part to checkout only test files and helpers.
**This part should be backported to master and release 52.**, @heypoom 

### How to verify

CI should pass

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
