### PR TITLE
Fix empty state color for accordion list

### DIFF
--- a/frontend/src/metabase/components/EmptyState/EmptyState.tsx
+++ b/frontend/src/metabase/components/EmptyState/EmptyState.tsx
@@ -79,7 +79,7 @@ const EmptyState = ({
         </h2>
       )}
       {message && (
-        <Text role="status" color="medium" mt="xs">
+        <Text role="status" color="text-medium" mt="xs">
           {message}
         </Text>
       )}

--- a/frontend/src/metabase/static-viz/components/ProgressBar/ProgressBar.tsx
+++ b/frontend/src/metabase/static-viz/components/ProgressBar/ProgressBar.tsx
@@ -112,7 +112,7 @@ const ProgressBar = ({
             <Text
               fontSize={layout.fontSize}
               textAnchor="start"
-              color="#ffffff"
+              color="text-white"
               x={layout.iconSize + 16}
               y={layout.barHeight / 2}
               verticalAnchor="middle"

--- a/frontend/src/metabase/static-viz/components/Text/Text.tsx
+++ b/frontend/src/metabase/static-viz/components/Text/Text.tsx
@@ -1,6 +1,12 @@
 import type { TextProps } from "@visx/text";
 import { Text as VText } from "@visx/text";
 
-export const Text = (props: TextProps) => {
+import type { ColorPalette } from "metabase/lib/colors/types";
+
+type Props = Omit<TextProps, "color"> & {
+  color?: keyof ColorPalette;
+};
+
+export const Text = (props: Props) => {
   return <VText fontFamily="Lato" fontSize="13" fill="#4C5773" {...props} />;
 };


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/46667
The wrong unsupported value was used

Fixed visuals:
![image](https://github.com/user-attachments/assets/2c1b772b-295b-4f27-bbc9-a6e659f07aae)

# How to verify:
- New > Question > Orders
- Click `filter` and `summarize` buttons
- Type gibberish in the search so there are no results
- See empty state, text should have a gray color
