### PR TITLE
Fix non-legible text and icon colors in fullscreen dark mode

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
@@ -1557,7 +1557,7 @@ describe("issue 47170", () => {
   it("should show legible dark mode colors in fullscreen mode (metabase#51524)", () => {
     cy.visit(`/dashboard/${ORDERS_DASHBOARD_ID}`);
 
-    cy.findByLabelText("Move, trash, and more…").click();
+    H.dashboardHeader().findByLabelText("Move, trash, and more…").click();
     H.popover().findByText("Enter fullscreen").click();
     H.dashboardHeader().findByLabelText("Nighttime mode").click();
 

--- a/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
@@ -1553,4 +1553,30 @@ describe("issue 47170", () => {
       cy.findByText("Dashboard A").should("be.visible");
     });
   });
+
+  it("should show legible dark mode colors in fullscreen mode (metabase#51524)", () => {
+    cy.visit(`/dashboard/${ORDERS_DASHBOARD_ID}`);
+
+    cy.findByLabelText("Move, trash, and more…").click();
+    H.popover().findByText("Enter fullscreen").click();
+    H.dashboardHeader().findByLabelText("Nighttime mode").click();
+
+    const primaryTextColor = "color(srgb 1 1 1 / 0.9)";
+
+    cy.findByTestId("dashboard-name-heading").should(
+      "have.css",
+      "color",
+      primaryTextColor,
+    );
+
+    H.getDashboardCard(0)
+      .findByText("37.65")
+      .should("have.css", "color", primaryTextColor);
+
+    cy.findByTestId("sharing-menu-button").should(
+      "have.css",
+      "color",
+      primaryTextColor,
+    );
+  });
 });

--- a/frontend/src/metabase/components/ToolbarButton/ToolbarButton.tsx
+++ b/frontend/src/metabase/components/ToolbarButton/ToolbarButton.tsx
@@ -25,7 +25,6 @@ export const ToolbarButton = forwardRef(function ToolbarButton(
     hasBackground = true,
     children,
     disabled,
-    className,
     ...actionIconProps
   }: ToolbarButtonProps,
   ref: Ref<HTMLButtonElement>,

--- a/frontend/src/metabase/components/ToolbarButton/ToolbarButton.tsx
+++ b/frontend/src/metabase/components/ToolbarButton/ToolbarButton.tsx
@@ -25,6 +25,7 @@ export const ToolbarButton = forwardRef(function ToolbarButton(
     hasBackground = true,
     children,
     disabled,
+    className,
     ...actionIconProps
   }: ToolbarButtonProps,
   ref: Ref<HTMLButtonElement>,
@@ -51,6 +52,7 @@ export const ToolbarButton = forwardRef(function ToolbarButton(
       onClick={handleButtonClick}
       bg={hasBackground ? undefined : "transparent"}
       disabled={disabled}
+      c="var(--mb-color-text-primary)"
       {...actionIconProps}
     >
       {children ?? (

--- a/frontend/src/metabase/core/components/EditableText/EditableText.styled.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.styled.tsx
@@ -9,7 +9,7 @@ export interface EditableTextRootProps {
 
 export const EditableTextRoot = styled.div<EditableTextRootProps>`
   position: relative;
-  color: var(--mb-color-text-dark);
+  color: var(--mb-color-text-primary);
   padding: 0.25rem;
   border: 1px solid transparent;
   border-radius: 4px;

--- a/frontend/src/metabase/css/dashboard.module.css
+++ b/frontend/src/metabase/css/dashboard.module.css
@@ -6,9 +6,27 @@
 
 /* Night mode */
 .Dashboard.DashboardNight {
-  /** Apply dark mode colors to semantic color variables. */
-  --mb-color-text-primary: var(--mb-color-text-white-alpha-85);
-  --mb-color-text-dark: var(--mb-color-text-white-alpha-85);
+  /**
+    * Apply dark mode colors to semantic color variables.
+    * Referenced from EmbedFrame.module.css
+   */
+  --mb-color-text-primary: color-mix(
+    in srgb,
+    var(--mb-color-text-white) 90%,
+    transparent
+  );
+  --mb-color-text-dark: var(--mb-color-text-primary);
+  --mb-color-text-secondary: color-mix(
+    in srgb,
+    var(--mb-color-text-white) 65%,
+    transparent
+  );
+  --mb-color-text-tertiary: color-mix(
+    in srgb,
+    var(--mb-color-text-white) 45%,
+    transparent
+  );
+  --mb-color-bg-light: var(--mb-base-color-gray-70);
 
   background-color: var(--mb-color-bg-black);
 }

--- a/frontend/src/metabase/css/dashboard.module.css
+++ b/frontend/src/metabase/css/dashboard.module.css
@@ -6,6 +6,10 @@
 
 /* Night mode */
 .Dashboard.DashboardNight {
+  /** Apply dark mode colors to semantic color variables. */
+  --mb-color-text-primary: var(--mb-color-text-white-alpha-85);
+  --mb-color-text-dark: var(--mb-color-text-white-alpha-85);
+
   background-color: var(--mb-color-bg-black);
 }
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/51524

### Description

The color of the table text, dashboard title and toolbar icon are not legible in the fullscreen dashboard's dark mode. We should use the same legible color mapping as dark mode in embedding.

### Demo

Before:

![CleanShot 2567-12-20 at 02 36 17@2x](https://github.com/user-attachments/assets/f0aa708e-ce94-4451-8efd-66f945545538)

![CleanShot 2567-12-20 at 02 36 24@2x](https://github.com/user-attachments/assets/c8af4bed-93a8-4a37-932c-ebebfc56dc71)

After:

![CleanShot 2567-12-20 at 02 48 44@2x](https://github.com/user-attachments/assets/9f7a047d-856e-4b4e-b1f8-dd653a63377b)

![CleanShot 2567-12-20 at 02 48 37@2x](https://github.com/user-attachments/assets/8ca7b8bd-abbe-444c-b3fd-591269f3f847)

### How to verify

- Go to a dashboard
- Click on "Fullscreen"
- Click on "Dark Mode" icon
- The above should be legible now. It should be similar to what we have in static embedding's dark mode.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - E2E
