### PR TITLE
[Cards in Dashboards] Fix focus getting lost in nested Save question modals

### DIFF
--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -24,6 +24,18 @@ describe("scenarios > question > saved", () => {
     H.popover().findByText("Count of rows").click();
     H.addSummaryGroupingField({ field: "Total" });
 
+    // Test save modal and nested entity picker can be closed via consecutive escape key presses
+    H.queryBuilderHeader().button("Save").click();
+    cy.findByTestId("save-question-modal").within(() => {
+      cy.findByTestId("dashboard-and-collection-picker-button").click();
+    });
+    H.entityPickerModal().should("exist");
+    cy.realPress("{esc}");
+    H.entityPickerModal().should("not.exist");
+    cy.findByTestId("save-question-modal").should("exist");
+    cy.realPress("{esc}");
+    cy.findByTestId("save-question-modal").should("not.exist");
+
     // Save the question
     H.queryBuilderHeader().button("Save").click();
     cy.findByTestId("save-question-modal").within(modal => {

--- a/frontend/src/metabase/collections/containers/FormCollectionAndDashboardPicker/FormCollectionAndDashboardPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionAndDashboardPicker/FormCollectionAndDashboardPicker.tsx
@@ -98,6 +98,7 @@ export function FormCollectionAndDashboardPicker({
   const error = dashboardIdMeta.error || collectionIdMeta.error;
 
   const formFieldRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
   const [isPickerOpen, setIsPickerOpen] = useState(false);
 
   const openCollection = useSelector(state =>
@@ -162,6 +163,13 @@ export function FormCollectionAndDashboardPicker({
     [collectionIdHelpers, dashboardIdHelpers],
   );
 
+  const handleModalClose = () => {
+    setIsPickerOpen(false);
+    // restore focus to form element so if Esc key is pressed multiple times,
+    // nested modals close in sequence
+    buttonRef.current?.focus();
+  };
+
   return (
     <>
       <FormField
@@ -174,6 +182,7 @@ export function FormCollectionAndDashboardPicker({
       >
         <Button
           data-testid="dashboard-and-collection-picker-button"
+          ref={buttonRef}
           id={id}
           onClick={() => setIsPickerOpen(true)}
           fullWidth
@@ -202,7 +211,7 @@ export function FormCollectionAndDashboardPicker({
           title={t`Select a collection or dashboard`}
           value={pickerValue}
           onChange={handleChange}
-          onClose={() => setIsPickerOpen(false)}
+          onClose={handleModalClose}
           options={options}
           {...collectionPickerModalProps}
         />

--- a/frontend/src/metabase/components/SaveQuestionForm/SaveQuestionForm.tsx
+++ b/frontend/src/metabase/components/SaveQuestionForm/SaveQuestionForm.tsx
@@ -10,7 +10,6 @@ import FormInput from "metabase/core/components/FormInput";
 import FormRadio from "metabase/core/components/FormRadio";
 import FormSelect from "metabase/core/components/FormSelect";
 import FormTextArea from "metabase/core/components/FormTextArea";
-import CoreStyles from "metabase/css/core/index.css";
 import { Form, FormSubmitButton } from "metabase/forms";
 import { isNullOrUndefined } from "metabase/lib/types";
 import type { Dashboard } from "metabase-types/api";
@@ -75,7 +74,7 @@ export const SaveQuestionForm = ({
         />
       )}
       {values.saveType === "create" && (
-        <div className={CoreStyles.overflowHidden}>
+        <div>
           <FormInput
             name="name"
             title={t`Name`}


### PR DESCRIPTION
Part of #50176

### Description

If a user opened the entity picker from the save question modal and closed it via an escape key press, they could not close the parent Save question modal with another escape key press. This PR fixes that.

### How to verify

1. Go to save question modal
2. Click on input to save where to save your question
3. Press escape (entity picker should go away)
4. Press escape again (save question modal should not also go away)

### Demo

https://github.com/user-attachments/assets/987d7ee7-df6f-40b4-9b41-e6782ccad32c

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
