### PR TITLE
Handle stale search index tracking gracefully for h2

### DIFF
--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -18,6 +18,7 @@
    [toucan2.core :as t2])
   (:import
    (clojure.lang ExceptionInfo)
+   (org.h2.jdbc JdbcSQLSyntaxErrorException)
    (org.postgresql.util PSQLException)))
 
 (comment
@@ -238,8 +239,9 @@
     (try
       (specialization/batch-upsert! table-name entries)
       (catch Exception e
-        ;; TODO we should handle the H2, MySQL, and MariaDB flavors here too
-        (if (instance? PSQLException (ex-cause e))
+        ;; TODO we should handle the MySQL and MariaDB flavors here too
+        (if (or (instance? PSQLException (ex-cause e))
+                (instance? JdbcSQLSyntaxErrorException (ex-cause e)))
           ;; Suppress database errors, which are likely due to stale tracking data.
           (sync-tracking-atoms!)
           (throw e))))))


### PR DESCRIPTION
In production, there is coordination around replacing the index table so that all instances have moved over before we delete the old one.

In tests, we do all sorts of things, like spin up new empty h2 databases, or nuke tables directly. In order to handle this, we respond to database write failures by refreshing our tracking atom to make sure we weren't pointing at a non-existent table.

This updates the conditional exception handling to know about the class used by H2.