### PR TITLE
Don't truncate 'Generate Key' label

### DIFF
--- a/frontend/src/metabase/forms/components/FormSecretKey/FormSecretKey.tsx
+++ b/frontend/src/metabase/forms/components/FormSecretKey/FormSecretKey.tsx
@@ -80,6 +80,7 @@ export const FormSecretKey = forwardRef(function FormSecretKey(
         </Confirm>
       ) : (
         <Button
+          className={CS.flexNoShrink}
           variant="filled"
           onClick={generateToken}
         >{t`Generate key`}</Button>


### PR DESCRIPTION
Before:

<img width="545" alt="image" src="https://github.com/user-attachments/assets/6bf3a494-ee25-4c11-b5db-788ec7d87a8e" />


After:

<img width="567" alt="image" src="https://github.com/user-attachments/assets/1a0c7ae1-a262-4251-a7d0-47e3519852c4" />
