### PR TITLE
Replace FormFooter default export  with named export

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModalView.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModalView.tsx
@@ -7,7 +7,7 @@ import Alert from "metabase/core/components/Alert";
 import Button from "metabase/core/components/Button";
 import ExternalLink from "metabase/core/components/ExternalLink/ExternalLink";
 import FormErrorMessage from "metabase/core/components/FormErrorMessage";
-import FormFooter from "metabase/core/components/FormFooter";
+import { FormFooter } from "metabase/core/components/FormFooter";
 import FormSelect from "metabase/core/components/FormSelect";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import Link from "metabase/core/components/Link/Link";

--- a/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionForm.tsx
@@ -7,7 +7,7 @@ import FormCollectionPicker from "metabase/collections/containers/FormCollection
 import type { CollectionPickerItem } from "metabase/common/components/CollectionPicker";
 import Button from "metabase/core/components/Button";
 import FormErrorMessage from "metabase/core/components/FormErrorMessage";
-import FormFooter from "metabase/core/components/FormFooter";
+import { FormFooter } from "metabase/core/components/FormFooter";
 import FormInput from "metabase/core/components/FormInput";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import FormTextArea from "metabase/core/components/FormTextArea";

--- a/frontend/src/metabase/actions/containers/ActionCreator/CreateActionForm/CreateActionForm.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/CreateActionForm/CreateActionForm.tsx
@@ -4,7 +4,7 @@ import * as Yup from "yup";
 
 import Button from "metabase/core/components/Button";
 import FormErrorMessage from "metabase/core/components/FormErrorMessage";
-import FormFooter from "metabase/core/components/FormFooter";
+import { FormFooter } from "metabase/core/components/FormFooter";
 import FormInput from "metabase/core/components/FormInput";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import FormTextArea from "metabase/core/components/FormTextArea";

--- a/frontend/src/metabase/admin/people/forms/UserForm.tsx
+++ b/frontend/src/metabase/admin/people/forms/UserForm.tsx
@@ -1,7 +1,7 @@
 import { t } from "ttag";
 import * as Yup from "yup";
 
-import FormFooter from "metabase/core/components/FormFooter";
+import { FormFooter } from "metabase/core/components/FormFooter";
 import {
   Form,
   FormErrorMessage,

--- a/frontend/src/metabase/collections/components/CreateCollectionForm/CreateCollectionForm.tsx
+++ b/frontend/src/metabase/collections/components/CreateCollectionForm/CreateCollectionForm.tsx
@@ -8,7 +8,7 @@ import FormCollectionPicker from "metabase/collections/containers/FormCollection
 import type { FilterItemsInPersonalCollection } from "metabase/common/components/EntityPicker";
 import Button from "metabase/core/components/Button";
 import FormErrorMessage from "metabase/core/components/FormErrorMessage";
-import FormFooter from "metabase/core/components/FormFooter";
+import { FormFooter } from "metabase/core/components/FormFooter";
 import FormInput from "metabase/core/components/FormInput";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import FormTextArea from "metabase/core/components/FormTextArea";

--- a/frontend/src/metabase/common/components/CollectionPicker/components/NewCollectionDialog.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/NewCollectionDialog.tsx
@@ -1,7 +1,7 @@
 import { t } from "ttag";
 
 import { useCreateCollectionMutation } from "metabase/api";
-import FormFooter from "metabase/core/components/FormFooter";
+import { FormFooter } from "metabase/core/components/FormFooter";
 import {
   Form,
   FormErrorMessage,

--- a/frontend/src/metabase/common/components/DashboardPicker/components/NewDashboardDialog.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/NewDashboardDialog.tsx
@@ -1,7 +1,7 @@
 import { t } from "ttag";
 
 import { useCreateDashboardMutation } from "metabase/api";
-import FormFooter from "metabase/core/components/FormFooter";
+import { FormFooter } from "metabase/core/components/FormFooter";
 import {
   Form,
   FormErrorMessage,

--- a/frontend/src/metabase/components/SaveQuestionForm/SaveQuestionForm.tsx
+++ b/frontend/src/metabase/components/SaveQuestionForm/SaveQuestionForm.tsx
@@ -5,7 +5,7 @@ import type { CollectionPickerModel } from "metabase/common/components/Collectio
 import { getPlaceholder } from "metabase/components/SaveQuestionForm/util";
 import Button from "metabase/core/components/Button";
 import FormErrorMessage from "metabase/core/components/FormErrorMessage";
-import FormFooter from "metabase/core/components/FormFooter";
+import { FormFooter } from "metabase/core/components/FormFooter";
 import FormInput from "metabase/core/components/FormInput";
 import FormRadio from "metabase/core/components/FormRadio";
 import FormSelect from "metabase/core/components/FormSelect";

--- a/frontend/src/metabase/core/components/FormFooter/FormFooter.tsx
+++ b/frontend/src/metabase/core/components/FormFooter/FormFooter.tsx
@@ -6,7 +6,7 @@ interface FormFooterProps {
   hasTopBorder?: boolean;
 }
 
-const FormFooter = ({
+export const FormFooter = ({
   hasTopBorder,
   children,
 }: PropsWithChildren<FormFooterProps>) => {
@@ -23,6 +23,3 @@ const FormFooter = ({
     </Group>
   );
 };
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default FormFooter;

--- a/frontend/src/metabase/core/components/FormFooter/index.ts
+++ b/frontend/src/metabase/core/components/FormFooter/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./FormFooter";
+export * from "./FormFooter";

--- a/frontend/src/metabase/dashboard/containers/CopyDashboardForm.tsx
+++ b/frontend/src/metabase/dashboard/containers/CopyDashboardForm.tsx
@@ -7,7 +7,7 @@ import * as Yup from "yup";
 import FormCollectionPicker from "metabase/collections/containers/FormCollectionPicker/FormCollectionPicker";
 import type { FilterItemsInPersonalCollection } from "metabase/common/components/EntityPicker";
 import Button from "metabase/core/components/Button";
-import FormFooter from "metabase/core/components/FormFooter";
+import { FormFooter } from "metabase/core/components/FormFooter";
 import Dashboards from "metabase/entities/dashboards";
 import {
   Form,

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
@@ -6,7 +6,7 @@ import * as Yup from "yup";
 import { useCreateDashboardMutation } from "metabase/api";
 import FormCollectionPicker from "metabase/collections/containers/FormCollectionPicker/FormCollectionPicker";
 import type { FilterItemsInPersonalCollection } from "metabase/common/components/EntityPicker";
-import FormFooter from "metabase/core/components/FormFooter";
+import { FormFooter } from "metabase/core/components/FormFooter";
 import Collections from "metabase/entities/collections";
 import {
   Form,

--- a/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
@@ -4,7 +4,7 @@ import { t } from "ttag";
 
 import Button from "metabase/core/components/Button";
 import FormErrorMessage from "metabase/core/components/FormErrorMessage";
-import FormFooter from "metabase/core/components/FormFooter";
+import { FormFooter } from "metabase/core/components/FormFooter";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import { Form, FormProvider } from "metabase/forms";
 import { useSelector } from "metabase/lib/redux";

--- a/frontend/src/metabase/questions/components/CopyQuestionForm.tsx
+++ b/frontend/src/metabase/questions/components/CopyQuestionForm.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 import * as Yup from "yup";
 
 import { FormCollectionAndDashboardPicker } from "metabase/collections/containers/FormCollectionAndDashboardPicker";
-import FormFooter from "metabase/core/components/FormFooter";
+import { FormFooter } from "metabase/core/components/FormFooter";
 import {
   Form,
   FormErrorMessage,


### PR DESCRIPTION
Converts the default export of `FormFooter` to a named export