### PR TITLE
Use pr-str so log data is parseable

### DIFF
--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -81,8 +81,11 @@
 (defn- sync-metadata [_old-setting-raw new-setting-raw]
   ;; Oh dear, we get the raw setting. Save a little bit of overhead by not converting keys
   (let [new-setting                          (json/decode new-setting-raw)
-        _                                    (log/debug "Updated appdb search index state" new-setting)
         this-index-metadata                  #(get-in % ["versions" *index-version-id*])
+        _                                    (log/debug "Updated appdb search index state"
+                                                        *index-version-id*
+                                                        (pr-str (dissoc new-setting "versions" "active-table" "pending-table"))
+                                                        (pr-str (this-index-metadata new-setting)))
         {:strs [active-table pending-table]} (this-index-metadata new-setting)
         ;; implicitly clear the pending table if we just activated it
         pending-table                        (when (not= active-table pending-table) pending-table)]


### PR DESCRIPTION
Without the `pr-str` there is no quoting around string keys and values in the data structure, so we are unable to parse the logs for data analysis. I'm surprised the default printer is so broken.

Before (Grafana)

```
2024-12-13 10:17:00.306	
{"lvl":"DEBUG","lgr":"metabase.search.appdb.index","m":"Updated appdb search index state {pending-table search_index__3d6c4123_d5ed_49c3_9eda_98282210dffd, active-table search_index__3d6c4123_d5ed_49c3_9eda_98282210dffd, recent-versions [afc1963 08771ef], versions {08771ef {active-table search_index__a819ea52_3ef7_41a5_a598_4d08efa92325, pending-table nil}, afc1963 {pending-table search_index__64bc3ffe_7920_47c8_af59_b3c3de11a62c}}}"}
```

After (local)

```
2024-12-13 11:08:41,437 INFO appdb.index :: Updated appdb search index state fda7f617-52e3-443c-b9ab-5bf113780824 {"recent-versions" ["fda7f617-52e3-443c-b9ab-5bf113780824"]} {"active-table" "search_index__1a2e5b10_76df_4084_9797_373a5d5bb8de", "pending-table" nil}
```