### PR TITLE
[Deets in Sheets] Add actions link to question info sidesheet

### DIFF
--- a/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
@@ -226,7 +226,7 @@ describe("Issue 32974", { tags: ["@external", "@actions"] }, () => {
 describe("issue 51020", () => {
   function setupBasicActionsInModel() {
     H.questionInfoButton().click();
-    H.modal().findByText("See more about this model").click();
+    H.sidesheet().findByText("Actions").click();
     cy.findByRole("tab", { name: "Actions" }).click();
     cy.button(/Create basic actions/).click();
   }

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
@@ -1796,7 +1796,7 @@ describe("issue 48878", () => {
     cy.log("create model action");
 
     cy.findByTestId("qb-header-info-button").click();
-    H.modal().findByText("See more about this model").click();
+    H.sidesheet().findByText("Actions").click();
 
     cy.findByRole("tab", { name: "Actions" }).click();
     cy.findByTestId("model-actions-header").findByText("New action").click();

--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -968,16 +968,6 @@ describe("issue 34574", () => {
     });
 
     cy.log(
-      "Make sure the markdown is properly preserved in the model details page",
-    );
-    // Let redux handle async actions so that they won't interfere with the action
-    // triggered by the next click. Test will flake without this due to wrong navigation.
-    cy.wait(1);
-    cy.findByRole("link", { name: "Actions" }).click();
-    cy.wait("@fks");
-    cy.findByLabelText("Description").within(assertMarkdownPreview);
-
-    cy.log(
       "Make sure the description is present in the collection entry tooltip",
     );
     cy.findByTestId("app-bar").findByText("Our analytics").click();

--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -973,7 +973,7 @@ describe("issue 34574", () => {
     // Let redux handle async actions so that they won't interfere with the action
     // triggered by the next click. Test will flake without this due to wrong navigation.
     cy.wait(1);
-    cy.findByRole("link", { name: "See more about this model" }).click();
+    cy.findByRole("link", { name: "Actions" }).click();
     cy.wait("@fks");
     cy.findByLabelText("Description").within(assertMarkdownPreview);
 

--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -965,6 +965,7 @@ describe("issue 34574", () => {
       cy.log("Make sure we immediately render the proper markdown");
       cy.findByTestId("editable-text").get("textarea").should("not.exist");
       cy.findByTestId("editable-text").within(assertMarkdownPreview);
+      cy.findByLabelText("Close").click();
     });
 
     cy.log(

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/components/InsightsLink.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/components/InsightsLink.tsx
@@ -59,13 +59,7 @@ export const InsightsLink = ({
     Urls.dashboard({ id: entityId, name: "" }) + `?${linkQueryParams}`;
 
   return (
-    <Flex
-      className={SidesheetS.InsightsTab}
-      p="11px 8px"
-      c="var(--mb-color-text-dark)"
-      fw="bold"
-      lh="1rem"
-    >
+    <Flex className={SidesheetS.TabSibling}>
       <Link
         to={instanceAnalyticsUrl}
         className={S.InsightsLink}

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/components/InsightsLink.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/components/InsightsLink.tsx
@@ -59,18 +59,16 @@ export const InsightsLink = ({
     Urls.dashboard({ id: entityId, name: "" }) + `?${linkQueryParams}`;
 
   return (
-    <Flex className={SidesheetS.TabSibling}>
-      <Link
-        to={instanceAnalyticsUrl}
-        className={S.InsightsLink}
-        role="link"
-        {...linkProps}
-      >
-        <Flex gap="xs">
-          <Icon name="external" />
-          {t`Insights`}
-        </Flex>
-      </Link>
-    </Flex>
+    <Link
+      to={instanceAnalyticsUrl}
+      className={S.InsightsLink}
+      role="link"
+      {...linkProps}
+    >
+      <Flex gap="xs" className={SidesheetS.TabSibling}>
+        <Icon name="external" />
+        {t`Insights`}
+      </Flex>
+    </Link>
   );
 };

--- a/frontend/src/metabase/common/components/Sidesheet/sidesheet.module.css
+++ b/frontend/src/metabase/common/components/Sidesheet/sidesheet.module.css
@@ -34,7 +34,7 @@
 
 /* For divs that are not tabs but which sit next to the tabs */
 .TabSibling {
-  padding: 11px 8px;
+  padding: 0.6875rem 0.5rem;
   color: var(--mb-color-text-dark);
   font-weight: bold;
   line-height: 1rem;

--- a/frontend/src/metabase/common/components/Sidesheet/sidesheet.module.css
+++ b/frontend/src/metabase/common/components/Sidesheet/sidesheet.module.css
@@ -31,3 +31,20 @@
     }
   }
 }
+
+.TabSibling {
+  padding: 11px 8px;
+  color: var(--mb-color-text-dark);
+  font-weight: bold;
+  line-height: 1rem;
+
+  &:hover {
+    color: var(--mb-color-brand);
+  }
+
+  &:not([data-specificity-hack]) {
+    &:disabled {
+      cursor: pointer;
+    }
+  }
+}

--- a/frontend/src/metabase/common/components/Sidesheet/sidesheet.module.css
+++ b/frontend/src/metabase/common/components/Sidesheet/sidesheet.module.css
@@ -32,6 +32,7 @@
   }
 }
 
+/* For divs that are not tabs but which sit next to the tabs */
 .TabSibling {
   padding: 11px 8px;
   color: var(--mb-color-text-dark);

--- a/frontend/src/metabase/models/routes.tsx
+++ b/frontend/src/metabase/models/routes.tsx
@@ -5,6 +5,7 @@ import { ModalRoute } from "metabase/hoc/ModalRoute";
 import { Route } from "metabase/hoc/Title";
 import ModelDetailPage from "metabase/models/containers/ModelDetailPage/ModelDetailPage";
 
+Intl.Collator("en");
 export const getRoutes = () => (
   <Route path="/model/:slug/detail">
     <IndexRedirect to="usage" />

--- a/frontend/src/metabase/models/routes.tsx
+++ b/frontend/src/metabase/models/routes.tsx
@@ -5,7 +5,6 @@ import { ModalRoute } from "metabase/hoc/ModalRoute";
 import { Route } from "metabase/hoc/Title";
 import ModelDetailPage from "metabase/models/containers/ModelDetailPage/ModelDetailPage";
 
-"a".localeCompare("b", "en");
 export const getRoutes = () => (
   <Route path="/model/:slug/detail">
     <IndexRedirect to="usage" />

--- a/frontend/src/metabase/models/routes.tsx
+++ b/frontend/src/metabase/models/routes.tsx
@@ -5,6 +5,7 @@ import { ModalRoute } from "metabase/hoc/ModalRoute";
 import { Route } from "metabase/hoc/Title";
 import ModelDetailPage from "metabase/models/containers/ModelDetailPage/ModelDetailPage";
 
+"a".localeCompare("b", "en");
 export const getRoutes = () => (
   <Route path="/model/:slug/detail">
     <IndexRedirect to="usage" />

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/QuestionInfoSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/QuestionInfoSidebar.tsx
@@ -19,7 +19,7 @@ import * as Urls from "metabase/lib/urls";
 import { PLUGIN_MODERATION } from "metabase/plugins";
 import { onCloseQuestionInfo } from "metabase/query_builder/actions";
 import { QuestionActivityTimeline } from "metabase/query_builder/components/QuestionActivityTimeline";
-import { Box, Flex, Icon, Stack, Tabs, Title } from "metabase/ui";
+import { Flex, Icon, Stack, Tabs, Title } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";
 
 import { QuestionDetails } from "./QuestionDetails";
@@ -76,13 +76,12 @@ export const QuestionInfoSidebar = ({
           <Tabs.Tab value="overview">{t`Overview`}</Tabs.Tab>
           {!isIAQuestion && <Tabs.Tab value="history">{t`History`}</Tabs.Tab>}
           {question.type() === "model" && !question.isArchived() && (
-            <Flex gap="xs" className={SidesheetStyles.TabSibling}>
-              <Icon name="external" />
-              <Box
-                component={Link}
-                to={Urls.modelDetail(question.card())}
-              >{t`Actions`}</Box>
-            </Flex>
+            <Link to={Urls.modelDetail(question.card())}>
+              <Flex gap="xs" className={SidesheetStyles.TabSibling}>
+                <Icon name="external" />
+                {t`Actions`}
+              </Flex>
+            </Link>
           )}
           <InsightsTabOrLink question={question} />
         </Tabs.List>

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/QuestionInfoSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/QuestionInfoSidebar.tsx
@@ -19,7 +19,7 @@ import * as Urls from "metabase/lib/urls";
 import { PLUGIN_MODERATION } from "metabase/plugins";
 import { onCloseQuestionInfo } from "metabase/query_builder/actions";
 import { QuestionActivityTimeline } from "metabase/query_builder/components/QuestionActivityTimeline";
-import { Box, Stack, Tabs, Title } from "metabase/ui";
+import { Box, Flex, Icon, Stack, Tabs, Title } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";
 
 import { QuestionDetails } from "./QuestionDetails";
@@ -75,6 +75,15 @@ export const QuestionInfoSidebar = ({
         <Tabs.List mx="xl">
           <Tabs.Tab value="overview">{t`Overview`}</Tabs.Tab>
           {!isIAQuestion && <Tabs.Tab value="history">{t`History`}</Tabs.Tab>}
+          {question.type() === "model" && !question.isArchived() && (
+            <Flex gap="xs" className={SidesheetStyles.TabSibling}>
+              <Icon name="external" />
+              <Box
+                component={Link}
+                to={Urls.modelDetail(question.card())}
+              >{t`Actions`}</Box>
+            </Flex>
+          )}
           <InsightsTabOrLink question={question} />
         </Tabs.List>
 
@@ -94,15 +103,6 @@ export const QuestionInfoSidebar = ({
                   <PLUGIN_MODERATION.ModerationReviewTextForQuestion
                     question={question}
                   />
-                  {question.type() === "model" && !question.isArchived() && (
-                    <Box
-                      component={Link}
-                      variant="brand"
-                      to={Urls.modelDetail(question.card())}
-                      pt="xs"
-                      pb="sm"
-                    >{t`See more about this model`}</Box>
-                  )}
                 </Stack>
               </SidesheetCard>
               <SidesheetCard>

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/common.unit.spec.tsx
@@ -192,7 +192,7 @@ describe("QuestionInfoSidebar", () => {
     });
   });
 
-  describe("model detail link", () => {
+  describe("actions link", () => {
     it("is shown for models", async () => {
       const card = createMockCard({
         name: "abc",
@@ -200,8 +200,7 @@ describe("QuestionInfoSidebar", () => {
       });
       await setup({ card });
 
-      const link = screen.getByText("See more about this model");
-
+      const link = screen.getByText("Actions");
       expect(link).toBeInTheDocument();
       expect(link).toHaveAttribute("href", Urls.modelDetail(card));
     });
@@ -213,9 +212,7 @@ describe("QuestionInfoSidebar", () => {
       });
       await setup({ card });
       expect(screen.getByText(DESCRIPTION)).toBeInTheDocument();
-      expect(
-        screen.queryByText("See more about this model"),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText("Actions")).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/common.unit.spec.tsx
@@ -200,7 +200,7 @@ describe("QuestionInfoSidebar", () => {
       });
       await setup({ card });
 
-      const link = screen.getByText("Actions");
+      const link = await screen.findByRole("link", { name: /Actions/ });
       expect(link).toBeInTheDocument();
       expect(link).toHaveAttribute("href", Urls.modelDetail(card));
     });


### PR DESCRIPTION
This PR removes the 'See more about this model' link from the question info sidesheet and adds an 'Actions' link to the top of the sidesheet

![image](https://github.com/user-attachments/assets/f703cfaf-5455-4db7-a481-efbfca3a73ac)
