### PR TITLE
Adjust initialDashboardId calculation

### DIFF
--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-query-stages.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-query-stages.cy.spec.ts
@@ -1955,7 +1955,11 @@ describe("scenarios > dashboard > filters > query stages + temporal unit paramet
       );
 
       cy.get("@myNewDash").then((dashId: number | any) => {
-        H.visitDashboard(dashId);
+        cy.request("POST", "/api/activity/recents", {
+          context: "selection",
+          model: "dashboard",
+          model_id: dashId,
+        });
       });
 
       H.startNewQuestion();

--- a/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
@@ -299,8 +299,15 @@ describe("Dashboard > Dashboard Questions", () => {
       );
 
       cy.get("@dashboardId").then(dashboardId => {
-        H.visitDashboard(dashboardId);
+        //Simulate having picked the dashboard in the entity picker previously
+        cy.request("POST", "/api/activity/recents", {
+          context: "selection",
+          model: "dashboard",
+          model_id: dashboardId,
+        });
       });
+
+      cy.visit("/");
 
       cy.findByLabelText("Navigation bar").findByText("New").click();
       H.popover().findByText("Question").click();

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -93,6 +93,10 @@ describe("scenarios > dashboard", () => {
       H.queryBuilderHeader().findByText("Save").click();
       cy.findByTestId("save-question-modal").within(modal => {
         cy.findByLabelText("Name").clear().type(newQuestionName);
+        cy.findByLabelText("Where do you want to save this?").should(
+          "contain.text",
+          dashboardName,
+        );
         cy.findByText("Save").click();
       });
       cy.wait("@createQuestion");

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -5,10 +5,7 @@ import {
   WRITABLE_DB_ID,
 } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  ORDERS_DASHBOARD_ID,
-  THIRD_COLLECTION_ID,
-} from "e2e/support/cypress_sample_instance_data";
+import { THIRD_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
 
@@ -58,12 +55,21 @@ describe("scenarios > question > native", () => {
         "have.text",
         "Third collection",
       );
-
-      cy.button("Cancel").click();
+      cy.log("after selecting a dashboard, it should be the new suggestion");
+      cy.findByLabelText(/Where do you want to save this/).click();
     });
 
-    cy.log("after visiting a dashboard, it should be the new suggestion");
-    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.entityPickerModal().within(() => {
+      cy.findByText("Orders in a dashboard").click();
+      cy.button("Select this dashboard").click();
+    });
+
+    cy.findByTestId("save-question-modal")
+      .findByLabelText(/Where do you want to save this/)
+      .should("have.text", "Orders in a dashboard");
+
+    cy.visit("/");
+
     H.openNativeEditor({ fromCurrentPage: true });
     cy.realType("select count(*) from orders");
 

--- a/frontend/src/metabase/components/SaveQuestionForm/context.tsx
+++ b/frontend/src/metabase/components/SaveQuestionForm/context.tsx
@@ -82,7 +82,7 @@ export const SaveQuestionProvider = ({
     }
   }, [isLoading]);
 
-  const lastUsedDashboard = useMemo(() => {
+  const defaultDashboard = useMemo(() => {
     if (!recentItems || recentItems.length === 0) {
       return undefined;
     }
@@ -106,13 +106,13 @@ export const SaveQuestionProvider = ({
   const initialDashboardId =
     question.type() === "question" &&
     !isAnalytics &&
-    lastUsedDashboard?.can_write
-      ? lastUsedDashboard?.id
+    defaultDashboard?.can_write
+      ? defaultDashboard?.id
       : undefined;
 
   const initialCollectionId = isAnalytics
     ? defaultCollectionId
-    : (lastUsedDashboard?.parent_collection.id ?? defaultCollectionId);
+    : (defaultDashboard?.parent_collection.id ?? defaultCollectionId);
 
   const initialValues: FormValues = useMemo(
     () =>

--- a/frontend/src/metabase/components/SaveQuestionForm/context.tsx
+++ b/frontend/src/metabase/components/SaveQuestionForm/context.tsx
@@ -70,7 +70,7 @@ export const SaveQuestionProvider = ({
 
   const [hasLoadedRecentItems, setHasLoadedRecentItems] = useState(false);
   const { data: recentItems, isLoading } = useListRecentsQuery(
-    { context: ["selections", "views"] },
+    { context: ["selections"] },
     { skip: hasLoadedRecentItems },
   );
   // We need to stop refetching recent items as the user makes selections in the ui that could cause a refetch
@@ -82,9 +82,23 @@ export const SaveQuestionProvider = ({
     }
   }, [isLoading]);
 
-  const lastUsedDashboard = recentItems?.find(
-    item => item.model === "dashboard",
-  ) as RecentCollectionItem | undefined;
+  const lastUsedDashboard = useMemo(() => {
+    if (!recentItems || recentItems.length === 0) {
+      return undefined;
+    }
+    const lastUsedDashboardIndex = recentItems?.findIndex(
+      item => item.model === "dashboard",
+    );
+    const lastUsedEntityModelIndex = recentItems?.findIndex(
+      item => item.model === "collection" || item.model === "dashboard",
+    );
+
+    if (lastUsedDashboardIndex === lastUsedEntityModelIndex) {
+      return recentItems[lastUsedDashboardIndex] as RecentCollectionItem;
+    } else {
+      return undefined;
+    }
+  }, [recentItems]);
 
   // analytics questions should not default to saving in dashboard
   const isAnalytics = isInstanceAnalyticsCollection(question.collection());

--- a/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.unit.spec.tsx
@@ -93,7 +93,13 @@ const setup = async (
     collectionItems: [],
   });
 
-  setupRecentViewsAndSelectionsEndpoints([]);
+  setupRecentViewsAndSelectionsEndpoints([], ["selections"]);
+  setupRecentViewsAndSelectionsEndpoints(
+    [],
+    ["selections", "views"],
+    {},
+    false,
+  );
 
   const settings = mockSettings();
 

--- a/frontend/src/metabase/dashboard/components/Dashboard/DashboardEmptyState/DashboardEmptyState.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/DashboardEmptyState/DashboardEmptyState.tsx
@@ -48,6 +48,7 @@ export function DashboardEmptyState({
                     creationType: "custom_question",
                     collectionId: dashboard.collection_id ?? undefined,
                     cardType: "question",
+                    dashboardId: dashboard.id,
                   })}
                   className={cx(CS.textBold, CS.textBrand)}
                   onClick={closeNavbar}

--- a/frontend/test/__support__/server-mocks/activity.ts
+++ b/frontend/test/__support__/server-mocks/activity.ts
@@ -18,6 +18,7 @@ export function setupRecentViewsAndSelectionsEndpoints(
   recentItems: RecentItem[],
   context: RecentContexts[] = ["selections", "views"],
   mockOptions: MockOptionsMethodGet = {},
+  mockPostRequest: boolean = true,
 ) {
   fetchMock.get(
     url =>
@@ -30,7 +31,9 @@ export function setupRecentViewsAndSelectionsEndpoints(
     { ...mockOptions },
   );
 
-  fetchMock.post("path:/api/activity/recents", 200);
+  if (mockPostRequest) {
+    fetchMock.post("path:/api/activity/recents", 200);
+  }
 }
 
 export function setupPopularItemsEndpoints(popularItems: PopularItem[]) {


### PR DESCRIPTION
### Description
Adjusts whether or not we suggest a dashboard as a default location for saving a question. If the most recent thing you have picked in the entity picker is a dashboard, then we will suggest it. Otherwise, we use the existing logic for suggesting a collection

### How to verify
1. Create a question, and save it to a dashboard
2. Create another question and hit save, the dashboard should be suggested as a destination.
3. Instead of saving to the dashboard again, choose a collection and save
4. Now create a 3rd question and hit save, no dashboard should be suggested, and we should fall back to existing `initialCollectionId` logic

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
