### PR TITLE
Keep `deps.edn` deps sorted

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -21,6 +21,7 @@
   camel-snake-kebab/camel-snake-kebab       {:mvn/version "0.4.3"}              ; util functions for converting between camel, snake, and kebob case
   cheshire/cheshire                         {:mvn/version "5.13.0"}             ; fast JSON encoding (used by Ring JSON middleware)
   clj-bom/clj-bom                           {:mvn/version "0.1.2"}              ; handle BOMs in imported CSVs
+  clj-commons/clj-yaml                      {:mvn/version "1.0.29"}             ; Clojure wrapper for YAML library SnakeYAML
   clj-commons/iapetos                       {:mvn/version "0.1.14"}             ; prometheus metrics
   clj-http/clj-http                         {:mvn/version "3.13.0"              ; HTTP client
                                              :exclusions  [commons-codec/commons-codec
@@ -36,6 +37,7 @@
                                              :exclusions  [it.unimi.dsi/fastutil
                                                            org.slf4j/slf4j-api]}
   com.draines/postal                        {:mvn/version "2.0.5"}              ; SMTP library
+  com.fasterxml.woodstox/woodstox-core      {:mvn/version "7.1.0"}              ; trans dep of commons-codec
   ; Detect the charset in uploaded CSV files
   com.github.albfernandez/juniversalchardet {:mvn/version "2.5.0"}
   com.github.jknack/handlebars              ^:antq/exclude                      ; 4.4.0 requires java 17+
@@ -45,10 +47,8 @@
   com.github.steffan-westcott/clj-otel-api  {:mvn/version "0.2.7"}              ; Telemetry library
   com.github.vertical-blank/sql-formatter   {:mvn/version "2.0.5"}              ; Java SQL formatting library https://github.com/vertical-blank/sql-formatter
   com.google.guava/guava                    {:mvn/version "33.3.1-jre"}         ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
-  com.fasterxml.woodstox/woodstox-core      {:mvn/version "7.1.0"}              ; trans dep of commons-codec
   com.h2database/h2                         ^:antq/exclude                      ; https://metaboat.slack.com/archives/CKZEMT1MJ/p1727191010259979
                                             {:mvn/version "2.1.214"}            ; embedded SQL database
-  com.gfredericks/test.chuck                {:mvn/version "0.2.14"}             ; generating strings from regex
   com.mchange/c3p0                          {:mvn/version "0.10.1"}             ; DB connection pool
   com.snowplowanalytics/snowplow-java-tracker ^:antq/exclude                    ; 2+ depend on apache httpclient 5.x, but saml and clj-http depend on 4.x
                                             {:mvn/version "1.0.1"}              ; Snowplow analytics
@@ -74,8 +74,6 @@
   hiccup/hiccup                             {:mvn/version "1.0.5"}              ; HTML templating
   inflections/inflections                   {:mvn/version "0.14.2"}             ; Clojure/Script library used for prularizing words
   instaparse/instaparse                     {:mvn/version "1.5.0"}              ; Make your own parser
-  junegunn/grouper                          {:mvn/version "0.1.1"}              ; Batch processing helper
-  clj-commons/clj-yaml                      {:mvn/version "1.0.29"}             ; Clojure wrapper for YAML library SnakeYAML
   io.github.camsaul/toucan2                 {:mvn/version "1.0.560"}
   io.github.eerohele/pp                     {#_#_:git/tag "2024-11-13.77"       ; super fast pretty-printing library
                                              :git/sha "7ac1bc56de95520ff4938df05e3518e9b051415d"
@@ -86,6 +84,7 @@
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector
   io.prometheus/simpleclient_jetty          {:mvn/version "0.16.0"}             ; prometheus jetty collector
   javax.servlet/servlet-api                 {:mvn/version "2.5"}                ; used by ring's multipart-params (file upload)
+  junegunn/grouper                          {:mvn/version "0.1.1"}              ; Batch processing helper
   kixi/stats                                {:mvn/version "0.5.6"               ; Various statistic measures implemented as transducers
                                              :exclusions  [org.clojure/data.avl]}
   lambdaisland/uri                          {:mvn/version "1.19.155"}           ; Used by openai-clojure
@@ -118,10 +117,10 @@
   org.apache.logging.log4j/log4j-core       {:mvn/version "2.24.2"}             ; apache logging framework
   org.apache.logging.log4j/log4j-jcl        {:mvn/version "2.24.2"}             ; allows the commons-logging API to work with log4j 2
   org.apache.logging.log4j/log4j-jul        {:mvn/version "2.24.2"}             ; java.util.logging (JUL) -> Log4j2 adapter
-  org.apache.logging.log4j/log4j-slf4j2-impl
-  {:mvn/version "2.24.2"}             ; allows the slf4j2 API to work with log4j 2
   org.apache.logging.log4j/log4j-layout-template-json
   {:mvn/version "2.24.2"}             ; allows the custom json logging format
+  org.apache.logging.log4j/log4j-slf4j2-impl
+  {:mvn/version "2.24.2"}             ; allows the slf4j2 API to work with log4j 2
   org.apache.poi/poi                        {:mvn/version "5.3.0"}              ; Work with Office documents (e.g. Excel spreadsheets) -- newer version than one specified by Docjure
   org.apache.poi/poi-ooxml                  {:mvn/version "5.3.0"
                                              :exclusions  [org.bouncycastle/bcpkix-jdk15on
@@ -231,15 +230,16 @@
   ;;    (dev/start!)
   :dev
   {:extra-deps
-   {com.clojure-goes-fast/clj-async-profiler
-    {:mvn/version "1.5.1"}                     ; Enables local profiling and heat map generation
-    com.clojure-goes-fast/clj-memory-meter
-    {:mvn/version "0.3.0"}                     ; Enables easy memory measurement
-    clj-http-fake/clj-http-fake  {:mvn/version "1.0.4"
+   {clj-http-fake/clj-http-fake  {:mvn/version "1.0.4"
                                   :exclusions  [slingshot/slingshot]}
     clj-kondo/clj-kondo          {:mvn/version "2024.11.14"}                ; included here mainly to facilitate working on the stuff in `.clj-kondo/src`
     cloverage/cloverage          {:mvn/version "1.2.4"}
+    com.clojure-goes-fast/clj-async-profiler
+    {:mvn/version "1.5.1"}                     ; Enables local profiling and heat map generation
+    com.clojure-goes-fast/clj-memory-meter
+    {:mvn/version "0.3.0"}                     ; Enables easy memory measurement
     com.gfredericks/test.chuck   {:mvn/version "0.2.14"}                    ; generating strings from regexes (useful with malli)
+    criterium/criterium          {:mvn/version "0.4.6"}                     ; benchmarking library
     djblue/portal                {:mvn/version "0.58.3"}                    ; ui for inspecting values
     hashp/hashp                  {:mvn/version "0.2.2"}                     ; debugging/spying utility
     io.github.camsaul/humane-are {:mvn/version "1.0.2"}
@@ -247,7 +247,6 @@
     jonase/eastwood              {:mvn/version "1.4.3"                      ; inspects namespaces and reports possible problems using tools.analyzer
                                   :exclusions
                                   [org.ow2.asm/asm-all]}
-    criterium/criterium          {:mvn/version "0.4.6"}                     ; benchmarking library
     lambdaisland/deep-diff2      {:mvn/version "2.11.216"}                  ; way better diffs
     org.clojure/algo.generic     {:mvn/version "1.0.1"}
     peridot/peridot              {:git/url "https://github.com/piranha/peridot.git"
@@ -256,6 +255,7 @@
     reifyhealth/specmonstah      {:mvn/version "2.1.0"
                                   :exclusions  [org.clojure/clojure
                                                 org.clojure/clojurescript]} ; lets you write test fixtures that are clear, concise, and easy to maintain (clojure.spec)
+    rewrite-clj/rewrite-clj      {:mvn/version "1.1.49"}                    ; clojure source parsing and rewriting
     ring/ring-mock               {:mvn/version "0.4.0"}                     ; creating Ring request maps for testing purposes
     talltale/talltale            {:mvn/version "0.5.14"}}                   ; generates fake data, useful for prototyping or load testing
 
@@ -658,11 +658,11 @@
     expound/expound                   {:mvn/version "0.9.0"}                    ; better output of spec validation errors
     io.github.borkdude/grasp          {:mvn/version "0.1.4"}
     io.github.clojure/tools.build     {:mvn/version "0.10.6"}
+    io.github.seancorfield/build-uber-log4j2-handler
+    {:git/tag "v2.24.0" :git/sha "de93f51"}                                     ; collect binary files for log4j2
     org.clojure/data.xml              {:mvn/version "0.2.0-alpha9"}
     org.clojure/tools.deps.alpha      {:mvn/version "0.15.1254"}
-    org.fedorahosted.tennera/jgettext {:mvn/version "0.15.1"}
-
-    io.github.seancorfield/build-uber-log4j2-handler {:git/tag "v2.24.0" :git/sha "de93f51"}} ; collect binary files for log4j2
+    org.fedorahosted.tennera/jgettext {:mvn/version "0.15.1"}}
 
    :jvm-opts
    ["-Dclojure.main.report=stderr"

--- a/test/metabase/deps_edn_test.clj
+++ b/test/metabase/deps_edn_test.clj
@@ -1,0 +1,60 @@
+(ns metabase.deps-edn-test
+  (:require
+   [clojure.test :refer :all]
+   [rewrite-clj.node :as r.node]
+   [rewrite-clj.parser :as r.parser]))
+
+(set! *warn-on-reflection* true)
+
+(defn- map-node? [node]
+  (= (r.node/tag node) :map))
+
+(defn- map-pairs [node]
+  (loop [pairs [], current-key nil, [child & more] (r.node/children node)]
+    (cond
+      (not child)
+      pairs
+
+      (r.node/whitespace-or-comment? child)
+      (recur pairs current-key more)
+
+      (nil? current-key)
+      (recur pairs child more)
+
+      (some? current-key)
+      (recur (conj pairs [current-key child]) nil more))))
+
+(defn- check-pairs-at-path [path pairs]
+  (when (#{:deps :extra-deps :replace-deps} (last path))
+    (testing path
+      (let [ks (map (comp r.node/sexpr first) pairs)]
+        (is (= (sort ks)
+               ks))))))
+
+(declare check-node)
+
+(defn- check-children [path node]
+  (when (r.node/inner? node)
+    (doseq [child (r.node/children node)]
+      (check-node path child))))
+
+(defn- check-map [path node]
+  (let [pairs (map-pairs node)]
+    (check-pairs-at-path path pairs)
+    (doseq [[k v] pairs
+            :when (r.node/sexpr-able? k)]
+      (check-node (conj path (r.node/sexpr k)) v))))
+
+(defn- check-node [path node]
+  (let [f (if (map-node? node)
+            check-map
+            check-children)]
+    (f path node)))
+
+(defn- check-deps-edn []
+  (with-open [r (clojure.lang.LineNumberingPushbackReader. (java.io.FileReader. "deps.edn"))]
+    (check-node [] (r.parser/parse-all r))))
+
+(deftest ^:parallel keep-deps-edn-sorted-test
+  (testing "deps should be sorted"
+    (check-deps-edn)))


### PR DESCRIPTION
I have asked people very nicely to keep the deps in `deps.edn` sorted

https://github.com/metabase/metabase/blob/85a341cf55cfe8966cbd46f1dc3e89795ab13949/deps.edn#L3-L6

however people either don't see the request or just ignore it, then I have to go in and clean up the mess manually. 


Well no more, I wrote a test to make sure it stays sorted permanently 