### PR TITLE
Make JWT provider URI optional

### DIFF
--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -738,7 +738,7 @@ Enable group membership synchronization with JWT.
 - Default: `null`
 - [Configuration file name](./config-file.md): `jwt-identity-provider-uri`
 
-URL of JWT based login page.
+URL for JWT-based login page. Optional if using JWT SSO only with the embedded analytics SDK.
 
 ### `MB_JWT_SHARED_SECRET`
 

--- a/e2e/test/scenarios/admin-2/sso/jwt.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/sso/jwt.cy.spec.js
@@ -19,7 +19,10 @@ H.describeEE("scenarios > admin > settings > SSO > JWT", () => {
   it("should allow to save and enable jwt", () => {
     cy.visit("/admin/settings/authentication/jwt");
 
-    H.typeAndBlurUsingLabel(/JWT Identity Provider URI/, "https://example.test");
+    H.typeAndBlurUsingLabel(
+      /JWT Identity Provider URI/,
+      "https://example.test",
+    );
     cy.button("Generate key").click();
     cy.button("Save and enable").click();
     cy.wait("@updateSettings");

--- a/e2e/test/scenarios/admin-2/sso/jwt.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/sso/jwt.cy.spec.js
@@ -19,7 +19,19 @@ H.describeEE("scenarios > admin > settings > SSO > JWT", () => {
   it("should allow to save and enable jwt", () => {
     cy.visit("/admin/settings/authentication/jwt");
 
-    enterJwtSettings();
+    H.typeAndBlurUsingLabel(/JWT Identity Provider URI/, "https://example.test");
+    cy.button("Generate key").click();
+    cy.button("Save and enable").click();
+    cy.wait("@updateSettings");
+    cy.findAllByRole("link", { name: "Authentication" }).first().click();
+
+    getJwtCard().findByText("Active").should("exist");
+  });
+
+  it("should allow to save jwt settings without a JWT URI", () => {
+    cy.visit("/admin/settings/authentication/jwt");
+
+    cy.button("Generate key").click();
     cy.button("Save and enable").click();
     cy.wait("@updateSettings");
     cy.findAllByRole("link", { name: "Authentication" }).first().click();
@@ -106,9 +118,4 @@ H.describeEE("scenarios > admin > settings > SSO > JWT", () => {
 
 const getJwtCard = () => {
   return cy.findByText("JWT").parent().parent();
-};
-
-const enterJwtSettings = () => {
-  H.typeAndBlurUsingLabel(/JWT Identity Provider URI/, "https://example.test");
-  cy.button("Generate key").click();
 };

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_settings.clj
@@ -198,7 +198,7 @@ on your IdP, this usually looks something like `http://www.example.com/141xkex60
                false)))
 
 (defsetting jwt-identity-provider-uri
-  (deferred-tru "URL of JWT based login page")
+  (deferred-tru "URL for JWT-based login page. Optional if using JWT SSO only with the embedded analytics SDK.")
   :encryption :when-encryption-key-set
   :feature    :sso-jwt
   :audit      :getter)
@@ -267,9 +267,7 @@ on your IdP, this usually looks something like `http://www.example.com/141xkex60
   :default false
   :feature :sso-jwt
   :setter  :none
-  :getter  (fn [] (boolean
-                   (and (jwt-identity-provider-uri)
-                        (jwt-shared-secret)))))
+  :getter  (fn [] (boolean (jwt-shared-secret))))
 
 (defsetting jwt-enabled
   (deferred-tru "Is JWT authentication configured and enabled?")

--- a/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm/SettingsJWTForm.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm/SettingsJWTForm.unit.spec.tsx
@@ -41,7 +41,7 @@ const elements = [
     value: null,
     is_env_setting: false,
     env_name: "MB_JWT_IDENTITY_PROVIDER_URI",
-    description: "URL of JWT based login page",
+    description: "URL for JWT-based login page. Optional if using JWT SSO only with the embedded analytics SDK.",
     originalValue: null,
     display_name: "JWT Identity Provider URI",
     type: "string",

--- a/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm/SettingsJWTForm.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm/SettingsJWTForm.unit.spec.tsx
@@ -41,7 +41,8 @@ const elements = [
     value: null,
     is_env_setting: false,
     env_name: "MB_JWT_IDENTITY_PROVIDER_URI",
-    description: "URL for JWT-based login page. Optional if using JWT SSO only with the embedded analytics SDK.",
+    description:
+      "URL for JWT-based login page. Optional if using JWT SSO only with the embedded analytics SDK.",
     originalValue: null,
     display_name: "JWT Identity Provider URI",
     type: "string",

--- a/enterprise/frontend/src/metabase-enterprise/auth/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/auth/index.js
@@ -192,7 +192,7 @@ PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections => ({
         display_name: t`JWT Identity Provider URI`,
         placeholder: "https://jwt.yourdomain.org",
         type: "string",
-        required: true,
+        required: false,
         autoFocus: true,
         getHidden: (_, derivedSettings) => !derivedSettings["jwt-enabled"],
       },


### PR DESCRIPTION
Closes #51826 

Makes the JWT Provider UI setting optional to enable JWT auth, since we don't use that field for the embedding SDK

![Screen Shot 2025-01-07 at 1 09 24 PM](https://github.com/user-attachments/assets/ac052f8b-0aa8-4c2b-90ac-1033f7cc2014)
![Screen Shot 2025-01-07 at 12 57 49 PM](https://github.com/user-attachments/assets/b3f04183-c048-4930-8526-1e161edade6f)

- [x] Tested!