### PR TITLE
Update migration to allow query_execution.parameterized to be null

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/task/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/task/cache_test.clj
@@ -60,16 +60,17 @@
 
 (defn- query-execution-defaults
   [query]
-  {:hash         (qp.util/query-hash query)
-   :cache_hash   (qp.util/query-hash query)
-   :running_time 1
-   :result_rows  1
-   :native       false
-   :is_sandboxed false
-   :executor_id  nil
-   :card_id      nil
-   :context      :ad-hoc
-   :started_at   (t/offset-date-time)})
+  {:hash          (qp.util/query-hash query)
+   :cache_hash    (qp.util/query-hash query)
+   :running_time  1
+   :result_rows   1
+   :native        false
+   :is_sandboxed  false
+   :executor_id   nil
+   :card_id       nil
+   :context       :ad-hoc
+   :parameterized false
+   :started_at    (t/offset-date-time)})
 
 (deftest scheduled-queries-to-rerun-test
   (mt/with-premium-features #{:cache-granular-controls :cache-preemptive}

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10239,7 +10239,9 @@ databaseChangeLog:
 
   - changeSet:
       id: v53.2024-12-02T17:21:16
-      validCheckSum: 9:209a494b250a08f022114249697cbc1b
+      validCheckSum:
+        - 9:209a494b250a08f022114249697cbc1b
+        - 9:8adcf08936200cc74153d0c306452e0c
       author: noahmoss
       comment: Add query_execution.parameterized column
       preConditions:

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10239,6 +10239,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v53.2024-12-02T17:21:16
+      validCheckSum: 9:8adcf08936200cc74153d0c306452e0c
       author: noahmoss
       comment: Add query_execution.parameterized column
       preConditions:
@@ -10254,9 +10255,8 @@ databaseChangeLog:
                   name: parameterized
                   type: ${boolean.type}
                   remarks: Whether or not the query has parameters with non-nil values
-                  defaultValueBoolean: false
                   constraints:
-                    nullable: false
+                    nullable: true
 
   - changeSet:
       id: v53.2024-12-10T10:00:00

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10239,7 +10239,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v53.2024-12-02T17:21:16
-      validCheckSum: 9:8adcf08936200cc74153d0c306452e0c
+      validCheckSum: 9:209a494b250a08f022114249697cbc1b
       author: noahmoss
       comment: Add query_execution.parameterized column
       preConditions:


### PR DESCRIPTION
Follow-on to https://github.com/metabase/metabase/pull/50816

Removes the `NOT NULL` constraint and default value from the new `query_execution.parameterized` field used by preemptive caching.

It's more correct semantically to not set a value for old query executions. And we won't have to write values for a huge table during the upgrade process.