### PR TITLE
[WIP] group helpers in UI

### DIFF
--- a/e2e/support/commands/overwrites/log.js
+++ b/e2e/support/commands/overwrites/log.js
@@ -1,3 +1,5 @@
+import { addCustomCommandStyles } from "../timeline/customStyles";
+
 Cypress.Commands.overwrite("log", (originalFn, text) => {
   const logConfig = {
     displayName: `${window.logCalls}. ${text}`,
@@ -5,7 +7,7 @@ Cypress.Commands.overwrite("log", (originalFn, text) => {
     message: "",
   };
 
-  appendStyleIfNotExists(logConfig);
+  addCustomCommandStyles(logConfig);
   Cypress.log(logConfig);
   window.logCalls++;
 });
@@ -14,27 +16,3 @@ Cypress.Commands.overwrite("log", (originalFn, text) => {
 beforeEach(() => {
   window.logCalls = 1;
 });
-
-function appendStyleIfNotExists(logConfig) {
-  const doc = window.top.document;
-  const headHTML = doc.head;
-  const styleId = "customLogStyle";
-  const customStyle = doc.getElementById(styleId);
-  const bgColor = "#7f43c9";
-
-  if (!customStyle) {
-    const style = document.createElement("style");
-
-    style.textContent = `
-    .command-name-${logConfig.name} .command-pin-target{
-      color: #ffffff !important;
-      background-color: ${bgColor} !important;
-      font-weight: bold !important;
-    }
-    `;
-    style.type = "text/css";
-    style.id = styleId;
-
-    headHTML.append(style);
-  }
-}

--- a/e2e/support/commands/timeline/customStyles.ts
+++ b/e2e/support/commands/timeline/customStyles.ts
@@ -1,0 +1,45 @@
+const doc = window.top?.document;
+const styleId = "customLogStyle";
+const customStyle = doc?.getElementById(styleId);
+
+function appendStyleIfNotExists() {
+  const headHTML = doc?.head;
+
+  if (!customStyle) {
+    const style = document.createElement("style");
+
+    style.textContent = `
+    .command-name-then, .command-name-end-logGroup {
+      display: none !important;
+    }
+    `;
+    style.type = "text/css";
+    style.id = styleId;
+
+    headHTML?.append(style);
+  }
+}
+
+type LogConfig = {
+  name: string;
+  displayName: string;
+  message: string | string[];
+};
+
+export function addCustomCommandStyles(logConfig: LogConfig) {
+  const bgColor = "#7f43c9";
+
+  if (customStyle) {
+    customStyle.textContent += `
+  .command-name-${logConfig.name} .command-pin-target{
+    color: #ffffff !important;
+    background-color: ${bgColor} !important;
+    font-weight: bold !important;
+  }
+  `;
+  }
+}
+
+before(() => {
+  appendStyleIfNotExists();
+});

--- a/e2e/support/cypress.js
+++ b/e2e/support/cypress.js
@@ -1,6 +1,7 @@
 import registerCypressGrep from "@cypress/grep"; // eslint-disable-line import/order
 registerCypressGrep();
 
+import "../support/commands/timeline/customStyles";
 import "@cypress/skip-test/support";
 import "@testing-library/cypress/add-commands";
 import { configure } from "@testing-library/cypress";

--- a/e2e/support/index.ts
+++ b/e2e/support/index.ts
@@ -27,10 +27,38 @@ const formatArgs = (args: any[]): string[] => {
   }
 };
 
-const wrappedHelpers = Object.entries(OriginalHelpers).reduce<
-  Record<string, any>
->((acc, [key, helper]) => {
-  acc[key] = function (...args: any[]) {
+// Helper functions that should not be wrapped (they just return data)
+const DATA_ONLY_HELPERS = new Set([
+  "getTextCardDetails",
+  "getActionCardDetails",
+  // Add other data-only helpers here
+]);
+
+const isCypressCommand = (result: any) => {
+  return (
+    result &&
+    (typeof result.then === "function" ||
+      result.constructor?.name === "chainer" ||
+      (typeof result === "object" && result.jquery))
+  );
+};
+
+const wrapFunction = (key: string, fn: (...args: any[]) => any) => {
+  // Skip wrapping for data-only helpers
+  if (DATA_ONLY_HELPERS.has(key)) {
+    return fn;
+  }
+
+  return (...args: any[]) => {
+    // First call the function to check its result
+    const result = fn(...args);
+
+    // If the result is not a Cypress command, return it directly
+    if (!isCypressCommand(result)) {
+      return result;
+    }
+
+    // Only wrap with logGroup if it returns a Cypress command
     return logGroup(
       cy,
       {
@@ -38,9 +66,37 @@ const wrappedHelpers = Object.entries(OriginalHelpers).reduce<
         displayName: `H.${key}`,
         message: formatArgs(args),
       },
-      () => helper.apply(this, args),
+      () => result,
     );
   };
+};
+
+const wrapObject = (key: string, obj: Record<string, any>) => {
+  return Object.entries(obj).reduce(
+    (acc, [methodKey, method]) => {
+      if (typeof method === "function") {
+        acc[methodKey] = wrapFunction(`${key}.${methodKey}`, method.bind(obj));
+      } else if (method && typeof method === "object") {
+        acc[methodKey] = wrapObject(`${key}.${methodKey}`, method);
+      } else {
+        acc[methodKey] = method;
+      }
+      return acc;
+    },
+    {} as Record<string, any>,
+  );
+};
+
+const wrappedHelpers = Object.entries(OriginalHelpers).reduce<
+  Record<string, any>
+>((acc, [key, helper]) => {
+  if (typeof helper === "function") {
+    acc[key] = wrapFunction(key, helper);
+  } else if (helper && typeof helper === "object") {
+    acc[key] = wrapObject(key, helper);
+  } else {
+    acc[key] = helper;
+  }
   return acc;
 }, {});
 

--- a/e2e/support/index.ts
+++ b/e2e/support/index.ts
@@ -30,7 +30,7 @@ const formatArgs = (args: any[]): string[] => {
 const wrappedHelpers = Object.entries(OriginalHelpers).reduce<
   Record<string, any>
 >((acc, [key, helper]) => {
-  acc[key] = (...args: any[]) => {
+  acc[key] = function (...args: any[]) {
     return logGroup(
       cy,
       {
@@ -38,10 +38,22 @@ const wrappedHelpers = Object.entries(OriginalHelpers).reduce<
         displayName: `H.${key}`,
         message: formatArgs(args),
       },
-      () => helper(...args),
+      () => helper.apply(this, args),
     );
   };
   return acc;
 }, {});
 
-export const H = wrappedHelpers;
+const H = wrappedHelpers;
+
+type HelperTypes = typeof OriginalHelpers;
+
+declare global {
+  namespace Cypress {
+    interface Chainable extends HelperTypes {
+      H: typeof OriginalHelpers;
+    }
+  }
+}
+
+export { H };

--- a/e2e/support/index.ts
+++ b/e2e/support/index.ts
@@ -1,14 +1,47 @@
-// H is for helpers 🤗
-import * as H from "./helpers";
+import * as OriginalHelpers from "./helpers";
+import { logGroup } from "./logGroup";
 
-type HelperTypes = typeof H;
-
-declare global {
-  namespace Cypress {
-    interface Chainable extends HelperTypes {
-      H: typeof H;
+const formatArgs = (args: any[]): string[] => {
+  try {
+    if (args.length === 0) {
+      return [""];
     }
+    return args.map(arg => {
+      if (arg === undefined) {
+        return "undefined";
+      }
+      if (arg === null) {
+        return "null";
+      }
+      if (typeof arg === "object") {
+        try {
+          return JSON.stringify(arg, null, 1);
+        } catch {
+          return "[Complex Object]";
+        }
+      }
+      return String(arg);
+    });
+  } catch (e) {
+    return ["Unable to stringify args"];
   }
-}
+};
 
-export { H };
+const wrappedHelpers = Object.entries(OriginalHelpers).reduce<
+  Record<string, any>
+>((acc, [key, helper]) => {
+  acc[key] = (...args: any[]) => {
+    return logGroup(
+      cy,
+      {
+        name: key,
+        displayName: `H.${key}`,
+        message: formatArgs(args),
+      },
+      () => helper(...args),
+    );
+  };
+  return acc;
+}, {});
+
+export const H = wrappedHelpers;

--- a/e2e/support/logGroup.ts
+++ b/e2e/support/logGroup.ts
@@ -1,76 +1,79 @@
-/// <reference types="cypress" />
-
-declare global {
-  namespace Cypress {
-    interface Log {
-      endGroup: () => void;
-    }
-
-    interface LogConfig {
-      groupStart?: boolean;
-    }
-
-    interface Cypress {
-      Command: {
-        create: (options: CommandOptions) => any;
-      };
-    }
-  }
-}
-
-interface CommandOptions extends Cypress.CommandOptions {
+type userOptions = {
   name: string;
-  type: "parent" | "child";
-  args: any[];
-  fn: () => any;
-  chainerId?: string;
-  logs?: Cypress.Log[];
-}
-
-export interface LogGroupConfig {
-  name?: string;
-  displayName?: string;
-  message?: string | string[];
-}
-
-type LogCallback = (log: Cypress.Log) => unknown;
+  displayName: string;
+  message: string | string[];
+};
 
 export const logGroup = (
-  cy: any,
-  userOptions: LogGroupConfig,
-  fn: LogCallback,
+  cy: Cypress.Chainable,
+  userOptions: userOptions,
+  fn: any,
 ) => {
-  const log = Cypress.log({
-    name: userOptions.name || "",
-    displayName: userOptions.displayName || "",
-    message: Array.isArray(userOptions.message)
-      ? userOptions.message
-      : [userOptions.message || ""],
-    type: "parent",
-    autoEnd: false,
-    groupStart: true,
-  });
-
-  // Track command additions
-  const onCommand = (command: any) => {
-    if (command.get("logs")) {
-      command.get("logs").forEach((cmdLog: Cypress.Log) => {
-        // @ts-expect-error - Cypress internal API for grouping logs
-        log.set("group", cmdLog);
-      });
-    }
-  };
-
-  cy.on("command:start", onCommand);
-
-  // Execute the function
-  const result = fn(log);
-
-  // Clean up the listener and end the group
   cy.then(() => {
-    cy.removeListener("command:start", onCommand);
-    log.endGroup();
+    Cypress.log({
+      name: userOptions.name || "",
+      displayName: userOptions.displayName || "",
+      message: Array.isArray(userOptions.message)
+        ? userOptions.message
+        : [userOptions.message || ""],
+      type: "parent",
+      // @ts-expect-error - groupStart is not typed by Cypress
+      groupStart: true,
+      consoleProps() {
+        return {
+          name: userOptions.name || "",
+          displayName: userOptions.displayName || "",
+          message: Array.isArray(userOptions.message)
+            ? userOptions.message
+            : [userOptions.message || ""],
+        };
+      },
+    });
   });
 
-  return result;
+  // Handle both function calls and object method calls
+  let result;
+  if (typeof fn === "function") {
+    result = fn();
+  } else if (fn && typeof fn === "object") {
+    // For object methods like NativeEditor.get(), preserve the object context
+    result = Object.getPrototypeOf(fn).constructor.prototype.apply.call(fn);
+  } else {
+    result = fn;
+  }
+
+  // If the result is not a chainable (doesn't have .then), wrap it in a command
+  if (!result || typeof result.then !== "function") {
+    return cy.then(() => {
+      // @ts-expect-error - queue is not typed by Cypress
+      const restoreCmdIndex = cy.queue.index + 1;
+
+      // @ts-expect-error - Command is not typed by Cypress
+      const endLogGroupCmd = Cypress.Command.create({
+        name: "end-logGroup",
+        injected: true,
+        args: [],
+      });
+
+      const forwardYieldedSubject = () => {
+        // @ts-expect-error - endGroup is not typed by Cypress
+        Cypress.log({}).endGroup();
+        return result;
+      };
+
+      // @ts-expect-error - queue is not typed by Cypress
+      cy.queue.insert(
+        restoreCmdIndex,
+        endLogGroupCmd.set("fn", forwardYieldedSubject),
+      );
+      return result;
+    });
+  }
+
+  // For chainable results, use the original .then approach
+  return result.then((chainedResult: any) => {
+    // @ts-expect-error - endGroup is not typed by Cypress
+    Cypress.log({}).endGroup();
+    return chainedResult;
+  });
 };

--- a/e2e/support/logGroup.ts
+++ b/e2e/support/logGroup.ts
@@ -1,0 +1,92 @@
+/// <reference types="cypress" />
+
+declare global {
+  namespace Cypress {
+    interface Log {
+      endGroup: () => void;
+    }
+
+    interface LogConfig {
+      groupStart?: boolean;
+    }
+
+    interface Cypress {
+      Command: {
+        create: (options: CommandOptions) => any;
+      };
+    }
+  }
+}
+
+interface CommandOptions extends Cypress.CommandOptions {
+  name: string;
+  type: "parent" | "child";
+  args: any[];
+  fn: () => any;
+  chainerId?: string;
+  logs?: Cypress.Log[];
+}
+
+export interface LogGroupConfig {
+  name?: string;
+  displayName?: string;
+  message?: string | string[];
+}
+
+type LogCallback = (log: Cypress.Log) => unknown;
+
+export const logGroup = (
+  cy: any,
+  userOptions: LogGroupConfig,
+  fn: LogCallback,
+) => {
+  const cmd = Cypress.Command.create({
+    name: userOptions.name || "",
+    type: "parent",
+    args: Array.isArray(userOptions.message)
+      ? userOptions.message
+      : [userOptions.message || ""],
+    fn: () => {
+      const log = Cypress.log({
+        name: userOptions.name || "",
+        displayName: userOptions.displayName || "",
+        message: Array.isArray(userOptions.message)
+          ? userOptions.message
+          : [userOptions.message || ""],
+        type: "parent",
+        autoEnd: true,
+        groupStart: true,
+      });
+
+      cmd.log(log);
+
+      try {
+        const result = fn(log) as any;
+
+        if (result?.then) {
+          return result.then((value: any) => {
+            log.endGroup();
+            return value;
+          });
+        }
+
+        if (!result) {
+          return cy.wrap(true, { log: false }).then(() => {
+            log.endGroup();
+          });
+        }
+
+        log.endGroup();
+        return result;
+      } catch (e) {
+        log.endGroup();
+        throw e;
+      }
+    },
+  } as CommandOptions);
+
+  return cy.wrap(null, { log: false }).then(() => {
+    cy.queue.insert(cy.queue.index + 1, cmd);
+    return cmd;
+  });
+};


### PR DESCRIPTION
### Description

I find working with helpers very complicated, especially with debugging. This change wraps every helper with an undocumented "groupStart" option, which will visually group all the commands in helpers for better orientation in abstractions. This is similar to what commands such as cy.within() or cy.session() have going on. Feedbacks are appreciated.

### How to verify

Pretty much just open any test and you’ll see the effect. One small caveat - if helper doesn’t have a return statement it will show the helper in the Cypress timeline, but it will not show the visual grouping of commands inside the helper. Thought of adding an eslint rule for this, but don’t want to overdo it (I have played with it and stashed it on the side)

### Demo
![Screenshot 2024-12-30 at 14 08 25](https://github.com/user-attachments/assets/e9128d25-540f-4713-b5c6-1326842ab6f1)
![Screenshot 2024-12-30 at 14 08 12](https://github.com/user-attachments/assets/3ebd19d9-ccd1-47b5-8e52-79cd78c9e6e2)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
