### PR TITLE
Distinguish structured and textual tool results

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/envelope.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/envelope.clj
@@ -32,11 +32,11 @@
    (map (fn [{:keys [content structured-content] :as msg}]
           (cond-> msg
             stringify-content?
-            (-> #_msg
-                (dissoc :structured-content)
-                (assoc :content (or content
-                                    (when structured-content
-                                      (json/encode structured-content)))))))
+            (->
+             (dissoc :structured-content)
+             (assoc :content (or content
+                                 (when structured-content
+                                   (json/encode structured-content)))))))
         (concat (:dummy-history e)
                 (:history e)))))
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/envelope.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/envelope.clj
@@ -4,6 +4,7 @@
   The 'envelope' holds the context for our conversation with the LLM. Specifically, it bundles up the history, and the
   context into one convenient location, with a simple API for querying and modifying."
   (:require
+   [medley.core :as m]
    [metabase-enterprise.metabot-v3.context :as metabot-v3.context]
    [metabase.util :as u]
    [metabase.util.json :as json]))
@@ -24,23 +25,20 @@
    :dummy-history []
    :query-id->query {}})
 
-(defn- decode-json
-  [s]
-  (try
-    (json/decode s true)
-    (catch Exception _e
-      s)))
-
 (defn full-history
   "History including the dummy tool invocations"
   ([e] (full-history e nil))
   ([e {:keys [stringify-content?] :or {stringify-content? true}}]
-   (map (fn [{:keys [content] :as msg}]
-          (assoc msg :content (cond-> content
-                                (and stringify-content? (map? content)) json/encode
-                                (and (not stringify-content?) (string? content)) decode-json)))
-        (into (:dummy-history e)
-              (:history e)))))
+   (map (fn [{:keys [content structured-content] :as msg}]
+          (cond-> msg
+            stringify-content?
+            (-> #_msg
+                (dissoc :structured-content)
+                (assoc :content (or content
+                                    (when structured-content
+                                      (json/encode structured-content)))))))
+        (concat (:dummy-history e)
+                (:history e)))))
 
 (defn session-id
   "Get the session ID from the envelope"
@@ -117,11 +115,12 @@
 
 (defn add-tool-response
   "Given an output string and new context, adds them to the envelope."
-  [e tool-call-id {:keys [output context reactions]}]
+  [e tool-call-id {:keys [output structured-output context reactions]}]
   (-> e
-      (add-message {:role :tool
-                    :tool-call-id tool-call-id
-                    :content output})
+      (add-message (-> {:role :tool
+                        :tool-call-id tool-call-id}
+                       (m/assoc-some :content output)
+                       (m/assoc-some :structured-content structured-output)))
       (update-context context)
       (update-reactions reactions)))
 
@@ -141,8 +140,7 @@
   [e query-id]
   (->> (full-history e {:stringify-content? false})
        (filter is-tool-call-response?)
-       (keep :content)
-
+       (keep :structured-content)
        (filter #(contains? #{:query "query"} (:type %)))
        (filter #(or (= (:query-id %) query-id)
                     (= (:query_id %) query-id)))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/find_metric.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/find_metric.clj
@@ -10,5 +10,7 @@
                       (t2/select [:model/Card :id :name :description]
                                  :type [:= "metric"])
                       message)]
-    {:output (or (some-> id dummy-tools/metric-details)
-                 "Metric not found.")}))
+    (if-let [result (when id
+                       (dummy-tools/metric-details id))]
+      {:structured-output result}
+      {:output "Metric not found."})))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/find_metric.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/find_metric.clj
@@ -11,6 +11,6 @@
                                  :type [:= "metric"])
                       message)]
     (if-let [result (when id
-                       (dummy-tools/metric-details id))]
+                      (dummy-tools/metric-details id))]
       {:structured-output result}
       {:output "Metric not found."})))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/find_outliers.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/find_outliers.clj
@@ -35,9 +35,9 @@
                              (m/find-first (fn [[_i col]]
                                              (lib.types.isa/numeric? (u/normalize-map col))))
                              first)]
-      {:output (->> data
-                    :rows
-                    (map (fn [row]
-                           {:dimension (nth row dimension-col-idx)
-                            :value (nth row value-col-idx)}))
-                    (metabot-v3.client/find-outliers-request))})))
+      {:structured-output (->> data
+                               :rows
+                               (map (fn [row]
+                                      {:dimension (nth row dimension-col-idx)
+                                       :value (nth row value-col-idx)}))
+                               (metabot-v3.client/find-outliers-request))})))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/who_is_your_favorite.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/who_is_your_favorite.clj
@@ -5,4 +5,4 @@
 
 (mu/defmethod metabot-v3.tools.interface/*invoke-tool* :metabot.tool/who-is-your-favorite
   [_tool-name _arg-map _env]
-  {:output  "You are... but don't tell anyone!"})
+  {:output "You are... but don't tell anyone!"})

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
@@ -108,7 +108,7 @@
                                     :role :assistant,
                                     :tool-calls
                                     [{:id "call_1drvrXfHb6q9Doxh8leujqKB", :name :metabot.tool/invite-user, :arguments {:email "cam@metabase.com"}}]}
-                                   {:role :tool, :tool-call-id "call_1drvrXfHb6q9Doxh8leujqKB", :content nil}
+                                   {:role :tool, :tool-call-id "call_1drvrXfHb6q9Doxh8leujqKB"}
                                    {:content "Cool, I invited him"
                                     :role :assistant}]}]]
                     @calls))))))))


### PR DESCRIPTION
I don't like guessing if a tool result should be serialized when sending to the LLM or if it should be parsed when digging in the history. This PR lets the tools themselves specify what kind of result they produce. Structured results are serialized before sent to the LLM. (I could also imagine (and prefer) always returning a textual `message` and and a structured `details` if the LLM can work with that.)