### PR TITLE
[Cards in Dashboards] Edit dashboard save changes modal adjustments

### DIFF
--- a/frontend/src/metabase/components/LeaveConfirmationModal/LeaveConfirmationModal.tsx
+++ b/frontend/src/metabase/components/LeaveConfirmationModal/LeaveConfirmationModal.tsx
@@ -1,12 +1,10 @@
 import type { Location } from "history";
-import { type ReactNode, useEffect, useState } from "react";
+import type { ReactNode } from "react";
 import type { InjectedRouter, Route } from "react-router";
 import { withRouter } from "react-router";
-import { push } from "react-router-redux";
 
 import Modal from "metabase/components/Modal";
-import useBeforeUnload from "metabase/hooks/use-before-unload";
-import { useDispatch } from "metabase/lib/redux";
+import { useConfirmLeaveModal } from "metabase/hooks/use-confirm-leave-modal";
 
 import { LeaveConfirmationModalContent } from "./LeaveConfirmationModalContent";
 
@@ -22,71 +20,30 @@ interface Props {
   }) => ReactNode;
 }
 
-export const IS_LOCATION_ALLOWED = (location?: Location) => {
-  /**
-   * If there is no "location" then it's beforeunload event, which is
-   * handled by useBeforeUnload hook - no reason to duplicate its work.
-   */
-  if (!location) {
-    return true;
-  }
-
-  return false;
-};
-
 const LeaveConfirmationModalBase = ({
   isEnabled,
-  isLocationAllowed = IS_LOCATION_ALLOWED,
+  isLocationAllowed,
   route,
   router,
   children,
 }: Props) => {
-  const dispatch = useDispatch();
-  const [isConfirmed, setIsConfirmed] = useState(false);
-  const [isConfirmationVisible, setIsConfirmationVisible] = useState(false);
-  const [nextLocation, setNextLocation] = useState<Location>();
-
-  useBeforeUnload(isEnabled);
-
-  useEffect(() => {
-    const removeLeaveHook = router.setRouteLeaveHook(route, location => {
-      if (isEnabled && !isConfirmed && !isLocationAllowed(location)) {
-        setIsConfirmationVisible(true);
-        setNextLocation(location);
-        return false;
-      }
-    });
-
-    return removeLeaveHook;
-  }, [isLocationAllowed, router, route, isEnabled, isConfirmed]);
-
-  useEffect(() => {
-    if (isConfirmed && nextLocation) {
-      dispatch(push(nextLocation));
-    }
-  }, [dispatch, isConfirmed, nextLocation]);
-
-  const handleClose = () => {
-    setIsConfirmationVisible(false);
-  };
-
-  const handleConfirm = () => {
-    setIsConfirmed(true);
-  };
+  const { opened, close, confirm, nextLocation } = useConfirmLeaveModal({
+    isEnabled,
+    isLocationAllowed,
+    route,
+    router,
+  });
 
   return (
-    <Modal isOpen={isConfirmationVisible}>
+    <Modal isOpen={opened}>
       {children ? (
         children({
           nextLocation,
-          onAction: handleConfirm,
-          onClose: handleClose,
+          onAction: confirm,
+          onClose: close,
         })
       ) : (
-        <LeaveConfirmationModalContent
-          onAction={handleConfirm}
-          onClose={handleClose}
-        />
+        <LeaveConfirmationModalContent onAction={confirm} onClose={close} />
       )}
     </Modal>
   );

--- a/frontend/src/metabase/components/LeaveConfirmationModal/LeaveConfirmationModal.tsx
+++ b/frontend/src/metabase/components/LeaveConfirmationModal/LeaveConfirmationModal.tsx
@@ -1,5 +1,4 @@
 import type { Location } from "history";
-import type { ReactNode } from "react";
 import type { InjectedRouter, Route } from "react-router";
 import { withRouter } from "react-router";
 
@@ -13,11 +12,6 @@ interface Props {
   isLocationAllowed?: (location?: Location) => boolean;
   route: Route;
   router: InjectedRouter;
-  children?: (props: {
-    nextLocation: Location | undefined;
-    onAction?: () => void;
-    onClose?: () => void;
-  }) => ReactNode;
 }
 
 const LeaveConfirmationModalBase = ({
@@ -25,9 +19,8 @@ const LeaveConfirmationModalBase = ({
   isLocationAllowed,
   route,
   router,
-  children,
 }: Props) => {
-  const { opened, close, confirm, nextLocation } = useConfirmLeaveModal({
+  const { opened, close, confirm } = useConfirmLeaveModal({
     isEnabled,
     isLocationAllowed,
     route,
@@ -36,15 +29,7 @@ const LeaveConfirmationModalBase = ({
 
   return (
     <Modal isOpen={opened}>
-      {children ? (
-        children({
-          nextLocation,
-          onAction: confirm,
-          onClose: close,
-        })
-      ) : (
-        <LeaveConfirmationModalContent onAction={confirm} onClose={close} />
-      )}
+      <LeaveConfirmationModalContent onAction={confirm} onClose={close} />
     </Modal>
   );
 };

--- a/frontend/src/metabase/components/LeaveConfirmationModal/LeaveConfirmationModal.tsx
+++ b/frontend/src/metabase/components/LeaveConfirmationModal/LeaveConfirmationModal.tsx
@@ -3,7 +3,7 @@ import type { InjectedRouter, Route } from "react-router";
 import { withRouter } from "react-router";
 
 import Modal from "metabase/components/Modal";
-import { useConfirmLeaveModal } from "metabase/hooks/use-confirm-leave-modal";
+import { useConfirmRouteLeaveModal } from "metabase/hooks/use-confirm-route-leave-modal";
 
 import { LeaveConfirmationModalContent } from "./LeaveConfirmationModalContent";
 
@@ -20,7 +20,7 @@ const LeaveConfirmationModalBase = ({
   route,
   router,
 }: Props) => {
-  const { opened, close, confirm } = useConfirmLeaveModal({
+  const { opened, close, confirm } = useConfirmRouteLeaveModal({
     isEnabled,
     isLocationAllowed,
     route,

--- a/frontend/src/metabase/dashboard/components/DashboardLeaveConfirmationModal/DashboardLeaveConfirmationModal.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardLeaveConfirmationModal/DashboardLeaveConfirmationModal.tsx
@@ -47,7 +47,7 @@ export const DashboardLeaveConfirmationModal = withRouter(
         }
       : {
           title: t`Discard your changes?`,
-          message: t`Your changes haven't been saved, so you'll lose them if you navigate away.`,
+          message: t`Your changes haven’t been saved, so you’ll lose them if you navigate away.`,
           actionBtn: {
             color: "danger",
             message: t`Discard changes`,

--- a/frontend/src/metabase/dashboard/components/DashboardLeaveConfirmationModal/DashboardLeaveConfirmationModal.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardLeaveConfirmationModal/DashboardLeaveConfirmationModal.tsx
@@ -2,7 +2,7 @@ import { type Route, type WithRouterProps, withRouter } from "react-router";
 import { t } from "ttag";
 
 import { updateDashboardAndCards } from "metabase/dashboard/actions/save";
-import { useConfirmLeaveModal } from "metabase/hooks/use-confirm-leave-modal";
+import { useConfirmRouteLeaveModal } from "metabase/hooks/use-confirm-route-leave-modal";
 import { useDispatch } from "metabase/lib/redux";
 import { dismissAllUndo } from "metabase/redux/undo";
 import { Button, Flex, Modal, Text } from "metabase/ui";
@@ -24,7 +24,7 @@ export const DashboardLeaveConfirmationModal = withRouter(
   }: DashboardLeaveConfirmationModalProps) => {
     const dispatch = useDispatch();
 
-    const { opened, close, confirm, nextLocation } = useConfirmLeaveModal({
+    const { opened, close, confirm, nextLocation } = useConfirmRouteLeaveModal({
       isEnabled: isEditing && isDirty,
       route,
       router,

--- a/frontend/src/metabase/dashboard/components/DashboardLeaveConfirmationModal/DashboardLeaveConfirmationModal.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardLeaveConfirmationModal/DashboardLeaveConfirmationModal.tsx
@@ -1,64 +1,62 @@
-import type { Route } from "react-router";
+import { type Route, type WithRouterProps, withRouter } from "react-router";
 import { t } from "ttag";
 
 import ConfirmContent from "metabase/components/ConfirmContent";
-import {
-  LeaveConfirmationModal,
-  LeaveConfirmationModalContent,
-} from "metabase/components/LeaveConfirmationModal";
+import { LeaveConfirmationModalContent } from "metabase/components/LeaveConfirmationModal";
 import { updateDashboardAndCards } from "metabase/dashboard/actions/save";
+import { useConfirmLeaveModal } from "metabase/hooks/use-confirm-leave-modal";
 import { useDispatch } from "metabase/lib/redux";
 import { dismissAllUndo } from "metabase/redux/undo";
+import { Modal } from "metabase/ui";
 
 import { isNavigatingToCreateADashboardQuestion } from "./utils";
 
-interface DashboardLeaveConfirmationModalProps {
+interface DashboardLeaveConfirmationModalProps extends WithRouterProps {
   isEditing: boolean;
   isDirty: boolean;
   route: Route;
 }
 
-export const DashboardLeaveConfirmationModal = ({
-  isEditing,
-  isDirty,
-  route,
-}: DashboardLeaveConfirmationModalProps) => {
-  const dispatch = useDispatch();
+export const DashboardLeaveConfirmationModal = withRouter(
+  ({
+    isEditing,
+    isDirty,
+    router,
+    route,
+  }: DashboardLeaveConfirmationModalProps) => {
+    const dispatch = useDispatch();
 
-  // TODO: should this come from props?
-  const onSave = async () => {
-    dispatch(dismissAllUndo());
-    await dispatch(updateDashboardAndCards());
-  };
+    const { opened, close, confirm, nextLocation } = useConfirmLeaveModal({
+      isEnabled: isEditing && isDirty,
+      route,
+      router,
+    });
 
-  return (
-    <LeaveConfirmationModal isEnabled={isEditing && isDirty} route={route}>
-      {({ nextLocation, onAction, onClose }) => {
-        if (isNavigatingToCreateADashboardQuestion(nextLocation)) {
-          return (
-            <ConfirmContent
-              cancelButtonText={t`Cancel`}
-              confirmButtonText={t`Save changes and go`}
-              confirmButtonPrimary
-              data-testid="leave-for-new-dashboard-question-confirmation"
-              message={t`That’ll keep things tidy.`}
-              title={t`Let’s save your changes and create your new question`}
-              onAction={async () => {
-                await onSave();
-                onAction?.();
-              }}
-              onClose={onClose}
-            />
-          );
-        }
+    const onSave = async () => {
+      dispatch(dismissAllUndo());
+      await dispatch(updateDashboardAndCards());
+    };
 
-        return (
-          <LeaveConfirmationModalContent
-            onAction={onAction}
-            onClose={onClose}
+    return (
+      <Modal opened={opened} onClose={close} size="md">
+        {isNavigatingToCreateADashboardQuestion(nextLocation) ? (
+          <ConfirmContent
+            cancelButtonText={t`Cancel`}
+            confirmButtonText={t`Save changes and go`}
+            confirmButtonPrimary
+            data-testid="leave-for-new-dashboard-question-confirmation"
+            message={t`That’ll keep things tidy.`}
+            title={t`Let’s save your changes and create your new question`}
+            onAction={async () => {
+              await onSave();
+              confirm?.();
+            }}
+            onClose={close}
           />
-        );
-      }}
-    </LeaveConfirmationModal>
-  );
-};
+        ) : (
+          <LeaveConfirmationModalContent onAction={confirm} onClose={close} />
+        )}
+      </Modal>
+    );
+  },
+);

--- a/frontend/src/metabase/dashboard/components/DashboardLeaveConfirmationModal/DashboardLeaveConfirmationModal.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardLeaveConfirmationModal/DashboardLeaveConfirmationModal.tsx
@@ -55,14 +55,9 @@ export const DashboardLeaveConfirmationModal = withRouter(
         };
 
     return (
-      <Modal.Root
-        opened={opened}
-        onClose={close}
-        size={"28.5rem"}
-        data-testid="leave-confirmation"
-      >
+      <Modal.Root opened={opened} onClose={close} size="28.5rem">
         <Modal.Overlay />
-        <Modal.Content>
+        <Modal.Content data-testid="leave-confirmation">
           <Modal.Header p="2.5rem 3rem" mb="sm">
             <Modal.Title fz="1rem" color="text-primary">
               {content.title}

--- a/frontend/src/metabase/dashboard/components/DashboardLeaveConfirmationModal/DashboardLeaveConfirmationModal.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardLeaveConfirmationModal/DashboardLeaveConfirmationModal.tsx
@@ -1,13 +1,11 @@
 import { type Route, type WithRouterProps, withRouter } from "react-router";
 import { t } from "ttag";
 
-import ConfirmContent from "metabase/components/ConfirmContent";
-import { LeaveConfirmationModalContent } from "metabase/components/LeaveConfirmationModal";
 import { updateDashboardAndCards } from "metabase/dashboard/actions/save";
 import { useConfirmLeaveModal } from "metabase/hooks/use-confirm-leave-modal";
 import { useDispatch } from "metabase/lib/redux";
 import { dismissAllUndo } from "metabase/redux/undo";
-import { Modal } from "metabase/ui";
+import { Button, Flex, Modal, Text } from "metabase/ui";
 
 import { isNavigatingToCreateADashboardQuestion } from "./utils";
 
@@ -35,28 +33,58 @@ export const DashboardLeaveConfirmationModal = withRouter(
     const onSave = async () => {
       dispatch(dismissAllUndo());
       await dispatch(updateDashboardAndCards());
+      confirm?.();
     };
 
+    const content = isNavigatingToCreateADashboardQuestion(nextLocation)
+      ? {
+          title: t`Save your changes?`,
+          message: t`You’ll need to save your changes before leaving to create a new question.`,
+          actionBtn: {
+            color: "primary",
+            message: t`Save changes`,
+          },
+        }
+      : {
+          title: t`Discard your changes?`,
+          message: t`Your changes haven't been saved, so you'll lose them if you navigate away.`,
+          actionBtn: {
+            color: "danger",
+            message: t`Discard changes`,
+          },
+        };
+
     return (
-      <Modal opened={opened} onClose={close} size="md">
-        {isNavigatingToCreateADashboardQuestion(nextLocation) ? (
-          <ConfirmContent
-            cancelButtonText={t`Cancel`}
-            confirmButtonText={t`Save changes and go`}
-            confirmButtonPrimary
-            data-testid="leave-for-new-dashboard-question-confirmation"
-            message={t`That’ll keep things tidy.`}
-            title={t`Let’s save your changes and create your new question`}
-            onAction={async () => {
-              await onSave();
-              confirm?.();
-            }}
-            onClose={close}
-          />
-        ) : (
-          <LeaveConfirmationModalContent onAction={confirm} onClose={close} />
-        )}
-      </Modal>
+      <Modal.Root
+        opened={opened}
+        onClose={close}
+        size={"28.5rem"}
+        data-testid="leave-confirmation"
+      >
+        <Modal.Overlay />
+        <Modal.Content>
+          <Modal.Header p="2.5rem 3rem" mb="sm">
+            <Modal.Title fz="1rem" color="text-primary">
+              {content.title}
+            </Modal.Title>
+          </Modal.Header>
+          <Modal.Body p="2.5rem 3rem">
+            <Text lh="1.5rem" mb={"lg"}>
+              {content.message}
+            </Text>
+            <Flex justify="flex-end" gap="md">
+              <Button onClick={close}>{t`Cancel`}</Button>
+              <Button
+                color={content.actionBtn.color}
+                variant="filled"
+                onClick={onSave}
+              >
+                {content.actionBtn.message}
+              </Button>
+            </Flex>
+          </Modal.Body>
+        </Modal.Content>
+      </Modal.Root>
     );
   },
 );

--- a/frontend/src/metabase/hooks/use-confirm-leave-modal.ts
+++ b/frontend/src/metabase/hooks/use-confirm-leave-modal.ts
@@ -20,17 +20,11 @@ interface UseConfirmLeaveModalResult {
   nextLocation: Location | undefined;
 }
 
-export const IS_LOCATION_ALLOWED = (location?: Location) => {
-  /**
-   * If there is no "location" then it's beforeunload event, which is
-   * handled by useBeforeUnload hook - no reason to duplicate its work.
-   */
-  if (!location) {
-    return true;
-  }
-
-  return false;
-};
+/**
+ * If there is no "location" then it's beforeunload event, which is
+ * handled by useBeforeUnload hook - no reason to duplicate its work.
+ */
+export const IS_LOCATION_ALLOWED = (location?: Location) => !location;
 
 export const useConfirmLeaveModal = ({
   router,

--- a/frontend/src/metabase/hooks/use-confirm-leave-modal.ts
+++ b/frontend/src/metabase/hooks/use-confirm-leave-modal.ts
@@ -17,7 +17,6 @@ interface UseConfirmLeaveModalResult {
   opened: boolean;
   close: () => void;
   confirm: () => void;
-  // TODO: remove, only used by custom children option used for the dashboard edit view
   nextLocation: Location | undefined;
 }
 

--- a/frontend/src/metabase/hooks/use-confirm-leave-modal.ts
+++ b/frontend/src/metabase/hooks/use-confirm-leave-modal.ts
@@ -1,0 +1,79 @@
+import type { Location } from "history";
+import { useCallback, useEffect, useState } from "react";
+import type { InjectedRouter, Route } from "react-router";
+import { push } from "react-router-redux";
+
+import useBeforeUnload from "metabase/hooks/use-before-unload";
+import { useDispatch } from "metabase/lib/redux";
+
+interface UseConfirmLeaveModalInput {
+  router: InjectedRouter;
+  route: Route;
+  isEnabled: boolean;
+  isLocationAllowed?: (location: Location | undefined) => boolean;
+}
+
+interface UseConfirmLeaveModalResult {
+  opened: boolean;
+  close: () => void;
+  confirm: () => void;
+  // TODO: remove, only used by custom children option used for the dashboard edit view
+  nextLocation: Location | undefined;
+}
+
+export const IS_LOCATION_ALLOWED = (location?: Location) => {
+  /**
+   * If there is no "location" then it's beforeunload event, which is
+   * handled by useBeforeUnload hook - no reason to duplicate its work.
+   */
+  if (!location) {
+    return true;
+  }
+
+  return false;
+};
+
+export const useConfirmLeaveModal = ({
+  router,
+  route,
+  isEnabled,
+  isLocationAllowed = IS_LOCATION_ALLOWED,
+}: UseConfirmLeaveModalInput): UseConfirmLeaveModalResult => {
+  const dispatch = useDispatch();
+  const [nextLocation, setNextLocation] = useState<Location | undefined>();
+
+  const [opened, setOpened] = useState<boolean>(false);
+  const close = useCallback(() => setOpened(false), []);
+
+  const [isConfirmed, setIsConfirmed] = useState(false);
+  const confirm = useCallback(() => {
+    setIsConfirmed(true);
+  }, []);
+
+  useBeforeUnload(isEnabled);
+
+  useEffect(() => {
+    const removeLeaveHook = router.setRouteLeaveHook(route, location => {
+      if (isEnabled && !isConfirmed && !isLocationAllowed?.(location)) {
+        setOpened(true);
+        setNextLocation(location);
+        return false;
+      }
+    });
+
+    return removeLeaveHook;
+  }, [isLocationAllowed, router, route, isEnabled, isConfirmed]);
+
+  useEffect(() => {
+    if (isConfirmed && nextLocation) {
+      dispatch(push(nextLocation));
+    }
+  }, [dispatch, isConfirmed, nextLocation]);
+
+  return {
+    opened,
+    close,
+    confirm,
+    nextLocation,
+  };
+};

--- a/frontend/src/metabase/hooks/use-confirm-route-leave-modal.ts
+++ b/frontend/src/metabase/hooks/use-confirm-route-leave-modal.ts
@@ -26,7 +26,14 @@ interface UseConfirmLeaveModalResult {
  */
 export const IS_LOCATION_ALLOWED = (location?: Location) => !location;
 
-export const useConfirmLeaveModal = ({
+// NOTE: there's a similar hook called useConfirmOnRouteLeave that should
+// ported to use this format instead
+
+/**
+ * Provides props for using a Modal that is presented to users
+ * whenever they try to leave a route
+ */
+export const useConfirmRouteLeaveModal = ({
   router,
   route,
   isEnabled,

--- a/frontend/src/metabase/hooks/use-modal.ts
+++ b/frontend/src/metabase/hooks/use-modal.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 
-type ModalHookResult = {
+export type ModalHookResult = {
   opened: boolean;
   open: () => void;
   close: () => void;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/51237

### Description

This PR polishes the "save changes" modal when creating a new question in a dashboard and updates the existing "discard changes" warning modal to match. Design can be found here: [Figma Link](https://www.figma.com/design/YzWNe48JlYGjhmFFtoAdTy/Questions-in-Dashboards---open-questions-answers?node-id=7-132&t=vCMTc9rDyyGS92cu-4).

As part of my solution, changing the confirm leave modal everywhere seems too high risk of a change for such a small ask of design. I instead chose to move the core logic in our `LeaveConfirmationModal` component into a hook which could be used by any ol' Mantine modal. This frees up folks to compose this hook with any modal to do whatever they'd like.

### How to verify

Save changes scenario
- Edit a dashboard w/ content
- Move an existing card
- Add a new dashboard question
- You should encounter the correct modal

Save changes scenario
- Edit a dashboard w/ content
- Move an existing card
- Try to go back in browser history
- You should encounter the correct modal

### Demo

![CleanShot 2024-12-16 at 13 28 01@2x](https://github.com/user-attachments/assets/7b1fd365-6585-432d-8ca4-11f7eb6ab6ef)

![CleanShot 2024-12-16 at 13 28 19@2x](https://github.com/user-attachments/assets/958b2f0d-b66b-40fe-bb8b-6be549277cea)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR