### PR TITLE
[Cards in Dashboards] Prevent saving to other dashboards when creating a dashboard question

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -96,8 +96,7 @@ describe("scenarios > dashboard", () => {
       cy.findByTestId("save-question-modal").within(modal => {
         cy.findByLabelText("Name").clear().type(newQuestionName);
         cy.findByLabelText("Where do you want to save this?").should(
-          "contain.text",
-          dashboardName,
+          "not.exist",
         );
         cy.findByText("Save").click();
       });

--- a/frontend/src/metabase/components/SaveQuestionForm/SaveQuestionForm.module.css
+++ b/frontend/src/metabase/components/SaveQuestionForm/SaveQuestionForm.module.css
@@ -1,3 +1,0 @@
-.dashboardTabSelectContainer {
-  z-index: 201 !important; /* DEFAULT_MODAL_Z_INDEX + 1 */
-}

--- a/frontend/src/metabase/components/SaveQuestionForm/SaveQuestionForm.tsx
+++ b/frontend/src/metabase/components/SaveQuestionForm/SaveQuestionForm.tsx
@@ -8,13 +8,11 @@ import FormErrorMessage from "metabase/core/components/FormErrorMessage";
 import { FormFooter } from "metabase/core/components/FormFooter";
 import FormInput from "metabase/core/components/FormInput";
 import FormRadio from "metabase/core/components/FormRadio";
-import FormSelect from "metabase/core/components/FormSelect";
 import FormTextArea from "metabase/core/components/FormTextArea";
 import { Form, FormSubmitButton } from "metabase/forms";
 import { isNullOrUndefined } from "metabase/lib/types";
 import type { Dashboard } from "metabase-types/api";
 
-import CS from "./SaveQuestionForm.module.css";
 import { useSaveQuestionContext } from "./context";
 
 export const SaveQuestionForm = ({
@@ -51,11 +49,6 @@ export const SaveQuestionForm = ({
       : ["collection"];
 
   const showPickerInput = values.saveType === "create" && !saveToDashboard;
-  const showTabSelect =
-    values.saveType === "overwrite" &&
-    saveToDashboard &&
-    saveToDashboard.tabs &&
-    saveToDashboard.tabs.length > 1;
 
   return (
     <Form>
@@ -91,17 +84,6 @@ export const SaveQuestionForm = ({
               dashboardIdFieldName="dashboard_id"
               title={t`Where do you want to save this?`}
               collectionPickerModalProps={{ models }}
-            />
-          )}
-          {showTabSelect && (
-            <FormSelect
-              name="tab_id"
-              title="Which tab should this go on?"
-              containerClassName={CS.dashboardTabSelectContainer}
-              options={saveToDashboard.tabs?.map(tab => ({
-                name: tab.name,
-                value: tab.id,
-              }))}
             />
           )}
         </div>

--- a/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.tsx
@@ -65,6 +65,7 @@ export const SaveQuestionModal = ({
           </Modal.Header>
           <Modal.Body>
             <SaveQuestionForm
+              saveToDashboard={saveToDashboard}
               onSaveSuccess={() => closeOnSuccess && modalProps.onClose()}
               onCancel={modalProps.onClose}
             />


### PR DESCRIPTION
### Description

Users could change the dashboard they were saving to when they started creating a dashboard question for a specific dashboard. It appears that a value was not getting passed in correctly preventing the functionality from working as expect.

This PR also removes some UI for saving to tab that wasn't being used. When we added auto-place logic the save to tab feature was broken. Ideally these code changes can get reverted soon.

### How to verify

- Edit a dashboard, add a new question via one of these buttons
![CleanShot 2025-01-20 at 13 35 19@2x](https://github.com/user-attachments/assets/019491ef-b901-4996-ba59-9fd76b2aa868)
- Create a question, save it
- You should see no select button for changing the destination dashboard save location

### Demo

https://github.com/user-attachments/assets/a6a681d5-b87f-41e5-bab2-66e8795c6690

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
