### PR TITLE
perf: Add fastpaths to url? and email? predicates

### DIFF
--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -337,7 +337,7 @@
 (defn email?
   "Is `s` a valid email address string?"
   ^Boolean [^String s]
-  (boolean (when (string? s)
+  (boolean (when (and (string? s) (str/includes? s "@")) ;; early bail
              (re-matches #"[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"
                          (lower-case-en s)))))
 
@@ -365,10 +365,15 @@
 (defn url?
   "Is `s` a valid HTTP/HTTPS URL string?"
   ^Boolean [s]
-  #?(:clj  (let [validator (UrlValidator. (u.jvm/varargs String ["http" "https"])
-                                          (RegexValidator. url-regex-pattern)
-                                          UrlValidator/ALLOW_LOCAL_URLS)]
-             (.isValid validator (str s)))
+  #?(:clj  (and s
+                ;; UrlValidator is very expensive when non-URLs are passed to it, so we verify if the string looks
+                ;; urlish before passing to UrlValidator.
+                (str/includes? s "://")
+                (let [validator (UrlValidator. (u.jvm/varargs String ["http" "https"])
+                                               (RegexValidator. url-regex-pattern)
+                                               UrlValidator/ALLOW_LOCAL_URLS)]
+                  ;; (swap! -args conj s)
+                  (.isValid validator (str s))))
      :cljs (try
              (let [url (js/URL. (str s))]
                (boolean (and (re-matches (js/RegExp. url-regex-pattern "u")


### PR DESCRIPTION
`email?` is pretty simple: there is this big, complex regex used for validation, but it obligates `@` to be present. So, checking for `@` inside the string first is a simple way to speed up the whole predicate (1.5us current vs ~20ns optimized).

Similar idea with `url?`, except that Apache UrlValidator tries to create a `java.net.URI` object underneath and throws an exception if the given string is not a URI, and that is incredibly expensive. The fast path helps a great ton here.
