### PR TITLE
fix(sdk): simplify font config by not providing sans-serif fallback

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
@@ -61,11 +61,7 @@ describeEE("scenarios > embedding-sdk > styles", () => {
           "font-family",
           defaultBrowserFontFamily,
         );
-        cy.findByText("Product ID").should(
-          "have.css",
-          "font-family",
-          "Lato, sans-serif",
-        );
+        cy.findByText("Product ID").should("have.css", "font-family", "Lato");
       });
     });
 
@@ -112,7 +108,7 @@ describeEE("scenarios > embedding-sdk > styles", () => {
         cy.findByText(/Failed to fetch the user/).should(
           "have.css",
           "font-family",
-          "Lato, sans-serif",
+          "Lato",
         );
       });
     });
@@ -135,7 +131,7 @@ describeEE("scenarios > embedding-sdk > styles", () => {
 
       getSdkRoot()
         .findByText("Product ID")
-        .should("have.css", "font-family", "Impact, sans-serif");
+        .should("have.css", "font-family", "Impact");
     });
 
     it("should fallback to the font from the instance if no fontFamily is set on the theme", () => {
@@ -168,7 +164,7 @@ describeEE("scenarios > embedding-sdk > styles", () => {
 
       getSdkRoot()
         .findByText("Product ID")
-        .should("have.css", "font-family", '"Roboto Mono", sans-serif');
+        .should("have.css", "font-family", '"Roboto Mono"');
     });
 
     it("should work with 'Custom' fontFamily, using the font files linked in the instance", () => {
@@ -219,7 +215,7 @@ describeEE("scenarios > embedding-sdk > styles", () => {
 
       getSdkRoot()
         .findByText("Product ID")
-        .should("have.css", "font-family", "Custom, sans-serif");
+        .should("have.css", "font-family", "Custom");
     });
   });
 
@@ -235,7 +231,7 @@ describeEE("scenarios > embedding-sdk > styles", () => {
       modal()
         .findByText("New dashboard")
         .should("exist")
-        .and("have.css", "font-family", "Lato, sans-serif");
+        .and("have.css", "font-family", "Lato");
 
       // TODO: good place for a visual regression test
     });
@@ -264,7 +260,7 @@ describeEE("scenarios > embedding-sdk > styles", () => {
       getSdkRoot()
         .findByText("Select a collection or dashboard")
         .should("exist")
-        .and("have.css", "font-family", "Lato, sans-serif");
+        .and("have.css", "font-family", "Lato");
 
       // TODO: good place for a visual regression test
     });

--- a/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentStylesWrapper.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentStylesWrapper.tsx
@@ -25,7 +25,7 @@ const PublicComponentStylesWrapperInner = styled.div`
 
   font-weight: 400;
   color: var(--mb-color-text-dark);
-  font-family: var(--mb-default-font-family), sans-serif;
+  font-family: var(--mb-default-font-family);
 
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
We've had the `e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx` suite flaky for a while, this PR should fix it.

I'm still not 100% sure of what's the root issue, I think it may be a race condition as we had a default font of `Lato, sans-serif` but when the settings loaded we changed it to `Lato`.
The weird thing is that the tests were looking for the former 🙃.

Because we fallback to the instance font anyway, which defaults to just `Lato`,  we can just remove the `, sans-serif` fallback and we should make the test more stable.