### PR TITLE
Optimize Backend & Driver Tests

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -67,6 +67,7 @@ jobs:
       (needs.files-changed.outputs.backend_all == 'true' || needs.static-viz-files-changed.outputs.static_viz == 'true')
     runs-on: ubuntu-22.04
     timeout-minutes: 10
+    name: Clj-Kondo
     steps:
       - uses: actions/checkout@v4
       - name: Prepare back-end environment
@@ -84,6 +85,7 @@ jobs:
       (needs.files-changed.outputs.backend_all == 'true' || needs.static-viz-files-changed.outputs.static_viz == 'true')
     runs-on: ubuntu-22.04
     timeout-minutes: 20
+    name: Eastwood
     steps:
       - uses: actions/checkout@v4
       - name: Prepare back-end environment
@@ -103,7 +105,7 @@ jobs:
       github.event.pull_request.draft == true &&
       (needs.files-changed.outputs.backend_all == 'true' || needs.static-viz-files-changed.outputs.static_viz == 'true')
     runs-on: ubuntu-22.04
-    name: be-tests-java-11-ee-pre-check
+    name: Java 11 EE Pre-Check
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -139,16 +141,53 @@ jobs:
       github.event.pull_request.draft == false &&
       (needs.files-changed.outputs.backend_all == 'true' || needs.static-viz-files-changed.outputs.static_viz == 'true')
     runs-on: ubuntu-22.04
-    name: be-tests-java-${{ matrix.java-version }}-${{ matrix.edition }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        edition: [oss, ee]
-        java-version: [11, 17, 21]
+        java-version:
+          - 11
+          - 17
+          - 21
+        job:
+          - name: Enterprise Tests
+            edition: ee
+            build-static-viz: 'false'
+            test-args: >-
+              :only '"enterprise/backend/test"'
+          - name: EE App DB Tests (Part 1)
+            edition: ee
+            build-static-viz: 'true'
+            test-args: >-
+              :only '["test" ".clj-kondo/test"]'
+              :partition/total 2
+              :partition/index 0
+          - name: EE App DB Tests (Part 2)
+            edition: ee
+            build-static-viz: 'true'
+            test-args: >-
+              :only '["test" ".clj-kondo/test"]'
+              :partition/total 2
+              :partition/index 1
+          - name: OSS App DB Tests (Part 1)
+            edition: oss
+            build-static-viz: 'true'
+            test-args: >-
+              :only '["test" ".clj-kondo/test"]'
+              :partition/total 2
+              :partition/index 0
+          - name: OSS App DB Tests (Part 2)
+            edition: oss
+            build-static-viz: 'true'
+            test-args: >-
+              :only '["test" ".clj-kondo/test"]'
+              :partition/total 2
+              :partition/index 1
+    name: "Java ${{ matrix.java-version }} ${{ matrix.job.name }}"
     steps:
       - uses: actions/checkout@v4
       - name: Prepare front-end environment
+        if: ${{ matrix.job.build-static-viz == 'true' }}
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
@@ -158,27 +197,28 @@ jobs:
       # Depending on which files changed, we might either have to build static-viz
       # from scratch or download the previously built artifact
       - name: Build static-viz frontend
-        if: needs.files-changed.outputs.backend_all == 'true'
+        if: ${{ matrix.job.build-static-viz == 'true' && needs.files-changed.outputs.backend_all == 'true' }}
         run: yarn build-static-viz
       - name: Download Static Viz Bundle Artifact
-        if: needs.static-viz-files-changed.outputs.static_viz == 'true'
+        if: ${{ matrix.job.build-static-viz == 'true' && needs.static-viz-files-changed.outputs.static_viz == 'true' }}
         uses: actions/download-artifact@v4
         with:
           name: static-viz-bundle-${{ github.sha }}
           path: resources/frontend_client/app/dist
 
-      - name: Run App DB tests
+      - name: Run ${{ matrix.job.name }}
         id: run-java-tests
         run: >-
-          clojure -X:dev:ci:test:${{ matrix.edition }}:${{ matrix.edition }}-dev
+          clojure -X:dev:ci:test:${{ matrix.job.edition }}:${{ matrix.job.edition }}-dev
           :exclude-tags [:mb/driver-tests]
+          ${{ matrix.job.test-args }}
 
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
         if: always() && (steps.run-java-tests.conclusion != 'skipped' || steps.run-java-tests-21.conclusion != 'skipped')
         with:
           input-path: ./target/junit/
-          output-name: be-tests-java-${{ matrix.java-version }}-${{ matrix.edition }}
+          output-name: be-tests-java-${{ matrix.java-version }}-${{ matrix.job.edition }}
           bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
           aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
@@ -190,7 +230,7 @@ jobs:
         if: failure()
         with:
           path: "target/junit/**/*_test.xml"
-          name: JUnit Test Report be-tests-java-${{ matrix.java-version }}-${{ matrix.edition }}
+          name: JUnit Test Report be-tests-java-${{ matrix.java-version }}-${{ matrix.job.edition }}
           reporter: java-junit
           list-suites: failed
           list-tests: failed
@@ -205,11 +245,11 @@ jobs:
       github.event.pull_request.draft == false &&
       (needs.files-changed.outputs.backend_all == 'true' || needs.static-viz-files-changed.outputs.static_viz == 'true')
     runs-on: ubuntu-22.04
-    name: be-check-java-${{ matrix.java-version }}
     timeout-minutes: 10
     strategy:
       matrix:
         java-version: [11, 17, 21]
+    name: "Check Java ${{ matrix.java-version }}"
     steps:
       - uses: actions/checkout@v4
       - name: Prepare backend
@@ -225,6 +265,7 @@ jobs:
       !cancelled() && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
+    name: Cljfmt
     steps:
       - uses: actions/checkout@v4
       - name: Prepare back-end environment

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -35,6 +35,7 @@ jobs:
     timeout-minutes: 60
     env:
       CI: 'true'
+    name: H2
     steps:
     - uses: actions/checkout@v4
     - name: Test H2 driver
@@ -70,6 +71,7 @@ jobs:
       # These credentials are used to test the driver when the user does not have the athena:GetTableMetadata permission
       MB_ATHENA_TEST_WITHOUT_GET_TABLE_METADATA_ACCESS_KEY: ${{ secrets.MB_ATHENA_TEST_WITHOUT_GET_TABLE_METADATA_ACCESS_KEY }}
       MB_ATHENA_TEST_WITHOUT_GET_TABLE_METADATA_SECRET_KEY: ${{ secrets.MB_ATHENA_TEST_WITHOUT_GET_TABLE_METADATA_SECRET_KEY }}
+    name: Athena
     steps:
     - uses: actions/checkout@v4
     - name: Test Athena driver
@@ -104,6 +106,7 @@ jobs:
       MB_BIGQUERY_TEST_ACCESS_TOKEN: ${{ secrets.MB_BIGQUERY_TEST_ACCESS_TOKEN }}
       MB_BIGQUERY_TEST_REFRESH_TOKEN: ${{ secrets.MB_BIGQUERY_TEST_REFRESH_TOKEN }}
       MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON: ${{ secrets.MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON }}
+    name: BigQuery
     steps:
     - uses: actions/checkout@v4
     - name: Test BigQuery Cloud SDK driver
@@ -139,6 +142,7 @@ jobs:
           - "8082:8082"
         env:
           CLUSTER_SIZE: nano-quickstart
+    name: Druid (Legacy)
     steps:
     - uses: actions/checkout@v4
     - name: Test Druid driver
@@ -173,6 +177,7 @@ jobs:
       MB_DATABRICKS_TEST_CATALOG: 'metabase_ci'
       MB_DATABRICKS_TEST_CLIENT_ID: ${{ secrets.MB_DATABRICKS_JDBC_TEST_CLIENT_ID }}
       MB_DATABRICKS_TEST_OAUTH_SECRET: ${{ secrets.MB_DATABRICKS_JDBC_TEST_OAUTH_SECRET }}
+    name: Databricks
     steps:
     - uses: actions/checkout@v4
     - name: Test Databricks driver
@@ -208,6 +213,7 @@ jobs:
           - "8888:8888"
         env:
           CLUSTER_SIZE: nano-quickstart
+    name: Druid (JDBC)
     steps:
     - uses: actions/checkout@v4
     - name: Test Druid JDBC driver
@@ -262,15 +268,22 @@ jobs:
             build-static-viz: false
             test-args: >-
               :only-tags [:mb/driver-tests]
-          - name: App DB Tests (Part 1)
+          - name: Enterprise Tests
+            build-static-viz: false
+            test-args: >-
+              :only '"enterprise/backend/test"'
+              :exclude-tags [:mb/driver-tests]
+          - name: EE App DB Tests (Part 1)
             build-static-viz: true
             test-args: >-
+              :only '"test"'
               :exclude-tags [:mb/driver-tests]
               :partition/total 2
               :partition/index 0
-          - name: App DB Tests (Part 2)
+          - name: EE App DB Tests (Part 2)
             build-static-viz: true
             test-args: >-
+              :only '"test"'
               :exclude-tags [:mb/driver-tests]
               :partition/total 2
               :partition/index 1
@@ -331,11 +344,24 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
-  be-tests-mongo-4-4-ee:
+  be-tests-mongo:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - name: MongoDB 4.4
+            junit-name: be-tests-mongo-4-4-ee
+            image: metabase/qa-databases:mongo-sample-4.4
+          - name: MongoDB 5.0
+            junit-name: be-tests-mongo-5-0-ee
+            image: metabase/qa-databases:mongo-sample-5.0
+          - name: MongoDB Latest
+            junit-name: be-tests-mongo-latest-ee
+            image: circleci/mongo:latest
     env:
       CI: 'true'
       DRIVERS: mongo
@@ -343,15 +369,19 @@ jobs:
       MB_MONGO_TEST_PASSWORD: metasample123
     services:
       mongodb:
-        image: metabase/qa-databases:mongo-sample-4.4
+        image: ${{ matrix.version.image }}
         ports:
           - "27017:27017"
+        env:
+          MONGO_INITDB_ROOT_USERNAME: metabase
+          MONGO_INITDB_ROOT_PASSWORD: metasample123
+    name: ${{ matrix.version.name }}
     steps:
     - uses: actions/checkout@v4
-    - name: Test MongoDB driver (4.4)
+    - name: Test ${{ matrix.version.name }}
       uses: ./.github/actions/test-driver
       with:
-        junit-name: 'be-tests-mongo-4-4-ee'
+        junit-name: ${{ matrix.version.junit-name }}
         test-args: >-
           :exclude-tags [:mongo-sharded-cluster-tests]
           :only-tags [:mb/driver-tests]
@@ -367,17 +397,28 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
-  be-tests-mongo-4-4-ssl-ee:
+  be-tests-mongo-ssl:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - name: MongoDB 4.4
+            junit-name: be-tests-mongo-4-4-ee
+            image: metabase/qa-databases:mongo-sample-4.4
+          - name: MongoDB 5.0
+            junit-name: be-tests-mongo-5-0-ssl-ee
+            image: metabase/qa-databases:mongo-sample-5.0
     env:
       CI: 'true'
       DRIVERS: mongo
       MB_MONGO_TEST_USER: metabase
       MB_MONGO_TEST_PASSWORD: metasample123
       MB_TEST_MONGO_REQUIRES_SSL: true
+    name: "${{ matrix.version.name }} (SSL)"
     steps:
       - uses: actions/checkout@v4
       - name: Spin up Mongo docker container
@@ -385,7 +426,7 @@ jobs:
           docker run -d
           -p 27017:27017
           --name metamongo
-          metabase/qa-databases:mongo-sample-4.4
+          ${{ matrix.version.image }}
           mongod
           --dbpath /data/db2/
           --tlsMode requireTLS
@@ -405,10 +446,10 @@ jobs:
 
           curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metaca.crt \
           -o ./test_resources/ssl/mongo/metaca.crt
-      - name: Test MongoDB SSL driver (4.4)
+      - name: Test ${{ matrix.version.name }}
         uses: ./.github/actions/test-driver
         with:
-          junit-name: 'be-tests-mongo-4-4-ee'
+          junit-name: ${{ matrix.version.junit-name }}
           test-args: >-
             :exclude-tags [:mongo-sharded-cluster-tests]
             :only-tags [:mb/driver-tests]
@@ -424,138 +465,6 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
-  be-tests-mongo-5-0-ee:
-    needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-22.04
-    timeout-minutes: 90
-    env:
-      CI: 'true'
-      DRIVERS: mongo
-      MB_MONGO_TEST_USER: metabase
-      MB_MONGO_TEST_PASSWORD: metasample123
-    services:
-      mongodb:
-        image: metabase/qa-databases:mongo-sample-5.0
-        ports:
-          - "27017:27017"
-    steps:
-    - uses: actions/checkout@v4
-    - name: Test MongoDB driver (5.0)
-      uses: ./.github/actions/test-driver
-      with:
-        junit-name: 'be-tests-mongo-5-0-ee'
-        test-args: >-
-          :exclude-tags [:mongo-sharded-cluster-tests]
-          :only-tags [:mb/driver-tests]
-    - name: Upload Test Results
-      uses: ./.github/actions/upload-test-results
-      if: always()
-      with:
-        input-path: ./target/junit/
-        output-name: ${{ github.job }}
-        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
-        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ vars.AWS_REGION }}
-        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
-
-  be-tests-mongo-5-0-ssl-ee:
-    needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-22.04
-    timeout-minutes: 90
-    env:
-      CI: 'true'
-      DRIVERS: mongo
-      MB_MONGO_TEST_USER: metabase
-      MB_MONGO_TEST_PASSWORD: metasample123
-      MB_TEST_MONGO_REQUIRES_SSL: true
-    steps:
-    - uses: actions/checkout@v4
-    - name: Spin up Mongo docker container
-      run: >-
-        docker run -d
-        -p 27017:27017
-        --name metamongo
-        metabase/qa-databases:mongo-sample-5.0
-        mongod
-        --dbpath /data/db2/
-        --tlsMode requireTLS
-        --tlsCertificateKeyFile /etc/mongo/metamongo.pem
-        --tlsCAFile /etc/mongo/metaca.crt
-    - uses: ./.github/actions/await-port
-      with:
-        port: 27017
-      timeout-minutes: 5
-    - name: Make SSL certificates for Mongo available
-      run: |
-        curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metabase.crt \
-        -o ./test_resources/ssl/mongo/metabase.crt
-
-        curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metabase.key \
-        -o ./test_resources/ssl/mongo/metabase.key
-
-        curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metaca.crt \
-        -o ./test_resources/ssl/mongo/metaca.crt
-    - name: Test MongoDB SSL driver (5.0)
-      uses: ./.github/actions/test-driver
-      with:
-        junit-name: 'be-tests-mongo-5-0-ee'
-        test-args: >-
-          :exclude-tags [:mongo-sharded-cluster-tests]
-          :only-tags [:mb/driver-tests]
-    - name: Upload Test Results
-      uses: ./.github/actions/upload-test-results
-      if: always()
-      with:
-        input-path: ./target/junit/
-        output-name: ${{ github.job }}
-        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
-        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ vars.AWS_REGION }}
-        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
-
-  be-tests-mongo-latest-ee:
-    needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-22.04
-    timeout-minutes: 90
-    env:
-      CI: 'true'
-      DRIVERS: mongo
-      MB_MONGO_TEST_USER: metabase
-      MB_MONGO_TEST_PASSWORD: metasample123
-    services:
-      mongodb:
-        image: circleci/mongo:latest
-        ports:
-          - "27017:27017"
-        env:
-          MONGO_INITDB_ROOT_USERNAME: metabase
-          MONGO_INITDB_ROOT_PASSWORD: metasample123
-    steps:
-    - uses: actions/checkout@v4
-    - name: Test MongoDB driver (latest)
-      uses: ./.github/actions/test-driver
-      with:
-        junit-name: 'be-tests-mongo-latest-ee'
-        test-args: >-
-          :exclude-tags [:mongo-sharded-cluster-tests]
-          :only-tags [:mb/driver-tests]
-    - name: Upload Test Results
-      uses: ./.github/actions/upload-test-results
-      if: always()
-      with:
-        input-path: ./target/junit/
-        output-name: ${{ github.job }}
-        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
-        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ vars.AWS_REGION }}
-        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
-
   be-tests-mongo-sharded-cluster-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
@@ -569,52 +478,15 @@ jobs:
         image: metabase/mongo-sharded-cluster:6
         ports:
           - "27017:17017"
+    name: MongoDB Sharded Cluster
     steps:
     - uses: actions/checkout@v4
     - name: Test MongoDB driver (Sharded cluster)
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-mongo-sharded-cluster-ee'
-        test-args: ':only "[metabase.driver.mongo.sharded-cluster-test]"'
-    - name: Upload Test Results
-      uses: ./.github/actions/upload-test-results
-      if: always()
-      with:
-        input-path: ./target/junit/
-        output-name: ${{ github.job }}
-        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
-        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ vars.AWS_REGION }}
-        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
-
-  be-tests-oracle-18-4-ee:
-    needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-22.04
-    timeout-minutes: 90
-    env:
-      CI: 'true'
-      DRIVERS: oracle
-      MB_ORACLE_TEST_HOST: localhost
-      MB_ORACLE_TEST_USER: system
-      MB_ORACLE_TEST_PASSWORD: password
-      MB_ORACLE_TEST_SERVICE_NAME: XEPDB1
-    services:
-      oracle:
-        image: gvenzl/oracle-xe:18.4.0-slim
-        env:
-          ORACLE_PASSWORD: password
-        ports:
-          - "1521:1521"
-    steps:
-    - uses: actions/checkout@v4
-    - name: Test Oracle driver (18.4)
-      uses: ./.github/actions/test-driver
-      with:
-        junit-name: 'be-tests-oracle-18-4-ee'
         test-args: >-
-          :only-tags [:mb/driver-tests]
+          :only metabase.driver.mongo.sharded-cluster-test
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -627,40 +499,64 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
-  be-tests-oracle-21-3-ee:
+  be-tests-oracle:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - name: Oracle 18.4
+            junit-name: be-tests-oracle-18-4-ee
+            image: gvenzl/oracle-xe:18.4.0-slim
+            port: 1521
+            env:
+              user: system
+              password: 'password'
+              enable-ssl-tests: false
+          - name: Oracle 21.3
+            junit-name: be-tests-oracle-21-3-ee
+            image: metabase/qa-databases:oracle-xe-21.3
+            port: 2484
+            env:
+              user: ''
+              password: ''
+              enable-ssl-tests: true
     env:
       CI: 'true'
       DRIVERS: oracle
       MB_ORACLE_TEST_HOST: localhost
-      MB_ORACLE_TEST_PORT: 2484
+      MB_ORACLE_TEST_USER: '${{ matrix.version.env.user }}'
       MB_ORACLE_TEST_SERVICE_NAME: XEPDB1
-      MB_ORACLE_TEST_SSL: true
-      MB_ORACLE_TEST_SSL_USE_TRUSTSTORE: true
+      # Only the non-SSL 18.4 tests specify password as an env var; the SSL 21.3 tests get it from the keystore I guess
+      MB_ORACLE_TEST_PASSWORD: '${{ matrix.version.env.password }}'
+      # These are ignored for the 18.4 tests which do not test SSL
+      MB_ORACLE_TEST_SSL: ${{ matrix.version.env.enable-ssl-tests }}
+      MB_ORACLE_SSL_TEST_SSL: ${{ matrix.version.env.enable-ssl-tests }}
+      MB_ORACLE_TEST_SSL_USE_TRUSTSTORE: ${{ matrix.version.env.enable-ssl-tests }}
       MB_ORACLE_TEST_SSL_TRUSTSTORE_PATH: './test_resources/ssl/oracle/truststore.p12'
       MB_ORACLE_TEST_SSL_TRUSTSTORE_OPTIONS: local
       MB_ORACLE_TEST_SSL_TRUSTSTORE_PASSWORD_VALUE: 'PassworD_#1234'
-      MB_ORACLE_TEST_SSL_USE_KEYSTORE: true
+      MB_ORACLE_TEST_SSL_USE_KEYSTORE: ${{ matrix.version.env.enable-ssl-tests }}
       MB_ORACLE_TEST_SSL_KEYSTORE_PATH: './test_resources/ssl/oracle/keystore.p12'
       MB_ORACLE_TEST_SSL_KEYSTORE_OPTIONS: local
       MB_ORACLE_TEST_SSL_KEYSTORE_PASSWORD_VALUE: 'PassworD_#1234'
-      MB_ORACLE_SSL_TEST_SSL: true
     services:
       oracle:
-        image: metabase/qa-databases:oracle-xe-21.3
+        image: ${{ matrix.version.image }}
         env:
           ORACLE_PASSWORD: password
         ports:
-          - "2484:2484"
+          - "1521:${{ matrix.version.port }}"
+    name: ${{ matrix.version.name }}
     steps:
     - uses: actions/checkout@v4
-    - name: Test Oracle driver (21.3)
+    - name: Test ${{ matrix.version.name }}
       uses: ./.github/actions/test-driver
       with:
-        junit-name: 'be-tests-oracle-21-3-ee'
+        junit-name: ${{ matrix.version.junit-name }}
         test-args: >-
           :only-tags [:mb/driver-tests]
     - name: Upload Test Results
@@ -675,7 +571,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
-  be-tests-postgres-ee:
+  be-tests-postgres:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
@@ -699,15 +595,22 @@ jobs:
             build-static-viz: false
             test-args: >-
               :only-tags [:mb/driver-tests]
-          - name: App DB Tests (Part 1)
+          - name: Enterprise Tests
+            build-static-viz: false
+            test-args: >-
+              :only '"enterprise/backend/test"'
+              :exclude-tags [:mb/driver-tests]
+          - name: EE App DB Tests (Part 1)
             build-static-viz: true
             test-args: >-
+              :only '"test"'
               :exclude-tags [:mb/driver-tests]
               :partition/total 2
               :partition/index 0
-          - name: App DB Tests (Part 2)
+          - name: EE App DB Tests (Part 2)
             build-static-viz: true
             test-args: >-
+              only '"test"'
               :exclude-tags [:mb/driver-tests]
               :partition/total 2
               :partition/index 1
@@ -771,6 +674,7 @@ jobs:
       MB_PRESTO_JDBC_TEST_PASSWORD: metabase
       MB_ENABLE_PRESTO_JDBC_DRIVER: true
       MB_PRESTO_JDBC_TEST_ADDITIONAL_OPTIONS: 'SSLTrustStorePath=/tmp/cacerts-with-presto-ssl.jks&SSLTrustStorePassword=changeit'
+    name: Presto
     services:
       presto:
         image: metabase/presto-mb-ci:latest # version 0.254
@@ -835,6 +739,7 @@ jobs:
       MB_REDSHIFT_TEST_DB: testdb
       MB_REDSHIFT_TEST_HOST: ${{ secrets.MB_REDSHIFT_TEST_HOST }}
       MB_REDSHIFT_TEST_PASSWORD: ${{ secrets.MB_REDSHIFT_TEST_PASSWORD }}
+    name: Redshift
     steps:
     - uses: actions/checkout@v4
     - name: Test Redshift driver
@@ -874,6 +779,7 @@ jobs:
       MB_SNOWFLAKE_TEST_RSA_ROLE_TEST_CUSTOM_USER: RSA_ROLE_TEST_CUSTOM_USER
       MB_SNOWFLAKE_TEST_RSA_ROLE_TEST_ROLE: RSA_ROLE_TEST_ROLE
       MB_SNOWFLAKE_TEST_RSA_ROLE_TEST_DB: RSA_ROLE_TEST_DB
+    name: Snowflake
     steps:
     - uses: actions/checkout@v4
     - name: Test Snowflake driver
@@ -907,6 +813,7 @@ jobs:
         image: metabase/spark:3.2.1
         ports:
           - "10000:10000"
+    name: Spark SQL
     steps:
     - uses: actions/checkout@v4
     - name: Test Spark driver
@@ -935,6 +842,7 @@ jobs:
     env:
       CI: 'true'
       DRIVERS: sqlite
+    name: SQLite
     steps:
     - uses: actions/checkout@v4
     - name: Test SQLite driver
@@ -955,11 +863,21 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
-  be-tests-sqlserver-2017-ee:
+  be-tests-sqlserver:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-20.04
     timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - name: SQL Server 2017
+            junit-name: be-tests-sqlserver-2017-ee
+            image: mcr.microsoft.com/mssql/server:2017-latest
+          - name: SQL Server 2022
+            junit-name: be-tests-sqlserver-2022-ee
+            image: mcr.microsoft.com/mssql/server:2022-latest
     env:
       CI: 'true'
       DRIVERS: sqlserver
@@ -968,59 +886,20 @@ jobs:
       MB_SQLSERVER_TEST_USER: SA
     services:
       sqlserver:
-        image: mcr.microsoft.com/mssql/server:2017-latest
+        image: ${{ matrix.version.image }}
         ports:
           - "1433:1433"
         env:
           ACCEPT_EULA: Y
           SA_PASSWORD: 'P@ssw0rd'
           MSSQL_MEMORY_LIMIT_MB: 1024
+    name: ${{ matrix.version.name }}
     steps:
     - uses: actions/checkout@v4
-    - name: Test MS SQL Server 2017 driver
+    - name: Test ${{ matrix.version.name }}
       uses: ./.github/actions/test-driver
       with:
-        junit-name: 'be-tests-sqlserver-ee'
-        test-args: >-
-          :only-tags [:mb/driver-tests]
-    - name: Upload Test Results
-      uses: ./.github/actions/upload-test-results
-      if: always()
-      with:
-        input-path: ./target/junit/
-        output-name: ${{ github.job }}
-        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
-        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ vars.AWS_REGION }}
-        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
-
-  be-tests-sqlserver-2022-ee:
-    needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-22.04
-    timeout-minutes: 90
-    env:
-      CI: 'true'
-      DRIVERS: sqlserver
-      MB_SQLSERVER_TEST_HOST: localhost
-      MB_SQLSERVER_TEST_PASSWORD: 'P@ssw0rd'
-      MB_SQLSERVER_TEST_USER: SA
-    services:
-      sqlserver:
-        image: mcr.microsoft.com/mssql/server:2022-latest
-        ports:
-          - "1433:1433"
-        env:
-          ACCEPT_EULA: Y
-          SA_PASSWORD: 'P@ssw0rd'
-          MSSQL_MEMORY_LIMIT_MB: 1024
-    steps:
-    - uses: actions/checkout@v4
-    - name: Test MS SQL Server 2022 driver
-      uses: ./.github/actions/test-driver
-      with:
-        junit-name: 'be-tests-sqlserver-2022-ee'
+        junit-name: ${{ matrix.version.junit-name }}
         test-args: >-
           :only-tags [:mb/driver-tests]
     - name: Upload Test Results
@@ -1048,6 +927,7 @@ jobs:
         image: vertica/vertica-ce:12.0.2-0
         ports:
           - "5433:5433"
+    name: Vertica
     steps:
     - uses: actions/checkout@v4
     - name: Make plugins directory
@@ -1080,22 +960,17 @@ jobs:
       - be-tests-databricks-ee
       - be-tests-druid-jdbc-ee
       - be-tests-mysql-mariadb
-      - be-tests-mongo-4-4-ee
-      - be-tests-mongo-4-4-ssl-ee
-      - be-tests-mongo-5-0-ee
-      - be-tests-mongo-5-0-ssl-ee
-      - be-tests-mongo-latest-ee
+      - be-tests-mongo
+      - be-tests-mongo-ssl
       - be-tests-mongo-sharded-cluster-ee
-      - be-tests-oracle-18-4-ee
-      - be-tests-oracle-21-3-ee
-      - be-tests-postgres-ee
+      - be-tests-oracle
+      - be-tests-postgres
       - be-tests-presto-jdbc-ee
       - be-tests-redshift-ee
       - be-tests-snowflake-ee
       - be-tests-sparksql-ee
       - be-tests-sqlite-ee
-      - be-tests-sqlserver-2017-ee
-      - be-tests-sqlserver-2022-ee
+      - be-tests-sqlserver
       - be-tests-vertica-ee
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -1118,12 +993,35 @@ jobs:
 
             // are all jobs skipped or successful?
             if (jobs.every(job => (job.result === 'skipped' || job.result === 'success'))) {
-              console.log('All jobs are skipped or successful');
+                console.log("");
+                console.log("        _------.        ");
+                console.log("       /  ,     \_      ");
+                console.log("     /   /  /{}\ |o\_   ");
+                console.log("    /    \  `--' /-' \  ");
+                console.log("   |      \      \    | ");
+                console.log("  |              |`-, | ");
+                console.log("  /              /__/)/ ");
+                console.log(" |              |       ");
+                console.log("");
+                console.log("All driver tests have passed (or have been skipped). Cam is very proud of you.");
               process.exit(0);
             }
 
             // otherwise, something failed
-            console.log('Some drivers jobs failed');
+            console.log("");
+            console.log("       .::::::::::.                          .::::::::::.       ");
+            console.log("     .::::''''''::::.                      .::::''''''::::.     ");
+            console.log("   .:::'          `::::....          ....::::'          `:::.   ");
+            console.log("  .::'             `:::::::|        |:::::::'             `::.  ");
+            console.log(" .::|               |::::::|_ ___ __|::::::|               |::. ");
+            console.log(" `--'               |::::::|_()__()_|::::::|               `--' ");
+            console.log("  :::               |::-o::|        |::o-::|               :::  ");
+            console.log("  `::.             .|::::::|        |::::::|.             .::'  ");
+            console.log("   `:::.          .::\-----'        `-----/::.          .:::'   ");
+            console.log("     `::::......::::'                      `::::......::::'     ");
+            console.log("       `::::::::::'                          `::::::::::'       ");
+            console.log("");
+            console.log("Driver tests have failed. You have been sentenced to MetaJail.");
 
             jobs.forEach((job) => {
               if (job.result !== 'success') {

--- a/deps.edn
+++ b/deps.edn
@@ -243,7 +243,7 @@
     djblue/portal                {:mvn/version "0.58.3"}                    ; ui for inspecting values
     hashp/hashp                  {:mvn/version "0.2.2"}                     ; debugging/spying utility
     io.github.camsaul/humane-are {:mvn/version "1.0.2"}
-    io.github.metabase/hawk      {:mvn/version "1.0.5"}
+    io.github.metabase/hawk      {:mvn/version "1.0.6"}
     jonase/eastwood              {:mvn/version "1.4.3"                      ; inspects namespaces and reports possible problems using tools.analyzer
                                   :exclusions
                                   [org.ow2.asm/asm-all]}
@@ -382,7 +382,7 @@
     cider/piggieback                   {:mvn/version "0.5.3"}
     cljs-bean/cljs-bean                {:mvn/version "1.9.0"}
     com.lambdaisland/glogi             {:mvn/version "1.3.169"}
-    io.github.metabase/hawk            {:mvn/version "1.0.5"}
+    io.github.metabase/hawk            {:mvn/version "1.0.6"}
     org.clojars.mmb90/cljs-cache       {:mvn/version "0.1.4"}
     refactor-nrepl/refactor-nrepl      {:mvn/version "3.10.0"}
     thheller/shadow-cljs               {:mvn/version "2.28.20"}}}

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -4,6 +4,7 @@
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [environ.core :as env]
    [java-time.api :as t]
    [metabase.api.common :as api]
    [metabase.driver :as driver]
@@ -388,7 +389,7 @@
 (deftest oracle-connect-with-ssl-test
   ;; ridiculously hacky test; hopefully it can be simplified; see inline comments for full explanations
   (mt/test-driver :oracle
-    (if (System/getenv "MB_ORACLE_SSL_TEST_SSL") ; only even run this test if this env var is set
+    (if (some-> (env/env :mb-oracle-ssl-test-ssl) Boolean/parseBoolean)
       ;; swap out :oracle env vars with any :oracle-ssl ones that were defined
       (mt/with-env-keys-renamed-by #(str/replace-first % "mb-oracle-ssl-test" "mb-oracle-test")
         ;; need to get a fresh instance of details to pick up env key changes

--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -9,6 +9,7 @@
    [metabase.search.ingestion :as search.ingestion]
    [metabase.search.spec :as search.spec]
    [metabase.search.util :as search.util]
+   [metabase.util.log :as log]
    [potemkin :as p]))
 
 (comment
@@ -57,10 +58,13 @@
   "Populate a new index, and make it active. Simultaneously updates the current index."
   [& {:as opts}]
   ;; If there are multiple indexes, return the peak inserted for each type. In practice, they should all be the same.
-  (reduce (partial merge-with max)
-          nil
-          (for [e (search.engine/active-engines)]
-            (search.engine/reindex! e opts))))
+  (try
+    (reduce (partial merge-with max)
+            nil
+            (for [e (search.engine/active-engines)]
+              (search.engine/reindex! e opts)))
+    (catch Throwable e
+      (log/fatal e "Error reindexing search indexes."))))
 
 (defn reset-tracking!
   "Stop tracking the current indexes. Used when resetting the appdb."


### PR DESCRIPTION
- Consolidate CI configs for Mongo, Oracle, and SQL Server. This will make it easier to partition these jobs in the future
- Split off MySQL/MariaDB and Postgres enterprise tests into separate job
- Split up the backend tests a bit