### PR TITLE
[User KV] Add FE APIs for working with the user key value store

### DIFF
--- a/frontend/src/metabase-types/api/user.ts
+++ b/frontend/src/metabase-types/api/user.ts
@@ -114,3 +114,25 @@ export type UpdateUserRequest = {
   login_attributes?: Record<UserAttribute, UserAttribute> | null;
   user_group_memberships?: { id: number; is_group_manager: boolean }[];
 };
+
+export type UserKeyValueNamespace = string; // TODO;
+export type UserKeyValueKey = string; // TODO;
+
+export type DeleteUserKeyValueRequest = {
+  namespace: UserKeyValueNamespace;
+  key: UserKeyValueKey;
+};
+
+export type GetUserKeyValueRequest = {
+  namespace: UserKeyValueNamespace;
+  key: UserKeyValueKey;
+};
+
+export type UpdateUserKeyValueRequest = {
+  namespace: UserKeyValueNamespace;
+  key: UserKeyValueKey;
+  // TODO: type
+  // TODO: send as v
+  value: any;
+  expires_at?: string;
+};

--- a/frontend/src/metabase-types/api/user.ts
+++ b/frontend/src/metabase-types/api/user.ts
@@ -122,7 +122,7 @@ export type UserKeyValue = {
   value: string;
 };
 
-type UserKeyValueKey = Pick<UserKeyValue, "namespace" | "key">;
+export type UserKeyValueKey = Pick<UserKeyValue, "namespace" | "key">;
 
 export type DeleteUserKeyValueRequest = UserKeyValueKey;
 

--- a/frontend/src/metabase-types/api/user.ts
+++ b/frontend/src/metabase-types/api/user.ts
@@ -115,24 +115,19 @@ export type UpdateUserRequest = {
   user_group_memberships?: { id: number; is_group_manager: boolean }[];
 };
 
-export type UserKeyValueNamespace = string; // TODO;
-export type UserKeyValueKey = string; // TODO;
-
-export type DeleteUserKeyValueRequest = {
-  namespace: UserKeyValueNamespace;
-  key: UserKeyValueKey;
+// NOTE: remove silly value namespace/key from FE once we add a real feature
+export type UserKeyValue = {
+  namespace: "meow";
+  key: "meow";
+  value: string;
 };
 
-export type GetUserKeyValueRequest = {
-  namespace: UserKeyValueNamespace;
-  key: UserKeyValueKey;
-};
+type UserKeyValueKey = Pick<UserKeyValue, "namespace" | "key">;
 
-export type UpdateUserKeyValueRequest = {
-  namespace: UserKeyValueNamespace;
-  key: UserKeyValueKey;
-  // TODO: type
-  // TODO: send as v
-  value: any;
+export type DeleteUserKeyValueRequest = UserKeyValueKey;
+
+export type GetUserKeyValueRequest = UserKeyValueKey;
+
+export type UpdateUserKeyValueRequest = UserKeyValue & {
   expires_at?: string;
 };

--- a/frontend/src/metabase/api/index.ts
+++ b/frontend/src/metabase/api/index.ts
@@ -30,4 +30,5 @@ export * from "./table";
 export * from "./task";
 export * from "./timeline";
 export * from "./timeline-event";
+export * from "./user-key-value";
 export * from "./user";

--- a/frontend/src/metabase/api/tags/constants.ts
+++ b/frontend/src/metabase/api/tags/constants.ts
@@ -35,6 +35,7 @@ export const TAG_TYPES = [
   "public-card",
   "embed-card",
   "public-action",
+  "user-key-value",
 ] as const;
 
 export const TAG_TYPE_MAPPING = {

--- a/frontend/src/metabase/api/tags/utils.ts
+++ b/frontend/src/metabase/api/tags/utils.ts
@@ -20,6 +20,7 @@ import type {
   FieldDimension,
   FieldId,
   ForeignKey,
+  GetUserKeyValueRequest,
   Group,
   GroupListQuery,
   ModelCacheRefreshStatus,
@@ -562,4 +563,11 @@ export function provideUserListTags(
 
 export function provideUserTags(user: UserInfo): TagDescription<TagType>[] {
   return [idTag("user", user.id)];
+}
+
+export function provideUserKeyValueTags({
+  namespace,
+  key,
+}: GetUserKeyValueRequest) {
+  return [{ type: "user-key-value" as const, id: `${namespace}#${key}` }];
 }

--- a/frontend/src/metabase/api/user-key-value.ts
+++ b/frontend/src/metabase/api/user-key-value.ts
@@ -6,7 +6,6 @@ import type {
 
 import { Api } from "./api";
 
-// TODO: add types
 export const userKeyValueApi = Api.injectEndpoints({
   endpoints: builder => ({
     getUserKeyValue: builder.query<any, GetUserKeyValueRequest>({

--- a/frontend/src/metabase/api/user-key-value.ts
+++ b/frontend/src/metabase/api/user-key-value.ts
@@ -1,0 +1,66 @@
+import type {
+  DeleteUserKeyValueRequest,
+  GetUserKeyValueRequest,
+  UpdateUserKeyValueRequest,
+} from "metabase-types/api";
+
+import { Api } from "./api";
+
+// TODO: add types
+export const userKeyValueApi = Api.injectEndpoints({
+  endpoints: builder => ({
+    getUserKeyValue: builder.query<any, GetUserKeyValueRequest>({
+      query: ({ namespace, key }) =>
+        `/api/user-key-value/namespace/${namespace}/key/${key}`,
+    }),
+    updateKeyValue: builder.mutation<any, UpdateUserKeyValueRequest>({
+      query: ({ namespace, key, ...body }) => ({
+        method: "PUT",
+        url: `/api/user-key-value/namespace/${namespace}/key/${key}`,
+        body,
+      }),
+      async onQueryStarted(
+        { key, namespace, value },
+        { dispatch, queryFulfilled },
+      ) {
+        const kvResult = dispatch(
+          userKeyValueApi.util.updateQueryData(
+            "getUserKeyValue",
+            { key, namespace },
+            () => value,
+          ),
+        );
+        queryFulfilled.catch(err => {
+          console.error("Unable to update user key value", err);
+          kvResult.undo();
+        });
+      },
+    }),
+    deleteUserKeyValue: builder.mutation<unknown, DeleteUserKeyValueRequest>({
+      query: ({ namespace, key, ...body }) => ({
+        method: "DELETE",
+        url: `/api/user-key-value/namespace/${namespace}/key/${key}`,
+        body,
+      }),
+      async onQueryStarted({ key, namespace }, { dispatch, queryFulfilled }) {
+        const kvResult = dispatch(
+          userKeyValueApi.util.updateQueryData(
+            "getUserKeyValue",
+            { key, namespace },
+            () => undefined,
+          ),
+        );
+        queryFulfilled.catch(err => {
+          console.error("Unable to update user key value", err);
+          kvResult.undo();
+        });
+      },
+    }),
+  }),
+});
+
+export const {
+  useGetUserKeyValueQuery,
+  useUpdateKeyValueMutation,
+  useDeleteUserKeyValueMutation,
+} = userKeyValueApi;

--- a/frontend/src/metabase/hooks/use-user-key-value.ts
+++ b/frontend/src/metabase/hooks/use-user-key-value.ts
@@ -1,0 +1,60 @@
+import { useCallback } from "react";
+
+import {
+  useDeleteUserKeyValueMutation,
+  useGetUserKeyValueQuery,
+  useUpdateKeyValueMutation,
+} from "metabase/api";
+
+export interface UseUserKeyValueParams<ValueType> {
+  namespace: string;
+  key: string;
+  defaultValue?: ValueType;
+}
+
+export type UseUserKeyValueResult<ValueType> = [
+  value: ValueType,
+  setValue: (value: ValueType) => Promise<{ data?: unknown; error?: unknown }>,
+  {
+    isLoading: boolean;
+    isMutating: boolean;
+    error: unknown;
+    clearValue: () => Promise<{ data?: unknown; error?: unknown }>;
+  },
+];
+
+export function useUserKeyValue<ValueType>({
+  namespace,
+  key,
+  defaultValue,
+}: UseUserKeyValueParams<ValueType>): UseUserKeyValueResult<ValueType> {
+  const {
+    data: value = defaultValue,
+    isLoading,
+    error: fetchError,
+  } = useGetUserKeyValueQuery({ namespace, key });
+
+  const [setMutation, setMutationReq] = useUpdateKeyValueMutation();
+  const setValue = useCallback(
+    async (value: ValueType) => {
+      return await setMutation({ namespace, key, value });
+    },
+    [setMutation, namespace, key],
+  );
+
+  const [clearMutation, clearMutationReq] = useDeleteUserKeyValueMutation();
+  const clearValue = useCallback(async () => {
+    return await clearMutation({ namespace, key });
+  }, [clearMutation, namespace, key]);
+
+  return [
+    value,
+    setValue,
+    {
+      isLoading,
+      isMutating: setMutationReq.isLoading || clearMutationReq.isLoading,
+      error: fetchError ?? setMutationReq.error ?? clearMutationReq.error,
+      clearValue,
+    },
+  ];
+}

--- a/frontend/src/metabase/hooks/use-user-key-value.unit.spec.tsx
+++ b/frontend/src/metabase/hooks/use-user-key-value.unit.spec.tsx
@@ -1,0 +1,236 @@
+import { act, renderHook } from "@testing-library/react-hooks";
+import fetchMock from "fetch-mock";
+
+import {
+  setupDeleteUserKeyValueEndpoint,
+  setupGetUserKeyValueEndpoint,
+  setupUpdateUserKeyValueEndpoint,
+} from "__support__/server-mocks/user-key-value";
+import { waitFor } from "__support__/ui";
+import { MetabaseReduxProvider } from "metabase/lib/redux";
+import { mainReducers as reducers } from "metabase/reducers-main";
+import { getStore } from "metabase/store";
+import { createMockState } from "metabase-types/store/mocks";
+
+import {
+  type UseUserKeyValueParams,
+  useUserKeyValue,
+} from "./use-user-key-value";
+
+function setup<ValueType = any>({
+  hookArgs,
+}: {
+  hookArgs: UseUserKeyValueParams<ValueType>;
+}) {
+  const store = getStore(reducers, undefined, createMockState());
+
+  function Wrapper({ children }: any) {
+    return (
+      <MetabaseReduxProvider store={store}>{children}</MetabaseReduxProvider>
+    );
+  }
+
+  const { result } = renderHook(() => useUserKeyValue(hookArgs), {
+    wrapper: Wrapper,
+  });
+
+  return result;
+}
+
+describe("useUserKeyValue", () => {
+  describe("value", () => {
+    it("should return undefined until value has loaded", async () => {
+      setupGetUserKeyValueEndpoint("test", "test", "server-value");
+      const result = setup({
+        hookArgs: { namespace: "test", key: "test" },
+      });
+      expect(result.current[0]).toBe(undefined);
+      expect(result.current[2]?.isLoading).toBe(true);
+    });
+
+    it("should return server value once loaded", async () => {
+      setupGetUserKeyValueEndpoint("test", "test", "server-value");
+      const result = setup({
+        hookArgs: { namespace: "test", key: "test" },
+      });
+      expect(result.current[2]?.isLoading).toBe(true);
+      await waitFor(() => {
+        expect(result.current[2]?.isLoading).toBe(false);
+      });
+      expect(result.current[0]).toBe("server-value");
+    });
+
+    it("should be able to set a default value", async () => {
+      setupGetUserKeyValueEndpoint("test", "test", "server-value");
+      const result = setup({
+        hookArgs: {
+          namespace: "test",
+          key: "test",
+          defaultValue: "default-value",
+        },
+      });
+      expect(result.current[0]).toBe("default-value");
+      expect(result.current[2]?.isLoading).toBe(true);
+      await waitFor(() => {
+        expect(result.current[2]?.isLoading).toBe(false);
+      });
+      expect(result.current[0]).toBe("server-value");
+    });
+  });
+
+  describe("setValue", () => {
+    it("should optimistically update the value and skip refetching", async () => {
+      const mockedFetch = setupGetUserKeyValueEndpoint(
+        "test",
+        "test",
+        "before-value",
+      );
+      setupUpdateUserKeyValueEndpoint("test", "test", "after-value");
+
+      const result = setup({
+        hookArgs: { namespace: "test", key: "test" },
+      });
+
+      // assert initial value
+      await waitFor(() => {
+        expect(result.current[2]?.isLoading).toBe(false);
+      });
+      expect(result.current[0]).toBe("before-value");
+
+      // set new value
+      expect(mockedFetch.calls().length).toBe(1);
+      act(() => {
+        result.current[1]("after-value");
+      });
+
+      // assert optimisitic update occurred
+      expect(result.current[0]).toBe("after-value");
+      expect(result.current[2]?.isMutating).toBe(true);
+      await waitFor(() => {
+        expect(result.current[2]?.isMutating).toBe(false);
+      });
+      expect(result.current[2]?.isLoading).toBe(false);
+      expect(
+        mockedFetch.calls(`path:/api/user-key-value/namespace/test/key/test`, {
+          method: "GET",
+        }),
+      ).toHaveLength(1);
+      expect(result.current[0]).toBe("after-value");
+    });
+
+    it("should revert optimisitic update if update fails", async () => {
+      const mockedFetch = setupGetUserKeyValueEndpoint(
+        "test",
+        "test",
+        "before-value",
+      );
+      fetchMock.put(`path:/api/user-key-value/namespace/test/key/test`, 400);
+
+      const result = setup({
+        hookArgs: { namespace: "test", key: "test" },
+      });
+
+      // assert initial value is correct
+      await waitFor(() => {
+        expect(result.current[2]?.isLoading).toBe(false);
+      });
+      expect(result.current[0]).toBe("before-value");
+
+      // set new value
+      expect(mockedFetch.calls().length).toBe(1);
+      act(() => {
+        result.current[1]("after-value");
+      });
+
+      // assert optimisitic update works as expected
+      expect(result.current[0]).toBe("after-value");
+      expect(result.current[2]?.isMutating).toBe(true);
+      await waitFor(() => {
+        expect(result.current[2]?.isMutating).toBe(false);
+      });
+      expect(result.current[2]?.isLoading).toBe(false);
+      expect(
+        mockedFetch.calls(`path:/api/user-key-value/namespace/test/key/test`, {
+          method: "GET",
+        }),
+      ).toHaveLength(1);
+      expect(result.current[0]).toBe("before-value");
+    });
+  });
+
+  describe("clearValue", () => {
+    it("should optimistically delete a key and skip refetching its value", async () => {
+      const mockedFetch = setupGetUserKeyValueEndpoint("test", "test", "value");
+      setupDeleteUserKeyValueEndpoint("test", "test");
+
+      const result = setup({
+        hookArgs: { namespace: "test", key: "test" },
+      });
+
+      // assert initial value
+      await waitFor(() => {
+        expect(result.current[2]?.isLoading).toBe(false);
+      });
+      expect(result.current[0]).toBe("value");
+
+      // set new value
+      expect(mockedFetch.calls().length).toBe(1);
+      act(() => {
+        result.current[2].clearValue();
+      });
+
+      // assert optimisitic deletion worked
+      expect(result.current[0]).toBe(undefined);
+      expect(result.current[2]?.isMutating).toBe(true);
+      await waitFor(() => {
+        expect(result.current[2]?.isMutating).toBe(false);
+      });
+      expect(result.current[2]?.isLoading).toBe(false);
+      expect(
+        mockedFetch.calls(`path:/api/user-key-value/namespace/test/key/test`, {
+          method: "GET",
+        }),
+      ).toHaveLength(1);
+      expect(result.current[0]).toBe(undefined);
+    });
+
+    it("should revert optimisitic delete if deletion fails", async () => {
+      const mockedFetch = setupGetUserKeyValueEndpoint(
+        "test",
+        "test",
+        "before-value",
+      );
+      fetchMock.delete(`path:/api/user-key-value/namespace/test/key/test`, 400);
+
+      const result = setup({
+        hookArgs: { namespace: "test", key: "test" },
+      });
+
+      // assert initial value is correct
+      await waitFor(() => {
+        expect(result.current[2]?.isLoading).toBe(false);
+      });
+      expect(result.current[0]).toBe("before-value");
+
+      // set new value
+      expect(mockedFetch.calls().length).toBe(1);
+      act(() => {
+        result.current[2].clearValue();
+      });
+
+      // assert optimisitic deletion was reverted
+      expect(result.current[0]).toBe(undefined);
+      expect(result.current[2]?.isMutating).toBe(true);
+      await waitFor(() => {
+        expect(result.current[2]?.isMutating).toBe(false);
+      });
+      expect(result.current[2]?.isLoading).toBe(false);
+      expect(
+        mockedFetch.calls(`path:/api/user-key-value/namespace/test/key/test`, {
+          method: "GET",
+        }),
+      ).toHaveLength(1);
+      expect(result.current[0]).toBe("before-value");
+    });
+  });
+});

--- a/frontend/src/metabase/hooks/use-user-key-value.unit.spec.tsx
+++ b/frontend/src/metabase/hooks/use-user-key-value.unit.spec.tsx
@@ -18,10 +18,10 @@ import {
   useUserKeyValue,
 } from "./use-user-key-value";
 
-function setup<ValueType extends UserKeyValue>({
+function setup({
   hookArgs,
 }: {
-  hookArgs: UseUserKeyValueParams<ValueType>;
+  hookArgs: UseUserKeyValueParams<UserKeyValue>;
 }) {
   const store = getStore(reducers, undefined, createMockState());
 
@@ -41,7 +41,11 @@ function setup<ValueType extends UserKeyValue>({
 describe("useUserKeyValue", () => {
   describe("value", () => {
     it("should return undefined until value has loaded", async () => {
-      setupGetUserKeyValueEndpoint("meow", "meow", "server-value");
+      setupGetUserKeyValueEndpoint({
+        namespace: "meow",
+        key: "meow",
+        value: "server-value",
+      });
       const result = setup({
         hookArgs: { namespace: "meow", key: "meow" },
       });
@@ -50,7 +54,11 @@ describe("useUserKeyValue", () => {
     });
 
     it("should return server value once loaded", async () => {
-      setupGetUserKeyValueEndpoint("meow", "meow", "server-value");
+      setupGetUserKeyValueEndpoint({
+        namespace: "meow",
+        key: "meow",
+        value: "server-value",
+      });
       const result = setup({
         hookArgs: { namespace: "meow", key: "meow" },
       });
@@ -62,7 +70,11 @@ describe("useUserKeyValue", () => {
     });
 
     it("should be able to set a default value", async () => {
-      setupGetUserKeyValueEndpoint("meow", "meow", "server-value");
+      setupGetUserKeyValueEndpoint({
+        namespace: "meow",
+        key: "meow",
+        value: "server-value",
+      });
       const result = setup({
         hookArgs: {
           namespace: "meow",
@@ -81,12 +93,16 @@ describe("useUserKeyValue", () => {
 
   describe("setValue", () => {
     it("should optimistically update the value and skip refetching", async () => {
-      const mockedFetch = setupGetUserKeyValueEndpoint(
-        "meow",
-        "meow",
-        "before-value",
-      );
-      setupUpdateUserKeyValueEndpoint("meow", "meow", "after-value");
+      const mockedFetch = setupGetUserKeyValueEndpoint({
+        namespace: "meow",
+        key: "meow",
+        value: "before-value",
+      });
+      setupUpdateUserKeyValueEndpoint({
+        namespace: "meow",
+        key: "meow",
+        value: "after-value",
+      });
 
       const result = setup({
         hookArgs: { namespace: "meow", key: "meow" },
@@ -120,11 +136,11 @@ describe("useUserKeyValue", () => {
     });
 
     it("should revert optimisitic update if update fails", async () => {
-      const mockedFetch = setupGetUserKeyValueEndpoint(
-        "meow",
-        "meow",
-        "before-value",
-      );
+      const mockedFetch = setupGetUserKeyValueEndpoint({
+        namespace: "meow",
+        key: "meow",
+        value: "before-value",
+      });
       fetchMock.put(`path:/api/user-key-value/namespace/meow/key/meow`, 400);
 
       const result = setup({
@@ -161,8 +177,12 @@ describe("useUserKeyValue", () => {
 
   describe("clearValue", () => {
     it("should optimistically delete a key and skip refetching its value", async () => {
-      const mockedFetch = setupGetUserKeyValueEndpoint("meow", "meow", "value");
-      setupDeleteUserKeyValueEndpoint("meow", "meow");
+      const mockedFetch = setupGetUserKeyValueEndpoint({
+        namespace: "meow",
+        key: "meow",
+        value: "value",
+      });
+      setupDeleteUserKeyValueEndpoint({ namespace: "meow", key: "meow" });
 
       const result = setup({
         hookArgs: { namespace: "meow", key: "meow" },
@@ -196,11 +216,11 @@ describe("useUserKeyValue", () => {
     });
 
     it("should revert optimisitic delete if deletion fails", async () => {
-      const mockedFetch = setupGetUserKeyValueEndpoint(
-        "meow",
-        "meow",
-        "before-value",
-      );
+      const mockedFetch = setupGetUserKeyValueEndpoint({
+        namespace: "meow",
+        key: "meow",
+        value: "before-value",
+      });
       fetchMock.delete(`path:/api/user-key-value/namespace/meow/key/meow`, 400);
 
       const result = setup({

--- a/frontend/test/__support__/server-mocks/user-key-value.ts
+++ b/frontend/test/__support__/server-mocks/user-key-value.ts
@@ -1,36 +1,27 @@
 import fetchMock from "fetch-mock";
 
+import type { UserKeyValue, UserKeyValueKey } from "metabase-types/api";
+
 // TODO: value type?
-export function setupGetUserKeyValueEndpoint(
-  namespace: string,
-  key: string,
-  value: any,
-) {
+export function setupGetUserKeyValueEndpoint(kv: UserKeyValue) {
   return fetchMock.get(
-    `path:/api/user-key-value/namespace/${namespace}/key/${key}`,
-    { status: 200, body: value },
+    `path:/api/user-key-value/namespace/${kv.namespace}/key/${kv.key}`,
+    { status: 200, body: kv.value },
     { overwriteRoutes: true },
   );
 }
 
-export function setupUpdateUserKeyValueEndpoint(
-  namespace: string,
-  key: string,
-  newValue: any,
-) {
+export function setupUpdateUserKeyValueEndpoint(kv: UserKeyValue) {
   return fetchMock.put(
-    `path:/api/user-key-value/namespace/${namespace}/key/${key}`,
-    { status: 200, body: newValue },
+    `path:/api/user-key-value/namespace/${kv.namespace}/key/${kv.key}`,
+    { status: 200, body: kv.value },
     { overwriteRoutes: true },
   );
 }
 
-export function setupDeleteUserKeyValueEndpoint(
-  namespace: string,
-  key: string,
-) {
+export function setupDeleteUserKeyValueEndpoint(k: UserKeyValueKey) {
   return fetchMock.delete(
-    `path:/api/user-key-value/namespace/${namespace}/key/${key}`,
+    `path:/api/user-key-value/namespace/${k.namespace}/key/${k.key}`,
     { status: 200 },
     { overwriteRoutes: true },
   );

--- a/frontend/test/__support__/server-mocks/user-key-value.ts
+++ b/frontend/test/__support__/server-mocks/user-key-value.ts
@@ -1,0 +1,37 @@
+import fetchMock from "fetch-mock";
+
+// TODO: value type?
+export function setupGetUserKeyValueEndpoint(
+  namespace: string,
+  key: string,
+  value: any,
+) {
+  return fetchMock.get(
+    `path:/api/user-key-value/namespace/${namespace}/key/${key}`,
+    { status: 200, body: value },
+    { overwriteRoutes: true },
+  );
+}
+
+export function setupUpdateUserKeyValueEndpoint(
+  namespace: string,
+  key: string,
+  newValue: any,
+) {
+  return fetchMock.put(
+    `path:/api/user-key-value/namespace/${namespace}/key/${key}`,
+    { status: 200, body: newValue },
+    { overwriteRoutes: true },
+  );
+}
+
+export function setupDeleteUserKeyValueEndpoint(
+  namespace: string,
+  key: string,
+) {
+  return fetchMock.delete(
+    `path:/api/user-key-value/namespace/${namespace}/key/${key}`,
+    { status: 200 },
+    { overwriteRoutes: true },
+  );
+}


### PR DESCRIPTION
### Description

Adds FE API endpoints and a helper hook for working with the new user key value store. This PR lays the groundwork for being able to build UIs that need to persist small bits of arbitrary data.

Also props to @npfitz for [his prior art](https://github.com/metabase/metabase/commit/0924e88f75d22e134274b19a797b6f46c6cbbcb3#diff-7ce64a29f125bb2c425efaa1b494d4a1655559da57b73346b6c22d3db2c3d245R90). He's a giant and I'm standing on his shoulders.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
