### PR TITLE
show all columns in scatter tooltip by default

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/scatter.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/scatter.cy.spec.js
@@ -175,13 +175,15 @@ select 10 as size, 2 as x, 5 as y`,
   });
 
   it("should allow adding non-series columns to the tooltip", () => {
-    const additionalColumns = [
-      "Total",
-      "Discount",
-      "Created At",
-      "ID",
-      "User ID",
-      "Product ID",
+    const allTooltipRows = [
+      { name: "Tax", value: "0.86" },
+      { name: "ID", value: "562" },
+      { name: "User ID", value: "70" },
+      { name: "Product ID", value: "61" },
+      { name: "Total", value: "16.55" },
+      { name: "Discount", value: "" },
+      { name: "Created At", value: "July 4, 2023, 4:57 AM" },
+      { name: "Quantity", value: "4" },
     ];
 
     H.visitQuestionAdhoc({
@@ -200,35 +202,33 @@ select 10 as size, 2 as x, 5 as y`,
     H.cartesianChartCircle().first().realHover();
     H.assertEChartsTooltip({
       header: "15.69",
-      rows: [{ name: "Tax", value: "0.86" }],
+      rows: allTooltipRows,
     });
 
-    H.assertEChartsTooltipNotContain(additionalColumns);
-
     cy.findByTestId("viz-settings-button").click();
+    // Resizing animation due to the sidebar
+    cy.wait(200);
+
+    const columnsToRemove = allTooltipRows.slice(2).map(row => row.name);
 
     H.leftSidebar().within(() => {
       cy.findByText("Display").click();
-      cy.findByPlaceholderText("Enter metric names").click();
+
+      columnsToRemove.map(columnName => {
+        cy.findByRole("combobox")
+          .findByText(columnName)
+          .siblings("button")
+          .click();
+      });
     });
-
-    additionalColumns.forEach(name =>
-      cy.findByRole("option", { name }).click(),
-    );
-
-    // Close the popover
-    cy.get("body").type("{esc}");
 
     H.cartesianChartCircle().first().realHover();
+
+    H.assertEChartsTooltipNotContain(columnsToRemove);
     H.assertEChartsTooltip({
       header: "15.69",
-      rows: [
-        { name: "Tax", value: "0.86" },
-        { name: "Total", value: "16.55" },
-        { name: "Discount", value: "(empty)" },
-      ],
+      rows: allTooltipRows.slice(0, 2),
     });
-    H.assertEChartsTooltipNotContain(["Quantity"]);
   });
 });
 

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -314,7 +314,6 @@ export const TOOLTIP_SETTINGS = {
   },
   "graph.tooltip_columns": {
     section: t`Display`,
-
     title: t`Additional tooltip metrics`,
     placeholder: t`Enter metric names`,
     widget: "multiselect",

--- a/frontend/src/metabase/visualizations/lib/settings/graph.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.unit.spec.js
@@ -487,6 +487,61 @@ describe("graph.tooltip_columns", () => {
 
       expect(isHidden).toBe(false);
     });
+
+    describe("getValue", () => {
+      const getMockSeries = display => [
+        createMockSingleSeries(
+          createMockCard({ display }),
+          createMockDataset({
+            data: createMockDatasetData({
+              cols: [
+                createMockColumn({ name: "dim", base_type: "type/Text" }),
+                createMockColumn({
+                  name: "metric1",
+                  base_type: "type/Number",
+                }),
+                createMockColumn({
+                  name: "metric2",
+                  base_type: "type/Number",
+                }),
+                createMockColumn({
+                  name: "metric3",
+                  base_type: "type/Number",
+                }),
+                createMockColumn({
+                  name: "category",
+                  base_type: "type/Text",
+                }),
+              ],
+            }),
+          }),
+        ),
+      ];
+
+      it("should return all available columns on scatter charts by default", () => {
+        const value = tooltipColumnsSetting.getValue(getMockSeries("scatter"), {
+          "graph.tooltip_type": "series_comparison",
+          "graph.dimensions": ["dim"],
+          "graph.metrics": ["metric1"],
+        });
+
+        expect(value).toStrictEqual([
+          '["name","metric2"]',
+          '["name","metric3"]',
+          '["name","category"]',
+        ]);
+      });
+
+      it("should return no additional columns by default", () => {
+        const value = tooltipColumnsSetting.getValue(getMockSeries("line"), {
+          "graph.tooltip_type": "series_comparison",
+          "graph.dimensions": ["dim"],
+          "graph.metrics": ["metric1"],
+        });
+
+        expect(value).toHaveLength(0);
+      });
+    });
   });
 
   describe("getProps", () => {

--- a/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
@@ -430,13 +430,17 @@ export function getComputedAdditionalColumnsValue(
   rawSeries: RawSeries,
   settings: ComputedVisualizationSettings,
 ) {
-  const isAggregatedChart = rawSeries[0].card.display !== "scatter";
+  const isScatter = rawSeries[0].card.display === "scatter";
 
   const availableAdditionalColumnKeys = new Set(
-    getAvailableAdditionalColumns(rawSeries, settings, isAggregatedChart).map(
-      column => getColumnKey(column),
+    getAvailableAdditionalColumns(rawSeries, settings, !isScatter).map(column =>
+      getColumnKey(column),
     ),
   );
+
+  if (!settings["graph.tooltip_columns"] && isScatter) {
+    return Array.from(availableAdditionalColumnKeys);
+  }
 
   const filteredStoredColumns = (
     settings["graph.tooltip_columns"] ?? []


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/51483
[Slack convo](https://metaboat.slack.com/archives/C01LQQ2UW03/p1734548339473699?thread_ts=1734547528.367109&cid=C01LQQ2UW03)

### Description

Starting from v51 the scatter chart tooltip shows only single metric column value. We added possibility of selecting additional columns to show in tooltips, however, for users it is more desired to see all available columns by default.

### How to verify

- New Orders -> 2 summarizations: by Created At and Product: Category
- Change viz type to `scatter`, x-axis: Created At, y-axis: Count
- Hover bubbles
- Ensure the tooltip also shows Product: Category

### Demo

<img width="338" alt="Screenshot 2024-12-18 at 3 48 36 PM" src="https://github.com/user-attachments/assets/8eff7a2e-3c15-4e68-9b5d-779e9dfc8928" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
