### PR TITLE
Filter after summarize drill-thru cleanups

### DIFF
--- a/src/metabase/lib/drill_thru/automatic_insights.cljc
+++ b/src/metabase/lib/drill_thru/automatic_insights.cljc
@@ -28,7 +28,7 @@
              (lib.metadata/setting query :enable-xrays)
              (not-empty dimensions)
              ;; Disabled because xrays do not work with multi-stage queries (metabase#52129).
-             (not (lib.drill-thru.common/strictly-underlying-aggregation? query column)))
+             (not (lib.underlying/strictly-underlying-aggregation? query column)))
     {:lib/type   :metabase.lib.drill-thru/drill-thru
      :type       :drill-thru/automatic-insights
      :column-ref column-ref

--- a/src/metabase/lib/drill_thru/automatic_insights.cljc
+++ b/src/metabase/lib/drill_thru/automatic_insights.cljc
@@ -27,7 +27,7 @@
              (or (not column) (some? value))
              (lib.metadata/setting query :enable-xrays)
              (not-empty dimensions)
-             ;; TODO fix this drill to work with underlying aggregations and remove this check (metabase#46932).
+             ;; Disabled because xrays do not work with multi-stage queries (metabase#52129).
              (not (lib.drill-thru.common/strictly-underlying-aggregation? query column)))
     {:lib/type   :metabase.lib.drill-thru/drill-thru
      :type       :drill-thru/automatic-insights

--- a/src/metabase/lib/drill_thru/common.cljc
+++ b/src/metabase/lib/drill_thru/common.cljc
@@ -48,34 +48,9 @@
   [value]
   (if (= value :null) nil value))
 
-(defn- has-source-or-underlying-source-fn
-  [source]
-  (fn has-source?
-    ([column]
-     (= (:lib/source column) source))
-    ([query column]
-     (and
-      (seq column)
-      (or (has-source? column)
-          (has-source? (lib.underlying/top-level-column query column)))))))
-
-(def aggregation-sourced?
-  "Does column or top-level-column have :source/aggregations?"
-  (has-source-or-underlying-source-fn :source/aggregations))
-
-(def breakout-sourced?
-  "Does column or top-level-column have :source/breakouts?"
-  (has-source-or-underlying-source-fn :source/breakouts))
-
-(defn strictly-underlying-aggregation?
-  "Does the top-level-column for `column` in `query` have :source/aggregations?"
-  [query column]
-  (and (not (aggregation-sourced? column))
-       (aggregation-sourced? query column)))
-
 (defn dimensions-from-breakout-columns
   "Convert `row` data into dimensions for `column`s that come from an aggregation in a previous stage."
   [query column row]
-  (when (strictly-underlying-aggregation? query column)
-    (not-empty (filterv #(breakout-sourced? query (:column %))
+  (when (lib.underlying/strictly-underlying-aggregation? query column)
+    (not-empty (filterv #(lib.underlying/breakout-sourced? query (:column %))
                         row))))

--- a/src/metabase/lib/drill_thru/distribution.cljc
+++ b/src/metabase/lib/drill_thru/distribution.cljc
@@ -51,7 +51,7 @@
   (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
              column
              (nil? value)
-             (not (lib.drill-thru.common/aggregation-sourced? query column))
+             (not (lib.underlying/aggregation-sourced? query column))
              (not (lib.types.isa/primary-key? column))
              (not (lib.types.isa/structured?  column))
              (not (lib.types.isa/comment?     column))

--- a/src/metabase/lib/drill_thru/pivot.cljc
+++ b/src/metabase/lib/drill_thru/pivot.cljc
@@ -65,7 +65,7 @@
   (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
              column
              (some? value)
-             (lib.drill-thru.common/aggregation-sourced? query column))
+             (lib.underlying/aggregation-sourced? query column))
     (->> (lib.breakout/breakoutable-columns query stage-number)
          (filter field-pred))))
 
@@ -128,7 +128,7 @@
     (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
                column
                (some? value)
-               (lib.drill-thru.common/aggregation-sourced? query column)
+               (lib.underlying/aggregation-sourced? query column)
                (-> (lib.aggregation/aggregations query stage-number) count pos?))
       (let [breakout-pivot-types (permitted-pivot-types query stage-number)
             pivots               (into {} (for [pivot-type breakout-pivot-types

--- a/src/metabase/lib/drill_thru/quick_filter.cljc
+++ b/src/metabase/lib/drill_thru/quick_filter.cljc
@@ -51,6 +51,7 @@
    [metabase.lib.schema.expression :as lib.schema.expression]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.types.isa :as lib.types.isa]
+   [metabase.lib.underlying :as lib.underlying]
    [metabase.util.malli :as mu]))
 
 (defn- operator [op & args]
@@ -113,7 +114,7 @@
              column
              (some? value) ; Deliberately allows value :null, only a missing value should fail this test.
              ;; If this is an aggregation, there must be breakouts (dimensions).
-             (or (not (lib.drill-thru.common/aggregation-sourced? query column))
+             (or (not (lib.underlying/aggregation-sourced? query column))
                  (seq dimensions))
              (not (lib.types.isa/structured?  column))
              (not (lib.types.isa/primary-key? column))

--- a/src/metabase/lib/drill_thru/summarize_column.cljc
+++ b/src/metabase/lib/drill_thru/summarize_column.cljc
@@ -39,7 +39,7 @@
              column
              (nil? value)
              (not (lib.types.isa/structured? column))
-             (not (lib.drill-thru.common/aggregation-sourced? query column))
+             (not (lib.underlying/aggregation-sourced? query column))
              (not (lib.breakout/breakout-column? query (lib.underlying/top-level-stage-number query) column)))
     ;; I'm not really super clear on how the FE is supposed to be able to display these.
     (let [aggregation-ops (concat [:distinct]

--- a/src/metabase/lib/drill_thru/summarize_column_by_time.cljc
+++ b/src/metabase/lib/drill_thru/summarize_column_by_time.cljc
@@ -49,7 +49,7 @@
              (nil? value)
              (not (lib.types.isa/structured? column))
              (lib.types.isa/summable? column)
-             (not (lib.drill-thru.common/aggregation-sourced? query column)))
+             (not (lib.underlying/aggregation-sourced? query column)))
     ;; There must be a date dimension available.
     (let [stage-number (lib.underlying/top-level-stage-number query)]
       (when-let [breakout-column (m/find-first lib.types.isa/temporal?

--- a/src/metabase/lib/drill_thru/underlying_records.cljc
+++ b/src/metabase/lib/drill_thru/underlying_records.cljc
@@ -83,7 +83,7 @@
   (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
              (lib.underlying/has-aggregation-or-breakout? query)
              ;; Either we clicked the aggregation, or there are dimensions.
-             (or (lib.drill-thru.common/aggregation-sourced? query column)
+             (or (lib.underlying/aggregation-sourced? query column)
                  (not-empty dimensions))
              ;; Either we need both column and value (cell/map/data point click) or neither (chart legend click).
              (or (and column (some? value))
@@ -105,7 +105,7 @@
      ;; If the underlying column comes from an aggregation, then the column-ref needs to be updated as well to the
      ;; corresponding aggregation ref so that [[drill-underlying-records]] knows to extract the filter implied by
      ;; aggregations like sum-where.
-     :column-ref (if (lib.drill-thru.common/strictly-underlying-aggregation? query column)
+     :column-ref (if (lib.underlying/strictly-underlying-aggregation? query column)
                    (lib.aggregation/column-metadata->aggregation-ref (lib.underlying/top-level-column query column))
                    column-ref)}))
 

--- a/test/metabase/lib/drill_thru/distribution_test.cljc
+++ b/test/metabase/lib/drill_thru/distribution_test.cljc
@@ -42,40 +42,18 @@
 (deftest ^:parallel distribution-not-returned-for-aggregate-or-breakout-cols-test
   (doseq [column-name ["PRODUCT_ID" "CREATED_AT" "count" "sum" "max"]]
     (testing (str "distribution drill not returned for ORDERS." column-name)
-      (lib.drill-thru.tu/test-drill-not-returned
+      (lib.drill-thru.tu/test-drill-variants-with-merged-args
+       lib.drill-thru.tu/test-drill-not-returned
+       "single-stage query"
        {:drill-type  :drill-thru/distribution
         :click-type  :header
         :query-kinds [:mbql]
         :query-type  :aggregated
         :query-table "ORDERS"
-        :column-name column-name}))))
+        :column-name column-name}
 
-(deftest ^:parallel distribution-not-returned-for-aggregate-or-breakout-cols-for-multi-stage-query-test
-  (doseq [column-name ["PRODUCT_ID" "CREATED_AT" "count" "sum" "max"]]
-    (testing (str "distribution drill not returned for ORDERS." column-name)
-      (lib.drill-thru.tu/test-drill-not-returned
-       {:drill-type  :drill-thru/distribution
-        :click-type  :header
-        :query-kinds [:mbql]
-        :query-type  :aggregated
-        :custom-query (let [base-query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
-                                           (lib/aggregate (lib/count))
-                                           (lib/aggregate (lib/sum (meta/field-metadata :orders :tax)))
-                                           (lib/aggregate (lib/max (meta/field-metadata :orders :discount)))
-                                           (lib/breakout (meta/field-metadata :orders :product-id))
-                                           (lib/breakout (-> (meta/field-metadata :orders :created-at)
-                                                             (lib/with-temporal-bucket :month)))
-                                           lib/append-stage)
-                            count-col  (m/find-first #(= (:name %) "count")
-                                                     (lib/returned-columns base-query))
-                            _          (is (some? count-col))]
-                        (lib/filter base-query (lib/> count-col 0)))
-        :custom-row   {"PRODUCT_ID" 3
-                       "CREATED_AT" "2023-12-01"
-                       "count"      77
-                       "sum"        1
-                       "max"        nil}
-        :column-name column-name}))))
+       "multi-stage query"
+       {:custom-query #(lib.drill-thru.tu/append-filter-stage % "count")}))))
 
 (deftest ^:parallel returns-distribution-test-1
   (lib.drill-thru.tu/test-returns-drill

--- a/test/metabase/lib/drill_thru/distribution_test.cljc
+++ b/test/metabase/lib/drill_thru/distribution_test.cljc
@@ -50,7 +50,7 @@
         :query-table "ORDERS"
         :column-name column-name}))))
 
-(deftest ^:parallel distribution-not-returned-for-aggregate-or-breakout-cols-for-multi-stage-queries-test
+(deftest ^:parallel distribution-not-returned-for-aggregate-or-breakout-cols-for-multi-stage-query-test
   (doseq [column-name ["PRODUCT_ID" "CREATED_AT" "count" "sum" "max"]]
     (testing (str "distribution drill not returned for ORDERS." column-name)
       (lib.drill-thru.tu/test-drill-not-returned

--- a/test/metabase/lib/drill_thru/quick_filter_test.cljc
+++ b/test/metabase/lib/drill_thru/quick_filter_test.cljc
@@ -213,10 +213,8 @@
        "multi-stage query"
        (fn [base-case]
          {:custom-query #(lib.drill-thru.tu/append-filter-stage % "sum")
-          :expected-query (lib.drill-thru.tu/prepend-filter-to-stage
-                           (:expected-query base-case)
-                           -1
-                           [:> {} [:field {} "sum"] -1])})))))
+          :expected-query (-> (:expected-query base-case)
+                              (lib.drill-thru.tu/prepend-filter-to-test-expectation-stage "sum"))})))))
 
 (deftest ^:parallel apply-quick-filter-on-correct-level-test-2
   (testing "quick-filter on a breakout should not introduce a new stage"
@@ -247,10 +245,9 @@
         :custom-query   #(lib.drill-thru.tu/append-filter-stage % "sum")
         ;; the extra stage is added by append-filter-stage, not by the quick-filter
         :expected       (update-in (:expected base-case) [:query :stages] conj {})
-        :expected-query (lib.drill-thru.tu/prepend-filter-to-stage
-                         (update (:expected-query base-case) :stages #(into [{}] %))
-                         -1
-                         [:> {} [:field {} "sum"] -1])}))))
+        :expected-query (-> (:expected-query base-case)
+                            lib.drill-thru.tu/prepend-stage-to-test-expectation
+                            (lib.drill-thru.tu/prepend-filter-to-test-expectation-stage "sum"))}))))
 
 (deftest ^:parallel apply-quick-filter-on-correct-level-test-3
   (testing "quick-filter on an aggregation should introduce an new stage (#34346)"
@@ -275,10 +272,8 @@
      "multi-stage query: no new stage added"
      (fn [base-case]
        {:custom-query   #(lib.drill-thru.tu/append-filter-stage % "max")
-        :expected-query (lib.drill-thru.tu/prepend-filter-to-stage
-                         (:expected-query base-case)
-                         -1
-                         [:> {} [:field {} "max"] -1])}))))
+        :expected-query (-> (:expected-query base-case)
+                            (lib.drill-thru.tu/prepend-filter-to-test-expectation-stage "max"))}))))
 
 (deftest ^:parallel contains-does-not-contain-test
   (testing "Should return :contains/:does-not-contain for text columns (#33560)"

--- a/test/metabase/lib/drill_thru/summarize_column_test.cljc
+++ b/test/metabase/lib/drill_thru/summarize_column_test.cljc
@@ -70,7 +70,7 @@
         :query-table "ORDERS"
         :column-name column-name}))))
 
-(deftest ^:parallel summarize-column-not-returned-for-aggregate-or-breakout-cols-for-multi-stage-queries-test
+(deftest ^:parallel summarize-column-not-returned-for-aggregate-or-breakout-cols-for-multi-stage-query-test
   (doseq [column-name ["PRODUCT_ID" "count"]]
     (testing (str "summarize-column drill not returned for ORDERS." column-name)
       (lib.drill-thru.tu/test-drill-not-returned

--- a/test/metabase/lib/drill_thru/summarize_column_test.cljc
+++ b/test/metabase/lib/drill_thru/summarize_column_test.cljc
@@ -1,7 +1,6 @@
 (ns metabase.lib.drill-thru.summarize-column-test
   (:require
-   [clojure.test :refer [deftest is testing]]
-   [medley.core :as m]
+   [clojure.test :refer [deftest testing]]
    [metabase.lib.core :as lib]
    [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
    [metabase.lib.drill-thru.test-util.canned :as canned]
@@ -78,14 +77,7 @@
         :click-type  :header
         :query-kinds [:mbql]
         :query-type  :aggregated
-        :custom-query (let [base-query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
-                                           (lib/aggregate (lib/count))
-                                           (lib/breakout (meta/field-metadata :orders :product-id))
-                                           lib/append-stage)
-                            count-col  (m/find-first #(= (:name %) "count")
-                                                     (lib/returned-columns base-query))
-                            _          (is (some? count-col))]
-                        (lib/filter base-query (lib/> count-col 0)))
+        :custom-query #(lib.drill-thru.tu/append-filter-stage % "count")
         :custom-row   {"PRODUCT_ID" 3
                        "count"      77}
         :column-name column-name}))))

--- a/test/metabase/lib/drill_thru/underlying_records_test.cljc
+++ b/test/metabase/lib/drill_thru/underlying_records_test.cljc
@@ -88,7 +88,7 @@
       :column-name "max"
       :expected    #(->> % (map :type) (filter #{:drill-thru/underlying-records}) count (= 1))})))
 
-(deftest ^:parallel returns-underlying-records-for-multi-stage-queries-test
+(deftest ^:parallel returns-underlying-records-for-multi-stage-query-test
   (lib.drill-thru.tu/test-returns-drill
    {:drill-type   :drill-thru/underlying-records
     :click-type   :cell

--- a/test/metabase/lib/drill_thru/underlying_records_test.cljc
+++ b/test/metabase/lib/drill_thru/underlying_records_test.cljc
@@ -95,20 +95,7 @@
     :query-type   :aggregated
     :query-kinds  [:mbql]
     :column-name  "count"
-    :custom-query (let [base-query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
-                                       (lib/aggregate (lib/count))
-                                       (lib/breakout (meta/field-metadata :orders :product-id))
-                                       (lib/breakout (-> (meta/field-metadata :orders :created-at)
-                                                         (lib/with-temporal-bucket :month)))
-                                       lib/append-stage)
-                        count-col  (m/find-first #(= (:name %) "count")
-                                                 (lib/returned-columns base-query))
-                        _          (is (some? count-col))
-                        query      (lib/filter base-query (lib/> count-col 0))]
-                    query)
-    :custom-row   {"PRODUCT_ID" 3
-                   "CREATED_AT" "2023-12-01"
-                   "count"      77}
+    :custom-query #(lib.drill-thru.tu/append-filter-stage % "count")
     :expected     {:type       :drill-thru/underlying-records
                    :row-count  77
                    :table-name "Orders"
@@ -122,7 +109,7 @@
                                 {:column     {:name       "CREATED_AT"
                                               :lib/source :source/previous-stage}
                                  :column-ref [:field {} "CREATED_AT"]
-                                 :value      "2023-12-01"}]}}))
+                                 :value      "2022-12-01T00:00:00+02:00"}]}}))
 
 (def ^:private last-month
   #?(:cljs (let [now    (js/Date.)

--- a/test/metabase/lib/drill_thru/zoom_in_bins_test.cljc
+++ b/test/metabase/lib/drill_thru/zoom_in_bins_test.cljc
@@ -288,11 +288,11 @@
           base-query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
                          (lib/aggregate (lib/count))
                          (lib/breakout (lib/with-binning (meta/field-metadata :orders :subtotal)
-                                         {:strategy  :num-bins
-                                          :num-bins  8
-                                          :bin-width 2.5
-                                          :min-value 40
-                                          :max-value 60})))]
+                                                         {:strategy  :num-bins
+                                                          :num-bins  8
+                                                          :bin-width 2.5
+                                                          :min-value 40
+                                                          :max-value 60})))]
       (lib.drill-thru.tu/test-drill-variants-with-merged-args
        lib.drill-thru.tu/test-drill-application
        "single-stage query"

--- a/test/metabase/lib/drill_thru/zoom_in_bins_test.cljc
+++ b/test/metabase/lib/drill_thru/zoom_in_bins_test.cljc
@@ -10,25 +10,16 @@
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 
-(defn- add-trivial-filter-stage
-  [query name-of-column-to-filter]
-  (let [query'           (lib/append-stage query)
-        column-to-filter (m/find-first #(= (:name %) name-of-column-to-filter)
-                                       (lib/returned-columns query'))]
-    (is (some? column-to-filter))
-    (lib/filter query' (lib/> column-to-filter -1))))
+(defn- variant-expected-query-with-count-filter-stage [base-expected-query]
+  (let [base-filters (get-in base-expected-query [:stages 0 :filters])]
+    (-> base-expected-query
+        (update-in [:stages 0] dissoc :filters)
+        (update :stages conj {:filters (into [[:> {} [:field {} "count"] -1]]
+                                             base-filters)}))))
 
-(defn- test-drill-application-with-extra-stage
-  [test-drill-context
-   & {:keys [custom-query-with-extra-stage expected-query-with-extra-stage]}]
-  (testing "base query"
-    (lib.drill-thru.tu/test-drill-application test-drill-context))
-  (when (and custom-query-with-extra-stage expected-query-with-extra-stage)
-    (testing "base query with extra stage"
-      (lib.drill-thru.tu/test-drill-application
-       (assoc test-drill-context
-              :custom-query   custom-query-with-extra-stage
-              :expected-query expected-query-with-extra-stage)))))
+(defn- variant-with-count-filter-stage [base-case]
+  {:custom-query (lib.drill-thru.tu/append-filter-stage (:custom-query base-case) "count")
+   :expected-query (variant-expected-query-with-count-filter-stage (:expected-query base-case))})
 
 (deftest ^:parallel zoom-in-bins-available-test
   (testing "zoom-in for bins is available for cells, pivots and legends on numeric columns which have binning set"
@@ -44,95 +35,72 @@
 
 (deftest ^:parallel num-bins->default-test
   (testing ":num-bins binning => :default binning + between filter"
-    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
-                    (lib/aggregate (lib/count))
-                    (lib/breakout (-> (meta/field-metadata :orders :total)
-                                      (lib/with-binning {:strategy :num-bins, :num-bins 10}))))]
-      (test-drill-application-with-extra-stage
-       {:click-type     :cell
-        :query-type     :aggregated
-        :custom-query   query
-        :custom-row     {"count" 100
-                         "TOTAL" 40}
-        :column-name    "TOTAL"
-        :drill-type     :drill-thru/zoom-in.binning
-        :expected       {:type        :drill-thru/zoom-in.binning
-                         :column      {:name "TOTAL"}
-                         :min-value   40
-                         :max-value   60.0
-                         :new-binning {:strategy :default}}
-        :expected-query {:stages [{:source-table (meta/id :orders)
+    (lib.drill-thru.tu/test-drill-variants-with-merged-args
+     lib.drill-thru.tu/test-drill-application
+     "single-stage query"
+     {:click-type     :cell
+      :query-type     :aggregated
+      :custom-query   (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                          (lib/aggregate (lib/count))
+                          (lib/breakout (-> (meta/field-metadata :orders :total)
+                                            (lib/with-binning {:strategy :num-bins, :num-bins 10}))))
+      :custom-row     {"count" 100
+                       "TOTAL" 40}
+      :column-name    "TOTAL"
+      :drill-type     :drill-thru/zoom-in.binning
+      :expected       {:type        :drill-thru/zoom-in.binning
+                       :column      {:name "TOTAL"}
+                       :min-value   40
+                       :max-value   60.0
+                       :new-binning {:strategy :default}}
+      :expected-query (let [total-field (lib.drill-thru.tu/field-key= "TOTAL" (meta/id :orders :total))]
+                        {:stages [{:source-table (meta/id :orders)
                                    :aggregation  [[:count {}]]
-                                   :breakout     [[:field
-                                                   {:binning {:strategy :default}}
-                                                   (meta/id :orders :total)]]
+                                   :breakout     [[:field {:binning {:strategy :default}} total-field]]
                                    :filters      [[:>= {}
-                                                   [:field {} (meta/id :orders :total)]
+                                                   [:field {} total-field]
                                                    40]
                                                   [:< {}
-                                                   [:field {} (meta/id :orders :total)]
-                                                   60.0]]}]}}
-       :custom-query-with-extra-stage (add-trivial-filter-stage query "count")
-       :expected-query-with-extra-stage {:stages [{:source-table (meta/id :orders)
-                                                   :aggregation  [[:count {}]]
-                                                   :breakout     [[:field
-                                                                   {:binning {:strategy :default}}
-                                                                   "TOTAL"]]}
-                                                  {:filters      [[:> {}
-                                                                   [:field {} "count"]
-                                                                   -1]
-                                                                  [:>= {}
-                                                                   [:field {} "TOTAL"]
-                                                                   40]
-                                                                  [:< {}
-                                                                   [:field {} "TOTAL"]
-                                                                   60.0]]}]}))))
+                                                   [:field {} total-field]
+                                                   60.0]]}]})}
+
+     "multi-stage query"
+     variant-with-count-filter-stage)))
 
 (deftest ^:parallel bin-width-test
   (testing ":bin-width binning => :bin-width binning (width ÷= 10) + between filter"
-    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :people))
-                    (lib/aggregate (lib/count))
-                    (lib/breakout (-> (meta/field-metadata :people :latitude)
-                                      (lib/with-binning {:strategy :bin-width, :bin-width 1.0}))))]
-      (test-drill-application-with-extra-stage
-       {:click-type     :cell
-        :query-type     :aggregated
-        :custom-query   query
-        :custom-row     {"count"    100
-                         "LATITUDE" 41.0}
-        :column-name    "LATITUDE"
-        :drill-type     :drill-thru/zoom-in.binning
-        :expected       {:type        :drill-thru/zoom-in.binning
-                         :column      {:name "LATITUDE"}
-                         :min-value   41.0
-                         :max-value   42.0
-                         :new-binning {:strategy :bin-width, :bin-width 0.1}}
-        :expected-query {:stages [{:source-table (meta/id :people)
+    (lib.drill-thru.tu/test-drill-variants-with-merged-args
+     lib.drill-thru.tu/test-drill-application
+     "single-stage query"
+     {:click-type     :cell
+      :query-type     :aggregated
+      :custom-query   (-> (lib/query meta/metadata-provider (meta/table-metadata :people))
+                          (lib/aggregate (lib/count))
+                          (lib/breakout (-> (meta/field-metadata :people :latitude)
+                                            (lib/with-binning {:strategy :bin-width, :bin-width 1.0}))))
+      :custom-row     {"count"    100
+                       "LATITUDE" 41.0}
+      :column-name    "LATITUDE"
+      :drill-type     :drill-thru/zoom-in.binning
+      :expected       {:type        :drill-thru/zoom-in.binning
+                       :column      {:name "LATITUDE"}
+                       :min-value   41.0
+                       :max-value   42.0
+                       :new-binning {:strategy :bin-width, :bin-width 0.1}}
+      :expected-query (let [lat-field (lib.drill-thru.tu/field-key= "LATITUDE" (meta/id :people :latitude))]
+                        {:stages [{:source-table (meta/id :people)
                                    :aggregation  [[:count {}]]
                                    :breakout     [[:field
                                                    {:binning {:strategy :bin-width, :bin-width 0.1}}
-                                                   (meta/id :people :latitude)]]
+                                                   lat-field]]
                                    :filters      [[:>= {}
-                                                   [:field {} (meta/id :people :latitude)]
+                                                   [:field {} lat-field]
                                                    41.0]
                                                   [:< {}
-                                                   [:field {} (meta/id :people :latitude)]
-                                                   42.0]]}]}}
-       :custom-query-with-extra-stage (add-trivial-filter-stage query "count")
-       :expected-query-with-extra-stage {:stages [{:source-table (meta/id :people)
-                                                   :aggregation  [[:count {}]]
-                                                   :breakout     [[:field
-                                                                   {:binning {:strategy :bin-width, :bin-width 0.1}}
-                                                                   "LATITUDE"]]}
-                                                  {:filters      [[:> {}
-                                                                   [:field {} "count"]
-                                                                   -1]
-                                                                  [:>= {}
-                                                                   [:field {} "LATITUDE"]
-                                                                   41.0]
-                                                                  [:< {}
-                                                                   [:field {} "LATITUDE"]
-                                                                   42.0]]}]}))))
+                                                   [:field {} lat-field]
+                                                   42.0]]}]})}
+     "multi-stage query"
+     variant-with-count-filter-stage)))
 
 (deftest ^:parallel default-binning-test
   (testing ":default binning => :bin-width binning. Should consider :dimensions in drill context (#36117)"
@@ -184,59 +152,45 @@
 ;; TODO: Add a test for clicking on pivot column cells (and headers?) - but that's broken on master. See #38265.
 (deftest ^:parallel cell-click-filters-and-updates-only-one-dimension-test
   (testing "when zooming in on one dimension, existing breakouts are dropped and replaced, along with new filters"
-    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
-                    (lib/aggregate (lib/count))
-                    (lib/breakout (-> (meta/field-metadata :orders :quantity)
-                                      (lib/with-binning {:strategy :num-bins, :num-bins 10})))
-                    (lib/breakout (-> (meta/field-metadata :orders :created-at)
-                                      (lib/with-temporal-bucket :month))))]
-      (test-drill-application-with-extra-stage
-       {:click-type     :cell
-        :query-type     :aggregated
-        :custom-query   query
-        :custom-row     {"count"      100
-                         "QUANTITY"   10
-                         "CREATED_AT" "2024-09-08T22:03:20.239+03:00"}
-         ;; TODO: Clicking on breakout columns in table views doesn't work properly.
-        :column-name    "count"
-        :drill-type     :drill-thru/zoom-in.binning
-        :expected       {:type        :drill-thru/zoom-in.binning
-                         :column      {:name "QUANTITY"}
-                         :min-value   10
-                         :max-value   20.0
-                         :new-binning {:strategy :default}}
-        :expected-query {:stages [{:source-table (meta/id :orders)
+    (lib.drill-thru.tu/test-drill-variants-with-merged-args
+     lib.drill-thru.tu/test-drill-application
+     "single-stage query"
+     {:click-type     :cell
+      :query-type     :aggregated
+      :custom-query   (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                          (lib/aggregate (lib/count))
+                          (lib/breakout (-> (meta/field-metadata :orders :quantity)
+                                            (lib/with-binning {:strategy :num-bins, :num-bins 10})))
+                          (lib/breakout (-> (meta/field-metadata :orders :created-at)
+                                            (lib/with-temporal-bucket :month))))
+      :custom-row     {"count"      100
+                       "QUANTITY"   10
+                       "CREATED_AT" "2024-09-08T22:03:20.239+03:00"}
+        ;; TODO: Clicking on breakout columns in table views doesn't work properly.
+      :column-name    "count"
+      :drill-type     :drill-thru/zoom-in.binning
+      :expected       {:type        :drill-thru/zoom-in.binning
+                       :column      {:name "QUANTITY"}
+                       :min-value   10
+                       :max-value   20.0
+                       :new-binning {:strategy :default}}
+      :expected-query (let [quantity-field   (lib.drill-thru.tu/field-key= "QUANTITY"   (meta/id :orders :quantity))]
+                        {:stages [{:source-table (meta/id :orders)
                                    :aggregation  [[:count {}]]
                                    :breakout     [[:field
                                                    {:binning {:strategy :default}}
-                                                   (meta/id :orders :quantity)]
+                                                   quantity-field]
                                                   [:field
                                                    {:temporal-unit :month}
                                                    (meta/id :orders :created-at)]]
                                    :filters      [[:>= {}
-                                                   [:field {} (meta/id :orders :quantity)]
+                                                   [:field {} quantity-field]
                                                    10]
                                                   [:< {}
-                                                   [:field {} (meta/id :orders :quantity)]
-                                                   20.0]]}]}}
-       :custom-query-with-extra-stage (add-trivial-filter-stage query "count")
-       :expected-query-with-extra-stage {:stages [{:source-table (meta/id :orders)
-                                                   :aggregation  [[:count {}]]
-                                                   :breakout     [[:field
-                                                                   {:binning {:strategy :default}}
-                                                                   "QUANTITY"]
-                                                                  [:field
-                                                                   {:temporal-unit :month}
-                                                                   (meta/id :orders :created-at)]]}
-                                                  {:filters      [[:> {}
-                                                                   [:field {} "count"]
-                                                                   -1]
-                                                                  [:>= {}
-                                                                   [:field {} "QUANTITY"]
-                                                                   10]
-                                                                  [:< {}
-                                                                   [:field {} "QUANTITY"]
-                                                                   20.0]]}]}))))
+                                                   [:field {} quantity-field]
+                                                   20.0]]}]})}
+     "multi-stage query"
+     variant-with-count-filter-stage)))
 
 (deftest ^:parallel legend-zoom-binning-numeric-test
   ;; Sum of Subtotal by month and Product->Rating with binning, then click a rating to zoom in.
@@ -334,12 +288,14 @@
           base-query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
                          (lib/aggregate (lib/count))
                          (lib/breakout (lib/with-binning (meta/field-metadata :orders :subtotal)
-                                                         {:strategy  :num-bins
-                                                          :num-bins  8
-                                                          :bin-width 2.5
-                                                          :min-value 40
-                                                          :max-value 60})))]
-      (test-drill-application-with-extra-stage
+                                         {:strategy  :num-bins
+                                          :num-bins  8
+                                          :bin-width 2.5
+                                          :min-value 40
+                                          :max-value 60})))]
+      (lib.drill-thru.tu/test-drill-variants-with-merged-args
+       lib.drill-thru.tu/test-drill-application
+       "single-stage query"
        {:click-type     :cell
         :query-type     :aggregated
         :custom-query   (add-zoom-in-filters base-query)
@@ -352,29 +308,19 @@
                          :min-value   50
                          :max-value   52.5
                          :new-binning {:strategy :default}}
-        :expected-query {:stages [{:source-table (meta/id :orders)
-                                   :aggregation  [[:count {}]]
-                                   :breakout     [[:field
-                                                   {:binning {:strategy :default}}
-                                                   (meta/id :orders :subtotal)]]
-                                   :filters      [[:>= {}
-                                                   [:field {} (meta/id :orders :subtotal)]
-                                                   50]
-                                                  [:< {}
-                                                   [:field {} (meta/id :orders :subtotal)]
-                                                   52.5]]}]}}
-       :custom-query-with-extra-stage (add-zoom-in-filters (add-trivial-filter-stage base-query "count"))
-       :expected-query-with-extra-stage {:stages [{:source-table (meta/id :orders)
-                                                   :aggregation  [[:count {}]]
-                                                   :breakout     [[:field
-                                                                   {:binning {:strategy :default}}
-                                                                   "SUBTOTAL"]]}
-                                                  {:filters      [[:> {}
-                                                                   [:field {} "count"]
-                                                                   -1]
-                                                                  [:>= {}
-                                                                   [:field {} "SUBTOTAL"]
-                                                                   50]
-                                                                  [:< {}
-                                                                   [:field {} "SUBTOTAL"]
-                                                                   52.5]]}]}))))
+        :expected-query (let [subtotal-field (lib.drill-thru.tu/field-key= "SUBTOTAL" (meta/id :orders :subtotal))]
+                          {:stages [{:source-table (meta/id :orders)
+                                     :aggregation  [[:count {}]]
+                                     :breakout     [[:field
+                                                     {:binning {:strategy :default}}
+                                                     subtotal-field]]
+                                     :filters      [[:>= {}
+                                                     [:field {} subtotal-field]
+                                                     50]
+                                                    [:< {}
+                                                     [:field {} subtotal-field]
+                                                     52.5]]}]})}
+       "multi-stage query"
+       (fn [base-case]
+         {:custom-query (add-zoom-in-filters (lib.drill-thru.tu/append-filter-stage base-query "count"))
+          :expected-query (variant-expected-query-with-count-filter-stage (:expected-query base-case))})))))

--- a/test/metabase/lib/drill_thru/zoom_in_timeseries_test.cljc
+++ b/test/metabase/lib/drill_thru/zoom_in_timeseries_test.cljc
@@ -195,26 +195,14 @@
     :click-type   :cell
     :query-type   :aggregated
     :column-name  "count"
-    :custom-query (let [base-query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
-                                       (lib/aggregate (lib/count))
-                                       (lib/breakout (meta/field-metadata :orders :product-id))
-                                       (lib/breakout (-> (meta/field-metadata :orders :created-at)
-                                                         (lib/with-temporal-bucket :month)))
-                                       lib/append-stage)
-                        count-col  (m/find-first #(= (:name %) "count")
-                                                 (lib/returned-columns base-query))
-                        _          (is (some? count-col))]
-                    (lib/filter base-query (lib/> count-col 0)))
-    :custom-row   {"PRODUCT_ID" 3
-                   "CREATED_AT" "2023-12-01"
-                   "count"      77}
+    :custom-query #(lib.drill-thru.tu/append-filter-stage % "count")
     :expected     {:type      :drill-thru/zoom-in.timeseries
                    :next-unit :week
                    ;; the "underlying" dimension is reconstructed from the row.
                    :dimension {:column     {:name       "CREATED_AT"
                                             :lib/source :source/breakouts}
                                :column-ref [:field {} (meta/id :orders :created-at)]
-                               :value      "2023-12-01"}}}))
+                               :value      "2022-12-01T00:00:00+02:00"}}}))
 
 (deftest ^:parallel returns-zoom-in-timeseries-e2e-test-2
   (testing "zoom-in.timeseries should be returned for a"
@@ -225,11 +213,7 @@
           created-at-col    (m/find-first #(= (:name %) "CREATED_AT")
                                           (lib/returned-columns base-query))
           _                 (is (some? created-at-col))
-          multi-stage-query (lib/append-stage base-query)
-          count-col         (m/find-first #(= (:name %) "count")
-                                          (lib/returned-columns multi-stage-query))
-          _                 (is (some? count-col))
-          multi-stage-query (lib/filter multi-stage-query (lib/> count-col 0))]
+          multi-stage-query (lib.drill-thru.tu/append-filter-stage base-query "count")]
       (doseq [[query-type query] {"single-stage" base-query
                                   "multi-stage" multi-stage-query}
               [message context]  {"pivot cell (no column, value = NULL) (#36173)"
@@ -251,15 +235,17 @@
           (let [[drill :as drills] (filter #(= (:type %) :drill-thru/zoom-in.timeseries)
                                            (lib/available-drill-thrus query -1 context))
                 ;; both queries have the base-query stage where the drill filter should be added
-                expected-stages (cond-> [{:aggregation [[:count {}]]
-                                          :breakout    [[:field {:temporal-unit :quarter} (meta/id :orders :created-at)]],
+                expected-query (cond-> {:stages
+                                        [{:aggregation [[:count {}]]
+                                          :breakout    [[:field
+                                                         {:temporal-unit :quarter}
+                                                         (meta/id :orders :created-at)]],
                                           :filters     [[:=
                                                          {}
                                                          [:field {:temporal-unit :year} (meta/id :orders :created-at)]
-                                                         "2022-12-01T00:00:00+02:00"]]}]
-                                  ;; the multi-stage-query has an additional filter stage
-                                  (= query multi-stage-query) (conj {:filters
-                                                                     [[:> {} [:field {} "count"] 0]]}))]
+                                                         "2022-12-01T00:00:00+02:00"]]}]}
+                                 (= query multi-stage-query)
+                                 (lib.drill-thru.tu/append-filter-stage-to-test-expectation "count"))]
             (is (= 1
                    (count drills)))
             (is (=? {:lib/type     :metabase.lib.drill-thru/drill-thru
@@ -269,7 +255,7 @@
                                     :value  "2022-12-01T00:00:00+02:00"}
                      :next-unit    :quarter}
                     drill))
-            (is (=? {:stages expected-stages}
+            (is (=? expected-query
                     (lib/drill-thru query -1 nil drill)))))))))
 
 (deftest ^:parallel zoom-in-timeseries-unit-tower-test
@@ -278,25 +264,23 @@
                                 (lib/aggregate (lib/count))
                                 (lib/breakout (-> (meta/field-metadata :orders :created-at)
                                                   (lib/with-temporal-bucket unit1))))
-          multi-stage-query (lib/append-stage base-query)
-          count-col         (m/find-first #(= (:name %) "count")
-                                          (lib/returned-columns multi-stage-query))
-          _                 (is (some? count-col))
-          multi-stage-query (lib/filter multi-stage-query (lib/> count-col 0))]
+          multi-stage-query (lib.drill-thru.tu/append-filter-stage base-query "count")]
       (doseq [[query-type query] {"single-stage" base-query
                                   "multi-stage"  multi-stage-query}]
         (testing (str "zoom-in.timeseries for a DateTime column in a " query-type " query should zoom from " unit1 " to " unit2)
-          (let [expected-stages (cond-> [{:source-table (meta/id :orders)
+          (let [expected-query (cond-> {:stages
+                                        [{:source-table (meta/id :orders)
                                           :aggregation  [[:count {}]]
                                           :breakout     [[:field
                                                           {:temporal-unit unit2}
                                                           (meta/id :orders :created-at)]]
                                           :filters      [[:= {}
-                                                          [:field {:temporal-unit unit1} (meta/id :orders :created-at)]
-                                                          "2022-12-09T11:22:33+02:00"]]}]
-                                  ;; the multi-stage-query has an additional filter stage
-                                  (= query multi-stage-query) (conj {:filters
-                                                                     [[:> {} [:field {} "count"] 0]]}))]
+                                                          [:field
+                                                           {:temporal-unit unit1}
+                                                           (meta/id :orders :created-at)]
+                                                          "2022-12-09T11:22:33+02:00"]]}]}
+                                 (= query multi-stage-query)
+                                 (lib.drill-thru.tu/append-filter-stage-to-test-expectation "count"))]
             (lib.drill-thru.tu/test-drill-application
              {:click-type     :cell
               :query-type     :aggregated
@@ -311,7 +295,7 @@
                                               :column-ref [:field {:temporal-unit unit1} (meta/id :orders :created-at)]
                                               :value      "2022-12-09T11:22:33+02:00"}
                                :next-unit    unit2}
-              :expected-query {:stages expected-stages}})))))))
+              :expected-query expected-query})))))))
 
 (deftest ^:parallel zoom-in-timeseries-unit-tower-test-2
   (doseq [[unit1 unit2] date-unit-pairs]

--- a/test/metabase/lib/drill_thru/zoom_in_timeseries_test.cljc
+++ b/test/metabase/lib/drill_thru/zoom_in_timeseries_test.cljc
@@ -189,7 +189,7 @@
           bucketing
           {"CREATED_AT" "2022-12-01"}))))))
 
-(deftest ^:parallel returns-zoom-in-timeseries-for-multi-stage-queries-test
+(deftest ^:parallel returns-zoom-in-timeseries-for-multi-stage-query-test
   (lib.drill-thru.tu/test-returns-drill
    {:drill-type   :drill-thru/zoom-in.timeseries
     :click-type   :cell


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/46932

### Description

Some final cleanups / refactoring of recently-added drill thru changes, mostly in the tests, to make things more consistent.

* Update the comment in automatic-insights drill to point to new github issue
* Update drills tests added in previous PRs to use the new test helpers
* Consistent naming for drill-thru multi-stage query tests
* Move some funcs that deal with "underlying" columns into `lib.underlying`.
     * `aggregation-sourced?`
     * `breakout-sourced?`
     * `strictly-underlying-aggregation?`
* Homogenize apis for drill thru test helpers
  * Rename `prepend-filter-to-stage` to `prepend-filter-to-test-expectation-stage` and make the calling interface match that of `append-filter-stage-to-test-expectation`.

### How to verify

Run tests

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
