### PR TITLE
introduce tree-shaking of helpers by adding them to the Cypress object

### DIFF
--- a/e2e/.eslintrc
+++ b/e2e/.eslintrc
@@ -45,6 +45,7 @@
         ]
       }
     ],
+    "no-direct-helper-import": 2,
     "no-unsafe-element-filtering": ["warn"]
   },
   "env": {

--- a/e2e/support/commands.js
+++ b/e2e/support/commands.js
@@ -1,3 +1,5 @@
+// this is the only place we allow direct helper import
+// eslint-disable-next-line no-direct-helper-import
 import { H } from "e2e/support";
 
 import "./commands/ui/button";

--- a/e2e/support/commands.js
+++ b/e2e/support/commands.js
@@ -1,3 +1,5 @@
+import { H } from "e2e/support";
+
 import "./commands/ui/button";
 import "./commands/ui/icon";
 
@@ -19,3 +21,5 @@ import "./commands/component";
 
 import { addCustomCommands } from "./commands/downloads/downloadUtils";
 addCustomCommands();
+
+cy.H = { ...H };

--- a/e2e/support/helpers/e2e-api-key-helpers.ts
+++ b/e2e/support/helpers/e2e-api-key-helpers.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 export const visitApiKeySettings = () => {
   cy.visit("/admin/settings/authentication/api-keys");

--- a/e2e/support/helpers/e2e-api-key-helpers.ts
+++ b/e2e/support/helpers/e2e-api-key-helpers.ts
@@ -1,4 +1,5 @@
-const { H } = cy;
+// eslint-disable-next-line no-direct-helper-import
+import { H } from "e2e/support";
 
 export const visitApiKeySettings = () => {
   cy.visit("/admin/settings/authentication/api-keys");

--- a/e2e/support/index.ts
+++ b/e2e/support/index.ts
@@ -1,4 +1,14 @@
 // H is for helpers 🤗
 import * as H from "./helpers";
 
+type HelperTypes = typeof H;
+
+declare global {
+  namespace Cypress {
+    interface Chainable extends HelperTypes {
+      H: typeof H;
+    }
+  }
+}
+
 export { H };

--- a/e2e/support/integration/visit-dashboard.cy.spec.js
+++ b/e2e/support/integration/visit-dashboard.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { USERS } from "e2e/support/cypress_data";
 
 import { setup } from "./visit-dashboard";

--- a/e2e/test-component/scenarios/embedding-sdk/dashboard-click-behavior.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/dashboard-click-behavior.cy.spec.tsx
@@ -1,6 +1,6 @@
 import { InteractiveDashboard } from "@metabase/embedding-sdk-react";
 
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   POPOVER_ELEMENT,

--- a/e2e/test-component/scenarios/embedding-sdk/tooltip-reproductions.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/tooltip-reproductions.cy.spec.tsx
@@ -1,6 +1,6 @@
 import { InteractiveDashboard } from "@metabase/embedding-sdk-react";
 
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { describeEE } from "e2e/support/helpers";
 import {

--- a/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
@@ -1,6 +1,6 @@
 import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
 
-import { H } from "e2e/support";
+const { H } = cy;
 import { USER_GROUPS, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 
 const WRITABLE_TEST_TABLE = "scoreboard_actions";

--- a/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
@@ -1,6 +1,6 @@
 import { assocIn } from "icepick";
 
-import { H } from "e2e/support";
+const { H } = cy;
 import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { many_data_types_rows } from "e2e/support/test_tables_data";
 import { createMockActionParameter } from "metabase-types/api/mocks";

--- a/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -1,6 +1,6 @@
 import { assocIn } from "icepick";
 
-import { H } from "e2e/support";
+const { H } = cy;
 import {
   SAMPLE_DB_ID,
   USER_GROUPS,

--- a/e2e/test/scenarios/admin-2/api-keys.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/api-keys.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/admin-2/authentication.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/authentication.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 import { setupSaml } from "./sso/shared/helpers.js";
 

--- a/e2e/test/scenarios/admin-2/error-reporting.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/error-reporting.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
 const downloadsFolder = Cypress.config("downloadsFolder");

--- a/e2e/test/scenarios/admin-2/people.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/people.cy.spec.js
@@ -1,6 +1,6 @@
 import _ from "underscore";
 
-import { H } from "e2e/support";
+const { H } = cy;
 import { USERS, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import {
   SAMPLE_DB_ID,
   SAMPLE_DB_SCHEMA_ID,

--- a/e2e/test/scenarios/admin-2/sso/google.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/sso/google.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 const CLIENT_ID_SUFFIX = "apps.googleusercontent.com";
 

--- a/e2e/test/scenarios/admin-2/sso/jwt.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/sso/jwt.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { enableJwtAuth } from "e2e/support/helpers/e2e-jwt-helpers";
 
 import {

--- a/e2e/test/scenarios/admin-2/sso/ldap.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/sso/ldap.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 import {
   checkGroupConsistencyAfterDeletingMappings,

--- a/e2e/test/scenarios/admin-2/sso/saml.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/sso/saml.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 import {
   checkGroupConsistencyAfterDeletingMappings,

--- a/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 function checkFavicon(url) {

--- a/e2e/test/scenarios/admin/admin-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/admin/admin-reproductions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 
 describe("issue 26470", { tags: "@external" }, () => {

--- a/e2e/test/scenarios/admin/databases.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import {
   QA_MONGO_PORT,
   QA_MYSQL_PORT,

--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import {
   SAMPLE_DB_ID,
   SAMPLE_DB_SCHEMA_ID,

--- a/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import {
   SAMPLE_DB_ID,
   SAMPLE_DB_SCHEMA_ID,

--- a/e2e/test/scenarios/admin/datamodel/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/reproductions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import {
   SAMPLE_DB_ID,
   SAMPLE_DB_SCHEMA_ID,

--- a/e2e/test/scenarios/admin/performance/clock.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/clock.cy.spec.ts
@@ -1,7 +1,7 @@
 import dayjs from "dayjs";
 import timezone from "dayjs/plugin/timezone";
 
-import { H } from "e2e/support";
+const { H } = cy;
 dayjs.extend(timezone);
 
 import {

--- a/e2e/test/scenarios/admin/performance/dashboardsAndQuestions.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/dashboardsAndQuestions.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 import {
   TEST_TABLE,

--- a/e2e/test/scenarios/admin/performance/schedule.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/schedule.cy.spec.ts
@@ -1,6 +1,6 @@
 import _ from "underscore";
 
-import { H } from "e2e/support";
+const { H } = cy;
 import type { ScheduleComponentType } from "metabase/components/Schedule/constants";
 import type { CacheableModel } from "metabase-types/api";
 

--- a/e2e/test/scenarios/admin/performance/strategyForm.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/strategyForm.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_QUESTION_ID,

--- a/e2e/test/scenarios/admin/query-validator.cy.spec.js
+++ b/e2e/test/scenarios/admin/query-validator.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
 
 import { createNativeQuestion } from "../../../support/helpers/api/createNativeQuestion";

--- a/e2e/test/scenarios/admin/troubleshooting.cy.spec.js
+++ b/e2e/test/scenarios/admin/troubleshooting.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 describe("scenarios > admin > troubleshooting > help", () => {
   beforeEach(() => {

--- a/e2e/test/scenarios/binning/binning-options.cy.spec.js
+++ b/e2e/test/scenarios/binning/binning-options.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/binning/binning-reproductions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/binning/correctness/longitude.cy.spec.js
+++ b/e2e/test/scenarios/binning/correctness/longitude.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 import { LONGITUDE_OPTIONS } from "./shared/constants";
 

--- a/e2e/test/scenarios/binning/correctness/time-series.cy.spec.js
+++ b/e2e/test/scenarios/binning/correctness/time-series.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 import { TIME_OPTIONS } from "./shared/constants";

--- a/e2e/test/scenarios/binning/qb-explicit-joins.cy.spec.js
+++ b/e2e/test/scenarios/binning/qb-explicit-joins.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS_ID, ORDERS, PEOPLE_ID, PEOPLE, PRODUCTS_ID, PRODUCTS } =

--- a/e2e/test/scenarios/binning/qb-implicit-joins.cy.spec.js
+++ b/e2e/test/scenarios/binning/qb-implicit-joins.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 /**

--- a/e2e/test/scenarios/binning/qb-regular-table.cy.spec.js
+++ b/e2e/test/scenarios/binning/qb-regular-table.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS_ID, PEOPLE_ID } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/binning/reproductions/23851-drill-temporal-extraction.cy.spec.js
+++ b/e2e/test/scenarios/binning/reproductions/23851-drill-temporal-extraction.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/binning/reproductions/34688-34690-time-series-footer.cy.spec.js
+++ b/e2e/test/scenarios/binning/reproductions/34688-34690-time-series-footer.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/binning/sql.cy.spec.js
+++ b/e2e/test/scenarios/binning/sql.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 
 const questionDetails = {

--- a/e2e/test/scenarios/collections/cleanup.cy.spec.js
+++ b/e2e/test/scenarios/collections/cleanup.cy.spec.js
@@ -2,7 +2,7 @@ import dayjs from "dayjs";
 import { assocIn } from "icepick";
 import { P, isMatching } from "ts-pattern";
 
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_TABLES } from "e2e/support/cypress_data";
 import {
   FIRST_COLLECTION_ID,

--- a/e2e/test/scenarios/collections/collection-pinned-overview.cy.spec.js
+++ b/e2e/test/scenarios/collections/collection-pinned-overview.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_COUNT_QUESTION_ID,

--- a/e2e/test/scenarios/collections/collections-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections-reproductions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import {
   ADMIN_PERSONAL_COLLECTION_ID,
   FIRST_COLLECTION_ID,

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -1,7 +1,7 @@
 import { assocIn } from "icepick";
 import _ from "underscore";
 
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, USERS, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/collections/instance-analytics.cy.spec.js
+++ b/e2e/test/scenarios/collections/instance-analytics.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,

--- a/e2e/test/scenarios/collections/permissions.cy.spec.js
+++ b/e2e/test/scenarios/collections/permissions.cy.spec.js
@@ -1,6 +1,6 @@
 import { onlyOn } from "@cypress/skip-test";
 
-import { H } from "e2e/support";
+const { H } = cy;
 import { USERS } from "e2e/support/cypress_data";
 import { FIRST_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data.js";
 

--- a/e2e/test/scenarios/collections/personal-collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/personal-collections.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { USERS } from "e2e/support/cypress_data";
 import {
   ADMIN_PERSONAL_COLLECTION_ID,

--- a/e2e/test/scenarios/collections/revision-history.cy.spec.js
+++ b/e2e/test/scenarios/collections/revision-history.cy.spec.js
@@ -1,6 +1,6 @@
 import { onlyOn } from "@cypress/skip-test";
 
-import { H } from "e2e/support";
+const { H } = cy;
 import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,

--- a/e2e/test/scenarios/collections/trash.cy.spec.js
+++ b/e2e/test/scenarios/collections/trash.cy.spec.js
@@ -1,6 +1,6 @@
 import { P, isMatching } from "ts-pattern";
 
-import { H } from "e2e/support";
+const { H } = cy;
 import {
   FIRST_COLLECTION_ID,
   ORDERS_COUNT_QUESTION_ID,

--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { USER_GROUPS, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { FIRST_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data";
 

--- a/e2e/test/scenarios/cross-version/source/01-generate-metadata.cy.spec.js
+++ b/e2e/test/scenarios/cross-version/source/01-generate-metadata.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 it("should generate metadata", () => {
   cy.signInAsAdmin();

--- a/e2e/test/scenarios/cross-version/source/03-questions.cy.spec.js
+++ b/e2e/test/scenarios/cross-version/source/03-questions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import {
   fillAreaUnderLineChart,
   newQuestion,

--- a/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import type { CardId, DashboardParameterMapping } from "metabase-types/api";
 import { createMockDashboardCard } from "metabase-types/api/mocks";

--- a/e2e/test/scenarios/custom-column/cc-shortcuts-combine.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-shortcuts-combine.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 
 describe("scenarios > question > custom column > expression shortcuts > combine", () => {

--- a/e2e/test/scenarios/custom-column/cc-shortcuts.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-shortcuts.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 describe("scenarios > question > custom column > typing suggestion", () => {
   beforeEach(() => {

--- a/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-fetching.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-fetching.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import {
   ORDERS_BY_YEAR_QUESTION_ID,
   ORDERS_COUNT_QUESTION_ID,

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
@@ -1,6 +1,6 @@
 import _ from "underscore";
 
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { GRID_WIDTH } from "metabase/lib/dashboard_grid";

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-undo.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-undo.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 describe("scenarios > dashboard cards > undo", () => {
   beforeEach(() => {

--- a/e2e/test/scenarios/dashboard-cards/dashboard-drill.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-drill.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/dashboard-cards/dashcard-replace-question.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashcard-replace-question.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/dashboard-cards/duplicate-dashcards-tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/duplicate-dashcards-tabs.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   createMockDashboardCard,

--- a/e2e/test/scenarios/dashboard-cards/visualization-options.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/visualization-options.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-1-stage.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-1-stage.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 import * as QSHelpers from "./shared/dashboard-filters-query-stages";
 

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-1.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-1.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy
 
 import * as QSHelpers from "./shared/dashboard-filters-query-stages";
 

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-1.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-1.cy.spec.ts
@@ -1,4 +1,4 @@
-const { H } = cy
+const { H } = cy;
 
 import * as QSHelpers from "./shared/dashboard-filters-query-stages";
 

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-2.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-2.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy
 
 import * as QSHelpers from "./shared/dashboard-filters-query-stages";
 

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-2.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-2.cy.spec.ts
@@ -1,4 +1,4 @@
-const { H } = cy
+const { H } = cy;
 
 import * as QSHelpers from "./shared/dashboard-filters-query-stages";
 

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-3.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-3.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy
 
 import * as QSHelpers from "./shared/dashboard-filters-query-stages";
 

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-3.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-3.cy.spec.ts
@@ -1,4 +1,4 @@
-const { H } = cy
+const { H } = cy;
 
 import * as QSHelpers from "./shared/dashboard-filters-query-stages";
 

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-4.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-4.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy
 
 import * as QSHelpers from "./shared/dashboard-filters-query-stages";
 

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-4.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-4.cy.spec.ts
@@ -1,4 +1,4 @@
-const { H } = cy
+const { H } = cy;
 
 import * as QSHelpers from "./shared/dashboard-filters-query-stages";
 

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage.cy.spec.ts
@@ -1,0 +1,1585 @@
+const { H } = cy;
+
+import * as QSHelpers from "./shared/dashboard-filters-query-stages";
+
+/**
+ * Empty section title element is rendered.
+ * TODO: https://github.com/metabase/metabase/issues/47218
+ */
+const NAMELESS_SECTION = "";
+
+/**
+ * Abbreviations used for card aliases in this test suite:
+ *  qbq = question-based question
+ *  qbm = question-based model
+ *  mbq = model-based question
+ *  mbm = model-based model
+ */
+describe("scenarios > dashboard > filters > query stages", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    QSHelpers.createBaseQuestions();
+
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.intercept("GET", "/api/dashboard/**").as("getDashboard");
+    cy.intercept("PUT", "/api/dashboard/**").as("updateDashboard");
+    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
+      "dashboardData",
+    );
+    cy.intercept("GET", "/api/public/dashboard/*/dashcard/*/card/*").as(
+      "publicDashboardData",
+    );
+    cy.intercept("GET", "/api/embed/dashboard/*/dashcard/*/card/*").as(
+      "embeddedDashboardData",
+    );
+  });
+
+  describe("2-stage queries", () => {
+    describe("Q5 - Q4 + 2nd stage with join, custom column, no aggregations, no breakouts", () => {
+      beforeEach(() => {
+        QSHelpers.createAndVisitDashboardWithCardMatrix(
+          QSHelpers.createQ5Query,
+        );
+      });
+
+      it("allows to map to all relevant columns", () => {
+        H.editDashboard();
+
+        cy.log("## date columns");
+        QSHelpers.getFilter("Date").click();
+        verifyDateMappingOptions();
+
+        cy.log("## text columns");
+        QSHelpers.getFilter("Text").click();
+        verifyTextMappingOptions();
+
+        cy.log("## number columns");
+        QSHelpers.getFilter("Number").click();
+        verifyNumberMappingOptions();
+
+        function verifyDateMappingOptions() {
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.QUESTION_BASED_QUESTION_INDEX,
+            [
+              ["Base Orders Question", QSHelpers.ORDERS_DATE_COLUMNS],
+              [
+                "Reviews",
+                [
+                  ...QSHelpers.REVIEWS_DATE_COLUMNS,
+                  ...QSHelpers.REVIEWS_DATE_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              [
+                "Product",
+                [
+                  ...QSHelpers.PRODUCTS_DATE_COLUMNS,
+                  ...QSHelpers.PRODUCTS_DATE_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              ["User", QSHelpers.PEOPLE_DATE_COLUMNS],
+              ["Summaries", ["Created At: Month", "Created At: Year"]],
+            ],
+          );
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.MODEL_BASED_QUESTION_INDEX,
+            [
+              ["Base Orders Model", QSHelpers.ORDERS_DATE_COLUMNS],
+              [
+                "Reviews",
+                [
+                  ...QSHelpers.REVIEWS_DATE_COLUMNS,
+                  ...QSHelpers.REVIEWS_DATE_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              [
+                "Product",
+                [
+                  ...QSHelpers.PRODUCTS_DATE_COLUMNS,
+                  ...QSHelpers.PRODUCTS_DATE_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              ["User", QSHelpers.PEOPLE_DATE_COLUMNS],
+              ["Summaries", ["Created At: Month", "Created At: Year"]],
+            ],
+          );
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.QUESTION_BASED_MODEL_INDEX,
+            [
+              [
+                NAMELESS_SECTION,
+                ["Created At: Month", "User → Created At: Year"],
+              ],
+            ],
+          );
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.MODEL_BASED_MODEL_INDEX,
+            [
+              [
+                NAMELESS_SECTION,
+                ["Created At: Month", "User → Created At: Year"],
+              ],
+            ],
+          );
+        }
+
+        function verifyTextMappingOptions() {
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.QUESTION_BASED_QUESTION_INDEX,
+            [
+              [
+                "Reviews",
+                [
+                  ...QSHelpers.REVIEWS_TEXT_COLUMNS,
+                  ...QSHelpers.REVIEWS_TEXT_COLUMNS,
+                ],
+              ],
+              [
+                "Product",
+                [
+                  ...QSHelpers.PRODUCTS_TEXT_COLUMNS,
+                  ...QSHelpers.PRODUCTS_TEXT_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              ["User", QSHelpers.PEOPLE_TEXT_COLUMNS],
+              ["Summaries", ["Category"]],
+            ],
+          );
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.MODEL_BASED_QUESTION_INDEX,
+            [
+              [
+                "Reviews",
+                [
+                  ...QSHelpers.REVIEWS_TEXT_COLUMNS,
+                  ...QSHelpers.REVIEWS_TEXT_COLUMNS,
+                ],
+              ],
+              [
+                "Product",
+                [
+                  ...QSHelpers.PRODUCTS_TEXT_COLUMNS,
+                  ...QSHelpers.PRODUCTS_TEXT_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              ["User", QSHelpers.PEOPLE_TEXT_COLUMNS],
+              ["Summaries", ["Category"]],
+            ],
+          );
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.QUESTION_BASED_MODEL_INDEX,
+            [[NAMELESS_SECTION, ["Product → Category"]]],
+          );
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.MODEL_BASED_MODEL_INDEX,
+            [[NAMELESS_SECTION, ["Product → Category"]]],
+          );
+        }
+
+        function verifyNumberMappingOptions() {
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.QUESTION_BASED_QUESTION_INDEX,
+            [
+              [
+                "Base Orders Question",
+                [...QSHelpers.ORDERS_NUMBER_COLUMNS, "Net"],
+              ],
+              [
+                "Reviews",
+                [
+                  ...QSHelpers.REVIEWS_NUMBER_COLUMNS,
+                  ...QSHelpers.REVIEWS_NUMBER_COLUMNS,
+                ],
+              ],
+              [
+                "Product",
+                [
+                  ...QSHelpers.PRODUCTS_NUMBER_COLUMNS,
+                  ...QSHelpers.PRODUCTS_NUMBER_COLUMNS,
+                ], // TODO: https://github.com/metabase/metabase/issues/46845
+              ],
+              ["User", QSHelpers.PEOPLE_NUMBER_COLUMNS],
+              ["Summaries", ["Count", "Sum of Total", "5 * Count"]],
+            ],
+          );
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.MODEL_BASED_QUESTION_INDEX,
+            [
+              [
+                "Base Orders Model",
+                [...QSHelpers.ORDERS_NUMBER_COLUMNS, "Net"],
+              ],
+              [
+                "Reviews",
+                [
+                  ...QSHelpers.REVIEWS_NUMBER_COLUMNS,
+                  ...QSHelpers.REVIEWS_NUMBER_COLUMNS,
+                ],
+              ],
+              [
+                "Product",
+                [
+                  ...QSHelpers.PRODUCTS_NUMBER_COLUMNS,
+                  ...QSHelpers.PRODUCTS_NUMBER_COLUMNS,
+                ], // TODO: https://github.com/metabase/metabase/issues/46845
+              ],
+              ["User", QSHelpers.PEOPLE_NUMBER_COLUMNS],
+              ["Summaries", ["Count", "Sum of Total", "5 * Count"]],
+            ],
+          );
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.QUESTION_BASED_MODEL_INDEX,
+            [[NAMELESS_SECTION, ["Count", "Sum of Total", "5 * Count"]]],
+          );
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.MODEL_BASED_MODEL_INDEX,
+            [[NAMELESS_SECTION, ["Count", "Sum of Total", "5 * Count"]]],
+          );
+        }
+      });
+    });
+
+    describe("Q6 - Q4 + 2nd stage with join, custom column, 2 aggregations, no breakouts", () => {
+      beforeEach(() => {
+        QSHelpers.createAndVisitDashboardWithCardMatrix(
+          QSHelpers.createQ6Query,
+        );
+      });
+
+      it("allows to map to all relevant columns", () => {
+        H.editDashboard();
+
+        cy.log("## date columns");
+        QSHelpers.getFilter("Date").click();
+        verifyDateMappingOptions();
+
+        cy.log("## text columns");
+        QSHelpers.getFilter("Text").click();
+        verifyTextMappingOptions();
+
+        cy.log("## number columns");
+        QSHelpers.getFilter("Number").click();
+        verifyNumberMappingOptions();
+
+        function verifyDateMappingOptions() {
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.QUESTION_BASED_QUESTION_INDEX,
+            [
+              ["Base Orders Question", QSHelpers.ORDERS_DATE_COLUMNS],
+              [
+                "Reviews",
+                [
+                  ...QSHelpers.REVIEWS_DATE_COLUMNS,
+                  ...QSHelpers.REVIEWS_DATE_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              [
+                "Product",
+                [
+                  ...QSHelpers.PRODUCTS_DATE_COLUMNS,
+                  ...QSHelpers.PRODUCTS_DATE_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              ["User", QSHelpers.PEOPLE_DATE_COLUMNS],
+              ["Summaries", ["Created At: Month", "Created At: Year"]],
+            ],
+          );
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.MODEL_BASED_QUESTION_INDEX,
+            [
+              ["Base Orders Model", QSHelpers.ORDERS_DATE_COLUMNS],
+              [
+                "Reviews",
+                [
+                  ...QSHelpers.REVIEWS_DATE_COLUMNS,
+                  ...QSHelpers.REVIEWS_DATE_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              [
+                "Product",
+                [
+                  ...QSHelpers.PRODUCTS_DATE_COLUMNS,
+                  ...QSHelpers.PRODUCTS_DATE_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              ["User", QSHelpers.PEOPLE_DATE_COLUMNS],
+              ["Summaries", ["Created At: Month", "Created At: Year"]],
+            ],
+          );
+          QSHelpers.verifyNoDashcardMappingOptions(
+            QSHelpers.QUESTION_BASED_MODEL_INDEX,
+          );
+          QSHelpers.verifyNoDashcardMappingOptions(
+            QSHelpers.MODEL_BASED_MODEL_INDEX,
+          );
+        }
+
+        function verifyTextMappingOptions() {
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.QUESTION_BASED_QUESTION_INDEX,
+            [
+              [
+                "Reviews",
+                [
+                  ...QSHelpers.REVIEWS_TEXT_COLUMNS,
+                  ...QSHelpers.REVIEWS_TEXT_COLUMNS,
+                ],
+              ],
+              [
+                "Product",
+                [
+                  ...QSHelpers.PRODUCTS_TEXT_COLUMNS,
+                  ...QSHelpers.PRODUCTS_TEXT_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              ["User", QSHelpers.PEOPLE_TEXT_COLUMNS],
+              ["Summaries", ["Category"]],
+            ],
+          );
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.MODEL_BASED_QUESTION_INDEX,
+            [
+              [
+                "Reviews",
+                [
+                  ...QSHelpers.REVIEWS_TEXT_COLUMNS,
+                  ...QSHelpers.REVIEWS_TEXT_COLUMNS,
+                ],
+              ],
+              [
+                "Product",
+                [
+                  ...QSHelpers.PRODUCTS_TEXT_COLUMNS,
+                  ...QSHelpers.PRODUCTS_TEXT_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              ["User", QSHelpers.PEOPLE_TEXT_COLUMNS],
+              ["Summaries", ["Category"]],
+            ],
+          );
+          QSHelpers.verifyNoDashcardMappingOptions(
+            QSHelpers.QUESTION_BASED_MODEL_INDEX,
+          );
+          QSHelpers.verifyNoDashcardMappingOptions(
+            QSHelpers.MODEL_BASED_MODEL_INDEX,
+          );
+        }
+
+        function verifyNumberMappingOptions() {
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.QUESTION_BASED_QUESTION_INDEX,
+            [
+              [
+                "Base Orders Question",
+                [...QSHelpers.ORDERS_NUMBER_COLUMNS, "Net"],
+              ],
+              [
+                "Reviews",
+                [
+                  ...QSHelpers.REVIEWS_NUMBER_COLUMNS,
+                  ...QSHelpers.REVIEWS_NUMBER_COLUMNS,
+                ],
+              ],
+              [
+                "Product",
+                [
+                  ...QSHelpers.PRODUCTS_NUMBER_COLUMNS,
+                  ...QSHelpers.PRODUCTS_NUMBER_COLUMNS,
+                ], // TODO: https://github.com/metabase/metabase/issues/46845
+              ],
+              ["User", QSHelpers.PEOPLE_NUMBER_COLUMNS],
+              ["Summaries", ["Count", "Sum of Total", "5 * Count"]],
+            ],
+          );
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.MODEL_BASED_QUESTION_INDEX,
+            [
+              [
+                "Base Orders Model",
+                [...QSHelpers.ORDERS_NUMBER_COLUMNS, "Net"],
+              ],
+              [
+                "Reviews",
+                [
+                  ...QSHelpers.REVIEWS_NUMBER_COLUMNS,
+                  ...QSHelpers.REVIEWS_NUMBER_COLUMNS,
+                ],
+              ],
+              [
+                "Product",
+                [
+                  ...QSHelpers.PRODUCTS_NUMBER_COLUMNS,
+                  ...QSHelpers.PRODUCTS_NUMBER_COLUMNS,
+                ], // TODO: https://github.com/metabase/metabase/issues/46845
+              ],
+              ["User", QSHelpers.PEOPLE_NUMBER_COLUMNS],
+              ["Summaries", ["Count", "Sum of Total", "5 * Count"]],
+            ],
+          );
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.QUESTION_BASED_MODEL_INDEX,
+            [
+              [
+                NAMELESS_SECTION,
+                ["Count", "Sum of Reviews - Created At: Month → Rating"],
+              ],
+            ],
+          );
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.MODEL_BASED_MODEL_INDEX,
+            [
+              [
+                NAMELESS_SECTION,
+                ["Count", "Sum of Reviews - Created At: Month → Rating"],
+              ],
+            ],
+          );
+        }
+      });
+
+      describe("applies filter to the the dashcard and allows to drill via dashcard header", () => {
+        it("1st stage explicit join", () => {
+          QSHelpers.setup1stStageExplicitJoinFilter();
+          QSHelpers.apply1stStageExplicitJoinFilter();
+          cy.wait(["@dashboardData", "@dashboardData"]);
+
+          QSHelpers.verifyDashcardCellValues({
+            dashcardIndex: 0,
+            values: ["1,813", "7,218"],
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardCellValues({
+            dashcardIndex: 1,
+            values: ["1,813", "7,218"],
+          });
+        });
+
+        it("1st stage implicit join (data source)", () => {
+          QSHelpers.setup1stStageImplicitJoinFromSourceFilter();
+
+          QSHelpers.verifyDashcardCellValues({
+            dashcardIndex: 0,
+            values: ["2,071", "8,252"],
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardCellValues({
+            dashcardIndex: 1,
+            values: ["2,071", "8,252"],
+          });
+        });
+
+        // TODO: https://github.com/metabase/metabase/issues/46774
+        it.skip("1st stage implicit join (joined data source)", () => {
+          QSHelpers.setup1stStageImplicitJoinFromJoinFilter();
+
+          QSHelpers.verifyDashcardCellValues({
+            dashcardIndex: 0,
+            values: ["4,447", "17,714"],
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardCellValues({
+            dashcardIndex: 1,
+            values: ["4,447", "17,714"],
+          });
+        });
+
+        it("1st stage custom column", () => {
+          QSHelpers.setup1stStageCustomColumnFilter();
+
+          QSHelpers.verifyDashcardCellValues({
+            dashcardIndex: 0,
+            values: ["971", "3,900"],
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardCellValues({
+            dashcardIndex: 1,
+            values: ["971", "3,900"],
+          });
+        });
+
+        it("1st stage aggregation", () => {
+          QSHelpers.setup1stStageAggregationFilter();
+
+          QSHelpers.verifyDashcardCellValues({
+            dashcardIndex: 0,
+            values: ["3", "13"],
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardCellValues({
+            dashcardIndex: 1,
+            values: ["3", "13"],
+          });
+        });
+
+        // TODO: https://github.com/metabase/metabase/issues/46774
+        it.skip("1st stage breakout", () => {
+          QSHelpers.setup1stStageBreakoutFilter();
+
+          QSHelpers.verifyDashcardCellValues({
+            dashcardIndex: 0,
+            values: ["4,447", "17,714"],
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardCellValues({
+            dashcardIndex: 1,
+            values: ["4,447", "17,714"],
+          });
+        });
+
+        it("2nd stage explicit join", () => {
+          QSHelpers.setup2ndStageExplicitJoinFilter();
+
+          QSHelpers.verifyDashcardCellValues({
+            dashcardIndex: 0,
+            values: ["16", "80"],
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardCellValues({
+            dashcardIndex: 1,
+            values: ["16", "80"],
+          });
+        });
+
+        it("2nd stage custom column", () => {
+          QSHelpers.setup2ndStageCustomColumnFilter();
+          QSHelpers.apply2ndStageCustomColumnFilter();
+          cy.wait(["@dashboardData", "@dashboardData"]);
+
+          QSHelpers.verifyDashcardCellValues({
+            dashcardIndex: 0,
+            values: ["31", "114"],
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardCellValues({
+            dashcardIndex: 1,
+            values: ["31", "114"],
+          });
+        });
+      });
+    });
+
+    describe("Q7 - Q4 + 2nd stage with join, custom column, no aggregations, 2 breakouts", () => {
+      beforeEach(() => {
+        QSHelpers.createAndVisitDashboardWithCardMatrix(
+          QSHelpers.createQ7Query,
+        );
+      });
+
+      it("allows to map to all relevant columns", () => {
+        H.editDashboard();
+
+        cy.log("## date columns");
+        QSHelpers.getFilter("Date").click();
+        verifyDateMappingOptions();
+
+        cy.log("## text columns");
+        QSHelpers.getFilter("Text").click();
+        verifyTextMappingOptions();
+
+        cy.log("## number columns");
+        QSHelpers.getFilter("Number").click();
+        verifyNumberMappingOptions();
+
+        function verifyDateMappingOptions() {
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.QUESTION_BASED_QUESTION_INDEX,
+            [
+              ["Base Orders Question", QSHelpers.ORDERS_DATE_COLUMNS],
+              [
+                "Reviews",
+                [
+                  ...QSHelpers.REVIEWS_DATE_COLUMNS,
+                  ...QSHelpers.REVIEWS_DATE_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              [
+                "Product",
+                [
+                  ...QSHelpers.PRODUCTS_DATE_COLUMNS,
+                  ...QSHelpers.PRODUCTS_DATE_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              ["User", QSHelpers.PEOPLE_DATE_COLUMNS],
+              ["Summaries", ["Created At: Month", "Created At: Year"]],
+            ],
+          );
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.MODEL_BASED_QUESTION_INDEX,
+            [
+              ["Base Orders Model", QSHelpers.ORDERS_DATE_COLUMNS],
+              [
+                "Reviews",
+                [
+                  ...QSHelpers.REVIEWS_DATE_COLUMNS,
+                  ...QSHelpers.REVIEWS_DATE_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              [
+                "Product",
+                [
+                  ...QSHelpers.PRODUCTS_DATE_COLUMNS,
+                  ...QSHelpers.PRODUCTS_DATE_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              ["User", QSHelpers.PEOPLE_DATE_COLUMNS],
+              ["Summaries", ["Created At: Month", "Created At: Year"]],
+            ],
+          );
+          QSHelpers.verifyNoDashcardMappingOptions(
+            QSHelpers.QUESTION_BASED_MODEL_INDEX,
+          );
+          QSHelpers.verifyNoDashcardMappingOptions(
+            QSHelpers.MODEL_BASED_MODEL_INDEX,
+          );
+        }
+
+        function verifyTextMappingOptions() {
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.QUESTION_BASED_QUESTION_INDEX,
+            [
+              [
+                "Reviews",
+                [
+                  ...QSHelpers.REVIEWS_TEXT_COLUMNS,
+                  ...QSHelpers.REVIEWS_TEXT_COLUMNS,
+                ],
+              ],
+              [
+                "Product",
+                [
+                  ...QSHelpers.PRODUCTS_TEXT_COLUMNS,
+                  ...QSHelpers.PRODUCTS_TEXT_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              ["User", QSHelpers.PEOPLE_TEXT_COLUMNS],
+              ["Summaries", ["Category"]],
+              ["Summaries (2)", ["Reviewer", "Category"]],
+            ],
+          );
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.MODEL_BASED_QUESTION_INDEX,
+            [
+              [
+                "Reviews",
+                [
+                  ...QSHelpers.REVIEWS_TEXT_COLUMNS,
+                  ...QSHelpers.REVIEWS_TEXT_COLUMNS,
+                ],
+              ],
+              [
+                "Product",
+                [
+                  ...QSHelpers.PRODUCTS_TEXT_COLUMNS,
+                  ...QSHelpers.PRODUCTS_TEXT_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              ["User", QSHelpers.PEOPLE_TEXT_COLUMNS],
+              ["Summaries", ["Category"]],
+              ["Summaries (2)", ["Reviewer", "Category"]],
+            ],
+          );
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.QUESTION_BASED_MODEL_INDEX,
+            [
+              [
+                NAMELESS_SECTION,
+                [
+                  "Reviews - Created At: Month → Reviewer",
+                  "Products Via Product ID Category",
+                ],
+              ],
+            ],
+          );
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.MODEL_BASED_MODEL_INDEX,
+            [
+              [
+                NAMELESS_SECTION,
+                [
+                  "Reviews - Created At: Month → Reviewer",
+                  "Products Via Product ID Category",
+                ],
+              ],
+            ],
+          );
+        }
+
+        function verifyNumberMappingOptions() {
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.QUESTION_BASED_QUESTION_INDEX,
+            [
+              [
+                "Base Orders Question",
+                [...QSHelpers.ORDERS_NUMBER_COLUMNS, "Net"],
+              ],
+              [
+                "Reviews",
+                [
+                  ...QSHelpers.REVIEWS_NUMBER_COLUMNS,
+                  ...QSHelpers.REVIEWS_NUMBER_COLUMNS,
+                ],
+              ],
+              [
+                "Product",
+                [
+                  ...QSHelpers.PRODUCTS_NUMBER_COLUMNS,
+                  ...QSHelpers.PRODUCTS_NUMBER_COLUMNS,
+                ], // TODO: https://github.com/metabase/metabase/issues/46845
+              ],
+              ["User", QSHelpers.PEOPLE_NUMBER_COLUMNS],
+              ["Summaries", ["Count", "Sum of Total", "5 * Count"]],
+            ],
+          );
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.MODEL_BASED_QUESTION_INDEX,
+            [
+              [
+                "Base Orders Model",
+                [...QSHelpers.ORDERS_NUMBER_COLUMNS, "Net"],
+              ],
+              [
+                "Reviews",
+                [
+                  ...QSHelpers.REVIEWS_NUMBER_COLUMNS,
+                  ...QSHelpers.REVIEWS_NUMBER_COLUMNS,
+                ],
+              ],
+              [
+                "Product",
+                [
+                  ...QSHelpers.PRODUCTS_NUMBER_COLUMNS,
+                  ...QSHelpers.PRODUCTS_NUMBER_COLUMNS,
+                ], // TODO: https://github.com/metabase/metabase/issues/46845
+              ],
+              ["User", QSHelpers.PEOPLE_NUMBER_COLUMNS],
+              ["Summaries", ["Count", "Sum of Total", "5 * Count"]],
+            ],
+          );
+          QSHelpers.verifyNoDashcardMappingOptions(
+            QSHelpers.QUESTION_BASED_MODEL_INDEX,
+          );
+          QSHelpers.verifyNoDashcardMappingOptions(
+            QSHelpers.MODEL_BASED_MODEL_INDEX,
+          );
+        }
+      });
+
+      describe("applies filter to the the dashcard and allows to drill via dashcard header", () => {
+        it("1st stage explicit join", () => {
+          QSHelpers.setup1stStageExplicitJoinFilter();
+          QSHelpers.apply1stStageExplicitJoinFilter();
+          cy.wait(["@dashboardData", "@dashboardData"]);
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 0,
+            dashboardCount: "Rows 1-1 of 953",
+            queryBuilderCount: "Showing 953 rows",
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 1,
+            dashboardCount: "Rows 1-1 of 953",
+            queryBuilderCount: "Showing 953 rows",
+          });
+        });
+
+        it("1st stage implicit join (data source)", () => {
+          QSHelpers.setup1stStageImplicitJoinFromSourceFilter();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 0,
+            dashboardCount: "Rows 1-1 of 1044",
+            queryBuilderCount: "Showing 1,044 rows",
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 1,
+            dashboardCount: "Rows 1-1 of 1044",
+            queryBuilderCount: "Showing 1,044 rows",
+          });
+        });
+
+        // TODO: https://github.com/metabase/metabase/issues/46774
+        it.skip("1st stage implicit join (joined data source)", () => {
+          QSHelpers.setup1stStageImplicitJoinFromJoinFilter();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 0,
+            dashboardCount: "Rows 1-1 of 1077",
+            queryBuilderCount: "Showing 1,077 rows",
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 1,
+            dashboardCount: "Rows 1-1 of 1077",
+            queryBuilderCount: "Showing 1,077 rows",
+          });
+        });
+
+        it("1st stage custom column", () => {
+          QSHelpers.setup1stStageCustomColumnFilter();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 0,
+            dashboardCount: "Rows 1-1 of 688",
+            queryBuilderCount: "Showing 688 rows",
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 1,
+            dashboardCount: "Rows 1-1 of 688",
+            queryBuilderCount: "Showing 688 rows",
+          });
+        });
+
+        it("1st stage aggregation", () => {
+          QSHelpers.setup1stStageAggregationFilter();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 1,
+            dashboardCount: "Rows 1-1 of 3",
+            queryBuilderCount: "Showing 3 rows",
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 1,
+            dashboardCount: "Rows 1-1 of 3",
+            queryBuilderCount: "Showing 3 rows",
+          });
+        });
+
+        // TODO: https://github.com/metabase/metabase/issues/46774
+        it.skip("1st stage breakout", () => {
+          QSHelpers.setup1stStageBreakoutFilter();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 0,
+            dashboardCount: "Rows 1-1 of 1077",
+            queryBuilderCount: "Showing 1,077 rows",
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 1,
+            dashboardCount: "Rows 1-1 of 1077",
+            queryBuilderCount: "Showing 1,077 rows",
+          });
+        });
+
+        it("2nd stage explicit join", () => {
+          QSHelpers.setup2ndStageExplicitJoinFilter();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 0,
+            dashboardCount: "Rows 1-1 of 4",
+            queryBuilderCount: "Showing 4 rows",
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 1,
+            dashboardCount: "Rows 1-1 of 4",
+            queryBuilderCount: "Showing 4 rows",
+          });
+        });
+
+        it("2nd stage custom column", () => {
+          QSHelpers.setup2ndStageCustomColumnFilter();
+          QSHelpers.apply2ndStageCustomColumnFilter();
+          cy.wait(["@dashboardData", "@dashboardData"]);
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 0,
+            dashboardCount: "Rows 1-1 of 31",
+            queryBuilderCount: "Showing 31 rows",
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 1,
+            dashboardCount: "Rows 1-1 of 31",
+            queryBuilderCount: "Showing 31 rows",
+          });
+        });
+
+        it("2nd stage breakout", () => {
+          QSHelpers.setup2ndStageBreakoutFilter();
+          QSHelpers.apply2ndStageBreakoutFilter();
+          cy.wait(["@dashboardData", "@dashboardData"]);
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 0,
+            dashboardCount: "Rows 1-1 of 1077",
+            queryBuilderCount: "Showing 1,077 rows",
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 1,
+            dashboardCount: "Rows 1-1 of 1077",
+            queryBuilderCount: "Showing 1,077 rows",
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 2,
+            dashboardCount: "Rows 1-1 of 1077",
+            queryBuilderCount: "Showing 1,077 rows",
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 3,
+            dashboardCount: "Rows 1-1 of 1077",
+            queryBuilderCount: "Showing 1,077 rows",
+          });
+        });
+      });
+    });
+
+    describe("Q8 - Q4 + 2nd stage with join, custom column, 2 aggregations, 2 breakouts", () => {
+      beforeEach(() => {
+        QSHelpers.createAndVisitDashboardWithCardMatrix(
+          QSHelpers.createQ8Query,
+        );
+      });
+
+      it("allows to map to all relevant columns", () => {
+        H.editDashboard();
+
+        cy.log("## date columns");
+        QSHelpers.getFilter("Date").click();
+        verifyDateMappingOptions();
+
+        cy.log("## text columns");
+        QSHelpers.getFilter("Text").click();
+        verifyTextMappingOptions();
+
+        cy.log("## number columns");
+        QSHelpers.getFilter("Number").click();
+        verifyNumberMappingOptions();
+
+        function verifyDateMappingOptions() {
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.QUESTION_BASED_QUESTION_INDEX,
+            [
+              ["Base Orders Question", QSHelpers.ORDERS_DATE_COLUMNS],
+              [
+                "Reviews",
+                [
+                  ...QSHelpers.REVIEWS_DATE_COLUMNS,
+                  ...QSHelpers.REVIEWS_DATE_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              [
+                "Product",
+                [
+                  ...QSHelpers.PRODUCTS_DATE_COLUMNS,
+                  ...QSHelpers.PRODUCTS_DATE_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              ["User", QSHelpers.PEOPLE_DATE_COLUMNS],
+              ["Summaries", ["Created At: Month", "Created At: Year"]],
+            ],
+          );
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.MODEL_BASED_QUESTION_INDEX,
+            [
+              ["Base Orders Model", QSHelpers.ORDERS_DATE_COLUMNS],
+              [
+                "Reviews",
+                [
+                  ...QSHelpers.REVIEWS_DATE_COLUMNS,
+                  ...QSHelpers.REVIEWS_DATE_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              [
+                "Product",
+                [
+                  ...QSHelpers.PRODUCTS_DATE_COLUMNS,
+                  ...QSHelpers.PRODUCTS_DATE_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              ["User", QSHelpers.PEOPLE_DATE_COLUMNS],
+              ["Summaries", ["Created At: Month", "Created At: Year"]],
+            ],
+          );
+          QSHelpers.verifyNoDashcardMappingOptions(
+            QSHelpers.QUESTION_BASED_MODEL_INDEX,
+          );
+          QSHelpers.verifyNoDashcardMappingOptions(
+            QSHelpers.MODEL_BASED_MODEL_INDEX,
+          );
+        }
+
+        function verifyTextMappingOptions() {
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.QUESTION_BASED_QUESTION_INDEX,
+            [
+              [
+                "Reviews",
+                [
+                  ...QSHelpers.REVIEWS_TEXT_COLUMNS,
+                  ...QSHelpers.REVIEWS_TEXT_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              [
+                "Product",
+                [
+                  ...QSHelpers.PRODUCTS_TEXT_COLUMNS,
+                  ...QSHelpers.PRODUCTS_TEXT_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              ["User", QSHelpers.PEOPLE_TEXT_COLUMNS],
+              ["Summaries", ["Category"]],
+              ["Summaries (2)", ["Reviewer", "Category"]],
+            ],
+          );
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.MODEL_BASED_QUESTION_INDEX,
+            [
+              [
+                "Reviews",
+                [
+                  ...QSHelpers.REVIEWS_TEXT_COLUMNS,
+                  ...QSHelpers.REVIEWS_TEXT_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              [
+                "Product",
+                [
+                  ...QSHelpers.PRODUCTS_TEXT_COLUMNS,
+                  ...QSHelpers.PRODUCTS_TEXT_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              ["User", QSHelpers.PEOPLE_TEXT_COLUMNS],
+              ["Summaries", ["Category"]],
+              ["Summaries (2)", ["Reviewer", "Category"]],
+            ],
+          );
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.QUESTION_BASED_MODEL_INDEX,
+            [
+              [
+                NAMELESS_SECTION,
+                [
+                  "Reviews - Created At: Month → Reviewer",
+                  "Products Via Product ID Category",
+                ],
+              ],
+            ],
+          );
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.MODEL_BASED_MODEL_INDEX,
+            [
+              [
+                NAMELESS_SECTION,
+                [
+                  "Reviews - Created At: Month → Reviewer",
+                  "Products Via Product ID Category",
+                ],
+              ],
+            ],
+          );
+        }
+
+        function verifyNumberMappingOptions() {
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.QUESTION_BASED_QUESTION_INDEX,
+            [
+              [
+                "Base Orders Question",
+                [...QSHelpers.ORDERS_NUMBER_COLUMNS, "Net"],
+              ],
+              [
+                "Reviews",
+                [
+                  ...QSHelpers.REVIEWS_NUMBER_COLUMNS,
+                  ...QSHelpers.REVIEWS_NUMBER_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              [
+                "Product",
+                [
+                  ...QSHelpers.PRODUCTS_NUMBER_COLUMNS,
+                  ...QSHelpers.PRODUCTS_NUMBER_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              ["User", QSHelpers.PEOPLE_NUMBER_COLUMNS],
+              ["Summaries", ["Count", "Sum of Total", "5 * Count"]],
+              ["Summaries (2)", ["Count", "Sum of Rating"]],
+            ],
+          );
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.MODEL_BASED_QUESTION_INDEX,
+            [
+              [
+                "Base Orders Model",
+                [...QSHelpers.ORDERS_NUMBER_COLUMNS, "Net"],
+              ],
+              [
+                "Reviews",
+                [
+                  ...QSHelpers.REVIEWS_NUMBER_COLUMNS,
+                  ...QSHelpers.REVIEWS_NUMBER_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              [
+                "Product",
+                [
+                  ...QSHelpers.PRODUCTS_NUMBER_COLUMNS,
+                  ...QSHelpers.PRODUCTS_NUMBER_COLUMNS,
+                ],
+              ], // TODO: https://github.com/metabase/metabase/issues/46845
+              ["User", QSHelpers.PEOPLE_NUMBER_COLUMNS],
+              ["Summaries", ["Count", "Sum of Total", "5 * Count"]],
+              ["Summaries (2)", ["Count", "Sum of Rating"]],
+            ],
+          );
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.QUESTION_BASED_MODEL_INDEX,
+            [
+              [
+                NAMELESS_SECTION,
+                ["Count", "Sum of Reviews - Created At: Month → Rating"],
+              ],
+            ],
+          );
+          QSHelpers.verifyDashcardMappingOptions(
+            QSHelpers.MODEL_BASED_MODEL_INDEX,
+            [
+              [
+                NAMELESS_SECTION,
+                ["Count", "Sum of Reviews - Created At: Month → Rating"],
+              ],
+            ],
+          );
+        }
+      });
+
+      describe("applies filter to the the dashcard and allows to drill via dashcard header", () => {
+        it("1st stage explicit join", () => {
+          QSHelpers.setup1stStageExplicitJoinFilter();
+          QSHelpers.apply1stStageExplicitJoinFilter();
+          cy.wait(["@dashboardData", "@dashboardData"]);
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 0,
+            dashboardCount: "Rows 1-1 of 953",
+            queryBuilderCount: "Showing 953 rows",
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 1,
+            dashboardCount: "Rows 1-1 of 953",
+            queryBuilderCount: "Showing 953 rows",
+          });
+
+          cy.log("public dashboard");
+          QSHelpers.getDashboardId().then(dashboardId =>
+            H.visitPublicDashboard(dashboardId),
+          );
+          QSHelpers.waitForPublicDashboardData();
+          QSHelpers.apply1stStageExplicitJoinFilter();
+          QSHelpers.waitForPublicDashboardData();
+
+          H.getDashboardCard(0)
+            .findByText("Rows 1-1 of 953")
+            .should("be.visible");
+          H.getDashboardCard(1)
+            .findByText("Rows 1-1 of 953")
+            .should("be.visible");
+
+          cy.log("embedded dashboard");
+          QSHelpers.getDashboardId().then(dashboardId => {
+            H.visitEmbeddedPage({
+              resource: { dashboard: dashboardId },
+              params: {},
+            });
+          });
+          QSHelpers.waitForEmbeddedDashboardData();
+          QSHelpers.apply1stStageExplicitJoinFilter();
+          QSHelpers.waitForEmbeddedDashboardData();
+
+          H.getDashboardCard(0)
+            .findByText("Rows 1-1 of 953")
+            .should("be.visible");
+          H.getDashboardCard(1)
+            .findByText("Rows 1-1 of 953")
+            .should("be.visible");
+        });
+
+        it("1st stage implicit join (data source)", () => {
+          QSHelpers.setup1stStageImplicitJoinFromSourceFilter();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 0,
+            dashboardCount: "Rows 1-1 of 1044",
+            queryBuilderCount: "Showing 1,044 rows",
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 1,
+            dashboardCount: "Rows 1-1 of 1044",
+            queryBuilderCount: "Showing 1,044 rows",
+          });
+        });
+
+        // TODO: https://github.com/metabase/metabase/issues/46774
+        it.skip("1st stage implicit join (joined data source)", () => {
+          QSHelpers.setup1stStageImplicitJoinFromJoinFilter();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 0,
+            dashboardCount: "Rows 1-1 of 1077",
+            queryBuilderCount: "Showing 1,077 rows",
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 1,
+            dashboardCount: "Rows 1-1 of 1077",
+            queryBuilderCount: "Showing 1,077 rows",
+          });
+        });
+
+        it("1st stage custom column", () => {
+          QSHelpers.setup1stStageCustomColumnFilter();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 0,
+            dashboardCount: "Rows 1-1 of 688",
+            queryBuilderCount: "Showing 688 rows",
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 1,
+            dashboardCount: "Rows 1-1 of 688",
+            queryBuilderCount: "Showing 688 rows",
+          });
+        });
+
+        it("1st stage aggregation", () => {
+          QSHelpers.setup1stStageAggregationFilter();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 1,
+            dashboardCount: "Rows 1-1 of 3",
+            queryBuilderCount: "Showing 3 rows",
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 1,
+            dashboardCount: "Rows 1-1 of 3",
+            queryBuilderCount: "Showing 3 rows",
+          });
+        });
+
+        // TODO: https://github.com/metabase/metabase/issues/46774
+        it.skip("1st stage breakout", () => {
+          QSHelpers.setup1stStageBreakoutFilter();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 0,
+            dashboardCount: "Rows 1-1 of 1077",
+            queryBuilderCount: "Showing 1,077 rows",
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 1,
+            dashboardCount: "Rows 1-1 of 1077",
+            queryBuilderCount: "Showing 1,077 rows",
+          });
+        });
+
+        it("2nd stage explicit join", () => {
+          QSHelpers.setup2ndStageExplicitJoinFilter();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 0,
+            dashboardCount: "Rows 1-1 of 4",
+            queryBuilderCount: "Showing 4 rows",
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 1,
+            dashboardCount: "Rows 1-1 of 4",
+            queryBuilderCount: "Showing 4 rows",
+          });
+        });
+
+        it("2nd stage custom column", () => {
+          QSHelpers.setup2ndStageCustomColumnFilter();
+          QSHelpers.apply2ndStageCustomColumnFilter();
+          cy.wait(["@dashboardData", "@dashboardData"]);
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 0,
+            dashboardCount: "Rows 1-1 of 31",
+            queryBuilderCount: "Showing 31 rows",
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 1,
+            dashboardCount: "Rows 1-1 of 31",
+            queryBuilderCount: "Showing 31 rows",
+          });
+
+          cy.log("public dashboard");
+          QSHelpers.getDashboardId().then(dashboardId =>
+            H.visitPublicDashboard(dashboardId),
+          );
+          QSHelpers.waitForPublicDashboardData();
+          QSHelpers.apply2ndStageCustomColumnFilter();
+          QSHelpers.waitForPublicDashboardData();
+
+          H.getDashboardCard(0)
+            .findByText("Rows 1-1 of 31")
+            .should("be.visible");
+          H.getDashboardCard(1)
+            .findByText("Rows 1-1 of 31")
+            .should("be.visible");
+
+          cy.log("embedded dashboard");
+          QSHelpers.getDashboardId().then(dashboardId => {
+            H.visitEmbeddedPage({
+              resource: { dashboard: dashboardId },
+              params: {},
+            });
+          });
+          QSHelpers.waitForEmbeddedDashboardData();
+          QSHelpers.apply2ndStageCustomColumnFilter();
+          QSHelpers.waitForEmbeddedDashboardData();
+
+          H.getDashboardCard(0)
+            .findByText("Rows 1-1 of 31")
+            .should("be.visible");
+          H.getDashboardCard(1)
+            .findByText("Rows 1-1 of 31")
+            .should("be.visible");
+        });
+
+        it("2nd stage aggregation", () => {
+          QSHelpers.setup2ndStageAggregationFilter();
+          QSHelpers.apply2ndStageAggregationFilter();
+          cy.wait(["@dashboardData", "@dashboardData"]);
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 0,
+            dashboardCount: "Rows 1-1 of 6",
+            queryBuilderCount: "Showing 6 rows",
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 1,
+            dashboardCount: "Rows 1-1 of 6",
+            queryBuilderCount: "Showing 6 rows",
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 2,
+            dashboardCount: "Rows 1-1 of 6",
+            queryBuilderCount: "Showing 6 rows",
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 3,
+            dashboardCount: "Rows 1-1 of 6",
+            queryBuilderCount: "Showing 6 rows",
+          });
+
+          cy.log("public dashboard");
+          QSHelpers.getDashboardId().then(dashboardId =>
+            H.visitPublicDashboard(dashboardId),
+          );
+          QSHelpers.waitForPublicDashboardData();
+          QSHelpers.apply2ndStageAggregationFilter();
+          QSHelpers.waitForPublicDashboardData();
+
+          H.getDashboardCard(0)
+            .findByText("Rows 1-1 of 6")
+            .should("be.visible");
+          H.getDashboardCard(1)
+            .findByText("Rows 1-1 of 6")
+            .should("be.visible");
+          H.getDashboardCard(2)
+            .findByText("Rows 1-1 of 6")
+            .should("be.visible");
+          H.getDashboardCard(3)
+            .findByText("Rows 1-1 of 6")
+            .should("be.visible");
+
+          cy.log("embedded dashboard");
+          QSHelpers.getDashboardId().then(dashboardId => {
+            H.visitEmbeddedPage({
+              resource: { dashboard: dashboardId },
+              params: {},
+            });
+          });
+          QSHelpers.waitForEmbeddedDashboardData();
+          QSHelpers.apply2ndStageAggregationFilter();
+          QSHelpers.waitForEmbeddedDashboardData();
+
+          H.getDashboardCard(0)
+            .findByText("Rows 1-1 of 6")
+            .should("be.visible");
+          H.getDashboardCard(1)
+            .findByText("Rows 1-1 of 6")
+            .should("be.visible");
+          H.getDashboardCard(2)
+            .findByText("Rows 1-1 of 6")
+            .should("be.visible");
+          H.getDashboardCard(3)
+            .findByText("Rows 1-1 of 6")
+            .should("be.visible");
+        });
+
+        it("2nd stage breakout", () => {
+          QSHelpers.setup2ndStageBreakoutFilter();
+          QSHelpers.apply2ndStageBreakoutFilter();
+          cy.wait(["@dashboardData", "@dashboardData"]);
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 0,
+            dashboardCount: "Rows 1-1 of 1077",
+            queryBuilderCount: "Showing 1,077 rows",
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 1,
+            dashboardCount: "Rows 1-1 of 1077",
+            queryBuilderCount: "Showing 1,077 rows",
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 2,
+            dashboardCount: "Rows 1-1 of 1077",
+            queryBuilderCount: "Showing 1,077 rows",
+          });
+
+          QSHelpers.goBackToDashboard();
+
+          QSHelpers.verifyDashcardRowsCount({
+            dashcardIndex: 3,
+            dashboardCount: "Rows 1-1 of 1077",
+            queryBuilderCount: "Showing 1,077 rows",
+          });
+
+          cy.log("public dashboard");
+          QSHelpers.getDashboardId().then(dashboardId =>
+            H.visitPublicDashboard(dashboardId),
+          );
+          QSHelpers.waitForPublicDashboardData();
+          // We're not using apply2ndStageBreakoutFilter() here because in public dashboards
+          // there are no field values to choose from. We need to search for those values manually.
+          H.filterWidget().eq(0).click();
+          H.popover().within(() => {
+            cy.findByPlaceholderText("Enter some text").type("Gadget");
+            cy.button("Add filter").click();
+          });
+          QSHelpers.waitForPublicDashboardData();
+
+          H.getDashboardCard(0)
+            .findByText("Rows 1-1 of 1077")
+            .should("be.visible");
+          H.getDashboardCard(1)
+            .findByText("Rows 1-1 of 1077")
+            .should("be.visible");
+          H.getDashboardCard(2)
+            .findByText("Rows 1-1 of 1077")
+            .should("be.visible");
+          H.getDashboardCard(3)
+            .findByText("Rows 1-1 of 1077")
+            .should("be.visible");
+
+          cy.log("embedded dashboard");
+          QSHelpers.getDashboardId().then(dashboardId => {
+            H.visitEmbeddedPage({
+              resource: { dashboard: dashboardId },
+              params: {},
+            });
+          });
+          QSHelpers.waitForEmbeddedDashboardData();
+          // We're not using apply2ndStageBreakoutFilter() here because in public dashboards
+          // there are no field values to choose from. We need to search for those values manually.
+          H.filterWidget().eq(0).click();
+          H.popover().within(() => {
+            cy.findByPlaceholderText("Enter some text").type("Gadget");
+            cy.button("Add filter").click();
+          });
+          QSHelpers.waitForEmbeddedDashboardData();
+
+          H.getDashboardCard(0)
+            .findByText("Rows 1-1 of 1077")
+            .should("be.visible");
+          H.getDashboardCard(1)
+            .findByText("Rows 1-1 of 1077")
+            .should("be.visible");
+          H.getDashboardCard(2)
+            .findByText("Rows 1-1 of 1077")
+            .should("be.visible");
+          H.getDashboardCard(3)
+            .findByText("Rows 1-1 of 1077")
+            .should("be.visible");
+        });
+      });
+    });
+  });
+});

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-3-stage.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-3-stage.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 import * as QSHelpers from "./shared/dashboard-filters-query-stages";
 

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-misc.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-misc.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import type { Card, StructuredQuery } from "metabase-types/api";
 

--- a/e2e/test/scenarios/dashboard-filters-2/shared/dashboard-filters-query-stages.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/shared/dashboard-filters-query-stages.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import type {
   Card,

--- a/e2e/test/scenarios/dashboard-filters-matrix/helpers/matrix-helpers.ts
+++ b/e2e/test/scenarios/dashboard-filters-matrix/helpers/matrix-helpers.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import type { ValuesQueryType } from "metabase-types/api";
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-chained-filters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-chained-filters.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filter-data-permissions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filter-data-permissions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
 function filterDashboard(suggests = true) {

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filter-defaults.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filter-defaults.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-wiring.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-wiring.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_BY_YEAR_QUESTION_ID,

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-clear-and-restore.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-clear-and-restore.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import {
   ORDERS_DASHBOARD_DASHCARD_ID,
   ORDERS_DASHBOARD_ID,

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-explicit-join.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-explicit-join.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-id.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-id.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
 import { addWidgetStringFilter } from "../native-filters/helpers/e2e-field-filter-helpers";

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-location.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-location.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import {
   ORDERS_DASHBOARD_DASHCARD_ID,
   ORDERS_DASHBOARD_ID,

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-management.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-management.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { createMockParameter } from "metabase-types/api/mocks";
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-nested.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-nested.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { PRODUCTS_ID } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-number-source.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-number-source.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ACCOUNTS, ORDERS_ID } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
 import { addWidgetNumberFilter } from "../native-filters/helpers/e2e-field-filter-helpers";

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-reset-clear.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-reset-clear.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_COUNT_QUESTION_ID,

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-source.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-source.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { USER_GROUPS, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-date.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-date.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 import * as DateFilter from "../native-filters/helpers/e2e-date-filter-helpers";
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-id.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-id.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 import { addWidgetStringFilter } from "../native-filters/helpers/e2e-field-filter-helpers";

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-location.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-location.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 import { addWidgetStringFilter } from "../native-filters/helpers/e2e-field-filter-helpers";
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-management.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-management.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 describe("scenarios > dashboard > filters > SQL > management", () => {
   beforeEach(() => {

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-number.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-number.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 import { addWidgetNumberFilter } from "../native-filters/helpers/e2e-field-filter-helpers";
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-required-field-filter.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-required-field-filter.cy.spec.js
@@ -1,6 +1,6 @@
 import { produce } from "immer";
 
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { PRODUCTS } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-required-simple-filter.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-required-simple-filter.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 const questionDetails = {
   name: "Return input value",

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-text-category.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-text-category.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 import { applyFilterByType } from "../native-filters/helpers/e2e-field-filter-helpers";
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 import {

--- a/e2e/test/scenarios/dashboard-filters/old-parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/old-parameters.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { PEOPLE, PEOPLE_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/dashboard/dashboard-management.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-management.cy.spec.js
@@ -1,6 +1,6 @@
 import { onlyOn } from "@cypress/skip-test";
 
-import { H } from "e2e/support";
+const { H } = cy;
 import { USERS } from "e2e/support/cypress_data";
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 

--- a/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import * as S from "e2e/support/cypress_sample_instance_data";
 import { createMockDashboardCard } from "metabase-types/api/mocks";

--- a/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
@@ -1,7 +1,7 @@
 import { assoc } from "icepick";
 import _ from "underscore";
 
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, USERS, USER_GROUPS } from "e2e/support/cypress_data";
 import {
   ORDERS_COUNT_QUESTION_ID,

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1,7 +1,7 @@
 import { assoc } from "icepick";
 import _ from "underscore";
 
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ADMIN_PERSONAL_COLLECTION_ID,

--- a/e2e/test/scenarios/dashboard/text-cards.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/text-cards.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 import { createMockParameter } from "metabase-types/api/mocks";

--- a/e2e/test/scenarios/dashboard/title-drill.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/title-drill.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PEOPLE, PEOPLE_ID, PRODUCTS, PRODUCTS_ID } =

--- a/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_BY_YEAR_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";

--- a/e2e/test/scenarios/embedding-sdk/static-dashboard-cors.cy.spec.js
+++ b/e2e/test/scenarios/embedding-sdk/static-dashboard-cors.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { USERS } from "e2e/support/cypress_data";
 import {
   ORDERS_DASHBOARD_DASHCARD_ID,

--- a/e2e/test/scenarios/embedding/embed-resource-downloads.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embed-resource-downloads.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_BY_YEAR_QUESTION_ID,

--- a/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 import { createMockParameter } from "metabase-types/api/mocks";

--- a/e2e/test/scenarios/embedding/embedding-linked-filters.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-linked-filters.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 import {
   guiDashboard,

--- a/e2e/test/scenarios/embedding/embedding-native.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-native.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 import * as SQLFilter from "../native-filters/helpers/e2e-sql-filter-helpers";
 

--- a/e2e/test/scenarios/embedding/embedding-questions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-questions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_DASHBOARD_ID,

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 import { defer } from "metabase/lib/promise";

--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { METABASE_SECRET_KEY } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/embedding/embedding-snippets.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-snippets.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,

--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { USER_GROUPS, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -1,6 +1,6 @@
 import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
 
-import { H } from "e2e/support";
+const { H } = cy;
 import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-with-question-revert.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-with-question-revert.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import {
   SAMPLE_DB_ID,
   SAMPLE_DB_SCHEMA_ID,

--- a/e2e/test/scenarios/filters/filter-bulk.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter-bulk.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/filters/filter-sources.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter-sources.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/filters/filter-types.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter-types.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 const STRING_CASES = [
   {

--- a/e2e/test/scenarios/filters/filter.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/filters/operators.cy.spec.js
+++ b/e2e/test/scenarios/filters/operators.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { PRODUCTS_ID, PEOPLE_ID } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/filters/relative-datetime.cy.spec.js
+++ b/e2e/test/scenarios/filters/relative-datetime.cy.spec.js
@@ -1,6 +1,6 @@
 import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
 
-import { H } from "e2e/support";
+const { H } = cy;
 
 const STARTING_FROM_UNITS = [
   "minutes",

--- a/e2e/test/scenarios/filters/time-series-chrome.cy.spec.ts
+++ b/e2e/test/scenarios/filters/time-series-chrome.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/filters/view.cy.spec.js
+++ b/e2e/test/scenarios/filters/view.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { PRODUCTS } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/joins/joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/metrics/browse.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/browse.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   FIRST_COLLECTION_ID,

--- a/e2e/test/scenarios/metrics/metrics-collection.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-collection.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/metrics/metrics-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-dashboard.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_MODEL_ID } from "e2e/support/cypress_sample_instance_data";
 

--- a/e2e/test/scenarios/metrics/metrics-question.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-question.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/metrics/metrics-search.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-search.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/models/create.cy.spec.js
+++ b/e2e/test/scenarios/models/create.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { THIRD_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 const modelName = "A name";

--- a/e2e/test/scenarios/models/model-indexes.cy.spec.js
+++ b/e2e/test/scenarios/models/model-indexes.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { createModelIndex } from "e2e/support/helpers/e2e-model-index-helper";
 

--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 import { startQuestionFromModel } from "./helpers/e2e-models-helpers";

--- a/e2e/test/scenarios/models/models-query-editor.cy.spec.js
+++ b/e2e/test/scenarios/models/models-query-editor.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 import { selectFromDropdown } from "./helpers/e2e-models-helpers";

--- a/e2e/test/scenarios/models/models-revision-history.cy.spec.js
+++ b/e2e/test/scenarios/models/models-revision-history.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { ORDERS_BY_YEAR_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 describe("scenarios > models > revision history", () => {

--- a/e2e/test/scenarios/models/models-with-aggregation-and-breakout.cy.spec.js
+++ b/e2e/test/scenarios/models/models-with-aggregation-and-breakout.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 import { turnIntoModel } from "./helpers/e2e-models-helpers";

--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/models/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, SAMPLE_DB_SCHEMA_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   FIRST_COLLECTION_ID,

--- a/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/native-filters/sql-field-filter-types.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-field-filter-types.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 import * as DateFilter from "./helpers/e2e-date-filter-helpers";
 import {

--- a/e2e/test/scenarios/native-filters/sql-field-filter.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-field-filter.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 import * as FieldFilter from "./helpers/e2e-field-filter-helpers";

--- a/e2e/test/scenarios/native-filters/sql-filters-reset-clear.cy.spec.ts
+++ b/e2e/test/scenarios/native-filters/sql-filters-reset-clear.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import type { TemplateTag } from "metabase-types/api";
 

--- a/e2e/test/scenarios/native-filters/sql-filters-source.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-filters-source.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/native-filters/sql-filters.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-filters.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 import * as DateFilter from "./helpers/e2e-date-filter-helpers";
 import * as SQLFilter from "./helpers/e2e-sql-filter-helpers";

--- a/e2e/test/scenarios/native/native-database-source.cy.spec.js
+++ b/e2e/test/scenarios/native/native-database-source.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 
 const PG_DB_ID = 2;

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 import { getRunQueryButton } from "../native-filters/helpers/e2e-sql-filter-helpers";

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import {
   SAMPLE_DB_ID,
   USER_GROUPS,

--- a/e2e/test/scenarios/native/native_subquery.cy.spec.js
+++ b/e2e/test/scenarios/native/native_subquery.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import {
   ADMIN_PERSONAL_COLLECTION_ID,
   ORDERS_QUESTION_ID,

--- a/e2e/test/scenarios/native/snippets.cy.spec.js
+++ b/e2e/test/scenarios/native/snippets.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { USER_GROUPS } from "e2e/support/cypress_data";
 
 const { ALL_USERS_GROUP } = USER_GROUPS;

--- a/e2e/test/scenarios/native/suggestions.cy.spec.ts
+++ b/e2e/test/scenarios/native/suggestions.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 describe("scenarios > question > native > suggestions", () => {
   beforeEach(() => {

--- a/e2e/test/scenarios/navigation/navbar.cy.spec.js
+++ b/e2e/test/scenarios/navigation/navbar.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_DASHBOARD_ID,

--- a/e2e/test/scenarios/onboarding/about.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/about.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 describe("scenarios > about Metabase", () => {
   beforeEach(() => {

--- a/e2e/test/scenarios/onboarding/add-initial-data.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/add-initial-data.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 H.describeWithSnowplow(
   "better onboarding via sidebar",

--- a/e2e/test/scenarios/onboarding/auth/forgot_password.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/auth/forgot_password.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { USERS } from "e2e/support/cypress_data";
 
 const { admin } = USERS;

--- a/e2e/test/scenarios/onboarding/auth/signin.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/auth/signin.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { USERS } from "e2e/support/cypress_data";
 
 const sizes = [

--- a/e2e/test/scenarios/onboarding/auth/sso.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/auth/sso.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { USERS } from "e2e/support/cypress_data";
 
 const { admin } = USERS;

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { USERS } from "e2e/support/cypress_data";
 import {
   ORDERS_COUNT_QUESTION_ID,

--- a/e2e/test/scenarios/onboarding/embedding-homepage.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/embedding-homepage.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 H.describeWithSnowplow(
   "scenarios > embedding-homepage > snowplow events",

--- a/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_MODEL_ID } from "e2e/support/cypress_sample_instance_data";

--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { USERS } from "e2e/support/cypress_data";
 import {
   ADMIN_PERSONAL_COLLECTION_ID,

--- a/e2e/test/scenarios/onboarding/navbar/new-menu.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/navbar/new-menu.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 describe("metabase > scenarios > navbar > new menu", () => {
   beforeEach(() => {

--- a/e2e/test/scenarios/onboarding/navbar/whats-new.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/navbar/whats-new.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import {
   createMockVersionInfo,
   createMockVersionInfoRecord as mockVersion,

--- a/e2e/test/scenarios/onboarding/notifications.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/notifications.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/onboarding/onboarding-checklist.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/onboarding-checklist.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import type { ChecklistItemValue } from "metabase/home/components/Onboarding/types";
 
 describe("Onboarding checklist page", () => {

--- a/e2e/test/scenarios/onboarding/reference/databases.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/reference/databases.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 describe("scenarios > reference > databases", () => {
   beforeEach(() => {

--- a/e2e/test/scenarios/onboarding/reference/reproductions/5276-remove-field-type.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/reference/reproductions/5276-remove-field-type.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 describe("issue 5276", () => {
   beforeEach(() => {

--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { USERS } from "e2e/support/cypress_data";
 import { SUBSCRIBE_URL } from "metabase/setup/constants";
 

--- a/e2e/test/scenarios/onboarding/setup/user_settings.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/setup/user_settings.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { USERS } from "e2e/support/cypress_data";
 import { NORMAL_USER_ID } from "e2e/support/cypress_sample_instance_data";
 

--- a/e2e/test/scenarios/onboarding/urls.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/urls.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, USERS } from "e2e/support/cypress_data";
 import {
   ADMIN_PERSONAL_COLLECTION_ID,

--- a/e2e/test/scenarios/organization/bookmarks-collection.cy.spec.js
+++ b/e2e/test/scenarios/organization/bookmarks-collection.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_TABLES, USERS } from "e2e/support/cypress_data";
 import {
   ADMIN_PERSONAL_COLLECTION_ID,

--- a/e2e/test/scenarios/organization/bookmarks-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/organization/bookmarks-dashboard.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
 describe("scenarios > dashboard > bookmarks", () => {

--- a/e2e/test/scenarios/organization/bookmarks-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/bookmarks-question.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 import { toggleQuestionBookmarkStatus } from "./helpers/bookmark-helpers";

--- a/e2e/test/scenarios/organization/bookmarks-reordering.cy.spec.ts
+++ b/e2e/test/scenarios/organization/bookmarks-reordering.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_QUESTION_ID,

--- a/e2e/test/scenarios/organization/content-verification.cy.spec.js
+++ b/e2e/test/scenarios/organization/content-verification.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_DASHBOARD_ID,

--- a/e2e/test/scenarios/organization/edit-history-metadata.cy.spec.js
+++ b/e2e/test/scenarios/organization/edit-history-metadata.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { USERS } from "e2e/support/cypress_data";
 import {
   ORDERS_DASHBOARD_ID,

--- a/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
+++ b/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { USER_GROUPS, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/organization/official-collections.cy.spec.js
+++ b/e2e/test/scenarios/organization/official-collections.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/organization/timelines-collection.cy.spec.js
+++ b/e2e/test/scenarios/organization/timelines-collection.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { USERS } from "e2e/support/cypress_data";
 
 const { admin } = USERS;

--- a/e2e/test/scenarios/organization/timelines-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/timelines-question.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_BY_YEAR_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import {
   ORDERS_DASHBOARD_ID,

--- a/e2e/test/scenarios/permissions/application-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/application-permissions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_DASHBOARD_ID,

--- a/e2e/test/scenarios/permissions/create-queries.cy.spec.js
+++ b/e2e/test/scenarios/permissions/create-queries.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { USER_GROUPS } from "e2e/support/cypress_data";
 
 const { ALL_USERS_GROUP } = USER_GROUPS;

--- a/e2e/test/scenarios/permissions/data-model-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/data-model-permissions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, SAMPLE_DB_SCHEMA_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/permissions/database-details-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/database-details-permissions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 
 const DETAILS_PERMISSION_INDEX = 4;

--- a/e2e/test/scenarios/permissions/downgrade-ee-to-oss.cy.spec.js
+++ b/e2e/test/scenarios/permissions/downgrade-ee-to-oss.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { USER_GROUPS } from "e2e/support/cypress_data";
 
 const { ALL_USERS_GROUP } = USER_GROUPS;

--- a/e2e/test/scenarios/permissions/download-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/download-permissions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/permissions/impersonated.cy.spec.js
+++ b/e2e/test/scenarios/permissions/impersonated.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { USER_GROUPS } from "e2e/support/cypress_data";
 
 const { ALL_USERS_GROUP, COLLECTION_GROUP } = USER_GROUPS;

--- a/e2e/test/scenarios/permissions/permissions-baseline.cy.spec.js
+++ b/e2e/test/scenarios/permissions/permissions-baseline.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import {
   ADMIN_PERSONAL_COLLECTION_ID,

--- a/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, USERS, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import type {

--- a/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, USERS, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/permissions/view-data.cy.spec.js
+++ b/e2e/test/scenarios/permissions/view-data.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";

--- a/e2e/test/scenarios/question-reproductions/reproductions-1.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-1.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";

--- a/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { NO_COLLECTION_PERSONAL_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data";

--- a/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import type { Filter, LocalFieldReference } from "metabase-types/api";
 

--- a/e2e/test/scenarios/question/caching.cy.spec.js
+++ b/e2e/test/scenarios/question/caching.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 import { interceptPerformanceRoutes } from "../admin/performance/helpers/e2e-performance-helpers";

--- a/e2e/test/scenarios/question/column-compare.cy.spec.ts
+++ b/e2e/test/scenarios/question/column-compare.cy.spec.ts
@@ -1,6 +1,6 @@
 import _ from "underscore";
 
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import type { FieldReference, StructuredQuery } from "metabase-types/api";

--- a/e2e/test/scenarios/question/document-title.cy.spec.js
+++ b/e2e/test/scenarios/question/document-title.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 const PG_DB_ID = 2;
 

--- a/e2e/test/scenarios/question/multiple-column-breakouts.cy.spec.ts
+++ b/e2e/test/scenarios/question/multiple-column-breakouts.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS_ID, ORDERS, PEOPLE_ID, PEOPLE } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/question/native-query-drill.cy.spec.ts
+++ b/e2e/test/scenarios/question/native-query-drill.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 
 const ordersTableQuestionDetails: H.NativeQuestionDetails = {

--- a/e2e/test/scenarios/question/nested.cy.spec.js
+++ b/e2e/test/scenarios/question/nested.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, USERS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/question/notebook-link-to-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-link-to-data-source.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, USERS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/question/nulls.cy.spec.js
+++ b/e2e/test/scenarios/question/nulls.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/question/offset.cy.spec.ts
+++ b/e2e/test/scenarios/question/offset.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { uuid } from "metabase/lib/uuid";
 import type {

--- a/e2e/test/scenarios/question/query-external.cy.spec.js
+++ b/e2e/test/scenarios/question/query-external.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
 
 const supportedDatabases = [

--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -1,7 +1,7 @@
 import { onlyOn } from "@cypress/skip-test";
 import _ from "underscore";
 
-import { H } from "e2e/support";
+const { H } = cy;
 import { USERS, USER_GROUPS } from "e2e/support/cypress_data";
 import {
   ORDERS_COUNT_QUESTION_ID,

--- a/e2e/test/scenarios/question/questions-entity-id.cy.spec.ts
+++ b/e2e/test/scenarios/question/questions-entity-id.cy.spec.ts
@@ -1,4 +1,5 @@
 const { H } = cy;
+
 import {
   ORDERS_QUESTION_ENTITY_ID,
   ORDERS_QUESTION_ID,

--- a/e2e/test/scenarios/question/questions-entity-id.cy.spec.ts
+++ b/e2e/test/scenarios/question/questions-entity-id.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import {
   ORDERS_QUESTION_ENTITY_ID,
   ORDERS_QUESTION_ID,

--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_COUNT_QUESTION_ID,

--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/question/summarization.cy.spec.js
+++ b/e2e/test/scenarios/question/summarization.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 

--- a/e2e/test/scenarios/search/recently-viewed.cy.spec.js
+++ b/e2e/test/scenarios/search/recently-viewed.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,

--- a/e2e/test/scenarios/search/search-filters.cy.spec.js
+++ b/e2e/test/scenarios/search/search-filters.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/search/search-pagination.cy.spec.js
+++ b/e2e/test/scenarios/search/search-pagination.cy.spec.js
@@ -1,6 +1,6 @@
 import _ from "underscore";
 
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/search/search-snowplow.cy.spec.js
+++ b/e2e/test/scenarios/search/search-snowplow.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 import { commandPaletteInput } from "../../../support/helpers/e2e-command-palette-helpers";
 

--- a/e2e/test/scenarios/search/search-typeahead.cy.spec.js
+++ b/e2e/test/scenarios/search/search-typeahead.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { USERS } from "e2e/support/cypress_data";
 
 ["admin", "normal"].forEach(user => {

--- a/e2e/test/scenarios/search/search.cy.spec.js
+++ b/e2e/test/scenarios/search/search.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_DASHBOARD_ID,

--- a/e2e/test/scenarios/sharing/alert/alert-permissions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/alert-permissions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { USERS } from "e2e/support/cypress_data";
 import {
   ORDERS_BY_YEAR_QUESTION_ID,

--- a/e2e/test/scenarios/sharing/alert/alert-types.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/alert-types.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_BY_YEAR_QUESTION_ID,

--- a/e2e/test/scenarios/sharing/alert/alert.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/alert.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_COUNT_QUESTION_ID,

--- a/e2e/test/scenarios/sharing/alert/email-alert.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/email-alert.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 

--- a/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_DASHBOARD_DASHCARD_ID,

--- a/e2e/test/scenarios/sharing/downloads/sharing-download-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/sharing-download-reproductions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { PRODUCTS, ORDERS_ID } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/sharing/public-question.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-question.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { PEOPLE } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/sharing/public-resource-downloads.cy.spec.ts
+++ b/e2e/test/scenarios/sharing/public-resource-downloads.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import {
   ORDERS_BY_YEAR_QUESTION_ID,
   ORDERS_DASHBOARD_DASHCARD_ID,

--- a/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 ["dashboard", "question"].forEach(resource => {
   describe(`embed modal behavior for ${resource}s`, () => {

--- a/e2e/test/scenarios/sharing/public-sharing.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-sharing.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/sharing/sharing-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/sharing-reproductions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, USERS, WEBMAIL_CONFIG } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {

--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { USERS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";

--- a/e2e/test/scenarios/stats/instance-stats-snowplow.cy.spec.js
+++ b/e2e/test/scenarios/stats/instance-stats-snowplow.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 H.describeWithSnowplow("scenarios > stats > snowplow", () => {
   beforeEach(() => {

--- a/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/visualizations-charts/combo.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/combo.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/visualizations-charts/funnel.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/funnel.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/visualizations-charts/gauge.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/gauge.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/visualizations-charts/legend.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/legend.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PEOPLE, PRODUCTS } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/visualizations-charts/progress-bar.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/progress-bar.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/visualizations-charts/rows.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/rows.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 
 describe("scenarios > visualizations > rows", () => {
   beforeEach(() => {

--- a/e2e/test/scenarios/visualizations-charts/sankey.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/sankey.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 
 const SANKEY_QUERY = `

--- a/e2e/test/scenarios/visualizations-charts/scatter.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/scatter.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/visualizations-charts/trendline.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/trendline.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS_ID, ORDERS, PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/visualizations-charts/waterfall.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/waterfall.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/visualizations-tabular/column-shortcuts.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-tabular/column-shortcuts.cy.spec.ts
@@ -1,6 +1,6 @@
 import _ from "underscore";
 
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/chart_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/chart_drill.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/column_extract_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/column_extract_drill.cy.spec.js
@@ -1,6 +1,6 @@
 import _ from "underscore";
 
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/combine-column.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/combine-column.cy.spec.ts
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/dash_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/dash_drill.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_COUNT_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/table_drills.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/table_drills.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { REVIEWS, REVIEWS_ID, ACCOUNTS_ID } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { PIVOT_TABLE_BODY_LABEL } from "metabase/visualizations/visualizations/PivotTable/constants";

--- a/e2e/test/scenarios/visualizations-tabular/scalar.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/scalar.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
@@ -1,6 +1,6 @@
 import Color from "color";
 
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { colors } from "metabase/lib/colors";
 

--- a/e2e/test/scenarios/visualizations-tabular/table-column-settings.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table-column-settings.cy.spec.js
@@ -1,6 +1,6 @@
 import _ from "underscore";
 
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS_ID, ORDERS, PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;

--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 

--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -1,4 +1,4 @@
-import { H } from "e2e/support";
+const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ADMIN_USER_ID } from "e2e/support/cypress_sample_instance_data";

--- a/frontend/lint/eslint-rules/no-direct-helper-import.js
+++ b/frontend/lint/eslint-rules/no-direct-helper-import.js
@@ -1,0 +1,68 @@
+/**
+ * @fileoverview Rule to disallow importing H from e2e/support or e2e/support/helpers
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const ERROR_MESSAGE =
+  'Do not import "H" from "e2e/support". use "const { H } = cy" instead.';
+
+// eslint-disable-next-line import/no-commonjs
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow importing H directly from e2e support modules",
+      category: "Best Practices",
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      noHImport: ERROR_MESSAGE,
+    },
+    fixable: "code",
+  },
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value === "e2e/support") {
+          const hImportSpecifier = node.specifiers.find(
+            specifier =>
+              specifier.type === "ImportSpecifier" &&
+              specifier.imported.name === "H",
+          );
+
+          if (hImportSpecifier) {
+            context.report({
+              node,
+              message: ERROR_MESSAGE,
+              fix(fixer) {
+                if (node.specifiers.length > 1) {
+                  const start = hImportSpecifier.range[0];
+                  const end = node.specifiers[
+                    node.specifiers.indexOf(hImportSpecifier) + 1
+                  ]
+                    ? node.specifiers[node.specifiers.indexOf(hImportSpecifier)]
+                        .range[1] + 1
+                    : hImportSpecifier.range[1];
+
+                  return [
+                    fixer.removeRange([start, end]),
+                    fixer.insertTextBefore(node, "const { H } = cy;"),
+                  ];
+                }
+
+                return [
+                  fixer.remove(node),
+                  fixer.insertTextBefore(node, "const { H } = cy;"),
+                ];
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
`import { H } from "e2e/support"` was an important step in helpers discoverability. However, this increased the bundle rapidly, because we pretty much import everything all the time.

This PR introduces a change that will treeshake all the unused functions. This saves about 1 MB on each spec load.

~as a result, we are rewriting `H.helperName()` to `cy.H.helperName()`~

~as a result, we are rewriting `H.helperName()` to `cy.helperName()`~

~This may initially result in some naming conflicts with our custom commands, however these are soon to be moved to helpers. when both custom command and helper is present, custom command will be used.~

Just as I went to bed yesterday, I found a way that could actually work without minimal disruption. No renaming of the `H` object, but instead:

add helpers to cypress object
```js
// commands.js
cy.H = { ...H };
```

add helper types to Cypress
```ts
// e2e/support/index.ts
declare global {
  namespace Cypress {
    interface Chainable extends HelperTypes {
      H: typeof H;
    }
  }
}
```

and then in tests:
```diff
- import { H } from "e2e/support"
+ const { H } = cy
```

works like a charm (I think), what do you think @iethree ?
