### PR TITLE
Properly tag external db tests

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -93,14 +93,13 @@ sources: &sources
   - *backend_sources
 
 e2e_ci: &e2e_ci
-  - ".github/actions/build-e2e-matrix/**"
   - ".github/actions/prepare-frontend/**"
   - ".github/actions/prepare-backend/**"
   - ".github/actions/prepare-uberjar-artifact/**"
   - ".github/actions/e2e-prepare-containers/**"
   - ".github/actions/prepare-cypress/**"
   - ".github/actions/run-snowplow-micro/**"
-  - ".github/workflows/e2e-tests.yml"
+  - ".github/workflows/e2e-*"
 
 e2e_specs: &e2e_specs
   - "**/*.cy.*.js"

--- a/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
@@ -308,7 +308,7 @@ describe("issue 51020", () => {
     });
   });
 
-  describe("when primary key is not called 'id'", () => {
+  describe("when primary key is not called 'id'", { tags: "@external" }, () => {
     function createTemporaryTable() {
       H.queryWritableDB(
         "CREATE TABLE IF NOT EXISTS foo (foo INT PRIMARY KEY, name VARCHAR)",

--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -517,35 +517,7 @@ describe(
           cy.findByLabelText(TEST_PARAMETER.name).type("1");
           cy.findByLabelText("Current Status").should("not.exist");
 
-        cy.findByLabelText("Current Status").type("active");
-
-        cy.button(SAMPLE_QUERY_ACTION.name).click();
-      });
-
-      verifyScoreValue(22, dialect);
-    });
-
-    it("should allow implicit action execution from the model details page", () => {
-      cy.get("@writableModelId").then(id => {
-        cy.visit(`/model/${id}/detail`);
-        cy.wait("@getModel");
-      });
-
-      createBasicActions();
-
-      openActionEditorFor("Create");
-
-      cy.wait("@getAction").then(({ response }) => {
-        const { parameters, visualization_settings } = response.body;
-        expect(parameters).to.have.length(5);
-        expect(visualization_settings).to.have.property("fields");
-      });
-
-      cy.findAllByTestId("form-field-container")
-        .filter(":contains('Created At')")
-        .within(() => {
-          cy.findByLabelText("Show field").click();
-          cy.findByLabelText("Show field").should("not.be.checked");
+          cy.button(SAMPLE_QUERY_ACTION.name).click();
         });
 
         cy.findByTestId("toast-undo")
@@ -613,10 +585,6 @@ describe(
           cy.wait("@getModel");
         });
 
-        cy.findByRole("tablist").within(() => {
-          cy.findByText("Actions").click();
-        });
-
         createBasicActions();
 
         openActionEditorFor("Create");
@@ -670,17 +638,8 @@ describe(
             model_id: modelId,
           });
 
-      createBasicActions();
-
-      enableSharingFor("Update", { publicUrlAlias: "updatePublicURL" });
-
-      openActionEditorFor("Update");
-
-      cy.findAllByTestId("form-field-container")
-        .filter(":contains('Created At')")
-        .within(() => {
-          cy.findByLabelText("Show field").click();
-          cy.findByLabelText("Show field").should("not.be.checked");
+          cy.visit(`/model/${modelId}/detail/actions`);
+          cy.wait("@getModel");
         });
 
         enableSharingFor(SAMPLE_WRITABLE_QUERY_ACTION.name, {
@@ -734,10 +693,6 @@ describe(
         cy.get("@writableModelId").then(id => {
           cy.visit(`/model/${id}/detail`);
           cy.wait("@getModel");
-        });
-
-        cy.findByRole("tablist").within(() => {
-          cy.findByText("Actions").click();
         });
 
         createBasicActions();

--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -312,109 +312,65 @@ describe(
 );
 
 ["postgres", "mysql"].forEach(dialect => {
-  describe(`Write actions on model detail page (${dialect})`, () => {
-    beforeEach(() => {
-      cy.intercept("GET", "/api/card/*").as("getModel");
-      cy.intercept("GET", "/api/action/*").as("getAction");
+  describe(
+    `Write actions on model detail page (${dialect})`,
+    { tags: "@external" },
+    () => {
+      beforeEach(() => {
+        cy.intercept("GET", "/api/card/*").as("getModel");
+        cy.intercept("GET", "/api/action/*").as("getAction");
 
-      cy.intercept("PUT", "/api/action/*").as("updateAction");
-      cy.intercept("POST", "/api/action").as("createAction");
-      cy.intercept("POST", "/api/action/*/public_link").as(
-        "enableActionSharing",
-      );
-      cy.intercept("DELETE", "/api/action/*/public_link").as(
-        "disableActionSharing",
-      );
+        cy.intercept("PUT", "/api/action/*").as("updateAction");
+        cy.intercept("POST", "/api/action").as("createAction");
+        cy.intercept("POST", "/api/action/*/public_link").as(
+          "enableActionSharing",
+        );
+        cy.intercept("DELETE", "/api/action/*/public_link").as(
+          "disableActionSharing",
+        );
 
-      H.resetTestTable({ type: dialect, table: WRITABLE_TEST_TABLE });
-      H.restore(`${dialect}-writable`);
-      cy.signInAsAdmin();
-      H.resyncDatabase({
-        dbId: WRITABLE_DB_ID,
-        tableName: WRITABLE_TEST_TABLE,
-      });
-
-      H.createModelFromTableName({
-        tableName: WRITABLE_TEST_TABLE,
-        idAlias: "writableModelId",
-      });
-    });
-
-    it("should allow action execution from the model detail page", () => {
-      H.queryWritableDB(
-        `SELECT * FROM ${WRITABLE_TEST_TABLE} WHERE id = 1`,
-        dialect,
-      ).then(result => {
-        const row = result.rows[0];
-        expect(row.score).to.equal(0);
-      });
-
-      cy.get("@writableModelId").then(modelId => {
-        H.createAction({
-          ...SAMPLE_WRITABLE_QUERY_ACTION,
-          model_id: modelId,
+        H.resetTestTable({ type: dialect, table: WRITABLE_TEST_TABLE });
+        H.restore(`${dialect}-writable`);
+        cy.signInAsAdmin();
+        H.resyncDatabase({
+          dbId: WRITABLE_DB_ID,
+          tableName: WRITABLE_TEST_TABLE,
         });
-        cy.visit(`/model/${modelId}/detail/actions`);
-        cy.wait("@getModel");
-      });
 
-      runActionFor(SAMPLE_QUERY_ACTION.name);
-
-      H.modal().within(() => {
-        cy.findByLabelText(TEST_PARAMETER.name).type("1");
-        cy.button(SAMPLE_QUERY_ACTION.name).click();
-      });
-
-      cy.findByTestId("toast-undo")
-        .findByText(`${SAMPLE_QUERY_ACTION.name} ran successfully`)
-        .should("be.visible");
-
-      H.queryWritableDB(
-        `SELECT * FROM ${WRITABLE_TEST_TABLE} WHERE id = 1`,
-        dialect,
-      ).then(result => {
-        const row = result.rows[0];
-
-        expect(row.score).to.equal(22);
-      });
-    });
-
-    it("should allow public sharing of actions and execution of public actions", () => {
-      const IMPLICIT_ACTION_NAME = "Update";
-
-      cy.get("@writableModelId").then(modelId => {
-        H.createAction({
-          ...SAMPLE_WRITABLE_QUERY_ACTION,
-          model_id: modelId,
+        H.createModelFromTableName({
+          tableName: WRITABLE_TEST_TABLE,
+          idAlias: "writableModelId",
         });
-        H.createAction({
-          type: "implicit",
-          kind: "row/update",
-          name: IMPLICIT_ACTION_NAME,
-          model_id: modelId,
+      });
+
+      it("should allow action execution from the model detail page", () => {
+        H.queryWritableDB(
+          `SELECT * FROM ${WRITABLE_TEST_TABLE} WHERE id = 1`,
+          dialect,
+        ).then(result => {
+          const row = result.rows[0];
+          expect(row.score).to.equal(0);
         });
-        cy.visit(`/model/${modelId}/detail/actions`);
-        cy.wait("@getModel");
-      });
 
-      enableSharingFor(SAMPLE_WRITABLE_QUERY_ACTION.name, {
-        publicUrlAlias: "queryActionPublicUrl",
-      });
-      enableSharingFor(IMPLICIT_ACTION_NAME, {
-        publicUrlAlias: "implicitActionPublicUrl",
-      });
+        cy.get("@writableModelId").then(modelId => {
+          H.createAction({
+            ...SAMPLE_WRITABLE_QUERY_ACTION,
+            model_id: modelId,
+          });
+          cy.visit(`/model/${modelId}/detail/actions`);
+          cy.wait("@getModel");
+        });
 
-      cy.signOut();
+        runActionFor(SAMPLE_QUERY_ACTION.name);
 
-      cy.get("@queryActionPublicUrl").then(url => {
-        cy.visit(url);
-        cy.findByLabelText(TEST_PARAMETER.name).type("1");
-        cy.button(SAMPLE_QUERY_ACTION.name).click();
-        cy.findByText(
-          `${SAMPLE_WRITABLE_QUERY_ACTION.name} ran successfully`,
-        ).should("be.visible");
-        cy.findByRole("form").should("not.exist");
-        cy.button(SAMPLE_QUERY_ACTION.name).should("not.exist");
+        H.modal().within(() => {
+          cy.findByLabelText(TEST_PARAMETER.name).type("1");
+          cy.button(SAMPLE_QUERY_ACTION.name).click();
+        });
+
+        cy.findByTestId("toast-undo")
+          .findByText(`${SAMPLE_QUERY_ACTION.name} ran successfully`)
+          .should("be.visible");
 
         H.queryWritableDB(
           `SELECT * FROM ${WRITABLE_TEST_TABLE} WHERE id = 1`,
@@ -426,147 +382,140 @@ describe(
         });
       });
 
-      cy.get("@implicitActionPublicUrl").then(url => {
-        cy.visit(url);
+      it("should allow public sharing of actions and execution of public actions", () => {
+        const IMPLICIT_ACTION_NAME = "Update";
 
-        // team 2 has 10 points, let's give them more
-        cy.findByLabelText("ID").type("2");
-        cy.findByLabelText(/score/i).type("16");
-        cy.findByLabelText(/team name/i).type("Bouncy Bears");
+        cy.get("@writableModelId").then(modelId => {
+          H.createAction({
+            ...SAMPLE_WRITABLE_QUERY_ACTION,
+            model_id: modelId,
+          });
+          H.createAction({
+            type: "implicit",
+            kind: "row/update",
+            name: IMPLICIT_ACTION_NAME,
+            model_id: modelId,
+          });
+          cy.visit(`/model/${modelId}/detail/actions`);
+          cy.wait("@getModel");
+        });
 
-        cy.button(IMPLICIT_ACTION_NAME).click();
-        cy.findByText(`${IMPLICIT_ACTION_NAME} ran successfully`).should(
-          "be.visible",
-        );
-        cy.findByRole("form").should("not.exist");
-        cy.button(IMPLICIT_ACTION_NAME).should("not.exist");
+        enableSharingFor(SAMPLE_WRITABLE_QUERY_ACTION.name, {
+          publicUrlAlias: "queryActionPublicUrl",
+        });
+        enableSharingFor(IMPLICIT_ACTION_NAME, {
+          publicUrlAlias: "implicitActionPublicUrl",
+        });
 
-        H.queryWritableDB(
-          `SELECT * FROM ${WRITABLE_TEST_TABLE} WHERE id = 2`,
-          dialect,
-        ).then(result => {
-          const row = result.rows[0];
+        cy.signOut();
 
-          expect(row.score).to.equal(16);
-          expect(row.team_name).to.equal("Bouncy Bears");
-          // should not mutate form fields that we don't touch
-          expect(row.status).to.not.be.a("null");
+        cy.get("@queryActionPublicUrl").then(url => {
+          cy.visit(url);
+          cy.findByLabelText(TEST_PARAMETER.name).type("1");
+          cy.button(SAMPLE_QUERY_ACTION.name).click();
+          cy.findByText(
+            `${SAMPLE_WRITABLE_QUERY_ACTION.name} ran successfully`,
+          ).should("be.visible");
+          cy.findByRole("form").should("not.exist");
+          cy.button(SAMPLE_QUERY_ACTION.name).should("not.exist");
+
+          H.queryWritableDB(
+            `SELECT * FROM ${WRITABLE_TEST_TABLE} WHERE id = 1`,
+            dialect,
+          ).then(result => {
+            const row = result.rows[0];
+
+            expect(row.score).to.equal(22);
+          });
+        });
+
+        cy.get("@implicitActionPublicUrl").then(url => {
+          cy.visit(url);
+
+          // team 2 has 10 points, let's give them more
+          cy.findByLabelText("ID").type("2");
+          cy.findByLabelText(/score/i).type("16");
+          cy.findByLabelText(/team name/i).type("Bouncy Bears");
+
+          cy.button(IMPLICIT_ACTION_NAME).click();
+          cy.findByText(`${IMPLICIT_ACTION_NAME} ran successfully`).should(
+            "be.visible",
+          );
+          cy.findByRole("form").should("not.exist");
+          cy.button(IMPLICIT_ACTION_NAME).should("not.exist");
+
+          H.queryWritableDB(
+            `SELECT * FROM ${WRITABLE_TEST_TABLE} WHERE id = 2`,
+            dialect,
+          ).then(result => {
+            const row = result.rows[0];
+
+            expect(row.score).to.equal(16);
+            expect(row.team_name).to.equal("Bouncy Bears");
+            // should not mutate form fields that we don't touch
+            expect(row.status).to.not.be.a("null");
+          });
+        });
+
+        cy.signInAsAdmin();
+        cy.get("@writableModelId").then(modelId => {
+          cy.visit(`/model/${modelId}/detail/actions`);
+          cy.wait("@getModel");
+        });
+
+        disableSharingFor(SAMPLE_QUERY_ACTION.name);
+        disableSharingFor(IMPLICIT_ACTION_NAME);
+
+        cy.signOut();
+
+        cy.get("@queryActionPublicUrl").then(url => {
+          cy.visit(url);
+          cy.findByRole("form").should("not.exist");
+          cy.button(SAMPLE_QUERY_ACTION.name).should("not.exist");
+          cy.findByText("Not found").should("be.visible");
+        });
+
+        cy.get("@implicitActionPublicUrl").then(url => {
+          cy.visit(url);
+          cy.findByRole("form").should("not.exist");
+          cy.button(SAMPLE_QUERY_ACTION.name).should("not.exist");
+          cy.findByText("Not found").should("be.visible");
         });
       });
 
-      cy.signInAsAdmin();
-      cy.get("@writableModelId").then(modelId => {
-        cy.visit(`/model/${modelId}/detail/actions`);
-        cy.wait("@getModel");
-      });
+      it("should allow query action execution from the model details page", () => {
+        verifyScoreValue(0, dialect);
 
-      disableSharingFor(SAMPLE_QUERY_ACTION.name);
-      disableSharingFor(IMPLICIT_ACTION_NAME);
-
-      cy.signOut();
-
-      cy.get("@queryActionPublicUrl").then(url => {
-        cy.visit(url);
-        cy.findByRole("form").should("not.exist");
-        cy.button(SAMPLE_QUERY_ACTION.name).should("not.exist");
-        cy.findByText("Not found").should("be.visible");
-      });
-
-      cy.get("@implicitActionPublicUrl").then(url => {
-        cy.visit(url);
-        cy.findByRole("form").should("not.exist");
-        cy.button(SAMPLE_QUERY_ACTION.name).should("not.exist");
-        cy.findByText("Not found").should("be.visible");
-      });
-    });
-
-    it("should allow query action execution from the model details page", () => {
-      verifyScoreValue(0, dialect);
-
-      cy.get("@writableModelId").then(modelId => {
-        H.createAction({
-          ...SAMPLE_WRITABLE_QUERY_ACTION,
-          model_id: modelId,
-        });
-        cy.visit(`/model/${modelId}/detail/actions`);
-        cy.wait("@getModel");
-      });
-
-      openActionEditorFor(SAMPLE_QUERY_ACTION.name);
-
-      H.fillActionQuery(" [[and status = {{ current_status}}]]");
-      cy.findAllByTestId("form-field-container")
-        .filter(":contains('Current Status')")
-        .within(() => {
-          cy.findByLabelText("Show field").click();
-          cy.icon("gear").click();
+        cy.get("@writableModelId").then(modelId => {
+          H.createAction({
+            ...SAMPLE_WRITABLE_QUERY_ACTION,
+            model_id: modelId,
+          });
+          cy.visit(`/model/${modelId}/detail/actions`);
+          cy.wait("@getModel");
         });
 
-      H.popover().within(() => {
-        cy.findByLabelText("Required").uncheck();
-      });
+        openActionEditorFor(SAMPLE_QUERY_ACTION.name);
 
-      cy.findByRole("button", { name: "Update" }).click();
-
-      runActionFor(SAMPLE_QUERY_ACTION.name);
-
-      H.modal().within(() => {
-        cy.findByLabelText(TEST_PARAMETER.name).type("1");
-        cy.findByLabelText("Current Status").should("not.exist");
-
-        cy.button(SAMPLE_QUERY_ACTION.name).click();
-      });
-
-      cy.findByTestId("toast-undo")
-        .findByText(`${SAMPLE_QUERY_ACTION.name} ran successfully`)
-        .should("be.visible");
-
-      verifyScoreValue(22, dialect);
-
-      openActionEditorFor(SAMPLE_QUERY_ACTION.name);
-
-      cy.findAllByTestId("form-field-container")
-        .filter(":contains('Current Status')")
-        .within(() => {
-          cy.icon("gear").click();
-        });
-
-      H.popover().within(() => {
-        cy.findByLabelText("Required").check();
-      });
-      cy.findByRole("button", { name: "Update" }).click();
-
-      runActionFor(SAMPLE_QUERY_ACTION.name);
-
-      H.modal().within(() => {
-        cy.findByLabelText(TEST_PARAMETER.name).type("1");
-        cy.findByLabelText("Current Status").should("not.exist");
-
-        cy.button(SAMPLE_QUERY_ACTION.name).should("be.disabled");
-
-        cy.findByRole("button", { name: "Cancel" }).click();
-      });
-
-      openActionEditorFor(SAMPLE_QUERY_ACTION.name);
-
-      // reset score value to 0
-      resetAndVerifyScoreValue(dialect);
-
-      cy.findByRole("dialog").within(() => {
+        H.fillActionQuery(" [[and status = {{ current_status}}]]");
         cy.findAllByTestId("form-field-container")
           .filter(":contains('Current Status')")
           .within(() => {
             cy.findByLabelText("Show field").click();
-            cy.findByLabelText("Show field").should("be.checked");
+            cy.icon("gear").click();
           });
+
+        H.popover().within(() => {
+          cy.findByLabelText("Required").uncheck();
+        });
+
         cy.findByRole("button", { name: "Update" }).click();
-      });
 
-      runActionFor(SAMPLE_QUERY_ACTION.name);
+        runActionFor(SAMPLE_QUERY_ACTION.name);
 
-      H.modal().within(() => {
-        cy.findByLabelText(TEST_PARAMETER.name).type("1");
-        cy.button(SAMPLE_QUERY_ACTION.name).should("be.disabled");
+        H.modal().within(() => {
+          cy.findByLabelText(TEST_PARAMETER.name).type("1");
+          cy.findByLabelText("Current Status").should("not.exist");
 
         cy.findByLabelText("Current Status").type("active");
 
@@ -599,98 +548,127 @@ describe(
           cy.findByLabelText("Show field").should("not.be.checked");
         });
 
-      cy.findByRole("button", { name: "Update" }).click();
+        cy.findByTestId("toast-undo")
+          .findByText(`${SAMPLE_QUERY_ACTION.name} ran successfully`)
+          .should("be.visible");
 
-      runActionFor("Create");
+        verifyScoreValue(22, dialect);
 
-      H.modal().within(() => {
-        cy.findByLabelText("Created At").should("not.exist");
-        cy.findByLabelText("Team Name").type("Zebras");
-        cy.findByLabelText("Score").type("1");
+        openActionEditorFor(SAMPLE_QUERY_ACTION.name);
 
-        cy.findByRole("button", { name: "Save" }).click();
-      });
+        cy.findAllByTestId("form-field-container")
+          .filter(":contains('Current Status')")
+          .within(() => {
+            cy.icon("gear").click();
+          });
 
-      cy.findByTestId("toast-undo")
-        .findByText("Successfully saved")
-        .should("be.visible");
+        H.popover().within(() => {
+          cy.findByLabelText("Required").check();
+        });
+        cy.findByRole("button", { name: "Update" }).click();
 
-      // show toast
-      H.queryWritableDB(
-        `SELECT * FROM ${WRITABLE_TEST_TABLE} WHERE team_name = 'Zebras'`,
-        dialect,
-      ).then(result => {
-        expect(result.rows.length).to.equal(1);
+        runActionFor(SAMPLE_QUERY_ACTION.name);
 
-        const row = result.rows[0];
+        H.modal().within(() => {
+          cy.findByLabelText(TEST_PARAMETER.name).type("1");
+          cy.findByLabelText("Current Status").should("not.exist");
 
-        expect(row.score).to.equal(1);
-      });
-    });
+          cy.button(SAMPLE_QUERY_ACTION.name).should("be.disabled");
 
-    it("should allow public sharing of query action and execution", () => {
-      cy.get("@writableModelId").then(modelId => {
-        H.createAction({
-          ...SAMPLE_WRITABLE_QUERY_ACTION,
-          model_id: modelId,
+          cy.findByRole("button", { name: "Cancel" }).click();
         });
 
-        cy.visit(`/model/${modelId}/detail/actions`);
-        cy.wait("@getModel");
-      });
+        openActionEditorFor(SAMPLE_QUERY_ACTION.name);
 
-      enableSharingFor(SAMPLE_WRITABLE_QUERY_ACTION.name, {
-        publicUrlAlias: "queryActionPublicUrl",
-      });
+        // reset score value to 0
+        resetAndVerifyScoreValue(dialect);
 
-      openActionEditorFor(SAMPLE_WRITABLE_QUERY_ACTION.name);
-
-      H.fillActionQuery(" [[ AND status = {{new_status}} ]]");
-
-      cy.findAllByTestId("form-field-container")
-        .filter(":contains('New Status')")
-        .within(() => {
-          cy.findByLabelText("Show field").click();
-          cy.findByLabelText("Show field").should("not.be.checked");
-
-          cy.icon("gear").click();
+        cy.findByRole("dialog").within(() => {
+          cy.findAllByTestId("form-field-container")
+            .filter(":contains('Current Status')")
+            .within(() => {
+              cy.findByLabelText("Show field").click();
+              cy.findByLabelText("Show field").should("be.checked");
+            });
+          cy.findByRole("button", { name: "Update" }).click();
         });
 
-      H.popover().within(() => {
-        cy.findByLabelText("Required").uncheck();
+        runActionFor(SAMPLE_QUERY_ACTION.name);
+
+        H.modal().within(() => {
+          cy.findByLabelText(TEST_PARAMETER.name).type("1");
+          cy.button(SAMPLE_QUERY_ACTION.name).should("be.disabled");
+
+          cy.findByLabelText("Current Status").type("active");
+
+          cy.button(SAMPLE_QUERY_ACTION.name).click();
+        });
+
+        verifyScoreValue(22, dialect);
       });
 
-      cy.findByRole("button", { name: "Update" }).click();
+      it("should allow implicit action execution from the model details page", () => {
+        cy.get("@writableModelId").then(id => {
+          cy.visit(`/model/${id}/detail`);
+          cy.wait("@getModel");
+        });
 
-      cy.signOut();
+        cy.findByRole("tablist").within(() => {
+          cy.findByText("Actions").click();
+        });
 
-      cy.get("@queryActionPublicUrl").then(url => {
-        cy.visit(url);
-        cy.findByLabelText(TEST_PARAMETER.name).type("1");
-        cy.findByLabelText("New Status").should("not.exist");
+        createBasicActions();
 
-        cy.button(SAMPLE_QUERY_ACTION.name).click();
+        openActionEditorFor("Create");
 
-        cy.findByText(
-          `${SAMPLE_WRITABLE_QUERY_ACTION.name} ran successfully`,
-        ).should("be.visible");
+        cy.wait("@getAction").then(({ response }) => {
+          const { parameters, visualization_settings } = response.body;
+          expect(parameters).to.have.length(5);
+          expect(visualization_settings).to.have.property("fields");
+        });
 
+        cy.findAllByTestId("form-field-container")
+          .filter(":contains('Created At')")
+          .within(() => {
+            cy.findByLabelText("Show field").click();
+            cy.findByLabelText("Show field").should("not.be.checked");
+          });
+
+        cy.findByRole("button", { name: "Update" }).click();
+
+        runActionFor("Create");
+
+        H.modal().within(() => {
+          cy.findByLabelText("Created At").should("not.exist");
+          cy.findByLabelText("Team Name").type("Zebras");
+          cy.findByLabelText("Score").type("1");
+
+          cy.findByRole("button", { name: "Save" }).click();
+        });
+
+        cy.findByTestId("toast-undo")
+          .findByText("Successfully saved")
+          .should("be.visible");
+
+        // show toast
         H.queryWritableDB(
-          `SELECT * FROM ${WRITABLE_TEST_TABLE} WHERE id = 1`,
+          `SELECT * FROM ${WRITABLE_TEST_TABLE} WHERE team_name = 'Zebras'`,
           dialect,
         ).then(result => {
+          expect(result.rows.length).to.equal(1);
+
           const row = result.rows[0];
 
-          expect(row.score).to.equal(22);
+          expect(row.score).to.equal(1);
         });
       });
-    });
 
-    it("should allow public sharing of implicit action and execution", () => {
-      cy.get("@writableModelId").then(id => {
-        cy.visit(`/model/${id}/detail`);
-        cy.wait("@getModel");
-      });
+      it("should allow public sharing of query action and execution", () => {
+        cy.get("@writableModelId").then(modelId => {
+          H.createAction({
+            ...SAMPLE_WRITABLE_QUERY_ACTION,
+            model_id: modelId,
+          });
 
       createBasicActions();
 
@@ -705,117 +683,188 @@ describe(
           cy.findByLabelText("Show field").should("not.be.checked");
         });
 
-      cy.findByRole("button", { name: "Update" }).click();
+        enableSharingFor(SAMPLE_WRITABLE_QUERY_ACTION.name, {
+          publicUrlAlias: "queryActionPublicUrl",
+        });
 
-      cy.wait("@updateAction");
+        openActionEditorFor(SAMPLE_WRITABLE_QUERY_ACTION.name);
 
-      cy.signOut();
+        H.fillActionQuery(" [[ AND status = {{new_status}} ]]");
 
-      cy.get("@updatePublicURL").then(url => {
-        cy.visit(url);
+        cy.findAllByTestId("form-field-container")
+          .filter(":contains('New Status')")
+          .within(() => {
+            cy.findByLabelText("Show field").click();
+            cy.findByLabelText("Show field").should("not.be.checked");
 
-        // team 2 has 10 points, let's give them more
-        cy.findByLabelText("ID").type("2");
-        cy.findByLabelText("Score").type("16");
-        cy.findByLabelText("Team Name").type("Bouncy Bears");
-        cy.findByLabelText("Create At").should("not.exist");
+            cy.icon("gear").click();
+          });
 
-        cy.button("Update").click();
+        H.popover().within(() => {
+          cy.findByLabelText("Required").uncheck();
+        });
 
-        cy.findByText("Update ran successfully").should("be.visible");
+        cy.findByRole("button", { name: "Update" }).click();
+
+        cy.signOut();
+
+        cy.get("@queryActionPublicUrl").then(url => {
+          cy.visit(url);
+          cy.findByLabelText(TEST_PARAMETER.name).type("1");
+          cy.findByLabelText("New Status").should("not.exist");
+
+          cy.button(SAMPLE_QUERY_ACTION.name).click();
+
+          cy.findByText(
+            `${SAMPLE_WRITABLE_QUERY_ACTION.name} ran successfully`,
+          ).should("be.visible");
+
+          H.queryWritableDB(
+            `SELECT * FROM ${WRITABLE_TEST_TABLE} WHERE id = 1`,
+            dialect,
+          ).then(result => {
+            const row = result.rows[0];
+
+            expect(row.score).to.equal(22);
+          });
+        });
+      });
+
+      it("should allow public sharing of implicit action and execution", () => {
+        cy.get("@writableModelId").then(id => {
+          cy.visit(`/model/${id}/detail`);
+          cy.wait("@getModel");
+        });
+
+        cy.findByRole("tablist").within(() => {
+          cy.findByText("Actions").click();
+        });
+
+        createBasicActions();
+
+        enableSharingFor("Update", { publicUrlAlias: "updatePublicURL" });
+
+        openActionEditorFor("Update");
+
+        cy.findAllByTestId("form-field-container")
+          .filter(":contains('Created At')")
+          .within(() => {
+            cy.findByLabelText("Show field").click();
+            cy.findByLabelText("Show field").should("not.be.checked");
+          });
+
+        cy.findByRole("button", { name: "Update" }).click();
+
+        cy.wait("@updateAction");
+
+        cy.signOut();
+
+        cy.get("@updatePublicURL").then(url => {
+          cy.visit(url);
+
+          // team 2 has 10 points, let's give them more
+          cy.findByLabelText("ID").type("2");
+          cy.findByLabelText("Score").type("16");
+          cy.findByLabelText("Team Name").type("Bouncy Bears");
+          cy.findByLabelText("Create At").should("not.exist");
+
+          cy.button("Update").click();
+
+          cy.findByText("Update ran successfully").should("be.visible");
+
+          H.queryWritableDB(
+            `SELECT * FROM ${WRITABLE_TEST_TABLE} WHERE id = 2`,
+            dialect,
+          ).then(result => {
+            const row = result.rows[0];
+
+            expect(row.score).to.equal(16);
+            expect(row.team_name).to.equal("Bouncy Bears");
+          });
+        });
+      });
+
+      it("should respect impersonated permission", () => {
+        cy.onlyOn(dialect === "postgres");
+        const role = "readonly_role";
+        const sql = getCreatePostgresRoleIfNotExistSql(
+          role,
+          `GRANT SELECT ON ${WRITABLE_TEST_TABLE} TO ${role};`,
+        );
+        H.setTokenFeatures("all");
+        H.queryWritableDB(sql);
+
+        cy.request("PUT", `/api/user/${IMPERSONATED_USER_ID}`, {
+          login_attributes: { role },
+        });
+
+        cy.updatePermissionsGraph(
+          {
+            [USER_GROUPS.ALL_USERS_GROUP]: {
+              [WRITABLE_DB_ID]: {
+                "view-data": "impersonated",
+                "create-queries": "query-builder-and-native",
+              },
+            },
+            // By default, all groups get `unrestricted` access that will override the impersonation.
+            [USER_GROUPS.COLLECTION_GROUP]: {
+              [WRITABLE_DB_ID]: {
+                "view-data": "blocked",
+              },
+            },
+          },
+          [
+            {
+              db_id: WRITABLE_DB_ID,
+              group_id: USER_GROUPS.ALL_USERS_GROUP,
+              attribute: "role",
+            },
+          ],
+        );
 
         H.queryWritableDB(
-          `SELECT * FROM ${WRITABLE_TEST_TABLE} WHERE id = 2`,
+          `SELECT *
+         FROM ${WRITABLE_TEST_TABLE}
+         WHERE id = 1`,
           dialect,
         ).then(result => {
           const row = result.rows[0];
-
-          expect(row.score).to.equal(16);
-          expect(row.team_name).to.equal("Bouncy Bears");
+          expect(row.score).to.equal(0);
         });
-      });
-    });
 
-    it("should respect impersonated permission", () => {
-      cy.onlyOn(dialect === "postgres");
-      const role = "readonly_role";
-      const sql = getCreatePostgresRoleIfNotExistSql(
-        role,
-        `GRANT SELECT ON ${WRITABLE_TEST_TABLE} TO ${role};`,
-      );
-      H.setTokenFeatures("all");
-      H.queryWritableDB(sql);
+        cy.get("@writableModelId").then(modelId => {
+          H.createAction({
+            ...SAMPLE_WRITABLE_QUERY_ACTION,
+            model_id: modelId,
+          });
+          cy.signInAsImpersonatedUser();
+          cy.visit(`/model/${modelId}/detail/actions`);
+          cy.wait("@getModel");
+        });
 
-      cy.request("PUT", `/api/user/${IMPERSONATED_USER_ID}`, {
-        login_attributes: { role },
-      });
+        runActionFor(SAMPLE_QUERY_ACTION.name);
 
-      cy.updatePermissionsGraph(
-        {
-          [USER_GROUPS.ALL_USERS_GROUP]: {
-            [WRITABLE_DB_ID]: {
-              "view-data": "impersonated",
-              "create-queries": "query-builder-and-native",
-            },
-          },
-          // By default, all groups get `unrestricted` access that will override the impersonation.
-          [USER_GROUPS.COLLECTION_GROUP]: {
-            [WRITABLE_DB_ID]: {
-              "view-data": "blocked",
-            },
-          },
-        },
-        [
-          {
-            db_id: WRITABLE_DB_ID,
-            group_id: USER_GROUPS.ALL_USERS_GROUP,
-            attribute: "role",
-          },
-        ],
-      );
+        H.modal().within(() => {
+          cy.findByLabelText(TEST_PARAMETER.name).type("1");
+          cy.button(SAMPLE_QUERY_ACTION.name).click();
 
-      H.queryWritableDB(
-        `SELECT *
+          cy.findByText(
+            "Error executing Action: Error executing write query: ERROR: permission denied for table scoreboard_actions",
+          );
+        });
+
+        H.queryWritableDB(
+          `SELECT *
          FROM ${WRITABLE_TEST_TABLE}
          WHERE id = 1`,
-        dialect,
-      ).then(result => {
-        const row = result.rows[0];
-        expect(row.score).to.equal(0);
-      });
-
-      cy.get("@writableModelId").then(modelId => {
-        H.createAction({
-          ...SAMPLE_WRITABLE_QUERY_ACTION,
-          model_id: modelId,
+          dialect,
+        ).then(result => {
+          const row = result.rows[0];
+          expect(row.score).to.equal(0);
         });
-        cy.signInAsImpersonatedUser();
-        cy.visit(`/model/${modelId}/detail/actions`);
-        cy.wait("@getModel");
       });
-
-      runActionFor(SAMPLE_QUERY_ACTION.name);
-
-      H.modal().within(() => {
-        cy.findByLabelText(TEST_PARAMETER.name).type("1");
-        cy.button(SAMPLE_QUERY_ACTION.name).click();
-
-        cy.findByText(
-          "Error executing Action: Error executing write query: ERROR: permission denied for table scoreboard_actions",
-        );
-      });
-
-      H.queryWritableDB(
-        `SELECT *
-         FROM ${WRITABLE_TEST_TABLE}
-         WHERE id = 1`,
-        dialect,
-      ).then(result => {
-        const row = result.rows[0];
-        expect(row.score).to.equal(0);
-      });
-    });
-  });
+    },
+  );
 });
 
 function runActionFor(actionName) {

--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.js
@@ -283,7 +283,7 @@ describe("scenarios > admin > datamodel > field", () => {
   });
 });
 
-describe("Unfold JSON", () => {
+describe("Unfold JSON", { tags: "@external" }, () => {
   function getUnfoldJsonContent() {
     return cy
       .findByText("Unfold JSON")

--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -226,7 +226,7 @@ H.describeWithSnowplow(
   },
 );
 
-describe("permissions", () => {
+describe("permissions", { tags: "@external" }, () => {
   it("should not show you upload buttons if you are a sandboxed user", () => {
     H.restore("postgres-12");
     cy.signInAsAdmin();
@@ -268,45 +268,41 @@ describe("permissions", () => {
     });
   });
 
-  it(
-    "should show you upload buttons if you have unrestricted access to the upload schema",
-    { tags: ["@external"] },
-    () => {
-      H.restore("postgres-12");
-      cy.signInAsAdmin();
+  it("should show you upload buttons if you have unrestricted access to the upload schema", () => {
+    H.restore("postgres-12");
+    cy.signInAsAdmin();
 
-      H.setTokenFeatures("all");
-      H.enableUploads("postgres");
+    H.setTokenFeatures("all");
+    H.enableUploads("postgres");
 
-      cy.updatePermissionsGraph({
-        [ALL_USERS_GROUP]: {
-          [WRITABLE_DB_ID]: {
-            "view-data": "blocked",
-          },
+    cy.updatePermissionsGraph({
+      [ALL_USERS_GROUP]: {
+        [WRITABLE_DB_ID]: {
+          "view-data": "blocked",
         },
-        [NOSQL_GROUP]: {
-          [WRITABLE_DB_ID]: {
-            "view-data": "unrestricted",
-            "create-queries": "query-builder",
-          },
+      },
+      [NOSQL_GROUP]: {
+        [WRITABLE_DB_ID]: {
+          "view-data": "unrestricted",
+          "create-queries": "query-builder",
         },
-      });
+      },
+    });
 
-      cy.updateCollectionGraph({
-        [NOSQL_GROUP]: { root: "write" },
-      });
+    cy.updateCollectionGraph({
+      [NOSQL_GROUP]: { root: "write" },
+    });
 
-      cy.signIn("nosql");
-      cy.visit("/collection/root");
-      cy.findByTestId("collection-menu").within(() => {
-        cy.findByLabelText("Upload data").should("exist");
-        cy.findByRole("img", { name: /upload/i }).should("exist");
-      });
-    },
-  );
+    cy.signIn("nosql");
+    cy.visit("/collection/root");
+    cy.findByTestId("collection-menu").within(() => {
+      cy.findByLabelText("Upload data").should("exist");
+      cy.findByRole("img", { name: /upload/i }).should("exist");
+    });
+  });
 });
 
-describe("Upload Table Cleanup/Management", () => {
+describe("Upload Table Cleanup/Management", { tags: "@external" }, () => {
   beforeEach(() => {
     cy.intercept("GET", "/api/ee/upload-management/tables").as(
       "getUploadTables",

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -486,7 +486,7 @@ describe("issues 20845, 25031", () => {
 // - Add tests for embedding previews in both cases
 // - Add tests for disabled, editable and locked parameters in both cases
 // BONUS: Ideally add tests for email subscriptions with the filter applied
-describe("issue 27643", () => {
+describe("issue 27643", { tags: "@external" }, () => {
   const PG_DB_ID = 2;
   const TEMPLATE_TAG_NAME = "expected_invoice";
   const getQuestionDetails = fieldId => {

--- a/e2e/test/scenarios/permissions/impersonated.cy.spec.js
+++ b/e2e/test/scenarios/permissions/impersonated.cy.spec.js
@@ -5,7 +5,7 @@ const { ALL_USERS_GROUP, COLLECTION_GROUP } = USER_GROUPS;
 
 const PG_DB_ID = 2;
 
-H.describeEE("impersonated permission", () => {
+H.describeEE("impersonated permission", { tags: "@external" }, () => {
   describe("admins", () => {
     beforeEach(() => {
       H.restore("postgres-12");

--- a/e2e/test/scenarios/permissions/view-data.cy.spec.js
+++ b/e2e/test/scenarios/permissions/view-data.cy.spec.js
@@ -251,6 +251,7 @@ H.describeEE("scenarios > admin > permissions > view data > granular", () => {
 
 H.describeEE(
   "scenarios > admin > permissions > view data > impersonated",
+  { tags: "@external" },
   () => {
     beforeEach(() => {
       H.restore("postgres-12");
@@ -770,45 +771,53 @@ H.describeEE(
       );
     });
 
-    it("should allow you to impersonate view permissions and also edit the create queries permissions and saving should persist both (metabase#46450)", () => {
-      H.restore("postgres-12");
-      H.createTestRoles({ type: "postgres" });
-      cy.signInAsAdmin();
-      H.setTokenFeatures("all");
+    it(
+      "should allow you to impersonate view permissions and also edit the create queries permissions and saving should persist both (metabase#46450)",
+      { tags: "@external" },
+      () => {
+        H.restore("postgres-12");
+        H.createTestRoles({ type: "postgres" });
+        cy.signInAsAdmin();
+        H.setTokenFeatures("all");
 
-      cy.intercept("PUT", "/api/permissions/graph").as("saveGraph");
+        cy.intercept("PUT", "/api/permissions/graph").as("saveGraph");
 
-      cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
+        cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
 
-      // Set impersonated access on Postgres database
-      H.modifyPermission("QA Postgres12", DATA_ACCESS_PERM_IDX, "Impersonated");
+        // Set impersonated access on Postgres database
+        H.modifyPermission(
+          "QA Postgres12",
+          DATA_ACCESS_PERM_IDX,
+          "Impersonated",
+        );
 
-      H.selectImpersonatedAttribute("role");
-      H.saveImpersonationSettings();
+        H.selectImpersonatedAttribute("role");
+        H.saveImpersonationSettings();
 
-      H.modifyPermission(
-        "QA Postgres12",
-        CREATE_QUERIES_PERM_IDX,
-        "Query builder only",
-      );
+        H.modifyPermission(
+          "QA Postgres12",
+          CREATE_QUERIES_PERM_IDX,
+          "Query builder only",
+        );
 
-      H.savePermissions();
+        H.savePermissions();
 
-      cy.wait("@saveGraph").then(({ response }) => {
-        expect(response.statusCode).to.equal(200);
-      });
+        cy.wait("@saveGraph").then(({ response }) => {
+          expect(response.statusCode).to.equal(200);
+        });
 
-      H.assertPermissionForItem(
-        "QA Postgres12",
-        DATA_ACCESS_PERM_IDX,
-        "Impersonated",
-      );
-      H.assertPermissionForItem(
-        "QA Postgres12",
-        CREATE_QUERIES_PERM_IDX,
-        "Query builder only",
-      );
-    });
+        H.assertPermissionForItem(
+          "QA Postgres12",
+          DATA_ACCESS_PERM_IDX,
+          "Impersonated",
+        );
+        H.assertPermissionForItem(
+          "QA Postgres12",
+          CREATE_QUERIES_PERM_IDX,
+          "Query builder only",
+        );
+      },
+    );
   },
 );
 H.describeEE(

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -1552,7 +1552,7 @@ describe("issue 44668", () => {
   });
 });
 
-describe("issue 44974", () => {
+describe("issue 44974", { tags: "@external" }, () => {
   const PG_DB_ID = 2;
 
   beforeEach(() => {

--- a/e2e/test/scenarios/question/document-title.cy.spec.js
+++ b/e2e/test/scenarios/question/document-title.cy.spec.js
@@ -2,28 +2,32 @@ import { H } from "e2e/support";
 
 const PG_DB_ID = 2;
 
-describe("question loading changes document title", () => {
-  beforeEach(() => {
-    H.restore("postgres-12");
-    cy.signInAsNormalUser();
-  });
+describe(
+  "question loading changes document title",
+  { tags: "@external" },
+  () => {
+    beforeEach(() => {
+      H.restore("postgres-12");
+      cy.signInAsNormalUser();
+    });
 
-  it("should verify document title changes while loading a slow question (metabase#40051)", () => {
-    cy.log("run a slow question");
+    it("should verify document title changes while loading a slow question (metabase#40051)", () => {
+      cy.log("run a slow question");
 
-    H.visitQuestionAdhoc(
-      {
-        dataset_query: {
-          type: "native",
-          native: {
-            query: "select pg_sleep(60)",
+      H.visitQuestionAdhoc(
+        {
+          dataset_query: {
+            type: "native",
+            native: {
+              query: "select pg_sleep(60)",
+            },
+            database: PG_DB_ID,
           },
-          database: PG_DB_ID,
         },
-      },
-      { skipWaiting: true },
-    );
+        { skipWaiting: true },
+      );
 
-    cy.title().should("eq", "Doing science... · Metabase");
-  });
-});
+      cy.title().should("eq", "Doing science... · Metabase");
+    });
+  },
+);

--- a/e2e/test/scenarios/question/query-external.cy.spec.js
+++ b/e2e/test/scenarios/question/query-external.cy.spec.js
@@ -15,31 +15,35 @@ const supportedDatabases = [
 ];
 
 supportedDatabases.forEach(({ database, snapshotName, dbName }) => {
-  describe("scenarios > question > query > external", () => {
-    beforeEach(() => {
-      cy.intercept("POST", "/api/dataset").as("dataset");
+  describe(
+    "scenarios > question > query > external",
+    { tags: "@external" },
+    () => {
+      beforeEach(() => {
+        cy.intercept("POST", "/api/dataset").as("dataset");
 
-      H.restore(snapshotName);
-      cy.signInAsAdmin();
+        H.restore(snapshotName);
+        cy.signInAsAdmin();
 
-      cy.request(`/api/database/${WRITABLE_DB_ID}/schema/`).as("schema");
-    });
-
-    it(`can query ${database} database`, () => {
-      cy.get("@schema").then(({ body }) => {
-        const tabelId = body.find(
-          table => table.name.toLowerCase() === "orders",
-        ).id;
-        H.openTable({
-          database: WRITABLE_DB_ID,
-          table: tabelId,
-          mode: "notebook",
-        });
+        cy.request(`/api/database/${WRITABLE_DB_ID}/schema/`).as("schema");
       });
 
-      H.visualize();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("37.65");
-    });
-  });
+      it(`can query ${database} database`, () => {
+        cy.get("@schema").then(({ body }) => {
+          const tabelId = body.find(
+            table => table.name.toLowerCase() === "orders",
+          ).id;
+          H.openTable({
+            database: WRITABLE_DB_ID,
+            table: tabelId,
+            mode: "notebook",
+          });
+        });
+
+        H.visualize();
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+        cy.contains("37.65");
+      });
+    },
+  );
 });


### PR DESCRIPTION
part of ENG-9172

(mostly whitespace changes)

Properly tag tests that require an external DB with `@external`. This is prep for isolating these tests on separate runners so we don't have to unnecessarily spin up docker containers on runners that don't need them. (saving ~30 seconds per runner)

