### PR TITLE
Use NanoIDs instead of field IDs for the LLM

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
@@ -119,7 +119,7 @@
   (try
     (let [url      (agent-endpoint-url)
           body     (u/prog1 (build-request-body context messages session-id tools)
-                     (metabot-v3.context/log (last (:messages <>)) :llm.log/be->llm))
+                     (metabot-v3.context/log (:messages <>) :llm.log/be->llm))
           _        (log/debugf "Request to AI Proxy:\n%s" (u/pprint-to-str body))
           options  (build-request-options body)
           response (post! url options)]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/repl.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/repl.clj
@@ -112,7 +112,7 @@
   ;; actually, only filter for current year
   (mt/with-test-user :crowberto
     (user-repl-with-context
-     {:user_is_viewing [{:type :report :ref 111}]}))
+     {:user_is_viewing [{:type :report :id 111}]}))
 
   ;; any outliers?
   ;; breakout by plan

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
@@ -21,10 +21,11 @@
 (defn ->result-column
   "Return an tool result columns for `column` prefixing :id with `field-id-prefix`."
   [column field-id-prefix]
-  (-> {:id (str field-id-prefix (-> column
-                                    lib/ref
-                                    (lib.options/update-options dissoc :lib/uuid)
-                                    pr-str))
+  (-> {:id (u/generate-nano-id)
+       :internal-id (str field-id-prefix (-> column
+                                             lib/ref
+                                             (lib.options/update-options dissoc :lib/uuid)
+                                             pr-str))
        :name (get column :display-name)
        :type (convert-field-type column)}
       (m/assoc-some :description (get column :description))))


### PR DESCRIPTION
We don't want to send our real field IDs to the LLM because they're kind of a mess. Instead, just send the LLM nanoIDs and then find the *actual* field in the history.

A little messy and inefficient, but it's a small diff and it works.
