### PR TITLE
ci: Only run driver tests when testing Databricks driver

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -150,7 +150,8 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-databricks-ee'
-        test-args: ":exclude-tags '[:mb/once]'"
+        test-args: >-
+          :only-tags [:mb/driver-tests]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()


### PR DESCRIPTION
I assume it's an oversight that Databricks driver tests runs all the non-driver tests too, even though Databricks cannot be used as an application DB. Am I right with this?
