### PR TITLE
Revise new table permissions logic to handle sandboxes

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
@@ -154,21 +154,15 @@
   "Returns the default view-data permission level for a new database for a given group. This is `blocked` if the
   group has block permissions for any existing database, or if any connection impersonation policies or sandboxes
   exist. Otherwise, it is `unrestricted`."
-  ;; We use :feature :none here since sandboxing uses a different feature flag from block perms & connection
-  ;; impersonation, so we need to check the flags in the function body.
-  :feature :none
+  :feature :advanced-permissions
   [group-id]
   (if (or
-       (and
-        (premium-features/enable-advanced-permissions?)
-        (t2/exists? :model/DataPermissions
-                    :perm_type :perms/view-data
-                    :perm_value :blocked
-                    :group_id group-id))
-       (and
-        (premium-features/enable-advanced-permissions?)
-        (t2/exists? :model/ConnectionImpersonation
-                    :group_id group-id))
+       (t2/exists? :model/DataPermissions
+                   :perm_type :perms/view-data
+                   :perm_value :blocked
+                   :group_id group-id)
+       (t2/exists? :model/ConnectionImpersonation
+                   :group_id group-id)
        (and
         (premium-features/enable-sandboxes?)
         (t2/exists? :model/GroupTableAccessPolicy
@@ -185,13 +179,11 @@
   ;; We don't check for connection impersonations here, because impersonations are set at the DB-level, so a new table
   ;; should get `:unrestricted` permissions and then inherit the DB-level impersonation policy.
   (if (or
-       (and
-        (premium-features/enable-advanced-permissions?)
-        (t2/exists? :model/DataPermissions
-                    :db_id db-id
-                    :perm_type :perms/view-data
-                    :perm_value :blocked
-                    :group_id group-id))
+       (t2/exists? :model/DataPermissions
+                   :db_id db-id
+                   :perm_type :perms/view-data
+                   :perm_value :blocked
+                   :group_id group-id)
        (and
         (premium-features/enable-sandboxes?)
         (t2/exists?
@@ -209,22 +201,18 @@
   "Returns the default view-data permission level for a new group for a given database. This is `blocked` if All Users
   has block permissions for the database, or if any connection impersonation policies or sandboxes exist. Otherwise, it
   is `unrestricted`."
-  :feature :none
+  :feature :advanced-permissions
   [db-id]
   (let [all-users-group-id (u/the-id (perms-group/all-users))]
     (if (or
-         (and
-          (premium-features/enable-advanced-permissions?)
-          (t2/exists? :model/DataPermissions
-                      :perm_type :perms/view-data
-                      :perm_value :blocked
-                      :db_id db-id
-                      :group_id all-users-group-id))
-         (and
-          (premium-features/enable-advanced-permissions?)
-          (t2/exists? :model/ConnectionImpersonation
-                      :group_id all-users-group-id
-                      :db_id db-id))
+         (t2/exists? :model/DataPermissions
+                     :perm_type :perms/view-data
+                     :perm_value :blocked
+                     :db_id db-id
+                     :group_id all-users-group-id)
+         (t2/exists? :model/ConnectionImpersonation
+                     :group_id all-users-group-id
+                     :db_id db-id)
          (and
           (premium-features/enable-sandboxes?)
           (t2/exists? :model/GroupTableAccessPolicy

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -889,14 +889,18 @@
                                                       :db_id       db-id
                                                       :table_id    (u/the-id table)
                                                       :schema_name schema-name}]
-                                        (if (and (db-level-group-ids group-id)
-                                                 (= new-value :blocked))
-                                           ;; Perms that are being added at the table-level for a group currently set at the DB
-                                           ;; level. This should only happen when adding a table to a DB where some existing
-                                           ;; tables are sandboxed, because the DB might have `:unrestricted` DB-level perms which
-                                           ;; need to be split out to table-level perms.
+                                        (cond
+                                          ;; Perms that are being added at the table-level for a group currently set at the DB
+                                          ;; level. This should only happen when adding a table to a DB where some existing
+                                          ;; tables are sandboxed, because the DB might have `:unrestricted` DB-level perms which
+                                          ;; need to be split out to table-level perms.
+                                          (and (db-level-group-ids group-id)
+                                               (= new-value :blocked))
                                           (update new-perms :going-granular conj new-perm)
-                                           ;; Perms that can be
+
+                                          ;; Otherwise, we only add a new table-level permission row if existing perms
+                                          ;; are table-level
+                                          (not (db-level-group-ids group-id))
                                           (update new-perms :simple-perms conj new-perm))))
                                     {:simple-perms [] :going-granular []}
                                     group-ids)

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -874,14 +874,14 @@
             new-perms              (reduce
                                     (fn [new-perms group-id]
                                       (let [new-value (or
-                                                         ;; Make sure we set `blocked` data access if we're on EE and *any*
-                                                         ;; other table in the DB has `blocked` or `sandboxed`
+                                                       ;; Make sure we set `blocked` data access if we're on EE and *any*
+                                                       ;; other table in the DB has `blocked` or `sandboxed`
                                                        (and (= perm-type :perms/view-data)
                                                             (new-table-view-data-permission-level db-id group-id))
-                                                         ;; Otherwise, if all tables in the schema have the same
-                                                         ;; value, use that value for the new table
+                                                       ;; Otherwise, if all tables in the schema have the same
+                                                       ;; value, use that value for the new table
                                                        (schema-permission-value db-id group-id schema-name perm-type)
-                                                         ;; Otherwise
+                                                       ;; Otherwise, use the default value passed in
                                                        default-value)
                                             new-perm {:perm_type   perm-type
                                                       :group_id    group-id

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -846,7 +846,7 @@
 
 (mu/defn set-new-table-permissions!
   "Sets permissions for a single table all the provided groups, based on the following rules:
-    - :view-data is set to :blocked if any other tables in the DB are :blocked
+    - :view-data is set to :blocked if any other tables in the DB are :blocked or sandboxed
     - If all existing tables in the schema have the same permission value, the new table is set to match them.
     - If permissions are set at the DB-level, no table permission is inserted.
     - Otherwise we use the provided `default-value`."
@@ -859,35 +859,51 @@
                     {perm-type (Permissions perm-type)})))
   (when (seq groups-or-ids)
     (t2/with-transaction [_conn]
-      (let [group-ids          (map u/the-id groups-or-ids)
-            table              (if (map? table-or-id)
-                                 table-or-id
-                                 (t2/select-one [:model/Table :id :db_id :schema] :id table-or-id))
-            db-id              (:db_id table)
-            schema-name        (:schema table)
-            db-level-perms     (t2/select :model/DataPermissions
-                                          :perm_type (u/qualified-name perm-type)
-                                          :db_id db-id
-                                          :table_id nil
-                                          {:where [:in :group_id group-ids]})
-            db-level-group-ids (set (map :group_id db-level-perms))
-            granular-group-ids (set/difference (set group-ids) db-level-group-ids)
-            new-perms          (map (fn [group-id]
-                                      {:perm_type   perm-type
-                                       :group_id    group-id
-                                       :perm_value  (or
-                                                     ;; Make sure we set `blocked` data access if any other table in the
-                                                     ;; DB has `blocked`
-                                                     (and (= perm-type :perms/view-data)
-                                                          (new-table-view-data-permission-level db-id group-id))
-
-                                                     ;; If all tables in the schema have the same value, use that value
-                                                     ;; for the new table
-                                                     (schema-permission-value db-id group-id schema-name perm-type)
-
-                                                     default-value)
-                                       :db_id       db-id
-                                       :table_id    (u/the-id table)
-                                       :schema_name schema-name})
-                                    granular-group-ids)]
-        (t2/insert! :model/DataPermissions new-perms)))))
+      (let [group-ids              (map u/the-id groups-or-ids)
+            table                  (if (map? table-or-id)
+                                     table-or-id
+                                     (t2/select-one [:model/Table :id :db_id :schema] :id table-or-id))
+            db-id                  (:db_id table)
+            schema-name            (:schema table)
+            db-level-perms         (t2/select :model/DataPermissions
+                                              :perm_type (u/qualified-name perm-type)
+                                              :db_id db-id
+                                              :table_id nil
+                                              {:where [:in :group_id group-ids]})
+            db-level-group-ids     (set (map :group_id db-level-perms))
+            new-perms              (reduce
+                                    (fn [new-perms group-id]
+                                      (let [new-value (or
+                                                         ;; Make sure we set `blocked` data access if we're on EE and *any*
+                                                         ;; other table in the DB has `blocked` or `sandboxed`
+                                                       (and (= perm-type :perms/view-data)
+                                                            (new-table-view-data-permission-level db-id group-id))
+                                                         ;; Otherwise, if all tables in the schema have the same
+                                                         ;; value, use that value for the new table
+                                                       (schema-permission-value db-id group-id schema-name perm-type)
+                                                         ;; Otherwise
+                                                       default-value)
+                                            new-perm {:perm_type   perm-type
+                                                      :group_id    group-id
+                                                      :perm_value  new-value
+                                                      :db_id       db-id
+                                                      :table_id    (u/the-id table)
+                                                      :schema_name schema-name}]
+                                        (if (and (db-level-group-ids group-id)
+                                                 (= new-value :blocked))
+                                           ;; Perms that are being added at the table-level for a group currently set at the DB
+                                           ;; level. This should only happen when adding a table to a DB where some existing
+                                           ;; tables are sandboxed, because the DB might have `:unrestricted` DB-level perms which
+                                           ;; need to be split out to table-level perms.
+                                          (update new-perms :going-granular conj new-perm)
+                                           ;; Perms that can be
+                                          (update new-perms :simple-perms conj new-perm))))
+                                    {:simple-perms [] :going-granular []}
+                                    group-ids)
+            {:keys [going-granular
+                    simple-perms]} new-perms]
+        ;; These perms might need existing DB-level perms to be broken out to table-level perms
+        (doseq [{:keys [perm_type perm_value group_id]} going-granular]
+          (set-table-permission! group_id table perm_type perm_value))
+        ;; These perms can be inserted raw, and don't require changes to existing perms in the DB
+        (t2/insert! :model/DataPermissions simple-perms)))))

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -901,7 +901,10 @@
                                           ;; Otherwise, we only add a new table-level permission row if existing perms
                                           ;; are table-level
                                           (not (db-level-group-ids group-id))
-                                          (update new-perms :simple-perms conj new-perm))))
+                                          (update new-perms :simple-perms conj new-perm)
+
+                                          :else
+                                          new-perms)))
                                     {:simple-perms [] :going-granular []}
                                     group-ids)
             {:keys [going-granular

--- a/src/metabase/premium_features/core.clj
+++ b/src/metabase/premium_features/core.clj
@@ -141,8 +141,7 @@
   :dashboard-subscription-filters)
 
 (define-premium-feature ^{:added "0.41.0"} enable-advanced-permissions?
-  "Should we enable extra knobs around permissions (block access, and in the future, moderator roles, feature-level
-  permissions, etc.)?"
+  "Should we enable extra knobs around permissions (block access, connection impersonation, etc.)?"
   :advanced-permissions)
 
 (define-premium-feature ^{:added "0.41.0"} enable-content-verification?


### PR DESCRIPTION
Makes sure that we detect sandboxes when a new table is added and set the table to use table-level block.

This is slightly complicated because sandboxes are stored in a separate table from data permissions, so a DB with sandboxes in some tables and `unrestricted` in all the others will have its permissions stored as `unrestricted` for the entire DB.

So if we add a new table, it should get block permissions, but we need to _also_ break out the DB-level `unrestricted` perms to table-level perms.

I've adjusted `set-new-table-permissions!` to handle this case. It differentiates between perms that need to be broken out from DB->table-level and perms that don't, and calls `set-table-permission!` individually on the former. This is more overhead but I think it's worth it here, since we need to ensure perms stay consistent when new tables are added.

Resolves https://github.com/metabase/metabase-private/issues/268