### PR TITLE
allow selecting non-metric columns for tooltips of cartesian charts

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
@@ -262,16 +262,14 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       H.openVizSettingsSidebar();
       H.leftSidebar().within(() => {
         cy.findByText("Display").click();
-        cy.findByPlaceholderText("Enter metric names").click();
+        cy.findByPlaceholderText("Enter column names").click();
       });
 
-      // Select two additional metric columns to show in the tooltip
+      // Select two additional columns to show in the tooltip
       cy.findByRole("option", { name: SUM_OF_TOTAL }).click();
       cy.findByRole("option", { name: AVG_OF_QUANTITY }).click();
-      // It should not suggest categorical columns
-      cy.findByRole("option", { name: "Product → Category" }).should(
-        "not.exist",
-      );
+      // It should suggest categorical columns as well
+      cy.findByRole("option", { name: "Product → Category" }).should("exist");
 
       // Ensure the tooltip shows additional columns
       showTooltipForBarInSeries(COUNT_COLOR);

--- a/e2e/test/scenarios/visualizations-charts/waterfall.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/waterfall.cy.spec.js
@@ -381,7 +381,7 @@ describe("scenarios > visualizations > waterfall", () => {
 
     H.leftSidebar().within(() => {
       cy.findByText("Display").click();
-      cy.findByPlaceholderText("Enter metric names").click();
+      cy.findByPlaceholderText("Enter column names").click();
     });
     cy.findByRole("option", { name: "Sum of Total" }).click();
 

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -317,17 +317,13 @@ export const TOOLTIP_SETTINGS = {
   },
   "graph.tooltip_columns": {
     section: t`Display`,
-    title: t`Additional tooltip metrics`,
-    placeholder: t`Enter metric names`,
+    title: t`Additional tooltip columns`,
+    placeholder: t`Enter column names`,
     widget: "multiselect",
     useRawSeries: true,
     getValue: getComputedAdditionalColumnsValue,
     getHidden: (rawSeries, vizSettings) => {
-      const isAggregatedChart = rawSeries[0].card.display !== "scatter";
-      return (
-        getAvailableAdditionalColumns(rawSeries, vizSettings, isAggregatedChart)
-          .length === 0
-      );
+      return getAvailableAdditionalColumns(rawSeries, vizSettings).length === 0;
     },
     getProps: (rawSeries, vizSettings) => {
       const isAggregatedChart = rawSeries[0].card.display !== "scatter";

--- a/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
@@ -392,7 +392,6 @@ function getDefaultLineAreaBarColumns(series: RawSeries) {
 export function getAvailableAdditionalColumns(
   rawSeries: RawSeries,
   settings: ComputedVisualizationSettings,
-  metricsOnly: boolean,
 ): DatasetColumn[] {
   const alreadyIncludedColumns = new Set<DatasetColumn>();
 
@@ -419,11 +418,7 @@ export function getAvailableAdditionalColumns(
     .flatMap(singleSeries => {
       return singleSeries.data.cols;
     })
-    .filter(
-      column =>
-        (isMetric(column) || !metricsOnly) &&
-        !alreadyIncludedColumns.has(column),
-    );
+    .filter(column => !alreadyIncludedColumns.has(column));
 }
 
 export function getComputedAdditionalColumnsValue(
@@ -433,7 +428,7 @@ export function getComputedAdditionalColumnsValue(
   const isScatter = rawSeries[0].card.display === "scatter";
 
   const availableAdditionalColumnKeys = new Set(
-    getAvailableAdditionalColumns(rawSeries, settings, !isScatter).map(column =>
+    getAvailableAdditionalColumns(rawSeries, settings).map(column =>
       getColumnKey(column),
     ),
   );


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/52043

### Description

When updating tooltips of cartesian charts we decided to show only metric columns there, however, based on feedback we received users want to show categorical or date columns as well. By default we still show only columns that are plotted on the chart but with this PR users will be able to add any column to the tooltip from chart dataset.

Since the bug is P2 and requires a copy update it is not being backported.

### How to verify

- New -> Orders: Count by Created At and Category
- Set x-axis to Created At
- Set y-axis to Count
- Go to viz settings -> display
- Ensure you can add the Category column to the tooltip

### Demo

<img width="351" alt="Screenshot 2025-01-15 at 10 28 52 PM" src="https://github.com/user-attachments/assets/2a2e2695-e215-4549-9d81-a11bb1aed551" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
