### PR TITLE
Change order of input wrapper elements

### DIFF
--- a/frontend/src/metabase/lib/errors/validation.ts
+++ b/frontend/src/metabase/lib/errors/validation.ts
@@ -2,14 +2,14 @@ import { t } from "ttag";
 
 import type { LengthParams, MaxLengthParams } from "./types";
 
-export const required = () => t`required`;
+export const required = () => t`Required`;
 
-export const email = () => t`must be a valid email address`;
+export const email = () => t`Must be a valid email address`;
 
 export const maxLength = ({ max }: MaxLengthParams) =>
-  t`must be ${max} characters or less`;
+  t`Must be ${max} characters or less`;
 
 export const exactLength = ({ length }: LengthParams) =>
-  t`must be exactly ${length} characters`;
+  t`Must be exactly ${length} characters`;
 
-export const positive = () => t`must be a positive integer value`;
+export const positive = () => t`Must be a positive integer value`;

--- a/frontend/src/metabase/lib/errors/validation.ts
+++ b/frontend/src/metabase/lib/errors/validation.ts
@@ -1,15 +1,15 @@
-import { t } from "ttag";
+import { c, t } from "ttag";
 
 import type { LengthParams, MaxLengthParams } from "./types";
 
-export const required = () => t`Required`;
+export const required = () => t`required`;
 
-export const email = () => t`Must be a valid email address`;
+export const email = () => t`must be a valid email address`;
 
 export const maxLength = ({ max }: MaxLengthParams) =>
-  t`Must be ${max} characters or less`;
+  c("{0} is a number greater than 1").t`must be ${max} characters or less`;
 
 export const exactLength = ({ length }: LengthParams) =>
-  t`Must be exactly ${length} characters`;
+  c("{0} is a number greater than 1").t`must be exactly ${length} characters`;
 
-export const positive = () => t`Must be a positive integer value`;
+export const positive = () => t`must be a positive integer value`;

--- a/frontend/src/metabase/ui/components/inputs/DateInput/DateInput.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/DateInput/DateInput.styled.tsx
@@ -5,6 +5,7 @@ export const getDateInputOverrides =
     DateInput: {
       defaultProps: {
         size: "md",
+        inputWrapperOrder: ["label", "description", "input", "error"],
       },
       styles: theme => ({
         calendar: {

--- a/frontend/src/metabase/ui/components/inputs/DateInput/DateInput.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/DateInput/DateInput.styled.tsx
@@ -15,6 +15,9 @@ export const getDateInputOverrides =
           color: "var(--mb-color-text-primary)",
           backgroundColor: "var(--mb-color-background)",
         },
+        error: {
+          "&::first-letter": { textTransform: "capitalize" },
+        },
       }),
     },
   });

--- a/frontend/src/metabase/ui/components/inputs/Input/Input.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Input/Input.styled.tsx
@@ -123,7 +123,7 @@ export const getInputOverrides = (): MantineThemeOverride["components"] => ({
   InputWrapper: {
     defaultProps: {
       size: "md",
-      inputWrapperOrder: ["label", "description", "input", "error"],
+      inputWrapperOrder: ["label", "description", "error", "input"],
     },
     styles: theme => ({
       label: {

--- a/frontend/src/metabase/ui/components/inputs/Input/Input.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Input/Input.styled.tsx
@@ -15,6 +15,7 @@ export const getInputOverrides = (): MantineThemeOverride["components"] => ({
   Input: {
     defaultProps: {
       size: "md",
+      error: "Hello world this is an error",
     },
     styles: (
       theme,
@@ -123,7 +124,7 @@ export const getInputOverrides = (): MantineThemeOverride["components"] => ({
   InputWrapper: {
     defaultProps: {
       size: "md",
-      inputWrapperOrder: ["label", "description", "error", "input"],
+      inputWrapperOrder: ["label", "description", "input", "error"],
     },
     styles: theme => ({
       label: {

--- a/frontend/src/metabase/ui/components/inputs/Input/Input.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Input/Input.styled.tsx
@@ -15,7 +15,6 @@ export const getInputOverrides = (): MantineThemeOverride["components"] => ({
   Input: {
     defaultProps: {
       size: "md",
-      error: "Hello world this is an error",
     },
     styles: (
       theme,

--- a/frontend/src/metabase/ui/components/inputs/MultiSelect/MultiSelect.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiSelect/MultiSelect.styled.tsx
@@ -39,6 +39,7 @@ export const getMultiSelectOverrides =
           color: "text-dark",
         },
         "data-testid": "multi-select",
+        inputWrapperOrder: ["label", "description", "input", "error"],
       },
       styles: (
         theme,

--- a/frontend/src/metabase/ui/components/inputs/MultiSelect/MultiSelect.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiSelect/MultiSelect.styled.tsx
@@ -128,6 +128,9 @@ export const getMultiSelectOverrides =
           borderColor: "var(--mb-color-border)",
           overflow: "auto",
         },
+        error: {
+          "&::first-letter": { textTransform: "capitalize" },
+        },
       }),
       variants: {
         default: () => ({

--- a/frontend/src/metabase/ui/components/inputs/Select/Select.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.styled.tsx
@@ -23,6 +23,7 @@ export const getSelectOverrides = (): MantineThemeOverride["components"] => ({
       clearButtonProps: {
         color: "text-dark",
       },
+      inputWrapperOrder: ["label", "description", "input", "error"],
     }),
     styles: (theme, _, { size = "md" }) => ({
       ...getSelectInputOverrides(theme),

--- a/frontend/src/metabase/ui/components/inputs/Select/Select.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.styled.tsx
@@ -60,6 +60,7 @@ export const getSelectInputOverrides = (
     },
     error: {
       ref: getStylesRef("error"),
+      "&::first-letter": { textTransform: "capitalize" },
     },
     wrapper: {
       ref: getStylesRef("wrapper"),

--- a/frontend/src/metabase/ui/components/inputs/TextInput/TextInput.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/TextInput/TextInput.styled.tsx
@@ -5,6 +5,7 @@ export const getTextInputOverrides =
     TextInput: {
       defaultProps: {
         size: "md",
+        inputWrapperOrder: ["label", "description", "input", "error"],
       },
       styles: () => ({
         input: {

--- a/frontend/src/metabase/ui/components/inputs/TextInput/TextInput.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/TextInput/TextInput.styled.tsx
@@ -6,12 +6,18 @@ export const getTextInputOverrides =
       defaultProps: {
         size: "md",
         inputWrapperOrder: ["label", "description", "input", "error"],
+        errorProps: {
+          role: "alert",
+        },
       },
       styles: () => ({
         input: {
           color: "var(--mb-color-text-primary)",
           background: "var(--mb-color-background)",
           borderColor: "var(--mb-color-border)",
+        },
+        error: {
+          "&::first-letter": { textTransform: "capitalize" },
         },
       }),
     },

--- a/frontend/src/metabase/ui/components/inputs/Textarea/Textarea.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Textarea/Textarea.styled.tsx
@@ -9,5 +9,8 @@ export const getTextareaOverrides = (): MantineThemeOverride["components"] => ({
       maxRows: 6,
       inputWrapperOrder: ["label", "description", "input", "error"],
     },
+    styles: {
+      error: { "&::first-letter": { textTransform: "capitalize" } },
+    },
   },
 });

--- a/frontend/src/metabase/ui/components/inputs/Textarea/Textarea.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Textarea/Textarea.styled.tsx
@@ -7,6 +7,7 @@ export const getTextareaOverrides = (): MantineThemeOverride["components"] => ({
       autosize: true,
       minRows: 2,
       maxRows: 6,
+      inputWrapperOrder: ["label", "description", "input", "error"],
     },
   },
 });

--- a/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.styled.tsx
@@ -12,6 +12,7 @@ export const getTimeInputOverrides =
           color: "var(--mb-color-text-primary)",
           backgroundColor: "var(--mb-color-background)",
         },
+        error: { "&::first-letter": { textTransform: "capitalize" } },
       }),
     },
   });

--- a/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.styled.tsx
@@ -5,6 +5,7 @@ export const getTimeInputOverrides =
     TimeInput: {
       defaultProps: {
         size: "md",
+        inputWrapperOrder: ["label", "description", "input", "error"],
       },
       styles: () => ({
         input: {


### PR DESCRIPTION
[Thread in slack](https://metaboat.slack.com/archives/C02H619CJ8K/p1736876493549419)

_Note: backporting because this is a fix for the SDK_

Moves the error message to below the input for components that have a similar form to `TextInput`. This includes `TextInput`, `NumberInput`, and `Select` to ensure some form of consistency among the components


**Number input**
<img width="345" alt="image" src="https://github.com/user-attachments/assets/546c404d-5369-4513-999f-7069866f060f" />


**Text inputs**
<img width="394" alt="image" src="https://github.com/user-attachments/assets/b76d3688-abd2-4d08-ba65-85665780d2c3" />

**Select**
<img width="464" alt="image" src="https://github.com/user-attachments/assets/e41c9f3a-f4f4-489a-bc51-4a386be89876" />

--- 

_**Old:**_ I was going to change the order within the `InputWrapper`, but the `Switch` component has an issue with alignment. If this should be a global change, it should be done in a separate PR. Here is what some of those other components look like with the error below the component

**Checkbox**
<img width="276" alt="image" src="https://github.com/user-attachments/assets/2eab5c36-49c3-4ed1-a3c2-da7fdb9f2dba" />

**Radio**
<img width="330" alt="image" src="https://github.com/user-attachments/assets/6c528f19-bce5-44d1-aae8-4a488b495e2c" />

**Switch**
<img width="354" alt="image" src="https://github.com/user-attachments/assets/79342fde-66f5-4a70-b20d-27b6614263b5" />
