### PR TITLE
fix(sdk): Restore z-index for v52

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidgetPopover.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidgetPopover.tsx
@@ -3,7 +3,7 @@ import _ from "underscore";
 
 import TippyPopover from "metabase/components/Popover/TippyPopover";
 import CS from "metabase/css/core/index.css";
-import { Box, Space, Tabs } from "metabase/ui";
+import { Box, DEFAULT_POPOVER_Z_INDEX, Space, Tabs } from "metabase/ui";
 
 import ChartSettingsWidget from "./ChartSettingsWidget";
 
@@ -50,6 +50,7 @@ export const ChartSettingsWidgetPopover = ({
   return (
     <TippyPopover
       reference={anchor}
+      zIndex={DEFAULT_POPOVER_Z_INDEX}
       content={
         widgets.length > 0 ? (
           <Box


### PR DESCRIPTION
Since we didn't backport the z-index PR to v52, we have to manually specify the z index for tippy popovers. This will be a bandaid until we can get the Mantine popover to this component.

This has no effect on the main app - since the popover is triggered by an element on the main screen (rather than another popover), this isn't an issue. This is only an issue when the user tries to trigger this popover from _another_ popover, which happens only in the SDK.

Before:
<img width="625" alt="image" src="https://github.com/user-attachments/assets/00b36b8e-e41e-48d9-aff3-47476e687801" />


After:

<img width="640" alt="image" src="https://github.com/user-attachments/assets/60830b12-d9de-40ca-840f-ae7f461b63e9" />
