### PR TITLE
[refs] Add `:lib.columns/breakouts` for reified breakout columns

### DIFF
--- a/src/metabase/lib/breakout.cljc
+++ b/src/metabase/lib/breakout.cljc
@@ -2,24 +2,18 @@
   (:require
    [clojure.string :as str]
    [medley.core :as m]
-   [metabase.lib.binning :as lib.binning]
-   [metabase.lib.equality :as lib.equality]
    [metabase.lib.join :as-alias lib.join]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
-   [metabase.lib.metadata.ident :as lib.metadata.ident]
    [metabase.lib.options :as lib.options]
    [metabase.lib.ref :as lib.ref]
-   [metabase.lib.remove-replace :as lib.remove-replace]
    [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.columns :as lib.schema.columns]
    [metabase.lib.schema.expression :as lib.schema.expression]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
-   [metabase.lib.schema.ref :as lib.schema.ref]
    [metabase.lib.schema.util :as lib.schema.util]
-   [metabase.lib.temporal-bucket :as lib.temporal-bucket]
    [metabase.lib.util :as lib.util]
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
-   [metabase.util.log :as log]
    [metabase.util.malli :as mu]))
 
 (defmethod lib.metadata.calculation/describe-top-level-key-method :breakout
@@ -45,7 +39,8 @@
   [query stage-number breakout-clause]
   ;; TODO: Make sure the default `metadata-method` is including the `:ident` for breakouts!
   (-> (lib.metadata.calculation/metadata query stage-number breakout-clause)
-      (assoc :lib/source :source/breakouts)))
+      (assoc :lib/source :source/breakouts
+             :ident      (lib.options/ident breakout-clause))))
 
 (mu/defn breakouts-metadata :- [:maybe [:sequential ::lib.schema.metadata/column]]
   "Get metadata about the breakouts in a given stage of a `query`.
@@ -57,10 +52,30 @@
     stage-number :- :int]
    (some->> (breakouts query stage-number)
             (mapv (fn [field-ref]
-                    (or (when-let [ident (lib.options/ident field-ref)]
-                          (or (lib.metadata.ident/lookup-column-of-type query stage-number :lib.columns/breakouts ident)
-                              (log/warnf "Breakout metadata not found for ident '%s'" ident)))
-                        (metadata-for-breakout query stage-number field-ref)))))))
+                    (metadata-for-breakout query stage-number field-ref)
+                    ;; TODO: Dynamic variables only present during returned-columns-method mean that we can't really
+                    ;; cache the columns! (At least, not before we have new refs end to end.)
+                    ;; So we always recompute the metadata for the breakouts for now.
+                    #_(or (when-let [ident (lib.options/ident field-ref)]
+                            (or (lib.metadata.ident/lookup-column-of-type query stage-number :lib.columns/breakout ident)
+                                (log/warnf "Breakout metadata not found for ident '%s'\n%s"
+                                           ident (-> query
+                                                     :stages
+                                                     (nth stage-number)
+                                                     :lib.columns/breakout
+                                                     u/pprint-to-str))))
+                          (metadata-for-breakout query stage-number field-ref)))))))
+
+(mu/defn breakout-columns-map :- ::lib.schema.columns/columns-map
+  "Generate the complete map of `:ident` to breakout metadata for the given `query` and `stage-number`."
+  [query        :- ::lib.schema/query
+   stage-number :- :int]
+  (->> (breakouts query stage-number)
+       (map-indexed
+        (fn [i break]
+          (-> (metadata-for-breakout query stage-number break)
+              (assoc :position i))))
+       (m/index-by :ident)))
 
 ;; TODO: This can be made smarter once we trust that an existing cache is still valid!
 ;; To keep the scope of the refs overhaul down I'm not relying on them.
@@ -70,13 +85,8 @@
   No caching or shortcuts - this regenerates them from scratch for all the breakouts on this stage."
   [query        :- ::lib.schema/query
    stage-number :- :int]
-  (->> (breakouts query stage-number)
-       (map-indexed
-        (fn [i break]
-          (-> (metadata-for-breakout query stage-number break)
-              (assoc :position i))))
-       (m/index-by :ident)
-       (lib.util/update-query-stage query stage-number assoc :lib.columns/breakouts)))
+  (->> (breakout-columns-map query stage-number)
+       (lib.util/update-query-stage query stage-number assoc :lib.columns/breakout)))
 
 (mu/defn breakout-clause? :- :boolean
   "Returns true if `x` is a well-formed breakout clause."
@@ -111,121 +121,3 @@
        (-> query
            (lib.util/add-summary-clause stage-number :breakout expr)
            (populate-breakout-metadata stage-number))))))
-
-(mu/defn breakoutable-columns :- [:sequential ::lib.schema.metadata/column]
-  "Get column metadata for all the columns that can be broken out by in
-  the stage number `stage-number` of the query `query`
-  If `stage-number` is omitted, the last stage is used.
-  The rules for determining which columns can be broken out by are as follows:
-
-  1. custom `:expressions` in this stage of the query
-
-  2. Fields 'exported' by the previous stage of the query, if there is one;
-     otherwise Fields from the current `:source-table`
-
-  3. Fields exported by explicit joins
-
-  4. Fields in Tables that are implicitly joinable."
-
-  ([query :- ::lib.schema/query]
-   (breakoutable-columns query -1))
-
-  ([query        :- ::lib.schema/query
-    stage-number :- :int]
-   (let [columns (let [stage   (lib.util/query-stage query stage-number)
-                       options {:include-implicitly-joinable-for-source-card? false}]
-                   (lib.metadata.calculation/visible-columns query stage-number stage options))]
-     (when (seq columns)
-       (let [existing-breakouts         (breakouts query stage-number)
-             column->breakout-positions (group-by
-                                         (fn [position]
-                                           (lib.equality/find-matching-column query
-                                                                              stage-number
-                                                                              (get existing-breakouts position)
-                                                                              columns
-                                                                              {:generous? true}))
-                                         (range (count existing-breakouts)))]
-         (mapv #(let [positions  (column->breakout-positions %)]
-                  (cond-> (assoc % :lib/hide-bin-bucket? true)
-                    positions (assoc :breakout-positions positions)))
-               columns))))))
-
-(mu/defn existing-breakouts :- [:maybe [:sequential {:min 1} ::lib.schema.ref/ref]]
-  "Returns existing breakouts (as MBQL expressions) for `column` in a stage if there are any. Returns `nil` if there
-  are no existing breakouts."
-  ([query stage-number column]
-   (existing-breakouts query stage-number column nil))
-
-  ([query                                         :- ::lib.schema/query
-    stage-number                                  :- :int
-    column                                        :- ::lib.schema.metadata/column
-    {:keys [same-binning-strategy?
-            same-temporal-bucket?], :as _options} :- [:maybe
-                                                      [:map
-                                                       [:same-binning-strategy? {:optional true} [:maybe :boolean]]
-                                                       [:same-temporal-bucket? {:optional true} [:maybe :boolean]]]]]
-   (not-empty
-    (into []
-          (filter (fn [[_ref {:keys [join-alias source-field]} _id-or-name :as a-breakout]]
-                    (and (lib.equality/find-matching-column query stage-number a-breakout [column] {:generous? true})
-                         (= source-field (:fk-field-id column)) ; Must match, including both being nil/missing.
-                         (= join-alias   (::lib.join/join-alias column))  ; Must match, including both being nil/missing.
-                         (or (not same-temporal-bucket?)
-                             (= (lib.temporal-bucket/temporal-bucket a-breakout)
-                                (lib.temporal-bucket/temporal-bucket column)))
-                         (or (not same-binning-strategy?)
-                             (lib.binning/binning= (lib.binning/binning a-breakout)
-                                                   (lib.binning/binning column))))))
-          (breakouts query stage-number)))))
-
-(defn breakout-column?
-  "Returns if `column` is a breakout column of stage with `stage-number` of `query`."
-  ([query stage-number column]
-   (breakout-column? query stage-number column nil))
-  ([query stage-number column opts]
-   (seq (existing-breakouts query stage-number column opts))))
-
-(mu/defn remove-existing-breakouts-for-column :- ::lib.schema/query
-  "Remove all existing breakouts against `column` if there are any in the stage in question. Disregards temporal
-  bucketing and binning."
-  ([query column]
-   (remove-existing-breakouts-for-column query -1 column))
-
-  ([query        :- ::lib.schema/query
-    stage-number :- :int
-    column       :- ::lib.schema.metadata/column]
-   (reduce
-    (fn [query a-breakout]
-      (lib.remove-replace/remove-clause query stage-number a-breakout))
-    query
-    (existing-breakouts query stage-number column))))
-
-(mu/defn breakout-column :- ::lib.schema.metadata/column
-  "Returns the input column used for this breakout."
-  ([query        :- ::lib.schema/query
-    breakout-ref  :- ::lib.schema.ref/ref]
-   (breakout-column query -1 breakout-ref))
-  ([query       :- ::lib.schema/query
-    stage-number :- :int
-    breakout-ref :- ::lib.schema.ref/ref]
-   (when-let [column (lib.equality/find-matching-column breakout-ref
-                                                        (breakoutable-columns query stage-number)
-                                                        {:generous? true})]
-     (let [binning (lib.binning/binning breakout-ref)
-           bucket  (lib.temporal-bucket/temporal-bucket breakout-ref)]
-       (cond-> column
-         binning (lib.binning/with-binning binning)
-         bucket  (lib.temporal-bucket/with-temporal-bucket bucket))))))
-
-(mu/defn remove-all-breakouts :- ::lib.schema/query
-  "Remove all breakouts from a query stage."
-  ([query]
-   (remove-all-breakouts query -1))
-
-  ([query        :- ::lib.schema/query
-    stage-number :- :int]
-   (reduce
-    (fn [query a-breakout]
-      (lib.remove-replace/remove-clause query stage-number a-breakout))
-    query
-    (breakouts query stage-number))))

--- a/src/metabase/lib/breakout.cljc
+++ b/src/metabase/lib/breakout.cljc
@@ -2,7 +2,6 @@
   (:require
    [clojure.string :as str]
    [medley.core :as m]
-   [metabase.lib.join :as-alias lib.join]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.options :as lib.options]
    [metabase.lib.ref :as lib.ref]
@@ -38,6 +37,9 @@
   Should only be necessary to call on new breakouts. Otherwise they should be looked up in the reified column maps."
   [query stage-number breakout-clause]
   ;; TODO: Make sure the default `metadata-method` is including the `:ident` for breakouts!
+  ;; XXX: I don't think this is actually what we want to be returning here. It includes a lot of pieces from the input
+  ;; column that I don't think should be part of the breakout. I think the breakout column should be minimal and link
+  ;; back to the original column...
   (-> (lib.metadata.calculation/metadata query stage-number breakout-clause)
       (assoc :lib/source :source/breakouts
              :ident      (lib.options/ident breakout-clause))))

--- a/src/metabase/lib/breakout/metadata.cljc
+++ b/src/metabase/lib/breakout/metadata.cljc
@@ -1,0 +1,132 @@
+(ns metabase.lib.breakout.metadata
+  (:require
+   [metabase.lib.binning :as lib.binning]
+   [metabase.lib.breakout :as lib.breakout]
+   [metabase.lib.equality :as lib.equality]
+   [metabase.lib.join :as-alias lib.join]
+   [metabase.lib.metadata.calculation :as lib.metadata.calculation]
+   [metabase.lib.remove-replace :as lib.remove-replace]
+   [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.metadata :as lib.schema.metadata]
+   [metabase.lib.schema.ref :as lib.schema.ref]
+   [metabase.lib.temporal-bucket :as lib.temporal-bucket]
+   [metabase.lib.util :as lib.util]
+   [metabase.util.malli :as mu]))
+
+(mu/defn breakoutable-columns :- [:sequential ::lib.schema.metadata/column]
+  "Get column metadata for all the columns that can be broken out by in
+  the stage number `stage-number` of the query `query`
+  If `stage-number` is omitted, the last stage is used.
+  The rules for determining which columns can be broken out by are as follows:
+
+  1. custom `:expressions` in this stage of the query
+
+  2. Fields 'exported' by the previous stage of the query, if there is one;
+     otherwise Fields from the current `:source-table`
+
+  3. Fields exported by explicit joins
+
+  4. Fields in Tables that are implicitly joinable."
+
+  ([query :- ::lib.schema/query]
+   (breakoutable-columns query -1))
+
+  ([query        :- ::lib.schema/query
+    stage-number :- :int]
+   (let [columns (let [stage   (lib.util/query-stage query stage-number)
+                       options {:include-implicitly-joinable-for-source-card? false}]
+                   (lib.metadata.calculation/visible-columns query stage-number stage options))]
+     (when (seq columns)
+       (let [existing-breakouts         (lib.breakout/breakouts query stage-number)
+             column->breakout-positions (group-by
+                                         (fn [position]
+                                           (lib.equality/find-matching-column query
+                                                                              stage-number
+                                                                              (get existing-breakouts position)
+                                                                              columns
+                                                                              {:generous? true}))
+                                         (range (count existing-breakouts)))]
+         (mapv #(let [positions  (column->breakout-positions %)]
+                  (cond-> (assoc % :lib/hide-bin-bucket? true)
+                    positions (assoc :breakout-positions positions)))
+               columns))))))
+
+(mu/defn existing-breakouts :- [:maybe [:sequential {:min 1} ::lib.schema.ref/ref]]
+  "Returns existing breakouts (as MBQL expressions) for `column` in a stage if there are any. Returns `nil` if there
+  are no existing breakouts."
+  ([query stage-number column]
+   (existing-breakouts query stage-number column nil))
+
+  ([query                                         :- ::lib.schema/query
+    stage-number                                  :- :int
+    column                                        :- ::lib.schema.metadata/column
+    {:keys [same-binning-strategy?
+            same-temporal-bucket?], :as _options} :- [:maybe
+                                                      [:map
+                                                       [:same-binning-strategy? {:optional true} [:maybe :boolean]]
+                                                       [:same-temporal-bucket? {:optional true} [:maybe :boolean]]]]]
+   (not-empty
+    (into []
+          (filter (fn [[_ref {:keys [join-alias source-field]} _id-or-name :as a-breakout]]
+                    (and (lib.equality/find-matching-column query stage-number a-breakout [column] {:generous? true})
+                         (= source-field (:fk-field-id column)) ; Must match, including both being nil/missing.
+                         (= join-alias   (::lib.join/join-alias column))  ; Must match, including both being nil/missing.
+                         (or (not same-temporal-bucket?)
+                             (= (lib.temporal-bucket/temporal-bucket a-breakout)
+                                (lib.temporal-bucket/temporal-bucket column)))
+                         (or (not same-binning-strategy?)
+                             (lib.binning/binning= (lib.binning/binning a-breakout)
+                                                   (lib.binning/binning column))))))
+          (lib.breakout/breakouts query stage-number)))))
+
+(defn breakout-column?
+  "Returns if `column` is a breakout column of stage with `stage-number` of `query`."
+  ([query stage-number column]
+   (breakout-column? query stage-number column nil))
+  ([query stage-number column opts]
+   (seq (existing-breakouts query stage-number column opts))))
+
+(mu/defn remove-existing-breakouts-for-column :- ::lib.schema/query
+  "Remove all existing breakouts against `column` if there are any in the stage in question. Disregards temporal
+  bucketing and binning."
+  ([query column]
+   (remove-existing-breakouts-for-column query -1 column))
+
+  ([query        :- ::lib.schema/query
+    stage-number :- :int
+    column       :- ::lib.schema.metadata/column]
+   (reduce
+    (fn [query a-breakout]
+      (lib.remove-replace/remove-clause query stage-number a-breakout))
+    query
+    (existing-breakouts query stage-number column))))
+
+(mu/defn breakout-column :- ::lib.schema.metadata/column
+  "Returns the input column used for this breakout."
+  ([query        :- ::lib.schema/query
+    breakout-ref  :- ::lib.schema.ref/ref]
+   (breakout-column query -1 breakout-ref))
+  ([query       :- ::lib.schema/query
+    stage-number :- :int
+    breakout-ref :- ::lib.schema.ref/ref]
+   (when-let [column (lib.equality/find-matching-column breakout-ref
+                                                        (breakoutable-columns query stage-number)
+                                                        {:generous? true})]
+     (let [binning (lib.binning/binning breakout-ref)
+           bucket  (lib.temporal-bucket/temporal-bucket breakout-ref)]
+       (cond-> column
+         binning (lib.binning/with-binning binning)
+         bucket  (lib.temporal-bucket/with-temporal-bucket bucket))))))
+
+(mu/defn remove-all-breakouts :- ::lib.schema/query
+  "Remove all breakouts from a query stage."
+  ([query]
+   (remove-all-breakouts query -1))
+
+  ([query        :- ::lib.schema/query
+    stage-number :- :int]
+   (reduce
+    (fn [query a-breakout]
+      (lib.remove-replace/remove-clause query stage-number a-breakout))
+    query
+    (lib.breakout/breakouts query stage-number))))

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -7,6 +7,7 @@
    [metabase.lib.aggregation :as lib.aggregation]
    [metabase.lib.binning :as lib.binning]
    [metabase.lib.breakout :as lib.breakout]
+   [metabase.lib.breakout.metadata :as lib.breakout.metadata]
    [metabase.lib.card :as lib.card]
    [metabase.lib.column-group :as lib.column-group]
    [metabase.lib.common :as lib.common]
@@ -109,10 +110,11 @@
   with-binning]
  [lib.breakout
   breakout
-  breakout-column
-  breakoutable-columns
   breakouts
-  breakouts-metadata
+  breakouts-metadata]
+ [lib.breakout.metadata
+  breakoutable-columns
+  breakout-column
   remove-all-breakouts]
  [lib.column-group
   columns-group-columns

--- a/src/metabase/lib/drill_thru/distribution.cljc
+++ b/src/metabase/lib/drill_thru/distribution.cljc
@@ -29,6 +29,7 @@
    [metabase.lib.aggregation :as lib.aggregation]
    [metabase.lib.binning :as lib.binning]
    [metabase.lib.breakout :as lib.breakout]
+   [metabase.lib.breakout.metadata :as lib.breakout.metadata]
    [metabase.lib.drill-thru.common :as lib.drill-thru.common]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
@@ -56,7 +57,7 @@
              (not (lib.types.isa/structured?  column))
              (not (lib.types.isa/comment?     column))
              (not (lib.types.isa/description? column))
-             (not (lib.breakout/breakout-column? query (lib.underlying/top-level-stage-number query) column)))
+             (not (lib.breakout.metadata/breakout-column? query (lib.underlying/top-level-stage-number query) column)))
     {:lib/type  :metabase.lib.drill-thru/drill-thru
      :type      :drill-thru/distribution
      :column    column}))

--- a/src/metabase/lib/drill_thru/pivot.cljc
+++ b/src/metabase/lib/drill_thru/pivot.cljc
@@ -44,6 +44,7 @@
   (:require
    [metabase.lib.aggregation :as lib.aggregation]
    [metabase.lib.breakout :as lib.breakout]
+   [metabase.lib.breakout.metadata :as lib.breakout.metadata]
    [metabase.lib.drill-thru.common :as lib.drill-thru.common]
    [metabase.lib.filter :as lib.filter]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
@@ -65,7 +66,7 @@
              column
              (some? value)
              (= (:lib/source column) :source/aggregations))
-    (->> (lib.breakout/breakoutable-columns query stage-number)
+    (->> (lib.breakout.metadata/breakoutable-columns query stage-number)
          (filter field-pred))))
 
 (def ^:private pivot-type-predicates
@@ -162,7 +163,7 @@
 
 (defn- breakouts->filters [query stage-number {:keys [column value] :as _dimension}]
   (-> query
-      (lib.breakout/remove-existing-breakouts-for-column stage-number column)
+      (lib.breakout.metadata/remove-existing-breakouts-for-column stage-number column)
       (lib.filter/filter stage-number (lib.filter/= column value))))
 
 ;; Pivot drills are in play when clicking an aggregation cell. Pivoting is applied by:

--- a/src/metabase/lib/drill_thru/summarize_column.cljc
+++ b/src/metabase/lib/drill_thru/summarize_column.cljc
@@ -21,7 +21,7 @@
   - Set default display"
   (:require
    [metabase.lib.aggregation :as lib.aggregation]
-   [metabase.lib.breakout :as lib.breakout]
+   [metabase.lib.breakout.metadata :as lib.breakout.metadata]
    [metabase.lib.drill-thru.common :as lib.drill-thru.common]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
@@ -40,7 +40,7 @@
              (nil? value)
              (not (lib.types.isa/structured? column))
              (not (lib.drill-thru.common/aggregation-sourced? query column))
-             (not (lib.breakout/breakout-column? query (lib.underlying/top-level-stage-number query) column)))
+             (not (lib.breakout.metadata/breakout-column? query (lib.underlying/top-level-stage-number query) column)))
     ;; I'm not really super clear on how the FE is supposed to be able to display these.
     (let [aggregation-ops (concat [:distinct]
                                   (when (lib.types.isa/summable? column)

--- a/src/metabase/lib/drill_thru/summarize_column_by_time.cljc
+++ b/src/metabase/lib/drill_thru/summarize_column_by_time.cljc
@@ -28,6 +28,7 @@
    [medley.core :as m]
    [metabase.lib.aggregation :as lib.aggregation]
    [metabase.lib.breakout :as lib.breakout]
+   [metabase.lib.breakout.metadata :as lib.breakout.metadata]
    [metabase.lib.drill-thru.common :as lib.drill-thru.common]
    [metabase.lib.ref :as lib.ref]
    [metabase.lib.schema :as lib.schema]
@@ -53,7 +54,7 @@
     ;; There must be a date dimension available.
     (let [stage-number (lib.underlying/top-level-stage-number query)]
       (when-let [breakout-column (m/find-first lib.types.isa/temporal?
-                                               (lib.breakout/breakoutable-columns query stage-number))]
+                                               (lib.breakout.metadata/breakoutable-columns query stage-number))]
         (when-let [bucketing-unit (m/find-first :default
                                                 (lib.temporal-bucket/available-temporal-buckets query stage-number breakout-column))]
           ;; only suggest this drill thru if the breakout it would apply does not already exist.

--- a/src/metabase/lib/drill_thru/zoom_in_bins.cljc
+++ b/src/metabase/lib/drill_thru/zoom_in_bins.cljc
@@ -71,6 +71,7 @@
   (:require
    [metabase.lib.binning :as lib.binning]
    [metabase.lib.breakout :as lib.breakout]
+   [metabase.lib.breakout.metadata :as lib.breakout.metadata]
    [metabase.lib.drill-thru.common :as lib.drill-thru.common]
    [metabase.lib.equality :as lib.equality]
    [metabase.lib.filter :as lib.filter]
@@ -93,9 +94,10 @@
    _stage-number                         :- :int
    {:keys [column value], :as _context}  :- ::lib.schema.drill-thru/context]
   (when (and column value)
-    (when-let [existing-breakout (first (lib.breakout/existing-breakouts query
-                                                                         (lib.underlying/top-level-stage-number query)
-                                                                         column))]
+    (when-let [existing-breakout (first (lib.breakout.metadata/existing-breakouts
+                                         query
+                                         (lib.underlying/top-level-stage-number query)
+                                         column))]
       (when-let [binning (lib.binning/binning existing-breakout)]
         (when-let [{:keys [min-value max-value bin-width]}
                    ;; If the column has binning options, use those; otherwise, check the top-level-column.
@@ -131,7 +133,7 @@
    stage-number :- :int
    column       :- ::lib.schema.metadata/column
    new-binning  :- ::lib.schema.binning/binning]
-  (if-let [existing-breakout (first (lib.breakout/existing-breakouts query stage-number column))]
+  (if-let [existing-breakout (first (lib.breakout.metadata/existing-breakouts query stage-number column))]
     (lib.remove-replace/replace-clause query stage-number existing-breakout (lib.binning/with-binning column new-binning))
     (lib.breakout/breakout query stage-number (lib.binning/with-binning column new-binning))))
 

--- a/src/metabase/lib/drill_thru/zoom_in_geographic.cljc
+++ b/src/metabase/lib/drill_thru/zoom_in_geographic.cljc
@@ -78,6 +78,7 @@
    [medley.core :as m]
    [metabase.lib.binning :as lib.binning]
    [metabase.lib.breakout :as lib.breakout]
+   [metabase.lib.breakout.metadata :as lib.breakout.metadata]
    [metabase.lib.drill-thru.common :as lib.drill-thru.common]
    [metabase.lib.filter :as lib.filter]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
@@ -213,7 +214,7 @@
    bin-width    :- pos?]
   (let [binning {:strategy  :bin-width
                  :bin-width bin-width}]
-    (if-let [existing-breakout (first (lib.breakout/existing-breakouts query stage-number column))]
+    (if-let [existing-breakout (first (lib.breakout.metadata/existing-breakouts query stage-number column))]
       (let [new-breakout (lib.binning/with-binning existing-breakout binning)]
         (lib.remove-replace/replace-clause query stage-number existing-breakout new-breakout))
       (lib.breakout/breakout query stage-number (lib.binning/with-binning column binning)))))
@@ -232,7 +233,7 @@
    stage-number                      :- :int
    {:keys [column value], :as drill} :- ::lib.schema.drill-thru/drill-thru.zoom-in.geographic.country-state-city->binned-lat-lon]
   (-> query
-      (lib.breakout/remove-existing-breakouts-for-column stage-number column)
+      (lib.breakout.metadata/remove-existing-breakouts-for-column stage-number column)
       ;; TODO -- remove/update existing filter?
       (lib.filter/filter stage-number (lib.filter/= column value))
       (add-or-update-lat-lon-binning stage-number drill)))

--- a/src/metabase/lib/metadata/ident.cljc
+++ b/src/metabase/lib/metadata/ident.cljc
@@ -1,7 +1,9 @@
 (ns metabase.lib.metadata.ident
   "Helpers for working with `:ident` fields on columns."
   (:require
-   [clojure.string :as str]))
+   [clojure.string :as str]
+   [metabase.lib.hierarchy :as lib.hierarchy]
+   [metabase.lib.util :as lib.util]))
 
 (defn table-prefix
   "Given the DB name and a `table` with `:name` and optional `:schema`, returns a string prefix for the `:ident`s
@@ -48,3 +50,39 @@
    (map #(attach-ident (prefix-fn (:table-id %)) %)))
   ([prefix-fn columns]
    (sequence (attach-idents prefix-fn) columns)))
+
+(defmulti column-maps-of-type
+  "Given a `query`, `stage-number` and a `column-type` keyword, returns a sequence of all column maps of that type on
+  the given stage. There might be only one map (eg. aggregations, expressions) or several (eg. joins).
+
+  This is a multimethod to allow each part of the code to override it."
+  (fn [_query _stage-number column-type]
+    column-type)
+  :hierarchy lib.hierarchy/hierarchy)
+
+;; The default is for the key to exist at the top level on the stage.
+(defmethod column-maps-of-type :default [query stage-number column-type]
+  (some-> (lib.util/query-stage query stage-number)
+          (get column-type)
+          vector))
+
+(defn lookup-column-of-type
+  "Looks up a column by ident, in the given column-type map.
+
+  This handles both one-layer nesting (eg. aggregations) and two-layer nesting (eg. join + column)."
+  [query stage-number column-type ident]
+  (let [maps    (column-maps-of-type query stage-number column-type)
+        matches (keep #(get % ident) maps)]
+    (case (count matches)
+      0 nil ;; XXX: Maybe this should be an error? Two functions?
+      1 (first matches)
+      (throw (ex-info "Can't happen! Ambiguous column ident" {:query        query
+                                                              :stage-number stage-number
+                                                              :column-type  column-type
+                                                              :ident        ident
+                                                              :matches      matches})))))
+
+#_(defn lookup-column
+  "Looks up a column (of any type) by ident on the given query and stage."
+  [query stage-number ident]
+  )

--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -12,6 +12,7 @@
    [metabase.legacy-mbql.util :as mbql.u]
    [metabase.lib.schema.actions :as actions]
    [metabase.lib.schema.aggregation :as aggregation]
+   [metabase.lib.schema.columns :as columns]
    [metabase.lib.schema.common :as common]
    [metabase.lib.schema.expression :as expression]
    [metabase.lib.schema.expression.arithmetic]
@@ -182,7 +183,17 @@
     [:order-by     {:optional true} [:ref ::order-by/order-bys]]
     [:source-table {:optional true} [:ref ::id/table]]
     [:source-card  {:optional true} [:ref ::id/card]]
-    [:page         {:optional true} [:ref ::page]]]
+    [:page         {:optional true} [:ref ::page]]
+    [:lib.columns/source         {:optional true} [:ref ::columns/columns-map]]
+    [:lib.columns/synthetic      {:optional true} [:ref ::columns/columns-map]]
+    [:lib.columns/breakout       {:optional true} [:ref ::columns/columns-map]]
+    [:lib.columns/aggregation    {:optional true} [:ref ::columns/columns-map]]
+    [:lib.columns/expressions    {:optional true} [:ref ::columns/columns-map]]
+    ;; TODO: This might need more details about the implicit joins than just their column maps?
+    ;; So maybe there's an extra layer of maps here:
+    ;; {:lib.columns/implicit-joins {"FK ident" {:lib/type           :mbql.join/implicit
+    ;;                                           :lib.columns/joined {"ident" {...}}}}}
+    [:lib.columns/implicit-joins {:optional true} [:ref ::columns/nested-columns-maps]]]
    [:fn
     {:error/message ":source-query is not allowed in pMBQL queries."}
     #(not (contains? % :source-query))]

--- a/src/metabase/lib/schema/columns.cljc
+++ b/src/metabase/lib/schema/columns.cljc
@@ -1,0 +1,15 @@
+(ns metabase.lib.schema.columns
+  (:require
+   [metabase.lib.schema.common :as lib.schema.common]
+   [metabase.lib.schema.metadata :as lib.schema.metadata]
+   [metabase.util.malli.registry :as mr]))
+
+(mr/def ::columns-map
+  [:map-of
+   [:string {:decode/normalize lib.schema.common/normalize-string-key}]
+   [:ref ::lib.schema.metadata/column]])
+
+(mr/def ::nested-columns-maps
+  [:map-of
+   [:string {:decode/normalize lib.schema.common/normalize-string-key}]
+   ::columns-map])

--- a/src/metabase/lib/schema/join.cljc
+++ b/src/metabase/lib/schema/join.cljc
@@ -1,6 +1,7 @@
 (ns metabase.lib.schema.join
   "Schemas for things related to joins."
   (:require
+   [metabase.lib.schema.columns :as columns]
    [metabase.lib.schema.common :as common]
    [metabase.lib.schema.expression :as expression]
    [metabase.util.i18n :as i18n]
@@ -65,7 +66,8 @@
    [:alias       ::alias]
    [:ident    {:optional true} ::common/non-blank-string]
    [:fields   {:optional true} ::fields]
-   [:strategy {:optional true} ::strategy]])
+   [:strategy {:optional true} ::strategy]
+   [:lib.columns/joined {:optional true} [:ref ::columns/columns-map]]])
 
 (mr/def ::joins
   [:and

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -356,8 +356,8 @@
   (boolean (seq (dissoc (lib.util/query-stage query stage-number)
                         :lib/type :source-table :source-card
                         :lib.columns/source
-                        :lib.columns/aggregations
-                        :lib.columns/breakouts
+                        :lib.columns/aggregation
+                        :lib.columns/breakout
                         :lib.columns/expressions
                         :lib.columns/implicit-joins
                         :lib.columns/synthetic))))

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -353,7 +353,14 @@
   "Does given query stage have any clauses?"
   [query        :- ::lib.schema/query
    stage-number :- :int]
-  (boolean (seq (dissoc (lib.util/query-stage query stage-number) :lib/type :source-table :source-card))))
+  (boolean (seq (dissoc (lib.util/query-stage query stage-number)
+                        :lib/type :source-table :source-card
+                        :lib.columns/source
+                        :lib.columns/aggregations
+                        :lib.columns/breakouts
+                        :lib.columns/expressions
+                        :lib.columns/implicit-joins
+                        :lib.columns/synthetic))))
 
 (mu/defn append-stage :- ::lib.schema/query
   "Adds a new blank stage to the end of the pipeline."

--- a/test/metabase/lib/breakout_test.cljc
+++ b/test/metabase/lib/breakout_test.cljc
@@ -3,7 +3,7 @@
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
    [clojure.test :refer [deftest is testing]]
    [medley.core :as m]
-   [metabase.lib.breakout :as lib.breakout]
+   [metabase.lib.breakout.metadata :as lib.breakout.metadata]
    [metabase.lib.card :as lib.card]
    [metabase.lib.core :as lib]
    [metabase.lib.query :as lib.query]
@@ -653,7 +653,7 @@
               (meta/id :people :latitude)]
              [:field {:temporal-unit :month}
               (meta/id :people :latitude)]]
-            (lib.breakout/existing-breakouts query -1 (meta/field-metadata :people :latitude))))))
+            (lib.breakout.metadata/existing-breakouts query -1 (meta/field-metadata :people :latitude))))))
 
 (deftest ^:parallel existing-breakouts-multiple-implicit-joins-test
   (let [base   (lib/query meta/metadata-provider (meta/table-metadata :ic/reports))
@@ -675,10 +675,10 @@
       (testing "are not considered 'existing breakouts'"
         (is (nil? (-> base
                       (lib/breakout name-by-created-by)
-                      (lib.breakout/existing-breakouts -1 name-by-updated-by))))
+                      (lib.breakout.metadata/existing-breakouts -1 name-by-updated-by))))
         (is (nil? (-> base
                       (lib/breakout name-by-updated-by)
-                      (lib.breakout/existing-breakouts -1 name-by-created-by))))))))
+                      (lib.breakout.metadata/existing-breakouts -1 name-by-created-by))))))))
 
 (deftest ^:parallel existing-breakouts-multiple-explicit-joins-test
   (let [base (-> (lib/query meta/metadata-provider (meta/table-metadata :ic/reports))
@@ -705,10 +705,10 @@
       (testing "are not considered 'existing breakouts'"
         (is (nil? (-> base
                       (lib/breakout name-by-created-by)
-                      (lib.breakout/existing-breakouts -1 name-by-updated-by))))
+                      (lib.breakout.metadata/existing-breakouts -1 name-by-updated-by))))
         (is (nil? (-> base
                       (lib/breakout name-by-updated-by)
-                      (lib.breakout/existing-breakouts -1 name-by-created-by))))))))
+                      (lib.breakout.metadata/existing-breakouts -1 name-by-created-by))))))))
 
 (deftest ^:parallel remove-existing-breakouts-for-column-test
   (let [query  (-> (lib/query meta/metadata-provider (meta/table-metadata :people))
@@ -717,14 +717,14 @@
                    (lib/breakout (lib/with-binning (meta/field-metadata :people :latitude) {:strategy :bin-width, :bin-width 1}))
                    (lib/breakout (lib/with-temporal-bucket (meta/field-metadata :people :latitude) :month))
                    (lib/breakout (meta/field-metadata :people :longitude)))
-        query' (lib.breakout/remove-existing-breakouts-for-column query (meta/field-metadata :people :latitude))]
+        query' (lib.breakout.metadata/remove-existing-breakouts-for-column query (meta/field-metadata :people :latitude))]
     (is (=? {:stages [{:aggregation [[:count {}]]
                        :breakout    [[:field {} (meta/id :people :longitude)]]}]}
             query'))
     (testing "Don't explode if there are no existing breakouts"
       (is (=? {:stages [{:aggregation [[:count {}]]
                          :breakout    [[:field {} (meta/id :people :longitude)]]}]}
-              (lib.breakout/remove-existing-breakouts-for-column query' (meta/field-metadata :people :latitude)))))))
+              (lib.breakout.metadata/remove-existing-breakouts-for-column query' (meta/field-metadata :people :latitude)))))))
 
 (deftest ^:parallel breakout-column-test
   (testing "should find the correct column"
@@ -738,9 +738,9 @@
       (is (= 2
              (count breakouts)))
       (is (=? category
-              (lib.breakout/breakout-column query (first breakouts))))
+              (lib/breakout-column query (first breakouts))))
       (is (=? price
-              (lib.breakout/breakout-column query (second breakouts)))))))
+              (lib/breakout-column query (second breakouts)))))))
 
 (deftest ^:parallel breakout-column-test-2
   (testing "should set the binning strategy from the breakout clause"

--- a/test/metabase/lib/drill_thru/test_util.cljc
+++ b/test/metabase/lib/drill_thru/test_util.cljc
@@ -229,9 +229,18 @@
   (walk/postwalk #(cond-> % (map? %) (dissoc :lib/uuid :ident))
                  form))
 
+(defn- drop-column-maps [form]
+  (walk/postwalk
+    (fn [m]
+      (cond->> m
+        (map? m) (m/filter-keys #(not (and (keyword? %)
+                                           (= (namespace %) "lib.columns"))))))
+    form))
+
 (defn- clean-expected-query [form]
   (-> form
       drop-uuids-and-idents
+      drop-column-maps
       (dissoc :lib/metadata)))
 
 (defn- clean-expected-query-on-drill [form query-kind]

--- a/test/metabase/lib/order_by_test.cljc
+++ b/test/metabase/lib/order_by_test.cljc
@@ -12,6 +12,7 @@
    [metabase.lib.query :as lib.query]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
+   [metabase.lib.test-util.macros :as lib.tu.macros]
    [metabase.lib.util :as lib.util]
    [metabase.util :as u]))
 
@@ -155,20 +156,16 @@
       (lib.metadata.calculation/describe-top-level-key -1 :order-by)))
 
 (deftest ^:parallel describe-order-by-test
-  (let [query {:database (meta/id)
-               :type     :query
-               :query    {:source-table (meta/id :venues)
-                          :order-by     [[:asc [:field (meta/id :venues :category-id) nil]]]}}]
+  (let [query (lib.tu.macros/mbql-query venues
+                {:order-by [[:asc $category-id]]})]
     (is (= "Sorted by Category ID ascending"
            (describe-legacy-query-order-by query)))))
 
 (deftest ^:parallel describe-order-by-aggregation-reference-test
-  (let [query {:database (meta/id)
-               :type     :query
-               :query    {:source-table (meta/id :venues)
-                          :aggregation  [[:count]]
-                          :breakout     [[:field (meta/id :venues :category-id) nil]]
-                          :order-by     [[:asc [:aggregation 0]]]}}]
+  (let [query (lib.tu.macros/mbql-query venues
+                {:aggregation        [[:count]]
+                 :breakout           [$category-id]
+                 :order-by           [[:asc [:aggregation 0]]]})]
     (is (= "Sorted by Count ascending"
            (describe-legacy-query-order-by query)))))
 

--- a/test/metabase/lib/test_util/generators.cljc
+++ b/test/metabase/lib/test_util/generators.cljc
@@ -4,7 +4,7 @@
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [medley.core :as m]
-   [metabase.lib.breakout :as lib.breakout]
+   [metabase.lib.breakout.metadata :as lib.breakout.metadata]
    [metabase.lib.core :as lib]
    [metabase.lib.equality :as lib.equality]
    [metabase.lib.metadata :as lib.metadata]
@@ -156,8 +156,8 @@
 (add-step {:kind :breakout})
 
 (defn- breakout-exists? [query stage-number column]
-  (boolean (lib.breakout/breakout-column? query stage-number column {:same-binning-strategy? true
-                                                                     :same-temporal-bucket?  true})))
+  (boolean (lib.breakout.metadata/breakout-column? query stage-number column {:same-binning-strategy? true
+                                                                              :same-temporal-bucket?  true})))
 
 (defmethod next-steps* :breakout [query _breakout]
   (let [stage-number (choose-stage query)

--- a/test/metabase/query_processor_test/model_test.clj
+++ b/test/metabase/query_processor_test/model_test.clj
@@ -34,7 +34,8 @@
                                                         (m/find-first (comp #{"Price"} :display-name)))))
                         (lib/breakout $q (-> (m/find-first (comp #{"Reviews → Created At"} :display-name)
                                                            (lib/breakoutable-columns $q))
-                                             (lib/with-temporal-bucket :month))))
+                                             (lib/with-temporal-bucket :month)))
+                        (lib.convert/->legacy-MBQL $q))
                       :database_id (mt/id)
                       :name "Products+Reviews Summary"
                       :type :model}]


### PR DESCRIPTION
**DRAFT, do not submit**

Part of #49687, which is part of Milestone 2 of #49182.

### Description

Add `:lib.columns/breakouts` maps to query stages, which map `:ident` strings for the
breakouts to their column metadata.

Nothing is consuming these values yet.


### How to verify

TODO

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
