### PR TITLE
[refs] Preserve `:ident`s in `replace-clause`

### DIFF
--- a/src/metabase/lib/common.cljc
+++ b/src/metabase/lib/common.cljc
@@ -69,6 +69,13 @@
   [clause]
   (lib.options/update-options clause update :ident #(or % (lib.ident/random-ident))))
 
+(defn preserve-ident-of
+  "Given two clauses, preserve the `original`'s `:ident` on `replacement`."
+  [replacement original]
+  (if-let [ident (lib.options/ident original)]
+    (lib.options/update-options replacement assoc :ident ident)
+    replacement))
+
 (defn defop-create
   "Impl for [[defop]]."
   [op-name args]

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -124,8 +124,10 @@
   [stage location target-clause new-clause]
   {:pre [((some-fn clause? #(= (:lib/type %) :mbql/join)) target-clause)]}
   (let [new-clause (if (= :expressions (first location))
-                     (top-level-expression-clause new-clause (or (custom-name new-clause)
-                                                                 (expression-name target-clause)))
+                     (-> new-clause
+                         (top-level-expression-clause (or (custom-name new-clause)
+                                                          (expression-name target-clause)))
+                         (lib.common/preserve-ident-of target-clause))
                      new-clause)]
     (m/update-existing-in
      stage


### PR DESCRIPTION
### Description

`replace-clause` is for editing an existing clause, which should
*preserve* its identity. But the new clause was getting its own
random ident which didn't match the original.

I've added tests for this, and fixed the `lib.remove-replace` logic to
make them pass.

Hat tip to Mike for catching this case!

### How to verify

1. Create a query with clauses with random idents
    - expressions, aggregations, breakouts, joins
2. Execute the query and note the idents in the Network tab
3. Edit one or more of those clauses

On master, the edited clauses will get new idents generated.
With this change, they will correctly retain their original identity.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
