### PR TITLE
docs - add enterprise-only key to SDK blockquote

### DIFF
--- a/docs/embedding/sdk/appearance.md
+++ b/docs/embedding/sdk/appearance.md
@@ -6,7 +6,7 @@ title: "Embedded analytics SDK - appearance"
 
 {% include beta-blockquote.html %}
 
-{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true %}
+{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true enterprise-only=true %}
 
 You can style your embedded Metabase components with a theme.
 

--- a/docs/embedding/sdk/authentication.md
+++ b/docs/embedding/sdk/authentication.md
@@ -6,7 +6,7 @@ title: Embedded analytics SDK - authentication
 
 {% include beta-blockquote.html %}
 
-{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true %}
+{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true enterprise-only=true %}
 
 Notes on handling authentication when working with the SDK.
 

--- a/docs/embedding/sdk/collections.md
+++ b/docs/embedding/sdk/collections.md
@@ -6,7 +6,7 @@ title: Embedded analytics SDK - collections
 
 {% include beta-blockquote.html %}
 
-{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true %}
+{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true enterprise-only=true %}
 
 You can embed Metabase's collection browser so that people can explore items in your Metabase from your application.
 

--- a/docs/embedding/sdk/config.md
+++ b/docs/embedding/sdk/config.md
@@ -6,7 +6,7 @@ title: Embedded analytics SDK - config
 
 {% include beta-blockquote.html %}
 
-{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true %}
+{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true enterprise-only=true %}
 
 To use the SDK in your app, you need to import the `MetabaseProvider` component and provide it with an `authConfig` object, like so:
 

--- a/docs/embedding/sdk/dashboards.md
+++ b/docs/embedding/sdk/dashboards.md
@@ -6,7 +6,7 @@ title: "Embedded analytics SDK - dashboards"
 
 {% include beta-blockquote.html %}
 
-{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true %}
+{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true enterprise-only=true %}
 
 You can embed an interactive, editable, or static dashboard.
 

--- a/docs/embedding/sdk/introduction.md
+++ b/docs/embedding/sdk/introduction.md
@@ -6,7 +6,7 @@ title: Embedded analytics SDK
 
 {% include beta-blockquote.html %}
 
-{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true %}
+{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true enterprise-only=true %}
 
 With the Embedded analytics SDK, you can embed individual Metabase components with React (like standalone charts, dashboards, the query builder, and more). You can manage access and interactivity per component, and you have advanced customization for seamless styling.
 

--- a/docs/embedding/sdk/next-js.md
+++ b/docs/embedding/sdk/next-js.md
@@ -6,7 +6,7 @@ title: Embedded analytics SDK - Using the SDK with Next.js
 
 {% include beta-blockquote.html %}
 
-{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true %}
+{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true enterprise-only=true %}
 
 Some notes on using the Embedded analytics SDK with [Next.js](https://nextjs.org/). The SDK is tested to work with Next.js 14, although it may work with other versions.
 

--- a/docs/embedding/sdk/plugins.md
+++ b/docs/embedding/sdk/plugins.md
@@ -6,7 +6,7 @@ title: Embedded analytics SDK - plugins
 
 {% include beta-blockquote.html %}
 
-{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true %}
+{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true enterprise-only=true %}
 
 The Metabase Embedding SDK supports plugins to customize the behavior of components. These plugins can be used in a global context or on a per-component basis.
 

--- a/docs/embedding/sdk/questions.md
+++ b/docs/embedding/sdk/questions.md
@@ -6,7 +6,7 @@ title: "Embedded analytics SDK - components"
 
 {% include beta-blockquote.html %}
 
-{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true %}
+{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true enterprise-only=true %}
 
 There are different ways you can embed questions:
 

--- a/docs/embedding/sdk/quickstart-cli.md
+++ b/docs/embedding/sdk/quickstart-cli.md
@@ -6,7 +6,7 @@ title: Embedded analytics SDK - CLI quickstart
 
 {% include beta-blockquote.html %}
 
-{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true %}
+{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true enterprise-only=true %}
 
 We built a single command to spin up a Metabase and help you get an embedded dashboard in your app. This setup with API keys won't work in production; it's only intended for you to quickly try out the SDK on your local machine. A production setup requires a Pro/Enterprise license, and SSO with JWT.
 

--- a/docs/embedding/sdk/quickstart.md
+++ b/docs/embedding/sdk/quickstart.md
@@ -6,7 +6,7 @@ title: Embedded analytics SDK - quickstart with sample app
 
 {% include beta-blockquote.html %}
 
-{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true %}
+{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true enterprise-only=true %}
 
 This guide sets up the embedded analytics SDK with a [sample React app](https://github.com/metabase/metabase-nodejs-react-sdk-embedding-sample), but you can follow along with your own application.
 

--- a/docs/embedding/sdk/version.md
+++ b/docs/embedding/sdk/version.md
@@ -6,7 +6,7 @@ title: Embedded analytics SDK - versions
 
 {% include beta-blockquote.html %}
 
-{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true %}
+{% include plans-blockquote.html feature="Embedded analytics SDK" sdk=true enterprise-only=true %}
 
 The SDK stable version tracks with the Metabase version.
 


### PR DESCRIPTION
Like it says on the tin.

Context: https://metaboat.slack.com/archives/C021BPRNNBT/p1736171894496769.