### PR TITLE
chore: enable local cache for cljs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,5 @@ modules/drivers/*/.lsp/*
 .swc/
 
 *storybook.log
+
+.wireit/

--- a/package.json
+++ b/package.json
@@ -357,7 +357,7 @@
     "build-embedding-sdk:watch": "yarn embedding-sdk:generate-package && yarn embedding-sdk:generate-nextjs-compat && yarn build-embedding-sdk:pure --watch",
     "build-embedding-sdk-cli": "webpack --config webpack.embedding-sdk-cli.config.js",
     "build-embedding-sdk-cli:watch": "yarn build-embedding-sdk-cli --watch",
-    "build-hot": "rm -f target/cljs_dev/cljs.core.js && yarn build:cljs && yarn build-hot:js",
+    "build-hot": "yarn && yarn build-pure:cljs && yarn build-hot:js",
     "build-hot:cljs": "yarn && shadow-cljs watch app",
     "build-hot:js": "yarn clean-dev:js && NODE_OPTIONS=--max-old-space-size=8196 WEBPACK_BUNDLE=hot rspack serve",
     "build-hot:js-wait": "yarn wait:cljs; yarn build-hot:js",

--- a/package.json
+++ b/package.json
@@ -324,6 +324,7 @@
     "webpack-dev-server": "^5.0.4",
     "webpack-notifier": "1.15.0",
     "webpack-stats-plugin": "^1.1.3",
+    "wireit": "^0.14.9",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz",
     "yaml-lint": "~1.6.0",
     "yarn-deduplicate": "^6.0.2"
@@ -356,11 +357,11 @@
     "build-embedding-sdk:watch": "yarn embedding-sdk:generate-package && yarn embedding-sdk:generate-nextjs-compat && yarn build-embedding-sdk:pure --watch",
     "build-embedding-sdk-cli": "webpack --config webpack.embedding-sdk-cli.config.js",
     "build-embedding-sdk-cli:watch": "yarn build-embedding-sdk-cli --watch",
-    "build-hot": "rm -f target/cljs_dev/cljs.core.js && yarn concurrently -n 'cljs,js' -c 'yellow,green' 'yarn build-hot:cljs' 'yarn build-hot:js-wait'",
+    "build-hot": "rm -f target/cljs_dev/cljs.core.js && yarn build:cljs && yarn build-hot:js",
     "build-hot:cljs": "yarn && shadow-cljs watch app",
-    "build-hot:js": "yarn && yarn clean-dev:js && NODE_OPTIONS=--max-old-space-size=8196 WEBPACK_BUNDLE=hot rspack serve",
+    "build-hot:js": "yarn clean-dev:js && NODE_OPTIONS=--max-old-space-size=8196 WEBPACK_BUNDLE=hot rspack serve",
     "build-hot:js-wait": "yarn wait:cljs; yarn build-hot:js",
-    "build-pure:cljs": "yarn clean-dev:cljs && shadow-cljs compile app",
+    "build-pure:cljs": "wireit",
     "build-release": "yarn build-release:cljs && yarn build-release:js",
     "build-release:cljs": "yarn clean-release:cljs && shadow-cljs release app",
     "build-release:js": "WEBPACK_BUNDLE=production NODE_OPTIONS=--max-old-space-size=8196 rspack build",
@@ -451,6 +452,25 @@
     "type-check-pure": "tsc --noEmit",
     "validate-e2e-filenames": "node e2e/validate-e2e-test-files.js",
     "wait:cljs": "echo Waiting for first CLJS build; until [ -f target/cljs_dev/cljs.core.js ]; do sleep 1; done; echo CLJS build done"
+  },
+  "wireit": {
+    "build-pure:cljs": {
+      "command": "shadow-cljs compile app",
+      "clean": true,
+      "files": [
+        "src/**/*.cljc",
+        "src/**/*.cljs",
+        "src/**/*.clj",
+        "**deps.edn",
+        "enterprise/backend/src/**",
+        "src/**",
+        "modules/drivers/{*,*/{*,!(test)/**}}",
+        ".clj-kondo/**"
+      ],
+      "output": [
+        "target/cljs_dev"
+      ]
+    }
   },
   "lint-staged": {
     "+(frontend|enterprise)/**/*.styled.tsx": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -6453,6 +6453,11 @@ balanced-match@^2.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-2.0.0.tgz#dc70f920d78db8b858535795867bf48f820633d9"
   integrity sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==
 
+balanced-match@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-3.0.1.tgz#e854b098724b15076384266497392a271f4a26a0"
+  integrity sha512-vjtV3hiLqYDNRoiAv0zC4QaGAMPomEoq83PRmYIofPswwZurCeWR5LByXm7SyoL0Zh5+2z0+HC7jG8gSZJUh0w==
+
 base64-arraybuffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz#1c37589a7c4b0746e34bd1feb951da2df01c1bdc"
@@ -6595,6 +6600,13 @@ brace-expansion@^2.0.1:
   integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
   dependencies:
     balanced-match "^1.0.0"
+
+brace-expansion@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-4.0.0.tgz#bb24b89bf4d4b37d742acac89b65d1a32b379a81"
+  integrity sha512-l/mOwLWs7BQIgOKrL46dIAbyCKvPV7YJPDspkuc88rHsZRlg3hptUGdU7Trv0VFP4d3xnSGBQrKu5ZvGB7UeIw==
+  dependencies:
+    balanced-match "^3.0.0"
 
 braces@^3.0.3, braces@~3.0.2:
   version "3.0.3"
@@ -10239,6 +10251,17 @@ fast-glob@^3.1.1:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
+fast-glob@^3.2.11:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
+  integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.8"
+
 fast-glob@^3.2.9:
   version "3.2.11"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
@@ -13355,6 +13378,11 @@ json5@2.2.2, json5@^1.0.2, json5@^2.1.2, json5@^2.2.2, json5@^2.2.3:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.2.tgz#64471c5bdcc564c18f7c1d4df2e2297f2457c5ab"
   integrity sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==
 
+jsonc-parser@^3.0.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.3.1.tgz#f2a524b4f7fd11e3d791e559977ad60b98b798b4"
+  integrity sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
@@ -14547,7 +14575,7 @@ micromark@^3.0.0:
     micromark-util-types "^1.0.1"
     uvu "^0.5.0"
 
-micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
+micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5, micromatch@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
   integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
@@ -16680,6 +16708,15 @@ prop-types@15.x, prop-types@^15.0.0, prop-types@^15.5.0, prop-types@^15.5.10, pr
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
+proper-lockfile@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/proper-lockfile/-/proper-lockfile-4.1.2.tgz#c8b9de2af6b2f1601067f98e01ac66baa223141f"
+  integrity sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==
+  dependencies:
+    graceful-fs "^4.2.4"
+    retry "^0.12.0"
+    signal-exit "^3.0.2"
+
 property-expr@^2.0.4:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.5.tgz#278bdb15308ae16af3e3b9640024524f4dc02cb4"
@@ -17926,6 +17963,11 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
+
+retry@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
+  integrity sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==
 
 retry@^0.13.1:
   version "0.13.1"
@@ -21047,6 +21089,17 @@ wildcard@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.0.tgz#a77d20e5200c6faaac979e4b3aadc7b3dd7f8fec"
   integrity sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==
+
+wireit@^0.14.9:
+  version "0.14.9"
+  resolved "https://registry.yarnpkg.com/wireit/-/wireit-0.14.9.tgz#72fb1e3a605f246104c0e292f10472ecc106fe1d"
+  integrity sha512-hFc96BgyslfO1WGSzQqOVYd5N3TB+4u9w70L9GHR/T7SYjvFmeznkYMsRIjMLhPcVabCEYPW1vV66wmIVDs+dQ==
+  dependencies:
+    brace-expansion "^4.0.0"
+    chokidar "^3.5.3"
+    fast-glob "^3.2.11"
+    jsonc-parser "^3.0.0"
+    proper-lockfile "^4.1.2"
 
 word-wrap@1.2.3, word-wrap@^1.2.3:
   version "1.2.3"


### PR DESCRIPTION
### Description

It's been discussed that cljs live reload is used by a few devs, at the same time it's a blocker for using local cache of cljs between branches.

### How to verify

`yarn build-hot` runs a server without cljs live reload
`yarn build-hot-be` runs a server with cljs live reload, as `build-hot` used to do
