### PR TITLE
delete old dashcards when moving question from QB view

### DIFF
--- a/frontend/src/metabase/query_builder/components/MoveQuestionModal/MoveQuestionModal.tsx
+++ b/frontend/src/metabase/query_builder/components/MoveQuestionModal/MoveQuestionModal.tsx
@@ -48,7 +48,10 @@ export const MoveQuestionModal = ({
     boolean | undefined
   >();
 
-  const handleMove = async (destination: MoveDestination) => {
+  const handleMove = async (
+    destination: MoveDestination,
+    _deleteOldDashcards?: boolean | undefined,
+  ) => {
     const update =
       destination.model === "dashboard"
         ? { dashboard_id: destination.id as number }
@@ -59,7 +62,7 @@ export const MoveQuestionModal = ({
 
     await updateQuestion({
       id: question.id(),
-      delete_old_dashcards: deleteOldDashcards,
+      delete_old_dashcards: _deleteOldDashcards,
       ...update,
     })
       .then(({ data: updatedCard }) => {
@@ -99,7 +102,8 @@ export const MoveQuestionModal = ({
 
   const handleMoveConfirm = () => {
     if (confirmMoveState?.destination) {
-      handleMove(confirmMoveState?.destination);
+      setDeleteOldDashcards(true);
+      handleMove(confirmMoveState?.destination, true);
     }
   };
 
@@ -128,7 +132,9 @@ export const MoveQuestionModal = ({
       <Modal>
         <ConfirmContent
           data-testid="dashboard-to-collection-move-confirmation"
-          onAction={() => handleMove(confirmMoveState?.destination)}
+          onAction={() =>
+            handleMove(confirmMoveState?.destination, deleteOldDashcards)
+          }
           onCancel={onClose}
           onClose={onClose}
           title={
@@ -172,7 +178,7 @@ export const MoveQuestionModal = ({
       <Modal>
         <ConfirmContent
           data-testid="dashboard-to-dashboard-move-confirmation"
-          onAction={() => handleMove(confirmMoveState.destination)}
+          onAction={() => handleMove(confirmMoveState.destination, true)}
           onCancel={onClose}
           onClose={onClose}
           title={


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/51150

### Description
Passes the `delete_old_dashcards` query param when moving a question into a dashboard from the Query Builder perspective. previously, after confirming that it was okay to remove a question from other dashboards that it appears in, we would not pass this prop and the update would fail. This works as expected in the other view, of moving questions in the collection view.

Also adds an additional test to ensure the that "It should still appear here" flow of dashboard -> collection works apropriately.

### How to verify

1. Go to a question that appears in a dashboard
2. Try to move it to another dashboard
3. On the confirmation screen, click confirm
4. There should be no API errors, and the question should be in it's new home, with appearances removed from other dashboards

### Demo
![chrome_jRBfmYakBx](https://github.com/user-attachments/assets/6c3859a0-a138-4027-a283-27b5f334274e)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
