### PR TITLE
[Cards in Dashboards] Bug fix - Query builder breaks with DQ in root collection as init value

### DIFF
--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.tsx
@@ -146,11 +146,16 @@ export const QuestionPicker = ({
   useDeepCompareEffect(
     function setInitialPath() {
       if (currentDashboard?.id) {
+        const location =
+          currentDashboard.collection_id === null
+            ? "/"
+            : `${currentDashboard.collection?.location ?? ""}${currentDashboard.collection?.id ?? ""}/`;
+
         const idPath = getCollectionIdPath(
           {
             ...currentDashboard,
             model: "dashboard",
-            location: `${currentDashboard.collection?.location}${currentDashboard.collection_id}/`,
+            location,
           },
           userPersonalCollectionId,
         );

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.unit.spec.tsx
@@ -86,10 +86,10 @@ const nestedDashboard = createMockCollectionItem({
   ...createMockDashboard({
     name: "Nested Dashboard",
     collection_id: 3,
-    collection: {
+    collection: createMockCollection({
       id: 3,
       location: "/4/",
-    },
+    }),
   }),
   location: "/4/",
   id: 106,

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.unit.spec.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { setupEnterprisePlugins } from "__support__/enterprise";
 import {
   setupCollectionItemsEndpoint,
+  setupDashboardItemsEndpoint,
   setupRecentViewsAndSelectionsEndpoints,
   setupSearchEndpoints,
 } from "__support__/server-mocks";
@@ -22,6 +23,7 @@ import {
   createMockCard,
   createMockCollection,
   createMockCollectionItem,
+  createMockDashboard,
   createMockSettings,
   createMockTokenFeatures,
 } from "metabase-types/api/mocks";
@@ -42,11 +44,65 @@ type NestedCollectionItem = Partial<CollectionItem> & {
   descendants?: NestedCollectionItem[];
 };
 
-const myQuestion = createMockCollectionItem({
+const rootQuestion = createMockCollectionItem({
+  ...createMockCard({
+    id: 104,
+    name: "Question in Root",
+    collection_id: null,
+  }),
+  model: "card",
+});
+
+const rootDashboard = createMockCollectionItem({
+  ...createMockDashboard({
+    name: "Root Dashboard",
+    collection_id: null,
+  }),
+  id: 105,
+  location: "/",
+  model: "dashboard",
+});
+
+const rootDashboardQuestion = createMockCollectionItem({
+  ...createMockCard({
+    id: 107,
+    name: "DQ in Root",
+    collection_id: null,
+    dashboard_id: rootDashboard.id,
+  }),
+  model: "card",
+});
+
+const nestedQuestion = createMockCollectionItem({
   ...createMockCard({
     id: 100,
-    name: "My Question",
+    name: "Nested Question",
     collection_id: 3,
+  }),
+  model: "card",
+});
+
+const nestedDashboard = createMockCollectionItem({
+  ...createMockDashboard({
+    name: "Nested Dashboard",
+    collection_id: 3,
+    collection: {
+      id: 3,
+      location: "/4/",
+    },
+  }),
+  location: "/4/",
+  id: 106,
+  model: "dashboard",
+});
+
+const nestedDashboardQuestion = createMockCollectionItem({
+  ...createMockCard({
+    id: 108,
+    name: "Nested DQ",
+    collection_id: 3,
+    dashboard_id: nestedDashboard.id,
+    dashboard: nestedDashboard,
   }),
   model: "card",
 });
@@ -99,7 +155,14 @@ const collectionTree: NestedCollectionItem[] = [
             id: 3,
             name: "Collection 3",
             model: "collection",
-            descendants: [myQuestion, myModel, myMetric, myVerifiedQuestion],
+            descendants: [
+              nestedQuestion,
+              nestedDashboard,
+              nestedDashboardQuestion,
+              myModel,
+              myMetric,
+              myVerifiedQuestion,
+            ],
             location: "/4/",
             can_write: true,
             is_personal: false,
@@ -115,6 +178,9 @@ const collectionTree: NestedCollectionItem[] = [
         can_write: true,
         descendants: [],
       },
+      rootQuestion,
+      rootDashboard,
+      rootDashboardQuestion,
     ],
   },
   {
@@ -190,10 +256,21 @@ const commonSetup = () => {
   );
 
   allItems.forEach(item => {
-    if (item.model !== "collection") {
-      fetchMock.get(`path:/api/card/${item.id}`, item);
-    } else {
+    if (item.model === "collection") {
       fetchMock.get(`path:/api/collection/${item.id}`, item);
+    } else if (item.model === "dashboard") {
+      fetchMock.get(`path:/api/dashboard/${item.id}`, item);
+
+      const dashboardId = item.id;
+      const dashboardItems = allItems.filter(
+        (item: any) => item.dashboard_id === dashboardId,
+      );
+      setupDashboardItemsEndpoint({
+        dashboard: item as any,
+        dashboardItems,
+      });
+    } else {
+      fetchMock.get(`path:/api/card/${item.id}`, item);
     }
   });
 
@@ -229,7 +306,7 @@ const setupPicker = async ({
     return (
       <QuestionPicker
         initialValue={initialValue}
-        models={["card"]}
+        models={["card", "dashboard"]}
         options={defaultOptions}
         path={path}
         onInit={jest.fn()}
@@ -242,6 +319,11 @@ const setupPicker = async ({
   renderWithProviders(<TestComponent />, { storeInitialState: state });
 
   await waitForLoaderToBeRemoved();
+};
+
+// zero indexed
+const level = async (index: number) => {
+  return within(await screen.findByTestId(`item-picker-level-${index}`));
 };
 
 const setupModal = async ({
@@ -301,31 +383,95 @@ describe("QuestionPicker", () => {
     ).toHaveAttribute("data-active", "true");
   });
 
-  it("should render the path to the question provided", async () => {
-    await setupPicker({ initialValue: { id: 100, model: "card" } });
+  describe("initial value", () => {
+    it("should render the path to a question in the root collection", async () => {
+      await setupPicker({ initialValue: { id: 104, model: "card" } });
 
-    expect(
-      await screen.findByRole("button", { name: /Our Analytics/ }),
-    ).toHaveAttribute("data-active", "true");
+      expect(
+        await (await level(0)).findByRole("button", { name: /Our Analytics/ }),
+      ).toHaveAttribute("data-active", "true");
 
-    expect(
-      await screen.findByRole("button", { name: /Collection 4/ }),
-    ).toHaveAttribute("data-active", "true");
+      expect(
+        await (
+          await level(1)
+        ).findByRole("button", { name: /Question in Root/ }),
+      ).toHaveAttribute("data-active", "true");
+    });
 
-    expect(
-      await screen.findByRole("button", { name: /Collection 3/ }),
-    ).toHaveAttribute("data-active", "true");
+    it("should render the path to a question nested in multiple collections", async () => {
+      await setupPicker({ initialValue: { id: 100, model: "card" } });
 
-    // question itself should start selected
-    expect(
-      await screen.findByRole("button", { name: /My Question/ }),
-    ).toHaveAttribute("data-active", "true");
+      expect(
+        await (await level(0)).findByRole("button", { name: /Our Analytics/ }),
+      ).toHaveAttribute("data-active", "true");
 
-    expect(
-      await within(
-        await screen.findByRole("button", { name: /My Verified Question/ }),
-      ).findByRole("img", { name: /verified_filled/ }),
-    ).toBeInTheDocument();
+      expect(
+        await (await level(1)).findByRole("button", { name: /Collection 4/ }),
+      ).toHaveAttribute("data-active", "true");
+
+      expect(
+        await (await level(2)).findByRole("button", { name: /Collection 3/ }),
+      ).toHaveAttribute("data-active", "true");
+
+      // question itself should start selected
+      expect(
+        await (
+          await level(3)
+        ).findByRole("button", { name: /Nested Question/ }),
+      ).toHaveAttribute("data-active", "true");
+
+      expect(
+        await within(
+          await screen.findByRole("button", { name: /My Verified Question/ }),
+        ).findByRole("img", { name: /verified_filled/ }),
+      ).toBeInTheDocument();
+    });
+
+    it("should render the path to a dashboard question where dashboard is in the root collection", async () => {
+      await setupPicker({
+        initialValue: { id: rootDashboardQuestion.id, model: "card" },
+      });
+
+      expect(
+        await (await level(0)).findByRole("button", { name: /Our Analytics/ }),
+      ).toHaveAttribute("data-active", "true");
+
+      expect(
+        await (await level(1)).findByRole("button", { name: /Root Dashboard/ }),
+      ).toHaveAttribute("data-active", "true");
+
+      expect(
+        await (await level(2)).findByRole("button", { name: /DQ in Root/ }),
+      ).toHaveAttribute("data-active", "true");
+    });
+
+    it("should render the path to a dashboard question in a nested collection", async () => {
+      await setupPicker({
+        initialValue: { id: nestedDashboardQuestion.id, model: "card" },
+      });
+
+      expect(
+        await (await level(0)).findByRole("button", { name: /Our Analytics/ }),
+      ).toHaveAttribute("data-active", "true");
+
+      expect(
+        await (await level(1)).findByRole("button", { name: /Collection 4/ }),
+      ).toHaveAttribute("data-active", "true");
+
+      expect(
+        await (await level(2)).findByRole("button", { name: /Collection 3/ }),
+      ).toHaveAttribute("data-active", "true");
+
+      expect(
+        await (
+          await level(3)
+        ).findByRole("button", { name: /Nested Dashboard/ }),
+      ).toHaveAttribute("data-active", "true");
+
+      expect(
+        await (await level(4)).findByRole("button", { name: /Nested DQ/ }),
+      ).toHaveAttribute("data-active", "true");
+    });
   });
 });
 
@@ -414,7 +560,7 @@ describe("QuestionPickerModal", () => {
     );
 
     expect(
-      await screen.findByRole("button", { name: /My Question/ }),
+      await screen.findByRole("button", { name: /Nested Question/ }),
     ).toHaveAttribute("data-active", "true");
   });
 
@@ -511,12 +657,12 @@ describe("QuestionPickerModal", () => {
   });
 
   it("should be able to search for metrics", async () => {
-    await setupSearchEndpoints([myQuestion, myModel, myMetric]);
+    await setupSearchEndpoints([nestedQuestion, myModel, myMetric]);
     await setupModal({ models: ["card", "dataset", "metric"] });
     const searchInput = await screen.findByPlaceholderText(/search/i);
     await userEvent.type(searchInput, myMetric.name);
     await userEvent.click(screen.getByText("Everywhere"));
     expect(await screen.findByText(myMetric.name)).toBeInTheDocument();
-    expect(screen.queryByText(myQuestion.name)).not.toBeInTheDocument();
+    expect(screen.queryByText(nestedQuestion.name)).not.toBeInTheDocument();
   });
 });

--- a/frontend/test/__support__/server-mocks/collection.ts
+++ b/frontend/test/__support__/server-mocks/collection.ts
@@ -113,6 +113,32 @@ export function setupCollectionItemsEndpoint({
   });
 }
 
+export function setupDashboardItemsEndpoint({
+  dashboard,
+  dashboardItems,
+  models: modelsParam,
+}: {
+  dashboard: Dashboard;
+  dashboardItems: CollectionItem[];
+  models?: string[];
+}) {
+  fetchMock.get(`path:/api/dashboard/${dashboard.id}/items`, uri => {
+    const url = new URL(uri);
+    const models = modelsParam ?? url.searchParams.getAll("models") ?? ["card"];
+    const limit =
+      Number(url.searchParams.get("limit")) || dashboardItems.length;
+    const offset = Number(url.searchParams.get("offset")) || 0;
+
+    return {
+      data: dashboardItems.slice(offset, offset + limit),
+      total: dashboardItems.length,
+      models,
+      limit,
+      offset,
+    };
+  });
+}
+
 export function setupCollectionsWithError({
   error,
   status = 500,


### PR DESCRIPTION
### Description

Fixes a bug where the QuestionPicker breaks when its initial value is a dashboard question in a dashboard within the root collection. This generates a request to `/api/collection/NaN/items?models=collection&models=card&models=dashboard` and produces the following bug:
<img width="949" alt="image" src="https://github.com/user-attachments/assets/96a7de11-6816-4dda-b239-33e85338c3a4" />

### How to verify

- Create a dashboard in the root collection with a new dashboard question in it
- Go to admin permissions and set the dashboard question as the source for sandboxing
- Save then edit the sandboxing configuration
- The error should now no longer be there

### Demo

https://github.com/user-attachments/assets/c71dad99-a139-4ac5-8788-3fab5b594f1b

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
