### PR TITLE
ci(sdk): re-enable sdk e2e cross version tests for 52 branch

### DIFF
--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -2,12 +2,15 @@ name: E2E Cross-version Component Tests for Embedding SDK
 
 on:
   push:
-    branches:
-      - "ci-sdk-re-enable-cross-version-52"
-#  pull_request:
-#    types: [opened, synchronize, reopened, ready_for_review]
-#    branches:
-#      - "release-**"
+    # branches:
+    #   - "release-**"
+    branches-ignore: ['**']  # FIXME: ignores all branches until the workflow is fixed
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    # branches:
+    #   - "release-**"
+    branches-ignore: ['**']  # FIXME: ignores all branches until the workflow is fixed
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
@@ -53,9 +56,7 @@ jobs:
               getBuildRequirements,
               getVersionFromReleaseBranch,
             } = require('${{ github.workspace }}/release/dist/index.cjs');
-            // FIXME: revert this once the CI issue is fixed!
-            // const targetBranchName = '${{ github.base_ref || github.ref }}';
-            const targetBranchName = "release-x.52.x"
+            const targetBranchName = '${{ github.base_ref || github.ref }}';
 
             const version = getVersionFromReleaseBranch(targetBranchName);
             const requirements = getBuildRequirements(version);
@@ -116,10 +117,7 @@ jobs:
         with:
           script: | # js
             const { getSdkVersionFromReleaseBranchName } = require('${{ github.workspace }}/release/dist/index.cjs');
-
-            // FIXME: This is for debugging purposes only. TO REVERT.
-            // const branchName = '${{ github.base_ref || github.ref }}';
-            const branchName = "release-x.52.x"
+            const branchName = '${{ github.base_ref || github.ref }}';
 
             const sdk_version = await getSdkVersionFromReleaseBranchName({
               github,

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -2,15 +2,12 @@ name: E2E Cross-version Component Tests for Embedding SDK
 
 on:
   push:
-    # branches:
-    #   - "release-**"
-    branches-ignore: ['**']  # FIXME: ignores all branches until the workflow is fixed
+    branches:
+      - "release-**"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    # branches:
-    #   - "release-**"
-    branches-ignore: ['**']  # FIXME: ignores all branches until the workflow is fixed
-  workflow_dispatch:
+    branches:
+      - "release-**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -2,15 +2,12 @@ name: E2E Cross-version Component Tests for Embedding SDK
 
 on:
   push:
-    # branches:
-    #   - "release-**"
-    branches-ignore: ['**']  # FIXME: ignores all branches until the workflow is fixed
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    # branches:
-    #   - "release-**"
-    branches-ignore: ['**']  # FIXME: ignores all branches until the workflow is fixed
-  workflow_dispatch:
+    branches:
+      - "ci-sdk-re-enable-cross-version-52"
+#  pull_request:
+#    types: [opened, synchronize, reopened, ready_for_review]
+#    branches:
+#      - "release-**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
@@ -56,7 +53,9 @@ jobs:
               getBuildRequirements,
               getVersionFromReleaseBranch,
             } = require('${{ github.workspace }}/release/dist/index.cjs');
-            const targetBranchName = '${{ github.base_ref || github.ref }}';
+            // FIXME: revert this once the CI issue is fixed!
+            // const targetBranchName = '${{ github.base_ref || github.ref }}';
+            const targetBranchName = "release-x.52.x"
 
             const version = getVersionFromReleaseBranch(targetBranchName);
             const requirements = getBuildRequirements(version);
@@ -117,7 +116,10 @@ jobs:
         with:
           script: | # js
             const { getSdkVersionFromReleaseBranchName } = require('${{ github.workspace }}/release/dist/index.cjs');
-            const branchName = '${{ github.base_ref || github.ref }}';
+
+            // FIXME: This is for debugging purposes only. TO REVERT.
+            // const branchName = '${{ github.base_ref || github.ref }}';
+            const branchName = "release-x.52.x"
 
             const sdk_version = await getSdkVersionFromReleaseBranchName({
               github,


### PR DESCRIPTION
Re-enables embedding cross version testing for 52 branch. For real this time!

## Why did the workflow fail?

1. We released the SDK from [master](https://github.com/metabase/metabase/actions/workflows/release-embedding-sdk.yml) instead of from `release-x.52.x` and that causes the cross-version tests to break, because it sparsed-checkout from the git tag `embedding-sdk-0.52.4-nightly` and it brings e2e changes from the `master` branch that is inherently incompatible with `release-x.52.x`
2. The `styles-test` tests was flaking most of the time. 

## How did we fix it?

- We bumped the sdk version number in `master` to 52.4 (instead of 52.2), then released `0.52.5-nightly` from `release-x.52.x` to reconcile the e2e tests with the correct version
- We skipped the failing test case for styles testing.

## How to verify

- Run to check: https://github.com/metabase/metabase/actions/runs/12377949070/job/34549820773?pr=51402.
  - Check that the above has green CI.
  - Commit with passing checks: https://github.com/metabase/metabase/pull/51402/commits/d1a688504f909b9beee8c02fcbf4d227184c8481
  - Note that this is done by tricking the workflow into thinking that this branch is "release-x.52.x", see https://github.com/metabase/metabase/pull/51402/commits/09026adc45e036d5e060afbb14ad383553b05bc3 for more info.

![CleanShot 2567-12-18 at 00 41 44@2x](https://github.com/user-attachments/assets/770ebec2-6464-4859-9142-6f106a63ca1f)
