### PR TITLE
[Backend modularization] `analyze` module cleanup

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -323,7 +323,7 @@
                                      metabase.analytics.snowplow
                                      metabase.analytics.stats
                                      metabase.analytics.sdk}                                        ; TODO -- consolidate these into a real API namespace.
-    metabase.analyze               #{metabase.analyze}
+    metabase.analyze               #{metabase.analyze.core}
     metabase.api                   #{metabase.api.common
                                      metabase.api.dataset
                                      metabase.api.macros

--- a/src/metabase/analyze/core.clj
+++ b/src/metabase/analyze/core.clj
@@ -1,4 +1,4 @@
-(ns metabase.analyze
+(ns metabase.analyze.core
   "API namespace for the `metabase.analyze` module."
   (:require
    [metabase.analyze.classifiers.category]

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -4,7 +4,7 @@
    [clojure.java.io :as io]
    [compojure.core :refer [DELETE GET POST PUT]]
    [medley.core :as m]
-   [metabase.analyze :as analyze]
+   [metabase.analyze.core :as analyze]
    [metabase.api.common :as api]
    [metabase.api.common.validation :as validation]
    [metabase.api.dataset :as api.dataset]

--- a/src/metabase/models/card/metadata.clj
+++ b/src/metabase/models/card/metadata.clj
@@ -1,7 +1,7 @@
 (ns metabase.models.card.metadata
   "Code related to Card metadata (re)calculation and saving updated metadata asynchronously."
   (:require
-   [metabase.analyze :as analyze]
+   [metabase.analyze.core :as analyze]
    [metabase.api.common :as api]
    [metabase.compatibility :as compatibility]
    [metabase.legacy-mbql.normalize :as mbql.normalize]

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -26,7 +26,7 @@
    [clojure.string :as str]
    [java-time.api :as t]
    [medley.core :as m]
-   [metabase.analyze :as analyze]
+   [metabase.analyze.core :as analyze]
    [metabase.db.metadata-queries :as metadata-queries]
    [metabase.db.query :as mdb.query]
    [metabase.lib.ident :as lib.ident]

--- a/src/metabase/query_processor/metadata.clj
+++ b/src/metabase/query_processor/metadata.clj
@@ -4,7 +4,7 @@
   [[metabase.driver/query-result-metadata]], which hopefully can calculate metadata without running the query. If
   that's not possible, our fallback `:default` implementation adds the equivalent of `LIMIT 1` to query and runs it."
   (:require
-   [metabase.analyze :as analyze]
+   [metabase.analyze.core :as analyze]
    [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
    [metabase.lib.metadata.jvm :as lib.metadata.jvm]

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -4,7 +4,7 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [medley.core :as m]
-   [metabase.analyze :as analyze]
+   [metabase.analyze.core :as analyze]
    [metabase.driver.common :as driver.common]
    [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.legacy-mbql.schema :as mbql.s]

--- a/src/metabase/query_processor/middleware/results_metadata.clj
+++ b/src/metabase/query_processor/middleware/results_metadata.clj
@@ -3,7 +3,7 @@
    and returns that metadata (which can be passed *back* to the backend when saving a Card) as well
    as a checksum in the API response."
   (:require
-   [metabase.analyze :as analyze]
+   [metabase.analyze.core :as analyze]
    [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
    [metabase.lib.metadata :as lib.metadata]

--- a/src/metabase/sync/analyze/classify.clj
+++ b/src/metabase/sync/analyze/classify.clj
@@ -18,7 +18,7 @@
   In the future, we plan to add more classifiers, including ML ones that run offline."
   (:require
    [clojure.data :as data]
-   [metabase.analyze :as analyze]
+   [metabase.analyze.core :as analyze]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.models.interface :as mi]
    [metabase.query-processor.store :as qp.store]

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -4,7 +4,7 @@
   (:require
    [clojure.set :as set]
    [honey.sql.helpers :as sql.helpers]
-   [metabase.analyze :as analyze]
+   [metabase.analyze.core :as analyze]
    [metabase.db.metadata-queries :as metadata-queries]
    [metabase.db.query :as mdb.query]
    [metabase.driver :as driver]

--- a/src/metabase/xrays/automagic_dashboards/core.clj
+++ b/src/metabase/xrays/automagic_dashboards/core.clj
@@ -33,7 +33,7 @@
 
   _Most_ tables and _all_ models (as of this writing) will bottom out at `:entity/GenericTable` and thus, use the
   `resources/automagic_dashboards/table/GenericTable.yaml` template. `:entity_type` for a given table type is made in
-  the [[metabase.analyze/infer-entity-type-by-name]] function, where the primary logic is table naming based on the
+  the [[metabase.analyze.core/infer-entity-type-by-name]] function, where the primary logic is table naming based on the
   `prefix-or-postfix` var in that ns.
 
   ProTip: If you want to introduce a new template type, do the following:
@@ -148,7 +148,7 @@
    [kixi.stats.core :as stats]
    [kixi.stats.math :as math]
    [medley.core :as m]
-   [metabase.analyze :as analyze]
+   [metabase.analyze.core :as analyze]
    [metabase.db.query :as mdb.query]
    [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.models.field :as field]

--- a/src/metabase/xrays/automagic_dashboards/util.clj
+++ b/src/metabase/xrays/automagic_dashboards/util.clj
@@ -3,7 +3,7 @@
    [buddy.core.codecs :as codecs]
    [clojure.string :as str]
    [medley.core :as m]
-   [metabase.analyze :as analyze]
+   [metabase.analyze.core :as analyze]
    [metabase.legacy-mbql.predicates :as mbql.preds]
    [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.legacy-mbql.util :as mbql.u]

--- a/test/metabase/analyze/classify_test.clj
+++ b/test/metabase/analyze/classify_test.clj
@@ -1,7 +1,7 @@
 (ns metabase.analyze.classify-test
   (:require
    [clojure.test :refer :all]
-   [metabase.analyze :as analyze]
+   [metabase.analyze.core :as analyze]
    [metabase.analyze.classifiers.core :as classifiers]
    [metabase.models.interface :as mi]))
 

--- a/test/metabase/analyze/classify_test.clj
+++ b/test/metabase/analyze/classify_test.clj
@@ -1,8 +1,8 @@
 (ns metabase.analyze.classify-test
   (:require
    [clojure.test :refer :all]
-   [metabase.analyze.core :as analyze]
    [metabase.analyze.classifiers.core :as classifiers]
+   [metabase.analyze.core :as analyze]
    [metabase.models.interface :as mi]))
 
 (defn- ->field [field]

--- a/test/metabase/sync/field_values_test.clj
+++ b/test/metabase/sync/field_values_test.clj
@@ -4,7 +4,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [java-time.api :as t]
-   [metabase.analyze :as analyze]
+   [metabase.analyze.core :as analyze]
    [metabase.models.field-values :as field-values]
    [metabase.sync :as sync]
    [metabase.sync.util-test :as sync.util-test]


### PR DESCRIPTION
Resolves #52178

I recently cleaned up this module and gave it an API namespace of `metabase.analyze`, so the only thing we need to do is rename it to `metabase.analyze.core` to follow the updated rules we agreed on