### PR TITLE
Port dashboards to use new `EntityListLoaderRtkQuery`

### DIFF
--- a/frontend/src/metabase/entities/dashboards.js
+++ b/frontend/src/metabase/entities/dashboards.js
@@ -4,6 +4,7 @@ import {
   automagicDashboardsApi,
   dashboardApi,
   useGetDashboardQuery,
+  useListDashboardsQuery,
 } from "metabase/api";
 import {
   canonicalCollectionId,
@@ -53,6 +54,7 @@ const Dashboards = createEntity({
     getUseGetQuery: () => ({
       useGetQuery: useGetDashboardQuery,
     }),
+    useListQuery: useListDashboardsQuery,
   },
 
   api: {


### PR DESCRIPTION
Depends on #51496

### Description

Temporary PR to run CI for one specific entity.