### PR TITLE
Cache logins in e2e tests

### DIFF
--- a/e2e/snapshot-creators/default.cy.snap.js
+++ b/e2e/snapshot-creators/default.cy.snap.js
@@ -147,7 +147,7 @@ describe("snapshots", () => {
     cy.request("GET", "/api/user");
 
     Object.keys(USERS).forEach(user => {
-      cy.signIn(user);
+      cy.signIn(user, true);
     });
 
     cy.signInAsAdmin();

--- a/e2e/snapshot-creators/default.cy.snap.js
+++ b/e2e/snapshot-creators/default.cy.snap.js
@@ -1,5 +1,6 @@
 import _ from "underscore";
 
+import { loginCache } from "e2e/support/commands/user/authentication";
 import {
   METABASE_SECRET_KEY,
   SAMPLE_DB_ID,
@@ -144,6 +145,12 @@ describe("snapshots", () => {
 
     // Make a call to `/api/user` because some things (personal collections) get created there
     cy.request("GET", "/api/user");
+
+    Object.keys(USERS).forEach(user => {
+      cy.signIn(user);
+    });
+
+    cy.signInAsAdmin();
 
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
@@ -344,6 +351,8 @@ describe("snapshots", () => {
 
 function getDefaultInstanceData() {
   const instanceData = {};
+
+  instanceData.loginCache = loginCache;
 
   cy.request("/api/card").then(({ body: cards }) => {
     instanceData.questions = cards;

--- a/e2e/snapshot-creators/default.cy.snap.js
+++ b/e2e/snapshot-creators/default.cy.snap.js
@@ -88,6 +88,8 @@ describe("snapshots", () => {
       // Dismiss `it's ok to play around` modal for admin
       cy.request("PUT", `/api/user/${id}/modal/qbnewb`);
     });
+
+    cy.signIn("admin", { setupCache: true }); // cache admin credentials
   }
 
   function updateSettings() {
@@ -147,7 +149,11 @@ describe("snapshots", () => {
     cy.request("GET", "/api/user");
 
     Object.keys(USERS).forEach(user => {
-      cy.signIn(user, true);
+      if (user === "admin") {
+        // we already cached admin user credentials during setup
+        return;
+      }
+      cy.signIn(user, { setupCache: true });
     });
 
     cy.signInAsAdmin();

--- a/e2e/support/commands/user/authentication.ts
+++ b/e2e/support/commands/user/authentication.ts
@@ -1,4 +1,5 @@
 import { USERS } from "e2e/support/cypress_data";
+import  { LOGIN_CACHE } from "e2e/support/cypress_sample_instance_data";
 
 declare global {
   namespace Cypress {
@@ -13,14 +14,48 @@ declare global {
   }
 }
 
+export const loginCache: Partial<Record<keyof typeof USERS, {
+  sessionId: string;
+  deviceId: string;
+}>> = {};
+
+// Load login cache from sample instance data
+if (Object.keys(LOGIN_CACHE).length) {
+  Object.entries(LOGIN_CACHE).forEach(([user, { sessionId, deviceId }]) => {
+    loginCache[user] = { sessionId, deviceId };
+  });
+}
+
 Cypress.Commands.add("signIn", (user = "admin") => {
-  const { email: username, password } = USERS[user];
+  if (loginCache[user]) {
+    const { sessionId, deviceId } = loginCache[user];
+    cy.log("Using cached login token for user", user);
+    cy.setCookie("metabase.SESSION", sessionId,
+      { httpOnly: true });
+    cy.setCookie("metabase.TIMEOUT", "alive");
+    cy.setCookie("metabase.DEVICE", deviceId ?? "",
+       { httpOnly: true });
+    return;
+  }
+
   cy.log(`Logging in as ${user}`);
-  cy.request("POST", "/api/session", { username, password });
+
+  const { email: username, password } = USERS[user];
+  cy.request("POST", "/api/session", { username, password }).then(
+    response => {
+      cy.log("saving login token for user", user);
+      cy.getCookie("metabase.DEVICE").then(deviceCookie => {
+        loginCache[user] = {
+          sessionId: response.body.id,
+          deviceId: deviceCookie?.value ?? "my-device-id",
+        };
+      });
+    },
+  );
 });
 
 Cypress.Commands.add("signInAsAdmin", () => {
-  cy.signIn("admin");
+  return cy.signIn("admin");
 });
 
 Cypress.Commands.add("signInAsNormalUser", () => {

--- a/e2e/support/commands/user/authentication.ts
+++ b/e2e/support/commands/user/authentication.ts
@@ -1,5 +1,5 @@
 import { USERS } from "e2e/support/cypress_data";
-import  { LOGIN_CACHE } from "e2e/support/cypress_sample_instance_data";
+import { LOGIN_CACHE } from "e2e/support/cypress_sample_instance_data";
 
 declare global {
   namespace Cypress {
@@ -14,10 +14,15 @@ declare global {
   }
 }
 
-export const loginCache: Partial<Record<keyof typeof USERS, {
-  sessionId: string;
-  deviceId: string;
-}>> = {};
+export const loginCache: Partial<
+  Record<
+    keyof typeof USERS,
+    {
+      sessionId: string;
+      deviceId: string;
+    }
+  >
+> = {};
 
 // Load login cache from sample instance data
 if (Object.keys(LOGIN_CACHE).length) {
@@ -30,28 +35,24 @@ Cypress.Commands.add("signIn", (user = "admin") => {
   if (loginCache[user]) {
     const { sessionId, deviceId } = loginCache[user];
     cy.log("Using cached login token for user", user);
-    cy.setCookie("metabase.SESSION", sessionId,
-      { httpOnly: true });
+    cy.setCookie("metabase.SESSION", sessionId, { httpOnly: true });
     cy.setCookie("metabase.TIMEOUT", "alive");
-    cy.setCookie("metabase.DEVICE", deviceId ?? "",
-       { httpOnly: true });
+    cy.setCookie("metabase.DEVICE", deviceId ?? "", { httpOnly: true });
     return;
   }
 
   cy.log(`Logging in as ${user}`);
 
   const { email: username, password } = USERS[user];
-  cy.request("POST", "/api/session", { username, password }).then(
-    response => {
-      cy.log("saving login token for user", user);
-      cy.getCookie("metabase.DEVICE").then(deviceCookie => {
-        loginCache[user] = {
-          sessionId: response.body.id,
-          deviceId: deviceCookie?.value ?? "my-device-id",
-        };
-      });
-    },
-  );
+  cy.request("POST", "/api/session", { username, password }).then(response => {
+    cy.log("saving login token for user", user);
+    cy.getCookie("metabase.DEVICE").then(deviceCookie => {
+      loginCache[user] = {
+        sessionId: response.body.id,
+        deviceId: deviceCookie?.value ?? "my-device-id",
+      };
+    });
+  });
 });
 
 Cypress.Commands.add("signInAsAdmin", () => {

--- a/e2e/support/cypress_sample_instance_data.js
+++ b/e2e/support/cypress_sample_instance_data.js
@@ -139,3 +139,5 @@ export const NOSQL_GROUP_ID = _.findWhere(SAMPLE_INSTANCE_DATA.groups, {
 export const READONLY_GROUP_ID = _.findWhere(SAMPLE_INSTANCE_DATA.groups, {
   name: "readonly",
 }).id;
+
+export const LOGIN_CACHE = SAMPLE_INSTANCE_DATA.loginCache;

--- a/e2e/support/helpers/e2e-setup-helpers.js
+++ b/e2e/support/helpers/e2e-setup-helpers.js
@@ -21,5 +21,5 @@ export function restore(name = "default") {
   cy.skipOn(name.includes("mongo") && Cypress.env("QA_DB_MONGO") !== true);
 
   cy.log("Restore Data Set");
-  cy.request("POST", `/api/testing/restore/${name}`);
+  return cy.request("POST", `/api/testing/restore/${name}`);
 }

--- a/e2e/test/scenarios/embedding-sdk/static-dashboard-cors.cy.spec.js
+++ b/e2e/test/scenarios/embedding-sdk/static-dashboard-cors.cy.spec.js
@@ -19,7 +19,7 @@ const STORYBOOK_ID = "embeddingsdk-cypressstaticdashboardwithcors--default";
 H.describeEE("scenarios > embedding-sdk > static-dashboard", () => {
   beforeEach(() => {
     H.restore();
-    cy.signInAsAdmin();
+    cy.signIn("admin", { skipCache: true });
     H.setTokenFeatures("all");
     enableJwtAuth();
 


### PR DESCRIPTION
ENG-9250

### Description

Instead of spending ~150ms logging in for every test, let's save session ids as part of our snapshotting process, and then just set cookies manually to log in (~10ms).

