### PR TITLE
Remove unused REPL connection string from Cypress backend

### DIFF
--- a/e2e/runner/cypress-runner-backend.js
+++ b/e2e/runner/cypress-runner-backend.js
@@ -29,7 +29,6 @@ const CypressBackend = {
         "-Duser.timezone=US/Pacific",
         // if you comment this line 👇 you can get (very noisy) backend console logs in the terminal for e2e tests
         `-Dlog4j.configurationFile=file:${__dirname}/../../frontend/test/__runner__/log4j2.xml`,
-        "-Dclojure.server.repl={:port,5555,:accept,clojure.core.server/repl}",
       ];
 
       const metabaseConfig = {


### PR DESCRIPTION
Context in [Slack](https://metaboat.slack.com/archives/C0645JP1W81/p1737038147323309?thread_ts=1737018147.606599&cid=C0645JP1W81).

This was added by @piranha to debug some state of the backend during cypress testing. It's almost always unused. The issue arises if something else is on port 5555. Cypress dies with a quite ugly stacktrace.

```
Waiting for backend (host=http://localhost:4000/, dbFile=/var/folders/mh/kd7c6ftx2117pj531f1x4ytc0000gn/T/metabase-test-4076.db).Exception in thread "main" java.lang.ExceptionInInitializerError
Caused by: java.net.BindException: Address already in use
	at java.base/sun.nio.ch.Net.bind0(Native Method)
	at java.base/sun.nio.ch.Net.bind(Net.java:565)
	at java.base/sun.nio.ch.Net.bind(Net.java:554)
	at java.base/sun.nio.ch.NioSocketImpl.bind(NioSocketImpl.java:636)
	at java.base/java.net.ServerSocket.bind(ServerSocket.java:391)
	at java.base/java.net.ServerSocket.<init>(ServerSocket.java:278)
	at clojure.core.server$start_server.invokeStatic(server.clj:102)
	at clojure.core.server$start_servers.invokeStatic(server.clj:163)
	at clojure.core.server$start_servers.invoke(server.clj:160)
	at clojure.lang.Var.invoke(Var.java:386)
	at clojure.lang.RT.doInit(RT.java:513)
	at clojure.lang.RT.init(RT.java:487)
	at clojure.lang.Util.loadWithClass(Util.java:248)
	at metabase.core.bootstrap.<clinit>(Unknown Source)
```