### PR TITLE
[svg] Limit the lifetime of a cached Truffle JS object to sidestep apparent memory leaks

### DIFF
--- a/src/metabase/util/delay.clj
+++ b/src/metabase/util/delay.clj
@@ -1,0 +1,25 @@
+(ns metabase.util.delay
+  "Re-implementation of `delay` with custom behavior."
+  (:import
+   (java.util.concurrent.locks ReentrantLock)))
+
+(set! *warn-on-reflection* true)
+
+(deftype DelayWithTTL [ttl-ms f state, ^ReentrantLock lock]
+  clojure.lang.IDeref
+  (deref [_]
+    (.lock lock)
+    (try (let [[deadline val] @state
+               now (System/currentTimeMillis)]
+           (if (or (nil? deadline) (> now deadline))
+             (let [new-val (f)]
+               (reset! state [(+ now ttl-ms) new-val])
+               new-val)
+             val))
+         (finally (.unlock lock)))))
+
+(defn delay-with-ttl
+  "Return a `delay`-like object that caches the result of invoking `(f)` for up to `ttl-ms` milliseconds. Once the TTL
+  exceeds, the next deref will invoke `(f)` again."
+  [ttl-ms f]
+  (->DelayWithTTL ttl-ms f (atom [nil nil]) (ReentrantLock.)))

--- a/test/metabase/util/delay_test.clj
+++ b/test/metabase/util/delay_test.clj
@@ -1,0 +1,14 @@
+(ns ^:mb/once metabase.util.delay-test
+  (:require [clojure.test :refer :all]
+            [metabase.util.delay :as delay]))
+
+(set! *warn-on-reflection* true)
+
+(deftest delay-with-ttl-test
+  (let [d (delay/delay-with-ttl 300 #(Object.))
+        val1 @d
+        val2 @d
+        _ (Thread/sleep 500)
+        val3 @d]
+    (is (= val1 val2))
+    (is (not= val3 val2))))


### PR DESCRIPTION
https://github.com/metabase/metabase/issues/50726 hints that there can be a memory leak inside Truffle JS engine object. I couldn't reproduce the leak locally, but I assume it is possible. Since we are unlikely to dig inside the implementation to address or at least understand the leak, our second best bet is not to retain the engine object forever. Currently, the reusable engine is kept in a timeless delay. Ideally, we would want the lifetime of the reused engine to be tied to some finite event, like a request or a trigger. But it appears to me that `metabase.channel.render.js.svg` has multiple users and hence multiple entrypoints; so, it will be cumbersome to rewrite this API so that callers have to set up the engine explicitly.

The proposed band-aid replaces the regular `delay` with a custom `delay-with-ttl`. Think of it as of a cache with TTL but for a single value only and which guarantees that only one thread will compute the value concurrently. I've set the TTL to be 1 hour which is completely arbitrary and might not prevent the leak from inflating too much in some cases (when there are a lot of subscriptions?). I suppose the TTL can be reduced to 5-10 minutes without becoming too expensive.
