### PR TITLE
Entity picker search dashboard questions

### DIFF
--- a/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
+++ b/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
@@ -7,6 +7,7 @@ import {
   NORMAL_PERSONAL_COLLECTION_ID,
   NO_COLLECTION_PERSONAL_COLLECTION_ID,
   ORDERS_COUNT_QUESTION_ID,
+  ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
 import type { DashboardCard } from "metabase-types/api";
@@ -353,6 +354,22 @@ describe("scenarios > organization > entity picker", () => {
           H.getNotebookStep("data").findByText(sourceName).should("be.visible");
           H.visualize();
         });
+
+        cy.log("scope search in a dashboard");
+        H.startNewQuestion();
+        H.entityPickerModal().within(() => {
+          H.entityPickerModalTab("Collections").click();
+          H.entityPickerModalItem(1, "Orders in a dashboard").click();
+          enterSearchText({
+            text: "Orders",
+            placeholder: "Search this dashboard or everywhere…",
+          });
+          cy.findByText("Orders Dashboard question 2").click();
+        });
+        H.getNotebookStep("data")
+          .findByText("Orders Dashboard question 2")
+          .should("be.visible");
+        H.visualize();
       });
 
       it("should select a card from global search results", () => {
@@ -391,6 +408,22 @@ describe("scenarios > organization > entity picker", () => {
           H.getNotebookStep("data").findByText(sourceName).should("be.visible");
           H.visualize();
         });
+
+        cy.log("should find dashboard questions in global search");
+        H.startNewQuestion();
+        H.entityPickerModal().within(() => {
+          H.entityPickerModalTab("Collections").click();
+          enterSearchText({
+            text: "Dashboard question 1",
+            placeholder: "Search this collection or everywhere…",
+          });
+          selectGlobalSearchTab();
+          cy.findByText("Orders Dashboard question 1").click();
+        });
+        H.getNotebookStep("data")
+          .findByText("Orders Dashboard question 1")
+          .should("be.visible");
+        H.visualize();
       });
 
       it("should search for cards for a normal user", () => {
@@ -1003,6 +1036,14 @@ function createTestCards() {
           collection_id: id,
         });
       });
+    });
+  });
+
+  suffixes.forEach(suffix => {
+    H.createQuestion({
+      ...cardDetails,
+      name: `Orders Dashboard question ${suffix}`,
+      dashboard_id: ORDERS_DASHBOARD_ID,
     });
   });
 }

--- a/frontend/src/metabase-types/api/activity.ts
+++ b/frontend/src/metabase-types/api/activity.ts
@@ -1,6 +1,7 @@
 import type { CollectionId } from "./collection";
 import type { DashboardId } from "./dashboard";
 import type { DatabaseId, InitialSyncStatus } from "./database";
+import type { ModerationReviewStatus } from "./moderation";
 import type { CardDisplayType } from "./visualization";
 
 export const ACTIVITY_MODELS = [
@@ -58,6 +59,7 @@ export type RecentCollectionItem = BaseRecentItem & {
   dashboard?: {
     name: string;
     id: DashboardId;
+    moderation_status: ModerationReviewStatus;
   };
 };
 

--- a/frontend/src/metabase/api/dashboard.ts
+++ b/frontend/src/metabase/api/dashboard.ts
@@ -76,7 +76,7 @@ export const dashboardApi = Api.injectEndpoints({
         providesTags: metadata =>
           metadata ? provideDashboardQueryMetadataTags(metadata) : [],
       }),
-      getDashboardItemsList: builder.query<
+      listDashboardItems: builder.query<
         ListCollectionItemsResponse,
         Omit<ListCollectionItemsRequest, "id"> & { id: DashboardId }
       >({
@@ -201,7 +201,7 @@ export const {
   useGetDashboardQuery,
   useGetDashboardQueryMetadataQuery,
   useListDashboardsQuery,
-  useGetDashboardItemsListQuery,
+  useListDashboardItemsQuery,
   useCreateDashboardMutation,
   useUpdateDashboardMutation,
   useSaveDashboardMutation,

--- a/frontend/src/metabase/common/components/CollectionPicker/components/DashboardItemList.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/DashboardItemList.tsx
@@ -1,4 +1,4 @@
-import { skipToken, useGetDashboardItemsListQuery } from "metabase/api";
+import { skipToken, useListDashboardItemsQuery } from "metabase/api";
 
 import { ItemList } from "../../EntityPicker";
 import type { CollectionItemListProps, CollectionPickerItem } from "../types";
@@ -16,7 +16,7 @@ export const DashboardItemList = ({
     data: dashboardItems,
     error,
     isLoading,
-  } = useGetDashboardItemsListQuery<{
+  } = useListDashboardItemsQuery<{
     data: {
       data: CollectionPickerItem[];
     };

--- a/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
@@ -132,7 +132,11 @@ export const DataPickerModal = ({
   );
 
   const searchParams = useMemo(() => {
-    return databaseId ? { table_db_id: databaseId } : undefined;
+    const tableParams = databaseId ? { table_db_id: databaseId } : undefined;
+    return {
+      include_dashboard_questions: true,
+      ...tableParams,
+    };
   }, [databaseId]);
 
   const handleItemSelect = useCallback(
@@ -199,7 +203,7 @@ export const DataPickerModal = ({
         id: "questions-tab",
         displayName: t`Collections`,
         models: ["card" as const, "dataset" as const, "metric" as const],
-        folderModels: ["collection" as const],
+        folderModels: ["collection" as const, "dashboard" as const],
         icon: "folder",
         extraButtons: [filterButton],
         render: ({ onItemSelect }) => (

--- a/frontend/src/metabase/common/components/DataPicker/types.ts
+++ b/frontend/src/metabase/common/components/DataPicker/types.ts
@@ -1,6 +1,7 @@
 import type {
   CardId,
   Collection,
+  DashboardId,
   DatabaseId,
   SchemaName,
   TableId,
@@ -42,6 +43,12 @@ export type QuestionItem = {
   model: "card";
 };
 
+export type DashboardItem = {
+  id: DashboardId;
+  name: string;
+  model: "dashboard";
+};
+
 export type ModelItem = {
   id: CardId;
   name: string;
@@ -68,7 +75,11 @@ export type DataPickerValue =
   | ModelItem
   | MetricItem;
 
-export type DataPickerFolderItem = CollectionItem | DatabaseItem | SchemaItem;
+export type DataPickerFolderItem =
+  | CollectionItem
+  | DatabaseItem
+  | SchemaItem
+  | DashboardItem;
 
 export type DataPickerValueItem =
   | TableItem

--- a/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.tsx
@@ -105,6 +105,13 @@ function getParentInfo(item: SearchItem) {
     return null;
   }
 
+  if (item.dashboard) {
+    return {
+      icon: getIcon({ model: "dashboard", ...item.dashboard }).name,
+      name: getName(item.dashboard),
+    };
+  }
+
   if (!item.collection) {
     return null;
   }

--- a/frontend/src/metabase/common/components/EntityPicker/types.ts
+++ b/frontend/src/metabase/common/components/EntityPicker/types.ts
@@ -90,6 +90,7 @@ export type SearchItem = Pick<SearchResult, "id" | "model" | "name"> &
     Pick<
       SearchResult,
       | "collection"
+      | "dashboard"
       | "description"
       | "collection_authority_level"
       | "moderated_status"

--- a/frontend/src/metabase/common/components/EntityPicker/utils.ts
+++ b/frontend/src/metabase/common/components/EntityPicker/utils.ts
@@ -170,6 +170,10 @@ export const getSearchInputPlaceholder = <
     return t`Search this schema or everywhere…`;
   }
 
+  if (folder?.model === "dashboard") {
+    return t`Search this dashboard or everywhere…`;
+  }
+
   return t`Search…`;
 };
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/51346

### Description
Adds dashboards as a possible scope for searching in the entity picker, as well as surfaces dashboard questions in data picker search

### How to verify

1. New question -> Choose a dashboard that contains questions
2. Search bar should say "Search in this dashboard". Do a search and see that results are scoped to the current dashboard
3. Now click "Everywhere" and search for other dashboard questions. They should appear in search results, with the parent dashboard in the result item on the right.

### Demo
![image](https://github.com/user-attachments/assets/6f26554b-fe61-466d-bb55-fbccec5c93ff)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
