### PR TITLE
docs - preference for docker when self-hosting

### DIFF
--- a/docs/installation-and-operation/backing-up-metabase-application-data.md
+++ b/docs/installation-and-operation/backing-up-metabase-application-data.md
@@ -18,13 +18,6 @@ But if you're at the point where you have questions and dashboards that you want
 
 If you're just using Metabase for personal use and want to keep your application data, here's what you'll need to do.
 
-### If you're running the Metabase JAR
-
-1. Navigate to your Metabase directory.
-2. If your Metabase is running, stop the Metabase process. You can either close the terminal or kill the process with CTRL-C. If you are running the process as a service, then stop the service.
-3. Copy the application database file (called `metabase.db.mv.db`) and keep that copy somewhere safe. That's it.
-4. Restart Metabase: `java --add-opens java.base/java.nio=ALL-UNNAMED -jar metabase.jar` or start the service again.
-
 ### If you're running the Metabase Docker image
 
 If you're running Docker, you should already have switched to a [production-ready database](migrating-from-h2.md).
@@ -36,6 +29,13 @@ docker cp metabase:/metabase.db/metabase.db.mv.db ./
 ```
 
 The above command would copy the database file to the directory you ran the command from. You can also create a copy of this H2 file and use it to migrate the data to a production-ready database. See [Migrating from H2](migrating-from-h2.md).
+
+### If you're running the Metabase JAR
+
+1. Navigate to your Metabase directory.
+2. If your Metabase is running, stop the Metabase process. You can either close the terminal or kill the process with CTRL-C. If you are running the process as a service, then stop the service.
+3. Copy the application database file (called `metabase.db.mv.db`) and keep that copy somewhere safe. That's it.
+4. Restart Metabase: `java --add-opens java.base/java.nio=ALL-UNNAMED -jar metabase.jar` or start the service again.
 
 ## Amazon RDS for the application database
 

--- a/docs/installation-and-operation/configuring-application-database.md
+++ b/docs/installation-and-operation/configuring-application-database.md
@@ -6,9 +6,9 @@ redirect_from:
 
 # Configuring the Metabase application database
 
-The application database is where Metabase stores information about user accounts, questions, dashboards, and any other data needed to run the Metabase application.
+The application database is where Metabase stores information about user accounts, questions, dashboards, and any other data needed to run the Metabase application. This app DB is distinct from the database where you store your data, also known as your data warehouse. For connecting to your data warehouse, see [Connecting to a supported database](../databases/connecting.md).
 
-For production, we recommend using PostgreSQL as your application database.
+For production, we recommend using PostgreSQL as your Metabase application database.
 
 - [PostgreSQL](#postgresql) (recommended for production)
 - [MySQL](#mysql-or-mariadb) (also works for production)

--- a/docs/installation-and-operation/installing-metabase.md
+++ b/docs/installation-and-operation/installing-metabase.md
@@ -10,7 +10,7 @@ Metabase is built and packaged as a Java JAR file and can be run anywhere that J
 
 ## Metabase Cloud (Recommended)
 
-The easiest way to run Metabase. All you need to do is [sign up for a free trial](https://store.metabase.com/checkout), and you're off to the races.
+[Metabase Cloud](https://www.metabase.com/cloud) is the easiest way to run Metabase. All you need to do is [sign up for a free trial](https://store.metabase.com/checkout), and you're off to the races.
 
 ## Self-hosting Metabase
 

--- a/docs/installation-and-operation/installing-metabase.md
+++ b/docs/installation-and-operation/installing-metabase.md
@@ -22,7 +22,7 @@ Run Metabase in a [Docker container](./running-metabase-on-docker.md).
 
 ### Running the Jar file
 
-Metabase can run anywhere Java is available. See [running the Metabase Jar](./running-the-metabase-jar-file.md)
+If you're self-hosting but don’t use Docker, the JAR is the easiest way to get started, but it might make it more challenging to move to production. See [running the Metabase Jar](./running-the-metabase-jar-file.md).
 
 ## Air-gapped Metabase
 

--- a/docs/installation-and-operation/installing-metabase.md
+++ b/docs/installation-and-operation/installing-metabase.md
@@ -42,7 +42,7 @@ Check out our [professional services](https://www.metabase.com/product/professio
 
 ## Upgrading Metabase
 
-See [Upgrading Metabase](upgrading-metabase.md)
+See [Upgrading Metabase](upgrading-metabase.md).
 
 ## Other installation options
 

--- a/docs/installation-and-operation/installing-metabase.md
+++ b/docs/installation-and-operation/installing-metabase.md
@@ -8,7 +8,7 @@ redirect_from:
 
 Metabase is built and packaged as a Java JAR file and can be run anywhere that Java is available.
 
-## [Metabase Cloud](https://store.metabase.com/checkout)
+## Metabase Cloud (Recommended)
 
 The easiest way to run Metabase. All you need to do is [sign up for a free trial](https://store.metabase.com/checkout), and you're off to the races.
 
@@ -16,13 +16,17 @@ The easiest way to run Metabase. All you need to do is [sign up for a free trial
 
 For an overview on how to self-host Metabase, check out [how to run Metabase in production](https://www.metabase.com/learn/metabase-basics/administration/administration-and-operation/metabase-in-production).
 
-### [Running the Jar File](running-the-metabase-jar-file.md)
+### Running on Docker (Recommended for self-hosting)
 
-Metabase can run anywhere Java is available.
+Run Metabase in a [Docker container](./running-metabase-on-docker.md).
 
-### [Running on Docker](running-metabase-on-docker.md)
+### Running the Jar file
 
-If you prefer to use a Docker container, we've got you covered.
+Metabase can run anywhere Java is available. See [running the Metabase Jar](./running-the-metabase-jar-file.md)
+
+## Air-gapped Metabase
+
+If you're self-hosting because you need an air-gapped environment, check out the [air-gapped edition of Metabase](https://www.metabase.com/product/air-gapping).
 
 ## Professional services from the Metabase team
 

--- a/docs/installation-and-operation/running-metabase-on-docker.md
+++ b/docs/installation-and-operation/running-metabase-on-docker.md
@@ -6,6 +6,8 @@ redirect_from:
 
 # Running Metabase on Docker
 
+> To get fast, reliable, and secure deployment with none of the work or hidden costs that come with self-hosting, check out [Metabase Cloud](https://www.metabase.com/cloud).
+
 Metabase provides an official Docker image via Dockerhub that can be used for deployments on any system that is running Docker.
 
 If you're trying to upgrade your Metabase version on Docker, check out these [upgrading instructions](upgrading-metabase.md).

--- a/docs/installation-and-operation/running-the-metabase-jar-file.md
+++ b/docs/installation-and-operation/running-the-metabase-jar-file.md
@@ -7,6 +7,8 @@ redirect_from:
 
 # Running the Metabase OSS JAR file
 
+> We recommend running Metabase on [Metabase Cloud](https://www.metabase.com/cloud). If you need to self-host, you _can_ run Metabase as a standalone JAR, but [we recommend running Metabase in a Docker container](./running-metabase-on-docker.md).
+
 To run the free, Open Source version of Metabase via a JAR file, you will need to have a Java Runtime Environment (JRE) installed on your system.
 
 If you have a token for the [Pro or Enterprise editions](https://www.metabase.com/pricing) of Metabase, see [Activating your Metabase commercial license](../paid-features/activating-the-enterprise-edition.md).

--- a/docs/installation-and-operation/start.md
+++ b/docs/installation-and-operation/start.md
@@ -8,7 +8,7 @@ The birth, care, and feeding of your Metabase.
 
 ## [Installing Metabase](./installing-metabase.md)
 
-Start here.
+Options for installing Metabase.
 
 ## [Migrating to a production database](./migrating-from-h2.md)
 


### PR DESCRIPTION
- Updates docs to show a preference for either Cloud or Docker deployments.
- Adds a mention of our air-gapped support.
- Adds note about the application database being distinct from data warehouses.