### PR TITLE
Don't compute a different hash key if they only differ on the order of values in a parameter

### DIFF
--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -86,6 +86,11 @@
        x))
    x))
 
+(mu/defn- sort-parameter-values
+  "Return the sequence of parameter maps, but with any :value keys sorted if they are a sequence"
+  [params :- [:or :nil [:sequential :any]]]
+  (mapv #(if (sequential? (:value %)) (update % :value sort) %) params))
+
 (mu/defn- select-keys-for-hashing
   "Return `query` with only the keys relevant to hashing kept.
   (This is done so irrelevant info or options that don't affect query results doesn't result in the same query
@@ -94,7 +99,7 @@
   (let [{:keys [constraints parameters], :as query} (select-keys query [:database :lib/type :stages :parameters :constraints])]
     (cond-> query
       (empty? constraints) (dissoc :constraints)
-      true                 (update :parameters  (fn [params] (mapv #(if (sequential? (:value %)) (update % :value sort) %) params)))
+      true                 (update :parameters sort-parameter-values)
       (empty? parameters)  (dissoc :parameters)
       true                 lib.schema.util/remove-randomized-idents
       true                 walk-query-sort-maps)))

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -94,6 +94,7 @@
   (let [{:keys [constraints parameters], :as query} (select-keys query [:database :lib/type :stages :parameters :constraints])]
     (cond-> query
       (empty? constraints) (dissoc :constraints)
+      true                 (update :parameters  (fn [params] (mapv #(if (sequential? (:value %)) (update % :value sort) %) params)))
       (empty? parameters)  (dissoc :parameters)
       true                 lib.schema.util/remove-randomized-idents
       true                 walk-query-sort-maps)))

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -89,7 +89,7 @@
 (mu/defn- sort-parameter-values
   "Return the sequence of parameter maps, but with any :value keys sorted if they are a sequence"
   [params :- [:or :nil [:sequential :any]]]
-  (mapv #(if (sequential? (:value %)) (update % :value sort) %) params))
+  (map #(if (sequential? (:value %)) (update % :value sort) %) params))
 
 (mu/defn- select-keys-for-hashing
   "Return `query` with only the keys relevant to hashing kept.

--- a/test/metabase/query_processor/util_test.clj
+++ b/test/metabase/query_processor/util_test.clj
@@ -114,3 +114,11 @@
   (is (= "7e144bc5b43ee850648f353cda978b2911e2f66260ac03c5e1744bce6ca668ff"
          (query-hash-hex {:parameters [{:value 1, :name "parameter"}]})
          (query-hash-hex {:parameters [{:name "parameter", :value 1}]}))))
+
+(deftest ^:parallel parameter-order-should-not-affect-query-hash-test
+  (is (= "db4583f6192234b4bfc076446a0836a4438e5d0182a1ef9a9d737ad6ea180617"
+         (query-hash-hex {:parameters [{:name "parameter", :value ["a" "b"]}]})
+         (query-hash-hex {:parameters [{:name "parameter", :value ["b" "a"]}]})))
+  (is (= "e51a6617a34f3955a8d9b275535c2d0a611ce0bace4f52630229ba9975ed44c3"
+         (query-hash-hex {:parameters [{:name "parameter", :value [1 2]}]})
+         (query-hash-hex {:parameters [{:name "parameter", :value [2 1]}]}))))


### PR DESCRIPTION
Closes #48887

### Description

Updated `select-keys-for-hashing` to sort parameter values

### How to verify

Steps from the issue:

1. Create a question
2. Add it to a dashboard and link a category filter
3. Set caching policy for the dashboard: Duration: 1 hour
4. Select two values in the filter, e.g. 'Widget', 'Gizmo'
5. Check the logs, and note the question is being cached
6. Deselect the values
7. Select the same values again, but in a different order: 'Gizmo', 'Widget'
8. Check the logs and see a different cache key has been generated for the query
 

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
