### PR TITLE
Auto rewrite legacy `defendpoint` 1 forms (part 1)

### DIFF
--- a/dev/src/dev/rewrite_defendpoint_1.clj
+++ b/dev/src/dev/rewrite_defendpoint_1.clj
@@ -1,0 +1,410 @@
+(ns dev.rewrite-defendpoint-1
+  (:require
+   [clojure.string :as str]
+   [flatland.ordered.map :as ordered-map]
+   [metabase.util :as u]
+   [metabase.util.files :as u.files]
+   [metabase.util.malli :as mu]
+   [metabase.util.malli.registry :as mr]
+   [rewrite-clj.node :as n]
+   [rewrite-clj.parser :as r.parser]
+   [rewrite-clj.zip :as z]))
+
+(set! *warn-on-reflection* true)
+
+(mr/def ::zloc vector?)
+
+(mr/def ::node
+  [:fn
+   {:error/message "Valid rewrite-clj node"}
+   (fn node? [x]
+     (and
+      (n/node? x)
+      (or (not (n/inner? x))
+          (every? node? (n/children x)))))])
+
+(mr/def ::schema-map
+  "Map of raw symbol => schema node."
+  [:maybe
+   [:map-of symbol? ::node]])
+
+(mr/def ::parsed
+  [:map
+   [:route      ::node]
+   [:method     ::node]
+   [:fn-args    ::node]
+   [:schema-map ::schema-map]])
+
+(mu/defn- parse-defendpoint-1-args :- ::parsed
+  [defendpoint :- ::zloc]
+  (let [symb       (z/down defendpoint)
+        method     (z/right symb)
+        route      (z/right method)
+        args       (z/right route)
+        ;; skip over docstring
+        fn-args    (if (string? (z/sexpr args))
+                     (z/right args)
+                     args)
+        args       (z/right fn-args)
+        schema-map (when (and (= (z/tag args) :map)
+                              ;; there has to be more stuff after this
+                              (z/right args))
+                     (into (ordered-map/ordered-map)
+                           (comp (take-while some?)
+                                 (partition-all 2)
+                                 (map (fn [[k v]]
+                                        [(z/sexpr k) (z/node v)])))
+                           (iterate z/right (z/down args))))]
+    {:route      (z/node route)
+     :method     (z/node method)
+     :fn-args    (z/node fn-args)
+     :schema-map schema-map}))
+
+(mu/defn- route-query-args-symbols :- [:sequential symbol?]
+  [{:keys [fn-args], :as _parsed} :- ::parsed]
+  (into []
+        (comp (take-while some?)
+              (take-while #(not= (z/sexpr %) :as))
+              (map z/sexpr))
+        (iterate z/right (z/down (z/of-node fn-args)))))
+
+(defn- max-key-length [m]
+  (transduce
+   (comp (map str)
+         (map count))
+   max
+   Long/MIN_VALUE
+   (keys m)))
+
+(mu/defn- schema-map->malli :- [:maybe ::node]
+  [schema-map :- ::schema-map]
+  (when (seq schema-map)
+    (n/vector-node
+     (into [(n/keyword-node :map)]
+           (mapcat (let [max-key-length (max-key-length schema-map)]
+                     (fn [[k schema]]
+                       [(n/newline-node "\n")
+                        (n/whitespace-node "          ")
+                        (n/vector-node
+                         (concat
+                          [(n/keyword-node (keyword k))
+                           ;; pad the space between key and schema so the map is nicely aligned.
+                           (n/whitespace-node (str/join (repeat (- (+ max-key-length 2)
+                                                                   (count (str (keyword k))))
+                                                                \space)))]
+                          (when (and (= (n/tag schema) :vector)
+                                     (= (n/sexpr (first (n/children schema))) :maybe))
+                            [(n/map-node
+                              [(n/keyword-node :optional) (n/whitespace-node " ") (n/token-node true)])
+                             (n/whitespace-node " ")])
+                          [schema]))])))
+           schema-map))))
+
+(defn- select-keys*
+  "Normal Clojure select-keys does not preserve the original map type e.g. ordered-map."
+  [m ks]
+  (when m
+    (into (empty m)
+          (filter (let [key-set (set ks)]
+                    (fn [[k v]]
+                      (when (key-set k)
+                        [k v]))))
+          m)))
+
+(mu/defn- keys-map :- ::node
+  [args :- [:sequential symbol?]]
+  (n/map-node [(n/keyword-node :keys)
+               (n/whitespace-node " ")
+               (n/vector-node (into []
+                                    (comp (map n/token-node)
+                                          (interpose (n/whitespace-node " ")))
+                                    args))]))
+
+(mu/defn- unused-binding? [node :- ::node]
+  (and (= (n/tag node) :token)
+       (str/starts-with? (n/sexpr node) "_")))
+
+(mu/defn- schema-specifier :- [:maybe [:sequential ::node]]
+  [schema :- [:maybe ::node]]
+  (when schema
+    [(n/whitespace-node " ")
+     (n/keyword-node :-)
+     (n/whitespace-node " ")
+     schema]))
+
+;;;
+;;; route params
+;;;
+
+(declare query-args-binding
+         body-binding)
+
+(mu/defn- route-args-symbols :- [:sequential symbol?]
+  [{:keys [route], :as _parsed}]
+  (let [route (if (= (n/tag route) :vector)
+                (-> route z/of-node z/down z/node)
+                route)
+        route (n/sexpr route)]
+    (assert (string? route)
+            (format "Expected route string, got %s" (pr-str route)))
+    (map (comp symbol second) (re-seq #":([^:/]+)" route))))
+
+(mu/defn- route-args-schema :- [:maybe ::node]
+  [{:keys [schema-map], :as parsed} :- ::parsed]
+  (some-> schema-map
+          (select-keys* (route-args-symbols parsed))
+          schema-map->malli))
+
+(mu/defn- route-args-binding :- ::node
+  [parsed]
+  (if-let [args (not-empty (route-args-symbols parsed))]
+    (keys-map args)
+    (n/token-node '_route-params)))
+
+(mu/defn- new-route-param-arg-nodes :- [:maybe [:sequential ::node]]
+  [parsed]
+  (when (or (not (unused-binding? (route-args-binding parsed)))
+            (not (unused-binding? (query-args-binding parsed)))
+            (not (unused-binding? (body-binding parsed))))
+    (list*
+     (route-args-binding parsed)
+     (schema-specifier (route-args-schema parsed)))))
+
+;;;
+;;; query params
+;;;
+
+(mu/defn- query-args-symbols :- [:sequential symbol?]
+  [parsed]
+  (remove (set (route-args-symbols parsed))
+          (route-query-args-symbols parsed)))
+
+(mu/defn- query-args-binding :- ::node
+  [parsed]
+  (if-let [args (not-empty (query-args-symbols parsed))]
+    (keys-map args)
+    (n/token-node '_query-params)))
+
+(mu/defn- query-args-schema :- [:maybe ::node]
+  [{:keys [schema-map], :as parsed} :- ::parsed]
+  (some-> schema-map
+          (select-keys* (query-args-symbols parsed))
+          schema-map->malli))
+
+(mu/defn- new-query-param-arg-nodes :- [:maybe [:sequential ::node]]
+  [parsed :- ::parsed]
+  (when (or (not (unused-binding? (query-args-binding parsed)))
+            (not (unused-binding? (body-binding parsed))))
+    (list*
+     (n/newline-node "\n")
+     (n/whitespace-node "   ")
+     (query-args-binding parsed)
+     (schema-specifier (query-args-schema parsed)))))
+
+;;;
+;;; body
+;;;
+
+(mu/defn- body-binding :- ::node
+  [{:keys [fn-args], :as _parsed} :- ::parsed]
+  (or (when-let [as (z/find (z/down (z/of-node fn-args))
+                            #(= (z/sexpr %) :as))]
+        (let [request-map (z/right as)]
+          (assert (= #{:body}
+                     (set (vals (z/sexpr request-map))))
+                  (format "Don't know how to rewrite request map with non-:body keys: %s" (pr-str request-map)))
+          (when-let [body-key (z/find (z/down request-map)
+                                      #(= (z/sexpr %) :body))]
+            (z/node (z/left body-key)))))
+      (n/token-node '_body)))
+
+(mu/defn- body-schema :- [:maybe ::node]
+  [{:keys [schema-map], :as parsed} :- ::parsed]
+  (when schema-map
+    (if (= (n/tag (body-binding parsed)) :token)
+      ;; body is a plain symbol, do not build a the usual map schema.
+      (get schema-map (n/sexpr (body-binding parsed)))
+      ;; otherwise body is a destructured map
+      (let [body-keys (->> schema-map
+                           keys
+                           (remove (set (route-args-symbols parsed)))
+                           (remove (set (query-args-symbols parsed))))]
+        (schema-map->malli (select-keys* schema-map body-keys))))))
+
+(mu/defn- new-body-arg-nodes :- [:maybe [:sequential ::node]]
+  [parsed :- ::parsed]
+  (when-not (unused-binding? (body-binding parsed))
+    (list*
+     (n/newline-node "\n")
+     (n/whitespace-node "   ")
+     (body-binding parsed)
+     (schema-specifier (body-schema parsed)))))
+
+;;;
+;;; rewriting defendpoint symbol
+;;;
+
+(mu/defn- rewrite-defendpoint-symbol :- ::zloc
+  [_parsed     :- ::parsed
+   defendpoint :- ::zloc]
+  (z/replace (z/down defendpoint) (n/token-node 'api.macros/defendpoint)))
+
+;;;
+;;; rewrite method
+;;;
+
+(mu/defn- rewrite-method :- ::zloc
+  [_parsed defendpoint :- ::zloc]
+  (let [method (-> defendpoint z/down z/right)]
+    (z/replace method (n/keyword-node (keyword (u/lower-case-en (name (z/sexpr method))))))))
+
+;;;
+;;; rewrite argslist
+;;;
+
+(mu/defn- find-argslist :- [:and
+                            ::zloc
+                            [:fn
+                             {:error/message "zipper location pointing to vector node"}
+                             #(= (z/tag %) :vector)]]
+  [defendpoint :- ::zloc]
+  (let [route (-> defendpoint
+                  z/down    ; symb
+                  z/right   ; method
+                  z/right)] ; route
+    ;; first vector after route
+    (z/find-next route #(= (z/tag %) :vector))))
+
+(mu/defn- new-args-node :- ::node
+  [parsed :- ::parsed]
+  (n/vector-node
+   (into []
+         (mapcat (fn [f]
+                   (f parsed)))
+         [new-route-param-arg-nodes
+          new-query-param-arg-nodes
+          new-body-arg-nodes])))
+
+(mu/defn- rewrite-args :- ::zloc
+  [parsed      :- ::parsed
+   defendpoint :- ::zloc]
+  (z/replace (find-argslist defendpoint) (new-args-node parsed)))
+
+;;;
+;;; Add metadata map if needed
+;;;
+
+(mu/defn- add-metadata-map :- ::zloc
+  [parsed      :- ::parsed
+   defendpoint :- ::zloc]
+  (if (= (n/tag (:method parsed)) :meta)
+    (let [metadata  (first (n/children (:method parsed)))
+          node      (if (= (n/tag metadata) :token)
+                      ;; TODO -- what about multiple tokens? Does this work?
+                      (n/map-node [metadata (n/whitespace-node " ") (n/token-node true)])
+                      metadata)]
+      (as-> defendpoint defendpoint
+        (z/insert-left (find-argslist defendpoint) node)
+        (z/insert-left (find-argslist defendpoint) (n/newline-node "\n"))))
+    defendpoint))
+
+;;;
+;;; rewrite body
+;;;
+
+(mu/defn- find-body :- ::zloc
+  [defendpoint :- ::zloc]
+  (z/right (find-argslist defendpoint)))
+
+(mu/defn- rewrite-body :- ::zloc
+  [_parsed     :- ::parsed
+   defendpoint :- ::zloc]
+  (let [body (find-body defendpoint)]
+    ;; if the first form is a map but there are more forms after, it's the schema map and we can remove it.
+    (if (and (= (z/tag body) :map)
+             (z/right body))
+      (z/remove body)
+      body)))
+
+;;;
+;;; rewrite entire form
+;;;
+
+(mu/defn- rewrite-defendpoint* :- ::zloc
+  [defendpoint :- ::zloc]
+  (let [parsed (parse-defendpoint-1-args defendpoint)]
+    (reduce
+     (fn [defendpoint f]
+       (z/subedit-node defendpoint (partial f parsed)))
+     defendpoint
+     [rewrite-defendpoint-symbol
+      rewrite-method
+      add-metadata-map
+      rewrite-args
+      rewrite-body])))
+
+(mu/defn- defendpoint-node? [node :- ::node]
+  (and
+   (= (n/tag node) :list)
+   (let [first-child (first (n/children node))]
+     (and
+      (n/symbol-node? first-child)
+      (= (n/sexpr first-child) 'api/defendpoint)))))
+
+(mu/defn- kondo-ignore-node? [node :- ::node]
+  (and
+   (= (n/tag node) :uneval)
+   (= (n/sexpr (first (n/children node)))
+      {:clj-kondo/ignore [:deprecated-var]})))
+
+(mu/defn- remove-preceding-kondo-ignore-node :- [:maybe ::zloc]
+  [defendpoint :- ::zloc]
+  (when-let [previous (z/left defendpoint)]
+    (when (some-> previous z/node kondo-ignore-node?)
+      (-> (z/subedit-node
+           (z/up defendpoint) ; move up to top-level <forms> node so the kondo ignore form is subeditable
+           (fn [_]
+             (z/remove previous)))
+          ; move back to first child
+          z/down))))
+
+(mu/defn- rewrite-defendpoint :- ::zloc
+  [defendpoint :- ::zloc]
+  (try
+    (-> defendpoint
+        rewrite-defendpoint*
+        remove-preceding-kondo-ignore-node)
+    (catch Throwable e
+      (println "Error rewriting defendpoint:" e)
+      defendpoint)))
+
+(mu/defn- rewrite-namespace :- ::zloc
+  [zloc :- ::zloc]
+  (if-let [defendpoint (z/find-next zloc #(defendpoint-node? (z/node %)))]
+    (let [zloc' (rewrite-defendpoint defendpoint)]
+      (recur zloc'))
+    zloc))
+
+;; TODO -- require needs to include api.macros.
+
+(defn rewrite-defendpoints! [^String filename & {:keys [write?], :or {write? true}}]
+  (println "Rewriting" filename)
+  (let [node (r.parser/parse-file-all filename)
+        zloc (-> (z/of-node node)
+                 rewrite-namespace)]
+    (letfn [(print-root [w]
+              (z/print-root zloc w))]
+      (if write?
+        (with-open [w (java.io.FileWriter. filename)]
+          (print-root w))
+        (print-root *out*)))))
+
+(def ^:private files
+  (->> (u.files/files-seq (u.files/get-path "src/metabase/api/"))
+       (map str)
+       (filter #(str/ends-with? % ".clj"))
+       sort))
+
+(defn rewrite-all! []
+  (doseq [file (take 3 files)]
+    (rewrite-defendpoints! file :write? true)))

--- a/modules/drivers/mongo/test/metabase/driver/mongo/parameters_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/parameters_test.clj
@@ -244,7 +244,7 @@
                 (substitute {:price (field-filter "price" :type/Integer :number/!= [1 2])}
                             ["[{$match: " (param :price) "}]"]))))))))
 
-(deftest ^:parallel ^:parallel substitute-native-query-snippets-test
+(deftest ^:parallel substitute-native-query-snippets-test
   (testing "Native query snippet substitution"
     (is (= (strip (to-bson [{:$match {"price" {:$gt 2}}}]))
            (strip (substitute {"snippet: high price" (params/->ReferencedQuerySnippet 123 (to-bson {"price" {:$gt 2}}))}

--- a/src/metabase/api/action.clj
+++ b/src/metabase/api/action.clj
@@ -1,11 +1,11 @@
 (ns metabase.api.action
   "`/api/action/` endpoints."
   (:require
-   [compojure.core :refer [POST]]
    [metabase.actions.core :as actions]
    [metabase.analytics.snowplow :as snowplow]
    [metabase.api.common :as api]
    [metabase.api.common.validation :as validation]
+   [metabase.api.macros :as api.macros]
    [metabase.models.action :as action]
    [metabase.models.card :as card]
    [metabase.models.collection :as collection]
@@ -47,12 +47,12 @@
    [:parameters         {:optional true} [:maybe [:sequential map?]]]
    [:parameter_mappings {:optional true} [:maybe map?]]])
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/"
+(api.macros/defendpoint :get "/"
   "Returns actions that can be used for QueryActions. By default lists all viewable actions. Pass optional
   `?model-id=<model-id>` to limit to actions on a particular model."
-  [model-id]
-  {model-id [:maybe ms/PositiveInt]}
+  [_route-params
+   {:keys [model-id]} :- [:map
+                          [:model-id {:optional true} [:maybe ms/PositiveInt]]]]
   (letfn [(actions-for [models]
             (if (seq models)
               (t2/hydrate (action/select-actions models
@@ -71,28 +71,25 @@
                                             (collection/visible-collection-filter-clause)]}))]
       (actions-for models))))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/public"
+(api.macros/defendpoint :get "/public"
   "Fetch a list of Actions with public UUIDs. These actions are publicly-accessible *if* public sharing is enabled."
   []
   (validation/check-has-application-permission :setting)
   (validation/check-public-sharing-enabled)
   (t2/select [:model/Action :name :id :public_uuid :model_id], :public_uuid [:not= nil], :archived false))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/:action-id"
+(api.macros/defendpoint :get "/:action-id"
   "Fetch an Action."
-  [action-id]
-  {action-id ms/PositiveInt}
+  [{:keys [action-id]} :- [:map
+                           [:action-id ms/PositiveInt]]]
   (-> (action/select-action :id action-id :archived false)
       (t2/hydrate :creator)
       api/read-check))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint DELETE "/:action-id"
+(api.macros/defendpoint :delete "/:action-id"
   "Delete an Action."
-  [action-id]
-  {action-id ms/PositiveInt}
+  [{:keys [action-id]} :- [:map
+                           [:action-id ms/PositiveInt]]]
   (let [action (api/write-check :model/Action action-id)]
     (snowplow/track-event! ::snowplow/action
                            {:event     :action-deleted
@@ -101,26 +98,25 @@
   (t2/delete! :model/Action :id action-id)
   api/generic-204-no-content)
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint POST "/"
+(api.macros/defendpoint :post "/"
   "Create a new action."
-  [:as {{:keys [type name description model_id parameters parameter_mappings visualization_settings
-                kind
-                database_id dataset_query
-                template response_handle error_handle] :as action} :body}]
-  {name                   :string
-   model_id               ms/PositiveInt
-   type                   [:maybe supported-action-type]
-   description            [:maybe :string]
-   parameters             [:maybe [:sequential map?]]
-   parameter_mappings     [:maybe map?]
-   visualization_settings [:maybe map?]
-   kind                   [:maybe implicit-action-kind]
-   database_id            [:maybe ms/PositiveInt]
-   dataset_query          [:maybe map?]
-   template               [:maybe http-action-template]
-   response_handle        [:maybe json-query-schema]
-   error_handle           [:maybe json-query-schema]}
+  [_route-params
+   _query-params
+   {:keys [type model_id parameters database_id]
+    :as action} :- [:map
+                    [:name                   :string]
+                    [:model_id               ms/PositiveInt]
+                    [:type                   {:optional true} [:maybe supported-action-type]]
+                    [:description            {:optional true} [:maybe :string]]
+                    [:parameters             {:optional true} [:maybe [:sequential map?]]]
+                    [:parameter_mappings     {:optional true} [:maybe map?]]
+                    [:visualization_settings {:optional true} [:maybe map?]]
+                    [:kind                   {:optional true} [:maybe implicit-action-kind]]
+                    [:database_id            {:optional true} [:maybe ms/PositiveInt]]
+                    [:dataset_query          {:optional true} [:maybe map?]]
+                    [:template               {:optional true} [:maybe http-action-template]]
+                    [:response_handle        {:optional true} [:maybe json-query-schema]]
+                    [:error_handle           {:optional true} [:maybe json-query-schema]]]]
   (when (and (nil? database_id)
              (= "query" type))
     (throw (ex-info (tru "Must provide a database_id for query actions")
@@ -146,26 +142,26 @@
       ;; so we return the most recently updated http action.
       (last (action/select-actions nil :type type)))))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint PUT "/:id"
+(api.macros/defendpoint :put "/:id"
   "Update an Action."
-  [id :as {action :body}]
-  {id     ms/PositiveInt
-   action [:map
-           [:archived               {:optional true} [:maybe :boolean]]
-           [:database_id            {:optional true} [:maybe ms/PositiveInt]]
-           [:dataset_query          {:optional true} [:maybe :map]]
-           [:description            {:optional true} [:maybe :string]]
-           [:error_handle           {:optional true} [:maybe json-query-schema]]
-           [:kind                   {:optional true} [:maybe implicit-action-kind]]
-           [:model_id               {:optional true} [:maybe ms/PositiveInt]]
-           [:name                   {:optional true} [:maybe :string]]
-           [:parameter_mappings     {:optional true} [:maybe :map]]
-           [:parameters             {:optional true} [:maybe [:sequential :map]]]
-           [:response_handle        {:optional true} [:maybe json-query-schema]]
-           [:template               {:optional true} [:maybe http-action-template]]
-           [:type                   {:optional true} [:maybe supported-action-type]]
-           [:visualization_settings {:optional true} [:maybe :map]]]}
+  [{:keys [id]} :- [:map
+                    [:id ms/PositiveInt]]
+   _query-params
+   action :- [:map
+              [:archived               {:optional true} [:maybe :boolean]]
+              [:database_id            {:optional true} [:maybe ms/PositiveInt]]
+              [:dataset_query          {:optional true} [:maybe :map]]
+              [:description            {:optional true} [:maybe :string]]
+              [:error_handle           {:optional true} [:maybe json-query-schema]]
+              [:kind                   {:optional true} [:maybe implicit-action-kind]]
+              [:model_id               {:optional true} [:maybe ms/PositiveInt]]
+              [:name                   {:optional true} [:maybe :string]]
+              [:parameter_mappings     {:optional true} [:maybe :map]]
+              [:parameters             {:optional true} [:maybe [:sequential :map]]]
+              [:response_handle        {:optional true} [:maybe json-query-schema]]
+              [:template               {:optional true} [:maybe http-action-template]]
+              [:type                   {:optional true} [:maybe supported-action-type]]
+              [:visualization_settings {:optional true} [:maybe :map]]]]
   (actions/check-actions-enabled! id)
   (let [existing-action (api/write-check :model/Action id)]
     (action/update! (assoc action :id id) existing-action))
@@ -177,13 +173,12 @@
                             :num_parameters (count parameters)})
     action))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint POST "/:id/public_link"
+(api.macros/defendpoint :post "/:id/public_link"
   "Generate publicly-accessible links for this Action. Returns UUID to be used in public links. (If this
   Action has already been shared, it will return the existing public link rather than creating a new one.) Public
   sharing must be enabled."
-  [id]
-  {id ms/PositiveInt}
+  [{:keys [id]} :- [:map
+                    [:id ms/PositiveInt]]]
   (api/check-superuser)
   (validation/check-public-sharing-enabled)
   (let [action (api/read-check :model/Action id :archived false)]
@@ -194,11 +189,10 @@
                              {:public_uuid <>
                               :made_public_by_id api/*current-user-id*})))}))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint DELETE "/:id/public_link"
+(api.macros/defendpoint :delete "/:id/public_link"
   "Delete the publicly-accessible link to this Dashboard."
-  [id]
-  {id ms/PositiveInt}
+  [{:keys [id]} :- [:map
+                    [:id ms/PositiveInt]]]
   ;; check the /application/setting permission, not superuser because removing a public link is possible from /admin/settings
   (validation/check-has-application-permission :setting)
   (validation/check-public-sharing-enabled)
@@ -207,25 +201,26 @@
   (t2/update! :model/Action id {:public_uuid nil, :made_public_by_id nil})
   {:status 204, :body nil})
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/:action-id/execute"
+(api.macros/defendpoint :get "/:action-id/execute"
   "Fetches the values for filling in execution parameters. Pass PK parameters and values to select."
-  [action-id parameters]
-  {action-id  ms/PositiveInt
-   parameters ms/JSONString}
+  [{:keys [action-id]} :- [:map
+                           [:action-id ms/PositiveInt]]
+   {:keys [parameters]} :- [:map
+                            [:parameters ms/JSONString]]]
   (actions/check-actions-enabled! action-id)
   (-> (action/select-action :id action-id :archived false)
       api/read-check
       (actions/fetch-values (json/decode parameters))))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint POST "/:id/execute"
+(api.macros/defendpoint :post "/:id/execute"
   "Execute the Action.
 
    `parameters` should be the mapped dashboard parameters with values."
-  [id :as {{:keys [parameters], :as _body} :body}]
-  {id         ms/PositiveInt
-   parameters [:maybe [:map-of :keyword any?]]}
+  [{:keys [id]} :- [:map
+                    [:id ms/PositiveInt]]
+   _query-params
+   {:keys [parameters], :as _body} :- [:map
+                                       [:parameters {:optional true} [:maybe [:map-of :keyword any?]]]]]
   (let [{:keys [type] :as action} (api/check-404 (action/select-action :id id :archived false))]
     (snowplow/track-event! ::snowplow/action
                            {:event     :action-executed

--- a/src/metabase/api/action.clj
+++ b/src/metabase/api/action.clj
@@ -18,6 +18,8 @@
 
 (set! *warn-on-reflection* true)
 
+;;; TODO -- by convention these should either have class-like names e.g. `JSONQuery` and `SupportedActionType` or we
+;;; should use [[metabase.util.malli.registry/def]] and register them and make them namespaced keywords
 (def ^:private json-query-schema
   [:and
    string?

--- a/src/metabase/api/action.clj
+++ b/src/metabase/api/action.clj
@@ -221,8 +221,8 @@
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]
    _query-params
-   {:keys [parameters], :as _body} :- [:map
-                                       [:parameters {:optional true} [:maybe [:map-of :keyword any?]]]]]
+   {:keys [parameters], :as _body} :- [:maybe [:map
+                                               [:parameters {:optional true} [:maybe [:map-of :keyword any?]]]]]]
   (let [{:keys [type] :as action} (api/check-404 (action/select-action :id id :archived false))]
     (snowplow/track-event! ::snowplow/action
                            {:event     :action-executed

--- a/src/metabase/api/activity.clj
+++ b/src/metabase/api/activity.clj
@@ -4,6 +4,7 @@
    [compojure.core :refer [GET]]
    [medley.core :as m]
    [metabase.api.common :as api :refer [*current-user-id*]]
+   [metabase.api.macros :as api.macros]
    [metabase.db.query :as mdb.query]
    [metabase.models.interface :as mi]
    [metabase.models.recent-views :as recent-views]
@@ -124,13 +125,14 @@
   (when-not (seq context) (throw (ex-info "context is required." {})))
   (recent-views/get-recents *current-user-id* context))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint POST "/recents"
+(api.macros/defendpoint :post "/recents"
   "Adds a model to the list of recently selected items."
-  [:as {{:keys [model model_id context]} :body}]
-  {model (into [:enum] recent-views/rv-models)
-   model_id ms/PositiveInt
-   context [:enum :selection]}
+  [_route-params
+   _query-params
+   {:keys [model model_id context]} :- [:map
+                                        [:model    (into [:enum] recent-views/rv-models)]
+                                        [:model_id ms/PositiveInt]
+                                        [:context  [:enum :selection]]]]
   (let [model-id model_id
         model-type (recent-views/rv-model->model model)]
     (when-not (t2/exists? model-type :id model-id)
@@ -138,8 +140,7 @@
     (api/read-check (t2/select-one model-type :id model-id))
     (recent-views/update-users-recent-views! *current-user-id* model-type model-id context)))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/most_recently_viewed_dashboard"
+(api.macros/defendpoint :get "/most_recently_viewed_dashboard"
   "Get the most recently viewed dashboard for the current user. Returns a 204 if the user has not viewed any dashboards
    in the last 24 hours."
   []
@@ -235,8 +236,7 @@
                    (assoc :timestamp (:max_ts % ""))
                    recent-views/fill-recent-view-info)))))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/popular_items"
+(api.macros/defendpoint :get "/popular_items"
   "Get the list of 5 popular things on the instance. Query takes 8 and limits to 5 so that if it finds anything
   archived, deleted, etc it can usually still get 5. "
   []

--- a/src/metabase/api/alert.clj
+++ b/src/metabase/api/alert.clj
@@ -163,7 +163,7 @@
   [alert]
   (when (email/email-configured?)
     (doseq [recipient (collect-alert-recipients alert)]
-./      (messages/send-admin-unsubscribed-alert-email! alert recipient @api/*current-user*))))
+      (messages/send-admin-unsubscribed-alert-email! alert recipient @api/*current-user*))))
 
 (api.macros/defendpoint :put "/:id"
   "Update a `Alert` with ID."

--- a/src/metabase/api/alert.clj
+++ b/src/metabase/api/alert.clj
@@ -5,10 +5,10 @@
   (:require
    [clojure.data :as data]
    [clojure.set :refer [difference]]
-   [compojure.core :refer [DELETE GET POST PUT]]
    [medley.core :as m]
    [metabase.api.common :as api]
    [metabase.api.common.validation :as validation]
+   [metabase.api.macros :as api.macros]
    [metabase.channel.email :as email]
    [metabase.channel.email.messages :as messages]
    [metabase.config :as config]
@@ -27,13 +27,13 @@
 (when config/ee-available?
   (classloader/require 'metabase-enterprise.advanced-permissions.common))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/"
+(api.macros/defendpoint :get "/"
   "Fetch alerts which the current user has created or will receive, or all alerts if the user is an admin.
   The optional `user_id` will return alerts created by the corresponding user, but is ignored for non-admin users."
-  [archived user_id]
-  {archived [:maybe ms/BooleanValue]
-   user_id  [:maybe ms/PositiveInt]}
+  [_route-params
+   {:keys [archived user_id]} :- [:map
+                                  [:archived {:optional true} [:maybe ms/BooleanValue]]
+                                  [:user_id  {:optional true} [:maybe ms/PositiveInt]]]]
   (let [user-id (if api/*is-superuser?*
                   user_id
                   api/*current-user-id*)]
@@ -42,20 +42,19 @@
       (filter mi/can-read? <>)
       (t2/hydrate <> :can_write))))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/:id"
+(api.macros/defendpoint :get "/:id"
   "Fetch an alert by ID"
-  [id]
-  {id ms/PositiveInt}
+  [{:keys [id]} :- [:map
+                    [:id ms/PositiveInt]]]
   (-> (api/read-check (models.pulse/retrieve-alert id))
       (t2/hydrate :can_write)))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/question/:id"
+(api.macros/defendpoint :get "/question/:id"
   "Fetch all alerts for the given question (`Card`) id"
-  [id archived]
-  {id       [:maybe ms/PositiveInt]
-   archived [:maybe ms/BooleanValue]}
+  [{:keys [id]} :- [:map
+                    [:id {:optional true} [:maybe ms/PositiveInt]]]
+   {:keys [archived]} :- [:map
+                          [:archived {:optional true} [:maybe ms/BooleanValue]]]]
   (-> (if api/*is-superuser?*
         (models.pulse/retrieve-alerts-for-cards {:card-ids [id], :archived? archived})
         (models.pulse/retrieve-user-alerts-for-card {:card-id id, :user-id api/*current-user-id*, :archived?  archived}))
@@ -134,16 +133,17 @@
     (assoc card :include_csv true)
     card))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint POST "/"
+(api.macros/defendpoint :post "/"
   "Create a new Alert."
-  [:as {{:keys [alert_condition card channels alert_first_only alert_above_goal]
-         :as new-alert-request-body} :body}]
-  {alert_condition  models.pulse/AlertConditions
-   alert_first_only :boolean
-   alert_above_goal [:maybe :boolean]
-   card             models.pulse/CardRef
-   channels         [:+ :map]}
+  [_route-params
+   _query-params
+   {:keys [alert_condition card channels]
+    :as new-alert-request-body} :- [:map
+                                    [:alert_condition  models.pulse/AlertConditions]
+                                    [:alert_first_only :boolean]
+                                    [:alert_above_goal {:optional true} [:maybe :boolean]]
+                                    [:card             models.pulse/CardRef]
+                                    [:channels         [:+ :map]]]]
   (validation/check-has-application-permission :subscription false)
   ;; To create an Alert you need read perms for its Card
   (api/read-check :model/Card (u/the-id card))
@@ -163,20 +163,21 @@
   [alert]
   (when (email/email-configured?)
     (doseq [recipient (collect-alert-recipients alert)]
-      (messages/send-admin-unsubscribed-alert-email! alert recipient @api/*current-user*))))
+./      (messages/send-admin-unsubscribed-alert-email! alert recipient @api/*current-user*))))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint PUT "/:id"
+(api.macros/defendpoint :put "/:id"
   "Update a `Alert` with ID."
-  [id :as {{:keys [alert_condition alert_first_only alert_above_goal card channels archived]
-            :as alert-updates} :body}]
-  {id               ms/PositiveInt
-   alert_condition  [:maybe models.pulse/AlertConditions]
-   alert_first_only [:maybe :boolean]
-   alert_above_goal [:maybe :boolean]
-   card             [:maybe models.pulse/CardRef]
-   channels         [:maybe [:+ [:map]]]
-   archived         [:maybe :boolean]}
+  [{:keys [id]} :- [:map
+                    [:id ms/PositiveInt]]
+   _query-params
+   {:keys [card channels archived]
+    :as alert-updates} :- [:map
+                           [:alert_condition  {:optional true} [:maybe models.pulse/AlertConditions]]
+                           [:alert_first_only {:optional true} [:maybe :boolean]]
+                           [:alert_above_goal {:optional true} [:maybe :boolean]]
+                           [:card             {:optional true} [:maybe models.pulse/CardRef]]
+                           [:channels         {:optional true} [:maybe [:+ [:map]]]]
+                           [:archived         {:optional true} [:maybe :boolean]]]]
   (try
     (validation/check-has-application-permission :monitoring)
     (catch clojure.lang.ExceptionInfo _e
@@ -245,11 +246,10 @@
       ;; Finally, return the updated Alert
       updated-alert)))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint DELETE "/:id/subscription"
+(api.macros/defendpoint :delete "/:id/subscription"
   "For users to unsubscribe themselves from the given alert."
-  [id]
-  {id ms/PositiveInt}
+  [{:keys [id]} :- [:map
+                    [:id ms/PositiveInt]]]
   (validation/check-has-application-permission :subscription false)
   (let [alert (models.pulse/retrieve-alert id)]
     (api/read-check alert)

--- a/src/metabase/api/alert.clj
+++ b/src/metabase/api/alert.clj
@@ -32,7 +32,7 @@
   The optional `user_id` will return alerts created by the corresponding user, but is ignored for non-admin users."
   [_route-params
    {:keys [archived user_id]} :- [:map
-                                  [:archived {:optional true} [:maybe ms/BooleanValue]]
+                                  [:archived {:default false} [:maybe ms/BooleanValue]]
                                   [:user_id  {:optional true} [:maybe ms/PositiveInt]]]]
   (let [user-id (if api/*is-superuser?*
                   user_id
@@ -52,9 +52,9 @@
 (api.macros/defendpoint :get "/question/:id"
   "Fetch all alerts for the given question (`Card`) id"
   [{:keys [id]} :- [:map
-                    [:id {:optional true} [:maybe ms/PositiveInt]]]
+                    [:id ms/PositiveInt]]
    {:keys [archived]} :- [:map
-                          [:archived {:optional true} [:maybe ms/BooleanValue]]]]
+                          [:archived {:default false} [:maybe ms/BooleanValue]]]]
   (-> (if api/*is-superuser?*
         (models.pulse/retrieve-alerts-for-cards {:card-ids [id], :archived? archived})
         (models.pulse/retrieve-user-alerts-for-card {:card-id id, :user-id api/*current-user-id*, :archived?  archived}))

--- a/src/metabase/api/macros.clj
+++ b/src/metabase/api/macros.clj
@@ -247,7 +247,8 @@
       (me/humanize {:wrap mu/humanize-include-value})))
 
 (defn- invalid-params-errors [schema explanation specific-errors]
-  (or (when (= (mc/type schema) :map)
+  (or (when (and (map? specific-errors)
+                 (= (mc/type schema) :map))
         (into {}
               (let [specific-error-keys (set (keys specific-errors))]
                 (keep (fn [child]

--- a/src/metabase/api/macros.clj
+++ b/src/metabase/api/macros.clj
@@ -249,9 +249,10 @@
 (defn- invalid-params-errors [schema explanation specific-errors]
   (or (when (= (mc/type schema) :map)
         (into {}
-              (keep (fn [child]
-                      (when (contains? (set (keys specific-errors)) (first child))
-                        [(first child) (umd/describe (last child))])))
+              (let [specific-error-keys (set (keys specific-errors))]
+                (keep (fn [child]
+                        (when (contains? specific-error-keys (first child))
+                          [(first child) (umd/describe (last child))]))))
               (mc/children schema)))
       (me/humanize explanation {:wrap #(umd/describe (:schema %))})))
 

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -403,9 +403,9 @@
   "Find all alerts for `card-ids`, used for admin users"
   [{:keys [archived? card-ids]
     :or   {archived? false}} :- [:map
-                                 [:card-ids [:or
-                                             [:sequential {:min 1} pos-int?]
-                                             [:set {:min 1} pos-int?]]]
+                                 [:card-ids [:maybe [:or
+                                                     [:sequential pos-int?]
+                                                     [:set pos-int?]]]]
                                  [:archived? {:optional true} boolean?]]]
   (when (seq card-ids)
     (map (comp notification->alert hydrate-notification)

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -378,10 +378,13 @@
           hydrate-notification
           notification->pulse))))
 
-(defn retrieve-user-alerts-for-card
+(mu/defn retrieve-user-alerts-for-card
   "Find all alerts for `card-id` that `user-id` is set to receive"
   [{:keys [archived? card-id user-id]
-    :or   {archived? false}}]
+    :or   {archived? false}} :- [:map
+                                 [:card-id pos-int?]
+                                 [:user-id pos-int?]
+                                 [:archived? {:optional true} boolean?]]]
   (assert boolean? archived?)
   (map (comp notification->alert hydrate-notification)
        (query-as :model/Pulse
@@ -396,10 +399,12 @@
                            [:= :pcr.user_id user-id]
                            [:= :p.archived archived?]]})))
 
-(defn retrieve-alerts-for-cards
+(mu/defn retrieve-alerts-for-cards
   "Find all alerts for `card-ids`, used for admin users"
   [{:keys [archived? card-ids]
-    :or   {archived? false}}]
+    :or   {archived? false}} :- [:map
+                                 [:card-ids [:sequential {:min 1} pos-int?]]
+                                 [:archived? {:optional true} boolean?]]]
   (when (seq card-ids)
     (map (comp notification->alert hydrate-notification)
          (query-as :model/Pulse

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -403,7 +403,9 @@
   "Find all alerts for `card-ids`, used for admin users"
   [{:keys [archived? card-ids]
     :or   {archived? false}} :- [:map
-                                 [:card-ids [:sequential {:min 1} pos-int?]]
+                                 [:card-ids [:or
+                                             [:sequential {:min 1} pos-int?]
+                                             [:set {:min 1} pos-int?]]]
                                  [:archived? {:optional true} boolean?]]]
   (when (seq card-ids)
     (map (comp notification->alert hydrate-notification)

--- a/test/metabase/api/action_test.clj
+++ b/test/metabase/api/action_test.clj
@@ -375,31 +375,32 @@
             (is (false? (t2/select-one-fn :archived :model/Action :id action-id))))
           (testing "Validate POST"
             (testing "Required fields"
-              (is (partial= {:errors {:name "string"},
-                             :specific-errors {:name ["should be a string, received: nil"]}}
-                            (mt/user-http-request :crowberto :post 400 "action" {:type "http"})))
-              (is (partial= {:errors {:model_id "value must be an integer greater than zero."}
-                             :specific-errors {:model_id ["value must be an integer greater than zero., received: nil"]}}
-                            (mt/user-http-request :crowberto :post 400 "action" {:type "http" :name "test"}))))
+              (is (=? {:errors {:name "string"},
+                       :specific-errors {:name ["missing required key, received: nil"]}}
+                      (mt/user-http-request :crowberto :post 400 "action" {:type "http"})))
+              (is (=? {:errors {:model_id "value must be an integer greater than zero."}
+                       :specific-errors {:model_id ["missing required key, received: nil"]}}
+                      (mt/user-http-request :crowberto :post 400 "action" {:type "http" :name "test"}))))
             (testing "Handles need to be valid jq"
-              (is (partial= {:errors {:response_handle "nullable string, and must be a valid json-query, something like '.item.title'"}
-                             :specific-errors {:response_handle ["must be a valid json-query, something like '.item.title', received: \"body\""]}}
-                            (mt/user-http-request :crowberto :post 400 "action" (assoc initial-action :response_handle "body"))))
-              (is (partial= {:errors {:error_handle "nullable string, and must be a valid json-query, something like '.item.title'"}
-                             :specific-errors {:error_handle ["must be a valid json-query, something like '.item.title', received: \"x\""]}}
-                            (mt/user-http-request :crowberto :post 400 "action" (assoc initial-action :error_handle "x"))))))
+              (is (=? {:errors {:response_handle "nullable string, and must be a valid json-query, something like '.item.title'"}
+                       :specific-errors {:response_handle ["must be a valid json-query, something like '.item.title', received: \"body\""]}}
+                      (mt/user-http-request :crowberto :post 400 "action" (assoc initial-action :response_handle "body"))))
+              (is (=? {:errors {:error_handle "nullable string, and must be a valid json-query, something like '.item.title'"}
+                       :specific-errors {:error_handle ["must be a valid json-query, something like '.item.title', received: \"x\""]}}
+                      (mt/user-http-request :crowberto :post 400 "action" (assoc initial-action :error_handle "x"))))))
           (testing "Validate PUT"
             (testing "Template needs method and url"
-              (is (partial= {:errors {:action "map where {:archived (optional) -> <nullable boolean>, :database_id (optional) -> <nullable value must be an integer greater than zero.>, :dataset_query (optional) -> <nullable map>, :description (optional) -> <nullable string>, :error_handle (optional) -> <nullable string, and must be a valid json-query, something like '.item.title'>, :kind (optional) -> <nullable Unsupported implicit action kind>, :model_id (optional) -> <nullable value must be an integer greater than zero.>, :name (optional) -> <nullable string>, :parameter_mappings (optional) -> <nullable map>, :parameters (optional) -> <nullable sequence of map>, :response_handle (optional) -> <nullable string, and must be a valid json-query, something like '.item.title'>, :template (optional) -> <nullable map where {:method -> <enum of GET, POST, PUT, DELETE, PATCH>, :url -> <string with length >= 1>, :body (optional) -> <nullable string>, :headers (optional) -> <nullable string>, :parameters (optional) -> <nullable sequence of map>, :parameter_mappings (optional) -> <nullable map>} with no other keys>, :type (optional) -> <nullable Unsupported action type>, :visualization_settings (optional) -> <nullable map>}"},
-                             :specific-errors {:action {:template {:method ["missing required key, received: nil"] :url ["missing required key, received: nil"]}}}}
-                            (mt/user-http-request :crowberto :put 400 action-path {:type "http" :template {}}))))
+              (is (=? {:specific-errors
+                       {:template {:method ["missing required key, received: nil"], :url ["missing required key, received: nil"]}},
+                       :errors {:template "nullable map where {:method -> <enum of GET, POST, PUT, DELETE, PATCH>, :url -> <string with length >= 1>, :body (optional) -> <nullable string>, :headers (optional) -> <nullable string>, :parameters (optional) -> <nullable sequence of map>, :parameter_mappings (optional) -> <nullable map>} with no other keys"}}
+                      (mt/user-http-request :crowberto :put 400 action-path {:type "http" :template {}}))))
             (testing "Handles need to be valid jq"
-              (is (partial= {:errors {:action "map where {:archived (optional) -> <nullable boolean>, :database_id (optional) -> <nullable value must be an integer greater than zero.>, :dataset_query (optional) -> <nullable map>, :description (optional) -> <nullable string>, :error_handle (optional) -> <nullable string, and must be a valid json-query, something like '.item.title'>, :kind (optional) -> <nullable Unsupported implicit action kind>, :model_id (optional) -> <nullable value must be an integer greater than zero.>, :name (optional) -> <nullable string>, :parameter_mappings (optional) -> <nullable map>, :parameters (optional) -> <nullable sequence of map>, :response_handle (optional) -> <nullable string, and must be a valid json-query, something like '.item.title'>, :template (optional) -> <nullable map where {:method -> <enum of GET, POST, PUT, DELETE, PATCH>, :url -> <string with length >= 1>, :body (optional) -> <nullable string>, :headers (optional) -> <nullable string>, :parameters (optional) -> <nullable sequence of map>, :parameter_mappings (optional) -> <nullable map>} with no other keys>, :type (optional) -> <nullable Unsupported action type>, :visualization_settings (optional) -> <nullable map>}"},
-                             :specific-errors {:action {:response_handle ["must be a valid json-query, something like '.item.title', received: \"body\""]}}}
-                            (mt/user-http-request :crowberto :put 400 action-path (assoc initial-action :response_handle "body"))))
-              (is (partial= {:errors {:action "map where {:archived (optional) -> <nullable boolean>, :database_id (optional) -> <nullable value must be an integer greater than zero.>, :dataset_query (optional) -> <nullable map>, :description (optional) -> <nullable string>, :error_handle (optional) -> <nullable string, and must be a valid json-query, something like '.item.title'>, :kind (optional) -> <nullable Unsupported implicit action kind>, :model_id (optional) -> <nullable value must be an integer greater than zero.>, :name (optional) -> <nullable string>, :parameter_mappings (optional) -> <nullable map>, :parameters (optional) -> <nullable sequence of map>, :response_handle (optional) -> <nullable string, and must be a valid json-query, something like '.item.title'>, :template (optional) -> <nullable map where {:method -> <enum of GET, POST, PUT, DELETE, PATCH>, :url -> <string with length >= 1>, :body (optional) -> <nullable string>, :headers (optional) -> <nullable string>, :parameters (optional) -> <nullable sequence of map>, :parameter_mappings (optional) -> <nullable map>} with no other keys>, :type (optional) -> <nullable Unsupported action type>, :visualization_settings (optional) -> <nullable map>}"},
-                             :specific-errors {:action {:error_handle ["must be a valid json-query, something like '.item.title', received: \"x\""]}}}
-                            (mt/user-http-request :crowberto :put 400 action-path (assoc initial-action :error_handle "x")))))))))))
+              (is (=? {:errors {:response_handle "nullable string, and must be a valid json-query, something like '.item.title'"},
+                       :specific-errors {:response_handle ["must be a valid json-query, something like '.item.title', received: \"body\""]}}
+                      (mt/user-http-request :crowberto :put 400 action-path (assoc initial-action :response_handle "body"))))
+              (is (=? {:errors {:error_handle "nullable string, and must be a valid json-query, something like '.item.title'"},
+                       :specific-errors {:error_handle ["must be a valid json-query, something like '.item.title', received: \"x\""]}}
+                      (mt/user-http-request :crowberto :put 400 action-path (assoc initial-action :error_handle "x")))))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                            PUBLIC SHARING ENDPOINTS                                            |

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -3690,7 +3690,7 @@
               (is (mi/can-read? card)))
             (is (= [[1] [2]] (mt/rows (process-query))))))))))
 
-(deftest query-metadata-test
+(deftest ^:parallel query-metadata-test
   (mt/with-temp
     [:model/Card {card-id-1 :id} {:dataset_query (mt/mbql-query products)
                                   :database_id (mt/id)}

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4534,7 +4534,6 @@
   (let [can-restore? (fn [dash-id user]
                        (:can_restore (mt/user-http-request user :get 200 (str "dashboard/" dash-id))))]
     (testing "I can restore a simply trashed dashboard"
-
       (mt/with-temp [:model/Collection {coll-id :id} {:name "A"}
                      :model/Dashboard {dash-id :id} {:name          "My Dashboard"
                                                      :collection_id coll-id}]

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4530,6 +4530,7 @@
                          (format "/dashboard/%s/dashcard/%s/card/%s/query/%s" dashboard-id dashcard-id card-id (name export-format))
                          :format_rows apply-formatting?)
                         ((get output-helper export-format)))))))))))
+
 (deftest can-restore
   (let [can-restore? (fn [dash-id user]
                        (:can_restore (mt/user-http-request user :get 200 (str "dashboard/" dash-id))))]

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -273,7 +273,9 @@
       "table orders"
       "call 1 + 1"
       ;; Note this passes the check, but will fail on execution
-      "update venues set name = 'bill'; some query that can't be parsed;"))
+      "update venues set name = 'bill'; some query that can't be parsed;")))
+
+(deftest ^:parallel check-read-only-test-2
   (testing "not read only statements should fail"
     (are [query] (thrown?
                   clojure.lang.ExceptionInfo
@@ -304,7 +306,11 @@
             (is (=? {:message "Error executing Action: DDL commands are not allowed to be used with H2."}
                     (mt/user-http-request :crowberto
                                           :post 500
-                                          (format "action/%s/execute" action-id)))))))
+                                          (format "action/%s/execute" action-id))))))))))
+
+(deftest disallowed-commands-in-action-test-2
+  (mt/test-driver :h2
+    (mt/with-actions-test-data-and-actions-enabled
       (testing "Should be able to execute query actions with allowed commands"
         (let [sql "update categories set name = 'stomp' where id = 1; update categories set name = 'stomp' where id = 2;"]
           (mt/with-actions [{:keys [action-id]} {:type :query


### PR DESCRIPTION
I decided reworking ~250 `defendpoint` forms by hand was way too much work so I wrote code that can do it for us.

I wrote some [`rewrite-clj`](https://github.com/clj-commons/rewrite-clj) code to rewrite legacy `defendpoint` 1 forms as modern `defendpoint` 2 forms, and then ran it on a few namespaces.

Generally pretty good about outputting stuff in a nice format, but isn't currently smart enough to remove unused bindings so it needs a tiny bit of manual cleanup. Output is not indented 100% correctly either so we need to run `./bin/cljfmt-updated.sh` on the rewritten files as well.

I fixed some inconsistencies with the way the new `defendpoint` returns error responses as much as possible (not possible to make it 100% the same since the schemas are grouped together in `:map` schemas but the error messages are still at least as useful as the old ones) and fixed a few other small things like that with the `defendpoint` macro.

Once this PR lands and we work out the kinks we can open follow-on PRs that update a lot more endpoints