### PR TITLE
Fix Postgres XML column visualization

### DIFF
--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -948,7 +948,7 @@
 
 (defmethod sql-jdbc.execute/read-column-thunk [:postgres Types/SQLXML]
   [_driver ^ResultSet rs ^ResultSetMetaData _rsmeta ^Integer i]
-  (fn [] (.getString (.getObject rs i))))
+  (fn [] (.getString rs i)))
 
 ;; de-CLOB any CLOB values that come back
 (defmethod sql-jdbc.execute/read-column-thunk :postgres

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -946,6 +946,10 @@
     (fn []
       (.getObject rs i))))
 
+(defmethod sql-jdbc.execute/read-column-thunk [:postgres Types/SQLXML]
+  [_driver ^ResultSet rs ^ResultSetMetaData _rsmeta ^Integer i]
+  (fn [] (.getString (.getObject rs i))))
+
 ;; de-CLOB any CLOB values that come back
 (defmethod sql-jdbc.execute/read-column-thunk :postgres
   [_ ^ResultSet rs _ ^Integer i]

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -1602,3 +1602,13 @@
                               :target [:variable [:template-tag "date"]]
                               :value  "2024-07-02"}]
                 :middleware {:format-rows? false}})))))))
+
+(deftest ^:parallel xml-column-is-readable-test
+  (mt/with-driver :postgres
+    (let [xml-str "<abc>abc</abc>"]
+      (is (= [[xml-str]]
+             (mt/rows
+              (qp/process-query
+               {:database (mt/id)
+                :type :native
+                :native {:query (format "SELECT '%s'::xml" xml-str)}})))))))

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -1603,8 +1603,8 @@
                               :value  "2024-07-02"}]
                 :middleware {:format-rows? false}})))))))
 
-(deftest xml-column-is-readable-test
-  (mt/with-driver :postgres
+(deftest ^:parallel xml-column-is-readable-test
+  (mt/test-driver :postgres
     (let [xml-str "<abc>abc</abc>"]
       (is (= [[xml-str]]
              (mt/rows

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -1603,7 +1603,7 @@
                               :value  "2024-07-02"}]
                 :middleware {:format-rows? false}})))))))
 
-(deftest ^:parallel xml-column-is-readable-test
+(deftest xml-column-is-readable-test
   (mt/with-driver :postgres
     (let [xml-str "<abc>abc</abc>"]
       (is (= [[xml-str]]


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50065

### Description

Postgres XML columns are being displayed as Java objects (e.g. `org.postgresql.jdbc.PgSQLXML@1a90017b`) instead of readable strings. This adds a `read-column-thunk` method to the Postgres driver to convert the XML objects to strings.

Converts Postgres XML columns to a string when returned in `sql-jdbc.execute/read-column-thunk`. 

### How to verify

1. Create a Postgres table with an XML type column. 
2. Populate this table with some XML data. 
3. When viewing or exporting this table from Metabase the XML should be displayed as a readable string.

### Demo

<img width="752" alt="Screenshot 2025-01-20 at 2 48 42 PM" src="https://github.com/user-attachments/assets/a14305fc-0211-4c2f-9ded-602f5ade6423" />

JSON export
```json
[
{"ID":1,"Json Data → Foo":"bar","Json Data → X":1,"Name":"row 1","Xml Data":"<root><child>Sample Data</child></root>"},
{"ID":3,"Json Data → Foo":"bar","Json Data → X":1,"Name":"row 2","Xml Data":"<root><child>Sample Data</child></root>"},
{"ID":4,"Json Data → Foo":"bar","Json Data → X":1,"Name":"row 3","Xml Data":"<root><child>Sample Data</child></root>"},
{"ID":5,"Json Data → Foo":"bar","Json Data → X":1,"Name":"row 4","Xml Data":"<root><child>Sample Data</child></root>"}
]
```

CSV export
```csv
ID,Json Data → Foo,Json Data → X,Name,Xml Data,Json Data,Bytes Arr,Date Bytes
1,bar,1,row 1,<root><child>Sample Data</child></root>
3,bar,1,row 2,<root><child>Sample Data</child></root>
4,bar,1,row 3,<root><child>Sample Data</child></root>
5,bar,1,row 4,<root><child>Sample Data</child></root>
```

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
