### PR TITLE
Fixed resetting the embedded preview to the default font

### DIFF
--- a/frontend/src/metabase/dashboard/hooks/use-dashboard-url-params.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-dashboard-url-params.ts
@@ -72,9 +72,7 @@ export const useDashboardUrlParams = ({
   useEffect(() => {
     const { font } = parseHashOptions(location.hash) as DashboardUrlHashOptions;
 
-    if (font) {
-      setFont(font);
-    }
+    setFont(font ?? null);
   }, [location.hash, setFont]);
 
   return {

--- a/frontend/src/metabase/dashboard/hooks/use-dashboard-url-params.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/hooks/use-dashboard-url-params.unit.spec.tsx
@@ -1,0 +1,59 @@
+import { renderHook } from "@testing-library/react";
+import type { Location } from "history";
+import type { PropsWithChildren } from "react";
+
+import { MetabaseReduxProvider } from "metabase/lib/redux";
+import { mainReducers } from "metabase/reducers-main";
+import { getStore } from "metabase/store";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { useDashboardUrlParams } from "./use-dashboard-url-params";
+import { useEmbedFont } from "./use-embed-font";
+
+jest.mock("./use-embed-font", () => ({
+  useEmbedFont: jest.fn(),
+}));
+
+const setup = ({ location }: { location: Location }) => {
+  const store = getStore(mainReducers, undefined, createMockState());
+
+  const Wrapper = ({ children }: PropsWithChildren) => (
+    <MetabaseReduxProvider store={store}>{children}</MetabaseReduxProvider>
+  );
+
+  const setFontMock = jest.fn();
+  const onRefreshMock = jest.fn();
+
+  (useEmbedFont as jest.Mock).mockReturnValue({
+    font: null,
+    setFont: setFontMock,
+  });
+
+  const { result, rerender } = renderHook(
+    props => useDashboardUrlParams(props),
+    {
+      wrapper: Wrapper,
+      initialProps: { location, onRefresh: onRefreshMock },
+    },
+  );
+
+  return { result, rerender, setFontMock, onRefreshMock };
+};
+
+describe("useDashboardUrlParams", () => {
+  it("sets and updates font", () => {
+    const { setFontMock, onRefreshMock, rerender } = setup({
+      location: { hash: "#font=Roboto" } as Location,
+    });
+
+    expect(setFontMock).toHaveBeenCalledWith("Roboto");
+
+    rerender({
+      location: { hash: "" } as Location,
+      onRefresh: onRefreshMock,
+    });
+
+    expect(setFontMock).toHaveBeenCalledWith(null);
+    expect(setFontMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/45637

To fix it, we just need to handle a case in `frontend/src/metabase/dashboard/hooks/use-dashboard-url-params.ts` when a font is empty or nullable