### PR TITLE
[openapi] reduce amount of oneOf/allOf we generate in documentation

### DIFF
--- a/src/metabase/lib/schema/common.cljc
+++ b/src/metabase/lib/schema/common.cljc
@@ -52,7 +52,8 @@
 ;;; Schema for a string that cannot be blank.
 (mr/def ::non-blank-string
   [:and
-   {:error/message "non-blank string"}
+   {:error/message "non-blank string"
+    :json-schema   {:type "string" :minLength 1}}
    [:string {:min 1}]
    [:fn
     {:error/message "non-blank string"}

--- a/src/metabase/util/malli/schema.clj
+++ b/src/metabase/util/malli/schema.clj
@@ -268,14 +268,15 @@
 
 (def ^:private keyword-or-non-blank-str-malli
   (mc/schema
-   [:or :keyword NonBlankString]))
+   [:or {:json-schema {:type "string" :minLength 1}} :keyword NonBlankString]))
 
 (def BooleanValue
   "Schema for a valid representation of a boolean
   (one of `\"true\"` or `true` or `\"false\"` or `false`.).
   Used by [[metabase.api.common/defendpoint]] to coerce the value for this schema to a boolean.
    Garanteed to evaluate to `true` or `false` when passed through a json decoder."
-  (-> [:enum {:decode/json (fn [b] (contains? #{"true" true} b))}
+  (-> [:enum {:decode/json (fn [b] (contains? #{"true" true} b))
+              :json-schema {:type "boolean"}}
        "true" "false" true false]
       (mu/with-api-error-message
        (deferred-tru "value must be a valid boolean string (''true'' or ''false'')."))))
@@ -283,7 +284,8 @@
 (def MaybeBooleanValue
   "Same as above, but allows distinguishing between `nil` (the user did not specify a value)
   and `false` (the user specified `false`)."
-  (-> [:enum {:decode/json (fn [b] (some->> b (contains? #{"true" true})))}
+  (-> [:enum {:decode/json (fn [b] (some->> b (contains? #{"true" true})))
+              :json-schema {:type "boolean" :optional true}}
        "true" "false" true false nil]
       (mu/with-api-error-message
        (deferred-tru "value must be a valid boolean string (''true'' or ''false'')."))))

--- a/test/metabase/api/common/openapi_test.clj
+++ b/test/metabase/api/common/openapi_test.clj
@@ -10,6 +10,40 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]))
 
+;;; json-schema upgrades
+
+(deftest json-schema-conversion
+  (testing ":maybe turns into optionality"
+    (is (= {:type       "object"
+            :required   []
+            :properties {:name {:type "string"}}}
+           (#'openapi/fix-json-schema
+            (mjs/transform [:map [:name [:maybe string?]]])))))
+
+  (testing ":json-schema basically works (see definition of NonBlankString)"
+    (is (=? {:description map?
+             :$ref        "#/definitions/metabase.lib.schema.common~1non-blank-string",
+             :definitions {"metabase.lib.schema.common/non-blank-string" {:type "string", :minLength 1}}}
+            (mjs/transform ms/NonBlankString))))
+
+  (testing "maps-with-unique-key do not generate weirdness"
+    (is (=? {:description map?
+             :type        "array"
+             :items       {:type       "object"
+                           :required   [:id]
+                           :properties {:id {:type "integer"}}}}
+            (#'openapi/fix-json-schema
+             (mjs/transform (ms/maps-with-unique-key [:sequential [:map [:id :int]]] :id))))))
+
+  (testing "nested data structures are still fixed up"
+    (is (=? {:type  "array"
+             :items {:type       "object"
+                     :properties {:params {:type  "array"
+                                           :items {:type "string"}}}}}
+            (#'openapi/fix-json-schema
+             (mjs/transform [:sequential [:map
+                                          [:params {:optional true} [:maybe [:sequential :string]]]]]))))))
+
 ;;; inner helpers
 
 (deftest ^:parallel parse-compojure-test
@@ -59,13 +93,31 @@
   {c ms/PositiveInt}
   {:count c})
 
+(api/defendpoint PUT "/complex/:id"
+  "More complex body schema"
+  [id :as {data :body}]
+  {id   ms/PositiveInt
+   data [:map
+         [:name {:optional true} [:maybe ms/NonBlankString]]
+         [:dashcards (ms/maps-with-unique-key
+                      [:sequential [:map
+                                    [:id int?]
+                                    [:params {:optional true} [:maybe [:sequential [:map
+                                                                                    [:param_id ms/NonBlankString]
+                                                                                    [:target  :any]]]]]]]
+                      :id)]]}
+  {:id id :data data})
+
 (api/define-routes)
 
 ;;; tests
 
-(deftest ^:parallel fix-locations-test
-  (is (=? {:properties {:value {:$ref "#/components/schemas/metabase.lib.schema.common~1non-blank-string"}}}
-          (#'openapi/fix-locations (mjs/transform [:map [:value ms/NonBlankString]])))))
+(deftest ^:parallel collect-definitions-test
+  (binding [openapi/*definitions* (atom [])]
+    (is (=? {:properties {:value {:$ref "#/components/schemas/metabase.lib.schema.common~1non-blank-string"}}}
+            (#'openapi/mjs-collect-definitions [:map [:value ms/NonBlankString]])))
+    (is (= [{"metabase.lib.schema.common/non-blank-string" {:type "string", :minLength 1}}]
+           @@#'openapi/*definitions*))))
 
 (deftest ^:parallel path->openapi-test
   (is (= "/{model}/{yyyy-mm}"
@@ -73,7 +125,8 @@
 
 (deftest ^:parallel collect-routes-test
   (testing "can collect routes in simple case"
-    (is (=? [{:path "/export"}
+    (is (=? [{:path "/complex/{id}"}
+             {:path "/export"}
              {:path "/rename"}
              {:path "/{id}"}
              {:path "/{id}"}
@@ -143,15 +196,45 @@
                                :name     :count
                                :required false
                                :schema   {:type "integer" :minimum 1}}]}}
-          (#'openapi/defendpoint->path-item nil "/rename" #'GET_rename))))
+          (#'openapi/defendpoint->path-item nil "/rename" #'GET_rename)))
+  (is (=? {:put
+           {:summary "PUT /complex/{id}"
+            :parameters
+            [{:in          :path
+              :name        :id
+              :required    true
+              :schema      {:type "integer", :minimum 1}
+              :description map?}]
+            :requestBody
+            {:content
+             {"application/json"
+              {:schema
+               {:type     "object"
+                :required [:data]
+                :properties
+                {:data
+                 {:type     "object"
+                  :required [:dashcards]
+                  :properties
+                  {:name      {:description map?
+                               :$ref        "#/components/schemas/metabase.lib.schema.common~1non-blank-string"}
+                   :dashcards {:type        "array"
+                               :description map?
+                               :items       {:type       "object"
+                                             :required   [:id]
+                                             :properties {:id     {:type "integer"}
+                                                          :params {:type        "array"
+                                                                   :items       {:type       "object"
+                                                                                 :required   [:param_id :target]
+                                                                                 :properties {:param_id {}
+                                                                                              :target   {}}}}}}}}}}}}}}}}
+          (#'openapi/defendpoint->path-item nil "/complex/{id}" #'PUT_complex_:id))))
 
 (deftest ^:parallel openapi-object-test
   (is (=? {:paths      {"/{id}"        {:get  {}
                                         :post {}}
                         "/{id}/upload" {:post {}}}
-           :components {:schemas {"metabase.lib.schema.common/non-blank-string"
-                                  {:allOf [{:type "string", :minLength 1}
-                                           {}]}}}}
+           :components {:schemas {"metabase.lib.schema.common/non-blank-string" {:type "string", :minLength 1}}}}
           (openapi/openapi-object #'routes))))
 
 (deftest ^:parallel openapi-all-routes


### PR DESCRIPTION
We generate way too many oneOf/allOf crap (because of `[:smth {:optional true} [:maybe ....]]` stuff in our code - maybe we should fix that?), and the OpenAPI doc is really hard to read because of that, since no viewers handle them.

This makes stuff a bit nicer. I think a better solution would be to augment Malli's json-schema generation, but this is already in our code and fast enough so it'll do for now.