### PR TITLE
Set proper box-sizing value for Alert icon

### DIFF
--- a/frontend/src/metabase/core/components/Alert/Alert.styled.tsx
+++ b/frontend/src/metabase/core/components/Alert/Alert.styled.tsx
@@ -50,6 +50,7 @@ interface AlertIconProps {
 }
 
 export const AlertIcon = styled(Icon)<AlertIconProps>`
+  box-sizing: content-box;
   flex-shrink: 0;
   padding: 0.5rem 1rem 0.5rem 0.5rem;
   color: ${props => colorsByVariant.icon[props.variant]};


### PR DESCRIPTION
Set proper box-sizing value for Alert icon

Fixes https://github.com/metabase/metabase/issues/50673

The initial fix is obsolete because now the `box-sizing` is applied to all elements:
```
:where(:global(.mb-wrapper)) {
  *,
  *::before,
  *::after {
    box-sizing: border-box;
  }
}
```

And this approach breaks the Alert Icon on the Core App level as well.

# How to verify
- Add the following component anywhere and check that Alert Icon is visible
```
<Alert variant="error" icon="warning">
        test
      </Alert>
```

- Add the following styles on the site, that you use for embedding SDK testing
```
*, *::before, *::after {
  box-sizing: border-box
}
```

-  Embed anything with an SDK, and disable SDK embedding in admin settings.
- The error banner should have a visible icon