### PR TITLE
Backport Databricks M2M auth to 52

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -144,6 +144,8 @@ jobs:
       MB_DATABRICKS_TEST_HTTP_PATH: ${{ secrets.MB_DATABRICKS_JDBC_TEST_HTTP_PATH }}
       MB_DATABRICKS_TEST_TOKEN: ${{ secrets.MB_DATABRICKS_JDBC_TEST_TOKEN }}
       MB_DATABRICKS_TEST_CATALOG: 'metabase_ci'
+      MB_DATABRICKS_TEST_CLIENT_ID: ${{ secrets.MB_DATABRICKS_JDBC_TEST_CLIENT_ID }}
+      MB_DATABRICKS_TEST_OAUTH_SECRET: ${{ secrets.MB_DATABRICKS_JDBC_TEST_OAUTH_SECRET }}
     steps:
     - uses: actions/checkout@v4
     - name: Test Databricks driver

--- a/docs/databases/connections/databricks.md
+++ b/docs/databases/connections/databricks.md
@@ -73,7 +73,7 @@ See [Compute settings for the Databricks JDBC Driver](https://docs.databricks.co
 
 ## Re-run queries for simple explorations
 
-Turn this option **OFF** if people want to click **Run** (the play button) before applying any summarizations or filters in the query builder.
+Turn this option **OFF** if people want to click **Run** (the play button) before applying any [Summarize](../../questions/query-builder/introduction.md#grouping-your-metrics) or filter selections.
 
 By default, Metabase will execute a query as soon as you choose an grouping option from the **Summarize** menu or a filter condition from the [drill-through menu](https://www.metabase.com/learn/metabase-basics/querying-and-dashboards/questions/drill-through). If your database is slow, you may want to disable re-running to avoid loading data on each click.
 

--- a/docs/databases/connections/databricks.md
+++ b/docs/databases/connections/databricks.md
@@ -14,22 +14,30 @@ The display name for the database in the Metabase interface.
 
 ## Host
 
-Your database's IP address, or its domain name (e.g., esc.mydatabase.com). This is the value of your Databrick's compute resource's Server Hostname.
+Your database's IP address, or its domain name (e.g., `xxxxxxxxxx.cloud.databricks.com` or `adb-xxxxx.azuredatabricks.net`). This is the value of your Databrick's compute resource's Server Hostname.
 
 See [Compute settings for the Databricks JDBC Driver](https://docs.databricks.com/en/integrations/jdbc/compute.html).
 
 ## HTTP path
 
-This is the Databrick's compute resources HTTP Path value.
+This is the Databrick's compute resources HTTP Path value. This value is often a SQL warehouse endpoint in the format `/sql/1.0/endpoints/abcdef1234567890`. See [Connect to a SQL warehouse](https://docs.databricks.com/en/compute/sql-warehouse/index.html).
 
-See [Compute settings for the Databricks JDBC Driver](https://docs.databricks.com/en/integrations/jdbc/compute.html).
+Additionally, see [Compute settings for the Databricks JDBC Driver](https://docs.databricks.com/en/integrations/jdbc/compute.html).
 
-## Personal access token
+## Authentication
 
+There are two ways to authenticate with Databricks. You can use a personal access token (PAT) or a service principal using OAuth (OAuth M2M).
+
+The Databricks driver supports both options. Use the toggle to select the authentication method you want to use.
+
+### Personal access token authentication
 See [Personal Access Token (PAT)](https://docs.databricks.com/en/dev-tools/auth/pat.html).
 
-## Catalog
+### Authenticate access with a service principal using OAuth (OAuth M2M)
 
+See [Authenticate access with a service principal using OAuth](https://docs.databricks.com/en/dev-tools/auth/oauth-m2m.html).
+
+## Catalog
 For now, you can only select one catalog. Metabase doesn't support multi-catalog connections. If you want to use more than one catalog in Metabase, you can set up multiple connections, each selecting a different catalog.
 
 You can't sync Databricks's legacy catalogs, however, including the `samples` or `hive_metastore` catalogs.

--- a/modules/drivers/databricks/deps.edn
+++ b/modules/drivers/databricks/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {com.databricks/databricks-jdbc {:mvn/version "2.6.34"}}}
+ {com.databricks/databricks-jdbc {:mvn/version "2.6.40"}}}

--- a/modules/drivers/databricks/resources/metabase-plugin.yaml
+++ b/modules/drivers/databricks/resources/metabase-plugin.yaml
@@ -1,7 +1,7 @@
 info:
   name: Metabase Databricks Driver
-  version: 1.0.0
-  description: Allows Metabase to connect to Databricks SQL warehouse
+  version: 1.2.0
+  description: Allows Metabase to connect to Databricks SQL warehouse with personal access tokens or OAuth M2M
 dependencies:
   - plugin: Metabase Hive Like Abstract Driver
 driver:
@@ -12,27 +12,58 @@ driver:
     connection-properties:
       - merge:
         - host
-        - placeholder: 'xxxxxxxxxx.cloud.databricks.com'
+        - display-name: Host
+          required: true
+          placeholder: xxxxxxxxxx.cloud.databricks.com
+          helper-text: The Databricks host URL. Could also be adb-xxxxx.azuredatabricks.net
       - name: http-path
-        display-name: HTTP path
+        display-name: HTTP Path
         helper-text: Found in SQL Warehouses > Connection details
         required: true
+        placeholder: /sql/1.0/endpoints/abcdef1234567890
+      - name: use-m2m
+        display-name: Use Machine to Machine (M2M) authentication
+        type: boolean
+        default: true
+        helper-text: Use Personal Access Token for authentication.
       - merge:
         - password
         - name: token
           display-name: Personal Access Token
           required: true
+          helper-text: Personal Access Token for authentication. Not required if using OAuth M2M.
+          placeholder: dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+          visible-if:
+            use-m2m: false
+      - name: client-id
+        display-name: Service Principal Client ID
+        placeholder: e26ce240-0a12-454f-934f-4c646603cb61
+        helper-text: For M2M OAuth authentication, corresponds to the service principal's Client ID.
+        required: true
+        visible-if:
+          use-m2m: true
+      - merge:
+        - password
+        - name: oauth-secret
+          display-name: Service Principal OAuth Secret
+          placeholder: dosexxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+          helper-text: OAuth Secret for M2M OAuth authentication.
+          required: true
+          visible-if:
+            use-m2m: true
       - name: catalog
         display-name: Catalog
         default: default
         required: true
+        helper-text: Specify the catalog to connect to.
       - name: schema-filters
         type: schema-filters
         display-name: Schemas
+        helper-text: Optionally filter which schemas are visible.
       - advanced-options-start
       - merge:
-        - additional-options
-        - placeholder: 'IgnoreTransactions=0'
+          - additional-options
+          - placeholder: IgnoreTransactions=0
       - default-advanced-options
 init:
   - step: load-namespace

--- a/modules/drivers/databricks/src/metabase/driver/databricks.clj
+++ b/modules/drivers/databricks/src/metabase/driver/databricks.clj
@@ -201,29 +201,35 @@
     (str/replace-first additional-options #"^(?!;)" ";")))
 
 (defmethod sql-jdbc.conn/connection-details->spec :databricks
-  [_driver {:keys [catalog host http-path log-level token additional-options] :as _details}]
+  [_driver {:keys [catalog host http-path use-m2m token client-id oauth-secret log-level additional-options] :as _details}]
   (assert (string? (not-empty catalog)) "Catalog is mandatory.")
-  (merge
-   {:classname        "com.databricks.client.jdbc.Driver"
-    :subprotocol      "databricks"
-    ;; Reading through the changelog revealed `EnableArrow=0` solves multiple problems. Including the exception logged
-    ;; during first `can-connect?` call. Ref:
-    ;; https://databricks-bi-artifacts.s3.us-east-2.amazonaws.com/simbaspark-drivers/jdbc/2.6.40/docs/release-notes.txt
-    :subname          (str "//" host ":443/;EnableArrow=0"
-                           ";ConnCatalog=" (codec/url-encode catalog)
-                           (preprocess-additional-options additional-options))
-    :transportMode  "http"
-    :ssl            1
-    :AuthMech       3
-    :HttpPath       http-path
-    :uid            "token"
-    :pwd            token
-    :UserAgentEntry (format "Metabase/%s" (:tag config/mb-version-info))
-    :UseNativeQuery 1}
-   ;; Following is used just for tests. See the [[metabase.driver.sql-jdbc.connection-test/perturb-db-details]]
-   ;; and test that is using the function.
-   (when log-level
-     {:LogLevel log-level})))
+  (let [base-spec
+        {:classname      "com.databricks.client.jdbc.Driver"
+         :subprotocol    "databricks"
+         ;; Reading through the changelog revealed `EnableArrow=0` solves multiple problems. Including the exception logged
+         ;; during first `can-connect?` call. Ref:
+         ;; https://databricks-bi-artifacts.s3.us-east-2.amazonaws.com/simbaspark-drivers/jdbc/2.6.40/docs/release-notes.txt
+         :subname        (str "//" host ":443/;EnableArrow=0"
+                              ";ConnCatalog=" (codec/url-encode catalog)
+                              (preprocess-additional-options additional-options))
+         :transportMode  "http"
+         :ssl            1
+         :HttpPath       http-path
+         :UserAgentEntry (format "Metabase/%s" (:tag config/mb-version-info))
+         :UseNativeQuery 1}]
+    (merge base-spec
+           (when log-level
+             {:LogLevel log-level})
+           (if use-m2m
+             ;; M2M OAuth
+             {:AuthMech 11
+              :Auth_Flow 1
+              :OAuth2ClientId client-id
+              :OAuth2Secret oauth-secret}
+             ;; PAT authentication
+             {:AuthMech 3
+              :uid "token"
+              :pwd token}))))
 
 (defmethod sql.qp/quote-style :databricks
   [_driver]

--- a/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
+++ b/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
@@ -8,6 +8,7 @@
    [metabase.driver.databricks :as databricks]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.test :as mt]
+   [metabase.test.data.interface :as tx]
    [toucan2.core :as t2]))
 
 ;; Because the datasets that are tested are preloaded, it is fine just to modify the database details to sync other schemas.
@@ -287,3 +288,15 @@
       (is (true? (driver/can-connect? :databricks (:details (mt/db))))))
     (testing "Can connect returns false for catalog that is NOT present on the instance (#49444)"
       (is (false? (driver/can-connect? :databricks (assoc (:details (mt/db)) :catalog "xixixix")))))))
+
+(deftest can-connect-using-m2m-test
+  (mt/test-driver
+    :databricks
+    (testing "Can connect using m2m (#51276)"
+      (is (true? (driver/can-connect?
+                  :databricks
+                  (-> (:details (mt/db))
+                      (dissoc :token)
+                      (assoc :use-m2m      true
+                             :client-id    (tx/db-test-env-var-or-throw :databricks :client-id)
+                             :oauth-secret (tx/db-test-env-var-or-throw :databricks :oauth-secret)))))))))


### PR DESCRIPTION
This PR is a backport of https://github.com/metabase/metabase/pull/51476 (auth) and https://github.com/metabase/metabase/pull/51693 (test). Bump of Databricks (that's present on master already) had to be also added to make the m2m work.