### PR TITLE
docs(sdk): fix initial parameter props name in dashboards

### DIFF
--- a/docs/embedding/sdk/dashboards.md
+++ b/docs/embedding/sdk/dashboards.md
@@ -22,10 +22,10 @@ You can embed a dashboard using the one of the dashboard components:
 
 ## Dashboard component props
 
-| Prop                          | Type                                            | Description                                                                                                                                                                                                                                                                                                                      |
-|-------------------------------| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Prop                         | Type                                            | Description                                                                                                                                                                                                                                                                                                                      |
+|------------------------------| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | dashboardId                  | `number \| string`                              | The ID of the dashboard. This is either:<br>- the numerical ID when accessing a dashboard link, i.e. `http://localhost:3000/dashboard/1-my-dashboard` where the ID is `1`<br>- the string ID found in the `entity_id` key of the dashboard object when using the API directly or using the SDK Collection Browser to return data |
-| initialSqlParameters         | `Record<string, string \| string[]>`            | Query parameters for the dashboard. For a single option, use a `string` value, and use a list of strings for multiple options.                                                                                                                                                                                                   |
+| initialParameters            | `Record<string, string \| string[]>`            | Query parameters for the dashboard. For a single option, use a `string` value, and use a list of strings for multiple options.                                                                                                                                                                                                   |
 | withTitle                    | `boolean`                                       | Whether the dashboard should display a title.                                                                                                                                                                                                                                                                                    |
 | withCardTitle                | `boolean`                                       | Whether the dashboard cards should display a title.                                                                                                                                                                                                                                                                              |
 | withDownloads                | `boolean \| null`                               | Whether to hide the download button.                                                                                                                                                                                                                                                                                             |
@@ -60,7 +60,7 @@ const authConfig = {...}
 
 export default function App() {
     const dashboardId = 1; // This is the dashboard ID you want to embed
-    const initialSqlParameters = {}; // Define your query parameters here
+    const initialParameters = {}; // Define your query parameters here
 
     // choose parameter names that are in your dashboard
     const hiddenParameters = ["location", "city"]
@@ -69,7 +69,7 @@ export default function App() {
         <MetabaseProvider authConfig={authConfig}>
             <InteractiveDashboard
                 dashboardId={dashboardId}
-                initialSqlParameters={initialSqlParameters}
+                initialParameters={initialParameters}
                 withTitle={false}
                 withDownloads={false}
                 hiddenParameters={hideParameters}


### PR DESCRIPTION
Use `initialParameters` instead of `initialSqlParameters` in sdk dashboard docs