### PR TITLE
[Cards in Dashboards] Revision history copy change

### DIFF
--- a/src/metabase/models/revision/diff.clj
+++ b/src/metabase/models/revision/diff.clj
@@ -136,7 +136,7 @@
     (let [all-ks         (keys (or after before))
           ;; ignore collection_id as part of diff if the dashboard_id has changed
           ;; so that the final diff string doesn't contain two messages about moving
-          ks         (if (not= (:dashboard_id before) (:dashboard_id after))
+          ks         (if (and (= model "Card") (not= (:dashboard_id before) (:dashboard_id after)))
                        (remove #{:collection_id} all-ks)
                        all-ks)
           model-name (model-str->i18n-str model)]

--- a/src/metabase/models/revision/diff.clj
+++ b/src/metabase/models/revision/diff.clj
@@ -133,13 +133,13 @@
   The directionality of the statement should indicate that `o1` changed into `o2`."
   [model o1 o2]
   (when-let [[before after] (data/diff o1 o2)]
-    (let [all-ks         (keys (or after before))
+    (let [model-name (model-str->i18n-str model)
           ;; ignore collection_id as part of diff if the dashboard_id has changed
           ;; so that the final diff string doesn't contain two messages about moving
-          ks         (if (and (= model "Card") (not= (:dashboard_id before) (:dashboard_id after)))
-                       (remove #{:collection_id} all-ks)
-                       all-ks)
-          model-name (model-str->i18n-str model)]
+          ks         (cond->> (keys (or after before))
+                       (and (= model "Card")
+                            (not= (:dashboard_id before) (:dashboard_id after)))
+                       (remove #{:collection_id}))]
       (loop [ks               ks
              identifier-count 0
              strings          []]

--- a/src/metabase/models/revision/diff.clj
+++ b/src/metabase/models/revision/diff.clj
@@ -94,9 +94,9 @@
       (and v1 v2) (deferred-tru "moved from dashboard {0} to {1}"
                                 (t2/select-one-fn :name :model/Dashboard :id v1)
                                 (t2/select-one-fn :name :model/Dashboard :id v2))
-      (nil? v1) (deferred-tru "made this a dashboard-internal question in {0}"
+      (nil? v1) (deferred-tru "moved this question into {0}"
                               (t2/select-one-fn :name :model/Dashboard :id v2))
-      (nil? v2) (deferred-tru "extracted this question from {0}"
+      (nil? v2) (deferred-tru "moved this question from {0}"
                               (t2/select-one-fn :name :model/Dashboard :id v1)))
 
     [:width v1 v2]
@@ -133,7 +133,12 @@
   The directionality of the statement should indicate that `o1` changed into `o2`."
   [model o1 o2]
   (when-let [[before after] (data/diff o1 o2)]
-    (let [ks         (keys (or after before))
+    (let [all-ks         (keys (or after before))
+          ;; ignore collection_id as part of diff if the dashboard_id has changed
+          ;; so that the final diff string doesn't contain two messages about moving
+          ks         (if (not= (:dashboard_id before) (:dashboard_id after))
+                       (remove #{:collection_id} all-ks)
+                       all-ks)
           model-name (model-str->i18n-str model)]
       (loop [ks               ks
              identifier-count 0


### PR DESCRIPTION
[ENG-14249](https://linear.app/metabase-inc/issue/ENG-14249/change-revision-history-copy)

### Description

Instead of showing "dashboard-internal" this PR tweaks the copy to show these messages in the question's revision history:
- `You moved this question from {dashboard_name}`
- `You moved this question into {dashboard_name}`

Additionally, when questions move to/from dashboards and collections and the dashboard is in a different collection, we were producing two notifications about moving (once for the dashboard move and another for the collection move).

### How to verify

- Create a question, save it in collection 
- Move it into a dashboard
- Move it back to a collection
- Visit the question + view it's revision history
- See the messages appear as expected

### Demo

Before (dashboard + collection children of the same collection)
![image](https://github.com/user-attachments/assets/0630dacb-755c-44b0-b442-3d803a0e8650)

Before (dashboard + collection have different parent collections)
![CleanShot 2025-01-20 at 20 33 04@2x](https://github.com/user-attachments/assets/8d473da7-2dd9-44a8-b7ba-7174bf029af9)

After
![CleanShot 2025-01-20 at 20 32 40@2x](https://github.com/user-attachments/assets/3e3bd07a-003e-4f61-b2ca-1a607fb3f66c)

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
I have zero clue how our BE tests work
