### PR TITLE
ci(sdk): reconcile sdk version number in 52 branch with npm

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk/package.template.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabase/embedding-sdk-react",
-  "version": "0.52.2-nightly",
+  "version": "0.52.4-nightly",
   "description": "Metabase Embedding SDK for React",
   "bin": "./dist/cli.js",
   "repository": {


### PR DESCRIPTION
We have released [v0.52.4-nightly](https://www.npmjs.com/package/@metabase/embedding-sdk-react/v/0.52.4-nightly?activeTab=versions) to NPM by using "[release from master]( https://github.com/metabase/metabase/actions/workflows/release-embedding-sdk.yml)", but that broke cross-version tests (see https://github.com/metabase/metabase/pull/51389). This also breaks releasing from `release-x.52.x` from the release workflow as it still understands that 0.52.2 is the latest version:

<img src="https://github.com/user-attachments/assets/027a96a0-9c52-4c73-8988-be3a1fa3369b" width="600">

Let's bump the version number to `0.52.4-nightly` to match what we have in NPM.
