### PR TITLE
Upgrade Athena jdbc driver to 3.3.0

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -212,6 +212,7 @@
  ;; `:drivers` alias instead.
  :mvn/repos
  {"athena"   {:url "https://s3.amazonaws.com/maven-athena"}
+  "metabase-maven-downloads" {:url "https://s3.amazonaws.com/metabase-maven-downloads"}
   "redshift" {:url "https://s3.amazonaws.com/redshift-maven-repository/release"}
   ;; for metabase/saml20-clj
   "opensaml" {:url "https://build.shibboleth.net/nexus/content/repositories/releases/"}}

--- a/deps.edn
+++ b/deps.edn
@@ -211,8 +211,7 @@
  ;; https://ask.clojure.org/index.php/12367/support-mvn-repos-inside-an-alias -- if we could, this could go in the
  ;; `:drivers` alias instead.
  :mvn/repos
- {"athena"   {:url "https://s3.amazonaws.com/maven-athena"}
-  "metabase-maven-downloads" {:url "https://s3.amazonaws.com/metabase-maven-downloads"}
+ {"metabase-maven-downloads" {:url "https://s3.amazonaws.com/metabase-maven-downloads"}
   "redshift" {:url "https://s3.amazonaws.com/redshift-maven-repository/release"}
   ;; for metabase/saml20-clj
   "opensaml" {:url "https://build.shibboleth.net/nexus/content/repositories/releases/"}}

--- a/modules/drivers/athena/deps.edn
+++ b/modules/drivers/athena/deps.edn
@@ -2,8 +2,7 @@
  ["src" "resources"]
 
  :mvn/repos
- {"athena" {:url "https://s3.amazonaws.com/maven-athena"}}
+ {"metabase-maven-downloads" {:url "https://s3.amazonaws.com/metabase-maven-downloads"}}
 
  :deps
- {com.amazonaws/aws-java-sdk-core {:mvn/version "1.12.779"}
-  com.metabase/athena-jdbc {:mvn/version "2.0.35"}}}
+ {com.metabase/athena-jdbc {:mvn/version "3.3.0"}}}

--- a/modules/drivers/athena/resources/metabase-plugin.yaml
+++ b/modules/drivers/athena/resources/metabase-plugin.yaml
@@ -50,4 +50,4 @@ init:
   - step: load-namespace
     namespace: metabase.driver.athena
   - step: register-jdbc-driver
-    class: com.simba.athena.jdbc.Driver
+    class: com.amazon.athena.jdbc.AthenaDriver

--- a/modules/drivers/athena/src/metabase/driver/athena.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena.clj
@@ -77,7 +77,7 @@
                :db :catalog :metabase.driver.athena/schema
                ;; Remove 2.x jdbc driver version options from details. Those are mapped to appropriate 3.x keys few
                ;; on preceding lines
-               :region :access_key :secret_key :s3_staging_dir :workgroup :catalog))
+               :region :access_key :secret_key :s3_staging_dir :workgroup))
       (sql-jdbc.common/handle-additional-options details, :seperator-style :semicolon)))
 
 (defmethod sql-jdbc.conn/data-source-name :athena

--- a/modules/drivers/athena/src/metabase/driver/athena.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena.clj
@@ -15,12 +15,13 @@
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.premium-features.core :as premium-features]
+   [metabase.query-processor.timezone :as qp.timezone]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.log :as log])
   (:import
-   (java.sql Connection DatabaseMetaData)
+   (java.sql Connection DatabaseMetaData Date ResultSet Time Timestamp Types)
    (java.time OffsetDateTime ZonedDateTime)
    [java.util UUID]))
 
@@ -57,22 +58,26 @@
 (defmethod sql-jdbc.conn/connection-details->spec :athena
   [_driver {:keys [region access_key secret_key s3_staging_dir workgroup catalog], :as details}]
   (-> (merge
-       {:classname      "com.simba.athena.jdbc.Driver"
-        :subprotocol    "awsathena"
+       {:classname      "com.amazon.athena.jdbc.AthenaDriver"
+        :subprotocol    "athena"
         :subname        (str "//athena." region (endpoint-for-region region) ":443")
-        :user           access_key
-        :password       secret_key
-        :s3_staging_dir s3_staging_dir
-        :workgroup      workgroup
-        :AwsRegion      region}
+        :User           access_key
+        :Password       secret_key
+        :OutputLocation s3_staging_dir
+        :WorkGroup      workgroup
+        :Region      region}
        (when (and (not (premium-features/is-hosted?)) (str/blank? access_key))
-         {:AwsCredentialsProviderClass "com.simba.athena.amazonaws.auth.DefaultAWSCredentialsProviderChain"})
+         {:CredentialsProvider "DefaultChain"})
        (when-not (str/blank? catalog)
          {:MetadataRetrievalMethod "ProxyAPI"
           :Catalog                 catalog})
-       ;; `:metabase.driver.athena/schema` is just a gross hack for testing so we can treat multiple tests datasets as
-       ;; different DBs -- see [[metabase.driver.athena/fast-active-tables]]. Not used outside of tests.
-       (dissoc details :db :catalog :metabase.driver.athena/schema))
+       (dissoc details
+               ;; `:metabase.driver.athena/schema` is just a gross hack for testing so we can treat multiple tests datasets as
+               ;; different DBs -- see [[metabase.driver.athena/fast-active-tables]]. Not used outside of tests. -- Cam
+               :db :catalog :metabase.driver.athena/schema
+               ;; Remove 2.x jdbc driver version options from details. Those are mapped to appropriate 3.x keys few
+               ;; on preceding lines
+               :region :access_key :secret_key :s3_staging_dir :workgroup :catalog))
       (sql-jdbc.common/handle-additional-options details, :seperator-style :semicolon)))
 
 (defmethod sql-jdbc.conn/data-source-name :athena
@@ -147,6 +152,39 @@
             nil))))
 
     ((get-method sql-jdbc.execute/read-column-thunk [:sql-jdbc java.sql.Types/VARCHAR]) driver rs rsmeta i)))
+
+(defmethod sql-jdbc.execute/read-column-thunk [:athena Types/TIMESTAMP_WITH_TIMEZONE]
+  [_driver ^ResultSet rs _rs-meta ^Long i]
+  (fn []
+    ;; Using OffsetDateTime to be consistent with :sql-jdbc implementation
+    (let [^Timestamp timestamp (.getObject rs i Timestamp)
+          timestamp-instant (.toInstant timestamp)
+          results-timezone (qp.timezone/results-timezone-id)]
+      (try
+        (.toOffsetDateTime (t/zoned-date-time timestamp-instant (t/zone-id results-timezone)))
+        (catch Throwable _
+          (log/warnf "Failed to construct ZonedDateTime from `%s` using `%s` timezone."
+                     (pr-str timestamp-instant)
+                     (pr-str results-timezone))
+          (try
+            (t/offset-date-time timestamp-instant results-timezone)
+            (catch Throwable _
+              (log/warnf "Failed to construct OffsetDateTime from `%s` using `%s` offset. Using `Z` fallback."
+                         (pr-str timestamp-instant)
+                         (pr-str results-timezone))
+              (t/offset-date-time timestamp-instant "Z"))))))))
+
+(defmethod sql-jdbc.execute/read-column-thunk [:athena Types/TIMESTAMP]
+  [_driver ^ResultSet rs _rs-meta ^Long i]
+  (fn [] (.toLocalDateTime ^Timestamp (.getObject rs i Timestamp))))
+
+(defmethod sql-jdbc.execute/read-column-thunk [:athena Types/DATE]
+  [_driver ^ResultSet rs _rs-meta ^Long i]
+  (fn [] (.toLocalDate ^Date (.getObject rs i Date))))
+
+(defmethod sql-jdbc.execute/read-column-thunk [:athena Types/TIME]
+  [_driver ^ResultSet rs _rs-meta ^Long i]
+  (fn [] (.toLocalTime ^Time (.getObject rs i Time))))
 
 ;;; ------------------------------------------------- date functions -------------------------------------------------
 
@@ -336,9 +374,19 @@
         (distinct)                                     ; driver can return twice the partitioning fields
         (map describe-database->clj)))
 
+(defn- normalize-field-info
+  "Normalize values [[describe-table-fields-with-nested-fields]]. The JDBC driver of version 3.3 returns results of
+  `DESCRIBE...` as {:_col0 \"<name>\t<typename>\t<remark>\"}."
+  [raw-field-info]
+  (let [field-info-str (:_col0 raw-field-info)
+        components (map (comp not-empty str/trim) (str/split field-info-str #"\t"))
+        field-info (zipmap [:col_name :data_type :remark] components)]
+    (into {} (remove (fn [[_ v]] (nil? v))) field-info)))
+
 (defn- describe-table-fields-with-nested-fields [database schema table-name]
   (into #{}
-        (comp (remove-invalid-columns)
+        (comp (map normalize-field-info)
+              (remove-invalid-columns)
               (map-indexed (fn [i column-metadata]
                              (assoc column-metadata :database-position i)))
               (map athena.schema-parser/parse-schema))
@@ -363,18 +411,27 @@
 (defn- table-has-nested-fields? [columns]
   (some #(= "struct" (:type_name %)) columns))
 
+(defn- get-columns
+  [^DatabaseMetaData metadata catalog schema table-name]
+  (try
+    (with-open [rs (.getColumns metadata catalog schema table-name nil)]
+      (jdbc/metadata-result rs))
+    (catch Throwable e
+      (log/warnf "`.getColumns` failed for catalog `%s`, schema `%s`, table name `%s` with message: `%s`"
+                 catalog schema table-name (ex-message e))
+      #{})))
+
 (defn describe-table-fields
   "Returns a set of column metadata for `schema` and `table-name` using `metadata`. "
   [^DatabaseMetaData metadata database driver {^String schema :schema, ^String table-name :name} catalog]
   (try
-    (with-open [rs (.getColumns metadata catalog schema table-name nil)]
-      (let [columns (jdbc/metadata-result rs)]
-        (if (or (table-has-nested-fields? columns)
+    (let [columns (get-columns metadata catalog schema table-name)]
+      (if (or (table-has-nested-fields? columns)
                 ; If `.getColumns` returns an empty result, try to use DESCRIBE, which is slower
                 ; but doesn't suffer from the bug in the JDBC driver as metabase#43980
-                (empty? columns))
-          (describe-table-fields-with-nested-fields database schema table-name)
-          (describe-table-fields-without-nested-fields driver columns))))
+              (empty? columns))
+        (describe-table-fields-with-nested-fields database schema table-name)
+        (describe-table-fields-without-nested-fields driver columns)))
     (catch Throwable e
       (log/errorf e "Error retreiving fields for DB %s.%s" schema table-name)
       (throw e))))
@@ -394,22 +451,39 @@
                         (describe-table-fields metadata database driver table catalog)
                         (catch Throwable _
                           (set nil))))))))
-
 (defn- get-tables
-  "Athena can query EXTERNAL and MANAGED tables."
   [^DatabaseMetaData metadata, ^String schema-or-nil, ^String db-name-or-nil]
   ;; tablePattern "%" = match all tables
   (with-open [rs (.getTables metadata db-name-or-nil schema-or-nil "%"
-                             (into-array String ["EXTERNAL_TABLE"
-                                                 "EXTERNAL TABLE"
-                                                 "EXTERNAL"
-                                                 "TABLE"
-                                                 "VIEW"
-                                                 "VIRTUAL_VIEW"
-                                                 "FOREIGN TABLE"
-                                                 "MATERIALIZED VIEW"
-                                                 "MANAGED_TABLE"]))]
+                             (into-array String ["TABLE"
+                                                 "VIEW"]))]
     (vec (jdbc/metadata-result rs))))
+
+#_:clj-kondo/ignore
+(comment
+  ;; Script on next lines was used to get available table types, used in the `get-tables` implementation.
+  (with-open [conn (clojure.java.jdbc/get-connection
+                    (sql-jdbc.conn/connection-details->spec
+                     :athena
+                     (metabase.test.data.interface/dbdef->connection-details
+                      :athena :server (metabase.test.data.interface/get-dataset-definition
+                                       metabase.test.data.dataset-definitions/test-data))))]
+    (let [db-meta-rs (.getMetaData conn)]
+      (with-open [table-types (.getTableTypes db-meta-rs)]
+        (let [table-types-meta (.getMetaData table-types)
+              columns (mapv (fn [idx]
+                              {:column-name (.getColumnName table-types-meta idx)
+                               :column-label (.getColumnLabel table-types-meta idx)})
+                            (map inc (range (.getColumnCount table-types-meta))))
+              rows (loop [rows []]
+                     (.next table-types)
+                     (if (.isAfterLast table-types)
+                       rows
+                       (recur (conj rows (mapv (fn [idx]
+                                                 (.getObject table-types idx))
+                                               (map inc (range (.getColumnCount table-types-meta))))))))]
+          [columns rows]))))
+  )
 
 (defn- fast-active-tables
   "Required because we're calling our own custom private get-tables method to support Athena.

--- a/modules/drivers/athena/test/metabase/driver/athena_test.clj
+++ b/modules/drivers/athena/test/metabase/driver/athena_test.clj
@@ -1,6 +1,5 @@
 (ns ^:mb/driver-tests metabase.driver.athena-test
   (:require
-   #_[clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.driver :as driver]
@@ -20,9 +19,7 @@
    [metabase.test.data.interface :as tx]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
-   [toucan2.core :as t2])
-  #_(:import
-   (java.sql Connection)))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -260,13 +257,13 @@
                 ;; If this test fails and .getColumns returns results, the athena JDBC driver has been fixed and we can
                 ;; undo the changes in https://github.com/metabase/metabase/pull/44032
                 (is (seq (sql-jdbc.execute/do-with-connection-with-options
-                             :athena
-                             db
-                             nil
-                             (fn [^Connection conn]
-                               (let [metadata (.getMetaData conn)]
-                                 (with-open [rs (.getColumns metadata catalog (:schema table) (:name table) nil)]
-                                   (jdbc/metadata-result rs))))))))
+                          :athena
+                          db
+                          nil
+                          (fn [^Connection conn]
+                            (let [metadata (.getMetaData conn)]
+                              (with-open [rs (.getColumns metadata catalog (:schema table) (:name table) nil)]
+                                (jdbc/metadata-result rs))))))))
             (testing "`describe-table` returns the fields anyway"
               (is (not-empty (:fields (driver/describe-table :athena db table)))))))))))
 

--- a/modules/drivers/athena/test/metabase/driver/athena_test.clj
+++ b/modules/drivers/athena/test/metabase/driver/athena_test.clj
@@ -104,7 +104,7 @@
               (is (= #t "05:03"
                      t)))))))))
 
-(deftest ^:parallel set-time-and-timestamp-with-time-zone-test
+(deftest ^:synchronized set-time-and-timestamp-with-time-zone-test
   ;; The 3.3.0 Athena jdbc driver returns timestamp not as java.sql.Types/VARCHAR but is using dedicated temporal types.
   ;; The class that represents temporal value is java.sql.Timestamp. Hence the read-column-thunk implementation uses
   ;; `qp.timezone/results-timezone-id` to convert returned value into appropriate timezone.

--- a/modules/drivers/athena/test/metabase/test/data/athena.clj
+++ b/modules/drivers/athena/test/metabase/test/data/athena.clj
@@ -220,7 +220,7 @@
    (server-connection-spec)
    nil
    (fn [^java.sql.Connection conn]
-     (let [dbs (into #{} (map :database_name) (jdbc/query {:connection conn} ["SHOW DATABASES;"]))]
+     (let [dbs (into #{} (map :_col0) (jdbc/query {:connection conn} ["SHOW DATABASES;"]))]
        (log/infof "The following Athena databases have already been created: %s" (pr-str (sort dbs)))
        dbs))))
 

--- a/modules/drivers/deps.edn
+++ b/modules/drivers/deps.edn
@@ -3,8 +3,7 @@
  ;; apparently done on purpose, as a security thing. See
  ;; https://ask.clojure.org/index.php/10726/deps-manifest-dependencies-respect-repos-dependent-project
  :mvn/repos
- {"athena"   {:url "https://s3.amazonaws.com/maven-athena"}
-  "metabase-maven-downloads" {:url "https://s3.amazonaws.com/metabase-maven-downloads"}
+ {"metabase-maven-downloads" {:url "https://s3.amazonaws.com/metabase-maven-downloads"}
   "redshift" {:url "https://s3.amazonaws.com/redshift-maven-repository/release"}}
 
  :deps

--- a/modules/drivers/deps.edn
+++ b/modules/drivers/deps.edn
@@ -4,6 +4,7 @@
  ;; https://ask.clojure.org/index.php/10726/deps-manifest-dependencies-respect-repos-dependent-project
  :mvn/repos
  {"athena"   {:url "https://s3.amazonaws.com/maven-athena"}
+  "metabase-maven-downloads" {:url "https://s3.amazonaws.com/metabase-maven-downloads"}
   "redshift" {:url "https://s3.amazonaws.com/redshift-maven-repository/release"}}
 
  :deps


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/35965

This PR upgrades Athena jdbc driver to 3.3.0. Notable changes:

- Maven repository is stored in different location ([slack thread](https://metaboat.slack.com/archives/C04DN5VRQM6/p1717417986335689)),
- types previously returned via Types/VARCHAR are not anymore,
- different shape of DESCRIBE results,
- differences in getTables results,
- differences in connection properties.