### PR TITLE
Gsheets simplify gsheet definition

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/gsheets.clj
+++ b/enterprise/backend/src/metabase_enterprise/gsheets.clj
@@ -131,11 +131,11 @@
   "Hook up a new google drive folder that will be watched and have its content ETL'd into Metabase."
   [{} {} {:keys [url]} :- [:map [:url ms/NonBlankString]]]
   (let [[status _resp] (setup-drive-folder-sync url)]
-      (if (= status :ok)
-        (u/prog1 {:status "connected" :folder_url url} (gsheets! <>))
-        (throw (ex-info (str/join ["Unable to setup drive folder sync.\n"
-                                   "Please check that the folder is shared with the proper service account email "
-                                   "and sharing permissions."]) {})))))
+    (if (= status :ok)
+      (u/prog1 {:status "connected" :folder_url url} (gsheets! <>))
+      (throw (ex-info (str/join ["Unable to setup drive folder sync.\n"
+                                 "Please check that the folder is shared with the proper service account email "
+                                 "and sharing permissions."]) {})))))
 
 (api.macros/defendpoint :delete "/folder"
   "Disconnect the google service account"

--- a/enterprise/backend/src/metabase_enterprise/upload_management/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/upload_management/api.clj
@@ -1,29 +1,39 @@
 (ns metabase-enterprise.upload-management.api
   (:require
-   [compojure.core :refer [DELETE]]
    [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
    [metabase.models.interface :as mi]
+   [metabase.premium-features.core :as premium-features]
    [metabase.upload :as upload]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/tables"
+(defn- attached-dwh-tables
+  "Used for adding attached DWH tables to the list of tables visible to the user. In practice these are to manage
+  google sheets uploads."
+  []
+  (when (premium-features/has-feature? :attached-dwh)
+    (when-let [dw-db-id (t2/select-one-fn :id :model/Database :is_attached_dwh true)]
+      (when-let [dw-tables (t2/select :model/Table :database_id dw-db-id)]
+        dw-tables))))
+
+(api.macros/defendpoint :get "/tables"
   "Get all `Tables` visible to the current user which were created by uploading a file."
   []
   (as-> (t2/select :model/Table, :active true, :is_upload true, {:order-by [[:name :asc]]}) tables
-        ;; See https://github.com/metabase/metabase/issues/41023
+    ;; See https://github.com/metabase/metabase/issues/41023
+    (concat tables (attached-dwh-tables))
     (map #(update % :schema str) tables)
     (filterv mi/can-read? tables)))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint DELETE "/tables/:id"
+(api.macros/defendpoint :delete "/tables/:id"
   "Delete the uploaded table from the database, optionally archiving cards for which it is the primary source."
-  [id archive-cards]
-  {id            ms/PositiveInt
-   archive-cards [:maybe {:default false} ms/BooleanValue]}
+  [{:keys [id]} :- [:map
+                    [:id ms/PositiveInt]]
+   {}
+   {:keys [archive-cards]} :- [:map [:archive-cards {:default false} ms/BooleanValue]]]
   (try
     ;; To be idempotent, we do not check whether the table has already been deactivated.
     (let [table  (api/check-404 (t2/select-one :model/Table id))

--- a/frontend/src/metabase-types/api/mocks/table.ts
+++ b/frontend/src/metabase-types/api/mocks/table.ts
@@ -14,7 +14,6 @@ export const createMockTable = (opts?: Partial<Table>): Table => {
     initial_sync_status: "complete",
     segments: [],
     is_upload: false,
-    is_gsheet: false,
     created_at: "2021-05-01T00:00:00",
     updated_at: "2021-05-01T00:00:00",
     ...opts,

--- a/frontend/src/metabase-types/api/table.ts
+++ b/frontend/src/metabase-types/api/table.ts
@@ -43,7 +43,6 @@ export type Table = {
   visibility_type: TableVisibilityType;
   initial_sync_status: InitialSyncStatus;
   is_upload: boolean;
-  is_gsheet: boolean;
   caveats?: string;
   points_of_interest?: string;
   created_at: string;

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/v_alerts.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/v_alerts.yaml
@@ -7,7 +7,6 @@ schema: public
 entity_type: entity/GenericTable
 active: true
 is_upload: false
-is_gsheet: false
 field_order: database
 visibility_type: null
 show_in_getting_started: false

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/v_audit_log.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/v_audit_log.yaml
@@ -7,7 +7,6 @@ schema: public
 entity_type: entity/EventTable
 active: true
 is_upload: false
-is_gsheet: false
 field_order: database
 visibility_type: null
 show_in_getting_started: false

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/v_content.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/v_content.yaml
@@ -7,7 +7,6 @@ schema: public
 entity_type: entity/GenericTable
 active: true
 is_upload: false
-is_gsheet: false
 field_order: database
 visibility_type: null
 show_in_getting_started: false

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/v_dashboardcard.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/v_dashboardcard.yaml
@@ -7,7 +7,6 @@ schema: public
 entity_type: entity/GenericTable
 active: true
 is_upload: false
-is_gsheet: false
 field_order: database
 visibility_type: null
 show_in_getting_started: false

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/v_databases.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/v_databases.yaml
@@ -7,7 +7,6 @@ schema: public
 entity_type: entity/GenericTable
 active: true
 is_upload: false
-is_gsheet: false
 field_order: database
 visibility_type: null
 show_in_getting_started: false

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/v_fields.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/v_fields.yaml
@@ -7,7 +7,6 @@ schema: public
 entity_type: entity/GenericTable
 active: true
 is_upload: false
-is_gsheet: false
 field_order: database
 visibility_type: null
 show_in_getting_started: false

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_group_members/v_group_members.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_group_members/v_group_members.yaml
@@ -7,7 +7,6 @@ schema: public
 entity_type: entity/GenericTable
 active: true
 is_upload: false
-is_gsheet: false
 field_order: database
 visibility_type: null
 show_in_getting_started: false

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/v_query_log.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/v_query_log.yaml
@@ -7,7 +7,6 @@ schema: public
 entity_type: entity/EventTable
 active: true
 is_upload: false
-is_gsheet: false
 field_order: database
 visibility_type: null
 show_in_getting_started: false

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/v_subscriptions.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/v_subscriptions.yaml
@@ -7,7 +7,6 @@ schema: public
 entity_type: entity/SubscriptionTable
 active: true
 is_upload: false
-is_gsheet: false
 field_order: database
 visibility_type: null
 show_in_getting_started: false

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/v_tables.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/v_tables.yaml
@@ -7,7 +7,6 @@ schema: public
 entity_type: entity/GenericTable
 active: true
 is_upload: false
-is_gsheet: false
 field_order: database
 visibility_type: null
 show_in_getting_started: false

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/v_tasks.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/v_tasks.yaml
@@ -7,7 +7,6 @@ schema: public
 entity_type: entity/GenericTable
 active: true
 is_upload: false
-is_gsheet: false
 field_order: database
 visibility_type: null
 show_in_getting_started: false

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/v_users.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/v_users.yaml
@@ -7,7 +7,6 @@ schema: public
 entity_type: entity/UserTable
 active: true
 is_upload: false
-is_gsheet: false
 field_order: database
 visibility_type: null
 show_in_getting_started: false

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/v_view_log.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/v_view_log.yaml
@@ -7,7 +7,6 @@ schema: public
 entity_type: entity/EventTable
 active: true
 is_upload: false
-is_gsheet: false
 field_order: database
 visibility_type: null
 show_in_getting_started: false

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10469,28 +10469,6 @@ databaseChangeLog:
                   type: ${timestamp_type}
                   remarks: The timestamp at which a user was deactivated
 
-  - changeSet:
-      id: v53.2025-01-09T09:00:00
-      author: escherize
-      comment: add is_gsheet to metabase_table
-      validCheckSum: ANY
-      preConditions:
-        - not:
-            - columnExists:
-                tableName: metabase_table
-                columnName: is_gsheet
-      changes:
-        - addColumn:
-            tableName: metabase_table
-            columns:
-              - column:
-                  name: is_gsheet
-                  type: ${boolean.type}
-                  defaultValueBoolean: false
-                  remarks: Indicates that this table is associated with a google sheet
-                  constraints:
-                        nullable: false
-
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -278,7 +278,7 @@
 (defmethod serdes/make-spec "Table" [_model-name _opts]
   {:copy      [:name :description :entity_type :active :display_name :visibility_type :schema
                :points_of_interest :caveats :show_in_getting_started :field_order :initial_sync_status :is_upload
-               :database_require_filter :is_gsheet]
+               :database_require_filter]
    :skip      [:estimated_row_count :view_count]
    :transform {:created_at (serdes/date)
                :db_id      (serdes/fk :model/Database :name)}})

--- a/test_resources/serialization_baseline/databases/My Database/tables/Schemaless Table/Schemaless Table.yaml
+++ b/test_resources/serialization_baseline/databases/My Database/tables/Schemaless Table/Schemaless Table.yaml
@@ -7,8 +7,6 @@ schema: null
 entity_type: null
 active: true
 is_upload: false
-is_gsheet: false
-is_gsheet: false
 field_order: database
 visibility_type: null
 show_in_getting_started: false

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CATEGORIES/CATEGORIES.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CATEGORIES/CATEGORIES.yaml
@@ -7,7 +7,6 @@ schema: PUBLIC
 entity_type: entity/GenericTable
 active: true
 is_upload: false
-is_gsheet: false
 field_order: database
 visibility_type: null
 show_in_getting_started: false

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/CHECKINS.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/CHECKINS.yaml
@@ -7,7 +7,6 @@ schema: PUBLIC
 entity_type: entity/EventTable
 active: true
 is_upload: false
-is_gsheet: false
 field_order: database
 visibility_type: null
 show_in_getting_started: false

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/ORDERS.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/ORDERS.yaml
@@ -7,7 +7,6 @@ schema: PUBLIC
 entity_type: entity/TransactionTable
 active: true
 is_upload: false
-is_gsheet: false
 field_order: database
 visibility_type: null
 show_in_getting_started: false

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/PEOPLE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/PEOPLE.yaml
@@ -7,7 +7,6 @@ schema: PUBLIC
 entity_type: entity/UserTable
 active: true
 is_upload: false
-is_gsheet: false
 field_order: database
 visibility_type: null
 show_in_getting_started: false

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/PRODUCTS.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/PRODUCTS.yaml
@@ -7,7 +7,6 @@ schema: PUBLIC
 entity_type: entity/ProductTable
 active: true
 is_upload: false
-is_gsheet: false
 field_order: database
 visibility_type: null
 show_in_getting_started: false

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/REVIEWS.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/REVIEWS.yaml
@@ -7,7 +7,6 @@ schema: PUBLIC
 entity_type: entity/GenericTable
 active: true
 is_upload: false
-is_gsheet: false
 field_order: database
 visibility_type: null
 show_in_getting_started: false

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/USERS.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/USERS.yaml
@@ -7,7 +7,6 @@ schema: PUBLIC
 entity_type: entity/UserTable
 active: true
 is_upload: false
-is_gsheet: false
 field_order: database
 visibility_type: null
 show_in_getting_started: false

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/VENUES.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/VENUES.yaml
@@ -7,7 +7,6 @@ schema: PUBLIC
 entity_type: entity/GenericTable
 active: true
 is_upload: false
-is_gsheet: false
 field_order: database
 visibility_type: null
 show_in_getting_started: false


### PR DESCRIPTION
We are going to put all tables in the dwh into the `GET /api/ee/upload-management/tables`, so no need to differentiate them at this time.