### PR TITLE
Update keyboard command palette nav to support ctrl + enter

### DIFF
--- a/frontend/src/metabase/admin/app/components/SettingsCommandPaletteActions.tsx
+++ b/frontend/src/metabase/admin/app/components/SettingsCommandPaletteActions.tsx
@@ -1,6 +1,5 @@
 import { type Action, useKBar, useRegisterActions } from "kbar";
 import { useMemo } from "react";
-import { push } from "react-router-redux";
 import { useMount } from "react-use";
 
 import { getSections } from "metabase/admin/settings/selectors";
@@ -45,20 +44,16 @@ export const SettingsCommandPaletteActions = () => {
             name: s.display_name || "",
             section: "admin",
             id: `admin-setting-${s.key}`,
-            perform: () => {
-              dispatch(
-                push({
-                  pathname: path,
-                  hash: `#${s.key}`,
-                }),
-              );
-            },
+            perform: () => {},
             icon: "gear",
+            extra: {
+              href: `${path}#${s.key}`,
+            },
           })),
       ];
       return acc;
     }, []);
-  }, [sections, dispatch]);
+  }, [sections]);
 
   useRegisterActions(hasQuery ? adminSettingsActions : [], [hasQuery]);
 

--- a/frontend/src/metabase/palette/components/PaletteResultsList.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResultsList.tsx
@@ -75,10 +75,16 @@ export const PaletteResultList: React.FC<PaletteResultListProps> = props => {
         //If we have a link for a child, then click that instead
         const childAnchor = activeRef.current?.querySelector("a");
 
-        if (childAnchor) {
-          childAnchor.click();
+        const target = childAnchor || activeRef?.current;
+
+        if (!target) {
+          return;
+        } else if (event.ctrlKey) {
+          target.dispatchEvent(
+            new MouseEvent("click", { ctrlKey: event.ctrlKey }),
+          );
         } else {
-          activeRef.current?.click();
+          target.click();
         }
       }
     };

--- a/frontend/src/metabase/palette/components/PaletteResultsList.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResultsList.tsx
@@ -79,9 +79,12 @@ export const PaletteResultList: React.FC<PaletteResultListProps> = props => {
 
         if (!target) {
           return;
-        } else if (event.ctrlKey) {
+        } else if (event.ctrlKey || event.metaKey) {
           target.dispatchEvent(
-            new MouseEvent("click", { ctrlKey: event.ctrlKey }),
+            new MouseEvent("click", {
+              ctrlKey: event.ctrlKey,
+              metaKey: event.metaKey,
+            }),
           );
         } else {
           target.click();
@@ -119,13 +122,15 @@ export const PaletteResultList: React.FC<PaletteResultListProps> = props => {
   }, [search, currentRootActionId, props.items, query]);
 
   const execute = React.useCallback(
-    (item: RenderParams["item"]) => {
+    (item: RenderParams["item"], e?: React.MouseEvent) => {
       if (typeof item === "string") {
         return;
       }
       if (item.command) {
         item.command.perform(item);
-        query.toggle();
+        if (!(e?.metaKey === true || e?.ctrlKey === true)) {
+          query.toggle();
+        }
       } else if (!item.extra?.href) {
         query.setSearch("");
         query.setCurrentRootAction(item.id);
@@ -157,7 +162,7 @@ export const PaletteResultList: React.FC<PaletteResultListProps> = props => {
               onPointerMove: () =>
                 activeIndex !== index && query.setActiveIndex(index),
               onPointerDown: () => query.setActiveIndex(index),
-              onClick: () => execute(item),
+              onClick: (e: React.MouseEvent) => execute(item, e),
             };
           const active = index === activeIndex;
 

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -1,7 +1,6 @@
 import type { Query } from "history";
 import { Priority, useKBar, useRegisterActions } from "kbar";
 import { useMemo, useState } from "react";
-import { push } from "react-router-redux";
 import { useDebounce } from "react-use";
 import { jt, t } from "ttag";
 
@@ -273,10 +272,13 @@ export const useCommandPalette = ({
       id: `admin-page-${adminPath.key}`,
       name: `${adminPath.name}`,
       icon: "gear",
-      perform: () => dispatch(push(adminPath.path)),
+      perform: () => {},
       section: "admin",
+      extra: {
+        href: adminPath.path,
+      },
     }));
-  }, [isAdmin, adminPaths, dispatch]);
+  }, [isAdmin, adminPaths]);
 
   const settingsActions = useMemo<PaletteAction[]>(() => {
     if (!canUserAccessSettings) {
@@ -299,16 +301,13 @@ export const useCommandPalette = ({
         id: `admin-settings-${slug}`,
         name: `${t`Settings`} - ${section.name}`,
         icon: "gear",
-        perform: () => dispatch(push(`/admin/settings/${slug}`)),
+        perform: () => {},
         section: "admin",
+        extra: {
+          href: `/admin/settings/${slug}`,
+        },
       }));
-  }, [
-    canUserAccessSettings,
-    isAdmin,
-    settingsSections,
-    settingValues,
-    dispatch,
-  ]);
+  }, [canUserAccessSettings, isAdmin, settingsSections, settingValues]);
 
   useRegisterActions(hasQuery ? [...adminActions, ...settingsActions] : [], [
     adminActions,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/35902

### Description
`ctrl + click` was already supported in the command palette, but @luizarakaki requested that `ctrl + enter` be supported as well. doing so will open links in new tabs

### How to verify

1. Open the command palette, and use your keyboard to navigate to a recent item or search result
2. hold down `cmd / ctrl` and press `enter`
3. You should see the item open in a new tab

### Demo
![chrome_3r1wxQsjxa](https://github.com/user-attachments/assets/aed90c17-5401-4665-ac3d-e0392f116e9f)

### Checklist

- ~[ ] Tests have been added/updated to cover changes in this PR~
As far as I'm aware, there is no good way to test this in cypress or in unit tests. Very open to suggestions
