### PR TITLE
Run search index worker on every instance

### DIFF
--- a/src/metabase/task/search_index.clj
+++ b/src/metabase/task/search_index.clj
@@ -91,8 +91,7 @@
   SearchIndexReindex [_ctx]
   (reindex!))
 
-(jobs/defjob ^{DisallowConcurrentExecution true
-               :doc                        "Keep Search Index updated"}
+(jobs/defjob ^{:doc                        "Keep Search Index updated"}
   SearchIndexUpdate [_ctx]
   (update-index!))
 


### PR DESCRIPTION
This should fix the issue where items are not always indexed for search in almost-realtime.

It should also fix a memory leak where all the instances without the job running never have messages consumed off their unbounded queues.