### PR TITLE
Manual Backport: skip tracking non react-sdk x-metabase-clients

### DIFF
--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -203,6 +203,10 @@
                        {:description "Number of successful SDK requests."})
    (prometheus/counter :metabase-sdk/response-error
                        {:description "Number of errors when responding to SDK requests."})
+   (prometheus/counter :metabase-embedding-iframe/response-ok
+                       {:description "Number of successful iframe embedding requests."})
+   (prometheus/counter :metabase-embedding-iframe/response-error
+                       {:description "Number of errors when responding to iframe embedding requests."})
    (prometheus/counter :metabase-scim/response-ok
                        {:description "Number of successful responses from SCIM endpoints"})
    (prometheus/counter :metabase-scim/response-error

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -615,7 +615,7 @@
   (let [qe (t2/select [:model/QueryExecution :embedding_client :context :executor_id :started_at])
         one-day-ago (->one-day-ago)
         ;; reuse the query data:
-        qe-24h (filter (fn [{started-at :started_at}] (t/after? one-day-ago started-at)) qe)]
+        qe-24h (filter (fn [{started-at :started_at}] (t/after? started-at one-day-ago)) qe)]
     {:query-executions (merge
                         {"sdk_embed" 0 "interactive_embed" 0 "static_embed" 0 "public_link" 0 "internal" 0}
                         (-> (group-by categorize-query-execution qe)

--- a/test/metabase/server/middleware/sdk_test.clj
+++ b/test/metabase/server/middleware/sdk_test.clj
@@ -38,10 +38,11 @@
     nil
     "1.1.1"))
 
-(deftest embeding-mw-bumps-metrics-with-sdk-header
+(deftest embeding-mw-bumps-metrics-with-react-sdk-client-header
   (let [prometheus-standin (atom {})]
     (with-redefs [prometheus/inc! (fn [k] (swap! prometheus-standin update k (fnil inc 0)))]
-      (let [request (mock-request {:client "my-client"}) ;; <-- has X-Metabase-Client header => SDK context
+      ;; X-Metabase-Client header == "embedding-sdk-react" => SDK context
+      (let [request (mock-request {:client @#'sdk/embedding-sdk-client})
             good (sdk/embedding-mw (fn [_ respond _] (respond {:status 200})))
             bad (sdk/embedding-mw (fn [_ respond _] (respond {:status 400})))
             exception (sdk/embedding-mw (fn [_ _respond raise] (raise {})))]
@@ -53,6 +54,38 @@
         (exception request identity identity)
         (is (= {:metabase-sdk/response-ok 1
                 :metabase-sdk/response-error 2} @prometheus-standin))))))
+
+(deftest embeding-mw-bumps-metrics-with-iframe-client-header
+  (let [prometheus-standin (atom {})]
+    (with-redefs [prometheus/inc! (fn [k] (swap! prometheus-standin update k (fnil inc 0)))]
+      ;; X-Metabase-Client header == "embedding-sdk-react" => SDK context
+      (let [request (mock-request {:client @#'sdk/embedding-iframe-client})
+            good (sdk/embedding-mw (fn [_ respond _] (respond {:status 200})))
+            bad (sdk/embedding-mw (fn [_ respond _] (respond {:status 400})))
+            exception (sdk/embedding-mw (fn [_ _respond raise] (raise {})))]
+        (good request identity identity)
+        (is (= {:metabase-embedding-iframe/response-ok 1} @prometheus-standin))
+        (bad request identity identity)
+        (is (= {:metabase-embedding-iframe/response-ok 1
+                :metabase-embedding-iframe/response-error 1} @prometheus-standin))
+        (exception request identity identity)
+        (is (= {:metabase-embedding-iframe/response-ok 1
+                :metabase-embedding-iframe/response-error 2} @prometheus-standin))))))
+
+(deftest embeding-mw-does-not-bump-metrics-with-random-sdk-header
+  (let [prometheus-standin (atom {})]
+    (with-redefs [prometheus/inc! (fn [k] (swap! prometheus-standin update k (fnil inc 0)))]
+       ;; has X-Metabase-Client header, but it's not the SDK, so we don't track it
+      (let [request (mock-request {:client "my-client"})
+            good (sdk/embedding-mw (fn [_ respond _] (respond {:status 200})))
+            bad (sdk/embedding-mw (fn [_ respond _] (respond {:status 400})))
+            exception (sdk/embedding-mw (fn [_ _respond raise] (raise {})))]
+        (good request identity identity)
+        (is (= {} @prometheus-standin))
+        (bad request identity identity)
+        (is (= {} @prometheus-standin))
+        (exception request identity identity)
+        (is (= {} @prometheus-standin))))))
 
 (deftest embeding-mw-does-not-bump-sdk-metrics-without-sdk-header
   (let [prometheus-standin (atom {})]


### PR DESCRIPTION
Manual backport of #51179 to 51.

- Do not do promethus tracking for sdk.
- tracking ignores x-metabase-client headers when they're not == "embedding-sdk-react"
- remedy 24h query execution inaccuracy
