### PR TITLE
surface errors in move confirmation modal

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
@@ -203,8 +203,6 @@ describe("Dashboard > Dashboard Questions", () => {
     });
 
     it("can bulk move questions into a dashboard", () => {
-      cy.intercept("PUT", "/api/card/*").as("updateCard");
-
       new Array(20).fill("pikachu").forEach((_, i) => {
         H.createQuestion({
           name: `Question ${i + 1}`,
@@ -257,6 +255,52 @@ describe("Dashboard > Dashboard Questions", () => {
       H.visitDashboard(S.ORDERS_DASHBOARD_ID);
       H.dashboardCards().findByText("Orders");
       H.dashboardCards().findByText("Orders, Count");
+    });
+
+    it("should tell users which dashboards will be affected when doing bulk question moves", () => {
+      H.createQuestionAndDashboard({
+        questionDetails: {
+          name: "Sample Question",
+          collection_id: S.THIRD_COLLECTION_ID,
+          query: {
+            "source-table": SAMPLE_DATABASE.PRODUCTS_ID,
+            limit: 1,
+          },
+          display: "scalar",
+        },
+        dashboardDetails: {
+          collection_id: S.THIRD_COLLECTION_ID,
+          name: "Test Dashboard",
+        },
+      });
+
+      H.visitCollection(S.THIRD_COLLECTION_ID);
+      selectCollectionItem("Sample Question");
+
+      cy.findByTestId("toast-card").button("Move").click();
+
+      H.entityPickerModal().within(() => {
+        cy.findByRole("button", { name: /Orders in a dashboard/ }).click();
+        cy.button("Move").click();
+      });
+
+      cy.findByRole("dialog", { name: /Move this question/ }).should("exist");
+
+      H.modal().within(() => {
+        cy.findByText("Sample Question").should("exist");
+        cy.findByText("Test Dashboard").should("exist");
+
+        cy.button("Move it").should("exist").click();
+      });
+
+      H.collectionTable().findByText("Test Dashboard").click();
+
+      cy.findByTestId("dashboard-empty-state")
+        .findByText("This dashboard is looking empty.")
+        .should("exist");
+
+      H.visitDashboard(S.ORDERS_DASHBOARD_ID);
+      H.dashboardCards().findByText("Sample Question").should("exist");
     });
 
     it("can edit a dashboard question", () => {
@@ -748,11 +792,34 @@ describe("Dashboard > Dashboard Questions", () => {
       H.entityPickerModal().findByText("Orders in a dashboard").click();
       H.entityPickerModal().button("Move").click();
 
+      let shouldError = true;
+
+      // Simulate an error to ensure that it's passed back and shown in the modal.
+      cy.get("@avgQuanityQuestionId").then(questionId => {
+        cy.intercept("PUT", `**/api/card/${questionId}**`, req => {
+          if (shouldError === true) {
+            shouldError = false;
+            req.reply({
+              statusCode: 400,
+              body: {
+                message: "Ryan said no",
+              },
+            });
+          } else {
+            req.continue();
+          }
+        });
+      });
+
       // should warn about removing from 2 dashboards
       H.modal().within(() => {
         cy.findByText(/will be removed from/i);
         cy.findByText(/purple dashboard/i);
         cy.findByText(/blue dashboard/i);
+        cy.button("Move it").click();
+        cy.findByText("Ryan said no");
+
+        //Continue with the expected behavior
         cy.button("Move it").click();
       });
 

--- a/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
@@ -203,6 +203,8 @@ describe("Dashboard > Dashboard Questions", () => {
     });
 
     it("can bulk move questions into a dashboard", () => {
+      cy.intercept("PUT", "/api/card/*").as("updateCard");
+
       new Array(20).fill("pikachu").forEach((_, i) => {
         H.createQuestion({
           name: `Question ${i + 1}`,

--- a/frontend/src/metabase/collections/components/CollectionBulkActions/QuestionMoveConfirmModal.tsx
+++ b/frontend/src/metabase/collections/components/CollectionBulkActions/QuestionMoveConfirmModal.tsx
@@ -29,11 +29,13 @@ export const QuestionMoveConfirmModal = ({
   onConfirm,
   onClose,
   destination,
+  errorMessage,
 }: {
   selectedItems: Pick<CollectionItem, "id" | "model" | "name">[];
   onConfirm: () => void;
   onClose: () => void;
   destination: Destination | null;
+  errorMessage?: string;
 }) => {
   const onConfirmRef = useLatest(onConfirm);
   const { currentData: cardDashboards, isFetching: isLoading } =
@@ -154,17 +156,20 @@ export const QuestionMoveConfirmModal = ({
               })}
             </List>
 
-            <Flex justify="end" gap="1rem" mt="1rem">
-              <Button variant="subtle" onClick={onClose}>
-                {t`Cancel`}
-              </Button>
-              <Button variant="filled" onClick={onConfirm}>
-                {ngettext(
-                  msgid`Move it`,
-                  `Move them`,
-                  cardsThatAppearInOtherDashboards.length,
-                )}
-              </Button>
+            <Flex justify="space-between" mt="1rem">
+              <Text c="error">{errorMessage}</Text>
+              <Flex justify="end" gap="1rem">
+                <Button variant="subtle" onClick={onClose}>
+                  {t`Cancel`}
+                </Button>
+                <Button variant="filled" onClick={onConfirm}>
+                  {ngettext(
+                    msgid`Move it`,
+                    `Move them`,
+                    cardsThatAppearInOtherDashboards.length,
+                  )}
+                </Button>
+              </Flex>
             </Flex>
           </>
         );
@@ -178,6 +183,7 @@ export const QuestionMoveConfirmModal = ({
     destination,
     selectedItems,
     hasError,
+    errorMessage,
   ]);
 
   return (


### PR DESCRIPTION
### Description

Small adjustment to allow API errors to be surfaced into the move confirmation modal. https://github.com/metabase/metabase/pull/51187 fixed the underlying problem of not passing along the required query param, but this addresses the fact that the API error was essentially swallowed and we never surfaced anything to the end user. We just closed the modal and pretended like nothing happened.

This PR also adds an e2e test testing the 

### How to verify

1. Go to a question that is in a collection, but appears in a dashboard
2. Attempt to move that question to a different dashboard
3. You'll need to induce an error for the update request, but click Move
4. The error should be presented in the confirmation modal

### Demo
![image](https://github.com/user-attachments/assets/a37c511d-4b23-46f6-a493-c8ec6ac488da)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
