### PR TITLE
Change label from "Filter by this date" to "Filter by this date and time" for quick filter drills for datetime columns

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -1282,7 +1282,7 @@ H.describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
       H.popover().should("contain.text", "Filter by this value");
 
       getTableCell(COLUMN_INDEX.CREATED_AT).click();
-      H.popover().should("contain.text", "Filter by this date");
+      H.popover().should("contain.text", "Filter by this date and time");
 
       H.editDashboard();
 

--- a/e2e/test/scenarios/question/native-query-drill.cy.spec.ts
+++ b/e2e/test/scenarios/question/native-query-drill.cy.spec.ts
@@ -95,7 +95,7 @@ describe("scenarios > question > native query drill", () => {
 
       H.tableInteractive().findByText("October 7, 2023, 1:34 AM").click();
       H.popover().within(() => {
-        cy.findByText("Filter by this date").should("not.exist");
+        cy.findByText("Filter by this date and time").should("not.exist");
         cy.button("Save").click();
       });
       H.modal().within(() => {
@@ -107,7 +107,7 @@ describe("scenarios > question > native query drill", () => {
 
       H.tableInteractive().findByText("October 7, 2023, 1:34 AM").click();
       H.popover().within(() => {
-        cy.findByText("Filter by this date").should("be.visible");
+        cy.findByText("Filter by this date and time").should("be.visible");
         cy.findByText("On").click();
       });
       cy.wait("@dataset");
@@ -394,7 +394,7 @@ describe("scenarios > question > native query drill", () => {
       }).then(({ body }) => H.visitDashboard(body.dashboard_id));
       H.getDashboardCard().findByText("May 15, 2024, 8:04 AM").click();
       H.popover().within(() => {
-        cy.findByText("Filter by this date").should("be.visible");
+        cy.findByText("Filter by this date and time").should("be.visible");
         cy.findByText("On").click();
         cy.wait("@dataset");
       });

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/table_drills.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/table_drills.cy.spec.js
@@ -392,7 +392,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills > nulls", ()
       .click({ force: true });
 
     H.popover().within(() => {
-      cy.findByText("Filter by this date").should("be.visible");
+      cy.findByText("Filter by this date and time").should("be.visible");
       cy.findByText("Is empty").should("be.visible");
       cy.findByText("Not empty").should("be.visible").click();
     });

--- a/frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx
+++ b/frontend/src/metabase/querying/drills/utils/quick-filter-drill.tsx
@@ -39,7 +39,9 @@ function getActionOverrides(
 ): Partial<ClickAction> {
   if (Lib.isDateOrDateTime(column)) {
     const action: Partial<ClickAction> = {
-      sectionTitle: t`Filter by this date`,
+      sectionTitle: Lib.isDateWithoutTime(column)
+        ? t`Filter by this date`
+        : t`Filter by this date and time`,
       sectionDirection: "column",
       buttonType: "horizontal",
     };


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/51172
See comment https://github.com/metabase/metabase/issues/51172#issuecomment-2538438313

How to verify:
- Open `People` table
- Click on cells for `Birth Date` and `Created At` columns

Date:
<img width="218" alt="Screenshot 2025-01-06 at 13 25 41" src="https://github.com/user-attachments/assets/b744a95c-d179-4105-a3f4-28e46e04ec8d" />

DateTime:
<img width="216" alt="Screenshot 2025-01-06 at 13 25 48" src="https://github.com/user-attachments/assets/872588d1-c762-4426-b04d-bbd5c3615282" />
