### PR TITLE
Fix instance stats cypress test + ensure it runs in CI

### DIFF
--- a/.github/actions/build-e2e-matrix/action.yml
+++ b/.github/actions/build-e2e-matrix/action.yml
@@ -51,6 +51,7 @@ runs:
             ["question-reproductions", {} ],
             ["search", {}],
             ["sharing", {} ],
+            ["stats", {} ],
             ["visualizations-charts", {} ],
             ["visualizations-tabular", {} ],
             ["oss-subset", { edition: 'oss', context: "special" } ],

--- a/e2e/test/scenarios/stats/instance-stats-snowplow.cy.spec.js
+++ b/e2e/test/scenarios/stats/instance-stats-snowplow.cy.spec.js
@@ -8,17 +8,17 @@ H.describeWithSnowplow("scenarios > stats > snowplow", () => {
     H.enableTracking();
   });
 
-  describe("instance stats", () => {
+  H.describeWithSnowplow("instance stats", () => {
     it("should send a snowplow event when the stats ping is triggered on OSS", () => {
       cy.request("POST", "api/testing/stats");
       H.expectGoodSnowplowEvents(1);
     });
   });
 
-  H.describeEE("instance stats", () => {
+  H.describeWithSnowplowEE("instance stats", () => {
     it("should send a snowplow event when the stats ping is triggered on EE", () => {
       cy.request("POST", "api/testing/stats");
-      H.expectGoodSnowplowEvent(1);
+      H.expectGoodSnowplowEvents(1);
     });
   });
 

--- a/e2e/test/scenarios/stats/instance-stats-snowplow.cy.spec.js
+++ b/e2e/test/scenarios/stats/instance-stats-snowplow.cy.spec.js
@@ -8,18 +8,18 @@ H.describeWithSnowplow("scenarios > stats > snowplow", () => {
     H.enableTracking();
   });
 
-  H.describeWithSnowplow("instance stats", () => {
-    it("should send a snowplow event when the stats ping is triggered on OSS", () => {
+  it(
+    "should send a snowplow event when the stats ping is triggered on OSS",
+    { tags: "@OSS" },
+    () => {
       cy.request("POST", "api/testing/stats");
       H.expectGoodSnowplowEvents(1);
-    });
-  });
+    },
+  );
 
-  H.describeWithSnowplowEE("instance stats", () => {
-    it("should send a snowplow event when the stats ping is triggered on EE", () => {
-      cy.request("POST", "api/testing/stats");
-      H.expectGoodSnowplowEvents(1);
-    });
+  it("should send a snowplow event when the stats ping is triggered on EE", () => {
+    cy.request("POST", "api/testing/stats");
+    H.expectGoodSnowplowEvents(1);
   });
 
   afterEach(() => {

--- a/e2e/test/scenarios/stats/instance-stats-snowplow.cy.spec.js
+++ b/e2e/test/scenarios/stats/instance-stats-snowplow.cy.spec.js
@@ -11,14 +11,14 @@ H.describeWithSnowplow("scenarios > stats > snowplow", () => {
   describe("instance stats", () => {
     it("should send a snowplow event when the stats ping is triggered on OSS", () => {
       cy.request("POST", "api/testing/stats");
-      H.expectGoodSnowplowEvent();
+      H.expectGoodSnowplowEvents(1);
     });
   });
 
   H.describeEE("instance stats", () => {
     it("should send a snowplow event when the stats ping is triggered on EE", () => {
       cy.request("POST", "api/testing/stats");
-      H.expectGoodSnowplowEvent();
+      H.expectGoodSnowplowEvent(1);
     });
   });
 

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -515,10 +515,10 @@
    (or (.exists (io/file "/.dockerenv"))
        (when (.exists (io/file "/proc/self/cgroup"))
          (try
-          (some #(re-find #"docker" %)
-                (line-seq (io/reader "/proc/self/cgroup")))
-          (catch java.io.IOException _
-            false))))))
+           (some #(re-find #"docker" %)
+                 (line-seq (io/reader "/proc/self/cgroup")))
+           (catch java.io.IOException _
+             false))))))
 
 (defn- deployment-model
   []

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -512,9 +512,9 @@
   []
   (boolean
    (or (.exists (io/file "/.dockerenv"))
-       (when (.exists (io/file "/proc/self/cgroup"))
-         (some #(re-find #"docker" %)
-               (line-seq (io/reader "/proc/self/cgroup")))))))
+       #_(when (.exists (io/file "/proc/self/cgroup"))
+           (some #(re-find #"docker" %)
+                 (line-seq (io/reader "/proc/self/cgroup")))))))
 
 (defn- deployment-model
   []

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -508,13 +508,17 @@
       (log/error e "Sending usage stats FAILED"))))
 
 (defn- in-docker?
-  "Is the current Metabase process running in a Docker container?"
+  "Is the current Metabase process running in a Docker container?
+  (Best-effort check based on a `.dockerenv` file in the root directory, or docker mentioned in `/proc/self/cgroup`)"
   []
   (boolean
    (or (.exists (io/file "/.dockerenv"))
-       #_(when (.exists (io/file "/proc/self/cgroup"))
-           (some #(re-find #"docker" %)
-                 (line-seq (io/reader "/proc/self/cgroup")))))))
+       (when (.exists (io/file "/proc/self/cgroup"))
+         (try
+          (some #(re-find #"docker" %)
+                (line-seq (io/reader "/proc/self/cgroup")))
+          (catch java.io.IOException _
+            false))))))
 
 (defn- deployment-model
   []

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -894,7 +894,7 @@
      "grouped_metrics"     grouped-metrics
      "instance_attributes" instance-attributes
      "metrics"             metrics
-     "settings"             []}))
+     "settings"            []}))
 
 (defn- generate-instance-stats!
   "Generate stats for this instance as data"


### PR DESCRIPTION
Context: https://metaboat.slack.com/archives/C064EB1UE5P/p1734632025761349?thread_ts=1734627251.422309&cid=C064EB1UE5P 

This PR
* Adds the `stats` test directory to the GH actions e2e test matrix so that it actually runs
* Updates `instance-stats-snowplow.cy.spec.js` to use `expectGoodSnowplowEvents` instead of `expectGoodSnowplowEvent` (the correct API now)
* Adds a try/catch around the code that tries to read `/proc/self/cgroup` since that can throw if there aren't read perms for that file (which seems to be the case in CI). This is a best-effort helper function for detecting if we're in a docker container (there doesn't seem to be a 100% reliable method) so if we can't read that file we can just move on.