### PR TITLE
Close Stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,8 +20,8 @@ jobs:
         with:
           stale-pr-message: 'This pull request has had no activity for 90 days, it will be closed in 2 weeks if no further activity occurs.'
           close-pr-message: 'This pull request was closed because it had no activity for more than one year.'
-          days-before-issue-stale: -1 # never
-          days-before-pr-stale: 365 # FIXME: let's do 90
+          days-before-issue-stale: -1 # never auto-close issues
+          days-before-pr-stale: 90
           days-before-pr-close: 14
           operations-per-run: 999
           debug-only: true # FIXME

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,8 +20,7 @@ jobs:
         with:
           stale-pr-message: 'This pull request has had no activity for 90 days, it will be closed in 2 weeks if no further activity occurs.'
           close-pr-message: 'This pull request was closed because it had no activity for more than one year.'
-          exempt-issue-labels: 'Type:Bug,Type:New Feature'
-          days-before-issue-stale: 365
+          days-before-issue-stale: -1 # never
           days-before-pr-stale: 365 # FIXME: let's do 90
           days-before-pr-close: 14
           operations-per-run: 999

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,19 +2,27 @@ name: 'Close Stale PRs'
 on:
   schedule:
     - cron: '00 1 * * *'
+  pull_request: # for testing
 
 permissions:
+  contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   close-stale-prs:
     # don't run this workflow on a cron for forks
     if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/stale@v6
+      - uses: actions/stale@v9
         with:
-          stale-pr-message: 'This pull request has had no activity for one year, it will be closed in 1 week if no further activity occurs.'
+          stale-pr-message: 'This pull request has had no activity for 90 days, it will be closed in 2 weeks if no further activity occurs.'
           close-pr-message: 'This pull request was closed because it had no activity for more than one year.'
-          days-before-pr-stale: 365
-          days-before-pr-close: 7
+          exempt-issue-labels: 'Type:Bug,Type:New Feature'
+          days-before-issue-stale: 365
+          days-before-pr-stale: 365 # FIXME: let's do 90
+          days-before-pr-close: 14
+          operations-per-run: 999
+          debug-only: true # FIXME

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,7 @@
-name: 'Close Stale PRs'
+name: Close Stale PRs
 on:
   schedule:
     - cron: '00 1 * * *'
-  pull_request: # for testing
 
 permissions:
   contents: write
@@ -24,4 +23,3 @@ jobs:
           days-before-pr-stale: 90
           days-before-pr-close: 14
           operations-per-run: 999
-          debug-only: true # FIXME

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/stale@v9
         with:
           stale-pr-message: 'This pull request has had no activity for 90 days, it will be closed in 2 weeks if no further activity occurs.'
-          close-pr-message: 'This pull request was closed because it had no activity for more than one year.'
+          close-pr-message: 'This pull request was closed because it had no activity for more than 90 days.'
           days-before-issue-stale: -1 # never auto-close issues
           days-before-pr-stale: 90
           days-before-pr-close: 14


### PR DESCRIPTION
# Description

Currently, we have 371 open PRs. too many!

- If any PR has not been updated in 90 days, add a "Stale" label and a comment that it will be closed in 14 days if there's no new activity
- After 14 more days, the PR will be closed (but can be revived if we ever want!)
- Currently, this action will close 182 stale PRs