### PR TITLE
ci: Cache final H2 app DB scheme when running tests

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
@@ -5,7 +5,7 @@
    [metabase-enterprise.serialization.names :as names]
    [metabase.db :as mdb]
    [metabase.db.connection :as mdb.connection]
-   [metabase.db.data-source :as mdb.data-source]
+   [metabase.db.schema-migrations-test.impl :as schema-migrations-test.impl]
    [metabase.models.collection :as collection]
    [metabase.models.serialization :as serdes]
    [metabase.models.visualization-settings :as mb.viz]
@@ -13,6 +13,7 @@
    [metabase.test.data :as data]
    [metabase.util :as u]
    [metabase.util.files :as u.files]
+   [next.jdbc]
    [toucan2.connection :as t2.conn]
    [toucan2.core :as t2]))
 
@@ -68,14 +69,15 @@
          (testing (format "\nApp DB = %s" (pr-str (-data-source-url ~data-source)))
            ~@body)))))
 
-(defn- do-with-in-memory-h2-db [db-name-prefix f]
-  (let [db-name           (str db-name-prefix "-" (mt/random-name))
-        connection-string (format "jdbc:h2:mem:%s" db-name)
-        data-source       (mdb.data-source/raw-connection-string->DataSource connection-string)]
-    ;; DB should stay open as long as `conn` is held open.
-    (with-open [_conn (.getConnection data-source)]
-      (with-db data-source (mdb/setup-db! :create-sample-content? false)) ; skip sample content for speedy tests. this doesn't reflect production
-      (f data-source))))
+(defn- do-with-in-memory-h2-db [f]
+  (schema-migrations-test.impl/do-with-temp-empty-app-db*
+   :h2
+   (fn [data-source]
+     ;; DB should stay open as long as `conn` is held open.
+     (with-open [_conn (.getConnection data-source)]
+       (next.jdbc/execute! data-source ["RUNSCRIPT FROM ?" (str @data/h2-app-db-script)])
+       (with-db data-source (mdb/finish-db-setup))
+       (f data-source)))))
 
 (defn do-with-dbs
   "Given a function with the given arity, create an in-memory db for each argument and then call the fn with these dbs"
@@ -85,7 +87,6 @@
     (recur (dec arity)
            (fn [& args]
              (do-with-in-memory-h2-db
-              (str "db-" arity)
               (fn [data-source]
                 (apply f data-source args)))))))
 

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -64,6 +64,11 @@
   []
   (= @(:status mdb.connection/*application-db*) ::setup-finished))
 
+(defn finish-db-setup
+  "Mark the bound Metabase DB as set up and ready."
+  []
+  (reset! (:status mdb.connection/*application-db*) ::setup-finished))
+
 (defn app-db
   "The Application database. A record, but use accessors [[db-type]], [[data-source]], etc to access. Also
   implements [[javax.sql.DataSource]] directly, so you can call [[.getConnection]] on it directly."
@@ -89,7 +94,7 @@
               data-source   (data-source)
               auto-migrate? (config/config-bool :mb-db-automigrate)]
           (mdb.setup/setup-db! db-type data-source auto-migrate? create-sample-content?))
-        (reset! (:status mdb.connection/*application-db*) ::setup-finished))))
+        (finish-db-setup))))
   :done)
 
 (defn release-migration-locks!

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -47,7 +47,8 @@
    [metabase.test.data.impl :as data.impl]
    [metabase.test.data.interface :as tx]
    [metabase.test.data.mbql-query-impl :as mbql-query-impl]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [next.jdbc]))
 
 (set! *warn-on-reflection* true)
 
@@ -269,19 +270,31 @@
   [& body]
   `(data.impl/do-with-temp-copy-of-db (^:once fn* [] ~@body)))
 
+(def h2-app-db-script
+  "To save time during tests, instead of running all migrations for each new empty H2 app db, we perform the
+  migrations once and dump the schema into a script. Subsequently, this script can be used to instantiate new copies
+  of H2 app db. The result is a dereffable temp file."
+  (delay
+    (schema-migrations-test.impl/with-temp-empty-app-db [conn :h2]
+      ;; since the actual group defs are not dynamic, we need with-redefs to change them here
+      (with-redefs [perms-group/all-users (#'perms-group/magic-group perms-group/all-users-group-name)
+                    perms-group/admin     (#'perms-group/magic-group perms-group/admin-group-name)]
+        (mdb/setup-db! :create-sample-content? false)
+        (let [f (java.io.File/createTempFile "db-export" ".sql")]
+          (next.jdbc/execute! conn ["SCRIPT TO ?" (str f)])
+          f)))))
+
 ;;; TODO FIXME -- rename this to `with-empty-h2-app-db!`
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro with-empty-h2-app-db
   "Runs `body` under a new, blank, H2 application database (randomly named), in which all model tables have been
-  created via Liquibase schema migrations. After `body` is finished, the original app DB bindings are restored.
+  created from `h2-app-db-script`. After `body` is finished, the original app DB bindings are restored.
 
   Makes use of functionality in the [[metabase.db.schema-migrations-test.impl]] namespace since that already does what
   we need."
   {:style/indent 0}
   [& body]
   `(schema-migrations-test.impl/with-temp-empty-app-db [conn# :h2]
-     ;; since the actual group defs are not dynamic, we need with-redefs to change them here
-     (with-redefs [perms-group/all-users (#'perms-group/magic-group perms-group/all-users-group-name)
-                   perms-group/admin     (#'perms-group/magic-group perms-group/admin-group-name)]
-       (mdb/setup-db! :create-sample-content? false) ; skip sample content for speedy tests. this doesn't reflect production
-       ~@body)))
+     (next.jdbc/execute! conn# ["RUNSCRIPT FROM ?" (str @h2-app-db-script)])
+     (mdb/finish-db-setup)
+     ~@body))


### PR DESCRIPTION
This PR is a proof of concept. In some functions that are used in tests for bringing up a fresh H2 app db, It replaces running the whole stack of migrations with running migrations once, dumping the DB content into an SQL file, and then creating the subsequent DBs from that file. If the approach is deemed viable, I'll continue going in that direction and will implement the same logic for Postgres and MySQL app dbs.