### PR TITLE
Clean up `hasBeenReleased` checks

### DIFF
--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -100,21 +100,14 @@ jobs:
             oss: getCanonicalVersion(version, 'oss'),
           };
 
-          const ossReleased = await hasBeenReleased({
+          const released = await hasBeenReleased({
             github,
             owner: context.repo.owner,
             repo: context.repo.repo,
             version: versions.oss,
           });
 
-          const eeReleased = await hasBeenReleased({
-            github,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            version: versions.ee,
-          });
-
-          if (ossReleased || eeReleased) {
+          if (released) {
             throw new Error("This version has already been released!", version);
           }
 

--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -7,6 +7,9 @@ on:
       - release-x.*
     tags:
       - v*
+      - nightly-*
+      - latest-*
+      - beta-*
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -285,13 +285,6 @@ jobs:
           git push origin -f ${{ inputs.tag_name }}-oss
         fi
 
-  update-release-log:
-    needs: check-version
-    uses: ./.github/workflows/release-log.yml
-    with:
-      version: ${{ fromJSON(vars.CURRENT_VERSION) }} # cast string to number
-    secrets: inherit
-
   update-version-info:
     runs-on: ubuntu-22.04
     needs: check-version

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -101,21 +101,14 @@ jobs:
             oss: getCanonicalVersion(version, 'oss'),
           };
 
-          const ossReleased = await hasBeenReleased({
+          const released = await hasBeenReleased({
             github,
             owner: context.repo.owner,
             repo: context.repo.repo,
             version: versions.oss,
           });
 
-          const eeReleased = await hasBeenReleased({
-            github,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            version: versions.ee,
-          });
-
-          if (!ossReleased || !eeReleased) {
+          if (!released) {
             throw new Error("This version has not been released yet!", version);
           }
 

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -278,7 +278,7 @@ jobs:
       run: | # sh
 
         if [[ "${{ matrix.edition }}" == "ee" ]]; then
-          git tag -f ${{ inputs.tag_name }}-ee ${{ needs.check-version.outputs.ee }}
+          git tag -f ${{ inputs.tag_name }}-ee ${{ needs.check-version.outputs.oss }}
           git push origin -f ${{ inputs.tag_name }}-ee
         elif [[ "${{ matrix.edition }}" == "oss" ]]; then
           git tag -f ${{ inputs.tag_name }}-oss ${{ needs.check-version.outputs.oss }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,21 +88,14 @@ jobs:
             oss: getCanonicalVersion(version, 'oss'),
           };
 
-          const ossReleased = await hasBeenReleased({
+          const released = await hasBeenReleased({
             github,
             owner: context.repo.owner,
             repo: context.repo.repo,
             version: versions.oss,
           });
 
-          const eeReleased = await hasBeenReleased({
-            github,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            version: versions.ee,
-          });
-
-          if (ossReleased || eeReleased) {
+          if (released) {
             throw new Error("This version has already been released!", version);
           }
 

--- a/.github/workflows/tag-for-release.yml
+++ b/.github/workflows/tag-for-release.yml
@@ -83,21 +83,14 @@ jobs:
             oss: getCanonicalVersion(version, 'oss'),
           };
 
-          const ossReleased = await hasBeenReleased({
+          const released = await hasBeenReleased({
             github,
             owner: context.repo.owner,
             repo: context.repo.repo,
             version: versions.oss,
           });
 
-          const eeReleased = await hasBeenReleased({
-            github,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            version: versions.ee,
-          });
-
-          if (ossReleased || eeReleased) {
+          if (released) {
             throw new Error("This version has already been released!", version);
           }
 

--- a/release/src/github.ts
+++ b/release/src/github.ts
@@ -74,7 +74,7 @@ export const openNextMilestones = async ({
         owner,
         repo,
         title: milestoneName,
-      }),
+      }).catch(console.error),
     ),
   );
 };


### PR DESCRIPTION
Small follow up to https://github.com/metabase/metabase/pull/51184

### Description

To determine if a release has already happened, we don't need to check both enterprise and oss git tags anymore. This doesn't cause any bugs (since `hasBeenReleased()` always converts to the OSS tag name), but we should keep things tidy by removing these redundant checks.
