### PR TITLE
Remove deprecated open native editor helper

### DIFF
--- a/e2e/support/helpers/e2e-ad-hoc-question-helpers.js
+++ b/e2e/support/helpers/e2e-ad-hoc-question-helpers.js
@@ -60,17 +60,20 @@ export function startNewMetric() {
 
 /**
  * @param {("question" | "model")} type
- * @param {("number" | null)} config.database
- * @param {string} config.query
+ * @param {Object} [config]
+ * @param {("number" | null)} [config.database]
+ * @param {string} [config.query]
+ * @param {number} [config.collection_id]
  */
 function newNativeCardHash(
   type,
-  config = { database: SAMPLE_DB_ID, query: "" },
+  { database = SAMPLE_DB_ID, query = "", collection_id = null } = {},
 ) {
   const card = {
+    collection_id,
     dataset_query: {
-      database: config.database,
-      native: { query: config.query, "template-tags": {} },
+      database,
+      native: { query, "template-tags": {} },
       type: "native",
     },
     display: "scalar",
@@ -90,6 +93,7 @@ function newNativeCardHash(
  * @param {object} config
  * @param {number} config.database
  * @param {string} config.query
+ * @param {number} config.collection_id
  */
 export function startNewNativeQuestion(config) {
   const hash = newNativeCardHash("question", config);

--- a/e2e/support/helpers/e2e-ad-hoc-question-helpers.js
+++ b/e2e/support/helpers/e2e-ad-hoc-question-helpers.js
@@ -64,10 +64,16 @@ export function startNewMetric() {
  * @param {("number" | null)} [config.database]
  * @param {string} [config.query]
  * @param {number} [config.collection_id]
+ * @param {string} [config.display]
  */
 function newNativeCardHash(
   type,
-  { database = SAMPLE_DB_ID, query = "", collection_id = null } = {},
+  {
+    database = SAMPLE_DB_ID,
+    query = "",
+    collection_id = null,
+    display = "scalar",
+  } = {},
 ) {
   const card = {
     collection_id,
@@ -76,7 +82,7 @@ function newNativeCardHash(
       native: { query, "template-tags": {} },
       type: "native",
     },
-    display: "scalar",
+    display,
     parameters: [],
     visualization_settings: {},
     type,
@@ -94,6 +100,7 @@ function newNativeCardHash(
  * @param {number} config.database
  * @param {string} config.query
  * @param {number} config.collection_id
+ * @param {string} [config.display]
  */
 export function startNewNativeQuestion(config) {
   const hash = newNativeCardHash("question", config);

--- a/e2e/support/helpers/e2e-ad-hoc-question-helpers.js
+++ b/e2e/support/helpers/e2e-ad-hoc-question-helpers.js
@@ -73,7 +73,7 @@ function newNativeCardHash(
       native: { query: config.query, "template-tags": {} },
       type: "native",
     },
-    display: "table",
+    display: "scalar",
     parameters: [],
     visualization_settings: {},
     type,

--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -1,5 +1,4 @@
 import { pickEntity } from "./e2e-collection-helpers";
-import { focusNativeEditor } from "./e2e-native-editor-helpers";
 
 // Find a text field by label text, type it in, then blur the field.
 // Commonly used in our Admin section as we auto-save settings.
@@ -11,50 +10,6 @@ export function visitAlias(alias) {
   cy.get(alias).then(url => {
     cy.visit(url);
   });
-}
-
-/**
- * Open native (SQL) editor and alias it.
- * @deprecated To avoid typing SQL, which is unreliable, use the helper startNewNativeQuestion
- *
- * @param {object} options
- * @param {string} [options.databaseName] - If there is more than one database, select the desired one by its name.
- * @param {string} [options.alias="editor"] - The alias that can be used later in the test as `cy.get("@" + alias)`.
- * @example
- * openNativeEditor().type("SELECT 123");
- * @example
- * openNativeEditor({ databaseName: "QA Postgres12" }).type("SELECT 123");
- */
-export function openNativeEditor({
-  databaseName,
-  alias = "editor",
-  fromCurrentPage,
-  newMenuItemTitle = "SQL query",
-} = {}) {
-  if (!fromCurrentPage) {
-    cy.visit("/");
-  }
-  cy.findByText("New").click();
-  cy.findByText(newMenuItemTitle).click();
-
-  // We are first loading databases to see if we should show the
-  // database selector or simply display the previously selected database
-  cy.findAllByTestId("loading-indicator").should("not.exist");
-
-  databaseName && cy.findByText(databaseName).click();
-  // At this point we have either manually selected a database or the app has
-  // knowedge about the previously used database so it will pre-select it.
-  // See: `last-used-native-database-id`.
-  //
-  // The source of many native editor flakes in the past was the page re-render
-  // that happens when the UI updates from showing the database selector to
-  // displaying the previously selected database.
-  //
-  // Explicitly waiting for the database selector to be gone should give tests a
-  // better chance at passing (until we get rid of this helper altogether)!
-  cy.findByText("Select a database").should("not.exist");
-
-  return focusNativeEditor().as(alias);
 }
 
 /**

--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -466,7 +466,8 @@ describe.skip(
         cy.findByText("Saved");
 
         // Run the query and save the question
-        H.openNativeEditor({ databaseName: "QA Postgres12" }).type(nativeQuery);
+        H.startNewNativeQuestion().as("editor");
+        cy.get("@editor").type(nativeQuery);
         H.runNativeQuery();
 
         getCellText().then(res => {

--- a/e2e/test/scenarios/collections/permissions.cy.spec.js
+++ b/e2e/test/scenarios/collections/permissions.cy.spec.js
@@ -376,7 +376,7 @@ describe("collection permissions", () => {
   it("should offer to save items to 'Our analytics' if user has a 'curate' access to it", () => {
     cy.signIn("normal");
 
-    H.openNativeEditor().type("select * from people");
+    H.startNewNativeQuestion().type("select * from people");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
 

--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -1594,7 +1594,7 @@ describe("issue 44665", () => {
   });
 
   it("should use the correct widget for the default value picker (metabase#44665)", () => {
-    H.openNativeEditor().type("select * from {{param");
+    H.startNewNativeQuestion().type("select * from {{param");
     H.sidebar()
       .last()
       .within(() => {

--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -653,7 +653,7 @@ describe("scenarios > models", () => {
     it("should allow using models in native queries", () => {
       cy.intercept("POST", "/api/dataset").as("query");
       cy.get("@modelId").then(id => {
-        H.openNativeEditor().type(`select * from {{#${id}}}`, {
+        H.startNewNativeQuestion().type(`select * from {{#${id}}}`, {
           parseSpecialCharSequences: false,
         });
       });

--- a/e2e/test/scenarios/models/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.js
@@ -352,7 +352,7 @@ describe("issue 20963", () => {
   it("should allow converting questions with static snippets to models (metabase#20963)", () => {
     cy.visit("/");
 
-    H.openNativeEditor();
+    H.startNewNativeQuestion().as("editor");
 
     // Creat a snippet
     cy.icon("snippet").click();

--- a/e2e/test/scenarios/native-filters/helpers/e2e-field-filter-helpers.js
+++ b/e2e/test/scenarios/native-filters/helpers/e2e-field-filter-helpers.js
@@ -28,7 +28,7 @@ export function addWidgetStringFilter(
   { buttonLabel = "Add filter" } = {},
 ) {
   setWidgetStringFilter(value);
-  selectFilterValueFromList(value, { buttonLabel });
+  cy.button(buttonLabel).click();
 }
 
 export function clearWidgetValue() {

--- a/e2e/test/scenarios/native-filters/helpers/e2e-field-filter-helpers.js
+++ b/e2e/test/scenarios/native-filters/helpers/e2e-field-filter-helpers.js
@@ -28,7 +28,7 @@ export function addWidgetStringFilter(
   { buttonLabel = "Add filter" } = {},
 ) {
   setWidgetStringFilter(value);
-  cy.button(buttonLabel).click();
+  selectFilterValueFromList(value, { buttonLabel });
 }
 
 export function clearWidgetValue() {

--- a/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
@@ -974,12 +974,12 @@ describe("issue 29786", { tags: "@external" }, () => {
       H.startNewNativeQuestion({
         display: "table",
         collection_id: COLLECTION_GROUP,
+        database: 2,
+        query: SQL_QUERY,
       });
 
-      cy.findByTestId("gui-builder-data").click();
-      cy.findByLabelText("QA MySQL8").click();
-
-      SQLFilter.enterParameterizedQuery(SQL_QUERY);
+      // type a space to trigger fields
+      cy.focused().type(" ");
 
       cy.findAllByTestId("variable-type-select").first().click();
       SQLFilter.chooseType("Field Filter");

--- a/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
@@ -971,7 +971,7 @@ describe("issue 29786", { tags: "@external" }, () => {
     "should allow using field filters with null schema (metabase#29786)",
     { tags: "@flaky" },
     () => {
-      H.startNewNativeQuestion();
+      H.startNewNativeQuestion({ display: "table" });
 
       cy.findByTestId("gui-builder-data").click();
       cy.findByLabelText("QA MySQL8").click();

--- a/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
@@ -971,7 +971,12 @@ describe("issue 29786", { tags: "@external" }, () => {
     "should allow using field filters with null schema (metabase#29786)",
     { tags: "@flaky" },
     () => {
-      H.openNativeEditor({ databaseName: "QA MySQL8" });
+
+      H.startNewNativeQuestion()
+
+      cy.findByTestId("gui-builder-data").click()
+      cy.findByLabelText("QA MySQL8").click();
+
       SQLFilter.enterParameterizedQuery(SQL_QUERY);
 
       cy.findAllByTestId("variable-type-select").first().click();

--- a/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
@@ -974,23 +974,27 @@ describe("issue 29786", { tags: "@external" }, () => {
       H.startNewNativeQuestion({
         display: "table",
         collection_id: COLLECTION_GROUP,
-        database: 2,
         query: SQL_QUERY,
       });
 
       // type a space to trigger fields
       cy.focused().type(" ");
 
-      cy.findAllByTestId("variable-type-select").first().click();
+      cy.findByTestId("tag-editor-variable-f1")
+        .findByTestId("variable-type-select")
+        .click();
       SQLFilter.chooseType("Field Filter");
       FieldFilter.mapTo({ table: "Products", field: "Category" });
-      cy.findAllByTestId("variable-type-select").last().click();
+
+      cy.findByTestId("tag-editor-variable-f2")
+        .findByTestId("variable-type-select")
+        .click();
       SQLFilter.chooseType("Field Filter");
       FieldFilter.mapTo({ table: "Products", field: "Vendor" });
 
-      H.filterWidget().first().click();
+      H.filterWidget().should("have.length", 2).first().click();
       FieldFilter.selectFilterValueFromList("Widget");
-      H.filterWidget().last().click();
+      H.filterWidget().should("have.length", 2).last().click();
       FieldFilter.addWidgetStringFilter("Von-Gulgowski");
 
       SQLFilter.runQuery();

--- a/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
@@ -24,7 +24,7 @@ describe("issue 9357", () => {
   });
 
   it("should reorder template tags by drag and drop (metabase#9357)", () => {
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     SQLFilter.enterParameterizedQuery(
       "{{firstparameter}} {{nextparameter}} {{lastparameter}}",
     );
@@ -52,7 +52,7 @@ describe("issue 11480", () => {
   });
 
   it("should clear a template tag's default value when the type changes (metabase#11480)", () => {
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     // Parameter `x` defaults to a text parameter.
     SQLFilter.enterParameterizedQuery(
       "select * from orders where total = {{x}}",
@@ -92,7 +92,7 @@ describe("issue 11580", () => {
   });
 
   it("shouldn't reorder template tags when updated (metabase#11580)", () => {
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     SQLFilter.enterParameterizedQuery("{{foo}} {{bar}}");
 
     cy.findAllByText("Variable name").next().as("variableLabels");
@@ -450,7 +450,7 @@ describe("issue 15444", () => {
   });
 
   it("should run with the default field filter set (metabase#15444)", () => {
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     SQLFilter.enterParameterizedQuery(
       "select * from products where {{category}}",
     );
@@ -541,7 +541,7 @@ describe("issue 15700", () => {
   });
 
   it("should be able to select 'Field Filter' category in native query (metabase#15700)", () => {
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     SQLFilter.enterParameterizedQuery("{{filter}}");
 
     SQLFilter.openTypePickerFromDefaultFilterType();
@@ -561,7 +561,7 @@ describe("issue 15981", () => {
     H.restore();
     cy.signInAsAdmin();
 
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
 
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
@@ -776,7 +776,7 @@ describe("issue 17490", () => {
   });
 
   it.skip("nav bar shouldn't cut off the popover with the tables for field filter selection (metabase#17490)", () => {
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     SQLFilter.enterParameterizedQuery("{{f}}");
 
     SQLFilter.openTypePickerFromDefaultFilterType();
@@ -929,7 +929,7 @@ describe("issue 27257", () => {
     H.restore();
     cy.signInAsAdmin();
 
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     SQLFilter.enterParameterizedQuery("SELECT {{number}}");
 
     H.filterWidget().within(() => {
@@ -1004,7 +1004,7 @@ describe("issue 31606", { tags: "@external" }, () => {
   });
 
   it("should clear values on UI for Text, Number, Date and Field Filter Types (metabase#31606)", () => {
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
 
     SQLFilter.enterParameterizedQuery(SQL_QUERY);
 
@@ -1184,7 +1184,7 @@ describe("issue 31606", () => {
   });
 
   it("should not start drag and drop from clicks on popovers", () => {
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
 
     SQLFilter.enterParameterizedQuery("{{foo}} {{bar}}");
 
@@ -1209,7 +1209,7 @@ describe("issue 49577", () => {
   });
 
   it("should not show the values initially when using a single select search box (metabase#49577)", () => {
-    H.openNativeEditor().type("select * from {{param");
+    H.startNewNativeQuestion().type("select * from {{param");
     H.sidebar()
       .last()
       .within(() => {

--- a/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
@@ -971,10 +971,9 @@ describe("issue 29786", { tags: "@external" }, () => {
     "should allow using field filters with null schema (metabase#29786)",
     { tags: "@flaky" },
     () => {
+      H.startNewNativeQuestion();
 
-      H.startNewNativeQuestion()
-
-      cy.findByTestId("gui-builder-data").click()
+      cy.findByTestId("gui-builder-data").click();
       cy.findByLabelText("QA MySQL8").click();
 
       SQLFilter.enterParameterizedQuery(SQL_QUERY);

--- a/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
@@ -971,7 +971,10 @@ describe("issue 29786", { tags: "@external" }, () => {
     "should allow using field filters with null schema (metabase#29786)",
     { tags: "@flaky" },
     () => {
-      H.startNewNativeQuestion({ display: "table" });
+      H.startNewNativeQuestion({
+        display: "table",
+        collection_id: COLLECTION_GROUP,
+      });
 
       cy.findByTestId("gui-builder-data").click();
       cy.findByLabelText("QA MySQL8").click();
@@ -986,7 +989,7 @@ describe("issue 29786", { tags: "@external" }, () => {
       FieldFilter.mapTo({ table: "Products", field: "Vendor" });
 
       H.filterWidget().first().click();
-      FieldFilter.addWidgetStringFilter("Widget");
+      FieldFilter.selectFilterValueFromList("Widget");
       H.filterWidget().last().click();
       FieldFilter.addWidgetStringFilter("Von-Gulgowski");
 

--- a/e2e/test/scenarios/native-filters/sql-field-filter-types.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-field-filter-types.cy.spec.js
@@ -189,7 +189,7 @@ describe("scenarios > filters > sql filters > field filter > String", () => {
 
     cy.signInAsAdmin();
 
-    H.startNewNativeQuestion();
+    H.startNewNativeQuestion({ display: "table" });
     SQLFilter.enterParameterizedQuery("SELECT * FROM products WHERE {{f}}");
 
     SQLFilter.openTypePickerFromDefaultFilterType();

--- a/e2e/test/scenarios/native-filters/sql-field-filter.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-field-filter.cy.spec.js
@@ -16,7 +16,7 @@ describe("scenarios > filters > sql filters > field filter", () => {
 
   describe("required tag", () => {
     beforeEach(() => {
-      H.openNativeEditor();
+      H.startNewNativeQuestion();
       SQLFilter.enterParameterizedQuery(
         "SELECT * FROM products WHERE {{filter}}",
       );
@@ -90,7 +90,7 @@ describe("scenarios > filters > sql filters > field filter", () => {
 
   context("ID filter", () => {
     beforeEach(() => {
-      H.openNativeEditor();
+      H.startNewNativeQuestion();
       SQLFilter.enterParameterizedQuery(
         "SELECT * FROM products WHERE {{filter}}",
       );
@@ -128,7 +128,7 @@ describe("scenarios > filters > sql filters > field filter", () => {
 
   context("None", () => {
     beforeEach(() => {
-      H.openNativeEditor();
+      H.startNewNativeQuestion();
       SQLFilter.enterParameterizedQuery(
         "SELECT * FROM people WHERE {{filter}}",
       );

--- a/e2e/test/scenarios/native-filters/sql-field-filter.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-field-filter.cy.spec.js
@@ -90,7 +90,7 @@ describe("scenarios > filters > sql filters > field filter", () => {
 
   context("ID filter", () => {
     beforeEach(() => {
-      H.startNewNativeQuestion();
+      H.startNewNativeQuestion({ display: "table" });
       SQLFilter.enterParameterizedQuery(
         "SELECT * FROM products WHERE {{filter}}",
       );
@@ -128,7 +128,7 @@ describe("scenarios > filters > sql filters > field filter", () => {
 
   context("None", () => {
     beforeEach(() => {
-      H.startNewNativeQuestion();
+      H.startNewNativeQuestion({ display: "table" });
       SQLFilter.enterParameterizedQuery(
         "SELECT * FROM people WHERE {{filter}}",
       );

--- a/e2e/test/scenarios/native-filters/sql-filters-source.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-filters-source.cy.spec.js
@@ -44,7 +44,7 @@ describe("scenarios > filters > sql filters > values source", () => {
     it("should be able to use a structured question source", () => {
       cy.createQuestion(structuredSourceQuestion);
 
-      H.openNativeEditor();
+      H.startNewNativeQuestion();
       SQLFilter.enterParameterizedQuery("SELECT * FROM PRODUCTS WHERE {{tag}}");
       SQLFilter.openTypePickerFromDefaultFilterType();
       SQLFilter.chooseType("Field Filter");
@@ -70,7 +70,7 @@ describe("scenarios > filters > sql filters > values source", () => {
     it("should be able to use a structured question source with a text tag", () => {
       cy.createQuestion(structuredSourceQuestion);
 
-      H.openNativeEditor();
+      H.startNewNativeQuestion();
       SQLFilter.enterParameterizedQuery(
         "SELECT * FROM PRODUCTS WHERE CATEGORY = {{tag}}",
       );
@@ -103,7 +103,7 @@ describe("scenarios > filters > sql filters > values source", () => {
     it("should be able to use a structured question source without saving the question", () => {
       cy.createQuestion(structuredSourceQuestion);
 
-      H.openNativeEditor();
+      H.startNewNativeQuestion();
       SQLFilter.enterParameterizedQuery(
         "SELECT * FROM PRODUCTS WHERE CATEGORY = {{tag}}",
       );
@@ -118,7 +118,7 @@ describe("scenarios > filters > sql filters > values source", () => {
 
     it("should properly cache parameter values api calls", () => {
       cy.createQuestion(structuredSourceQuestion);
-      H.openNativeEditor();
+      H.startNewNativeQuestion();
       SQLFilter.enterParameterizedQuery(
         "SELECT * FROM PRODUCTS WHERE CATEGORY = {{tag}}",
       );
@@ -224,7 +224,7 @@ describe("scenarios > filters > sql filters > values source", () => {
     it("should be able to use a native question source in the query builder", () => {
       cy.createNativeQuestion(nativeSourceQuestion);
 
-      H.openNativeEditor();
+      H.startNewNativeQuestion();
       SQLFilter.enterParameterizedQuery("SELECT * FROM PRODUCTS WHERE {{tag}}");
       SQLFilter.openTypePickerFromDefaultFilterType();
       SQLFilter.chooseType("Field Filter");
@@ -309,7 +309,7 @@ describe("scenarios > filters > sql filters > values source", () => {
 
   describe("static list source (dropdown)", () => {
     it("should be able to use a static list source in the query builder", () => {
-      H.openNativeEditor();
+      H.startNewNativeQuestion();
       SQLFilter.enterParameterizedQuery("SELECT * FROM PRODUCTS WHERE {{tag}}");
       SQLFilter.openTypePickerFromDefaultFilterType();
       SQLFilter.chooseType("Field Filter");
@@ -361,7 +361,7 @@ describe("scenarios > filters > sql filters > values source", () => {
 
   describe("static list source with custom labels (dropdown)", () => {
     it("should be able to use a static list source in the query builder", () => {
-      H.openNativeEditor();
+      H.startNewNativeQuestion();
       SQLFilter.enterParameterizedQuery("SELECT * FROM PRODUCTS WHERE {{tag}}");
       SQLFilter.openTypePickerFromDefaultFilterType();
       SQLFilter.chooseType("Field Filter");
@@ -418,7 +418,7 @@ describe("scenarios > filters > sql filters > values source", () => {
 
   describe("static list source (search box)", () => {
     it("should be able to use a static list source in the query builder", () => {
-      H.openNativeEditor();
+      H.startNewNativeQuestion();
       SQLFilter.enterParameterizedQuery("SELECT * FROM PRODUCTS WHERE {{tag}}");
       SQLFilter.openTypePickerFromDefaultFilterType();
       SQLFilter.chooseType("Field Filter");
@@ -494,7 +494,7 @@ describe("scenarios > filters > sql filters > values source", () => {
 
   describe("static list source with custom labels (search box)", () => {
     it("should be able to use a static list source in the query builder", () => {
-      H.openNativeEditor();
+      H.startNewNativeQuestion();
       SQLFilter.enterParameterizedQuery("SELECT * FROM PRODUCTS WHERE {{tag}}");
       SQLFilter.openTypePickerFromDefaultFilterType();
       SQLFilter.chooseType("Field Filter");
@@ -638,7 +638,7 @@ describe("scenarios > filters > sql filters > values source > number parameter",
 
   describe("static list source (dropdown)", () => {
     it("should be able to use a static list source in the query builder", () => {
-      H.openNativeEditor();
+      H.startNewNativeQuestion();
       SQLFilter.enterParameterizedQuery("SELECT {{ x }}");
       SQLFilter.openTypePickerFromDefaultFilterType();
       SQLFilter.chooseType("Number");
@@ -704,7 +704,7 @@ describe("scenarios > filters > sql filters > values source > number parameter",
 
   describe("static list source with custom labels (dropdown)", () => {
     it("should be able to use a static list source in the query builder", () => {
-      H.openNativeEditor();
+      H.startNewNativeQuestion();
       SQLFilter.enterParameterizedQuery("SELECT * FROM {{ tag }}");
       SQLFilter.openTypePickerFromDefaultFilterType();
       SQLFilter.chooseType("Number");
@@ -783,7 +783,7 @@ describe("scenarios > filters > sql filters > values source > number parameter",
 
   describe("static list source (search box)", () => {
     it("should be able to use a static list source in the query builder", () => {
-      H.openNativeEditor();
+      H.startNewNativeQuestion();
       SQLFilter.enterParameterizedQuery("SELECT {{ tag }}");
       SQLFilter.openTypePickerFromDefaultFilterType();
       SQLFilter.chooseType("Number");
@@ -839,7 +839,7 @@ describe("scenarios > filters > sql filters > values source > number parameter",
   });
 
   it("should show the values when picking the default value", () => {
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     SQLFilter.enterParameterizedQuery("SELECT {{ x }}");
     SQLFilter.openTypePickerFromDefaultFilterType();
     SQLFilter.chooseType("Number");
@@ -868,7 +868,7 @@ describe("scenarios > filters > sql filters > values source > number parameter",
   });
 
   it("should clear the value type and config when changing the template tag type and restore them when changing the type back", () => {
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     SQLFilter.enterParameterizedQuery("SELECT * FROM PRODUCTS WHERE {{tag}}");
     SQLFilter.openTypePickerFromDefaultFilterType();
     SQLFilter.chooseType("Text");

--- a/e2e/test/scenarios/native-filters/sql-filters.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-filters.cy.spec.js
@@ -10,7 +10,7 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
 
     cy.signInAsAdmin();
 
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
   });
 
   describe("should work for text", () => {

--- a/e2e/test/scenarios/native/native-database-source.cy.spec.js
+++ b/e2e/test/scenarios/native/native-database-source.cy.spec.js
@@ -249,7 +249,12 @@ describe("scenatios > question > native > mysql", { tags: "@external" }, () => {
 
   it("can write a native MySQL query with a field filter", () => {
     // Write Native query that includes a filter
-    H.openNativeEditor({ databaseName: MYSQL_DB_NAME }).type(
+    H.startNewNativeQuestion().as("editor");
+
+    cy.findByTestId("gui-builder-data").click()
+    cy.findByLabelText(MYSQL_DB_NAME).click();
+
+    cy.get("@editor").type(
       "SELECT TOTAL, CATEGORY FROM ORDERS LEFT JOIN PRODUCTS ON ORDERS.PRODUCT_ID = PRODUCTS.ID [[WHERE PRODUCTS.ID = {{id}}]];",
       {
         parseSpecialCharSequences: false,
@@ -274,7 +279,12 @@ describe("scenatios > question > native > mysql", { tags: "@external" }, () => {
   });
 
   it("can save a native MySQL query", () => {
-    H.openNativeEditor({ databaseName: MYSQL_DB_NAME }).type(
+    H.startNewNativeQuestion().as("editor");
+
+    cy.findByTestId("gui-builder-data").click()
+    cy.findByLabelText(MYSQL_DB_NAME).click();
+
+    cy.get("@editor").type(
       "SELECT * FROM ORDERS",
     );
     cy.findByTestId("native-query-editor-container").icon("play").click();

--- a/e2e/test/scenarios/native/native-database-source.cy.spec.js
+++ b/e2e/test/scenarios/native/native-database-source.cy.spec.js
@@ -251,7 +251,7 @@ describe("scenatios > question > native > mysql", { tags: "@external" }, () => {
     // Write Native query that includes a filter
     H.startNewNativeQuestion().as("editor");
 
-    cy.findByTestId("gui-builder-data").click()
+    cy.findByTestId("gui-builder-data").click();
     cy.findByLabelText(MYSQL_DB_NAME).click();
 
     cy.get("@editor").type(
@@ -281,12 +281,10 @@ describe("scenatios > question > native > mysql", { tags: "@external" }, () => {
   it("can save a native MySQL query", () => {
     H.startNewNativeQuestion().as("editor");
 
-    cy.findByTestId("gui-builder-data").click()
+    cy.findByTestId("gui-builder-data").click();
     cy.findByLabelText(MYSQL_DB_NAME).click();
 
-    cy.get("@editor").type(
-      "SELECT * FROM ORDERS",
-    );
+    cy.get("@editor").type("SELECT * FROM ORDERS");
     cy.findByTestId("native-query-editor-container").icon("play").click();
 
     cy.wait("@dataset");

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.js
@@ -252,38 +252,6 @@ describe("issue 18148", () => {
   });
 });
 
-describe("issue 18418", () => {
-  const questionDetails = {
-    name: "REVIEWS SQL",
-    native: { query: "select REVIEWER from REVIEWS LIMIT 1" },
-  };
-
-  beforeEach(() => {
-    cy.intercept("POST", "/api/card").as("cardCreated");
-
-    H.restore();
-    cy.signInAsAdmin();
-  });
-
-  it("should not show saved questions DB in native question's DB picker (metabase#18418)", () => {
-    cy.createNativeQuestion(questionDetails, { visitQuestion: true });
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Explore results").click();
-
-    H.saveQuestion(undefined, undefined, {
-      tab: "Browse",
-      path: ["Our analytics"],
-    });
-
-    H.openNativeEditor({ fromCurrentPage: true });
-
-    // Clicking native question's database picker usually opens a popover with a list of databases
-    // As default Cypress environment has only the sample database available, we expect no popup to appear
-    cy.get(H.POPOVER_ELEMENT).should("not.exist");
-  });
-});
-
 describe("issue 19451", () => {
   const question = {
     name: "19451",
@@ -463,10 +431,12 @@ describe("issue 21597", { tags: "@external" }, () => {
     H.addPostgresDatabase(databaseCopyName);
 
     // Create a native query and run it
-    H.openNativeEditor({
-      databaseName,
-    });
-    cy.realType(
+    H.startNewNativeQuestion().as("editor");
+
+    cy.findByTestId("gui-builder-data").click();
+    cy.findByLabelText(databaseName).click();
+
+    cy.get("@editor").type(
       `SELECT COUNT(*) FROM PRODUCTS WHERE ${DOUBLE_LEFT_BRACKET}FILTER}}`,
     );
 

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.js
@@ -71,7 +71,7 @@ describe("issue 15029", () => {
   });
 
   it("should allow dots in the variable reference (metabase#15029)", () => {
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     cy.realType(
       `select * from products where RATING = ${DOUBLE_LEFT_BRACKET}number.of.stars}}`,
       {
@@ -96,8 +96,7 @@ describe("issue 16886", () => {
     "shouldn't remove parts of the query when choosing 'Run selected text' (metabase#16886)",
     { tags: "@flaky" },
     () => {
-      H.openNativeEditor();
-      cy.wait(1000); // attempt to decrease flakiness
+      H.startNewNativeQuestion().as("editor");
       cy.realType(ORIGINAL_QUERY);
       cy.realPress("Home");
       Cypress._.range(SELECTED_TEXT.length).forEach(() =>
@@ -369,7 +368,7 @@ describe("issue 20625", { tags: "@quarantine" }, () => {
 
   // realpress messes with cypress 13
   it("should continue to request more prefix matches (metabase#20625)", () => {
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     cy.realType("s");
 
     // autocomplete_suggestions?prefix=s
@@ -387,7 +386,7 @@ describe("issue 21034", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     cy.intercept(
       "GET",
       "/api/database/**/autocomplete_suggestions?**",
@@ -418,7 +417,7 @@ describe("issue 21550", () => {
   });
 
   it("should not show scrollbars for very short snippet (metabase#21550)", () => {
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
 
     cy.icon("snippet").click();
     cy.wait("@rootCollection");
@@ -585,7 +584,7 @@ describe("issue 34330", { tags: "@flaky" }, () => {
   });
 
   it("should only call the autocompleter with all text typed (metabase#34330)", () => {
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     cy.realType("USER");
 
     cy.wait("@autocomplete").then(({ request }) => {
@@ -598,7 +597,7 @@ describe("issue 34330", { tags: "@flaky" }, () => {
   });
 
   it("should call the autocompleter eventually, even when only 1 character was typed (metabase#34330)", () => {
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     cy.realType("U");
 
     cy.wait("@autocomplete").then(({ request }) => {
@@ -611,7 +610,7 @@ describe("issue 34330", { tags: "@flaky" }, () => {
   });
 
   it("should call the autocompleter when backspacing to a 1-character prefix(metabase#34330)", () => {
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     cy.realType("SE{backspace}");
 
     cy.wait("@autocomplete").then(({ request }) => {
@@ -748,7 +747,7 @@ describe("issue 22991", () => {
     cy.signOut();
     cy.signInAsNormalUser();
 
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     cy.get("@questionId").then(questionId => {
       // can't use cy.type because it does not simulate the bug
       cy.realType(`select * from ${DOUBLE_LEFT_BRACKET}#${questionId}`);

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.js
@@ -433,9 +433,6 @@ describe("issue 21597", { tags: "@external" }, () => {
     // Create a native query and run it
     H.startNewNativeQuestion().as("editor");
 
-    cy.findByTestId("gui-builder-data").click();
-    cy.findByLabelText(databaseName).click();
-
     cy.get("@editor").type(
       `SELECT COUNT(*) FROM PRODUCTS WHERE ${DOUBLE_LEFT_BRACKET}FILTER}}`,
     );

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -50,7 +50,7 @@ describe("issue 16584", () => {
     // - the issue is unrelated to using a date filter, using a text filter works too
     // - the issue is unrelated to whether or not the parameter is required or if default value is set
     // - the space at the end of the query is not needed to reproduce this issue
-    H.openNativeEditor()
+    H.startNewNativeQuestion()
       .type(
         "SELECT COUNTRY FROM ACCOUNTS WHERE COUNTRY = {{ country }} LIMIT 1",
         {
@@ -173,7 +173,7 @@ describe("issue 49454", () => {
   });
 
   it("should be possible to use metrics in native queries (metabase#49454)", () => {
-    H.openNativeEditor().type("select * from {{ #test");
+    H.startNewNativeQuestion().type("select * from {{ #test");
 
     H.nativeEditorCompletions().within(() => {
       cy.findByText("-question-49454").should("be.visible");

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -34,8 +34,7 @@ describe("scenarios > question > native", () => {
   });
 
   it("lets you create and run a SQL question", () => {
-    H.openNativeEditor();
-    cy.wait(1000); // attempt to decrease flakiness
+    H.startNewNativeQuestion();
     cy.realType("select count(*) from orders");
     runQuery();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -88,7 +87,7 @@ describe("scenarios > question > native", () => {
   });
 
   it("displays an error", { tags: "@flaky" }, () => {
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     cy.realType("select * from not_a_table");
     runQuery();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -96,7 +95,7 @@ describe("scenarios > question > native", () => {
   });
 
   it("displays an error when running selected text", { tags: "@flaky" }, () => {
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     cy.realType("select * from orders");
     // move left three
     Cypress._.range(3).forEach(() => cy.realPress("ArrowLeft"));
@@ -108,7 +107,7 @@ describe("scenarios > question > native", () => {
   });
 
   it("should handle template tags", { tags: "@flaky" }, () => {
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     cy.realType(
       `select * from PRODUCTS where RATING > ${DOUBLE_LEFT_BRACKET}Stars}}`,
     );
@@ -119,7 +118,7 @@ describe("scenarios > question > native", () => {
   });
 
   it("should modify parameters accordingly when tags are modified", () => {
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     cy.realType(
       `select * from PRODUCTS where CATEGORY = ${DOUBLE_LEFT_BRACKET}cat}}`,
     );
@@ -149,7 +148,7 @@ describe("scenarios > question > native", () => {
   });
 
   it("can save a question with no rows", { tags: "@flaky" }, () => {
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     cy.realType("select * from people where false");
     runQuery();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -233,7 +232,7 @@ describe("scenarios > question > native", () => {
     "should be able to add new columns after hiding some (metabase#15393)",
     { tags: "@flaky" },
     () => {
-      H.openNativeEditor();
+      H.startNewNativeQuestion().as("editor");
       cy.realType("select 1 as visible, 2 as hidden");
       cy.findByTestId("native-query-editor-container")
         .icon("play")
@@ -255,7 +254,7 @@ describe("scenarios > question > native", () => {
   );
 
   it("should recognize template tags and save them as parameters", () => {
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     cy.realType(
       `select * from PRODUCTS where CATEGORY=${DOUBLE_LEFT_BRACKET}cat}} and RATING >= ${DOUBLE_LEFT_BRACKET}stars}}`,
     );
@@ -312,7 +311,7 @@ describe("scenarios > question > native", () => {
   });
 
   it("should allow to preview a fully parameterized query", () => {
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     cy.realType(
       `select * from PRODUCTS where CATEGORY=${DOUBLE_LEFT_BRACKET}category}}`,
     );
@@ -325,7 +324,7 @@ describe("scenarios > question > native", () => {
   });
 
   it("should show errors when previewing a query", () => {
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     cy.realType(
       `select * from PRODUCTS where CATEGORY=${DOUBLE_LEFT_BRACKET}category}}`,
     );
@@ -454,7 +453,7 @@ describe("scenarios > native question > data reference sidebar", () => {
   });
 
   it("should show tables", () => {
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     referenceButton().click();
 
     sidebarHeaderTitle().should("have.text", "Sample Database");
@@ -496,7 +495,7 @@ describe("scenarios > native question > data reference sidebar", () => {
       cy.button("Move").click();
     });
 
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     referenceButton().click();
 
     dataReferenceSidebar().within(() => {
@@ -512,7 +511,7 @@ describe("scenarios > native question > data reference sidebar", () => {
 
   describe("metrics", () => {
     it("should not show metrics when they are not defined on the selected table", () => {
-      H.openNativeEditor();
+      H.startNewNativeQuestion();
       referenceButton().click();
       sidebarHeaderTitle().should("have.text", "Sample Database");
 
@@ -525,7 +524,7 @@ describe("scenarios > native question > data reference sidebar", () => {
     it("should show metrics defined on tables", () => {
       H.createQuestion(ORDERS_SCALAR_METRIC);
 
-      H.openNativeEditor();
+      H.startNewNativeQuestion();
       referenceButton().click();
       sidebarHeaderTitle().should("have.text", "Sample Database");
 

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -232,7 +232,7 @@ describe("scenarios > question > native", () => {
     "should be able to add new columns after hiding some (metabase#15393)",
     { tags: "@flaky" },
     () => {
-      H.startNewNativeQuestion().as("editor");
+      H.startNewNativeQuestion({ display: "table" }).as("editor");
       cy.realType("select 1 as visible, 2 as hidden");
       cy.findByTestId("native-query-editor-container")
         .icon("play")

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -43,8 +43,8 @@ describe("scenarios > question > native", () => {
 
   it("should suggest the currently viewed collection when saving question if the user has not recently visited a dashboard", () => {
     H.visitCollection(THIRD_COLLECTION_ID);
+    H.startNewNativeQuestion({ collection_id: THIRD_COLLECTION_ID});
 
-    H.openNativeEditor({ fromCurrentPage: true });
     cy.realType("select count(*) from orders");
 
     cy.findByTestId("qb-header").within(() => {
@@ -70,7 +70,7 @@ describe("scenarios > question > native", () => {
 
     cy.visit("/");
 
-    H.openNativeEditor({ fromCurrentPage: true });
+    H.startNewNativeQuestion();
     cy.realType("select count(*) from orders");
 
     cy.findByTestId("qb-header").within(() => {
@@ -416,8 +416,9 @@ describe("no native access", { tags: ["@external", "@quarantine"] }, () => {
       H.restore("mongo-5");
       cy.signInAsNormalUser();
 
-      H.openNativeEditor({ newMenuItemTitle: "Native query" });
-      H.popover().findByText(MONGO_DB_NAME).click();
+      H.startNewNativeQuestion()
+      cy.findByTestId("gui-builder-data").click()
+      cy.findByLabelText(MONGO_DB_NAME).click();
       cy.findByLabelText("Format query").should("not.exist");
 
       cy.findByTestId("native-query-top-bar").findByText(MONGO_DB_NAME).click();

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -43,7 +43,7 @@ describe("scenarios > question > native", () => {
 
   it("should suggest the currently viewed collection when saving question if the user has not recently visited a dashboard", () => {
     H.visitCollection(THIRD_COLLECTION_ID);
-    H.startNewNativeQuestion({ collection_id: THIRD_COLLECTION_ID});
+    H.startNewNativeQuestion({ collection_id: THIRD_COLLECTION_ID });
 
     cy.realType("select count(*) from orders");
 
@@ -416,8 +416,8 @@ describe("no native access", { tags: ["@external", "@quarantine"] }, () => {
       H.restore("mongo-5");
       cy.signInAsNormalUser();
 
-      H.startNewNativeQuestion()
-      cy.findByTestId("gui-builder-data").click()
+      H.startNewNativeQuestion();
+      cy.findByTestId("gui-builder-data").click();
       cy.findByLabelText(MONGO_DB_NAME).click();
       cy.findByLabelText("Format query").should("not.exist");
 

--- a/e2e/test/scenarios/native/native_subquery.cy.spec.js
+++ b/e2e/test/scenarios/native/native_subquery.cy.spec.js
@@ -308,7 +308,7 @@ describe("scenarios > question > native subquery", () => {
       ({ body: { id: baseQuestionId } }) => {
         const tagID = `#${baseQuestionId}`;
 
-        H.startNewNativeQuestion();
+        H.startNewNativeQuestion({ display: "table" });
         H.focusNativeEditor().type(`SELECT * FROM {{${tagID}`);
 
         H.runNativeQuery();

--- a/e2e/test/scenarios/native/native_subquery.cy.spec.js
+++ b/e2e/test/scenarios/native/native_subquery.cy.spec.js
@@ -80,7 +80,7 @@ describe("scenarios > question > native subquery", () => {
             cy.button("Move").click();
           });
 
-          H.openNativeEditor();
+          H.startNewNativeQuestion();
           cy.reload(); // Refresh the state, so previously created questions need to be loaded again.
           H.focusNativeEditor();
           cy.wait(1000); // attempt to decrease flakiness

--- a/e2e/test/scenarios/native/snippets.cy.spec.js
+++ b/e2e/test/scenarios/native/snippets.cy.spec.js
@@ -55,7 +55,7 @@ describe("scenarios > question > snippets", () => {
     H.startNewNativeQuestion().as("editor");
     cy.get("@editor").type("select ");
     // 2. snippet
-    cy.get("@editor").icon("snippet").click();
+    cy.icon("snippet").click();
     cy.findByTestId("sidebar-right").within(() => {
       cy.findByText("stuff-snippet").click();
 

--- a/e2e/test/scenarios/native/snippets.cy.spec.js
+++ b/e2e/test/scenarios/native/snippets.cy.spec.js
@@ -21,7 +21,8 @@ describe("scenarios > question > snippets", () => {
 
   it("should let you create and use a snippet", () => {
     cy.log("Type a query and highlight some of the text");
-    H.openNativeEditor().type(
+    H.startNewNativeQuestion().as("editor");
+    cy.get("@editor").type(
       "select 'stuff'" + "{shift}{leftarrow}".repeat("'stuff'".length),
     );
 
@@ -51,9 +52,10 @@ describe("scenarios > question > snippets", () => {
 
     // Populate the native editor first
     // 1. select
-    H.openNativeEditor().type("select ");
+    H.startNewNativeQuestion().as("editor");
+    cy.get("@editor").type("select ");
     // 2. snippet
-    cy.icon("snippet").click();
+    cy.get("@editor").icon("snippet").click();
     cy.findByTestId("sidebar-right").within(() => {
       cy.findByText("stuff-snippet").click();
 
@@ -156,7 +158,7 @@ describe("scenarios > question > snippets (OSS)", { tags: "@OSS" }, () => {
     createNestedSnippet();
 
     // Open editor and sidebar
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     cy.icon("snippet").click();
 
     // Confirm snippet is not in folder
@@ -179,7 +181,7 @@ H.describeEE("scenarios > question > snippets (EE)", () => {
 
       cy.signIn(user);
 
-      H.openNativeEditor();
+      H.startNewNativeQuestion();
       cy.icon("snippet").click();
       cy.findByTestId("sidebar-content").findByText("Create a snippet").click();
 
@@ -211,7 +213,7 @@ H.describeEE("scenarios > question > snippets (EE)", () => {
       collection_id: null,
     });
 
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
 
     // create folder
     cy.icon("snippet").click();
@@ -294,7 +296,7 @@ H.describeEE("scenarios > question > snippets (EE)", () => {
       cy.signIn(user);
 
       // Open editor and sidebar
-      H.openNativeEditor();
+      H.startNewNativeQuestion();
       cy.icon("snippet").click();
 
       // Confirm snippet is in folder
@@ -327,7 +329,7 @@ H.describeEE("scenarios > question > snippets (EE)", () => {
     });
 
     it("should not allow you to move a snippet collection into a itself or a child (metabase#44930)", () => {
-      H.openNativeEditor();
+      H.startNewNativeQuestion();
       cy.icon("snippet").click();
 
       // Edit snippet folder
@@ -359,7 +361,7 @@ H.describeEE("scenarios > question > snippets (EE)", () => {
         "updatePermissions",
       );
 
-      H.openNativeEditor();
+      H.startNewNativeQuestion();
       cy.icon("snippet").click();
 
       // Edit permissions for a snippet folder

--- a/e2e/test/scenarios/permissions/impersonated.cy.spec.js
+++ b/e2e/test/scenarios/permissions/impersonated.cy.spec.js
@@ -71,8 +71,14 @@ H.describeEE("impersonated permission", () => {
         cy.get("main").findByText("Orders").click();
         cy.findAllByTestId("header-cell").contains("Subtotal");
 
+        cy.reload();
+
         // No access through the native query builder
-        H.openNativeEditor({ databaseName: "QA Postgres12" }).type(
+        H.startNewNativeQuestion({ database: PG_DB_ID }).as("editor");
+
+        cy.findByTestId("gui-builder-data").click()
+        cy.findByLabelText("QA Postgres12").click();
+        cy.get("@editor").type(
           "select * from reviews",
         );
         H.runNativeQuery();

--- a/e2e/test/scenarios/permissions/impersonated.cy.spec.js
+++ b/e2e/test/scenarios/permissions/impersonated.cy.spec.js
@@ -76,11 +76,9 @@ H.describeEE("impersonated permission", () => {
         // No access through the native query builder
         H.startNewNativeQuestion({ database: PG_DB_ID }).as("editor");
 
-        cy.findByTestId("gui-builder-data").click()
+        cy.findByTestId("gui-builder-data").click();
         cy.findByLabelText("QA Postgres12").click();
-        cy.get("@editor").type(
-          "select * from reviews",
-        );
+        cy.get("@editor").type("select * from reviews");
         H.runNativeQuery();
 
         cy.findByTestId("query-builder-main").within(() => {

--- a/e2e/test/scenarios/question-reproductions/reproductions-1.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-1.cy.spec.js
@@ -277,14 +277,11 @@ describe("issue 14957", { tags: "@external" }, () => {
   });
 
   it("should save a question before query has been executed (metabase#14957)", () => {
-
     H.startNewNativeQuestion().as("editor");
 
-    cy.findByTestId("gui-builder-data").click()
+    cy.findByTestId("gui-builder-data").click();
     cy.findByLabelText(PG_DB_NAME).click();
-    cy.get("@editor").type(
-      "select pg_sleep(60)",
-    );
+    cy.get("@editor").type("select pg_sleep(60)");
     H.saveQuestion("14957", undefined, {
       tab: "Browse",
       path: ["Our analytics"],

--- a/e2e/test/scenarios/question-reproductions/reproductions-1.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-1.cy.spec.js
@@ -135,7 +135,7 @@ describe("issue 9027", () => {
       cy.button("Close").click();
     });
 
-    H.openNativeEditor({ fromCurrentPage: true });
+    H.startNewNativeQuestion();
 
     H.focusNativeEditor().type("select 0");
     cy.findByTestId("native-query-editor-container").icon("play").click();
@@ -277,7 +277,12 @@ describe("issue 14957", { tags: "@external" }, () => {
   });
 
   it("should save a question before query has been executed (metabase#14957)", () => {
-    H.openNativeEditor({ databaseName: PG_DB_NAME }).type(
+
+    H.startNewNativeQuestion().as("editor");
+
+    cy.findByTestId("gui-builder-data").click()
+    cy.findByLabelText(PG_DB_NAME).click();
+    cy.get("@editor").type(
       "select pg_sleep(60)",
     );
     H.saveQuestion("14957", undefined, {

--- a/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
@@ -479,7 +479,7 @@ describe("issue 30165", () => {
   });
 
   it("should not autorun native queries after updating a question (metabase#30165)", () => {
-    H.openNativeEditor();
+    H.startNewNativeQuestion();
     cy.findByTestId("native-query-editor").type("SELECT * FROM ORDERS");
     H.saveQuestionToCollection("Q1");
 

--- a/e2e/test/scenarios/sharing/public-question.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-question.cy.spec.js
@@ -125,7 +125,7 @@ describe("scenarios > public > question", () => {
   );
 
   it("should be able to view public questions with snippets", () => {
-    H.startNewNativeQuestion().as("editor");
+    H.startNewNativeQuestion({ display: "table" }).as("editor");
 
     // Create a snippet
     cy.icon("snippet").click();
@@ -168,7 +168,7 @@ describe("scenarios > public > question", () => {
         query: "SELECT * FROM PEOPLE LIMIT 5",
       },
     }).then(({ body: { id } }) => {
-      H.startNewNativeQuestion().as("editor");
+      H.startNewNativeQuestion({ display: "table" }).as("editor");
 
       cy.get("@editor")
         .type("select * from {{#")

--- a/e2e/test/scenarios/sharing/public-question.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-question.cy.spec.js
@@ -125,7 +125,7 @@ describe("scenarios > public > question", () => {
   );
 
   it("should be able to view public questions with snippets", () => {
-    H.openNativeEditor();
+    H.startNewNativeQuestion().as("editor");
 
     // Create a snippet
     cy.icon("snippet").click();
@@ -168,7 +168,7 @@ describe("scenarios > public > question", () => {
         query: "SELECT * FROM PEOPLE LIMIT 5",
       },
     }).then(({ body: { id } }) => {
-      H.openNativeEditor();
+      H.startNewNativeQuestion().as("editor");
 
       cy.get("@editor")
         .type("select * from {{#")

--- a/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
@@ -13,7 +13,7 @@ describe("scenarios > visualizations > maps", () => {
   it("should display a pin map for a native query", () => {
     cy.signInAsNormalUser();
     // create a native query with lng/lat fields
-    H.openNativeEditor().type(
+    H.startNewNativeQuestion().type(
       "select -80 as lng, 40 as lat union all select -120 as lng, 40 as lat",
     );
     cy.findByTestId("native-query-editor-container").icon("play").click();

--- a/e2e/test/scenarios/visualizations-charts/waterfall.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/waterfall.cy.spec.js
@@ -24,7 +24,7 @@ describe("scenarios > visualizations > waterfall", () => {
   }
 
   it("should work with ordinal series", () => {
-    H.openNativeEditor().type(
+    H.startNewNativeQuestion().type(
       "select 'A' as product, 10 as profit union select 'B' as product, -4 as profit",
     );
     cy.findByTestId("native-query-editor-container").icon("play").click();
@@ -36,7 +36,7 @@ describe("scenarios > visualizations > waterfall", () => {
   });
 
   it("should work with ordinal series and numeric X-axis (metabase#15550)", () => {
-    H.openNativeEditor().type(
+    H.startNewNativeQuestion().type(
       "select 1 as X, 20 as Y union select 2 as X, -10 as Y",
     );
 
@@ -61,7 +61,7 @@ describe("scenarios > visualizations > waterfall", () => {
   });
 
   it("should work with quantitative series", { tags: "@flaky" }, () => {
-    H.openNativeEditor().type(
+    H.startNewNativeQuestion().type(
       "select 1 as X, 10 as Y union select 2 as X, -2 as Y",
     );
     cy.findByTestId("native-query-editor-container").icon("play").click();
@@ -424,7 +424,7 @@ describe("scenarios > visualizations > waterfall", () => {
       H.restore();
       cy.signInAsNormalUser();
 
-      H.openNativeEditor().type("select 'A' as X, -4.56 as Y");
+      H.startNewNativeQuestion().type("select 'A' as X, -4.56 as Y");
       cy.findByTestId("native-query-editor-container").icon("play").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Visualization").click();

--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -268,7 +268,10 @@ describe("scenarios > visualizations > table", () => {
   });
 
   it("should show field metadata hovercards for native query tables", () => {
-    H.startNewNativeQuestion({ query: "select * from products limit 1" });
+    H.startNewNativeQuestion({
+      query: "select * from products limit 1",
+      display: "table",
+    });
     cy.findByTestId("native-query-editor-container").icon("play").click();
 
     cy.log("Wait for the table to load");


### PR DESCRIPTION
### Description

Removes deprecated openNativeEditor helper from all instances. This change also adds some functionality to the `H.startNewNativeQuestion();` helper such as specifying `collection_id` and display type (e.g. `table` or `scalar`)

### How to verify

running all tests without failure should be enough of a verification

- [x] Tests have been added/updated to cover changes in this PR
