### PR TITLE
Refactor collection list query for performance

### DIFF
--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -114,7 +114,7 @@
                              [:= :type collection/trash-collection-type] 1
                              :else 2]] :asc]
                           [:%lower.name :asc]]})
-   exclude-other-user-collections (remove-other-users-personal-subcollections api/*current-user-id*)))
+    exclude-other-user-collections (remove-other-users-personal-subcollections api/*current-user-id*)))
 
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint GET "/"
@@ -412,8 +412,8 @@
                     [:u.last_name :last_edit_last_name]
                     [:r.timestamp :last_edit_timestamp]
                     [:mr.status :moderated_status]]
-                   (#{:question :model} card-type)
-                   (conj :c.database_id))
+                    (#{:question :model} card-type)
+                    (conj :c.database_id))
        :from      [[:report_card :c]]
        :left-join [[:revision :r] [:and
                                    [:= :r.model_id :c.id]

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -795,7 +795,7 @@
       (cond-> #_changes
        (or (empty? (:result_metadata card))
            (not verified-result-metadata?))
-        card.metadata/populate-result-metadata)
+       card.metadata/populate-result-metadata)
       pre-update
       populate-query-fields
       maybe-populate-initially-published-at))

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -795,7 +795,7 @@
       (cond-> #_changes
        (or (empty? (:result_metadata card))
            (not verified-result-metadata?))
-       card.metadata/populate-result-metadata)
+        card.metadata/populate-result-metadata)
       pre-update
       populate-query-fields
       maybe-populate-initially-published-at))

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -606,7 +606,7 @@
                                                      (seq (user->personal-collection-and-descendant-ids current-user-id))]
                                             {:select [:c.id :c.location :c.archived :c.archive_operation_id :c.archived_directly]
                                              :from   [[:collection :c]]
-                                             :where  [:in :id personal-collection-and-descendant-ids]})])}
+                                             :where  [:in :id [:inline personal-collection-and-descendant-ids]]})])}
               :c])]
     ;; The `WHERE` clause is where we apply the other criteria we were given:
     :where [:and

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -589,7 +589,7 @@
         [:= collection-id-field nil])
       ;; the non-root collections are here. We're saying "let this row through if..."
       [:in collection-id-field
-       {:select :id
+       {:select [:id]
         ;; the `FROM` clause is where we limit the collections to the ones we have permissions on. For a superuser,
         ;; that's all of them. For regular users, it's:
         ;; a) the collections they have permission in the DB for,
@@ -597,7 +597,7 @@
         ;; c) their personal collection and its descendants
         :from [(if is-superuser?
                  [:collection :c]
-                 [{:union-all (keep identity [{:select [:c.*]
+                 [{:union-all (keep identity [{:select [:c.id :c.location]
                                                :from   [[:collection :c]]
                                                :join   [[:permissions :p]
                                                         [:= :c.id :p.collection_id]
@@ -610,12 +610,12 @@
                                                          [:= :p.perm_value "read-and-write"]
                                                          (when (= :read (:permission-level visibility-config))
                                                            [:= :p.perm_value "read"])]]}
-                                              {:select [[:c.*]]
+                                              {:select [:c.id :c.location]
                                                :from   [[:collection :c]]
                                                :where  [:= :type "trash"]}
                                               (when-let [personal-collection-and-descendant-ids
                                                          (seq (user->personal-collection-and-descendant-ids current-user-id))]
-                                                {:select [:c.*]
+                                                {:select [:c.id :c.location]
                                                  :from   [[:collection :c]]
                                                  :where  [:in :id personal-collection-and-descendant-ids]})])}
                   :c])]

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2637,7 +2637,7 @@
           (update-card card {:description "a new description"})
           (is (empty? (reviews card)))))
       (testing "Does not add nil moderation reviews when there are reviews but not verified"
-     ;; testing that we aren't just adding a nil moderation each time we update a card
+        ;; testing that we aren't just adding a nil moderation each time we update a card
         (with-card :verified
           (is (verified? card))
           (moderation-review/create-review! {:moderated_item_id   (u/the-id card)

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -1679,7 +1679,7 @@
   (testing "Change the collection and the position, causing both collections and the updated card to have their order changed"
     (mt/with-non-admin-groups-no-root-collection-perms
       (mt/with-temp [:model/Collection collection-1 {}
-                     :model/Collection collection-2] {}
+                     :model/Collection collection-2 {}]
         (with-ordered-items collection-1 [:model/Pulse     a
                                           :model/Pulse     b
                                           :model/Dashboard c
@@ -2582,72 +2582,72 @@
                                      :status              "verified"
                                      :text                "lookin good"}]))
          ~@body))]
-    (letfn [(verified? [card]
-              (-> card (t2/hydrate [:moderation_reviews :moderator_details])
-                  :moderation_reviews first :status #{"verified"} boolean))
-            (reviews [card]
-              (t2/select :model/ModerationReview
-                         :moderated_item_type "card"
-                         :moderated_item_id (u/the-id card)
-                         {:order-by [[:id :desc]]}))
-            (update-card [card diff]
-              (mt/user-http-request :crowberto :put 200 (str "card/" (u/the-id card)) (merge card diff)))]
-      (testing "Changing core attributes un-verifies the card"
-        (with-card :verified
-          (is (verified? card))
-          (update-card card (update-in card [:dataset_query :query :source-table] inc))
-          (is (not (verified? card)))
-          (testing "The unverification edit has explanatory text"
-            (is (= "Unverified due to edit"
-                   (-> (reviews card) first :text))))))
-      (testing "Changing some attributes does not unverify"
-        (tools.macro/macrolet [(remains-verified [& body]
-                                 `(~'with-card :verified
-                                               (is (~'verified? ~'card) "Not verified initially")
-                                               ~@body
-                                               (is (~'verified? ~'card) "Not verified after action")))]
-          (testing "changing collection"
-            (remains-verified
-             (update-card card {:collection_id (u/the-id collection2)})))
-          (testing "pinning"
-            (remains-verified
-             (update-card card {:collection_position 1})))
-          (testing "making public"
-            (remains-verified
-             (update-card card {:made_public_by_id (mt/user->id :rasta)
-                                :public_uuid (random-uuid)})))
-          (testing "Changing description"
-            (remains-verified
-             (update-card card {:description "foo"})))
-          (testing "Changing name"
-            (remains-verified
-             (update-card card {:name "foo"})))
-          (testing "Changing archived"
-            (remains-verified
-             (update-card card {:archived true})))
-          (testing "Changing display"
-            (remains-verified
-             (update-card card {:display :line})))
-          (testing "Changing visualization settings"
-            (remains-verified
-             (update-card card {:visualization_settings {:table.cell_column "FOO"}})))))
-      (testing "Does not add a new nil moderation review when not verified"
-        (with-card :not-verified
-          (is (empty? (reviews card)))
-          (update-card card {:description "a new description"})
-          (is (empty? (reviews card)))))
-      (testing "Does not add nil moderation reviews when there are reviews but not verified"
-     ;; testing that we aren't just adding a nil moderation each time we update a card
-        (with-card :verified
-          (is (verified? card))
-          (moderation-review/create-review! {:moderated_item_id   (u/the-id card)
-                                             :moderated_item_type "card"
-                                             :moderator_id        (mt/user->id :rasta)
-                                             :status              nil})
-          (is (not (verified? card)))
-          (is (= 2 (count (reviews card))))
-          (update-card card {:description "a new description"})
-          (is (= 2 (count (reviews card)))))))))
+   (letfn [(verified? [card]
+             (-> card (t2/hydrate [:moderation_reviews :moderator_details])
+                 :moderation_reviews first :status #{"verified"} boolean))
+           (reviews [card]
+             (t2/select :model/ModerationReview
+                        :moderated_item_type "card"
+                        :moderated_item_id (u/the-id card)
+                        {:order-by [[:id :desc]]}))
+           (update-card [card diff]
+             (mt/user-http-request :crowberto :put 200 (str "card/" (u/the-id card)) (merge card diff)))]
+     (testing "Changing core attributes un-verifies the card"
+       (with-card :verified
+         (is (verified? card))
+         (update-card card (update-in card [:dataset_query :query :source-table] inc))
+         (is (not (verified? card)))
+         (testing "The unverification edit has explanatory text"
+           (is (= "Unverified due to edit"
+                  (-> (reviews card) first :text))))))
+     (testing "Changing some attributes does not unverify"
+       (tools.macro/macrolet [(remains-verified [& body]
+                                `(~'with-card :verified
+                                              (is (~'verified? ~'card) "Not verified initially")
+                                              ~@body
+                                              (is (~'verified? ~'card) "Not verified after action")))]
+         (testing "changing collection"
+           (remains-verified
+            (update-card card {:collection_id (u/the-id collection2)})))
+         (testing "pinning"
+           (remains-verified
+            (update-card card {:collection_position 1})))
+         (testing "making public"
+           (remains-verified
+            (update-card card {:made_public_by_id (mt/user->id :rasta)
+                               :public_uuid (random-uuid)})))
+         (testing "Changing description"
+           (remains-verified
+            (update-card card {:description "foo"})))
+         (testing "Changing name"
+           (remains-verified
+            (update-card card {:name "foo"})))
+         (testing "Changing archived"
+           (remains-verified
+            (update-card card {:archived true})))
+         (testing "Changing display"
+           (remains-verified
+            (update-card card {:display :line})))
+         (testing "Changing visualization settings"
+           (remains-verified
+            (update-card card {:visualization_settings {:table.cell_column "FOO"}})))))
+     (testing "Does not add a new nil moderation review when not verified"
+       (with-card :not-verified
+         (is (empty? (reviews card)))
+         (update-card card {:description "a new description"})
+         (is (empty? (reviews card)))))
+     (testing "Does not add nil moderation reviews when there are reviews but not verified"
+       ;; testing that we aren't just adding a nil moderation each time we update a card
+       (with-card :verified
+         (is (verified? card))
+         (moderation-review/create-review! {:moderated_item_id   (u/the-id card)
+                                            :moderated_item_type "card"
+                                            :moderator_id        (mt/user->id :rasta)
+                                            :status              nil})
+         (is (not (verified? card)))
+         (is (= 2 (count (reviews card))))
+         (update-card card {:description "a new description"})
+         (is (= 2 (count (reviews card)))))))))
 
 (deftest test-that-we-can-bulk-move-some-cards-with-no-collection-into-a-collection
   (mt/with-temp [:model/Collection  collection {:name "Pog Collection"}

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -1679,7 +1679,7 @@
   (testing "Change the collection and the position, causing both collections and the updated card to have their order changed"
     (mt/with-non-admin-groups-no-root-collection-perms
       (mt/with-temp [:model/Collection collection-1 {}
-                     :model/Collection collection-2 {}]
+                     :model/Collection collection-2] {}
         (with-ordered-items collection-1 [:model/Pulse     a
                                           :model/Pulse     b
                                           :model/Dashboard c
@@ -2582,72 +2582,72 @@
                                      :status              "verified"
                                      :text                "lookin good"}]))
          ~@body))]
-   (letfn [(verified? [card]
-             (-> card (t2/hydrate [:moderation_reviews :moderator_details])
-                 :moderation_reviews first :status #{"verified"} boolean))
-           (reviews [card]
-             (t2/select :model/ModerationReview
-                        :moderated_item_type "card"
-                        :moderated_item_id (u/the-id card)
-                        {:order-by [[:id :desc]]}))
-           (update-card [card diff]
-             (mt/user-http-request :crowberto :put 200 (str "card/" (u/the-id card)) (merge card diff)))]
-     (testing "Changing core attributes un-verifies the card"
-       (with-card :verified
-         (is (verified? card))
-         (update-card card (update-in card [:dataset_query :query :source-table] inc))
-         (is (not (verified? card)))
-         (testing "The unverification edit has explanatory text"
-           (is (= "Unverified due to edit"
-                  (-> (reviews card) first :text))))))
-     (testing "Changing some attributes does not unverify"
-       (tools.macro/macrolet [(remains-verified [& body]
-                                `(~'with-card :verified
-                                              (is (~'verified? ~'card) "Not verified initially")
-                                              ~@body
-                                              (is (~'verified? ~'card) "Not verified after action")))]
-         (testing "changing collection"
-           (remains-verified
-            (update-card card {:collection_id (u/the-id collection2)})))
-         (testing "pinning"
-           (remains-verified
-            (update-card card {:collection_position 1})))
-         (testing "making public"
-           (remains-verified
-            (update-card card {:made_public_by_id (mt/user->id :rasta)
-                               :public_uuid (random-uuid)})))
-         (testing "Changing description"
-           (remains-verified
-            (update-card card {:description "foo"})))
-         (testing "Changing name"
-           (remains-verified
-            (update-card card {:name "foo"})))
-         (testing "Changing archived"
-           (remains-verified
-            (update-card card {:archived true})))
-         (testing "Changing display"
-           (remains-verified
-            (update-card card {:display :line})))
-         (testing "Changing visualization settings"
-           (remains-verified
-            (update-card card {:visualization_settings {:table.cell_column "FOO"}})))))
-     (testing "Does not add a new nil moderation review when not verified"
-       (with-card :not-verified
-         (is (empty? (reviews card)))
-         (update-card card {:description "a new description"})
-         (is (empty? (reviews card)))))
-     (testing "Does not add nil moderation reviews when there are reviews but not verified"
-       ;; testing that we aren't just adding a nil moderation each time we update a card
-       (with-card :verified
-         (is (verified? card))
-         (moderation-review/create-review! {:moderated_item_id   (u/the-id card)
-                                            :moderated_item_type "card"
-                                            :moderator_id        (mt/user->id :rasta)
-                                            :status              nil})
-         (is (not (verified? card)))
-         (is (= 2 (count (reviews card))))
-         (update-card card {:description "a new description"})
-         (is (= 2 (count (reviews card)))))))))
+    (letfn [(verified? [card]
+              (-> card (t2/hydrate [:moderation_reviews :moderator_details])
+                  :moderation_reviews first :status #{"verified"} boolean))
+            (reviews [card]
+              (t2/select :model/ModerationReview
+                         :moderated_item_type "card"
+                         :moderated_item_id (u/the-id card)
+                         {:order-by [[:id :desc]]}))
+            (update-card [card diff]
+              (mt/user-http-request :crowberto :put 200 (str "card/" (u/the-id card)) (merge card diff)))]
+      (testing "Changing core attributes un-verifies the card"
+        (with-card :verified
+          (is (verified? card))
+          (update-card card (update-in card [:dataset_query :query :source-table] inc))
+          (is (not (verified? card)))
+          (testing "The unverification edit has explanatory text"
+            (is (= "Unverified due to edit"
+                   (-> (reviews card) first :text))))))
+      (testing "Changing some attributes does not unverify"
+        (tools.macro/macrolet [(remains-verified [& body]
+                                 `(~'with-card :verified
+                                               (is (~'verified? ~'card) "Not verified initially")
+                                               ~@body
+                                               (is (~'verified? ~'card) "Not verified after action")))]
+          (testing "changing collection"
+            (remains-verified
+             (update-card card {:collection_id (u/the-id collection2)})))
+          (testing "pinning"
+            (remains-verified
+             (update-card card {:collection_position 1})))
+          (testing "making public"
+            (remains-verified
+             (update-card card {:made_public_by_id (mt/user->id :rasta)
+                                :public_uuid (random-uuid)})))
+          (testing "Changing description"
+            (remains-verified
+             (update-card card {:description "foo"})))
+          (testing "Changing name"
+            (remains-verified
+             (update-card card {:name "foo"})))
+          (testing "Changing archived"
+            (remains-verified
+             (update-card card {:archived true})))
+          (testing "Changing display"
+            (remains-verified
+             (update-card card {:display :line})))
+          (testing "Changing visualization settings"
+            (remains-verified
+             (update-card card {:visualization_settings {:table.cell_column "FOO"}})))))
+      (testing "Does not add a new nil moderation review when not verified"
+        (with-card :not-verified
+          (is (empty? (reviews card)))
+          (update-card card {:description "a new description"})
+          (is (empty? (reviews card)))))
+      (testing "Does not add nil moderation reviews when there are reviews but not verified"
+     ;; testing that we aren't just adding a nil moderation each time we update a card
+        (with-card :verified
+          (is (verified? card))
+          (moderation-review/create-review! {:moderated_item_id   (u/the-id card)
+                                             :moderated_item_type "card"
+                                             :moderator_id        (mt/user->id :rasta)
+                                             :status              nil})
+          (is (not (verified? card)))
+          (is (= 2 (count (reviews card))))
+          (update-card card {:description "a new description"})
+          (is (= 2 (count (reviews card)))))))))
 
 (deftest test-that-we-can-bulk-move-some-cards-with-no-collection-into-a-collection
   (mt/with-temp [:model/Collection  collection {:name "Pog Collection"}


### PR DESCRIPTION
* Uses a CTE for fetching visible collections for permission checks to avoid unnecessary duplicated work
* Fetches total row count and the limited results in a single query instead of doing all of the work twice
* Only fetches the necessary rows for the `visible-collection-query` instead of `:c.*`

For a test case on MariaDB of a user in 50 groups that all have permissions for 2000 collections, this cuts the response time for `/api/collection/:id/items` from consistently 5-6 seconds to 1-2 seconds. Still not snappy, but this should be a noticeable improvement.

Pursuant to https://github.com/metabase/metabase/issues/51560