### PR TITLE
Include the card ID in field IDs generated for models

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
@@ -38,11 +38,12 @@
       (lib.types.isa/temporal? db-field)              "date")))
 
 (defn- convert-field
-  [db-field]
-  (-> db-field
-      (select-keys [:id :name :description])
-      (update :id #(str "field_" %))
-      (assoc :type (convert-field-type db-field))))
+  ([db-field] (convert-field db-field ""))
+  ([db-field prefix]
+   (-> db-field
+       (select-keys [:id :name :description])
+       (update :id #(str "field_" prefix %))
+       (assoc :type (convert-field-type db-field)))))
 
 (defn- convert-metric
   [db-metric]
@@ -80,7 +81,7 @@
         fields (remove (comp #{:hidden :sensitive} :visibility_type) (:fields base))]
     (some-> base
             (select-keys [:id :description])
-            (assoc :fields (mapv convert-field fields)
+            (assoc :fields (mapv #(convert-field % (str "[card__" id "]_")) fields)
                    :name (:display_name base))
             (update :metrics #(mapv convert-metric %))
             (assoc :queryable_foreign_key_tables (foreign-key-tables fields)))))


### PR DESCRIPTION
This is to make the generated field IDs globally unambiguous. Model fields always get such a prefix, so a field ID like `field_280` is known to refer to a field of a table.

An example of a generated model field ID: `field_[card__137]_[:field "avg" {:base-type :type/Float}]`

