### PR TITLE
ci(sdk): skip flaky mantine styles test for sdk

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
@@ -236,7 +236,7 @@ describeEE("scenarios > embedding-sdk > styles", () => {
       // TODO: good place for a visual regression test
     });
 
-    it("mantine modals should render with our styles", () => {
+    it.skip("mantine modals should render with our styles", () => {
       cy.mount(
         <MetabaseProvider authConfig={DEFAULT_SDK_AUTH_PROVIDER_CONFIG}>
           <InteractiveQuestion questionId={ORDERS_QUESTION_ID} />


### PR DESCRIPTION
![CleanShot 2567-12-17 at 22 35 02@2x](https://github.com/user-attachments/assets/087a1258-9a20-4b2e-abb5-575d26bb137b)

this is failing in both master and release-x.52.x branches. let's skip it for now