### PR TITLE
Fix module errors when Embedding SDK Cypress tests running in dev mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 /*.trace.db
 /.babel_cache
 /.env
+/.envrc
 /.lein-env
 /.lein-failures
 /.lein-plugins

--- a/webpack.embedding-sdk.config.js
+++ b/webpack.embedding-sdk.config.js
@@ -2,7 +2,6 @@
 /* eslint-disable import/no-commonjs */
 /* eslint-disable import/order */
 const NodePolyfillPlugin = require("node-polyfill-webpack-plugin");
-const TerserPlugin = require("terser-webpack-plugin");
 const webpack = require("webpack");
 const BundleAnalyzerPlugin =
   require("webpack-bundle-analyzer").BundleAnalyzerPlugin;
@@ -125,17 +124,14 @@ module.exports = env => {
       "react/jsx-runtime": "react/jsx-runtime",
     },
 
-    optimization: !isDevMode
-      ? {
-          minimizer: [
-            new TerserPlugin({
-              minify: TerserPlugin.swcMinify,
-              parallel: true,
-              test: /\.(tsx?|jsx?)($|\?)/i,
-            }),
-          ],
-        }
-      : undefined,
+    optimization: {
+      // The default `moduleIds: 'named'` setting breaks Cypress tests when `development` mode is enabled,
+      // so we use a different value instead
+      moduleIds: isDevMode ? "natural" : undefined,
+
+      minimize: !isDevMode,
+      minimizer: mainConfig.optimization.minimizer,
+    },
 
     plugins: [
       new webpack.BannerPlugin({


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/51930

For some reason, the default `moduleIds: 'named'` setting breaks Cypress tests when `development` mode is enabled,
so we use a different value instead.