### PR TITLE
Manual backport workflow fixes from 51171

### DIFF
--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -156,10 +156,20 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Needed to omit newly added tests for functionality that is not yet released
-      - name: Checkout SDK release commit
+      - name: Sparse checkout tests from SDK release commit
         uses: actions/checkout@v4
         with:
           ref: embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }}
+          path: sdk-release-e2e
+          sparse-checkout: e2e
+
+      - name: Move tests from the release commit into the repo
+        run: |
+          rm -rf ./e2e/support/helpers/*
+          mv ./sdk-release-e2e/e2e/support/helpers/* ./e2e/support/helpers
+          rm -rf ./e2e/test-component/*
+          mv ./sdk-release-e2e/e2e/test-component/* ./e2e/test-component
+        shell: bash
 
       - name: Retrieve uberjar artifact for ee
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Manually backports the workflow fixes from #51171 to master branch. From the PR description:

> Then, the second issue is that we checkout FE files to get stable set of tests and this overrides webpack config file. SO, I had to refactor this part to checkout only test files and helpers. This part should be backported to master and release 52.