### PR TITLE
fix(qb): do not truncate long tab name

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/BaseChartSettings.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/BaseChartSettings.tsx
@@ -200,7 +200,13 @@ export const BaseChartSettings = ({
                 // tab should stay at the same position even when number of tabs
                 // change. e.g. 2 tabs to 3 tabs -> layout should not change
                 flexBasis: "25%",
-                maxWidth: "50%", // show ... for long tab names
+
+                // last element in english is "conditional formatting" which is
+                // longer than 25% of the tab to avoid having ... displayed with
+                // the cropped text, we show it fully
+                "&:last-of-type": {
+                  maxWidth: "100%",
+                },
               },
               tabsList: {
                 flexWrap: "nowrap",


### PR DESCRIPTION
### Description

address [product review](https://metaboat.slack.com/archives/C01LQQ2UW03/p1736779279093619)

- [x]  avoid text truncation in the tabs
- [ ] align chart type selector header with a table on the right