### PR TITLE
Ensure with-dynamic-redefs is only used with functions

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -131,8 +131,8 @@
                          (tar-file-types f)))))
 
               (testing "On exception API returns log"
-                (mt/with-dynamic-redefs [serdes/extract-one (extract-one-error (:entity_id card)
-                                                                               (mt/dynamic-value serdes/extract-one))]
+                (mt/with-dynamic-fn-redefs [serdes/extract-one (extract-one-error (:entity_id card)
+                                                                                  (mt/dynamic-value serdes/extract-one))]
                   (let [res (binding [api.serialization/*additive-logging* false]
                               (mt/user-http-request :crowberto :post 500 "ee/serialization/export" {}
                                                     :collection (:id coll) :data_model false :settings false))
@@ -230,14 +230,14 @@
                                "error_message" nil}
                               (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))))
 
-                (mt/with-dynamic-redefs [v2.load/load-one! (let [load-one! (mt/dynamic-value #'v2.load/load-one!)]
-                                                             (fn [ctx path & [modfn]]
-                                                               (load-one! ctx path
-                                                                          (or modfn
-                                                                              (fn [ingested]
-                                                                                (cond-> ingested
-                                                                                  (= (:entity_id ingested) (:entity_id card))
-                                                                                  (assoc :collection_id "DoesNotExist")))))))]
+                (mt/with-dynamic-fn-redefs [v2.load/load-one! (let [load-one! (mt/dynamic-value #'v2.load/load-one!)]
+                                                                (fn [ctx path & [modfn]]
+                                                                  (load-one! ctx path
+                                                                             (or modfn
+                                                                                 (fn [ingested]
+                                                                                   (cond-> ingested
+                                                                                     (= (:entity_id ingested) (:entity_id card))
+                                                                                     (assoc :collection_id "DoesNotExist")))))))]
                   (testing "ERROR /api/ee/serialization/import"
                     (let [res (binding [api.serialization/*additive-logging* false]
                                 (mt/user-http-request :crowberto :post 500 "ee/serialization/import"
@@ -292,8 +292,8 @@
                       log (slurp (io/input-stream res))]
                   (is (re-find #"Cannot unpack archive" log))))
 
-              (mt/with-dynamic-redefs [serdes/extract-one (extract-one-error (:entity_id card)
-                                                                             (mt/dynamic-value serdes/extract-one))]
+              (mt/with-dynamic-fn-redefs [serdes/extract-one (extract-one-error (:entity_id card)
+                                                                                (mt/dynamic-value serdes/extract-one))]
                 (testing "ERROR /api/ee/serialization/export"
                   (binding [api.serialization/*additive-logging* false]
                     (let [res (mt/user-http-request :crowberto :post 500 "ee/serialization/export"

--- a/enterprise/backend/test/metabase_enterprise/task/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/task/cache_test.clj
@@ -510,8 +510,8 @@
                                           :refresh_automatically true
                                           :config {:schedule "0 0 * * * ?"}}]
       (let [call-count (atom 0)]
-        (mt/with-dynamic-redefs [task.cache/refresh-schedule-cache! (fn [_] (swap! call-count inc))
-                                 task.cache/maybe-refresh-duration-caches! (fn [] (swap! call-count inc))]
+        (mt/with-dynamic-fn-redefs [task.cache/refresh-schedule-cache! (fn [_] (swap! call-count inc))
+                                    task.cache/maybe-refresh-duration-caches! (fn [] (swap! call-count inc))]
           (@#'task.cache/refresh-cache-configs!)
           (is (= 0 @call-count))
 

--- a/enterprise/backend/test/metabase_enterprise/upload_management/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/upload_management/api_test.clj
@@ -81,9 +81,9 @@
 
             (testing "The archive_cards argument is passed through"
               (let [passed-value (atom nil)]
-                (mt/with-dynamic-redefs [upload/delete-upload! (fn [_ & {:keys [archive-cards?]}]
-                                                                 (reset! passed-value archive-cards?)
-                                                                 :done)]
+                (mt/with-dynamic-fn-redefs [upload/delete-upload! (fn [_ & {:keys [archive-cards?]}]
+                                                                    (reset! passed-value archive-cards?)
+                                                                    :done)]
                   (let [table-id (:id (oss-test/create-csv!))]
                     (is (mt/user-http-request :crowberto :delete 200 (delete-url table-id) :archive-cards true))
                     (is (true? @passed-value))))))))))))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4770,18 +4770,18 @@
     (let [uncached-calls-count (atom 0)
           cached-calls-count   (atom 0)]
       ;; Get _uncached_ call count of t2/select count for :metadata/table
-      (mt/with-dynamic-redefs [t2/select (fn [& args]
-                                           (when (= :metadata/table (first args))
-                                             (swap! uncached-calls-count inc))
-                                           (apply (mt/dynamic-value t2/select) args))]
+      (mt/with-dynamic-fn-redefs [t2/select (fn [& args]
+                                              (when (= :metadata/table (first args))
+                                                (swap! uncached-calls-count inc))
+                                              (apply (mt/dynamic-value t2/select) args))]
         (mt/user-http-request :crowberto :get 200 (format "dashboard/%d" (:id d)))
         (mt/user-http-request :crowberto :get 200 (format "dashboard/%d/query_metadata" (:id d))))
       ;; Get _cached_ call count of t2/select count for :metadata/table
       (let [load-id (str (random-uuid))]
-        (mt/with-dynamic-redefs [t2/select (fn [& args]
-                                             (when (= :metadata/table (first args))
-                                               (swap! cached-calls-count inc))
-                                             (apply (mt/dynamic-value t2/select) args))]
+        (mt/with-dynamic-fn-redefs [t2/select (fn [& args]
+                                                (when (= :metadata/table (first args))
+                                                  (swap! cached-calls-count inc))
+                                                (apply (mt/dynamic-value t2/select) args))]
           (mt/user-http-request :crowberto :get 200
                                 (format "dashboard/%d?dashboard_load_id=%s" (:id d) load-id))
           (mt/user-http-request :crowberto :get 200
@@ -4797,9 +4797,9 @@
       (testing "dashboard card /query calls reuse metadata providers"
         (let [providers               (atom [])
               load-id                 (str (random-uuid))]
-          (mt/with-dynamic-redefs [lib.metadata.protocols/table (fn [mp table-id]
-                                                                  (swap! providers conj mp)
-                                                                  ((mt/dynamic-value lib.metadata.protocols/table) mp table-id))]
+          (mt/with-dynamic-fn-redefs [lib.metadata.protocols/table (fn [mp table-id]
+                                                                     (swap! providers conj mp)
+                                                                     ((mt/dynamic-value lib.metadata.protocols/table) mp table-id))]
             (mt/user-http-request :rasta :post (format "dashboard/%d/dashcard/%s/card/%s/query"
                                                        (:id d) (:id dc1) (:id c1))
                                   {"dashboard_load_id" load-id})

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -1744,7 +1744,7 @@
 (deftest prometheus-response-metrics-test
   (testing "Prometheus counters get incremented for error responses"
     (let [calls (atom nil)]
-      (mt/with-dynamic-redefs [prometheus/inc! #(swap! calls conj %)]
+      (mt/with-dynamic-fn-redefs [prometheus/inc! #(swap! calls conj %)]
         (testing "Success response"
           (search-request :crowberto :q "test")
           (is (= 1 (count (filter #{:metabase-search/response-ok} @calls))))
@@ -1757,7 +1757,7 @@
           (is (= 0 (count (filter #{:metabase-search/response-error} @calls)))))
 
         (testing "Unexpected server error (500)"
-          (mt/with-dynamic-redefs [search/search (fn [& _] (throw (Exception.)))]
+          (mt/with-dynamic-fn-redefs [search/search (fn [& _] (throw (Exception.)))]
             (mt/user-http-request :crowberto :get 500 "/search" :q "test")
             (is (= 1 (count (filter #{:metabase-search/response-ok} @calls))))
             (is (= 1 (count (filter #{:metabase-search/response-error} @calls))))))))))

--- a/test/metabase/cmd/dump_to_h2_test.clj
+++ b/test/metabase/cmd/dump_to_h2_test.clj
@@ -31,8 +31,8 @@
           file-contents        {tmp-h2-db    h2-file-dump-content
                                 tmp-h2-db-mv h2-file-dump-content}]
       ;; 1. Don't actually run the copy steps themselves or the flush
-      (mt/with-dynamic-redefs [copy/copy!    (constantly nil)
-                               jdbc/execute! (constantly nil)]
+      (mt/with-dynamic-fn-redefs [copy/copy!    (constantly nil)
+                                  jdbc/execute! (constantly nil)]
         (doseq [[filename contents] file-contents]
           (spit filename contents))
         (dump-to-h2/dump-to-h2! tmp-h2-db)

--- a/test/metabase/events/notification_test.clj
+++ b/test/metabase/events/notification_test.clj
@@ -36,7 +36,7 @@
                         nil)
             sent-notis (atom [])]
         (testing "publishing event will send all the actively subscribed notifciations"
-          (mt/with-dynamic-redefs
+          (with-redefs
             [notification/send-notification!      (fn [notification] (swap! sent-notis conj notification))
              events.notification/supported-topics #{:event/test-notification}]
             (events/publish-event! topic {::hi true})
@@ -58,7 +58,7 @@
            :event_name topic}]
          nil)
         (testing "publish an event that is not supported for notifications will not send any notifications"
-          (mt/with-dynamic-redefs
+          (with-redefs
             [notification/send-notification!      (fn [notification] (swap! sent-notis conj notification))
              events.notification/supported-topics #{}]
             (events/publish-event! :event/unsupported-topic {::hi true})

--- a/test/metabase/events/notification_test.clj
+++ b/test/metabase/events/notification_test.clj
@@ -37,8 +37,8 @@
             sent-notis (atom [])]
         (testing "publishing event will send all the actively subscribed notifciations"
           (with-redefs
-            [notification/send-notification!      (fn [notification] (swap! sent-notis conj notification))
-             events.notification/supported-topics #{:event/test-notification}]
+           [notification/send-notification!      (fn [notification] (swap! sent-notis conj notification))
+            events.notification/supported-topics #{:event/test-notification}]
             (events/publish-event! topic {::hi true})
             (is (=? [[(:id n-1) {:event_info {::hi true}}]
                      [(:id n-2) {:event_info {::hi true}}]]
@@ -59,8 +59,8 @@
          nil)
         (testing "publish an event that is not supported for notifications will not send any notifications"
           (with-redefs
-            [notification/send-notification!      (fn [notification] (swap! sent-notis conj notification))
-             events.notification/supported-topics #{}]
+           [notification/send-notification!      (fn [notification] (swap! sent-notis conj notification))
+            events.notification/supported-topics #{}]
             (events/publish-event! :event/unsupported-topic {::hi true})
             (is (empty? @sent-notis))))))))
 

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -579,7 +579,7 @@
                                                                     :type       "category"
                                                                     :values_source_type    "card"
                                                                     :values_source_config {:card_id source-card-id}}]}]
-      (mt/with-dynamic-redefs [parameter-card/upsert-or-delete-from-parameters! (fn [& _] (throw (ex-info "Should not be called" {})))]
+      (mt/with-dynamic-fn-redefs [parameter-card/upsert-or-delete-from-parameters! (fn [& _] (throw (ex-info "Should not be called" {})))]
         (t2/update! :model/Card card-id-1 {:name "new name"})))))
 
 (deftest cleanup-parameter-on-card-changes-test

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -841,7 +841,7 @@
                                                                       :type       "category"
                                                                       :values_source_type    "card"
                                                                       :values_source_config {:card_id source-card-id}}]}]
-      (mt/with-dynamic-redefs [parameter-card/upsert-or-delete-from-parameters! (fn [& _] (throw (ex-info "Should not be called" {})))]
+      (mt/with-dynamic-fn-redefs [parameter-card/upsert-or-delete-from-parameters! (fn [& _] (throw (ex-info "Should not be called" {})))]
         (t2/update! :model/Dashboard dashboard-id {:name "new name"})))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -313,8 +313,8 @@
   ;; when it should return true.
   (testing "Make sure selecting a database calls `driver/database-supports?` with a database instance"
     (mt/with-temp [:model/Database {db-id :id} {:engine (u/qualified-name ::test)}]
-      (mt/with-dynamic-redefs [driver.u/supports? (fn [_ _ db]
-                                                    (is (true? (mi/instance-of? :model/Database db))))]
+      (mt/with-dynamic-fn-redefs [driver.u/supports? (fn [_ _ db]
+                                                       (is (true? (mi/instance-of? :model/Database db))))]
         (is (some? (t2/select-one-fn :features :model/Database :id db-id)))))))
 
 (deftest hydrate-tables-test

--- a/test/metabase/models/params/chain_filter_test.clj
+++ b/test/metabase/models/params/chain_filter_test.clj
@@ -686,12 +686,12 @@
                                 :fk :users}]
                               []]]
       (mt/$ids nil
-        (mt/with-dynamic-redefs [chain-filter/database-fk-relationships @#'chain-filter/database-fk-relationships*
-                                 chain-filter/find-joins                (fn
-                                                                          ([a b c]
-                                                                           (#'chain-filter/find-joins* a b c false))
-                                                                          ([a b c d]
-                                                                           (#'chain-filter/find-joins* a b c d)))]
+        (mt/with-dynamic-fn-redefs [chain-filter/database-fk-relationships @#'chain-filter/database-fk-relationships*
+                                    chain-filter/find-joins                (fn
+                                                                             ([a b c]
+                                                                              (#'chain-filter/find-joins* a b c false))
+                                                                             ([a b c d]
+                                                                              (#'chain-filter/find-joins* a b c d)))]
           (testing "receiver_id is active and should be used for the join"
             (is (= [{:lhs {:table $$messages, :field %messages.receiver_id}
                      :rhs {:table $$users, :field %users.id}}]

--- a/test/metabase/models/search_index_metadata_test.clj
+++ b/test/metabase/models/search_index_metadata_test.clj
@@ -66,7 +66,7 @@
         (is (= (set (take-last 3 versions))
                (t2/select-fn-set :version :model/SearchIndexMetadata))))
       (testing "After 1 day, it deletes version which are neither the latest, nor used by this instance"
-        (mt/with-dynamic-redefs [t/zoned-date-time (constantly (t/plus (t/zoned-date-time) (t/days 1) (t/minutes 1)))]
+        (mt/with-dynamic-fn-redefs [t/zoned-date-time (constantly (t/plus (t/zoned-date-time) (t/days 1) (t/minutes 1)))]
           (search-index-metadata/delete-obsolete! our-version)
           (is (= #{our-version (last versions)}
                  (t2/select-fn-set :version :model/SearchIndexMetadata))))))))

--- a/test/metabase/notification/send_test.clj
+++ b/test/metabase/notification/send_test.clj
@@ -37,13 +37,13 @@
                                               [:context :map]
                                               [:payload :map]])
               renders           (atom [])]
-          (mt/with-dynamic-redefs [channel/render-notification (fn [channel-type notification-payload template recipients]
-                                                                 (swap! renders conj {:channel-type channel-type
-                                                                                      :notification-payload notification-payload
-                                                                                      :template template
-                                                                                      :recipients recipients})
+          (mt/with-dynamic-fn-redefs [channel/render-notification (fn [channel-type notification-payload template recipients]
+                                                                    (swap! renders conj {:channel-type channel-type
+                                                                                         :notification-payload notification-payload
+                                                                                         :template template
+                                                                                         :recipients recipients})
                                                                  ;; rendered messages are recipients
-                                                                 recipients)]
+                                                                    recipients)]
             (testing "channel/send! are called on rendered messages"
               (is (=? {:channel/metabase-test [{:type :notification-recipient/user :user_id (mt/user->id :crowberto)}
                                                {:type :notification-recipient/user :user_id (mt/user->id :rasta)}]}

--- a/test/metabase/query_analysis_test.clj
+++ b/test/metabase/query_analysis_test.clj
@@ -115,7 +115,7 @@
   (str/replace (apply str (repeatedly 10 random-uuid)) "-" "_"))
 
 (defmacro with-analysis-on [& body]
-  `(mt/with-dynamic-redefs [query-analysis/enabled-type? (constantly true)]
+  `(mt/with-dynamic-fn-redefs [query-analysis/enabled-type? (constantly true)]
      (query-analysis/with-immediate-analysis
        ~@body)))
 
@@ -155,7 +155,7 @@
 (deftest analysis-error-test
   (with-analysis-on
     (testing "Errors analyzing queries will not prevent cards being created or updated"
-      (mt/with-dynamic-redefs [query-analysis/update-query-analysis-for-card! throw-empty-exception]
+      (mt/with-dynamic-fn-redefs [query-analysis/update-query-analysis-for-card! throw-empty-exception]
         (mt/with-temp [:model/Card {c-id :id} {:dataset_query (mt/native-query {:query "SELECT c FROM t"})}]
           (testing "The card was created"
             (is (t2/exists? :model/Card c-id)))

--- a/test/metabase/search/appdb/index_test.clj
+++ b/test/metabase/search/appdb/index_test.clj
@@ -530,7 +530,7 @@
                    table->descendants))))))
 
 (defn- active-table-after [simulated-delay-ns]
-  (mt/with-dynamic-redefs [search.index/now (constantly (+ simulated-delay-ns (System/nanoTime)))]
+  (mt/with-dynamic-fn-redefs [search.index/now (constantly (+ simulated-delay-ns (System/nanoTime)))]
     (search.index/active-table)))
 
 (deftest auto-refresh-test

--- a/test/metabase/search/appdb/scoring_test.clj
+++ b/test/metabase/search/appdb/scoring_test.clj
@@ -40,7 +40,7 @@
         (search.tu/search-results search-string (assoc raw-ctx :search-engine "appdb"))))
 
 (defmacro with-weights [weight-map & body]
-  `(mt/with-dynamic-redefs [search.config/weights (constantly ~weight-map)]
+  `(mt/with-dynamic-fn-redefs [search.config/weights (constantly ~weight-map)]
      ~@body))
 
 (defn search-results

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -174,7 +174,7 @@
 
  [metabase.test.util.dynamic-redefs
   dynamic-value
-  with-dynamic-redefs]
+  with-dynamic-fn-redefs]
 
  [premium-features.test-util
   with-premium-features

--- a/test/metabase/test/util/dynamic_redefs.clj
+++ b/test/metabase/test/util/dynamic_redefs.clj
@@ -44,7 +44,7 @@
   [binding]
   (update-keys (into {} (partition-all 2) binding) sym->var))
 
-(defmacro with-dynamic-redefs
+(defmacro with-dynamic-fn-redefs
   "A thread-safe version of with-redefs. It only supports functions, and adds a fair amount of overhead.
    It works by replacing each original definition with a proxy the first time it is redefined.
    This proxy uses a dynamic mapping to check whether the function is currently redefined."

--- a/test/metabase/test/util/dynamic_redefs.clj
+++ b/test/metabase/test/util/dynamic_redefs.clj
@@ -1,6 +1,6 @@
 (ns metabase.test.util.dynamic-redefs
-  (:require [medley.core :as m])
-  (:import (clojure.lang Var)))
+  (:import
+   (clojure.lang Var)))
 
 (set! *warn-on-reflection* true)
 
@@ -17,6 +17,9 @@
 (defn- var->proxy
   "Build a proxy function to intercept the given var. The proxy checks the current scope for what to call."
   [a-var]
+  (assert (ifn? @a-var) "Cannot proxy non-functions")
+  (assert (not (keyword? @a-var)) "Cannot proxy keywords")
+  (assert (not (coll? @a-var)) "Cannot proxy collections")
   (fn [& args]
     (let [current-f (dynamic-value a-var)]
       (apply current-f args))))
@@ -39,7 +42,7 @@
 (defn- bindings->var->definition
   "Given a with-redefs style binding, return a mapping from each corresponding var to its given replacement."
   [binding]
-  (m/map-keys sym->var (into {} (partition-all 2) binding)))
+  (update-keys (into {} (partition-all 2) binding) sym->var))
 
 (defmacro with-dynamic-redefs
   "A thread-safe version of with-redefs. It only supports functions, and adds a fair amount of overhead.

--- a/test/metabase/test/util_test.clj
+++ b/test/metabase/test/util_test.clj
@@ -103,6 +103,31 @@
       (testing "The original definition survives"
         (is (= "original" (clump "orig" "inal")))))))
 
+(def not-a-function 23)
+
+(def accidentally-a-function :wut-up)
+
+(def also-accidentally-a-function #{:wut-up})
+
+(deftest ^:parallel with-dynamic-redefs-non-function
+  (testing "It is an error to redefine a non-function"
+    (is (thrown-with-msg?
+         AssertionError
+         #"Cannot proxy non-functions"
+         (mt/with-dynamic-redefs [not-a-function 5]
+           (is (= 5 not-a-function))))))
+  (testing "Redefining keywords or collections is likely to surprise you, so we don't allow it"
+    (is (thrown-with-msg?
+         AssertionError
+         #"Cannot proxy keywords"
+         (mt/with-dynamic-redefs [accidentally-a-function :not-much]
+           (is (= :not-much accidentally-a-function)))))
+    (is (thrown-with-msg?
+         AssertionError
+         #"Cannot proxy collections"
+         (mt/with-dynamic-redefs [also-accidentally-a-function #{:butter-cup}]
+           (is (= #{:butter-cup} also-accidentally-a-function)))))))
+
 (defn mock-me-inner []
   :mock/original)
 

--- a/test/metabase/test/util_test.clj
+++ b/test/metabase/test/util_test.clj
@@ -51,7 +51,7 @@
 
 (defn- clump [x y] (str x y))
 
-(deftest ^:parallel with-dynamic-redefs-test
+(deftest ^:parallel with-dynamic-fn-redefs-test
   (testing "Three threads can independently redefine a regular var"
     (let [n-threads  3
           ;; Note that .getId is deprecated in favor of .threadId, but that method is only introduced in Java 19
@@ -82,7 +82,7 @@
       (future
         (testing "A thread that redefines it in reverse"
           (log/debug "Starting reverse thread, thread-id:" (thread-id))
-          (mt/with-dynamic-redefs [clump #(str %2 %1)]
+          (mt/with-dynamic-fn-redefs [clump #(str %2 %1)]
             (is (= "ok" (clump "k" "o")))
             (take-latch)
             (is (= "ko" (clump "o" "k"))))))
@@ -90,9 +90,9 @@
       (future
         (testing "A thread that redefines it twice"
           (log/debug "Starting double-redefining thread, thread-id:" (thread-id))
-          (mt/with-dynamic-redefs [clump (fn [_ y] (str y y))]
+          (mt/with-dynamic-fn-redefs [clump (fn [_ y] (str y y))]
             (is (= "zz" (clump "a" "z")))
-            (mt/with-dynamic-redefs [clump (fn [x _] (str x x))]
+            (mt/with-dynamic-fn-redefs [clump (fn [x _] (str x x))]
               (is (= "aa" (clump "a" "z")))
               (take-latch)
               (is (= "mm" (clump "m" "l"))))
@@ -109,23 +109,23 @@
 
 (def also-accidentally-a-function [:wut-up])
 
-(deftest ^:parallel with-dynamic-redefs-non-function
+(deftest ^:parallel with-dynamic-fn-redefs-non-function
   (testing "It is an error to redefine a non-function"
     (is (thrown-with-msg?
          AssertionError
          #"Cannot proxy non-functions"
-         (mt/with-dynamic-redefs [not-a-function 5]
+         (mt/with-dynamic-fn-redefs [not-a-function 5]
            (is (= 5 not-a-function))))))
   (testing "Redefining keywords or collections is likely to surprise you, so we don't allow it"
     (is (thrown-with-msg?
          AssertionError
          #"Cannot proxy keywords"
-         (mt/with-dynamic-redefs [accidentally-a-function :not-much]
+         (mt/with-dynamic-fn-redefs [accidentally-a-function :not-much]
            (is (= :not-much accidentally-a-function)))))
     (is (thrown-with-msg?
          AssertionError
          #"Cannot proxy collections"
-         (mt/with-dynamic-redefs [also-accidentally-a-function #{:butter-cup}]
+         (mt/with-dynamic-fn-redefs [also-accidentally-a-function #{:butter-cup}]
            (is (= [:butter-cup] also-accidentally-a-function)))))))
 
 (defn mock-me-inner []
@@ -134,13 +134,13 @@
 (defn mock-me-outer []
   (mock-me-inner))
 
-(deftest with-dynamic-redefs-nested-binding-test
+(deftest with-dynamic-fn-redefs-nested-binding-test
   (defn z []
-    (mt/with-dynamic-redefs [mock-me-outer
-                             (let [orig (mt/dynamic-value mock-me-outer)]
-                               (fn []
-                                 (mt/with-dynamic-redefs [mock-me-inner (constantly :mock/redefined)]
-                                   (orig))))]
+    (mt/with-dynamic-fn-redefs [mock-me-outer
+                                (let [orig (mt/dynamic-value mock-me-outer)]
+                                  (fn []
+                                    (mt/with-dynamic-fn-redefs [mock-me-inner (constantly :mock/redefined)]
+                                      (orig))))]
       (mock-me-outer)))
   (is (= :mock/redefined (z))))
 

--- a/test/metabase/test/util_test.clj
+++ b/test/metabase/test/util_test.clj
@@ -107,7 +107,7 @@
 
 (def accidentally-a-function :wut-up)
 
-(def also-accidentally-a-function #{:wut-up})
+(def also-accidentally-a-function [:wut-up])
 
 (deftest ^:parallel with-dynamic-redefs-non-function
   (testing "It is an error to redefine a non-function"
@@ -126,7 +126,7 @@
          AssertionError
          #"Cannot proxy collections"
          (mt/with-dynamic-redefs [also-accidentally-a-function #{:butter-cup}]
-           (is (= #{:butter-cup} also-accidentally-a-function)))))))
+           (is (= [:butter-cup] also-accidentally-a-function)))))))
 
 (defn mock-me-inner []
   :mock/original)

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1201,7 +1201,7 @@
                      (last (snowplow-test/pop-event-data-and-user-id!)))))
 
            (testing "Failures when creating a CSV Upload will publish statistics to Snowplow"
-             (mt/with-dynamic-redefs [upload/create-from-csv! (fn [_ _ _ _] (throw (Exception.)))]
+             (mt/with-dynamic-fn-redefs [upload/create-from-csv! (fn [_ _ _ _] (throw (Exception.)))]
                (try (do-with-uploaded-example-csv! {} identity)
                     (catch Throwable _
                       nil))
@@ -1282,7 +1282,7 @@
               {:db-id Integer/MAX_VALUE, :schema-name "public", :table-prefix "uploaded_magic_"}
               identity))))
       (testing "Uploads must be supported"
-        (mt/with-dynamic-redefs [driver.u/supports? (constantly false)]
+        (mt/with-dynamic-fn-redefs [driver.u/supports? (constantly false)]
           (is (thrown-with-msg?
                java.lang.Exception
                #"^Uploads are not supported on \w+ databases\."
@@ -1478,7 +1478,7 @@
                       :data    {:status-code 422}}
                      (catch-ex-info (update-csv-with-defaults! action :file (csv-file-with []))))))
             (testing "Uploads must be supported"
-              (mt/with-dynamic-redefs [driver.u/supports? (constantly false)]
+              (mt/with-dynamic-fn-redefs [driver.u/supports? (constantly false)]
                 (is (= {:message (format "Uploads are not supported on %s databases." (str/capitalize (name driver/*driver*)))
                         :data    {:status-code 422}}
                        (catch-ex-info (update-csv-with-defaults! action))))))))))))
@@ -1582,8 +1582,8 @@
         (with-mysql-local-infile-on-and-off
           (mt/with-report-timezone-id! "UTC"
             (testing "Append should succeed for all possible CSV column types"
-              (mt/with-dynamic-redefs [driver/db-default-timezone (constantly "Z")
-                                       upload/current-database    (constantly (mt/db))]
+              (mt/with-dynamic-fn-redefs [driver/db-default-timezone (constantly "Z")
+                                          upload/current-database    (constantly (mt/db))]
                 (with-upload-table!
                   [table (create-upload-table!
                           {:col->upload-type (columns-with-auto-pk
@@ -1799,7 +1799,7 @@
                 (io/delete-file file)))
 
             (testing "Failures when appending to CSV Uploads will publish statistics to Snowplow"
-              (mt/with-dynamic-redefs [upload/create-from-csv! (fn [_ _ _ _] (throw (Exception.)))]
+              (mt/with-dynamic-fn-redefs [upload/create-from-csv! (fn [_ _ _ _] (throw (Exception.)))]
                 (let [csv-rows ["mispelled_name, unexpected_column" "Duke Cakewalker, r2dj"]
                       file     (csv-file-with csv-rows (mt/random-name))]
                   (try
@@ -2460,7 +2460,7 @@
         expected [:%ce%b1bcd%  :%_b59bccce :%ce%b1bc_2 :%ce%b1bc_3]
         displays ["αbcdεf" "αbcdεfg" "αbc 2 etc" "αbc 3 xyz"]]
     (is (= expected (#'upload/derive-column-names ::short-column-test-driver original)))
-    (mt/with-dynamic-redefs [upload/max-bytes (constantly 10)]
+    (mt/with-dynamic-fn-redefs [upload/max-bytes (constantly 10)]
       (is (= displays
              ;; The whitespace linter rejects capital greek characters that look like their roman equivalents.
              ;; This is the easiest way to work around the capitalization of alpha.

--- a/test/metabase/util/malli/defn_test.clj
+++ b/test/metabase/util/malli/defn_test.clj
@@ -174,13 +174,13 @@
 (deftest ^:parallel defn-forms-are-not-emitted-for-skippable-ns-in-prod-test
   (testing "omission in macroexpansion"
     (testing "returns a simple fn*"
-      (mt/with-dynamic-redefs [mu.fn/instrument-ns? (constantly false)]
+      (mt/with-dynamic-fn-redefs [mu.fn/instrument-ns? (constantly false)]
         (let [expansion (macroexpand `(mu/defn ~'f :- :int [] "foo"))]
           (is (= '(def f
                     "Inputs: []\n  Return: :int" (clojure.core/fn f [] "foo"))
                  (deanon-fn-names expansion))))))
     (testing "returns an instrumented fn"
-      (mt/with-dynamic-redefs [mu.fn/instrument-ns? (constantly true)]
+      (mt/with-dynamic-fn-redefs [mu.fn/instrument-ns? (constantly true)]
         (let [expansion (macroexpand `(mu/defn ~'f :- :int [] "foo"))]
           (is (= '(def f
                     "Inputs: []\n  Return: :int"

--- a/test/metabase/util/malli/fn_test.clj
+++ b/test/metabase/util/malli/fn_test.clj
@@ -335,12 +335,12 @@
 (deftest ^:parallel instrumentation-can-be-omitted
   (testing "omission in macroexpansion"
     (testing "returns a simple fn*"
-      (mt/with-dynamic-redefs [mu.fn/instrument-ns? (constantly false)]
+      (mt/with-dynamic-fn-redefs [mu.fn/instrument-ns? (constantly false)]
         (let [expansion (macroexpand `(mu.fn/fn :- :int [] "foo"))]
           (is (= '(fn* ([] "foo"))
                  expansion)))))
     (testing "returns an instrumented fn"
-      (mt/with-dynamic-redefs [mu.fn/instrument-ns? (constantly true)]
+      (mt/with-dynamic-fn-redefs [mu.fn/instrument-ns? (constantly true)]
         (let [expansion (macroexpand `(mu.fn/fn :- :int [] "foo"))]
           (is (= '(let* [&f (clojure.core/fn [] "foo")])
                  (take 2 expansion)))))))
@@ -351,7 +351,7 @@
            (catch Exception e
              (is (=? {:type ::mu.fn/invalid-output} (ex-data e)))))))
   (testing "when instrument-ns? returns false, unvalidated form is emitted"
-    (mt/with-dynamic-redefs [mu.fn/instrument-ns? (constantly false)]
+    (mt/with-dynamic-fn-redefs [mu.fn/instrument-ns? (constantly false)]
       ;; we have to use eval here because `mu.fn/fn` is expanded at _read_ time and we want to change the
       ;; expansion via [[mu.fn/instrument-ns?]]. So that's why we call eval here. Could definitely use some
       ;; macroexpansion tests as well.


### PR DESCRIPTION
The trick we use for dynamic re-definitions only works for functions. This is mentioned in the docstring, but here we add some validation to help save time when people trip over this.