### PR TITLE
[serdes] extract tabId in click_behavior (#51588)

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1,5 +1,6 @@
 (ns ^:mb/once metabase-enterprise.serialization.v2.load-test
   (:require
+   [cheshire.core :as json]
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase-enterprise.serialization.test-util :as ts]
@@ -440,6 +441,7 @@
           field3s    (atom nil)
           dash1s     (atom nil)
           dash2s     (atom nil)
+          tab2s      (atom nil)
           card1s     (atom nil)
           dashcard1s (atom nil)
           user1s     (atom nil)
@@ -449,6 +451,7 @@
           field2d    (atom nil)
           user1d     (atom nil)
           dash1d     (atom nil)
+          tab2d      (atom nil)
           card1d     (atom nil)
           dashcard1d (atom nil)
           db2d       (atom nil)
@@ -468,6 +471,7 @@
             (reset! user1s   (ts/create! User  :first_name "Tom" :last_name "Scholz" :email "tom@bost.on"))
             (reset! dash1s   (ts/create! Dashboard :name "My Dashboard" :collection_id (:id @coll1s) :creator_id (:id @user1s)))
             (reset! dash2s   (ts/create! Dashboard :name "Linked dashboard" :collection_id (:id @coll1s) :creator_id (:id @user1s)))
+            (reset! tab2s    (ts/create! :model/DashboardTab :name "Tab for dash2" :dashboard_id (:id @dash2s) :position 0))
             (let [columns           [{:name     "SOME_FIELD"
                                       :fieldRef [:field (:id @field1s) nil]
                                       :enabled  true}
@@ -498,11 +502,12 @@
                                               :table.cell_column  "sum"
                                               :table.columns      columns
                                               :column_settings
-                                              {(str "[\"ref\",[\"field\"," (:id @field1s) ",null]]")
+                                              {(json/encode [:ref [:field (:id @field1s) nil]])
                                                {:click_behavior {:type     "link"
                                                                  :linkType "dashboard"
-                                                                 :targetId (:id @dash2s)}}
-                                               (str "[\"ref\",[\"field\"," (:id @field2s) ",null]]")
+                                                                 :targetId (:id @dash2s)
+                                                                 :tabId    (:id @tab2s)}}
+                                               (json/encode [:ref [:field (:id @field2s) nil]])
                                                {:column_title "Locus"
                                                 :click_behavior
                                                 {:type     "link"
@@ -512,7 +517,7 @@
                                                  {mapping-id {:id     mapping-id
                                                               :source {:type "column" :id "Category_ID" :name "Category ID"}
                                                               :target {:type "dimension" :id mapping-id :dimension mapping-dimension}}}}}
-                                               (str "[\"ref\",[\"field\"," (:id @field3s) ",null]]")
+                                               (json/encode [:ref [:field (:id @field3s) nil]])
                                                {:click_behavior
                                                 {:type     "link"
                                                  :linkType "question"
@@ -561,19 +566,22 @@
                                     :column_settings
                                     {"[\"ref\",[\"field\",[\"my-db\",null,\"orders\",\"invoice\"],null]]" {:column_title "Locus"}}}
                       dimension    [:dimension [:field ["my-db" nil "orders" "invoice"] {:source-field ["my-db" nil "orders" "subtotal"]}]]
-                      dimension-id "[\"dimension\",[\"fk->\",[\"field\",[\"my-db\",null,\"orders\",\"subtotal\"],null],[\"field\",[\"my-db\",null,\"orders\",\"invoice\"],null]]]"
+                      dimension-id (json/encode [:dimension [:fk->
+                                                             [:field [:my-db nil :orders :subtotal] nil]
+                                                             [:field [:my-db nil :orders :invoice] nil]]])
                       exp-dashcard (-> exp-card
                                        (assoc :click_behavior {:type     "link"
                                                                :linkType "question"
                                                                :targetId (:entity_id @card1s)})
                                        (assoc-in [:column_settings
-                                                  "[\"ref\",[\"field\",[\"my-db\",null,\"orders\",\"subtotal\"],null]]"
+                                                  (json/encode [:ref [:field [:my-db nil :orders :subtotal] nil]])
                                                   :click_behavior]
                                                  {:type     "link"
                                                   :linkType "dashboard"
-                                                  :targetId (:entity_id @dash2s)})
+                                                  :targetId (:entity_id @dash2s)
+                                                  :tabId    [(:entity_id @dash2s) (:entity_id @tab2s)]})
                                        (assoc-in [:column_settings
-                                                  "[\"ref\",[\"field\",[\"my-db\",null,\"orders\",\"invoice\"],null]]"
+                                                  (json/encode [:ref [:field [:my-db nil :orders :invoice] nil]])
                                                   :click_behavior]
                                                  {:type     "link"
                                                   :linkType "question"
@@ -584,7 +592,7 @@
                                                     :source {:type "column" :id "Category_ID" :name "Category ID"}
                                                     :target {:type "dimension" :id dimension-id :dimension dimension}}}})
                                        (assoc-in [:column_settings
-                                                  "[\"ref\",[\"field\",[\"my-db\",null,\"orders\",\"discount\"],null]]"
+                                                  (json/encode [:ref [:field [:my-db nil :orders :discount] nil]])
                                                   :click_behavior]
                                                  {:type "link"
                                                   :linkType "question"
@@ -618,6 +626,7 @@
             (reset! field1d    (t2/select-one Field :table_id (:id @table1d) :name "subtotal"))
             (reset! field2d    (t2/select-one Field :table_id (:id @table1d) :name "invoice"))
             (reset! dash1d     (t2/select-one Dashboard :name "My Dashboard"))
+            (reset! tab2d      (t2/select-one :model/DashboardTab :name "Tab for dash2"))
             (reset! card1d     (t2/select-one Card :name "The Card"))
             (reset! dashcard1d (t2/select-one DashboardCard :card_id (:id @card1d) :dashboard_id (:id @dash1d)))
 
@@ -639,7 +648,13 @@
               (is (= [{:parameter_id "deadbeef"
                        :card_id      (:id @card1d)
                        :target       [:dimension [:field (:id @field1d) {:source-field (:id @field2d)}]]}]
-                     (:parameter_mappings @dashcard1d))))))))))
+                     (:parameter_mappings @dashcard1d))))
+            (testing "DashboardTab was exported even though he wasn't mentioned by click_behavior"
+              (is (= (:entity_id @tab2s) (:entity_id @tab2d)))
+              (let [settings (-> @dashcard1d :visualization_settings :column_settings)
+                    setting  (get settings (json/encode [:ref [:field (:id @field1d) nil]]))]
+                (is (= (:id @tab2d)
+                       (-> setting :click_behavior :tabId)))))))))))
 
 (deftest timelines-test
   (testing "timelines"

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/dashboards/jm7KgY6IuS6pQjkBZ7WUI_question_overview.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/dashboards/jm7KgY6IuS6pQjkBZ7WUI_question_overview.yaml
@@ -306,7 +306,7 @@ dashcards:
               target:
                 id: 6b3da96f
                 type: parameter
-          tabId: 1
+          tabId: ["DHMhMa1FYxiyIgM7_xdgR", "VLzpbzPlShrECFp-dG4pH"]
           targetId: DHMhMa1FYxiyIgM7_xdgR
           type: link
 - entity_id: PljXyyyfScG10byiLANCg

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/dashboards/vFnGZMNN2K_KW1I0B52bq_metabase_metrics.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/dashboards/vFnGZMNN2K_KW1I0B52bq_metabase_metrics.yaml
@@ -337,7 +337,7 @@ dashcards:
               target:
                 id: 6b3da96f
                 type: parameter
-          tabId: 1
+          tabId: ["DHMhMa1FYxiyIgM7_xdgR", "VLzpbzPlShrECFp-dG4pH"]
           targetId: DHMhMa1FYxiyIgM7_xdgR
           type: link
         column_title: Person Name
@@ -421,7 +421,7 @@ dashcards:
               target:
                 id: 6b3da96f
                 type: parameter
-          tabId: 1
+          tabId: ["DHMhMa1FYxiyIgM7_xdgR", "VLzpbzPlShrECFp-dG4pH"]
           targetId: DHMhMa1FYxiyIgM7_xdgR
           type: link
       ? '["ref",["field",["Internal Metabase Database","public","v_users","full_name"],{"base-type":"type/Text","join-alias":"People - User"}]]'
@@ -437,7 +437,7 @@ dashcards:
               target:
                 id: 6b3da96f
                 type: parameter
-          tabId: 1
+          tabId: ["DHMhMa1FYxiyIgM7_xdgR", "VLzpbzPlShrECFp-dG4pH"]
           targetId: DHMhMa1FYxiyIgM7_xdgR
           type: link
         column_title: Person Name

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1198,12 +1198,14 @@
 (defn- export-viz-click-behavior-link
   [{:keys [linkType type] :as click-behavior}]
   (cond-> click-behavior
-    (= type "link") (update :targetId *export-fk* (link-card-model->toucan-model linkType))))
+    (= type "link") (-> (update :targetId *export-fk* (link-card-model->toucan-model linkType))
+                        (u/update-some :tabId *export-fk* :model/DashboardTab))))
 
 (defn- import-viz-click-behavior-link
   [{:keys [linkType type] :as click-behavior}]
   (cond-> click-behavior
-    (= type "link") (update :targetId *import-fk* (link-card-model->toucan-model linkType))))
+    (= type "link") (-> (update :targetId *import-fk* (link-card-model->toucan-model linkType))
+                        (u/update-some :tabId *import-fk* :model/DashboardTab))))
 
 (defn- export-viz-click-behavior-mapping [mapping]
   (-> mapping
@@ -1245,7 +1247,7 @@
 
 (defn- export-viz-click-behavior [settings]
   (some-> settings
-          (m/update-existing    :click_behavior export-viz-click-behavior-link)
+          (u/update-some :click_behavior export-viz-click-behavior-link)
           (m/update-existing-in [:click_behavior :parameterMapping] export-viz-click-behavior-mappings)))
 
 (defn- import-viz-click-behavior [settings]
@@ -1371,10 +1373,11 @@
 
 (defn- viz-click-behavior-deps
   [settings]
-  (when-let [{:keys [linkType targetId type]} (:click_behavior settings)]
+  (let [{:keys [linkType targetId type]} (:click_behavior settings)
+        model (when linkType (link-card-model->toucan-model linkType))]
     (case type
-      "link" (when-let [model (some-> linkType link-card-model->toucan-model name)]
-               #{[{:model model
+      "link" (when model
+               #{[{:model (name model)
                    :id    targetId}]})
       ;; TODO: We might need to handle the click behavior that updates dashboard filters? I can't figure out how get
       ;; that to actually attach to a filter to check what it looks like.
@@ -1401,9 +1404,10 @@
          (reduce set/union #{}))))
 
 (defn- viz-click-behavior-descendants [{:keys [click_behavior]}]
-  (when-let [{:keys [linkType targetId type]} click_behavior]
+  (let [{:keys [linkType targetId type]} click_behavior
+        model (when linkType (link-card-model->toucan-model linkType))]
     (case type
-      "link" (when-let [model (link-card-model->toucan-model linkType)]
+      "link" (when model
                #{[(name model) targetId]})
       ;; TODO: We might need to handle the click behavior that updates dashboard filters? I can't figure out how get
       ;; that to actually attach to a filter to check what it looks like.

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -906,3 +906,12 @@
                          (partition 2 clauses))
                  (when (odd? (count clauses))
                    (list (last clauses))))))))))
+
+(defn update-some
+  "Update a value by key in the `m`, if it's `some?`. If `nil` is returned, dissoc it instead"
+  [m k f & args]
+  (let [v (get m k)
+        res (when v (apply f v args))]
+    (if res
+      (assoc m k res)
+      (dissoc m k))))


### PR DESCRIPTION
also, somewhat relatedly, create `elide-fk` function to skip pieces of data holding FKs to deleted targets

#51588