### PR TITLE
Fix the inconsistency of card title length limit

### DIFF
--- a/frontend/src/metabase/components/SaveQuestionForm/schema.ts
+++ b/frontend/src/metabase/components/SaveQuestionForm/schema.ts
@@ -1,6 +1,7 @@
 import * as Yup from "yup";
 
 import * as Errors from "metabase/lib/errors";
+import { QUESTION_TITLE_MAX_LENGTH } from "metabase/questions/constants";
 
 export const SAVE_QUESTION_SCHEMA = Yup.object({
   saveType: Yup.string().oneOf(["overwrite", "create"]),
@@ -8,7 +9,9 @@ export const SAVE_QUESTION_SCHEMA = Yup.object({
     // We don't care if the form is valid when overwrite mode is enabled,
     // as original question's data will be submitted instead of the form values
     is: (value: string) => value !== "overwrite",
-    then: Yup.string().required(Errors.required),
+    then: Yup.string()
+      .max(QUESTION_TITLE_MAX_LENGTH, Errors.maxLength)
+      .required(Errors.required),
     otherwise: Yup.string().nullable(true),
   }),
 });

--- a/frontend/src/metabase/core/components/EditableText/EditableText.styled.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.styled.tsx
@@ -5,6 +5,7 @@ export interface EditableTextRootProps {
   isEditing?: boolean;
   isDisabled: boolean;
   isEditingMarkdown?: boolean;
+  error?: boolean;
 }
 
 export const EditableTextRoot = styled.div<EditableTextRootProps>`
@@ -36,6 +37,12 @@ export const EditableTextRoot = styled.div<EditableTextRootProps>`
         white-space: pre-wrap;
         word-wrap: break-word;
       }
+    `}
+  ${props =>
+    props.error &&
+    css`
+      color: #ed6e6e;
+      border-color: #ed6e6e;
     `}
 `;
 

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { t } from "ttag";
+import * as Yup from "yup";
 
 import { useInteractiveDashboardContext } from "embedding-sdk/components/public/InteractiveDashboard/context";
 import { isInstanceAnalyticsCollection } from "metabase/collections/utils";
@@ -14,6 +15,7 @@ import {
 import { useSetDashboardAttributeHandler } from "metabase/dashboard/components/Dashboard/use-set-dashboard-attribute";
 import { DashboardHeaderButtonRow } from "metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/DashboardHeaderButtonRow";
 import { DashboardTabs } from "metabase/dashboard/components/DashboardTabs";
+import { DASHBOARD_TITLE_MAX_LENGTH } from "metabase/dashboard/constants";
 import {
   getCanResetFilters,
   getIsEditing,
@@ -28,6 +30,7 @@ import type {
   DashboardRefreshPeriodControls,
 } from "metabase/dashboard/types";
 import { color } from "metabase/lib/colors";
+import * as Errors from "metabase/lib/errors";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import {
   PLUGIN_COLLECTION_COMPONENTS,
@@ -62,6 +65,11 @@ type DashboardHeaderViewProps = {
 } & DashboardFullscreenControls &
   DashboardRefreshPeriodControls &
   DashboardNightModeControls;
+
+const TITLE_SCHEMA = Yup.string()
+  .required(Errors.required)
+  .max(DASHBOARD_TITLE_MAX_LENGTH, Errors.maxLength)
+  .default("");
 
 export function DashboardHeaderView({
   editingTitle = "",
@@ -199,6 +207,7 @@ export function DashboardHeaderView({
                     isDisabled={!dashboard.can_write}
                     data-testid="dashboard-name-heading"
                     onChange={handleUpdateCaption}
+                    validationSchema={TITLE_SCHEMA}
                   />
                   <PLUGIN_MODERATION.EntityModerationIcon
                     dashboard={dashboard}

--- a/frontend/src/metabase/dashboard/constants.ts
+++ b/frontend/src/metabase/dashboard/constants.ts
@@ -7,6 +7,8 @@ import type { EmbedDisplayParams } from "./types";
 
 export const DASHBOARD_DESCRIPTION_MAX_LENGTH = 1500;
 
+export const DASHBOARD_TITLE_MAX_LENGTH = 100;
+
 export const SIDEBAR_NAME: Record<DashboardSidebarName, DashboardSidebarName> =
   {
     addQuestion: "addQuestion",

--- a/frontend/src/metabase/dashboard/containers/CopyDashboardForm.tsx
+++ b/frontend/src/metabase/dashboard/containers/CopyDashboardForm.tsx
@@ -36,7 +36,6 @@ const DASHBOARD_SCHEMA = Yup.object({
     .max(DASHBOARD_DESCRIPTION_MAX_LENGTH, Errors.maxLength)
     .default(null),
   collection_id: Yup.number().nullable().default(null),
-  is_shallow_copy: Yup.boolean().default(false),
 });
 
 export interface CopyDashboardFormProperties {

--- a/frontend/src/metabase/dashboard/containers/CopyDashboardForm.tsx
+++ b/frontend/src/metabase/dashboard/containers/CopyDashboardForm.tsx
@@ -23,12 +23,15 @@ import * as Errors from "metabase/lib/errors";
 import type { CollectionId, Dashboard } from "metabase-types/api";
 
 import { DashboardCopyModalShallowCheckboxLabel } from "../components/DashboardCopyModal/DashboardCopyModalShallowCheckboxLabel/DashboardCopyModalShallowCheckboxLabel";
-import { DASHBOARD_DESCRIPTION_MAX_LENGTH } from "../constants";
+import {
+  DASHBOARD_DESCRIPTION_MAX_LENGTH,
+  DASHBOARD_TITLE_MAX_LENGTH,
+} from "../constants";
 
 const DASHBOARD_SCHEMA = Yup.object({
   name: Yup.string()
     .required(Errors.required)
-    .max(100, Errors.maxLength)
+    .max(DASHBOARD_TITLE_MAX_LENGTH, Errors.maxLength)
     .default(""),
   description: Yup.string()
     .nullable()

--- a/frontend/src/metabase/dashboard/containers/CopyDashboardForm.tsx
+++ b/frontend/src/metabase/dashboard/containers/CopyDashboardForm.tsx
@@ -11,7 +11,6 @@ import FormFooter from "metabase/core/components/FormFooter";
 import Dashboards from "metabase/entities/dashboards";
 import {
   Form,
-  FormCheckbox,
   FormErrorMessage,
   FormObserver,
   FormProvider,
@@ -22,7 +21,6 @@ import {
 import * as Errors from "metabase/lib/errors";
 import type { CollectionId, Dashboard } from "metabase-types/api";
 
-import { DashboardCopyModalShallowCheckboxLabel } from "../components/DashboardCopyModal/DashboardCopyModalShallowCheckboxLabel/DashboardCopyModalShallowCheckboxLabel";
 import {
   DASHBOARD_DESCRIPTION_MAX_LENGTH,
   DASHBOARD_TITLE_MAX_LENGTH,
@@ -116,10 +114,6 @@ function CopyDashboardForm({
           name="collection_id"
           title={t`Which collection should this go in?`}
           filterPersonalCollections={filterPersonalCollections}
-        />
-        <FormCheckbox
-          name="is_shallow_copy"
-          label={<DashboardCopyModalShallowCheckboxLabel />}
         />
         <FormFooter>
           <FormErrorMessage inline />

--- a/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.jsx
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.jsx
@@ -1,5 +1,9 @@
 import PropTypes from "prop-types";
 import { t } from "ttag";
+import * as Yup from "yup";
+
+import * as Errors from "metabase/lib/errors";
+import { QUESTION_TITLE_MAX_LENGTH } from "metabase/questions/constants";
 
 import { CollectionIcon } from "./CollectionIcon";
 import { HeaderRoot, HeaderTitle } from "./SavedQuestionHeaderButton.styled";
@@ -10,6 +14,11 @@ SavedQuestionHeaderButton.propTypes = {
   onSave: PropTypes.func,
 };
 
+const TITLE_SCHEMA = Yup.string()
+  .required(Errors.required)
+  .max(QUESTION_TITLE_MAX_LENGTH, Errors.maxLength)
+  .default("");
+
 function SavedQuestionHeaderButton({ question, onSave }) {
   return (
     <HeaderRoot>
@@ -19,6 +28,7 @@ function SavedQuestionHeaderButton({ question, onSave }) {
         placeholder={t`Add title`}
         onChange={onSave}
         data-testid="saved-question-header-title"
+        validationSchema={TITLE_SCHEMA}
       />
 
       <CollectionIcon

--- a/frontend/src/metabase/questions/components/CopyQuestionForm.tsx
+++ b/frontend/src/metabase/questions/components/CopyQuestionForm.tsx
@@ -16,10 +16,12 @@ import * as Errors from "metabase/lib/errors";
 import { Button } from "metabase/ui";
 import type { CollectionId } from "metabase-types/api";
 
+import { QUESTION_TITLE_MAX_LENGTH } from "../constants";
+
 const QUESTION_SCHEMA = Yup.object({
   name: Yup.string()
     .required(Errors.required)
-    .max(100, Errors.maxLength)
+    .max(QUESTION_TITLE_MAX_LENGTH, Errors.maxLength)
     .default(""),
   description: Yup.string().nullable().default(null),
   collection_id: Yup.number().nullable().default(null),

--- a/frontend/src/metabase/questions/constants.ts
+++ b/frontend/src/metabase/questions/constants.ts
@@ -1,0 +1,1 @@
+export const QUESTION_TITLE_MAX_LENGTH = 100;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/49600

### Description
1. Add name length validation (under 100 characters) for question creation.
2. Add name length validation (under 100 characters) for  all card title editions.


### How to verify
1. Create a new question with a name length over 100.
2. Open an existing card (like a question or a dashboard) and rename the name at the top.

### Demo
<details>
<summary>Create a new question:</summary>

before:
![before](https://github.com/user-attachments/assets/3d1de4ed-bd86-4609-9fb1-c6e719292c13)

now:
![now](https://github.com/user-attachments/assets/6cf09daf-3572-423a-aac9-387903413781)

</details>

<details>
<summary>Rename a existing card:</summary>

before:
![before](https://github.com/user-attachments/assets/f0fde047-ada8-4c0c-857a-97a8e9d6a640)

now:
![now](https://github.com/user-attachments/assets/228a0c27-244a-4ec7-8c37-c598895e6b7f)

</details>



### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
