### PR TITLE
Fix in-progress selection in the date range picker

### DIFF
--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePickerBody/DateRangePickerBody.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePickerBody/DateRangePickerBody.tsx
@@ -22,19 +22,24 @@ interface DateRangePickerBodyProps {
 }
 
 export function DateRangePickerBody({
-  value: [startDate, endDate],
+  value,
   hasTime,
   onChange,
 }: DateRangePickerBodyProps) {
-  const [hasEndDate, setHasEndDate] = useState(true);
+  const [startDate, endDate] = value;
+  const [inProgressDateRange, setInProgressDateRange] =
+    useState<DatesRangeValue | null>(value);
 
-  const handleRangeChange = ([newStartDate, newEndDate]: DatesRangeValue) => {
-    setHasEndDate(newEndDate != null);
+  const handleRangeChange = (newDateRange: DatesRangeValue) => {
+    const [newStartDate, newEndDate] = newDateRange;
     if (newStartDate && newEndDate) {
       onChange([
         setDatePart(startDate, newStartDate),
         setDatePart(endDate, newEndDate),
       ]);
+      setInProgressDateRange(null);
+    } else {
+      setInProgressDateRange(newDateRange);
     }
   };
 
@@ -92,7 +97,7 @@ export function DateRangePickerBody({
       )}
       <DatePicker
         type="range"
-        value={[startDate, hasEndDate ? endDate : null]}
+        value={inProgressDateRange ?? value}
         defaultDate={startDate}
         numberOfColumns={2}
         allowSingleDateInRange

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePickerBody/DateRangePickerBody.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePickerBody/DateRangePickerBody.unit.spec.tsx
@@ -1,0 +1,55 @@
+import userEvent from "@testing-library/user-event";
+
+import { render, screen } from "__support__/ui";
+
+import { DateRangePickerBody } from "./DateRangePickerBody";
+
+type SetupOpts = {
+  value: [Date, Date];
+  hasTime?: boolean;
+};
+
+function setup({ value, hasTime = false }: SetupOpts) {
+  const onChange = jest.fn();
+  render(
+    <DateRangePickerBody value={value} hasTime={hasTime} onChange={onChange} />,
+  );
+  return { onChange };
+}
+
+describe("DateRangePickerBody", () => {
+  it("should highlight the start date of the in-progress date range selection (metabase#51994)", async () => {
+    const { onChange } = setup({
+      value: [new Date(2020, 0, 5), new Date(2020, 1, 20)],
+    });
+    expect(screen.getByLabelText("5 January 2020")).toHaveAttribute(
+      "data-selected",
+      "true",
+    );
+    expect(screen.getByLabelText("20 February 2020")).toHaveAttribute(
+      "data-selected",
+      "true",
+    );
+
+    await userEvent.click(screen.getByLabelText("10 January 2020"));
+    expect(screen.getByLabelText("5 January 2020")).not.toHaveAttribute(
+      "data-selected",
+      "true",
+    );
+    expect(screen.getByLabelText("20 February 2020")).not.toHaveAttribute(
+      "data-selected",
+      "true",
+    );
+    expect(screen.getByLabelText("10 January 2020")).toHaveAttribute(
+      "data-selected",
+      "true",
+    );
+    expect(onChange).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByLabelText("8 February 2020"));
+    expect(onChange).toHaveBeenCalledWith([
+      new Date(2020, 0, 10),
+      new Date(2020, 1, 8),
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/51994

How to verify:
- Open a dashboard with a `date/range` or `date/all-options` widget
- Select a date range
- Now start to select a new date range, starting from a date inside the current range
- The new start date should be highlighted before the selection is completed, i.e. before the end date is clicked.

<img width="673" alt="Screenshot 2025-01-14 at 16 05 58" src="https://github.com/user-attachments/assets/ecef8d2e-62c1-405d-a3b1-d4e4f43fae53" />
