### PR TITLE
Disable pivot drill thru for multi-stage queries

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -220,9 +220,10 @@ describe("issue 18770", () => {
     H.popover().within(() => {
       cy.findByText("Filter by this value").should("be.visible");
       cy.findAllByRole("button")
-        .should("have.length", 6)
+        .should("have.length", 5)
         .and("contain", "See these Orders")
-        .and("contain", "Break out by")
+        // TODO fix this drill thru and re-enable this check (metabase#52236)
+        // .and("contain", "Break out by")
         .and("contain", "<")
         .and("contain", ">")
         .and("contain", "=")

--- a/src/metabase/lib/drill_thru/pivot.cljc
+++ b/src/metabase/lib/drill_thru/pivot.cljc
@@ -129,6 +129,8 @@
                column
                (some? value)
                (lib.underlying/aggregation-sourced? query column)
+               ;; TODO fix this drill thru and remove this check (metabase#52236)
+               (not (lib.underlying/strictly-underlying-aggregation? query column))
                (-> (lib.aggregation/aggregations query stage-number) count pos?))
       (let [breakout-pivot-types (permitted-pivot-types query stage-number)
             pivots               (into {} (for [pivot-type breakout-pivot-types

--- a/test/metabase/lib/drill_thru/pivot_test.cljc
+++ b/test/metabase/lib/drill_thru/pivot_test.cljc
@@ -196,8 +196,9 @@
    "single-stage query"
    (merge (orders-count-with-breakouts [bv-date])
           (expecting ["CREATED_AT"] [:category :location]))
-   "multi-stage query"
-   variant-with-count-filter-stage))
+   ;; TODO fix this drill thru and re-enable this check (metabase#52236)
+   #_"multi-stage query"
+   #_variant-with-count-filter-stage))
 
 (deftest ^:parallel returns-pivot-test-2b-cat+loc-with-date+category
   (lib.drill-thru.tu/test-drill-variants-with-merged-args
@@ -205,8 +206,9 @@
    "single-stage query"
    (merge (orders-count-with-breakouts [bv-date bv-category1])
           (expecting ["CREATED_AT" "CATEGORY"] [:category :location]))
-   "multi-stage query"
-   variant-with-count-filter-stage))
+   ;; TODO fix this drill thru and re-enable this check (metabase#52236)
+   #_"multi-stage query"
+   #_variant-with-count-filter-stage))
 
 (deftest ^:parallel returns-pivot-test-3a-cat+time-with-address
   (lib.drill-thru.tu/test-drill-variants-with-merged-args
@@ -214,8 +216,9 @@
    "single-stage query"
    (merge (orders-count-with-breakouts [bv-address])
           (expecting ["STATE"] [:category :time]))
-   "multi-stage query"
-   variant-with-count-filter-stage))
+   ;; TODO fix this drill thru and re-enable this check (metabase#52236)
+   #_"multi-stage query"
+   #_variant-with-count-filter-stage))
 
 (deftest ^:parallel returns-pivot-test-3b-cat+time-with-category
   (lib.drill-thru.tu/test-drill-variants-with-merged-args
@@ -223,8 +226,9 @@
    "single-stage query"
    (merge (orders-count-with-breakouts [bv-category2])
           (expecting ["SOURCE"] [:category :time]))
-   "multi-stage query"
-   variant-with-count-filter-stage))
+   ;; TODO fix this drill thru and re-enable this check (metabase#52236)
+   #_"multi-stage query"
+   #_variant-with-count-filter-stage))
 
 (deftest ^:parallel returns-pivot-test-3c-cat+time-with-category+category
   (lib.drill-thru.tu/test-drill-variants-with-merged-args
@@ -232,8 +236,9 @@
    "single-stage query"
    (merge (orders-count-with-breakouts [bv-category2 bv-category1])
           (expecting ["SOURCE" "CATEGORY"] [:category :time]))
-   "multi-stage query"
-   variant-with-count-filter-stage))
+   ;; TODO fix this drill thru and re-enable this check (metabase#52236)
+   #_"multi-stage query"
+   #_variant-with-count-filter-stage))
 
 (deftest ^:parallel returns-pivot-test-4a-none-with-no-breakouts
   (lib.drill-thru.tu/test-drill-variants-with-merged-args
@@ -241,8 +246,9 @@
    "single-stage query"
    (merge (orders-count-with-breakouts [])
           (expecting [] [:category :location :time]))
-   "multi-stage query"
-   variant-with-count-filter-stage))
+   ;; TODO fix this drill thru and re-enable this check (metabase#52236)
+   #_"multi-stage query"
+   #_variant-with-count-filter-stage))
 
 (deftest ^:parallel pivot-application-test-1
   (lib.drill-thru.tu/test-drill-variants-with-merged-args
@@ -258,12 +264,13 @@
                                                   (get-in lib.drill-thru.tu/test-queries
                                                           ["ORDERS" :aggregated :row "CREATED_AT"])))
                                (lib/breakout (meta/field-metadata :products :category)))})
-   "multi-stage query"
-   (fn [base-case]
-     {:custom-query (-> base-case
-                        :custom-query
-                        (lib.drill-thru.tu/append-filter-stage "count"))
-      :expected-query (-> base-case
-                          :expected-query
-                          (assoc-in [:stages 0 :filters 0 2 2] "CREATED_AT")
-                          (lib.drill-thru.tu/append-filter-stage-to-test-expectation "count"))})))
+   ;; TODO fix this drill thru and re-enable this check (metabase#52236)
+   #_"multi-stage query"
+   #_(fn [base-case]
+       {:custom-query (-> base-case
+                          :custom-query
+                          (lib.drill-thru.tu/append-filter-stage "count"))
+        :expected-query (-> base-case
+                            :expected-query
+                            (assoc-in [:stages 0 :filters 0 2 2] "CREATED_AT")
+                            (lib.drill-thru.tu/append-filter-stage-to-test-expectation "count"))})))


### PR DESCRIPTION
Closes #52221
Related to  #52236

### Description

This drill thru was recently enabled for multi-stage queries in #51950, but there is a bug which causes the QueryColumnPicker to fail if a join is present. Disable the drill thru for now while we work on a fix.

Slack discussion:

https://metaboat.slack.com/archives/C0645JP1W81/p1736970278902299

### How to verify

See repro steps for #52221. The "Break out by..." option should no longer appear in the drill context menu.

### Demo

![Screenshot 2025-01-15 at 2 10 20 PM](https://github.com/user-attachments/assets/f0f01251-1279-4c3f-9c8f-365734d47df8)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
