### PR TITLE
Fix formatting of month-of-year when there are 53 weeks in the year

### DIFF
--- a/frontend/src/metabase/lib/formatting/date.tsx
+++ b/frontend/src/metabase/lib/formatting/date.tsx
@@ -26,7 +26,7 @@ const DEFAULT_DATE_FORMATS: DEFAULT_DATE_FORMATS_TYPE = {
   "day-of-week": "dddd",
   "day-of-month": "D",
   "day-of-year": "DDD",
-  "week-of-year": "wo",
+  "week-of-year": "Wo",
   "month-of-year": "MMMM",
   "quarter-of-year": "[Q]Q",
 };
@@ -118,8 +118,8 @@ export const DATE_RANGE_FORMAT_SPECS: {
   const DDDoP = "DDDo [days of the year]";
   const DoS = "Do [day of the month]";
   const DoP = "Do [days of the month]";
-  const woS = "wo [week of the year]";
-  const woP = "wo [weeks of the year]";
+  const WoS = "Wo [week of the year]";
+  const WoP = "Wo [weeks of the year]";
   const mmS = "[minute] :mm";
   const mmP = "[minutes] :mm";
 
@@ -350,7 +350,7 @@ export const DATE_RANGE_FORMAT_SPECS: {
     "week-of-year": [
       {
         same: "week",
-        format: [woS],
+        format: [WoS],
         tests: {
           verbose: {
             output: "20th week of the year",
@@ -360,7 +360,7 @@ export const DATE_RANGE_FORMAT_SPECS: {
       },
       {
         same: null,
-        format: ["wo", woP],
+        format: ["Wo", WoP],
         tests: {
           verbose: {
             output: "34th–40th weeks of the year",
@@ -979,7 +979,7 @@ export function formatRange(
 }
 
 function formatWeek(m: Moment, options: OptionsType = {}) {
-  return formatMajorMinor(m.format("wo"), m.format("gggg"), options);
+  return formatMajorMinor(m.format("Wo"), m.format("gggg"), options);
 }
 
 function formatMajorMinor(

--- a/frontend/src/metabase/lib/formatting/date.tsx
+++ b/frontend/src/metabase/lib/formatting/date.tsx
@@ -26,7 +26,7 @@ const DEFAULT_DATE_FORMATS: DEFAULT_DATE_FORMATS_TYPE = {
   "day-of-week": "dddd",
   "day-of-month": "D",
   "day-of-year": "DDD",
-  "week-of-year": "Wo",
+  "week-of-year": "wo",
   "month-of-year": "MMMM",
   "quarter-of-year": "[Q]Q",
 };
@@ -118,8 +118,8 @@ export const DATE_RANGE_FORMAT_SPECS: {
   const DDDoP = "DDDo [days of the year]";
   const DoS = "Do [day of the month]";
   const DoP = "Do [days of the month]";
-  const WoS = "Wo [week of the year]";
-  const WoP = "Wo [weeks of the year]";
+  const woS = "wo [week of the year]";
+  const woP = "wo [weeks of the year]";
   const mmS = "[minute] :mm";
   const mmP = "[minutes] :mm";
 
@@ -350,7 +350,7 @@ export const DATE_RANGE_FORMAT_SPECS: {
     "week-of-year": [
       {
         same: "week",
-        format: [WoS],
+        format: [woS],
         tests: {
           verbose: {
             output: "20th week of the year",
@@ -360,7 +360,7 @@ export const DATE_RANGE_FORMAT_SPECS: {
       },
       {
         same: null,
-        format: ["Wo", WoP],
+        format: ["wo", woP],
         tests: {
           verbose: {
             output: "34th–40th weeks of the year",
@@ -979,7 +979,7 @@ export function formatRange(
 }
 
 function formatWeek(m: Moment, options: OptionsType = {}) {
-  return formatMajorMinor(m.format("Wo"), m.format("gggg"), options);
+  return formatMajorMinor(m.format("wo"), m.format("gggg"), options);
 }
 
 function formatMajorMinor(

--- a/frontend/src/metabase/lib/time-dayjs.ts
+++ b/frontend/src/metabase/lib/time-dayjs.ts
@@ -50,7 +50,7 @@ const NUMERIC_UNIT_FORMATS: Record<string, (value: number) => Dayjs> = {
       .startOf("day"),
   "week-of-year": (value: number) =>
     dayjs("2016-01-01") // initial date must be in a year with 53 iso weeks to format properly
-      .isoWeek(value)
+      .isoWeek(value) // set the iso week number to not depend on the first day of week
       .startOf("isoWeek"),
   "month-of-year": (value: number) =>
     dayjs()

--- a/frontend/src/metabase/lib/time-dayjs.ts
+++ b/frontend/src/metabase/lib/time-dayjs.ts
@@ -41,10 +41,17 @@ const NUMERIC_UNIT_FORMATS: Record<string, (value: number) => Dayjs> = {
       .weekday(value - 1)
       .startOf("day"),
   "day-of-month": (value: number) =>
-    dayjs("2016-01-01").date(value).startOf("day"),
+    dayjs("2016-01-01") // initial date must be in leap year to format properly
+      .date(value)
+      .startOf("day"),
   "day-of-year": (value: number) =>
-    dayjs("2016-01-01").dayOfYear(value).startOf("day"),
-  "week-of-year": (value: number) => dayjs().week(value).startOf("week"),
+    dayjs("2016-01-01") // initial date must be in leap year to format properly
+      .dayOfYear(value)
+      .startOf("day"),
+  "week-of-year": (value: number) =>
+    dayjs("2016-01-01") // initial date must be in a year with 53 iso weeks to format properly
+      .isoWeek(value)
+      .startOf("isoWeek"),
   "month-of-year": (value: number) =>
     dayjs()
       .month(value - 1)

--- a/frontend/src/metabase/lib/time-dayjs.unit.spec.ts
+++ b/frontend/src/metabase/lib/time-dayjs.unit.spec.ts
@@ -1,0 +1,20 @@
+import dayjs from "dayjs";
+
+import { parseTimestamp } from "metabase/lib/time-dayjs";
+
+describe("parseTimestamp", () => {
+  afterEach(() => {
+    dayjs.updateLocale(dayjs.locale(), { weekStart: 0 });
+  });
+
+  it("should parse week of year correctly", () => {
+    const daysOfWeek = [0, 1, 2, 3, 4, 5, 6];
+    daysOfWeek.forEach(dayOfWeek => {
+      dayjs.updateLocale(dayjs.locale(), { weekStart: dayOfWeek });
+      expect(parseTimestamp(1, "week-of-year").isoWeek()).toBe(1);
+      expect(parseTimestamp(2, "week-of-year").isoWeek()).toBe(2);
+      expect(parseTimestamp(52, "week-of-year").isoWeek()).toBe(52);
+      expect(parseTimestamp(53, "week-of-year").isoWeek()).toBe(53);
+    });
+  });
+});

--- a/frontend/src/metabase/lib/time.ts
+++ b/frontend/src/metabase/lib/time.ts
@@ -32,7 +32,10 @@ const NUMERIC_UNIT_FORMATS = {
     moment("2016-01-01") // initial date must be in leap year to format properly
       .dayOfYear(value)
       .startOf("day"),
-  "week-of-year": (value: number) => moment().week(value).startOf("week"),
+  "week-of-year": (value: number) =>
+    moment("2016-01-01") // initial date must be in a year with 53 iso weeks to format properly
+      .isoWeek(value)
+      .startOf("isoWeek"),
   "month-of-year": (value: number) =>
     moment()
       .month(value - 1)

--- a/frontend/src/metabase/lib/time.ts
+++ b/frontend/src/metabase/lib/time.ts
@@ -34,7 +34,7 @@ const NUMERIC_UNIT_FORMATS = {
       .startOf("day"),
   "week-of-year": (value: number) =>
     moment("2016-01-01") // initial date must be in a year with 53 iso weeks to format properly
-      .isoWeek(value)
+      .isoWeek(value) // set the iso week number to not depend on the first day of week
       .startOf("isoWeek"),
   "month-of-year": (value: number) =>
     moment()

--- a/frontend/test/metabase/lib/time.unit.spec.js
+++ b/frontend/test/metabase/lib/time.unit.spec.js
@@ -12,6 +12,10 @@ import {
 } from "metabase/lib/time";
 
 describe("time", () => {
+  afterEach(() => {
+    moment.updateLocale(moment.locale(), { week: { dow: 0 } });
+  });
+
   describe("parseTimestamp", () => {
     const NY15_TOKYO = moment(1420038000000); // 2014-12-31 15:00 UTC
     const NY15_UTC = moment(1420070400000); // 2015-01-01 00:00 UTC
@@ -58,6 +62,17 @@ describe("time", () => {
       const result = parseTimestamp("2015-01-01", "year");
       expect(moment.isMoment(result)).toBe(true);
       expect(result.unix()).toEqual(NY15_UTC.unix());
+    });
+
+    it("should parse week of year correctly", () => {
+      const daysOfWeek = [0, 1, 2, 3, 4, 5, 6];
+      daysOfWeek.forEach(dayOfWeek => {
+        moment.updateLocale(moment.locale(), { week: { dow: dayOfWeek } });
+        expect(parseTimestamp(1, "week-of-year").isoWeek()).toBe(1);
+        expect(parseTimestamp(2, "week-of-year").isoWeek()).toBe(2);
+        expect(parseTimestamp(52, "week-of-year").isoWeek()).toBe(52);
+        expect(parseTimestamp(53, "week-of-year").isoWeek()).toBe(53);
+      });
     });
   });
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/51777

How to verify:
- New -> Question -> Orders
- Summarize -> Count
- Breakout -> Created At -> Week of Year
- Visualize as a bar chart
- However over the last bar. It should say it's for the 53rd week
- Switch to table viz. It should correctly display the value as 53rd as well.

<img width="437" alt="Screenshot 2025-01-08 at 21 05 21" src="https://github.com/user-attachments/assets/ed49d4fc-8399-4f69-8ad2-640ab0025e96" />
<img width="508" alt="Screenshot 2025-01-08 at 21 05 25" src="https://github.com/user-attachments/assets/59cb974f-a0f6-4533-88f1-55b0e850ca6c" />
