### PR TITLE
Various fixes for the native editor revamp

### DIFF
--- a/e2e/support/helpers/e2e-ad-hoc-question-helpers.js
+++ b/e2e/support/helpers/e2e-ad-hoc-question-helpers.js
@@ -87,7 +87,7 @@ function newNativeCardHash(
  *
  * @example
  * H.startNewNativeQuestion({ query: "SELECT * FROM ORDERS" });
- * @param {object} config
+ * @param {object} [config]
  * @param {number} config.database
  * @param {string} config.query
  */

--- a/e2e/support/helpers/e2e-ad-hoc-question-helpers.js
+++ b/e2e/support/helpers/e2e-ad-hoc-question-helpers.js
@@ -88,7 +88,7 @@ function newNativeCardHash(
  * @example
  * H.startNewNativeQuestion({ query: "SELECT * FROM ORDERS" });
  * @param {object} [config]
- * @param {number} config.database
+ * @param {number} [config.database]
  * @param {string} config.query
  */
 export function startNewNativeQuestion(config) {

--- a/e2e/support/helpers/e2e-native-editor-helpers.ts
+++ b/e2e/support/helpers/e2e-native-editor-helpers.ts
@@ -108,7 +108,7 @@ function nativeEditorType(
 
 export const NativeEditor = {
   get: nativeEditor,
-  type(text: string, options: TypeOptions) {
+  type(text: string, options: TypeOptions = {}) {
     nativeEditorType(text, options);
     return NativeEditor;
   },

--- a/e2e/support/helpers/e2e-native-editor-helpers.ts
+++ b/e2e/support/helpers/e2e-native-editor-helpers.ts
@@ -75,6 +75,12 @@ function nativeEditorType(
       case "{rightarrow}":
         return cy.realPress(["ArrowRight"]);
 
+      case "{downarrow}":
+        return cy.realPress(["ArrowDown"]);
+
+      case "{uparrow}":
+        return cy.realPress(["ArrowUp"]);
+
       case "{enter}":
         return cy.realPress(["Enter"]);
 

--- a/e2e/support/helpers/e2e-native-editor-helpers.ts
+++ b/e2e/support/helpers/e2e-native-editor-helpers.ts
@@ -48,6 +48,9 @@ function nativeEditorType(
     focusNativeEditor();
   }
 
+  const isMac = Cypress.platform === "darwin";
+  const metaKey = isMac ? "Meta" : "Control";
+
   const parts = text.replaceAll("{{", "{{}{{}").split(/(\{[^}]+\})/);
 
   function type(text: string) {
@@ -97,11 +100,11 @@ function nativeEditorType(
 
       case "{nextcompletion}":
         cy.wait(50);
-        return cy.realPress(["Meta", "j"]);
+        return cy.realPress([metaKey, "j"]);
 
       case "{prevcompletion}":
         cy.wait(50);
-        return cy.realPress(["Meta", "k"]);
+        return cy.realPress([metaKey, "k"]);
 
       case "{{}":
         return cy.realType("{");

--- a/e2e/support/helpers/e2e-native-editor-helpers.ts
+++ b/e2e/support/helpers/e2e-native-editor-helpers.ts
@@ -98,6 +98,9 @@ function nativeEditorType(
       case "{backspace}":
         return cy.realPress(["Backspace"]);
 
+      case "{tab}":
+        return cy.realPress(["Tab"]);
+
       case "{nextcompletion}":
         cy.wait(50);
         return cy.realPress([metaKey, "j"]);

--- a/e2e/support/helpers/e2e-native-editor-helpers.ts
+++ b/e2e/support/helpers/e2e-native-editor-helpers.ts
@@ -89,6 +89,14 @@ function nativeEditorType(
       case "{backspace}":
         return cy.realPress(["Backspace"]);
 
+      case "{nextcompletion}":
+        cy.wait(50);
+        return cy.realPress(["Meta", "j"]);
+
+      case "{prevcompletion}":
+        cy.wait(50);
+        return cy.realPress(["Meta", "k"]);
+
       case "{{}":
         return cy.realType("{");
     }

--- a/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
@@ -381,6 +381,10 @@ describe("Dashboard > Dashboard Questions", () => {
 
     it("can save a native question to a dashboard", { tags: "@flaky" }, () => {
       H.startNewNativeQuestion({ query: "SELECT 123" });
+
+      // this reduces the flakiness
+      cy.wait(500);
+
       H.queryBuilderHeader().button("Save").click();
       H.modal().within(() => {
         cy.findByLabelText("Name").type("Half Orders");

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -179,3 +179,29 @@ describe("issue 49454", () => {
     });
   });
 });
+
+describe("issue 48712", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should not reset the suggesions when the query is edited (metabase#48712)", () => {
+    H.startNewNativeQuestion();
+
+    H.NativeEditor.type("pro");
+    H.NativeEditor.completion("PRODUCTS").should("be.visible");
+
+    H.NativeEditor.type("{backspace}{backspace}{backspace}");
+    H.NativeEditor.type("select * from pro");
+
+    H.NativeEditor.completion("PRODUCTS").should("be.visible");
+
+    H.NativeEditor.type("{nextcompletion}", { focus: false });
+    H.NativeEditor.completion("PROCEDURE").should("have.attr", "aria-selected");
+
+    // wait for all completions to finish
+    cy.wait(1000);
+    H.NativeEditor.completion("PROCEDURE").should("have.attr", "aria-selected");
+  });
+});

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -322,6 +322,21 @@ describe("scenarios > question > native", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/missing required parameters/).should("be.visible");
   });
+
+  it("should run the query when pressing meta+enter", () => {
+    H.startNewNativeQuestion({
+      query: "SELECT COUNT(*) FROM ORDERS",
+    });
+    H.NativeEditor.focus();
+    cy.realPress(["Meta", "Enter"]);
+
+    cy.wait("@dataset");
+
+    cy.findByTestId("query-visualization-root").should("contain", "18,760");
+
+    // make sure a new line was not inserted
+    cy.get(".cm-lineNumbers").should("contain", "1").should("not.contain", "2");
+  });
 });
 
 // causes error in cypress 13

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -328,7 +328,10 @@ describe("scenarios > question > native", () => {
       query: "SELECT COUNT(*) FROM ORDERS",
     });
     H.NativeEditor.focus();
-    cy.realPress(["Meta", "Enter"]);
+
+    const isMac = Cypress.platform === "darwin";
+    const metaKey = isMac ? "Meta" : "Control";
+    cy.realPress([metaKey, "Enter"]);
 
     cy.wait("@dataset");
 

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -362,6 +362,15 @@ describe("scenarios > question > native", () => {
 
     H.NativeEditor.get().should("have.text", "\tSELECT");
   });
+
+  it("should indent the next line to the same level when entering newline", () => {
+    H.startNewNativeQuestion();
+
+    H.NativeEditor.focus()
+      .type("{tab}SELECT{enter}FOO")
+      .get()
+      .should("have.text", "\tSELECT\tFOO");
+  });
 });
 
 // causes error in cypress 13

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -337,6 +337,28 @@ describe("scenarios > question > native", () => {
     // make sure a new line was not inserted
     cy.get(".cm-lineNumbers").should("contain", "1").should("not.contain", "2");
   });
+
+  it("should add tab at the end of the query", () => {
+    H.startNewNativeQuestion({
+      query: "SELECT",
+    });
+
+    H.NativeEditor.focus();
+    cy.realPress(["Tab"]);
+
+    H.NativeEditor.get().should("have.text", "SELECT\t");
+  });
+
+  it("should indent the line when pressing tab while selected", () => {
+    H.startNewNativeQuestion({
+      query: "SELECT",
+    });
+
+    H.NativeEditor.focus().type("{selectall}");
+    cy.realPress(["Tab"]);
+
+    H.NativeEditor.get().should("have.text", "\tSELECT");
+  });
 });
 
 // causes error in cypress 13

--- a/e2e/test/scenarios/native/native_subquery.cy.spec.js
+++ b/e2e/test/scenarios/native/native_subquery.cy.spec.js
@@ -80,6 +80,9 @@ describe("scenarios > question > native subquery", () => {
 
           H.openNativeEditor();
           cy.reload(); // Refresh the state, so previously created questions need to be loaded again.
+
+          cy.wait(200); // This reduces flakiness
+
           H.NativeEditor.focus().type(" {{#people");
 
           // Wait until another explicit autocomplete is triggered

--- a/e2e/test/scenarios/native/suggestions.cy.spec.ts
+++ b/e2e/test/scenarios/native/suggestions.cy.spec.ts
@@ -1,0 +1,41 @@
+import { H } from "e2e/support";
+
+describe("scenarios > question > native > suggestions", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should show suggestions for tables", () => {
+    H.startNewNativeQuestion();
+    H.NativeEditor.type("se");
+
+    H.NativeEditor.completions().within(() => {
+      H.NativeEditor.completion("SEATS")
+        .should("be.visible")
+        .should("contain.text", "ACCOUNTS :type/Integer");
+    });
+  });
+
+  it("should show suggestions for syntax keywords", () => {
+    H.startNewNativeQuestion();
+    H.NativeEditor.type("se");
+
+    H.NativeEditor.completions().within(() => {
+      H.NativeEditor.completion("SELECT")
+        .should("be.visible")
+        .should("contain.text", "keyword");
+    });
+  });
+
+  it("should not show duplicate suggestions", () => {
+    H.startNewNativeQuestion();
+    H.NativeEditor.type("acc");
+
+    H.NativeEditor.completions().within(() => {
+      H.NativeEditor.completion("ACCOUNT_ID")
+        .should("be.visible")
+        .should("have.length", 1);
+    });
+  });
+});

--- a/e2e/test/scenarios/native/suggestions.cy.spec.ts
+++ b/e2e/test/scenarios/native/suggestions.cy.spec.ts
@@ -28,6 +28,20 @@ describe("scenarios > question > native > suggestions", () => {
     });
   });
 
+  it("should suggest locals", () => {
+    H.startNewNativeQuestion({
+      query:
+        "SELECT date_trunc('month', CREATED_AT) as order_month FROM ORDERS GROUP BY ",
+    });
+    H.NativeEditor.type("order_mo");
+
+    H.NativeEditor.completions().within(() => {
+      H.NativeEditor.completion("order_month")
+        .should("be.visible")
+        .should("contain.text", "local");
+    });
+  });
+
   it("should not show duplicate suggestions", () => {
     H.startNewNativeQuestion();
     H.NativeEditor.type("acc");

--- a/e2e/test/scenarios/native/suggestions.cy.spec.ts
+++ b/e2e/test/scenarios/native/suggestions.cy.spec.ts
@@ -42,6 +42,19 @@ describe("scenarios > question > native > suggestions", () => {
     });
   });
 
+  it("should suggest quoted locals", () => {
+    H.startNewNativeQuestion({
+      query: "SELECT foo as 'QUOTED_local' FROM ORDERS GROUP BY ",
+    });
+    H.NativeEditor.type("QU");
+
+    H.NativeEditor.completions().within(() => {
+      H.NativeEditor.completion("QUOTED_local")
+        .should("be.visible")
+        .should("contain.text", "local");
+    });
+  });
+
   it("should not show duplicate suggestions", () => {
     H.startNewNativeQuestion();
     H.NativeEditor.type("acc");

--- a/frontend/src/metabase-lib/native.ts
+++ b/frontend/src/metabase-lib/native.ts
@@ -46,7 +46,7 @@ export function withDifferentDatabase(
   return ML.with_different_database(query, databaseId, metadata);
 }
 
-export function engine(query: Query): string {
+export function engine(query: Query): string | null {
   return ML.engine(query);
 }
 

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.module.css
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.module.css
@@ -135,6 +135,7 @@
 
       .cm-completionDetail {
         color: var(--mb-color-text-light);
+        font-style: normal;
         text-align: right;
         overflow: hidden;
         text-overflow: ellipsis;

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.module.css
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.module.css
@@ -135,7 +135,7 @@
 
       .cm-completionDetail {
         color: var(--mb-color-text-light);
-        text-align: end;
+        text-align: right;
         overflow: hidden;
         text-overflow: ellipsis;
       }

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.tsx
@@ -27,7 +27,6 @@ export type EditorProps = {
 
 export interface EditorRef {
   focus: () => void;
-  resize: () => void;
   getSelectionTarget: () => Element | null;
 }
 
@@ -64,9 +63,6 @@ export const CodeMirrorEditor = forwardRef<EditorRef, CodeMirrorEditorProps>(
       return {
         focus() {
           editor.current?.editor?.focus();
-        },
-        resize() {
-          // noop
         },
         getSelectionTarget() {
           return document.querySelector(".cm-selectionBackground");

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.tsx
@@ -16,7 +16,7 @@ import type { CardId } from "metabase-types/api";
 
 import type { SelectionRange } from "../types";
 
-export type EditorProps = {
+export type CodeMirrorEditorProps = {
   query: Lib.Query;
   onChange?: (queryText: string) => void;
   readOnly?: boolean;
@@ -25,7 +25,7 @@ export type EditorProps = {
   onSelectionChange?: (range: SelectionRange) => void;
 };
 
-export interface EditorRef {
+export interface CodeMirrorEditorRef {
   focus: () => void;
   getSelectionTarget: () => Element | null;
 }
@@ -34,88 +34,87 @@ import S from "./CodeMirrorEditor.module.css";
 import { useExtensions } from "./extensions";
 import { convertIndexToPosition, matchCardIdAtCursor } from "./util";
 
-type CodeMirrorEditorProps = EditorProps;
+export const CodeMirrorEditor = forwardRef<
+  CodeMirrorEditorRef,
+  CodeMirrorEditorProps
+>(function CodeMirrorEditor(props, ref) {
+  const editor = useRef<ReactCodeMirrorRef>(null);
+  const {
+    query,
+    onChange,
+    readOnly,
+    onSelectionChange,
+    onRightClickSelection,
+    onCursorMoveOverCardTag,
+  } = props;
 
-export const CodeMirrorEditor = forwardRef<EditorRef, CodeMirrorEditorProps>(
-  function CodeMirrorEditor(props, ref) {
-    const editor = useRef<ReactCodeMirrorRef>(null);
-    const {
-      query,
-      onChange,
-      readOnly,
-      onSelectionChange,
-      onRightClickSelection,
-      onCursorMoveOverCardTag,
-    } = props;
+  const extensions = useExtensions(query);
 
-    const extensions = useExtensions(query);
-
-    useImperativeHandle(ref, () => {
-      return {
-        focus() {
-          editor.current?.editor?.focus();
-        },
-        getSelectionTarget() {
-          return document.querySelector(".cm-selectionBackground");
-        },
-      };
-    }, []);
-
-    const handleUpdate = useCallback(
-      (update: ViewUpdate) => {
-        // handle selection changes
-        const value = update.state.doc.toString();
-        if (onSelectionChange) {
-          onSelectionChange({
-            start: convertIndexToPosition(
-              value,
-              update.state.selection.main.from,
-            ),
-            end: convertIndexToPosition(value, update.state.selection.main.to),
-          });
-        }
-        if (onCursorMoveOverCardTag) {
-          const cardId = matchCardIdAtCursor(update.state);
-          if (cardId !== null) {
-            onCursorMoveOverCardTag(cardId);
-          }
-        }
+  useImperativeHandle(ref, () => {
+    return {
+      focus() {
+        editor.current?.editor?.focus();
       },
-      [onSelectionChange, onCursorMoveOverCardTag],
-    );
+      getSelectionTarget() {
+        return document.querySelector(".cm-selectionBackground");
+      },
+    };
+  }, []);
 
-    useEffect(() => {
-      function handler(evt: MouseEvent) {
-        const selection = editor.current?.state?.selection.main;
-        if (!selection) {
-          return;
-        }
-
-        const selections = Array.from(
-          document.querySelectorAll(".cm-selectionBackground"),
-        );
-
-        if (selections.some(selection => isEventOverElement(evt, selection))) {
-          evt.preventDefault();
-          onRightClickSelection?.();
+  const handleUpdate = useCallback(
+    (update: ViewUpdate) => {
+      // handle selection changes
+      const value = update.state.doc.toString();
+      if (onSelectionChange) {
+        onSelectionChange({
+          start: convertIndexToPosition(
+            value,
+            update.state.selection.main.from,
+          ),
+          end: convertIndexToPosition(value, update.state.selection.main.to),
+        });
+      }
+      if (onCursorMoveOverCardTag) {
+        const cardId = matchCardIdAtCursor(update.state);
+        if (cardId !== null) {
+          onCursorMoveOverCardTag(cardId);
         }
       }
-      document.addEventListener("contextmenu", handler);
-      return () => document.removeEventListener("contextmenu", handler);
-    }, [onRightClickSelection]);
+    },
+    [onSelectionChange, onCursorMoveOverCardTag],
+  );
 
-    return (
-      <CodeMirror
-        ref={editor}
-        data-testid="native-query-editor"
-        className={S.editor}
-        extensions={extensions}
-        value={Lib.rawNativeQuery(query)}
-        readOnly={readOnly}
-        onChange={onChange}
-        height="100%"
-        onUpdate={handleUpdate}
-      />
-    );
-  },
-);
+  useEffect(() => {
+    function handler(evt: MouseEvent) {
+      const selection = editor.current?.state?.selection.main;
+      if (!selection) {
+        return;
+      }
+
+      const selections = Array.from(
+        document.querySelectorAll(".cm-selectionBackground"),
+      );
+
+      if (selections.some(selection => isEventOverElement(evt, selection))) {
+        evt.preventDefault();
+        onRightClickSelection?.();
+      }
+    }
+    document.addEventListener("contextmenu", handler);
+    return () => document.removeEventListener("contextmenu", handler);
+  }, [onRightClickSelection]);
+
+  return (
+    <CodeMirror
+      ref={editor}
+      data-testid="native-query-editor"
+      className={S.editor}
+      extensions={extensions}
+      value={Lib.rawNativeQuery(query)}
+      readOnly={readOnly}
+      onChange={onChange}
+      height="100%"
+      onUpdate={handleUpdate}
+    />
+  );
+});

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.tsx
@@ -11,13 +11,13 @@ import {
 } from "react";
 
 import { isEventOverElement } from "metabase/lib/dom";
-import type NativeQuery from "metabase-lib/v1/queries/NativeQuery";
+import * as Lib from "metabase-lib";
 import type { CardId } from "metabase-types/api";
 
 import type { SelectionRange } from "../types";
 
 export type EditorProps = {
-  query: NativeQuery;
+  query: Lib.Query;
   onChange?: (queryText: string) => void;
   readOnly?: boolean;
   onCursorMoveOverCardTag?: (id: CardId) => void;
@@ -32,11 +32,7 @@ export interface EditorRef {
 
 import S from "./CodeMirrorEditor.module.css";
 import { useExtensions } from "./extensions";
-import {
-  convertIndexToPosition,
-  matchCardIdAtCursor,
-  useMemoized,
-} from "./util";
+import { convertIndexToPosition, matchCardIdAtCursor } from "./util";
 
 type CodeMirrorEditorProps = EditorProps;
 
@@ -51,13 +47,8 @@ export const CodeMirrorEditor = forwardRef<EditorRef, CodeMirrorEditorProps>(
       onRightClickSelection,
       onCursorMoveOverCardTag,
     } = props;
-    const referencedQuestionIds = useMemoized(query.referencedQuestionIds());
 
-    const extensions = useExtensions({
-      engine: query.engine() ?? undefined,
-      databaseId: query.datasetQuery()?.database ?? undefined,
-      referencedQuestionIds,
-    });
+    const extensions = useExtensions(query);
 
     useImperativeHandle(ref, () => {
       return {
@@ -119,7 +110,7 @@ export const CodeMirrorEditor = forwardRef<EditorRef, CodeMirrorEditorProps>(
         data-testid="native-query-editor"
         className={S.editor}
         extensions={extensions}
-        value={query.queryText()}
+        value={Lib.rawNativeQuery(query)}
         readOnly={readOnly}
         onChange={onChange}
         height="100%"

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.unit.spec.tsx
@@ -1,0 +1,70 @@
+import fetchMock from "fetch-mock";
+
+import { createMockMetadata } from "__support__/metadata";
+import { renderWithProviders, screen } from "__support__/ui";
+import { createQuery } from "metabase-lib/test-helpers";
+import type { NativeQuerySnippet } from "metabase-types/api";
+import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+
+import { CodeMirrorEditor } from "./CodeMirrorEditor";
+
+function setup({
+  text = "",
+  readOnly = false,
+  snippets = [],
+}: {
+  text?: string;
+  readOnly?: boolean;
+  snippets?: NativeQuerySnippet[];
+} = {}) {
+  const onChange = jest.fn();
+  const onCursorMoveOverCardTag = jest.fn();
+  const onRightClickSelection = jest.fn();
+  const onSelectionChange = jest.fn();
+
+  fetchMock.get("path:/api/native-query-snippet", {
+    body: snippets,
+  });
+
+  const database = createSampleDatabase();
+  const metadata = createMockMetadata({
+    databases: [database],
+  });
+  const query = createQuery({
+    metadata,
+    query: {
+      database: database.id,
+      type: "native",
+      native: {
+        query: text,
+      },
+    },
+  });
+
+  renderWithProviders(
+    <CodeMirrorEditor
+      query={query}
+      onChange={onChange}
+      readOnly={readOnly}
+      onCursorMoveOverCardTag={onCursorMoveOverCardTag}
+      onRightClickSelection={onRightClickSelection}
+      onSelectionChange={onSelectionChange}
+    />,
+  );
+
+  return {
+    onChange,
+    onCursorMoveOverCardTag,
+    onRightClickSelection,
+    onSelectionChange,
+  };
+}
+
+describe("CodemirrorEditor", () => {
+  it("Should render the natie query's text", () => {
+    const text = "SELECT 1;";
+
+    setup({ text });
+    expect(screen.getByRole("textbox")).toHaveTextContent(text);
+  });
+});

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.tsx
@@ -64,9 +64,19 @@ export function useSchemaCompletion({ databaseId }: SchemaCompletionOptions) {
         return null;
       }
 
+      const seen = new Set();
+
+      const deduped = data.filter(([value]) => {
+        if (seen.has(value)) {
+          return false;
+        }
+        seen.add(value);
+        return true;
+      });
+
       return {
         from: word.from,
-        options: data.map(([value, meta]) => ({
+        options: deduped.map(([value, meta]) => ({
           label: value,
           detail: meta,
           boost: 50,

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.tsx
@@ -138,9 +138,7 @@ export function useSnippetCompletion() {
 
       return {
         from: tag.content.from,
-        validFor(text: string) {
-          return text.startsWith(query);
-        },
+        to: tag.content.to,
         options: results.map(snippet => ({
           label: snippet.name,
           apply: tag.hasClosingTag ? snippet.name : `${snippet.name} }}`,

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.tsx
@@ -200,6 +200,7 @@ export function useCardTagCompletion({ databaseId }: CardTagCompletionOptions) {
       return {
         // -1 because we want to include the # in the autocomplete
         from: tag.content.from - 1,
+        to: tag.content.to,
         options: data.map(({ id, name, type, collection_name }) => ({
           label: `#${id}-${slugg(name)}`,
           detail: getCardAutocompleteResultMeta(type, collection_name),

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.tsx
@@ -304,6 +304,17 @@ type LocalsCompletionOptions = {
   engine?: string | null;
 };
 
+function unquote(str: string) {
+  let res = str;
+  if (res[0] === '"' || res[0] === "'") {
+    res = res.slice(1);
+  }
+  if (res[res.length - 1] === '"' || res[res.length - 1] === "'") {
+    res = res.slice(0, -1);
+  }
+  return res;
+}
+
 export function useLocalsCompletion({ engine }: LocalsCompletionOptions) {
   const { language, keywords } = useMemo(() => {
     const { dialect, language } = source(engine);
@@ -330,6 +341,12 @@ export function useLocalsCompletion({ engine }: LocalsCompletionOptions) {
             const value = context.state.doc.sliceString(node.from, node.to);
             if (!keywords.has(value)) {
               set.add(value);
+            }
+          }
+          if (node.type.name === "QuotedIdentifier") {
+            const value = context.state.doc.sliceString(node.from, node.to);
+            if (!keywords.has(value)) {
+              set.add(unquote(value));
             }
           }
         },

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.tsx
@@ -79,7 +79,6 @@ export function useSchemaCompletion({ databaseId }: SchemaCompletionOptions) {
         options: deduped.map(([value, meta]) => ({
           label: value,
           detail: meta,
-          boost: 50,
         })),
         validFor(text: string) {
           if (data.length >= AUTOCOMPLETE_SUGGESTIONS_LIMIT) {
@@ -127,7 +126,6 @@ export function useSnippetCompletion() {
           label: snippet.name,
           apply: tag.hasClosingTag ? snippet.name : `${snippet.name} }}`,
           detail: t`Snippet`,
-          boost: 50,
         })),
       };
     },
@@ -191,7 +189,6 @@ export function useCardTagCompletion({ databaseId }: CardTagCompletionOptions) {
           apply: tag.hasClosingTag
             ? `#${id}-${slugg(name)}`
             : `#${id}-${slugg(name)} }}`,
-          boost: 50,
         })),
         validFor(text: string) {
           if (data.length >= AUTOCOMPLETE_CARD_SUGGESTIONS_LIMIT) {
@@ -267,7 +264,6 @@ export function useReferencedCardCompletion({
         options: results.map(column => ({
           label: column.field.name,
           detail: `${column.card.name} :${column.field.base_type}`,
-          boost: 50,
         })),
       };
     },

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.tsx
@@ -241,6 +241,7 @@ export function useReferencedCardCompletion({
     const data = await Promise.all(
       referencedQuestionIds.map(id => getCard({ id }, shouldCache)),
     );
+
     return data
       .map(item => item.data)
       .filter(isNotNull)
@@ -272,10 +273,16 @@ export function useReferencedCardCompletion({
         return null;
       }
 
+      const suffix = matchAfter(context, /\w+/);
+
       const results = await getCardColumns();
+      if (results.length === 0) {
+        return null;
+      }
 
       return {
         from: word.from,
+        to: suffix?.to,
         validFor(text: string) {
           return text.startsWith(word.text);
         },

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.unit.spec.tsx
@@ -1,0 +1,250 @@
+import {
+  CompletionContext,
+  type CompletionSource,
+} from "@codemirror/autocomplete";
+import { EditorState } from "@codemirror/state";
+import fetchMock from "fetch-mock";
+
+import { mockSettings } from "__support__/settings";
+import { act, renderWithProviders } from "__support__/ui";
+import type {
+  AutocompleteMatchStyle,
+  AutocompleteSuggestion,
+} from "metabase-types/api";
+import type { State } from "metabase-types/store";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { useSchemaCompletion } from "./completers";
+
+function completer(
+  useCompletion: () => CompletionSource,
+  state: Partial<State>,
+) {
+  let completer: CompletionSource | null = null;
+
+  function Wrapper() {
+    completer = useCompletion();
+    return null;
+  }
+
+  renderWithProviders(<Wrapper />, {
+    storeInitialState: state,
+  });
+
+  return (doc: string) =>
+    act(function () {
+      if (!completer) {
+        return null;
+      }
+
+      const cur = doc.indexOf("|");
+      if (cur === -1) {
+        throw new Error("Please use | to indicate the position of the cursor");
+      }
+
+      doc = doc.slice(0, cur) + doc.slice(cur + 1);
+
+      const state = EditorState.create({
+        doc,
+        selection: { anchor: cur },
+      });
+
+      const ctx = new CompletionContext(state, cur, false);
+      return completer(ctx);
+    });
+}
+
+describe("useSchemaCompletion", () => {
+  const DATABASE_ID = 1;
+  const MOCK_RESULTS: AutocompleteSuggestion[] = [
+    ["SEATS", "ACCOUNTS :type/Integer"],
+    ["SOURCE", "PEOPLE :type/Text :type/State"],
+  ];
+
+  function setup({
+    databaseId = DATABASE_ID,
+    matchStyle = "prefix",
+    results = MOCK_RESULTS,
+  }: {
+    databaseId?: number;
+    matchStyle?: AutocompleteMatchStyle;
+    results?: AutocompleteSuggestion[];
+  }) {
+    const state = createMockState({
+      settings: mockSettings({
+        "native-query-autocomplete-match-style": matchStyle,
+      }),
+    });
+
+    const url = `path:/api/database/${databaseId}/autocomplete_suggestions`;
+    fetchMock.get(url, results);
+
+    const complete = completer(
+      () => useSchemaCompletion({ databaseId: DATABASE_ID }),
+      state,
+    );
+
+    return { complete, url };
+  }
+
+  it("should not call the endpoint if the cursor is inside an open tag", async () => {
+    const { complete, url } = setup({ matchStyle: "prefix" });
+
+    const results = await complete("SELECT {{ foo|");
+    expect(results).toBe(null);
+    expect(fetchMock.calls(url)).toHaveLength(0);
+  });
+
+  it("should not call the endpoint if the cursor is inside a closed tag", async () => {
+    const { complete, url } = setup({ matchStyle: "prefix" });
+    const results = await complete("SELECT {{ foo| }}");
+    expect(results).toBe(null);
+    expect(fetchMock.calls(url)).toHaveLength(0);
+  });
+
+  it("should not call the endpoint if the cursor is inside an open snippet tag", async () => {
+    const { complete, url } = setup({ matchStyle: "prefix" });
+    const results = await complete("SELECT {{ snippet: foo|");
+
+    expect(results).toBe(null);
+    expect(fetchMock.calls(url)).toHaveLength(0);
+  });
+
+  it("should not call the endpoint if the cursor is inside a closed snippet tag", async () => {
+    const { complete, url } = setup({ matchStyle: "prefix" });
+    const results = await complete("SELECT {{ snippet: foo| }}");
+
+    expect(results).toBe(null);
+    expect(fetchMock.calls(url)).toHaveLength(0);
+  });
+
+  it("should not call the endpoint if the cursor is inside an open card tag", async () => {
+    const { complete, url } = setup({ matchStyle: "prefix" });
+    const results = await complete("SELECT {{ #foo|");
+
+    expect(results).toBe(null);
+    expect(fetchMock.calls(url)).toHaveLength(0);
+  });
+
+  it("should not call the endpoint if the cursor is inside a closed card tag", async () => {
+    const { complete, url } = setup({ matchStyle: "prefix" });
+    const results = await complete("SELECT {{ #foo| }}");
+
+    expect(results).toBe(null);
+    expect(fetchMock.calls(url)).toHaveLength(0);
+  });
+
+  it("should complete even when inside a word", async () => {
+    const { complete, url } = setup({ matchStyle: "prefix" });
+    const results = await complete("AAA\nSELECT S|EA");
+
+    expect(results).toEqual({
+      from: 11,
+      to: 14,
+      validFor: expect.any(Function),
+      options: [
+        {
+          label: "SEATS",
+          detail: "ACCOUNTS :type/Integer",
+        },
+        {
+          label: "SOURCE",
+          detail: "PEOPLE :type/Text :type/State",
+        },
+      ],
+    });
+    expect(fetchMock.calls(url)).toHaveLength(1);
+  });
+
+  it("should deduplicate results", async () => {
+    const { complete, url } = setup({
+      matchStyle: "prefix",
+      results: [
+        ["SOURCE", "ACCOUNTS :type/String"],
+        ["SOURCE", "ANALYTICS :type/Integer"],
+      ],
+    });
+    const results = await complete("SELECT S|");
+
+    expect(results).toEqual({
+      from: 7,
+      validFor: expect.any(Function),
+      options: [
+        {
+          detail: "ACCOUNTS :type/String",
+          label: "SOURCE",
+        },
+      ],
+    });
+    expect(fetchMock.calls(url)).toHaveLength(1);
+  });
+
+  describe("native-query-autocomplete-match-style = off", () => {
+    const matchStyle = "off";
+
+    it("should not call the endpoint", async () => {
+      const { complete, url } = setup({ matchStyle });
+      const result = await complete("SELECT S|");
+
+      expect(result).toEqual(null);
+      expect(fetchMock.calls(url)).toHaveLength(0);
+    });
+  });
+
+  describe("native-query-autocomplete-match-style = prefix", () => {
+    const matchStyle = "prefix";
+
+    it("should call the endpoint with the current word", async () => {
+      const { complete, url } = setup({ matchStyle });
+      const result = await complete("SELECT S|");
+
+      const calls = fetchMock.calls(url);
+      expect(calls).toHaveLength(1);
+      expect(new URL(calls[0][0]).searchParams.get("prefix")).toBe("S");
+
+      expect(result).toEqual({
+        from: 7,
+        validFor: expect.any(Function),
+        options: [
+          {
+            label: "SEATS",
+            detail: "ACCOUNTS :type/Integer",
+          },
+          {
+            label: "SOURCE",
+            detail: "PEOPLE :type/Text :type/State",
+          },
+        ],
+      });
+    });
+  });
+
+  describe("native-query-autocomplete-match-style = substring", () => {
+    const matchStyle = "substring";
+
+    it("should call the endpoint with the current word", async () => {
+      const { complete, url } = setup({ matchStyle });
+      const result = await complete("SELECT S|");
+
+      const calls = fetchMock.calls(url);
+
+      expect(calls).toHaveLength(1);
+      expect(new URL(calls[0][0]).searchParams.get("substring")).toBe("S");
+
+      expect(result).toEqual({
+        from: 7,
+        validFor: expect.any(Function),
+        options: [
+          {
+            label: "SEATS",
+            detail: "ACCOUNTS :type/Integer",
+          },
+          {
+            label: "SOURCE",
+            detail: "PEOPLE :type/Text :type/State",
+          },
+        ],
+      });
+    });
+  });
+});

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.unit.spec.tsx
@@ -673,6 +673,22 @@ describe("useLocalsCompletion", () => {
     expect(results).toBe(null);
   });
 
+  it("should not complete quoted locals that come from the dialect", async () => {
+    const { complete } = setup({ engine: "postgres" });
+    const results = await complete(
+      `SELECT foo as "QUOTED_local" FROM bar WHERE QUO|`,
+    );
+    expect(results).toEqual({
+      from: 44,
+      options: [
+        {
+          label: "QUOTED_local",
+          detail: "local",
+        },
+      ],
+    });
+  });
+
   it("should not complete locals in a non-sql query", async () => {
     const { complete } = setup({ engine: "mongo" });
     const results = await complete("{|}");

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
@@ -18,12 +18,14 @@ import {
   indentUnit,
   syntaxHighlighting,
 } from "@codemirror/language";
+import { Prec } from "@codemirror/state";
 import {
   Decoration,
   EditorView,
   MatchDecorator,
   ViewPlugin,
   drawSelection,
+  keymap,
 } from "@codemirror/view";
 import { type Tag, tags } from "@lezer/highlight";
 import type { EditorState, Extension } from "@uiw/react-codemirror";
@@ -82,6 +84,7 @@ export function useExtensions({
       tagDecorator(),
       folds(),
       indentUnit.of("\t"),
+      disableCmdEnter(),
     ]
       .flat()
       .filter(isNotNull);
@@ -92,6 +95,19 @@ export function useExtensions({
     cardTagCompletion,
     referencedCardCompletion,
   ]);
+}
+
+function disableCmdEnter() {
+  // Stop Cmd+Enter in CodeMirror from inserting a newline
+  // Has to be Prec.highest so that it overwrites after the default Cmd+Enter handler
+  return Prec.highest(
+    keymap.of([
+      {
+        key: "Mod-Enter",
+        run: () => true,
+      },
+    ]),
+  );
 }
 
 function nonce() {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
@@ -15,6 +15,7 @@ import {
 import {
   HighlightStyle,
   foldService,
+  indentUnit,
   syntaxHighlighting,
 } from "@codemirror/language";
 import {
@@ -80,6 +81,7 @@ export function useExtensions({
       highlighting(),
       tagDecorator(),
       folds(),
+      indentUnit.of("\t"),
     ]
       .flat()
       .filter(isNotNull);

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
@@ -15,6 +15,7 @@ import {
 import {
   HighlightStyle,
   foldService,
+  indentService,
   indentUnit,
   syntaxHighlighting,
 } from "@codemirror/language";
@@ -83,7 +84,7 @@ export function useExtensions({
       highlighting(),
       tagDecorator(),
       folds(),
-      indentUnit.of("\t"),
+      indentation(),
       disableCmdEnter(),
     ]
       .flat()
@@ -108,6 +109,23 @@ function disableCmdEnter() {
       },
     ]),
   );
+}
+
+function indentation() {
+  return [
+    // set indentation to tab
+    indentUnit.of("\t"),
+
+    // persist the indentation from the previous line
+    indentService.of((context, pos) => {
+      const previousLine = context.lineAt(pos, -1);
+      const previousLineText = previousLine.text.replaceAll(
+        "\t",
+        " ".repeat(context.state.tabSize),
+      );
+      return previousLineText.match(/^(\s)*/)?.[0].length ?? 0;
+    }),
+  ];
 }
 
 function nonce() {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
@@ -2,6 +2,7 @@ import {
   type CompletionContext,
   type CompletionResult,
   type CompletionSource,
+  acceptCompletion,
   autocompletion,
   moveCompletionSelection,
 } from "@codemirror/autocomplete";
@@ -107,6 +108,10 @@ function disableCmdEnter() {
       {
         key: "Mod-Enter",
         run: () => true,
+      },
+      {
+        key: "Tab",
+        run: acceptCompletion,
       },
       {
         key: "Mod-j",

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
@@ -39,7 +39,7 @@ import { useMemo } from "react";
 
 import { isNotNull } from "metabase/lib/types";
 import { monospaceFontFamily } from "metabase/styled-components/theme";
-import type { CardId, DatabaseId } from "metabase-types/api";
+import * as Lib from "metabase-lib";
 
 import {
   useCardTagCompletion,
@@ -47,19 +47,21 @@ import {
   useSchemaCompletion,
   useSnippetCompletion,
 } from "./completers";
-import { matchTagAtCursor } from "./util";
+import {
+  referencedQuestionIds as getReferencedQuestionIds,
+  matchTagAtCursor,
+} from "./util";
 
-type ExtensionOptions = {
-  engine?: string;
-  databaseId?: DatabaseId;
-  referencedQuestionIds?: CardId[];
-};
+export function useExtensions(query: Lib.Query): Extension[] {
+  const { databaseId, engine, referencedQuestionIds } = useMemo(
+    () => ({
+      databaseId: Lib.databaseID(query),
+      engine: Lib.engine(query),
+      referencedQuestionIds: getReferencedQuestionIds(query),
+    }),
+    [query],
+  );
 
-export function useExtensions({
-  engine,
-  databaseId,
-  referencedQuestionIds = [],
-}: ExtensionOptions): Extension[] {
   const schemaCompletion = useSchemaCompletion({ databaseId });
   const snippetCompletion = useSnippetCompletion();
   const cardTagCompletion = useCardTagCompletion({ databaseId });

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
@@ -250,11 +250,11 @@ const engineToDialect = {
 };
 
 type LanguageOptions = {
-  engine?: string;
+  engine?: string | null;
   completers?: CompletionSource[];
 };
 
-function source(engine?: string) {
+function source(engine?: string | null) {
   // TODO: this should be provided by the engine driver through the API
   switch (engine) {
     case "mongo":
@@ -287,7 +287,6 @@ function source(engine?: string) {
 
 function language({ engine, completers = [] }: LanguageOptions) {
   const { language } = source(engine);
-
   if (!language) {
     return [];
   }

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
@@ -6,6 +6,7 @@ import {
   autocompletion,
   moveCompletionSelection,
 } from "@codemirror/autocomplete";
+import { insertTab } from "@codemirror/commands";
 import { json } from "@codemirror/lang-json";
 import {
   MySQL,
@@ -112,6 +113,10 @@ function disableCmdEnter() {
       {
         key: "Tab",
         run: acceptCompletion,
+      },
+      {
+        key: "Tab",
+        run: insertTab,
       },
       {
         key: "Mod-j",

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
@@ -3,6 +3,7 @@ import {
   type CompletionResult,
   type CompletionSource,
   autocompletion,
+  moveCompletionSelection,
 } from "@codemirror/autocomplete";
 import { json } from "@codemirror/lang-json";
 import {
@@ -106,6 +107,14 @@ function disableCmdEnter() {
       {
         key: "Mod-Enter",
         run: () => true,
+      },
+      {
+        key: "Mod-j",
+        run: moveCompletionSelection(true),
+      },
+      {
+        key: "Mod-k",
+        run: moveCompletionSelection(false),
       },
     ]),
   );

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/index.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/index.tsx
@@ -1,5 +1,5 @@
 export {
   CodeMirrorEditor,
-  type EditorProps,
-  type EditorRef,
+  type CodeMirrorEditorProps,
+  type CodeMirrorEditorRef,
 } from "./CodeMirrorEditor";

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/util.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/util.tsx
@@ -1,8 +1,7 @@
 import type { EditorState } from "@codemirror/state";
-import { useState } from "react";
-import { useDeepCompareEffect } from "react-use";
 import { t } from "ttag";
 
+import * as Lib from "metabase-lib";
 import type { CardId, CardType } from "metabase-types/api";
 
 import type { Location } from "../types";
@@ -225,10 +224,9 @@ export function matchCardIdAtCursor(
   return parsedId;
 }
 
-export function useMemoized<T>(value: T): T {
-  const [memoized, setMemoized] = useState(value);
-  useDeepCompareEffect(() => {
-    setMemoized(value);
-  }, [value]);
-  return memoized;
+export function referencedQuestionIds(query: Lib.Query): CardId[] {
+  return Object.values(Lib.templateTags(query))
+    .filter(tag => tag.type === "card")
+    .map(tag => tag["card-id"])
+    .filter(cardId => cardId != null);
 }

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/util.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/util.tsx
@@ -1,6 +1,7 @@
 import type { EditorState } from "@codemirror/state";
 import { t } from "ttag";
 
+import { isNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
 import type { CardId, CardType } from "metabase-types/api";
 
@@ -228,5 +229,5 @@ export function referencedQuestionIds(query: Lib.Query): CardId[] {
   return Object.values(Lib.templateTags(query) ?? {})
     .filter(tag => tag.type === "card")
     .map(tag => tag["card-id"])
-    .filter(cardId => cardId != null);
+    .filter(isNotNull);
 }

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/util.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/util.tsx
@@ -225,7 +225,7 @@ export function matchCardIdAtCursor(
 }
 
 export function referencedQuestionIds(query: Lib.Query): CardId[] {
-  return Object.values(Lib.templateTags(query))
+  return Object.values(Lib.templateTags(query) ?? {})
     .filter(tag => tag.type === "card")
     .map(tag => tag["card-id"])
     .filter(cardId => cardId != null);

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/util.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/util.tsx
@@ -1,3 +1,11 @@
+import { json } from "@codemirror/lang-json";
+import {
+  MySQL,
+  PLSQL,
+  PostgreSQL,
+  StandardSQL,
+  sql,
+} from "@codemirror/lang-sql";
 import type { EditorState } from "@codemirror/state";
 import { t } from "ttag";
 
@@ -230,4 +238,49 @@ export function referencedQuestionIds(query: Lib.Query): CardId[] {
     .filter(tag => tag.type === "card")
     .map(tag => tag["card-id"])
     .filter(isNotNull);
+}
+
+const engineToDialect = {
+  "bigquery-cloud-sdk": StandardSQL,
+  mysql: MySQL,
+  oracle: PLSQL,
+  postgres: PostgreSQL,
+  // TODO:
+  // "presto-jdbc": "trino",
+  // redshift: "redshift",
+  // snowflake: "snowflake",
+  // sparksql: "spark",
+  // h2: "h2",
+};
+
+export function source(engine?: string | null) {
+  // TODO: this should be provided by the engine driver through the API
+  switch (engine) {
+    case "mongo":
+    case "druid":
+      return {
+        language: json(),
+      };
+
+    case "bigquery-cloud-sdk":
+    case "mysql":
+    case "oracle":
+    case "postgres":
+    case "presto-jdbc":
+    case "redshift":
+    case "snowflake":
+    case "sparksql":
+    case "h2":
+    default: {
+      const dialect =
+        engineToDialect[engine as keyof typeof engineToDialect] ?? StandardSQL;
+      return {
+        dialect,
+        language: sql({
+          dialect,
+          upperCaseKeywords: true,
+        }),
+      };
+    }
+  }
 }

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -310,6 +310,11 @@ export class NativeQueryEditor extends Component<
     const engine = Lib.engine(query);
     const queryText = Lib.rawNativeQuery(query);
 
+    if (!engine) {
+      // no engine found, do nothing
+      return;
+    }
+
     const formattedQuery = await formatQuery(queryText, engine);
     this.onChange(formattedQuery);
     this.focus();

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -405,7 +405,7 @@ export class NativeQueryEditor extends Component<
           <>
             <Editor
               ref={this.editor}
-              query={query}
+              query={question.query()}
               readOnly={readOnly}
               onChange={this.onChange}
               onSelectionChange={setNativeEditorSelectedRange}

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -293,7 +293,6 @@ export class NativeQueryEditor extends Component<
 
     if (newHeight > element.offsetHeight) {
       element.style.height = `${newHeight}px`;
-      this.editor.current?.resize();
     }
   }
 
@@ -401,7 +400,6 @@ export class NativeQueryEditor extends Component<
             if (typeof resizableBoxProps?.onResizeStop === "function") {
               resizableBoxProps.onResizeStop(e, data);
             }
-            this.editor.current?.resize();
           }}
         >
           <>

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -26,9 +26,9 @@ import type {
 import { ResponsiveParametersList } from "../ResponsiveParametersList";
 
 import {
-  CodeMirrorEditor as Editor,
-  type EditorProps,
-  type EditorRef,
+  CodeMirrorEditor,
+  type CodeMirrorEditorProps,
+  type CodeMirrorEditorRef,
 } from "./CodeMirrorEditor";
 import DataSourceSelectors from "./DataSourceSelectors";
 import S from "./NativeQueryEditor.module.css";
@@ -108,7 +108,10 @@ interface EntityLoaderProps {
   snippetCollections?: Collection[];
 }
 
-type Props = OwnProps & ExplicitSizeProps & EntityLoaderProps & EditorProps;
+type Props = OwnProps &
+  ExplicitSizeProps &
+  EntityLoaderProps &
+  Omit<CodeMirrorEditorProps, "query">;
 
 interface NativeQueryEditorState {
   initialHeight: number;
@@ -122,7 +125,7 @@ export class NativeQueryEditor extends Component<
   NativeQueryEditorState
 > {
   resizeBox = createRef<HTMLDivElement & ResizableBox>();
-  editor = createRef<EditorRef>();
+  editor = createRef<CodeMirrorEditorRef>();
 
   constructor(props: Props) {
     super(props);
@@ -403,7 +406,7 @@ export class NativeQueryEditor extends Component<
           }}
         >
           <>
-            <Editor
+            <CodeMirrorEditor
               ref={this.editor}
               query={question.query()}
               readOnly={readOnly}

--- a/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/NotebookNativePreview.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/NotebookNativePreview.tsx
@@ -101,7 +101,7 @@ export const NotebookNativePreview = (): JSX.Element => {
             <Box mt="sm">{getErrorMessage(error)}</Box>
           </Flex>
         )}
-        {showQuery && <Editor query={query} readOnly />}
+        {showQuery && query && <Editor query={query} readOnly />}
       </Flex>
       <Box ta="end" p="1.5rem">
         <Button

--- a/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/utils.ts
+++ b/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/utils.ts
@@ -1,6 +1,5 @@
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
-import NativeQuery from "metabase-lib/v1/queries/NativeQuery";
 import type { DatasetQuery } from "metabase-types/api";
 
 export function createDatasetQuery(
@@ -22,11 +21,12 @@ export function createDatasetQuery(
 }
 
 export function createNativeQuery(question: Question, query: string = "") {
-  return new NativeQuery(question, {
-    type: "native",
-    database: question.database()?.id ?? null,
-    native: {
-      query,
-    },
-  });
+  const databaseId = question.database()?.id;
+  if (!databaseId) {
+    return null;
+  }
+
+  const metadata = Lib.metadataProvider(databaseId, question.metadata());
+
+  return Lib.nativeQuery(databaseId, metadata, query);
 }

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -1938,7 +1938,7 @@
 
   > **Code health:** Healthy."
   [a-query]
-  (name (lib.core/engine a-query)))
+  (some-> (lib.core/engine a-query) name))
 
 ;; # Legacy Segments
 ;; Segments are a deprecated kind of reusable query fragments, roughly equivalent to a set of filter clauses.

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -254,7 +254,7 @@
                 (set (keys (native-extras query))))
    (not (str/blank? (raw-native-query query)))))
 
-(mu/defn engine :- :keyword
+(mu/defn engine :- [:maybe :keyword]
   "Returns the database engine.
    Must be a native query"
   [query :- ::lib.schema/query]


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/52585

### Description

Fixes product issues brought up by @mngr in the native editor revamp:

> When I press Return in the middle of the text a new line is inserted as well as 2 trailing spaces, stats - the number of inserted trailing spaces or tabs depends on what was in the beginning of the previous line (correct)

✅ Fixed


> When I hit Cmd+Return a new line is inserted (it shouldn't)

✅ Fixed


> When I press tab, 2 spaces are inserted, stats - tab is inserted (ideally this should be a user setting)

✅ Fixed


> The designation 'keyword' is not shown

✅ Fixed


> The designations like 'table' or 'ACCOUNTS :type/integer' are aligned left and shown in italic, they should be aligned right and shown in normal font (correct)

✅ Fixed


> The same suggestion shown multiple times (same column name in different tables), they should be deduplicated

🟡 Partially fixed. 
Due to how CodeMirror compares completions internally, we cannot deduplicate all completions. I think it's not a huge issues.  @mngr can you confirm this works ok? You can reproduce it by 
typing `{{ #1-orders-people }} STA`. It only happens when there are referenced questions.

<img width="588" alt="Screenshot 2025-01-21 at 12 01 07" src="https://github.com/user-attachments/assets/c93fee8c-85f5-4b1a-accd-14a313f73837" />


> Make the editor use query from MBQL lib instead of the legacy JS query. There are MBQL lib functions for native queries in metabase-lib/native.ts

✅ Fixed


> Have component or unit tests for custom logic like autocompletion. Currently this seems to be covered with mostly e2e tests.

✅ Added


> When hitting Tab in the end of the text, the indentation is inserted in the beginning of the text - it should be added in the end (as on stats)

✅ Fixed


> Accept completions with tab

✅ Fixed


> no need to show the suggestion when the word is entered already (as on stats)

🔴 Believe it or not, this adds a lot of complexity to the completer, since we have to add some special cases to hide the word if it is already typed. I don't think it's worth it. What do you think @mngr?


> Move this component from query_builder to the querying module, perhaps to a new querying/native submodule.

🔵 I want to postpone this until we have other components that rely on CodeMirror too.

> When aliases are set in the query they should be returned in the list of suggestions

✅ Fixed