### PR TITLE
Return is-null filter in underlying-records drill thru if value is nil

### DIFF
--- a/src/metabase/lib/drill_thru/underlying_records.cljc
+++ b/src/metabase/lib/drill_thru/underlying_records.cljc
@@ -138,7 +138,9 @@
                            (let [column (if-let [temporal-unit (::lib.underlying/temporal-unit column)]
                                           (lib.temporal-bucket/with-temporal-bucket column temporal-unit)
                                           column)]
-                             [(lib.filter/= column value)]))]
+                             (if (some? value)
+                               [(lib.filter/= column value)]
+                               [(lib.filter/is-null column)])))]
     (reduce
      (fn [query filter-clause]
        (lib.filter/filter query stage-number filter-clause))


### PR DESCRIPTION
Closes #51751

### Description

Return an `is-null` filter rather than an `=` filter for unbinned dimension values. The drill thru already did this for binned values. This prevents a crash when the user clicks on the filter pill after the drill is applied.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> Analytic Events
2. Summarize: Count by Button Label
3. Click on the (empty) bar
4. Click on "See these Analytic Events"
5. Click on the "Button Label is empty" filter pill at the top
6. Filter editor should appear

### Demo

![Screenshot 2025-01-16 at 5 06 37 PM](https://github.com/user-attachments/assets/ee5b38ad-ac24-409f-b1d3-e0483e62e393)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
