### PR TITLE
fix(sdk): wrap InteractiveDashboard with renderOnlyInSdkProvider

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentWrapper/PublicComponentWrapper.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentWrapper/PublicComponentWrapper.tsx
@@ -7,9 +7,9 @@ import { SdkLoader } from "embedding-sdk/components/private/PublicComponentWrapp
 import { useSdkSelector } from "embedding-sdk/store";
 import { getLoginStatus, getUsageProblem } from "embedding-sdk/store/selectors";
 
-import { useIsInSdkProvider } from "../SdkContext";
+import { RenderOnlyInSdkProvider } from "../SdkContext";
 
-type PublicComponentWrapperProps = {
+export type PublicComponentWrapperProps = {
   children: React.ReactNode;
   className?: string;
   style?: CSSProperties;
@@ -51,13 +51,9 @@ export const PublicComponentWrapper = React.forwardRef<
   HTMLDivElement,
   PublicComponentWrapperProps
 >(function PublicComponentWrapper(props, ref) {
-  // metabase##50736: make sure we don't break the host app if for a render the
-  // sdk components is rendered outside of the sdk provider
-  const isInSdkProvider = useIsInSdkProvider();
-  if (!isInSdkProvider) {
-    // eslint-disable-next-line no-literal-metabase-strings -- error message
-    return "This component requires the MetabaseProvider parent component. Please wrap it within <MetabaseProvider>...</MetabaseProvider> in your component tree.";
-  }
-
-  return <PublicComponentWrapperInner ref={ref} {...props} />;
+  return (
+    <RenderOnlyInSdkProvider>
+      <PublicComponentWrapperInner ref={ref} {...props} />
+    </RenderOnlyInSdkProvider>
+  );
 });

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkContext.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkContext.tsx
@@ -1,6 +1,10 @@
 import type React from "react";
 import { createContext, useContext } from "react";
 
+// Currently, we use this context to know if a component is rendered inside the provider or not.
+// This is needed for metabase##50736, to make sure we don't break the host app if for a render the
+// sdk components is rendered outside of the sdk provider
+
 const SdkContext = createContext<boolean>(false);
 
 export const SdkContextProvider = ({ children }: React.PropsWithChildren) => {
@@ -10,3 +14,31 @@ export const SdkContextProvider = ({ children }: React.PropsWithChildren) => {
 export const useIsInSdkProvider = () => {
   return useContext(SdkContext);
 };
+
+export const RenderOnlyInSdkProvider = ({
+  children,
+}: React.PropsWithChildren) => {
+  const isInSdkProvider = useIsInSdkProvider();
+  if (!isInSdkProvider) {
+    // eslint-disable-next-line no-literal-metabase-strings -- error message
+    return "This component requires the MetabaseProvider parent component. Please wrap it within <MetabaseProvider>...</MetabaseProvider> in your component tree.";
+  }
+
+  return children;
+};
+
+export function renderOnlyInSdkProvider<P extends object>(
+  Component: React.ComponentType<P>,
+) {
+  const WithRenderOnlyInSdkProvider = (props: P) => (
+    <RenderOnlyInSdkProvider>
+      <Component {...props} />
+    </RenderOnlyInSdkProvider>
+  );
+
+  WithRenderOnlyInSdkProvider.displayName = `withRenderOnlyInSdkProvider(${
+    Component.displayName || Component.name || "Component"
+  })`;
+
+  return WithRenderOnlyInSdkProvider;
+}

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/InteractiveDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/InteractiveDashboard.tsx
@@ -7,6 +7,7 @@ import {
   SdkError,
   SdkLoader,
 } from "embedding-sdk/components/private/PublicComponentWrapper";
+import { renderOnlyInSdkProvider } from "embedding-sdk/components/private/SdkContext";
 import { StyledPublicComponentWrapper } from "embedding-sdk/components/public/InteractiveDashboard/InteractiveDashboard.styled";
 import { useCommonDashboardParams } from "embedding-sdk/components/public/InteractiveDashboard/use-common-dashboard-params";
 import {
@@ -129,22 +130,21 @@ const InteractiveDashboardInner = ({
   );
 };
 
-export const InteractiveDashboard = ({
-  dashboardId,
-  ...rest
-}: InteractiveDashboardProps) => {
-  const { id, isLoading } = useValidatedEntityId({
-    type: "dashboard",
-    id: dashboardId,
-  });
+export const InteractiveDashboard = renderOnlyInSdkProvider(
+  ({ dashboardId, ...rest }: InteractiveDashboardProps) => {
+    const { id, isLoading } = useValidatedEntityId({
+      type: "dashboard",
+      id: dashboardId,
+    });
 
-  if (isLoading) {
-    return <SdkLoader />;
-  }
+    if (isLoading) {
+      return <SdkLoader />;
+    }
 
-  if (!id) {
-    return <SdkError message="ID not found" />;
-  }
+    if (!id) {
+      return <SdkError message="ID not found" />;
+    }
 
-  return <InteractiveDashboardInner dashboardId={id} {...rest} />;
-};
+    return <InteractiveDashboardInner dashboardId={id} {...rest} />;
+  },
+);


### PR DESCRIPTION

A followup for https://github.com/metabase/metabase/issues/50736

The InteractiveDashboard code had hooks that were used outside of the PublicComponentWrapper, that was because it needed to customize some styles etc.

This PR adds `RenderOnlyInSdkProvider` and a`renderOnlyInSdkProvider` functions that help us add the "don't render outside of provider" logic more easily for cases when we need to separate the concerns of that logic and the one of styles.

To repro, you'd need to verify that the interactive dashboard page on the pages router (https://github.com/metabase/metabase-nextjs-sdk-embedding-sample) don't crash when you navigate to another page and then back at it.

Note that you'll probably need to cherry-pick https://github.com/metabase/metabase/pull/51071 to make it work as we renamed some things in master but not on the compat layer, and also the sample apps use the old naming