### PR TITLE
Add an order by to the batched truncation

### DIFF
--- a/src/metabase/task/truncate_audit_tables.clj
+++ b/src/metabase/task/truncate_audit_tables.clj
@@ -90,6 +90,7 @@ If set to 0, Metabase will keep all rows.")
                :where [:<=
                        (keyword time-column)
                        (t/minus (t/offset-date-time) (t/days (audit-max-retention-days)))]
+               :order-by [[:id :asc]]
                :limit (audit-table-truncation-batch-size)}]}
 
      (:mysql :mariadb)


### PR DESCRIPTION
Context:
we need to remove old query execution logs. The table gets quite big.
What we used to do: pick a date N months ago, and then `delete from query_execution where started_at <= [some time]`
This does a table scan and is bad.
Solution: we can do this in batches. https://github.com/metabase/metabase/pull/51490

Problem: we still have a table scan in practice.

And now, the PR description:

This is a strange one. But in practice, this was still doing a seq scan on postgres.

```sql
clean=# explain DELETE FROM query_execution WHERE id IN (SELECT id FROM query_execution WHERE started_at <= '2025-01-02 01:10:15.651839+00' LIMIT 50000);
                                                           QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------
 Delete on query_execution  (cost=526084.17..1066675.96 rows=0 width=0)
   ->  Nested Loop  (cost=526084.17..1066675.96 rows=50000 width=34)
         ->  Unique  (cost=526076.73..526326.73 rows=50000 width=32)
               ->  Sort  (cost=526076.73..526201.73 rows=50000 width=32)
                     Sort Key: "ANY_subquery".id
                     ->  Subquery Scan on "ANY_subquery"  (cost=0.00..522174.32 rows=50000 width=32)
                           ->  Limit  (cost=0.00..521674.32 rows=50000 width=4)
table scan >>>>>              ->  Seq Scan on query_execution query_execution_1  (cost=0.00..1704153.49 rows=163335 width=4)
                                       Filter: (started_at <= '2025-01-01 19:10:15.651839-06'::timestamp with time zone)
         ->  Bitmap Heap Scan on query_execution  (cost=7.44..11.46 rows=1 width=10)
               Recheck Cond: (id = "ANY_subquery".id)
               ->  Bitmap Index Scan on query_execution_pkey  (cost=0.00..7.44 rows=1 width=0)
                     Index Cond: (id = "ANY_subquery".id)
(13 rows)

```

The odd thing is that it is sensitive to what timestamp you use. Here's the same query but with a timestamp in 2024:

```sql
clean=# explain DELETE FROM query_execution WHERE id IN (SELECT id FROM query_execution WHERE started_at <= '2024-12-19 01:10:15.651839+00' LIMIT 50000);
                                                             QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------
 Delete on query_execution  (cost=225736.06..641819.90 rows=0 width=0)
   ->  Nested Loop  (cost=225736.06..641819.90 rows=28490 width=34)
         ->  HashAggregate  (cost=225724.95..226009.85 rows=28490 width=32)
               Group Key: "ANY_subquery".id
               ->  Subquery Scan on "ANY_subquery"  (cost=122917.34..225653.72 rows=28490 width=32)
                     ->  Limit  (cost=122917.34..225368.82 rows=28490 width=4)
                           ->  Bitmap Heap Scan on query_execution query_execution_1  (cost=122917.34..225368.82 rows=28490 width=4)
                                 Recheck Cond: (started_at <= '2024-12-18 19:10:15.651839-06'::timestamp with time zone)
index scan >>>>                  ->  Bitmap Index Scan on idx_query_execution_started_at  (cost=0.00..122910.22 rows=28490 width=0)
                                       Index Cond: (started_at <= '2024-12-18 19:10:15.651839-06'::timestamp with time zone)
         ->  Bitmap Heap Scan on query_execution  (cost=11.11..15.12 rows=1 width=10)
               Recheck Cond: (id = "ANY_subquery".id)
               ->  Bitmap Index Scan on query_execution_pkey  (cost=0.00..11.11 rows=1 width=0)
                     Index Cond: (id = "ANY_subquery".id)
(14 rows)
```

And this is because the db engine knows that most of my data is around 2025 and will just hit the whole table rather than hit an index and then go return most of the table.

The logic we want here is basically, "work up the index on created_at until we get to a notion of recent".

If we add an order by, we're close to that and things go much faster again

```sql
clean=# explain DELETE FROM query_execution WHERE id IN (SELECT id FROM query_execution WHERE started_at <= '2025-01-02 01:10:15.651839+00' order by id asc LIMIT 50000);
                                                                         QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------------------
 Delete on query_execution  (cost=851615.84..1392207.62 rows=0 width=0)
   ->  Nested Loop  (cost=851615.84..1392207.62 rows=50000 width=34)
         ->  Unique  (cost=851608.39..851858.39 rows=50000 width=32)
               ->  Sort  (cost=851608.39..851733.39 rows=50000 width=32)
                     Sort Key: "ANY_subquery".id
                     ->  Subquery Scan on "ANY_subquery"  (cost=0.55..847705.98 rows=50000 width=32)
                           ->  Limit  (cost=0.55..847205.98 rows=50000 width=4)
index scan >>>>>                 ->  Index Scan using query_execution_pkey on query_execution query_execution_1  (cost=0.55..2767566.54 rows=163335 width=4)
                                       Filter: (started_at <= '2025-01-01 19:10:15.651839-06'::timestamp with time zone)
         ->  Bitmap Heap Scan on query_execution  (cost=7.44..11.46 rows=1 width=10)
               Recheck Cond: (id = "ANY_subquery".id)
               ->  Bitmap Index Scan on query_execution_pkey  (cost=0.00..7.44 rows=1 width=0)
                     Index Cond: (id = "ANY_subquery".id)
(13 rows)
```
