### PR TITLE
[Cards in Dashboards] Prevent dashboard from appearing in breadcrumbs when not on a DQ page

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
@@ -57,6 +57,7 @@ describe("Dashboard > Dashboard Questions", () => {
       H.modal().button("Done").click();
       H.undoToast().findByText("First collection");
       H.appBar().findByText("First collection"); // breadcrumb should change
+      H.appBar().findByText("Orders in a dashboard").should("not.exist"); // dashboard name should no longer be visible
 
       // card should still be visible in dashboard
       cy.visit(`/dashboard/${S.ORDERS_DASHBOARD_ID}`);

--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -2,6 +2,7 @@ import { H } from "e2e/support";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_COUNT_QUESTION_ID,
+  ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
   SECOND_COLLECTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
@@ -210,6 +211,30 @@ describe("scenarios > question > saved", () => {
     H.visitQuestion(ORDERS_QUESTION_ID);
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     H.appBar().within(() => cy.findByText("Second collection").click());
+
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.findByText("Orders").should("be.visible");
+  });
+
+  it("should show dashboard breadcrumbs for a saved question in a dashboard", () => {
+    cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, {
+      dashboard_id: ORDERS_DASHBOARD_ID,
+    });
+
+    H.visitQuestion(ORDERS_QUESTION_ID);
+    H.appBar().within(() => {
+      cy.findByText("Our analytics").should("exist");
+      cy.log("should be able to navigate to the parent dashboard");
+      cy.findByText("Orders in a dashboard").should("exist").click();
+    });
+
+    cy.log(
+      "should have dashboard info disappear when navigating away from question",
+    );
+    H.appBar().within(() => {
+      cy.findByText("Our analytics").should("exist");
+      cy.findByText("Orders in a dashboard").should("not.exist");
+    });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders").should("be.visible");

--- a/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
@@ -271,13 +271,14 @@ function setup({
   dashboardState?: { dashboard: DashboardState };
   initialRoute?: string;
 }) {
+  // Need to set the location because CollectionBreadcrumbs uses the useLocation()
+  window.history.pushState({}, "", initialRoute);
+
   setupCollectionsEndpoints({
     collections: [FOO_COLLECTION],
   });
   setupCollectionByIdEndpoint({ collections: [FOO_COLLECTION] });
   setupCardEndpoints(card);
-  // setupCardEndpoints(CARD_IN_COLLECTION);
-  // setupCardEndpoints(CARD_IN_DASHBOARD);
   setupDashboardEndpoints(BAR_DASHBOARD);
 
   return renderWithProviders(<Route path="*" component={AppBar} />, {

--- a/frontend/src/metabase/nav/containers/CollectionBreadcrumbs/CollectionBreadcrumbs.tsx
+++ b/frontend/src/metabase/nav/containers/CollectionBreadcrumbs/CollectionBreadcrumbs.tsx
@@ -1,3 +1,4 @@
+import { useLocation } from "react-use";
 import _ from "underscore";
 
 import { useGetCollectionQuery } from "metabase/api";
@@ -26,12 +27,15 @@ export const CollectionBreadcrumbs = (props: CollectionBreadcrumbsProps) => {
   const { data: collection } = useGetCollectionQuery({ id: collectionId });
 
   const question = useSelector(getQuestion);
+  const { pathname } = useLocation();
+  const isOnQuestionPage = pathname && /\/question\//.test(pathname);
+  const dashboard = isOnQuestionPage ? question?.dashboard() : undefined;
 
   return (
     <Breadcrumbs
       {...props}
       collection={collection}
-      dashboard={question?.dashboard()}
+      dashboard={dashboard}
       baseCollectionId={props.baseCollectionId ?? null}
     />
   );


### PR DESCRIPTION
### Description

Noticed an issue when navigating from a dashboard question to another collection that the dashboard would sometimes persist when visiting other items in the same collection, resulting in this:
![CleanShot 2024-12-19 at 15 29 16@2x](https://github.com/user-attachments/assets/05a2c1f8-3079-4365-84d7-b3e63a9a4cf3)

It appears this was introduced by me in #51084.

### How to verify

- Visit a dashboard question
- Navigate directly to a dashboard
- You should no longer see the issue

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
