### PR TITLE
Don't pass locale codes to localeCompare

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
@@ -355,7 +355,6 @@ const TableSkeleton = ({ columns }: { columns: ColumnItem[] }) => (
       </tr>
     )}
     className={Styles.CacheableItemTable}
-    locale="en-US"
   />
 );
 

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
@@ -13,7 +13,6 @@ import { useSaveStrategy } from "metabase/admin/performance/hooks/useSaveStrateg
 import { skipToken, useSearchQuery } from "metabase/api";
 import { ClientSortableTable } from "metabase/common/components/Table/ClientSortableTable";
 import type { ColumnItem } from "metabase/common/components/Table/types";
-import { useLocale } from "metabase/common/hooks/use-locale/use-locale";
 import { DelayedLoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
 import {
   Box,
@@ -248,8 +247,6 @@ const _StrategyEditorForQuestionsAndDashboards = ({
     updateTarget({ id: null, model: null }, isStrategyFormDirty);
   }, [updateTarget, isStrategyFormDirty]);
 
-  const locale = useLocale();
-
   return (
     <Flex
       role="region"
@@ -292,7 +289,6 @@ const _StrategyEditorForQuestionsAndDashboards = ({
                 rowRenderer={rowRenderer}
                 defaultSortColumn="name"
                 defaultSortDirection={SortDirection.Asc}
-                locale={locale}
                 formatValueForSorting={formatValueForSorting}
                 emptyBody={<NoResultsTableRow />}
                 aria-labelledby={explanatoryAsideId}

--- a/enterprise/frontend/src/metabase-enterprise/upload_management/UploadManagementTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/upload_management/UploadManagementTable.tsx
@@ -3,7 +3,6 @@ import { msgid, ngettext, t } from "ttag";
 
 import SettingHeader from "metabase/admin/settings/components/SettingHeader";
 import { ClientSortableTable } from "metabase/common/components/Table";
-import { useLocale } from "metabase/common/hooks";
 import {
   BulkActionBar,
   BulkActionButton,
@@ -36,7 +35,6 @@ export function UploadManagementTable() {
   const [deleteTableRequest] = useDeleteUploadTableMutation();
   const [showDeleteConfirmModal, setShowDeleteConfirmModal] = useState(false);
   const dispatch = useDispatch();
-  const locale = useLocale();
 
   // TODO: once we have uploads running through RTK Query, we can remove the force update
   // because we can properly invalidate the tables tag
@@ -156,7 +154,6 @@ export function UploadManagementTable() {
         columns={columns}
         rows={uploadTables}
         rowRenderer={row => renderRow(row)}
-        locale={locale}
       />
     </Box>
   );

--- a/frontend/src/metabase/admin/settings/components/ApiKeys/ManageApiKeys.tsx
+++ b/frontend/src/metabase/admin/settings/components/ApiKeys/ManageApiKeys.tsx
@@ -3,7 +3,6 @@ import { t } from "ttag";
 
 import { useListApiKeysQuery } from "metabase/api";
 import { ClientSortableTable } from "metabase/common/components/Table";
-import { useLocale } from "metabase/common/hooks/use-locale/use-locale";
 import { DelayedLoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
 import { Ellipsified } from "metabase/core/components/Ellipsified";
 import CS from "metabase/css/core/index.css";
@@ -67,7 +66,6 @@ function ApiKeysTable({
   error?: unknown;
 }) {
   const flatApiKeys = useMemo(() => apiKeys?.map(flattenApiKey), [apiKeys]);
-  const locale = useLocale();
 
   if (loading || error) {
     return <DelayedLoadingAndErrorWrapper loading={loading} error={error} />;
@@ -82,7 +80,6 @@ function ApiKeysTable({
       data-testid="api-keys-table"
       columns={columns}
       rows={flatApiKeys}
-      locale={locale}
       rowRenderer={row => (
         <ApiKeyRow
           apiKey={row}

--- a/frontend/src/metabase/browse/metrics/MetricsTable.tsx
+++ b/frontend/src/metabase/browse/metrics/MetricsTable.tsx
@@ -8,7 +8,6 @@ import {
 } from "metabase/api";
 import { getCollectionName } from "metabase/collections/utils";
 import { EllipsifiedCollectionPath } from "metabase/common/components/EllipsifiedPath/EllipsifiedCollectionPath";
-import { useLocale } from "metabase/common/hooks/use-locale/use-locale";
 import EntityItem from "metabase/components/EntityItem";
 import { SortableColumnHeader } from "metabase/components/ItemsTable/BaseItemsTable";
 import {
@@ -93,8 +92,7 @@ export function MetricsTable({
     DEFAULT_SORTING_OPTIONS,
   );
 
-  const locale = useLocale();
-  const sortedMetrics = sortMetrics(metrics, sortingOptions, locale);
+  const sortedMetrics = sortMetrics(metrics, sortingOptions);
 
   const handleSortingOptionsChange = skeleton ? undefined : setSortingOptions;
 

--- a/frontend/src/metabase/browse/metrics/utils.tsx
+++ b/frontend/src/metabase/browse/metrics/utils.tsx
@@ -42,7 +42,6 @@ export const getSecondarySortColumn = (
 export function sortMetrics(
   metrics: MetricResult[],
   sortingOptions: SortingOptions,
-  localeCode: string = "en",
 ) {
   const { sort_column, sort_direction } = sortingOptions;
 
@@ -51,8 +50,7 @@ export function sortMetrics(
     return metrics;
   }
 
-  const compare = (a: string, b: string) =>
-    a.localeCompare(b, localeCode, { sensitivity: "base" });
+  const compare = (a: string, b: string) => a.localeCompare(b);
 
   return [...metrics].sort((metricA, metricB) => {
     const a = getValueForSorting(metricA, sort_column);

--- a/frontend/src/metabase/browse/metrics/utils.unit.spec.tsx
+++ b/frontend/src/metabase/browse/metrics/utils.unit.spec.tsx
@@ -132,63 +132,6 @@ describe("sortMetrics", () => {
         metricMap["model named B, with collection path D / E / F"],
       ]);
     });
-
-    it("can sort by collection path, ascending, and then does a secondary sort by name - with a localized sort order", () => {
-      const sortingOptions = {
-        sort_column: "collection",
-        sort_direction: SortDirection.Asc,
-      } as const;
-
-      const addUmlauts = (model: MetricResult): MetricResult => ({
-        ...model,
-        name: model.name.replace(/^B$/g, "Bä"),
-        collection: {
-          ...model.collection,
-          effective_ancestors: model.collection?.effective_ancestors?.map(
-            ancestor => ({
-              ...ancestor,
-              name: ancestor.name.replace("X", "Ä"),
-            }),
-          ),
-        },
-      });
-
-      const swedishmetricMap = {
-        "model named A, with collection path Ä / Y / Z": addUmlauts(
-          metricMap["model named A, with collection path X / Y / Z"],
-        ),
-        "model named Bä, with collection path D / E / F": addUmlauts(
-          metricMap["model named B, with collection path D / E / F"],
-        ),
-        "model named Bz, with collection path D / E / F": addUmlauts(
-          metricMap["model named Bz, with collection path D / E / F"],
-        ),
-        "model named C, with collection path Y": addUmlauts(
-          metricMap["model named C, with collection path Y"],
-        ),
-        "model named C, with collection path Z": addUmlauts(
-          metricMap["model named C, with collection path Z"],
-        ),
-      };
-
-      const swedishResults = Object.values(swedishmetricMap);
-
-      // When sorting in Swedish, z comes before ä
-      const swedishLocaleCode = "sv";
-      const sorted = sortMetrics(
-        swedishResults,
-        sortingOptions,
-        swedishLocaleCode,
-      );
-      expect("ä".localeCompare("z", "sv", { sensitivity: "base" })).toEqual(1);
-      expect(sorted).toEqual([
-        swedishmetricMap["model named Bz, with collection path D / E / F"], // Model Bz sorts before Bä
-        swedishmetricMap["model named Bä, with collection path D / E / F"],
-        swedishmetricMap["model named C, with collection path Y"],
-        swedishmetricMap["model named C, with collection path Z"], // Collection Z sorts before Ä
-        swedishmetricMap["model named A, with collection path Ä / Y / Z"],
-      ]);
-    });
   });
 });
 

--- a/frontend/src/metabase/browse/models/ModelsTable.tsx
+++ b/frontend/src/metabase/browse/models/ModelsTable.tsx
@@ -4,7 +4,6 @@ import { t } from "ttag";
 
 import { getCollectionName } from "metabase/collections/utils";
 import { EllipsifiedCollectionPath } from "metabase/common/components/EllipsifiedPath/EllipsifiedCollectionPath";
-import { useLocale } from "metabase/common/hooks/use-locale/use-locale";
 import EntityItem from "metabase/components/EntityItem";
 import { SortableColumnHeader } from "metabase/components/ItemsTable/BaseItemsTable";
 import {
@@ -67,8 +66,7 @@ export const ModelsTable = ({
     DEFAULT_SORTING_OPTIONS,
   );
 
-  const locale = useLocale();
-  const sortedModels = sortModels(models, sortingOptions, locale);
+  const sortedModels = sortModels(models, sortingOptions);
 
   /** The name column has an explicitly set width. The remaining columns divide the remaining width. This is the percentage allocated to the collection column */
   const collectionWidth = 38.5;

--- a/frontend/src/metabase/browse/models/utils.ts
+++ b/frontend/src/metabase/browse/models/utils.ts
@@ -48,7 +48,6 @@ export const getSecondarySortColumn = (
 export function sortModels(
   models: ModelResult[],
   sortingOptions: SortingOptions,
-  localeCode: string = "en",
 ) {
   const { sort_column, sort_direction } = sortingOptions;
 
@@ -57,8 +56,7 @@ export function sortModels(
     return models;
   }
 
-  const compare = (a: string, b: string) =>
-    a.localeCompare(b, localeCode, { sensitivity: "base" });
+  const compare = (a: string, b: string) => a.localeCompare(b);
 
   return [...models].sort((modelA, modelB) => {
     const a = getValueForSorting(modelA, sort_column);

--- a/frontend/src/metabase/browse/models/utils.unit.spec.tsx
+++ b/frontend/src/metabase/browse/models/utils.unit.spec.tsx
@@ -121,63 +121,6 @@ describe("sortModels", () => {
         modelMap["model named B, with collection path D / E / F"],
       ]);
     });
-
-    it("can sort by collection path, ascending, and then does a secondary sort by name - with a localized sort order", () => {
-      const sortingOptions = {
-        sort_column: "collection",
-        sort_direction: SortDirection.Asc,
-      } as const;
-
-      const addUmlauts = (model: ModelResult): ModelResult => ({
-        ...model,
-        name: model.name.replace(/^B$/g, "Bä"),
-        collection: {
-          ...model.collection,
-          effective_ancestors: model.collection?.effective_ancestors?.map(
-            ancestor => ({
-              ...ancestor,
-              name: ancestor.name.replace("X", "Ä"),
-            }),
-          ),
-        },
-      });
-
-      const swedishModelMap = {
-        "model named A, with collection path Ä / Y / Z": addUmlauts(
-          modelMap["model named A, with collection path X / Y / Z"],
-        ),
-        "model named Bä, with collection path D / E / F": addUmlauts(
-          modelMap["model named B, with collection path D / E / F"],
-        ),
-        "model named Bz, with collection path D / E / F": addUmlauts(
-          modelMap["model named Bz, with collection path D / E / F"],
-        ),
-        "model named C, with collection path Y": addUmlauts(
-          modelMap["model named C, with collection path Y"],
-        ),
-        "model named C, with collection path Z": addUmlauts(
-          modelMap["model named C, with collection path Z"],
-        ),
-      };
-
-      const swedishResults = Object.values(swedishModelMap);
-
-      // When sorting in Swedish, z comes before ä
-      const swedishLocaleCode = "sv";
-      const sorted = sortModels(
-        swedishResults,
-        sortingOptions,
-        swedishLocaleCode,
-      );
-      expect("ä".localeCompare("z", "sv", { sensitivity: "base" })).toEqual(1);
-      expect(sorted).toEqual([
-        swedishModelMap["model named Bz, with collection path D / E / F"], // Model Bz sorts before Bä
-        swedishModelMap["model named Bä, with collection path D / E / F"],
-        swedishModelMap["model named C, with collection path Y"],
-        swedishModelMap["model named C, with collection path Z"], // Collection Z sorts before Ä
-        swedishModelMap["model named A, with collection path Ä / Y / Z"],
-      ]);
-    });
   });
 });
 

--- a/frontend/src/metabase/common/components/Table/ClientSortableTable.tsx
+++ b/frontend/src/metabase/common/components/Table/ClientSortableTable.tsx
@@ -7,7 +7,6 @@ import TableS from "./Table.module.css";
 import { useTableSorting } from "./useTableSorting";
 
 export type ClientSortableTableProps<T extends BaseRow> = TableProps<T> & {
-  locale: string;
   formatValueForSorting?: (row: T, columnName: string) => any;
   defaultSortColumn?: string;
   defaultSortDirection?: SortDirection;
@@ -25,7 +24,6 @@ export function ClientSortableTable<Row extends BaseRow>({
   formatValueForSorting = (row: Row, columnName: string) => row[columnName],
   defaultSortColumn,
   defaultSortDirection,
-  locale,
   ...rest
 }: ClientSortableTableProps<Row>) {
   const {
@@ -38,7 +36,6 @@ export function ClientSortableTable<Row extends BaseRow>({
     rows,
     defaultSortColumn,
     formatValueForSorting,
-    locale,
   });
 
   return (

--- a/frontend/src/metabase/common/components/Table/Table.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/Table/Table.unit.spec.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 
-import { getIcon, queryIcon, render, screen, within } from "__support__/ui";
+import { getIcon, queryIcon, render, screen } from "__support__/ui";
 
 import { ClientSortableTable } from "./ClientSortableTable";
 import { Table } from "./Table";
@@ -45,22 +45,6 @@ const sampleData: Pokemon[] = [
   },
 ];
 
-/** The Japanese words for blue and green are sorted differently in the ja-JP locale vs. the en-US locale */
-const sampleJapaneseData: Pokemon[] = [
-  {
-    id: 1,
-    name: "青いゼニガメ (Blue Squirtle)",
-    type: "Water",
-    generation: 1,
-  },
-  {
-    id: 2,
-    name: "緑のフシギダネ (Green Bulbasaur)",
-    type: "Grass",
-    generation: 1,
-  },
-];
-
 const sampleColumns = [
   {
     key: "name",
@@ -93,7 +77,6 @@ describe("common > components > ClientSortableTable", () => {
         columns={sampleColumns}
         rows={sampleData}
         rowRenderer={renderRow}
-        locale="en-US"
       />,
     );
     expect(screen.getByText("Name")).toBeInTheDocument();
@@ -108,7 +91,6 @@ describe("common > components > ClientSortableTable", () => {
         columns={sampleColumns}
         rows={sampleData}
         rowRenderer={renderRow}
-        locale="en-US"
       />,
     );
     expect(screen.getByText("Bulbasaur")).toBeInTheDocument();
@@ -126,7 +108,6 @@ describe("common > components > ClientSortableTable", () => {
         columns={sampleColumns}
         rows={sampleData}
         rowRenderer={renderRow}
-        locale="en-US"
       />,
     );
     const sortButton = screen.getByText("Name");
@@ -144,53 +125,12 @@ describe("common > components > ClientSortableTable", () => {
     firstRowShouldHaveText("Squirtle");
   });
 
-  it("should respect locales when sorting tables", async () => {
-    render(
-      <>
-        <ClientSortableTable
-          data-testid="japanese-table"
-          columns={sampleColumns}
-          rows={sampleJapaneseData}
-          rowRenderer={renderRow}
-          locale="ja-JP"
-        />
-        <ClientSortableTable
-          data-testid="english-table"
-          columns={sampleColumns}
-          rows={sampleJapaneseData}
-          rowRenderer={renderRow}
-          locale="en-US"
-        />
-      </>,
-    );
-
-    expect(queryIcon("chevrondown")).not.toBeInTheDocument();
-    expect(queryIcon("chevronup")).not.toBeInTheDocument();
-
-    const japaneseTable = await screen.findByTestId("japanese-table");
-    const englishTable = await screen.findByTestId("english-table");
-
-    // Sort both tables
-    await userEvent.click(await within(japaneseTable).findByText("Name"));
-    await userEvent.click(await within(englishTable).findByText("Name"));
-
-    // The locales affect the order of the rows:
-    const englishRows = within(englishTable).getAllByRole("row");
-    expect(englishRows[1]).toHaveTextContent("Green");
-    expect(englishRows[2]).toHaveTextContent("Blue");
-
-    const japaneseRows = within(japaneseTable).getAllByRole("row");
-    expect(japaneseRows[1]).toHaveTextContent("Blue");
-    expect(japaneseRows[2]).toHaveTextContent("Green");
-  });
-
   it("should sort on multiple columns", async () => {
     render(
       <ClientSortableTable
         columns={sampleColumns}
         rows={sampleData}
         rowRenderer={renderRow}
-        locale="en-US"
       />,
     );
     const sortNameButton = screen.getByText("Name");
@@ -224,7 +164,6 @@ describe("common > components > ClientSortableTable", () => {
             <td colSpan={3}>No Results</td>
           </tr>
         }
-        locale="en-US"
       />,
     );
     expect(screen.getByText("Name")).toBeInTheDocument();
@@ -239,7 +178,6 @@ describe("common > components > ClientSortableTable", () => {
         columns={sampleColumns}
         rows={sampleData}
         rowRenderer={renderRow}
-        locale="en-US"
         formatValueForSorting={(row, colName) => {
           if (colName === "type") {
             if (row.type === "Water") {

--- a/frontend/src/metabase/common/components/Table/useTableSorting.tsx
+++ b/frontend/src/metabase/common/components/Table/useTableSorting.tsx
@@ -11,13 +11,11 @@ export const useTableSorting = <Row extends BaseRow>({
   defaultSortColumn,
   defaultSortDirection = SortDirection.Asc,
   formatValueForSorting,
-  locale,
 }: {
   rows: Row[];
   defaultSortColumn?: string;
   defaultSortDirection?: SortDirection;
   formatValueForSorting: (row: Row, columnName: string) => any;
-  locale: string;
 }) => {
   const [sortColumn, setSortColumn] = useState<string | undefined>(
     defaultSortColumn,
@@ -26,9 +24,8 @@ export const useTableSorting = <Row extends BaseRow>({
     useState<SortDirection>(defaultSortDirection);
 
   const compareStrings = useCallback(
-    (a: string, b: string) =>
-      a.localeCompare(b, locale, { sensitivity: "base" }),
-    [locale],
+    (a: string, b: string) => a.localeCompare(b),
+    [],
   );
 
   const sortedRows = useMemo(() => {

--- a/frontend/src/metabase/common/hooks/use-locale/use-locale.ts
+++ b/frontend/src/metabase/common/hooks/use-locale/use-locale.ts
@@ -2,7 +2,14 @@ import { getCurrentUser } from "metabase/admin/datamodel/selectors";
 import { useSelector } from "metabase/lib/redux";
 import { getSetting } from "metabase/selectors/settings";
 
-/** Get the user's locale or, if that has not been set, the instance locale */
+/** Get the user's locale or, if that has not been set, the instance locale
+ *
+ * WARNING: Certain locale codes, like 'pt_BR', are not supported by the native
+ * Intl API, which wants to see 'pt-BR'. These will cause an error if they are
+ * passed to String.localeCompare.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#locales
+ * */
 export const useLocale = () => {
   const instanceLocale = useSelector(state => getSetting(state, "site-locale"));
   const userLocale: string | undefined =


### PR DESCRIPTION
Closes #48144

The locale codes we get from the BE look like this:

```
en
fr
pt_BR
ar_SA
```

However, the `Intl` API in js, and related functions, expect locale codes to look a bit different:

```
en
fr
pt-BR
ar-SA
```

On master we sometimes pass locale codes into `String.localeCompare`:

```
const locale = useLocale() // Retrieves locale from settings
a.localeCompare(b, locale);
```
This breaks if the locale is not recognized by `localeCompare`.

In this branch, we simplify by using `localeCompare` without specifying the locale. This way, `localeCompare` uses the browser locale, which is usually the desired one.