### PR TITLE
Fix pivot drill thru for multi-stage queries

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -202,7 +202,7 @@ describe("issue 18770", () => {
 
   it("post-aggregation filter shouldn't affect the drill-through options (metabase#18770)", () => {
     H.openNotebook();
-    // It is important to manually triger "visualize" in order to generate the `result_metadata`
+    // It is important to manually trigger "visualize" in order to generate the `result_metadata`
     // Otherwise, we might get false negative even when this issue gets resolved.
     // In order to do that, we have to change the breakout field first or it will never generate and send POST /api/dataset request.
     cy.findAllByTestId("notebook-cell-item")
@@ -220,8 +220,9 @@ describe("issue 18770", () => {
     H.popover().within(() => {
       cy.findByText("Filter by this value").should("be.visible");
       cy.findAllByRole("button")
-        .should("have.length", 5)
+        .should("have.length", 6)
         .and("contain", "See these Orders")
+        .and("contain", "Break out by")
         .and("contain", "<")
         .and("contain", ">")
         .and("contain", "=")

--- a/src/metabase/lib/drill_thru/pivot.cljc
+++ b/src/metabase/lib/drill_thru/pivot.cljc
@@ -51,6 +51,7 @@
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.types.isa :as lib.types.isa]
+   [metabase.lib.underlying :as lib.underlying]
    [metabase.util.malli :as mu]))
 
 (mu/defn- pivot-drill-pred :- [:sequential ::lib.schema.metadata/column]
@@ -64,7 +65,7 @@
   (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
              column
              (some? value)
-             (= (:lib/source column) :source/aggregations))
+             (lib.drill-thru.common/aggregation-sourced? query column))
     (->> (lib.breakout/breakoutable-columns query stage-number)
          (filter field-pred))))
 
@@ -121,24 +122,25 @@
   See `:pivots` key, which holds a map `{t [breakouts...]}` where `t` is `:category`, `:location`, or `:time`.
   If a key is missing, there are no breakouts of that kind."
   [query                                         :- ::lib.schema/query
-   stage-number                                  :- :int
+   _stage-number                                 :- :int
    {:keys [column dimensions value] :as context} :- ::lib.schema.drill-thru/context]
-  (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
-             column
-             (some? value)
-             (= (:lib/source column) :source/aggregations)
-             (-> (lib.aggregation/aggregations query stage-number) count pos?))
-    (let [breakout-pivot-types (permitted-pivot-types query stage-number)
-          pivots               (into {} (for [pivot-type breakout-pivot-types
-                                              :let [pred    (get pivot-type-predicates pivot-type)
-                                                    columns (pivot-drill-pred query stage-number context pred)]
-                                              :when (not-empty columns)]
-                                          [pivot-type columns]))]
-      (when-not (empty? pivots)
-        {:lib/type   :metabase.lib.drill-thru/drill-thru
-         :type       :drill-thru/pivot
-         :dimensions dimensions
-         :pivots     pivots}))))
+  (let [stage-number (lib.underlying/top-level-stage-number query)]
+    (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
+               column
+               (some? value)
+               (lib.drill-thru.common/aggregation-sourced? query column)
+               (-> (lib.aggregation/aggregations query stage-number) count pos?))
+      (let [breakout-pivot-types (permitted-pivot-types query stage-number)
+            pivots               (into {} (for [pivot-type breakout-pivot-types
+                                                :let [pred    (get pivot-type-predicates pivot-type)
+                                                      columns (pivot-drill-pred query stage-number context pred)]
+                                                :when (not-empty columns)]
+                                            [pivot-type columns]))]
+        (when-not (empty? pivots)
+          {:lib/type   :metabase.lib.drill-thru/drill-thru
+           :type       :drill-thru/pivot
+           :dimensions dimensions
+           :pivots     pivots})))))
 
 (defmethod lib.drill-thru.common/drill-thru-info-method :drill-thru/pivot
   [_query _stage-number drill-thru]
@@ -171,6 +173,7 @@
 ;;     b. Go through the breakouts, and remove any that match this dimension from the query.
 ;; 2. Add a new breakout for the selected column.
 (defmethod lib.drill-thru.common/drill-thru-method :drill-thru/pivot
-  [query stage-number drill-thru & [column]]
-  (let [filtered (reduce #(breakouts->filters %1 stage-number %2) query (:dimensions drill-thru))]
+  [query _stage-number drill-thru & [column]]
+  (let [stage-number (lib.underlying/top-level-stage-number query)
+        filtered (reduce #(breakouts->filters %1 stage-number %2) query (:dimensions drill-thru))]
     (lib.breakout/breakout filtered stage-number column)))

--- a/test/metabase/lib/drill_thru/pivot_test.cljc
+++ b/test/metabase/lib/drill_thru/pivot_test.cljc
@@ -53,20 +53,34 @@
                           (lib/available-drill-thrus query -1 context)))))))
 
 (deftest ^:parallel returns-pivot-test-1b-no-pivots-without-aggregation
-  (lib.drill-thru.tu/test-drill-not-returned
+  (lib.drill-thru.tu/test-drill-variants-with-merged-args
+   lib.drill-thru.tu/test-drill-not-returned
+   "single-stage query"
    {:drill-type   :drill-thru/pivot
     :click-type   :cell
     :query-type   :unaggregated
     :query-table  "ORDERS"
-    :column-name  "CREATED_AT"}))
+    :column-name  "CREATED_AT"}
+
+   "multi-stage query"
+   {:custom-query #(lib.drill-thru.tu/append-filter-stage
+                    %
+                    "CREATED_AT"
+                    (fn [col]
+                      (lib/= col "2025-01-01T13:24:00")))}))
 
 (deftest ^:parallel returns-pivot-test-1c-no-pivots-for-column-click
-  (lib.drill-thru.tu/test-drill-not-returned
+  (lib.drill-thru.tu/test-drill-variants-with-merged-args
+   lib.drill-thru.tu/test-drill-not-returned
+   "single-stage query"
    {:drill-type   :drill-thru/pivot
     :click-type   :header
     :query-type   :aggregated
     :query-table  "ORDERS"
-    :column-name  "count"}))
+    :column-name  "count"}
+
+   "multi-stage query"
+   {:custom-query #(lib.drill-thru.tu/append-filter-stage % "count")}))
 
 (defn- orders-count-with-breakouts [breakout-values]
   {:drill-type   :drill-thru/pivot
@@ -107,33 +121,64 @@
   [(meta/field-metadata :orders :product-id)
    6])
 
+(defn- variant-with-count-filter-stage [base-case]
+  {:custom-query (lib.drill-thru.tu/append-filter-stage (:custom-query base-case) "count")})
+
 (deftest ^:parallel returns-pivot-test-1d-no-pivots-date+address
-  (lib.drill-thru.tu/test-drill-not-returned
-   (orders-count-with-breakouts [bv-date bv-address])))
+  (lib.drill-thru.tu/test-drill-variants-with-merged-args
+   lib.drill-thru.tu/test-drill-not-returned
+   "single-stage query"
+   (orders-count-with-breakouts [bv-date bv-address])
+   "multi-stage-query"
+   variant-with-count-filter-stage))
 
 (deftest ^:parallel returns-pivot-test-1e-no-pivots-address+category
-  (lib.drill-thru.tu/test-drill-not-returned
-   (orders-count-with-breakouts [bv-address bv-category1])))
+  (lib.drill-thru.tu/test-drill-variants-with-merged-args
+   lib.drill-thru.tu/test-drill-not-returned
+   "single-stage query"
+   (orders-count-with-breakouts [bv-address bv-category1])
+   "multi-stage-query"
+   variant-with-count-filter-stage))
 
 (deftest ^:parallel returns-pivot-test-1f-no-pivots-triple-category
-  (lib.drill-thru.tu/test-drill-not-returned
-   (orders-count-with-breakouts [bv-category1 bv-category2 bv-category3])))
+  (lib.drill-thru.tu/test-drill-variants-with-merged-args
+   lib.drill-thru.tu/test-drill-not-returned
+   "single-stage query"
+   (orders-count-with-breakouts [bv-category1 bv-category2 bv-category3])
+   "multi-stage-query"
+   variant-with-count-filter-stage))
 
 (deftest ^:parallel returns-pivot-test-1g-no-pivots-unknown-type
-  (lib.drill-thru.tu/test-drill-not-returned
-   (orders-count-with-breakouts [bv-unknown])))
+  (lib.drill-thru.tu/test-drill-variants-with-merged-args
+   lib.drill-thru.tu/test-drill-not-returned
+   "single-stage query"
+   (orders-count-with-breakouts [bv-unknown])
+   "multi-stage-query"
+   variant-with-count-filter-stage))
 
 (deftest ^:parallel returns-pivot-test-1h-no-pivots-unknown+date
-  (lib.drill-thru.tu/test-drill-not-returned
-   (orders-count-with-breakouts [bv-unknown bv-date])))
+  (lib.drill-thru.tu/test-drill-variants-with-merged-args
+   lib.drill-thru.tu/test-drill-not-returned
+   "single-stage query"
+   (orders-count-with-breakouts [bv-unknown bv-date])
+   "multi-stage-query"
+   variant-with-count-filter-stage))
 
 (deftest ^:parallel returns-pivot-test-1i-no-pivots-unknown+category
-  (lib.drill-thru.tu/test-drill-not-returned
-   (orders-count-with-breakouts [bv-unknown bv-category2])))
+  (lib.drill-thru.tu/test-drill-variants-with-merged-args
+   lib.drill-thru.tu/test-drill-not-returned
+   "single-stage query"
+   (orders-count-with-breakouts [bv-unknown bv-category2])
+   "multi-stage-query"
+   variant-with-count-filter-stage))
 
 (deftest ^:parallel returns-pivot-test-1j-no-pivots-unknown+address
-  (lib.drill-thru.tu/test-drill-not-returned
-   (orders-count-with-breakouts [bv-unknown bv-address])))
+  (lib.drill-thru.tu/test-drill-variants-with-merged-args
+   lib.drill-thru.tu/test-drill-not-returned
+   "single-stage query"
+   (orders-count-with-breakouts [bv-unknown bv-address])
+   "multi-stage-query"
+   variant-with-count-filter-stage))
 
 (defn- expecting [dim-names pivot-types]
   {:expected {:type       :drill-thru/pivot
@@ -146,44 +191,79 @@
                                (into {}))}})
 
 (deftest ^:parallel returns-pivot-test-2a-cat+loc-with-date
-  (lib.drill-thru.tu/test-returns-drill
+  (lib.drill-thru.tu/test-drill-variants-with-merged-args
+   lib.drill-thru.tu/test-returns-drill
+   "single-stage query"
    (merge (orders-count-with-breakouts [bv-date])
-          (expecting ["CREATED_AT"] [:category :location]))))
+          (expecting ["CREATED_AT"] [:category :location]))
+   "multi-stage query"
+   variant-with-count-filter-stage))
 
 (deftest ^:parallel returns-pivot-test-2b-cat+loc-with-date+category
-  (lib.drill-thru.tu/test-returns-drill
+  (lib.drill-thru.tu/test-drill-variants-with-merged-args
+   lib.drill-thru.tu/test-returns-drill
+   "single-stage query"
    (merge (orders-count-with-breakouts [bv-date bv-category1])
-          (expecting ["CREATED_AT" "CATEGORY"] [:category :location]))))
+          (expecting ["CREATED_AT" "CATEGORY"] [:category :location]))
+   "multi-stage query"
+   variant-with-count-filter-stage))
 
 (deftest ^:parallel returns-pivot-test-3a-cat+time-with-address
-  (lib.drill-thru.tu/test-returns-drill
+  (lib.drill-thru.tu/test-drill-variants-with-merged-args
+   lib.drill-thru.tu/test-returns-drill
+   "single-stage query"
    (merge (orders-count-with-breakouts [bv-address])
-          (expecting ["STATE"] [:category :time]))))
+          (expecting ["STATE"] [:category :time]))
+   "multi-stage query"
+   variant-with-count-filter-stage))
 
 (deftest ^:parallel returns-pivot-test-3b-cat+time-with-category
-  (lib.drill-thru.tu/test-returns-drill
+  (lib.drill-thru.tu/test-drill-variants-with-merged-args
+   lib.drill-thru.tu/test-returns-drill
+   "single-stage query"
    (merge (orders-count-with-breakouts [bv-category2])
-          (expecting ["SOURCE"] [:category :time]))))
+          (expecting ["SOURCE"] [:category :time]))
+   "multi-stage query"
+   variant-with-count-filter-stage))
 
 (deftest ^:parallel returns-pivot-test-3c-cat+time-with-category+category
-  (lib.drill-thru.tu/test-returns-drill
+  (lib.drill-thru.tu/test-drill-variants-with-merged-args
+   lib.drill-thru.tu/test-returns-drill
+   "single-stage query"
    (merge (orders-count-with-breakouts [bv-category2 bv-category1])
-          (expecting ["SOURCE" "CATEGORY"] [:category :time]))))
+          (expecting ["SOURCE" "CATEGORY"] [:category :time]))
+   "multi-stage query"
+   variant-with-count-filter-stage))
 
 (deftest ^:parallel returns-pivot-test-4a-none-with-no-breakouts
-  (lib.drill-thru.tu/test-returns-drill
+  (lib.drill-thru.tu/test-drill-variants-with-merged-args
+   lib.drill-thru.tu/test-returns-drill
+   "single-stage query"
    (merge (orders-count-with-breakouts [])
-          (expecting [] [:category :location :time]))))
+          (expecting [] [:category :location :time]))
+   "multi-stage query"
+   variant-with-count-filter-stage))
 
 (deftest ^:parallel pivot-application-test-1
-  (lib.drill-thru.tu/test-drill-application
+  (lib.drill-thru.tu/test-drill-variants-with-merged-args
+   lib.drill-thru.tu/test-drill-application
+   "single-stage query"
    (merge orders-date-only-test-case
           {:expected       {:type :drill-thru/pivot}
-            ;; Expecting the original query with filters for the old breakouts, and one new breakout by CATEGORY.
+           ;; Expecting the original query with filters for the old breakouts, and one new breakout by CATEGORY.
            :drill-args     [(meta/field-metadata :products :category)]
            :expected-query (-> (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :query])
                                (update-in [:stages 0] dissoc :breakout)
                                (lib/filter (lib/= (meta/field-metadata :orders :created-at)
                                                   (get-in lib.drill-thru.tu/test-queries
                                                           ["ORDERS" :aggregated :row "CREATED_AT"])))
-                               (lib/breakout (meta/field-metadata :products :category)))})))
+                               (lib/breakout (meta/field-metadata :products :category)))})
+   "multi-stage query"
+   (fn [base-case]
+     {:custom-query (-> base-case
+                        :custom-query
+                        (lib.drill-thru.tu/append-filter-stage "count"))
+      :expected-query (-> base-case
+                          :expected-query
+                          (assoc-in [:stages 0 :filters 0 2 2] "CREATED_AT")
+                          (lib.drill-thru.tu/append-filter-stage-to-test-expectation "count"))})))


### PR DESCRIPTION
### Description

Fix the pivot drill thru for queries with a filter stage after the aggregations.

Related to https://github.com/metabase/metabase/issues/46932

~~This is currently diffing against [appleby-zoom-in.geographic-multi-stage-query](https://github.com/metabase/metabase/tree/appleby-zoom-in.geographic-multi-stage-query) because the tests depend on a test helper added there. Once https://github.com/metabase/metabase/pull/51891 merges I will rebase this onto master.~~

### How to verify

* New question: People
* summarize: Count by State
* Add filter stage after summarize, e.g. Count > 1
* Visualize
* Click on a cell in the "count" column
* Click "Break out by..." in the context menu
* Click "Category" -> "Source" (e.g.)
* Filter should be added for the state with a breakout on Source

### Demo

![Screenshot 2025-01-09 at 5 21 34 PM](https://github.com/user-attachments/assets/2945132b-167f-4ad6-bbe7-688f86591df9)

![Screenshot 2025-01-09 at 5 21 14 PM](https://github.com/user-attachments/assets/9191758f-8a7c-4201-8c3f-ad985663a336)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
