### PR TITLE
Added "remove-encryption" command

### DIFF
--- a/docs/installation-and-operation/commands.md
+++ b/docs/installation-and-operation/commands.md
@@ -116,6 +116,10 @@ Reset the password for a user with `email-address`.
 
 Rotate the encryption key of a metabase database. The MB_ENCRYPTION_SECRET_KEY environment variable has to be set to the current key, and the parameter `new-key` has to be the new key. `new-key` has to be at least 16 chars.
 
+## `remove-encryption`
+
+Decrypts data in the metabase database. The MB_ENCRYPTION_SECRET_KEY environment variable has to be set to the current key.
+
 ## `seed-entity-ids`
 
 Add entity IDs for instances of serializable models that don't already have them.

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -16,16 +16,16 @@
   associated with each command's entrypoint function to generate descriptions for each command."
   (:refer-clojure :exclude [load import])
   (:require
-    [clojure.string :as str]
-    [clojure.tools.cli :as cli]
-    [environ.core :as env]
-    [metabase.config :as config]
-    [metabase.legacy-mbql.util :as mbql.u]
-    [metabase.plugins.classloader :as classloader]
-    [metabase.util :as u]
-    [metabase.util.encryption :as encryption]
-    [metabase.util.i18n :refer [trs]]
-    [metabase.util.log :as log]))
+   [clojure.string :as str]
+   [clojure.tools.cli :as cli]
+   [environ.core :as env]
+   [metabase.config :as config]
+   [metabase.legacy-mbql.util :as mbql.u]
+   [metabase.plugins.classloader :as classloader]
+   [metabase.util :as u]
+   [metabase.util.encryption :as encryption]
+   [metabase.util.i18n :refer [trs]]
+   [metabase.util.log :as log]))
 
 (set! *warn-on-reflection* true)
 

--- a/test/metabase/cmd_test.clj
+++ b/test/metabase/cmd_test.clj
@@ -9,7 +9,7 @@
 
 (deftest ^:parallel error-message-test
   (is (= ["Unrecognized command: 'a-command-that-does-not-exist'"
-          "Valid commands: version, help, drop-entity-ids, import, dump, profile, api-documentation, load, seed-entity-ids, dump-to-h2, environment-variables-documentation, migrate, config-template, driver-methods, load-from-h2, export, rotate-encryption-key, reset-password"]
+          "Valid commands: version, help, drop-entity-ids, import, dump, profile, api-documentation, load, seed-entity-ids, dump-to-h2, environment-variables-documentation, remove-encryption, migrate, config-template, driver-methods, load-from-h2, export, rotate-encryption-key, reset-password"]
          (#'cmd/validate "a-command-that-does-not-exist" [])))
   (is (= ["The 'rotate-encryption-key' command requires the following arguments: [new-key], but received: []."]
          (#'cmd/validate "rotate-encryption-key" [])))


### PR DESCRIPTION
### Description

Adds a new remove-encryption CLI command as a more obvious alternative to rotate-encryption-key passing an empty key.

### How to verify

Run `java -jar metabase.jar remove-encryption`

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
