### PR TITLE
Support find-outliers for reports and queries in simple cases

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
@@ -135,7 +135,9 @@
   (let [details (if-let [[_ card-id] (when (string? metric-id)
                                        (re-matches #"card__(\d+)" metric-id))]
                   (metric-details (parse-long card-id))
-                  "invalid metric_id")]
+                  (if (int? metric-id)
+                    (metric-details metric-id)
+                    "invalid metric_id"))]
     (if (map? details)
       {:structured-output details}
       {:output (or details "metric not found")})))
@@ -147,7 +149,7 @@
                   (let [details (card-details (parse-long card-id))]
                     (some-> details
                             (select-keys [:id :description :name])
-                            (assoc :result-columns (:fields details))))
+                            (assoc :result_columns (:fields details))))
                   "invalid report_id")]
     (if (map? details)
       {:structured-output details}
@@ -179,21 +181,21 @@
     (reduce envelope/add-dummy-message env (dummy-tool-messages :get-current-user {} content))))
 
 (def ^:private detail-getters
-  {:dashboard {:id :get-dashboard-details
-               :fn get-dashboard-details
+  {:dashboard {:id     :get-dashboard-details
+               :fn     get-dashboard-details
                :arg-fn (fn [id] {:dashboard-id id})}
-   :table {:id :get-table-details
-           :fn get-table-details
-           :arg-fn (fn [id] {:table-id (str id)})}
-   :model {:id :get-table-details
-           :fn get-table-details
-           :arg-fn (fn [id] {:table-id (str "card__" id)})}
-   :metric {:id :get-metric-details
-            :fn get-metric-details
-            :arg-fn (fn [id] {:metric-id id})}
-   :report {:id :get-report-details
-            :fn get-report-details
-            :arg-fn (fn [id] {:report-id (str "card__" id)})}})
+   :table     {:id     :get-table-details
+               :fn     get-table-details
+               :arg-fn (fn [id] {:table-id (str id)})}
+   :model     {:id     :get-table-details
+               :fn     get-table-details
+               :arg-fn (fn [id] {:table-id (str "card__" id)})}
+   :metric    {:id     :get-metric-details
+               :fn     get-metric-details
+               :arg-fn (fn [id] {:metric-id id})}
+   :question  {:id     :get-report-details
+               :fn     get-report-details
+               :arg-fn (fn [id] {:report-id (str "card__" id)})}})
 
 (defn- dummy-get-item-details
   [{:keys [context] :as env}]
@@ -215,7 +217,7 @@
     {:type :query
      :query-id query-id
      :query legacy-query
-     :result-columns (into []
+     :result_columns (into []
                            (map-indexed #(metabot-v3.tools.u/->result-column %2 %1 field-id-prefix))
                            returned-cols)}))
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/find_outliers.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/find_outliers.clj
@@ -2,6 +2,7 @@
   (:require
    [medley.core :as m]
    [metabase-enterprise.metabot-v3.client :as metabot-v3.client]
+   [metabase-enterprise.metabot-v3.envelope :as metabot-v3.envelope]
    [metabase-enterprise.metabot-v3.tools.interface :as metabot-v3.tools.interface]
    [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]
    [metabase.api.common :as api]
@@ -11,38 +12,66 @@
    [metabase.util.malli :as mu]
    [toucan2.core :as t2]))
 
+(defn- checked-card-dataset-query
+  [card-id]
+  (-> (t2/select-one [:model/Card :collection_id :dataset_query] card-id)
+      api/read-check
+      :dataset_query))
+
+(defn- find-dataset-query
+  [{:keys [query_id report_id metric_id] :as data-source} env]
+  (cond
+    metric_id [(metabot-v3.tools.u/card-field-id-prefix metric_id)
+               (checked-card-dataset-query metric_id)]
+    report_id (if-let [card-id (if (string? report_id)
+                                 (some-> (re-matches #"card__(\d+)" report_id)
+                                         second
+                                         parse-long)
+                                 report_id)]
+                [(metabot-v3.tools.u/card-field-id-prefix card-id)
+                 (checked-card-dataset-query card-id)]
+                (throw (ex-info "Invalid report_id as data_source" {:agent-error? true
+                                                                    :data_source data-source})))
+    query_id  (if-let [query (metabot-v3.envelope/find-query env query_id)]
+                (do
+                  (api/read-check :model/Database (:database query))
+                  [(metabot-v3.tools.u/query-field-id-prefix query_id)
+                   query])
+                (throw (ex-info (str "No query found with query_id " query_id) {:agent-error? true
+                                                                                :data_source data-source})))
+    :else     (throw (ex-info "Invalid data_source" {:agent-error? true
+                                                     :data_source data-source}))))
+
 (mu/defmethod metabot-v3.tools.interface/*invoke-tool* :metabot.tool/find-outliers
-  [_tool-name {{:keys [query_id
-                       report_id
-                       metric_id
-                       result_field_id]}
-               :data-source} _env]
-  (try
-    (when (or query_id report_id result_field_id)
-      (throw (ex-info "Not implemented" {:agent-error? true})))
-    (let [{:keys [dataset_query]} (api/read-check (t2/select-one [:model/Card :collection_id :dataset_query] metric_id))
-          {:keys [data status]} (qp/process-query (qp/userland-query-with-default-constraints dataset_query))]
-      (when-not (= :completed status)
-        (throw (ex-info "Unexpected error running query" {:agent-error? true
-                                                          :status status})))
-      (let [dimension-col-idx (->> data
-                                   :cols
-                                   (map-indexed vector)
-                                   (m/find-first (fn [[_i col]]
-                                                   (lib.types.isa/temporal? (u/normalize-map col))))
-                                   first)
-            _ (or dimension-col-idx (throw (ex-info "No temporal dimension found. Outliers can only be detected when a temporal dimension is available." {:agent-error? true})))
-            value-col-idx (->> data
-                               :cols
-                               (map-indexed vector)
-                               (m/find-first (fn [[_i col]]
-                                               (lib.types.isa/numeric? (u/normalize-map col))))
-                               first)]
+  [_tool-name {:keys [data-source]} env]
+  (let [{:keys [metric_id result_field_id]} data-source]
+    (try
+      (let [[field-id-prefix dataset-query] (find-dataset-query data-source env)
+            {:keys [data]} (u/prog1 (qp/process-query (qp/userland-query-with-default-constraints dataset-query))
+                             (when-not (= :completed (:status <>))
+                               (throw (ex-info "Unexpected error running query" {:agent-error? true
+                                                                                 :status (:status <>)}))))
+            dimension-col-idx (or (->> data
+                                       :cols
+                                       (map-indexed vector)
+                                       (m/find-first (fn [[_i col]]
+                                                       (lib.types.isa/temporal? (u/normalize-map col))))
+                                       first)
+                                  (throw (ex-info "No temporal dimension found. Outliers can only be detected when a temporal dimension is available."
+                                                  {:agent-error? true})))
+            value-col-idx (if metric_id
+                            (->> data
+                                 :cols
+                                 (map-indexed vector)
+                                 (m/find-first (fn [[_i col]]
+                                                 (lib.types.isa/numeric? (u/normalize-map col))))
+                                 first)
+                            (metabot-v3.tools.u/resolve-column-index result_field_id field-id-prefix))]
         {:structured-output (->> data
                                  :rows
                                  (map (fn [row]
                                         {:dimension (nth row dimension-col-idx)
                                          :value (nth row value-col-idx)}))
-                                 (metabot-v3.client/find-outliers-request))}))
-    (catch Exception e
-      (metabot-v3.tools.u/handle-agent-error e))))
+                                 (metabot-v3.client/find-outliers-request))})
+      (catch Exception e
+        (metabot-v3.tools.u/handle-agent-error e)))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
@@ -59,15 +59,20 @@
          :type (convert-field-type column)}
         (m/assoc-some :description (get column :description)))))
 
+(defn resolve-column-index
+  "Resolve the reference `field_id` to the index of the result columns in the entity with `field-id-prefix`."
+  [field_id field-id-prefix]
+  (when-not (str/starts-with? field_id field-id-prefix)
+    (throw (ex-info (str "field " field_id " not found") {:agent-error? true
+                                                          :expected-prefix field-id-prefix})))
+  (-> field_id (subs (count field-id-prefix)) parse-long))
+
 (defn resolve-column
   "Resolve the reference `field_id` in filter `item` by finding the column in `columns` specified by `field_id`.
   `field-id-prefix` is used to check if the filter refers to a column from the right entity."
   [{:keys [field_id] :as item} field-id-prefix columns]
-  (when-not (str/starts-with? field_id field-id-prefix)
-    (throw (ex-info (str "field " field_id " not found") {:expected-prefix field-id-prefix})))
-  (let [index (-> field_id (subs (count field-id-prefix)) parse-long)
-        column (nth columns index)]
-    (assoc item :column column)))
+  (let [index (resolve-column-index field_id field-id-prefix)]
+    (assoc item :column (nth columns index))))
 
 (defn get-table
   "Get the `fields` of the table with ID `id`."


### PR DESCRIPTION
When the result has a temporal column, the first in the list is taken as the basis of the analysis.
