### PR TITLE
Fix quick-filter drill thru for multi-stage queries

### DIFF
--- a/src/metabase/lib/drill_thru/quick_filter.cljc
+++ b/src/metabase/lib/drill_thru/quick_filter.cljc
@@ -113,7 +113,7 @@
              column
              (some? value) ; Deliberately allows value :null, only a missing value should fail this test.
              ;; If this is an aggregation, there must be breakouts (dimensions).
-             (or (not= (:lib/source column) :source/aggregations)
+             (or (not (lib.drill-thru.common/aggregation-sourced? query column))
                  (seq dimensions))
              (not (lib.types.isa/structured?  column))
              (not (lib.types.isa/primary-key? column))

--- a/test/metabase/lib/drill_thru/quick_filter_test.cljc
+++ b/test/metabase/lib/drill_thru/quick_filter_test.cljc
@@ -88,12 +88,44 @@
                               {:name "="}
                               {:name "≠"}]}}))
 
+(deftest ^:parallel returns-quick-filter-multi-stage-query-test-5
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/quick-filter
+    :click-type  :cell
+    :query-type  :aggregated
+    :column-name "CREATED_AT"
+    :custom-query (lib.drill-thru.tu/append-filter-stage
+                   (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :query])
+                   "count")
+    :expected    {:type      :drill-thru/quick-filter
+                  :value     (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "CREATED_AT"])
+                  :operators [{:name "<"}
+                              {:name ">"}
+                              {:name "="}
+                              {:name "≠"}]}}))
+
 (deftest ^:parallel returns-quick-filter-test-6
   (lib.drill-thru.tu/test-returns-drill
    {:drill-type  :drill-thru/quick-filter
     :click-type  :cell
     :query-type  :aggregated
     :column-name "count"
+    :expected    {:type      :drill-thru/quick-filter
+                  :value     (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "count"])
+                  :operators [{:name "<"}
+                              {:name ">"}
+                              {:name "="}
+                              {:name "≠"}]}}))
+
+(deftest ^:parallel returns-quick-filter-multi-stage-query-test-6
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/quick-filter
+    :click-type  :cell
+    :query-type  :aggregated
+    :column-name "count"
+    :custom-query (lib.drill-thru.tu/append-filter-stage
+                   (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :query])
+                   "count")
     :expected    {:type      :drill-thru/quick-filter
                   :value     (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "count"])
                   :operators [{:name "<"}
@@ -114,6 +146,22 @@
                               {:name "="}
                               {:name "≠"}]}}))
 
+(deftest ^:parallel returns-quick-filter-multi-stage-query-test-7
+  (lib.drill-thru.tu/test-returns-drill
+   {:drill-type  :drill-thru/quick-filter
+    :click-type  :cell
+    :query-type  :aggregated
+    :column-name "sum"
+    :custom-query (lib.drill-thru.tu/append-filter-stage
+                   (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :query])
+                   "sum")
+    :expected    {:type      :drill-thru/quick-filter
+                  :value     (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "sum"])
+                  :operators [{:name "<"}
+                              {:name ">"}
+                              {:name "="}
+                              {:name "≠"}]}}))
+
 (deftest ^:parallel returns-quick-filter-test-8
   (testing "quick-filter should not return < or > for cell with no value (#34445)"
     (lib.drill-thru.tu/test-returns-drill
@@ -121,6 +169,21 @@
       :click-type  :cell
       :query-type  :aggregated
       :column-name "max"
+      :expected    {:type      :drill-thru/quick-filter
+                    :value     :null
+                    :operators [{:name "="}
+                                {:name "≠"}]}})))
+
+(deftest ^:parallel returns-quick-filter-multi-stage-query-test-8
+  (testing "quick-filter should not return < or > for cell with no value for multi-stage queries"
+    (lib.drill-thru.tu/test-returns-drill
+     {:drill-type  :drill-thru/quick-filter
+      :click-type  :cell
+      :query-type  :aggregated
+      :column-name "max"
+      :custom-query (lib.drill-thru.tu/append-filter-stage
+                     (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :query])
+                     "max")
       :expected    {:type      :drill-thru/quick-filter
                     :value     :null
                     :operators [{:name "="}
@@ -157,26 +220,51 @@
 
 (deftest ^:parallel apply-quick-filter-on-correct-level-test
   (testing "quick-filter on an aggregation should introduce an new stage (#34346)"
-    (testing "native query"
-      (lib.drill-thru.tu/test-drill-application
-       {:click-type     :cell
-        :query-type     :aggregated
-        :query-kinds    [:mbql]
-        :column-name    "sum"
-        :drill-type     :drill-thru/quick-filter
-        :expected       {:type         :drill-thru/quick-filter
-                         :operators    [{:name "<"}
-                                        {:name ">"}
-                                        {:name "="}
-                                        {:name "≠"}]
-                         :query        {:stages [{} {}]}
-                         :stage-number -1
-                         :value        1}
-        :drill-args     ["="]
-        :expected-query {:stages [{}
-                                  {:filters [[:= {}
-                                              [:field {} "sum"]
-                                              (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "sum"])]]}]}}))))
+    (lib.drill-thru.tu/test-drill-application
+     {:click-type     :cell
+      :query-type     :aggregated
+      :query-kinds    [:mbql]
+      :column-name    "sum"
+      :drill-type     :drill-thru/quick-filter
+      :expected       {:type         :drill-thru/quick-filter
+                       :operators    [{:name "<"}
+                                      {:name ">"}
+                                      {:name "="}
+                                      {:name "≠"}]
+                       :query        {:stages [{} {}]}
+                       :stage-number -1
+                       :value        1}
+      :drill-args     ["="]
+      :expected-query {:stages [{}
+                                {:filters [[:= {}
+                                            [:field {} "sum"]
+                                            (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "sum"])]]}]}})))
+
+(deftest ^:parallel apply-quick-filter-on-correct-level-multi-stage-query-test
+  (testing "quick-filter on an aggregation should not introduce an new stage if one already exists"
+    (lib.drill-thru.tu/test-drill-application
+     {:click-type     :cell
+      :query-type     :aggregated
+      :query-kinds    [:mbql]
+      :column-name    "sum"
+      :drill-type     :drill-thru/quick-filter
+      :custom-query   (lib.drill-thru.tu/append-filter-stage
+                       (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :query])
+                       "sum")
+      :expected       {:type         :drill-thru/quick-filter
+                       :operators    [{:name "<"}
+                                      {:name ">"}
+                                      {:name "="}
+                                      {:name "≠"}]
+                       :query        {:stages [{} {}]}
+                       :stage-number -1
+                       :value        1}
+      :drill-args     ["="]
+      :expected-query {:stages [{}
+                                {:filters [[:> {} [:field {} "sum"] -1]
+                                           [:= {}
+                                            [:field {} "sum"]
+                                            (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "sum"])]]}]}})))
 
 (deftest ^:parallel apply-quick-filter-on-correct-level-test-2
   (testing "quick-filter on a breakout should not introduce a new stage"
@@ -199,6 +287,33 @@
                                                                                      "CREATED_AT")]
                                             (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "CREATED_AT"])]]}]}})))
 
+(deftest ^:parallel apply-quick-filter-on-correct-level-mutli-stage-query-test-2
+  (testing "quick-filter on a breakout should not introduce a new stage if one already exists"
+    (lib.drill-thru.tu/test-drill-application
+     {:click-type     :cell
+      :query-type     :aggregated
+      :query-kinds    [:mbql]
+      :column-name    "CREATED_AT"
+      :drill-type     :drill-thru/quick-filter
+      :custom-query   (lib.drill-thru.tu/append-filter-stage
+                       (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :query])
+                       "sum")
+      :expected       {:type         :drill-thru/quick-filter
+                       :operators    [{:name "<"}
+                                      {:name ">"}
+                                      {:name "="}
+                                      {:name "≠"}]
+                       :query        {:stages [{} {}]}
+                       :stage-number -1
+                       :value        (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "CREATED_AT"])}
+      :drill-args     ["<"]
+      :expected-query {:stages [{}
+                                {:filters [[:> {} [:field {} "sum"] -1]
+                                           [:< {}
+                                            [:field {} (lib.drill-thru.tu/field-key= (meta/id :orders :created-at)
+                                                                                     "CREATED_AT")]
+                                            (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "CREATED_AT"])]]}]}})))
+
 (deftest ^:parallel apply-quick-filter-on-correct-level-test-3
   (testing "quick-filter on an aggregation should introduce an new stage (#34346)"
     (lib.drill-thru.tu/test-drill-application
@@ -216,6 +331,28 @@
       :drill-args     ["≠"]
       :expected-query {:stages [{}
                                 {:filters [[:not-null {} [:field {} "max"]]]}]}})))
+
+(deftest ^:parallel apply-quick-filter-on-correct-level-mutli-stage-query-test-3
+  (testing "quick-filter on an aggregation should not introduce an new stage if one already exists"
+    (lib.drill-thru.tu/test-drill-application
+     {:click-type     :cell
+      :query-type     :aggregated
+      :query-kinds    [:mbql]
+      :column-name    "max"
+      :drill-type     :drill-thru/quick-filter
+      :custom-query   (lib.drill-thru.tu/append-filter-stage
+                       (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :query])
+                       "max")
+      :expected       {:type         :drill-thru/quick-filter
+                       :operators    [{:name "=", :filter [:is-null {} [:field {} "max"]]}
+                                      {:name "≠", :filter [:not-null {} [:field {} "max"]]}]
+                       :query        {:stages [{} {}]}
+                       :stage-number -1
+                       :value        :null}
+      :drill-args     ["≠"]
+      :expected-query {:stages [{}
+                                {:filters [[:> {} [:field {} "max"] -1]
+                                           [:not-null {} [:field {} "max"]]]}]}})))
 
 (deftest ^:parallel contains-does-not-contain-test
   (testing "Should return :contains/:does-not-contain for text columns (#33560)"

--- a/test/metabase/lib/drill_thru/quick_filter_test.cljc
+++ b/test/metabase/lib/drill_thru/quick_filter_test.cljc
@@ -27,8 +27,7 @@
 (deftest ^:parallel returns-quick-filter-test-1
   (lib.drill-thru.tu/test-drill-variants-with-merged-args
    lib.drill-thru.tu/test-returns-drill
-
-   "quick-filter on unaggregated numeric column\n"
+   "quick-filter on unaggregated numeric column"
    {:drill-type  :drill-thru/quick-filter
     :click-type  :cell
     :query-type  :unaggregated
@@ -40,14 +39,13 @@
                               {:name "="}
                               {:name "≠"}]}}
 
-   "quick-filter on unaggregated numeric column for multi-stage query\n"
+   "quick-filter on unaggregated numeric column for multi-stage query"
    {:custom-query #(lib.drill-thru.tu/append-filter-stage % "SUBTOTAL")}))
 
 (deftest ^:parallel returns-quick-filter-test-2
   (lib.drill-thru.tu/test-drill-variants-with-merged-args
    lib.drill-thru.tu/test-returns-drill
-
-   "if the value is NULL, only = and ≠ are allowed\n"
+   "if the value is NULL, only = and ≠ are allowed"
    {:drill-type  :drill-thru/quick-filter
     :click-type  :cell
     :query-type  :unaggregated
@@ -57,7 +55,7 @@
                   :operators [{:name "="}
                               {:name "≠"}]}}
 
-   "if the value is NULL, only = and ≠ are allowed for multi-stage query\n"
+   "if the value is NULL, only = and ≠ are allowed for multi-stage query"
    {:custom-query #(lib.drill-thru.tu/append-filter-stage % "DISCOUNT")}))
 
 (deftest ^:parallel returns-quick-filter-test-3
@@ -89,8 +87,7 @@
 (deftest ^:parallel returns-quick-filter-test-5
   (lib.drill-thru.tu/test-drill-variants-with-merged-args
    lib.drill-thru.tu/test-returns-drill
-
-   "quick-filter on a datetime breakout column\n"
+   "quick-filter on a datetime breakout column"
    {:drill-type  :drill-thru/quick-filter
     :click-type  :cell
     :query-type  :aggregated
@@ -102,14 +99,13 @@
                               {:name "="}
                               {:name "≠"}]}}
 
-   "quick-filter on a datetime breakout column for multi-stage query\n"
+   "quick-filter on a datetime breakout column for multi-stage query"
    {:custom-query #(lib.drill-thru.tu/append-filter-stage % "count")}))
 
 (deftest ^:parallel returns-quick-filter-test-6
   (lib.drill-thru.tu/test-drill-variants-with-merged-args
    lib.drill-thru.tu/test-returns-drill
-
-   "quick-filter on an aggregated count column\n"
+   "quick-filter on an aggregated count column"
    {:drill-type  :drill-thru/quick-filter
     :click-type  :cell
     :query-type  :aggregated
@@ -121,14 +117,13 @@
                               {:name "="}
                               {:name "≠"}]}}
 
-   "quick-filter on an aggregated count column for multi-stage query\n"
+   "quick-filter on an aggregated count column for multi-stage query"
    {:custom-query #(lib.drill-thru.tu/append-filter-stage % "count")}))
 
 (deftest ^:parallel returns-quick-filter-test-7
   (lib.drill-thru.tu/test-drill-variants-with-merged-args
    lib.drill-thru.tu/test-returns-drill
-
-   "quick-filter on an aggregated sum column\n"
+   "quick-filter on an aggregated sum column"
    {:drill-type  :drill-thru/quick-filter
     :click-type  :cell
     :query-type  :aggregated
@@ -140,14 +135,13 @@
                               {:name "="}
                               {:name "≠"}]}}
 
-   "quick-filter on an aggregated sum column for multi-stage query\n"
+   "quick-filter on an aggregated sum column for multi-stage query"
    {:custom-query #(lib.drill-thru.tu/append-filter-stage % "sum")}))
 
 (deftest ^:parallel returns-quick-filter-test-8
   (lib.drill-thru.tu/test-drill-variants-with-merged-args
    lib.drill-thru.tu/test-returns-drill
-
-   "quick-filter should not return < or > for cell with no value (#34445)\n"
+   "quick-filter should not return < or > for cell with no value (#34445)"
    {:drill-type  :drill-thru/quick-filter
     :click-type  :cell
     :query-type  :aggregated
@@ -157,7 +151,7 @@
                   :operators [{:name "="}
                               {:name "≠"}]}}
 
-   "quick-filter should not return < or > for cell with no value for multi-stage queries\n"
+   "quick-filter should not return < or > for cell with no value for multi-stage queries"
    {:custom-query #(lib.drill-thru.tu/append-filter-stage % "max")}))
 
 (deftest ^:parallel returns-quick-filter-test-9
@@ -196,8 +190,7 @@
                                              (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "sum"])]]}]}]
     (lib.drill-thru.tu/test-drill-variants-with-merged-args
      lib.drill-thru.tu/test-drill-application
-
-     "quick-filter on an aggregation should introduce an new stage (#34346)\n"
+     "quick-filter on an aggregation should introduce an new stage (#34346)"
      {:click-type     :cell
       :query-type     :aggregated
       :query-kinds    [:mbql]
@@ -214,7 +207,7 @@
       :drill-args     ["="]
       :expected-query expected-query}
 
-     "quick-filter on an aggregation should introduce an new stage for multi-stage query\n"
+     "quick-filter on an aggregation should introduce an new stage for multi-stage query"
      {:custom-query #(lib.drill-thru.tu/append-filter-stage % "sum")
       :expected-query (lib.drill-thru.tu/prepend-filter-to-stage
                        expected-query -1 [:> {} [:field {} "sum"] -1])})))
@@ -235,8 +228,7 @@
                                              value]]}]}]
     (lib.drill-thru.tu/test-drill-variants-with-merged-args
      lib.drill-thru.tu/test-drill-application
-
-     "quick-filter on a breakout should not introduce a new stage\n"
+     "quick-filter on a breakout should not introduce a new stage"
      {:click-type     :cell
       :query-type     :aggregated
       :column-name    "CREATED_AT"
@@ -245,7 +237,7 @@
       :expected       expected-drill
       :expected-query expected-query}
 
-     "quick-filter on a breakout should not introduce a new stage for multi-stage query\n"
+     "quick-filter on a breakout should not introduce a new stage for multi-stage query"
      {:query-kinds    [:mbql]
       :custom-query   #(lib.drill-thru.tu/append-filter-stage % "sum")
       ;; the extra stage is added by append-filter-stage, not by the quick-filter
@@ -259,8 +251,7 @@
   (let [expected-query {:stages [{} {:filters [[:not-null {} [:field {} "max"]]]}]}]
     (lib.drill-thru.tu/test-drill-variants-with-merged-args
      lib.drill-thru.tu/test-drill-application
-
-     "quick-filter on an aggregation should introduce an new stage (#34346)\n"
+     "quick-filter on an aggregation should introduce an new stage (#34346)"
      {:click-type     :cell
       :query-type     :aggregated
       :query-kinds    [:mbql]
@@ -275,7 +266,7 @@
       :drill-args     ["≠"]
       :expected-query expected-query}
 
-     "quick-filter on an aggregation should not introduce an new stage if one already exists\n"
+     "quick-filter on an aggregation should not introduce an new stage if one already exists"
      {:custom-query   #(lib.drill-thru.tu/append-filter-stage % "max")
       :expected-query (lib.drill-thru.tu/prepend-filter-to-stage
                        expected-query -1 [:> {} [:field {} "max"] -1])})))

--- a/test/metabase/lib/drill_thru/quick_filter_test.cljc
+++ b/test/metabase/lib/drill_thru/quick_filter_test.cljc
@@ -25,7 +25,10 @@
                 (seq dimensions)))))))
 
 (deftest ^:parallel returns-quick-filter-test-1
-  (lib.drill-thru.tu/test-returns-drill
+  (lib.drill-thru.tu/test-drill-variants-with-merged-args
+   lib.drill-thru.tu/test-returns-drill
+
+   "quick-filter on unaggregated numeric column\n"
    {:drill-type  :drill-thru/quick-filter
     :click-type  :cell
     :query-type  :unaggregated
@@ -35,19 +38,27 @@
                   :operators [{:name "<"}
                               {:name ">"}
                               {:name "="}
-                              {:name "≠"}]}}))
+                              {:name "≠"}]}}
+
+   "quick-filter on unaggregated numeric column for multi-stage query\n"
+   {:custom-query #(lib.drill-thru.tu/append-filter-stage % "SUBTOTAL")}))
 
 (deftest ^:parallel returns-quick-filter-test-2
-  (testing "if the value is NULL, only = and ≠ are allowed"
-    (lib.drill-thru.tu/test-returns-drill
-     {:drill-type  :drill-thru/quick-filter
-      :click-type  :cell
-      :query-type  :unaggregated
-      :column-name "DISCOUNT"
-      :expected    {:type      :drill-thru/quick-filter
-                    :value     :null
-                    :operators [{:name "="}
-                                {:name "≠"}]}})))
+  (lib.drill-thru.tu/test-drill-variants-with-merged-args
+   lib.drill-thru.tu/test-returns-drill
+
+   "if the value is NULL, only = and ≠ are allowed\n"
+   {:drill-type  :drill-thru/quick-filter
+    :click-type  :cell
+    :query-type  :unaggregated
+    :column-name "DISCOUNT"
+    :expected    {:type      :drill-thru/quick-filter
+                  :value     :null
+                  :operators [{:name "="}
+                              {:name "≠"}]}}
+
+   "if the value is NULL, only = and ≠ are allowed for multi-stage query\n"
+   {:custom-query #(lib.drill-thru.tu/append-filter-stage % "DISCOUNT")}))
 
 (deftest ^:parallel returns-quick-filter-test-3
   (lib.drill-thru.tu/test-returns-drill

--- a/test/metabase/lib/drill_thru/quick_filter_test.cljc
+++ b/test/metabase/lib/drill_thru/quick_filter_test.cljc
@@ -76,118 +76,78 @@
                               {:name "≠"}]}}))
 
 (deftest ^:parallel returns-quick-filter-test-5
-  (lib.drill-thru.tu/test-returns-drill
-   {:drill-type  :drill-thru/quick-filter
-    :click-type  :cell
-    :query-type  :aggregated
-    :column-name "CREATED_AT"
-    :expected    {:type      :drill-thru/quick-filter
-                  :value     (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "CREATED_AT"])
-                  :operators [{:name "<"}
-                              {:name ">"}
-                              {:name "="}
-                              {:name "≠"}]}}))
+  (lib.drill-thru.tu/test-drill-variants-with-merged-args
+   lib.drill-thru.tu/test-returns-drill
 
-(deftest ^:parallel returns-quick-filter-multi-stage-query-test-5
-  (lib.drill-thru.tu/test-returns-drill
+   "quick-filter on a datetime breakout column\n"
    {:drill-type  :drill-thru/quick-filter
     :click-type  :cell
     :query-type  :aggregated
     :column-name "CREATED_AT"
-    :custom-query (lib.drill-thru.tu/append-filter-stage
-                   (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :query])
-                   "count")
     :expected    {:type      :drill-thru/quick-filter
                   :value     (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "CREATED_AT"])
                   :operators [{:name "<"}
                               {:name ">"}
                               {:name "="}
-                              {:name "≠"}]}}))
+                              {:name "≠"}]}}
+
+   "quick-filter on a datetime breakout column for multi-stage query\n"
+   {:custom-query #(lib.drill-thru.tu/append-filter-stage % "count")}))
 
 (deftest ^:parallel returns-quick-filter-test-6
-  (lib.drill-thru.tu/test-returns-drill
-   {:drill-type  :drill-thru/quick-filter
-    :click-type  :cell
-    :query-type  :aggregated
-    :column-name "count"
-    :expected    {:type      :drill-thru/quick-filter
-                  :value     (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "count"])
-                  :operators [{:name "<"}
-                              {:name ">"}
-                              {:name "="}
-                              {:name "≠"}]}}))
+  (lib.drill-thru.tu/test-drill-variants-with-merged-args
+   lib.drill-thru.tu/test-returns-drill
 
-(deftest ^:parallel returns-quick-filter-multi-stage-query-test-6
-  (lib.drill-thru.tu/test-returns-drill
+   "quick-filter on an aggregated count column\n"
    {:drill-type  :drill-thru/quick-filter
     :click-type  :cell
     :query-type  :aggregated
     :column-name "count"
-    :custom-query (lib.drill-thru.tu/append-filter-stage
-                   (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :query])
-                   "count")
     :expected    {:type      :drill-thru/quick-filter
                   :value     (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "count"])
                   :operators [{:name "<"}
                               {:name ">"}
                               {:name "="}
-                              {:name "≠"}]}}))
+                              {:name "≠"}]}}
+
+   "quick-filter on an aggregated count column for multi-stage query\n"
+   {:custom-query #(lib.drill-thru.tu/append-filter-stage % "count")}))
 
 (deftest ^:parallel returns-quick-filter-test-7
-  (lib.drill-thru.tu/test-returns-drill
-   {:drill-type  :drill-thru/quick-filter
-    :click-type  :cell
-    :query-type  :aggregated
-    :column-name "sum"
-    :expected    {:type      :drill-thru/quick-filter
-                  :value     (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "sum"])
-                  :operators [{:name "<"}
-                              {:name ">"}
-                              {:name "="}
-                              {:name "≠"}]}}))
+  (lib.drill-thru.tu/test-drill-variants-with-merged-args
+   lib.drill-thru.tu/test-returns-drill
 
-(deftest ^:parallel returns-quick-filter-multi-stage-query-test-7
-  (lib.drill-thru.tu/test-returns-drill
+   "quick-filter on an aggregated sum column\n"
    {:drill-type  :drill-thru/quick-filter
     :click-type  :cell
     :query-type  :aggregated
     :column-name "sum"
-    :custom-query (lib.drill-thru.tu/append-filter-stage
-                   (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :query])
-                   "sum")
     :expected    {:type      :drill-thru/quick-filter
                   :value     (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "sum"])
                   :operators [{:name "<"}
                               {:name ">"}
                               {:name "="}
-                              {:name "≠"}]}}))
+                              {:name "≠"}]}}
+
+   "quick-filter on an aggregated sum column for multi-stage query\n"
+   {:custom-query #(lib.drill-thru.tu/append-filter-stage % "sum")}))
 
 (deftest ^:parallel returns-quick-filter-test-8
-  (testing "quick-filter should not return < or > for cell with no value (#34445)"
-    (lib.drill-thru.tu/test-returns-drill
-     {:drill-type  :drill-thru/quick-filter
-      :click-type  :cell
-      :query-type  :aggregated
-      :column-name "max"
-      :expected    {:type      :drill-thru/quick-filter
-                    :value     :null
-                    :operators [{:name "="}
-                                {:name "≠"}]}})))
+  (lib.drill-thru.tu/test-drill-variants-with-merged-args
+   lib.drill-thru.tu/test-returns-drill
 
-(deftest ^:parallel returns-quick-filter-multi-stage-query-test-8
-  (testing "quick-filter should not return < or > for cell with no value for multi-stage queries"
-    (lib.drill-thru.tu/test-returns-drill
-     {:drill-type  :drill-thru/quick-filter
-      :click-type  :cell
-      :query-type  :aggregated
-      :column-name "max"
-      :custom-query (lib.drill-thru.tu/append-filter-stage
-                     (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :query])
-                     "max")
-      :expected    {:type      :drill-thru/quick-filter
-                    :value     :null
-                    :operators [{:name "="}
-                                {:name "≠"}]}})))
+   "quick-filter should not return < or > for cell with no value (#34445)\n"
+   {:drill-type  :drill-thru/quick-filter
+    :click-type  :cell
+    :query-type  :aggregated
+    :column-name "max"
+    :expected    {:type      :drill-thru/quick-filter
+                  :value     :null
+                  :operators [{:name "="}
+                              {:name "≠"}]}}
+
+   "quick-filter should not return < or > for cell with no value for multi-stage queries\n"
+   {:custom-query #(lib.drill-thru.tu/append-filter-stage % "max")}))
 
 (deftest ^:parallel returns-quick-filter-test-9
   (testing "quick-filter should return = and ≠ only for other field types (eg. generic strings)"
@@ -219,38 +179,19 @@
                                   {:name "≠", :filter [:not-empty {} [:field {} field-key]]}]}}))))
 
 (deftest ^:parallel apply-quick-filter-on-correct-level-test
-  (testing "quick-filter on an aggregation should introduce an new stage (#34346)"
-    (lib.drill-thru.tu/test-drill-application
-     {:click-type     :cell
-      :query-type     :aggregated
-      :query-kinds    [:mbql]
-      :column-name    "sum"
-      :drill-type     :drill-thru/quick-filter
-      :expected       {:type         :drill-thru/quick-filter
-                       :operators    [{:name "<"}
-                                      {:name ">"}
-                                      {:name "="}
-                                      {:name "≠"}]
-                       :query        {:stages [{} {}]}
-                       :stage-number -1
-                       :value        1}
-      :drill-args     ["="]
-      :expected-query {:stages [{}
-                                {:filters [[:= {}
-                                            [:field {} "sum"]
-                                            (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "sum"])]]}]}})))
+  (let [expected-query {:stages [{}
+                                 {:filters [[:= {}
+                                             [:field {} "sum"]
+                                             (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "sum"])]]}]}]
+    (lib.drill-thru.tu/test-drill-variants-with-merged-args
+     lib.drill-thru.tu/test-drill-application
 
-(deftest ^:parallel apply-quick-filter-on-correct-level-multi-stage-query-test
-  (testing "quick-filter on an aggregation should not introduce an new stage if one already exists"
-    (lib.drill-thru.tu/test-drill-application
+     "quick-filter on an aggregation should introduce an new stage (#34346)\n"
      {:click-type     :cell
       :query-type     :aggregated
       :query-kinds    [:mbql]
       :column-name    "sum"
       :drill-type     :drill-thru/quick-filter
-      :custom-query   (lib.drill-thru.tu/append-filter-stage
-                       (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :query])
-                       "sum")
       :expected       {:type         :drill-thru/quick-filter
                        :operators    [{:name "<"}
                                       {:name ">"}
@@ -260,89 +201,60 @@
                        :stage-number -1
                        :value        1}
       :drill-args     ["="]
-      :expected-query {:stages [{}
-                                {:filters [[:> {} [:field {} "sum"] -1]
-                                           [:= {}
-                                            [:field {} "sum"]
-                                            (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "sum"])]]}]}})))
+      :expected-query expected-query}
+
+     "quick-filter on an aggregation should introduce an new stage for multi-stage query\n"
+     {:custom-query #(lib.drill-thru.tu/append-filter-stage % "sum")
+      :expected-query (lib.drill-thru.tu/prepend-filter-to-stage
+                       expected-query -1 [:> {} [:field {} "sum"] -1])})))
 
 (deftest ^:parallel apply-quick-filter-on-correct-level-test-2
-  (testing "quick-filter on a breakout should not introduce a new stage"
-    (lib.drill-thru.tu/test-drill-application
-     {:click-type     :cell
-      :query-type     :aggregated
-      :column-name    "CREATED_AT"
-      :drill-type     :drill-thru/quick-filter
-      :expected       {:type         :drill-thru/quick-filter
-                       :operators    [{:name "<"}
-                                      {:name ">"}
-                                      {:name "="}
-                                      {:name "≠"}]
-                       :query        {:stages [{}]}
-                       :stage-number -1
-                       :value        (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "CREATED_AT"])}
-      :drill-args     ["<"]
-      :expected-query {:stages [{:filters [[:< {}
-                                            [:field {} (lib.drill-thru.tu/field-key= (meta/id :orders :created-at)
-                                                                                     "CREATED_AT")]
-                                            (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "CREATED_AT"])]]}]}})))
+  (let [value          (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "CREATED_AT"])
+        expected-drill {:type         :drill-thru/quick-filter
+                        :operators    [{:name "<"}
+                                       {:name ">"}
+                                       {:name "="}
+                                       {:name "≠"}]
+                        :query        {:stages [{}]}
+                        :stage-number -1
+                        :value        value}
+        expected-query {:stages [{:filters [[:< {}
+                                             [:field {} (lib.drill-thru.tu/field-key= (meta/id :orders :created-at)
+                                                                                      "CREATED_AT")]
+                                             value]]}]}]
+    (lib.drill-thru.tu/test-drill-variants-with-merged-args
+     lib.drill-thru.tu/test-drill-application
 
-(deftest ^:parallel apply-quick-filter-on-correct-level-mutli-stage-query-test-2
-  (testing "quick-filter on a breakout should not introduce a new stage if one already exists"
-    (lib.drill-thru.tu/test-drill-application
+     "quick-filter on a breakout should not introduce a new stage\n"
      {:click-type     :cell
       :query-type     :aggregated
-      :query-kinds    [:mbql]
       :column-name    "CREATED_AT"
       :drill-type     :drill-thru/quick-filter
-      :custom-query   (lib.drill-thru.tu/append-filter-stage
-                       (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :query])
-                       "sum")
-      :expected       {:type         :drill-thru/quick-filter
-                       :operators    [{:name "<"}
-                                      {:name ">"}
-                                      {:name "="}
-                                      {:name "≠"}]
-                       :query        {:stages [{} {}]}
-                       :stage-number -1
-                       :value        (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "CREATED_AT"])}
       :drill-args     ["<"]
-      :expected-query {:stages [{}
-                                {:filters [[:> {} [:field {} "sum"] -1]
-                                           [:< {}
-                                            [:field {} (lib.drill-thru.tu/field-key= (meta/id :orders :created-at)
-                                                                                     "CREATED_AT")]
-                                            (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "CREATED_AT"])]]}]}})))
+      :expected       expected-drill
+      :expected-query expected-query}
+
+     "quick-filter on a breakout should not introduce a new stage for multi-stage query\n"
+     {:query-kinds    [:mbql]
+      :custom-query   #(lib.drill-thru.tu/append-filter-stage % "sum")
+      ;; the extra stage is added by append-filter-stage, not by the quick-filter
+      :expected       (update-in expected-drill [:query :stages] conj {})
+      :expected-query (lib.drill-thru.tu/prepend-filter-to-stage
+                       (update expected-query :stages #(into [{}] %))
+                       -1
+                       [:> {} [:field {} "sum"] -1])})))
 
 (deftest ^:parallel apply-quick-filter-on-correct-level-test-3
-  (testing "quick-filter on an aggregation should introduce an new stage (#34346)"
-    (lib.drill-thru.tu/test-drill-application
-     {:click-type     :cell
-      :query-type     :aggregated
-      :query-kinds    [:mbql]
-      :column-name    "max"
-      :drill-type     :drill-thru/quick-filter
-      :expected       {:type         :drill-thru/quick-filter
-                       :operators    [{:name "=", :filter [:is-null {} [:field {} "max"]]}
-                                      {:name "≠", :filter [:not-null {} [:field {} "max"]]}]
-                       :query        {:stages [{} {}]}
-                       :stage-number -1
-                       :value        :null}
-      :drill-args     ["≠"]
-      :expected-query {:stages [{}
-                                {:filters [[:not-null {} [:field {} "max"]]]}]}})))
+  (let [expected-query {:stages [{} {:filters [[:not-null {} [:field {} "max"]]]}]}]
+    (lib.drill-thru.tu/test-drill-variants-with-merged-args
+     lib.drill-thru.tu/test-drill-application
 
-(deftest ^:parallel apply-quick-filter-on-correct-level-mutli-stage-query-test-3
-  (testing "quick-filter on an aggregation should not introduce an new stage if one already exists"
-    (lib.drill-thru.tu/test-drill-application
+     "quick-filter on an aggregation should introduce an new stage (#34346)\n"
      {:click-type     :cell
       :query-type     :aggregated
       :query-kinds    [:mbql]
       :column-name    "max"
       :drill-type     :drill-thru/quick-filter
-      :custom-query   (lib.drill-thru.tu/append-filter-stage
-                       (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :query])
-                       "max")
       :expected       {:type         :drill-thru/quick-filter
                        :operators    [{:name "=", :filter [:is-null {} [:field {} "max"]]}
                                       {:name "≠", :filter [:not-null {} [:field {} "max"]]}]
@@ -350,9 +262,12 @@
                        :stage-number -1
                        :value        :null}
       :drill-args     ["≠"]
-      :expected-query {:stages [{}
-                                {:filters [[:> {} [:field {} "max"] -1]
-                                           [:not-null {} [:field {} "max"]]]}]}})))
+      :expected-query expected-query}
+
+     "quick-filter on an aggregation should not introduce an new stage if one already exists\n"
+     {:custom-query   #(lib.drill-thru.tu/append-filter-stage % "max")
+      :expected-query (lib.drill-thru.tu/prepend-filter-to-stage
+                       expected-query -1 [:> {} [:field {} "max"] -1])})))
 
 (deftest ^:parallel contains-does-not-contain-test
   (testing "Should return :contains/:does-not-contain for text columns (#33560)"

--- a/test/metabase/lib/drill_thru/test_util.cljc
+++ b/test/metabase/lib/drill_thru/test_util.cljc
@@ -159,6 +159,18 @@
      (assert (some? column-to-filter) (str "Failed to find " column-name " in " query))
      (lib/filter query' (column-filter-fn column-to-filter)))))
 
+(mu/defn prepend-filter-to-stage :- :map
+  "Prepend `filter-expr` to the filters in `expected-query`.
+
+  Useful for updating the `:expected-query` for [[test-drill-application]] when the `:custom-query` was modified
+  by [[append-filter-stage]]."
+  [expected-query :- :map
+   stage-number   :- :int
+   filter-expr    :- vector?]
+  (update-in expected-query
+             [:stages (lib.util/canonical-stage-index expected-query stage-number) :filters]
+             #(into [filter-expr] %)))
+
 (def ^:private unsupported-on-native
   #{:drill-thru/automatic-insights
     :drill-thru/pivot

--- a/test/metabase/lib/drill_thru/test_util.cljc
+++ b/test/metabase/lib/drill_thru/test_util.cljc
@@ -393,3 +393,30 @@
                           expected-native)
                         (clean-expected-query expected-query))
                     query'))))))))
+
+(mu/defn test-drill-variants-with-merged-args
+  "Run `test-fn` first with `base-case` then with each of the specified `variants`.
+
+  `test-fn` is probably one of these functions, but could be any func that can be called with a single map argument:
+
+    - [[test-returns-drill]]
+    - [[test-drill-not-returned]]
+    - [[test-drill-application]]
+
+  `base-desc` will be passed directly to [[clojure.test/testing]].
+  `base-case` will be passed unmodified to `test-fn`. It is probably a TestCase derivative, but could be any map.
+  `variants` is a flat sequence of `variant-desc` `variant-case` pairs indicating variations on the base-case.
+
+  For each `variants` pair:
+    - `variant-desc` will be passed directly to [[clojure.test/testing]].
+    - `variant-case` will be `merge`d with the `base-case` and the result will be passed to `test-fn`."
+  [test-fn   :- [:-> :map :any]
+   base-desc :- :string
+   base-case :- :map
+   & variants]
+  (assert (even? (count variants)) "variants must come in variant-desc and variant-case pairs")
+  (testing base-desc
+    (test-fn base-case))
+  (doseq [[variant-desc variant-case] (partition 2 variants)]
+    (testing variant-desc
+      (test-fn (merge base-case variant-case)))))

--- a/test/metabase/lib/drill_thru/test_util.cljc
+++ b/test/metabase/lib/drill_thru/test_util.cljc
@@ -409,14 +409,19 @@
 
   For each `variants` pair:
     - `variant-desc` will be passed directly to [[clojure.test/testing]].
-    - `variant-case` will be `merge`d with the `base-case` and the result will be passed to `test-fn`."
+    - `variant-case` will be `merge`d with the `base-case` and the result will be passed to `test-fn`.
+
+  If any `base-desc` or `variant-desc` is the special string \"SKIP\", then the corresponding case will be
+  skipped. Useful when you want to debug one of the `variants` in isolation."
   [test-fn   :- [:-> :map :any]
    base-desc :- :string
    base-case :- :map
    & variants]
   (assert (even? (count variants)) "variants must come in variant-desc and variant-case pairs")
-  (testing base-desc
-    (test-fn base-case))
+  (when-not (= "SKIP" base-desc)
+    (testing base-desc
+      (test-fn base-case)))
   (doseq [[variant-desc variant-case] (partition 2 variants)]
-    (testing variant-desc
-      (test-fn (merge base-case variant-case)))))
+    (when-not (= "SKIP" variant-desc)
+      (testing variant-desc
+        (test-fn (merge base-case variant-case))))))

--- a/test/metabase/lib/drill_thru/test_util/canned.cljc
+++ b/test/metabase/lib/drill_thru/test_util/canned.cljc
@@ -4,6 +4,7 @@
    [clojure.test :refer [is testing]]
    [medley.core :as m]
    [metabase.lib.core :as lib]
+   [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util.metadata-providers.merged-mock :as merged-mock]
    [metabase.util :as u]))
@@ -19,8 +20,7 @@
                (base-context column (get row (:name column))))))
 
 (defn- column-by-name [{:keys [query]} column-name]
-  (let [columns (lib/returned-columns query)]
-    (m/find-first #(= (:name %) column-name) columns)))
+  (lib.drill-thru.tu/column-by-name query column-name))
 
 (defn- null-value [{:keys [value] :as context}]
   ; This special case is only for *top-level* contexts, not :dimensions or :row, hence the separate function.

--- a/test/metabase/lib/drill_thru_test.cljc
+++ b/test/metabase/lib/drill_thru_test.cljc
@@ -16,9 +16,6 @@
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 
-(defn by-name [cols column-name]
-  (first (filter #(= (:name %) column-name) cols)))
-
 (def ^:private orders-query
   (lib/query meta/metadata-provider (meta/table-metadata :orders)))
 
@@ -540,7 +537,7 @@
                                              (meta/field-metadata :orders :created-at)
                                              :month)))
             columns      (lib/returned-columns query)
-            sum          (by-name columns "sum")
+            sum          (lib.drill-thru.tu/column-by-name columns "sum")
             sum-dim      {:column     sum
                           :column-ref (lib/ref sum)
                           :value      42295.12}


### PR DESCRIPTION
### Description

Fix the quick-filter drill thru for queries with a filter stage after the aggregations.

Related to https://github.com/metabase/metabase/issues/46932

### How to verify

* New question: Orders
* summarize: Count by Created At: Month
* Add filter stage after summarize, e.g. Count > 1
* Visualize
* Select Table viz
* Click on a cell in the "count" column
* "Filter by this value" drill through should appear in the context menu
* Select the "Filter by this value" drill: should add a new filter for the value and should *not* append a new stage since one already exists after the aggregation.

### Demo

![Screenshot 2025-01-06 at 6 26 02 PM](https://github.com/user-attachments/assets/3557dbd6-e395-43b9-a13c-ba7381fc945a)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
