### PR TITLE
chore: replace global icon selector with local

### DIFF
--- a/frontend/src/metabase/components/Badge/Badge.tsx
+++ b/frontend/src/metabase/components/Badge/Badge.tsx
@@ -1,3 +1,4 @@
+import cx from "classnames";
 import type { PropsWithChildren } from "react";
 import _ from "underscore";
 
@@ -25,9 +26,14 @@ type BadgeProps = PropsWithChildren<{
   activeColor?: string;
   isSingleLine?: boolean;
   className?: string;
+  classNames?: {
+    root?: string;
+    icon?: string;
+  };
 }>;
 
 export const Badge = ({
+  className,
   to,
   icon,
   inactiveColor = "text-medium",
@@ -35,6 +41,7 @@ export const Badge = ({
   isSingleLine = false,
   onClick,
   children,
+  classNames = {},
   ...props
 }: BadgeProps) => (
   <MaybeLink
@@ -43,9 +50,16 @@ export const Badge = ({
     isSingleLine={isSingleLine}
     to={to}
     onClick={onClick}
+    className={cx(classNames.root, className)}
     {...props}
   >
-    {icon && <BadgeIcon {...getIconProps(icon)} hasMargin={!!children} />}
+    {icon && (
+      <BadgeIcon
+        {...getIconProps(icon)}
+        className={classNames.icon}
+        hasMargin={!!children}
+      />
+    )}
     {children && (
       <BadgeText className={CS.textWrap} isSingleLine={isSingleLine}>
         {children}

--- a/frontend/src/metabase/components/SelectList/SelectListItem.tsx
+++ b/frontend/src/metabase/components/SelectList/SelectListItem.tsx
@@ -1,3 +1,4 @@
+import cx from "classnames";
 import type * as React from "react";
 import _ from "underscore";
 
@@ -13,6 +14,10 @@ export interface SelectListItemProps
   icon?: string | IconProps;
   rightIcon?: string | IconProps;
   children?: React.ReactNode;
+  classNames?: {
+    root?: string;
+    icon?: string;
+  };
 }
 
 const getIconProps = (icon?: string | IconProps): IconProps =>
@@ -22,6 +27,8 @@ export function SelectListItem({
   name,
   icon,
   rightIcon,
+  className,
+  classNames = {},
   ...otherProps
 }: SelectListItemProps) {
   const iconProps = getIconProps(icon);
@@ -30,17 +37,22 @@ export function SelectListItem({
   return (
     <BaseSelectListItem
       as={ItemRoot}
+      className={cx(classNames.root, className)}
       {...otherProps}
       name={name}
       aria-label={name}
       hasLeftIcon={!!icon}
       hasRightIcon={!!rightIcon}
     >
-      {icon && <ItemIcon color="brand" {...iconProps} />}
+      {icon && (
+        <ItemIcon className={classNames.icon} color="brand" {...iconProps} />
+      )}
       <ItemTitle fw="bold" lh="normal" data-testid="option-text">
         {name}
       </ItemTitle>
-      {rightIconProps.name && <ItemIcon {...rightIconProps} />}
+      {rightIconProps.name && (
+        <ItemIcon className={classNames.icon} {...rightIconProps} />
+      )}
     </BaseSelectListItem>
   );
 }

--- a/frontend/src/metabase/core/components/Button/Button.tsx
+++ b/frontend/src/metabase/core/components/Button/Button.tsx
@@ -85,6 +85,11 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   fullWidth?: boolean;
   onlyText?: boolean;
   light?: boolean;
+
+  classNames?: {
+    root?: string;
+    icon?: string;
+  };
 }
 
 const BaseButton = forwardRef(function BaseButton(
@@ -98,6 +103,7 @@ const BaseButton = forwardRef(function BaseButton(
     iconVertical = false,
     labelBreakpoint,
     children,
+    classNames = {},
     ...props
   }: ButtonProps,
   ref: Ref<HTMLButtonElement>,
@@ -111,9 +117,15 @@ const BaseButton = forwardRef(function BaseButton(
       ref={ref}
       as={as}
       {..._.omit(props, ...BUTTON_VARIANTS)}
-      className={cx(ButtonsS.Button, className, variantClasses, {
-        [SpacingS.p1]: !children,
-      })}
+      className={cx(
+        ButtonsS.Button,
+        classNames.root,
+        variantClasses,
+        {
+          [SpacingS.p1]: !children,
+        },
+        className,
+      )}
       purple={props.purple}
     >
       <ButtonContent iconVertical={iconVertical}>
@@ -140,6 +152,7 @@ const BaseButton = forwardRef(function BaseButton(
         )}
         {iconRight && (
           <Icon
+            className={classNames.icon}
             color={iconColor}
             name={iconRight}
             size={iconSize ? iconSize : 16}

--- a/frontend/src/metabase/core/components/SelectButton/SelectButton.tsx
+++ b/frontend/src/metabase/core/components/SelectButton/SelectButton.tsx
@@ -1,3 +1,4 @@
+import cx from "classnames";
 import type { ButtonHTMLAttributes, Ref } from "react";
 import { forwardRef, useCallback, useMemo } from "react";
 import * as React from "react";
@@ -21,6 +22,10 @@ export interface SelectButtonProps
   onClick?: () => void;
   onClear?: () => void;
   dataTestId?: string;
+  classNames?: {
+    root?: string;
+    icon?: string;
+  };
 }
 
 const SelectButton = forwardRef(function SelectButton(
@@ -36,6 +41,7 @@ const SelectButton = forwardRef(function SelectButton(
     onClick,
     onClear,
     dataTestId,
+    classNames = {},
     ...rest
   }: SelectButtonProps,
   ref: Ref<HTMLButtonElement>,
@@ -63,7 +69,7 @@ const SelectButton = forwardRef(function SelectButton(
       type="button"
       data-testid={`${dataTestId ? `${dataTestId}-` : ""}select-button`}
       ref={ref}
-      className={className}
+      className={cx(classNames.root, className)}
       style={style}
       hasValue={hasValue}
       disabled={disabled}
@@ -77,6 +83,7 @@ const SelectButton = forwardRef(function SelectButton(
         {children}
       </SelectButtonContent>
       <SelectButtonIcon
+        className={classNames.icon}
         name={rightIcon}
         size={12}
         hasValue={hasValue}

--- a/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityList.module.css
+++ b/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityList.module.css
@@ -9,7 +9,7 @@
 }
 
 .SavedEntityListItem {
-  :global(.Icon):last-child {
+  .SavedEntityListItemIcon:last-child {
     justify-self: start;
   }
 }

--- a/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityList.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityList.tsx
@@ -59,7 +59,10 @@ const SavedEntityList = ({
 
                     return (
                       <SelectList.Item
-                        className={SavedEntityListS.SavedEntityListItem}
+                        classNames={{
+                          root: SavedEntityListS.SavedEntityListItem,
+                          icon: SavedEntityListS.SavedEntityListItemIcon,
+                        }}
                         key={id}
                         id={id}
                         isSelected={selectedId === virtualTableId}

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.module.css
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.module.css
@@ -28,6 +28,8 @@
   color: var(--mb-color-text-white);
   border-radius: 0.3em;
   padding: 0.2em;
+  margin-right: 8px;
+  transition: all 0.25s;
 
   &.isSelected {
     background-color: var(--mb-color-bg-white);
@@ -92,16 +94,11 @@
     background-color: var(--mb-color-brand);
   }
 
-  :global(.Icon) {
-    margin-right: 8px;
-    transition: all 0.25s;
-  }
-
   &:hover {
     color: var(--mb-color-text-white);
     background-color: var(--mb-color-brand);
 
-    :global(.Icon) {
+    .FieldTypeIcon {
       background-color: var(--mb-color-bg-white);
       color: var(--mb-color-brand);
     }

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/MappedFieldPicker/MappedFieldPicker.module.css
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/MappedFieldPicker/MappedFieldPicker.module.css
@@ -3,7 +3,7 @@
     background-color: var(--mb-color-brand);
     border-color: var(--mb-color-brand);
 
-    :global(.Icon) {
+    .StyledSelectIcon {
       color: var(--mb-color-text-white);
     }
 

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/MappedFieldPicker/MappedFieldPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/MappedFieldPicker/MappedFieldPicker.tsx
@@ -66,13 +66,16 @@ function MappedFieldPicker({
 
     return (
       <SelectButton
-        className={cx(
-          MappedFieldPickerS.StyledSelectButton,
-          {
-            [MappedFieldPickerS.hasValue]: fieldObject,
-          },
-          className,
-        )}
+        classNames={{
+          root: cx(
+            MappedFieldPickerS.StyledSelectButton,
+            {
+              [MappedFieldPickerS.hasValue]: fieldObject,
+            },
+            className,
+          ),
+          icon: MappedFieldPickerS.StyledSelectIcon,
+        }}
         hasValue={!!fieldObject}
         tabIndex={tabIndex}
         ref={selectButtonRef as any}

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/EditorTabs/EditorTabs.module.css
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/EditorTabs/EditorTabs.module.css
@@ -33,10 +33,6 @@
   opacity: 1;
   cursor: pointer;
 
-  :global(.Icon) {
-    margin-right: 10px;
-  }
-
   &.active {
     background-color: var(--active-tab-color);
     border-color: var(--active-tab-color);

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/EditorTabs/EditorTabs.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/EditorTabs/EditorTabs.tsx
@@ -37,7 +37,7 @@ export function EditorTabs({ currentTab, disabledMetadata, onChange }: Props) {
           })}
           htmlFor="editor-tabs-query"
         >
-          <Icon name="notebook" />
+          <Icon name="notebook" mr="10px" />
           <input
             className={EditorTabsS.RadioInput}
             type="radio"
@@ -62,7 +62,7 @@ export function EditorTabs({ currentTab, disabledMetadata, onChange }: Props) {
           })}
           htmlFor="editor-tabs-metadata"
         >
-          <Icon name="notebook" />
+          <Icon name="notebook" mr="10px" />
           <input
             type="radio"
             className={EditorTabsS.RadioInput}

--- a/frontend/src/metabase/query_builder/components/view/ViewButton.module.css
+++ b/frontend/src/metabase/query_builder/components/view/ViewButton.module.css
@@ -31,7 +31,7 @@
     }
   }
 
-  > :global(.Icon) {
+  .ViewButtonIcon {
     opacity: 0.6;
   }
 }

--- a/frontend/src/metabase/query_builder/components/view/ViewButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewButton.tsx
@@ -17,7 +17,10 @@ const ViewButton = ({ className, active, color, ...props }: Props) => {
 
   return (
     <Button
-      className={cx(S.ViewButton, { [S.active]: active }, className)}
+      classNames={{
+        root: cx(S.ViewButton, { [S.active]: active }, className),
+        icon: S.ViewButtonIcon,
+      }}
       style={
         {
           "--view-button-color": color ?? theme.fn.themeColor("brand"),

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/HeaderBreadcrumbs/HeaderBreadcrumbs.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/HeaderBreadcrumbs/HeaderBreadcrumbs.jsx
@@ -8,7 +8,13 @@ import { Box, Flex } from "metabase/ui";
 import HeaderBreadcrumbsS from "./HeaderBreadcrumbs.module.css";
 
 const HeaderBadge = props => (
-  <Badge className={HeaderBreadcrumbsS.HeaderBadge} {...props} />
+  <Badge
+    classNames={{
+      root: HeaderBreadcrumbsS.HeaderBadge,
+      icon: HeaderBreadcrumbsS.HeaderBadgeIcon,
+    }}
+    {...props}
+  />
 );
 
 HeaderBadge.propTypes = {

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/HeaderBreadcrumbs/HeaderBreadcrumbs.module.css
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/HeaderBreadcrumbs/HeaderBreadcrumbs.module.css
@@ -15,7 +15,7 @@
   user-select: none;
 }
 
-.HeaderBadge :global(.Icon) {
+.HeaderBadgeIcon {
   width: 1em;
   height: 1em;
   margin-right: 0.5em;

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/HeaderBreadcrumbs/HeaderBreadcrumbs.module.css
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/HeaderBreadcrumbs/HeaderBreadcrumbs.module.css
@@ -15,8 +15,11 @@
   user-select: none;
 }
 
-.HeaderBadgeIcon {
-  width: 1em;
-  height: 1em;
-  margin-right: 0.5em;
+.HeaderBadge {
+  /* specificity */
+  .HeaderBadgeIcon {
+    width: 1em;
+    height: 1em;
+    margin-right: 0.5em;
+  }
 }

--- a/frontend/src/metabase/querying/notebook/components/ClauseStep/ClauseStep.module.css
+++ b/frontend/src/metabase/querying/notebook/components/ClauseStep/ClauseStep.module.css
@@ -1,4 +1,5 @@
 .closeIcon {
   margin-left: 0.5rem;
   flex: 0 0 auto;
+  opacity: 0.6;
 }

--- a/frontend/src/metabase/querying/notebook/components/NotebookCell/NotebookCell.module.css
+++ b/frontend/src/metabase/querying/notebook/components/NotebookCell/NotebookCell.module.css
@@ -44,10 +44,6 @@
   &.disabled {
     pointer-events: none;
   }
-
-  :global(.Icon-close) {
-    opacity: 0.6;
-  }
 }
 
 .NotebookCellItemContentContainer {
@@ -55,7 +51,6 @@
   align-items: center;
   background-color: var(--notebook-cell-item-content-container-color);
   transition: background 300ms linear;
-  /* background-color: transparent; */
 
   &.inactive {
     background-color: transparent;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50985

### Description

replace `:global(.Icon)` with local css modules selector

### How to verify

check all places with icons:

<img width="354" alt="image" src="https://github.com/user-attachments/assets/3a74f102-2104-48f0-b24e-08aab0baeca9" />

<br><br><br>

<img width="187" alt="image" src="https://github.com/user-attachments/assets/37c81842-057f-4288-a8c4-965c0b1f8e1b" />
<br><br><br>
<img width="433" alt="image" src="https://github.com/user-attachments/assets/d6b520be-b080-48ff-948e-89e84ccaf6c8" />

etc
