### PR TITLE
[Backend modularization] Metabase `core` module cleanup

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -333,7 +333,6 @@
                                      metabase.async.streaming-response.thread-pool
                                      metabase.async.util}                                           ; TODO -- consolidate these into a real API namespace.
     metabase.audit                 #{metabase.audit}
-    metabase.bootstrap             #{metabase.bootstrap}
     metabase.cmd                   #{}                                                              ; there are no namespaces here since you shouldn't be using this in any other module.
     metabase.channel               #{metabase.channel.core
                                      metabase.channel.init
@@ -440,7 +439,6 @@
     metabase.audit                 :any
     metabase.auth-provider         #{metabase.util
                                      metabase.premium-features}
-    metabase.bootstrap             #{}
     metabase.cmd                   :any
     metabase.compatibility         :any
     metabase.channel               :any

--- a/.clj-kondo/src/hooks/clojure/core.clj
+++ b/.clj-kondo/src/hooks/clojure/core.clj
@@ -55,7 +55,7 @@
      metabase.api.public-test/add-card-to-dashboard!
      metabase.cmd.dump-to-h2/dump-to-h2!
      metabase.cmd.load-from-h2/load-from-h2!
-     metabase.core/ensure-audit-db-installed!
+     metabase.core.core/ensure-audit-db-installed!
      metabase.db.schema-migrations-test.impl/run-migrations-in-range!
      metabase.db.setup/migrate!
      metabase.db.setup/setup-db!

--- a/bin/build/src/build/uberjar.clj
+++ b/bin/build/src/build/uberjar.clj
@@ -80,7 +80,7 @@
                         (filter ns-symbols))
         orphans    (remove (set sorted) ns-symbols)
         all        (concat orphans sorted)]
-    (assert (contains? (set all) 'metabase.bootstrap))
+    (assert (contains? (set all) 'metabase.core.bootstrap))
     (when (contains? ns-symbols 'metabase-enterprise.core)
       (assert (contains? (set all) 'metabase-enterprise.core)))
     all))
@@ -147,7 +147,7 @@
    "Multi-Release"    "true"
    "Created-By"       "Metabase build.clj"
    "Build-Jdk-Spec"   (System/getProperty "java.specification.version")
-   "Main-Class"       "metabase.bootstrap"})
+   "Main-Class"       "metabase.core.bootstrap"})
 
 (defn- manifest ^Manifest []
   (doto (Manifest.)

--- a/deps.edn
+++ b/deps.edn
@@ -272,7 +272,8 @@
                  "-Djdk.attach.allowAttachSelf"
                  ;; This will suppress the warning about dynamically loaded agents (like clj-memory-meter)
                  "-XX:+EnableDynamicAgentLoading"
-                 ;; set the logging properties set in metabase.bootstrap. calling (dev) will load it but putting here to be sure
+                 ;; set the logging properties set in `metabase.core.bootstrap`. calling (dev) will load it but
+                 ;; putting here to be sure
                  "-Dlog4j2.contextSelector=org.apache.logging.log4j.core.selector.BasicContextSelector"
                  "-Dclojure.tools.logging.factory=clojure.tools.logging.impl/log4j2-factory"
                  ;; If Clojure fails to start (e.g. because of a compilation error somewhere) print the error
@@ -312,7 +313,7 @@
   ;; clojure -M:run:drivers (include all drivers)
   ;; clojure -M:run:ee (include EE code)
   :run
-  {:main-opts ["-m" "metabase.bootstrap"]
+  {:main-opts ["-m" "metabase.core.bootstrap"]
    :jvm-opts  ["-Dmb.run.mode=dev"
                "-Dmacaw.run.mode=dev"
                "-Djava.awt.headless=true"]}                   ; prevent Java icon from randomly popping up in macOS dock
@@ -322,7 +323,7 @@
   ;;
   ;;    clojure -M:ee:doc api-documentation
   :doc
-  {:main-opts ["-m" "metabase.bootstrap"]
+  {:main-opts ["-m" "metabase.core.bootstrap"]
    :jvm-opts  ["-Dmb.run.mode=prod"
                "-Djava.awt.headless=true"]}                   ; prevent Java icon from randomly popping up in macOS dock
 
@@ -740,7 +741,7 @@
 
   ;; Profile Metabase start time with clojure -M:profile
   :profile
-  {:main-opts ["-m" "metabase.core" "profile"]
+  {:main-opts ["-m" "metabase.core.bootstrap" "profile"]
    :jvm-opts  ["-XX:+CITime" ; print time spent in JIT compiler
                "-Xlog:gc"]}
 

--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -65,7 +65,7 @@
    [malli.dev :as malli-dev]
    [metabase.api.common :as api]
    [metabase.config :as config]
-   [metabase.core :as mbc]
+   [metabase.core.core :as mbc]
    [metabase.db :as mdb]
    [metabase.db.env :as mdb.env]
    [metabase.driver :as driver]

--- a/dev/src/user.clj
+++ b/dev/src/user.clj
@@ -1,9 +1,14 @@
 (ns user
   (:require
+   [clojure.java.io :as io]
    [environ.core :as env]
-   [metabase.bootstrap]
+   [metabase.core.bootstrap]
    [metabase.plugins.classloader :as classloader]
    [metabase.util :as u]))
+
+(set! *warn-on-reflection* true)
+
+(comment metabase.core.bootstrap/keep-me)
 
 ;; Load all user.clj files (including the system-wide one).
 (when *file* ; Ensure we don't load ourselves recursively, just in case.
@@ -11,7 +16,7 @@
        enumeration-seq
        rest ; First file in the enumeration will be this file, so skip it.
        (run! #(do (println "Loading" (str %))
-                  (clojure.lang.Compiler/load (clojure.java.io/reader %))))))
+                  (clojure.lang.Compiler/load (io/reader %))))))
 
 ;; Wrap these with ignore-exceptions to reduce the "required" deps of this namespace
 ;; We sometimes need to run cmd stuffs like `clojure -M:migrate rollback n 3` and these
@@ -31,11 +36,9 @@
  (classloader/require 'pjstadig.humane-test-output)
  ;; Initialize Humane Test Output if it's not already initialized. Don't enable humane-test-output when running tests
  ;; from the CLI, it breaks diffs. This uses [[env/env]] rather than [[metabase.config]] so we don't load that namespace
- ;; before we load [[metabase.bootstrap]]
+ ;; before we load [[metabase.core.bootstrap]]
  (when-not (= (env/env :mb-run-mode) "test")
    ((resolve 'pjstadig.humane-test-output/activate!))))
-
-(comment metabase.bootstrap/keep-me)
 
 (defn dev
   "Load and switch to the 'dev' namespace."

--- a/enterprise/backend/test/metabase_enterprise/audit_app/audit_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/audit_test.clj
@@ -8,7 +8,7 @@
    [metabase-enterprise.serialization.cmd :as serialization.cmd]
    [metabase-enterprise.serialization.v2.backfill-ids :as serdes.backfill]
    [metabase.audit :as audit]
-   [metabase.core :as mbc]
+   [metabase.core.core :as mbc]
    [metabase.models.data-permissions :as data-perms]
    [metabase.models.permissions-group :as perms-group]
    [metabase.models.serialization :as serdes]

--- a/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
@@ -6,7 +6,7 @@
    [metabase-enterprise.audit-app.permissions :as audit-app.permissions]
    [metabase.api.common :as api]
    [metabase.audit :as audit]
-   [metabase.core :as mbc]
+   [metabase.core.core :as mbc]
    [metabase.models.collection.graph :refer [update-graph!]]
    [metabase.models.collection.graph-test :refer [graph]]
    [metabase.models.data-permissions :as data-perms]

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -8,7 +8,7 @@
    [metabase-enterprise.serialization.v2.extract :as extract]
    [metabase-enterprise.serialization.v2.round-trip-test :as round-trip-test]
    [metabase.audit :as audit]
-   [metabase.core :as mbc]
+   [metabase.core.core :as mbc]
    [metabase.models.action :as action]
    [metabase.models.serialization :as serdes]
    [metabase.query-processor :as qp]

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -18,7 +18,6 @@
   (:require
    [clojure.string :as str]
    [clojure.tools.cli :as cli]
-   [environ.core :as env]
    [metabase.config :as config]
    [metabase.legacy-mbql.util :as mbql.u]
    [metabase.models]
@@ -99,13 +98,6 @@
     (catch Throwable e
       (log/error e "Failed to dump application database to H2 file")
       (system-exit! 1))))
-
-(defn ^:command profile
-  "Start Metabase the usual way and exit. Useful for profiling Metabase launch time."
-  []
-  ;; override env var that would normally make Jetty block forever
-  (alter-var-root #'env/env assoc :mb-jetty-join "false")
-  (u/profile "start-normally" ((resolve 'metabase.core/start-normally))))
 
 (defn ^:command reset-password
   "Reset the password for a user with `email-address`."

--- a/src/metabase/core/bootstrap.clj
+++ b/src/metabase/core/bootstrap.clj
@@ -26,6 +26,6 @@
 (System/setProperty "clojure.tools.logging.factory" "clojure.tools.logging.impl/log4j2-factory")
 
 (defn -main
-  "Main entrypoint. Invokes [[metabase.core/entrypoint]]"
+  "Main entrypoint. Invokes [[metabase.core.core/entrypoint]]"
   [& args]
-  (apply (requiring-resolve 'metabase.core/entrypoint) args))
+  (apply (requiring-resolve 'metabase.core.core/entrypoint) args))

--- a/src/metabase/core/bootstrap.clj
+++ b/src/metabase/core/bootstrap.clj
@@ -1,4 +1,4 @@
-(ns metabase.bootstrap
+(ns metabase.core.bootstrap
   (:gen-class)
   (:require [clojure.java.io :as io]))
 

--- a/src/metabase/core/config_from_file.clj
+++ b/src/metabase/core/config_from_file.clj
@@ -4,8 +4,8 @@
    [metabase.util.log :as log]))
 
 (defn init-from-file-if-code-available!
-  "Shim for running the config-from-file code, used by [[metabase.core]]. The config-from-file code only ships in the
-  Enterprise Edition™ JAR, so this checks whether the namespace exists, and if it does,
+  "Shim for running the config-from-file code, used by [[metabase.core.core]]. The config-from-file code only ships in
+  the Enterprise Edition™ JAR, so this checks whether the namespace exists, and if it does,
   invokes [[metabase-enterprise.advanced-config.file/initialize!]]; otherwise, this no-ops."
   []
   (when (try

--- a/src/metabase/core/core.clj
+++ b/src/metabase/core/core.clj
@@ -1,4 +1,4 @@
-(ns metabase.core
+(ns metabase.core.core
   (:require
    [clojure.string :as str]
    [clojure.tools.trace :as trace]
@@ -216,7 +216,7 @@
 ;;; ------------------------------------------------ App Entry Point -------------------------------------------------
 
 (defn entrypoint
-  "Launch Metabase in standalone mode. (Main application entrypoint is [[metabase.bootstrap/-main]].)"
+  "Launch Metabase in standalone mode. (Main application entrypoint is [[metabase.core.bootstrap/-main]].)"
   [& [cmd & args]]
   (maybe-enable-tracing)
   (if cmd

--- a/src/metabase/core/initialization_status.clj
+++ b/src/metabase/core/initialization_status.clj
@@ -1,7 +1,7 @@
 (ns metabase.core.initialization-status
   "Code related to tracking the progress of metabase initialization.
    This is kept in a separate, tiny namespace so it can be loaded right away when the application launches
-   (and so we don't need to wait for `metabase.core` to load to check the status).")
+   (and so we don't need to wait for [[metabase.core.core]] to load to check the status).")
 
 (defonce ^:private progress-atom
   (atom 0))

--- a/src/metabase/logger.clj
+++ b/src/metabase/logger.clj
@@ -1,7 +1,7 @@
 (ns metabase.logger
   "Configures the logger system for Metabase. Sets up an in-memory logger in a ring buffer for showing in the UI. Other
-  logging options are set in [[metabase.bootstrap]]: the context locator for log4j2 and ensuring log4j2 is the logger
-  that clojure.tools.logging uses."
+  logging options are set in [[metabase.core.bootstrap]]: the context locator for log4j2 and ensuring log4j2 is the
+  logger that clojure.tools.logging uses."
   (:require
    [amalloy.ring-buffer :refer [ring-buffer]]
    [clj-time.coerce :as time.coerce]

--- a/src/metabase/sample_data.clj
+++ b/src/metabase/sample_data.clj
@@ -1,4 +1,5 @@
 (ns metabase.sample-data
+  "Code related to adding the Sample Database on launch, or adding it back programmatically (used by the REST API)."
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]

--- a/src/metabase/server/core.clj
+++ b/src/metabase/server/core.clj
@@ -37,5 +37,5 @@
   ;; depends on [[metabase.api.routes]] and thus would make a big old circular deps MESS...
   ;;
   ;; TODO -- we should clean this up somehow. Need to think about how. This is only used in one
-  ;; place, [[metabase.core/start-normally]].
+  ;; place, [[metabase.core.core/start-normally]].
   (requiring-resolve 'metabase.server.handler/app))

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -6,7 +6,7 @@
    [java-time.api :as t]
    [metabase.analytics.stats :as stats :refer [legacy-anonymous-usage-stats]]
    [metabase.config :as config]
-   [metabase.core :as mbc]
+   [metabase.core.core :as mbc]
    [metabase.db :as mdb]
    [metabase.email :as email]
    [metabase.integrations.slack :as slack]

--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -7,7 +7,7 @@
    [metabase.analytics.snowplow-test :as snowplow-test]
    [metabase.api.setup :as api.setup]
    [metabase.config :as config]
-   [metabase.core :as mbc]
+   [metabase.core.core :as mbc]
    [metabase.db :as mdb]
    [metabase.driver.h2 :as h2]
    [metabase.events :as events]

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -6,7 +6,7 @@
    [java-time.api :as t]
    [metabase.actions.error :as actions.error]
    [metabase.config :as config]
-   [metabase.core :as mbc]
+   [metabase.core.core :as mbc]
    [metabase.db :as mdb]
    [metabase.driver :as driver]
    [metabase.driver.h2 :as h2]

--- a/test/metabase/driver/sql_jdbc/connection_test.clj
+++ b/test/metabase/driver/sql_jdbc/connection_test.clj
@@ -5,7 +5,7 @@
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.config :as config]
-   [metabase.core :as mbc]
+   [metabase.core.core :as mbc]
    [metabase.db :as mdb]
    [metabase.driver :as driver]
    [metabase.driver.h2 :as h2]

--- a/test/metabase/test_runner.clj
+++ b/test/metabase/test_runner.clj
@@ -7,8 +7,8 @@
    [clojure.string :as str]
    [humane-are.core :as humane-are]
    [mb.hawk.core :as hawk]
-   [metabase.bootstrap]
    [metabase.config :as config]
+   [metabase.core.bootstrap]
    [metabase.test-runner.assert-exprs]
    [metabase.test.data.env :as tx.env]
    [metabase.util.date-2]
@@ -20,7 +20,7 @@
 ;;; TODO -- consider whether we should just mode all of this stuff to [[user]] instead of doing it here
 
 (comment
-  metabase.bootstrap/keep-me
+  metabase.core.bootstrap/keep-me
   ;; make sure stuff like `=?` and what not are loaded
   metabase.test-runner.assert-exprs/keep-me
 


### PR DESCRIPTION
- Move `metabase.core` to `metabase.core.core` for consistency with the new module shapes
- Move `metabase.bootstrap` to `metabase.core.bootstrap` so it lives with the rest of the launch code 

Resolves #52153
Resolves #52154
