### PR TITLE
Fix 53rd week formatting

### DIFF
--- a/frontend/src/metabase/lib/formatting/date.tsx
+++ b/frontend/src/metabase/lib/formatting/date.tsx
@@ -26,7 +26,7 @@ const DEFAULT_DATE_FORMATS: DEFAULT_DATE_FORMATS_TYPE = {
   "day-of-week": "dddd",
   "day-of-month": "D",
   "day-of-year": "DDD",
-  "week-of-year": "wo",
+  "week-of-year": "Wo",
   "month-of-year": "MMMM",
   "quarter-of-year": "[Q]Q",
 };

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -681,6 +681,11 @@ describe("formatting", () => {
         ).toEqual(formatted);
       },
     );
+
+    it.each([1, 2, 52, 53])("should format week numbers correctly", value => {
+      const text = formatDateTimeWithUnit(value, "week-of-year");
+      expect(text).toMatch(new RegExp(`${value}[a-z]+`));
+    });
   });
 
   describe("formatTime", () => {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/51777
Follow up for https://github.com/metabase/metabase/pull/51892

The previous fix didn't fully solve the problem. It fixed parsing but not formatting.

In the previous PR we parsed week-of-year numbers as iso week numbers to support the 53rd week of year, but didn't formatted them as iso week numbers. This PR fixes formatting.