### PR TITLE
update tracking for embedding-sdk-react and embedding-iframe x-metabase-clients 

### DIFF
--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -203,6 +203,10 @@
                        {:description "Number of successful SDK requests."})
    (prometheus/counter :metabase-sdk/response-error
                        {:description "Number of errors when responding to SDK requests."})
+   (prometheus/counter :metabase-embedding-iframe/response-ok
+                       {:description "Number of successful iframe embedding requests."})
+   (prometheus/counter :metabase-embedding-iframe/response-error
+                       {:description "Number of errors when responding to iframe embedding requests."})
    (prometheus/counter :metabase-scim/response-ok
                        {:description "Number of successful responses from SCIM endpoints"})
    (prometheus/counter :metabase-scim/response-error

--- a/src/metabase/analytics/sdk.clj
+++ b/src/metabase/analytics/sdk.clj
@@ -15,8 +15,8 @@
 (def ^:dynamic *client* "Used to track information about the metabase embedding client." nil)
 
 (mu/defn include-analytics :- :map
-  "Adds the currently bound, or existing `*client*` and `*version*` to the given map, which is usually a row going into
-   the `view_log` or `query_execution` table. Falls back to the original value."
+  "Adds the currently bound, or existing `*client*` and `*version*` to the given map, which is usually a row going
+   into the `view_log` or `query_execution` table. Falls back to the original value."
   [m :- :map]
   (-> m
       (update :embedding_client (fn [client] (or *client* client)))
@@ -52,8 +52,10 @@
                 *version* version]
         (handler request
                  (fn responder [response]
-                   (when (= sdk-client embedding-sdk-client) (track-sdk-response (categorize-request response)))
+                   (when (= sdk-client embedding-sdk-client)
+                     (track-sdk-response (categorize-request response)))
                    (respond response))
                  (fn raiser [response]
-                   (when (= sdk-client embedding-sdk-client) (track-sdk-response :error))
+                   (when (= sdk-client embedding-sdk-client)
+                     (track-sdk-response :error))
                    (raise response)))))))

--- a/src/metabase/analytics/sdk.clj
+++ b/src/metabase/analytics/sdk.clj
@@ -31,15 +31,23 @@
       ;; ignore other status codes
       :else nil)))
 
+(def ^:private embedding-sdk-client "embedding-sdk-react")
+(def ^:private embedding-iframe-client "embedding-iframe")
+
 (defn- track-sdk-response
   "Tabulates the number of ok and erroring requests made by clients of the SDK."
-  [category]
-  (case category
-    :ok (prometheus/inc! :metabase-sdk/response-ok)
-    :error (prometheus/inc! :metabase-sdk/response-error)
-    nil nil))
+  [sdk-client status]
+  (condp = [sdk-client status]
+    [embedding-sdk-client :ok]       (prometheus/inc! :metabase-sdk/response-ok)
+    [embedding-sdk-client :error]    (prometheus/inc! :metabase-sdk/response-error)
+    [embedding-iframe-client :ok]    (prometheus/inc! :metabase-embedding-iframe/response-ok)
+    [embedding-iframe-client :error] (prometheus/inc! :metabase-embedding-iframe/response-error)))
 
-(def ^:private embedding-sdk-client "embedding-sdk-react")
+(defn- embedding-context?
+  "Should we track this request as being made by an embedding client?"
+  [client]
+  (or (= client embedding-sdk-client)
+      (= client embedding-iframe-client)))
 
 (defn embedding-mw
   "Reads Metabase Client and Version headers and binds them to *metabase-client{-version}*."
@@ -52,10 +60,10 @@
                 *version* version]
         (handler request
                  (fn responder [response]
-                   (when (= sdk-client embedding-sdk-client)
-                     (track-sdk-response (categorize-request response)))
+                   (when (embedding-context? sdk-client)
+                     (track-sdk-response sdk-client (categorize-request response)))
                    (respond response))
                  (fn raiser [response]
-                   (when (= sdk-client embedding-sdk-client)
-                     (track-sdk-response :error))
+                   (when (embedding-context? sdk-client)
+                     (track-sdk-response sdk-client :error))
                    (raise response)))))))

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -617,7 +617,7 @@
   (let [qe (t2/select [:model/QueryExecution :embedding_client :context :executor_id :started_at])
         one-day-ago (->one-day-ago)
         ;; reuse the query data:
-        qe-24h (filter (fn [{started-at :started_at}] (t/after? one-day-ago started-at)) qe)]
+        qe-24h (filter (fn [{started-at :started_at}] (t/after? started-at one-day-ago)) qe)]
     {:query-executions (merge
                         {"sdk_embed" 0 "interactive_embed" 0 "static_embed" 0 "public_link" 0 "internal" 0}
                         (-> (group-by categorize-query-execution qe)

--- a/test/metabase/server/middleware/sdk_test.clj
+++ b/test/metabase/server/middleware/sdk_test.clj
@@ -57,6 +57,23 @@
         (is (= {:metabase-sdk/response-ok 1
                 :metabase-sdk/response-error 2} @prometheus-standin))))))
 
+(deftest embeding-mw-bumps-metrics-with-iframe-client-header
+  (let [prometheus-standin (atom {})]
+    (with-redefs [prometheus/inc! (fn [k] (swap! prometheus-standin update k (fnil inc 0)))]
+      ;; X-Metabase-Client header == "embedding-sdk-react" => SDK context
+      (let [request (mock-request {:client @#'sdk/embedding-iframe-client})
+            good (sdk/embedding-mw (fn [_ respond _] (respond {:status 200})))
+            bad (sdk/embedding-mw (fn [_ respond _] (respond {:status 400})))
+            exception (sdk/embedding-mw (fn [_ _respond raise] (raise {})))]
+        (good request identity identity)
+        (is (= {:metabase-embedding-iframe/response-ok 1} @prometheus-standin))
+        (bad request identity identity)
+        (is (= {:metabase-embedding-iframe/response-ok 1
+                :metabase-embedding-iframe/response-error 1} @prometheus-standin))
+        (exception request identity identity)
+        (is (= {:metabase-embedding-iframe/response-ok 1
+                :metabase-embedding-iframe/response-error 2} @prometheus-standin))))))
+
 (deftest embeding-mw-does-not-bump-metrics-with-random-sdk-header
   (let [prometheus-standin (atom {})]
     (with-redefs [prometheus/inc! (fn [k] (swap! prometheus-standin update k (fnil inc 0)))]

--- a/test/metabase/server/middleware/sdk_test.clj
+++ b/test/metabase/server/middleware/sdk_test.clj
@@ -40,10 +40,11 @@
     nil
     "1.1.1"))
 
-(deftest embeding-mw-bumps-metrics-with-sdk-header
+(deftest embeding-mw-bumps-metrics-with-react-sdk-client-header
   (let [prometheus-standin (atom {})]
     (with-redefs [prometheus/inc! (fn [k] (swap! prometheus-standin update k (fnil inc 0)))]
-      (let [request (mock-request {:client "my-client"}) ;; <-- has X-Metabase-Client header => SDK context
+      ;; X-Metabase-Client header == "embedding-sdk-react" => SDK context
+      (let [request (mock-request {:client @#'sdk/embedding-sdk-client})
             good (sdk/embedding-mw (fn [_ respond _] (respond {:status 200})))
             bad (sdk/embedding-mw (fn [_ respond _] (respond {:status 400})))
             exception (sdk/embedding-mw (fn [_ _respond raise] (raise {})))]
@@ -55,6 +56,21 @@
         (exception request identity identity)
         (is (= {:metabase-sdk/response-ok 1
                 :metabase-sdk/response-error 2} @prometheus-standin))))))
+
+(deftest embeding-mw-does-not-bump-metrics-with-random-sdk-header
+  (let [prometheus-standin (atom {})]
+    (with-redefs [prometheus/inc! (fn [k] (swap! prometheus-standin update k (fnil inc 0)))]
+       ;; has X-Metabase-Client header, but it's not the SDK, so we don't track it
+      (let [request (mock-request {:client "my-client"})
+            good (sdk/embedding-mw (fn [_ respond _] (respond {:status 200})))
+            bad (sdk/embedding-mw (fn [_ respond _] (respond {:status 400})))
+            exception (sdk/embedding-mw (fn [_ _respond raise] (raise {})))]
+        (good request identity identity)
+        (is (= {} @prometheus-standin))
+        (bad request identity identity)
+        (is (= {} @prometheus-standin))
+        (exception request identity identity)
+        (is (= {} @prometheus-standin))))))
 
 (deftest embeding-mw-does-not-bump-sdk-metrics-without-sdk-header
   (let [prometheus-standin (atom {})]


### PR DESCRIPTION
- tracking ignores x-metabase-client headers when they're not == "embedding-sdk-react" or "embedding-iframe"
- adds tracking for "embeding-iframe" metabase clients
- remedy 24h query execution inaccuracy