### PR TITLE
ci: Trim stacktrace of intentional exceptions thrown during testing

### DIFF
--- a/test/metabase/query_analysis_test.clj
+++ b/test/metabase/query_analysis_test.clj
@@ -147,10 +147,15 @@
             (is (contains? tables "t"))
             (is (some (partial str/starts-with? long-table) tables))))))))
 
+(defn- throw-empty-exception [& _]
+  (let [ex (doto (ex-info "Oh no!" {})
+             (.setStackTrace (into-array StackTraceElement [])))]
+    (throw ex)))
+
 (deftest analysis-error-test
   (with-analysis-on
     (testing "Errors analyzing queries will not prevent cards being created or updated"
-      (mt/with-dynamic-redefs [query-analysis/update-query-analysis-for-card! (fn [& _] (throw (ex-info "Oh no!" {})))]
+      (mt/with-dynamic-redefs [query-analysis/update-query-analysis-for-card! throw-empty-exception]
         (mt/with-temp [Card {c-id :id} {:dataset_query (mt/native-query {:query "SELECT c FROM t"})}]
           (testing "The card was created"
             (is (t2/exists? :model/Card c-id)))

--- a/test/metabase/sync_test.clj
+++ b/test/metabase/sync_test.clj
@@ -266,7 +266,8 @@
 
 (defmethod driver/describe-database ::sync-database-error-test
   [_driver _database]
-  (throw (Exception. "OOPS!")))
+  (throw (doto (Exception. "OOPS!")
+           (.setStackTrace (into-array StackTraceElement [])))))
 
 (deftest sync-database!-error-test
   (testing "Errors in sync-database! should be caught and handled correctly (#45848)"


### PR DESCRIPTION
This removes long scary stacktraces that we throw intentionally during testing and makes it easier to locate the actual failed tests.
