### PR TITLE
New deactivated_at field on users

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10450,6 +10450,25 @@ databaseChangeLog:
             columnDataType: ${boolean.type}
             defaultNullValue: false
 
+  - changeSet:
+      id: v53.2025-01-03T19:07:39
+      author: noahmoss
+      comments: Add `deactivated_at` column to the `core_user` table
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: core_user
+                columnName: deactivated_at
+      changes:
+        - addColumn:
+            tableName: core_user
+            columns:
+              - column:
+                  name: deactivated_at
+                  type: ${timestamp_type}
+                  remarks: The timestamp at which a user was deactivated
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10453,7 +10453,7 @@ databaseChangeLog:
   - changeSet:
       id: v53.2025-01-03T19:07:39
       author: noahmoss
-      comments: Add `deactivated_at` column to the `core_user` table
+      comment: Add `deactivated_at` column to the `core_user` table
       preConditions:
         - onFail: MARK_RAN
         - not:

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -170,10 +170,13 @@
       (t2/delete! 'PulseChannelRecipient :user_id id))
     ;; If we're setting the reset_token then encrypt it before it goes into the DB
     (cond-> user
-      true        (merge (hashed-password-values (t2/changes user)))
-      reset-token (update :reset_token u.password/hash-bcrypt)
-      locale      (update :locale i18n/normalized-locale-string)
-      email       (update :email u/lower-case-en))))
+      true             (merge (hashed-password-values (t2/changes user)))
+      reset-token      (update :reset_token u.password/hash-bcrypt)
+      locale           (update :locale i18n/normalized-locale-string)
+      email            (update :email u/lower-case-en)
+      ;; Set or clear deactivated_at if the :is_active key changes. Not used directly in product.
+      active?          (assoc :deactivated_at nil)
+      (false? active?) (assoc :deactivated_at :%now))))
 
 (defn add-common-name
   "Conditionally add a `:common_name` key to `user` by combining their first and last names, or using their email if names are `nil`.

--- a/test/metabase/models/user_test.clj
+++ b/test/metabase/models/user_test.clj
@@ -588,3 +588,16 @@
                                           :sso_source "jwt"}
                                          default-invitor
                                          false))))))
+
+(deftest deactivated-at-test
+  (testing "deactivated_at is set when a user is deactivated and unset when reactivated (#51728)"
+    (mt/with-temp [:model/User {user-id :id :as user} {}]
+      (is (nil? (:deactivated_at user)))
+
+      (t2/update! :model/User user-id {:is_active false})
+      (let [deactivated-at (t2/select-one-fn :deactivated_at :model/User user-id)]
+        (is (instance? java.time.OffsetDateTime deactivated-at)))
+
+      (t2/update! :model/User user-id {:is_active true})
+      (let [deactivated-at (t2/select-one-fn :deactivated_at :model/User user-id)]
+        (is (nil? deactivated-at))))))


### PR DESCRIPTION
Adds a `deactivated_at` column on users, and updates/clears it accordingly when users are deactivated or reactivated.

Closes https://github.com/metabase/metabase/issues/51728