### PR TITLE
Remove the custom `--folder` flag when running Cypress

### DIFF
--- a/docs/developers-guide/e2e-tests.md
+++ b/docs/developers-guide/e2e-tests.md
@@ -30,13 +30,8 @@ To run all Cypress tests programmatically in the terminal:
 yarn run test-cypress-run
 ```
 
-You can run a specific set of scenarios by using a custom `--folder` flag, which will pick up the chosen scenarios under `e2e/test/scenarios/`.
-
-```sh
-yarn run test-cypress-run --folder sharing
-```
-
 You can quickly test a single file only by using the official `--spec` flag.
+This flag can be used to run all specs within a folder, or to run multiple assorted specs. Consult [the official documentation](https://docs.cypress.io/app/references/command-line#cypress-run-spec-lt-spec-gt) for instructions.
 
 ```sh
 yarn test-cypress-run --spec e2e/test/scenarios/question/new.cy.spec.js

--- a/e2e/runner/cypress-runner-run-tests.js
+++ b/e2e/runner/cypress-runner-run-tests.js
@@ -6,14 +6,7 @@ const {
   args,
 } = require("./cypress-runner-utils");
 
-const folder = args["--folder"];
-const isFolder = !!folder;
-
 const isOpenMode = args["--open"];
-
-const getSourceFolder = folder => {
-  return `./e2e/test/scenarios/${folder}/**/*.cy.spec.{js,ts}`;
-};
 
 const runCypress = async (baseUrl, exitFunction) => {
   await executeYarnCommand({
@@ -27,7 +20,6 @@ const runCypress = async (baseUrl, exitFunction) => {
     config: {
       baseUrl,
     },
-    spec: isFolder && getSourceFolder(folder),
   };
 
   const userArgs = await parseArguments(args);

--- a/e2e/runner/cypress-runner-utils.js
+++ b/e2e/runner/cypress-runner-utils.js
@@ -35,7 +35,6 @@ function executeYarnCommand({ command, message } = {}) {
 
 const args = arg(
   {
-    "--folder": String, // The name of the folder to run files from
     "--open": [Boolean], // Run Cypress in open mode or not? Doesn't accept additional arguments
   },
   { permissive: true }, // Passes all other flags and args to the Cypress parser


### PR DESCRIPTION
After @iethree introduced parallel runs in https://github.com/metabase/metabase/pull/51433, we no longer need to support the custom `--folder` flag.

This PR removes it.