### PR TITLE
[Notification] news entity are entities without id

### DIFF
--- a/src/metabase/models/util/spec_update.clj
+++ b/src/metabase/models/util/spec_update.clj
@@ -183,19 +183,8 @@
         (log/debugf "%s no change detected for %s %s" (format-path path) model existing-id)
         (handle-nested! existing-data new-data existing-id)))))
 
-(defn- check-id-exists
-  "if x is a map, check if it has id key, if x is a seq, check if all elements have id key."
-  [x id-col]
-  (when x
-    (assert (if (sequential? x)
-              (every? id-col x)
-              (id-col x))
-            (format "%s is missing in %s" id-col x))))
-
 (defn- do-update!*
-  [existing-data new-data {:keys [id-col] :as spec} path]
-  (check-id-exists existing-data id-col)
-  (check-id-exists new-data id-col)
+  [existing-data new-data spec path]
   (if (:multi-row? spec)
     (do
       (log/tracef "%s multi-row spec found" (format-path path))

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -439,12 +439,12 @@
                ;; First, "decompose" the characters. e.g. replace 'LATIN CAPITAL LETTER A WITH ACUTE' with
                ;; 'LATIN CAPITAL LETTER A' + 'COMBINING ACUTE ACCENT'
                ;; See http://docs.oracle.com/javase/8/docs/api/java/text/Normalizer.html
-              (Normalizer/normalize s Normalizer$Form/NFD)
+               (Normalizer/normalize s Normalizer$Form/NFD)
                ;; next, remove the combining diacritical marks -- this SO answer explains what's going on here best:
                ;; http://stackoverflow.com/a/5697575/1198455 The closest thing to a relevant JavaDoc I could find was
                ;; http://docs.oracle.com/javase/7/docs/api/java/lang/Character.UnicodeBlock.html#COMBINING_DIACRITICAL_MARKS
-              #"\p{Block=CombiningDiacriticalMarks}+"
-              "")
+               #"\p{Block=CombiningDiacriticalMarks}+"
+               "")
        :cljs (-> s
                  (.normalize "NFKD")  ;; Renders accented characters as base + accent.
                  (.replace (js/RegExp. "[\u0300-\u036f]" "gu") ""))))) ;; Drops all the accents.
@@ -884,11 +884,11 @@
        ret))))
 
 (defn row-diff
-  "Given 2 lists of seq maps of changes, where each map an has an `id` key,
-  return a map of 3 keys: `:to-create`, `:to-update`, `:to-delete`.
+  "Given 2 lists of seq maps of changes, where each map in current-rows has an `id` key,
+  return a map of 4 keys: `:to-create`, `:to-update`, `:to-delete`, `:to-skip`.
 
   Where:
-  - `:to-create` is a list of maps that has ids only in `new-rows`
+  - `:to-create` is a list of maps that either lack ids or have ids only in `new-rows`
   - `:to-delete` is a list of maps that has ids only in `current-rows`
   - `:to-skip`   is a list of identical maps that has ids in both lists
   - `:to-update` is a list of different maps that has ids in both lists
@@ -899,19 +899,25 @@
   [current-rows new-rows & {:keys [id-fn to-compare]
                             :or   {id-fn      :id
                                    to-compare identity}}]
-  (let [[delete-ids
+  (let [new-rows-with-ids    (filter id-fn new-rows)
+        new-rows-without-ids (remove id-fn new-rows)
+        [delete-ids
          create-ids
-         update-ids]     (diff (set (map id-fn current-rows))
-                               (set (map id-fn new-rows)))
-        known-map        (m/index-by id-fn current-rows)
+         update-ids]         (diff (set (map id-fn current-rows))
+                                   (set (map id-fn new-rows-with-ids)))
+        known-map            (m/index-by id-fn current-rows)
         {to-update false
-         to-skip   true} (when (seq update-ids)
-                           (clojure.core/group-by (fn [x]
-                                                    (let [y (get known-map (id-fn x))]
-                                                      (= (to-compare x) (to-compare y))))
-                                                  (filter #(update-ids (id-fn %)) new-rows)))]
-    {:to-create (when (seq create-ids) (filter #(create-ids (id-fn %)) new-rows))
-     :to-delete (when (seq delete-ids) (filter #(delete-ids (id-fn %)) current-rows))
+         to-skip   true}     (when (seq update-ids)
+                               (clojure.core/group-by (fn [x]
+                                                        (let [y (get known-map (id-fn x))]
+                                                          (= (to-compare x) (to-compare y))))
+                                                      (filter #(update-ids (id-fn %)) new-rows-with-ids)))]
+    {:to-create (concat
+                 new-rows-without-ids
+                 (when (seq create-ids)
+                   (filter #(create-ids (id-fn %)) new-rows-with-ids)))
+     :to-delete (when (seq delete-ids)
+                  (filter #(delete-ids (id-fn %)) current-rows))
      :to-update to-update
      :to-skip   to-skip}))
 

--- a/test/metabase/api/notification_test.clj
+++ b/test/metabase/api/notification_test.clj
@@ -203,8 +203,7 @@
                 existing-user-recipient (m/find-first #(= "notification-recipient/user" (:type %))
                                                       (:recipients existing-email-handler))
                 new-recipients          [(assoc existing-user-recipient :user_id (mt/user->id :rasta))
-                                         {:id                      -1
-                                          :type                    :notification-recipient/group
+                                         {:type                    :notification-recipient/group
                                           :notification_handler_id (:id existing-email-handler)
                                           :permissions_group_id    (:id (perms-group/admin))}]
                 new-handlers            [(assoc existing-email-handler :recipients new-recipients)]]
@@ -220,11 +219,9 @@
                           :handlers (m/find-first #(= "channel/email" (:channel_type %))) :recipients))))))
 
         (testing "can add new handler"
-          (let [new-handler {:id              -1
-                             :notification_id notification-id
+          (let [new-handler {:notification_id notification-id
                              :channel_type    :channel/slack
-                             :recipients      [{:id      -1
-                                                :type    :notification-recipient/user
+                             :recipients      [{:type    :notification-recipient/user
                                                 :user_id (mt/user->id :rasta)}]}
                 new-handlers (conj (:handlers @notification) new-handler)]
             (is (=? {:channel_type "channel/slack"
@@ -845,12 +842,10 @@
             (notification.tu/with-card-notification
               [{noti-id :id :as notification} base-notification]
               (let [handler-id (->> notification :handlers (m/find-first #(= :channel/email (:channel_type %))) :id)
-                    updated-recipients [{:id                      -1
-                                         :notification_handler_id handler-id
+                    updated-recipients [{:notification_handler_id handler-id
                                          :type                    :notification-recipient/user
                                          :user_id                 (mt/user->id :lucky)}
-                                        {:id                      -2
-                                         :notification_handler_id handler-id
+                                        {:notification_handler_id handler-id
                                          :type                    :notification-recipient/raw-value
                                          :details                 {:value "new@metabase.com"}}]
                     [removed-email added-email] (update-notification! noti-id notification

--- a/test/metabase/models/util/spec_update_test.clj
+++ b/test/metabase/models/util/spec_update_test.clj
@@ -35,10 +35,8 @@
 
 (deftest basic-create-test
   (testing "Creating a new record with no existing data"
-    (let [new-data {:id   -1
-                    :name "Test"
-                    :foo  {:id -1
-                           :name "Foo 1"}}]
+    (let [new-data {:name "Test"
+                    :foo  {:name "Foo 1"}}]
       (is (= [[:insert-returning-pk! :root {:name "Test"}]
               [:insert-returning-pk! :foo {:name "Foo 1" :root_id 2}]]
              (with-tracked-operations!

--- a/test/metabase/util_test.cljc
+++ b/test/metabase/util_test.cljc
@@ -419,11 +419,11 @@
   (testing "classify correctly"
     (is (= {:to-update [{:id 2 :name "c3"}]
             :to-delete [{:id 1 :name "c1"} {:id 3 :name "c3"}]
-            :to-create [{:id -1 :name "-c1"}]
+            :to-create [{:name "c5"} {:id -1 :name "-c1"}]
             :to-skip   [{:id 4 :name "c4"}]}
            (u/row-diff
             [{:id 1 :name "c1"}   {:id 2 :name "c2"} {:id 3 :name "c3"} {:id 4 :name "c4"}]
-            [{:id -1 :name "-c1"} {:id 2 :name "c3"} {:id 4 :name "c4"}])))
+            [{:id -1 :name "-c1"} {:id 2 :name "c3"} {:id 4 :name "c4"} {:name "c5"}])))
     (is (= {:to-skip   [{:god_id 10, :name "Zeus", :job "God of Thunder"}]
             :to-delete [{:id 2, :god_id 20, :name "Odin", :job "God of Thunder"}]
             :to-update [{:god_id 30, :name "Osiris", :job "God of Afterlife"}]


### PR DESCRIPTION
our update notification had a weird convention in which in order to create new entity (handler, recipient, subscription), you'll need to use negative ids for those entity.

it's weird and hard to play with, this PR changes it so that any rows without an id will be considered as a new row.