### PR TITLE
Fix flex-grow property on ChartSegmentedControl buttons

### DIFF
--- a/frontend/src/metabase/css/core/flex.module.css
+++ b/frontend/src/metabase/css/core/flex.module.css
@@ -28,6 +28,10 @@
   flex-shrink: 0;
 }
 
+.flexGrow1 {
+  flex-grow: 1;
+}
+
 /* The behavior of how `flex: <flex-grow>` sets flex-basis is inconsistent across
  * browsers. Specifically:
  * - On Chrome and FF it's set to `flex-basis: 0%`. That behaves equally as `height: 0%`.

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSegmentedControl/ChartSettingSegmentedControl.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSegmentedControl/ChartSettingSegmentedControl.tsx
@@ -14,7 +14,7 @@ export const ChartSettingSegmentedControl = ({
   onChange,
   value,
 }: ChartSettingSegmentedControlProps) => (
-  <Button.Group style={{ width: "100%", display: "flex" }}>
+  <Button.Group w="100%">
     {options.map(elem => (
       <Button
         className={cx(CS.borderBrand, CS.flexGrow1)}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSegmentedControl/ChartSettingSegmentedControl.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSegmentedControl/ChartSettingSegmentedControl.tsx
@@ -1,5 +1,7 @@
+import cx from "classnames";
+
 import CS from "metabase/css/core/index.css";
-import { Button, Center, Icon, type IconName } from "metabase/ui";
+import { Box, Button, Center, Icon, type IconName, Text } from "metabase/ui";
 
 interface ChartSettingSegmentedControlProps {
   options: { name: string; value: string; icon?: IconName }[];
@@ -12,19 +14,27 @@ export const ChartSettingSegmentedControl = ({
   onChange,
   value,
 }: ChartSettingSegmentedControlProps) => (
-  <Button.Group>
+  <Button.Group style={{ width: "100%", display: "flex" }}>
     {options.map(elem => (
       <Button
-        className={CS.borderBrand}
-        fullWidth
+        className={cx(CS.borderBrand, CS.flexGrow1)}
         py="sm"
+        px="xs"
         variant={value === elem.value ? "filled" : "default"}
         key={elem.value}
         onClick={() => onChange(elem.value)}
       >
-        <Center>
-          {elem.icon ? <Icon name={elem.icon} size={16}></Icon> : elem.name}
-        </Center>
+        {elem.icon ? (
+          <Center>
+            <Icon name={elem.icon} size={16}></Icon>
+          </Center>
+        ) : (
+          <Box>
+            <Text inherit c="inherit" lh="normal">
+              {elem.name}
+            </Text>
+          </Box>
+        )}
       </Button>
     ))}
   </Button.Group>


### PR DESCRIPTION
Restores a `flex-grow` property that allowed buttons to resize based on their text length. This is important with other languages, since the names for the same button can be longer or shorter based on the language

Before:
<img width="327" alt="image" src="https://github.com/user-attachments/assets/f8feb2ea-c21d-4b80-b79b-c46ff9b31098" />


After: 
<img width="335" alt="image" src="https://github.com/user-attachments/assets/ac07fbb1-99c6-4808-90e0-23a938bb786b" />
