### PR TITLE
Batch query_execution, audit_log and view_log truncations

### DIFF
--- a/src/metabase/task/truncate_audit_tables.clj
+++ b/src/metabase/task/truncate_audit_tables.clj
@@ -44,7 +44,6 @@
   :audit      :never
   :getter     (fn []
                 (let [env-var-value (setting/get-value-of-type :integer :audit-max-retention-days)]
-                  (def env-var-value env-var-value)
                   (cond
                     (nil? env-var-value)
                     default-retention-days
@@ -69,23 +68,47 @@
 Twice a day, Metabase will delete rows older than this threshold. The minimum value is 30 days (Metabase will treat entered values of 1 to 29 the same as 30).
 If set to 0, Metabase will keep all rows.")
 
+(defsetting audit-table-truncation-batch-size
+  (deferred-tru "Batch size to use for deletion of old rows for audit-related tables (like query_execution). Can be only set as an environment variable.")
+  :visibility :internal
+  :setter     :none
+  :type       :integer
+  :default    50000
+  :audit      :never
+  :export?    false)
+
+(defn- truncate-table-batched!
+  [table-name time-column]
+  (t2/query-one
+   {:delete-from (keyword table-name)
+    :where [:in
+            :id
+            {:select [:id]
+             :from (keyword table-name)
+             :where [:<=
+                     (keyword time-column)
+                     (t/minus (t/offset-date-time) (t/days (audit-max-retention-days)))]
+             :limit (audit-table-truncation-batch-size)}]}))
+
 (defn- truncate-table!
   "Given a model, deletes all rows older than the configured threshold"
   [model time-column]
   (when-not (infinite? (audit-max-retention-days))
     (let [table-name (name (t2/table-name model))]
-      (task-history/with-task-history {:task "task-history-cleanup"}
-        (try
-          (log/infof "Cleaning up %s table" table-name)
-          (let [rows-deleted (t2/delete!
-                              model
-                              time-column
-                              [:<= (t/minus (t/offset-date-time) (t/days (audit-max-retention-days)))])]
-            (if (> rows-deleted 0)
-              (log/infof "%s cleanup successful, %d rows were deleted" table-name rows-deleted)
-              (log/infof "%s cleanup successful, no rows were deleted" table-name)))
-          (catch Throwable e
-            (log/errorf e "%s cleanup failed" table-name)))))))
+      (try
+        (log/infof "Cleaning up %s table" table-name)
+        (let [total-rows-deleted (volatile! 0)]
+          (loop []
+            (let [batch-rows-deleted (truncate-table-batched! table-name time-column)]
+              (vswap! total-rows-deleted (partial + batch-rows-deleted))
+              ;; Only try to delete another batch if the last batch was full
+              (if (= batch-rows-deleted (audit-table-truncation-batch-size))
+                (recur)
+                (if (not= @total-rows-deleted 0)
+                  (log/infof "%s cleanup successful, %d rows were deleted" table-name @total-rows-deleted)
+                  (log/infof "%s cleanup successful, no rows were deleted" table-name))))))
+        (catch Throwable e
+          (log/errorf e "%s cleanup failed" table-name))))))
 
 (defenterprise audit-models-to-truncate
   "List of models to truncate. OSS implementation only truncates `query_execution` table."
@@ -97,7 +120,8 @@ If set to 0, Metabase will keep all rows.")
   []
   (run!
    (fn [{:keys [model timestamp-col]}]
-     (truncate-table! model timestamp-col))
+     (task-history/with-task-history {:task "task-history-cleanup"}
+       (truncate-table! model timestamp-col)))
    (audit-models-to-truncate)))
 
 (jobs/defjob ^{:doc "Triggers the removal of `query_execution` rows older than the configured threshold."} TruncateAuditTables [_]

--- a/src/metabase/task/truncate_audit_tables.clj
+++ b/src/metabase/task/truncate_audit_tables.clj
@@ -100,7 +100,6 @@ If set to 0, Metabase will keep all rows.")
               (t/minus (t/offset-date-time) (t/days (audit-max-retention-days)))]
       :limit (audit-table-truncation-batch-size)})))
 
-
 (defn- truncate-table!
   "Given a model, deletes all rows older than the configured threshold"
   [model time-column]


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/51432

Runs truncation jobs of all audit-related tables in batches instead of a single query that can lock up the tables and slow down the rest of the application. (Particularly relevant for `query_execution` which can get very large, but shouldn't hurt to use this for all the jobs.)

Set the default batch size to 50000 but configurable by env var `MB_AUDIT_TABLE_TRUNCATION_BATCH_SIZE`.