### PR TITLE
Fix the zoom-in.binning drill thru for multi-stage queries

### DIFF
--- a/frontend/src/metabase/visualizations/lib/table.js
+++ b/frontend/src/metabase/visualizations/lib/table.js
@@ -66,10 +66,8 @@ export function getTableCellClickedObject(
     };
   } else {
     // Clicks on aggregation columns can wind up here if the query has stages after the aggregation / breakout
-    // stage. In that case, column.source will be something like "fields", and it's up to the drill to check
-    // the underlying column and construct the dimensions from the passed in clickedRowData. Currently, only
-    // the underlying_records drill handles this, but other drills should be updated if they care about the
-    // column's underlying source.
+    // stage. In that case, column.source will be something like "fields", and it's up to Lib.availableDrillThrus
+    // to check the underlying column and construct the dimensions from the passed in clickedRowData.
     return {
       value,
       column,

--- a/src/metabase/lib/drill_thru.cljc
+++ b/src/metabase/lib/drill_thru.cljc
@@ -87,7 +87,7 @@
   ;; cannot determine that the clicked table cell was from an "underlying" aggregation-sourced column. See, e.g. the
   ;; comment in getTableCellClickedObject in table.js.
   (let [row-dimensions (lib.drill-thru.common/dimensions-from-breakout-columns query column row)]
-    (if (and (empty? dimensions) (not-empty row-dimensions))
+    (if (and (empty? dimensions) (seq row-dimensions))
       (assoc context :dimensions row-dimensions)
       context)))
 

--- a/src/metabase/lib/drill_thru.cljc
+++ b/src/metabase/lib/drill_thru.cljc
@@ -109,13 +109,13 @@
            (when (lib.metadata/editable? query)
              (let [{:keys [query stage-number]} (lib.query/wrap-native-query-with-mbql
                                                  query stage-number (:card-id context))
-                   context'                     (context-with-dimensions-or-row-dimensions query context)
-                   dim-contexts                 (dimension-contexts context')]
+                   context                      (context-with-dimensions-or-row-dimensions query context)
+                   dim-contexts                 (dimension-contexts context)]
                (for [{:keys [f return-drills-for-dimensions?]} available-drill-thru-fns
-                     context''                                 (if (and return-drills-for-dimensions? dim-contexts)
+                     context                                   (if (and return-drills-for-dimensions? dim-contexts)
                                                                  dim-contexts
-                                                                 [context'])
-                     :let                                      [drill (f query stage-number context'')]
+                                                                 [context])
+                     :let                                      [drill (f query stage-number context)]
                      :when                                     drill]
                  drill))))
      (catch #?(:clj Throwable :cljs :default) e

--- a/src/metabase/lib/drill_thru.cljc
+++ b/src/metabase/lib/drill_thru.cljc
@@ -78,6 +78,19 @@
    (for [dimension dimensions]
      (merge context dimension))))
 
+(mu/defn- context-with-dimensions-or-row-dimensions :- ::lib.schema.drill-thru/context
+  "Return an updated `context` with either the existing `dimensions` or dimensions constructed from the `row`."
+  [query                                       :- ::lib.schema/query
+   {:keys [column dimensions row] :as context} :- ::lib.schema.drill-thru/context]
+  ;; If no dimensions were provided but the underlying column comes from an aggregation, then construct the dimensions
+  ;; from the row data. This is needed in cases where the frontend normally provides dimensions, but will not if it
+  ;; cannot determine that the clicked table cell was from an "underlying" aggregation-sourced column. See, e.g. the
+  ;; comment in getTableCellClickedObject in table.js.
+  (let [row-dimensions (lib.drill-thru.common/dimensions-from-breakout-columns query column row)]
+    (if (and (empty? dimensions) (not-empty row-dimensions))
+      (assoc context :dimensions row-dimensions)
+      context)))
+
 (mu/defn available-drill-thrus :- [:sequential [:ref ::lib.schema.drill-thru/drill-thru]]
   "Get a list (possibly empty) of available drill-thrus for a column, or a column + value pair.
 
@@ -96,12 +109,13 @@
            (when (lib.metadata/editable? query)
              (let [{:keys [query stage-number]} (lib.query/wrap-native-query-with-mbql
                                                  query stage-number (:card-id context))
-                   dim-contexts                 (dimension-contexts context)]
+                   context'                     (context-with-dimensions-or-row-dimensions query context)
+                   dim-contexts                 (dimension-contexts context')]
                (for [{:keys [f return-drills-for-dimensions?]} available-drill-thru-fns
-                     context                                   (if (and return-drills-for-dimensions? dim-contexts)
+                     context''                                 (if (and return-drills-for-dimensions? dim-contexts)
                                                                  dim-contexts
-                                                                 [context])
-                     :let                                      [drill (f query stage-number context)]
+                                                                 [context'])
+                     :let                                      [drill (f query stage-number context'')]
                      :when                                     drill]
                  drill))))
      (catch #?(:clj Throwable :cljs :default) e

--- a/src/metabase/lib/drill_thru/automatic_insights.cljc
+++ b/src/metabase/lib/drill_thru/automatic_insights.cljc
@@ -28,7 +28,7 @@
              (lib.metadata/setting query :enable-xrays)
              (not-empty dimensions)
              ;; TODO fix this drill to work with underlying aggregations and remove this check (metabase#46932).
-             (not (lib.drill-thru.common/strictly-underyling-aggregation? query column)))
+             (not (lib.drill-thru.common/strictly-underlying-aggregation? query column)))
     {:lib/type   :metabase.lib.drill-thru/drill-thru
      :type       :drill-thru/automatic-insights
      :column-ref column-ref

--- a/src/metabase/lib/drill_thru/automatic_insights.cljc
+++ b/src/metabase/lib/drill_thru/automatic_insights.cljc
@@ -26,7 +26,9 @@
              ;; Column with no value is not allowed - that's a column header click. Other combinations are allowed.
              (or (not column) (some? value))
              (lib.metadata/setting query :enable-xrays)
-             (not-empty dimensions))
+             (not-empty dimensions)
+             ;; TODO fix this drill to work with underlying aggregations and remove this check (metabase#46932).
+             (not (lib.drill-thru.common/strictly-underyling-aggregation? query column)))
     {:lib/type   :metabase.lib.drill-thru/drill-thru
      :type       :drill-thru/automatic-insights
      :column-ref column-ref

--- a/src/metabase/lib/drill_thru/common.cljc
+++ b/src/metabase/lib/drill_thru/common.cljc
@@ -48,7 +48,7 @@
   [value]
   (if (= value :null) nil value))
 
-(defn- has-source-or-underyling-source-fn
+(defn- has-source-or-underlying-source-fn
   [source]
   (fn has-source?
     ([column]
@@ -61,13 +61,13 @@
 
 (def aggregation-sourced?
   "Does column or top-level-column have :source/aggregations?"
-  (has-source-or-underyling-source-fn :source/aggregations))
+  (has-source-or-underlying-source-fn :source/aggregations))
 
 (def breakout-sourced?
   "Does column or top-level-column have :source/breakouts?"
-  (has-source-or-underyling-source-fn :source/breakouts))
+  (has-source-or-underlying-source-fn :source/breakouts))
 
-(defn strictly-underyling-aggregation?
+(defn strictly-underlying-aggregation?
   "Does the top-level-column for `column` in `query` have :source/aggregations?"
   [query column]
   (and (not (aggregation-sourced? column))
@@ -76,6 +76,6 @@
 (defn dimensions-from-breakout-columns
   "Convert `row` data into dimensions for `column`s that come from an aggregation in a previous stage."
   [query column row]
-  (when (strictly-underyling-aggregation? query column)
+  (when (strictly-underlying-aggregation? query column)
     (not-empty (filterv #(breakout-sourced? query (:column %))
                         row))))

--- a/src/metabase/lib/drill_thru/underlying_records.cljc
+++ b/src/metabase/lib/drill_thru/underlying_records.cljc
@@ -54,9 +54,9 @@
 
   There is another quite different case: clicking the legend of a chart with multiple bars or lines broken out by
   category. Then `column` is nil!"
-  [query                                                          :- ::lib.schema/query
-   stage-number                                                   :- :int
-   {:keys [column column-ref dimensions row value], :as _context} :- ::lib.schema.drill-thru/context]
+  [query                                                      :- ::lib.schema/query
+   stage-number                                               :- :int
+   {:keys [column column-ref dimensions value], :as _context} :- ::lib.schema.drill-thru/context]
   ;; Clicking on breakouts is weird. Clicking on Count(People) by State: Minnesota yields a FE `clicked` with:
   ;; - column is COUNT
   ;; - row[0] has col: STATE, value: "Minnesota"
@@ -72,8 +72,7 @@
   ;; - (:lib/source column) is NOT :source/aggregations
   ;; - (:lib/source (lib.underlying/top-level-column query column) IS :source/aggregations
   ;; - column-ref is similarly NOT an :aggregation ref
-  ;; - dimensions is nil
-  ;; - rows is not nil and can be used to construct the breakout dimensions
+  ;; - dimensions is constructed from row data in available-drill-thrus
 
   ;; Clicking on a chart legend for eg. COUNT(Orders) by Products.CATEGORY and Orders.CREATED_AT has a context like:
   ;; - column is nil
@@ -102,10 +101,7 @@
      :table-name (when-let [table-or-card (or (some->> query lib.util/source-table-id (lib.metadata/table query))
                                               (some->> query lib.util/source-card-id  (lib.metadata/card  query)))]
                    (lib.metadata.calculation/display-name query stage-number table-or-card))
-     ;; If no dimensions were provided but the underlying column comes from an aggregation, then construct the
-     ;; dimensions from the row data.
-     :dimensions (or (not-empty dimensions)
-                     (lib.drill-thru.common/dimensions-from-breakout-columns query column row))
+     :dimensions dimensions
      ;; If the underlying column comes from an aggregation, then the column-ref needs to be updated as well to the
      ;; corresponding aggregation ref so that [[drill-underlying-records]] knows to extract the filter implied by
      ;; aggregations like sum-where.

--- a/src/metabase/lib/drill_thru/underlying_records.cljc
+++ b/src/metabase/lib/drill_thru/underlying_records.cljc
@@ -68,7 +68,7 @@
   ;; Clicking on a single-row aggregation, there's no dimensions, but we should support underlying records.
 
   ;; Clicking on a table cell for an aggregated column when there are additional query stages (e.g. filters) after the
-  ;; underyling breakouts/aggregations stage results in a context like:
+  ;; underlying breakouts/aggregations stage results in a context like:
   ;; - (:lib/source column) is NOT :source/aggregations
   ;; - (:lib/source (lib.underlying/top-level-column query column) IS :source/aggregations
   ;; - column-ref is similarly NOT an :aggregation ref
@@ -105,7 +105,7 @@
      ;; If the underlying column comes from an aggregation, then the column-ref needs to be updated as well to the
      ;; corresponding aggregation ref so that [[drill-underlying-records]] knows to extract the filter implied by
      ;; aggregations like sum-where.
-     :column-ref (if (lib.drill-thru.common/strictly-underyling-aggregation? query column)
+     :column-ref (if (lib.drill-thru.common/strictly-underlying-aggregation? query column)
                    (lib.aggregation/column-metadata->aggregation-ref (lib.underlying/top-level-column query column))
                    column-ref)}))
 

--- a/src/metabase/lib/drill_thru/zoom_in_bins.cljc
+++ b/src/metabase/lib/drill_thru/zoom_in_bins.cljc
@@ -79,6 +79,7 @@
    [metabase.lib.schema.binning :as lib.schema.binning]
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
+   [metabase.lib.underlying :as lib.underlying]
    [metabase.util.malli :as mu]))
 
 ;;;
@@ -88,13 +89,22 @@
 (mu/defn zoom-in-binning-drill :- [:maybe ::lib.schema.drill-thru/drill-thru.zoom-in.binning]
   "Return a drill thru that 'zooms in' on a breakout that uses `:binning` if applicable.
   See [[metabase.lib.drill-thru.zoom-in-bins]] docstring for more information."
-  [query                                :- ::lib.schema/query
-   stage-number                         :- :int
-   {:keys [column value], :as _context} :- ::lib.schema.drill-thru/context]
+  [query                                 :- ::lib.schema/query
+   _stage-number                         :- :int
+   {:keys [column value], :as _context}  :- ::lib.schema.drill-thru/context]
   (when (and column value)
-    (when-let [existing-breakout (first (lib.breakout/existing-breakouts query stage-number column))]
+    (when-let [existing-breakout (first (lib.breakout/existing-breakouts query
+                                                                         (lib.underlying/top-level-stage-number query)
+                                                                         column))]
       (when-let [binning (lib.binning/binning existing-breakout)]
-        (when-let [{:keys [min-value max-value bin-width]} (lib.binning/resolve-bin-width query column value)]
+        (when-let [{:keys [min-value max-value bin-width]}
+                   ;; If the column has binning options, use those; otherwise, check the top-level-column.
+                   (or (lib.binning/resolve-bin-width query column value)
+                       (lib.binning/resolve-bin-width
+                        query
+                        ;; One of the "superflous" options is ::lib.field/binning, which we want to preserve here.
+                        (lib.underlying/top-level-column query column :rename-superflous-options? false)
+                        value))]
           (case (:strategy binning)
             (:num-bins :default)
             {:lib/type    :metabase.lib.drill-thru/drill-thru
@@ -129,11 +139,15 @@
   [query                                        :- ::lib.schema/query
    stage-number                                 :- :int
    {:keys [column min-value max-value new-binning]} :- ::lib.schema.drill-thru/drill-thru.zoom-in.binning]
-  (let [old-filters (filter (fn [[operator _opts filter-column]]
+  ;; We add and remove filters on the last stage rather than top-level-stage-number because that is
+  ;; where [[metabase.query-processor.middleware.binning/update-binning-strategy]] expects to find them. Adding the
+  ;; filters to top-level-stage-number breaks the binning.
+  (let [top-level-stage-number (lib.underlying/top-level-stage-number query)
+        old-filters (filter (fn [[operator _opts filter-column]]
                               (and (#{:>= :<} operator)
                                    (lib.equality/find-matching-column filter-column [column])))
                             (lib.filter/filters query stage-number))]
-    (-> (reduce lib.remove-replace/remove-clause query old-filters)
+    (-> (reduce #(lib.remove-replace/remove-clause %1 stage-number %2) query old-filters)
+        (update-breakout top-level-stage-number column new-binning)
         (lib.filter/filter stage-number (lib.filter/>= column min-value))
-        (lib.filter/filter stage-number (lib.filter/< column max-value))
-        (update-breakout stage-number column new-binning))))
+        (lib.filter/filter stage-number (lib.filter/< column max-value)))))

--- a/src/metabase/lib/drill_thru/zoom_in_timeseries.cljc
+++ b/src/metabase/lib/drill_thru/zoom_in_timeseries.cljc
@@ -108,12 +108,9 @@
   This is different from the `:drill-thru/zoom` type, which is for showing the details of a single object."
   [query                                         :- ::lib.schema/query
    _stage-number                                 :- :int
-   {:keys [column dimensions row], :as _context} :- ::lib.schema.drill-thru/context]
+   {:keys [dimensions], :as _context}            :- ::lib.schema.drill-thru/context]
   ;; For multi-stage queries, we want the stage-number of the underlying stage with breakouts or aggregations.
-  ;; In such cases, the FE will not pass dimensions, so use the row data instead, if available.
-  (let [stage-number (lib.underlying/top-level-stage-number query)
-        dimensions   (or (not-empty dimensions)
-                         (lib.drill-thru.common/dimensions-from-breakout-columns query column row))]
+  (let [stage-number (lib.underlying/top-level-stage-number query)]
     (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
                dimensions)
       (when-let [{:keys [value column-ref], :as dimension}

--- a/test/metabase/lib/drill_thru/underlying_records_test.cljc
+++ b/test/metabase/lib/drill_thru/underlying_records_test.cljc
@@ -114,7 +114,7 @@
                    :table-name "Orders"
                    ;; the "underlying" aggregation ref is reconstructed.
                    :column-ref [:aggregation {:lib/source-name "count"} string?]
-                   ;; the "underyling" dimensions are reconstructed from the row.
+                   ;; the "underlying" dimensions are reconstructed from the row.
                    :dimensions [{:column     {:name       "PRODUCT_ID"
                                               :lib/source :source/previous-stage}
                                  :column-ref [:field {} "PRODUCT_ID"]

--- a/test/metabase/lib/drill_thru/zoom_in_bins_test.cljc
+++ b/test/metabase/lib/drill_thru/zoom_in_bins_test.cljc
@@ -10,6 +10,26 @@
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 
+(defn- add-trivial-filter-stage
+  [query name-of-column-to-filter]
+  (let [query'           (lib/append-stage query)
+        column-to-filter (m/find-first #(= (:name %) name-of-column-to-filter)
+                                       (lib/returned-columns query'))]
+    (is (some? column-to-filter))
+    (lib/filter query' (lib/> column-to-filter -1))))
+
+(defn- test-drill-application-with-extra-stage
+  [test-drill-context
+   & {:keys [custom-query-with-extra-stage expected-query-with-extra-stage]}]
+  (testing "base query"
+    (lib.drill-thru.tu/test-drill-application test-drill-context))
+  (when (and custom-query-with-extra-stage expected-query-with-extra-stage)
+    (testing "base query with extra stage"
+      (lib.drill-thru.tu/test-drill-application
+       (-> test-drill-context
+           (assoc :custom-query custom-query-with-extra-stage)
+           (assoc :expected-query expected-query-with-extra-stage))))))
+
 (deftest ^:parallel zoom-in-bins-available-test
   (testing "zoom-in for bins is available for cells, pivots and legends on numeric columns which have binning set"
     (canned/canned-test
@@ -28,7 +48,7 @@
                     (lib/aggregate (lib/count))
                     (lib/breakout (-> (meta/field-metadata :orders :total)
                                       (lib/with-binning {:strategy :num-bins, :num-bins 10}))))]
-      (lib.drill-thru.tu/test-drill-application
+      (test-drill-application-with-extra-stage
        {:click-type     :cell
         :query-type     :aggregated
         :custom-query   query
@@ -51,7 +71,22 @@
                                                    40]
                                                   [:< {}
                                                    [:field {} (meta/id :orders :total)]
-                                                   60.0]]}]}}))))
+                                                   60.0]]}]}}
+       :custom-query-with-extra-stage (add-trivial-filter-stage query "count")
+       :expected-query-with-extra-stage {:stages [{:source-table (meta/id :orders)
+                                                   :aggregation  [[:count {}]]
+                                                   :breakout     [[:field
+                                                                   {:binning {:strategy :default}}
+                                                                   "TOTAL"]]}
+                                                  {:filters      [[:> {}
+                                                                   [:field {} "count"]
+                                                                   -1]
+                                                                  [:>= {}
+                                                                   [:field {} "TOTAL"]
+                                                                   40]
+                                                                  [:< {}
+                                                                   [:field {} "TOTAL"]
+                                                                   60.0]]}]}))))
 
 (deftest ^:parallel bin-width-test
   (testing ":bin-width binning => :bin-width binning (width ÷= 10) + between filter"
@@ -59,7 +94,7 @@
                     (lib/aggregate (lib/count))
                     (lib/breakout (-> (meta/field-metadata :people :latitude)
                                       (lib/with-binning {:strategy :bin-width, :bin-width 1.0}))))]
-      (lib.drill-thru.tu/test-drill-application
+      (test-drill-application-with-extra-stage
        {:click-type     :cell
         :query-type     :aggregated
         :custom-query   query
@@ -82,7 +117,22 @@
                                                    41.0]
                                                   [:< {}
                                                    [:field {} (meta/id :people :latitude)]
-                                                   42.0]]}]}}))))
+                                                   42.0]]}]}}
+       :custom-query-with-extra-stage (add-trivial-filter-stage query "count")
+       :expected-query-with-extra-stage {:stages [{:source-table (meta/id :people)
+                                                   :aggregation  [[:count {}]]
+                                                   :breakout     [[:field
+                                                                   {:binning {:strategy :bin-width, :bin-width 0.1}}
+                                                                   "LATITUDE"]]}
+                                                  {:filters      [[:> {}
+                                                                   [:field {} "count"]
+                                                                   -1]
+                                                                  [:>= {}
+                                                                   [:field {} "LATITUDE"]
+                                                                   41.0]
+                                                                  [:< {}
+                                                                   [:field {} "LATITUDE"]
+                                                                   42.0]]}]}))))
 
 (deftest ^:parallel default-binning-test
   (testing ":default binning => :bin-width binning. Should consider :dimensions in drill context (#36117)"
@@ -140,7 +190,7 @@
                                       (lib/with-binning {:strategy :num-bins, :num-bins 10})))
                     (lib/breakout (-> (meta/field-metadata :orders :created-at)
                                       (lib/with-temporal-bucket :month))))]
-      (lib.drill-thru.tu/test-drill-application
+      (test-drill-application-with-extra-stage
        {:click-type     :cell
         :query-type     :aggregated
         :custom-query   query
@@ -168,7 +218,25 @@
                                                    10]
                                                   [:< {}
                                                    [:field {} (meta/id :orders :quantity)]
-                                                   20.0]]}]}}))))
+                                                   20.0]]}]}}
+       :custom-query-with-extra-stage (add-trivial-filter-stage query "count")
+       :expected-query-with-extra-stage {:stages [{:source-table (meta/id :orders)
+                                                   :aggregation  [[:count {}]]
+                                                   :breakout     [[:field
+                                                                   {:binning {:strategy :default}}
+                                                                   "QUANTITY"]
+                                                                  [:field
+                                                                   {:temporal-unit :month}
+                                                                   (meta/id :orders :created-at)]]}
+                                                  {:filters      [[:> {}
+                                                                   [:field {} "count"]
+                                                                   -1]
+                                                                  [:>= {}
+                                                                   [:field {} "QUANTITY"]
+                                                                   10]
+                                                                  [:< {}
+                                                                   [:field {} "QUANTITY"]
+                                                                   20.0]]}]}))))
 
 (deftest ^:parallel legend-zoom-binning-numeric-test
   ;; Sum of Subtotal by month and Product->Rating with binning, then click a rating to zoom in.
@@ -259,22 +327,23 @@
 
 (deftest ^:parallel nested-zoom-test
   (testing "repeatedly zooming in on smaller bins should work"
-    (let [query (as-> (lib/query meta/metadata-provider (meta/table-metadata :orders)) $q
-                  ;; Filtering like we'd already zoomed in once, on the 40-60 bin.
-                  (lib/filter $q (lib/>= (meta/field-metadata :orders :subtotal) 40))
-                  (lib/filter $q (lib/<  (meta/field-metadata :orders :subtotal) 60))
-                  (lib/aggregate $q (lib/count))
-                  (lib/breakout $q (lib/with-binning (meta/field-metadata :orders :subtotal)
-                                                     {:strategy  :num-bins
-                                                      :num-bins  8
-                                                      :bin-width 2.5
-                                                      :min-value 40
-                                                      :max-value 60})))]
-      (lib.drill-thru.tu/test-drill-application
+    (let [add-zoom-in-filters #(-> %
+                                   ;; Filtering like we'd already zoomed in once, on the 40-60 bin.
+                                   (lib/filter (lib/>= (meta/field-metadata :orders :subtotal) 40))
+                                   (lib/filter (lib/<  (meta/field-metadata :orders :subtotal) 60)))
+          base-query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                         (lib/aggregate (lib/count))
+                         (lib/breakout (lib/with-binning (meta/field-metadata :orders :subtotal)
+                                         {:strategy  :num-bins
+                                          :num-bins  8
+                                          :bin-width 2.5
+                                          :min-value 40
+                                          :max-value 60})))]
+      (test-drill-application-with-extra-stage
        {:click-type     :cell
         :query-type     :aggregated
-        :custom-query   query
-        :custom-row     {"count" 100
+        :custom-query   (add-zoom-in-filters base-query)
+        :custom-row     {"count"    100
                          "SUBTOTAL" 50} ;; Clicking the 50-52.5 bin
         :column-name    "count"
         :drill-type     :drill-thru/zoom-in.binning
@@ -293,4 +362,19 @@
                                                    50]
                                                   [:< {}
                                                    [:field {} (meta/id :orders :subtotal)]
-                                                   52.5]]}]}}))))
+                                                   52.5]]}]}}
+       :custom-query-with-extra-stage (add-zoom-in-filters (add-trivial-filter-stage base-query "count"))
+       :expected-query-with-extra-stage {:stages [{:source-table (meta/id :orders)
+                                                   :aggregation  [[:count {}]]
+                                                   :breakout     [[:field
+                                                                   {:binning {:strategy :default}}
+                                                                   "SUBTOTAL"]]}
+                                                  {:filters      [[:> {}
+                                                                   [:field {} "count"]
+                                                                   -1]
+                                                                  [:>= {}
+                                                                   [:field {} "SUBTOTAL"]
+                                                                   50]
+                                                                  [:< {}
+                                                                   [:field {} "SUBTOTAL"]
+                                                                   52.5]]}]}))))

--- a/test/metabase/lib/drill_thru/zoom_in_bins_test.cljc
+++ b/test/metabase/lib/drill_thru/zoom_in_bins_test.cljc
@@ -334,11 +334,11 @@
           base-query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
                          (lib/aggregate (lib/count))
                          (lib/breakout (lib/with-binning (meta/field-metadata :orders :subtotal)
-                                         {:strategy  :num-bins
-                                          :num-bins  8
-                                          :bin-width 2.5
-                                          :min-value 40
-                                          :max-value 60})))]
+                                                         {:strategy  :num-bins
+                                                          :num-bins  8
+                                                          :bin-width 2.5
+                                                          :min-value 40
+                                                          :max-value 60})))]
       (test-drill-application-with-extra-stage
        {:click-type     :cell
         :query-type     :aggregated

--- a/test/metabase/lib/drill_thru/zoom_in_bins_test.cljc
+++ b/test/metabase/lib/drill_thru/zoom_in_bins_test.cljc
@@ -26,9 +26,9 @@
   (when (and custom-query-with-extra-stage expected-query-with-extra-stage)
     (testing "base query with extra stage"
       (lib.drill-thru.tu/test-drill-application
-       (-> test-drill-context
-           (assoc :custom-query custom-query-with-extra-stage)
-           (assoc :expected-query expected-query-with-extra-stage))))))
+       (assoc test-drill-context
+              :custom-query   custom-query-with-extra-stage
+              :expected-query expected-query-with-extra-stage)))))
 
 (deftest ^:parallel zoom-in-bins-available-test
   (testing "zoom-in for bins is available for cells, pivots and legends on numeric columns which have binning set"

--- a/test/metabase/lib/underlying_test.cljc
+++ b/test/metabase/lib/underlying_test.cljc
@@ -1,6 +1,7 @@
 (ns metabase.lib.underlying-test
   (:require
    [clojure.test :refer [deftest is testing]]
+   [medley.core :as m]
    [metabase.lib.core :as lib]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.underlying :as lib.underlying]
@@ -71,3 +72,52 @@
             cols  (lib/returned-columns query)]
         (is (= (lib/returned-columns query 0 (lib.util/query-stage query 0))
                (map #(lib.underlying/top-level-column query %) cols)))))))
+
+(deftest ^:parallel top-level-column-rename-options-test
+  (testing `lib.underlying/top-level-column
+    (testing "respects rename-superflous-options?"
+      (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                      (lib/aggregate (lib/sum (meta/field-metadata :orders :subtotal)))
+                      (lib/breakout (-> (meta/field-metadata :orders :created-at)
+                                        (lib/with-temporal-bucket :month)))
+                      (lib/breakout (-> (meta/field-metadata :orders :quantity)
+                                        (lib/with-binning {:strategy :num-bins, :num-bins 10}))))
+            temporal-col (m/find-first #(= (:name %) "CREATED_AT")
+                                       (lib/returned-columns query))
+            _          (is (some? temporal-col))
+            binned-col (m/find-first #(= (:name %) "QUANTITY")
+                                     (lib/returned-columns query))
+            _          (is (some? binned-col))
+            query      (lib/append-stage query)]
+
+        (doseq [[col key-name] [[temporal-col "temporal-unit"]
+                                [binned-col "binning"]]
+                rename?        [true false]]
+          (let [orig-key      (keyword "metabase.lib.field" key-name)
+                renamed-key   (keyword "metabase.lib.underlying" key-name)
+                top-level-col (lib.underlying/top-level-column query col :rename-superflous-options? rename?)]
+            (testing (str "\nrename? " rename?
+                          "\norig-key " orig-key
+                          "\nrenamed-key " renamed-key
+                          "\ntop-level-col " top-level-col)
+              (if rename?
+                (do (is (= (orig-key col) (renamed-key top-level-col)))
+                    (is (= nil (orig-key top-level-col))))
+                (do (is (= (orig-key col) (orig-key top-level-col)))
+                    (is (= nil (renamed-key top-level-col))))))))))))
+
+(deftest ^:parallel top-level-stage-number-test
+  (testing `lib.underlying/top-level-stage-number
+    (testing "returns -1 if not nested"
+      (let [query (lib/query meta/metadata-provider (meta/table-metadata :orders))]
+        (is (= -1 (lib.underlying/top-level-stage-number query)))))
+
+    (testing "returns the stage-number of the top-level query"
+      (let [base-query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                           (lib/aggregate (lib/sum (meta/field-metadata :orders :subtotal)))
+                           (lib/breakout (meta/field-metadata :orders :created-at)))]
+        (doseq [[expected-stage query] [[-1 base-query]
+                                        [-2 (-> base-query lib/append-stage)]
+                                        [-3 (-> base-query lib/append-stage lib/append-stage)]]]
+          (is (= expected-stage
+                 (lib.underlying/top-level-stage-number query))))))))


### PR DESCRIPTION
### Description

Fix the `zoom-in.binning` drill thru for multi-stage queries, when, for example, the breakout dimensions are not on the final stage. Changes for this drill thru are similar to recents fixes for `zoom-in.timeseries` and `underlying-records` drills.

* Construct dimensions from row data once in `available-drill-thrus`, rather than doing it in each drill that needs it separately. The dimensions must be constructed in `available-drill-thrus` since some drills are expected to `return-drills-for-dimensions?`, but this also has the side benefit of reducing code duplication by lifting the rows->dimensions conversion up into a single place.
* Update the `zoom-in.timeseries` and `underlying-records` drills, which no longer need to convert rows->dimensions themselves.
* Add a new optional keyword arg `:rename-superflous-options?` to `lib.underlying/top-level-column` since `zoom-in.binning` wants to check and preserve the binning options on the top-level column.
* Fix the `zoom-in.binning` drill to also work the breakout column comes from an underlying stage
* Add some tests to `zoom-in-bins-test` to verify that the same drill results are returned for single and multi-stage queries.

Related to https://github.com/metabase/metabase/issues/46932

### How to verify

* New question: Orders
* summarize: Count by Quantity: Auto binned (or num bins)
* Add filter stage after summarize, e.g. Count > 1
* Visualize
* Select Table viz
* Click on a cell
* "Zoom in" drill through should appear in the context menu
* Select the "Zoom in" drill: results should zoom in to the selected bin

### Demo

#### Before

![Screenshot 2024-12-18 at 3 55 53 PM](https://github.com/user-attachments/assets/500da4ff-89ef-4ed4-a1d9-657ae8cee561)

#### After

![Screenshot 2024-12-18 at 3 55 18 PM](https://github.com/user-attachments/assets/266d51ef-8ca2-4916-8e53-e84b4fecc304)
![Screenshot 2024-12-18 at 3 57 00 PM](https://github.com/user-attachments/assets/c6a4a31f-3ed8-4b26-a312-387ae1b80c62)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
