### PR TITLE
Preemptive caching FE

### DIFF
--- a/e2e/test/scenarios/admin/performance/helpers/constants.ts
+++ b/e2e/test/scenarios/admin/performance/helpers/constants.ts
@@ -21,10 +21,12 @@ export const sampleDurationStrategy: DurationStrategy = {
   type: "duration",
   duration: 48,
   unit: CacheDurationUnit.Hours,
+  refresh_automatically: false,
 };
 export const sampleScheduleStrategy: ScheduleStrategy = {
   type: "schedule",
   schedule: "0 0 * * * ?", // Invalidate hourly at the start of the hour
+  refresh_automatically: false,
 };
 export const sampleDoNotCacheStrategy: DoNotCacheStrategy = { type: "nocache" };
 

--- a/e2e/test/scenarios/admin/performance/helpers/e2e-strategy-form-helpers.ts
+++ b/e2e/test/scenarios/admin/performance/helpers/e2e-strategy-form-helpers.ts
@@ -101,7 +101,7 @@ export const openStrategyFormForDatabaseOrDefaultPolicy = (
   currentStrategyLabel?: string,
 ) => {
   cy.visit("/admin/performance");
-  cy.findByRole("tablist").get("aria-selected").contains("Database caching");
+  cy.findByRole("tablist").get("[aria-selected]").contains("Database caching");
   cy.log(`Open strategy form for ${databaseNameOrDefaultPolicy}`);
   formLauncher(
     databaseNameOrDefaultPolicy,

--- a/e2e/test/scenarios/admin/performance/helpers/e2e-strategy-form-helpers.ts
+++ b/e2e/test/scenarios/admin/performance/helpers/e2e-strategy-form-helpers.ts
@@ -51,6 +51,34 @@ export const dontCacheResultsRadioButton = () =>
 export const useDefaultRadioButton = () =>
   cacheStrategyRadioButton(/Use default/);
 
+export const preemptiveCachingSwitch = () =>
+  cy.findByTestId("preemptive-caching-switch");
+export const enablePreemptiveCaching = () =>
+  preemptiveCachingSwitch().within(() => {
+    cy.findByRole("switch").should("not.be.checked");
+    cy.findByRole("switch").next("label").click();
+    cy.findByRole("switch").should("be.checked");
+  });
+export const disablePreemptiveCaching = () =>
+  preemptiveCachingSwitch().within(() => {
+    cy.findByRole("switch").should("be.checked");
+    cy.findByRole("switch").next("label").click();
+    cy.findByRole("switch").should("not.be.checked");
+  });
+export const checkPreemptiveCachingEnabled = () =>
+  preemptiveCachingSwitch().within(() => {
+    cy.findByRole("switch").should("be.checked");
+  });
+export const checkPreemptiveCachingDisabled = () =>
+  preemptiveCachingSwitch().within(() => {
+    cy.findByRole("switch").should("not.be.checked");
+  });
+
+export const dashboardAndQuestionsTable = () =>
+  cy.findByRole("table", {
+    name: /Here are the dashboards and questions/,
+  });
+
 export const formLauncher = (
   itemName: string,
   preface:
@@ -73,7 +101,7 @@ export const openStrategyFormForDatabaseOrDefaultPolicy = (
   currentStrategyLabel?: string,
 ) => {
   cy.visit("/admin/performance");
-  cy.findByRole("tablist").get("[aria-selected]").contains("Database caching");
+  cy.findByRole("tablist").get("aria-selected").contains("Database caching");
   cy.log(`Open strategy form for ${databaseNameOrDefaultPolicy}`);
   formLauncher(
     databaseNameOrDefaultPolicy,

--- a/enterprise/backend/src/metabase_enterprise/cache/strategies.clj
+++ b/enterprise/backend/src/metabase_enterprise/cache/strategies.clj
@@ -33,11 +33,13 @@
                 [:type [:= :duration]]
                 [:duration ms/PositiveInt]
                 [:unit [:enum "hours" "minutes" "seconds" "days"]]
+                [:refresh_automatically [:maybe :boolean]]
                 ^:internal
                 [:invalidated-at {:optional true} some?]]]
     [:schedule [:map {:closed true}
                 [:type [:= :schedule]]
                 [:schedule u.cron/CronScheduleString]
+                [:refresh_automatically [:maybe :boolean]]
                 ^:internal
                 [:invalidated-at {:optional true} some?]]]]])
 

--- a/enterprise/backend/src/metabase_enterprise/cache/strategies.clj
+++ b/enterprise/backend/src/metabase_enterprise/cache/strategies.clj
@@ -33,13 +33,13 @@
                 [:type [:= :duration]]
                 [:duration ms/PositiveInt]
                 [:unit [:enum "hours" "minutes" "seconds" "days"]]
-                [:refresh_automatically [:maybe :boolean]]
+                [:refresh_automatically {:optional true} [:maybe :boolean]]
                 ^:internal
                 [:invalidated-at {:optional true} some?]]]
     [:schedule [:map {:closed true}
                 [:type [:= :schedule]]
                 [:schedule u.cron/CronScheduleString]
-                [:refresh_automatically [:maybe :boolean]]
+                [:refresh_automatically {:optional true} [:maybe :boolean]]
                 ^:internal
                 [:invalidated-at {:optional true} some?]]]]])
 

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForDatabases.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForDatabases.unit.spec.tsx
@@ -218,6 +218,7 @@ describe("StrategyEditorForDatabases", () => {
     const strategy: ScheduleStrategy = {
       type: "schedule",
       schedule: "0 0 * * * ?",
+      refresh_automatically: false,
     };
     const result = getShortStrategyLabel(strategy);
     expect(result).toBe("Scheduled: hourly");
@@ -228,6 +229,7 @@ describe("StrategyEditorForDatabases", () => {
       type: "duration",
       duration: 5,
       unit: CacheDurationUnit.Hours,
+      refresh_automatically: false,
     };
     const result = getShortStrategyLabel(strategy);
     expect(result).toBe("Duration: 5h");

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/utils.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/utils.unit.spec.tsx
@@ -17,18 +17,22 @@ import { formatValueForSorting } from "./utils";
 const hourlyScheduleStrategy: ScheduleStrategy = {
   type: "schedule",
   schedule: "0 0 * * * ?",
+  refresh_automatically: false,
 };
 const dailyScheduleStrategy: ScheduleStrategy = {
   type: "schedule",
   schedule: "0 0 8 * * ?",
+  refresh_automatically: false,
 };
 const weeklyScheduleStrategy: ScheduleStrategy = {
   type: "schedule",
   schedule: "0 0 8 ? * 2",
+  refresh_automatically: false,
 };
 const monthlyScheduleStrategy: ScheduleStrategy = {
   type: "schedule",
   schedule: "0 0 8 ? * 2#1",
+  refresh_automatically: false,
 };
 const adaptiveStrategy: AdaptiveStrategy = {
   type: "ttl",
@@ -62,6 +66,7 @@ const unsortedRows: CacheableItem[] = [
       type: "duration",
       duration: 100,
       unit: CacheDurationUnit.Hours,
+      refresh_automatically: false,
     },
     collection: createMockCollection({
       ...b,
@@ -80,7 +85,12 @@ const unsortedRows: CacheableItem[] = [
   {
     model: "question",
     id: 3,
-    strategy: { type: "duration", duration: 10, unit: CacheDurationUnit.Hours },
+    strategy: {
+      type: "duration",
+      duration: 10,
+      unit: CacheDurationUnit.Hours,
+      refresh_automatically: false,
+    },
     collection: createMockCollection({
       ...d,
       effective_ancestors: [b, c],
@@ -98,7 +108,12 @@ const unsortedRows: CacheableItem[] = [
   {
     model: "question",
     id: 5,
-    strategy: { type: "duration", duration: 1, unit: CacheDurationUnit.Hours },
+    strategy: {
+      type: "duration",
+      duration: 1,
+      unit: CacheDurationUnit.Hours,
+      refresh_automatically: false,
+    },
     collection: createMockCollection({
       ...f,
       effective_ancestors: [d, e],

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyFormLauncher.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyFormLauncher.unit.spec.tsx
@@ -27,6 +27,7 @@ const defaultProps: Pick<
         type: "duration",
         duration: 96,
         unit: CacheDurationUnit.Hours,
+        refresh_automatically: false,
       },
     },
     { model: "database", model_id: 1, strategy: { type: "nocache" } },

--- a/enterprise/frontend/src/metabase-enterprise/caching/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/caching/constants.ts
@@ -22,6 +22,7 @@ const scheduleStrategyValidationSchema = Yup.object({
   schedule: Yup.string()
     .required(t`A cron expression is required`)
     .default(defaultCron),
+  refresh_automatically: Yup.boolean().nullable().default(false),
 });
 
 const durationStrategyValidationSchema = Yup.object({
@@ -32,6 +33,7 @@ const durationStrategyValidationSchema = Yup.object({
     "${path} is not a valid duration",
     value => !!value && durationUnits.has(value),
   ),
+  refresh_automatically: Yup.boolean().nullable().default(false),
 });
 
 /** Caching strategies available on EE only */

--- a/frontend/src/metabase-types/api/mocks/performance.ts
+++ b/frontend/src/metabase-types/api/mocks/performance.ts
@@ -26,6 +26,11 @@ export const createMockCacheConfigWithDurationStrategy = (
   opts?: Partial<CacheConfig>,
 ): CacheConfig =>
   createMockCacheConfig({
-    strategy: { type: "duration", duration: 1, unit: CacheDurationUnit.Hours },
+    strategy: {
+      type: "duration",
+      duration: 1,
+      unit: CacheDurationUnit.Hours,
+      refresh_automatically: false,
+    },
     ...opts,
   });

--- a/frontend/src/metabase-types/api/performance.ts
+++ b/frontend/src/metabase-types/api/performance.ts
@@ -34,6 +34,7 @@ export interface DurationStrategy extends CacheStrategyBase {
   type: "duration";
   duration: number;
   unit: CacheDurationUnit;
+  refresh_automatically: boolean;
 }
 
 export interface InheritStrategy extends CacheStrategyBase {
@@ -43,6 +44,7 @@ export interface InheritStrategy extends CacheStrategyBase {
 export interface ScheduleStrategy extends CacheStrategyBase {
   type: "schedule";
   schedule: string;
+  refresh_automatically: boolean;
 }
 
 /** Cache invalidation strategy */

--- a/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
@@ -312,7 +312,6 @@ const StrategyFormBody = ({
 const PreemptiveCachingSwitch = ({
   handleSwitchToggle,
 }: {
-  enabled?: boolean;
   handleSwitchToggle: () => void;
 }) => {
   const { values } = useFormikContext<DurationStrategy | ScheduleStrategy>();

--- a/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
@@ -350,7 +350,9 @@ const PreemptiveCachingSwitch = ({
         label: { fontWeight: "bold" },
         description: { fontWeight: "normal" },
       }}
-      data-testid="preemptive-caching-switch"
+      wrapperProps={{
+        "data-testid": "preemptive-caching-switch",
+      }}
     />
   );
 };

--- a/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
@@ -278,7 +278,6 @@ const StrategyFormBody = ({
                 <input type="hidden" name="unit" />
                 {targetModel !== "database" && (
                   <PreemptiveCachingSwitch
-                    enabled={values.refresh_automatically}
                     handleSwitchToggle={handleSwitchToggle}
                   />
                 )}
@@ -289,7 +288,6 @@ const StrategyFormBody = ({
                 <ScheduleStrategyFormFields />
                 {targetModel !== "database" && (
                   <PreemptiveCachingSwitch
-                    enabled={values.refresh_automatically}
                     handleSwitchToggle={handleSwitchToggle}
                   />
                 )}
@@ -312,30 +310,13 @@ const StrategyFormBody = ({
 };
 
 const PreemptiveCachingSwitch = ({
-  enabled,
   handleSwitchToggle,
 }: {
   enabled?: boolean;
   handleSwitchToggle: () => void;
 }) => {
-  const { values } = useFormikContext<CacheStrategy>();
-
-  const hasRefreshAutomatically = (
-    strategy: CacheStrategy,
-  ): strategy is DurationStrategy | ScheduleStrategy => {
-    return strategy.type === "duration" || strategy.type === "schedule";
-  };
-
-  const currentRefreshValue = hasRefreshAutomatically(values)
-    ? values.refresh_automatically
-    : false;
-
-  useEffect(() => {
-    if (hasRefreshAutomatically(values) && enabled !== currentRefreshValue) {
-      handleSwitchToggle();
-    }
-  }, [enabled, currentRefreshValue, handleSwitchToggle, values]);
-
+  const { values } = useFormikContext<DurationStrategy | ScheduleStrategy>();
+  const currentRefreshValue = values.refresh_automatically ?? false;
   return (
     <Switch
       checked={currentRefreshValue}

--- a/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
@@ -329,7 +329,6 @@ const PreemptiveCachingSwitch = ({
       styles={{
         labelWrapper: { paddingLeft: "16px" },
         label: { fontWeight: "bold" },
-        description: { fontWeight: "normal" },
       }}
       wrapperProps={{
         "data-testid": "preemptive-caching-switch",

--- a/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
@@ -276,19 +276,23 @@ const StrategyFormBody = ({
                   />
                 </Field>
                 <input type="hidden" name="unit" />
-                <PreemptiveCachingSwitch
-                  enabled={values.refresh_automatically}
-                  handleSwitchToggle={handleSwitchToggle}
-                />
+                {targetModel !== "database" && (
+                  <PreemptiveCachingSwitch
+                    enabled={values.refresh_automatically}
+                    handleSwitchToggle={handleSwitchToggle}
+                  />
+                )}
               </>
             )}
             {selectedStrategyType === "schedule" && (
               <>
                 <ScheduleStrategyFormFields />
-                <PreemptiveCachingSwitch
-                  enabled={values.refresh_automatically}
-                  handleSwitchToggle={handleSwitchToggle}
-                />
+                {targetModel !== "database" && (
+                  <PreemptiveCachingSwitch
+                    enabled={values.refresh_automatically}
+                    handleSwitchToggle={handleSwitchToggle}
+                  />
+                )}
               </>
             )}
           </Stack>
@@ -336,6 +340,7 @@ const PreemptiveCachingSwitch = ({
     <Switch
       checked={currentRefreshValue}
       onChange={handleSwitchToggle}
+      role="switch"
       size="sm"
       label="Refresh cache automatically"
       description="As soon as cached results expire, run and cache the query again to update

--- a/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
@@ -342,9 +342,9 @@ const PreemptiveCachingSwitch = ({
       onChange={handleSwitchToggle}
       role="switch"
       size="sm"
-      label="Refresh cache automatically"
-      description="As soon as cached results expire, run and cache the query again to update
-      the results and refresh the cache."
+      label={t`Refresh cache automatically`}
+      description={t`As soon as cached results expire, run and cache the query again to update the results and refresh
+        the cache.`}
       styles={{
         labelWrapper: { paddingLeft: "16px" },
         label: { fontWeight: "bold" },

--- a/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
@@ -340,6 +340,11 @@ const PreemptiveCachingSwitch = ({
       label="Refresh cache automatically"
       description="As soon as cached results expire, run and cache the query again to update
       the results and refresh the cache."
+      styles={{
+        labelWrapper: { paddingLeft: "16px" },
+        label: { fontWeight: "bold" },
+        description: { fontWeight: "normal" },
+      }}
       data-testid="preemptive-caching-switch"
     />
   );

--- a/frontend/src/metabase/admin/performance/components/test-utils.tsx
+++ b/frontend/src/metabase/admin/performance/components/test-utils.tsx
@@ -54,6 +54,7 @@ export const setupStrategyEditorForDatabases = ({
         type: "duration",
         duration: 1,
         unit: CacheDurationUnit.Hours,
+        refresh_automatically: false,
       },
     }),
   ];

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10418,7 +10418,12 @@ databaseChangeLog:
             tableName: cache_config
             columnName: refresh_automatically
             columnDataType: ${boolean.type}
-
+      rollback:
+        - addNotNullConstraint:
+            tableName: cache_config
+            columnName: refresh_automatically
+            columnDataType: ${boolean.type}
+            defaultNullValue: false
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10409,6 +10409,17 @@ databaseChangeLog:
             constraintName: unique_user_key_value_user_id_namespace_key
       rollback: # will be deleted with table
 
+  - changeSet:
+      id: v53.2024-12-27T20:17:23
+      author: noahmoss
+      comment: Drop unnecessary NOT NULL constraint from cache_config.refresh_automatically column
+      changes:
+        - dropNotNullConstraint:
+            tableName: cache_config
+            columnName: refresh_automatically
+            columnDataType: ${boolean.type}
+
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/models/cache_config.clj
+++ b/src/metabase/models/cache_config.clj
@@ -49,7 +49,9 @@
      :model_id (:model_id row)
      :strategy (-> (:config row)
                    (assoc :type (:strategy row))
-                   (assoc :refresh_automatically (:refresh_automatically row)))}))
+                   (cond->
+                     (#{:duration :schedule} (:strategy row))
+                     (assoc :refresh_automatically (:refresh_automatically row))))}))
 
 (defn card-strategy
   "Shapes `row` into strategy for a given `card`."

--- a/src/metabase/models/cache_config.clj
+++ b/src/metabase/models/cache_config.clj
@@ -48,7 +48,8 @@
     {:model    (:model row)
      :model_id (:model_id row)
      :strategy (-> (:config row)
-                   (assoc :type (:strategy row)))}))
+                   (assoc :type (:strategy row))
+                   (assoc :refresh_automatically (:refresh_automatically row)))}))
 
 (defn card-strategy
   "Shapes `row` into strategy for a given `card`."
@@ -60,10 +61,11 @@
 (defn config->row
   "Transform cache config from API form into db storage form."
   [{:keys [model model_id strategy]}]
-  {:model    model
-   :model_id model_id
-   :strategy (:type strategy)
-   :config   (dissoc strategy :type)})
+  {:model                 model
+   :model_id              model_id
+   :strategy              (:type strategy)
+   :config                (dissoc strategy :type :refresh_automatically)
+   :refresh_automatically (:refresh_automatically strategy)})
 
 (defn get-list
   "Get a list of cache configurations for given `models` and a `collection`."

--- a/src/metabase/models/cache_config.clj
+++ b/src/metabase/models/cache_config.clj
@@ -50,7 +50,7 @@
      :strategy (-> (:config row)
                    (assoc :type (:strategy row))
                    (cond->
-                     (#{:duration :schedule} (:strategy row))
+                    (#{:duration :schedule} (:strategy row))
                      (assoc :refresh_automatically (:refresh_automatically row))))}))
 
 (defn card-strategy

--- a/src/metabase/plugins/classloader.clj
+++ b/src/metabase/plugins/classloader.clj
@@ -8,7 +8,7 @@
   correct classloader.
 
   If you are unfamiliar with ClassLoaders in general, I found this article pretty helpful:
-  https://www.javaworld.com/article/2077344/core-java/find-a-way-out-of-the-classloader-maze.html.
+  https://www.infoworld.com/article/2171026/find-a-way-out-of-the-classloader-maze.html.
 
   <3 Cam"
   (:refer-clojure :exclude [require])

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -269,7 +269,7 @@
   [& body]
   `(data.impl/do-with-temp-copy-of-db (^:once fn* [] ~@body)))
 
-;;; TODO FIXME -- rename this to `with-empty-h2-app-db`
+;;; TODO FIXME -- rename this to `with-empty-h2-app-db!`
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro with-empty-h2-app-db
   "Runs `body` under a new, blank, H2 application database (randomly named), in which all model tables have been


### PR DESCRIPTION
* Preemptive caching FE: adds a switch to the `StrategyForm` component for questions and dashboards to enable preemptive caching (via a `refresh_automatically` boolean property)
* Updated the backend API & schemas to persist this value
* Adds a Cypress test

<img width="458" alt="image" src="https://github.com/user-attachments/assets/e5017bb9-fe44-4dec-8bef-8770f0f2ab68" />
