### PR TITLE
docs - separate google sign-in and ldap docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -157,7 +157,8 @@ Metabase's reference documentation.
 - [Managing people and groups](./people-and-groups/managing.md)
 - [Password complexity](./people-and-groups/changing-password-complexity.md)
 - [Session expiration](./people-and-groups/changing-session-expiration.md)
-- [Google Sign-In or LDAP](./people-and-groups/google-and-ldap.md)
+- [Google Sign-In](./people-and-groups/google-sign-in.md)
+- [LDAP](./people-and-groups/ldap.md)
 - [API keys](./people-and-groups/api-keys.md)
 
 #### Paid SSO options

--- a/docs/databases/connections/databricks.md
+++ b/docs/databases/connections/databricks.md
@@ -73,7 +73,7 @@ See [Compute settings for the Databricks JDBC Driver](https://docs.databricks.co
 
 ## Re-run queries for simple explorations
 
-Turn this option **OFF** if people want to click **Run** (the play button) before applying any [Summarize](../../questions/query-builder/introduction.md#grouping-your-metrics) or filter selections.
+Turn this option **OFF** if people want to click **Run** (the play button) before applying any [summarize](../../questions/query-builder/summarizing-and-grouping.md) or [filter](../../questions/query-builder/filters.md) selections.
 
 By default, Metabase will execute a query as soon as you choose an grouping option from the **Summarize** menu or a filter condition from the [drill-through menu](https://www.metabase.com/learn/metabase-basics/querying-and-dashboards/questions/drill-through). If your database is slow, you may want to disable re-running to avoid loading data on each click.
 

--- a/docs/paid-features/overview.md
+++ b/docs/paid-features/overview.md
@@ -22,7 +22,9 @@ Pro and Enterprise plans include more ways to authenticate people and manage gro
   - [Setting up SAML with Keycloak](../people-and-groups/saml-keycloak.md)
   - [Setting up SAML with Okta](../people-and-groups/saml-okta.md)
 - [Authenticating with JWT](../people-and-groups/authenticating-with-jwt.md)
-- [Multiple domains with Google Sign-in](../people-and-groups/google-and-ldap.md#multiple-domains-for-google-sign-in)
+- [Multiple domains with Google Sign-in](../people-and-groups/google-sign-in.md#multiple-domains-for-google-sign-in)
+- [LDAP group membership filter](../people-and-groups/ldap.md#ldap-group-membership-filter)
+- [LDAP sync user attributes](../people-and-groups/ldap.md#syncing-user-attributes-with-ldap)
 - [User provisioning with SCIM](../people-and-groups/user-provisioning.md)
 
 ## Permissions

--- a/docs/people-and-groups/changing-password-complexity.md
+++ b/docs/people-and-groups/changing-password-complexity.md
@@ -1,10 +1,14 @@
 ---
-title: Password complexity
+title: Passwords
 redirect_from:
   - /docs/latest/operations-guide/changing-password-complexity
 ---
 
-# Password complexity
+# Passwords
+
+Metabase can allow authentication via email and password.
+
+## Password complexity
 
 Metabase offers a couple controls for administrators who prefer to increase the password requirements on their user accounts.
 
@@ -19,3 +23,9 @@ The settings above can be used independently, so it's fine to use only one or th
 
 By default, Metabase also prevents users from setting passwords that are in a list of common passwords (like `qwerty123` and
 `passw0rd`). Changing the complexity requirement to `weak` disables this behavior.
+
+## Disabling password logins
+
+{% include plans-blockquote.html feature="Disabling password logins" %}
+
+On Pro and Enterprise plans, you can require people to log in with SSO by disabling password authentication from **Admin settings** > **Authentication**.

--- a/docs/people-and-groups/google-sign-in.md
+++ b/docs/people-and-groups/google-sign-in.md
@@ -2,6 +2,7 @@
 title: Google Sign-In
 redirect_from:
   - /docs/latest/administration-guide/10-single-sign-on
+  - /docs/latest/people-and-groups/google-and-ldap
 ---
 
 # Google Sign-In

--- a/docs/people-and-groups/google-sign-in.md
+++ b/docs/people-and-groups/google-sign-in.md
@@ -6,7 +6,7 @@ redirect_from:
 
 # Google Sign-In
 
-Enabling [Google Sign-In](https://developers.google.com/identity/sign-in/web/sign-in) or [LDAP](https://www.metabase.com/glossary/ldap) for single sign-on (SSO) lets your team log in with a click instead of using email and password. SSO can also be used to let people create Metabase accounts without asking an admin to add each person manually. You can find SSO options under **Settings** > **Admin settings** > **Authentication**.
+Enabling [Google Sign-In](https://developers.google.com/identity/sign-in/web/sign-in) for single sign-on (SSO) lets your team log in with a click instead of using email and password. SSO can also be used to let people create Metabase accounts without asking an admin to add each person manually. You can find SSO options under **Settings** > **Admin settings** > **Authentication**.
 
 If you'd like to have people authenticate with [SAML][saml-docs] or [JWT][jwt-docs], Metabase's [Pro and Enterprise](https://www.metabase.com/pricing) let you do just that.
 

--- a/docs/people-and-groups/google-sign-in.md
+++ b/docs/people-and-groups/google-sign-in.md
@@ -1,0 +1,65 @@
+---
+title: Google Sign-In
+redirect_from:
+  - /docs/latest/administration-guide/10-single-sign-on
+---
+
+# Google Sign-In
+
+Enabling [Google Sign-In](https://developers.google.com/identity/sign-in/web/sign-in) or [LDAP](https://www.metabase.com/glossary/ldap) for single sign-on (SSO) lets your team log in with a click instead of using email and password. SSO can also be used to let people create Metabase accounts without asking an admin to add each person manually. You can find SSO options under **Settings** > **Admin settings** > **Authentication**.
+
+If you'd like to have people authenticate with [SAML][saml-docs] or [JWT][jwt-docs], Metabase's [Pro and Enterprise](https://www.metabase.com/pricing) let you do just that.
+
+## Enabling Google Sign-In
+
+Google Sign-In is a good option for SSO if:
+
+- Your team is already using Google Workspace, or
+- You'd like to use Google's 2-step or multi-factor authentication (2FA or MFA) to secure your Metabase.
+
+## Get your Client ID from the Google developer console
+
+To let your team start signing in with Google, you’ll first need to create an application through Google’s [developer console](https://console.developers.google.com/projectselector2/apis/library).
+
+Next, you'll have to create authorization credentials and [get a Google API Client ID](https://developers.google.com/identity/gsi/web/guides/get-google-api-clientid):
+
+- In the `Authorized JavaScript origins` section, specify the URI of your Metabase instance.
+- Leave the `Authorized Redirect URIs` section blank.
+- Copy your Client ID, which you'll paste into Metabase when setting up Google Sign-in.
+
+## Setting up Google Sign-in in Metabase
+
+Once you have your Google API `Client ID` (ending in `.apps.googleusercontent.com`), visit your Metabase and:
+
+1. Click on the settings **Gear** icon in the upper right.
+2. Select **Admin settings**.
+3. In the **Settings** tab, click on **Authentication**.
+4. On the **Sign in with Google** card, click **Set up**.
+5. In the **Client ID** field, paste your Google API Client ID.
+
+## Creating Metabase accounts with Google Sign-in
+
+> On [paid plans](https://www.metabase.com/pricing), you're [charged for each active account](https://www.metabase.com/docs/latest/cloud/how-billing-works#what-counts-as-a-user-account).
+
+If people's Google account email addresses are from a specific domain, and you want to allow them to sign up on their own, you can enter that domain in the **Domain** field.
+
+Once set up, existing Metabase users signed in to a Google account that matches the email they used to set up their Metabase account will be able to sign in with just a click.
+
+Note that Metabase accounts _created_ with Google Sign-In will not have passwords; they must use Google to sign in to Metabase.
+
+## Multiple domains for Google Sign-in
+
+{% include plans-blockquote.html feature="Multiple domains for Google Sign-in" %}
+
+If you're on a [pro](https://www.metabase.com/product/pro) or [Enterprise](https://www.metabase.com/product/enterprise) plan, you can specify multiple domains in the **Domain** field, separated by a comma. For example, `mycompany.com,example.com.br,otherdomain.co.uk`.
+
+## Syncing user attributes with Google
+
+User attributes can't be synced with regular Google Sign-In. To synchronize user attributes, you'll need to set up [Google SAML][google-saml-docs] or [JWT][jwt-docs] instead.
+
+[data-sandboxing-docs]: ../permissions/data-sandboxes.md
+[google-saml-docs]: ./saml-google.md
+[jwt-docs]: ./authenticating-with-jwt.md
+[saml-docs]: ./authenticating-with-saml.md
+[user-attributes-docs]: ../permissions/data-sandboxes.md#choosing-user-attributes-for-data-sandboxes
+[user-attributes-def]: https://www.metabase.com/glossary/attribute#user-attributes-in-metabase

--- a/docs/people-and-groups/ldap.md
+++ b/docs/people-and-groups/ldap.md
@@ -6,6 +6,8 @@ title: LDAP
 
 Metabase supports authentication with Lightweight Directory Access Protocol (LDAP).
 
+You can find SSO options under **Admin settings** > **Settings** > **Authentication**.
+
 ## Required LDAP attributes
 
 You need to set up your LDAP directory with these attributes:
@@ -22,23 +24,33 @@ Your LDAP directory must have the email field populated for each entry that will
 
 ## Enabling LDAP authentication
 
-In the **Admin** > **Authentication** tab, go to the LDAP section and click **Configure**. Click the toggle at the top of the form to enable LDAP, then fill out the form with the following information about your LDAP server:
+In the **Admin settings** > **Settings** > **Authentication** tab, go to the LDAP section and click **Set up**. Click the toggle at the top of the form to enable LDAP, then fill out the form with the relevant details.
 
-- hostname
-- port
-- security settings
-- LDAP admin username
-- LDAP admin password
+## User provisioning
+
+When a person logs in via LDAP, Metabase can create a Metabase account for them automatically (if they don't already have a Metabase account).
+
+## Server settings
+
+- LDAP Host. Your server name. E.g., ldap.yourdomain.org
+- LDAP Port. The Server port, usually 389 or 636 if SSL is used.
+- LDAP Security settings. Options are None, SSL, or StarTLS.
+- LDAP admin username. The distinguished name to bind as (if any). This user will be used to look up information about other users.
+- LDAP admin password.
 
 Then save your changes. Metabase will automatically pull the [required attributes](#required-ldap-attributes) from your LDAP directory.
 
-## LDAP user schema
+## User schema
 
 The **User Schema** section on this same page is where you can adjust settings related to where and how Metabase connects to your LDAP server to authenticate users.
+
+### User search base
 
 The **User search base** field should be completed with the _distinguished name_ (DN) of the entry in your LDAP server that is the starting point when searching for users.
 
 For example, let's say you're configuring LDAP for your company, WidgetCo, where your base DN is `dc=widgetco,dc=com`. If entries for employees are all stored within an organizational unit in your LDAP server named `People`, you'll want to supply the user search base field with the DN `ou=People,dc=widgetco,dc=com`. This tells Metabase to begin searching for matching entries at that location within the LDAP server.
+
+### User filter
 
 You'll see the following grayed-out default value in the **User filter** field:
 

--- a/docs/people-and-groups/ldap.md
+++ b/docs/people-and-groups/ldap.md
@@ -1,61 +1,14 @@
 ---
-title: Google Sign-In or LDAP
-redirect_from:
-  - /docs/latest/administration-guide/10-single-sign-on
+title: LDAP
 ---
 
-# Google Sign-In or LDAP
+# LDAP
 
-Enabling [Google Sign-In](https://developers.google.com/identity/sign-in/web/sign-in) or [LDAP](https://www.metabase.com/glossary/ldap) for single sign-on (SSO) lets your team log in with a click instead of using email and password. SSO can also be used to let people create Metabase accounts without asking an admin to add each person manually. You can find SSO options under **Settings** > **Admin settings** > **Authentication**.
-
-If you'd like to have people authenticate with [SAML][saml-docs] or [JWT][jwt-docs], Metabase's [Pro and Enterprise](https://www.metabase.com/pricing) let you do just that. As time goes on we may add other auth providers. If you have a service you’d like to see work with Metabase, please let us know by [filing an issue](http://github.com/metabase/metabase/issues/new).
-
-## Enabling Google Sign-In
-
-Google Sign-In is a good option for SSO if:
-
-- Your team is already using Google Workspace, or
-- You'd like to use Google's 2-step or multi-factor authentication (2FA or MFA) to secure your Metabase.
-
-## Get your Client ID from the Google developer console
-
-To let your team start signing in with Google, you’ll first need to create an application through Google’s [developer console](https://console.developers.google.com/projectselector2/apis/library).
-
-Next, you'll have to create authorization credentials and [get a Google API Client ID](https://developers.google.com/identity/gsi/web/guides/get-google-api-clientid):
-
-- In the `Authorized JavaScript origins` section, specify the URI of your Metabase instance.
-- Leave the `Authorized Redirect URIs` section blank.
-- Copy your Client ID, which you'll paste into Metabase when setting up Google Sign-in.
-
-## Setting up Google Sign-in in Metabase
-
-Once you have your Google API `Client ID` (ending in `.apps.googleusercontent.com`), visit your Metabase and:
-
-1. Click on the settings **Gear** icon in the upper right.
-2. Select **Admin settings**.
-3. In the **Settings** tab, click on **Authentication**.
-4. On the **Sign in with Google** card, click **Set up**.
-5. In the **Client ID** field, paste your Google API Client ID.
-
-### Creating Metabase accounts with Google Sign-in
-
-> On [paid plans](https://www.metabase.com/pricing), you're [charged for each active account](https://www.metabase.com/docs/latest/cloud/how-billing-works#what-counts-as-a-user-account).
-
-If people's Google account email addresses are from a specific domain, and you want to allow them to sign up on their own, you can enter that domain in the **Domain** field.
-
-Once set up, existing Metabase users signed in to a Google account that matches the email they used to set up their Metabase account will be able to sign in with just a click.
-
-Note that Metabase accounts _created_ with Google Sign-In will not have passwords; they must use Google to sign in to Metabase.
-
-### Multiple domains for Google Sign-in
-
-{% include plans-blockquote.html feature="Multiple domains for Google Sign-in" %}
-
-If you're on a [pro](https://www.metabase.com/product/pro) or [Enterprise](https://www.metabase.com/product/enterprise) plan, you can specify multiple domains in the **Domain** field, separated by a comma. For example, `mycompany.com,example.com.br,otherdomain.co.uk`.
+Metabase supports authentication with Lightweight Directory Access Protocol (LDAP).
 
 ## Required LDAP attributes
 
-Make sure to set up your LDAP directory with these attributes:
+You need to set up your LDAP directory with these attributes:
 
 - email (defaulting to the `mail` attribute)
 - first name (defaulting to the `givenName` attribute)
@@ -79,7 +32,7 @@ In the **Admin** > **Authentication** tab, go to the LDAP section and click **Co
 
 Then save your changes. Metabase will automatically pull the [required attributes](#required-ldap-attributes) from your LDAP directory.
 
-### LDAP user schema
+## LDAP user schema
 
 The **User Schema** section on this same page is where you can adjust settings related to where and how Metabase connects to your LDAP server to authenticate users.
 
@@ -97,7 +50,7 @@ When a person logs into Metabase, this command confirms that the login they supp
 
 This default command will work for most LDAP servers, since `inetOrgPerson` is a widely-adopted objectClass. But if your company for example uses a different objectClass to categorize employees, this field is where you can set a different command for how Metabase finds and authenticates an LDAP entry upon a person logging in.
 
-### LDAP group mapping
+## LDAP group mapping
 
 Manually assigning people to [groups](./managing.md#groups) in Metabase after they've logged in via SSO can get tedious. Instead, you can take advantage of the groups that already exist in your LDAP directory by enabling [group mappings](https://www.metabase.com/learn/metabase-basics/administration/permissions/ldap-auth-access-control#group-management).
 
@@ -107,35 +60,23 @@ As you can see below, if you have an **Accounting** group in both your LDAP serv
 
 ![Group Mapping](images/ldap-group-mapping.png)
 
-#### Notes on group mapping
+Some things to keep in mind regarding group mapping:
 
 - The Administrator group works like any other group.
-- Updates to a person's group membership based on LDAP mappings are not instantaneous; the changes will take effect only after people log back in.
+- Updates to a person's group membership based on LDAP mappings are not instantaneous; the changes will take effect only _after_ people log back in.
 - People are only ever added to or removed from mapped groups; the sync has no effect on groups in your Metabase that don't have an LDAP mapping.
 
-### LDAP group membership filter
+## LDAP group membership filter
 
 {% include plans-blockquote.html feature="LDAP advanced features" %}
 
 Group membership lookup filter. The placeholders {dn} and {uid} will be replaced by the user's Distinguished Name and UID, respectively.
 
-## Syncing user attributes at login
+## Syncing user attributes with LDAP
 
-{% include plans-blockquote.html feature="Advanced authentication features" %}
-
-### Syncing user attributes with LDAP
+{% include plans-blockquote.html feature="LDAP advanced features" %}
 
 You can manage [user attributes][user-attributes-def] such as names, emails, and roles from your LDAP directory. When you set up [data sandboxing][data-sandboxing-docs], your LDAP directory will be able to [pass these attributes][user-attributes-docs] to Metabase.
-
-### Syncing user attributes with Google
-
-User attributes can't be synced with regular Google Sign-In. You'll need to set up [Google SAML][google-saml-docs] or [JWT][jwt-docs] instead.
-
-## Disabling password logins
-
-{% include plans-blockquote.html feature="Disabling password logins" %}
-
-On Pro and Enterprise plans, you can require people to log in with SSO by disabling password authentication from **Admin settings** > **Authentication**.
 
 ## Troubleshooting login issues
 

--- a/docs/people-and-groups/managing.md
+++ b/docs/people-and-groups/managing.md
@@ -1,12 +1,16 @@
 ---
-title: Managing people and groups
+title: People and groups
 redirect_from:
   - /docs/latest/administration-guide/04-managing-users
 ---
 
-# Managing people and groups
+# People and groups
 
-To start managing people:
+People can have [accounts](#creating-an-account) in Metabase, and those accounts can be members of [groups](#groups). These groups are used to define [permissions](../permissions/introduction.md). People can be in multiple groups.
+
+## Managing people and groups
+
+To start managing people and groups:
 
 Hit Cmd/Ctrl + K to bring up the command palette and search for "People". Click on the **People** settings result.
 
@@ -18,11 +22,13 @@ Click on the **gear** icon > **Admin settings** > **People**. You'll see a list 
 
 ## Creating an account
 
-To add a new person, click **Invite someone** in the upper right corner. You’ll be prompted to enter their email, and optionally their first and last names–only the email is required.
+Admins can add people to their Metabase. To add a new person manually, click on the gear icon and select **Admin settings**. Under the **People** tab, click **Invite someone** in the upper right corner. You’ll be prompted to enter their email, and optionally their first and last names–only the email is required.
 
 Click **Create** to activate an account. An account becomes active once you click **Create**, even if the person never signs into the account. The account remains active until you [deactivate the account](#deactivating-an-account). If you're on a Pro or Enterprise Metabase plan, all active accounts will count toward your user account total. If one person has more than one account, each account will count toward the total (see [how billing works](https://www.metabase.com/pricing/how-billing-works)).
 
 If you’ve already [configured Metabase to use email](../configuring-metabase/email.md), Metabase will send the person an email inviting them to log into Metabase. If you haven't yet setup email for your Metabase, Metabase will give you a temporary password that you’ll have to manually send to the person.
+
+To create accounts with SSO, check out [authentication options](./start.md#authentication).
 
 ## Editing an account
 
@@ -168,7 +174,7 @@ To make someone an admin of Metabase, you just need to add them to the Administr
 
 #### All users
 
-The **All Users** group is another special one. Every Metabase user is always a member of this group, though they can also be a member of as many other groups as you want. We recommend using the All Users group as a way to set default access levels for new Metabase users. If you have [Google single sign-on](./google-and-ldap.md) enabled, new users who join that way will be automatically added to the All Users group.
+The **All Users** group is another special one. Every Metabase user is always a member of this group, though they can also be a member of as many other groups as you want. We recommend using the All Users group as a way to set default access levels for new Metabase users. If you have [Google single sign-on](./google-sign-in.md) enabled, new users who join that way will be automatically added to the All Users group.
 
 It's important that your All Users group should never have _greater_ access for an item than a group for which you're trying to restrict access — otherwise the more permissive setting will win out. See [Setting permissions](../permissions/start.md).
 

--- a/docs/people-and-groups/managing.md
+++ b/docs/people-and-groups/managing.md
@@ -8,6 +8,8 @@ redirect_from:
 
 People can have [accounts](#creating-an-account) in Metabase, and those accounts can be members of [groups](#groups). These groups are used to define [permissions](../permissions/introduction.md). People can be in multiple groups.
 
+> This page covers accounts people use to log in to _your_ Metabase(s). These accounts are distinct from [Metabase _store_ accounts](https://store.metabase.com), which are used to manage paid Metabase plans.
+
 ## Managing people and groups
 
 To start managing people and groups:

--- a/docs/people-and-groups/start.md
+++ b/docs/people-and-groups/start.md
@@ -26,14 +26,14 @@ Tell Metabase how long it should wait before asking people to log in again.
 
 ## Authentication
 
-Metabase offers several options for single sign-on (SSO) authentication.
+Metabase offers several options for authentication.
 
 > If you need to set up 2-step or multi-factor authentication (2FA or MFA) for your Metabase, consider using one of the SSO options below.
 
 ### SSO for Metabase Open Source and Starter plans
 
-- [Google Sign-in][google-sign-in]
-- [LDAP][ldap]
+- [Google Sign-in](./google-sign-in.md)
+- [LDAP](./ldap.md)
 
 ### SSO for Metabase Pro and Enterprise plans
 
@@ -41,8 +41,8 @@ With [Pro and Enterprise plans](https://www.metabase.com/pricing/), you have mor
 
 - [JWT][jwt]
 - LDAP advanced features
-  - [Group membership filter][ldap-group-membership-filter]
-  - [Syncing user attributes][ldap-user-attributes]
+  - [Group membership filter](./ldap.md#ldap-group-membership-filter)
+  - [Syncing user attributes](./ldap.md#syncing-user-attributes-with-ldap)
 - [SAML][saml]
   - [Auth0][saml-auth0]
   - [Microsoft Entra ID][azure-ad]
@@ -53,6 +53,14 @@ With [Pro and Enterprise plans](https://www.metabase.com/pricing/), you have mor
 ## [API keys](./api-keys.md)
 
 Create keys to authenticate API calls.
+
+## [User provisioning](./user-provisioning.md)
+
+Metabase supports user provisioning via the SCIM protocol.
+
+## [Accessibility](./accessibility.md)
+
+Notes on Metabase's accessibility.
 
 [azure-ad]: ./saml-azure.md
 [google-sign-in]: ./google-and-ldap.md#enabling-google-sign-in
@@ -67,10 +75,3 @@ Create keys to authenticate API calls.
 [saml-keycloak]: ./saml-keycloak.md
 [sso-def]: https://www.metabase.com/glossary/sso
 
-## [User provisioning](./user-provisioning.md)
-
-Metabase supports user provisioning via the SCIM protocol.
-
-## [Accessibility](./accessibility.md)
-
-Notes on Metabase's accessibility.

--- a/docs/questions/alerts.md
+++ b/docs/questions/alerts.md
@@ -104,7 +104,7 @@ You'll be able to edit alerts that you set up. Admins get additional special pri
 
 - Admins can edit and delete any alert. This can't be undone, so be careful!
 - Admins can add or remove recipients on any alert, even ones that they did not create themselves.
-- Admins can remove all alerts created by a Metabase user and unsubscribe that user from all other alerts from the [People menu in Admin settings](../people-and-groups/managing#unsubscribe-from-all-subscriptions--alerts).
+- Admins can remove all alerts created by a Metabase user and unsubscribe that user from all other alerts from the [People menu in Admin settings](../people-and-groups/managing.md#unsubscribe-from-all-subscriptions--alerts).
 
 ## Avoid changing the name of the alerted channel in Slack
 


### PR DESCRIPTION
Breaks up the Google Sign-in and LDAP docs into separate pages. Added some additional edits as well.