### PR TITLE
fix(sdk): fix data picker crash by using mantine popover

### DIFF
--- a/frontend/src/metabase/components/Popover/Popover.jsx
+++ b/frontend/src/metabase/components/Popover/Popover.jsx
@@ -284,32 +284,10 @@ export default class Popover extends Component {
         targetOffset: `${o.offsetY}px ${o.offsetX}px`,
       };
     }
-
-    // // Add validation before creating/updating Tether
-    // if (!tetherOptions.element || !tetherOptions.target) {
-    //   console.warn("Missing required Tether options:", {
-    //     hasElement: !!tetherOptions.element,
-    //     hasTarget: !!tetherOptions.target,
-    //     tetherOptions,
-    //   });
-
-    //   return;
-    // }
-
-    try {
-      if (this._tether) {
-        this._tether.setOptions(tetherOptions);
-      } else {
-        this._tether = new Tether(tetherOptions);
-      }
-    } catch (error) {
-      console.error("[poom] error setting tether options", error, {
-        tetherOptions,
-        o,
-        self: this,
-      });
-
-      debugger;
+    if (this._tether) {
+      this._tether.setOptions(tetherOptions);
+    } else {
+      this._tether = new Tether(tetherOptions);
     }
   }
 

--- a/frontend/src/metabase/components/Popover/Popover.jsx
+++ b/frontend/src/metabase/components/Popover/Popover.jsx
@@ -284,10 +284,32 @@ export default class Popover extends Component {
         targetOffset: `${o.offsetY}px ${o.offsetX}px`,
       };
     }
-    if (this._tether) {
-      this._tether.setOptions(tetherOptions);
-    } else {
-      this._tether = new Tether(tetherOptions);
+
+    // // Add validation before creating/updating Tether
+    // if (!tetherOptions.element || !tetherOptions.target) {
+    //   console.warn("Missing required Tether options:", {
+    //     hasElement: !!tetherOptions.element,
+    //     hasTarget: !!tetherOptions.target,
+    //     tetherOptions,
+    //   });
+
+    //   return;
+    // }
+
+    try {
+      if (this._tether) {
+        this._tether.setOptions(tetherOptions);
+      } else {
+        this._tether = new Tether(tetherOptions);
+      }
+    } catch (error) {
+      console.error("[poom] error setting tether options", error, {
+        tetherOptions,
+        o,
+        self: this,
+      });
+
+      debugger;
     }
   }
 

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -598,6 +598,12 @@ export class UnconnectedDataSelector extends Component {
     return steps[index];
   }
 
+  togglePopoverOpen = () => {
+    this.setStateWithComputedState({
+      isPopoverOpen: !this.state.isPopoverOpen,
+    });
+  };
+
   nextStep = async (stateChange = {}, skipSteps = true) => {
     const nextStep = this.getNextStep();
     if (!nextStep) {
@@ -929,9 +935,7 @@ export class UnconnectedDataSelector extends Component {
       const table = this.props.metadata.table(tableOrCardId);
       this.props.setSourceTableFn(tableOrCardId, table.db_id);
     }
-    this.setStateWithComputedState({
-      isPopoverOpen: !this.state.isPopoverOpen,
-    });
+    this.togglePopoverOpen();
     this.handleClose();
   };
 
@@ -960,9 +964,7 @@ export class UnconnectedDataSelector extends Component {
       const table = this.props.metadata.table(tableOrCardId);
       this.props.setSourceTableFn(table.id, table.db_id);
     }
-    this.setStateWithComputedState({
-      isPopoverOpen: !this.state.isPopoverOpen,
-    });
+    this.togglePopoverOpen();
     this.handleClose();
   };
 
@@ -1104,7 +1106,12 @@ export class UnconnectedDataSelector extends Component {
           opened={this.isPopoverOpen()}
         >
           <Popover.Target>
-            <Box className={triggerTargetClassName}>{triggerElement}</Box>
+            <Box
+              className={triggerTargetClassName}
+              onClick={() => this.togglePopoverOpen()}
+            >
+              {triggerElement}
+            </Box>
           </Popover.Target>
 
           <Popover.Dropdown>{this.renderContent()}</Popover.Dropdown>

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -1,3 +1,5 @@
+// @ts-check
+
 /* eslint-disable react/prop-types */
 import cx from "classnames";
 import PropTypes from "prop-types";
@@ -8,7 +10,6 @@ import _ from "underscore";
 import EmptyState from "metabase/components/EmptyState";
 import ListSearchField from "metabase/components/ListSearchField";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
-import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 import CS from "metabase/css/core/index.css";
 import Databases from "metabase/entities/databases";
 import Questions from "metabase/entities/questions";
@@ -19,7 +20,7 @@ import { connect } from "metabase/lib/redux";
 import { getHasDataAccess } from "metabase/selectors/data";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getSetting } from "metabase/selectors/settings";
-import { Box } from "metabase/ui";
+import { Box, Popover } from "metabase/ui";
 import {
   SAVED_QUESTIONS_VIRTUAL_DB_ID,
   getQuestionIdFromVirtualTableId,
@@ -164,7 +165,6 @@ export class UnconnectedDataSelector extends Component {
     tableFilter: PropTypes.func,
     hasTableSearch: PropTypes.bool,
     canChangeDatabase: PropTypes.bool,
-    containerClassName: PropTypes.string,
     canSelectMetric: PropTypes.bool,
 
     // from search entity list loader
@@ -800,7 +800,7 @@ export class UnconnectedDataSelector extends Component {
       getTriggerElementContent: TriggerComponent,
       hasTriggerExpandControl,
       readOnly,
-      isMantine,
+      isMantine = true,
     } = this.props;
 
     if (triggerElement) {
@@ -811,7 +811,7 @@ export class UnconnectedDataSelector extends Component {
 
     return (
       <Trigger
-        className={className}
+        className={cx(this.getTriggerClasses(), className)}
         style={style}
         showDropdownIcon={!readOnly && hasTriggerExpandControl}
         iconSize={isMantine ? "1rem" : triggerIconSize}
@@ -1075,24 +1075,13 @@ export class UnconnectedDataSelector extends Component {
   render() {
     if (this.props.isPopover) {
       return (
-        <PopoverWithTrigger
-          id="DataPopover"
-          autoWidth
-          ref={this.popover}
-          isInitiallyOpen={this.props.isInitiallyOpen && !this.props.readOnly}
-          containerClassName={this.props.containerClassName}
-          triggerElement={this.getTriggerElement}
-          triggerClasses={this.getTriggerClasses()}
-          hasArrow={this.props.hasArrow}
-          tetherOptions={this.props.tetherOptions}
-          sizeToFit
-          isOpen={this.props.isOpen}
-          onClose={this.handleClose}
-        >
-          {this.renderContent()}
-        </PopoverWithTrigger>
+        <Popover opened={this.props.isOpen} onClose={this.handleClose}>
+          <Popover.Target>{this.getTriggerElement()}</Popover.Target>
+          <Popover.Dropdown>{this.renderContent()}</Popover.Dropdown>
+        </Popover>
       );
     }
+
     return this.renderContent();
   }
 }

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import cx from "classnames";
 import PropTypes from "prop-types";
-import { Component, createRef } from "react";
+import { Component } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -142,7 +142,6 @@ export class UnconnectedDataSelector extends Component {
       ...state,
       ...computedState,
     };
-    this.popover = createRef();
   }
 
   static propTypes = {
@@ -592,7 +591,6 @@ export class UnconnectedDataSelector extends Component {
     const nextStep = this.getNextStep();
     if (!nextStep) {
       await this.setStateWithComputedState(stateChange);
-      this.popover.current && this.popover.current.toggle();
     } else {
       await this.switchToStep(nextStep, stateChange, skipSteps);
     }
@@ -917,7 +915,6 @@ export class UnconnectedDataSelector extends Component {
       const table = this.props.metadata.table(tableOrCardId);
       this.props.setSourceTableFn(tableOrCardId, table.db_id);
     }
-    this.popover.current.toggle();
     this.handleClose();
   };
 
@@ -946,7 +943,6 @@ export class UnconnectedDataSelector extends Component {
       const table = this.props.metadata.table(tableOrCardId);
       this.props.setSourceTableFn(table.id, table.db_id);
     }
-    this.popover.current.toggle();
     this.handleClose();
   };
 

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -163,6 +163,7 @@ export class UnconnectedDataSelector extends Component {
     tableFilter: PropTypes.func,
     hasTableSearch: PropTypes.bool,
     canChangeDatabase: PropTypes.bool,
+    containerClassName: PropTypes.string,
     canSelectMetric: PropTypes.bool,
 
     // from search entity list loader

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -1075,7 +1075,11 @@ export class UnconnectedDataSelector extends Component {
   render() {
     if (this.props.isPopover) {
       return (
-        <Popover opened={this.props.isOpen} onClose={this.handleClose}>
+        <Popover
+          opened={this.props.isOpen}
+          onClose={this.handleClose}
+          position="bottom-start"
+        >
           <Popover.Target>{this.getTriggerElement()}</Popover.Target>
           <Popover.Dropdown>{this.renderContent()}</Popover.Dropdown>
         </Popover>

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -872,15 +872,17 @@ export class UnconnectedDataSelector extends Component {
     switch (this.state.activeStep) {
       case DATA_BUCKET_STEP:
         return (
-          <DataBucketPicker
-            dataTypes={getDataTypes({
-              hasModels: this.hasModels(),
-              hasNestedQueriesEnabled,
-              hasSavedQuestions: this.hasSavedQuestions(),
-              hasMetrics: this.hasMetrics(),
-            })}
-            {...props}
-          />
+          <Box p="sm">
+            <DataBucketPicker
+              dataTypes={getDataTypes({
+                hasModels: this.hasModels(),
+                hasNestedQueriesEnabled,
+                hasSavedQuestions: this.hasSavedQuestions(),
+                hasMetrics: this.hasMetrics(),
+              })}
+              {...props}
+            />
+          </Box>
         );
       case DATABASE_STEP:
         return combineDatabaseSchemaSteps ? (

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -1,5 +1,3 @@
-// @ts-check
-
 /* eslint-disable react/prop-types */
 import cx from "classnames";
 import PropTypes from "prop-types";

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -805,10 +805,12 @@ export class UnconnectedDataSelector extends Component {
     const {
       className,
       style,
+      triggerIconSize,
       triggerElement,
       getTriggerElementContent: TriggerComponent,
       hasTriggerExpandControl,
       readOnly,
+      isMantine,
     } = this.props;
 
     if (triggerElement) {
@@ -819,11 +821,11 @@ export class UnconnectedDataSelector extends Component {
 
     return (
       <Trigger
-        className={cx(this.getTriggerClasses(), className)}
+        className={className}
         style={style}
         showDropdownIcon={!readOnly && hasTriggerExpandControl}
-        iconSize="1rem"
-        isMantine
+        iconSize={isMantine ? "1rem" : triggerIconSize}
+        isMantine={isMantine}
       >
         <TriggerComponent
           database={selectedDatabase}
@@ -1088,13 +1090,23 @@ export class UnconnectedDataSelector extends Component {
 
   render() {
     if (this.props.isPopover) {
+      const triggerElement = this.getTriggerElement();
+
+      const triggerTargetClassName = cx(
+        this.props.containerClassName,
+        this.getTriggerClasses(),
+      );
+
       return (
         <Popover
           onClose={this.handleClose}
           position="bottom-start"
           opened={this.isPopoverOpen()}
         >
-          <Popover.Target>{this.getTriggerElement()}</Popover.Target>
+          <Popover.Target>
+            <Box className={triggerTargetClassName}>{triggerElement}</Box>
+          </Popover.Target>
+
           <Popover.Dropdown>{this.renderContent()}</Popover.Dropdown>
         </Popover>
       );

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -1076,9 +1076,11 @@ export class UnconnectedDataSelector extends Component {
     if (this.props.isPopover) {
       return (
         <Popover
-          opened={this.props.isOpen}
           onClose={this.handleClose}
           position="bottom-start"
+          {...(this.props.isInitiallyOpen && !this.props.readOnly
+            ? { defaultOpened: true }
+            : { opened: this.props.isOpen })}
         >
           <Popover.Target>{this.getTriggerElement()}</Popover.Target>
           <Popover.Dropdown>{this.renderContent()}</Popover.Dropdown>

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDataBucketPicker/DataSelectorDataBucketPicker.module.css
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDataBucketPicker/DataSelectorDataBucketPicker.module.css
@@ -1,6 +1,5 @@
 .DataBucketList {
   width: 300px;
-  padding: 4px 8px 12px;
 }
 
 .DataBucketListItemTitle {

--- a/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityList.module.css
+++ b/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityList.module.css
@@ -1,7 +1,6 @@
 .SavedEntityListRoot {
   overflow: auto;
   width: 100%;
-  padding: 0.5rem;
 
   @media screen and (max-width: 40em) {
     min-height: 220px;

--- a/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityList.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityList.tsx
@@ -49,42 +49,44 @@ const SavedEntityList = ({
   const list = data?.data ?? [];
 
   return (
-    <SelectList className={SavedEntityListS.SavedEntityListRoot}>
-      <LoadingAndErrorWrapper
-        className={SavedEntityListS.LoadingWrapper}
-        loading={!collection || isFetching}
-        error={error}
-      >
-        <Fragment>
-          {list.map(collectionItem => {
-            const { id, name, moderated_status } = collectionItem;
-            const virtualTableId = getQuestionVirtualTableId(id);
+    <Box p="sm" w="100%">
+      <SelectList className={SavedEntityListS.SavedEntityListRoot}>
+        <LoadingAndErrorWrapper
+          className={SavedEntityListS.LoadingWrapper}
+          loading={!collection || isFetching}
+          error={error}
+        >
+          <Fragment>
+            {list.map(collectionItem => {
+              const { id, name, moderated_status } = collectionItem;
+              const virtualTableId = getQuestionVirtualTableId(id);
 
-            return (
-              <SelectList.Item
-                classNames={{
-                  root: SavedEntityListS.SavedEntityListItem,
-                  icon: SavedEntityListS.SavedEntityListItemIcon,
-                }}
-                key={id}
-                id={id}
-                isSelected={selectedId === virtualTableId}
-                size="small"
-                name={name}
-                icon={{
-                  name: CARD_INFO[type].icon,
-                  size: 16,
-                }}
-                onSelect={() => onSelect(virtualTableId)}
-                rightIcon={PLUGIN_MODERATION.getStatusIcon(moderated_status)}
-              />
-            );
-          })}
-          {list.length === 0 ? emptyState : null}
-        </Fragment>
-        {isVirtualCollection && emptyState}
-      </LoadingAndErrorWrapper>
-    </SelectList>
+              return (
+                <SelectList.Item
+                  classNames={{
+                    root: SavedEntityListS.SavedEntityListItem,
+                    icon: SavedEntityListS.SavedEntityListItemIcon,
+                  }}
+                  key={id}
+                  id={id}
+                  isSelected={selectedId === virtualTableId}
+                  size="small"
+                  name={name}
+                  icon={{
+                    name: CARD_INFO[type].icon,
+                    size: 16,
+                  }}
+                  onSelect={() => onSelect(virtualTableId)}
+                  rightIcon={PLUGIN_MODERATION.getStatusIcon(moderated_status)}
+                />
+              );
+            })}
+            {list.length === 0 ? emptyState : null}
+          </Fragment>
+          {isVirtualCollection && emptyState}
+        </LoadingAndErrorWrapper>
+      </SelectList>
+    </Box>
   );
 };
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/51906

### Description

Rendering the data picker in the starter kit (https://github.com/metabase/metabase-nodejs-react-sdk-embedding-sample) such as with `<CreateQuestion />` or with `InteractiveQuestion.Editor` causes the following crash.

```tsx
Error: Tether Error: Both element and target must be defined
    at tether.js:700:1
    at Array.forEach (<anonymous>)
    at TetherClass2.setOptions (tether.js:698:1)
    at new TetherClass2 (tether.js:640:1)
    at Popover._setTetherOptions (Popover.jsx:293:1)
    at Popover._getBestAttachmentOptions (Popover.jsx:338:1)
    at Popover.updateComponentPosition (Popover.jsx:145:1)
    at Popover.componentDidMount (Popover.jsx:121:1)
    at invokeLayoutEffectMountInDEV (react-dom.development.js:25172:22)
    at invokeEffectsInDev (react-dom.development.js:27390:11)
```

Note that this crash cannot be reproduced in both the Storybook environment and in the [Shoppy demo app](https://embedded-analytics-sdk-demo.metabase.com) - it only happens in our starter kit.

A similar popover error happened before in https://github.com/metabase/metabase/issues/45488 in the parameter popover, and Oisin fixed this in in https://github.com/metabase/metabase/pull/45671 by replacing the legacy Popover with Mantine's. To quote Oisin:

> In the PopoverWithTrigger that we were using, there are issues with the usage of Tether (for a reason I still can't figure out) that cause the referred target to turn to null - something to the effect of the target component unmounting causes this error. The solution here is to get rid of this PopoverWithTrigger and replace it with the Mantine popover, which hasn't given us any issues on the SDK so far, so I felt it was a better option than attempt to debug deprecated code.

### How to verify

In the Embedding SDK

- Render the `<CreateQuestion />` component (or `InteractiveQuestion` with `InteractiveQuestion.Editor`)
- Run the demo again. It should crash
- Setup the starter kit via https://github.com/metabase/metabase-nodejs-react-sdk-embedding-sample
- Build the module locally via `yarn build-embedding-sdk`
- Link the locally built package to the starter kit.
   - Example: `rm -rf node_modules/.vite && rm -rf node_modules/@metabase/ && yarn add file:../../metabase/resources/embedding-sdk && env NODE_OPTIONS="--max-old-space-size=7000" yarn dev`. Tweak this to match your own folder structure.
- Run the demo again. It should no longer crash.

In the Metabase app

- Create a new SQL question
- The database dropdown should work as expected with no visual glitches

### Demo

<img src="https://github.com/user-attachments/assets/825ac164-10f0-4014-9f6e-59dce4d1672d" width="300">

<img src="https://github.com/user-attachments/assets/1d706b1b-f91f-4289-9a47-edb1a474afd3" width="300">

<img src="https://github.com/user-attachments/assets/26e3c0c8-b8e4-4c0a-ba7f-304673d22739" width="300">

The database dropdown in the SQL editor looks and works as before in the main Metabase app

![CleanShot 2568-01-15 at 19 28 02@2x](https://github.com/user-attachments/assets/9ce6e105-4484-4519-8807-45ea3c0cdb72)


