### PR TITLE
Avoid frequent setState calls in the add parameter popover in dashboards

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/AddFilterParameterButton/AddFilterParameterButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/AddFilterParameterButton/AddFilterParameterButton.tsx
@@ -41,7 +41,9 @@ export const AddFilterParameterButton = () => {
   };
 
   useLayoutEffect(() => {
-    setRightSectionWidth(rightSectionWidthRef.current);
+    if (isOpened) {
+      setRightSectionWidth(rightSectionWidthRef.current);
+    }
   }, [isOpened]);
 
   return (

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/AddFilterParameterButton/AddFilterParameterButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/AddFilterParameterButton/AddFilterParameterButton.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import { t } from "ttag";
 
 import { ToolbarButton } from "metabase/components/ToolbarButton";
@@ -20,8 +20,9 @@ import { Icon, Menu, Text } from "metabase/ui";
 export const AddFilterParameterButton = () => {
   const sections = getDashboardParameterSections();
   const dispatch = useDispatch();
-  const isAddParameterPopoverOpen = useSelector(getIsAddParameterPopoverOpen);
-  const [maxRightSectionWidth, setMaxRightSectionWidth] = useState(0);
+  const isOpened = useSelector(getIsAddParameterPopoverOpen);
+  const [rightSectionWidth, setRightSectionWidth] = useState(0);
+  const rightSectionWidthRef = useRef(0);
 
   const handleItemClick = (section: ParameterSection) => {
     const defaultOption = getDefaultOptionForParameterSectionMap()[section.id];
@@ -32,15 +33,20 @@ export const AddFilterParameterButton = () => {
 
   const handleRightSectionRef = (rightSection: HTMLDivElement | null) => {
     if (rightSection) {
-      setMaxRightSectionWidth(maxWidth =>
-        Math.max(maxWidth, rightSection.clientWidth),
+      rightSectionWidthRef.current = Math.max(
+        rightSectionWidthRef.current,
+        rightSection.clientWidth,
       );
     }
   };
 
+  useLayoutEffect(() => {
+    setRightSectionWidth(rightSectionWidthRef.current);
+  }, [isOpened]);
+
   return (
     <Menu
-      opened={isAddParameterPopoverOpen}
+      opened={isOpened}
       onClose={() => dispatch(hideAddParameterPopover())}
       position="bottom-end"
     >
@@ -48,7 +54,7 @@ export const AddFilterParameterButton = () => {
         <ToolbarButton
           icon="filter"
           onClick={() =>
-            isAddParameterPopoverOpen
+            isOpened
               ? dispatch(hideAddParameterPopover())
               : dispatch(showAddParameterPopover())
           }
@@ -66,7 +72,7 @@ export const AddFilterParameterButton = () => {
               <Text
                 ref={handleRightSectionRef}
                 c="inherit"
-                miw={maxRightSectionWidth}
+                miw={rightSectionWidth}
               >
                 {section.description}
               </Text>


### PR DESCRIPTION
Tries to fix a non-reproducible issue from https://metaboat.slack.com/archives/C013N8XL286/p1734048949422669. Based on the logs there was a React exception in `handleRightSectionRef` in `setState` call; it doesn't like that we might want to call it several times in a row:

```
"{\"name\":\"Error\",\"message\":\"Minified React error #185; visit https://reactjs.org/docs/error-decoder.html?invariant=185 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.\",\"stack\":\"Error: Minified React error #185; visit https://reactjs.org/docs/error-decoder.html?invariant=185
```

```
g=e=>{e&&f(t=>Math.max(t,e.clientWidth))}
```

In this PR I store the max width in a ref and re-render only once when the popover is opened.

How to verify:
- Dashboard -> Edit -> Click Add parameter
- The popover should have the same layout as before

<img width="402" alt="Screenshot 2024-12-16 at 21 34 56" src="https://github.com/user-attachments/assets/4da808a4-f6b9-4e34-9483-75b9deea3c58" />
