### PR TITLE
make flaky job detection case-insensitive

### DIFF
--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -64,7 +64,7 @@ jobs:
                 .filter(job => job.status === "completed" && job.conclusion === "failure");
 
               // don't bother slack if only the flaky job failed
-              if (failedJobs.every(job => job.name.includes("flaky"))) {
+              if (failedJobs.every(job => job.name.toLowerCase().includes("flaky"))) {
                 return;
               }
 


### PR DESCRIPTION
Updates our CI failure slack notification flaky job detection to be case-insensitive 🙃 



![Screen Shot 2025-01-10 at 8 33 24 AM](https://github.com/user-attachments/assets/816e1c95-869e-449f-bd3f-f81a02566059)
