### PR TITLE
Bump cssbox to 5.0.2 for dos bugfix

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -108,7 +108,7 @@
   net.i2p.crypto/eddsa                      {:mvn/version "0.3.0"}              ; ED25519 key support (optional dependency for org.apache.sshd/sshd-core)
   net.redhogs.cronparser/cron-parser-core   {:mvn/version "3.5"                 ; describe Cron schedule in human-readable language
                                              :exclusions  [org.slf4j/slf4j-api]}
-  net.sf.cssbox/cssbox                      {:mvn/version "5.0.1"               ; HTML / CSS rendering
+  net.sf.cssbox/cssbox                      {:mvn/version "5.0.2"               ; HTML / CSS rendering
                                              :exclusions  [org.slf4j/slf4j-api
                                                            junit/junit]}
   net.thisptr/jackson-jq                    {:mvn/version "1.0.0-preview.20240207"} ; Java implementation of the JQ json query language


### PR DESCRIPTION
I don't think we are susceptible to this, but the scanners pick it up and there's finally a release.

This was merged in https://github.com/metabase/metabase/pull/50642 to master and will target 53. There's lots of other stuff in there so I'm opening this smaller, targeted change against the 52 branch
