### PR TITLE
Prevent unsafe usage of localeCompare and related functions

### DIFF
--- a/frontend/lint/eslint-rules/no-locale-with-intl-functions.js
+++ b/frontend/lint/eslint-rules/no-locale-with-intl-functions.js
@@ -1,0 +1,69 @@
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+// eslint-disable-next-line import/no-commonjs
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallows providing a locale argument to certain Intl and String methods, since some of our locales (like pt_BR and zh_TW) are noncompliant and may throw a RangeError.",
+    },
+    messages: {
+      noLocalesArgument: "Avoid providing a locales argument to {{method}}.",
+      noDisplayNames: "Intl.DisplayNames is not supported in Metabase.",
+    },
+  },
+
+  create(context) {
+    return {
+      'NewExpression[callee.object.name="Intl"][callee.property.name=/^(DateTimeFormat|RelativeTimeFormat|ListFormat|NumberFormat|Collator|PluralRules|Segmenter)$/]'(
+        node,
+      ) {
+        if (node.arguments.length > 0) {
+          context.report({
+            node,
+            messageId: "noLocalesArgument",
+            data: {
+              method: `Intl.${node.callee.property.name}`,
+            },
+          });
+        }
+      },
+      'CallExpression[callee.object.name="Intl"][callee.property.name=/^(DateTimeFormat|RelativeTimeFormat|ListFormat|NumberFormat|Collator|PluralRules|Segmenter)$/]'(
+        node,
+      ) {
+        if (node.arguments.length > 0) {
+          context.report({
+            node,
+            messageId: "noLocalesArgument",
+            data: {
+              method: `Intl.${node.callee.property.name}`,
+            },
+          });
+        }
+      },
+      'CallExpression[callee.property.name="localeCompare"]'(node) {
+        const hasLocalesArgument = node.arguments.length > 1;
+        if (hasLocalesArgument) {
+          context.report({
+            node,
+            messageId: "noLocalesArgument",
+            data: {
+              method: `String.${node.callee.property.name}`,
+            },
+          });
+        }
+      },
+      'NewExpression[callee.object.name="Intl"][callee.property.name="DisplayNames"]'(
+        node,
+      ) {
+        context.report({
+          node,
+          messageId: "noDisplayNames",
+        });
+      },
+    };
+  },
+};

--- a/frontend/lint/tests/no-locale-with-intl-functions.unit.spec.js
+++ b/frontend/lint/tests/no-locale-with-intl-functions.unit.spec.js
@@ -37,42 +37,42 @@ const VALID_CASES = [
 const INVALID_CASES = [
   {
     name: "String.localeCompare should not take a locales argument",
-    code: `"a".localeCompare("b", "en")`,
+    code: `const locale = "pt_BR"; "a".localeCompare("b", locale);`,
     error: /Avoid providing a locales argument to String.localeCompare/,
   },
   {
     name: "Intl.NumberFormat should not take a locales argument",
-    code: `Intl.NumberFormat("en").format(1000);`,
+    code: `const locale = "pt_BR"; Intl.NumberFormat(locale).format(1000);`,
     error: /Avoid providing a locales argument to Intl.NumberFormat/,
   },
   {
     name: "Intl.DateTimeFormat should not take a locales argument",
-    code: `Intl.DateTimeFormat("en").format(Date.now());`,
+    code: `const locale = "pt_BR"; Intl.DateTimeFormat(locale).format(Date.now());`,
     error: /Avoid providing a locales argument to Intl.DateTimeFormat/,
   },
   {
     name: "Intl.RelativeTimeFormat should not take a locales argument",
-    code: `Intl.RelativeTimeFormat("en").format(3, 'seconds')`,
+    code: `const locale = "pt_BR"; Intl.RelativeTimeFormat(locale).format(3, 'seconds');`,
     error: /Avoid providing a locales argument to Intl.RelativeTimeFormat/,
   },
   {
     name: "Intl.ListFormat should not take a locales argument",
-    code: `new Intl.ListFormat('en').format(['Alice', 'Bob'])`,
+    code: `const locale = "pt_BR"; new Intl.ListFormat(locale).format(['Alice', 'Bob']);`,
     error: /Avoid providing a locales argument to Intl.ListFormat/,
   },
   {
     name: "Intl.Segmenter should not take a locales argument",
-    code: `new Intl.Segmenter('en').segment('a')[Symbol.iterator]().next()`,
+    code: `const locale = "pt_BR"; new Intl.Segmenter(locale).segment('a')[Symbol.iterator]().next();`,
     error: /Avoid providing a locales argument to Intl.Segmenter/,
   },
   {
     name: "Intl.Collator should not take a locales argument",
-    code: `new Intl.Collator('en').compare('a', 'b')`,
+    code: `const locale = "pt_BR"; new Intl.Collator(locale).compare('a', 'b');`,
     error: /Avoid providing a locales argument to Intl.Collator/,
   },
   {
     name: "Intl.DisplayNames cannot be called",
-    code: `new Intl.DisplayNames()`,
+    code: `new Intl.DisplayNames();`,
     error: /Intl.DisplayNames is not supported in Metabase/,
   },
 ];

--- a/frontend/lint/tests/no-locale-with-intl-functions.unit.spec.js
+++ b/frontend/lint/tests/no-locale-with-intl-functions.unit.spec.js
@@ -1,0 +1,92 @@
+import { RuleTester } from "eslint";
+
+import noLocaleWithIntlFunctions from "../eslint-rules/no-locale-with-intl-functions";
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2015,
+    sourceType: "module",
+    ecmaFeatures: { jsx: true },
+  },
+});
+
+const VALID_CASES = [
+  {
+    code: `'a'.localeCompare('b');`,
+  },
+  {
+    code: `new Intl.NumberFormat().format(1000);`,
+  },
+  {
+    code: `new Intl.DateTimeFormat().format(Date.now());`,
+  },
+  {
+    code: `new Intl.RelativeTimeFormat().format(3, 'seconds')`,
+  },
+  {
+    code: `new Intl.ListFormat().format(['Alice', 'Bob'])`,
+  },
+  {
+    code: `new Intl.Segmenter().segment('a')[Symbol.iterator]().next()`,
+  },
+  {
+    code: `new Intl.Collator().compare('a', 'b')`,
+  },
+];
+
+const INVALID_CASES = [
+  {
+    name: "String.localeCompare should not take a locales argument",
+    code: `"a".localeCompare("b", "en")`,
+    error: /Avoid providing a locales argument to String.localeCompare/,
+  },
+  {
+    name: "Intl.NumberFormat should not take a locales argument",
+    code: `Intl.NumberFormat("en").format(1000);`,
+    error: /Avoid providing a locales argument to Intl.NumberFormat/,
+  },
+  {
+    name: "Intl.DateTimeFormat should not take a locales argument",
+    code: `Intl.DateTimeFormat("en").format(Date.now());`,
+    error: /Avoid providing a locales argument to Intl.DateTimeFormat/,
+  },
+  {
+    name: "Intl.RelativeTimeFormat should not take a locales argument",
+    code: `Intl.RelativeTimeFormat("en").format(3, 'seconds')`,
+    error: /Avoid providing a locales argument to Intl.RelativeTimeFormat/,
+  },
+  {
+    name: "Intl.ListFormat should not take a locales argument",
+    code: `new Intl.ListFormat('en').format(['Alice', 'Bob'])`,
+    error: /Avoid providing a locales argument to Intl.ListFormat/,
+  },
+  {
+    name: "Intl.Segmenter should not take a locales argument",
+    code: `new Intl.Segmenter('en').segment('a')[Symbol.iterator]().next()`,
+    error: /Avoid providing a locales argument to Intl.Segmenter/,
+  },
+  {
+    name: "Intl.Collator should not take a locales argument",
+    code: `new Intl.Collator('en').compare('a', 'b')`,
+    error: /Avoid providing a locales argument to Intl.Collator/,
+  },
+  {
+    name: "Intl.DisplayNames cannot be called",
+    code: `new Intl.DisplayNames()`,
+    error: /Intl.DisplayNames is not supported in Metabase/,
+  },
+];
+
+ruleTester.run("no-locale-with-intl-functions", noLocaleWithIntlFunctions, {
+  valid: VALID_CASES,
+  invalid: INVALID_CASES.map(invalidCase => {
+    return {
+      code: invalidCase.code,
+      errors: [
+        {
+          message: invalidCase.error,
+        },
+      ],
+    };
+  }),
+});

--- a/frontend/src/metabase/.eslintrc
+++ b/frontend/src/metabase/.eslintrc
@@ -12,7 +12,11 @@
         "paths": [
           {
             "name": "react-redux",
-            "importNames": ["useSelector", "useDispatch", "connect"],
+            "importNames": [
+              "useSelector",
+              "useDispatch",
+              "connect"
+            ],
             "message": "Please import from `metabase/lib/redux` instead."
           },
           {
@@ -37,26 +41,34 @@
   },
   "overrides": [
     {
-      "files": ["**/*.unit.spec.{js,jsx,ts,tsx}"],
+      "files": [
+        "**/*.unit.spec.{js,jsx,ts,tsx}"
+      ],
       "rules": {
         "no-console": 0
       }
     },
     {
-      "files": ["**/*.stories.tsx"],
+      "files": [
+        "**/*.stories.tsx"
+      ],
       "rules": {
         "import/no-default-export": 0,
         "no-restricted-imports": 0
       }
     },
     {
-      "files": ["lib/redux/hooks.ts"],
+      "files": [
+        "lib/redux/hooks.ts"
+      ],
       "rules": {
         "no-restricted-imports": 0
       }
     },
     {
-      "files": ["ui/**/*.{js,jsx,ts,tsx}"],
+      "files": [
+        "ui/**/*.{js,jsx,ts,tsx}"
+      ],
       "rules": {
         "no-restricted-imports": [
           "error",

--- a/frontend/src/metabase/.eslintrc
+++ b/frontend/src/metabase/.eslintrc
@@ -12,11 +12,7 @@
         "paths": [
           {
             "name": "react-redux",
-            "importNames": [
-              "useSelector",
-              "useDispatch",
-              "connect"
-            ],
+            "importNames": ["useSelector", "useDispatch", "connect"],
             "message": "Please import from `metabase/lib/redux` instead."
           },
           {
@@ -41,34 +37,26 @@
   },
   "overrides": [
     {
-      "files": [
-        "**/*.unit.spec.{js,jsx,ts,tsx}"
-      ],
+      "files": ["**/*.unit.spec.{js,jsx,ts,tsx}"],
       "rules": {
         "no-console": 0
       }
     },
     {
-      "files": [
-        "**/*.stories.tsx"
-      ],
+      "files": ["**/*.stories.tsx"],
       "rules": {
         "import/no-default-export": 0,
         "no-restricted-imports": 0
       }
     },
     {
-      "files": [
-        "lib/redux/hooks.ts"
-      ],
+      "files": ["lib/redux/hooks.ts"],
       "rules": {
         "no-restricted-imports": 0
       }
     },
     {
-      "files": [
-        "ui/**/*.{js,jsx,ts,tsx}"
-      ],
+      "files": ["ui/**/*.{js,jsx,ts,tsx}"],
       "rules": {
         "no-restricted-imports": [
           "error",


### PR DESCRIPTION
As a follow-up to #52284, this PR adds lint rules banning the pattern that caused a P1 (#48144). These rules require us to use the browser default with `String.localeCompare` and related functions in the `Intl` library. Since we cannot pass these functions our own locale codes, since some of these are in the wrong format.

This is designed to be a good-enough, "80 percent of the value with 20 percent of the effort" solution, even though better solutions could be pursued such as aligning FE and BE around an international standard (BCP 47).

- [x] Tests have been added/updated to cover changes in this PR
