### PR TITLE
fix pie chart incorrect settings memoization

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/visualization.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/settings/visualization.unit.spec.js
@@ -211,6 +211,53 @@ describe("visualization_settings", () => {
       expect(settings["table.cell_column"]).toBe("col1");
     });
   });
+
+  describe("pie.rows memoization (metabase#50090) (metabase#50381)", () => {
+    it("should memoize results when data hasn't changed", () => {
+      const series = cardWithTimeseriesBreakout({
+        unit: "month",
+        display: "pie",
+        visualization_settings: {
+          "pie.dimension": ["col1"],
+          "pie.metric": "col2",
+        },
+      });
+
+      const originalSettings = getComputedSettingsForSeries(series);
+      const unchangedSettings = getComputedSettingsForSeries(series);
+
+      expect(originalSettings["pie.rows"]).toBe(unchangedSettings["pie.rows"]);
+
+      // Series with different data
+      const modifiedSeries = [
+        {
+          ...series[0],
+          data: {
+            ...series[0].data,
+            rows: [[1, 1]],
+          },
+        },
+      ];
+
+      const modifiedSettings = getComputedSettingsForSeries(modifiedSeries);
+
+      expect(originalSettings["pie.rows"]).not.toBe(
+        modifiedSettings["pie.rows"],
+      );
+      expect(modifiedSettings["pie.rows"]).toEqual([
+        {
+          color: "#88BF4D",
+          defaultColor: true,
+          enabled: true,
+          hidden: false,
+          isOther: false,
+          key: "1",
+          name: "1",
+          originalName: "1",
+        },
+      ]);
+    });
+  });
 });
 
 const cardWithTimeseriesBreakout = ({

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/chart-definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/chart-definition.ts
@@ -131,14 +131,13 @@ export const PIE_CHART_DEFINITION: VisualizationDefinition = {
             String(formatValue(value, options)),
           );
         },
-        ([{ json_query, started_at }], settings) =>
+        ([{ data }], settings) =>
           JSON.stringify({
-            json_query,
-            started_at,
+            cols: data.cols,
+            rows: data.rows,
             settings: _.pick(
               settings,
               ...pieRowsReadDeps,
-              "column",
               "pie.rows",
               "pie.sort_rows_dimension",
             ),


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50381
Closes https://github.com/metabase/metabase/issues/50090

### Description

Due to the architecture of the viz settings code their computation there is no memoization for always computed values via `getValue` function. It led to this issue https://github.com/metabase/metabase/pull/48670 about laggin pie charts. The "pie.rows" value computation was memoized in the PR but due to the [incorrect judgement](https://github.com/metabase/metabase/pull/48670/commits/5b73efa52fbeaf12f96e4e999ab6004431444943#r1802156429) about the memoization key the cache could return irrelevant `pie.rows` value from another card as `json_query`, `started_at` are not always present.

Reproduced with a unit test.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
