### PR TITLE
tests(jest): add ES module is-absolute-url to the transform ignore

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,25 @@
 // @ts-check
+
+const esmPackages = [
+  "character-entities-html4",
+  "comma-separated-tokens",
+  "d3-*",
+  "d3",
+  "devlop",
+  "echarts",
+  "hast.*",
+  "html-void-elements",
+  "is-absolute-url",
+  "property-information",
+  "rehype-external-links",
+  "screenfull",
+  "space-separated-tokens",
+  "stringify-entities",
+  "vfile-message",
+  "vfile",
+  "zrender",
+];
+
 /** @type {import('jest').Config} */
 const config = {
   moduleNameMapper: {
@@ -19,7 +40,7 @@ const config = {
       "<rootDir>/node_modules/csv-stringify/dist/cjs/sync",
   },
   transformIgnorePatterns: [
-    "<rootDir>/node_modules/(?!(screenfull|echarts|zrender|rehype-external-links|hast.*|devlop|property-information|comma-separated-tokens|space-separated-tokens|vfile|vfile-message|html-void-elements|stringify-entities|character-entities-html4|d3|d3-*)/)",
+    `<rootDir>/node_modules/(?!(${esmPackages.join("|")})/)`,
   ],
   testPathIgnorePatterns: [
     "<rootDir>/frontend/.*/.*.tz.unit.spec.{js,jsx,ts,tsx}",


### PR DESCRIPTION
### Description

added `is-absolute-url` to the transform ignore patterns as it's a ES module. 

caused by https://github.com/metabase/metabase/commit/e1a1e731281663ff2f4595513f7c98dfb6dc47d1#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2deL14721-L14726

*This change needs to be manually included to https://github.com/metabase/metabase/pull/51429*


### Before that change

<img width="804" alt="image" src="https://github.com/user-attachments/assets/c3caed71-0e5f-4844-8684-e00c1246bb47" />


### After

<img width="466" alt="image" src="https://github.com/user-attachments/assets/d52baa06-8e20-4e4a-85d6-4f8b0f457a31" />
