### PR TITLE
Fix - Confusing error message when trying to add a custom expression aggregation

### DIFF
--- a/frontend/src/metabase-lib/v1/expressions/diagnostics.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics.ts
@@ -204,8 +204,7 @@ function prattCompiler({
       const metric = parseMetric(name, options);
       if (!metric) {
         const dimension = parseDimension(name, options);
-        const segment = parseSegment(name, options);
-        const isNameKnown = Boolean(dimension || segment);
+        const isNameKnown = Boolean(dimension);
 
         if (isNameKnown) {
           const error = c(

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics.ts
@@ -1,4 +1,4 @@
-import { t } from "ttag";
+import { c, t } from "ttag";
 
 import * as Lib from "metabase-lib";
 import type { Expr, Node } from "metabase-lib/v1/expressions/pratt";
@@ -203,6 +203,19 @@ function prattCompiler({
     if (kind === "metric") {
       const metric = parseMetric(name, options);
       if (!metric) {
+        const dimension = parseDimension(name, options);
+        const segment = parseSegment(name, options);
+        const isNameKnown = Boolean(dimension || segment);
+
+        if (isNameKnown) {
+          const error = c(
+            "{0} is an identifier of the field provided by user in a custom expression",
+          )
+            .t`No aggregation found in: ${name}. Use functions like Sum() or custom Metrics`;
+
+          throw new ResolverError(error, node);
+        }
+
         throw new ResolverError(t`Unknown Metric: ${name}`, node);
       }
 

--- a/frontend/src/metabase-lib/v1/expressions/process.ts
+++ b/frontend/src/metabase-lib/v1/expressions/process.ts
@@ -1,4 +1,4 @@
-import { t } from "ttag";
+import { c, t } from "ttag";
 
 import * as Lib from "metabase-lib";
 
@@ -19,6 +19,19 @@ export function processSource(options: {
     if (kind === "metric") {
       const metric = parseMetric(name, options);
       if (!metric) {
+        const dimension = parseDimension(name, options);
+        const segment = parseSegment(name, options);
+        const isNameKnown = Boolean(dimension || segment);
+
+        if (isNameKnown) {
+          const error = c(
+            "{0} is an identifier of the field provided by user in a custom expression",
+          )
+            .t`No aggregation found in: ${name}. Use functions like Sum() or custom Metrics`;
+
+          throw new Error(error);
+        }
+
         throw new Error(t`Unknown Metric: ${name}`);
       }
 

--- a/frontend/src/metabase-lib/v1/expressions/process.ts
+++ b/frontend/src/metabase-lib/v1/expressions/process.ts
@@ -20,8 +20,7 @@ export function processSource(options: {
       const metric = parseMetric(name, options);
       if (!metric) {
         const dimension = parseDimension(name, options);
-        const segment = parseSegment(name, options);
-        const isNameKnown = Boolean(dimension || segment);
+        const isNameKnown = Boolean(dimension);
 
         if (isNameKnown) {
           const error = c(

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.unit.spec.tsx
@@ -174,6 +174,34 @@ describe("ExpressionWidget", () => {
       expect(getRecentExpressionClauseInfo().displayName).toBe("1 + 1");
     });
   });
+
+  it("should show 'unknown metric' error if the identifier is not recognized as a dimension (metabase#50753)", async () => {
+    setup({ startRule: "aggregation", withName: true });
+
+    await userEvent.paste("[Imagination]");
+    await userEvent.tab();
+
+    const doneButton = screen.getByRole("button", { name: "Done" });
+    expect(doneButton).toBeDisabled();
+
+    expect(screen.getByText("Unknown Metric: Imagination")).toBeInTheDocument();
+  });
+
+  it("should show 'no aggregation found' error if the identifier is recognized as a dimension (metabase#50753)", async () => {
+    setup({ startRule: "aggregation", withName: true });
+
+    await userEvent.paste("[Total] / [Subtotal]");
+    await userEvent.tab();
+
+    const doneButton = screen.getByRole("button", { name: "Done" });
+    expect(doneButton).toBeDisabled();
+
+    expect(
+      screen.getByText(
+        "No aggregation found in: Total. Use functions like Sum() or custom Metrics",
+      ),
+    ).toBeInTheDocument();
+  });
 });
 
 function setup(additionalProps?: Partial<ExpressionWidgetProps>) {

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.unit.spec.tsx
@@ -176,7 +176,7 @@ describe("ExpressionWidget", () => {
   });
 
   it("should show 'unknown metric' error if the identifier is not recognized as a dimension (metabase#50753)", async () => {
-    setup({ startRule: "aggregation", withName: true });
+    setup({ startRule: "aggregation" });
 
     await userEvent.paste("[Imagination]");
     await userEvent.tab();
@@ -188,7 +188,7 @@ describe("ExpressionWidget", () => {
   });
 
   it("should show 'no aggregation found' error if the identifier is recognized as a dimension (metabase#50753)", async () => {
-    setup({ startRule: "aggregation", withName: true });
+    setup({ startRule: "aggregation" });
 
     await userEvent.paste("[Total] / [Subtotal]");
     await userEvent.tab();

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.unit.spec.tsx
@@ -179,15 +179,13 @@ describe("ExpressionWidget", () => {
     it("should show 'unknown metric' error if the identifier is not recognized as a dimension (metabase#50753)", async () => {
       setup({ startRule: "aggregation" });
 
-      await userEvent.paste("[Imagination]");
+      await userEvent.paste("[Imaginary]");
       await userEvent.tab();
 
       const doneButton = screen.getByRole("button", { name: "Done" });
       expect(doneButton).toBeDisabled();
 
-      expect(
-        screen.getByText("Unknown Metric: Imagination"),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Unknown Metric: Imaginary")).toBeInTheDocument();
     });
 
     it("should show 'no aggregation found' error if the identifier is recognized as a dimension (metabase#50753)", async () => {

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.unit.spec.tsx
@@ -175,32 +175,36 @@ describe("ExpressionWidget", () => {
     });
   });
 
-  it("should show 'unknown metric' error if the identifier is not recognized as a dimension (metabase#50753)", async () => {
-    setup({ startRule: "aggregation" });
+  describe("startRule: aggregation", () => {
+    it("should show 'unknown metric' error if the identifier is not recognized as a dimension (metabase#50753)", async () => {
+      setup({ startRule: "aggregation" });
 
-    await userEvent.paste("[Imagination]");
-    await userEvent.tab();
+      await userEvent.paste("[Imagination]");
+      await userEvent.tab();
 
-    const doneButton = screen.getByRole("button", { name: "Done" });
-    expect(doneButton).toBeDisabled();
+      const doneButton = screen.getByRole("button", { name: "Done" });
+      expect(doneButton).toBeDisabled();
 
-    expect(screen.getByText("Unknown Metric: Imagination")).toBeInTheDocument();
-  });
+      expect(
+        screen.getByText("Unknown Metric: Imagination"),
+      ).toBeInTheDocument();
+    });
 
-  it("should show 'no aggregation found' error if the identifier is recognized as a dimension (metabase#50753)", async () => {
-    setup({ startRule: "aggregation" });
+    it("should show 'no aggregation found' error if the identifier is recognized as a dimension (metabase#50753)", async () => {
+      setup({ startRule: "aggregation" });
 
-    await userEvent.paste("[Total] / [Subtotal]");
-    await userEvent.tab();
+      await userEvent.paste("[Total] / [Subtotal]");
+      await userEvent.tab();
 
-    const doneButton = screen.getByRole("button", { name: "Done" });
-    expect(doneButton).toBeDisabled();
+      const doneButton = screen.getByRole("button", { name: "Done" });
+      expect(doneButton).toBeDisabled();
 
-    expect(
-      screen.getByText(
-        "No aggregation found in: Total. Use functions like Sum() or custom Metrics",
-      ),
-    ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "No aggregation found in: Total. Use functions like Sum() or custom Metrics",
+        ),
+      ).toBeInTheDocument();
+    });
   });
 });
 

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.unit.spec.tsx
@@ -106,7 +106,7 @@ describe("ExpressionWidget", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  describe("withName=true", () => {
+  describe("withName = true", () => {
     it("should render Name field", () => {
       setup({ withName: true });
 
@@ -175,7 +175,7 @@ describe("ExpressionWidget", () => {
     });
   });
 
-  describe("startRule: aggregation", () => {
+  describe("startRule = 'aggregation'", () => {
     it("should show 'unknown metric' error if the identifier is not recognized as a dimension (metabase#50753)", async () => {
       setup({ startRule: "aggregation" });
 


### PR DESCRIPTION
Fixes #50753

### Description

This PR changes the `Unknown Metric: ${name}`  error to `No aggregation found in: ${name}. Use functions like Sum() or custom Metrics` in case the identifier is a column available in the query.
If the name is not recognized as a query column, the error will still be `Unknown Metric: ${name}` since this is what's expected in the input.

This change applies to custom aggregation expressions only.

### Demo

[before](https://github.com/user-attachments/assets/6be4edf9-0321-4934-8599-fbd47c870427) & [after](https://github.com/user-attachments/assets/77a9af1e-e159-40c8-a347-a85809f9feff)


### How to verify

Follow repro steps from the issue.
