### PR TITLE
Implement run-query

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/context.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/context.clj
@@ -43,15 +43,15 @@
 
 (mu/defn create-context
   "Create a tool context."
-  [context]
+  [_context]
   (merge {}
-         (metabot-v3.tools.query/create-context context)))
+         #_(metabot-v3.tools.query/create-context context)))
 
 (mu/defn describe-context
   "Transforms the tool context into LLM context."
-  [context]
+  [_context]
   (merge {}
-         (metabot-v3.tools.query/describe-context context)))
+         #_(metabot-v3.tools.query/describe-context context)))
 
 (mu/defn create-reactions
   "Extracts reactions based on the current context."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/query_metric.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/query_metric.clj
@@ -90,9 +90,9 @@
                   (reduce add-filter $q (map #(resolve-column % field-id-prefix filterable-cols) filters))
                   (reduce add-breakout $q (map #(resolve-column % field-id-prefix breakoutable-cols) group-by)))]
       {:type :query
-       :query_id (u/generate-nano-id)
+       :query-id (u/generate-nano-id)
        :query (lib.convert/->legacy-MBQL query)
-       :result_columns (mapv #(metabot-v3.tools.u/->result-column % field-id-prefix) (lib/returned-columns query))})
+       :result-columns (mapv #(metabot-v3.tools.u/->result-column % field-id-prefix) (lib/returned-columns query))})
     "metric not found"))
 
 (comment


### PR DESCRIPTION
### Description

Implement `run-query` as a dummy tool. This tool has no core implementing the real tool interface, as it is the first to put the query into the history.

It also disables of the context processing implemented in the previous attempts.