### PR TITLE
POST endpoint to actually move DQ candidates

### DIFF
--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -6,6 +6,7 @@
    [clojure.test :refer :all]
    [metabase.api.card-test :as api.card-test]
    [metabase.api.collection :as api.collection]
+   [metabase.models.card :as card]
    [metabase.models.collection :as collection]
    [metabase.models.collection-permission-graph-revision :as c-perm-revision]
    [metabase.models.collection-test :as collection-test]
@@ -1617,29 +1618,6 @@
                     (map :id)
                     (into #{}))))))))
 
-(deftest get-dashboard-question-candidates-name-sorting
-  (testing "GET /api/collection/:id/dashboard-question-candidates"
-    (testing "Results are sorted by name"
-      (mt/with-temp [:model/Collection {coll-id :id} {}
-                     :model/Dashboard {dash-id :id} {:collection_id coll-id}
-                     :model/Card {card-a-id :id} {:collection_id coll-id :name "A"}
-                     :model/DashboardCard _ {:dashboard_id dash-id :card_id card-a-id}
-                     :model/Card {card-b-id :id} {:collection_id coll-id :name "B"}
-                     :model/DashboardCard _ {:dashboard_id dash-id :card_id card-b-id}]
-        (testing "ascending order"
-          (is (= ["A" "B"]
-                 (->> (mt/user-http-request :crowberto :get 200 (str "collection/" coll-id "/dashboard-question-candidates"))
-                      :data
-                      (map :name)))))
-
-        (testing "descending order"
-          (is (= ["B" "A"]
-                 (->> (mt/user-http-request :crowberto :get 200
-                                            (str "collection/" coll-id "/dashboard-question-candidates")
-                                            :sort_direction :desc)
-                      :data
-                      (map :name)))))))))
-
 (deftest get-root-dashboard-question-candidates-single-dashboard-card
   (testing "GET /api/collection/root/dashboard-question-candidates"
     (testing "Card is in single dashboard"
@@ -1760,25 +1738,134 @@
                                  set)
                             card-id)))))))
 
-(deftest get-root-dashboard-question-candidates-name-sorting
-  (testing "GET /api/collection/root/dashboard-question-candidates"
-    (testing "Results are sorted by name"
+(deftest post-move-dashboard-question-candidates-success
+  (testing "POST /api/collection/:id/move-dashboard-question-candidates"
+    (testing "Successfully move card to dashboard"
+      (mt/with-temp [:model/Collection {coll-id :id} {}
+                     :model/Dashboard {dash-id :id} {:collection_id coll-id}
+                     :model/Card {card-id :id} {:collection_id coll-id}
+                     :model/DashboardCard _ {:dashboard_id dash-id :card_id card-id}]
+        (is (nil? (t2/select-one-fn :dashboard_id :model/Card card-id)))
+        (mt/user-http-request :crowberto :post 200 (format "collection/%d/move-dashboard-question-candidates" coll-id))
+        (is (= dash-id (t2/select-one-fn :dashboard_id :model/Card card-id)))))))
+
+(deftest post-move-dashboard-question-candidates-root-collection
+  (testing "POST /api/collection/:id/move-dashboard-question-candidates"
+    (testing "Move card from root collection"
       (mt/with-temp [:model/Dashboard {dash-id :id} {:collection_id nil}
-                     :model/Card {card-a-id :id} {:collection_id nil :name "A"}
-                     :model/Card {card-b-id :id} {:collection_id nil :name "B"}
-                     :model/DashboardCard _ {:dashboard_id dash-id :card_id card-a-id}
-                     :model/DashboardCard _ {:dashboard_id dash-id :card_id card-b-id}]
-        (let [response-asc (mt/user-http-request :crowberto :get 200
-                                                 "collection/root/dashboard-question-candidates")
-              response-desc (mt/user-http-request :crowberto :get 200
-                                                  "collection/root/dashboard-question-candidates"
-                                                  :sort_direction :desc)
-              asc-names (->> response-asc :data (filter #(contains? #{card-a-id card-b-id} (:id %))) (map :name))
-              desc-names (->> response-desc :data (filter #(contains? #{card-a-id card-b-id} (:id %))) (map :name))]
-          (testing "ascending order"
-            (is (= ["A" "B"] asc-names)))
-          (testing "descending order"
-            (is (= ["B" "A"] desc-names))))))))
+                     :model/Card {card-id :id} {:collection_id nil}
+                     :model/DashboardCard _ {:dashboard_id dash-id :card_id card-id}]
+        (mt/user-http-request :crowberto :post 200 "collection/root/move-dashboard-question-candidates")
+        (is (= dash-id (t2/select-one-fn :dashboard_id :model/Card card-id)))))))
+
+(deftest post-move-dashboard-question-candidates-non-admin
+  (testing "POST /api/collection/:id/move-dashboard-question-candidates"
+    (testing "Non-admin request (using `:rasta` instead of `:crowberto`)"
+      (mt/with-temp [:model/Collection {coll-id :id} {}]
+        (is (= "You don't have permissions to do that."
+               (mt/user-http-request :rasta :post 403 (format "collection/%d/move-dashboard-question-candidates" coll-id))))))))
+
+(deftest post-move-dashboard-question-candidates-multiple-dashboards
+  (testing "POST /api/collection/:id/move-dashboard-question-candidates"
+    (testing "Card in multiple dashboards should not be moved"
+      (mt/with-temp [:model/Collection {coll-id :id} {}
+                     :model/Dashboard {dash1-id :id} {:collection_id coll-id}
+                     :model/Dashboard {dash2-id :id} {:collection_id coll-id}
+                     :model/Card {card-id :id} {:collection_id coll-id}
+                     :model/DashboardCard _ {:dashboard_id dash1-id :card_id card-id}
+                     :model/DashboardCard _ {:dashboard_id dash2-id :card_id card-id}]
+        (mt/user-http-request :crowberto :post 200 (format "collection/%d/move-dashboard-question-candidates" coll-id))
+        (is (nil? (t2/select-one-fn :dashboard_id :model/Card card-id)))))))
+
+(deftest post-move-dashboard-question-candidates-nonexistent
+  (testing "POST /api/collection/:id/move-dashboard-question-candidates"
+    (testing "Non-existent collection"
+      (is (= "Not found."
+             (mt/user-http-request :crowberto :post 404 "collection/99999999/move-dashboard-question-candidates"))))))
+
+(deftest post-move-dashboard-question-candidates-archived-card
+  (testing "POST /api/collection/:id/move-dashboard-question-candidates"
+    (testing "Archived card should not be moved"
+      (mt/with-temp [:model/Collection {coll-id :id} {}
+                     :model/Dashboard {dash-id :id} {:collection_id coll-id}
+                     :model/Card {card-id :id} {:collection_id coll-id :archived true}
+                     :model/DashboardCard _ {:dashboard_id dash-id :card_id card-id}]
+        (mt/user-http-request :crowberto :post 200 (format "collection/%d/move-dashboard-question-candidates" coll-id))
+        (is (nil? (t2/select-one-fn :dashboard_id :model/Card card-id)))))))
+
+(deftest post-move-dashboard-question-candidates-archived-dashboard
+  (testing "POST /api/collection/:id/move-dashboard-question-candidates"
+    (testing "Card in archived dashboard should not be moved"
+      (mt/with-temp [:model/Collection {coll-id :id} {}
+                     :model/Dashboard {dash-id :id} {:collection_id coll-id :archived true}
+                     :model/Card {card-id :id} {:collection_id coll-id}
+                     :model/DashboardCard _ {:dashboard_id dash-id :card_id card-id}]
+        (mt/user-http-request :crowberto :post 200 (format "collection/%d/move-dashboard-question-candidates" coll-id))
+        (is (nil? (t2/select-one-fn :dashboard_id :model/Card card-id)))))))
+
+(deftest post-move-dashboard-question-candidates-different-collection
+  (testing "POST /api/collection/:id/move-dashboard-question-candidates"
+    (testing "Card in different collection from dashboard should not be moved"
+      (mt/with-temp [:model/Collection {coll1-id :id} {}
+                     :model/Collection {coll2-id :id} {}
+                     :model/Dashboard {dash-id :id} {:collection_id coll1-id}
+                     :model/Card {card-id :id} {:collection_id coll2-id}
+                     :model/DashboardCard _ {:dashboard_id dash-id :card_id card-id}]
+        (mt/user-http-request :crowberto :post 200 (format "collection/%d/move-dashboard-question-candidates" coll2-id))
+        (is (nil? (t2/select-one-fn :dashboard_id :model/Card card-id)))))))
+
+(deftest post-move-dashboard-question-candidates-specific-cards
+  (testing "POST /api/collection/:id/move-dashboard-question-candidates"
+    (testing "It's possible to specify a specific set of card_ids to move"
+      (mt/with-temp [:model/Collection {coll-id :id} {}
+                     :model/Dashboard {dash1-id :id} {:collection_id coll-id}
+                     :model/Card {card1-id :id} {:collection_id coll-id}
+                     :model/Card {card2-id :id} {:collection_id coll-id}
+                     :model/Card {card3-id :id} {:collection_id coll-id}
+                     :model/DashboardCard _ {:dashboard_id dash1-id :card_id card1-id}
+                     :model/DashboardCard _ {:dashboard_id dash1-id :card_id card2-id}
+                     :model/DashboardCard _ {:dashboard_id dash1-id :card_id card3-id}]
+        (testing "initially no cards should have dashboard_id set"
+          (is (nil? (t2/select-one-fn :dashboard_id :model/Card card1-id)))
+          (is (nil? (t2/select-one-fn :dashboard_id :model/Card card2-id)))
+          (is (nil? (t2/select-one-fn :dashboard_id :model/Card card3-id))))
+
+        (testing "move only card1 and card2"
+          (mt/user-http-request :crowberto :post 200
+                                (format "collection/%d/move-dashboard-question-candidates" coll-id)
+                                {:card_ids #{card1-id card2-id}}))
+
+        (testing "verify only specified cards were moved"
+          (is (= dash1-id (t2/select-one-fn :dashboard_id :model/Card card1-id)))
+          (is (= dash1-id (t2/select-one-fn :dashboard_id :model/Card card2-id)))
+          (is (nil? (t2/select-one-fn :dashboard_id :model/Card card3-id))))))))
+
+(deftest move-dashboard-question-candidates-is-atomic-test
+  (testing "POST /api/collection/:id/move-dashboard-question-candidates is atomic"
+    (mt/with-temp [:model/Collection {coll-id :id} {}
+                   :model/Dashboard {dash-id :id} {:collection_id coll-id}
+                   :model/Card {card1-id :id} {:collection_id coll-id}
+                   :model/Card {card2-id :id} {:collection_id coll-id}
+                   :model/DashboardCard _ {:dashboard_id dash-id :card_id card1-id}
+                   :model/DashboardCard _ {:dashboard_id dash-id :card_id card2-id}]
+      ;; Initially no cards should have dashboard_id set
+      (is (nil? (t2/select-one-fn :dashboard_id :model/Card card1-id)))
+      (is (nil? (t2/select-one-fn :dashboard_id :model/Card card2-id)))
+
+      ;; Mock card/update-card! to fail on the second call
+      (mt/with-dynamic-fn-redefs [card/update-card!
+                                  (let [call-count (atom 0)]
+                                    (fn [& args]
+                                      (swap! call-count inc)
+                                      (when (= @call-count 2)
+                                        (throw (ex-info "Simulated failure" {})))
+                                      (apply (mt/dynamic-value card/update-card!) args)))]
+        (mt/user-http-request :crowberto :post 500
+                              (format "collection/%d/move-dashboard-question-candidates" coll-id)))
+
+        ;; Verify neither card was moved (operation rolled back)
+      (is (nil? (t2/select-one-fn :dashboard_id :model/Card card1-id)))
+      (is (nil? (t2/select-one-fn :dashboard_id :model/Card card2-id))))))
 
 (deftest fetch-root-items-limit-and-offset-test
   (testing "GET /api/collection/root/items"


### PR DESCRIPTION
Also removed the sort query param for the GET endpoint, since we don't need that.