### PR TITLE
Only push OSS Dot-x git tags

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -288,10 +288,10 @@ jobs:
           git push origin -f ${{ inputs.tag_name }}-oss
         fi
     - name: Add and push git tag for dot X tags
-      if: ${{ inputs.dot-x-tag }}
+      if: ${{ inputs.dot-x-tag && matrix.edition == 'oss' }} # we only need one git tag for dot X
       run: | # sh
         git tag -f ${{ inputs.tag_name }} ${{ needs.check-version.outputs.oss }}
-        git push origin -f ${{ inputs.tag_name }}
+        git push origin tag -f ${{ inputs.tag_name }}
 
   update-version-info:
     if: ${{ !inputs.dot-x-tag }}


### PR DESCRIPTION

### Description

We had a strange failure pushing a git tag when releasing v0.51.11.1,

The tag `v0.51.11.x` failed to push, all other tags pushed just fine

![Screen Shot 2025-01-08 at 9 00 42 PM](https://github.com/user-attachments/assets/67783178-6937-4470-a932-a0f5c7be56fc)

I really don't know why this failed to push, however it did highlight that we don't need to be pushing this particular git tag anyway: we want to keep the git clutter down, and the `ee` and `oss` tags will always be on the same commit, so we can just use the OSS version number. Note, however, that we do need to run this tag job for both oss and ee because we need to trigger dockerhub and s3 publishes for both oss and ee. It's just the git tagging step we can skip for dot x tags.

2 changes:
- make the git command more explicit that we're pushing a tag - if we just push and there's both a branch and a tag by that name, things could get weird
- only push the oss tag

This is a low-consequence failure, so I don't want to spend more time digging into this unless it fails again.


