### PR TITLE
Add trace logging for search index queue, and fix timer

### DIFF
--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -33,7 +33,8 @@
   search-context]
 
  [search.ingestion
-  process-next-batch!]
+  bulk-ingest!
+  get-next-batch!]
 
  [search.spec
   define-spec])

--- a/src/metabase/task/search_index.clj
+++ b/src/metabase/task/search_index.clj
@@ -66,8 +66,10 @@
 (defn- update-index! []
   (when (search/supports-index?)
     (while true
-      (let [timer    (u/start-timer)
-            report   (search/process-next-batch! Long/MAX_VALUE 100)
+      (let [batch    (search/get-next-batch! Long/MAX_VALUE 100)
+            _        (log/trace "Processing batch" batch)
+            timer    (u/start-timer)
+            report   (search/bulk-ingest! batch)
             duration (u/since-ms timer)]
         (when (seq report)
           (report->prometheus! duration report)


### PR DESCRIPTION
This adds trace logging around what is put on and taken from the search indexing queue.

While making this change, I noticed that we were including the waiting time in the processing time metrics. To fix this I needed to break the processing method in half.