### PR TITLE
Try a band-aid fix for native editor e2e flakes

### DIFF
--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -42,6 +42,16 @@ export function openNativeEditor({
   cy.findAllByTestId("loading-indicator").should("not.exist");
 
   databaseName && cy.findByText(databaseName).click();
+  // At this point we have either manually selected a database or the app has
+  // knowedge about the previously used database so it will pre-select it.
+  // See: `last-used-native-database-id`.
+  //
+  // The source of many native editor flakes in the past was the page re-render
+  // that happens when the UI updates from showing the database selector to
+  // displaying the previously selected database.
+  //
+  // Explicitly waiting for the database selector to be gone should give tests a
+  // better chance at passing (until we get rid of this helper altogether)!
   cy.findByText("Select a database").should("not.exist");
 
   return focusNativeEditor().as(alias);

--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -37,11 +37,12 @@ export function openNativeEditor({
   cy.findByText("New").click();
   cy.findByText(newMenuItemTitle).click();
 
-  databaseName && cy.findByText(databaseName).click();
-
   // We are first loading databases to see if we should show the
   // database selector or simply display the previously selected database
   cy.findAllByTestId("loading-indicator").should("not.exist");
+
+  databaseName && cy.findByText(databaseName).click();
+  cy.findByText("Select a database").should("not.exist");
 
   return focusNativeEditor().as(alias);
 }

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.js
@@ -221,29 +221,26 @@ describe("issue 18148", () => {
     cy.addSQLiteDatabase({
       name: dbName,
     });
-
-    H.openNativeEditor();
   });
 
   it("should not offer to save the question before it is actually possible to save it (metabase#18148)", () => {
+    cy.visit("/");
+    cy.findByTestId("app-bar").findByLabelText("New").click();
+    H.popover().findByText("SQL query").click();
+
     cy.findByTestId("qb-save-button").should(
       "have.attr",
       "aria-disabled",
       "true",
     );
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Select a database").click();
+    cy.findByTestId("gui-builder-data").should("contain", "Select a database");
+    H.popover().should("contain", "Sample Database").and("contain", dbName);
+    H.popover().findByText(dbName).click();
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(dbName).click();
+    H.focusNativeEditor().realType("select foo");
 
-    H.focusNativeEditor();
-    cy.realType("select foo");
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Save").click();
-
+    cy.findByTestId("qb-save-button").click();
     cy.findByTestId("save-question-modal").findByText("Save").should("exist");
   });
 });


### PR DESCRIPTION
### What does this PR accomplish?
- Greatly reduces the chance of native-editor-related e2e tests flaking by waiting for the right UI state in order for Cypress to start typing.

The inline comment should be self-explanatory.


> [!NOTE]
> I was planning to remove all instances of `openNativeEditor` and replace them with the `startNewNativeQuestion` but didn't have enough time. Will do that tomorrow. In meantime, this fix should be more than enough to unblock `master`.