### PR TITLE
ci(sdk): add CODEOWNERS for embedding sdk

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,7 @@ enterprise/backend/src/metabase_enterprise/sso @noahmoss
 enterprise/backend/src/metabase_enterprise/task/truncate_audit_table.clj @noahmoss
 enterprise/backend/src/metabase_enterprise/internal_user.clj @noahmoss
 enterprise/frontend/src/embedding-sdk @metabase/embedding
+frontend/src/metabase/embedding-sdk @metabase/embedding
 frontend/src/metabase/ui @metabase/core-frontend-admin-webapp
 src/metabase/**/*permissions* @noahmoss
 src/metabase/integrations @noahmoss

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@ enterprise/backend/src/metabase_enterprise/audit_app @noahmoss
 enterprise/backend/src/metabase_enterprise/sso @noahmoss
 enterprise/backend/src/metabase_enterprise/task/truncate_audit_table.clj @noahmoss
 enterprise/backend/src/metabase_enterprise/internal_user.clj @noahmoss
+enterprise/frontend/src/embedding-sdk @metabase/embedding
 frontend/src/metabase/ui @metabase/core-frontend-admin-webapp
 src/metabase/**/*permissions* @noahmoss
 src/metabase/integrations @noahmoss


### PR DESCRIPTION
Adds CODEOWNERS for embedding-sdk. Will also add `frontend/src/metabase/embedding-sdk` once https://github.com/metabase/metabase/pull/52020 is merged.