### PR TITLE
Repro #46832 - Aggregation picker does not show all columns

### DIFF
--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -1018,6 +1018,55 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     H.modal().should("be.visible").contains("Discard changes").click();
     cy.findByTestId("greeting-message").should("be.visible");
   });
+
+  it("shows all available columns and groups in the breakout picker (metabase#46832)", () => {
+    cy.visit("/");
+    H.newButton("Question").click();
+    H.entityPickerModal().findByText("Orders").click();
+    H.join();
+    H.joinTable("Reviews", "Product ID", "Product ID");
+    H.addSummaryField({ metric: "Count of rows" });
+    H.addSummaryGroupingField({ field: "Created At" });
+    cy.findAllByRole("button", { name: "Join data" }).last().click();
+    H.joinTable("Reviews", "Created At: Month", "Created At");
+    cy.button("Summarize").click();
+    H.addSummaryField({ metric: "Count of rows", stage: 1 });
+
+    cy.log("adding a new breakout");
+    H.getNotebookStep("summarize", { stage: 1 })
+      .findByText("Pick a column to group by")
+      .click();
+    H.popover().within(() => {
+      cy.findByText("Summaries").should("be.visible");
+      cy.findByText("Created At: Month").should("be.visible");
+      cy.findByText("Count").should("be.visible");
+
+      cy.findByText("Reviews").click();
+      cy.findByText("Created At: Month").should("not.exist");
+      cy.findByText("Count").should("not.exist");
+
+      cy.findByText("Summaries").click();
+      cy.findByText("Created At: Month").should("be.visible");
+      cy.findByText("Count").should("be.visible");
+
+      cy.findByText("Reviews").click();
+      cy.findByText("Rating").click();
+    });
+
+    cy.log("editing an existing breakout");
+    H.getNotebookStep("summarize", { stage: 1 })
+      .findByText("Reviews - Created At: Month → Rating: Auto binned")
+      .click();
+    H.popover().within(() => {
+      cy.findByText("Summaries").should("be.visible");
+      cy.findByText("Created At: Month").should("not.exist");
+      cy.findByText("Count").should("not.exist");
+
+      cy.findByText("Summaries").click();
+      cy.findByText("Created At: Month").should("be.visible");
+      cy.findByText("Count").should("be.visible");
+    });
+  });
 });
 
 function assertTableRowCount(expectedCount) {


### PR DESCRIPTION
Closes #46832

### Description

Just a repro. Bug is already fixed by introduction of the "Summaries" groups.

### How to verify

CI is green.