### PR TITLE
optimize matrix builder

### DIFF
--- a/.github/workflows/e2e-matrix-builder.yml
+++ b/.github/workflows/e2e-matrix-builder.yml
@@ -29,12 +29,18 @@ jobs:
         shell: bash
         run: |
           echo "::set-output name=filenames::$(find e2e/test/scenarios -name '*.cy.spec.*' | tr '\n' ',')"
-      - run: yarn add underscore
       - uses: actions/github-script@v7
         id: matrix
         with:
           script: | # js
-            const _ = require('underscore');
+            const chunk = (arr, size) => {
+              const chunks = [];
+              const n = Math.ceil(arr.length / size);
+              for (let i = 0; i < n; i++) {
+                chunks.push(arr.slice(i * size, (i + 1) * size));
+              }
+              return chunks;
+            };
 
             const java = 21;
             const defaultRunner = "ubuntu-22.04";
@@ -71,7 +77,7 @@ jobs:
 
 
 
-            const chunkedFiles = _.chunk(fileNames, chunkSize);
+            const chunkedFiles = chunk(fileNames, chunkSize);
 
             const regularTests = chunkedFiles.map((files, index) => ({
               name: `e2e-group-${index + 1}`,


### PR DESCRIPTION
### Description

Ain’t much, but it’s honest work. `yarn add underscore` takes minute and a half from the overal E2E tests pipeline. pretty much everything runs in instant for this action but the installation takes 97% of the time. underscore is installed just for the usage of chunk function, so instead we can write it manually and save some time

### How to verify

Passing tests should be enough