### PR TITLE
Fix distribution drill thru for multi-stage queries

### DIFF
--- a/src/metabase/lib/drill_thru/distribution.cljc
+++ b/src/metabase/lib/drill_thru/distribution.cljc
@@ -10,12 +10,12 @@
 
   Requirements:
 
-  - No aggregation or breakout clauses in the query
+  - Column not aggregation or breakout sourced
   - Column not `type/PK`, `type/SerializedJSON`, `type/Description`, `type/Comment`
 
   Query transformation (last stage only):
 
-  - Remove all aggregation, breakout, orderBy, limit clauses
+  - Remove all aggregation, breakout, order-by, limit clauses
 
   - Aggregate by \"count\" operator
 
@@ -34,6 +34,7 @@
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
    [metabase.lib.temporal-bucket :as lib.temporal-bucket]
    [metabase.lib.types.isa :as lib.types.isa]
+   [metabase.lib.underlying :as lib.underlying]
    [metabase.lib.util :as lib.util]
    [metabase.util.malli :as mu]))
 
@@ -50,12 +51,12 @@
   (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
              column
              (nil? value)
-             (not= (:lib/source column) :source/aggregations)
+             (not (lib.drill-thru.common/aggregation-sourced? query column))
              (not (lib.types.isa/primary-key? column))
              (not (lib.types.isa/structured?  column))
              (not (lib.types.isa/comment?     column))
              (not (lib.types.isa/description? column))
-             (not (lib.breakout/breakout-column? query stage-number column)))
+             (not (lib.breakout/breakout-column? query (lib.underlying/top-level-stage-number query) column)))
     {:lib/type  :metabase.lib.drill-thru/drill-thru
      :type      :drill-thru/distribution
      :column    column}))

--- a/test/metabase/lib/drill_thru/distribution_test.cljc
+++ b/test/metabase/lib/drill_thru/distribution_test.cljc
@@ -39,6 +39,44 @@
       (is (some? count-col))
       (is (nil? (lib.drill-thru.distribution/distribution-drill query -1 context))))))
 
+(deftest ^:parallel distribution-not-returned-for-aggregate-or-breakout-cols-test
+  (doseq [column-name ["PRODUCT_ID" "CREATED_AT" "count" "sum" "max"]]
+    (testing (str "distribution drill not returned for ORDERS." column-name)
+      (lib.drill-thru.tu/test-drill-not-returned
+       {:drill-type  :drill-thru/distribution
+        :click-type  :header
+        :query-kinds [:mbql]
+        :query-type  :aggregated
+        :query-table "ORDERS"
+        :column-name column-name}))))
+
+(deftest ^:parallel distribution-not-returned-for-aggregate-or-breakout-cols-for-multi-stage-queries-test
+  (doseq [column-name ["PRODUCT_ID" "CREATED_AT" "count" "sum" "max"]]
+    (testing (str "distribution drill not returned for ORDERS." column-name)
+      (lib.drill-thru.tu/test-drill-not-returned
+       {:drill-type  :drill-thru/distribution
+        :click-type  :header
+        :query-kinds [:mbql]
+        :query-type  :aggregated
+        :custom-query (let [base-query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                                           (lib/aggregate (lib/count))
+                                           (lib/aggregate (lib/sum (meta/field-metadata :orders :tax)))
+                                           (lib/aggregate (lib/max (meta/field-metadata :orders :discount)))
+                                           (lib/breakout (meta/field-metadata :orders :product-id))
+                                           (lib/breakout (-> (meta/field-metadata :orders :created-at)
+                                                             (lib/with-temporal-bucket :month)))
+                                           lib/append-stage)
+                            count-col  (m/find-first #(= (:name %) "count")
+                                                     (lib/returned-columns base-query))
+                            _          (is (some? count-col))]
+                        (lib/filter base-query (lib/> count-col 0)))
+        :custom-row   {"PRODUCT_ID" 3
+                       "CREATED_AT" "2023-12-01"
+                       "count"      77
+                       "sum"        1
+                       "max"        nil}
+        :column-name column-name}))))
+
 (deftest ^:parallel returns-distribution-test-1
   (lib.drill-thru.tu/test-returns-drill
    {:drill-type  :drill-thru/distribution

--- a/test/metabase/lib/drill_thru/underlying_records_test.cljc
+++ b/test/metabase/lib/drill_thru/underlying_records_test.cljc
@@ -88,7 +88,7 @@
       :column-name "max"
       :expected    #(->> % (map :type) (filter #{:drill-thru/underlying-records}) count (= 1))})))
 
-(deftest ^:parallel returns-underlying-records-for-multi-stage-queries
+(deftest ^:parallel returns-underlying-records-for-multi-stage-queries-test
   (lib.drill-thru.tu/test-returns-drill
    {:drill-type   :drill-thru/underlying-records
     :click-type   :cell

--- a/test/metabase/lib/drill_thru/zoom_in_timeseries_test.cljc
+++ b/test/metabase/lib/drill_thru/zoom_in_timeseries_test.cljc
@@ -189,7 +189,7 @@
           bucketing
           {"CREATED_AT" "2022-12-01"}))))))
 
-(deftest ^:parallel returns-zoom-in-timeseries-for-multi-stage-queries
+(deftest ^:parallel returns-zoom-in-timeseries-for-multi-stage-queries-test
   (lib.drill-thru.tu/test-returns-drill
    {:drill-type   :drill-thru/zoom-in.timeseries
     :click-type   :cell


### PR DESCRIPTION
### Description

Ensure the distribution drill thru is not returned by `available-drill-thrus` when a user clicks on an aggregation or breakout column, even if there are additional query stages after the last aggregation / breakout stage.

Relates to: https://github.com/metabase/metabase/issues/46932

### How to verify

* New question: Orders
* summarize: Count by Created At: Month
* Add filter stage after summarize, e.g. Count > 1
* Visualize
* Select Table viz
* Click on the column header for either column
* "Distribution" drill through should not appear in the context menu
* Edit query to remove the summarize stage
* Visualize
* Click on any non-PK column header: drill should appear

### Demo


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
