### PR TITLE
[serdes] extract tabId in click_behavior

### DIFF
--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/dashboards/Zf1jknwhPhazxIIJ2X6mX_dashboard_subscriptions_and_alerts.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/dashboards/Zf1jknwhPhazxIIJ2X6mX_dashboard_subscriptions_and_alerts.yaml
@@ -64,7 +64,7 @@ dashcards:
               target:
                 id: 6b3da96f
                 type: parameter
-          tabId: 1
+          tabId: ["DHMhMa1FYxiyIgM7_xdgR", "VLzpbzPlShrECFp-dG4pH"]
           targetId: DHMhMa1FYxiyIgM7_xdgR
           type: link
       '["name","name"]':
@@ -115,7 +115,7 @@ dashcards:
               target:
                 id: 6b3da96f
                 type: parameter
-          tabId: 1
+          tabId: ["DHMhMa1FYxiyIgM7_xdgR", "VLzpbzPlShrECFp-dG4pH"]
           targetId: DHMhMa1FYxiyIgM7_xdgR
           type: link
   serdes/meta:

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/dashboards/jm7KgY6IuS6pQjkBZ7WUI_question_overview.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/dashboards/jm7KgY6IuS6pQjkBZ7WUI_question_overview.yaml
@@ -357,7 +357,7 @@ dashcards:
               target:
                 id: 6b3da96f
                 type: parameter
-          tabId: 1
+          tabId: ["DHMhMa1FYxiyIgM7_xdgR", "VLzpbzPlShrECFp-dG4pH"]
           targetId: DHMhMa1FYxiyIgM7_xdgR
           type: link
   serdes/meta:

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/dashboards/vFnGZMNN2K_KW1I0B52bq_metabase_metrics.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/dashboards/vFnGZMNN2K_KW1I0B52bq_metabase_metrics.yaml
@@ -383,7 +383,7 @@ dashcards:
               target:
                 id: 6b3da96f
                 type: parameter
-          tabId: 1
+          tabId: ["DHMhMa1FYxiyIgM7_xdgR", "VLzpbzPlShrECFp-dG4pH"]
           targetId: DHMhMa1FYxiyIgM7_xdgR
           type: link
         column_title: Person Name
@@ -472,7 +472,7 @@ dashcards:
               target:
                 id: 6b3da96f
                 type: parameter
-          tabId: 1
+          tabId: ["DHMhMa1FYxiyIgM7_xdgR", "VLzpbzPlShrECFp-dG4pH"]
           targetId: DHMhMa1FYxiyIgM7_xdgR
           type: link
         column_title: Person Name
@@ -489,7 +489,7 @@ dashcards:
               target:
                 id: 6b3da96f
                 type: parameter
-          tabId: 1
+          tabId: ["DHMhMa1FYxiyIgM7_xdgR", "VLzpbzPlShrECFp-dG4pH"]
           targetId: DHMhMa1FYxiyIgM7_xdgR
           type: link
       ? '["ref",["field",["Internal Metabase Database","public","v_users","full_name"],{"base-type":"type/Text","join-alias":"Question 1"}]]'

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1510,8 +1510,9 @@
   (let [{:keys [linkType targetId type]} (:click_behavior settings)
         model (when linkType (link-card-model->toucan-model linkType))]
     (case type
-      "link" #{[{:model (name model)
-                 :id    targetId}]}
+      "link" (when model
+               #{[{:model (name model)
+                   :id    targetId}]})
       ;; TODO: We might need to handle the click behavior that updates dashboard filters? I can't figure out how get
       ;; that to actually attach to a filter to check what it looks like.
       nil)))
@@ -1540,9 +1541,9 @@
   (let [{:keys [linkType targetId type]} click_behavior
         model (when linkType (link-card-model->toucan-model linkType))]
     (case type
-      "link" (do (assert model (str "Unknown linkType: " linkType))
-                 (when (fk-elide (*export-fk* targetId model))
-                   {[(name model) targetId] src}))
+      "link" (when (and model
+                        (fk-elide (*export-fk* targetId model)))
+               {[(name model) targetId] src})
       ;; TODO: We might need to handle the click behavior that updates dashboard filters? I can't figure out how get
       ;; that to actually attach to a filter to check what it looks like.
       nil)))

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -849,14 +849,15 @@
         (= (count path) 1) (first path)
         :else              path))))
 
-(defn- maybe-export-fk
-  "Exactly like the above `*export-fk*`, except returns `nil` if the target was not found"
-  [id model]
-  (try (*export-fk* id model)
-       (catch clojure.lang.ExceptionInfo e
-         (when-not (= (::type (ex-data e)) :target-not-found)
-           (throw e))
-         nil)))
+(defmacro ^:private fk-elide
+  "If a call to `*export-fk*` inside of this fails, do not export the whole data structure"
+  [& body]
+  `(try
+     ~@body
+     (catch clojure.lang.ExceptionInfo e#
+       (when-not (= (::type (ex-data e#)) :target-not-found)
+         (throw e#))
+       nil)))
 
 (defn ^:dynamic ^::cache *import-fk*
   "Given an identifier, and the model it represents (symbol, name or IModel), looks up the corresponding
@@ -1339,17 +1340,17 @@
       json/encode))
 
 (defn- export-viz-click-behavior-link
-  [{:keys [linkType type] old-target-id :targetId :as click-behavior}]
-  (if-not (= type "link")
-    click-behavior
-    ;; if the card doesn't exist anymore, just remove the entire click behavior
-    (when-let [new-target-id (maybe-export-fk old-target-id (link-card-model->toucan-model linkType))]
-      (assoc click-behavior :targetId new-target-id))))
+  [{:keys [linkType type] :as click-behavior}]
+  (fk-elide
+   (cond-> click-behavior
+     (= type "link") (-> (update :targetId *export-fk* (link-card-model->toucan-model linkType))
+                         (u/update-some :tabId *export-fk* :model/DashboardTab)))))
 
 (defn- import-viz-click-behavior-link
   [{:keys [linkType type] :as click-behavior}]
   (cond-> click-behavior
-    (= type "link") (update :targetId *import-fk* (link-card-model->toucan-model linkType))))
+    (= type "link") (-> (update :targetId *import-fk* (link-card-model->toucan-model linkType))
+                        (u/update-some :tabId *import-fk* :model/DashboardTab))))
 
 (defn- export-viz-click-behavior-mapping [mapping]
   (-> mapping
@@ -1391,11 +1392,8 @@
 
 (defn- export-viz-click-behavior [settings]
   (some-> settings
-          (m/update-existing    :click_behavior export-viz-click-behavior-link)
-          (m/update-existing-in [:click_behavior :parameterMapping] export-viz-click-behavior-mappings)
-          (as-> updated-settings
-                (cond-> updated-settings
-                  (nil? (:click_behavior updated-settings)) (dissoc :click_behavior)))))
+          (u/update-some :click_behavior export-viz-click-behavior-link)
+          (m/update-existing-in [:click_behavior :parameterMapping] export-viz-click-behavior-mappings)))
 
 (defn- import-viz-click-behavior [settings]
   (some-> settings
@@ -1509,11 +1507,11 @@
 
 (defn- viz-click-behavior-deps
   [settings]
-  (when-let [{:keys [linkType targetId type]} (:click_behavior settings)]
+  (let [{:keys [linkType targetId type]} (:click_behavior settings)
+        model (when linkType (link-card-model->toucan-model linkType))]
     (case type
-      "link" (when-let [model (some-> linkType link-card-model->toucan-model name)]
-               #{[{:model model
-                   :id    targetId}]})
+      "link" #{[{:model (name model)
+                 :id    targetId}]}
       ;; TODO: We might need to handle the click behavior that updates dashboard filters? I can't figure out how get
       ;; that to actually attach to a filter to check what it looks like.
       nil)))
@@ -1539,12 +1537,12 @@
          (reduce set/union #{}))))
 
 (defn- viz-click-behavior-descendants [{:keys [click_behavior]} src]
-  (when-let [{:keys [linkType targetId type]} click_behavior]
+  (let [{:keys [linkType targetId type]} click_behavior
+        model (when linkType (link-card-model->toucan-model linkType))]
     (case type
-      "link" (when-let [model (link-card-model->toucan-model linkType)]
-               ;; if the card was deleted, just ignore it.
-               (when (maybe-export-fk targetId model)
-                 {[(name model) targetId] src}))
+      "link" (do (assert model (str "Unknown linkType: " linkType))
+                 (when (fk-elide (*export-fk* targetId model))
+                   {[(name model) targetId] src}))
       ;; TODO: We might need to handle the click behavior that updates dashboard filters? I can't figure out how get
       ;; that to actually attach to a filter to check what it looks like.
       nil)))

--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -327,8 +327,9 @@
   "Check whether there is a Job with the given key."
   [job-key]
   (boolean
-   (when-let [s (scheduler)]
-     (qs/get-job s (->job-key job-key)))))
+   (let [s (scheduler)]
+     (when (and s (not (.isShutdown s)))
+       (qs/get-job s (->job-key job-key))))))
 
 (defn job-info
   "Get info about a specific Job (`job-key` can be either a String or `JobKey`).

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -1193,3 +1193,12 @@
                             ba)))]
               (gen))
       :cljs (throw (ex-info "Seeded NanoIDs are not supported in CLJS" {:seed-str seed-str})))))
+
+(defn update-some
+  "Update a value by key in the `m`, if it's `some?`. If `nil` is returned, dissoc it instead"
+  [m k f & args]
+  (let [v (get m k)
+        res (when v (apply f v args))]
+    (if res
+      (assoc m k res)
+      (dissoc m k))))


### PR DESCRIPTION
also, somewhat relatedly, create `elide-fk` function to skip pieces of data holding FKs to deleted targets

fixes #51018