### PR TITLE
guard against a stage number in matching

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
@@ -76,7 +76,11 @@
          (into {} (for [[k v] attribute_remappings
                         ;; get attribute that map to fields of the same table
                         :when (contains? field-ids
-                                         (lib.util.match/match-one v [:dimension [:field field-id _]] field-id))]
+                                         (lib.util.match/match-one v
+                                                                   ;; new style with {:stage-number }
+                                                                   [:dimension [:field field-id _] _] field-id
+                                                                   ;; old style without stage number
+                                                                   [:dimension [:field field-id _]] field-id))]
                     {k (get login-attributes k)})))])))
 
 (defenterprise field-id->field-values-for-current-user

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
@@ -77,10 +77,10 @@
                         ;; get attribute that map to fields of the same table
                         :when (contains? field-ids
                                          (lib.util.match/match-one v
-                                                                   ;; new style with {:stage-number }
-                                                                   [:dimension [:field field-id _] _] field-id
-                                                                   ;; old style without stage number
-                                                                   [:dimension [:field field-id _]] field-id))]
+                                           ;; new style with {:stage-number }
+                                           [:dimension [:field field-id _] _] field-id
+                                           ;; old style without stage number
+                                           [:dimension [:field field-id _]] field-id))]
                     {k (get login-attributes k)})))])))
 
 (defenterprise field-id->field-values-for-current-user


### PR DESCRIPTION
old:

`{"category":["dimension",["field",5,{"base-type":"type/Integer"}]]}`

new:

`{"state":["dimension",["field",48,{"base-type":"type/Text"}],{"stage-number":0}]}`

```
(comment
  (let [login-attributes {"state" "CA"}
        field-ids #{55 46 54 48 50 56 51 47 57 45 53 52 49}
        attribute_remappings {"state" [:dimension
                                       [:field
                                        48
                                        {:base-type :type/Text}]
                                        ;; this stage-number is optional. Newer versions have it since https://github.com/metabase/metabase/issues/46914
                                       {:stage-number 0}]}]
    (into {} (for [[k v] attribute_remappings
                   ;; get attribute that map to fields of the same table
                   :when (contains? field-ids
                                    (lib.util.match/match-one v [:dimension [:field field-id _]] field-id))]
               {k (get login-attributes k)})))
  )
```