### PR TITLE
Fix zoom-in.geographic drill thru for multi-stage queries

### DIFF
--- a/src/metabase/lib/drill_thru/zoom_in_geographic.cljc
+++ b/src/metabase/lib/drill_thru/zoom_in_geographic.cljc
@@ -37,7 +37,7 @@
   - City -> LatLon(0.1). Add a filter based on the selected city and 2 breakouts (latitude and longitude) using \"Every
     0.1 degrees\" binning strategy.
 
-  - LatLon -> LatLon. If the binning strategy is more greater than every 20 degrees, change it to 10 degrees. Otherwise
+  - LatLon -> LatLon. If the binning strategy is greater than every 20 degrees, change it to 10 degrees. Otherwise,
     divide the value by 10 and use it as the new binning strategy.
 
   Question transformation:
@@ -87,6 +87,7 @@
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.types.isa :as lib.types.isa]
+   [metabase.lib.underlying :as lib.underlying]
    [metabase.lib.util :as lib.util]
    [metabase.util.malli :as mu]))
 
@@ -191,10 +192,10 @@
   for [[metabase.lib.drill-thru.zoom-in-geographic]] for more information on what circumstances this is returned in
   and what it means to apply this drill."
   [query                        :- ::lib.schema/query
-   stage-number                 :- :int
+   _stage-number                :- :int
    {:keys [value], :as context} :- ::lib.schema.drill-thru/context]
   (when value
-    (when-let [context (context-with-lat-lon query stage-number context)]
+    (when-let [context (context-with-lat-lon query (lib.underlying/top-level-stage-number query) context)]
       (some (fn [f]
               (f context))
             [country->binned-lat-lon-drill
@@ -253,11 +254,12 @@
 
 (mu/defmethod lib.drill-thru.common/drill-thru-method :drill-thru/zoom-in.geographic :- ::lib.schema/query
   [query                        :- ::lib.schema/query
-   stage-number                 :- :int
+   _stage-number                :- :int
    {:keys [subtype], :as drill} :- ::lib.schema.drill-thru/drill-thru.zoom-in.geographic]
-  (case subtype
-    :drill-thru.zoom-in.geographic/country-state-city->binned-lat-lon
-    (apply-country-state-city->binned-lat-lon-drill query stage-number drill)
+  (let [stage-number (lib.underlying/top-level-stage-number query)]
+    (case subtype
+      :drill-thru.zoom-in.geographic/country-state-city->binned-lat-lon
+      (apply-country-state-city->binned-lat-lon-drill query stage-number drill)
 
-    :drill-thru.zoom-in.geographic/binned-lat-lon->binned-lat-lon
-    (apply-binned-lat-lon->binned-lat-lon-drill query stage-number drill)))
+      :drill-thru.zoom-in.geographic/binned-lat-lon->binned-lat-lon
+      (apply-binned-lat-lon->binned-lat-lon-drill query stage-number drill))))

--- a/src/metabase/lib/drill_thru/zoom_in_timeseries.cljc
+++ b/src/metabase/lib/drill_thru/zoom_in_timeseries.cljc
@@ -14,8 +14,7 @@
   - `dimensions` have a date or datetime column with `year`, `quarter`, `month`, `week`, `day`, `hour` temporal unit.
     For other units, or when there is no temporal bucketing, this drill cannot be applied. Changing `hour` to `minute`
     ends the sequence for datetime columns (`week` to `day` for date columns). Only the first matching column would be
-    used in query transformation. If `dimensions` are not provided, `row` data will instead be used to try to find a
-    `matching-breakout-dimension`.
+    used in query transformation.
 
   - `displayInfo` returns `displayName` with `See this {0} by {1}` string using the current and the next available
     temporal unit.

--- a/src/metabase/lib/underlying.cljc
+++ b/src/metabase/lib/underlying.cljc
@@ -64,7 +64,7 @@
   [:map
    [:rename-superflous-options? {:optional true} :boolean]])
 
-(mu/defn top-level-column :- ::lib.schema.metadata/column
+(mu/defn top-level-column :- [:maybe ::lib.schema.metadata/column]
   "Given a column, returns the \"top-level\" equivalent.
 
   Top-level means to find the corresponding column in the [[top-level-query]], which requires walking back through the

--- a/test/metabase/lib/drill_thru/zoom_in_geographic_test.cljc
+++ b/test/metabase/lib/drill_thru/zoom_in_geographic_test.cljc
@@ -23,13 +23,29 @@
                                         :semantic-type  :type/Country}]})
           query             (-> (lib/query metadata-provider (meta/table-metadata :people))
                                 (lib/aggregate (lib/count))
-                                (lib/breakout (lib.metadata/field metadata-provider 1)))]
+                                (lib/breakout (lib.metadata/field metadata-provider 1)))
+          field-key         (lib.drill-thru.tu/field-key= "COUNTRY" 1)
+          expected-query    {:stages [{:source-table (meta/id :people)
+                                       :aggregation  [[:count {}]]
+                                       :breakout     [[:field
+                                                       {:binning {:strategy :bin-width, :bin-width 10}}
+                                                       (meta/id :people :latitude)]
+                                                      [:field
+                                                       {:binning {:strategy :bin-width, :bin-width 10}}
+                                                       (meta/id :people :longitude)]]
+                                       :filters      [[:= {}
+                                                       [:field {} field-key]
+                                                       "United States"]]}]}]
+
       (testing "sanity check: make sure COUNTRY has :type/Country semantic type"
         (testing `lib/returned-columns
           (let [[country _count] (lib/returned-columns query)]
             (is (=? {:semantic-type :type/Country}
                     country)))))
-      (lib.drill-thru.tu/test-drill-application
+
+      (lib.drill-thru.tu/test-drill-variants-with-merged-args
+       lib.drill-thru.tu/test-drill-application
+       "single-stage query"
        {:click-type     :cell
         :query-type     :aggregated
         :custom-query   query
@@ -45,33 +61,47 @@
                                      :bin-width 10}
                          :longitude {:column    {:name "LONGITUDE"}
                                      :bin-width 10}}
-        :expected-query {:stages [{:source-table (meta/id :people)
-                                   :aggregation  [[:count {}]]
-                                   :breakout     [[:field
-                                                   {:binning {:strategy :bin-width, :bin-width 10}}
-                                                   (meta/id :people :latitude)]
-                                                  [:field
-                                                   {:binning {:strategy :bin-width, :bin-width 10}}
-                                                   (meta/id :people :longitude)]]
-                                   :filters      [[:= {}
-                                                   [:field {} 1]
-                                                   "United States"]]}]}})
+        :expected-query expected-query}
+
+       "mutli-stage query"
+       {:custom-query   (lib.drill-thru.tu/append-filter-stage query "count")
+        :expected-query (lib.drill-thru.tu/append-filter-stage-to-test-expectation expected-query "count")})
+
       (testing "nil breakout value means we can't zoom in"
-        (lib.drill-thru.tu/test-drill-not-returned
+        (lib.drill-thru.tu/test-drill-variants-with-merged-args
+         lib.drill-thru.tu/test-drill-not-returned
+         "single-stage query"
          {:click-type     :cell
           :query-type     :aggregated
           :custom-query   query
           :custom-row     {"count"   100
                            "COUNTRY" nil}
           :column-name    "count"
-          :drill-type     :drill-thru/zoom-in.geographic})))))
+          :drill-type     :drill-thru/zoom-in.geographic}
+
+         "multi-stage query"
+         {:custom-query   (lib.drill-thru.tu/append-filter-stage query "count")})))))
 
 (deftest ^:parallel state-test
   (testing "State => Binned LatLon"
-    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :people))
-                    (lib/aggregate (lib/count))
-                    (lib/breakout (meta/field-metadata :people :state)))]
-      (lib.drill-thru.tu/test-drill-application
+    (let [query          (-> (lib/query meta/metadata-provider (meta/table-metadata :people))
+                             (lib/aggregate (lib/count))
+                             (lib/breakout (meta/field-metadata :people :state)))
+          field-key      (lib.drill-thru.tu/field-key= "STATE" (meta/id :people :state))
+          expected-query {:stages [{:source-table (meta/id :people)
+                                    :aggregation  [[:count {}]]
+                                    :breakout     [[:field
+                                                    {:binning {:strategy :bin-width, :bin-width 1}}
+                                                    (meta/id :people :latitude)]
+                                                   [:field
+                                                    {:binning {:strategy :bin-width, :bin-width 1}}
+                                                    (meta/id :people :longitude)]]
+                                    :filters      [[:= {}
+                                                    [:field {} field-key]
+                                                    "California"]]}]}]
+      (lib.drill-thru.tu/test-drill-variants-with-merged-args
+       lib.drill-thru.tu/test-drill-application
+       "single-stage query"
        {:click-type     :cell
         :query-type     :aggregated
         :custom-query   query
@@ -87,37 +117,54 @@
                                      :bin-width 1}
                          :longitude {:column    {:name "LONGITUDE"}
                                      :bin-width 1}}
-        :expected-query {:stages [{:source-table (meta/id :people)
-                                   :aggregation  [[:count {}]]
-                                   :breakout     [[:field
-                                                   {:binning {:strategy :bin-width, :bin-width 1}}
-                                                   (meta/id :people :latitude)]
-                                                  [:field
-                                                   {:binning {:strategy :bin-width, :bin-width 1}}
-                                                   (meta/id :people :longitude)]]
-                                   :filters      [[:= {}
-                                                   [:field {} (meta/id :people :state)]
-                                                   "California"]]}]}})
+        :expected-query expected-query}
+
+       "multi-stage query"
+       {:custom-query   (lib.drill-thru.tu/append-filter-stage query "count")
+        :expected-query (lib.drill-thru.tu/append-filter-stage-to-test-expectation expected-query "count")})
+
       (testing "nil breakout value means we can't zoom in"
-        (lib.drill-thru.tu/test-drill-not-returned
-         {:click-type     :cell
-          :query-type     :aggregated
-          :custom-query   query
-          :custom-row     {"count" 100
-                           "STATE" nil}
-          :column-name    "count"
-          :drill-type     :drill-thru/zoom-in.geographic})))))
+        (lib.drill-thru.tu/test-drill-variants-with-merged-args
+         lib.drill-thru.tu/test-drill-not-returned
+         "single-stage query"
+         {:click-type   :cell
+          :query-type   :aggregated
+          :custom-query query
+          :custom-row   {"count" 100
+                         "STATE" nil}
+          :column-name  "count"
+          :drill-type   :drill-thru/zoom-in.geographic}
+
+         "multi-stage query"
+         {:custom-query (lib.drill-thru.tu/append-filter-stage query "count")})))))
 
 (deftest ^:parallel update-existing-breakouts-on-lat-lon-test
   (testing "If there are already breakouts on lat/lon, we should update them rather than append new ones (#34874)"
-    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :people))
-                    (lib/aggregate (lib/count))
-                    ;; make sure we don't remove other, irrelevant breakouts.
-                    (lib/breakout (meta/field-metadata :people :name))
-                    (lib/breakout (meta/field-metadata :people :state))
-                    (lib/breakout (-> (meta/field-metadata :people :latitude)
-                                      (lib/with-binning {:strategy :bin-width, :bin-width 0.1}))))]
-      (lib.drill-thru.tu/test-drill-application
+    (let [query          (-> (lib/query meta/metadata-provider (meta/table-metadata :people))
+                             (lib/aggregate (lib/count))
+                               ;; make sure we don't remove other, irrelevant breakouts.
+                             (lib/breakout (meta/field-metadata :people :name))
+                             (lib/breakout (meta/field-metadata :people :state))
+                             (lib/breakout (-> (meta/field-metadata :people :latitude)
+                                               (lib/with-binning {:strategy :bin-width, :bin-width 0.1}))))
+          field-key      (lib.drill-thru.tu/field-key= "STATE" (meta/id :people :state))
+          expected-query {:stages [{:source-table (meta/id :people)
+                                    :aggregation  [[:count {}]]
+                                    :breakout     [[:field
+                                                    {}
+                                                    (meta/id :people :name)]
+                                                   [:field
+                                                    {:binning {:strategy :bin-width, :bin-width 1}}
+                                                    (meta/id :people :latitude)]
+                                                   [:field
+                                                    {:binning {:strategy :bin-width, :bin-width 1}}
+                                                    (meta/id :people :longitude)]]
+                                    :filters      [[:= {}
+                                                    [:field {} field-key]
+                                                    "California"]]}]}]
+      (lib.drill-thru.tu/test-drill-variants-with-merged-args
+       lib.drill-thru.tu/test-drill-application
+       "single-stage query"
        {:click-type     :cell
         :query-type     :aggregated
         :custom-query   query
@@ -135,27 +182,32 @@
                                      :bin-width 1}
                          :longitude {:column    {:name "LONGITUDE"}
                                      :bin-width 1}}
-        :expected-query {:stages [{:source-table (meta/id :people)
-                                   :aggregation  [[:count {}]]
-                                   :breakout     [[:field
-                                                   {}
-                                                   (meta/id :people :name)]
-                                                  [:field
-                                                   {:binning {:strategy :bin-width, :bin-width 1}}
-                                                   (meta/id :people :latitude)]
-                                                  [:field
-                                                   {:binning {:strategy :bin-width, :bin-width 1}}
-                                                   (meta/id :people :longitude)]]
-                                   :filters      [[:= {}
-                                                   [:field {} (meta/id :people :state)]
-                                                   "California"]]}]}}))))
+        :expected-query expected-query}
+
+       "multi-stage query"
+       {:custom-query   (lib.drill-thru.tu/append-filter-stage query "count")
+        :expected-query (lib.drill-thru.tu/append-filter-stage-to-test-expectation expected-query "count")}))))
 
 (deftest ^:parallel city-test
   (testing "City => Binned LatLon"
-    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :people))
-                    (lib/aggregate (lib/count))
-                    (lib/breakout (meta/field-metadata :people :city)))]
-      (lib.drill-thru.tu/test-drill-application
+    (let [query          (-> (lib/query meta/metadata-provider (meta/table-metadata :people))
+                             (lib/aggregate (lib/count))
+                             (lib/breakout (meta/field-metadata :people :city)))
+          field-key      (lib.drill-thru.tu/field-key= "CITY" (meta/id :people :city))
+          expected-query {:stages [{:source-table (meta/id :people)
+                                    :aggregation  [[:count {}]]
+                                    :breakout     [[:field
+                                                    {:binning {:strategy :bin-width, :bin-width 0.1}}
+                                                    (meta/id :people :latitude)]
+                                                   [:field
+                                                    {:binning {:strategy :bin-width, :bin-width 0.1}}
+                                                    (meta/id :people :longitude)]]
+                                    :filters      [[:= {}
+                                                    [:field {} field-key]
+                                                    "Long Beach"]]}]}]
+      (lib.drill-thru.tu/test-drill-variants-with-merged-args
+       lib.drill-thru.tu/test-drill-application
+       "single-stage query"
        {:click-type     :cell
         :query-type     :aggregated
         :custom-query   query
@@ -171,36 +223,58 @@
                                      :bin-width 0.1}
                          :longitude {:column    {:name "LONGITUDE"}
                                      :bin-width 0.1}}
-        :expected-query {:stages [{:source-table (meta/id :people)
-                                   :aggregation  [[:count {}]]
-                                   :breakout     [[:field
-                                                   {:binning {:strategy :bin-width, :bin-width 0.1}}
-                                                   (meta/id :people :latitude)]
-                                                  [:field
-                                                   {:binning {:strategy :bin-width, :bin-width 0.1}}
-                                                   (meta/id :people :longitude)]]
-                                   :filters      [[:= {}
-                                                   [:field {} (meta/id :people :city)]
-                                                   "Long Beach"]]}]}})
+        :expected-query expected-query}
+
+       "multi-stage query"
+       {:custom-query   (lib.drill-thru.tu/append-filter-stage query "count")
+        :expected-query (lib.drill-thru.tu/append-filter-stage-to-test-expectation expected-query "count")})
+
       (testing "nil breakout value means we can't zoom in"
-        (lib.drill-thru.tu/test-drill-not-returned
+        (lib.drill-thru.tu/test-drill-variants-with-merged-args
+         lib.drill-thru.tu/test-drill-not-returned
+         "single-stage query"
          {:click-type     :cell
           :query-type     :aggregated
           :custom-query   query
           :custom-row     {"count" 100
                            "CITY"  nil}
           :column-name    "count"
-          :drill-type     :drill-thru/zoom-in.geographic})))))
+          :drill-type     :drill-thru/zoom-in.geographic}
+
+         "multi-stage query"
+         {:custom-query (lib.drill-thru.tu/append-filter-stage query "count")})))))
 
 (deftest ^:parallel binned-lat-lon-large-bin-size-test
   (testing "Binned LatLon (width >= 20) => Binned LatLon (width = 10)"
-    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :people))
-                    (lib/aggregate (lib/count))
-                    (lib/breakout (-> (meta/field-metadata :people :latitude)
-                                      (lib/with-binning {:strategy :bin-width, :bin-width 20})))
-                    (lib/breakout (-> (meta/field-metadata :people :longitude)
-                                      (lib/with-binning {:strategy :bin-width, :bin-width 25}))))]
-      (lib.drill-thru.tu/test-drill-application
+    (let [query          (-> (lib/query meta/metadata-provider (meta/table-metadata :people))
+                             (lib/aggregate (lib/count))
+                             (lib/breakout (-> (meta/field-metadata :people :latitude)
+                                               (lib/with-binning {:strategy :bin-width, :bin-width 20})))
+                             (lib/breakout (-> (meta/field-metadata :people :longitude)
+                                               (lib/with-binning {:strategy :bin-width, :bin-width 25}))))
+          expected-query {:stages [{:source-table (meta/id :people)
+                                    :aggregation  [[:count {}]]
+                                    :breakout     [[:field
+                                                    {:binning {:strategy :bin-width, :bin-width 10}}
+                                                    (meta/id :people :latitude)]
+                                                   [:field
+                                                    {:binning {:strategy :bin-width, :bin-width 10}}
+                                                    (meta/id :people :longitude)]]
+                                    :filters      [[:>= {}
+                                                    [:field {} (meta/id :people :latitude)]
+                                                    20]
+                                                   [:< {}
+                                                    [:field {} (meta/id :people :latitude)]
+                                                    40]
+                                                   [:>= {}
+                                                    [:field {} (meta/id :people :longitude)]
+                                                    50]
+                                                   [:< {}
+                                                    [:field {} (meta/id :people :longitude)]
+                                                    75]]}]}]
+      (lib.drill-thru.tu/test-drill-variants-with-merged-args
+       lib.drill-thru.tu/test-drill-application
+       "single-stage query"
        {:click-type     :cell
         :query-type     :aggregated
         :custom-query   query
@@ -219,36 +293,43 @@
                                      :bin-width 10
                                      :min       50
                                      :max       75}}
-        :expected-query {:stages [{:source-table (meta/id :people)
-                                   :aggregation  [[:count {}]]
-                                   :breakout     [[:field
-                                                   {:binning {:strategy :bin-width, :bin-width 10}}
-                                                   (meta/id :people :latitude)]
-                                                  [:field
-                                                   {:binning {:strategy :bin-width, :bin-width 10}}
-                                                   (meta/id :people :longitude)]]
-                                   :filters      [[:>= {}
-                                                   [:field {} (meta/id :people :latitude)]
-                                                   20]
-                                                  [:< {}
-                                                   [:field {} (meta/id :people :latitude)]
-                                                   40]
-                                                  [:>= {}
-                                                   [:field {} (meta/id :people :longitude)]
-                                                   50]
-                                                  [:< {}
-                                                   [:field {} (meta/id :people :longitude)]
-                                                   75]]}]}}))))
+        :expected-query expected-query}
+
+       "multi-stage query"
+       {:custom-query   (lib.drill-thru.tu/append-filter-stage query "count")
+        :expected-query (lib.drill-thru.tu/append-filter-stage-to-test-expectation expected-query "count")}))))
 
 (deftest ^:parallel binned-lat-lon-small-bin-size-test
   (testing "Binned LatLon (width < 20) => Binned LatLon (width ÷= 10)"
-    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :people))
-                    (lib/aggregate (lib/count))
-                    (lib/breakout (-> (meta/field-metadata :people :latitude)
-                                      (lib/with-binning {:strategy :bin-width, :bin-width 10})))
-                    (lib/breakout (-> (meta/field-metadata :people :longitude)
-                                      (lib/with-binning {:strategy :bin-width, :bin-width 5}))))]
-      (lib.drill-thru.tu/test-drill-application
+    (let [query          (-> (lib/query meta/metadata-provider (meta/table-metadata :people))
+                             (lib/aggregate (lib/count))
+                             (lib/breakout (-> (meta/field-metadata :people :latitude)
+                                               (lib/with-binning {:strategy :bin-width, :bin-width 10})))
+                             (lib/breakout (-> (meta/field-metadata :people :longitude)
+                                               (lib/with-binning {:strategy :bin-width, :bin-width 5}))))
+          expected-query {:stages [{:source-table (meta/id :people)
+                                    :aggregation  [[:count {}]]
+                                    :breakout     [[:field
+                                                    {:binning {:strategy :bin-width, :bin-width 1.0}}
+                                                    (meta/id :people :latitude)]
+                                                   [:field
+                                                    {:binning {:strategy :bin-width, :bin-width 0.5}}
+                                                    (meta/id :people :longitude)]]
+                                    :filters      [[:>= {}
+                                                    [:field {} (meta/id :people :latitude)]
+                                                    20]
+                                                   [:< {}
+                                                    [:field {} (meta/id :people :latitude)]
+                                                    30]
+                                                   [:>= {}
+                                                    [:field {} (meta/id :people :longitude)]
+                                                    50]
+                                                   [:< {}
+                                                    [:field {} (meta/id :people :longitude)]
+                                                    55]]}]}]
+      (lib.drill-thru.tu/test-drill-variants-with-merged-args
+       lib.drill-thru.tu/test-drill-application
+       "single-stage query"
        {:click-type     :cell
         :query-type     :aggregated
         :custom-query   query
@@ -267,26 +348,11 @@
                                      :bin-width 0.5
                                      :min       50
                                      :max       55}}
-        :expected-query {:stages [{:source-table (meta/id :people)
-                                   :aggregation  [[:count {}]]
-                                   :breakout     [[:field
-                                                   {:binning {:strategy :bin-width, :bin-width 1.0}}
-                                                   (meta/id :people :latitude)]
-                                                  [:field
-                                                   {:binning {:strategy :bin-width, :bin-width 0.5}}
-                                                   (meta/id :people :longitude)]]
-                                   :filters      [[:>= {}
-                                                   [:field {} (meta/id :people :latitude)]
-                                                   20]
-                                                  [:< {}
-                                                   [:field {} (meta/id :people :latitude)]
-                                                   30]
-                                                  [:>= {}
-                                                   [:field {} (meta/id :people :longitude)]
-                                                   50]
-                                                  [:< {}
-                                                   [:field {} (meta/id :people :longitude)]
-                                                   55]]}]}}))))
+        :expected-query expected-query}
+
+       "multi-stage query"
+       {:custom-query   (lib.drill-thru.tu/append-filter-stage query "count")
+        :expected-query (lib.drill-thru.tu/append-filter-stage-to-test-expectation expected-query "count")}))))
 
 (deftest ^:parallel binned-lat-lon-default-binning-test
   (testing "Binned LatLon (default 'Auto-Bin') => Binned LatLon. Should use :dimensions (#36247)"
@@ -418,18 +484,40 @@
 
 (deftest ^:parallel zoom-in-on-join-test
   (testing "#11210"
-    (let [base       (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
-                         (lib/join (meta/table-metadata :people))
-                         (lib/aggregate (lib/count)))
-          join-alias (-> base :stages first :joins first :alias)
-          query      (-> base
-                         (lib/breakout (-> (meta/field-metadata :people :latitude)
-                                           (lib/with-binning {:strategy :bin-width, :bin-width 10})
-                                           (lib/with-join-alias join-alias)))
-                         (lib/breakout (-> (meta/field-metadata :people :longitude)
-                                           (lib/with-binning {:strategy :bin-width, :bin-width 10})
-                                           (lib/with-join-alias join-alias))))]
-      (lib.drill-thru.tu/test-drill-application
+    (let [base           (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                             (lib/join (meta/table-metadata :people))
+                             (lib/aggregate (lib/count)))
+          join-alias     (-> base :stages first :joins first :alias)
+          query          (-> base
+                             (lib/breakout (-> (meta/field-metadata :people :latitude)
+                                               (lib/with-binning {:strategy :bin-width, :bin-width 10})
+                                               (lib/with-join-alias join-alias)))
+                             (lib/breakout (-> (meta/field-metadata :people :longitude)
+                                               (lib/with-binning {:strategy :bin-width, :bin-width 10})
+                                               (lib/with-join-alias join-alias))))
+          expected-query {:stages [{:source-table (meta/id :orders)
+                                    :aggregation  [[:count {}]]
+                                    :breakout     [[:field
+                                                    {:binning {:strategy :bin-width, :bin-width 1.0}}
+                                                    (meta/id :people :latitude)]
+                                                   [:field
+                                                    {:binning {:strategy :bin-width, :bin-width 1.0}}
+                                                    (meta/id :people :longitude)]]
+                                    :filters      [[:>= {}
+                                                    [:field {} (meta/id :people :latitude)]
+                                                    20]
+                                                   [:< {}
+                                                    [:field {} (meta/id :people :latitude)]
+                                                    30]
+                                                   [:>= {}
+                                                    [:field {} (meta/id :people :longitude)]
+                                                    50]
+                                                   [:< {}
+                                                    [:field {} (meta/id :people :longitude)]
+                                                    60]]}]}]
+      (lib.drill-thru.tu/test-drill-variants-with-merged-args
+       lib.drill-thru.tu/test-drill-application
+       "single-stage query"
        {:click-type     :cell
         :query-type     :aggregated
         :custom-query   query
@@ -448,26 +536,11 @@
                                      :bin-width 1.0
                                      :min       50
                                      :max       60}}
-        :expected-query {:stages [{:source-table (meta/id :orders)
-                                   :aggregation  [[:count {}]]
-                                   :breakout     [[:field
-                                                   {:binning {:strategy :bin-width, :bin-width 1.0}}
-                                                   (meta/id :people :latitude)]
-                                                  [:field
-                                                   {:binning {:strategy :bin-width, :bin-width 1.0}}
-                                                   (meta/id :people :longitude)]]
-                                   :filters      [[:>= {}
-                                                   [:field {} (meta/id :people :latitude)]
-                                                   20]
-                                                  [:< {}
-                                                   [:field {} (meta/id :people :latitude)]
-                                                   30]
-                                                  [:>= {}
-                                                   [:field {} (meta/id :people :longitude)]
-                                                   50]
-                                                  [:< {}
-                                                   [:field {} (meta/id :people :longitude)]
-                                                   60]]}]}}))))
+        :expected-query expected-query}
+
+       "multi-stage query"
+       {:custom-query   (lib.drill-thru.tu/append-filter-stage query "count")
+        :expected-query (lib.drill-thru.tu/append-filter-stage-to-test-expectation expected-query "count")}))))
 
 ;; This actually tests pivots as well.
 (deftest ^:parallel zoom-in-on-legend-state-test


### PR DESCRIPTION
### Description

Fix the `zoom-in.geographic` drill thru for queries with a filter stage after the aggregations.

Related to https://github.com/metabase/metabase/issues/46932

~~This is currently diffing against [appleby-quick-filter-for-mutlistage-queries](https://github.com/metabase/metabase/tree/appleby-quick-filter-for-mutlistage-queries) because the tests depend on a test helper added there. Once #51807 merges I will rebase this onto master.~~

### How to verify

* New question: People
* summarize: Count by State
* Add filter stage after summarize, e.g. Count > 1
* Visualize
* Click on a cell in the "count" column
* "Zoom in" drill through should appear in the context menu
* Select the "Zoom in" drill: should add a new filter for the State and binned breakouts added for latitude / longitude

### Demo

![Screenshot 2025-01-08 at 5 17 43 PM](https://github.com/user-attachments/assets/84bdda36-c343-40d0-824a-faf76d13b185)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
