### PR TITLE
Fix compare-aggregations drill for multi-stage queries

### DIFF
--- a/src/metabase/lib/drill_thru/compare_aggregations.cljc
+++ b/src/metabase/lib/drill_thru/compare_aggregations.cljc
@@ -13,6 +13,7 @@
    [metabase.lib.drill-thru.common :as lib.drill-thru.common]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
+   [metabase.lib.underlying :as lib.underlying]
    [metabase.util.malli :as mu]))
 
 (mu/defn compare-aggregations-drill :- [:maybe ::lib.schema.drill-thru/drill-thru.compare-aggregations]
@@ -23,10 +24,13 @@
   (when (and column
              (nil? value)
              (lib.drill-thru.common/mbql-stage? query stage-number)
-             (= (:lib/source column) :source/aggregations))
+             (lib.drill-thru.common/aggregation-sourced? query column))
     {:lib/type    :metabase.lib.drill-thru/drill-thru
      :type        :drill-thru/compare-aggregations
-     :aggregation (lib.aggregation/resolve-aggregation query stage-number (:lib/source-uuid column))}))
+     :aggregation (lib.aggregation/resolve-aggregation
+                   query
+                   (lib.underlying/top-level-stage-number query)
+                   (:lib/source-uuid (lib.underlying/top-level-column query column)))}))
 
 (defmethod lib.drill-thru.common/drill-thru-method :drill-thru/compare-aggregations
   [_query _stage-number _drill & _args]

--- a/test/metabase/lib/drill_thru/compare_aggregations_test.cljc
+++ b/test/metabase/lib/drill_thru/compare_aggregations_test.cljc
@@ -1,0 +1,62 @@
+(ns metabase.lib.drill-thru.compare-aggregations-test
+  (:require
+   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
+   [clojure.test :refer [deftest is testing]]
+   [medley.core :as m]
+   [metabase.lib.core :as lib]
+   [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
+   [metabase.lib.drill-thru.test-util.canned :as canned]
+   [metabase.lib.test-metadata :as meta]))
+
+#?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
+
+(deftest ^:parallel compare-aggregations-availability-test
+  (testing "compare-aggregations is available for any header click on an aggregation column, and nothing else"
+    (canned/canned-test
+     :drill-thru/compare-aggregations
+     (fn [test-case _context {:keys [click column-kind]}]
+       (and (= click :header)
+            (not (:native? test-case))
+            (= :aggregation column-kind))))))
+
+(deftest ^:parallel returns-compare-aggregations-test
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/compare-aggregations
+    :click-type  :header
+    :query-type  :aggregated
+    :query-kinds [:mbql]
+    :column-name "count"
+    :expected    {:lib/type    :metabase.lib.drill-thru/drill-thru
+                  :type        :drill-thru/compare-aggregations
+                  :aggregation [:count {}]}}))
+
+(deftest ^:parallel returns-compare-aggregations-for-multi-stage-queries-test
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type   :drill-thru/compare-aggregations
+    :click-type   :header
+    :query-type   :aggregated
+    :query-kinds  [:mbql]
+    :column-name  "count"
+    :custom-query (let [base-query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                                       (lib/aggregate (lib/count))
+                                       (lib/breakout (meta/field-metadata :orders :product-id))
+                                       lib/append-stage)
+                        count-col  (m/find-first #(= (:name %) "count")
+                                                 (lib/returned-columns base-query))
+                        _          (is (some? count-col))
+                        query      (lib/filter base-query (lib/> count-col 0))]
+                    query)
+    :custom-row   {"PRODUCT_ID" 3
+                   "count"      77}
+    :expected     {:lib/type    :metabase.lib.drill-thru/drill-thru
+                   :type        :drill-thru/compare-aggregations
+                   :aggregation [:count {}]}}))
+
+(deftest ^:parallel compare-aggregations-not-returned-for-non-aggregation-cols-test
+  (lib.drill-thru.tu/test-drill-not-returned
+   {:drill-type  :drill-thru/compare-aggregations
+    :click-type  :header
+    :query-kinds [:mbql]
+    :query-type  :aggregated
+    :query-table "ORDERS"
+    :column-name "CREATED_AT"}))


### PR DESCRIPTION
### Description

Ensure the compare-aggregations drill thru is returned by `available-drill-thrus` when a user clicks on an aggregation column, even if there are additional query stages after the last aggregation / breakout stage.

Relates to: https://github.com/metabase/metabase/issues/46932

### How to verify

This drill thru is currently disabled in the FE, but see new BE tests

### Demo

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
