### PR TITLE
Add user_is_viewing to FE->BE context

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/context.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/context.clj
@@ -58,9 +58,7 @@
 (mu/defn create-context
   "Create a tool context."
   [context]
-  (-> context
-      set-user-time
-      (select-keys [:current_user_time])))
+  (set-user-time context))
 
 (mu/defn create-reactions
   "Extracts reactions based on the current context."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/context.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/context.clj
@@ -43,9 +43,8 @@
 
 (mu/defn create-context
   "Create a tool context."
-  [_context]
-  (merge {}
-         #_(metabot-v3.tools.query/create-context context)))
+  [context]
+  (or context {}))
 
 (mu/defn describe-context
   "Transforms the tool context into LLM context."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/handle_envelope.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/handle_envelope.clj
@@ -19,7 +19,7 @@
 (defn- request-llm-response [e]
   (let [context (envelope/context e)
         new-response-message (:message (metabot-v3.client/*request*
-                                        context
+                                        (select-keys context [:current_user_time])
                                         (envelope/full-history e)
                                         (envelope/session-id e)
                                         (metabot-v3.tools/applicable-tools (metabot-v3.tools/*tools-metadata*)

--- a/enterprise/frontend/src/metabase-enterprise/metabot/context.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/context.tsx
@@ -10,6 +10,7 @@ import type {
 
 export const defaultContext = {
   getChatContext: () => ({
+    user_is_viewing: [],
     current_time_with_timezone: dayjs.tz(dayjs()).format(),
   }),
   registerChatContextProvider: () => () => {},
@@ -29,6 +30,7 @@ export const MetabotProvider = ({
     const state = store.getState();
 
     const baseContext = {
+      user_is_viewing: [],
       current_time_with_timezone: dayjs.tz(dayjs()).format(),
     };
 

--- a/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
@@ -323,13 +323,11 @@ describe("metabot", () => {
         whoIsYourFavoriteResponse,
       );
 
-      const TestComponentOne = () => {
-        useRegisterMetabotContextProvider(() => ({ a: 1 }), []);
-        return null;
-      };
-
-      const TestComponentTwo = () => {
-        useRegisterMetabotContextProvider(() => ({ b: 2 }), []);
+      const TestComponent = () => {
+        useRegisterMetabotContextProvider(
+          () => ({ user_is_viewing: [{ type: "question", id: 1 }] }),
+          [],
+        );
         return null;
       };
 
@@ -337,8 +335,7 @@ describe("metabot", () => {
         ui: (
           <>
             <Metabot />
-            <TestComponentOne />
-            <TestComponentTwo />
+            <TestComponent />
           </>
         ),
       });
@@ -347,7 +344,10 @@ describe("metabot", () => {
 
       expect(
         isMatching(
-          { current_time_with_timezone: P.string, a: 1, b: 2 },
+          {
+            current_time_with_timezone: P.string,
+            user_is_viewing: [{ type: "question", id: 1 }],
+          },
           (await lastReqBody())?.context,
         ),
       ).toBe(true);

--- a/frontend/src/metabase-types/api/metabot.ts
+++ b/frontend/src/metabase-types/api/metabot.ts
@@ -1,6 +1,13 @@
 import type { CardDisplayType } from "./visualization";
 
-import type { ColumnSettings, DatasetQuery, SeriesSettings } from ".";
+import type {
+  CardId,
+  CardType,
+  ColumnSettings,
+  DashboardId,
+  DatasetQuery,
+  SeriesSettings,
+} from ".";
 
 export type MetabotFeedbackType =
   | "great"
@@ -11,8 +18,9 @@ export type MetabotFeedbackType =
 /* Metabot v3 - Base Types */
 
 export type MetabotChatContext = {
+  user_is_viewing: MetabotEntityInfo[];
   current_time_with_timezone: string;
-} & Record<string, any>;
+};
 
 export type MetabotTool = {
   name: string; // TODO: make strictly typed - currently there's no tools
@@ -136,6 +144,26 @@ export type MetabotReaction =
   | MetabotWriteBackReaction
   | MetabotApiCallReaction
   | MetabotRunQueryReaction;
+
+export type MetabotCardInfo = {
+  type: CardType;
+  id: CardId;
+};
+
+export type MetabotDashboardInfo = {
+  type: "dashboard";
+  id: DashboardId;
+};
+
+export type MetabotAdhocQueryInfo = {
+  type: "adhoc";
+  query: DatasetQuery;
+};
+
+export type MetabotEntityInfo =
+  | MetabotCardInfo
+  | MetabotDashboardInfo
+  | MetabotAdhocQueryInfo;
 
 /* Metabot v3 - API Request Types */
 

--- a/frontend/src/metabase/dashboard/hooks/use-register-dashboard-metabot-context.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-register-dashboard-metabot-context.ts
@@ -10,7 +10,7 @@ export const useRegisterDashboardMetabotContext = () => {
     }
 
     return {
-      dashboard_id: dashboard.id,
+      user_is_viewing: [{ type: "dashboard", id: dashboard.id }],
     };
   }, []);
 };

--- a/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.ts
+++ b/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.ts
@@ -10,7 +10,9 @@ export const useRegisterQueryBuilderMetabotContext = () => {
     }
 
     return {
-      dataset_query: question.datasetQuery(),
+      user_is_viewing: question.isSaved()
+        ? [{ type: question.type(), id: question.id() }]
+        : [{ type: "adhoc", query: question.datasetQuery() }],
     };
   }, []);
 };


### PR DESCRIPTION
Adds `user_is_viewing` to FE->BE context. Possible options:
- `[{ type: "question", id: 1}]`
- `[{ type: "model", id: 1}]`
- `[{ type: "metric", id: 1}]`
- `[{ type: "dashboard", id: 1}]`
- `[{ type: "adhoc", query: {database: 1, type: "query", query: { "source-table": 2 }}}]`

I used `id` and not `ref` here to match other API endpoints but can switch to `ref` if needed.