### PR TITLE
Fix bad wrapping on long names for ColumnItem 

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ColumnItem/ColumnItem.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ColumnItem/ColumnItem.tsx
@@ -82,8 +82,8 @@ export const ColumnItem = ({
         />
       )}
     </Group>
-    <Group className={CS.flex1} px="xs">
-      {icon && <Icon name={icon} />}
+    <Group className={CS.flex1} px="xs" noWrap>
+      {icon && <Icon name={icon} className={CS.flexNoShrink} />}
       <Text lh="normal" fw="bold">
         {title}
       </Text>


### PR DESCRIPTION
Fixes the bad wrapping in `ColumnItem` by adding `noWrap` to the surrounding `Group` component. Also adds a `flexNoShrink` to the icon to make sure it doesn't shrink when the name is longer

_Backporting due to the original PR being an SDK fix_

Before:
<img width="315" alt="image" src="https://github.com/user-attachments/assets/ba355799-e12e-4825-921c-d55546d3bbae" />


After:
<img width="309" alt="image" src="https://github.com/user-attachments/assets/6e487733-17f9-4528-8e93-4e51ae258931" />