### PR TITLE
Fix clickhouse uploads

### DIFF
--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -160,6 +160,7 @@
     (the-driver :baby)     ; -> Exception"
   [driver]
   {:pre [((some-fn keyword? string?) driver)]}
+  (classloader/the-classloader)
   (let [driver (keyword driver)]
     (driver.impl/load-driver-namespace-if-needed! driver)
     driver))


### PR DESCRIPTION
This change happened in peer
https://github.com/metabase/metabase/pull/51023 and is manifesting now it seems.

The removal of the call to `(classloader/the-classloader)` is what is hurting us.

Only clickhouse cloud instances can be set as a suitable upload spot so i'm doing the following changes in the local jar repro to fix it up:

```clojure
(in-ns 'metabase.driver.clickhouse)

(defmethod driver/database-supports? [:clickhouse :uploads] [_driver _feature db]
  true)

(in-ns 'metabase.public-settings)
(let [db_id 2, schema_name "default", table_prefix "upload_"]
  (t2/update! :model/Database db_id {:uploads_enabled      true
                                     :uploads_schema_name  schema_name
                                     :uploads_table_prefix table_prefix}))
```

#### Before

<img width="1120" alt="image" src="https://github.com/user-attachments/assets/af5964af-88a0-4c42-a558-55948fd58633" />

#### After
<img width="1122" alt="image" src="https://github.com/user-attachments/assets/73775f30-97a0-47d5-b4f9-bfd28b965509" />


#### What I think is happening

We are unable to load the class `metabase.driver.clickhouse$fn__113059$fn__113061`.

If we catch this error and get it's details, we see it's a class not found issue:

```clojure
#error {
 :cause Exception java.lang.ClassNotFoundException: com.clickhouse.jdbc.internal.ClickHouseStatementImpl [in thread "qtp1775711128-36"]
 :via
 [{:type java.lang.NoClassDefFoundError
   :message Could not initialize class metabase.driver.clickhouse$fn__113059$fn__113061
   :at [metabase.driver.clickhouse$fn__113059 invokeStatic clickhouse.clj 235]}
  {:type java.lang.ExceptionInInitializerError
   :message Exception java.lang.ClassNotFoundException: com.clickhouse.jdbc.internal.ClickHouseStatementImpl [in thread "qtp1775711128-36"]
   :at [jdk.internal.loader.BuiltinClassLoader loadClass BuiltinClassLoader.java 641]}]
 :trace
 [[jdk.internal.loader.BuiltinClassLoader loadClass BuiltinClassLoader.java 641]
  [jdk.internal.loader.ClassLoaders$AppClassLoader loadClass ClassLoaders.java 188]
  [java.lang.ClassLoader loadClass ClassLoader.java 526]
  [java.lang.Class forName0 Class.java -2]
  [java.lang.Class forName Class.java 534]
```

> :message Exception java.lang.ClassNotFoundException: com.clickhouse.jdbc.internal.ClickHouseStatementImpl

Of course we can load this if we do it correctly:

```clojure
card=> (.loadClass (metabase.plugins.classloader/the-classloader) "com.clickhouse.jdbc.internal.ClickHouseStatementImpl")
com.clickhouse.jdbc.internal.ClickHouseStatementImpl ;; <-- works
card=> (.loadClass (clojure.lang.RT/baseLoader)  "com.clickhouse.jdbc.internal.ClickHouseStatementImpl")
Execution error (ClassNotFoundException) at java.net.URLClassLoader/findClass (URLClassLoader.java:445).
com.clickhouse.jdbc.internal.ClickHouseStatementImpl ;; <-- fails
```

And this is the gist. We have to make sure that the threads that handle this can see these modules added to our classpath. 

We get this cryptic error of `metabase.driver.clickhouse$fn__113059$fn__113061` because that's the function that actually uses the `com.clickhouse.jdbc.internal.ClickHouseStatementImpl`. Each function in a namespace is compiled to it's own class, so it's not until this function is called (class `metabase.driver.clickhouse$fn__113059$fn__113061` is loaded and invoked) that we hit the failure to load this class.

hat tip to @snoe for having the gist of this and keeping us on track. I think he identified the root cause a while ago. Also props to @perivamsi for finding the PR that introduced it. Quite subtle. Good find.