### PR TITLE
Revert to using secrets.GITHUB_TOKEN for the auto-approve PR step

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -210,7 +210,7 @@ jobs:
         if: ${{ steps.create_backport_pull_request.outputs.has-conflicts == 'false' }}
         uses: juliangruber/approve-pull-request-action@v1
         with:
-          github-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           number: ${{ steps.create_backport_pull_request.outputs.backport_pr_number }}
       - name: Enable Pull Request Automerge
         if: ${{ steps.create_backport_pull_request.outputs.has-conflicts == 'false' }}


### PR DESCRIPTION
### Description

Using `secrets.METABASE_AUTOMATION_USER_TOKEN` causes the auto-approve PR step to fail with an error like

> Can not approve your own pull request

Revert to using `secrets.GITHUB_TOKEN` instead, which matches what the auto-backport.yml workflow does and what this workflow did previously.

Example of a failed auto-approve. The backport PR is created, it just isn't approved or set to auto-merge by the bot.

https://github.com/metabase/metabase/pull/51254#issuecomment-2542248706
https://github.com/metabase/metabase/pull/51299

### How to verify

Actually, I'm not sure how to test CI changes. Was planning to try back porting this PR if it's approved.

### Demo

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
