### PR TITLE
[WIP] target buttons instead of svg elements

### DIFF
--- a/e2e/support/commands/ui/icon.ts
+++ b/e2e/support/commands/ui/icon.ts
@@ -20,7 +20,8 @@ Cypress.Commands.add(
     prevSubject: "optional",
   },
   (subject, iconName) => {
-    const SELECTOR = `.Icon-${iconName}`;
+    const ICON = `.Icon-${iconName}`;
+    const SELECTOR = `a:has(${ICON}), button:has(${ICON})`;
 
     return subject ? cy.wrap(subject).find(SELECTOR) : cy.get(SELECTOR);
   },


### PR DESCRIPTION
### Description

Instead of clicking on svg elements, we should click on buttons that are parent elements to those svg elements. This mitigates all flakes related to using `cy.icon`

Cypress has [actionability checks](https://docs.cypress.io/app/core-concepts/interacting-with-elements#Actionability). However, these happen on targeted elements. If we target svg inside a button, these actionability checks happen on svg, not the button. Potentially, you could find yourself in a situation where button is disabled, but click on the svg element happens anyway, resulting in a dead click

### How to verify

if tests pass, we should be good. Assumption here is that all elements targeted by `cy.icon()` command are buttons, that’s why this PR is WIP
