### PR TITLE
Replace :notification-subscription/external-email with raw-value

### DIFF
--- a/src/metabase/channel/impl/email.clj
+++ b/src/metabase/channel/impl/email.clj
@@ -138,7 +138,7 @@
   [recipients]
   (update-vals
    {:user-emails     (mapv (comp :email :user) (filter #(= :notification-recipient/user (:type %)) recipients))
-    :non-user-emails (mapv (comp :email :details) (filter #(= :notification-recipient/external-email (:type %)) recipients))}
+    :non-user-emails (mapv (comp :value :details) (filter #(= :notification-recipient/raw-value (:type %)) recipients))}
    #(filter u/email? %)))
 
 (defn- construct-emails
@@ -298,8 +298,8 @@
                                     [(-> recipient :user :email)]
                                     :notification-recipient/group
                                     (->> recipient :permissions_group :members (map :email))
-                                    :notification-recipient/external-email
-                                    [(:email details)]
+                                    :notification-recipient/raw-value
+                                    [(:value details)]
                                     :notification-recipient/template
                                     [(not-empty (channel.params/substitute-params (:pattern details) notification-payload :ignore-missing? (:is_optional details)))]
                                     nil)]

--- a/src/metabase/models/notification.clj
+++ b/src/metabase/models/notification.clj
@@ -291,8 +291,6 @@
 (def ^:private notification-recipient-types
   #{:notification-recipient/user
     :notification-recipient/group
-    ;; TODO rename this to notification-recipient/raw-value so it's generic and can be used for slack channel
-    :notification-recipient/external-email
     :notification-recipient/raw-value
     :notification-recipient/template})
 
@@ -316,12 +314,6 @@
       [:permissions_group_id                  ms/PositiveInt]
       [:user_id              {:optional true} [:fn nil?]]
       [:details              {:optional true} [:fn empty?]]]]
-    [:notification-recipient/external-email
-     [:map
-      [:details                               [:map {:closed true}
-                                               [:email ms/Email]]]
-      [:user_id              {:optional true} [:fn nil?]]
-      [:permissions_group_id {:optional true} [:fn nil?]]]]
     [:notification-recipient/raw-value
      [:map
       [:details                               [:map {:closed true}

--- a/src/metabase/pulse/send.clj
+++ b/src/metabase/pulse/send.clj
@@ -27,8 +27,8 @@
     :email
     (for [recipient (:recipients pulse-channel)]
       (if-not (:id recipient)
-        {:type :notification-recipient/external-email
-         :details {:email (:email recipient)}}
+        {:type :notification-recipient/raw-value
+         :details {:value (:email recipient)}}
         {:type :notification-recipient/user
          :user recipient}))
     :http

--- a/test/metabase/api/notification_test.clj
+++ b/test/metabase/api/notification_test.clj
@@ -113,8 +113,8 @@
                      :handlers          [{:channel_type :channel/email
                                           :recipients   [{:type    :notification-recipient/user
                                                           :user_id (mt/user->id :crowberto)}
-                                                         {:type    :notification-recipient/external-email
-                                                          :details {:email "ngoc@metabase.com"}}]
+                                                         {:type    :notification-recipient/raw-value
+                                                          :details {:value "ngoc@metabase.com"}}]
                                           :template_id  tmpl-id}]}]
       (let [notification        (atom notification)
             notification-id     (:id @notification)

--- a/test/metabase/models/notification_test.clj
+++ b/test/metabase/models/notification_test.clj
@@ -254,29 +254,29 @@
                                 (insert! {:type                 :notification-recipient/group
                                           :permissions_group_id (t2/select-one-pk :model/PermissionsGroup)
                                           :details              {:something :new}})))))
-      (testing "notifciation-recipient/external-email"
-        (testing "success with email"
-          (is (some? (insert! {:type    :notification-recipient/external-email
-                               :details {:email "ngoc@metabase.com"}}))))
+      (testing "notifciation-recipient/raw-value"
+        (testing "success with value"
+          (is (some? (insert! {:type    :notification-recipient/raw-value
+                               :details {:value "ngoc@metabase.com"}}))))
 
         (testing "fail if details does not match schema"
           (is (thrown-with-msg? Exception #"Value does not match schema"
-                                (insert! {:type    :notification-recipient/external-email
-                                          :details {:email     "ngoc@metabase.com"
-                                                    :not-email true}}))))
-        (testing "fail without email"
+                                (insert! {:type    :notification-recipient/raw-value
+                                          :details {:value "ngoc@metabase.com"
+                                                    :extra true}}))))
+        (testing "fail without value"
           (is (thrown-with-msg? Exception #"Value does not match schema"
-                                (insert! {:type :notification-recipient/external-email}))))
+                                (insert! {:type :notification-recipient/raw-value}))))
         (testing "if has user_id"
           (is (thrown-with-msg? Exception #"Value does not match schema"
-                                (insert! {:type    :notification-recipient/external-email
+                                (insert! {:type    :notification-recipient/raw-value
                                           :user_id 1
-                                          :details {:email "ngoc@metabase.com"}}))))
+                                          :details {:value "ngoc@metabase.com"}}))))
         (testing "if has permissions_group_id"
           (is (thrown-with-msg? Exception #"Value does not match schema"
-                                (insert! {:type                 :notification-recipient/external-email
+                                (insert! {:type                 :notification-recipient/raw-value
                                           :permissions_group_id 1
-                                          :details              {:email "ngoc@metabase.com"}}))))))))
+                                          :details              {:value "ngoc@metabase.com"}}))))))))
 
 (defn- send-notification-triggers
   [subscription-id]

--- a/test/metabase/notification/payload/impl/system_event_test.clj
+++ b/test/metabase/notification/payload/impl/system_event_test.clj
@@ -43,8 +43,8 @@
                              :user_id (mt/user->id :crowberto)}
                             {:type                 :notification-recipient/group
                              :permissions_group_id group-id}
-                            {:type    :notification-recipient/external-email
-                             :details {:email "hi@metabase.com"}}]}])
+                            {:type    :notification-recipient/raw-value
+                             :details {:value "hi@metabase.com"}}]}])
           (mt/with-temporary-setting-values
             [site-name "Metabase Test"]
             (mt/with-fake-inbox
@@ -80,8 +80,8 @@
                              :user_id (mt/user->id :crowberto)}
                             {:type                 :notification-recipient/group
                              :permissions_group_id group-id}
-                            {:type    :notification-recipient/external-email
-                             :details {:email "hi@metabase.com"}}]}])
+                            {:type    :notification-recipient/raw-value
+                             :details {:value "hi@metabase.com"}}]}])
           (mt/with-temporary-setting-values
             [site-name "Metabase Test"]
             (mt/with-fake-inbox


### PR DESCRIPTION
external-email is too specific for email, we can use raw-value which is generic and also can be used for other things such as slack channel