### PR TITLE
[Cards in Dashboards] Update question save location filter to exclude items without can_write access

### DIFF
--- a/frontend/src/metabase/components/SaveQuestionForm/SaveQuestionForm.tsx
+++ b/frontend/src/metabase/components/SaveQuestionForm/SaveQuestionForm.tsx
@@ -90,7 +90,17 @@ export const SaveQuestionForm = ({
               collectionIdFieldName="collection_id"
               dashboardIdFieldName="dashboard_id"
               title={t`Where do you want to save this?`}
-              collectionPickerModalProps={{ models }}
+              collectionPickerModalProps={{
+                models,
+                recentFilter: items =>
+                  items.filter(
+                    item =>
+                      !(
+                        item.model === "collection" ||
+                        item.model === "dashboard"
+                      ) || item.can_write,
+                  ),
+              }}
             />
           )}
           {showTabSelect && (

--- a/frontend/src/metabase/components/SaveQuestionForm/SaveQuestionForm.tsx
+++ b/frontend/src/metabase/components/SaveQuestionForm/SaveQuestionForm.tsx
@@ -93,13 +93,11 @@ export const SaveQuestionForm = ({
               collectionPickerModalProps={{
                 models,
                 recentFilter: items =>
-                  items.filter(
-                    item =>
-                      !(
-                        item.model === "collection" ||
-                        item.model === "dashboard"
-                      ) || item.can_write,
-                  ),
+                  items.filter(item => {
+                    // narrow type and make sure it's a dashboard or
+                    // collection that the user can write to
+                    return item.model !== "table" && item.can_write;
+                  }),
               }}
             />
           )}

--- a/frontend/src/metabase/containers/MoveModal.tsx
+++ b/frontend/src/metabase/containers/MoveModal.tsx
@@ -76,7 +76,10 @@ export const MoveModal = ({
     : undefined;
 
   const searchResultFilter = makeSearchResultFilter(shouldDisableItem);
-  const recentFilter = makeRecentFilter(shouldDisableItem);
+
+  const recentFilter = makeRecentFilter(item => {
+    return Boolean(!item.can_write || shouldDisableItem?.(item));
+  });
 
   const handleMove = useCallback(
     (destination: CollectionPickerValueItem) => {


### PR DESCRIPTION
### Description

Prevents the user from seeing destinations that they do not have write access to within the recents tab of the move modal and save question modal.

### How to verify

- Sign in as an admin
- Visit the usage analytics collection and one of its dashboards
- Create a new question and select where to save it
- You should no longer see usage analytics items within the recents tab but you should see other items

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
