### PR TITLE
dopcs - add link to support matrix

### DIFF
--- a/docs/databases/connections/sql-server.md
+++ b/docs/databases/connections/sql-server.md
@@ -89,6 +89,7 @@ A fingerprinting query examines the first 10,000 rows from each column and uses 
 
 ## Further reading
 
+- [Microsoft JDBC Driver for SQL Server support matrix](https://learn.microsoft.com/en-us/sql/connect/jdbc/microsoft-jdbc-driver-for-sql-server-support-matrix)
 - [Managing databases](../../databases/connecting.md)
 - [Metadata editing](../../data-modeling/metadata-editing.md)
 - [Models](../../data-modeling/models.md)


### PR DESCRIPTION
Adds link to JDBC driver support matrix for SQL server.