### PR TITLE
Add `overflow:auto` to `Autocomplete` component

### DIFF
--- a/frontend/src/metabase/ui/components/inputs/Autocomplete/Autocomplete.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Autocomplete/Autocomplete.styled.tsx
@@ -20,6 +20,9 @@ export const getAutocompleteOverrides =
       styles: (theme, _, { size = "md" }) => ({
         ...getSelectInputOverrides(theme),
         ...getSelectItemsOverrides(theme, size),
+        dropdown: {
+          overflow: "auto",
+        },
       }),
     },
   });


### PR DESCRIPTION
We were running into issues where the contents of `Autocomplete` was overflowing the container of the dropdown, [like this](https://metaboat.slack.com/archives/C063Q3F1HPF/p1737031346278079).

The issue here is that the fix that worked for `Select` and `MultiSelect` wasn't applied to the `Autocomplete` component, which uses the same styles. Now, the values should stay within their container.
