### PR TITLE
[refs] Ignore `:ident`s when comparing queries

### DIFF
--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -12,7 +12,8 @@
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    [metabase.test-runner.assert-exprs.approximately-equal]
-   [metabase.test.util.js :as test.js]))
+   [metabase.test.util.js :as test.js]
+   [metabase.util :as u]))
 
 (deftest ^:parallel query=-test
   (doseq [q1 [nil js/undefined]
@@ -56,6 +57,36 @@
       (is (lib.js/query= q1 q2))
       (is (not (lib.js/query= q1 q3)))
       (is (not (lib.js/query= q2 q3))))))
+
+(deftest ^:parallel query=-idents-test
+  (testing "idents are ignored for query="
+    (testing "on legacy queries"
+      (let [q1 #js {"query" #js {"source-table"       1
+                                 "aggregation"        #js [#js ["count"]]
+                                 "aggregation-idents" #js {"0" (u/generate-nano-id)}
+                                 "breakout"           #js [#js ["field" 3 nil]]
+                                 "breakout-idents"    #js {"0" (u/generate-nano-id)}
+                                 "expressions"        #js {"some_expr" #js ["field" 12 nil]}
+                                 "expression-idents"  #js {"some_expr" (u/generate-nano-id)}}}
+            ;; Same query, but idents will be different.
+            q2 #js {"query" #js {"source-table"       1
+                                 "aggregation"        #js [#js ["count"]]
+                                 "aggregation-idents" #js {"0" (u/generate-nano-id)}
+                                 "breakout"           #js [#js ["field" 3 nil]]
+                                 "breakout-idents"    #js {"0" (u/generate-nano-id)}
+                                 "expressions"        #js {"some_expr" #js ["field" 12 nil]}
+                                 "expression-idents"  #js {"some_expr" (u/generate-nano-id)}}}]
+        (is (lib.js/query= q1 q2))))
+    (testing "on pMBQL queries"
+      (let [q1 (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                   (lib/expression "some_expr" (lib/+ (meta/field-metadata :orders :subtotal) 1))
+                   (lib/aggregate (lib/count))
+                   (lib/breakout (meta/field-metadata :products :category)))
+            q2 (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                   (lib/expression "some_expr" (lib/+ (meta/field-metadata :orders :subtotal) 1))
+                   (lib/aggregate (lib/count))
+                   (lib/breakout (meta/field-metadata :products :category)))]
+        (is (lib.js/query= q1 q2))))))
 
 (deftype FakeJoin [guts]
   Object


### PR DESCRIPTION
### Description

`query=` logic was returning false negatives when two queries were identical except for their `:ident`s.

This broke Metrics UI, for example, since it makes up a query based on the "old" and "new" metrics, and
compares those queries.

Now `:ident`s are ignored by `query=`, so two queries of the same shape are equal.

### How to verify

Try looking at a saved Metric. Previously, it always showed greyed out and with the "Play" button.
With this change, it works properly.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
