### PR TITLE
Only match issues in main repo for milestoning

### DIFF
--- a/release/src/linked-issues.ts
+++ b/release/src/linked-issues.ts
@@ -1,6 +1,6 @@
 export function getLinkedIssues(body: string) {
   const matches = body.match(
-    /(close(s|d)?|fixe?(s|d)?|resolve(s|d)?)(:?) (#|https?:\/\/github.com\/.+\/issues\/)(\d+)/gi,
+    /(close(s|d)?|fixe?(s|d)?|resolve(s|d)?)(:?) (#|https?:\/\/github.com\/.+metabase\/issues\/)(\d+)/gi,
   );
 
   if (matches) {

--- a/release/src/linked-issues.unit.spec.ts
+++ b/release/src/linked-issues.unit.spec.ts
@@ -1,4 +1,4 @@
-import { getLinkedIssues, getPRsFromCommitMessage, getBackportSourcePRNumber } from "./linked-issues";
+import { getBackportSourcePRNumber, getLinkedIssues, getPRsFromCommitMessage } from "./linked-issues";
 
 const closingKeywords = [
   "Close",
@@ -51,6 +51,11 @@ describe("getLinkedIssues", () => {
         #123
         `),
       ).toBeNull();
+    });
+
+    it("should not match issues from other repositories", () => {
+      expect(getLinkedIssues("closes https://github.com/metabase/metabase-fake/issues/123")).toBeNull();
+      expect(getLinkedIssues("closes https://github.com/metabase/metabae/issues/123")).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Description
Updates our linked issue regex to only match urls in the main `metabase/metabase` repo and ignore other metabase repos for the purpose of setting milestones for release notes.

to prevent situations like [this pr](https://github.com/metabase/metabase/pull/52052) setting a milestone on this [10 year old issue](https://github.com/metabase/metabase/pull/268) because it assumed all issue references were within this repo.