### PR TITLE
Fix flaky unit test of JoinStep

### DIFF
--- a/frontend/src/metabase/querying/notebook/components/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/JoinStep/JoinStep.unit.spec.tsx
@@ -531,19 +531,26 @@ describe("Notebook Editor > Join Step", () => {
     await userEvent.click(within(rhsTablePicker).getByRole("button"));
     const entityPickerModal = await screen.findByTestId("entity-picker-modal");
     await waitForLoaderToBeRemoved();
-    await userEvent.click(within(entityPickerModal).getByText("Reviews"));
+    await userEvent.click(
+      await within(entityPickerModal).findByText("Reviews"),
+    );
     const lhsColumnPicker = await screen.findByTestId("lhs-column-picker");
-    await userEvent.click(within(lhsColumnPicker).getByText("ID"));
-
+    await userEvent.click(await within(lhsColumnPicker).findByText("ID"));
     const newRhsTablePicker = screen.getByLabelText("Right table");
-    await userEvent.click(within(newRhsTablePicker).getByText("Reviews"));
+    await userEvent.click(
+      await within(newRhsTablePicker).findByText("Reviews"),
+    );
     const newEntityPickerModal = await screen.findByTestId(
       "entity-picker-modal",
     );
     await waitForLoaderToBeRemoved();
-    await userEvent.click(within(newEntityPickerModal).getByText("Orders"));
+    await userEvent.click(
+      await within(newEntityPickerModal).findByText("Orders"),
+    );
     const lhsColumn = screen.getByLabelText("Left column");
-    expect(within(lhsColumn).getByText("Pick a column…")).toBeInTheDocument();
+    expect(
+      await within(lhsColumn).findByText("Pick a column…"),
+    ).toBeInTheDocument();
     expect(within(lhsColumn).queryByText("ID")).not.toBeInTheDocument();
   });
 

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -306,6 +306,11 @@ export function getBrokenUpTextMatcher(textToFind: string): MatcherFunction {
  * @see https://metaboat.slack.com/archives/C505ZNNH4/p1684753502335459?thread_ts=1684751522.480859&cid=C505ZNNH4
  */
 export const waitForLoaderToBeRemoved = async () => {
+  // By waiting for the loader to appear, we avoid letting the next assertion
+  // pass in cases where the loader has not displayed yet
+  // expect(
+  //   await screen.findByTestId("loading-indicator", { timeout: 5000 }),
+  // ).toBeInTheDocument();
   await waitFor(
     () => {
       expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument();

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -306,11 +306,6 @@ export function getBrokenUpTextMatcher(textToFind: string): MatcherFunction {
  * @see https://metaboat.slack.com/archives/C505ZNNH4/p1684753502335459?thread_ts=1684751522.480859&cid=C505ZNNH4
  */
 export const waitForLoaderToBeRemoved = async () => {
-  // By waiting for the loader to appear, we avoid letting the next assertion
-  // pass in cases where the loader has not displayed yet
-  // expect(
-  //   await screen.findByTestId("loading-indicator", { timeout: 5000 }),
-  // ).toBeInTheDocument();
   await waitFor(
     () => {
       expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument();


### PR DESCRIPTION
A test in JoinStep was flaking locally. Let's use findBy queries to avoid this.