### PR TITLE
Consolidate numeric type system checks

### DIFF
--- a/frontend/src/metabase-lib/column_types.ts
+++ b/frontend/src/metabase-lib/column_types.ts
@@ -11,21 +11,18 @@ export const isTemporal: TypeFn = TYPES.temporal_QMARK_;
 export const isDateOrDateTime: TypeFn = TYPES.date_or_datetime_QMARK_;
 export const isDateWithoutTime: TypeFn = TYPES.date_without_time_QMARK_;
 export const isInteger: TypeFn = TYPES.integer_QMARK_;
+export const isNumeric: TypeFn = TYPES.numeric_QMARK_;
 export const isString: TypeFn = TYPES.string_QMARK_;
 export const isStringLike: TypeFn = TYPES.string_like_QMARK_;
 export const isStringOrStringLike: TypeFn = TYPES.string_or_string_like_QMARK_;
 export const isTime: TypeFn = TYPES.time_QMARK_;
-
-// Legacy helpers that mix effective and semantic types.
-export const isCategory: TypeFn = TYPES.category_QMARK_;
-export const isNumber: TypeFn = TYPES.number_QMARK_;
-export const isNumeric: TypeFn = TYPES.numeric_QMARK_;
 
 // Semantic type checks. A semantic type can be assigned to a column with an
 // unrelated effective type. Do not imply any effective type when checking for a
 // semantic type.
 export const isAddress: TypeFn = TYPES.address_QMARK_;
 export const isAvatarURL: TypeFn = TYPES.avatar_URL_QMARK_;
+export const isCategory: TypeFn = TYPES.category_QMARK_;
 export const isCity: TypeFn = TYPES.city_QMARK_;
 export const isComment: TypeFn = TYPES.comment_QMARK_;
 export const isCoordinate: TypeFn = TYPES.coordinate_QMARK_;

--- a/frontend/src/metabase-lib/column_types.ts
+++ b/frontend/src/metabase-lib/column_types.ts
@@ -11,11 +11,15 @@ export const isTemporal: TypeFn = TYPES.temporal_QMARK_;
 export const isDateOrDateTime: TypeFn = TYPES.date_or_datetime_QMARK_;
 export const isDateWithoutTime: TypeFn = TYPES.date_without_time_QMARK_;
 export const isInteger: TypeFn = TYPES.integer_QMARK_;
-export const isNumeric: TypeFn = TYPES.numeric_QMARK_;
 export const isString: TypeFn = TYPES.string_QMARK_;
 export const isStringLike: TypeFn = TYPES.string_like_QMARK_;
 export const isStringOrStringLike: TypeFn = TYPES.string_or_string_like_QMARK_;
 export const isTime: TypeFn = TYPES.time_QMARK_;
+
+// Checks for both effective and semantic types. This hack is required to
+// support numbers stored as strings in MySQL until there is a proper
+// coercion strategy.
+export const isNumeric: TypeFn = TYPES.numeric_QMARK_;
 
 // Semantic type checks. A semantic type can be assigned to a column with an
 // unrelated effective type. Do not imply any effective type when checking for a

--- a/frontend/src/metabase-lib/column_types.ts
+++ b/frontend/src/metabase-lib/column_types.ts
@@ -19,7 +19,7 @@ export const isTime: TypeFn = TYPES.time_QMARK_;
 // Checks for both effective and semantic types. This hack is required to
 // support numbers stored as strings in MySQL until there is a proper
 // coercion strategy. `isString` and `isNumeric` would be both `true` for such
-// columns; that's why `isNumeric` needs to be called first.
+// columns; that's why `isNumeric` needs to be called first. See #44431.
 export const isNumeric: TypeFn = TYPES.numeric_QMARK_;
 
 // Semantic type checks. A semantic type can be assigned to a column with an

--- a/frontend/src/metabase-lib/column_types.ts
+++ b/frontend/src/metabase-lib/column_types.ts
@@ -18,7 +18,8 @@ export const isTime: TypeFn = TYPES.time_QMARK_;
 
 // Checks for both effective and semantic types. This hack is required to
 // support numbers stored as strings in MySQL until there is a proper
-// coercion strategy.
+// coercion strategy. `isString` and `isNumeric` would be both `true` for such
+// columns; that's why `isNumeric` needs to be called first.
 export const isNumeric: TypeFn = TYPES.numeric_QMARK_;
 
 // Semantic type checks. A semantic type can be assigned to a column with an

--- a/frontend/src/metabase-lib/v1/parameters/utils/filters.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/filters.ts
@@ -49,7 +49,11 @@ export function columnFilterForParameter(
     case "location":
       return column => Lib.isLocation(column);
     case "number":
-      return column => Lib.isNumber(column) && !Lib.isLocation(column);
+      return column =>
+        Lib.isNumeric(column) &&
+        !Lib.isPrimaryKey(column) &&
+        !Lib.isForeignKey(column) &&
+        !Lib.isLocation(column);
     case "string":
       return column =>
         (Lib.isStringOrStringLike(column) ||

--- a/frontend/src/metabase-lib/v1/parameters/utils/filters.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/filters.ts
@@ -51,7 +51,6 @@ export function columnFilterForParameter(
     case "number":
       return column =>
         Lib.isNumeric(column) &&
-        !Lib.isStringOrStringLike(column) &&
         !Lib.isPrimaryKey(column) &&
         !Lib.isForeignKey(column) &&
         !Lib.isLocation(column);

--- a/frontend/src/metabase-lib/v1/parameters/utils/filters.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/filters.ts
@@ -51,6 +51,7 @@ export function columnFilterForParameter(
     case "number":
       return column =>
         Lib.isNumeric(column) &&
+        !Lib.isStringOrStringLike(column) &&
         !Lib.isPrimaryKey(column) &&
         !Lib.isForeignKey(column) &&
         !Lib.isLocation(column);

--- a/frontend/src/metabase/components/MetadataInfo/ColumnFingerprintInfo/ColumnFingerprintInfo.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/ColumnFingerprintInfo/ColumnFingerprintInfo.tsx
@@ -83,7 +83,7 @@ export function QueryColumnFingerprintInfo({
         timezone={timezone}
       />
     );
-  } else if (Lib.isNumber(column)) {
+  } else if (Lib.isNumeric(column)) {
     return (
       <NumberFingerprint
         className={className}

--- a/frontend/src/metabase/querying/filters/components/FilterModal/FilterModalBody/ColumnFilterList/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterModal/FilterModalBody/ColumnFilterList/utils.ts
@@ -14,8 +14,13 @@ function isCategoryAndNotNameOrAddress(column: Lib.ColumnMetadata) {
   );
 }
 
-function isNumberAndNotCoordinate(column: Lib.ColumnMetadata) {
-  return Lib.isNumber(column) && !Lib.isCoordinate(column);
+function isNumberAndNotKeyOrCoordinate(column: Lib.ColumnMetadata) {
+  return (
+    Lib.isNumeric(column) &&
+    !Lib.isPrimaryKey(column) &&
+    !Lib.isForeignKey(column) &&
+    !Lib.isCoordinate(column)
+  );
 }
 
 function isShortText(column: Lib.ColumnMetadata) {
@@ -37,7 +42,7 @@ const PRIORITIES = [
   Lib.isState,
   Lib.isZipCode,
   Lib.isCountry,
-  isNumberAndNotCoordinate,
+  isNumberAndNotKeyOrCoordinate,
   isShortText,
   Lib.isPrimaryKey,
   Lib.isLatitude,

--- a/frontend/src/metabase/querying/filters/components/FilterModal/FilterModalBody/ColumnFilterList/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterModal/FilterModalBody/ColumnFilterList/utils.ts
@@ -17,6 +17,7 @@ function isCategoryAndNotNameOrAddress(column: Lib.ColumnMetadata) {
 function isNumberAndNotKeyOrCoordinate(column: Lib.ColumnMetadata) {
   return (
     Lib.isNumeric(column) &&
+    !Lib.isStringOrStringLike(column) &&
     !Lib.isPrimaryKey(column) &&
     !Lib.isForeignKey(column) &&
     !Lib.isCoordinate(column)

--- a/frontend/src/metabase/querying/filters/components/FilterModal/FilterModalBody/ColumnFilterList/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterModal/FilterModalBody/ColumnFilterList/utils.ts
@@ -17,7 +17,6 @@ function isCategoryAndNotNameOrAddress(column: Lib.ColumnMetadata) {
 function isNumberAndNotKeyOrCoordinate(column: Lib.ColumnMetadata) {
   return (
     Lib.isNumeric(column) &&
-    !Lib.isStringOrStringLike(column) &&
     !Lib.isPrimaryKey(column) &&
     !Lib.isForeignKey(column) &&
     !Lib.isCoordinate(column)

--- a/src/metabase/lib/types/constants.cljc
+++ b/src/metabase/lib/types/constants.cljc
@@ -38,6 +38,9 @@
   "A front-end specific type hierarchy used by [[metabase.lib.types.isa/field-type?]].
   It is not meant to be used directly."
   {::temporal    {:effective-type [:type/Temporal]}
+   ;; Checks for both effective and semantic types. This hack is required to
+   ; support numbers stored as strings in MySQL until there is a proper
+   ; coercion strategy.
    ::number      {:effective-type [:type/Number]
                   :semantic-type  [:type/Number]}
    ::integer     {:effective-type [:type/Integer]}

--- a/src/metabase/lib/types/constants.cljc
+++ b/src/metabase/lib/types/constants.cljc
@@ -39,8 +39,8 @@
   It is not meant to be used directly."
   {::temporal    {:effective-type [:type/Temporal]}
    ;; Checks for both effective and semantic types. This hack is required to
-   ; support numbers stored as strings in MySQL until there is a proper
-   ; coercion strategy. See #44431.
+   ;; support numbers stored as strings in MySQL until there is a proper
+   ;; coercion strategy. See #44431.
    ::number      {:effective-type [:type/Number]
                   :semantic-type  [:type/Number]}
    ::integer     {:effective-type [:type/Integer]}

--- a/src/metabase/lib/types/constants.cljc
+++ b/src/metabase/lib/types/constants.cljc
@@ -40,7 +40,7 @@
   {::temporal    {:effective-type [:type/Temporal]}
    ;; Checks for both effective and semantic types. This hack is required to
    ; support numbers stored as strings in MySQL until there is a proper
-   ; coercion strategy.
+   ; coercion strategy. See #44431.
    ::number      {:effective-type [:type/Number]
                   :semantic-type  [:type/Number]}
    ::integer     {:effective-type [:type/Integer]}

--- a/src/metabase/lib/types/isa.cljc
+++ b/src/metabase/lib/types/isa.cljc
@@ -154,11 +154,6 @@
   [_column]
   true)
 
-(defn ^:export numeric-base-type?
-  "Is `column` a numneric base type?"
-  [column]
-  (clojure.core/isa? (:effective-type column) :type/Number))
-
 (defn ^:export date-or-datetime?
   "Is `column` a date or datetime?"
   [column]
@@ -184,16 +179,6 @@
   "Is `column` a creation time column?"
   [column]
   (clojure.core/isa? (:semantic-type column) :type/CreationTime))
-
-;; ZipCode, ID, etc derive from Number but should not be formatted as numbers
-(defn ^:export number?
-  "Is `column` a number without some other semantic type (like ZIP code)?"
-  [column]
-  (and (numeric-base-type? column)
-       (let [semantic-type (:semantic-type column)]
-         (or (nil? semantic-type)
-             ;; this is a precaution, :type/Number is not a semantic type
-             (clojure.core/isa? semantic-type :type/Number)))))
 
 (defn ^:export integer?
   "Is `column` a integer column?"
@@ -301,6 +286,6 @@
   [src-column dst-column]
   (or
    (and (string? src-column)   (string? dst-column))
-   (and (number? src-column)   (number? dst-column))
+   (and (numeric? src-column)  (numeric? dst-column))
    (and (temporal? src-column) (temporal? dst-column))
    (clojure.core/isa? (:base-type src-column) (:base-type dst-column))))

--- a/test/metabase/lib/test_util/generators.cljc
+++ b/test/metabase/lib/test_util/generators.cljc
@@ -247,7 +247,7 @@
   (lib/concat column "__concat"))
 
 (defn- gen-expression [columns]
-  (let [numbers (map #(vector gen-expression:number %) (filter lib.types.isa/number? columns))
+  (let [numbers (map #(vector gen-expression:number %) (filter lib.types.isa/numeric? columns))
         strings (map #(vector gen-expression:string %) (filter lib.types.isa/string? columns))
         [f col] (gen.u/choose (concat numbers strings))]
     (when (and f col)

--- a/test/metabase/lib/types/isa_test.cljc
+++ b/test/metabase/lib/types/isa_test.cljc
@@ -152,6 +152,7 @@
             [{:pred #'lib.types.isa/temporal?,           :positive :type/Date,              :negative :type/CreationDate}
              {:pred #'lib.types.isa/temporal?,           :positive :type/DateTime,          :negative :type/City}
              {:pred #'lib.types.isa/numeric?,            :positive :type/Integer,           :negative :type/FK}
+             {:pred #'lib.types.isa/numeric?,            :positive :type/Price,             :negative :type/CreationDate}
              {:pred #'lib.types.isa/boolean?,            :positive :type/Boolean,           :negative :type/PK}
              {:pred #'lib.types.isa/string?,             :positive :type/Text,              :negative :type/URL}
              {:pred #'lib.types.isa/string-like?,        :positive :type/TextLike,          :negative :type/Address}
@@ -166,14 +167,12 @@
              {:pred #'lib.types.isa/entity-name?,        :positive :type/Name,              :negative :type/Number}
              {:pred #'lib.types.isa/title?,              :positive :type/Title,             :negative :type/Name}
              {:pred #'lib.types.isa/any?,                :positive :type/*}
-             {:pred #'lib.types.isa/numeric-base-type?,  :positive :type/Integer,           :negative :type/String}
              {:pred #'lib.types.isa/date-or-datetime?,   :positive :type/Date,              :negative :type/Time}
              {:pred #'lib.types.isa/date-or-datetime?,   :positive :type/DateTime,          :negative :type/Interval}
              {:pred #'lib.types.isa/date-without-time?,  :positive :type/Date,              :negative :type/Time}
              {:pred #'lib.types.isa/creation-timestamp?, :positive :type/CreationTimestamp, :negative :type/CreationDate}
              {:pred #'lib.types.isa/creation-date?,      :positive :type/CreationDate,      :negative :type/CreationTimestamp}
              {:pred #'lib.types.isa/creation-time?,      :positive :type/CreationTime,      :negative :type/CreationTimestamp}
-             {:pred #'lib.types.isa/number?,             :positive :type/Number,            :negative :type/Text}
              {:pred #'lib.types.isa/time?,               :positive :type/Time,              :negative :type/Number}
              {:pred #'lib.types.isa/address?,            :positive :type/Address,           :negative :type/String}
              {:pred #'lib.types.isa/city?,               :positive :type/City,              :negative :type/ZipCode}


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/51799
Follow up for https://github.com/metabase/metabase/pull/51796
Related to https://github.com/metabase/metabase/issues/44431

Before:
- `isNumber` is `true` when the effective type is `type/Number` **and** either there is no semantic type or it's derived from `type/Number` as well. So for all PKs and FKs `isNumber` is false.
- `isNumeric` is `true` when the effective type is `type/Number` **or** the semantic type is `type/Number`. So `isNumeric` is true in more cases than `isNumber`.
- MySQL users rely on the fact that they can do numeric operations and aggregations with numbers stored as strings. We had several high priority bugs when we broke this behavior before, so we cannot drop this. MySQL users assign numeric semantic types for string fields to make Metabase use them as numbers. This whole hack works because of how `isNumeric` is implemented.

Now:
- Only one `isNumeric` function that works as before. MySQL hack is preserved.
- `isNumber` usages are replaced with `isNumeric`. PKs and FKs are ignored explicitly where needed. 

Unfortunately it's not possible to remove the hack from `isNumeric` without adding a coercion strategy, but we can at least have just 1 function.
