### PR TITLE
[serdes] extract tabId in click_behavior (#51588)

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1,5 +1,6 @@
 (ns ^:mb/once metabase-enterprise.serialization.v2.load-test
   (:require
+   [cheshire.core :as json]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [java-time.api :as t]
@@ -434,6 +435,7 @@
           field3s    (atom nil)
           dash1s     (atom nil)
           dash2s     (atom nil)
+          tab2s      (atom nil)
           card1s     (atom nil)
           dashcard1s (atom nil)
           user1s     (atom nil)
@@ -443,6 +445,7 @@
           field2d    (atom nil)
           user1d     (atom nil)
           dash1d     (atom nil)
+          tab2d      (atom nil)
           card1d     (atom nil)
           dashcard1d (atom nil)
           db2d       (atom nil)
@@ -461,6 +464,7 @@
             (reset! user1s   (ts/create! User  :first_name "Tom" :last_name "Scholz" :email "tom@bost.on"))
             (reset! dash1s   (ts/create! Dashboard :name "My Dashboard" :collection_id (:id @coll1s) :creator_id (:id @user1s)))
             (reset! dash2s   (ts/create! Dashboard :name "Linked dashboard" :collection_id (:id @coll1s) :creator_id (:id @user1s)))
+            (reset! tab2s    (ts/create! :model/DashboardTab :name "Tab for dash2" :dashboard_id (:id @dash2s) :position 0))
             (let [columns           [{:name     "SOME_FIELD"
                                       :fieldRef [:field (:id @field1s) nil]
                                       :enabled  true}
@@ -491,11 +495,12 @@
                                               :table.cell_column  "sum"
                                               :table.columns      columns
                                               :column_settings
-                                              {(str "[\"ref\",[\"field\"," (:id @field1s) ",null]]")
+                                              {(json/encode [:ref [:field (:id @field1s) nil]])
                                                {:click_behavior {:type     "link"
                                                                  :linkType "dashboard"
-                                                                 :targetId (:id @dash2s)}}
-                                               (str "[\"ref\",[\"field\"," (:id @field2s) ",null]]")
+                                                                 :targetId (:id @dash2s)
+                                                                 :tabId    (:id @tab2s)}}
+                                               (json/encode [:ref [:field (:id @field2s) nil]])
                                                {:column_title "Locus"
                                                 :click_behavior
                                                 {:type     "link"
@@ -505,7 +510,7 @@
                                                  {mapping-id {:id     mapping-id
                                                               :source {:type "column" :id "Category_ID" :name "Category ID"}
                                                               :target {:type "dimension" :id mapping-id :dimension mapping-dimension}}}}}
-                                               (str "[\"ref\",[\"field\"," (:id @field3s) ",null]]")
+                                               (json/encode [:ref [:field (:id @field3s) nil]])
                                                {:click_behavior
                                                 {:type     "link"
                                                  :linkType "question"
@@ -554,19 +559,22 @@
                                     :column_settings
                                     {"[\"ref\",[\"field\",[\"my-db\",null,\"orders\",\"invoice\"],null]]" {:column_title "Locus"}}}
                       dimension    [:dimension [:field ["my-db" nil "orders" "invoice"] {:source-field ["my-db" nil "orders" "subtotal"]}]]
-                      dimension-id "[\"dimension\",[\"fk->\",[\"field\",[\"my-db\",null,\"orders\",\"subtotal\"],null],[\"field\",[\"my-db\",null,\"orders\",\"invoice\"],null]]]"
+                      dimension-id (json/encode [:dimension [:fk->
+                                                             [:field [:my-db nil :orders :subtotal] nil]
+                                                             [:field [:my-db nil :orders :invoice] nil]]])
                       exp-dashcard (-> exp-card
                                        (assoc :click_behavior {:type     "link"
                                                                :linkType "question"
                                                                :targetId (:entity_id @card1s)})
                                        (assoc-in [:column_settings
-                                                  "[\"ref\",[\"field\",[\"my-db\",null,\"orders\",\"subtotal\"],null]]"
+                                                  (json/encode [:ref [:field [:my-db nil :orders :subtotal] nil]])
                                                   :click_behavior]
                                                  {:type     "link"
                                                   :linkType "dashboard"
-                                                  :targetId (:entity_id @dash2s)})
+                                                  :targetId (:entity_id @dash2s)
+                                                  :tabId    [(:entity_id @dash2s) (:entity_id @tab2s)]})
                                        (assoc-in [:column_settings
-                                                  "[\"ref\",[\"field\",[\"my-db\",null,\"orders\",\"invoice\"],null]]"
+                                                  (json/encode [:ref [:field [:my-db nil :orders :invoice] nil]])
                                                   :click_behavior]
                                                  {:type     "link"
                                                   :linkType "question"
@@ -577,7 +585,7 @@
                                                     :source {:type "column" :id "Category_ID" :name "Category ID"}
                                                     :target {:type "dimension" :id dimension-id :dimension dimension}}}})
                                        (assoc-in [:column_settings
-                                                  "[\"ref\",[\"field\",[\"my-db\",null,\"orders\",\"discount\"],null]]"
+                                                  (json/encode [:ref [:field [:my-db nil :orders :discount] nil]])
                                                   :click_behavior]
                                                  {:type "link"
                                                   :linkType "question"
@@ -610,6 +618,7 @@
             (reset! field1d    (t2/select-one Field :table_id (:id @table1d) :name "subtotal"))
             (reset! field2d    (t2/select-one Field :table_id (:id @table1d) :name "invoice"))
             (reset! dash1d     (t2/select-one Dashboard :name "My Dashboard"))
+            (reset! tab2d      (t2/select-one :model/DashboardTab :name "Tab for dash2"))
             (reset! card1d     (t2/select-one Card :name "The Card"))
             (reset! dashcard1d (t2/select-one DashboardCard :card_id (:id @card1d) :dashboard_id (:id @dash1d)))
 
@@ -631,7 +640,13 @@
               (is (= [{:parameter_id "deadbeef"
                        :card_id      (:id @card1d)
                        :target       [:dimension [:field (:id @field1d) {:source-field (:id @field2d)}]]}]
-                     (:parameter_mappings @dashcard1d))))))))))
+                     (:parameter_mappings @dashcard1d))))
+            (testing "DashboardTab was exported even though he wasn't mentioned by click_behavior"
+              (is (= (:entity_id @tab2s) (:entity_id @tab2d)))
+              (let [settings (-> @dashcard1d :visualization_settings :column_settings)
+                    setting  (get settings (json/encode [:ref [:field (:id @field1d) nil]]))]
+                (is (= (:id @tab2d)
+                       (-> setting :click_behavior :tabId)))))))))))
 
 (deftest timelines-test
   (testing "timelines"

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/dashboards/Zf1jknwhPhazxIIJ2X6mX_dashboard_subscriptions_and_alerts.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/dashboards/Zf1jknwhPhazxIIJ2X6mX_dashboard_subscriptions_and_alerts.yaml
@@ -47,7 +47,7 @@ dashcards:
               target:
                 id: 6b3da96f
                 type: parameter
-          tabId: 1
+          tabId: ["DHMhMa1FYxiyIgM7_xdgR", "VLzpbzPlShrECFp-dG4pH"]
           targetId: DHMhMa1FYxiyIgM7_xdgR
           type: link
       '["name","name"]':
@@ -87,7 +87,7 @@ dashcards:
               target:
                 id: 6b3da96f
                 type: parameter
-          tabId: 1
+          tabId: ["DHMhMa1FYxiyIgM7_xdgR", "VLzpbzPlShrECFp-dG4pH"]
           targetId: DHMhMa1FYxiyIgM7_xdgR
           type: link
   serdes/meta:

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/dashboards/jm7KgY6IuS6pQjkBZ7WUI_question_overview.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/dashboards/jm7KgY6IuS6pQjkBZ7WUI_question_overview.yaml
@@ -325,7 +325,7 @@ dashcards:
               target:
                 id: 6b3da96f
                 type: parameter
-          tabId: 1
+          tabId: ["DHMhMa1FYxiyIgM7_xdgR", "VLzpbzPlShrECFp-dG4pH"]
           targetId: DHMhMa1FYxiyIgM7_xdgR
           type: link
   serdes/meta:

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/dashboards/vFnGZMNN2K_KW1I0B52bq_metabase_metrics.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/dashboards/vFnGZMNN2K_KW1I0B52bq_metabase_metrics.yaml
@@ -381,7 +381,7 @@ dashcards:
               target:
                 id: 6b3da96f
                 type: parameter
-          tabId: 1
+          tabId: ["DHMhMa1FYxiyIgM7_xdgR", "VLzpbzPlShrECFp-dG4pH"]
           targetId: DHMhMa1FYxiyIgM7_xdgR
           type: link
         column_title: Person Name
@@ -470,7 +470,7 @@ dashcards:
               target:
                 id: 6b3da96f
                 type: parameter
-          tabId: 1
+          tabId: ["DHMhMa1FYxiyIgM7_xdgR", "VLzpbzPlShrECFp-dG4pH"]
           targetId: DHMhMa1FYxiyIgM7_xdgR
           type: link
         column_title: Person Name
@@ -487,7 +487,7 @@ dashcards:
               target:
                 id: 6b3da96f
                 type: parameter
-          tabId: 1
+          tabId: ["DHMhMa1FYxiyIgM7_xdgR", "VLzpbzPlShrECFp-dG4pH"]
           targetId: DHMhMa1FYxiyIgM7_xdgR
           type: link
       ? '["ref",["field",["Internal Metabase Database","public","v_users","full_name"],{"base-type":"type/Text","join-alias":"Question 1"}]]'

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -1026,3 +1026,12 @@
   "Return first item from Reducible"
   [reducible]
   (reduce (fn [_ fst] (reduced fst)) nil reducible))
+
+(defn update-some
+  "Update a value by key in the `m`, if it's `some?`. If `nil` is returned, dissoc it instead"
+  [m k f & args]
+  (let [v (get m k)
+        res (when v (apply f v args))]
+    (if res
+      (assoc m k res)
+      (dissoc m k))))


### PR DESCRIPTION
also, somewhat relatedly, create `elide-fk` function to skip pieces of data holding FKs to deleted targets

#51588