### PR TITLE
Update static embedding code template for nodejs

### DIFF
--- a/e2e/test/scenarios/embedding/shared/embedding-snippets.js
+++ b/e2e/test/scenarios/embedding/shared/embedding-snippets.js
@@ -9,18 +9,18 @@ export const getEmbeddingJsCode = ({
   return new RegExp(
     `// you will need to install via 'npm install jsonwebtoken' or in your package.json
 
-var jwt = require("jsonwebtoken");
+const jwt = require("jsonwebtoken");
 
-var METABASE_SITE_URL = "http://localhost:PORTPORTPORT";
-var METABASE_SECRET_KEY = "KEYKEYKEY";
-var payload = {
+const METABASE_SITE_URL = "http://localhost:PORTPORTPORT";
+const METABASE_SECRET_KEY = "KEYKEYKEY";
+const payload = {
   resource: { ${type}: ${id} },
   params: {},
   exp: Math.round(Date.now() / 1000) + (10 * 60) // 10 minute expiration
 };
-var token = jwt.sign(payload, METABASE_SECRET_KEY);
+const token = jwt.sign(payload, METABASE_SECRET_KEY);
 
-var iframeUrl = METABASE_SITE_URL + "/embed/${type}/" + token +
+const iframeUrl = METABASE_SITE_URL + "/embed/${type}/" + token +
   "#${getThemeParameter(theme)}${getBackgroundParameter(
     background,
   )}bordered=true&titled=true${getParameter({

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/common.unit.spec.tsx
@@ -160,7 +160,7 @@ describe("Static Embed Setup phase", () => {
         expect(screen.getByLabelText("Code")).toBeChecked();
 
         expect(screen.getByTestId("text-editor-mock")).toHaveTextContent(
-          `// you will need to install via 'npm install jsonwebtoken' or in your package.json var jwt = require("jsonwebtoken"); var METABASE_SITE_URL = "http://localhost:3000"; var METABASE_SECRET_KEY = "my_super_secret_key"; var payload = { resource: { ${resourceType}: 1 }, params: {}, exp: Math.round(Date.now() / 1000) + (10 * 60) // 10 minute expiration }; var token = jwt.sign(payload, METABASE_SECRET_KEY); var iframeUrl = METABASE_SITE_URL + "/embed/${resourceType}/" + token + "#bordered=true&titled=true";`,
+          `// you will need to install via 'npm install jsonwebtoken' or in your package.json const jwt = require("jsonwebtoken"); const METABASE_SITE_URL = "http://localhost:3000"; const METABASE_SECRET_KEY = "my_super_secret_key"; const payload = { resource: { ${resourceType}: 1 }, params: {}, exp: Math.round(Date.now() / 1000) + (10 * 60) // 10 minute expiration }; const token = jwt.sign(payload, METABASE_SECRET_KEY); const iframeUrl = METABASE_SITE_URL + "/embed/${resourceType}/" + token + "#bordered=true&titled=true";`,
         );
       });
 
@@ -414,7 +414,7 @@ describe("Static Embed Setup phase", () => {
         expect(screen.getByLabelText("Code")).toBeChecked();
 
         expect(screen.getByTestId("text-editor-mock")).toHaveTextContent(
-          `// you will need to install via 'npm install jsonwebtoken' or in your package.json var jwt = require("jsonwebtoken"); var METABASE_SITE_URL = "http://localhost:3000"; var METABASE_SECRET_KEY = "my_super_secret_key"; var payload = { resource: { ${resourceType}: ${resource.id} }, params: {}, exp: Math.round(Date.now() / 1000) + (10 * 60) // 10 minute expiration }; var token = jwt.sign(payload, METABASE_SECRET_KEY); var iframeUrl = METABASE_SITE_URL + "/embed/${resourceType}/" + token + "#bordered=true&titled=true";`,
+          `// you will need to install via 'npm install jsonwebtoken' or in your package.json const jwt = require("jsonwebtoken"); const METABASE_SITE_URL = "http://localhost:3000"; const METABASE_SECRET_KEY = "my_super_secret_key"; const payload = { resource: { ${resourceType}: ${resource.id} }, params: {}, exp: Math.round(Date.now() / 1000) + (10 * 60) // 10 minute expiration }; const token = jwt.sign(payload, METABASE_SECRET_KEY); const iframeUrl = METABASE_SITE_URL + "/embed/${resourceType}/" + token + "#bordered=true&titled=true";`,
         );
       });
 

--- a/frontend/src/metabase/public/lib/code-templates.ts
+++ b/frontend/src/metabase/public/lib/code-templates.ts
@@ -48,19 +48,19 @@ export const node = {
   }: CodeSampleParameters) =>
     `// you will need to install via 'npm install jsonwebtoken' or in your package.json
 
-var jwt = require("jsonwebtoken");
+const jwt = require("jsonwebtoken");
 
-var METABASE_SITE_URL = ${JSON.stringify(siteUrl)};
-var METABASE_SECRET_KEY = ${JSON.stringify(secretKey)};
+const METABASE_SITE_URL = ${JSON.stringify(siteUrl)};
+const METABASE_SECRET_KEY = ${JSON.stringify(secretKey)};
 
-var payload = {
+const payload = {
   resource: { ${resourceType}: ${resourceId} },
   ${node.getParametersSource(params)}
   exp: Math.round(Date.now() / 1000) + (10 * 60) // 10 minute expiration
 };
-var token = jwt.sign(payload, METABASE_SECRET_KEY);
+const token = jwt.sign(payload, METABASE_SECRET_KEY);
 
-var iframeUrl = METABASE_SITE_URL + "/embed/${resourceType}/" + token +
+const iframeUrl = METABASE_SITE_URL + "/embed/${resourceType}/" + token +
   ${node.getIframeQuerySource(displayOptions)};`,
 };
 


### PR DESCRIPTION
Update static embedding code template for nodejs

# How to verify:
- open any dashboard/question
- click the `sharing => embed` button and dropdown
- select the `Static embedding`
- the code template for nodejs should contain `const` declarations instead of `var` declarations

![image](https://github.com/user-attachments/assets/f28a3ac5-3bd4-4c59-b516-38e2921812c0)
