### PR TITLE
Look for field_granularity instead of field-granularity

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
@@ -70,12 +70,12 @@
     (lib/filter query filter)))
 
 (defn- add-breakout
-  [query {:keys [column field-granularity]}]
-  (when (and field-granularity
+  [query {:keys [column field_granularity]}]
+  (when (and field_granularity
              (not (lib.types.isa/temporal? column)))
     (throw (ex-info "field_granularity can only be specified for date fields" {})))
   (let [expr (cond-> column
-               field-granularity (lib/with-temporal-bucket (keyword field-granularity)))]
+               field_granularity (lib/with-temporal-bucket (keyword field_granularity)))]
     (lib/breakout query expr)))
 
 (defn- query-metric

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
@@ -71,11 +71,10 @@
 
 (defn- add-breakout
   [query {:keys [column field_granularity]}]
-  (when (and field_granularity
-             (not (lib.types.isa/temporal? column)))
-    (throw (ex-info "field_granularity can only be specified for date fields" {})))
   (let [expr (cond-> column
-               field_granularity (lib/with-temporal-bucket (keyword field_granularity)))]
+               (and field_granularity
+                    (lib.types.isa/temporal? column))
+               (lib/with-temporal-bucket (keyword field_granularity)))]
     (lib/breakout query expr)))
 
 (defn- query-metric


### PR DESCRIPTION
Also ignore bucketing for non-temporal columns as opposed to throwing an exception as [requested](https://www.notion.so/metabase/Time-granularity-in-query-metric-tool-is-not-respected-17d69354c9018005810df144fdbbb35c?pvs=4#17d69354c9018000a09bd179b245b413).