### PR TITLE
[refs] Joined columns get unique `:ident`s; new test metadata

### DIFF
--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -7,6 +7,7 @@
    [metabase.lib.hierarchy :as lib.hierarchy]
    [metabase.lib.join.util :as lib.join.util]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.metadata.ident :as lib.metadata.ident]
    [metabase.lib.options :as lib.options]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.common :as lib.schema.common]
@@ -614,17 +615,23 @@
           (comp (filter :fk-target-field-id)
                 (filter :id)
                 (filter (comp number? :id))
-                (map (fn [{source-field-id :id, :keys [fk-target-field-id] :as source}]
+                (map (fn [{source-field-id :id
+                           fk-ident       :ident
+                           :keys [fk-target-field-id]
+                           :as   source}]
                        (-> (lib.metadata/field query fk-target-field-id)
-                           (assoc ::source-field-id source-field-id
-                                  ::source-join-alias (:metabase.lib.join/join-alias source)))))
+                           (assoc ::source-field-id   source-field-id
+                                  ::source-join-alias (:metabase.lib.join/join-alias source)
+                                  ::fk-ident          fk-ident))))
                 (remove #(contains? existing-table-ids (:table-id %)))
-                (mapcat (fn [{:keys [table-id], ::keys [source-field-id source-join-alias]}]
+                (mapcat (fn [{:keys [table-id], ::keys [fk-ident source-field-id source-join-alias]}]
                           (let [table-metadata (lib.metadata/table query table-id)
                                 options        {:unique-name-fn               unique-name-fn
                                                 :include-implicitly-joinable? false}]
                             (for [field (visible-columns-method query stage-number table-metadata options)
-                                  :let  [field (assoc field
+                                  :let  [ident (lib.metadata.ident/implicitly-joined-ident fk-ident (:ident field))
+                                         field (assoc field
+                                                      :ident                    ident
                                                       :fk-field-id              source-field-id
                                                       :fk-join-alias            source-join-alias
                                                       :lib/source               :source/implicitly-joinable

--- a/src/metabase/lib/metadata/ident.cljc
+++ b/src/metabase/lib/metadata/ident.cljc
@@ -48,3 +48,17 @@
    (map #(attach-ident (prefix-fn (:table-id %)) %)))
   ([prefix-fn columns]
    (sequence (attach-idents prefix-fn) columns)))
+
+(defn implicitly-joined-ident
+  "Returns the ident for an implicitly joined column, given the idents of the foreign key column and the target column.
+
+  Remember that `:ident` strings should never be parsed - they are opaque, but should be legible during debugging."
+  [fk-ident target-ident]
+  (str "implicit_via__" fk-ident "__->__" target-ident))
+
+(defn explicitly-joined-ident
+  "Returns the ident for an explicitly joined column, given the idents of the join clause and the target column.
+
+  Remember that `:ident` strings should never be parsed - they are opaque, but should be legible during debugging."
+  [join-ident target-ident]
+  (str "join__" join-ident "__" target-ident))

--- a/test/metabase/lib/test_metadata.cljc
+++ b/test/metabase/lib/test_metadata.cljc
@@ -55,7 +55,10 @@
         :people       70
         :reviews      80
         :ic/accounts  90
-        :ic/reports  100)))
+        :ic/reports  100
+        :gh/issues   110
+        :gh/users    120
+        :gh/comments 130)))
 
   ([table-name field-name]
    (+ random-id-offset
@@ -125,8 +128,25 @@
                        :name      901)       ; :type/Text
         :ic/reports  (case field-name        ;
                        :id         1000      ; :type/Integer
-                       :created-by 1100      ; :type/Integer
-                       :updated-by 1200))))) ; :type/Integer
+                       :created-by 1001      ; :type/Integer
+                       :updated-by 1002)     ; :type/Integer
+        :gh/issues   (case field-name
+                       :id          1100     ; :type/UUID
+                       :reporter-id 1101     ; :type/Text (FK to :gh/users)
+                       :assignee-id 1102     ; :type/Text (FK to :gh/users)
+                       :is-open     1103     ; :type/Integer (but it wants to be :type/Boolean)
+                       :reported-at 1104     ; :type/DateTime
+                       :closed-at   1105)    ; :type/DateTime
+        :gh/users    (case field-name
+                       :id           1200    ; :type/Text (Github usernames eg. camsaul, bshepherdson)
+                       :birthday     1202    ; :type/Date
+                       :email        1203)   ; :type/Text
+        :gh/comments (case field-name
+                       :id            1300   ; :type/UUID
+                       :author-id     1301   ; :type/Text
+                       :posted-at     1302   ; :type/DateTime
+                       :reply-to      1303   ; :type/UUID (FK to the same table)
+                       :body-markdown 1304))))) ;type/Text
 
 (defmulti ^:private table-metadata-method
   {:arglists '([table-name])}
@@ -2356,6 +2376,567 @@
                              (field-metadata-method :ic/reports :created-by)
                              (field-metadata-method :ic/reports :updated-by)]})
 
+(defmethod field-metadata-method [:gh/issues :id]
+  [_table-name _field-name]
+  {:description                nil
+   :database-type              "UUID"
+   :base-type                  :type/UUID
+   :effective-type             :type/UUID
+   :semantic-type              :type/PK
+   :table-id                   (id :gh/issues)
+   :id                         (id :gh/issues :id)
+   :name                       "ID"
+   :coercion-strategy          nil
+   :fingerprint-version        5
+   :has-field-values           :auto-list
+   :settings                   nil
+   :caveats                    nil
+   :fk-target-field-id         nil
+   :position                   0
+   :custom-position            0
+   :database-position          0
+   :active                     true
+   :nfc-path                   nil
+   :parent-id                  nil
+   :database-is-auto-increment false
+   :json-unfolding             false
+   :visibility-type            :normal
+   :preview-display            true
+   :display-name               "ID"
+   :database-required          true
+   :points-of-interest         nil
+   :fingerprint                {:global {:distinct-count 2, :nil% 0.0}
+                                :type   {:type/UUID {}}}
+   :lib/type                   :metadata/column})
+
+(defmethod field-metadata-method [:gh/issues :reporter-id]
+  [_table-name _field-name]
+  {:description                nil
+   :database-type              "CHARACTER VARYING"
+   :base-type                  :type/Text
+   :effective-type             :type/Text
+   :semantic-type              :type/FK
+   :table-id                   (id :gh/issues)
+   :id                         (id :gh/issues :reporter-id)
+   :name                       "REPORTER_ID"
+   :display-name               "Reporter ID"
+   :coercion-strategy          nil
+   :fingerprint-version        5
+   :has-field-values           :auto-list
+   :settings                   nil
+   :caveats                    nil
+   :fk-target-field-id         (id :gh/users :id)
+   :active                     true
+   :nfc-path                   nil
+   :parent-id                  nil
+   :database-is-auto-increment false
+   :json-unfolding             false
+   :position                   2
+   :custom-position            2
+   :database-position          2
+   :visibility-type            :normal
+   :preview-display            true
+   :database-required          true
+   :points-of-interest         nil
+   :fingerprint                {:global {:distinct-count 200, :nil% 0.0}
+                                :type   {:type/Text {:percent-json   0.0
+                                                     :percent-url    0.0
+                                                     :percent-email  0.0
+                                                     :percent-state  0.0
+                                                     :average-length 11.4}}}
+   :lib/type                   :metadata/column})
+
+(defmethod field-metadata-method [:gh/issues :assignee-id]
+  [_table-name _field-name]
+  {:description                nil
+   :database-type              "CHARACTER VARYING"
+   :base-type                  :type/Text
+   :effective-type             :type/Text
+   :semantic-type              :type/FK
+   :table-id                   (id :gh/issues)
+   :id                         (id :gh/issues :assignee-id)
+   :name                       "ASSIGNEE_ID"
+   :display-name               "Assignee ID"
+   :coercion-strategy          nil
+   :fingerprint-version        5
+   :has-field-values           :auto-list
+   :settings                   nil
+   :caveats                    nil
+   :fk-target-field-id         (id :gh/users :id)
+   :active                     true
+   :nfc-path                   nil
+   :parent-id                  nil
+   :database-is-auto-increment false
+   :json-unfolding             false
+   :position                   2
+   :custom-position            2
+   :database-position          2
+   :visibility-type            :normal
+   :preview-display            true
+   :database-required          false
+   :points-of-interest         nil
+   :fingerprint                {:global {:distinct-count 200, :nil% 0.4}
+                                :type   {:type/Text {:percent-json   0.0
+                                                     :percent-url    0.0
+                                                     :percent-email  0.0
+                                                     :percent-state  0.0
+                                                     :average-length 11.4}}}
+   :lib/type                   :metadata/column})
+
+(defmethod field-metadata-method [:gh/issues :is-open]
+  [_table-name _field-name]
+  {:description                nil
+   :database-type              "int4"
+   :base-type                  :type/Integer
+   :effective-type             :type/Integer
+   :semantic-type              :type/Category
+   :table-id                   (id :gh/issues)
+   :id                         (id :gh/issues :is-open)
+   :name                       "IS_OPEN"
+   :display-name               "Is Open"
+   :coercion-strategy          nil
+   :fingerprint-version        5
+   :has-field-values           :auto-list
+   :settings                   nil
+   :caveats                    nil
+   :fk-target-field-id         nil
+   :active                     true
+   :nfc-path                   nil
+   :parent-id                  nil
+   :database-is-auto-increment false
+   :json-unfolding             false
+   :position                   3
+   :custom-position            3
+   :database-position          3
+   :visibility-type            :normal
+   :preview-display            true
+   :database-required          true
+   :points-of-interest         nil
+   :fingerprint                {:global {:distinct-count 2, :nil% 0.0}
+                                :type   {:type/Number {:min 0, :q1 0, :q3 0
+                                                       :max 1, :sd 0.7071067811865476, :avg 0.5}}}
+   :lib/type                   :metadata/column})
+
+(defmethod field-metadata-method [:gh/issues :reported-at]
+  [_table-name _field-name]
+  {:description                nil
+   :database-type              "TIMESTAMP"
+   :base-type                  :type/DateTime
+   :effective-type             :type/DateTime
+   :semantic-type              nil
+   :table-id                   (id :gh/issues)
+   :id                         (id :gh/issues :reported-at)
+   :name                       "REPORTED_AT"
+   :display-name               "Reported At"
+   :coercion-strategy          nil
+   :fingerprint-version        5
+   :has-field-values           :auto-list
+   :settings                   nil
+   :caveats                    nil
+   :fk-target-field-id         nil
+   :active                     true
+   :nfc-path                   nil
+   :parent-id                  nil
+   :database-is-auto-increment false
+   :json-unfolding             false
+   :position                   4
+   :custom-position            4
+   :database-position          4
+   :visibility-type            :normal
+   :preview-display            true
+   :database-required          true
+   :points-of-interest         nil
+   :fingerprint                {:global {:distinct-count 200, :nil% 0.0}
+                                :type   {:type/DateTime {:earliest "2016-06-03T00:37:05.818Z"
+                                                         :latest   "2020-04-19T14:15:25.677Z"}}}
+   :lib/type                   :metadata/column})
+
+(defmethod field-metadata-method [:gh/issues :closed-at]
+  [_table-name _field-name]
+  {:description                nil
+   :database-type              "TIMESTAMP"
+   :base-type                  :type/DateTime
+   :effective-type             :type/DateTime
+   :semantic-type              nil
+   :table-id                   (id :gh/issues)
+   :id                         (id :gh/issues :closed-at)
+   :name                       "CLOSED_AT"
+   :display-name               "Closed At"
+   :coercion-strategy          nil
+   :fingerprint-version        5
+   :has-field-values           :auto-list
+   :settings                   nil
+   :caveats                    nil
+   :fk-target-field-id         nil
+   :active                     true
+   :nfc-path                   nil
+   :parent-id                  nil
+   :database-is-auto-increment false
+   :json-unfolding             false
+   :position                   5
+   :custom-position            5
+   :database-position          5
+   :visibility-type            :normal
+   :preview-display            true
+   :database-required          false
+   :points-of-interest         nil
+   :fingerprint                {:global {:distinct-count 200, :nil% 0.6}
+                                :type   {:type/DateTime {:earliest "2016-06-03T00:37:05.818Z"
+                                                         :latest   "2020-04-19T14:15:25.677Z"}}}
+   :lib/type                   :metadata/column})
+
+(defmethod table-metadata-method :gh/issues
+  [_table-name]
+  {:description             nil
+   :entity-type             :entity/GenericTable
+   :schema                  "public"
+   :show-in-getting-started false
+   :name                    "GH_ISSUES"
+   :caveats                 nil
+   :active                  true
+   :id                      (id :gh/issues)
+   :db-id                   (id)
+   :visibility-type         nil
+   :field-order             :database
+   :is-upload               false
+   :initial-sync-status     :complete
+   :display-name            "GH Issues"
+   :points-of-interest      nil
+   :lib/type                :metadata/table
+   :fields                  [(field-metadata-method :gh/issues :id)
+                             (field-metadata-method :gh/issues :reporter-id)
+                             (field-metadata-method :gh/issues :assignee-id)
+                             (field-metadata-method :gh/issues :is-open)
+                             (field-metadata-method :gh/issues :reported-at)
+                             (field-metadata-method :gh/issues :closed-at)]})
+
+(defmethod field-metadata-method [:gh/users :id]
+  [_table-name _field-name]
+  {:description                nil
+   :database-type              "CHARACTER VARYING"
+   :base-type                  :type/Text
+   :effective-type             :type/Text
+   :semantic-type              :type/PK
+   :table-id                   (id :gh/users)
+   :id                         (id :gh/users :id)
+   :name                       "ID"
+   :display-name               "Username"
+   :coercion-strategy          nil
+   :fingerprint-version        5
+   :has-field-values           :auto-list
+   :settings                   nil
+   :caveats                    nil
+   :fk-target-field-id         nil
+   :active                     true
+   :nfc-path                   nil
+   :parent-id                  nil
+   :database-is-auto-increment false
+   :json-unfolding             false
+   :position                   0
+   :custom-position            0
+   :database-position          0
+   :visibility-type            :normal
+   :preview-display            true
+   :database-required          true
+   :points-of-interest         nil
+   :fingerprint                {:global {:distinct-count 200, :nil% 0.6}
+                                :type   {:type/Text {:percent-json   0.0
+                                                     :percent-url    0.0
+                                                     :percent-email  0.0
+                                                     :percent-state  0.0
+                                                     :average-length 11.4}}}
+   :lib/type                   :metadata/column})
+
+(defmethod field-metadata-method [:gh/users :birthday]
+  [_table-name _field-name]
+  {:description                nil
+   :database-type              "DATE"
+   :base-type                  :type/Date
+   :effective-type             :type/Date
+   :semantic-type              nil
+   :table-id                   (id :gh/users)
+   :id                         (id :gh/users :birthday)
+   :name                       "BIRTHDAY"
+   :display-name               "Birthday"
+   :coercion-strategy          nil
+   :fingerprint-version        5
+   :has-field-values           :auto-list
+   :settings                   nil
+   :caveats                    nil
+   :fk-target-field-id         nil
+   :active                     true
+   :nfc-path                   nil
+   :parent-id                  nil
+   :database-is-auto-increment false
+   :json-unfolding             false
+   :position                   1
+   :custom-position            1
+   :database-position          1
+   :visibility-type            :normal
+   :preview-display            true
+   :database-required          false
+   :points-of-interest         nil
+   :fingerprint                {:global {:distinct-count 105, :nil% 0.3}
+                                :type   {:type/Date {:earliest "2013-01-03", :latest "2015-12-29"}}}
+   :lib/type                   :metadata/column})
+
+(defmethod field-metadata-method [:gh/users :email]
+  [_table-name _field-name]
+  {:description                nil
+   :database-type              "CHARACTER VARYING"
+   :base-type                  :type/Text
+   :effective-type             :type/Text
+   :semantic-type              :type/Email
+   :table-id                   (id :gh/users)
+   :id                         (id :gh/users :email)
+   :name                       "EMAIL"
+   :display-name               "Email"
+   :coercion-strategy          nil
+   :fingerprint-version        5
+   :has-field-values           :auto-list
+   :settings                   nil
+   :caveats                    nil
+   :fk-target-field-id         nil
+   :active                     true
+   :nfc-path                   nil
+   :parent-id                  nil
+   :database-is-auto-increment false
+   :json-unfolding             false
+   :position                   2
+   :custom-position            2
+   :database-position          2
+   :visibility-type            :normal
+   :preview-display            true
+   :database-required          true
+   :points-of-interest         nil
+   :fingerprint                {:global {:distinct-count 150, :nil% 0.0}
+                                :type   {:type/Text {:percent-json   0.0
+                                                     :percent-url    0.0
+                                                     :percent-email  1.0
+                                                     :percent-state  0.0
+                                                     :average-length 26.1}}}
+   :lib/type                   :metadata/column})
+
+(defmethod table-metadata-method :gh/users
+  [_table-name]
+  {:description             nil
+   :entity-type             :entity/GenericTable
+   :schema                  "public"
+   :show-in-getting-started false
+   :name                    "GH_USERS"
+   :caveats                 nil
+   :active                  true
+   :id                      (id :gh/users)
+   :db-id                   (id)
+   :visibility-type         nil
+   :field-order             :database
+   :is-upload               false
+   :initial-sync-status     :complete
+   :display-name            "GH Users"
+   :points-of-interest      nil
+   :lib/type                :metadata/table
+   :fields                  [(field-metadata-method :gh/users :id)
+                             (field-metadata-method :gh/users :birthday)
+                             (field-metadata-method :gh/users :email)]})
+
+(defmethod field-metadata-method [:gh/comments :id]
+  [_table-name _field-name]
+  {:description                nil
+   :database-type              "UUID"
+   :base-type                  :type/UUID
+   :effective-type             :type/UUID
+   :semantic-type              :type/PK
+   :table-id                   (id :gh/comments)
+   :id                         (id :gh/comments :id)
+   :name                       "ID"
+   :display-name               "ID"
+   :coercion-strategy          nil
+   :fingerprint-version        5
+   :has-field-values           :auto-list
+   :settings                   nil
+   :caveats                    nil
+   :fk-target-field-id         nil
+   :active                     true
+   :nfc-path                   nil
+   :parent-id                  nil
+   :database-is-auto-increment false
+   :json-unfolding             false
+   :position                   0
+   :custom-position            0
+   :database-position          0
+   :visibility-type            :normal
+   :preview-display            true
+   :database-required          true
+   :points-of-interest         nil
+   :fingerprint                {:global {:distinct-count 150, :nil% 0.0}
+                                :type   {:type/UUID {}}}
+   :lib/type                   :metadata/column})
+
+(defmethod field-metadata-method [:gh/comments :author-id]
+  [_table-name _field-name]
+  {:description                nil
+   :database-type              "CHARACTER VARYING"
+   :base-type                  :type/Text
+   :effective-type             :type/Text
+   :semantic-type              :type/FK
+   :table-id                   (id :gh/comments)
+   :id                         (id :gh/comments :author-id)
+   :name                       "AUTHOR_ID"
+   :display-name               "Author ID"
+   :coercion-strategy          nil
+   :fingerprint-version        5
+   :has-field-values           :auto-list
+   :settings                   nil
+   :caveats                    nil
+   :fk-target-field-id         (id :gh/users :id)
+   :active                     true
+   :nfc-path                   nil
+   :parent-id                  nil
+   :database-is-auto-increment false
+   :json-unfolding             false
+   :position                   1
+   :custom-position            1
+   :database-position          1
+   :visibility-type            :normal
+   :preview-display            true
+   :database-required          true
+   :points-of-interest         nil
+   :fingerprint                {:global {:distinct-count 150, :nil% 0.0}
+                                :type   {:type/Text {:percent-json   0.0
+                                                     :percent-url    0.0
+                                                     :percent-email  0.0
+                                                     :percent-state  0.0
+                                                     :average-length 11.4}}}
+   :lib/type                   :metadata/column})
+
+(defmethod field-metadata-method [:gh/comments :posted-at]
+  [_table-name _field-name]
+  {:description                nil
+   :database-type              "TIMESTAMP"
+   :base-type                  :type/DateTime
+   :effective-type             :type/DateTime
+   :semantic-type              :type/CreationDate
+   :table-id                   (id :gh/comments)
+   :id                         (id :gh/comments :posted-at)
+   :name                       "POSTED_AT"
+   :display-name               "Posted At"
+   :coercion-strategy          nil
+   :fingerprint-version        5
+   :has-field-values           :auto-list
+   :settings                   nil
+   :caveats                    nil
+   :fk-target-field-id         nil
+   :active                     true
+   :nfc-path                   nil
+   :parent-id                  nil
+   :database-is-auto-increment false
+   :json-unfolding             false
+   :position                   2
+   :custom-position            2
+   :database-position          2
+   :visibility-type            :normal
+   :preview-display            true
+   :database-required          true
+   :points-of-interest         nil
+   :fingerprint                {:global {:distinct-count 150, :nil% 0.0}
+                                :type   {:type/DateTime {:earliest "2016-06-03T00:37:05.818Z"
+                                                         :latest   "2020-04-19T14:15:25.677Z"}}}
+   :lib/type                   :metadata/column})
+
+(defmethod field-metadata-method [:gh/comments :reply-to]
+  [_table-name _field-name]
+  {:description                nil
+   :database-type              "UUID"
+   :base-type                  :type/UUID
+   :effective-type             :type/UUID
+   :semantic-type              :type/FK
+   :table-id                   (id :gh/comments)
+   :id                         (id :gh/comments :reply-to)
+   :name                       "REPLY_TO"
+   :display-name               "Reply To"
+   :coercion-strategy          nil
+   :fingerprint-version        5
+   :has-field-values           :auto-list
+   :settings                   nil
+   :caveats                    nil
+   :fk-target-field-id         (id :gh/comments :id)
+   :active                     true
+   :nfc-path                   nil
+   :parent-id                  nil
+   :database-is-auto-increment false
+   :json-unfolding             false
+   :position                   4
+   :custom-position            4
+   :database-position          4
+   :visibility-type            :normal
+   :preview-display            true
+   :database-required          true
+   :points-of-interest         nil
+   :fingerprint                {:global {:distinct-count 200, :nil% 0.0}
+                                :type   {:type/UUID {}}}
+   :lib/type                   :metadata/column})
+
+(defmethod field-metadata-method [:gh/comments :body-markdown]
+  [_table-name _field-name]
+  {:description                nil
+   :database-type              "CHARACTER VARYING"
+   :base-type                  :type/Text
+   :effective-type             :type/Text
+   :semantic-type              nil
+   :table-id                   (id :gh/comments)
+   :id                         (id :gh/comments :body-markdown)
+   :name                       "BODY_MARKDOWN"
+   :display-name               "Body Markdown"
+   :coercion-strategy          nil
+   :fingerprint-version        5
+   :has-field-values           :auto-list
+   :settings                   nil
+   :caveats                    nil
+   :fk-target-field-id         nil
+   :active                     true
+   :nfc-path                   nil
+   :parent-id                  nil
+   :database-is-auto-increment false
+   :json-unfolding             false
+   :position                   4
+   :custom-position            4
+   :database-position          4
+   :visibility-type            :normal
+   :preview-display            true
+   :database-required          true
+   :points-of-interest         nil
+   :fingerprint                {:global {:distinct-count 150, :nil% 0.0}
+                                :type   {:type/Text {:percent-json   0.0
+                                                     :percent-url    0.0
+                                                     :percent-email  0.0
+                                                     :percent-state  0.0
+                                                     :average-length 301.9}}}
+   :lib/type                   :metadata/column})
+
+(defmethod table-metadata-method :gh/comments
+  [_table-name]
+  {:description             nil
+   :entity-type             :entity/GenericTable
+   :schema                  "public"
+   :show-in-getting-started false
+   :name                    "GH_COMMENTS"
+   :caveats                 nil
+   :active                  true
+   :id                      (id :gh/comments)
+   :db-id                   (id)
+   :visibility-type         nil
+   :field-order             :database
+   :is-upload               false
+   :initial-sync-status     :complete
+   :display-name            "GH Comments"
+   :points-of-interest      nil
+   :lib/type                :metadata/table
+   :fields                  [(field-metadata-method :gh/comments :id)
+                             (field-metadata-method :gh/comments :author-id)
+                             (field-metadata-method :gh/comments :posted-at)
+                             (field-metadata-method :gh/comments :reply-to)
+                             (field-metadata-method :gh/comments :body-markdown)]})
+
 (def metadata
   "Complete Database metadata for testing, captured from a call to `GET /api/database/:id/metadata`. For the H2 version
   of `test-data`. This is a representative example of the metadata the FE Query Builder would have available to it.
@@ -2403,7 +2984,10 @@
                                  (table-metadata-method :people)
                                  (table-metadata-method :reviews)
                                  (table-metadata-method :ic/accounts)
-                                 (table-metadata-method :ic/reports)]
+                                 (table-metadata-method :ic/reports)
+                                 (table-metadata-method :gh/issues)
+                                 (table-metadata-method :gh/users)
+                                 (table-metadata-method :gh/comments)]
    :creator-id                  nil
    :is-full-sync                true
    :cache-ttl                   nil
@@ -2437,7 +3021,7 @@
 (mu/defn tables :- [:set :keyword]
   "Set of valid table names."
   []
-  (set (keys (methods table-metadata-method))))
+  (into (sorted-set) (keys (methods table-metadata-method))))
 
 (mu/defn fields :- [:set :keyword]
   "Set of valid table names for a `:table-name`."


### PR DESCRIPTION
Part of #49687.

### Description

**Joined columns**

- `join__${IDENT_OF_JOIN_CLAUSE}__${IDENT_OF_COLUMN}` for explicit
  joins
- `implicit_via__${IDENT_OF_FK_COLUMN}__->__${IDENT_OF_TARGET_COLUMN}`
  for implicit joins

These fulfill the contract for column `:ident`s:
- Unique identity within one stage of a query
- Globally unique
    - Note that the same implicitly joined column (eg.
      `Products via Orders.PRODUCT_ID`) might be referenced in
      many queries, but it's the **same column** - same `display_name`,
      types, etc.

**New test metadata**

In order to test these properly, I needed test metadata with more
permutations of FKs.

I've added three new tables to `metabase.lib.test-metadata`, which are a
simplified version of Github issues, users and comments. The tables are
`:gh/issues`, `:gh/users` and `:gh/comments`.

Some notable things:
- `:gh/users` has a `:type/Text` PK, ie. Github usernames
- `:gh/issues` and `:gh/comments` have `:type/UUID` PKs
- `:gh/issues` has **two** FKs to `:gh/users`: `:reporter-id` and
  `:assignee-id`.
- `:gh/comments` has a **self FK**: `:reply-to`
- `:gh/issues :closed-at` is a `NULL`able `:type/DateTime` column, which
  we lacked previously


### How to verify

Check out the new metadata in the tests, eg. `metabase.lib.metadata.calculation-test`
where they're used to test the new `:ident`s in various explicit/implicit join scenarios.

Nothing is consuming the new `:ident`s yet, so there's nothing in particular to verify.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
