### PR TITLE
[Clean-up] Allow collection clean up banner to be dismissible

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/stale.clj
+++ b/enterprise/backend/src/metabase_enterprise/stale.clj
@@ -1,8 +1,10 @@
 (ns metabase-enterprise.stale
   (:require [malli.experimental.time]
             [metabase.embed.settings :as embed.settings]
+            [metabase.models.setting :refer [defsetting]]
             [metabase.public-settings :as public-settings]
             [metabase.util.honey-sql-2 :as h2x]
+            [metabase.util.i18n :refer [deferred-tru]]
             [metabase.util.malli :as mu]
             [toucan2.core :as t2]))
 
@@ -145,3 +147,11 @@
                 (map (fn [v] (update v :model #(keyword "model" %)))))
                (t2/query (rows-query args)))
    :total (:count (t2/query-one (total-query args)))})
+
+(defsetting dismissed-collection-cleanup-banner
+  (deferred-tru "Was the collection cleanup banner dismissed?")
+  :user-local :only
+  :visibility :authenticated
+  :type :boolean
+  :default false
+  :export? false)

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionModal.tsx
@@ -4,6 +4,7 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import { skipToken } from "metabase/api";
+import { useUserSetting } from "metabase/common/hooks";
 import { DelayedLoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
 import { PaginationControls } from "metabase/components/PaginationControls";
 import Search from "metabase/entities/search";
@@ -114,11 +115,18 @@ const _CleanupCollectionModal = ({
     setTotal(total);
   }, [setTotal, total]);
 
+  const [dismissed, setDismissed] = useUserSetting(
+    "dismissed-collection-cleanup-banner",
+  );
   const handleOnArchive = ({
     totalArchivedItems,
   }: {
     totalArchivedItems: number;
   }) => {
+    if (!dismissed) {
+      setDismissed(true);
+    }
+
     // In theory if we should only get numbers or root bad for a collection id
     // if we are dealing with Our Analytics / root, set collection_id to null
     if (typeof collectionId === "number" || collectionId === "root") {

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/CollectionCleanupAlert/CollectionCleanupAlert.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/CollectionCleanupAlert/CollectionCleanupAlert.tsx
@@ -48,10 +48,9 @@ export const CollectionCleanupAlert = ({
         }
       : skipToken,
   );
+  const totalStaleItems = shouldFetchStaleItems ? (staleItems?.total ?? 0) : 0;
 
-  const hasSomethingToCleanUp = !!staleItems?.total;
-
-  if (isLoading || error || dismissed || !hasSomethingToCleanUp) {
+  if (isLoading || error || totalStaleItems <= 0) {
     return null;
   }
 

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/CollectionCleanupAlert/CollectionCleanupAlert.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/CollectionCleanupAlert/CollectionCleanupAlert.tsx
@@ -14,15 +14,6 @@ import type { Collection } from "metabase-types/api";
 
 import { getDateFilterValue } from "../CleanupCollectionModal/utils";
 
-const TEXT = {
-  CLEAN_THINGS_UP: c(
-    "This is the heading of a banner that invites the user to clean up a collection.",
-  ).t`Clean things up!`,
-  GET_RID_OF_UNUSED_CONTENT: c(
-    "This is the heading of a banner that invites the user to clean up a collection.",
-  ).t`Get rid of unused content in this collection`,
-};
-
 export const CollectionCleanupAlert = ({
   collection,
 }: {
@@ -73,7 +64,9 @@ export const CollectionCleanupAlert = ({
       }}
     >
       <Box fz="md" c={"text-dark"}>
-        {TEXT.CLEAN_THINGS_UP}{" "}
+        {c(
+          "This is the heading of a banner that invites the user to clean up a collection.",
+        ).t`Keep your collections tidy!`}{" "}
         <Box
           component={Link}
           ml="2.5rem"
@@ -81,7 +74,9 @@ export const CollectionCleanupAlert = ({
           variant="brand"
           to={`${Urls.collection(collection)}/cleanup`}
         >
-          {TEXT.GET_RID_OF_UNUSED_CONTENT}
+          {c(
+            "This is the heading of a banner that invites the user to clean up a collection.",
+          ).t`View unused items and select which ones to move to the trash.`}
         </Box>
       </Box>
     </Alert>

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/CollectionCleanupAlert/CollectionCleanupAlert.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/CollectionCleanupAlert/CollectionCleanupAlert.tsx
@@ -1,6 +1,7 @@
 import { c } from "ttag";
 
 import { skipToken } from "metabase/api";
+import { useUserSetting } from "metabase/common/hooks";
 import Link from "metabase/core/components/Link";
 import { color } from "metabase/lib/colors";
 import { useSelector } from "metabase/lib/redux";
@@ -27,9 +28,12 @@ export const CollectionCleanupAlert = ({
 }: {
   collection: Collection;
 }) => {
+  const [dismissed, setDismissed] = useUserSetting(
+    "dismissed-collection-cleanup-banner",
+  );
   const isAdmin = useSelector(getUserIsAdmin);
   const shouldFetchStaleItems =
-    isAdmin && PLUGIN_COLLECTIONS.canCleanUp(collection);
+    isAdmin && !dismissed && PLUGIN_COLLECTIONS.canCleanUp(collection);
 
   const {
     data: staleItems,
@@ -47,7 +51,7 @@ export const CollectionCleanupAlert = ({
 
   const hasSomethingToCleanUp = !!staleItems?.total;
 
-  if (isLoading || error || !hasSomethingToCleanUp) {
+  if (isLoading || error || dismissed || !hasSomethingToCleanUp) {
     return null;
   }
 
@@ -55,12 +59,17 @@ export const CollectionCleanupAlert = ({
     <Alert
       data-testid="cleanup-alert"
       icon={<Icon name="ai" size={16} />}
+      withCloseButton
+      onClose={() => setDismissed(true)}
       styles={{
         root: { padding: 0, marginTop: "-.5rem", marginBottom: "2rem" },
         icon: { marginRight: ".5rem" },
         wrapper: {
           backgroundColor: color("brand-lighter"),
           padding: "1rem 1.5rem",
+        },
+        closeButton: {
+          color: "var(--mb-color-text-dark)",
         },
       }}
     >

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -389,6 +389,7 @@ interface PublicSettings {
 }
 
 export type UserSettings = {
+  "dismissed-collection-cleanup-banner"?: boolean;
   "dismissed-browse-models-banner"?: boolean;
   "dismissed-custom-dashboard-toast"?: boolean;
   "dismissed-onboarding-sidebar-link"?: boolean;


### PR DESCRIPTION
Milestone 1 of #51419

### Description

Adds UI and setting to dismiss the clean up banner when viewing a collection with stale content in it. Dismissing the banner will prevent all banners for all collections from appearing.

Also if the user makes use of the clean up modal, we'll globally dismiss the banner as the user knows how to use the feature.

Aside: Also fixes a stale data bug that would cause the banner to appear on the examples collection when coming from a collection with stale items. Currently this would only affect this single collection, so impact of issue is small.

### How to verify

- View a collection with stale items
- Dismiss the banner
- See the banner is dismissed, persists on reload, and is dismissed for other collections with stale content

### Demo

Globally dismiss banner from the banner (video)
https://github.com/user-attachments/assets/58ebd001-6b2d-4e19-a1ec-d0b475323ac2

Globally dismiss banner by using the feature (video)
https://github.com/user-attachments/assets/23ec5f1d-9895-49ff-860d-e48e112ffba8

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
