### PR TITLE
Fix summarize-column and summarize-column-by-time drills for multi-stage queries

### DIFF
--- a/src/metabase/lib/drill_thru/summarize_column.cljc
+++ b/src/metabase/lib/drill_thru/summarize_column.cljc
@@ -26,6 +26,7 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
    [metabase.lib.types.isa :as lib.types.isa]
+   [metabase.lib.underlying :as lib.underlying]
    [metabase.util.malli :as mu]))
 
 (mu/defn summarize-column-drill :- [:maybe ::lib.schema.drill-thru/drill-thru.summarize-column]
@@ -38,8 +39,8 @@
              column
              (nil? value)
              (not (lib.types.isa/structured? column))
-             (not= (:lib/source column) :source/aggregations)
-             (not (lib.breakout/breakout-column? query stage-number column)))
+             (not (lib.drill-thru.common/aggregation-sourced? query column))
+             (not (lib.breakout/breakout-column? query (lib.underlying/top-level-stage-number query) column)))
     ;; I'm not really super clear on how the FE is supposed to be able to display these.
     (let [aggregation-ops (concat [:distinct]
                                   (when (lib.types.isa/summable? column)

--- a/src/metabase/lib/drill_thru/summarize_column_by_time.cljc
+++ b/src/metabase/lib/drill_thru/summarize_column_by_time.cljc
@@ -35,6 +35,7 @@
    [metabase.lib.schema.util :as lib.schema.util]
    [metabase.lib.temporal-bucket :as lib.temporal-bucket]
    [metabase.lib.types.isa :as lib.types.isa]
+   [metabase.lib.underlying :as lib.underlying]
    [metabase.util.malli :as mu]))
 
 (mu/defn summarize-column-by-time-drill :- [:maybe ::lib.schema.drill-thru/drill-thru.summarize-column-by-time]
@@ -48,24 +49,26 @@
              (nil? value)
              (not (lib.types.isa/structured? column))
              (lib.types.isa/summable? column)
-             (not= (:lib/source column) :source/aggregations))
+             (not (lib.drill-thru.common/aggregation-sourced? query column)))
     ;; There must be a date dimension available.
-    (when-let [breakout-column (m/find-first lib.types.isa/temporal?
-                                             (lib.breakout/breakoutable-columns query stage-number))]
-      (when-let [bucketing-unit (m/find-first :default
-                                              (lib.temporal-bucket/available-temporal-buckets query stage-number breakout-column))]
-        ;; only suggest this drill thru if the breakout it would apply does not already exist.
-        (let [bucketed (lib.temporal-bucket/with-temporal-bucket breakout-column bucketing-unit)]
-          (when (lib.schema.util/distinct-refs? (map lib.ref/ref (cons bucketed (lib.breakout/breakouts query stage-number))))
-            {:lib/type :metabase.lib.drill-thru/drill-thru
-             :type     :drill-thru/summarize-column-by-time
-             :column   column
-             :breakout breakout-column
-             :unit     (lib.temporal-bucket/raw-temporal-bucket bucketing-unit)}))))))
+    (let [stage-number (lib.underlying/top-level-stage-number query)]
+      (when-let [breakout-column (m/find-first lib.types.isa/temporal?
+                                               (lib.breakout/breakoutable-columns query stage-number))]
+        (when-let [bucketing-unit (m/find-first :default
+                                                (lib.temporal-bucket/available-temporal-buckets query stage-number breakout-column))]
+          ;; only suggest this drill thru if the breakout it would apply does not already exist.
+          (let [bucketed (lib.temporal-bucket/with-temporal-bucket breakout-column bucketing-unit)]
+            (when (lib.schema.util/distinct-refs? (map lib.ref/ref (cons bucketed (lib.breakout/breakouts query stage-number))))
+              {:lib/type :metabase.lib.drill-thru/drill-thru
+               :type     :drill-thru/summarize-column-by-time
+               :column   column
+               :breakout breakout-column
+               :unit     (lib.temporal-bucket/raw-temporal-bucket bucketing-unit)})))))))
 
 (defmethod lib.drill-thru.common/drill-thru-method :drill-thru/summarize-column-by-time
-  [query stage-number {:keys [breakout column unit] :as _drill-thru} & _]
-  (let [bucketed (lib.temporal-bucket/with-temporal-bucket breakout unit)]
+  [query _stage-number {:keys [breakout column unit] :as _drill-thru} & _]
+  (let [bucketed (lib.temporal-bucket/with-temporal-bucket breakout unit)
+        stage-number (lib.underlying/top-level-stage-number query)]
     (-> query
         (lib.aggregation/aggregate stage-number (lib.aggregation/sum column))
         (lib.breakout/breakout stage-number bucketed))))


### PR DESCRIPTION
### Description

Ensure the `summarize-column` and `summarize-column-by-time` drill thrus are not returned by `available-drill-thrus` when a user clicks on an aggregation or breakout column, even if there are additional query stages after the last aggregation / breakout stage.

Relates to: https://github.com/metabase/metabase/issues/46932, https://github.com/metabase/metabase/pull/51247

### How to verify

* New question: Orders
* summarize: Count by Created At: Month
* Add filter stage after summarize, e.g. Count > 1
* Visualize
* Select Table viz
* Click on the column header for the Count column
* None of the summarize drill thru options should not appear in the context menu
  * for summarize: "Distinct values", "sum", "avg"
  * for summarize by time: "Sum over time"
* Edit query to remove the summarize stage
* Visualize
* Click on any column header: drill should appear

### Demo

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
