### PR TITLE
Fix autoplacement when a dashboard has empty tabs

### DIFF
--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -3887,7 +3887,19 @@
       (t2/delete! :model/DashboardCard :card_id card-id :dashboard_id dash-id)
       ;; unarchive it, it gets autoplaced
       (mt/user-http-request :crowberto :put 200 (str "card/" card-id) {:archived false})
-      (is (dashcard-exists?)))))
+      (is (dashcard-exists?))))
+  (testing "it works when the dashboard has an empty tab"
+    (mt/with-temp [:model/Collection {coll-id :id} {}
+                   :model/Dashboard {dash-id :id} {:collection_id coll-id}
+                   :model/DashboardTab {dt-id :id} {:dashboard_id dash-id}
+                   :model/Card {card-id :id} {}]
+      (mt/user-http-request :crowberto :put 200 (str "card/" card-id) {:dashboard_id dash-id})
+      (is (t2/exists? :model/DashboardCard :dashboard_id dash-id :dashboard_tab_id dt-id :card_id card-id))
+      (mt/user-http-request :crowberto :put 200 (str "card/" card-id) {:archived true})
+      (t2/delete! :model/DashboardCard :card_id card-id :dashboard_id dash-id)
+
+      (mt/user-http-request :crowberto :put 200 (str "card/" card-id) {:archived false})
+      (is (t2/exists? :model/DashboardCard :dashboard_id dash-id :dashboard_tab_id dt-id :card_id card-id)))))
 
 (deftest moving-dashboard-questions
   (testing "We can move a dashboard question to a collection"


### PR DESCRIPTION
We were getting the `dashboard_tab_id` from the existing cards on the first tab... but if no such card exists (the first tab is empty) then we end up with a dashboard with tabs, but a card with `dashboard_tab_id=null`, which doesn't show up.

This also fixes a bug in the revision history: we were publishing an event for the dashboard being updated. The object was the updated dashboard, but it had the old dashcards that we'd hydrated in order to autoplace. We can dissoc the dashcards to ensure that the handler hydrates them with the fresh, updated dashcards.
