### PR TITLE
put field usage behind a feature flag and turn it off by default

### DIFF
--- a/dev/src/dev/debug_qp.clj
+++ b/dev/src/dev/debug_qp.clj
@@ -102,7 +102,6 @@
        form))
    query))
 
-
 ;;;; [[add-names]]
 
 (defn- field-and-table-name [field-id]
@@ -148,7 +147,6 @@
              &match)))
        x)
       ->sorted-mbql-query-map))
-
 
 ;;;; [[process-query-debug]]
 
@@ -255,7 +253,6 @@
   (print-transform-result before after))
 
 (def ^:private ^:dynamic *printer* print-formatted-event)
-
 
 ;;;; [[to-mbql-shorthand]]
 

--- a/src/metabase/query_processor/middleware/process_userland_query.clj
+++ b/src/metabase/query_processor/middleware/process_userland_query.clj
@@ -80,7 +80,7 @@
   (if-not context
     (log/warn "Cannot save QueryExecution, missing :context")
     (let [qe-id (t2/insert-returning-pk! :model/QueryExecution (dissoc query-execution :json_query))]
-      (when (and enable-field-usage-analysis pmbql)
+      (when (and (enable-field-usage-analysis) pmbql)
         (grouper/submit! @field-usages-queue {:query_execution_id qe-id
                                               :pmbql              pmbql})))))
 

--- a/src/metabase/query_processor/middleware/process_userland_query.clj
+++ b/src/metabase/query_processor/middleware/process_userland_query.clj
@@ -49,7 +49,7 @@
   :default false)
 
 (defonce ^:private
- field-usages-queue
+  field-usages-queue
   (delay (grouper/start!
           (fn [inputs]
             (try

--- a/src/metabase/query_processor/middleware/process_userland_query.clj
+++ b/src/metabase/query_processor/middleware/process_userland_query.clj
@@ -12,10 +12,12 @@
    [metabase.lib.core :as lib]
    [metabase.models.field-usage :as field-usage]
    [metabase.models.query :as query]
+   [metabase.models.setting :refer [defsetting]]
    [metabase.query-processor.schema :as qp.schema]
    [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.util :as qp.util]
    [metabase.util.grouper :as grouper]
+   [metabase.util.i18n :refer [deferred-tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
@@ -35,8 +37,19 @@
 
 (def ^:private field-usage-interval-seconds 20)
 
+(defsetting enable-field-usage-analysis
+  (deferred-tru
+   "Enable field usage analysis for queries. This will analyze the fields used in queries and store them in the
+    application database.
+
+    Turn off by default since we haven't had an user-facing feature that uses this data yet.")
+  :type    :boolean
+  :export? false
+  :audit   :never
+  :default false)
+
 (defonce ^:private
-  field-usages-queue
+ field-usages-queue
   (delay (grouper/start!
           (fn [inputs]
             (try
@@ -45,8 +58,8 @@
                                                (try
                                                  (map #(assoc % :query_execution_id query_execution_id) (field-usage/pmbql->field-usages pmbql))
                                                  ;; one query fail shouldn't fail the whole batch
-                                                 (catch Exception e
-                                                   (log/error e "Error getting field usages from pmbql" pmbql)
+                                                 (catch Throwable e
+                                                   (log/warn e "Error getting field usages from pmbql" pmbql)
                                                    [])))
                                              inputs))
               (catch Throwable e
@@ -67,7 +80,7 @@
   (if-not context
     (log/warn "Cannot save QueryExecution, missing :context")
     (let [qe-id (t2/insert-returning-pk! :model/QueryExecution (dissoc query-execution :json_query))]
-      (when pmbql
+      (when (and enable-field-usage-analysis pmbql)
         (grouper/submit! @field-usages-queue {:query_execution_id qe-id
                                               :pmbql              pmbql})))))
 

--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -210,7 +210,8 @@
   (testing "execute an userland query will capture field usages"
     (mt/test-helpers-set-global-values!
       (mt/with-model-cleanup [:model/FieldUsage]
-        (mt/with-temporary-setting-values [synchronous-batch-updates true]
+        (mt/with-temporary-setting-values [synchronous-batch-updates   true
+                                           enable-field-usage-analysis true]
           (mt/with-temp [:model/Field {field-id :id} {:table_id  (mt/id :products)
                                                       :name      "very_interesting_field"
                                                       :base_type :type/Integer}


### PR DESCRIPTION
it's generating too much noise without getting used, so disable it by default

context: https://metaboat.slack.com/archives/C0641E4PB9B/p1735272546005879