### PR TITLE
Query Limits Do Not Override Download Row Limits

### DIFF
--- a/src/metabase/query_processor/middleware/limit.clj
+++ b/src/metabase/query_processor/middleware/limit.clj
@@ -38,9 +38,10 @@
   3. [[metabase.query-processor.interface/absolute-max-results]] (a constant, non-nil backstop value)"
   [query]
   (when-not (disable-max-results? query)
-    (cond-> (or (mbql.u/query->max-rows-limit query)
-                (public-settings/download-row-limit)
-                qp.i/absolute-max-results)
+    (cond-> (or
+             (min (or (mbql.u/query->max-rows-limit query) ##Inf)
+                  (or (public-settings/download-row-limit) ##Inf))
+             qp.i/absolute-max-results)
       (xlsx-export? query)
       (min qp.i/absolute-max-results))))
 


### PR DESCRIPTION
Fixes: #51620

Prior to this change, if a user set a limit in a query to, say 20 rows, but the MB_DOWNLOAD_ROW_LIMIT was 10, the download would contain 20 rows (the limit from the query). This is not the intended behaviour, so this PR fixes the logic in the middleware that applies the row limits.

It IS intended that the MB_DOWNLOAD_ROW_LIMIT can exceed the max-query-rows limit. Why? because it is sometimes desirable to download a CSV with more rows than the max-limit, which is actually derived from Excel's max. row limit, not necessarily a deliberate choice. This use case may be uncommon, but was partly the reason for the addition of the MB_DOWNLOAD_ROW_LIMIT env. var in the first place, so that behaviour is preserved.
