### PR TITLE
clean up the cleanup tests

### DIFF
--- a/e2e/test/scenarios/collections/cleanup.cy.spec.js
+++ b/e2e/test/scenarios/collections/cleanup.cy.spec.js
@@ -453,13 +453,6 @@ const moveToTrash = (numberOfItemsMoved = 0) => {
 
   if (numberOfItemsMoved > 0) {
     cy.wait(new Array(numberOfItemsMoved).fill("@updateCardOrDashboard"));
-    H.undoToast()
-      .findByText(
-        new RegExp(
-          `${numberOfItemsMoved} (item has|items have) been moved to the trash.`,
-        ),
-      )
-      .should("be.visible");
   }
 };
 


### PR DESCRIPTION
### Description

Adds assertions that items have actually been moved before we assert on the shape of the post-move UI


Stress Test: 
:x: https://github.com/metabase/metabase/actions/runs/12436468429/job/34724367808
🤞 https://github.com/metabase/metabase/actions/runs/12439068706