### PR TITLE
Update setting table name reference to :model/setting

### DIFF
--- a/src/metabase/models/setting/cache.clj
+++ b/src/metabase/models/setting/cache.clj
@@ -82,14 +82,14 @@
         ;; and ignore that Exception if one is thrown.
         (try
           ;; Use `simple-insert!` because we do *not* want to trigger pre-insert behavior, such as encrypting `:value`
-          (t2/insert! (t2/table-name (t2/resolve-model :model/setting)) :key settings-last-updated-key, :value current-timestamp-as-string-honeysql)
+          (t2/insert! (t2/table-name (t2/resolve-model :model/Setting)) :key settings-last-updated-key, :value current-timestamp-as-string-honeysql)
           (catch java.sql.SQLException e
             ;; go ahead and log the Exception anyway on the off chance that it *wasn't* just a race condition issue
             (log/errorf "Error updating Settings last updated value: %s"
                         (with-out-str (jdbc/print-sql-exception-chain e)))))))
   ;; Now that we updated the value in the DB, go ahead and update our cached value as well, because we know about the
   ;; changes
-  (swap! (cache*) assoc settings-last-updated-key (t2/select-one-fn :value :model/setting :key settings-last-updated-key)))
+  (swap! (cache*) assoc settings-last-updated-key (t2/select-one-fn :value :model/Setting :key settings-last-updated-key)))
 
 (defn- cache-out-of-date?
   "Check whether our Settings cache is out of date. We know the cache is out of date if either of the following
@@ -110,7 +110,7 @@
       (when-let [last-known-update (core/get current-cache settings-last-updated-key)]
           ;; compare it to the value in the DB. This is done be seeing whether a row exists
           ;; WHERE value > <local-value>
-        (u/prog1 (t2/select-one-fn :value :model/setting
+        (u/prog1 (t2/select-one-fn :value :model/Setting
                                    {:where [:and
                                             [:= :key settings-last-updated-key]
                                             [:> :value last-known-update]]})
@@ -135,7 +135,7 @@
   "Populate cache with the latest hotness from the db"
   []
   (log/debug "Refreshing Settings cache...")
-  (reset! (cache*) (t2/select-fn->fn :key :value :model/setting)))
+  (reset! (cache*) (t2/select-fn->fn :key :value :model/Setting)))
 
 (defonce ^:private ^ReentrantLock restore-cache-lock (ReentrantLock.))
 

--- a/src/metabase/models/setting/cache.clj
+++ b/src/metabase/models/setting/cache.clj
@@ -82,14 +82,14 @@
         ;; and ignore that Exception if one is thrown.
         (try
           ;; Use `simple-insert!` because we do *not* want to trigger pre-insert behavior, such as encrypting `:value`
-          (t2/insert! (t2/table-name (t2/resolve-model 'Setting)) :key settings-last-updated-key, :value current-timestamp-as-string-honeysql)
+          (t2/insert! (t2/table-name (t2/resolve-model :model/setting)) :key settings-last-updated-key, :value current-timestamp-as-string-honeysql)
           (catch java.sql.SQLException e
             ;; go ahead and log the Exception anyway on the off chance that it *wasn't* just a race condition issue
             (log/errorf "Error updating Settings last updated value: %s"
                         (with-out-str (jdbc/print-sql-exception-chain e)))))))
   ;; Now that we updated the value in the DB, go ahead and update our cached value as well, because we know about the
   ;; changes
-  (swap! (cache*) assoc settings-last-updated-key (t2/select-one-fn :value 'Setting :key settings-last-updated-key)))
+  (swap! (cache*) assoc settings-last-updated-key (t2/select-one-fn :value :model/setting :key settings-last-updated-key)))
 
 (defn- cache-out-of-date?
   "Check whether our Settings cache is out of date. We know the cache is out of date if either of the following
@@ -110,7 +110,7 @@
       (when-let [last-known-update (core/get current-cache settings-last-updated-key)]
           ;; compare it to the value in the DB. This is done be seeing whether a row exists
           ;; WHERE value > <local-value>
-        (u/prog1 (t2/select-one-fn :value 'Setting
+        (u/prog1 (t2/select-one-fn :value :model/setting
                                    {:where [:and
                                             [:= :key settings-last-updated-key]
                                             [:> :value last-known-update]]})
@@ -135,7 +135,7 @@
   "Populate cache with the latest hotness from the db"
   []
   (log/debug "Refreshing Settings cache...")
-  (reset! (cache*) (t2/select-fn->fn :key :value 'Setting)))
+  (reset! (cache*) (t2/select-fn->fn :key :value :model/setting)))
 
 (defonce ^:private ^ReentrantLock restore-cache-lock (ReentrantLock.))
 


### PR DESCRIPTION
### Description

Recent changes in master broke the `rotate-encryption-key` command by having it look for "Settings" as a table name, rather than the correctly-cased "settings" or "SETTINGS".

This updates the table references to be a version better handled by tucan. 

### How to verify

Run the `rotate-encryption-key` CLI command. Prior to the change, it failed with a SQL error

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR