### PR TITLE
Send pulse asynchronously with a small pool size

### DIFF
--- a/src/metabase/notification/core.clj
+++ b/src/metabase/notification/core.clj
@@ -4,6 +4,7 @@
    [metabase.notification.payload.core :as notification.payload]
    [metabase.notification.seed :as notification.seed]
    [metabase.notification.send :as notification.send]
+   [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [potemkin :as p]))
 
@@ -31,6 +32,7 @@
   "The function to send a notification. Defaults to `notification.send/send-notification-async!`."
   [notification & {:keys [] :as options} :- [:maybe Options]]
   (let [options (merge *default-options* options)]
+    (log/debugf "Sending notification: %s %s" (:id notification) (if (:notification/sync? options) "synchronously" "asynchronously"))
     (if (:notification/sync? options)
       (notification.send/send-notification-sync! notification)
       (notification.send/send-notification-async! notification))))

--- a/src/metabase/notification/send.clj
+++ b/src/metabase/notification/send.clj
@@ -32,7 +32,7 @@
 
 (setting/defsetting notification-thread-pool-size
   "The size of the thread pool used to send notifications."
-  :default 10
+  :default 2
   :export? false
   :type :integer
   :visibility :internal)

--- a/src/metabase/notification/send.clj
+++ b/src/metabase/notification/send.clj
@@ -32,9 +32,9 @@
 
 (setting/defsetting notification-thread-pool-size
   "The size of the thread pool used to send notifications."
-  :default 2
-  :export? false
-  :type :integer
+  :default    2
+  :export?    false
+  :type       :integer
   :visibility :internal)
 
 (defonce ^:private pool

--- a/src/metabase/pulse/send.clj
+++ b/src/metabase/pulse/send.clj
@@ -96,14 +96,14 @@
 (def ^:private send-notification! (requiring-resolve 'metabase.notification.core/send-notification!))
 
 (defn- send-pulse!*
-  [{:keys [channels channel-ids] :as pulse} dashboard]
+  [{:keys [channels channel-ids] :as pulse} dashboard async?]
   (let [;; `channel-ids` is the set of channels to send to now, so only send to those. Note the whole set of channels
         channels   (if (seq channel-ids)
                      (filter #((set channel-ids) (:id %)) channels)
                      channels)]
     (doseq [pulse-channel channels]
       (try
-        (send-notification! (notification-info pulse dashboard pulse-channel))
+        (send-notification! (notification-info pulse dashboard pulse-channel) :notification/sync? (not async?))
         (catch Exception e
           (log/errorf e "[Pulse %d] Error sending to %s channel" (:id pulse) (:channel_type pulse-channel)))))
     nil))
@@ -119,7 +119,8 @@
 
     (send-pulse! pulse)                    ; Send to all Channels
     (send-pulse! pulse :channel-ids [312]) ; Send only to Channel with :id = 312"
-  [{:keys [dashboard_id], :as pulse} & {:keys [channel-ids]}]
+  [{:keys [dashboard_id], :as pulse} & {:keys [channel-ids async?]
+                                        :or   {async? false}}]
   {:pre [(map? pulse) (integer? (:creator_id pulse))]}
   (let [dashboard (t2/select-one :model/Dashboard :id dashboard_id)
         pulse     (-> (mi/instance :model/Pulse pulse)
@@ -128,4 +129,4 @@
                       models.pulse/hydrate-notification
                       (merge (when channel-ids {:channel-ids channel-ids})))]
     (when (not (:archived dashboard))
-      (send-pulse!* pulse dashboard))))
+      (send-pulse!* pulse dashboard async?))))

--- a/src/metabase/task/send_pulses.clj
+++ b/src/metabase/task/send_pulses.clj
@@ -89,8 +89,8 @@
      (cron/schedule
       (cron/cron-schedule (u.cron/schedule-map->cron-string schedule-map))
       (cron/in-time-zone (TimeZone/getTimeZone ^String timezone))
-      ;; if we miss a sync for one reason or another (such as system being down) do not try to run the sync again.
-      ;; Just wait until the next sync cycle.
+      ;; If the trigger is misfired, fire it immediately and proceed with the next scheduled time.
+      ;; TODO: upon testing, look like re-firing on startup is not working as expected
       ;;
       ;; See https://www.nurkiewicz.com/2012/04/quartz-scheduler-misfire-instructions.html for more info
       (cron/with-misfire-handling-instruction-fire-and-proceed)))

--- a/src/metabase/task/send_pulses.clj
+++ b/src/metabase/task/send_pulses.clj
@@ -15,7 +15,6 @@
    [metabase.driver :as driver]
    [metabase.models.pulse :as models.pulse]
    [metabase.models.task-history :as task-history]
-   [metabase.notification.core :as notification]
    [metabase.pulse.core :as pulse]
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.task :as task]
@@ -56,8 +55,7 @@
                                                     :channel-ids (seq channel-ids)}}
       (when-let [pulse (models.pulse/retrieve-notification pulse-id :archived false)]
         (log/debugf "Starting Pulse Execution: %d" pulse-id)
-        (binding [notification/*default-options* {:notification/sync? true}]
-          (pulse/send-pulse! pulse :channel-ids channel-ids))
+        (pulse/send-pulse! pulse :channel-ids channel-ids :async? true)
         (log/debugf "Finished Pulse Execution: %d" pulse-id)
         :done))
     (catch Throwable e

--- a/test/metabase/channel/impl/http_test.clj
+++ b/test/metabase/channel/impl/http_test.clj
@@ -7,9 +7,9 @@
    [compojure.route :as compojure.route]
    [metabase.channel.core :as channel]
    [metabase.notification.test-util :as notification.tu]
+   [metabase.pulse.send :as pulse.send]
    [metabase.server.handler :as server.handler]
    [metabase.server.middleware.json :as mw.json]
-   [metabase.task.send-pulses :as task.send-pulses]
    [metabase.test :as mt]
    [metabase.util.i18n :refer [deferred-tru]]
    [ring.adapter.jetty :as jetty]
@@ -329,10 +329,10 @@
            :model/Channel      {chn-id :id}  {:type    :channel/http
                                               :details {:url         (str url (:path receive-route))
                                                         :auth-method "none"}}
-           :model/PulseChannel {pc-id :id}   {:pulse_id     pulse-id
+           :model/PulseChannel _             {:pulse_id     pulse-id
                                               :channel_type "http"
                                               :channel_id   chn-id}]
-          (#'task.send-pulses/send-pulse!* pulse-id [pc-id])
+          (pulse.send/send-pulse! (t2/select-one :model/Pulse pulse-id))
           (is (=? {:body {:type               "alert"
                           :alert_id           pulse-id
                           :alert_creator_id   (mt/malli=? int?)

--- a/test/metabase/pulse/send_test.clj
+++ b/test/metabase/pulse/send_test.clj
@@ -850,8 +850,7 @@
                                                  :max-interval-millis     30000}}
             send!                #(#'notification.send/channel-send-retrying! pulse-id :notification/card {:channel_type :channel/slack} fake-slack-notification)]
         (testing "channel send task history task details include retry config"
-          (with-redefs
-           [channel/send! (constantly true)]
+          (with-redefs [channel/send! (constantly true)]
             (send!)
             (is (=? {:task         "channel-send"
                      :db_id        nil


### PR DESCRIPTION
1.1 in https://www.notion.so/metabase/Send-pulse-OOM-15969354c90180a3a43edde37a9298e5?pvs=4

Making SendPulses task push jobs into a fixed thread pool queue of 2.

What's about recovery? it turns out that we didn't have any recovery mechanism before, so if a pulse fails, it won't be re-sent upon restart.
It's not ideal but at least this is not a breaking change.

