### PR TITLE
Add search reindexing button

### DIFF
--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -26,6 +26,7 @@ import getAdminPermissionsRoutes from "metabase/admin/permissions/routes";
 import { SettingsEditor } from "metabase/admin/settings/app/components/SettingsEditor";
 import { Help } from "metabase/admin/tasks/components/Help";
 import { Logs } from "metabase/admin/tasks/components/Logs";
+import { SearchTroubleShooting } from "metabase/admin/tasks/components/SearchTroubleshooting";
 import { JobInfoApp } from "metabase/admin/tasks/containers/JobInfoApp";
 import { JobTriggersModal } from "metabase/admin/tasks/containers/JobTriggersModal";
 import {
@@ -148,6 +149,7 @@ const getRoutes = (store, CanAccessSettings, IsAdmin) => (
             />
           </Route>
           <Route path="logs" component={Logs} />
+          <Route path="search" component={SearchTroubleShooting} />
           {PLUGIN_ADMIN_TROUBLESHOOTING.EXTRA_ROUTES}
         </Route>
       </Route>

--- a/frontend/src/metabase/admin/tasks/components/SearchTroubleshooting.tsx
+++ b/frontend/src/metabase/admin/tasks/components/SearchTroubleshooting.tsx
@@ -1,0 +1,20 @@
+import { t } from "ttag";
+
+import { useSearchReindexMutation } from "metabase/api";
+import { Box, Button, Text, Title } from "metabase/ui";
+
+export function SearchTroubleShooting() {
+  const [reindex, { isLoading }] = useSearchReindexMutation();
+
+  return (
+    <Box>
+      <Title mb="lg">{t`Search indexing`}</Title>
+      <Text mb="lg" maw="30rem">
+        {t`If you are having trouble with search indexing, you can reindex your data. Note: this is a heavy operation and should not be done unless you are seeing major search issues.`}
+      </Text>
+      <Button variant="filled" loading={isLoading} onClick={() => reindex()}>
+        {t`Reindex now`}
+      </Button>
+    </Box>
+  );
+}

--- a/frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx
@@ -36,6 +36,10 @@ export default class TroubleshootingApp extends Component {
               name={t`Logs`}
               path="/admin/troubleshooting/logs"
             />
+            <LeftNavPaneItem
+              name={t`Search`}
+              path="/admin/troubleshooting/search"
+            />
           </LeftNavPane>
         }
       >

--- a/frontend/src/metabase/api/search.ts
+++ b/frontend/src/metabase/api/search.ts
@@ -24,7 +24,13 @@ export const searchApi = Api.injectEndpoints({
         }
       },
     }),
+    searchReindex: builder.mutation<void, void>({
+      query: () => ({
+        method: "POST",
+        url: "/api/search/force-reindex",
+      }),
+    }),
   }),
 });
 
-export const { useSearchQuery } = searchApi;
+export const { useSearchQuery, useSearchReindexMutation } = searchApi;


### PR DESCRIPTION
see [discussion](https://metaboat.slack.com/archives/C072YM78NGK/p1734015913705809)

### Description

Adds a section to admin settings' troubleshooting page that allows a user to reset the search index by clicking a button.


![Screen Shot 2024-12-12 at 8 32 27 AM](https://github.com/user-attachments/assets/fdec8a43-8da0-4f90-be6d-5efe5f03bff0)
