### PR TITLE
ci(sdk): re-enable cross-version component tests workflow

### DIFF
--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -127,6 +127,116 @@ jobs:
               sdk_version,
             };
 
+  e2e-tests:
+    needs: [get-build-requirements, build, resolve-sdk-version]
+    if: |
+      !cancelled() && needs.build.result == 'success'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+    name: e2e-tests-embedding-sdk
+    env:
+      MB_EDITION: ee
+      DISPLAY: ""
+      # Any env starting with `CYPRESS_` will be available to all Cypress tests via `Cypress.env()`
+      # Example: you can get `CYPRESS_FOO` with `Cypress.env("FOO")`
+      CYPRESS_ALL_FEATURES_TOKEN: ${{ secrets.ENTERPRISE_TOKEN }}
+      CYPRESS_NO_FEATURES_TOKEN: ${{ secrets.E2E_STARTER_TOKEN }}
+      CYPRESS_PULL_REQUEST_ID: ${{ github.event.pull_request.number || '' }}
+      COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title || github.event.head_commit.message || github.event.head.sha }}
+      TZ: US/Pacific # to make node match the instance tz
+      CYPRESS_CI: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare Docker containers
+        uses: ./.github/actions/e2e-prepare-containers
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Needed to omit newly added tests for functionality that is not yet released
+      - name: Sparse checkout tests from SDK release commit
+        uses: actions/checkout@v4
+        with:
+          ref: embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }}
+          path: sdk-release-e2e
+          sparse-checkout: e2e
+
+      - name: Move tests from the release commit into the repo
+        run: |
+          rm -rf ./e2e/support/helpers/*
+          mv ./sdk-release-e2e/e2e/support/helpers/* ./e2e/support/helpers
+          rm -rf ./e2e/test-component/*
+          mv ./sdk-release-e2e/e2e/test-component/* ./e2e/test-component
+        shell: bash
+
+      - name: Retrieve uberjar artifact for ee
+        uses: actions/download-artifact@v4
+        with:
+          name: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
+
+      - name: Get the version info
+        run: |
+          jar xf target/uberjar/metabase.jar version.properties
+          mv version.properties resources/
+
+      - name: Prepare front-end environment
+        uses: ./.github/actions/prepare-frontend
+
+      - name: Prepare JDK ${{ needs.get-build-requirements.outputs.java_version || 11 }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ needs.get-build-requirements.outputs.java_version || 11 }}
+          distribution: "temurin"
+
+      - name: Prepare Cypress environment
+        id: cypress-prep
+        uses: ./.github/actions/prepare-cypress
+
+      - name: Install Embedding SDK package v${{ needs.resolve-sdk-version.outputs.sdk_version }}
+        run: yarn add @metabase/embedding-sdk-react@${{ needs.resolve-sdk-version.outputs.sdk_version }}
+
+      - name: Run E2E tests for Embedding SDK
+        run: yarn run test-cypress-run-component-sdk --browser ${{ steps.cypress-prep.outputs.chrome-path }}
+
+      - name: Upload Test Results
+        uses: ./.github/actions/upload-test-results
+        if: always()
+        with:
+          input-path: ./target/junit
+          output-name: e2e-embedding-sdk
+          bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+          aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+          trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+
+      - name: Upload Cypress Artifacts upon failure
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: cypress-recording-embedding-sdk-cross-version
+          path: |
+            ./cypress
+            ./logs/test.log
+          if-no-files-found: ignore
+
+      - name: Publish Summary
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: | #js
+            const {
+               parseReport,
+               formatSummary
+             } = require("./.github/scripts/handle-mochawesome-report.js");
+
+             const report = parseReport();
+             const summary = formatSummary(report);
+
+             await core.summary.addRaw(summary).write();
+
   e2e-tests-skipped-stub:
     needs: [e2e-tests]
     if: |

--- a/enterprise/frontend/src/embedding-sdk/index.ts
+++ b/enterprise/frontend/src/embedding-sdk/index.ts
@@ -28,3 +28,5 @@ export type {
 } from "./types/theme";
 
 export type { Dashboard } from "metabase-types/api";
+
+// REVERT ME - bogus comment to force e2e tests to run


### PR DESCRIPTION
This reverts https://github.com/metabase/metabase/pull/51265 to re-enable cross-version component tests. We've merged, backported and released https://github.com/metabase/metabase/pull/51328 so cross-version tests should be passing now.