### PR TITLE
Dont escape chars of header dashcards

### DIFF
--- a/src/metabase/notification/payload/execute.clj
+++ b/src/metabase/notification/payload/execute.clj
@@ -108,7 +108,7 @@
     ;; If there's no heading text, the heading is empty, so we return nil.
     (when (get-in dashcard [:visualization_settings :text])
       (update-in dashcard [:visualization_settings :text]
-                 #(str "## " (shared.params/escape-chars % shared.params/escaped-chars-regex))))
+                 #(str "## " %)))
     dashcard))
 
 (defn- escape-markdown-chars?


### PR DESCRIPTION
Closes #42057

- Stop escaping special characters in header dashcards
  - This was breaking when the header contains a url as the markdown / HTML renderer was inserting the escaped url string into an `href` which would fail

More context [here](https://github.com/metabase/metabase/issues/42057#issuecomment-2578560645)
