### PR TITLE
Revert #52018 to fix failing tests

### DIFF
--- a/src/metabase/models.clj
+++ b/src/metabase/models.clj
@@ -1,5 +1,8 @@
 (ns metabase.models
   (:require
+   [clojure.string :as str]
+   [environ.core :as env]
+   [metabase.config :as config]
    [metabase.models.action :as action]
    [metabase.models.application-permissions-revision :as a-perm-revision]
    [metabase.models.bookmark :as bookmark]
@@ -157,10 +160,20 @@
   (search/update! instance true)
   instance)
 
-(t2/define-after-update :hook/search-index
-  [instance]
-  (search/update! instance)
-  nil)
+;; Hidden behind an obscure environment variable, as it may cause performance problems.
+;; See https://github.com/camsaul/toucan2/issues/195
+(defn- update-hook-enabled? []
+  (or config/is-dev?
+      config/is-test?
+      (when-let [setting (:mb-experimental-search-index-realtime-updates env/env)]
+        (and (not (str/blank? setting))
+             (not= "false" setting)))))
+
+(when (update-hook-enabled?)
+  (t2/define-after-update :hook/search-index
+    [instance]
+    (search/update! instance)
+    nil))
 
 ;; Too much of a performance risk.
 #_(t2/define-before-delete :metabase/model


### PR DESCRIPTION
Backend tests have been failing consistently on `master` today -- I've seen errors like 

```
Unique index or primary key violation: "PUBLIC.SEARCH_INDEX__1E1868A0_2903_4A44_9E45_5F8C255DC829_IDENTITY_IDX ON PUBLIC.SEARCH_INDEX__1E1868A0_2903_4A44_9E45_5F8C255DC829(MODEL NULLS FIRST, MODEL_ID NULLS FIRST) VALUES ( /* key:306 */ 'table', 1)";
```

on at least 10 separate branches -- I think it has to do with #52018. I think we should revert this for now so it unblocks everyone else, maybe Chris or someone else can look at it tomorrow.