### PR TITLE
perf: Optimize metabase.formatter/strip-trailing-zeroes

### DIFF
--- a/src/metabase/formatter.clj
+++ b/src/metabase/formatter.clj
@@ -20,7 +20,8 @@
    [potemkin.types :as p.types])
   (:import
    (java.math RoundingMode)
-   (java.text DecimalFormat DecimalFormatSymbols)))
+   (java.text DecimalFormat DecimalFormatSymbols)
+   (java.util.regex Pattern)))
 
 (set! *warn-on-reflection* true)
 
@@ -41,14 +42,14 @@
 
 (defn- strip-trailing-zeroes
   [num-as-string decimal]
-  (if (str/includes? num-as-string (str decimal))
-    (let [pattern (re-pattern (str/escape (str decimal \$) {\. "\\."}))]
-      (-> num-as-string
-          (str/split #"0+$")
-          first
-          (str/split pattern)
-          first))
-    num-as-string))
+  (let [decimal (str decimal)]
+    (if (str/includes? num-as-string decimal)
+      (let [pattern (case decimal
+                      "." #"\.?0+$"
+                      "," #",?0+$"
+                      (re-pattern (str (Pattern/quote decimal) "?0+$")))]
+        (str/replace num-as-string pattern ""))
+      num-as-string)))
 
 (defn- digits-after-decimal
   ([value] (digits-after-decimal value "."))


### PR DESCRIPTION
This function is invoked quite a lot when generating reports (and, I think, when displaying the values too). I've noticed it taking a noticeable amount of time when running export tests.

The optimization makes sure that we use precompiled regexes when dealing with common decimal separators (`.`, `,`) and only revert to runtime-compile the regex otherwise. I also use a single str/replace instead of doing splits twice (those allocate plenty of extra garbage).