### PR TITLE
Don't automatically persist/cache models in EE

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/cache/config.clj
+++ b/enterprise/backend/src/metabase_enterprise/cache/config.clj
@@ -13,3 +13,9 @@
   :feature :cache-granular-controls
   []
   #{"deletable" "off"})
+
+(defenterprise default-persistent-info-state
+  "EE Version doesn't auto-persist models like the OSS version does. So default to 'off'"
+  :feature :cache-granular-controls
+  []
+  "off")

--- a/test/metabase/events/persisted_info_test.clj
+++ b/test/metabase/events/persisted_info_test.clj
@@ -7,10 +7,11 @@
    [toucan2.core :as t2]))
 
 (deftest event-test
-  (mt/with-temporary-setting-values [persisted-models-enabled true]
-    (mt/with-temp [:model/Database db {:settings {:persist-models-enabled true}}
-                   :model/Card     card {:database_id (u/the-id db)}]
-      (events/publish-event! :event/card-create {:object card :user-id (mt/user->id :rasta)})
-      (is (zero? (count (t2/select :model/PersistedInfo :card_id (u/the-id card)))))
-      (events/publish-event! :event/card-create {:object (assoc card :type :model) :user-id (mt/user->id :rasta)})
-      (is (= "creating" (:state (t2/select-one :model/PersistedInfo :card_id (u/the-id card))))))))
+  (mt/with-premium-features #{}
+    (mt/with-temporary-setting-values [persisted-models-enabled true]
+      (mt/with-temp [:model/Database db {:settings {:persist-models-enabled true}}
+                     :model/Card     card {:database_id (u/the-id db)}]
+        (events/publish-event! :event/card-create {:object card :user-id (mt/user->id :rasta)})
+        (is (zero? (count (t2/select :model/PersistedInfo :card_id (u/the-id card)))))
+        (events/publish-event! :event/card-create {:object (assoc card :type :model) :user-id (mt/user->id :rasta)})
+        (is (= "creating" (:state (t2/select-one :model/PersistedInfo :card_id (u/the-id card)))))))))


### PR DESCRIPTION
Closes #52209 

### Description

Modifies enterprise code to default model persistence info to "off".

Most models run quickly, so the caching doesn’t do anything but introduce a caching lag for the real data (problem 1). 

For big models, especially when you create many of them, this eventually leads to db performance/cost issues as it is doing unnecessary copying/caching of lots of data every hour (problem 2).

Due to problem 2, I think some models’ caches are not getting refreshed, which leads to stale data and confusion (problem 3).

Related to 3, having cache on by default isn’t what users expect and users that don’t know where the setting is as it isn’t that easy to find (hidden in dot menu and then Edit Settings; problem 4). Whenever cache is used, I would want to know that / something should be visible on the question result page (which then I can click/hover to learn more and change the cache setting).

Therefore, this changes EE usage to not automatically cache models when they are created. They must be explicitly enabled through the model configuration screen.

NOTES: 
- Because OSS doesn't support per-model configuration, **_all_** models continue to be cached when caching is enabled in general.
- Existing models for EE users will continue to be cached as there is no way to tell the difference between automatically-configured-cache and manually-configured-cache

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a a new model
2. See that the admin model persistence log shows "off"

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
