### PR TITLE
Fix `FormTextInput` styling

### DIFF
--- a/frontend/src/metabase/forms/components/FormTextInput/FormTextInput.tsx
+++ b/frontend/src/metabase/forms/components/FormTextInput/FormTextInput.tsx
@@ -60,7 +60,7 @@ export const FormTextInput = forwardRef(function FormTextInput(
       ref={ref}
       name={name}
       value={value ?? ""}
-      error={touched ? <div role="alert">{error}</div> : null}
+      error={touched && error ? <div role="alert">{error}</div> : null}
       onChange={handleChange}
       onBlur={handleBlur}
       rightSection={hasCopyButton ? <CopyWidgetButton value={value} /> : null}


### PR DESCRIPTION
### Description

#51395 introduced a mistake where we'd show an empty error state after our `FormTextInput` had been touched when there was no error. This PR fixes that.

### Demo

Before
![CleanShot 2025-01-02 at 15 13 16@2x](https://github.com/user-attachments/assets/0da127f1-a251-4bfc-a71b-82503292c1cc)

After
![CleanShot 2025-01-02 at 15 13 31@2x](https://github.com/user-attachments/assets/5e62404a-dfdf-488a-ae5f-d245dde652f2)