### PR TITLE
update eslint rules to restrict importing from react-redux directly

### DIFF
--- a/enterprise/frontend/.eslintrc
+++ b/enterprise/frontend/.eslintrc
@@ -12,7 +12,12 @@
           {
             "name": "moment-timezone",
             "message": "Moment is deprecated, please use dayjs"
-          }
+          },
+          {
+            "name": "react-redux",
+            "importNames": ["useSelector", "useDispatch", "connect"],
+            "message": "Please import from `metabase/lib/redux` instead."
+          },
         ]
       }
     ]

--- a/enterprise/frontend/src/embedding-sdk/.eslintrc
+++ b/enterprise/frontend/src/embedding-sdk/.eslintrc
@@ -5,6 +5,11 @@
       {
         "paths": [
           {
+            "name": "react-redux",
+            "importNames": ["useSelector", "useDispatch", "connect"],
+            "message": "Please use \"useSdkSelector\", \"useSdkDispatch\""
+          },
+          {
             "name": "metabase/lib/redux",
             "importNames": ["useStore", "useDispatch"],
             "message": "Please use \"useSdkStore\", \"useSdkDispatch\""

--- a/frontend/src/metabase/.eslintrc
+++ b/frontend/src/metabase/.eslintrc
@@ -11,7 +11,7 @@
         "paths": [
           {
             "name": "react-redux",
-            "importNames": ["useSelector", "useDispatch"],
+            "importNames": ["useSelector", "useDispatch", "connect"],
             "message": "Please import from `metabase/lib/redux` instead."
           },
           {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/51401

# Description
This PR updates our eslint config files to make sure we never import directly from `react-redux` so that we always use the custom context