### PR TITLE
Implement redirect reaction for Metabot

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/reactions.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/reactions.clj
@@ -4,6 +4,7 @@
   All reactions must have a `:type` with the namespace `metabot.reaction`, but declaring a schema for it is optional.
   If you want to declare a schema, you can use [[defreaction]]."
   (:require
+   [clojure.set :as set]
    [malli.core :as mc]
    [metabase.util :as u]
    [metabase.util.log :as log]
@@ -78,3 +79,19 @@
   [:map
    [:type [:= :metabot.reaction/run-query]]
    [:dataset_query :map]])
+
+(defreaction :metabot.reaction/redirect
+  [:map
+   [:type [:= :metabot.reaction/redirect]]
+   [:url :string]])
+
+(def ^:private terminating-reaction-types
+  "If one of these reactions is present in the reactions vector, stop the loop
+   and return the result to the user."
+  #{:metabot.reaction/redirect})
+
+(defn has-terminating-reaction?
+  "Checks if the envelope reactions vector contains a terminating reaction"
+  [reactions]
+  (let [reaction-types (->> reactions (map :type) set)]
+    (seq (set/intersection terminating-reaction-types reaction-types))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/reactions.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/reactions.clj
@@ -4,7 +4,6 @@
   All reactions must have a `:type` with the namespace `metabot.reaction`, but declaring a schema for it is optional.
   If you want to declare a schema, you can use [[defreaction]]."
   (:require
-   [clojure.set :as set]
    [malli.core :as mc]
    [metabase.util :as u]
    [metabase.util.log :as log]
@@ -90,8 +89,12 @@
    and return the result to the user."
   #{:metabot.reaction/redirect})
 
+(defn- terminating-reaction?
+  "Checks if a reaction is a terminating reaction"
+  [reaction]
+  (contains? terminating-reaction-types (:type reaction)))
+
 (defn has-terminating-reaction?
   "Checks if the envelope reactions vector contains a terminating reaction"
   [reactions]
-  (let [reaction-types (->> reactions (map :type) set)]
-    (seq (set/intersection terminating-reaction-types reaction-types))))
+  (some terminating-reaction? reactions))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/generate_insights.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/generate_insights.clj
@@ -26,8 +26,9 @@
                           json/encode
                           .getBytes
                           codecs/bytes->b64-str)
-                      id)]
-      {:output (str (public-settings/site-url) "/auto/dashboard/" entity-type "/" entity-id)
-       :reactions [{:type :metabot.reaction/redirect :url (str "/auto/dashboard/" entity-type "/" entity-id)}]})
+                      id)
+          results-url (str "/auto/dashboard/" entity-type "/" entity-id)]
+      {:output (str (public-settings/site-url) results-url)
+       :reactions [{:type :metabot.reaction/redirect :url results-url}]})
     (catch Exception e
       (metabot-v3.tools.u/handle-agent-error e))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/generate_insights.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/generate_insights.clj
@@ -27,6 +27,7 @@
                           .getBytes
                           codecs/bytes->b64-str)
                       id)]
-      {:output (str (public-settings/site-url) "/auto/dashboard/" entity-type "/" entity-id)})
+      {:output (str (public-settings/site-url) "/auto/dashboard/" entity-type "/" entity-id)
+       :reactions [{:type :metabot.reaction/redirect :url (str "/auto/dashboard/" entity-type "/" entity-id)}]})
     (catch Exception e
       (metabot-v3.tools.u/handle-agent-error e))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/show_results_to_user.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/show_results_to_user.clj
@@ -16,5 +16,6 @@
                          json/encode
                          (.getBytes "UTF-8")
                          codecs/bytes->b64-str)]
-      {:output (str "Results can be seen at: " (public-settings/site-url) "/question#" query-hash)})
+      {:output (str "Results can be seen at: " (public-settings/site-url) "/question#" query-hash)
+       :reactions [{:type :metabot.reaction/redirect :url (str "/question#" query-hash)}]})
     {:output (str "No query found with query_id " query-id)}))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/show_results_to_user.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/show_results_to_user.clj
@@ -15,7 +15,8 @@
     (let [query-hash (-> {:dataset_query query}
                          json/encode
                          (.getBytes "UTF-8")
-                         codecs/bytes->b64-str)]
-      {:output (str "Results can be seen at: " (public-settings/site-url) "/question#" query-hash)
-       :reactions [{:type :metabot.reaction/redirect :url (str "/question#" query-hash)}]})
+                         codecs/bytes->b64-str)
+          results-url (str "/question#" query-hash)]
+      {:output (str "Results can be seen at: " (public-settings/site-url) results-url)
+       :reactions [{:type :metabot.reaction/redirect :url results-url}]})
     {:output (str "No query found with query_id " query-id)}))

--- a/enterprise/frontend/src/metabase-enterprise/metabot/reactions/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/reactions/index.ts
@@ -2,7 +2,7 @@ import type { MetabotReaction } from "metabase-types/api";
 
 import { apiCall } from "./api";
 import { requireUserConfirmation, showMessage } from "./messages";
-import { writeBack } from "./metabot";
+import { redirect, writeBack } from "./metabot";
 import { runQuery } from "./queries";
 import type { ReactionHandler } from "./types";
 import {
@@ -33,4 +33,5 @@ export const reactionHandlers: ReactionHandlers = {
   "metabot.reaction/api-call": apiCall,
   "metabot.reaction/writeback": writeBack,
   "metabot.reaction/run-query": runQuery,
+  "metabot.reaction/redirect": redirect,
 };

--- a/enterprise/frontend/src/metabase-enterprise/metabot/reactions/metabot.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/reactions/metabot.ts
@@ -1,4 +1,9 @@
-import type { MetabotWriteBackReaction } from "metabase-types/api";
+import { push } from "react-router-redux";
+
+import type {
+  MetabotRedirectReaction,
+  MetabotWriteBackReaction,
+} from "metabase-types/api";
 
 import { sendWritebackMessageRequest } from "../state";
 
@@ -9,5 +14,19 @@ export const writeBack: ReactionHandler<
 > = reaction => {
   return async ({ dispatch }) => {
     await dispatch(sendWritebackMessageRequest(reaction.message));
+  };
+};
+
+export const redirect: ReactionHandler<MetabotRedirectReaction> = reaction => {
+  const redirectUrl = new URL(`${window.location.origin}${reaction.url}`);
+
+  return async ({ dispatch }) => {
+    await dispatch(
+      push({
+        pathname: redirectUrl.pathname,
+        hash: redirectUrl.hash,
+        search: redirectUrl.search,
+      }),
+    );
   };
 };

--- a/frontend/src/metabase-types/api/metabot.ts
+++ b/frontend/src/metabase-types/api/metabot.ts
@@ -133,6 +133,11 @@ export type MetabotChangeChartAppearanceReaction = {
   } | null;
 };
 
+export type MetabotRedirectReaction = {
+  type: "metabot.reaction/redirect";
+  url: string;
+};
+
 export type MetabotReaction =
   | MetabotChangeChartAppearanceReaction
   | MetabotChangeColumnSettingsReaction
@@ -143,7 +148,8 @@ export type MetabotReaction =
   | MetabotConfirmationReaction
   | MetabotWriteBackReaction
   | MetabotApiCallReaction
-  | MetabotRunQueryReaction;
+  | MetabotRunQueryReaction
+  | MetabotRedirectReaction;
 
 export type MetabotCardInfo = {
   type: CardType;


### PR DESCRIPTION
Redirect reaction redirects the user to the results page generated by a tool.
Currently `query-metric` and `generate-insights` tools use this reaction.

This also introduces a concept of "terminating" reactions. When a tool returns a
terminating reaction, this tool call result is not sent back to the LLM, instead
it returns the envelope and the frontend handles any sideffects.