### PR TITLE
removing broken e2e test assertion from dashboard-questions

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
@@ -523,7 +523,7 @@ describe("Dashboard > Dashboard Questions", () => {
         H.visitDashboard(dashboardId);
         H.openDashboardMenu("Move to trash");
         H.modal().button("Move to trash").click();
-        cy.findByText("Dashboard with a title").should("not.exist");
+
         cy.findByText(/gone wrong/, { timeout: 0 }).should("not.exist");
 
         cy.findByTestId("archive-banner").findByText(/is in the trash/);


### PR DESCRIPTION
### Description

Removes a broken assertion that is blocking CI. It's unclear how this ever passed CI to begin with, which is especially puzzling :/

### How to verify

CI should pass

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
