### PR TITLE
[Notification] Send notification APIs

### DIFF
--- a/src/metabase/api/notification.clj
+++ b/src/metabase/api/notification.clj
@@ -53,6 +53,12 @@
       (update :handlers (fn [handlers] (filter (comp (set handler_ids) :id) handlers)))
 
       true
-      notification/send-notification!)))
+      (notification/send-notification! :notification/sync? true))))
+
+(api/defendpoint POST "/send"
+  "Send an unsaved notification."
+  [:as {body :body}]
+  {body models.notification/FullyHydratedNotification}
+  (notification/send-notification! body :notification/sync? true))
 
 (api/define-routes)

--- a/src/metabase/api/notification.clj
+++ b/src/metabase/api/notification.clj
@@ -4,6 +4,7 @@
    [compojure.core :refer [DELETE GET POST PUT]]
    [metabase.api.common :as api]
    [metabase.models.notification :as models.notification]
+   [metabase.notification.core :as notification]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
@@ -40,5 +41,18 @@
     (api/check-404 existing-notification)
     (models.notification/update-notification! existing-notification body)
     (get-notification id)))
+
+(api/defendpoint POST "/:id/send"
+  "Send a notification by id."
+  [id :as {{:keys [handler_ids]} :body}]
+  {id          ms/PositiveInt
+   handler_ids [:maybe [:sequential ms/PositiveInt]]}
+  (api/let-404 [existing-notification (get-notification id)]
+    (cond-> existing-notification
+      (seq handler_ids)
+      (update :handlers (fn [handlers] (filter (comp (set handler_ids) :id) handlers)))
+
+      true
+      notification/send-notification!)))
 
 (api/define-routes)

--- a/src/metabase/models/channel.clj
+++ b/src/metabase/models/channel.clj
@@ -32,6 +32,15 @@
   {:type    (mi/transform-validator mi/transform-keyword (partial mi/assert-namespaced "channel"))
    :details mi/transform-encrypted-json})
 
+(def Channel
+  "Channel schema."
+  [:map
+   [:name                         string?]
+   [:type                         :keyword]
+   [:details                      :map]
+   [:active      {:optional true} :boolean]
+   [:description {:optional true} [:maybe string?]]])
+
 (defmethod mi/can-write? :model/Channel
   [& _]
   (or (mi/superuser?)
@@ -55,7 +64,7 @@
 
 (defmethod serdes/entity-id "Channel" [_ {:keys [name]}] name)
 
-(defmethod serdes/hash-fields :model/Channel         [_instance] [:name :type])
+(defmethod serdes/hash-fields :model/Channel [_instance] [:name :type])
 
 (defmethod serdes/make-spec "Channel"
   [_model-name _opts]

--- a/src/metabase/models/notification.clj
+++ b/src/metabase/models/notification.clj
@@ -6,6 +6,7 @@
   (:require
    [malli.core :as mc]
    [medley.core :as m]
+   [metabase.models.channel :as models.channel]
    [metabase.models.interface :as mi]
    [metabase.models.util.spec-update :as models.u.spec-update]
    [metabase.util :as u]
@@ -261,11 +262,11 @@
 (def ^:private NotificationHandler
   [:map
    ;; optional during insertion
-   [:notification_id {:optional true} ms/PositiveInt]
-   [:channel_type                     [:fn #(= "channel" (-> % keyword namespace))]]
-   [:channel_id      {:optional true} [:maybe ms/PositiveInt]]
-   [:template_id     {:optional true} [:maybe ms/PositiveInt]]
-   [:active          {:optional true} [:maybe :boolean]]])
+   [:notification_id {:optional true}       ms/PositiveInt]
+   [:channel_type    {:decode/json keyword} [:fn #(= "channel" (-> % keyword namespace))]]
+   [:channel_id      {:optional true}       [:maybe ms/PositiveInt]]
+   [:template_id     {:optional true}       [:maybe ms/PositiveInt]]
+   [:active          {:optional true}       [:maybe :boolean]]])
 
 (defn- validate-notification-handler
   [notification-handler]
@@ -390,8 +391,8 @@
     [:handlers      {:optional true} [:sequential [:merge
                                                    NotificationHandler
                                                    [:map
-                                                    [:template   {:optional true} [:maybe :map]]
-                                                    [:channel    {:optional true} [:maybe :map]]
+                                                    [:template   {:optional true} [:maybe models.channel/ChannelTemplate]]
+                                                    [:channel    {:optional true} [:maybe models.channel/Channel]]
                                                     [:recipients {:optional true} [:sequential NotificationRecipient]]]]]]]
    [:multi {:dispatch (comp keyword :payload_type)}
     [:notification/card [:map

--- a/test/metabase/api/notification_test.clj
+++ b/test/metabase/api/notification_test.clj
@@ -1,11 +1,11 @@
 (ns metabase.api.notification-test
   (:require
    [clojure.test :refer :all]
+   [clojure.walk :as walk]
    [medley.core :as m]
    [metabase.models.permissions-group :as perms-group]
    [metabase.notification.test-util :as notification.tu]
-   [metabase.test :as mt]
-   [toucan2.core :as t2]))
+   [metabase.test :as mt]))
 
 (deftest get-notication-card-test
   (mt/with-temp [:model/Channel {chn-id :id} notification.tu/default-can-connect-channel
@@ -65,29 +65,29 @@
 
 (deftest create-simple-card-notification-test
   (mt/with-model-cleanup [:model/Notification]
-    (testing "card notification with 1 subscription and 2 handlers"
       (mt/with-temp [:model/Card {card-id :id} {}]
-        (let [notification {:payload_type  "notification/card"
-                            :active        true
-                            :creator_id    (mt/user->id :crowberto)
-                            :payload       {:card_id        card-id
-                                            :send_condition "goal_above"
-                                            :send_once      true}
-                            :subscriptions [{:type          "notification-subscription/cron"
-                                             :cron_schedule "0 0 0 * * ?"}]
-                            :handlers      [{:channel_type "channel/email"
-                                             :recipients   [{:type    "notification-recipient/user"
-                                                             :user_id (mt/user->id :crowberto)}]}]}]
-          (is (=? (assoc notification :id (mt/malli=? int?))
-                  (mt/user-http-request :crowberto :post 200 "notification" notification))))))
+        (testing "card notification with 1 subscription and 2 handlers"
+          (let [notification {:payload_type  "notification/card"
+                              :active        true
+                              :creator_id    (mt/user->id :crowberto)
+                              :payload       {:card_id        card-id
+                                              :send_condition "goal_above"
+                                              :send_once      true}
+                              :subscriptions [{:type          "notification-subscription/cron"
+                                               :cron_schedule "0 0 0 * * ?"}]
+                              :handlers      [{:channel_type "channel/email"
+                                               :recipients   [{:type    "notification-recipient/user"
+                                                               :user_id (mt/user->id :crowberto)}]}]}]
+            (is (=? (assoc notification :id (mt/malli=? int?))
+                    (mt/user-http-request :crowberto :post 200 "notification" notification)))))
 
-    (testing "card notification with no subscriptions and handler is ok"
-      (let [notification {:payload_type  "notification/card"
-                          :active        true
-                          :creator_id    (mt/user->id :crowberto)
-                          :payload       {:card_id (-> (t2/select-one :model/Card) :id)}}]
-        (is (=? (assoc notification :id (mt/malli=? int?))
-                (mt/user-http-request :crowberto :post 200 "notification" notification)))))))
+        (testing "card notification with no subscriptions and handler is ok"
+          (let [notification {:payload_type  "notification/card"
+                              :active        true
+                              :creator_id    (mt/user->id :crowberto)
+                              :payload       {:card_id card-id}}]
+            (is (=? (assoc notification :id (mt/malli=? int?))
+                    (mt/user-http-request :crowberto :post 200 "notification" notification))))))))
 
 (deftest create-notification-error-test
   (testing "require auth"
@@ -216,3 +216,36 @@
                     (set (keys (notification.tu/with-captured-channel-send!
                                  (mt/user-http-request :crowberto :post 204 (format "notification/%d/send" (:id notification))
                                                        {:handler_ids handler-ids}))))))))))))
+
+(defn- strip-keys
+  [x to-remove-keys]
+  (walk/postwalk
+   (fn [x]
+     (if (map? x)
+       (apply dissoc x to-remove-keys)
+       x))
+   x))
+
+(deftest send-unsaved-notification-api-test
+  (mt/with-temp [:model/Channel {http-channel-id :id} {:type    :channel/http
+                                                       :details {:url         "https://metabase.com/testhttp"
+                                                                 :auth-method "none"}}]
+    (notification.tu/with-channel-fixtures [:channel/email :channel/slack]
+      (notification.tu/with-card-notification
+        [notification {:handlers [{:channel_type :channel/email
+                                   :recipients   [{:type    :notification-recipient/user
+                                                     :user_id (mt/user->id :crowberto)}]}
+                                  {:channel_type :channel/slack
+                                   :recipients   [{:type    :notification-recipient/raw-value
+                                                   :details {:value "#general"}}]}
+                                  {:channel_type :channel/http
+                                   :channel_id   http-channel-id}]}]
+        ;; this test only check that channel will send, the content are tested in [[metabase.notification.payload.impl.card-test]]
+        (testing "send to all handlers"
+          (is (=? {:channel/email [{:message    (mt/malli=? some?)
+                                    :recipients ["crowberto@metabase.com"]}]
+                   :channel/slack [{:attachments (mt/malli=? some?)
+                                    :channel-id  "#general"}]
+                   :channel/http  [{:body (mt/malli=? some?)}]}
+                  (notification.tu/with-captured-channel-send!
+                    (mt/user-http-request :crowberto :post 204 "notification/send" (strip-keys notification [:id :created_at :updated_at]))))))))))


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/50766
Add 2 apis:
- POST /api/notification/:id/send used to trigger sending a saved notification, can also take handler_ids list to selectively send to a list of handlers
- POST /api/notification/send used to trigger sending an unsaved notification

Note: we don't have permission checks yet, I'll revisit all the API permission model later, need to check with Product to set our permission model for notification.