### PR TITLE
Dot X Releases

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -53,6 +53,9 @@ on:
         description: Apply to OSS
         type: boolean
         default: true
+      dot-x-tag:
+        type: boolean
+        default: false
 
 jobs:
   green-check-stub:
@@ -274,9 +277,9 @@ jobs:
       with:
         fetch-depth: 0 # we want all branches and tags
         fetch-tags: true
-    - name: Add and push git tag
+    - name: Add and push git tag for nightly/beta/latest
+      if: ${{ !inputs.dot-x-tag }}
       run: | # sh
-
         if [[ "${{ matrix.edition }}" == "ee" ]]; then
           git tag -f ${{ inputs.tag_name }}-ee ${{ needs.check-version.outputs.oss }}
           git push origin -f ${{ inputs.tag_name }}-ee
@@ -284,8 +287,14 @@ jobs:
           git tag -f ${{ inputs.tag_name }}-oss ${{ needs.check-version.outputs.oss }}
           git push origin -f ${{ inputs.tag_name }}-oss
         fi
+    - name: Add and push git tag for dot X tags
+      if: ${{ inputs.dot-x-tag }}
+      run: | # sh
+        git tag -f ${{ inputs.tag_name }} ${{ needs.check-version.outputs.oss }}
+        git push origin -f ${{ inputs.tag_name }}
 
   update-version-info:
+    if: ${{ !inputs.dot-x-tag }}
     runs-on: ubuntu-22.04
     needs: check-version
     timeout-minutes: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -487,9 +487,8 @@ jobs:
       version: ${{ inputs.version }}
       tag_name: ${{ matrix.tag }}
       tag_ee: ${{ contains(matrix.tag, 'v1') }}
-      tag_oss: ${{ contains(matrix.tag, 'v0' ) }}
+      tag_oss: ${{ contains(matrix.tag, 'v0') }}
       dot-x-tag: true
-
 
   trigger-docs-update:
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -446,12 +446,8 @@ jobs:
             process.exit(1);
           });
 
-
   get-extra-tags:
-    needs:
-      - push-tags
-      - verify-docker-pull
-      - verify-s3-download
+    needs: [ check-version ]
     runs-on: ubuntu-22.04
     outputs:
       extra_tags: ${{ steps.taglist.outputs.extra_tags }}
@@ -477,7 +473,11 @@ jobs:
             core.setOutput('extra_tags', JSON.stringify(extra_tags));
 
   add-extra-tags:
-    needs: get-extra-tags
+    needs:
+      - get-extra-tags
+      - push-tags
+      - verify-docker-pull
+      - verify-s3-download
     strategy:
       matrix:
         tag: ${{ fromJson(needs.get-extra-tags.outputs.extra_tags) }}
@@ -486,10 +486,12 @@ jobs:
     with:
       version: ${{ inputs.version }}
       tag_name: ${{ matrix.tag }}
+      tag_ee: ${{ contains(matrix.tag, 'v1') }}
+      tag_oss: ${{ contains(matrix.tag, 'v0' ) }}
+      dot-x-tag: true
 
 
   trigger-docs-update:
-    if: ${{ !inputs.auto }}
     needs:
       - push-tags
       - check-version
@@ -606,7 +608,7 @@ jobs:
 
   draft-release-notes:
     if: ${{ !inputs.auto }}
-    needs: push-tags
+    needs: add-extra-tags
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     permissions: write-all
@@ -717,7 +719,7 @@ jobs:
 
   publish-complete-message:
     runs-on: ubuntu-22.04
-    needs: set-release-channel
+    needs: [set-release-channel, add-extra-tags]
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -775,11 +777,11 @@ jobs:
             owner: context.repo.owner,
             repo: context.repo.repo,
             version,
-          });
+          }).catch(console.error);
 
           await openNextMilestones({
             github,
             owner: context.repo.owner,
             repo: context.repo.repo,
             version,
-          });
+          }).catch(console.error);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -446,6 +446,120 @@ jobs:
             process.exit(1);
           });
 
+
+  get-extra-tags:
+    needs:
+      - push-tags
+      - verify-docker-pull
+      - verify-s3-download
+    runs-on: ubuntu-22.04
+    outputs:
+      extra_tags: ${{ steps.taglist.outputs.extra_tags }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: release
+      - name: prepare release scripts
+        run: cd release && yarn && yarn build
+      - name: Get extra tags
+        id: taglist
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: | # js
+            const { getExtraTagsForVersion } = require('${{ github.workspace }}/release/dist/index.cjs');
+
+            const version = '${{ inputs.version }}';
+
+            const extra_tags = getExtraTagsForVersion({ version });
+
+            console.log({ extra_tags });
+            core.setOutput('extra_tags', JSON.stringify(extra_tags));
+
+  add-extra-tags:
+    needs: get-extra-tags
+    strategy:
+      matrix:
+        tag: ${{ fromJson(needs.get-extra-tags.outputs.extra_tags) }}
+    uses: ./.github/workflows/release-tag.yml
+    secrets: inherit
+    with:
+      version: ${{ inputs.version }}
+      tag_name: ${{ matrix.tag }}
+
+
+  trigger-docs-update:
+    if: ${{ !inputs.auto }}
+    needs:
+      - push-tags
+      - check-version
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      NEW_OSS_VERSION: ${{ needs.check-version.outputs.oss }}
+      NEW_EE_VERSION: ${{ needs.check-version.outputs.ee }}
+      GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+          script: | # js
+            await github.rest.repos.createDispatchEvent({
+              owner: '${{ github.repository_owner }}',
+              repo: '${{ secrets.DOCS_REPO }}',
+              event_type: 'trigger-docs-update',
+              client_payload: {
+                version: '${{ inputs.version }}'
+              }
+            });
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+      - name: update releases.md
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+          script: | # js
+            const fs = require('fs');
+
+            const releaseText = fs.readFileSync('./docs/releases.md', 'utf8');
+
+            const newReleaseText = releaseText
+              .replace(
+                /## Metabase Enterprise Edition releases\n\n/,
+                `## Metabase Enterprise Edition releases\n\n- [${process.env.NEW_EE_VERSION}](https://github.com/metabase/metabase/releases/tag/${process.env.NEW_EE_VERSION})\n`
+              )
+              .replace(
+                /## Metabase Open Source Edition releases\n\n/,
+                `## Metabase Open Source Edition releases\n\n- [${process.env.NEW_OSS_VERSION}](https://github.com/metabase/metabase/releases/tag/${process.env.NEW_OSS_VERSION})\n`
+              );
+
+            fs.writeFileSync('./docs/releases.md', newReleaseText);
+
+      - name: commit and push updates
+        run: | # bash
+          git config --global user.email "metabase-bot@metabase.com"
+          git config --global user.name "Metabase bot"
+
+          git checkout -b docs-add-$NEW_OSS_VERSION
+          cd docs/
+
+          git add releases.md
+          git commit -m "Add $NEW_OSS_VERSION to the list of releases"
+          git push origin docs-add-$NEW_OSS_VERSION --force
+
+      - name: open pr with updates
+        run: | # bash
+          gh pr create --fill \
+            --body "Like it says on the tin 😁" \
+            --label "Type:Documentation" \
+            --label "backport" \
+            --reviewer "jeff-bruemmer" \
+            --assignee "jeff-bruemmer"
+
   trigger-cloud-issues:
     if: ${{ !inputs.auto }}
     needs: push-tags

--- a/release/src/release-channel-log.ts
+++ b/release/src/release-channel-log.ts
@@ -27,16 +27,17 @@ const format = "--pretty='format:%(decorate:prefix=,suffix=)||%s||%H||%ah'";
 
 export async function gitLog(channel: ReleaseChannel, edition: Edition): Promise<CommitInfo> {
   const { stdout } = await $`git log -1 ${format} refs/tags/${channel}-${edition}`.catch(() => ({ stdout: '' }));
-  const commitInfo = processCommit(stdout.trim(), edition);
+  const commitInfo = processCommit(stdout.trim());
 
   return commitInfo;
 }
 
-function processCommit(commitLine: string, edition: Edition): CommitInfo {
+function processCommit(commitLine: string): CommitInfo {
   const [refs, message, hash, date] = commitLine.split('||');
-  const version = edition === "ee"
-   ? refs?.match(/(v1\.[\d\.\-(RC|beta|alpha)]+)/i)?.[1] ?? ''
-   : refs?.match(/(v0\.[\d\.\-(RC|beta|alpha)]+)/i)?.[1] ?? '';
+
+  // match version strings that don't have an x in them
+  // https://regexr.com/8a5kb
+  const version = refs?.match(/(v(0|1)\.[\d\.\-(RC|beta|alpha)]+)(?!.*x)/i)?.[1] ?? '';
 
   return { version, message, hash, date};
 }

--- a/release/src/release-log.ts
+++ b/release/src/release-log.ts
@@ -22,7 +22,7 @@ export async function gitLog(majorVersion: number) {
 
 export function processCommit(commitLine: string): CommitInfo {
   const [refs, message, hash, date] = commitLine.split('||');
-  const tags = refs?.match(/tag: ([\w\d-_\.]+)/g) ?? '';
+  const tags = refs?.match(/tag: ([\w\d-_x\.]+)/g) ?? '';
 
   const versions = tags
     ? tags.map((v) => v.replace('tag: ', ''))

--- a/release/src/release-notes.ts
+++ b/release/src/release-notes.ts
@@ -4,6 +4,7 @@ import { hiddenLabels, nonUserFacingLabels } from "./constants";
 import { getMilestoneIssues, hasBeenReleased } from "./github";
 import type { Issue, ReleaseProps } from "./types";
 import {
+  getDotXVersion,
   getEnterpriseVersion,
   getGenericVersion,
   getOSSVersion,
@@ -79,17 +80,21 @@ const formatIssue = (issue: Issue) =>
   `- ${issue.title.trim()} (#${issue.number})`;
 
 export const getDockerTag = (version: string) => {
+  const dotXVersion = getDotXVersion(version);
+
   const imagePath = `${process.env.DOCKERHUB_OWNER}/${
     process.env.DOCKERHUB_REPO
   }${isEnterpriseVersion(version) ? "-enterprise" : ""}`;
 
-  return `[\`${imagePath}:${version}\`](https://hub.docker.com/r/${imagePath}/tags)`;
+  return `[\`${imagePath}:${dotXVersion}\`](https://hub.docker.com/r/${imagePath}/tags)`;
 };
 
 export const getDownloadUrl = (version: string) => {
+  const dotXVersion = getDotXVersion(version);
+
   return `https://${process.env.AWS_S3_DOWNLOADS_BUCKET}/${
     isEnterpriseVersion(version) ? "enterprise/" : ""
-  }${version}/metabase.jar`;
+  }${dotXVersion}/metabase.jar`;
 };
 
 export const getReleaseTitle = (version: string) => {

--- a/release/src/release-notes.unit.spec.ts
+++ b/release/src/release-notes.unit.spec.ts
@@ -86,13 +86,13 @@ describe("Release Notes", () => {
         "### Under the Hood\n\n**Administration**\n\n- Issue That Users Don't Care About (#4)",
       );
 
-      expect(notes).toContain("metabase/metabase-enterprise:v1.2.3");
-      expect(notes).toContain("metabase/metabase:v0.2.3");
+      expect(notes).toContain("metabase/metabase-enterprise:v1.2.3.x");
+      expect(notes).toContain("metabase/metabase:v0.2.3.x");
       expect(notes).toContain(
-        "https://downloads.metabase.com/enterprise/v1.2.3/metabase.jar",
+        "https://downloads.metabase.com/enterprise/v1.2.3.x/metabase.jar",
       );
       expect(notes).toContain(
-        "https://downloads.metabase.com/v0.2.3/metabase.jar",
+        "https://downloads.metabase.com/v0.2.3.x/metabase.jar",
       );
     });
   });

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -351,6 +351,7 @@ export function getLastReleaseFromTags({
 }) {
   return tags
     .map(tag => tag.ref.replace("refs/tags/", ""))
+    .filter(tag => !tag.includes(".x"))
     .filter(ignorePreReleases ? tag => !isPreReleaseVersion(tag) : () => true)
     .filter(ignorePatches ? v => !isPatchVersion(v) : () => true)
     .sort(versionSort)

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -154,6 +154,44 @@ export const getSdkVersionFromReleaseBranchName = async ({
   return sdkVersion;
 };
 
+export const getDotXs = (version: string, number: number) => {
+  const pieces = version.replace(/-.+/, '').split("."); // ignore any -suffixes
+  return pieces.slice(0, number + 1).join(".") + ".x";
+}
+
+export const getDotXVersion = (version: string) => {
+  const versionType = getVersionType(version);
+
+  if(versionType === "major") {
+    return getDotXs(version, 1);
+  }
+
+  return getDotXs(version, 2);
+}
+
+export const getExtraTagsForVersion = ({ version }: { version: string}) => {
+  const ossVerion = getOSSVersion(version);
+  const eeVersion = getEnterpriseVersion(version);
+  const versionType = getVersionType(version);
+
+  // eg. v0.23.x / v1.23.x
+  const tags = [
+    getDotXs(ossVerion, 1),
+    getDotXs(eeVersion, 1),
+  ];
+
+  if (versionType === "major") {
+    return tags;
+  }
+
+  // eg. v0.23.4.x / v1.23.4.x
+  return [
+    ...tags,
+    getDotXs(ossVerion, 2),
+    getDotXs(eeVersion, 2),
+  ];
+}
+
 /**
  * queries the github api to get all embedding sdk version tags
  */

--- a/release/src/version-helpers.unit.spec.ts
+++ b/release/src/version-helpers.unit.spec.ts
@@ -420,6 +420,7 @@ describe("version-helpers", () => {
           { ref: "refs/tags/v0.12.0" },
           { ref: "refs/tags/v0.12.2" },
           { ref: "refs/tags/v0.12.1" },
+          { ref: "refs/tags/v0.12.x" },
         ] as Tag[],
       });
       expect(latest).toBe("v0.12.2");
@@ -502,6 +503,21 @@ describe("version-helpers", () => {
         ignorePreReleases: true,
       });
       expect(latest).toBe("v0.12.1");
+    });
+
+    it("should ignore .x releases", () => {
+      const latest = getLastReleaseFromTags({
+        tags: [
+          { ref: "refs/tags/v0.11.x" },
+          { ref: "refs/tags/v0.20.x-beta" },
+          { ref: "refs/tags/v0.20.2.3.x" },
+          { ref: "refs/tags/v0.12.0" },
+          { ref: "refs/tags/v0.12.1" },
+          { ref: "refs/tags/v0.12.2" },
+          { ref: "refs/tags/v0.19.x" },
+        ] as Tag[],
+      });
+      expect(latest).toBe("v0.12.2");
     });
   });
 

--- a/release/src/version-helpers.unit.spec.ts
+++ b/release/src/version-helpers.unit.spec.ts
@@ -2,7 +2,9 @@ import type { Tag } from "./types";
 import {
   findNextPatchVersion,
   getBuildRequirements,
+  getDotXs,
   getEnterpriseVersion,
+  getExtraTagsForVersion,
   getGenericVersion,
   getLastReleaseFromTags,
   getMajorVersionNumberFromReleaseBranch,
@@ -16,7 +18,7 @@ import {
   isEnterpriseVersion,
   isPreReleaseVersion,
   isValidVersionString,
-  versionSort,
+  versionSort
 } from "./version-helpers";
 
 describe("version-helpers", () => {
@@ -660,6 +662,96 @@ describe("version-helpers", () => {
       ).toEqual("0.52.2-nightly");
 
       expect(() => getSdkVersionFromReleaseTagName("v0.51.5.1")).toThrow();
+    });
+  });
+
+  describe("getDotXs", ()=> {
+    it("should return the correct major dot Xs", () => {
+      expect(getDotXs("v1.75.0", 1)).toEqual("v1.75.x");
+      expect(getDotXs("v1.75.2", 1)).toEqual("v1.75.x");
+      expect(getDotXs("v1.75-beta", 1)).toEqual("v1.75.x");
+
+      expect(getDotXs("v1.75.0-beta", 1)).toEqual("v1.75.x");
+      expect(getDotXs("v1.75.0.1", 1)).toEqual("v1.75.x");
+      expect(getDotXs("v1.75.0.1-beta", 1)).toEqual("v1.75.x");
+
+      expect(getDotXs("v0.75.0", 1)).toEqual("v0.75.x");
+      expect(getDotXs("v0.75.34.1234", 1)).toEqual("v0.75.x");
+    });
+
+    it("should return the correct minor dot Xs", () => {
+      expect(getDotXs("v1.75.2.1", 2)).toEqual("v1.75.2.x");
+      expect(getDotXs("v1.75.2-beta", 2)).toEqual("v1.75.2.x");
+
+      expect(getDotXs("v0.75.2.1", 2)).toEqual("v0.75.2.x");
+      expect(getDotXs("v0.75.2.1-beta", 2)).toEqual("v0.75.2.x");
+    });
+  });
+
+  describe("getExtraTagsForVersion", () => {
+    it("should return the correct extra tags for a major version", () => {
+      expect(getExtraTagsForVersion({ version: "v1.75.0" })).toEqual([
+        "v0.75.x",
+        "v1.75.x",
+      ]);
+
+      expect(getExtraTagsForVersion({ version: "v0.75.0" })).toEqual([
+        "v0.75.x",
+        "v1.75.x",
+      ]);
+    });
+
+    it("should return the correct extra tags for a minor version", () => {
+      expect(getExtraTagsForVersion({ version: "v1.75.1" })).toEqual([
+        "v0.75.x",
+        "v1.75.x",
+        "v0.75.1.x",
+        "v1.75.1.x",
+      ]);
+
+      expect(getExtraTagsForVersion({ version: "v0.75.1" })).toEqual([
+        "v0.75.x",
+        "v1.75.x",
+        "v0.75.1.x",
+        "v1.75.1.x",
+      ]);
+    });
+
+    it("should return the correct extra tags for a patch version", () => {
+      expect(getExtraTagsForVersion({ version: "v1.75.1.3" })).toEqual([
+        "v0.75.x",
+        "v1.75.x",
+        "v0.75.1.x",
+        "v1.75.1.x",
+      ]);
+
+      expect(getExtraTagsForVersion({ version: "v0.75.1.3" })).toEqual([
+        "v0.75.x",
+        "v1.75.x",
+        "v0.75.1.x",
+        "v1.75.1.x",
+      ]);
+    });
+
+    it("should return the correct extra tags for a beta version", () => {
+      expect(getExtraTagsForVersion({ version: "v1.75.0-beta" })).toEqual([
+        "v0.75.x",
+        "v1.75.x",
+      ]);
+
+      expect(getExtraTagsForVersion({ version: "v1.75.1-beta" })).toEqual([
+        "v0.75.x",
+        "v1.75.x",
+        "v0.75.1.x",
+        "v1.75.1.x",
+      ]);
+
+      expect(getExtraTagsForVersion({ version: "v0.75.1.2-beta" })).toEqual([
+        "v0.75.x",
+        "v1.75.x",
+        "v0.75.1.x",
+        "v1.75.1.x",
+      ]);
     });
   });
 });


### PR DESCRIPTION
[Document](https://www.notion.so/metabase/Dot-X-releases-13769354c90180239d37cd5c9ea87a46)

## Description

In order to make it easier to link to the latest version of a particular version, we're introducing "dot x" release tags that will be linked in release notes and announcements.

for example
```ts
51.0    ->  51.x
51.2    ->  51.x and 51.2.x
51.2.2  ->  51.x and 51.2.x
51.3    ->  51.x and 51.3.x
51.3.1  ->  51.x and 51.3.x
```

That way we can easily distribute an always up-to-date version, and do less frequent "official" releases and stop spamming people so much with version update notices.

Individual JARs will still be tagged with precise version numbers, and links will still exist for non-variable versions.

- [x] [ test minor](https://github.com/iethree/metabase/actions/runs/12379371642)
- [x] [test patch](https://github.com/iethree/metabase/actions/runs/12380340590)
