### PR TITLE
revert to using selector instead of helper

### DIFF
--- a/e2e/test/scenarios/cross-version/source/03-questions.cy.spec.js
+++ b/e2e/test/scenarios/cross-version/source/03-questions.cy.spec.js
@@ -53,7 +53,7 @@ it("should create questions", () => {
 
   cy.get(".bar").should("have.length", 4);
 
-  H.openVizSettingsSidebar();
+  cy.findByTestId("viz-settings-button").click();
 
   //NOTE: In older versions of Metabase, Display is selected by default. Newer
   // versions default to Data. This will ensure we've selected the right tab
@@ -110,7 +110,7 @@ it("should create questions", () => {
   H.visualize();
   cy.get("circle");
 
-  H.openVizTypeSidebar();
+  cy.findByTestId("viz-type-button").click();
   cy.findByTestId("Area-button").click();
 
   // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage


### PR DESCRIPTION
Closes https://linear.app/metabase-inc/issue/ENG-14009/debug-cross-version-test-failure

### Description

This PR https://github.com/metabase/metabase/pull/51674 caused a regression in cross-version tests as it removes a button that some of these cross-version uses. It’s a simple fix that can be merged once tests pass.

However, it’s unclear to me how these test passed in that PR, when clearly they should fail.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
