### PR TITLE
Fix string, temporal, category type check functions

### DIFF
--- a/frontend/src/metabase-lib/column_types.ts
+++ b/frontend/src/metabase-lib/column_types.ts
@@ -5,10 +5,27 @@ import type { ColumnMetadata } from "./types";
 
 type TypeFn = (column: ColumnMetadata) => boolean;
 
+// Effective type checks.
+export const isBoolean: TypeFn = TYPES.boolean_QMARK_;
+export const isTemporal: TypeFn = TYPES.temporal_QMARK_;
+export const isDateOrDateTime: TypeFn = TYPES.date_or_datetime_QMARK_;
+export const isDateWithoutTime: TypeFn = TYPES.date_without_time_QMARK_;
+export const isInteger: TypeFn = TYPES.integer_QMARK_;
+export const isString: TypeFn = TYPES.string_QMARK_;
+export const isStringLike: TypeFn = TYPES.string_like_QMARK_;
+export const isStringOrStringLike: TypeFn = TYPES.string_or_string_like_QMARK_;
+export const isTime: TypeFn = TYPES.time_QMARK_;
+
+// Legacy helpers that mix effective and semantic types.
+export const isCategory: TypeFn = TYPES.category_QMARK_;
+export const isNumber: TypeFn = TYPES.number_QMARK_;
+export const isNumeric: TypeFn = TYPES.numeric_QMARK_;
+
+// Semantic type checks. A semantic type can be assigned to a column with an
+// unrelated effective type. Do not imply any effective type when checking for a
+// semantic type.
 export const isAddress: TypeFn = TYPES.address_QMARK_;
 export const isAvatarURL: TypeFn = TYPES.avatar_URL_QMARK_;
-export const isBoolean: TypeFn = TYPES.boolean_QMARK_;
-export const isCategory: TypeFn = TYPES.category_QMARK_;
 export const isCity: TypeFn = TYPES.city_QMARK_;
 export const isComment: TypeFn = TYPES.comment_QMARK_;
 export const isCoordinate: TypeFn = TYPES.coordinate_QMARK_;
@@ -17,9 +34,6 @@ export const isCreationDate: TypeFn = TYPES.creation_date_QMARK_;
 export const isCreationTime: TypeFn = TYPES.creation_time_QMARK_;
 export const isCreationTimestamp: TypeFn = TYPES.creation_timestamp_QMARK_;
 export const isCurrency: TypeFn = TYPES.currency_QMARK_;
-export const isTemporal: TypeFn = TYPES.temporal_QMARK_;
-export const isDateOrDateTime: TypeFn = TYPES.date_or_datetime_QMARK_;
-export const isDateWithoutTime: TypeFn = TYPES.date_without_time_QMARK_;
 export const isDescription: TypeFn = TYPES.description_QMARK_;
 export const isEmail: TypeFn = TYPES.email_QMARK_;
 export const isEntityName: TypeFn = TYPES.entity_name_QMARK_;
@@ -29,18 +43,8 @@ export const isImageURL: TypeFn = TYPES.image_URL_QMARK_;
 export const isLocation: TypeFn = TYPES.location_QMARK_;
 export const isLatitude: TypeFn = TYPES.latitude_QMARK_;
 export const isLongitude: TypeFn = TYPES.longitude_QMARK_;
-export const isMetric: TypeFn = TYPES.metric_QMARK_;
-export const isInteger: TypeFn = TYPES.integer_QMARK_;
-export const isNumber: TypeFn = TYPES.number_QMARK_;
-export const isNumeric: TypeFn = TYPES.numeric_QMARK_;
 export const isPrimaryKey: TypeFn = TYPES.primary_key_QMARK_;
-export const isScope: TypeFn = TYPES.scope_QMARK_;
 export const isState: TypeFn = TYPES.state_QMARK_;
-export const isString: TypeFn = TYPES.string_QMARK_;
-export const isStringLike: TypeFn = TYPES.string_like_QMARK_;
-export const isStringOrStringLike: TypeFn = TYPES.string_or_string_like_QMARK_;
-export const isSummable: TypeFn = TYPES.summable_QMARK_;
-export const isTime: TypeFn = TYPES.time_QMARK_;
 export const isTitle: TypeFn = TYPES.title_QMARK_;
 export const isURL: TypeFn = TYPES.URL_QMARK_;
 export const isZipCode: TypeFn = TYPES.zip_code_QMARK_;

--- a/frontend/src/metabase-lib/v1/parameters/utils/click-behavior.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/click-behavior.ts
@@ -174,7 +174,9 @@ function getTargetsForStructuredQuestion(question: Question): Target[] {
         parameter: parameter =>
           columnFilterForParameter(query, stageIndex, parameter)(targetColumn),
         userAttribute: () =>
-          Lib.isString(targetColumn) || Lib.isCategory(targetColumn),
+          Lib.isString(targetColumn) ||
+          Lib.isCategory(targetColumn) ||
+          Lib.isBoolean(targetColumn),
       },
     };
   });

--- a/frontend/src/metabase-lib/v1/parameters/utils/click-behavior.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/click-behavior.ts
@@ -173,7 +173,8 @@ function getTargetsForStructuredQuestion(question: Question): Target[] {
         },
         parameter: parameter =>
           columnFilterForParameter(query, stageIndex, parameter)(targetColumn),
-        userAttribute: () => Lib.isString(targetColumn),
+        userAttribute: () =>
+          Lib.isString(targetColumn) || Lib.isCategory(targetColumn),
       },
     };
   });

--- a/frontend/src/metabase-lib/v1/parameters/utils/filters.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/filters.ts
@@ -45,14 +45,16 @@ export function columnFilterForParameter(
     case "id":
       return column => Lib.isPrimaryKey(column) || Lib.isForeignKey(column);
     case "category":
-      return column => Lib.isCategory(column);
+      return column => Lib.isCategory(column) || Lib.isBoolean(column);
     case "location":
       return column => Lib.isLocation(column);
     case "number":
       return column => Lib.isNumber(column) && !Lib.isLocation(column);
     case "string":
       return column =>
-        (Lib.isStringOrStringLike(column) || Lib.isCategory(column)) &&
+        (Lib.isStringOrStringLike(column) ||
+          Lib.isCategory(column) ||
+          Lib.isBoolean(column)) &&
         !Lib.isLocation(column);
     case "temporal-unit":
       return column => Lib.isTemporalBucketable(query, stageIndex, column);

--- a/frontend/src/metabase-lib/v1/parameters/utils/filters.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/filters.ts
@@ -52,7 +52,8 @@ export function columnFilterForParameter(
       return column => Lib.isNumber(column) && !Lib.isLocation(column);
     case "string":
       return column =>
-        Lib.isStringOrStringLike(column) && !Lib.isLocation(column);
+        (Lib.isStringOrStringLike(column) || Lib.isCategory(column)) &&
+        !Lib.isLocation(column);
     case "temporal-unit":
       return column => Lib.isTemporalBucketable(query, stageIndex, column);
   }

--- a/frontend/src/metabase-lib/viz/display.ts
+++ b/frontend/src/metabase-lib/viz/display.ts
@@ -29,7 +29,7 @@ export const defaultDisplay = (query: Lib.Query): DefaultDisplay => {
   }
 
   if (aggregations.length === 1 && breakouts.length === 1) {
-    const [{ column }] = getBreakoutsWithColumns(query, stageIndex, breakouts);
+    const [column] = getBreakoutColumns(query, stageIndex);
 
     if (Lib.isState(column)) {
       return {
@@ -53,11 +53,8 @@ export const defaultDisplay = (query: Lib.Query): DefaultDisplay => {
   }
 
   if (aggregations.length >= 1 && breakouts.length === 1) {
-    const [{ breakout, column }] = getBreakoutsWithColumns(
-      query,
-      stageIndex,
-      breakouts,
-    );
+    const [breakout] = breakouts;
+    const [column] = getBreakoutColumns(query, stageIndex);
 
     if (Lib.isTemporal(column)) {
       const info = Lib.displayInfo(query, stageIndex, breakout);
@@ -82,20 +79,16 @@ export const defaultDisplay = (query: Lib.Query): DefaultDisplay => {
   }
 
   if (aggregations.length === 1 && breakouts.length === 2) {
-    const breakoutsWithColumns = getBreakoutsWithColumns(
-      query,
-      stageIndex,
-      breakouts,
-    );
+    const breakoutColumns = getBreakoutColumns(query, stageIndex);
 
-    const isAnyBreakoutTemporal = breakoutsWithColumns.some(({ column }) => {
+    const isAnyBreakoutTemporal = breakoutColumns.some(column => {
       return Lib.isTemporal(column);
     });
     if (isAnyBreakoutTemporal) {
       return { display: "line" };
     }
 
-    const areBreakoutsCoordinates = breakoutsWithColumns.every(({ column }) => {
+    const areBreakoutsCoordinates = breakoutColumns.every(column => {
       return Lib.isCoordinate(column);
     });
     if (areBreakoutsCoordinates) {
@@ -120,7 +113,7 @@ export const defaultDisplay = (query: Lib.Query): DefaultDisplay => {
       };
     }
 
-    const areBreakoutsCategories = breakoutsWithColumns.every(({ column }) => {
+    const areBreakoutsCategories = breakoutColumns.every(column => {
       return Lib.isCategory(column);
     });
     if (areBreakoutsCategories) {
@@ -131,13 +124,13 @@ export const defaultDisplay = (query: Lib.Query): DefaultDisplay => {
   return { display: "table" };
 };
 
-const getBreakoutsWithColumns = (
-  query: Lib.Query,
-  stageIndex: number,
-  breakouts: Lib.BreakoutClause[],
-) => {
-  return breakouts.map(breakout => {
-    const column = Lib.breakoutColumn(query, stageIndex, breakout);
-    return { breakout, column };
+const getBreakoutColumns = (query: Lib.Query, stageIndex: number) => {
+  return Lib.breakoutableColumns(query, stageIndex).filter(column => {
+    const { breakoutPositions = [] } = Lib.displayInfo(
+      query,
+      stageIndex,
+      column,
+    );
+    return breakoutPositions.length > 0;
   });
 };

--- a/frontend/src/metabase-lib/viz/display.ts
+++ b/frontend/src/metabase-lib/viz/display.ts
@@ -29,7 +29,7 @@ export const defaultDisplay = (query: Lib.Query): DefaultDisplay => {
   }
 
   if (aggregations.length === 1 && breakouts.length === 1) {
-    const [column] = getBreakoutColumns(query, stageIndex);
+    const [{ column }] = getBreakoutsWithColumns(query, stageIndex, breakouts);
 
     if (Lib.isState(column)) {
       return {
@@ -53,16 +53,17 @@ export const defaultDisplay = (query: Lib.Query): DefaultDisplay => {
   }
 
   if (aggregations.length >= 1 && breakouts.length === 1) {
-    const [breakout] = breakouts;
-    const [column] = getBreakoutColumns(query, stageIndex);
+    const [{ breakout, column }] = getBreakoutsWithColumns(
+      query,
+      stageIndex,
+      breakouts,
+    );
 
+    const breakoutInfo = Lib.displayInfo(query, stageIndex, breakout);
+    if (breakoutInfo.isTemporalExtraction) {
+      return { display: "bar" };
+    }
     if (Lib.isTemporal(column)) {
-      const info = Lib.displayInfo(query, stageIndex, breakout);
-
-      if (info.isTemporalExtraction) {
-        return { display: "bar" };
-      }
-
       return { display: "line" };
     }
 
@@ -79,16 +80,20 @@ export const defaultDisplay = (query: Lib.Query): DefaultDisplay => {
   }
 
   if (aggregations.length === 1 && breakouts.length === 2) {
-    const breakoutColumns = getBreakoutColumns(query, stageIndex);
+    const breakoutsWithColumns = getBreakoutsWithColumns(
+      query,
+      stageIndex,
+      breakouts,
+    );
 
-    const isAnyBreakoutTemporal = breakoutColumns.some(column => {
+    const isAnyBreakoutTemporal = breakoutsWithColumns.some(({ column }) => {
       return Lib.isTemporal(column);
     });
     if (isAnyBreakoutTemporal) {
       return { display: "line" };
     }
 
-    const areBreakoutsCoordinates = breakoutColumns.every(column => {
+    const areBreakoutsCoordinates = breakoutsWithColumns.every(({ column }) => {
       return Lib.isCoordinate(column);
     });
     if (areBreakoutsCoordinates) {
@@ -113,7 +118,7 @@ export const defaultDisplay = (query: Lib.Query): DefaultDisplay => {
       };
     }
 
-    const areBreakoutsCategories = breakoutColumns.every(column => {
+    const areBreakoutsCategories = breakoutsWithColumns.every(({ column }) => {
       return Lib.isCategory(column);
     });
     if (areBreakoutsCategories) {
@@ -124,13 +129,13 @@ export const defaultDisplay = (query: Lib.Query): DefaultDisplay => {
   return { display: "table" };
 };
 
-const getBreakoutColumns = (query: Lib.Query, stageIndex: number) => {
-  return Lib.breakoutableColumns(query, stageIndex).filter(column => {
-    const { breakoutPositions = [] } = Lib.displayInfo(
-      query,
-      stageIndex,
-      column,
-    );
-    return breakoutPositions.length > 0;
+const getBreakoutsWithColumns = (
+  query: Lib.Query,
+  stageIndex: number,
+  breakouts: Lib.BreakoutClause[],
+) => {
+  return breakouts.map(breakout => {
+    const column = Lib.breakoutColumn(query, stageIndex, breakout);
+    return { breakout, column };
   });
 };

--- a/frontend/src/metabase-lib/viz/display.ts
+++ b/frontend/src/metabase-lib/viz/display.ts
@@ -74,7 +74,7 @@ export const defaultDisplay = (query: Lib.Query): DefaultDisplay => {
       return { display: "bar" };
     }
 
-    if (Lib.isCategory(column)) {
+    if (Lib.isBoolean(column) || Lib.isCategory(column)) {
       return { display: "bar" };
     }
   }
@@ -119,7 +119,7 @@ export const defaultDisplay = (query: Lib.Query): DefaultDisplay => {
     }
 
     const areBreakoutsCategories = breakoutsWithColumns.every(({ column }) => {
-      return Lib.isCategory(column);
+      return Lib.isBoolean(column) || Lib.isCategory(column);
     });
     if (areBreakoutsCategories) {
       return { display: "bar" };

--- a/frontend/src/metabase/components/MetadataInfo/ColumnFingerprintInfo/ColumnFingerprintInfo.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/ColumnFingerprintInfo/ColumnFingerprintInfo.tsx
@@ -90,7 +90,7 @@ export function QueryColumnFingerprintInfo({
         fingerprintTypeInfo={fingerprint?.type?.["type/Number"]}
       />
     );
-  } else if (Lib.isCategory(column)) {
+  } else if (Lib.isBoolean(column) || Lib.isCategory(column)) {
     const info = Lib.fieldValuesSearchInfo(query, column);
 
     return (

--- a/frontend/src/metabase/query_builder/components/CompareAggregations/utils.ts
+++ b/frontend/src/metabase/query_builder/components/CompareAggregations/utils.ts
@@ -5,6 +5,41 @@ import type { TemporalUnit } from "metabase-types/api";
 
 import type { ColumnType } from "./types";
 
+export const getOffsetPeriod = (
+  query: Lib.Query,
+  stageIndex: number,
+): string => {
+  const firstBreakout = Lib.breakouts(query, stageIndex)[0];
+
+  if (!firstBreakout) {
+    return t`period`;
+  }
+
+  const firstBreakoutColumn = Lib.breakoutColumn(
+    query,
+    stageIndex,
+    firstBreakout,
+  );
+
+  if (!Lib.isTemporal(firstBreakoutColumn)) {
+    return t`rows`;
+  }
+
+  const bucket = Lib.temporalBucket(firstBreakout);
+
+  if (!bucket) {
+    return t`period`;
+  }
+
+  const bucketInfo = Lib.displayInfo(query, stageIndex, bucket);
+  const periodPlural = Lib.describeTemporalUnit(
+    bucketInfo.shortName,
+    2,
+  ).toLowerCase();
+
+  return periodPlural;
+};
+
 export const getTitle = (
   query: Lib.Query,
   stageIndex: number,

--- a/frontend/src/metabase/query_builder/components/CompareAggregations/utils.ts
+++ b/frontend/src/metabase/query_builder/components/CompareAggregations/utils.ts
@@ -10,7 +10,6 @@ export const getOffsetPeriod = (
   stageIndex: number,
 ): string => {
   const firstBreakout = Lib.breakouts(query, stageIndex)[0];
-
   if (!firstBreakout) {
     return t`period`;
   }
@@ -20,13 +19,11 @@ export const getOffsetPeriod = (
     stageIndex,
     firstBreakout,
   );
-
-  if (!Lib.isTemporal(firstBreakoutColumn)) {
+  if (!Lib.isTemporalBucketable(query, stageIndex, firstBreakoutColumn)) {
     return t`rows`;
   }
 
   const bucket = Lib.temporalBucket(firstBreakout);
-
   if (!bucket) {
     return t`period`;
   }

--- a/frontend/src/metabase/query_builder/components/CompareAggregations/utils.ts
+++ b/frontend/src/metabase/query_builder/components/CompareAggregations/utils.ts
@@ -5,38 +5,6 @@ import type { TemporalUnit } from "metabase-types/api";
 
 import type { ColumnType } from "./types";
 
-export const getOffsetPeriod = (
-  query: Lib.Query,
-  stageIndex: number,
-): string => {
-  const firstBreakout = Lib.breakouts(query, stageIndex)[0];
-  if (!firstBreakout) {
-    return t`period`;
-  }
-
-  const firstBreakoutColumn = Lib.breakoutColumn(
-    query,
-    stageIndex,
-    firstBreakout,
-  );
-  if (!Lib.isTemporalBucketable(query, stageIndex, firstBreakoutColumn)) {
-    return t`rows`;
-  }
-
-  const bucket = Lib.temporalBucket(firstBreakout);
-  if (!bucket) {
-    return t`period`;
-  }
-
-  const bucketInfo = Lib.displayInfo(query, stageIndex, bucket);
-  const periodPlural = Lib.describeTemporalUnit(
-    bucketInfo.shortName,
-    2,
-  ).toLowerCase();
-
-  return periodPlural;
-};
-
 export const getTitle = (
   query: Lib.Query,
   stageIndex: number,

--- a/src/metabase/lib/types/constants.cljc
+++ b/src/metabase/lib/types/constants.cljc
@@ -37,13 +37,11 @@
 (def type-hierarchies
   "A front-end specific type hierarchy used by [[metabase.lib.types.isa/field-type?]].
   It is not meant to be used directly."
-  {::temporal    {:effective-type [:type/Temporal]
-                  :semantic-type  [:type/Temporal]}
+  {::temporal    {:effective-type [:type/Temporal]}
    ::number      {:effective-type [:type/Number]
                   :semantic-type  [:type/Number]}
    ::integer     {:effective-type [:type/Integer]}
-   ::string      {:effective-type [:type/Text]
-                  :semantic-type  [:type/Text :type/Category]}
+   ::string      {:effective-type [:type/Text]}
    ::string_like {:effective-type [:type/TextLike]}
    ::boolean     {:effective-type [:type/Boolean]}
    ::coordinate  {:semantic-type [:type/Coordinate]}

--- a/src/metabase/lib/types/constants.cljc
+++ b/src/metabase/lib/types/constants.cljc
@@ -54,7 +54,7 @@
    ::structured  {:effective-type [:type/Structured]}
    ::summable    {:include [::number]
                   :exclude [::entity ::location ::temporal]}
-   ::scope       {:include [::number ::temporal ::category ::entity ::string]
+   ::scope       {:include [::number ::temporal ::category ::entity ::string ::boolean]
                   :exclude [::location]}
    ::category    {:semantic-type  [:type/Category]}
    ;; NOTE: this is defunct right now.  see definition of metabase.lib.types.isa/dimension?.

--- a/src/metabase/lib/types/constants.cljc
+++ b/src/metabase/lib/types/constants.cljc
@@ -56,8 +56,6 @@
                   :exclude [::entity ::location ::temporal]}
    ::scope       {:include [::number ::temporal ::category ::entity ::string]
                   :exclude [::location]}
-   ::category    {:effective-type [:type/Boolean]
-                  :semantic-type  [:type/Category]
-                  :include        [::location]}
+   ::category    {:semantic-type  [:type/Category]}
    ;; NOTE: this is defunct right now.  see definition of metabase.lib.types.isa/dimension?.
    ::dimension   {:include [::temporal ::category ::entity]}})

--- a/src/metabase/lib/types/isa.cljc
+++ b/src/metabase/lib/types/isa.cljc
@@ -115,19 +115,6 @@
   [column]
   (clojure.core/isa? (:semantic-type column) :type/Description))
 
-(defn ^:export dimension?
-  "Is `column` a dimension?"
-  [column]
-  (and column
-       (not= (:lib/source column) :source/aggregations)
-       (not (description? column))))
-
-(defn ^:export metric?
-  "Is `column` a metric?"
-  [column]
-  (and (not= (:lib/source column) :source/breakouts)
-       (summable? column)))
-
 (defn ^:export foreign-key?
   "Is `column` a foreign-key?"
   [column]

--- a/src/metabase/lib/types/isa.cljc
+++ b/src/metabase/lib/types/isa.cljc
@@ -4,7 +4,6 @@
   (:require
    [medley.core :as m]
    [metabase.lib.types.constants :as lib.types.constants]
-   [metabase.lib.util :as lib.util]
    [metabase.types]))
 
 (comment metabase.types/keep-me)
@@ -281,23 +280,6 @@
   "Is `column` an image URL?"
   [column]
   (clojure.core/isa? (:semantic-type column) :type/ImageURL))
-
-(defn ^:export has-latitude-and-longitude?
-  "Does the collection `columns` contain both a latitude and a longitude column?"
-  [columns]
-  (every? #(some % columns) [latitude? longitude?]))
-
-(defn ^:export primary-key-pred
-  "Return a prdicate for checking if a column is a primary key."
-  [table-id]
-  (fn primary-key-pred-for-table-id [column]
-    (let [pk? (primary-key? column)]
-      ;; comment from isa.js:
-      ;; > FIXME: columns of nested questions at this moment miss table_id value
-      ;; > which makes it impossible to match them with their tables that are nested cards
-      (if (lib.util/legacy-string-table-id->card-id table-id)
-        pk?
-        (and pk? (= (:table-id column) table-id))))))
 
 ;;; TODO -- This stuff should probably use the constants in [[metabase.lib.types.constants]], however this logic isn't
 ;;; supposed to include things with semantic type = Category which the `::string` constant define there includes.

--- a/test/metabase/lib/types/isa_test.cljc
+++ b/test/metabase/lib/types/isa_test.cljc
@@ -156,6 +156,7 @@
              {:pred #'lib.types.isa/string?,             :positive :type/Text,              :negative :type/URL}
              {:pred #'lib.types.isa/string-like?,        :positive :type/TextLike,          :negative :type/Address}
              {:pred #'lib.types.isa/summable?,           :positive :type/Number,            :negative :type/Address}
+             {:pred #'lib.types.isa/scope?,              :positive :type/Boolean,           :negative :type/Address}
              {:pred #'lib.types.isa/category?,           :positive :type/Category,          :negative :type/Boolean}
              {:pred #'lib.types.isa/category?,           :positive :type/Company,           :negative :type/URL}
              {:pred #'lib.types.isa/location?,           :positive :type/Address,           :negative :type/Number}

--- a/test/metabase/lib/types/isa_test.cljc
+++ b/test/metabase/lib/types/isa_test.cljc
@@ -156,6 +156,7 @@
              {:pred #'lib.types.isa/string?,             :positive :type/Text,              :negative :type/URL}
              {:pred #'lib.types.isa/string-like?,        :positive :type/TextLike,          :negative :type/Address}
              {:pred #'lib.types.isa/summable?,           :positive :type/Number,            :negative :type/Address}
+             {:pred #'lib.types.isa/category?,           :positive :type/Category,          :negative :type/Boolean}
              {:pred #'lib.types.isa/category?,           :positive :type/Company,           :negative :type/URL}
              {:pred #'lib.types.isa/location?,           :positive :type/Address,           :negative :type/Number}
              {:pred #'lib.types.isa/description?,        :positive :type/Description,       :negative :type/City}

--- a/test/metabase/lib/types/isa_test.cljc
+++ b/test/metabase/lib/types/isa_test.cljc
@@ -202,32 +202,6 @@
     true  {:effective-type :type/Text :semantic-type :type/SerializedJSON}
     false {:effective-type :type/JSON :semantic-type :type/SerializedJSON}))
 
-(deftest ^:parallel has-latitude-and-longitude?-test
-  (is (true? (lib.types.isa/has-latitude-and-longitude?
-              [{:semantic-type :type/Latitude} {:semantic-type :type/Longitude}])))
-  (are [columns] (false? (lib.types.isa/has-latitude-and-longitude?
-                          columns))
-    [{:semantic-type :type/Latitude}]
-    [{:semantic-type :type/Longitude}]
-    [{:semantic-type :type/Longitude} {:semantic-type :type/Address}]
-    []
-    nil))
-
-(deftest ^:parallel primary-key-pred-test
-  (let [integer-table-id 1
-        columns [{:semantic-type :type/PK, :table-id (inc integer-table-id), :name "column0"}
-                 {:semantic-type :type/PK, :name "column1"}
-                 {:semantic-type :type/PK, :table-id integer-table-id, :name "column2"}
-                 {:semantic-type :type/Address, :name "column3"}]]
-    (testing "with integer table-id :table-id has to match"
-      (let [primary-key? (lib.types.isa/primary-key-pred integer-table-id)]
-        (is (= ["column2"]
-               (map :name (filter primary-key? columns))))))
-    (testing "with string table-id all PK columns are returned"
-      (let [primary-key? (lib.types.isa/primary-key-pred "card__1")]
-        (is (= ["column0" "column1" "column2"]
-               (map :name (filter primary-key? columns))))))))
-
 (deftest ^:parallel valid-filter-for?-test
   (are [exp base-lhs eff-lhs base-rhs eff-rhs] (= exp (lib.types.isa/valid-filter-for?
                                                        {:base-type      base-lhs

--- a/test/metabase/lib/types/isa_test.cljc
+++ b/test/metabase/lib/types/isa_test.cljc
@@ -124,8 +124,8 @@
     (testing "string like"
       (are [typ] (= ::lib.types.constants/string_like (lib.types.isa/field-type {base-or-effective-type-key typ}))
         :type/TextLike :type/IPAddress))
-    (testing "strings, regardless of the effective type is"
-      (are [typ] (= ::lib.types.constants/string (lib.types.isa/field-type {base-or-effective-type-key :type/Float
+    (testing "number, regardless of the semantic type is"
+      (are [typ] (= ::lib.types.constants/number (lib.types.isa/field-type {base-or-effective-type-key :type/Float
                                                                             :semantic-type typ}))
         :type/Name :type/Category))
     (testing "boolean, regardless of the semantic type"
@@ -149,17 +149,16 @@
               (isa? x :Relation/*) {:semantic-type x}
               :else                {:effective-type x}))]
     (doseq [{:keys [pred positive negative]}
-            [{:pred #'lib.types.isa/temporal?,           :positive :type/DateTime,          :negative :type/City}
+            [{:pred #'lib.types.isa/temporal?,           :positive :type/Date,              :negative :type/CreationDate}
+             {:pred #'lib.types.isa/temporal?,           :positive :type/DateTime,          :negative :type/City}
              {:pred #'lib.types.isa/numeric?,            :positive :type/Integer,           :negative :type/FK}
              {:pred #'lib.types.isa/boolean?,            :positive :type/Boolean,           :negative :type/PK}
-             {:pred #'lib.types.isa/string?,             :positive :type/URL,               :negative :type/Address}
+             {:pred #'lib.types.isa/string?,             :positive :type/Text,              :negative :type/URL}
+             {:pred #'lib.types.isa/string-like?,        :positive :type/TextLike,          :negative :type/Address}
              {:pred #'lib.types.isa/summable?,           :positive :type/Number,            :negative :type/Address}
-             {:pred #'lib.types.isa/scope?,              :positive :type/Time,              :negative :type/Address}
              {:pred #'lib.types.isa/category?,           :positive :type/Company,           :negative :type/URL}
              {:pred #'lib.types.isa/location?,           :positive :type/Address,           :negative :type/Number}
              {:pred #'lib.types.isa/description?,        :positive :type/Description,       :negative :type/City}
-             {:pred #'lib.types.isa/dimension?,          :positive :type/City,              :negative :type/Description}
-             {:pred #'lib.types.isa/metric?,             :positive :type/Number,            :negative :type/City}
              {:pred #'lib.types.isa/foreign-key?,        :positive :type/FK,                :negative :type/ZipCode}
              {:pred #'lib.types.isa/primary-key?,        :positive :type/PK,                :negative :type/ZipCode}
              {:pred #'lib.types.isa/entity-name?,        :positive :type/Name,              :negative :type/Number}
@@ -199,8 +198,8 @@
 
 (deftest ^:parallel string?-test
   (are [exp column] (= exp (lib.types.isa/string? column))
-    true  {:base-type :type/Text :semantic-type :type/SerializedJSON}
-    false {:base-type :type/JSON :semantic-type :type/SerializedJSON}))
+    true  {:effective-type :type/Text :semantic-type :type/SerializedJSON}
+    false {:effective-type :type/JSON :semantic-type :type/SerializedJSON}))
 
 (deftest ^:parallel has-latitude-and-longitude?-test
   (is (true? (lib.types.isa/has-latitude-and-longitude?


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/51799

#### `string?`
Before:
- Was `true` for `type/Text` **effective** type OR `type/Text`, `type/Category` **semantic** types. 
- Known hacks - people used it to make boolean columns work in dashboards.

Now:
- Checks for `type/Text` **effective** type only.
- Dashboards were updated to explicitly check for `type/Category` and `type/Boolean`.

#### `temporal?`
Before:
- Was `true` for `type/Temporal` **effective** OR **semantic** types. A column with a temporal extraction unit (e.g. `Month of Year`) was considered temporal despite being an integer column. Any column can become temporal with changes to the semantic type in Admin.

Now:
- Checks for `type/Temporal` **effective** type only. Places that relied on `original-effective-type` on the FE were updated.

#### `category?`
Before:
- Was `true` for `type/Boolean` **effective** type or `type/Category` or `type/Address` **semantic** types.

Now:
- Checks for `type/Category` **semantic** type only. Places that needed booleans were updated to check for them explicitly. 

Note that `number?` and `numeric?` are still broken.

How to verify:
- Mostly internal change. This is already tested. The goal is make the API clean, explicit, and straightforward.
- Dashboard mapping to boolean columns should work (there are tests for this already).