### PR TITLE
Add description to metric API responses

### DIFF
--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -654,8 +654,8 @@
       (pre-update-check-sandbox-constraints changes)
       (assert-valid-type (merge old-card-info changes)))))
 
-(defn- add-suggested-name-to-metric-card
-  "Add `:suggested_name` key to returned card.
+(defn- add-query-description-to-metric-card
+  "Add `:query_description` key to returned card.
 
   Some users were missing description that was present in v1 metric API responses. This new key compensates for that.
 
@@ -680,7 +680,7 @@
       (dissoc :dataset_query_metrics_v2_migration_backup)
       (m/assoc-some :source_card_id (-> card :dataset_query source-card-id))
       public-settings/remove-public-uuid-if-public-sharing-is-disabled
-      add-suggested-name-to-metric-card))
+      add-query-description-to-metric-card))
 
 (t2/define-before-insert :model/Card
   [card]

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -657,7 +657,7 @@
 (defn- add-suggested-name-to-metric-card
   "Add `:suggested_name` key to returned card.
 
-  Some users were missing definition that was present in v1 metric API responses. This new key compensates for that.
+  Some users were missing description that was present in v1 metric API responses. This new key compensates for that.
 
   This function is used in `t2/define-after-select :model/Card`. Metadata provider caching should be considered when
   fetching multiple metric cards having common database, as done in eg. dashboard API context."

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -657,18 +657,21 @@
 (defn- add-suggested-name-to-metric-card
   "Add `:suggested_name` key to returned card.
 
-  Some users were missing definition that was present in v1 metric API responses. This new key compensates for that."
+  Some users were missing definition that was present in v1 metric API responses. This new key compensates for that.
+
+  This function is used in `t2/define-after-select :model/Card`. Metadata provider caching should be considered when
+  fetching multiple metric cards having common database, as done in eg. dashboard API context."
   [card]
   (if-not (and (map? card)
                (= :metric (:type card))
-               (:database_id card)
-               (:dataset_query card))
+               (-> card :dataset_query not-empty)
+               (-> card :database_id))
     card
     (or (when-some [suggested-name (some-> (lib.metadata.jvm/application-database-metadata-provider
                                             (:database_id card))
                                            (lib/query (:dataset_query card))
                                            lib/suggested-name)]
-          (assoc card :suggested_name suggested-name))
+          (assoc card :query_description suggested-name))
         card)))
 
 (t2/define-after-select :model/Card

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -667,12 +667,10 @@
                (-> card :dataset_query not-empty)
                (-> card :database_id))
     card
-    (or (when-some [suggested-name (some-> (lib.metadata.jvm/application-database-metadata-provider
-                                            (:database_id card))
-                                           (lib/query (:dataset_query card))
-                                           lib/suggested-name)]
-          (assoc card :query_description suggested-name))
-        card)))
+    (m/assoc-some card :query_description (some-> (lib.metadata.jvm/application-database-metadata-provider
+                                                   (:database_id card))
+                                                  (lib/query (:dataset_query card))
+                                                  lib/suggested-name))))
 
 (t2/define-after-select :model/Card
   [card]


### PR DESCRIPTION
Closes #51303

This PR adds `query_description` key to `:model/Card` for cards of a `:type` `:metric`. Purpose is to provide users what was known in `api/metric` responses as `definition_description`.