### PR TITLE
Change session-id generator

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -82,7 +82,7 @@
                                                    (group-names->ids group-names)
                                                    (all-mapped-group-ids)))))
 
-(mu/defn- fetch-or-create-user! :- [:maybe [:map [:id uuid?]]]
+(mu/defn- fetch-or-create-user! :- [:maybe [:map [:id string?]]]
   "Returns a Session for the given `email`. Will create the user if needed."
   [{:keys [first-name last-name email group-names user-attributes device-info]}]
   (when-not (sso-settings/saml-enabled)

--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -25,6 +25,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
+   [metabase.util.string :as str]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -52,7 +53,7 @@
     (throw (ex-info
             (tru "The /api/setup route can only be used to create the first user, however a user currently exists.")
             {:status-code 403})))
-  (let [session-id (str (random-uuid))
+  (let [session-id (str/random-string 32)
         new-user   (first (t2/insert-returning-instances! :model/User
                                                           :email        email
                                                           :first_name   first-name

--- a/src/metabase/request/cookies.clj
+++ b/src/metabase/request/cookies.clj
@@ -212,12 +212,10 @@
   "Add the appropriate cookies to the `response` for the Session."
   [request
    response
-   {session-uuid :id
+   {session-id :id
     session-type :type
     anti-csrf-token :anti_csrf_token
-    :as _session-instance} :- [:map [:id [:or
-                                          uuid?
-                                          [:re u/uuid-regex]]]]
+    :as _session-instance} :- [:map [:id [string?]]]
    request-time]
   (let [cookie-options (merge
                         (default-session-cookie-attributes session-type request)
@@ -239,4 +237,4 @@
         (cond-> (= session-type :full-app-embed)
           (assoc-in [:headers anti-csrf-token-header] anti-csrf-token))
         (set-session-timeout-cookie request session-type request-time)
-        (response/set-cookie (session-cookie-name session-type) (str session-uuid) cookie-options))))
+        (response/set-cookie (session-cookie-name session-type) (str session-id) cookie-options))))

--- a/src/metabase/util/string.clj
+++ b/src/metabase/util/string.clj
@@ -55,3 +55,8 @@
   "True if the given string is formatted like a UUID"
   [s] (try (java.util.UUID/fromString s) true
            (catch Exception _e false)))
+
+(defn random-string
+  "Returns a string of `n` random alphanumeric characters."
+  [n]
+  (apply str (take n (repeatedly #(rand-nth "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")))))

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -17,7 +17,6 @@
    [metabase.util :as u]
    [metabase.util.json :as json]
    [metabase.util.malli.schema :as ms]
-   [metabase.util.string :as string]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -35,7 +34,7 @@
 
 (def ^:private SessionResponse
   [:map
-   [:id ms/UUIDString]])
+   [:id ms/NonBlankString]])
 
 (def ^:private session-cookie request/metabase-session-cookie)
 
@@ -303,7 +302,7 @@
               (mt/client :post 200 "session" (:old creds))
               ;; Call reset password endpoint to change the PW
               (testing "reset password endpoint should return a valid session token"
-                (is (=? {:session_id string/valid-uuid?
+                (is (=? {:session_id string?
                          :success    true}
                         (mt/client :post 200 "session/reset_password" {:token    token
                                                                        :password (:new password)}))))

--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -22,7 +22,6 @@
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
    [metabase.util.malli.schema :as ms]
-   [metabase.util.string :as string]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
@@ -64,7 +63,7 @@
        (with-redefs [api.setup/*allow-api-setup-after-first-user-is-created* true
                      h2/*allow-testing-h2-connections*                       true]
          (testing "API response should return a Session UUID"
-           (is (=? {:id string/valid-uuid?}
+           (is (=? {:id string?}
                    (client/client :post 200 "setup" request-body))))
          ;; reset our setup token
          (setup/create-token!)

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -16,7 +16,6 @@
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
-   [metabase.util.string :as string]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -1158,7 +1157,7 @@
     (testing "Test that we return a session if we are changing our own password"
       (mt/with-temp [:model/User user {:password "def", :is_superuser false}]
         (let [creds {:username (:email user), :password "def"}]
-          (is (=? {:session_id string/valid-uuid?
+          (is (=? {:session_id string?
                    :success    true}
                   (mt/client creds :put 200 (format "user/%d/password" (:id user)) {:password     "abc123!!DEF"
                                                                                     :old_password "def"}))))))

--- a/test/metabase/http_client.clj
+++ b/test/metabase/http_client.clj
@@ -155,7 +155,7 @@
    [:username ms/NonBlankString]
    [:password ms/NonBlankString]])
 
-(mu/defn authenticate :- ms/UUIDString
+(mu/defn authenticate :- ms/NonBlankString
   "Authenticate a test user with `username` and `password`, returning their Metabase Session token; or throw an
   Exception if that fails."
   [credentials :- Credentials]
@@ -223,7 +223,7 @@
 
 (def ^:private ClientParamsMap
   [:map {:closed true}
-   [:credentials      {:optional true} [:maybe [:or ms/UUIDString map?]]]
+   [:credentials      {:optional true} [:maybe [:or ms/NonBlankString map?]]]
    [:method                            (into [:enum] (keys method->request-fn))]
    [:expected-status  {:optional true} [:maybe ms/PositiveInt]]
    [:url                               ms/NonBlankString]

--- a/test/metabase/util/string_test.clj
+++ b/test/metabase/util/string_test.clj
@@ -35,4 +35,4 @@
     (is (= 10 (count (u.str/random-string 10))))
     (is (= 20 (count (u.str/random-string 20))))
     (is (not (= (u.str/random-string 10)
-               (u.str/random-string 10))))))
+                (u.str/random-string 10))))))

--- a/test/metabase/util/string_test.clj
+++ b/test/metabase/util/string_test.clj
@@ -28,3 +28,11 @@
     (testing "works with custom end-limit"
       (is (= "ab...ra"
              (u.str/mask "abracadabra" 2 2))))))
+
+(deftest random-string-test
+  (testing "can generate a random string"
+    (is (string? (u.str/random-string 10)))
+    (is (= 10 (count (u.str/random-string 10))))
+    (is (= 20 (count (u.str/random-string 20))))
+    (is (not (= (u.str/random-string 10)
+               (u.str/random-string 10))))))


### PR DESCRIPTION
### Description

The random uuid we use for the session_id is random, but there are UUID libraries which are less random and people seeing a UUID session ID may make them wonder about our security.

This replaces the UUID-formatted string with a purely random string
 
Existing UUID session_ids in the database continue to work because we are just using them as a random string in general.

### How to verify

1. Log in with the change
2. See that your session_id is not UUIDI formatted 

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
