### PR TITLE
Update SDK npm version 52 to stable

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk/package.template.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabase/embedding-sdk-react",
-  "version": "0.52.5-nightly",
+  "version": "0.52.5",
   "description": "Metabase Embedding SDK for React",
   "bin": "./dist/cli.js",
   "repository": {


### PR DESCRIPTION
Npm version is determined from the version specified inside `enterprise/frontend/src/embedding-sdk/package.template.json`.

Since we've [cut gold for 52](https://metaboat.slack.com/archives/C063Q3F1HPF/p1733838766527049?thread_ts=1733838714.654729&cid=C063Q3F1HPF), we should update this version as well.

Other related PRs:
- https://github.com/metabase/metabase/pull/51113
