### PR TITLE
Update underlying-records drill to use code in lib.drill-thru.common

### DIFF
--- a/src/metabase/lib/drill_thru/underlying_records.cljc
+++ b/src/metabase/lib/drill_thru/underlying_records.cljc
@@ -47,20 +47,6 @@
    [metabase.lib.util :as lib.util]
    [metabase.util.malli :as mu]))
 
-(defn- has-source-or-underyling-source-fn
-  [source]
-  (fn has-source?
-    ([column]
-     (= (:lib/source column) source))
-    ([query column]
-     (and
-      (seq column)
-      (or (has-source? column)
-          (has-source? (lib.underlying/top-level-column query column)))))))
-
-(def ^:private aggregation-sourced? (has-source-or-underyling-source-fn :source/aggregations))
-(def ^:private breakout-sourced?    (has-source-or-underyling-source-fn :source/breakouts))
-
 (mu/defn underlying-records-drill :- [:maybe ::lib.schema.drill-thru/drill-thru.underlying-records]
   "When clicking on a particular broken-out group, offer a look at the details of all the rows that went into this
   bucket. Eg. distribution of People by State, then click New York and see the table of all People filtered by
@@ -98,38 +84,34 @@
   (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
              (lib.underlying/has-aggregation-or-breakout? query)
              ;; Either we clicked the aggregation, or there are dimensions.
-             (or (aggregation-sourced? query column)
+             (or (lib.drill-thru.common/aggregation-sourced? query column)
                  (not-empty dimensions))
              ;; Either we need both column and value (cell/map/data point click) or neither (chart legend click).
              (or (and column (some? value))
                  (and (nil? column) (nil? value)))
              ;; If the column exists, it must not be a structured column like JSON.
              (not (and column (lib.types.isa/structured? column))))
-    (let [underlying-aggregation? (and (not (aggregation-sourced? column))
-                                       (aggregation-sourced? query column))]
-      {:lib/type   :metabase.lib.drill-thru/drill-thru
-       :type       :drill-thru/underlying-records
-       ;; TODO: This is a bit confused for non-COUNT aggregations. Perhaps it should just always be 10 or something?
-       ;; Note that some languages have different plurals for exactly 2, or for 1, 2-5, and 6+.
-       :row-count  (if (and (number? value)
-                            (not (neg? value)))
-                     value
-                     2)
-       :table-name (when-let [table-or-card (or (some->> query lib.util/source-table-id (lib.metadata/table query))
-                                                (some->> query lib.util/source-card-id  (lib.metadata/card  query)))]
-                     (lib.metadata.calculation/display-name query stage-number table-or-card))
-       ;; If no dimensions were provided but the underlying column comes from an aggregation, then construct the
-       ;; dimensions from the row data.
-       :dimensions (or (not-empty dimensions)
-                       (when underlying-aggregation?
-                         (not-empty (filterv #(breakout-sourced? query (:column %))
-                                             row))))
-       ;; If the underlying column comes from an aggregation, then the column-ref needs to be updated as well to the
-       ;; corresponding aggregation ref so that [[drill-underlying-records]] knows to extract the filter implied by
-       ;; aggregations like sum-where.
-       :column-ref (if underlying-aggregation?
-                     (lib.aggregation/column-metadata->aggregation-ref (lib.underlying/top-level-column query column))
-                     column-ref)})))
+    {:lib/type   :metabase.lib.drill-thru/drill-thru
+     :type       :drill-thru/underlying-records
+     ;; TODO: This is a bit confused for non-COUNT aggregations. Perhaps it should just always be 10 or something?
+     ;; Note that some languages have different plurals for exactly 2, or for 1, 2-5, and 6+.
+     :row-count  (if (and (number? value)
+                          (not (neg? value)))
+                   value
+                   2)
+     :table-name (when-let [table-or-card (or (some->> query lib.util/source-table-id (lib.metadata/table query))
+                                              (some->> query lib.util/source-card-id  (lib.metadata/card  query)))]
+                   (lib.metadata.calculation/display-name query stage-number table-or-card))
+     ;; If no dimensions were provided but the underlying column comes from an aggregation, then construct the
+     ;; dimensions from the row data.
+     :dimensions (or (not-empty dimensions)
+                     (lib.drill-thru.common/dimensions-from-breakout-columns query column row))
+     ;; If the underlying column comes from an aggregation, then the column-ref needs to be updated as well to the
+     ;; corresponding aggregation ref so that [[drill-underlying-records]] knows to extract the filter implied by
+     ;; aggregations like sum-where.
+     :column-ref (if (lib.drill-thru.common/strictly-underyling-aggregation? query column)
+                   (lib.aggregation/column-metadata->aggregation-ref (lib.underlying/top-level-column query column))
+                   column-ref)}))
 
 (defmethod lib.drill-thru.common/drill-thru-info-method :drill-thru/underlying-records
   [_query _stage-number {:keys [row-count table-name]}]


### PR DESCRIPTION
### Description

Some funcs were added to `lib.drill-thru.common` for the recent fix to the `zoom-in.timeseries` drill. Update the `underlying-records` drill to use the common lib code rather than duplicating it.

Relates to: #50556, #46932

### How to verify

Underlying records drill continues to work as before.

### Demo

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
