### PR TITLE
Add M2M Oauth to Databricks Driver

### DIFF
--- a/docs/databases/connections/databricks.md
+++ b/docs/databases/connections/databricks.md
@@ -20,8 +20,7 @@ See [Compute settings for the Databricks JDBC Driver](https://docs.databricks.co
 
 ## HTTP path
 
-This is the Databrick's compute resources HTTP Path value. Often a SQL warehouse endpoint in the format `/sql/1.0/endpoints/abcdef1234567890`.
-Read [Connect to a SQL warehouse](https://docs.databricks.com/en/compute/sql-warehouse/index.html) article from Databricks for more information on how to create and connect to a SQL Warehouse.
+This is the Databrick's compute resources HTTP Path value. This value is often a SQL warehouse endpoint in the format `/sql/1.0/endpoints/abcdef1234567890`. See [Connect to a SQL warehouse](https://docs.databricks.com/en/compute/sql-warehouse/index.html).
 
 Additionally, see [Compute settings for the Databricks JDBC Driver](https://docs.databricks.com/en/integrations/jdbc/compute.html).
 

--- a/docs/databases/connections/databricks.md
+++ b/docs/databases/connections/databricks.md
@@ -34,6 +34,7 @@ The Databricks driver supports both options. Use the toggle to select the authen
 See [Personal Access Token (PAT)](https://docs.databricks.com/en/dev-tools/auth/pat.html).
 
 ### Authenticate access with a service principal using OAuth (OAuth M2M)
+
 See [Authenticate access with a service principal using OAuth](https://docs.databricks.com/en/dev-tools/auth/oauth-m2m.html).
 
 ## Catalog

--- a/docs/databases/connections/databricks.md
+++ b/docs/databases/connections/databricks.md
@@ -26,7 +26,8 @@ Read [Connect to a SQL warehouse](https://docs.databricks.com/en/compute/sql-war
 Additionally, see [Compute settings for the Databricks JDBC Driver](https://docs.databricks.com/en/integrations/jdbc/compute.html).
 
 ## Authentication
-There are two ways to authenticate with Databricks on Metabase. You can use a personal access token (PAT) or a service principal using OAuth (OAuth M2M).
+
+There are two ways to authenticate with Databricks. You can use a personal access token (PAT) or a service principal using OAuth (OAuth M2M).
 
 The Databricks driver supports both options. Use the toggle to select the authentication method you want to use.
 

--- a/docs/databases/connections/databricks.md
+++ b/docs/databases/connections/databricks.md
@@ -28,7 +28,7 @@ Additionally, see [Compute settings for the Databricks JDBC Driver](https://docs
 ## Authentication
 There are two ways to authenticate with Databricks on Metabase. You can use a personal access token (PAT) or a service principal using OAuth (OAuth M2M).
 
-The Databricks driver supports both options but will prioritize the OAuth M2M option if both are provided.
+The Databricks driver supports both options. Use the toggle to select the authentication method you want to use.
 
 ### Personal access token authentication
 See [Personal Access Token (PAT)](https://docs.databricks.com/en/dev-tools/auth/pat.html).

--- a/docs/databases/connections/databricks.md
+++ b/docs/databases/connections/databricks.md
@@ -14,22 +14,29 @@ The display name for the database in the Metabase interface.
 
 ## Host
 
-Your database's IP address, or its domain name (e.g., esc.mydatabase.com). This is the value of your Databrick's compute resource's Server Hostname.
+Your database's IP address, or its domain name (e.g., `xxxxxxxxxx.cloud.databricks.com` or `adb-xxxxx.azuredatabricks.net`). This is the value of your Databrick's compute resource's Server Hostname.
 
 See [Compute settings for the Databricks JDBC Driver](https://docs.databricks.com/en/integrations/jdbc/compute.html).
 
 ## HTTP path
 
-This is the Databrick's compute resources HTTP Path value.
+This is the Databrick's compute resources HTTP Path value. Often a SQL warehouse endpoint in the format `/sql/1.0/endpoints/abcdef1234567890`.
+Read [Connect to a SQL warehouse](https://docs.databricks.com/en/compute/sql-warehouse/index.html) article from Databricks for more information on how to create and connect to a SQL Warehouse.
 
-See [Compute settings for the Databricks JDBC Driver](https://docs.databricks.com/en/integrations/jdbc/compute.html).
+Additionally, see [Compute settings for the Databricks JDBC Driver](https://docs.databricks.com/en/integrations/jdbc/compute.html).
 
-## Personal access token
+## Authentication
+There are two ways to authenticate with Databricks on Metabase. You can use a personal access token (PAT) or a service principal using OAuth (OAuth M2M).
 
+The Databricks driver supports both options but will prioritize the OAuth M2M option if both are provided.
+
+### Personal access token authentication
 See [Personal Access Token (PAT)](https://docs.databricks.com/en/dev-tools/auth/pat.html).
 
-## Catalog
+### Authenticate access with a service principal using OAuth (OAuth M2M)
+See [Authenticate access with a service principal using OAuth](https://docs.databricks.com/en/dev-tools/auth/oauth-m2m.html).
 
+## Catalog
 For now, you can only select one catalog. Metabase doesn't support multi-catalog connections. If you want to use more than one catalog in Metabase, you can set up multiple connections, each selecting a different catalog.
 
 You can't sync Databricks's legacy catalogs, however, including the `samples` or `hive_metastore` catalogs.
@@ -62,3 +69,45 @@ Note that only the `*` wildcard is supported; you can't use other special charac
 You can append options to the connection string that Metabase uses to connect to your database. E.g., `IgnoreTransactions=0`.
 
 See [Compute settings for the Databricks JDBC Driver](https://docs.databricks.com/en/integrations/jdbc/compute.html).
+
+## Re-run queries for simple explorations
+
+Turn this option **OFF** if people want to click **Run** (the play button) before applying any [Summarize](../../questions/query-builder/introduction.md#grouping-your-metrics) or filter selections.
+
+By default, Metabase will execute a query as soon as you choose an grouping option from the **Summarize** menu or a filter condition from the [drill-through menu](https://www.metabase.com/learn/metabase-basics/querying-and-dashboards/questions/drill-through). If your database is slow, you may want to disable re-running to avoid loading data on each click.
+
+## Choose when Metabase syncs and scans
+
+Turn this option **ON** to manage the queries that Metabase uses to stay up to date with your database. For more information, see [Syncing and scanning databases](../sync-scan.md).
+
+### Database syncing
+
+If you've selected **Choose when syncs and scans happen** > **ON**, you'll be able to set:
+
+- The frequency of the [sync](../sync-scan.md#how-database-syncs-work): hourly (default) or daily.
+- The time to run the sync, in the timezone of the server where your Metabase app is running.
+
+### Scanning for filter values
+
+Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database.
+
+If you've selected **Choose when syncs and scans happen** > **ON**, you'll see the following options under **Scanning for filter values**:
+
+- **Regularly, on a schedule** allows you to run [scan queries](../sync-scan.md#how-database-scans-work) at a frequency that matches the rate of change to your database. The time is set in the timezone of the server where your Metabase app is running. This is the best option for a small database, or tables with distinct values that get updated often.
+- **Only when adding a new filter widget** is a great option if you want scan queries to run on demand. Turning this option **ON** means that Metabase will only scan and cache the values of the field(s) that are used when a new filter is added to a dashboard or SQL question.
+- **Never, I'll do this manually if I need to** is an option for databases that are either prohibitively large, or which never really have new values added. Use the [Re-scan field values now](../sync-scan.md#manually-scanning-column-values) button to run a manual scan and bring your filter values up to date.
+
+### Periodically refingerprint tables
+
+> Periodic refingerprinting will increase the load on your database.
+
+Turn this option **ON** to scan a sample of values every time Metabase runs a [sync](../sync-scan.md#how-database-syncs-work).
+
+A fingerprinting query examines the first 10,000 rows from each column and uses that data to guesstimate how many unique values each column has, what the minimum and maximum values are for numeric and timestamp columns, and so on. If you leave this option **OFF**, Metabase will only fingerprint your columns once during setup.
+
+## Further reading
+
+- [Managing databases](../../databases/connecting.md)
+- [Metadata editing](../../data-modeling/metadata-editing.md)
+- [Models](../../data-modeling/models.md)
+- [Setting data access permissions](../../permissions/data.md)

--- a/modules/drivers/databricks/resources/metabase-plugin.yaml
+++ b/modules/drivers/databricks/resources/metabase-plugin.yaml
@@ -24,7 +24,7 @@ driver:
       - name: use-m2m
         display-name: Use Machine to Machine (M2M) authentication
         type: boolean
-        default: false
+        default: true
         helper-text: Use Personal Access Token for authentication.
       - merge:
         - password

--- a/modules/drivers/databricks/resources/metabase-plugin.yaml
+++ b/modules/drivers/databricks/resources/metabase-plugin.yaml
@@ -21,8 +21,8 @@ driver:
         helper-text: Found in SQL Warehouses > Connection details
         required: true
         placeholder: /sql/1.0/endpoints/abcdef1234567890
-      - name: use-token
-        display-name: Use Personal Access Token
+      - name: use-m2m
+        display-name: Use Machine to Machine (M2M) authentication
         type: boolean
         default: false
         helper-text: Use Personal Access Token for authentication.
@@ -34,14 +34,14 @@ driver:
           helper-text: Personal Access Token for authentication. Not required if using OAuth M2M.
           placeholder: dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
           visible-if:
-            use-token: true
+            use-m2m: false
       - name: client-id
         display-name: Service Principal Client ID
         placeholder: e26ce240-0a12-454f-934f-4c646603cb61
         helper-text: For M2M OAuth authentication, corresponds to the service principal's Client ID.
         required: true
         visible-if:
-          use-token: false
+          use-m2m: true
       - merge:
         - password
         - name: oauth-secret
@@ -50,7 +50,7 @@ driver:
           helper-text: OAuth Secret for M2M OAuth authentication.
           required: true
           visible-if:
-            use-token: false
+            use-m2m: true
       - name: catalog
         display-name: Catalog
         default: default

--- a/modules/drivers/databricks/resources/metabase-plugin.yaml
+++ b/modules/drivers/databricks/resources/metabase-plugin.yaml
@@ -1,7 +1,7 @@
 info:
   name: Metabase Databricks Driver
-  version: 1.0.0
-  description: Allows Metabase to connect to Databricks SQL warehouse
+  version: 1.2.0
+  description: Allows Metabase to connect to Databricks SQL warehouse with personal access tokens or OAuth M2M
 dependencies:
   - plugin: Metabase Hive Like Abstract Driver
 driver:
@@ -11,28 +11,51 @@ driver:
     parent: hive-like
     connection-properties:
       - merge:
-        - host
-        - placeholder: 'xxxxxxxxxx.cloud.databricks.com'
+          - host
+          -
+            placeholder: "xxxxxxxxxx.cloud.databricks.com"
+            helper-text: "The Databricks host URL. Could also be adb-xxxxx.azuredatabricks.net"
       - name: http-path
-        display-name: HTTP path
-        helper-text: Found in SQL Warehouses > Connection details
+        display-name: HTTP Path
+        helper-text: "Found in SQL Warehouses > Connection details"
         required: true
+        placeholder: "/sql/1.0/endpoints/abcdef1234567890"
       - merge:
-        - password
-        - name: token
-          display-name: Personal Access Token
-          required: true
+          - password
+          -
+            name: token
+            display-name: Personal Access Token
+            required: false
+            type: secret
+            secret-kind: password
+            helper-text: "Personal Access Token for authentication. Not required if using OAuth M2M."
+            placeholder: "dapixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+      - name: client-id
+        display-name: Service Principal Client ID
+        placeholder: "e26ce240-0a12-454f-934f-4c646603cb61"
+        helper-text: "For M2M OAuth authentication, corresponds to the service principal's Client ID."
+        required: false
+      - name: oauth-secret
+        display-name: Service Principal OAuth Secret
+        type: secret
+        secret-kind: password
+        placeholder: "dosexxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        helper-text: "Oauth Secret for M2M OAuth authentication."
+        required: false
       - name: catalog
         display-name: Catalog
         default: default
         required: true
+        helper-text: "Specify the catalog to connect to."
       - name: schema-filters
         type: schema-filters
         display-name: Schemas
+        helper-text: "Optionally filter which schemas are visible."
       - advanced-options-start
       - merge:
-        - additional-options
-        - placeholder: 'IgnoreTransactions=0'
+          - additional-options
+          -
+            placeholder: "IgnoreTransactions=0"
       - default-advanced-options
 init:
   - step: load-namespace

--- a/modules/drivers/databricks/resources/metabase-plugin.yaml
+++ b/modules/drivers/databricks/resources/metabase-plugin.yaml
@@ -11,51 +11,59 @@ driver:
     parent: hive-like
     connection-properties:
       - merge:
-          - host
-          -
-            placeholder: "xxxxxxxxxx.cloud.databricks.com"
-            helper-text: "The Databricks host URL. Could also be adb-xxxxx.azuredatabricks.net"
+        - host
+        - display-name: Host
+          required: true
+          placeholder: xxxxxxxxxx.cloud.databricks.com
+          helper-text: The Databricks host URL. Could also be adb-xxxxx.azuredatabricks.net
       - name: http-path
         display-name: HTTP Path
-        helper-text: "Found in SQL Warehouses > Connection details"
+        helper-text: Found in SQL Warehouses > Connection details
         required: true
-        placeholder: "/sql/1.0/endpoints/abcdef1234567890"
+        placeholder: /sql/1.0/endpoints/abcdef1234567890
+      - name: use-token
+        display-name: Use Personal Access Token
+        type: boolean
+        default: false
+        helper-text: Use Personal Access Token for authentication.
       - merge:
-          - password
-          -
-            name: token
-            display-name: Personal Access Token
-            required: false
-            type: secret
-            secret-kind: password
-            helper-text: "Personal Access Token for authentication. Not required if using OAuth M2M."
-            placeholder: "dapixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        - password
+        - name: token
+          display-name: Personal Access Token
+          required: true
+          helper-text: Personal Access Token for authentication. Not required if using OAuth M2M.
+          placeholder: dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+          visible-if:
+            use-token: true
       - name: client-id
         display-name: Service Principal Client ID
-        placeholder: "e26ce240-0a12-454f-934f-4c646603cb61"
-        helper-text: "For M2M OAuth authentication, corresponds to the service principal's Client ID."
-        required: false
-      - name: oauth-secret
-        display-name: Service Principal OAuth Secret
-        type: secret
-        secret-kind: password
-        placeholder: "dosexxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-        helper-text: "Oauth Secret for M2M OAuth authentication."
-        required: false
+        placeholder: e26ce240-0a12-454f-934f-4c646603cb61
+        helper-text: For M2M OAuth authentication, corresponds to the service principal's Client ID.
+        required: true
+        visible-if:
+          use-token: false
+      - merge:
+        - password
+        - name: oauth-secret
+          display-name: Service Principal OAuth Secret
+          placeholder: dosexxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+          helper-text: OAuth Secret for M2M OAuth authentication.
+          required: true
+          visible-if:
+            use-token: false
       - name: catalog
         display-name: Catalog
         default: default
         required: true
-        helper-text: "Specify the catalog to connect to."
+        helper-text: Specify the catalog to connect to.
       - name: schema-filters
         type: schema-filters
         display-name: Schemas
-        helper-text: "Optionally filter which schemas are visible."
+        helper-text: Optionally filter which schemas are visible.
       - advanced-options-start
       - merge:
           - additional-options
-          -
-            placeholder: "IgnoreTransactions=0"
+          - placeholder: IgnoreTransactions=0
       - default-advanced-options
 init:
   - step: load-namespace

--- a/modules/drivers/databricks/src/metabase/driver/databricks.clj
+++ b/modules/drivers/databricks/src/metabase/driver/databricks.clj
@@ -204,35 +204,32 @@
   [_driver {:keys [catalog host http-path use-m2m token client-id oauth-secret log-level additional-options] :as _details}]
   (assert (string? (not-empty catalog)) "Catalog is mandatory.")
   (let [base-spec
-        {
-          :classname      "com.databricks.client.jdbc.Driver"
-          :subprotocol    "databricks"
-          ;; Reading through the changelog revealed `EnableArrow=0` solves multiple problems. Including the exception logged
-          ;; during first `can-connect?` call. Ref:
-          ;; https://databricks-bi-artifacts.s3.us-east-2.amazonaws.com/simbaspark-drivers/jdbc/2.6.40/docs/release-notes.txt
-          :subname        (str "//" host ":443/;EnableArrow=0"
+        {:classname      "com.databricks.client.jdbc.Driver"
+         :subprotocol    "databricks"
+         ;; Reading through the changelog revealed `EnableArrow=0` solves multiple problems. Including the exception logged
+         ;; during first `can-connect?` call. Ref:
+         ;; https://databricks-bi-artifacts.s3.us-east-2.amazonaws.com/simbaspark-drivers/jdbc/2.6.40/docs/release-notes.txt
+         :subname        (str "//" host ":443/;EnableArrow=0"
                               ";ConnCatalog=" (codec/url-encode catalog)
                               (preprocess-additional-options additional-options))
-          :transportMode  "http"
-          :ssl            1
-          :HttpPath       http-path
-          :UserAgentEntry (format "Metabase/%s" (:tag config/mb-version-info))
-          :UseNativeQuery 1}
-          ;; Following is used just for tests. See the [[metabase.driver.sql-jdbc.connection-test/perturb-db-details]]
-          ;; and test that is using the function.
-        base-spec (if log-level (assoc base-spec :LogLevel log-level) base-spec)]
-    (if use-m2m
-      ;; M2M OAuth
-      (assoc base-spec
-             :AuthMech 11
-             :Auth_Flow 1
-             :OAuth2ClientId client-id
-             :OAuth2Secret oauth-secret)
-      ;; PAT authentication
-      (assoc base-spec
-             :AuthMech 3
-             :uid "token"
-             :pwd token))))
+         :transportMode  "http"
+         :ssl            1
+         :HttpPath       http-path
+         :UserAgentEntry (format "Metabase/%s" (:tag config/mb-version-info))
+         :UseNativeQuery 1}]
+    (merge base-spec
+           (when log-level
+             {:LogLevel log-level})
+           (if use-m2m
+             ;; M2M OAuth
+             {:AuthMech 11
+              :Auth_Flow 1
+              :OAuth2ClientId client-id
+              :OAuth2Secret oauth-secret}
+             ;; PAT authentication
+             {:AuthMech 3
+              :uid "token"
+              :pwd token}))))
 
 (defmethod sql.qp/quote-style :databricks
   [_driver]


### PR DESCRIPTION
# Add M2M Oauth to Databricks Driver
Closes https://github.com/metabase/metabase/issues/51276

### Description
This pull request includes updates to the Databricks drivers and its documentation. The changes enhance the connection setup process and provide more detailed guidance on authentication methods and configuration options.

#### Documentation updates:

* [`docs/databases/connections/databricks.md`](diffhunk://#diff-0498b9e0ba7072177771a34a8ebdfddaf0a0af20d4cb4a6dc95eed9540ff6b3dL17-R39): Expanded the host and HTTP path descriptions with examples and added detailed sections on authentication methods, re-running queries, and managing database sync and scan settings. 

#### Driver configuration updates:

* `modules/drivers/databricks/resources/metabase-plugin.yaml`: Updated the driver version to 1.2.0, added placeholders and helper text for various connection properties, and included new options for OAuth M2M authentication.
* `modules/drivers/databricks/src/metabase/driver/databricks.clj`: Modified the connection details to support both personal access tokens and OAuth M2M authentication, with conditional logic to toggle between OAuth M2M and token based auth. M2M being the default.

### Demo
#### Empty, default

<img width="616" alt="image" src="https://github.com/user-attachments/assets/f8955c1e-6c42-480b-9b61-0795eed5c333" />

#### Empty, PAT

<img width="609" alt="image" src="https://github.com/user-attachments/assets/c2013a20-588a-419d-8915-0ac54a7913b4" />


