### PR TITLE
Fix png image paths when rendered inside Embedding SDK

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -296,6 +296,10 @@ export function tableInteractiveBody() {
   return cy.get("#main-data-grid");
 }
 
+export function tableAllFieldsHiddenImage() {
+  return cy.findByTestId("Table-all-fields-hidden-image");
+}
+
 export function tableHeaderClick(headerString) {
   tableInteractive().within(() => {
     cy.findByTextEnsureVisible(headerString).trigger("mousedown");
@@ -383,4 +387,8 @@ export function repeatAssertion(assertFn, timeout = 4000, interval = 400) {
 
   cy.wait(interval);
   repeatAssertion(assertFn, timeout - interval, interval);
+}
+
+export function mapPinIcon() {
+  return cy.get(".leaflet-marker-icon");
 }

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question-map.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question-map.cy.spec.tsx
@@ -10,7 +10,7 @@ import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 
 const { PEOPLE_ID } = SAMPLE_DATABASE;
 
-describeEE("scenarios > embedding-sdk > interactive-question", () => {
+describeEE("scenarios > embedding-sdk > interactive-question-map", () => {
   beforeEach(() => {
     signInAsAdminAndEnableEmbeddingSdk();
 

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question-map.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question-map.cy.spec.tsx
@@ -1,0 +1,44 @@
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { createQuestion, describeEE, mapPinIcon } from "e2e/support/helpers";
+import {
+  METABASE_INSTANCE_URL,
+  mockAuthProviderAndJwtSignIn,
+  mountInteractiveQuestion,
+  signInAsAdminAndEnableEmbeddingSdk,
+} from "e2e/support/helpers/component-testing-sdk";
+import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
+
+const { PEOPLE_ID } = SAMPLE_DATABASE;
+
+describeEE("scenarios > embedding-sdk > interactive-question", () => {
+  beforeEach(() => {
+    signInAsAdminAndEnableEmbeddingSdk();
+
+    createQuestion({
+      name: "13597",
+      display: "map",
+      query: {
+        "source-table": PEOPLE_ID,
+        limit: 2,
+      },
+    }).then(({ body: question }) => {
+      cy.wrap(question.id).as("questionId");
+      cy.wrap(question.entity_id).as("questionEntityId");
+    });
+
+    cy.signOut();
+
+    mockAuthProviderAndJwtSignIn();
+  });
+
+  it("should show pin icon", () => {
+    mountInteractiveQuestion();
+
+    getSdkRoot().within(() => {
+      mapPinIcon()
+        .should("be.visible")
+        .should("have.attr", "src")
+        .and("include", METABASE_INSTANCE_URL);
+    });
+  });
+});

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
@@ -93,9 +93,11 @@ describeEE("scenarios > embedding-sdk > interactive-question", () => {
       expect(response?.statusCode).to.equal(202);
     });
 
-    const columnNames = ["Product ID", "Max of Quantity"];
+    const firstColumnName = "Product ID";
+    const lastColumnName = "Max of Quantity";
+    const columnNames = [firstColumnName, lastColumnName];
 
-    columnNames.forEach((columnName, index) => {
+    columnNames.forEach(columnName => {
       tableInteractive().findByText(columnName).should("be.visible");
 
       tableHeaderClick(columnName);
@@ -104,7 +106,9 @@ describeEE("scenarios > embedding-sdk > interactive-question", () => {
         .findByTestId("click-actions-sort-control-formatting-hide")
         .click();
 
-      if (index < columnNames.length - 1) {
+      const lastColumnName = "Max of Quantity";
+
+      if (columnName !== lastColumnName) {
         tableInteractive().findByText(columnName).should("not.exist");
       } else {
         tableInteractive().should("not.exist");

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
@@ -14,10 +14,12 @@ import {
   createQuestion,
   describeEE,
   popover,
+  tableAllFieldsHiddenImage,
   tableHeaderClick,
   tableInteractive,
 } from "e2e/support/helpers";
 import {
+  METABASE_INSTANCE_URL,
   mockAuthProviderAndJwtSignIn,
   mountInteractiveQuestion,
   mountSdkContent,
@@ -91,15 +93,28 @@ describeEE("scenarios > embedding-sdk > interactive-question", () => {
       expect(response?.statusCode).to.equal(202);
     });
 
-    tableInteractive().findByText("Max of Quantity").should("be.visible");
+    const columnNames = ["Product ID", "Max of Quantity"];
 
-    tableHeaderClick("Max of Quantity");
+    columnNames.forEach((columnName, index) => {
+      tableInteractive().findByText(columnName).should("be.visible");
 
-    popover()
-      .findByTestId("click-actions-sort-control-formatting-hide")
-      .click();
+      tableHeaderClick(columnName);
 
-    tableInteractive().findByText("Max of Quantity").should("not.exist");
+      popover()
+        .findByTestId("click-actions-sort-control-formatting-hide")
+        .click();
+
+      if (index < columnNames.length - 1) {
+        tableInteractive().findByText(columnName).should("not.exist");
+      } else {
+        tableInteractive().should("not.exist");
+
+        tableAllFieldsHiddenImage()
+          .should("be.visible")
+          .should("have.attr", "src")
+          .and("include", METABASE_INSTANCE_URL);
+      }
+    });
   });
 
   it("can save a question to a default collection", () => {

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -9,6 +9,7 @@ import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
+import { mapPinIcon } from "e2e/support/helpers";
 import { GRID_WIDTH } from "metabase/lib/dashboard_grid";
 import {
   createMockVirtualCard,
@@ -855,9 +856,7 @@ describe("scenarios > dashboard", () => {
         });
 
         H.visitDashboard(dashboardId);
-        cy.get(".leaflet-marker-icon") // pin icon
-          .eq(0)
-          .click({ force: true });
+        mapPinIcon().eq(0).click({ force: true });
         cy.url().should("include", `/dashboard/${dashboardId}?id=1`);
         cy.contains("Hudson Borer - 1");
       });

--- a/frontend/src/metabase/lib/urls/utils.ts
+++ b/frontend/src/metabase/lib/urls/utils.ts
@@ -32,7 +32,11 @@ export function getEncodedUrlSearchParams(query: Record<string, unknown>) {
 }
 
 export function getSubpathSafeUrl(url: string) {
-  return api.basename + url;
+  const basename = api.basename;
+  const normalizedUrl =
+    !basename || !url || url.startsWith("/") ? url : `/${url}`;
+
+  return `${api.basename}${normalizedUrl}`;
 }
 
 /**

--- a/frontend/src/metabase/lib/urls/utils.unit.spec.ts
+++ b/frontend/src/metabase/lib/urls/utils.unit.spec.ts
@@ -25,6 +25,16 @@ describe("utils", () => {
     it("should return subpath-safe url", () => {
       expect(getSubpathSafeUrl("/baz")).toBe(`${fakeBasename}/baz`);
     });
+
+    it("should return subpath-safe url if url does not have leading `/` character", () => {
+      expect(getSubpathSafeUrl("baz")).toBe(`${fakeBasename}/baz`);
+    });
+
+    it("should return original url if `api.basename ` is empty", () => {
+      api.basename = "";
+
+      expect(getSubpathSafeUrl("baz")).toBe("baz");
+    });
   });
 
   describe("openInNewTab", () => {

--- a/frontend/src/metabase/visualizations/components/LeafletMarkerPinMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMarkerPinMap.jsx
@@ -1,22 +1,23 @@
 import L from "leaflet";
 import _ from "underscore";
 
+import { getSubpathSafeUrl } from "metabase/lib/urls";
 import { isPK } from "metabase-lib/v1/types/utils/isa";
 
 import LeafletMap from "./LeafletMap";
-
-const MARKER_ICON = L.icon({
-  iconUrl: "app/assets/img/pin.png",
-  iconSize: [28, 32],
-  iconAnchor: [15, 24],
-  popupAnchor: [0, -13],
-});
 
 export default class LeafletMarkerPinMap extends LeafletMap {
   componentDidMount() {
     super.componentDidMount();
 
     this.pinMarkerLayer = L.layerGroup([]).addTo(this.map);
+    this.pinMarkerIcon = L.icon({
+      iconUrl: getSubpathSafeUrl("app/assets/img/pin.png"),
+      iconSize: [28, 32],
+      iconAnchor: [15, 24],
+      popupAnchor: [0, -13],
+    });
+
     this.componentDidUpdate({}, {});
   }
 
@@ -53,7 +54,7 @@ export default class LeafletMarkerPinMap extends LeafletMap {
   }
 
   _createMarker = rowIndex => {
-    const marker = L.marker([0, 0], { icon: MARKER_ICON });
+    const marker = L.marker([0, 0], { icon: this.pinMarkerIcon });
     const { onHoverChange, onVisualizationClick, settings } = this.props;
     if (onHoverChange) {
       marker.on("mousemove", e => {

--- a/frontend/src/metabase/visualizations/visualizations/Table.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.tsx
@@ -6,6 +6,7 @@ import _ from "underscore";
 import CS from "metabase/css/core/index.css";
 import * as DataGrid from "metabase/lib/data_grid";
 import { displayNameForColumn } from "metabase/lib/formatting";
+import { getSubpathSafeUrl } from "metabase/lib/urls";
 import ChartSettingLinkUrlInput from "metabase/visualizations/components/settings/ChartSettingLinkUrlInput";
 import {
   ChartSettingsTableFormatting,
@@ -412,6 +413,7 @@ class Table extends Component<TableProps, TableState> {
   render() {
     const { series, isDashboard, settings } = this.props;
     const { data } = this.state;
+
     const isPivoted = Table.isPivoted(series, settings);
     const areAllColumnsHidden = data?.cols.length === 0;
     const TableComponent = isDashboard ? TableSimple : TableInteractive;
@@ -421,6 +423,13 @@ class Table extends Component<TableProps, TableState> {
     }
 
     if (areAllColumnsHidden) {
+      const allFieldsHiddenImageUrl = getSubpathSafeUrl(
+        "app/assets/img/hidden-field.png",
+      );
+      const allFieldsHiddenImage2xUrl = getSubpathSafeUrl(
+        "app/assets/img/hidden-field@2x.png",
+      );
+
       return (
         <div
           className={cx(
@@ -435,12 +444,13 @@ class Table extends Component<TableProps, TableState> {
           )}
         >
           <img
+            data-testid="Table-all-fields-hidden-image"
             width={99}
-            src="app/assets/img/hidden-field.png"
-            srcSet="
-              app/assets/img/hidden-field.png     1x,
-              app/assets/img/hidden-field@2x.png  2x
-            "
+            src={allFieldsHiddenImageUrl}
+            srcSet={`
+              ${allFieldsHiddenImageUrl}   1x,
+              ${allFieldsHiddenImage2xUrl} 2x
+            `}
             className={CS.mb2}
           />
           <span


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/52102

To fix images inside Embedded SDK, the `api.basename` is added to image URLs (via an existing helper).

Issue:
![image](https://github.com/user-attachments/assets/7edb94c7-abb5-462f-a421-fba3c3d233e1)


How to verify:
- setup any dashboard containing a map visualisation with visible `pin` icons
- open this dashboard via Embedded SDK and be sure that `pin` icons visible