### PR TITLE
[Cards in Dashboards] Allow creating dashboards from entity picker

### DIFF
--- a/e2e/support/helpers/e2e-collection-helpers.ts
+++ b/e2e/support/helpers/e2e-collection-helpers.ts
@@ -80,7 +80,7 @@ export const moveOpenedCollectionTo = (newParent: string) => {
 
   entityPickerModal().within(() => {
     cy.findByRole("tab", { name: /Collections/ }).click();
-    cy.findByText(newParent).click();
+    cy.findByTestId("nested-item-picker").findByText(newParent).click();
     cy.button("Move").click();
   });
 

--- a/e2e/test/scenarios/dashboard/dashboard-management.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-management.cy.spec.js
@@ -141,9 +141,7 @@ describe("managing dashboard from the dashboard's edit menu", () => {
                     .click();
                 }
 
-                H.entityPickerModal()
-                  .findByText("Create a new collection")
-                  .click();
+                H.entityPickerModal().findByText("New collection").click();
                 const NEW_COLLECTION = "Foo Collection";
                 H.collectionOnTheGoModal().within(() => {
                   cy.findByPlaceholderText("My new collection").type(

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -141,7 +141,7 @@ describe("scenarios > dashboard", () => {
           .findByRole("tab", { name: /Collections/ })
           .click();
         H.entityPickerModal()
-          .findByText("Create a new collection")
+          .findByText("New collection")
           .click({ force: true });
         const NEW_COLLECTION = "Bar";
         H.collectionOnTheGoModal().within(() => {
@@ -199,7 +199,7 @@ describe("scenarios > dashboard", () => {
       H.entityPickerModal()
         .findByRole("tab", { name: /Dashboards/ })
         .click();
-      H.entityPickerModal().findByText("Create a new dashboard").click();
+      H.entityPickerModal().findByText("New dashboard").click();
       cy.findByTestId("create-dashboard-on-the-go").within(() => {
         cy.findByPlaceholderText("My new dashboard").type("Foo");
         cy.findByText("Create").click();

--- a/e2e/test/scenarios/native/snippets.cy.spec.js
+++ b/e2e/test/scenarios/native/snippets.cy.spec.js
@@ -271,7 +271,7 @@ H.describeEE("scenarios > question > snippets (EE)", () => {
 
     H.modal().findByTestId("collection-picker-button").click();
     H.entityPickerModal()
-      .findByRole("button", { name: /Create a new collection/ })
+      .findByRole("button", { name: /New collection/ })
       .click();
     H.collectionOnTheGoModal()
       .findByLabelText("Give it a name")

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -334,6 +334,57 @@ describe("scenarios > question > new", () => {
     },
   );
 
+  it(
+    "should be able to save a question to a dashboard created on the go",
+    { tags: "@smoke" },
+    () => {
+      H.visitCollection(THIRD_COLLECTION_ID);
+
+      cy.findByLabelText("Navigation bar").findByText("New").click();
+      H.popover().findByText("Question").click();
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalTab("Tables").click();
+        cy.findByText("Orders").click();
+      });
+      cy.findByTestId("qb-header").findByText("Save").click();
+
+      cy.log("should be able to tab through fields (metabase#41683)");
+      cy.realPress("Tab").realPress("Tab");
+      cy.findByLabelText("Description").should("be.focused");
+
+      cy.findByTestId("save-question-modal")
+        .findByLabelText(/Where do you want to save/)
+        .click();
+
+      H.entityPickerModal()
+        .findByRole("tab", { name: /Browse/ })
+        .click();
+
+      H.entityPickerModal().findByText("New dashboard").click();
+
+      const NEW_DASHBOARD = "Foo Dashboard";
+      H.dashboardOnTheGoModal().within(() => {
+        cy.findByLabelText(/Give it a name/).type(NEW_DASHBOARD);
+        cy.findByText("Create").click();
+      });
+      H.entityPickerModal().within(() => {
+        cy.findByText(NEW_DASHBOARD).click();
+        cy.button(/Select/).click();
+      });
+      cy.findByTestId("save-question-modal").within(() => {
+        cy.findByText("Save new question");
+        cy.findByLabelText(/Where do you want to save/).should(
+          "have.text",
+          NEW_DASHBOARD,
+        );
+        cy.findByText("Save").click();
+      });
+
+      cy.get("header").findByText(NEW_DASHBOARD);
+      cy.url().should("include", "/dashboard/");
+    },
+  );
+
   it("should preserve the original question name (metabase#41196)", () => {
     const originalQuestionName = "Foo";
     const modifiedQuestionName = `${originalQuestionName} - Modified`;

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -310,7 +310,7 @@ describe("scenarios > question > new", () => {
         .findByRole("tab", { name: /Browse/ })
         .click();
 
-      H.entityPickerModal().findByText("Create a new collection").click();
+      H.entityPickerModal().findByText("New collection").click();
 
       const NEW_COLLECTION = "Foo";
       H.collectionOnTheGoModal().within(() => {
@@ -456,7 +456,7 @@ describe("scenarios > question > new", () => {
         );
         cy.findByText(collectionInRoot.name).should("be.visible");
         cy.findByText(dashboardInRoot.name).should("be.visible");
-        cy.findByText("Create a new dashboard").should("be.visible");
+        cy.findByText("New dashboard").should("be.visible");
       });
     });
 
@@ -493,7 +493,7 @@ describe("scenarios > question > new", () => {
         H.entityPickerModal().within(() => {
           H.entityPickerModalTab("Dashboards").click();
           H.entityPickerModalItem(1, "Collection in root collection").click();
-          cy.button(/Create a new dashboard/).click();
+          cy.button(/New dashboard/).click();
         });
 
         cy.findByRole("dialog", { name: "Create a new dashboard" }).within(
@@ -525,7 +525,7 @@ describe("scenarios > question > new", () => {
         H.entityPickerModal().within(() => {
           H.entityPickerModalTab("Dashboards").click();
           H.entityPickerModalItem(1, "First collection").click();
-          cy.button(/Create a new dashboard/).click();
+          cy.button(/New dashboard/).click();
         });
 
         cy.findByRole("dialog", { name: "Create a new dashboard" }).within(
@@ -557,7 +557,7 @@ describe("scenarios > question > new", () => {
         H.entityPickerModal().within(() => {
           H.entityPickerModalTab("Dashboards").click();
           H.entityPickerModalItem(1, "Orders in a dashboard").click();
-          cy.button(/Create a new dashboard/).click();
+          cy.button(/New dashboard/).click();
         });
 
         cy.findByRole("dialog", { name: "Create a new dashboard" }).within(

--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -109,7 +109,7 @@ describe(
                       cy.findByRole("tab", { name: /Browse/ }).click();
                     }
                     cy.findByText(/Personal Collection/).click();
-                    cy.findByText("Create a new collection").click();
+                    cy.findByText("New collection").click();
                   });
 
                   cy.findByTestId("create-collection-on-the-go").within(() => {

--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -151,7 +151,7 @@ describe("scenarios > question > saved", () => {
       cy.findByTestId("dashboard-and-collection-picker-button").click();
     });
 
-    H.entityPickerModal().findByText("Create a new collection").click();
+    H.entityPickerModal().findByText("New collection").click();
 
     const NEW_COLLECTION = "My New collection";
     H.collectionOnTheGoModal().then(() => {

--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -28,11 +28,19 @@ describe("scenarios > question > saved", () => {
     H.queryBuilderHeader().button("Save").click();
     cy.findByTestId("save-question-modal").within(() => {
       cy.findByTestId("dashboard-and-collection-picker-button").click();
+      // wait for focus to be removed from clicked element to avoid test flakes
+      // cypress executes faster than ui updates causing the focus position to lag behind on save modal
+      cy.findByTestId("dashboard-and-collection-picker-button").should(
+        "not.be.focused",
+      );
     });
     H.entityPickerModal().should("exist");
     cy.realPress("{esc}");
     H.entityPickerModal().should("not.exist");
     cy.findByTestId("save-question-modal").should("exist");
+    cy.findByTestId("dashboard-and-collection-picker-button").should(
+      "be.focused",
+    );
     cy.realPress("{esc}");
     cy.findByTestId("save-question-modal").should("not.exist");
 

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPicker.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPicker.tsx
@@ -5,8 +5,9 @@ import { useDeepCompareEffect } from "react-use";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import { useSelector } from "metabase/lib/redux";
 import { getUserPersonalCollectionId } from "metabase/selectors/user";
-import type { Collection } from "metabase-types/api";
+import type { Collection, Dashboard } from "metabase-types/api";
 
+import { handleNewDashboard as handleNewDashboardUtil } from "../../DashboardPicker/utils";
 import { LoadingSpinner, NestedItemPicker } from "../../EntityPicker";
 import { useEnsureCollectionSelected, useGetInitialContainer } from "../hooks";
 import type {
@@ -146,14 +147,35 @@ export const CollectionPickerInner = (
     [path, handleItemSelect, onItemSelect, onPathChange, options.namespace],
   );
 
+  const handleNewDashboard = useCallback(
+    (newDashboard: Dashboard) => {
+      handleNewDashboardUtil(
+        newDashboard,
+        path,
+        onItemSelect,
+        userPersonalCollectionId,
+        handleItemSelect,
+        onPathChange,
+      );
+    },
+    [
+      path,
+      onItemSelect,
+      userPersonalCollectionId,
+      handleItemSelect,
+      onPathChange,
+    ],
+  );
+
   // Exposing onNewCollection so that parent can select newly created
   // folder
   useImperativeHandle(
     ref,
     () => ({
       onNewCollection: handleNewCollection,
+      onNewDashboard: handleNewDashboard,
     }),
-    [handleNewCollection],
+    [handleNewCollection, handleNewDashboard],
   );
 
   useDeepCompareEffect(

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
@@ -207,7 +207,9 @@ export const CollectionPickerModal = ({
         title={title}
         onItemSelect={handleItemSelect}
         canSelectItem={
-          !isCreateCollectionDialogOpen && canSelectItem(selectedItem)
+          !isCreateCollectionDialogOpen &&
+          !isCreateDashboardDialogOpen &&
+          canSelectItem(selectedItem)
         }
         onConfirm={handleConfirm}
         onClose={onClose}

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
@@ -90,6 +90,7 @@ export const CollectionPickerModal = ({
 
   const pickerRef = useRef<{
     onNewCollection: (item: CollectionPickerItem) => void;
+    onNewDashboard: (item: CollectionPickerItem) => void;
   }>();
 
   const handleInit = useCallback((item: CollectionPickerItem) => {
@@ -175,8 +176,6 @@ export const CollectionPickerModal = ({
   };
 
   const handleNewDashboardCreate = (newDashboard: CollectionPickerItem) => {
-    // TODO: this doesn't work, but we don't have the same guarantees here as the dashboard picker :thinking:
-    // @ts-expect-error -- property isn't defined... will get to it
     pickerRef.current?.onNewDashboard(newDashboard);
   };
 

--- a/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPicker.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPicker.tsx
@@ -22,9 +22,9 @@ import type {
   DashboardPickerStatePath,
 } from "../types";
 import {
-  getCollectionId,
   getCollectionIdPath,
   getStateFromIdPath,
+  handleNewDashboard as handleNewDashboardUtil,
   isFolder,
 } from "../utils";
 
@@ -142,36 +142,14 @@ const DashboardPickerInner = (
 
   const handleNewDashboard = useCallback(
     (newDashboard: Dashboard) => {
-      const newCollectionItem: DashboardPickerItem = {
-        id: newDashboard.id,
-        name: newDashboard.name,
-        collection_id: newDashboard.collection_id || "root",
-        model: "dashboard",
-      };
-
-      // Needed to satisfy type between DashboardPickerItem and the query below.
-      const parentCollectionId = getCollectionId(newCollectionItem);
-
-      //Is the parent collection already in the path?
-      const isParentCollectionInPath =
-        getPathLevelForItem(newCollectionItem, path, userPersonalCollectionId) >
-        0;
-
-      if (!isParentCollectionInPath) {
-        onPathChange([
-          ...path,
-          {
-            query: {
-              id: parentCollectionId,
-              models: ["collection", "dashboard"],
-            },
-            selectedItem: newCollectionItem,
-          },
-        ]);
-        onItemSelect(newCollectionItem);
-        return;
-      }
-      handleItemSelect(newCollectionItem);
+      handleNewDashboardUtil(
+        newDashboard,
+        path,
+        onItemSelect,
+        userPersonalCollectionId,
+        handleItemSelect,
+        onPathChange,
+      );
     },
     [
       path,

--- a/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPickerModal.tsx
@@ -147,12 +147,12 @@ export const DashboardPickerModal = ({
   const modalActions = [
     <Button
       key="dashboard-on-the-go"
-      miw="21rem"
+      miw="9.5rem"
       onClick={openCreateDialog}
-      leftIcon={<Icon name="add" />}
+      leftIcon={<Icon name="add_to_dash" />}
       disabled={selectedItem?.can_write === false}
     >
-      {t`Create a new dashboard`}
+      {t`New dashboard`}
     </Button>,
   ];
 

--- a/frontend/src/metabase/common/components/DashboardPicker/components/NewDashboardDialog.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/NewDashboardDialog.tsx
@@ -62,7 +62,7 @@ export const NewDashboardDialog = ({
         initialValues={{ name: "" }}
         onSubmit={onCreateNewDashboard}
       >
-        {({ dirty }: { dirty: boolean }) => (
+        {({ dirty, isSubmitting }) => (
           <Form>
             <FormTextInput
               name="name"
@@ -79,7 +79,7 @@ export const NewDashboardDialog = ({
                 <FormSubmitButton
                   type="submit"
                   label={t`Create`}
-                  disabled={!dirty}
+                  disabled={!dirty || isSubmitting}
                   variant="filled"
                 />
               </Flex>

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/ButtonBar.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/ButtonBar.tsx
@@ -4,7 +4,6 @@ import { t } from "ttag";
 import { Button, Flex, Text } from "metabase/ui";
 
 export const ButtonBar = ({
-  modalRef,
   onConfirm,
   onCancel,
   canConfirm,
@@ -12,7 +11,6 @@ export const ButtonBar = ({
   confirmButtonText,
   cancelButtonText,
 }: {
-  modalRef: React.RefObject<HTMLElement>;
   onConfirm: () => void;
   onCancel: () => void;
   canConfirm?: boolean;
@@ -21,17 +19,18 @@ export const ButtonBar = ({
   cancelButtonText?: string;
 }) => {
   const [error, setError] = useState<string | null>(null);
+
   useEffect(() => {
     const handleEnter = (e: KeyboardEvent) => {
       if (canConfirm && e.key === "Enter") {
         onConfirm();
       }
     };
-    // TODO: kinda iffy on this idea...
-    const modal = modalRef.current;
-    modal?.addEventListener("keypress", handleEnter);
-    return () => modal?.removeEventListener("keypress", handleEnter);
-  }, [canConfirm, onConfirm, modalRef]);
+    document.addEventListener("keypress", handleEnter);
+    return () => {
+      document.removeEventListener("keypress", handleEnter);
+    };
+  }, [canConfirm, onConfirm]);
 
   return (
     <Flex

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/ButtonBar.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/ButtonBar.tsx
@@ -4,6 +4,7 @@ import { t } from "ttag";
 import { Button, Flex, Text } from "metabase/ui";
 
 export const ButtonBar = ({
+  modalRef,
   onConfirm,
   onCancel,
   canConfirm,
@@ -11,6 +12,7 @@ export const ButtonBar = ({
   confirmButtonText,
   cancelButtonText,
 }: {
+  modalRef: React.RefObject<HTMLElement>;
   onConfirm: () => void;
   onCancel: () => void;
   canConfirm?: boolean;
@@ -25,11 +27,11 @@ export const ButtonBar = ({
         onConfirm();
       }
     };
-    document.addEventListener("keypress", handleEnter);
-    return () => {
-      document.removeEventListener("keypress", handleEnter);
-    };
-  }, [canConfirm, onConfirm]);
+    // TODO: kinda iffy on this idea...
+    const modal = modalRef.current;
+    modal?.addEventListener("keypress", handleEnter);
+    return () => modal?.removeEventListener("keypress", handleEnter);
+  }, [canConfirm, onConfirm, modalRef]);
 
   return (
     <Flex

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -417,7 +417,6 @@ export function EntityPickerModal<
               )}
               {!!hydratedOptions.hasConfirmButtons && onConfirm && (
                 <ButtonBar
-                  modalRef={modalRef}
                   onConfirm={onConfirm}
                   onCancel={onClose}
                   canConfirm={canSelectItem}

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -4,6 +4,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { useDebounce, usePreviousDistinct } from "react-use";
@@ -347,6 +348,8 @@ export function EntityPickerModal<
 
   const titleId = useUniqueId("entity-picker-modal-title-");
 
+  const modalRef = useRef<HTMLElement>(null);
+
   return (
     <Modal.Root
       opened={open}
@@ -369,6 +372,7 @@ export function EntityPickerModal<
         maw="57.5rem"
         mah="40rem"
         aria-labelledby={titleId}
+        ref={modalRef}
       >
         <Modal.Header
           px="2.5rem"
@@ -413,6 +417,7 @@ export function EntityPickerModal<
               )}
               {!!hydratedOptions.hasConfirmButtons && onConfirm && (
                 <ButtonBar
+                  modalRef={modalRef}
                   onConfirm={onConfirm}
                   onCancel={onClose}
                   canConfirm={canSelectItem}

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -4,7 +4,6 @@ import {
   useCallback,
   useEffect,
   useMemo,
-  useRef,
   useState,
 } from "react";
 import { useDebounce, usePreviousDistinct } from "react-use";
@@ -348,8 +347,6 @@ export function EntityPickerModal<
 
   const titleId = useUniqueId("entity-picker-modal-title-");
 
-  const modalRef = useRef<HTMLElement>(null);
-
   return (
     <Modal.Root
       opened={open}
@@ -372,7 +369,6 @@ export function EntityPickerModal<
         maw="57.5rem"
         mah="40rem"
         aria-labelledby={titleId}
-        ref={modalRef}
       >
         <Modal.Header
           px="2.5rem"

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
@@ -591,12 +591,12 @@ describe("AddToDashSelectDashModal", () => {
     });
   });
 
-  describe('"Create a new dashboard" option', () => {
+  describe('"New dashboard" option', () => {
     it('should render "New dashboard" option', async () => {
       await setup();
       expect(
         await screen.findByRole("button", {
-          name: /Create a new dashboard/,
+          name: /New dashboard/,
         }),
       ).toBeInTheDocument();
     });
@@ -610,7 +610,7 @@ describe("AddToDashSelectDashModal", () => {
 
       await userEvent.click(
         await screen.findByRole("button", {
-          name: /Create a new dashboard/,
+          name: /New dashboard/,
         }),
       );
       // opened CreateDashboardModal

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
@@ -592,7 +592,7 @@ describe("AddToDashSelectDashModal", () => {
   });
 
   describe('"Create a new dashboard" option', () => {
-    it('should render "Create a new dashboard" option', async () => {
+    it('should render "New dashboard" option', async () => {
       await setup();
       expect(
         await screen.findByRole("button", {

--- a/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.unit.spec.tsx
@@ -841,13 +841,13 @@ describe("SaveQuestionModal", () => {
         await userEvent.click(collDropdown());
         await waitFor(() => expect(newCollBtn()).toBeInTheDocument());
         await userEvent.click(newCollBtn());
-        await waitFor(async () =>
+        await waitFor(async () => {
           expect(
             await screen.findByRole("heading", {
-              name: "New collection",
+              name: "Create a new collection",
             }),
-          ).toBeInTheDocument(),
-        );
+          ).toBeInTheDocument();
+        });
       });
     });
   });

--- a/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.unit.spec.tsx
@@ -17,6 +17,7 @@ import {
   renderWithProviders,
   screen,
   waitFor,
+  within,
 } from "__support__/ui";
 import { SaveQuestionModal } from "metabase/containers/SaveQuestionModal";
 import { ROOT_COLLECTION } from "metabase/entities/collections";
@@ -732,8 +733,8 @@ describe("SaveQuestionModal", () => {
     });
   });
 
-  describe("new collection modal", () => {
-    const collDropdown = () =>
+  describe("create new modals", () => {
+    const saveLocDropdown = () =>
       screen.getByLabelText(/Where do you want to save this/);
     const newCollBtn = () =>
       screen.getByRole("button", {
@@ -742,6 +743,11 @@ describe("SaveQuestionModal", () => {
     const questionModalTitle = () =>
       screen.getByRole("heading", { name: /new question/i });
     const cancelBtn = () => screen.getByRole("button", { name: /cancel/i });
+
+    const newDashBtn = () =>
+      screen.getByRole("button", {
+        name: /new dashboard/i,
+      });
 
     const COLLECTION = {
       USER: BOBBY_TEST_COLLECTION,
@@ -796,57 +802,118 @@ describe("SaveQuestionModal", () => {
       jest.restoreAllMocks();
     });
 
-    it("should have a new collection button in the collection picker", async () => {
-      await setup(getQuestion());
-      await userEvent.click(collDropdown());
-      await waitFor(() => {
-        expect(newCollBtn()).toBeInTheDocument();
-      });
-    });
-
-    it("should open new collection modal and return to dashboard modal when clicking close", async () => {
-      await setup(getQuestion());
-      await userEvent.click(collDropdown());
-      await waitFor(() => expect(newCollBtn()).toBeInTheDocument());
-      await userEvent.click(newCollBtn());
-      await screen.findByText("Give it a name");
-      await userEvent.click(cancelBtn());
-      await userEvent.click(cancelBtn());
-      await waitFor(() => expect(questionModalTitle()).toBeInTheDocument());
-    });
-
-    describe("new collection location", () => {
-      beforeEach(async () => {
-        await setup(getQuestion(), null, {
-          collectionEndpoints: {
-            collections: Object.values(COLLECTION),
-            rootCollection: COLLECTION.ROOT,
-          },
+    describe("new collection modal", () => {
+      it("should have a new collection button in the collection picker", async () => {
+        await setup(getQuestion());
+        await userEvent.click(saveLocDropdown());
+        await waitFor(() => {
+          expect(newCollBtn()).toBeInTheDocument();
         });
       });
 
-      it("should create collection inside nested folder", async () => {
-        await userEvent.click(collDropdown());
+      it("should open new collection modal and return to dashboard modal when clicking close", async () => {
+        await setup(getQuestion());
+        await userEvent.click(saveLocDropdown());
         await waitFor(() => expect(newCollBtn()).toBeInTheDocument());
-        await userEvent.click(
-          await screen.findByRole("button", {
-            name: new RegExp(BOBBY_TEST_COLLECTION.name),
-          }),
-        );
         await userEvent.click(newCollBtn());
         await screen.findByText("Give it a name");
+        await userEvent.click(cancelBtn());
+        await userEvent.click(cancelBtn());
+        await waitFor(() => expect(questionModalTitle()).toBeInTheDocument());
       });
 
-      it("should create collection inside root folder", async () => {
-        await userEvent.click(collDropdown());
-        await waitFor(() => expect(newCollBtn()).toBeInTheDocument());
-        await userEvent.click(newCollBtn());
-        await waitFor(async () => {
-          expect(
-            await screen.findByRole("heading", {
-              name: "Create a new collection",
+      describe("new collection location", () => {
+        beforeEach(async () => {
+          await setup(getQuestion(), null, {
+            collectionEndpoints: {
+              collections: Object.values(COLLECTION),
+              rootCollection: COLLECTION.ROOT,
+            },
+          });
+        });
+
+        it("should create collection inside nested folder", async () => {
+          await userEvent.click(saveLocDropdown());
+          await waitFor(() => expect(newCollBtn()).toBeInTheDocument());
+          await userEvent.click(
+            await screen.findByRole("button", {
+              name: new RegExp(BOBBY_TEST_COLLECTION.name),
             }),
-          ).toBeInTheDocument();
+          );
+          await userEvent.click(newCollBtn());
+          await screen.findByText("Give it a name");
+        });
+
+        it("should create collection inside root folder", async () => {
+          await userEvent.click(saveLocDropdown());
+          await waitFor(() => expect(newCollBtn()).toBeInTheDocument());
+          await userEvent.click(newCollBtn());
+          await waitFor(async () => {
+            expect(
+              await screen.findByRole("heading", {
+                name: "Create a new collection",
+              }),
+            ).toBeInTheDocument();
+          });
+        });
+      });
+    });
+
+    describe("new dashboard modal", () => {
+      it("should have a new dashboard button in the collection picker", async () => {
+        await setup(getQuestion());
+        await userEvent.click(saveLocDropdown());
+        await waitFor(() => {
+          expect(newDashBtn()).toBeInTheDocument();
+        });
+      });
+
+      it("should open new dashboard modal and return to dashboard modal when clicking close", async () => {
+        await setup(getQuestion());
+        await userEvent.click(saveLocDropdown());
+        await waitFor(() => expect(newDashBtn()).toBeInTheDocument());
+        await userEvent.click(newDashBtn());
+        await screen.findByText("Give it a name");
+        await within(
+          await screen.findByTestId("create-dashboard-on-the-go"),
+        ).findByRole("button", { name: /cancel/i });
+        await userEvent.click(cancelBtn());
+        await waitFor(() => expect(questionModalTitle()).toBeInTheDocument());
+      });
+
+      describe("new dashboard location", () => {
+        beforeEach(async () => {
+          await setup(getQuestion(), null, {
+            collectionEndpoints: {
+              collections: Object.values(COLLECTION),
+              rootCollection: COLLECTION.ROOT,
+            },
+          });
+        });
+
+        it("should create dashboard inside nested folder", async () => {
+          await userEvent.click(saveLocDropdown());
+          await waitFor(() => expect(newDashBtn()).toBeInTheDocument());
+          await userEvent.click(
+            await screen.findByRole("button", {
+              name: new RegExp(BOBBY_TEST_COLLECTION.name),
+            }),
+          );
+          await userEvent.click(newDashBtn());
+          await screen.findByText("Give it a name");
+        });
+
+        it("should create dashboard inside root folder", async () => {
+          await userEvent.click(saveLocDropdown());
+          await waitFor(() => expect(newDashBtn()).toBeInTheDocument());
+          await userEvent.click(newDashBtn());
+          await waitFor(async () => {
+            expect(
+              await screen.findByRole("heading", {
+                name: "Create a new dashboard",
+              }),
+            ).toBeInTheDocument();
+          });
         });
       });
     });

--- a/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.unit.spec.tsx
@@ -844,7 +844,7 @@ describe("SaveQuestionModal", () => {
         await waitFor(async () =>
           expect(
             await screen.findByRole("heading", {
-              name: "Create a new collection",
+              name: "New collection",
             }),
           ).toBeInTheDocument(),
         );


### PR DESCRIPTION
Part of #50176

### Description

This PR adds the option to create a dashboard from the Collection Picker when picking a save location for questions. Additionally, this PR updates the create dashboard button for the Dashboard Picker for consistency.

### How to verify

Positive test:
- Create a new question, try saving it
- Chose where to save it from the Save Question modal
- Navigate to the `Browse` tab
- See new 'New dashboard' button in the bottom left of the modal in addition to the updated 'New collection' button

Negative test:
- Create a new model, going through the same flow as above
- Navigate to the `Collections` tab
- See that only the 'New collection' button exists

### Demo

Question:
![CleanShot 2025-01-03 at 12 20 03@2x](https://github.com/user-attachments/assets/4d7a2398-14f0-412d-8bd9-a3199f9e3624)

Model:
![CleanShot 2025-01-03 at 12 19 08@2x](https://github.com/user-attachments/assets/7e79a6a5-1dac-49c1-935b-af9cb6a43584)

Updated dashboard picker to collection picker:
![CleanShot 2025-01-03 at 12 23 02@2x](https://github.com/user-attachments/assets/46ac4776-af20-447b-8ac9-69b24fd07b79)

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
