### PR TITLE
Make HoverCard keyboard-accessible

### DIFF
--- a/frontend/src/metabase/ui/components/overlays/HoverCard/HoverCard.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/overlays/HoverCard/HoverCard.unit.spec.tsx
@@ -8,8 +8,8 @@ const setup = () => {
   return render(
     <>
       <HoverCard>
-        <HoverCard.Target>
-          <Button>Target</Button>
+        <HoverCard.Target data-testid="hovercard-target">
+          Target
         </HoverCard.Target>
         <HoverCard.Dropdown>
           <Paper>Dropdown</Paper>
@@ -29,7 +29,7 @@ describe("HoverCard", () => {
 
     // Let's move the focus to the HoverCard's target
     await userEvent.tab();
-    expect(screen.getByRole("button", { name: "Target" })).toHaveFocus();
+    expect(await screen.findByTestId("hovercard-target")).toHaveFocus();
 
     // The dropdown should appear soon
     expect(await screen.findByText("Dropdown")).toBeVisible();

--- a/frontend/src/metabase/ui/components/overlays/HoverCard/HoverCard.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/overlays/HoverCard/HoverCard.unit.spec.tsx
@@ -1,0 +1,48 @@
+import { Button, Paper } from "@mantine/core";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { HoverCard } from ".";
+
+const setup = () => {
+  return render(
+    <>
+      <HoverCard>
+        <HoverCard.Target>
+          <Button>Target</Button>
+        </HoverCard.Target>
+        <HoverCard.Dropdown>
+          <Paper>Dropdown</Paper>
+        </HoverCard.Dropdown>
+      </HoverCard>
+      <Button>Another button</Button>
+    </>,
+  );
+};
+
+describe("HoverCard", () => {
+  it("opens its dropdown when its target is focused, and closes the dropdown when the target is blurred", async () => {
+    setup();
+
+    // The dropdown should initially not be present
+    expect(screen.queryByText("Dropdown")).not.toBeInTheDocument();
+
+    // Let's move the focus to the HoverCard's target
+    await userEvent.tab();
+    expect(screen.getByRole("button", { name: "Target" })).toHaveFocus();
+
+    // The dropdown should appear soon
+    expect(await screen.findByText("Dropdown")).toBeVisible();
+
+    // Let's move the focus to another button
+    await userEvent.tab();
+    expect(
+      screen.getByRole("button", { name: "Another button" }),
+    ).toHaveFocus();
+
+    // The dropdown should disappear soon
+    await waitFor(() => {
+      expect(screen.queryByText("Dropdown")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/metabase/ui/components/overlays/HoverCard/index.tsx
+++ b/frontend/src/metabase/ui/components/overlays/HoverCard/index.tsx
@@ -47,6 +47,7 @@ const HoverCardTarget = forwardRef<HTMLDivElement, HoverCardTargetProps>(
           onFocus={() => trigger("mouseover")}
           onBlur={() => trigger("mouseout")}
           ref={ref}
+          tabIndex={0}
         >
           {props.children}
         </div>

--- a/frontend/src/metabase/ui/components/overlays/HoverCard/index.tsx
+++ b/frontend/src/metabase/ui/components/overlays/HoverCard/index.tsx
@@ -29,9 +29,10 @@ const MantineHoverCardTarget = MantineHoverCard.Target;
 /** A HoverCard target that opens the dropdown on focus and closes it on blur.
  * This adds a missing a11y feature to the component.
  *
- * According to Mantine, its native HoverCard " cannot be activated with
- * keyboard, use it to display only additional information that is not required
- * to understand the context." (https://mantine.dev/core/hover-card/#accessibility)
+ * According to the Mantine docs, its native HoverCard "cannot be activated
+ * with keyboard, use it to display only additional information that is not
+ * required to understand the context."
+ * (https://mantine.dev/core/hover-card/#accessibility)
  */
 const HoverCardTarget = forwardRef<HTMLDivElement, HoverCardTargetProps>(
   function Target(props, targetRef) {

--- a/frontend/src/metabase/ui/components/overlays/HoverCard/index.tsx
+++ b/frontend/src/metabase/ui/components/overlays/HoverCard/index.tsx
@@ -1,12 +1,18 @@
 import {
   type HoverCardDropdownProps,
+  type HoverCardTargetProps,
   HoverCard as MantineHoverCard,
 } from "@mantine/core";
+import { forwardRef, useRef } from "react";
 
 import { PreventEagerPortal } from "metabase/ui";
 export { hoverCardOverrides } from "./HoverCard.config";
 
-export type { HoverCardDropdownProps, HoverCardProps } from "@mantine/core";
+export type {
+  HoverCardDropdownProps,
+  HoverCardTargetProps,
+  HoverCardProps,
+} from "@mantine/core";
 
 const MantineHoverCardDropdown = MantineHoverCard.Dropdown;
 const HoverCardDropdown = function Dropdown(props: HoverCardDropdownProps) {
@@ -18,6 +24,36 @@ const HoverCardDropdown = function Dropdown(props: HoverCardDropdownProps) {
 };
 HoverCardDropdown.displayName = MantineHoverCardDropdown.displayName;
 MantineHoverCard.Dropdown = HoverCardDropdown;
+
+const MantineHoverCardTarget = MantineHoverCard.Target;
+/** A HoverCard target that opens the dropdown on focus and closes it on blur.
+ * This adds a missing a11y feature to the component.
+ *
+ * According to Mantine, its native HoverCard " cannot be activated with
+ * keyboard, use it to display only additional information that is not required
+ * to understand the context." (https://mantine.dev/core/hover-card/#accessibility)
+ */
+const HoverCardTarget = forwardRef<HTMLDivElement, HoverCardTargetProps>(
+  function Target(props, targetRef) {
+    const ref = useRef<HTMLDivElement>(null);
+
+    const trigger = (eventName: string) =>
+      ref.current?.dispatchEvent(new Event(eventName, { bubbles: true }));
+
+    return (
+      <MantineHoverCardTarget {...props} ref={targetRef}>
+        <div
+          onFocus={() => trigger("mouseover")}
+          onBlur={() => trigger("mouseout")}
+          ref={ref}
+        >
+          {props.children}
+        </div>
+      </MantineHoverCardTarget>
+    );
+  },
+);
+MantineHoverCard.Target = HoverCardTarget as typeof MantineHoverCard.Target;
 
 const HoverCard: typeof MantineHoverCard = MantineHoverCard;
 


### PR DESCRIPTION
Contributes to closing #51652

According to the Mantine [documentation](https://mantine.dev/core/hover-card/#accessibility), the `HoverCard` component "cannot be activated with keyboard," and we should "use it to display only additional information that is not required to understand the context." However, we do use this component to display crucial information. For the sake of accessibility, let's tweak it so that the dropdown appears when the target is focused.

- [x] Tests have been added/updated to cover changes in this PR

## An example: Column headers

| Old |
| ---- | 
| ![Kapture 2025-01-08 at 10 05 31](https://github.com/user-attachments/assets/42c4e485-8ffe-4c10-a0d7-e0a027cd3e59) |

| New |
| ---- |
| ![Kapture 2025-01-08 at 10 07 39](https://github.com/user-attachments/assets/fe29417c-f769-42ce-966a-5e34aa8bc267) |

## Another example: The filter modal

| Old |
| ---- |
| ![Kapture 2025-01-08 at 09 46 54](https://github.com/user-attachments/assets/377a6974-0e7d-4694-a72f-ae4197a8b9d7) |

| New |
| ---- |
| ![Kapture 2025-01-08 at 10 02 38](https://github.com/user-attachments/assets/1b812d01-c40f-4b9f-adcb-62e44a8fc796) |	

(In the GIF above, after the target is focused, there is a brief delay before the dropdown appears. This is due to the way the filter modal's column info icons are configured. Typically there will be no delay.)
