### PR TITLE
ci: Fix be-tests stub

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -195,9 +195,9 @@ jobs:
           fail-on-error: false
 
   be-tests-stub:
-    needs: [be-tests]
+    needs: [files-changed, static-viz-files-changed, be-tests]
     if: |
-      !cancelled() &&
+      always() &&
       github.event.pull_request.draft == false && needs.be-tests.result == 'skipped'
     runs-on: ubuntu-22.04
     name: be-tests-java-${{ matrix.java-version }}-${{ matrix.edition }}


### PR DESCRIPTION
Fix the be-tests-stub not being generated if the be-tests themselves are cancelled (which was the whole point of running it). Not having the fix leads to situations when Github still waits on be-tests jobs that never start because they were skipped.