### PR TITLE
Rework flow to allow for a query store

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/envelope.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/envelope.clj
@@ -95,7 +95,8 @@
 (defn update-context
   "Given a new context, set it in the envelope."
   [e context]
-  (assoc e :context context))
+  (cond-> e
+    (some? context) (assoc :context context)))
 
 (defn add-tool-response
   "Given an output string and new context, adds them to the envelope."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/envelope.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/envelope.clj
@@ -19,7 +19,15 @@
    :history history
    :context context
    :max-round-trips max-round-trips
-   :round-trips-remaining max-round-trips})
+   :round-trips-remaining max-round-trips
+   :dummy-history []
+   :query-id->query {}})
+
+(defn full-history
+  "History including the dummy tool invocations"
+  [e]
+  (into (:dummy-history e)
+        (:history e)))
 
 (defn session-id
   "Get the session ID from the envelope"
@@ -77,6 +85,11 @@
   "Given a raw message, add it to the envelope."
   [e msg]
   (update e :history conj msg))
+
+(defn add-dummy-message
+  "Adds a message to the dummy history. This is sent to the LLM, but not part of the history we send to the frontend."
+  [e msg]
+  (update e :dummy-history conj msg))
 
 (defn update-context
   "Given a new context, set it in the envelope."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/handle_envelope.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/handle_envelope.clj
@@ -2,21 +2,15 @@
   "Code for handling responses from AI Proxy ([[metabase-enterprise.metabot-v3.client]])."
   (:require
    [metabase-enterprise.metabot-v3.client :as metabot-v3.client]
-   [metabase-enterprise.metabot-v3.dummy-tools :as metabot-v3.dummy-tools]
    [metabase-enterprise.metabot-v3.envelope :as envelope]
    [metabase-enterprise.metabot-v3.tools.interface :as metabot-v3.tools.interface]
    [metabase.util.o11y :as o11y]))
-
-(defn- full-history
-  [{:keys [context] :as e}]
-  (into (metabot-v3.dummy-tools/invoke-dummy-tools context)
-        (envelope/history e)))
 
 (defn- invoke-all-tool-calls! [{:keys [context] :as e}]
   (reduce (fn [e {tool-name :name, tool-call-id :id, :keys [arguments]}]
             (let [{:keys [output context]}
                   (o11y/with-span :info {:name tool-name}
-                    (metabot-v3.tools.interface/*invoke-tool* tool-name arguments context (full-history e)))]
+                    (metabot-v3.tools.interface/*invoke-tool* tool-name arguments context (envelope/full-history e)))]
               (envelope/add-tool-response e tool-call-id output context)))
           e
           (envelope/tool-calls-requiring-invocation e)))
@@ -24,7 +18,7 @@
 (defn- request-llm-response [e]
   (let [new-response-message (:message (metabot-v3.client/*request*
                                         (envelope/context e)
-                                        (full-history e)
+                                        (envelope/full-history e)
                                         (envelope/session-id e)))]
     (-> e
         envelope/decrement-round-trips

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/handle_envelope.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/handle_envelope.clj
@@ -6,11 +6,11 @@
    [metabase-enterprise.metabot-v3.tools.interface :as metabot-v3.tools.interface]
    [metabase.util.o11y :as o11y]))
 
-(defn- invoke-all-tool-calls! [{:keys [context] :as e}]
+(defn- invoke-all-tool-calls! [e]
   (reduce (fn [e {tool-name :name, tool-call-id :id, :keys [arguments]}]
             (let [{:keys [output context]}
                   (o11y/with-span :info {:name tool-name}
-                    (metabot-v3.tools.interface/*invoke-tool* tool-name arguments context (envelope/full-history e)))]
+                    (metabot-v3.tools.interface/*invoke-tool* tool-name arguments e))]
               (envelope/add-tool-response e tool-call-id output context)))
           e
           (envelope/tool-calls-requiring-invocation e)))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/repl.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/repl.clj
@@ -5,8 +5,8 @@
     clj -X:ee:metabot-v3/repl"
   (:require
    [clojure.string :as str]
+   [metabase-enterprise.metabot-v3.api :as api]
    [metabase-enterprise.metabot-v3.envelope :as metabot-v3.envelope]
-   [metabase-enterprise.metabot-v3.handle-envelope :as metabot-v3.handle-envelope]
    [metabase-enterprise.metabot-v3.reactions :as metabot-v3.reactions]
    [metabase.db :as mdb]
    [metabase.util :as u]
@@ -58,10 +58,7 @@
                                             :current_visualization_settings {:current_display_type "bar",
                                                                              :visible_columns [{:name "Created At"}, {:name "Id"}, {:name "Order Number"}, {:name "Status"}, {:name "Total"}],
                                                                              :hidden_columns [{:name "Customer Id"}, {:name "Customer Name"}, {:name "Customer Email"}]}}
-                                   env (metabot-v3.handle-envelope/handle-envelope
-                                        (metabot-v3.envelope/add-user-message
-                                         (metabot-v3.envelope/create context history session-id)
-                                         input))]
+                                   env (api/request input context history session-id)]
                                (handle-reactions (metabot-v3.envelope/reactions env))
                                (metabot-v3.envelope/history env))))
                          (catch Throwable e

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/create_dashboard_subscription.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/create_dashboard_subscription.clj
@@ -8,7 +8,7 @@
    [toucan2.core :as t2]))
 
 (mu/defmethod metabot-v3.tools.interface/*invoke-tool* :metabot.tool/create-dashboard-subscription
-  [_tool-name {:keys [dashboard-id email schedule] :as _arguments} context _full-history]
+  [_tool-name {:keys [dashboard-id email schedule] :as _arguments} _env]
   (let [dashboard (-> (t2/select-one :model/Dashboard :id dashboard-id)
                       (t2/hydrate [:dashcards :card]))
         cards (for [{:keys [id card]} (:dashcards dashboard)]
@@ -35,7 +35,5 @@
                               :skip_if_empty false))]
     (if recipient
       (do (models.pulse/create-pulse! (map models.pulse/card->ref cards) [channel] pulse-data)
-          {:output "success"
-           :context context})
-      {:output "no user with this email found"
-       :context context})))
+          {:output "success"})
+      {:output "no user with this email found"})))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filter_data.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filter_data.clj
@@ -4,6 +4,5 @@
    [metabase.util.malli :as mu]))
 
 (mu/defmethod metabot-v3.tools.interface/*invoke-tool* :metabot.tool/filter-data
-  [_tool-name _arguments context]
-  {:output "Not implemented"
-   :context context})
+  [_tool-name _arguments _env]
+  {:output "Not implemented"})

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/find_metric.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/find_metric.clj
@@ -5,11 +5,10 @@
             [toucan2.core :as t2]))
 
 (defmethod tools.interface/*invoke-tool* :metabot.tool/find-metric
-  [_ {:keys [message]} context]
+  [_ {:keys [message]} _env]
   (let [{:keys [id]} (client/select-metric-request
                       (t2/select [:model/Card :id :name :description]
                                  :type [:= "metric"])
                       message)]
     {:output (or (some-> id dummy-tools/metric-details)
-                 "Metric not found.")
-     :context context}))
+                 "Metric not found.")}))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/find_outliers.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/find_outliers.clj
@@ -4,6 +4,5 @@
    [metabase.util.malli :as mu]))
 
 (mu/defmethod metabot-v3.tools.interface/*invoke-tool* :metabot.tool/find-outliers
-  [_tool-name _arguments context]
-  {:output "Not implemented."
-   :context context})
+  [_tool-name _arguments _env]
+  {:output "Not implemented."})

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/generate_insights.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/generate_insights.clj
@@ -1,14 +1,26 @@
 (ns metabase-enterprise.metabot-v3.tools.generate-insights
   (:require
+   [buddy.core.codecs :as codecs]
+   [cheshire.core :as json]
+   [metabase-enterprise.metabot-v3.envelope :as env]
    [metabase-enterprise.metabot-v3.tools.interface :as metabot-v3.tools.interface]
    [metabase.public-settings :as public-settings]
    [metabase.util.malli :as mu]))
 
+(set! *warn-on-reflection* true)
+
 (mu/defmethod metabot-v3.tools.interface/*invoke-tool* :metabot.tool/generate-insights
-  [_tool-name {what-for :for :as _arguments} _env]
+  [_tool-name {what-for :for :as _arguments} env]
   (let [[k id] (some #(find what-for %) [:metric_id :table_id :report_id :query_id])
         entity-type (case k
                       (:metric_id :report_id) "question"
                       :table_id "table"
-                      :query_id (throw (ex-info "Unhandled" {})))]
-    {:output (str (public-settings/site-url) "/auto/dashboard/" entity-type "/" id)}))
+                      :query_id "adhoc")
+        entity-id (if (= entity-type "adhoc")
+                    (-> env
+                        (env/find-query id)
+                        json/generate-string
+                        .getBytes
+                        codecs/bytes->b64-str)
+                    id)]
+    {:output (str (public-settings/site-url) "/auto/dashboard/" entity-type "/" entity-id)}))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/generate_insights.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/generate_insights.clj
@@ -5,11 +5,10 @@
    [metabase.util.malli :as mu]))
 
 (mu/defmethod metabot-v3.tools.interface/*invoke-tool* :metabot.tool/generate-insights
-  [_tool-name {what-for :for :as _arguments} context]
+  [_tool-name {what-for :for :as _arguments} _env]
   (let [[k id] (some #(find what-for %) [:metric_id :table_id :report_id :query_id])
         entity-type (case k
                       (:metric_id :report_id) "question"
                       :table_id "table"
                       :query_id (throw (ex-info "Unhandled" {})))]
-    {:output (str (public-settings/site-url) "/auto/dashboard/" entity-type "/" id)
-     :context context}))
+    {:output (str (public-settings/site-url) "/auto/dashboard/" entity-type "/" id)}))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/interface.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/interface.clj
@@ -103,9 +103,9 @@
   Different reactions should get bundled with different keys, for example `:metabot.reaction/message` should include
   `:message`. This should match what the frontend expects."
   {:arglists '([tool-name argument-map context full-history])}
-  (fn [tool-name _argument-map _context _full-history]
+  (fn [tool-name _argument-map _env]
     (keyword tool-name)))
 
 (mu/defmethod *invoke-tool* :default
-  [tool-name _argument-map _context _full-history]
+  [tool-name _argument-map _env]
   {:output (format "Tool '%s' is not yet implemented." tool-name)})

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/invite_user.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/invite_user.clj
@@ -5,7 +5,7 @@
    [metabase.util.malli :as mu]))
 
 (mu/defmethod metabot-v3.tools.interface/*invoke-tool* :metabot.tool/invite-user
-  [_tool-name {:keys [email]} context]
+  [_tool-name {:keys [email]} _env]
   (let [output (try
                  (let [{:keys [id first_name last_name email]} (api.user/invite-user {:email email})]
                    {:id id
@@ -20,5 +20,4 @@
                     :email_address email})
                  (catch Exception e
                    {:error (ex-message e)}))]
-    {:output output
-     :context context}))
+    {:output output}))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/query.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/query.clj
@@ -192,7 +192,7 @@
   (reduce apply-filter query filters))
 
 (mu/defmethod metabot-v3.tools.interface/*invoke-tool* :metabot.tool/filter-data
-  [_tool-name {:keys [filters]} {:keys [query] :as context} _full-history]
+  [_tool-name {:keys [filters]} {{:keys [query] :as context} :context}]
   (try
     {:output  "success"
      :context (merge context {:query      (apply-filters query filters)
@@ -245,7 +245,7 @@
     query))
 
 (mu/defmethod metabot-v3.tools.interface/*invoke-tool* :metabot.tool/aggregate-data
-  [_tool-name {:keys [summarize group-by]} {:keys [query] :as context} _full-history]
+  [_tool-name {:keys [summarize group-by]} {{:keys [query] :as context} :context}]
   (try
     {:output "success"
      :context (merge context {:query      (-> query (apply-summarize summarize) (apply-group-by group-by))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/query_metric.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/query_metric.clj
@@ -102,6 +102,5 @@
   -)
 
 (mu/defmethod metabot-v3.tools.interface/*invoke-tool* :metabot.tool/query-metric
-  [_tool-name arguments context _full-history]
-  {:output (json/generate-string (query-metric arguments))
-   :context context})
+  [_tool-name arguments _env]
+  {:output (json/generate-string (query-metric arguments))})

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/who_is_your_favorite.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/who_is_your_favorite.clj
@@ -4,6 +4,5 @@
    [metabase.util.malli :as mu]))
 
 (mu/defmethod metabot-v3.tools.interface/*invoke-tool* :metabot.tool/who-is-your-favorite
-  [_tool-name _arg-map context _full-history]
-  {:output  "You are... but don't tell anyone!"
-   :context context})
+  [_tool-name _arg-map _env]
+  {:output  "You are... but don't tell anyone!"})

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
@@ -53,7 +53,7 @@
                   (#'metabot-v3.client/decode-response-body response)))
 
               metabot-v3.tools.interface/*invoke-tool*
-              (fn [tool-name arguments]
+              (fn [tool-name arguments _env]
                 [{:type :metabot.reaction/invoke-tool, :tool-name tool-name, :arguments arguments}])]
       (let [response-1 (#'metabot-v3.api/request "Send an email to Cam" {} [])]
         (swap! calls conj [:api-response response-1])

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/handle_envelope_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/handle_envelope_test.clj
@@ -35,7 +35,7 @@
                                             :greeting "Hello!"}}]}
         invocations (atom [])]
     (binding [metabot-v3.tools.interface/*tool-applicable?* (constantly true)
-              metabot-v3.tools.interface/*invoke-tool*      (fn [tool-name args]
+              metabot-v3.tools.interface/*invoke-tool*      (fn [tool-name args _env]
                                                               (swap! invocations conj [tool-name args])
                                                               (let [msg (format "Invoked tool %s" tool-name)]
                                                                 {:output msg

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/change_display_type_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/change_display_type_test.clj
@@ -6,4 +6,4 @@
   (is (= {:output "success",
           :reactions [{:display-type "foo"
                        :type :metabot.reaction/change-display-type}]}
-         (tools.interface/*invoke-tool* :metabot.tool/change-display-type {:type "foo"}))))
+         (tools.interface/*invoke-tool* :metabot.tool/change-display-type {:type "foo"} {}))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/confirm_invite_user_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/confirm_invite_user_test.clj
@@ -16,4 +16,4 @@
              [{:type :metabot.reaction/writeback,
                :message "<system message>The user refused the operation. Ask if they need anything else.</system message>"}]}}],
           :output "Confirmation required - awaiting user input."}
-         (tools.interface/*invoke-tool* :metabot.tool/confirm-invite-user {:email "email"}))))
+         (tools.interface/*invoke-tool* :metabot.tool/confirm-invite-user {:email "email"} {}))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/who_is_your_favorite_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/who_is_your_favorite_test.clj
@@ -4,4 +4,4 @@
 
 (deftest it-generates-a-reaction
   (is (= {:output "You are... but don't tell anyone!"}
-         (tools.interface/*invoke-tool* :metabot.tool/who-is-your-favorite {}))))
+         (tools.interface/*invoke-tool* :metabot.tool/who-is-your-favorite {} {}))))


### PR DESCRIPTION
Dummy tools need to be able to store queries for later use. Right now dummy tools work differently than regular tools: they can only (effectively) return an `output`. They can't change context, they can't return reactions, etc.

I was imagining that when we wanted to add queries to the query store, we'd do so in the `envelope`, and probably do this in a functional way by returning `:queries` or a `:query-id->query` map from the tool call itself. Then, we'd write a function in `envelope` that would basically just store this state for later retrieval.

The issue we had is that (before this commit) we don't actually invoke dummy tools in a way that changes the envelope - we just invoke them as needed before sending the history to the LLM.

So, this PR reworks things a bit:

- we invoke the dummy tool calls once, immediately after creating the envelope

- right now, this only means that we store the results of those tool calls in the env, for later retrieval to send to the LLM when we are actually making a call. (we don't just store the tool calls in normal history, because we don't want to return them to the FE when we respond).

- in the immediate future though, we'll want to *also*, in addition to adding tool `output` to the response, handle other tool results. One thing could be changing the context in response to a dummy tool call - which seems maybe a bit crazy, but on the other hand maybe dummy tool calls should be able to do anything a regular tool call can do?

- more immediately, we'll probably want to handle a new key from tool invocations, `:query-id->query-map`, that will store queries for later retrieval.
