### PR TITLE
[Backend modularization] `xrays` module cleanup

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -378,7 +378,6 @@
     metabase.query-processor       :any                                                             ; TODO omg scream, 29 namespaces used outside of the module. WHAT THE HECC
     metabase.query-analysis        #{metabase.query-analysis
                                      metabase.query-analysis.failure-map}
-    metabase.related               #{metabase.related}
     metabase.request               #{metabase.request.core}
     metabase.sample-data           #{metabase.sample-data}
     metabase.search                #{metabase.search.core
@@ -420,7 +419,7 @@
     metabase.types                 #{metabase.types}
     metabase.upload                #{metabase.upload}
     metabase.util                  :any                                                             ; I think util being `:any` is actually something I am ok with. But this has 32 namespaces.
-    metabase.xrays                 #{metabase.xrays}}
+    metabase.xrays                 #{metabase.xrays.core}}
 
    ;; Map of module => other modules you're allowed to use there. You have two options here:
    ;;
@@ -475,7 +474,6 @@
                                      metabase.query-processor
                                      metabase.util}
     metabase.query-processor       :any
-    metabase.related               :any
     metabase.request               #{metabase.config
                                      metabase.models
                                      metabase.public-settings
@@ -715,7 +713,6 @@
     metabase.query-processor.streaming.xlsx                       qp.xlsx
     metabase.query-processor.timezone                             qp.timezone
     metabase.query-processor.util                                 qp.util
-    metabase.related                                              related
     metabase.request.core                                         request
     metabase.search.config                                        search.config
     metabase.search.filter                                        search.filter
@@ -767,7 +764,7 @@
     metabase.util.schema                                          su
     metabase.util.ui-logic                                        ui-logic
     metabase.util.urls                                            urls
-    metabase.xrays                                                xrays
+    metabase.xrays.core                                           xrays
     metabuild-common.core                                         u
     metabuild-common.output                                       out
     metabuild-common.shell                                        shell
@@ -990,13 +987,13 @@
    clojurewerkz.quartzite.schedule.cron/schedule                                 macros.quartz/schedule
    clojurewerkz.quartzite.schedule.simple/schedule                               macros.quartz/simple-schedule
    clojurewerkz.quartzite.triggers/build                                         macros.quartz/build-trigger
+   metabase-enterprise.advanced-permissions.api.util-test/with-impersonations!   macros.metabase-enterprise.advanced-permissions.api.util-test/with-impersonations!
+   metabase-enterprise.query-reference-validation.api-test/with-test-setup!      macros.metabase-enterprise.query-reference-validation.api-test/with-test-setup!
    metabase-enterprise.sandbox.test-util/with-gtaps!                             macros.metabase-enterprise.sandbox.test-util/with-gtaps!
    metabase-enterprise.sandbox.test-util/with-gtaps-for-user!                    macros.metabase-enterprise.sandbox.test-util/with-gtaps!
    metabase-enterprise.serialization.test-util/with-world                        macros.metabase-enterprise.serialization.test-util/with-world
    metabase-enterprise.test/with-gtaps!                                          macros.metabase-enterprise.sandbox.test-util/with-gtaps!
    metabase-enterprise.test/with-gtaps-for-user!                                 macros.metabase-enterprise.sandbox.test-util/with-gtaps!
-   metabase-enterprise.advanced-permissions.api.util-test/with-impersonations!   macros.metabase-enterprise.advanced-permissions.api.util-test/with-impersonations!
-   metabase-enterprise.query-reference-validation.api-test/with-test-setup!      macros.metabase-enterprise.query-reference-validation.api-test/with-test-setup!
    metabase.api.card-test/with-ordered-items                                     macros.metabase.api.card-test/with-ordered-items
    metabase.api.collection-test/with-collection-hierarchy!                       macros.metabase.api.collection-test/with-collection-hierarchy!
    metabase.api.collection-test/with-some-children-of-collection!                macros.metabase.api.collection-test/with-some-children-of-collection!
@@ -1005,14 +1002,13 @@
    metabase.api.embed-test/with-embedding-enabled-and-temp-dashcard-referencing! macros.metabase.api.embed-test/with-embedding-enabled-and-temp-dashcard-referencing!
    metabase.api.public-test/with-sharing-enabled-and-temp-card-referencing!      macros.metabase.api.public-test/with-sharing-enabled-and-temp-card-referencing!
    metabase.api.public-test/with-sharing-enabled-and-temp-dashcard-referencing!  macros.metabase.api.public-test/with-sharing-enabled-and-temp-dashcard-referencing!
-   metabase.lib.filter/deffilter                                                 macros.metabase.lib.filter/deffilter
    metabase.lib.common/defop                                                     macros.metabase.lib.common/defop
+   metabase.lib.filter/deffilter                                                 macros.metabase.lib.filter/deffilter
    metabase.models.params.chain-filter-test/chain-filter                         macros.metabase.models.params.chain-filter-test/chain-filter
    metabase.models.params.chain-filter-test/chain-filter-search                  macros.metabase.models.params.chain-filter-test/chain-filter
    metabase.models.query-analysis-test/with-test-setup                           macros.metabase.models.query-analysis-test/with-test-setup
    metabase.models.user-test/with-groups                                         macros.metabase.models.user-test/with-groups
    metabase.query-processor.streaming/streaming-response                         macros.metabase.query-processor.streaming/streaming-response
-   metabase.related-test/with-world                                              macros.metabase.related-test/with-world
    metabase.task.setup.query-analysis-setup/with-test-setup!                     macros.metabase.task.setup.query-analysis-setup/with-test-setup!
    metabase.test.data.users/with-group-for-user                                  macros.metabase.test.data.users/with-group-for-user
    metabase.test.util/with-temp-env-var-value!                                   macros.metabase.test.util/with-temp-env-var-value!
@@ -1022,7 +1018,8 @@
    metabase.test/with-temp-env-var-value!                                        macros.metabase.test.util/with-temp-env-var-value!
    metabase.test/with-temporary-raw-setting-values                               macros.metabase.test.util/with-temporary-raw-setting-values
    metabase.util.namespaces/import-fn                                            macros.metabase.util.namespaces/import-fn
-   metabase.xrays.domain-entities.malli/define-getters-and-setters               macros.metabase.xrays.domain-entities.malli/define-getters-and-setters}}
+   metabase.xrays.domain-entities.malli/define-getters-and-setters               macros.metabase.xrays.domain-entities.malli/define-getters-and-setters
+   metabase.xrays.related-test/with-world                                        macros.metabase.xrays.related-test/with-world}}
 
  :config-in-comment
  {:linters {:unresolved-symbol {:level :off}}}

--- a/.clj-kondo/macros/metabase/xrays/related_test.clj
+++ b/.clj-kondo/macros/metabase/xrays/related_test.clj
@@ -1,4 +1,4 @@
-(ns macros.metabase.related-test
+(ns macros.metabase.xrays.related-test
   (:require [macros.common]))
 
 (defmacro with-world [& body]

--- a/src/metabase/api/automagic_dashboards.clj
+++ b/src/metabase/api/automagic_dashboards.clj
@@ -10,7 +10,7 @@
    [metabase.util.json :as json]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
-   [metabase.xrays :as xrays]
+   [metabase.xrays.core :as xrays]
    [ring.util.codec :as codec]
    [toucan2.core :as t2]))
 

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -44,7 +44,6 @@
    [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.query-processor.pivot :as qp.pivot]
    [metabase.query-processor.util :as qp.util]
-   [metabase.related :as related]
    [metabase.request.core :as request]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
@@ -53,7 +52,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
-   [metabase.xrays :as xrays]
+   [metabase.xrays.core :as xrays]
    [steffan-westcott.clj-otel.api.trace.span :as span]
    [toucan2.core :as t2]))
 
@@ -1073,7 +1072,7 @@
   "Return related entities."
   [id]
   {id ms/PositiveInt}
-  (-> (t2/select-one :model/Dashboard :id id) api/read-check related/related))
+  (-> (t2/select-one :model/Dashboard :id id) api/read-check xrays/related))
 
 ;;; ---------------------------------------------- Transient dashboards ----------------------------------------------
 

--- a/src/metabase/api/field.clj
+++ b/src/metabase/api/field.clj
@@ -12,7 +12,6 @@
    [metabase.models.params.chain-filter :as chain-filter]
    [metabase.models.params.field-values :as params.field-values]
    [metabase.query-processor :as qp]
-   [metabase.related :as related]
    [metabase.request.core :as request]
    [metabase.sync :as sync]
    [metabase.sync.concurrent :as sync.concurrent]
@@ -21,6 +20,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
+   [metabase.xrays.core :as xrays]
    [toucan2.core :as t2])
   (:import
    (java.text NumberFormat)))
@@ -455,6 +455,6 @@
   "Return related entities."
   [id]
   {id ms/PositiveInt}
-  (-> (t2/select-one :model/Field :id id) api/read-check related/related))
+  (-> (t2/select-one :model/Field :id id) api/read-check xrays/related))
 
 (api/define-routes)

--- a/src/metabase/api/segment.clj
+++ b/src/metabase/api/segment.clj
@@ -7,11 +7,11 @@
    [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.models.interface :as mi]
    [metabase.models.revision :as revision]
-   [metabase.related :as related]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
+   [metabase.xrays.core :as xrays]
    [toucan2.core :as t2]))
 
 #_{:clj-kondo/ignore [:deprecated-var]}
@@ -127,6 +127,6 @@
   "Return related entities."
   [id]
   {id ms/PositiveInt}
-  (-> (t2/select-one :model/Segment :id id) api/read-check related/related))
+  (-> (t2/select-one :model/Segment :id id) api/read-check xrays/related))
 
 (api/define-routes)

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -14,7 +14,6 @@
    [metabase.models.interface :as mi]
    [metabase.models.table :as table]
    [metabase.premium-features.core :refer [defenterprise]]
-   [metabase.related :as related]
    [metabase.request.core :as request]
    [metabase.sync :as sync]
    [metabase.sync.concurrent :as sync.concurrent]
@@ -26,6 +25,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
+   [metabase.xrays.core :as xrays]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -605,7 +605,7 @@
   "Return related entities."
   [id]
   {id ms/PositiveInt}
-  (-> (t2/select-one :model/Table :id id) api/read-check related/related))
+  (-> (t2/select-one :model/Table :id id) api/read-check xrays/related))
 
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint PUT "/:id/fields/order"

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -33,7 +33,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
-   [metabase.xrays :as xrays]
+   [metabase.xrays.core :as xrays]
    [methodical.core :as methodical]
    [toucan2.core :as t2]
    [toucan2.realize :as t2.realize]))

--- a/src/metabase/xrays/automagic_dashboards/comparison.clj
+++ b/src/metabase/xrays/automagic_dashboards/comparison.clj
@@ -5,7 +5,6 @@
    [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.models.interface :as mi]
    [metabase.query-processor.util :as qp.util]
-   [metabase.related :as related]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.xrays.automagic-dashboards.core
@@ -16,7 +15,8 @@
    [metabase.xrays.automagic-dashboards.filters :as filters]
    [metabase.xrays.automagic-dashboards.names :as names]
    [metabase.xrays.automagic-dashboards.populate :as populate]
-   [metabase.xrays.automagic-dashboards.util :as magic.util]))
+   [metabase.xrays.automagic-dashboards.util :as magic.util]
+   [metabase.xrays.related :as related]))
 
 (def ^:private ^{:arglists '([root])} comparison-name
   (comp capitalize-first (some-fn :comparison-name :full-name)))

--- a/src/metabase/xrays/automagic_dashboards/core.clj
+++ b/src/metabase/xrays/automagic_dashboards/core.clj
@@ -154,7 +154,6 @@
    [metabase.models.field :as field]
    [metabase.models.interface :as mi]
    [metabase.query-processor.util :as qp.util]
-   [metabase.related :as related]
    [metabase.util :as u]
    [metabase.util.i18n :as i18n :refer [tru trun]]
    [metabase.util.malli :as mu]
@@ -166,6 +165,7 @@
    [metabase.xrays.automagic-dashboards.names :as names]
    [metabase.xrays.automagic-dashboards.populate :as populate]
    [metabase.xrays.automagic-dashboards.util :as magic.util]
+   [metabase.xrays.related :as related]
    [toucan2.core :as t2]))
 
 (def ^:private public-endpoint "/auto/dashboard/")

--- a/src/metabase/xrays/core.clj
+++ b/src/metabase/xrays/core.clj
@@ -1,10 +1,11 @@
-(ns metabase.xrays
+(ns metabase.xrays.core
   "API namespace for X-Ray related stuff."
   (:require
    [metabase.xrays.automagic-dashboards.comparison]
    [metabase.xrays.automagic-dashboards.core]
    [metabase.xrays.automagic-dashboards.dashboard-templates]
    [metabase.xrays.automagic-dashboards.populate]
+   [metabase.xrays.related]
    [metabase.xrays.transforms.dashboard]
    [metabase.xrays.transforms.materialize]
    [potemkin :as p]))
@@ -14,6 +15,7 @@
   metabase.xrays.automagic-dashboards.core/keep-me
   metabase.xrays.automagic-dashboards.dashboard-templates/keep-me
   metabase.xrays.automagic-dashboards.populate/keep-me
+  metabase.xrays.related/keep-me
   metabase.xrays.transforms.dashboard/keep-me
   metabase.xrays.transforms.materialize/keep-me)
 
@@ -29,6 +31,8 @@
  [metabase.xrays.automagic-dashboards.populate
   create-collection!
   get-or-create-root-container-collection]
+ [metabase.xrays.related
+  related]
  [metabase.xrays.transforms.dashboard
   dashboard]
  [metabase.xrays.transforms.materialize

--- a/src/metabase/xrays/related.clj
+++ b/src/metabase/xrays/related.clj
@@ -1,4 +1,4 @@
-(ns metabase.related
+(ns metabase.xrays.related
   "Related entities recommendations."
   (:require
    [clojure.set :as set]

--- a/test/metabase/xrays/related_test.clj
+++ b/test/metabase/xrays/related_test.clj
@@ -1,13 +1,13 @@
-(ns metabase.related-test
+(ns metabase.xrays.related-test
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.test :refer :all]
    [medley.core :as m]
    [metabase.api.common :as api]
-   [metabase.related :as related]
    [metabase.sync :as sync]
    [metabase.test :as mt]
    [metabase.test.data.one-off-dbs :as one-off-dbs]
+   [metabase.xrays.related :as related]
    [toucan2.core :as t2]))
 
 (deftest ^:parallel collect-context-bearing-forms-test


### PR DESCRIPTION
- Move `metabase.xrays` to `metabase.xrays.core` for consistency with the new module shape
- Move `metabase.related` to `metabase.xrays.related`

Resolves #52142
Resolves #52146
