### PR TITLE
Hide preemptive caching toggle for root config

### DIFF
--- a/e2e/test/scenarios/admin/performance/strategyForm.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/strategyForm.cy.spec.ts
@@ -497,7 +497,7 @@ describe("scenarios > admin > performance > strategy form", () => {
         checkPreemptiveCachingDisabled();
       });
 
-      it("Preemptive caching is not available for other caching policies", () => {
+      it("Preemptive caching is not available for other caching policies, or for databases", () => {
         H.visitQuestion(ORDERS_QUESTION_ID);
         openSidebarCacheStrategyForm("question");
         preemptiveCachingSwitch().should("not.exist");
@@ -506,6 +506,24 @@ describe("scenarios > admin > performance > strategy form", () => {
         preemptiveCachingSwitch().should("not.exist");
 
         dontCacheResultsRadioButton().click();
+        preemptiveCachingSwitch().should("not.exist");
+
+        openStrategyFormForDatabaseOrDefaultPolicy(
+          "default policy",
+          "No caching",
+        );
+        durationRadioButton().click();
+        preemptiveCachingSwitch().should("not.exist");
+        scheduleRadioButton().click();
+        preemptiveCachingSwitch().should("not.exist");
+
+        openStrategyFormForDatabaseOrDefaultPolicy(
+          "Sample Database",
+          "No caching",
+        );
+        durationRadioButton().click();
+        preemptiveCachingSwitch().should("not.exist");
+        scheduleRadioButton().click();
         preemptiveCachingSwitch().should("not.exist");
       });
     });

--- a/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
@@ -276,7 +276,7 @@ const StrategyFormBody = ({
                   />
                 </Field>
                 <input type="hidden" name="unit" />
-                {targetModel !== "database" && (
+                {["question", "dashboard"].includes(targetModel) && (
                   <PreemptiveCachingSwitch
                     handleSwitchToggle={handleSwitchToggle}
                   />
@@ -286,7 +286,7 @@ const StrategyFormBody = ({
             {selectedStrategyType === "schedule" && (
               <>
                 <ScheduleStrategyFormFields />
-                {targetModel !== "database" && (
+                {["question", "dashboard"].includes(targetModel) && (
                   <PreemptiveCachingSwitch
                     handleSwitchToggle={handleSwitchToggle}
                   />


### PR DESCRIPTION
Quick fix for an issue noticed by Arakaki – we only want to show the preemptive caching toggle for questions and dashboards, which I was previously doing by checking that `targetModel` isn't `database`. But `targetModel` is `root` for the "Default policy" config. So I've flipped the check around to make it more explicit, and added extra test cases.