### PR TITLE
fix(sdk): add theme change transition to the root element

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentStylesWrapper.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentStylesWrapper.tsx
@@ -30,6 +30,8 @@ const PublicComponentStylesWrapperInner = styled.div`
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 
+  transition: var(--transition-theme-change);
+
   ${saveDomImageStyles}
 
   :where(svg) {


### PR DESCRIPTION
Add theme change transition to the root element of the SDK
This PR is the follow-up of https://github.com/metabase/metabase/pull/52259 with SDK-related code

We need it to smoothly change background color on the root element of SDK with the `mb-wrapper` class.

# How to verify
- build the SDK
- connect it to an app
- the root element of SDK with `mb-wrapper` class should have the `transition` property