### PR TITLE
[Backend modularization] `actions` module cleanup

### DIFF
--- a/.clj-kondo/src/hooks/clojure/core.clj
+++ b/.clj-kondo/src/hooks/clojure/core.clj
@@ -49,7 +49,7 @@
      metabase-enterprise.advanced-permissions.models.permissions/update-db-download-permissions!
      metabase-enterprise.internal-user/install-internal-user!
      metabase-enterprise.sso.integrations.saml-test/call-with-login-attributes-cleared!
-     metabase.actions/perform-action!
+     metabase.actions.actions/perform-action!
      metabase.analytics.snowplow-test/fake-track-event-impl!
      metabase.analytics.snowplow/track-event-impl!
      metabase.api.public-test/add-card-to-dashboard!

--- a/.cljfmt.edn
+++ b/.cljfmt.edn
@@ -93,7 +93,7 @@
   metabase-enterprise.test/with-gtaps!                                                 [[:inner 0]]
   metabase-enterprise.test/with-gtaps-for-user!                                        [[:inner 0]]
   metabase-enterprise.test/with-user-attributes                                        [[:block 2]]
-  metabase.actions-test/with-actions-test-data-and-actions-permissively-enabled        [[:block 0]]
+  metabase.actions.actions-test/with-actions-test-data-and-actions-permissively-enabled [[:block 0]]
   metabase.actions.test-util/with-actions                                              [[:block 1]]
   metabase.actions.test-util/with-actions-disabled                                     [[:block 0]]
   metabase.actions.test-util/with-actions-enabled                                      [[:block 0]]

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,3 +11,10 @@ src/metabase/**/*permissions* @noahmoss
 src/metabase/integrations @noahmoss
 snowplow/* @metabase/data
 e2e/* @filiphric
+
+#
+# Backend modules <=> teams that own them
+#
+
+src/metabase/actions/** @metabase/core-backend-admin-webapp
+test/metabase/actions/** @metabase/core-backend-admin-webapp

--- a/src/metabase/actions/actions.clj
+++ b/src/metabase/actions/actions.clj
@@ -1,4 +1,4 @@
-(ns metabase.actions
+(ns metabase.actions.actions
   "Code related to the new writeback Actions."
   (:require
    [clojure.spec.alpha :as s]

--- a/src/metabase/actions/core.clj
+++ b/src/metabase/actions/core.clj
@@ -1,32 +1,32 @@
 (ns metabase.actions.core
   "API namespace for the `metabase.actions` module."
   (:require
-   [metabase.actions :as actions]
-   [metabase.actions.error :as actions.error]
-   [metabase.actions.execution :as actions.execution]
-   [metabase.actions.http-action :as actions.http-action]
+   [metabase.actions.actions]
+   [metabase.actions.error]
+   [metabase.actions.execution]
+   [metabase.actions.http-action]
    [potemkin :as p]))
 
 (comment
-  actions/keep-me
-  actions.error/keep-me
-  actions.execution/keep-me
-  actions.http-action/keep-me)
+  metabase.actions.actions/keep-me
+  metabase.actions.error/keep-me
+  metabase.actions.execution/keep-me
+  metabase.actions.http-action/keep-me)
 
 (p/import-vars
- [actions
+ [metabase.actions.actions
   cached-value
   check-actions-enabled!
   check-actions-enabled-for-database!
   perform-action!*]
- [actions.error
+ [metabase.actions.error
   incorrect-value-type
   violate-foreign-key-constraint
   violate-not-null-constraint
   violate-unique-constraint]
- [actions.execution
+ [metabase.actions.execution
   execute-action!
   execute-dashcard!
   fetch-values]
- [actions.http-action
+ [metabase.actions.http-action
   apply-json-query])

--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.set :as set]
    [medley.core :as m]
-   [metabase.actions :as actions]
+   [metabase.actions.actions :as actions]
    [metabase.actions.http-action :as http-action]
    [metabase.analytics.snowplow :as snowplow]
    [metabase.api.common :as api]

--- a/test/metabase/actions/actions_test.clj
+++ b/test/metabase/actions/actions_test.clj
@@ -1,7 +1,7 @@
-(ns ^:mb/driver-tests metabase.actions-test
+(ns ^:mb/driver-tests metabase.actions.actions-test
   (:require
    [clojure.test :refer :all]
-   [metabase.actions :as actions]
+   [metabase.actions.actions :as actions]
    [metabase.actions.execution :as actions.execution]
    [metabase.api.common :refer [*current-user-permissions-set*]]
    [metabase.driver :as driver]

--- a/test/metabase/driver/sql_jdbc/actions_test.clj
+++ b/test/metabase/driver/sql_jdbc/actions_test.clj
@@ -3,7 +3,7 @@
   in [[metabase.api.action-test]]."
   (:require
    [clojure.test :refer :all]
-   [metabase.actions :as actions]
+   [metabase.actions.actions :as actions]
    [metabase.actions.error :as actions.error]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.actions :as sql-jdbc.actions]


### PR DESCRIPTION
Resolves #52169

- `actions` already had a nice `metabase.actions.core` API namespace, so we just needed to move `metabase.actions` (NOT the API namespace) into the module; I couldn't decide what to call it so it's `metabase.actions.actions` for now.
- Add CODEOWNERS entries for the people who own this module (Admin webapp)
- I didn't move `metabase.models.action` into this module for now [since I'm still waiting for a general consensus from the team](https://metaboat.slack.com/archives/CKZEMT1MJ/p1736894539370439) that this is the way to go.