### PR TITLE
Setting alignment to top for icons in subscription and alert emails

### DIFF
--- a/src/metabase/email/alert.hbs
+++ b/src/metabase/email/alert.hbs
@@ -6,7 +6,7 @@
           <div class="container" style="background-color: white; max-width: 555px; border-radius: 24px; margin: 0 auto; padding: 30px;">
             <table class="header">
               <tr>
-                <td width="28px">
+                <td width="28px" style="vertical-align: top;">
                   <img class="icon" style="padding-top: 4px; padding-right: 16px; width: 100%; height: auto; max-width: 20px" src="cid:{{computed.icon_cid}}"/>
                 </td>
                 <td>

--- a/src/metabase/email/dashboard_subscription.hbs
+++ b/src/metabase/email/dashboard_subscription.hbs
@@ -6,7 +6,7 @@
           <div class="container" style="background-color: white; max-width: 555px; border-radius: 24px; margin: 0 auto; padding: 30px;">
             <table class="header">
               <tr>
-                <td width="28px">
+                <td width="28px" style="vertical-align: top;">
                   <img class="icon" style="padding-top: 4px; padding-right: 16px; width: 100%; height: auto; max-width: 20px" src="cid:{{computed.icon_cid}}"/>
                 </td>
                 <td>


### PR DESCRIPTION
Closes #18791

- Changing vertical alignment of icons in subscription and alert emails to be `top` so they're not vertically aligned with the dashboard / question title when these text wrap (see example below)

<details>
<summary>Subscription (Before)</summary>
<img width="594" alt="image" src="https://github.com/user-attachments/assets/aa873cc8-23c6-4626-9421-be12e5363af9" />
</details>
<details>
<summary>Subscription (After)</summary>
<img width="594" alt="image" src="https://github.com/user-attachments/assets/f61bd7ea-5a70-4b47-a85c-5864ea9ae1a4" />
</details>
<details>
<summary>Alert (Before)</summary>
<img width="598" alt="image" src="https://github.com/user-attachments/assets/8ca5f072-955f-4fae-a0b3-9f0f559c08c6" />
</details>
<details>
<summary>Alert (After)</summary>
<img width="601" alt="image" src="https://github.com/user-attachments/assets/e3d408b2-cb3d-4e35-a57c-85485e398dda" />
</details>