### PR TITLE
fix(sdk): disable dashboard card click behavior and prevent url formatting

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/dashboard-click-behavior.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/dashboard-click-behavior.cy.spec.tsx
@@ -1,0 +1,141 @@
+import { InteractiveDashboard } from "@metabase/embedding-sdk-react";
+
+import { H } from "e2e/support";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import {
+  POPOVER_ELEMENT,
+  cartesianChartCircle,
+  describeEE,
+  popover,
+} from "e2e/support/helpers";
+import {
+  mockAuthProviderAndJwtSignIn,
+  mountSdkContent,
+  signInAsAdminAndEnableEmbeddingSdk,
+} from "e2e/support/helpers/component-testing-sdk";
+import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+describeEE("scenarios > embedding-sdk > interactive-dashboard", () => {
+  beforeEach(() => {
+    signInAsAdminAndEnableEmbeddingSdk();
+
+    // Make the PRODUCT_ID column a URL column for click behavior tests, to avoid having to create a new model
+    cy.request("PUT", `/api/field/${ORDERS.PRODUCT_ID}`, {
+      semantic_type: "type/URL",
+    });
+
+    H.createDashboardWithQuestions({
+      dashboardName: "Orders in a dashboard",
+      questions: [
+        {
+          name: "Orders",
+          query: { "source-table": ORDERS_ID, limit: 5 },
+        },
+        {
+          name: "Line chart with click behavior",
+          display: "line",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [["count"]],
+            breakout: [
+              ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+            ],
+            limit: 5,
+          },
+        },
+      ],
+      cards: [
+        {
+          size_x: 12,
+          col: 0,
+          visualization_settings: {
+            column_settings: {
+              '["name","SUBTOTAL"]': {
+                click_behavior: {
+                  type: "link",
+                  linkType: "url",
+                  linkTemplate: "https://metabase.com",
+                  linkTextTemplate: "Link Text Applied",
+                },
+              },
+            },
+          },
+        },
+        {
+          size_x: 12,
+          col: 12,
+          visualization_settings: {
+            click_behavior: {
+              type: "link",
+              linkType: "url",
+              linkTemplate: "https://metabase.com",
+            },
+          },
+        },
+      ],
+    }).then(({ dashboard }) => {
+      cy.wrap(dashboard.id).as("dashboardId");
+    });
+
+    cy.signOut();
+
+    mockAuthProviderAndJwtSignIn();
+
+    cy.intercept("GET", "/api/dashboard/*").as("getDashboard");
+    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
+      "dashcardQuery",
+    );
+  });
+
+  it("should not trigger url click behaviors in the sdk (metabase#51099)", () => {
+    cy.get<string>("@dashboardId").then(dashboardId => {
+      mountSdkContent(<InteractiveDashboard dashboardId={dashboardId} />);
+    });
+
+    cy.wait("@dashcardQuery").then(() => {
+      cy.location().then(location => {
+        cy.wrap(location.pathname).as("initialPath");
+      });
+
+      const root = getSdkRoot();
+
+      root.within(() => {
+        // Drill-through should work on columns without click behavior
+        H.getDashboardCard(0).findByText("39.72").click();
+        popover().should("contain.text", "Filter by this value");
+
+        // Drill-through should work on URL columns, which is PRODUCT_ID in this case.
+        // It should open a popover, not open a new link.
+        const urlCell = H.getDashboardCard(0).findByText("123");
+        urlCell.should("not.have.attr", "data-testid", "link-formatted-text");
+        urlCell.click();
+
+        popover().should("contain.text", "Filter by this value");
+
+        // Table column click behavior should be disabled in the sdk
+        H.getDashboardCard(0).should("not.contain.text", "Link Text Applied");
+        H.getDashboardCard(0).findByText("37.65").click();
+        cy.get(POPOVER_ELEMENT).should("not.exist");
+
+        // Line chart click behavior should be disabled in the sdk
+        H.getDashboardCard(1).within(() => {
+          cartesianChartCircle()
+            .eq(0)
+            .then(([circle]) => {
+              const { left, top } = circle.getBoundingClientRect();
+              root.click(left, top);
+            });
+        });
+
+        cy.get(POPOVER_ELEMENT).should("not.exist");
+      });
+
+      // We should not be navigated away from the current page
+      cy.location().then(location => {
+        cy.get("@initialPath").should("eq", location.pathname);
+      });
+    });
+  });
+});

--- a/e2e/test-component/scenarios/embedding-sdk/dashboard-click-behavior.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/dashboard-click-behavior.cy.spec.tsx
@@ -17,7 +17,7 @@ import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
-describeEE("scenarios > embedding-sdk > interactive-dashboard", () => {
+describeEE("scenarios > embedding-sdk > dashboard-click-behavior", () => {
   beforeEach(() => {
     signInAsAdminAndEnableEmbeddingSdk();
 

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-dashboard.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-dashboard.cy.spec.tsx
@@ -3,11 +3,14 @@ import {
   InteractiveQuestion,
 } from "@metabase/embedding-sdk-react";
 
+import { H } from "e2e/support";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 import {
-  ORDERS_DASHBOARD_DASHCARD_ID,
-  ORDERS_QUESTION_ID,
-} from "e2e/support/cypress_sample_instance_data";
-import { describeEE, getTextCardDetails } from "e2e/support/helpers";
+  POPOVER_ELEMENT,
+  cartesianChartCircle,
+  describeEE,
+  popover,
+} from "e2e/support/helpers";
 import {
   mockAuthProviderAndJwtSignIn,
   mountSdkContent,
@@ -20,19 +23,18 @@ describeEE("scenarios > embedding-sdk > interactive-dashboard", () => {
   beforeEach(() => {
     signInAsAdminAndEnableEmbeddingSdk();
 
-    const textCard = getTextCardDetails({ col: 16, text: "Test text card" });
     const questionCard = {
-      id: ORDERS_DASHBOARD_DASHCARD_ID,
+      id: 64,
       card_id: ORDERS_QUESTION_ID,
       row: 0,
       col: 0,
-      size_x: 16,
+      size_x: 8,
       size_y: 8,
     };
 
     cy.createDashboard({
       name: "Orders in a dashboard",
-      dashcards: [questionCard, textCard],
+      dashcards: [questionCard],
     }).then(({ body: dashboard }) => {
       cy.wrap(dashboard.id).as("dashboardId");
       cy.wrap(dashboard.entity_id).as("dashboardEntityId");
@@ -127,6 +129,48 @@ describeEE("scenarios > embedding-sdk > interactive-dashboard", () => {
           cy.findByText("Rows 1-6 of first 2000").should("not.exist");
           cy.findByText("Test text card").should("not.exist");
         });
+      });
+    });
+  });
+
+  it("should not trigger url click behaviours when clicking on sdk cards (metabase#51099)", () => {
+    cy.get<string>("@dashboardId").then(dashboardId => {
+      mountSdkContent(<InteractiveDashboard dashboardId={dashboardId} />);
+    });
+
+    cy.wait("@dashcardQuery").then(() => {
+      cy.location().then(location => {
+        cy.wrap(location.pathname).as("initialPath");
+      });
+
+      const root = getSdkRoot();
+
+      root.within(() => {
+        // Drill-through should work on columns without click behavior
+        H.getDashboardCard(0).findByText("2.07").click();
+        popover().should("contain.text", "Filter by this value");
+
+        // Table column click behavior should be disabled in the sdk
+        H.getDashboardCard(0).should("not.contain.text", "Link Text Applied");
+        H.getDashboardCard(0).findByText("37.65").click();
+        cy.get(POPOVER_ELEMENT).should("not.exist");
+
+        // Line chart click behavior should be disabled in the sdk
+        H.getDashboardCard(1).within(() => {
+          cartesianChartCircle()
+            .eq(0)
+            .then(([circle]) => {
+              const { left, top } = circle.getBoundingClientRect();
+              root.click(left, top);
+            });
+        });
+
+        cy.get(POPOVER_ELEMENT).should("not.exist");
+      });
+
+      // We should not be navigated away from the current page
+      cy.location().then(location => {
+        cy.get("@initialPath").should("eq", location.pathname);
       });
     });
   });

--- a/frontend/src/metabase/lib/formatting/url.tsx
+++ b/frontend/src/metabase/lib/formatting/url.tsx
@@ -3,6 +3,7 @@ import cx from "classnames";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import Link from "metabase/core/components/Link";
 import CS from "metabase/css/core/index.css";
+import { isEmbeddingSdk } from "metabase/env";
 import { isSameOrSiteUrlOrigin } from "metabase/lib/dom";
 import { getDataFromClicked } from "metabase-lib/v1/parameters/utils/click-behavior";
 import { isURL } from "metabase-lib/v1/types/utils/isa";
@@ -40,6 +41,12 @@ export function formatUrl(value: string, options: OptionsType = {}) {
   if (jsx && rich && url) {
     const text = getLinkText(value, options);
     const className = cx(CS.link, CS.linkWrappable);
+
+    // (metabase#51099) prevent url from being rendered as a link when in sdk
+    if (isEmbeddingSdk) {
+      return url;
+    }
+
     if (isSameOrSiteUrlOrigin(url)) {
       return (
         <Link className={className} to={url}>

--- a/frontend/src/metabase/lib/formatting/value.tsx
+++ b/frontend/src/metabase/lib/formatting/value.tsx
@@ -7,6 +7,7 @@ import ReactMarkdown from "react-markdown";
 
 import ExternalLink from "metabase/core/components/ExternalLink";
 import CS from "metabase/css/core/index.css";
+import { isEmbeddingSdk } from "metabase/env";
 import { NULL_DISPLAY_VALUE } from "metabase/lib/constants";
 import { renderLinkTextForClick } from "metabase/lib/formatting/link";
 import {
@@ -150,7 +151,8 @@ export function formatValueRaw(
     options.view_as !== "image" &&
     options.click_behavior &&
     clickBehaviorIsValid(options.click_behavior) &&
-    options.jsx
+    options.jsx &&
+    !isEmbeddingSdk // (metabase#51099) do not show as link in sdk
   ) {
     // Style this like a link if we're in a jsx context.
     // It's not actually a link since we handle the click differently for dashboard and question targets.
@@ -164,7 +166,8 @@ export function formatValueRaw(
     );
   } else if (
     options.click_behavior &&
-    options.click_behavior.linkTextTemplate
+    options.click_behavior.linkTextTemplate &&
+    !isEmbeddingSdk // (metabase#51099) do not show custom link text in sdk
   ) {
     return renderLinkTextForClick(
       options.click_behavior.linkTextTemplate,

--- a/frontend/src/metabase/visualizations/lib/action.js
+++ b/frontend/src/metabase/visualizations/lib/action.js
@@ -2,6 +2,7 @@ import { push } from "react-router-redux";
 import _ from "underscore";
 
 import { setParameterValuesFromQueryParams } from "metabase/dashboard/actions";
+import { isEmbeddingSdk } from "metabase/env";
 import { open } from "metabase/lib/dom";
 
 export function performAction(
@@ -13,10 +14,16 @@ export function performAction(
     const reduxAction = action.action();
     if (reduxAction) {
       dispatch(reduxAction);
+
       didPerform = true;
     }
   }
   if (action.url) {
+    // (metabase#51099) disable url click behavior when in sdk
+    if (isEmbeddingSdk) {
+      return true;
+    }
+
     const url = action.url();
     const ignoreSiteUrl = action.ignoreSiteUrl;
     if (url) {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/51099

### Description

Disables the dashboard card click behaviors by not invoking the URL action if we are in the embedding sdk environment. It also prevents URL formatting for columns with semantic type of URL. See [this thread](https://metaboat.slack.com/archives/C06FCQT0KMZ/p1733768624642749) for context.

### How to verify

Scenario 1: columns with custom destinations

- Create a dashboard card with "Go to a custom destination" click action
- Click on it in the embedding sdk
- Drill-through menu should not show up
- We should not be navigated to the custom destination, i.e. nothing should happen
- Links should be formatted as plain text

Scenario 2: columns of URL semantic type
- Create a dashboard card with the "URL" semantic type
- The column must not show be formatted as URL (anchor) when rendered in sdk's dashboard component

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - E2E
