### PR TITLE
Move session creation logic models.session and don't track session_id…

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -7,9 +7,9 @@
    [metabase-enterprise.sso.api.interface :as sso.i]
    [metabase-enterprise.sso.integrations.sso-settings :as sso-settings]
    [metabase-enterprise.sso.integrations.sso-utils :as sso-utils]
-   [metabase.api.session :as api.session]
    [metabase.embed.settings :as embed.settings]
    [metabase.integrations.common :as integrations.common]
+   [metabase.models.session :as session]
    [metabase.premium-features.core :as premium-features]
    [metabase.request.core :as request]
    [metabase.util.i18n :refer [tru]]
@@ -105,7 +105,7 @@
           first-name   (get jwt-data (jwt-attribute-firstname))
           last-name    (get jwt-data (jwt-attribute-lastname))
           user         (fetch-or-create-user! first-name last-name email login-attrs)
-          session      (api.session/create-session! :sso user (request/device-info request))]
+          session      (session/create-session! :sso user (request/device-info request))]
       (sync-groups! user jwt-data)
       {:session session, :redirect-url redirect-url, :jwt-data jwt-data})))
 

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -39,8 +39,8 @@
    [metabase-enterprise.sso.integrations.sso-settings :as sso-settings]
    [metabase-enterprise.sso.integrations.sso-utils :as sso-utils]
    [metabase.api.common :as api]
-   [metabase.api.session :as api.session]
    [metabase.integrations.common :as integrations.common]
+   [metabase.models.session :as session]
    [metabase.premium-features.core :as premium-features]
    [metabase.public-settings :as public-settings]
    [metabase.request.core :as request]
@@ -104,7 +104,7 @@
                         (sso-utils/check-user-provisioning :saml)
                         (sso-utils/create-new-sso-user! new-user))]
       (sync-groups! user group-names)
-      (api.session/create-session! :sso user device-info))))
+      (session/create-session! :sso user device-info))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10469,6 +10469,15 @@ databaseChangeLog:
                   type: ${timestamp_type}
                   remarks: The timestamp at which a user was deactivated
 
+  - changeSet:
+      id: v53.2025-01-10T16:22:30
+      author: nvoxland
+      comment: Drop `session_id` column from the `login_history` table
+      changes:
+        - dropColumn:
+            tableName: login_history
+            columnName: session_id
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -3,7 +3,6 @@
   (:require
    [compojure.core :refer [DELETE GET POST]]
    [java-time.api :as t]
-   [metabase.analytics.snowplow :as snowplow]
    [metabase.api.common :as api]
    [metabase.api.ldap :as api.ldap]
    [metabase.config :as config]
@@ -11,6 +10,7 @@
    [metabase.events :as events]
    [metabase.integrations.google :as google]
    [metabase.integrations.ldap :as ldap]
+   [metabase.models.session :as session]
    [metabase.models.setting :as setting :refer [defsetting]]
    [metabase.models.user :as user]
    [metabase.public-settings :as public-settings]
@@ -21,65 +21,12 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
    [metabase.util.password :as u.password]
-   [metabase.util.string :as str]
    [throttle.core :as throttle]
    [toucan2.core :as t2])
   (:import
    (com.unboundid.util LDAPSDKException)))
 
 (set! *warn-on-reflection* true)
-
-(mu/defn- record-login-history!
-  [session-id  :- string?
-   user-id     :- ms/PositiveInt
-   device-info :- request/DeviceInfo]
-  (t2/insert! :model/LoginHistory (merge {:user_id    user-id
-                                          :session_id (str session-id)}
-                                         device-info)))
-
-(defmulti create-session!
-  "Generate a new Session for a User. `session-type` is the currently either `:password` (for email + password login) or
-  `:sso` (for other login types). Returns the newly generated Session."
-  {:arglists '(^str [session-type user device-info])}
-  (fn [session-type & _]
-    session-type))
-
-(def ^:private CreateSessionUserInfo
-  [:map
-   [:id          ms/PositiveInt]
-   [:last_login :any]])
-
-(def ^:private SessionSchema
-  [:and
-   [:map-of :keyword :any]
-   [:map
-    [:id   string?]
-    [:type [:enum :normal :full-app-embed]]]])
-
-(mu/defmethod create-session! :sso :- SessionSchema
-  [_ user :- CreateSessionUserInfo device-info :- request/DeviceInfo]
-  (let [session-id (str/random-string 32)
-        session      (first (t2/insert-returning-instances! :model/Session
-                                                            :id      session-id
-                                                            :user_id (u/the-id user)))]
-    (assert (map? session))
-    (let [event {:user-id (u/the-id user)}]
-      (events/publish-event! :event/user-login event)
-      (when (nil? (:last_login user))
-        (events/publish-event! :event/user-joined event)))
-    (record-login-history! session-id (u/the-id user) device-info)
-    (when-not (:last_login user)
-      (snowplow/track-event! ::snowplow/account {:event :new-user-created} (u/the-id user)))
-    (assoc session :id session-id)))
-
-(mu/defmethod create-session! :password :- SessionSchema
-  [session-type
-   user         :- CreateSessionUserInfo
-   device-info  :- request/DeviceInfo]
-  ;; this is actually the same as `create-session!` for `:sso` but we check whether password login is enabled.
-  (when-not (public-settings/enable-password-login)
-    (throw (ex-info (str (tru "Password login is disabled for this instance.")) {:status-code 400})))
-  ((get-method create-session! :sso) session-type user device-info))
 
 ;;; ## API Endpoints
 
@@ -114,7 +61,7 @@
         ;; password is ok, return new session if user is not deactivated
         (let [user (ldap/fetch-or-create-user! user-info)]
           (if (:is_active user)
-            (create-session! :sso user device-info)
+            (session/create-session! :sso user device-info)
             (throw (ex-info (str disabled-account-message)
                             {:status-code 401
                              :errors      {:_error disabled-account-snippet}})))))
@@ -129,7 +76,7 @@
   (if-let [user (t2/select-one [:model/User :id :password_salt :password :last_login :is_active], :%lower.email (u/lower-case-en username))]
     (when (u.password/verify-password password (:password_salt user) (:password user))
       (if (:is_active user)
-        (create-session! :password user device-info)
+        (session/create-session! :password user device-info)
         (throw (ex-info (str disabled-account-message)
                         {:status-code 401
                          :errors      {:_error disabled-account-snippet}}))))
@@ -146,7 +93,7 @@
   (when-not throttling-disabled?
     (throttle/check throttler throttle-key)))
 
-(mu/defn- login :- SessionSchema
+(mu/defn- login :- session/SessionSchema
   "Attempt to login with different avaialable methods with `username` and `password`, returning new Session ID or
   throwing an Exception if login could not be completed."
   [username    :- ms/NonBlankString
@@ -295,7 +242,7 @@
             ;; Send all the active admins an email :D
             (messages/send-user-joined-admin-notification-email! (t2/select-one :model/User :id user-id)))
           ;; after a successful password update go ahead and offer the client a new session that they can use
-          (let [{session-id :id, :as session} (create-session! :password user (request/device-info request))
+          (let [{session-id :id, :as session} (session/create-session! :password user (request/device-info request))
                 response                        {:success    true
                                                  :session_id session-id}]
             (request/set-session-cookies request response session (t/zoned-date-time (t/zone-id "GMT"))))))
@@ -328,7 +275,7 @@
     (http-401-on-error
       (throttle/with-throttling [(login-throttlers :ip-address) (request/ip-address request)]
         (let [user (google/do-google-auth request)
-              {session-id :id, :as session} (create-session! :sso user (request/device-info request))
+              {session-id :id, :as session} (session/create-session! :sso user (request/device-info request))
               response {:id session-id}
               user (t2/select-one [:model/User :id :is_active], :email (:email user))]
           (if (and user (:is_active user))

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -8,13 +8,13 @@
    [metabase.api.common :as api]
    [metabase.api.common.validation :as validation]
    [metabase.api.ldap :as api.ldap]
-   [metabase.api.session :as api.session]
    [metabase.config :as config]
    [metabase.events :as events]
    [metabase.integrations.google :as google]
    [metabase.models.collection :as collection]
    [metabase.models.interface :as mi]
    [metabase.models.permissions-group :as perms-group]
+   [metabase.models.session :as session]
    [metabase.models.setting :refer [defsetting]]
    [metabase.models.user :as user]
    [metabase.permissions.util :as perms-util]
@@ -521,7 +521,7 @@
     (user/set-password! id password)
     ;; after a successful password update go ahead and offer the client a new session that they can use
     (when (= id api/*current-user-id*)
-      (let [{session-uuid :id, :as session} (api.session/create-session! :password user (request/device-info request))
+      (let [{session-uuid :id, :as session} (session/create-session! :password user (request/device-info request))
             response                        {:success    true
                                              :session_id (str session-uuid)}]
         (request/set-session-cookies request response session (t/zoned-date-time (t/zone-id "GMT")))))))

--- a/src/metabase/models/session.clj
+++ b/src/metabase/models/session.clj
@@ -2,8 +2,15 @@
   (:require
    [buddy.core.codecs :as codecs]
    [buddy.core.nonce :as nonce]
+   [metabase.analytics.snowplow :as snowplow]
+   [metabase.events :as events]
+   [metabase.public-settings :as public-settings]
    [metabase.request.core :as request]
+   [metabase.util :as u]
+   [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]
+   [metabase.util.malli.schema :as ms]
+   [metabase.util.string :as str]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
@@ -29,3 +36,55 @@
   [{anti-csrf-token :anti_csrf_token, :as session}]
   (let [session-type (if anti-csrf-token :full-app-embed :normal)]
     (assoc session :type session-type)))
+
+(def ^:private CreateSessionUserInfo
+  [:map
+   [:id ms/PositiveInt]
+   [:last_login :any]])
+
+
+(def SessionSchema
+  "Schema for a Session."
+  [:and
+   [:map-of :keyword :any]
+   [:map
+    [:id   string?]
+    [:type [:enum :normal :full-app-embed]]]])
+
+(defmulti create-session!
+  "Generate a new Session for a User. `session-type` is currently either `:password` (for email + password login) or
+  `:sso` (for other login types). Returns the newly generated Session."
+  {:arglists '(^str [session-type user device-info])}
+  (fn [session-type & _]
+    session-type))
+
+(mu/defn- record-login-history!
+  [user-id     :- ms/PositiveInt
+   device-info :- request/DeviceInfo]
+  (t2/insert! :model/LoginHistory (merge {:user_id    user-id}
+                                    device-info)))
+
+(mu/defmethod create-session! :sso :- SessionSchema
+  [_ user :- CreateSessionUserInfo device-info :- request/DeviceInfo]
+  (let [session-id (str/random-string 32)
+        session      (first (t2/insert-returning-instances! :model/Session
+                              :id      session-id
+                              :user_id (u/the-id user)))]
+    (assert (map? session))
+    (let [event {:user-id (u/the-id user)}]
+      (events/publish-event! :event/user-login event)
+      (when (nil? (:last_login user))
+        (events/publish-event! :event/user-joined event)))
+    (record-login-history! (u/the-id user) device-info)
+    (when-not (:last_login user)
+      (snowplow/track-event! ::snowplow/account {:event :new-user-created} (u/the-id user)))
+    (assoc session :id session-id)))
+
+(mu/defmethod create-session! :password :- SessionSchema
+  [session-type
+   user         :- CreateSessionUserInfo
+   device-info  :- request/DeviceInfo]
+  ;; this is actually the same as `create-session!` for `:sso` but we check whether password login is enabled.
+  (when-not (public-settings/enable-password-login)
+    (throw (ex-info (str (tru "Password login is disabled for this instance.")) {:status-code 400})))
+  ((get-method create-session! :sso) session-type user device-info))


### PR DESCRIPTION
### Description

Consolidates the session creation into metabase.models.session to remove duplication and ensure all sessions get logged to login_history, no matter how they get created.

Also removes the session_id from login_history since that is sensitive information and not needed/used in the history

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Start a new metabase instance and see that the initial user's login gets recorded
2. Ensure normal login still works

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
