### PR TITLE
add rule to prevent unsafe element filtering

### DIFF
--- a/e2e/.eslintrc
+++ b/e2e/.eslintrc
@@ -44,7 +44,8 @@
           "@metabase/embedding-sdk-react"
         ]
       }
-    ]
+    ],
+    "no-unsafe-element-filtering": ["warn"]
   },
   "env": {
     "cypress/globals": true,

--- a/e2e/support/helpers/e2e-bi-basics-helpers.js
+++ b/e2e/support/helpers/e2e-bi-basics-helpers.js
@@ -65,6 +65,7 @@ export function filterFieldPopover(
   { value, placeholder, order } = {},
 ) {
   getFilterField(fieldName, order).within(() => {
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.get("input").last().click();
   });
 
@@ -75,6 +76,7 @@ export function filterFieldPopover(
 }
 
 function getFilterField(fieldName, order = 0) {
+  // eslint-disable-next-line no-unsafe-element-filtering
   return cy.findAllByTestId(`filter-column-${fieldName}`).eq(order);
 }
 

--- a/e2e/support/helpers/e2e-collection-helpers.ts
+++ b/e2e/support/helpers/e2e-collection-helpers.ts
@@ -48,6 +48,7 @@ export function getPersonalCollectionName(
 }
 
 export function openCollectionItemMenu(item: string, index = 0) {
+  // eslint-disable-next-line no-unsafe-element-filtering
   cy.findAllByText(item).eq(index).closest("tr").icon("ellipsis").click();
 }
 

--- a/e2e/support/helpers/e2e-dashboard-helpers.ts
+++ b/e2e/support/helpers/e2e-dashboard-helpers.ts
@@ -28,10 +28,12 @@ export function getDashboardCards() {
 }
 
 export function getDashboardCard(index = 0) {
+  // eslint-disable-next-line no-unsafe-element-filtering
   return getDashboardCards().eq(index);
 }
 
 export function ensureDashboardCardHasText(text: string, index = 0) {
+  // eslint-disable-next-line no-unsafe-element-filtering
   cy.findAllByTestId("dashcard").eq(index).should("contain", text);
 }
 

--- a/e2e/support/helpers/e2e-dimension-list-helpers.js
+++ b/e2e/support/helpers/e2e-dimension-list-helpers.js
@@ -9,6 +9,7 @@ export function getDimensions(isSelected) {
 }
 
 export function getDimensionByName({ name, index = 0, isSelected }) {
+  // eslint-disable-next-line no-unsafe-element-filtering
   return getDimensions(isSelected).filter(`:contains("${name}")`).eq(index);
 }
 

--- a/e2e/support/helpers/e2e-dragndrop-helpers.js
+++ b/e2e/support/helpers/e2e-dragndrop-helpers.js
@@ -5,10 +5,12 @@ export function dragField(startIndex, dropIndex) {
 
   const BUTTON_INDEX = 0;
   const SLOPPY_CLICK_THRESHOLD = 10;
+  // eslint-disable-next-line no-unsafe-element-filtering
   cy.get("@dragHandle")
     .eq(dropIndex)
     .then($target => {
       const coordsDrop = $target[0].getBoundingClientRect();
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.get("@dragHandle")
         .eq(startIndex)
         .then(subject => {

--- a/e2e/support/helpers/e2e-embedding-sdk-interactive-question-helpers.tsx
+++ b/e2e/support/helpers/e2e-embedding-sdk-interactive-question-helpers.tsx
@@ -13,6 +13,7 @@ export function saveInteractiveQuestionAsNewQuestion(options: {
 
   cy.intercept("POST", "/api/card").as("createCard");
 
+  // eslint-disable-next-line no-unsafe-element-filtering
   cy.findAllByTestId("cell-data").last().click();
   popover().findByText(`See these ${entityName}`).click();
   cy.findByRole("button", { name: "Save" }).click();

--- a/e2e/support/helpers/e2e-notebook-helpers.ts
+++ b/e2e/support/helpers/e2e-notebook-helpers.ts
@@ -83,6 +83,7 @@ export function addSummaryField({
   stage?: number;
   index?: number;
 }) {
+  // eslint-disable-next-line no-unsafe-element-filtering
   getNotebookStep("summarize", { stage, index })
     .findByTestId("aggregate-step")
     .findAllByTestId("notebook-cell-item")
@@ -116,6 +117,7 @@ export function addSummaryGroupingField({
   index?: number;
   bucketSize?: string;
 }) {
+  // eslint-disable-next-line no-unsafe-element-filtering
   getNotebookStep("summarize", { stage, index })
     .findByTestId("breakout-step")
     .findAllByTestId("notebook-cell-item")
@@ -139,6 +141,7 @@ export function addSummaryGroupingField({
   });
 
   if (bucketSize) {
+    // eslint-disable-next-line no-unsafe-element-filtering
     popover().last().findByText(bucketSize).click();
   }
 }
@@ -340,6 +343,7 @@ function verifyNotebookExpressions(
     );
 
     for (let index = 0; index < expressions.length; ++index) {
+      // eslint-disable-next-line no-unsafe-element-filtering
       getExpressionItems(stageIndex)
         .eq(index)
         .should("have.text", expressions[index]);
@@ -360,6 +364,7 @@ function verifyNotebookFilters(
     );
 
     for (let index = 0; index < filters.length; ++index) {
+      // eslint-disable-next-line no-unsafe-element-filtering
       getFilterItems(stageIndex).eq(index).should("have.text", filters[index]);
     }
   } else {
@@ -380,6 +385,7 @@ function verifyNotebookAggregations(
     );
 
     for (let index = 0; index < aggregations.length; ++index) {
+      // eslint-disable-next-line no-unsafe-element-filtering
       getSummarizeItems(stageIndex, "aggregate")
         .eq(index)
         .should("have.text", aggregations[index]);
@@ -408,6 +414,7 @@ function verifyNotebookBreakouts(
     );
 
     for (let index = 0; index < breakouts.length; ++index) {
+      // eslint-disable-next-line no-unsafe-element-filtering
       getSummarizeItems(stageIndex, "breakout")
         .eq(index)
         .should("have.text", breakouts[index]);
@@ -441,7 +448,9 @@ function verifyNotebookSort(
 
     for (let index = 0; index < sort.length; ++index) {
       const { column, order } = sort[index];
+      // eslint-disable-next-line no-unsafe-element-filtering
       getSortItems(stageIndex).eq(index).should("have.text", column);
+      // eslint-disable-next-line no-unsafe-element-filtering
       getSortItems(stageIndex)
         .eq(index)
         .icon(order === "asc" ? "arrow_up" : "arrow_down")

--- a/e2e/support/helpers/e2e-permissions-helpers.js
+++ b/e2e/support/helpers/e2e-permissions-helpers.js
@@ -38,6 +38,7 @@ export function modifyPermission(
 }
 
 export function selectPermissionRow(item, permissionIndex) {
+  // eslint-disable-next-line no-unsafe-element-filtering
   getPermissionRowPermissions(item).eq(permissionIndex).click();
 }
 
@@ -79,6 +80,7 @@ export function assertPermissionForItem(
   permissionColumnIndex,
   permissionValue,
 ) {
+  // eslint-disable-next-line no-unsafe-element-filtering
   getPermissionRowPermissions(item)
     .eq(permissionColumnIndex)
     .should("have.text", permissionValue);
@@ -90,6 +92,7 @@ export function assertPermissionForItem(
  * @param {boolean} isDisabled
  */
 export function isPermissionDisabled(index, permission, isDisabled) {
+  // eslint-disable-next-line no-unsafe-element-filtering
   return cy
     .findAllByTestId("permissions-select")
     .eq(index)

--- a/e2e/support/helpers/e2e-relative-date-picker-helpers.js
+++ b/e2e/support/helpers/e2e-relative-date-picker-helpers.js
@@ -17,6 +17,7 @@ function setValue({ value, unit }) {
     cy.findByLabelText("Interval").clear().type(value);
     cy.findByLabelText("Unit").click();
   });
+  // eslint-disable-next-line no-unsafe-element-filtering
   cy.findAllByText(getUnitRegexp(unit)).last().click();
 }
 
@@ -31,6 +32,7 @@ function setStartingFrom({ value, unit }) {
     cy.findByLabelText("Starting from interval").clear().type(value);
     cy.findByLabelText("Starting from unit").click();
   });
+  // eslint-disable-next-line no-unsafe-element-filtering
   cy.findAllByText(getUnitRegexp(unit)).last().click();
 }
 

--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -149,10 +149,12 @@ export function filterWidget() {
 }
 
 export function clearFilterWidget(index = 0) {
+  // eslint-disable-next-line no-unsafe-element-filtering
   return filterWidget().eq(index).icon("close").click();
 }
 
 export function resetFilterWidgetToDefault(index = 0) {
+  // eslint-disable-next-line no-unsafe-element-filtering
   return filterWidget().eq(index).icon("revert").click();
 }
 
@@ -316,6 +318,7 @@ export function assertTableData({ columns, firstRows = [] }) {
     .should("have.length", columns.length);
 
   columns.forEach((column, index) => {
+    // eslint-disable-next-line no-unsafe-element-filtering
     tableInteractive()
       .findAllByTestId("header-cell")
       .eq(index)
@@ -324,6 +327,7 @@ export function assertTableData({ columns, firstRows = [] }) {
 
   firstRows.forEach((row, rowIndex) => {
     row.forEach((cell, cellIndex) => {
+      // eslint-disable-next-line no-unsafe-element-filtering
       tableInteractiveBody()
         .findAllByTestId("cell-data")
         .eq(columns.length * rowIndex + cellIndex)
@@ -347,22 +351,27 @@ export function newButton(menuItem) {
 }
 
 export function multiSelectInput(filter = ":eq(0)") {
+  // eslint-disable-next-line no-unsafe-element-filtering
   return cy.findByRole("combobox").filter(filter).get("input").last();
 }
 
 export function multiAutocompleteInput(filter = ":eq(0)") {
+  // eslint-disable-next-line no-unsafe-element-filtering
   return cy.findAllByRole("combobox").filter(filter).get("input").last();
 }
 
 export function fieldValuesInput(filter = ":eq(0)") {
+  // eslint-disable-next-line no-unsafe-element-filtering
   return cy.findAllByRole("textbox").filter(filter).get("input").last();
 }
 
 export function fieldValuesValue(index) {
+  // eslint-disable-next-line no-unsafe-element-filtering
   return cy.findAllByTestId("token-field").eq(index);
 }
 
 export function removeFieldValuesValue(index) {
+  // eslint-disable-next-line no-unsafe-element-filtering
   return cy.findAllByTestId("token-field").icon("close").eq(index).click();
 }
 

--- a/e2e/support/helpers/e2e-upload-helpers.js
+++ b/e2e/support/helpers/e2e-upload-helpers.js
@@ -78,6 +78,7 @@ export function uploadFile(
 
     cy.wait(`@${uploadMode}CSV`);
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByRole("status")
       .last()
       .findByText(`Data added to ${collectionName}`, {

--- a/e2e/support/helpers/e2e-visual-tests-helpers.js
+++ b/e2e/support/helpers/e2e-visual-tests-helpers.js
@@ -166,6 +166,7 @@ export function assertTooltipRow(
   name,
   { color, value, secondaryValue, index } = {},
 ) {
+  // eslint-disable-next-line no-unsafe-element-filtering
   cy.findAllByText(name)
     .eq(index ?? 0)
     .parent("tr")

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question-native.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question-native.cy.spec.tsx
@@ -57,6 +57,7 @@ describeEE("scenarios > embedding-sdk > interactive-question > native", () => {
       );
 
       // The first row should have the same ID column value as the initial SQL parameters
+      // eslint-disable-next-line no-unsafe-element-filtering
       rows
         .findAllByTestId("cell-data")
         .eq(idColumnIndex)

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
@@ -71,6 +71,7 @@ describeEE("scenarios > embedding-sdk > interactive-question", () => {
       expect(response?.statusCode).to.equal(202);
     });
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByTestId("cell-data").last().click();
 
     cy.on("uncaught:exception", error => {

--- a/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
@@ -301,6 +301,7 @@ function assertUpdatedScoreNotInTable() {
 
 function assertSuccessfullUpdateToast() {
   cy.log("it shows a toast informing the update was successful");
+  // eslint-disable-next-line no-unsafe-element-filtering
   H.undoToastList()
     .last()
     .should("be.visible")
@@ -310,6 +311,7 @@ function assertSuccessfullUpdateToast() {
 
 function assertSuccessfullDeleteToast() {
   cy.log("it shows a toast informing the delete was successful");
+  // eslint-disable-next-line no-unsafe-element-filtering
   H.undoToastList()
     .last()
     .should("be.visible")

--- a/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-reproductions.cy.spec.js
@@ -37,6 +37,7 @@ describe("metabase#31587", () => {
           const actionButtonContainer = cy.findByTestId(
             "action-button-full-container",
           );
+          // eslint-disable-next-line no-unsafe-element-filtering
           const dashCard = cy
             .findAllByTestId("dashcard-container")
             .last()
@@ -64,6 +65,7 @@ describe("metabase#31587", () => {
           const actionButtonContainer = cy.findByTestId(
             "action-button-full-container",
           );
+          // eslint-disable-next-line no-unsafe-element-filtering
           const dashCard = cy
             .findAllByTestId("dashcard-container")
             .last()

--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -287,6 +287,7 @@ H.describeWithSnowplow("scenarios > admin > settings", () => {
       cy.findByTestId("admin-list-settings-items").within(() => {
         cy.findAllByTestId("settings-sidebar-link").as("settingsOptions");
         cy.get("@settingsOptions").first().contains("Setup");
+        // eslint-disable-next-line no-unsafe-element-filtering
         cy.get("@settingsOptions").last().contains(lastItem);
       });
     },
@@ -416,6 +417,7 @@ describe.skip(
     }
 
     function getCellText() {
+      // eslint-disable-next-line no-unsafe-element-filtering
       return cy.get("[data-testid=cell-data]").eq(-1).invoke("text");
     }
 
@@ -1021,7 +1023,9 @@ describe("scenarios > admin > settings > map settings", () => {
     cy.wait(2000).findAllByText("Select…").first().click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("NAME").click();
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByText("Select…").last().click();
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByText("NAME").last().click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add map").click();

--- a/e2e/test/scenarios/admin/admin-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/admin/admin-reproductions.cy.spec.js
@@ -209,6 +209,7 @@ describe("(metabase#46714)", () => {
     cy.findByLabelText("Filter operator")
       .should("have.text", "Between")
       .click();
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.popover().last().findByText("Less than").click();
     cy.findByLabelText("Filter operator").should("have.text", "Less than");
     H.popover().findByPlaceholderText("Enter a number").clear().type("1000");

--- a/e2e/test/scenarios/admin/databases.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases.cy.spec.js
@@ -865,6 +865,7 @@ H.describeWithSnowplow("add database card", () => {
   it("should track the click on the card", () => {
     cy.visit("/browse/databases");
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findByTestId("database-browser")
       .findAllByRole("link")
       .last()

--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.js
@@ -934,6 +934,7 @@ describe("scenarios > admin > datamodel > segments", () => {
           .first()
           .should("contain", "You edited the description")
           .and("contain", "Foo");
+        // eslint-disable-next-line no-unsafe-element-filtering
         cy.get("@revisions")
           .last()
           .should("contain", `You created "${SEGMENT_NAME}"`)

--- a/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
@@ -701,6 +701,7 @@ const assertTableHeader = columns => {
   cy.findAllByTestId("header-cell").should("have.length", columns.length);
 
   columns.forEach((column, index) => {
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByTestId("header-cell").eq(index).should("have.text", column);
   });
 };

--- a/e2e/test/scenarios/binning/binning-options.cy.spec.js
+++ b/e2e/test/scenarios/binning/binning-options.cy.spec.js
@@ -325,6 +325,7 @@ function getAllOptions({ options, isSelected, shouldExpandList } = {}) {
   // Custom question has two popovers open.
   // The binning options are in the latest (last) one.
   // Using `.last()` works even when only one popover is open so it covers both scenarios.
+  // eslint-disable-next-line no-unsafe-element-filtering
   H.popover()
     .last()
     .within(() => {

--- a/e2e/test/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/binning/binning-reproductions.cy.spec.js
@@ -111,6 +111,7 @@ describe("binning related reproductions", () => {
       .findByRole("option", { name: "CREATED_AT" })
       .findByLabelText("Temporal bucket")
       .click();
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.popover().last().findByText("Quarter").click();
 
     H.getNotebookStep("sort").findByText("CREATED_AT: Quarter");

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -884,6 +884,7 @@ describe("scenarios > collection items listing", () => {
 
   function assertCollectionItemsOrder(testId, names) {
     for (let index = 0; index < names.length; ++index) {
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.findAllByTestId(testId).eq(index).should("have.text", names[index]);
     }
   }

--- a/e2e/test/scenarios/collections/revision-history.cy.spec.js
+++ b/e2e/test/scenarios/collections/revision-history.cy.spec.js
@@ -150,6 +150,7 @@ describe("revision history", () => {
               cy.findByRole("tab", { name: "History" }).click();
 
               // Last revert is the original state
+              // eslint-disable-next-line no-unsafe-element-filtering
               cy.findAllByTestId("question-revert-button").last().click();
 
               cy.wait("@revert").then(({ response: { statusCode, body } }) => {
@@ -189,6 +190,7 @@ describe("revision history", () => {
 });
 
 function clickRevert(event_name, index = 0) {
+  // eslint-disable-next-line no-unsafe-element-filtering
   cy.findAllByLabelText(event_name).eq(index).click();
 }
 

--- a/e2e/test/scenarios/collections/trash.cy.spec.js
+++ b/e2e/test/scenarios/collections/trash.cy.spec.js
@@ -28,6 +28,7 @@ describe("scenarios > collections > trash", () => {
 
     cy.log("should show trash at bottom of the side navbar");
     H.navigationSidebar().within(() => {
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.findAllByTestId("sidebar-collection-link-root")
         .last()
         .as("sidebar-trash-link")

--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -343,6 +343,7 @@ describe("Upload Table Cleanup/Management", { tags: "@external" }, () => {
 
       // multiple delete
       cy.findAllByRole("checkbox").first().click();
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.findAllByRole("checkbox").last().click();
     });
 
@@ -421,6 +422,7 @@ function uploadToExisting({
 
     cy.wait(uploadEndpoints[uploadMode]);
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByRole("status")
       .last()
       .findByText(/Data (added|replaced)/i, {

--- a/e2e/test/scenarios/custom-column/cc-shortcuts-combine.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-shortcuts-combine.cy.spec.ts
@@ -79,6 +79,7 @@ describe("scenarios > question > custom column > expression shortcuts > combine"
       "123.45678901234567 123.45678901234567 email@example.com",
     );
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByLabelText("Remove column").last().click();
 
     cy.findByTestId("combine-example").should(
@@ -165,9 +166,11 @@ function selectCombineColumns() {
 
 function selectColumn(index: number, table: string, name?: string) {
   H.expressionEditorWidget().within(() => {
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByTestId("column-input").eq(index).click();
   });
 
+  // eslint-disable-next-line no-unsafe-element-filtering
   H.popover()
     .last()
     .within(() => {

--- a/e2e/test/scenarios/custom-column/cc-shortcuts.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-shortcuts.cy.spec.ts
@@ -18,9 +18,11 @@ function selectCombineColumns() {
 
 function selectColumn(index: number, table: string, name?: string) {
   H.expressionEditorWidget().within(() => {
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByTestId("column-input").eq(index).click();
   });
 
+  // eslint-disable-next-line no-unsafe-element-filtering
   H.popover()
     .last()
     .within(() => {
@@ -162,6 +164,7 @@ describe("scenarios > question > custom column > expression shortcuts > extract"
 
     H.expressionEditorWidget().button("Done").click();
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByTestId("notebook-cell-item").last().click();
     selectExtractColumn();
 
@@ -308,6 +311,7 @@ describe("scenarios > question > custom column > expression shortcuts > combine"
       "123.45678901234567 123.45678901234567 email@example.com",
     );
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByLabelText("Remove column").last().click();
 
     cy.findByTestId("combine-example").should(

--- a/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
@@ -71,6 +71,7 @@ describe("issue 13289", () => {
 
     H.popover().findByText(CC_NAME).click();
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.icon("add").last().click();
 
     H.popover().within(() => {
@@ -938,6 +939,7 @@ describe("issue 42949", () => {
     cy.button("Add column").click();
     H.popover().findByText("Combine columns").click();
     H.popover().findAllByTestId("column-input").eq(0).click();
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.popover()
       .last()
       .within(() => {
@@ -983,6 +985,7 @@ describe("issue 42949", () => {
     H.popover().findByText("Extract part of column").should("not.exist");
     H.popover().findByText("Combine columns").click();
     H.popover().findAllByTestId("column-input").eq(0).click();
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.popover().last().findByText("N").should("be.visible");
   });
 
@@ -1010,6 +1013,7 @@ describe("issue 42949", () => {
     H.popover().findByText("Extract part of column").should("not.exist");
     H.popover().findByText("Combine columns").click();
     H.popover().findAllByTestId("column-input").eq(0).click();
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.popover().last().findByText("'abc'").should("be.visible");
   });
 });

--- a/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
@@ -213,6 +213,7 @@ describe("scenarios > question > custom column", () => {
 
     // TODO: There isn't a single unique parent that can be used to scope this icon within
     // (a good candidate would be `.NotebookCell`)
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.icon("add")
       .last() // This is brittle.
       .click();

--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -2109,6 +2109,7 @@ H.describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
       H.popover().findByText("User → Longitude: 10°").click();
 
       // 1st stage - Products (implicit join with Reviews)
+      // eslint-disable-next-line no-unsafe-element-filtering
       getClickMapping("Product → Vendor").last().click();
       H.popover().findByText("Product → Category").click();
 
@@ -2125,6 +2126,7 @@ H.describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
       H.popover().findByText("ID").click();
 
       // 2nd stage - Aggregations & breakouts
+      // eslint-disable-next-line no-unsafe-element-filtering
       getClickMapping("Count").last().click();
       H.popover().findByText("User → Longitude: 10°").click();
 
@@ -2640,6 +2642,7 @@ const onNextAnchorClick = callback => {
 };
 
 const clickLineChartPoint = () => {
+  // eslint-disable-next-line no-unsafe-element-filtering
   H.cartesianChartCircle()
     .eq(POINT_INDEX)
     /**
@@ -2819,6 +2822,7 @@ const testChangingBackToDefaultBehavior = () => {
 };
 
 const getTableCell = index => {
+  // eslint-disable-next-line no-unsafe-element-filtering
   return cy
     .findAllByTestId("table-row")
     .eq(POINT_INDEX)
@@ -2892,6 +2896,7 @@ function getClickMapping(columnName) {
 function verifyAvailableClickTargetColumns(columns) {
   cy.get("aside").within(() => {
     for (let index = 0; index < columns.length; ++index) {
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.findAllByTestId("click-target-column")
         .eq(index)
         .should("have.text", columns[index]);

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
@@ -1807,6 +1807,7 @@ describe("issue 48878", () => {
       cy.button("Save").click();
     });
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.modal()
       .last()
       .within(() => {

--- a/e2e/test/scenarios/dashboard-cards/dashboard-drill.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-drill.cy.spec.js
@@ -45,6 +45,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
         cy.get("input").first().type("/foo/{{my_number}}/{{my_param}}", {
           parseSpecialCharSequences: false,
         });
+        // eslint-disable-next-line no-unsafe-element-filtering
         cy.get("input")
           .last()
           .type("column value: {{my_number}}", {
@@ -286,6 +287,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
         cy.get("input")
           .first()
           .type(`/dashboard/${dashboardId}?my_param=Aaron Hand`, { delay: 0 });
+        // eslint-disable-next-line no-unsafe-element-filtering
         cy.get("input").last().type("Click behavior", { delay: 0 }).blur();
         cy.button("Done").click();
       });
@@ -990,6 +992,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
     function postDrillAssertion(filterName) {
       cy.findByTestId("qb-filters-panel").findByText(filterName).click();
       H.popover().within(() => {
+        // eslint-disable-next-line no-unsafe-element-filtering
         cy.findAllByRole("combobox")
           .last()
           .should("contain", "1")

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-misc.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-misc.cy.spec.ts
@@ -67,6 +67,7 @@ describe("scenarios > dashboard > filters > query stages + temporal unit paramet
         .findByLabelText("Created At")
         .findByLabelText("Temporal bucket")
         .click();
+      // eslint-disable-next-line no-unsafe-element-filtering
       H.popover().last().findByText("Week").click();
       H.getNotebookStep("summarize")
         .findByTestId("breakout-step")
@@ -78,6 +79,7 @@ describe("scenarios > dashboard > filters > query stages + temporal unit paramet
         cy.findByText("Category").click();
       });
 
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.findAllByTestId("action-buttons").last().button("Summarize").click();
       H.popover().findByText("Count of rows").click();
       H.getNotebookStep("summarize", { stage: 1 })

--- a/e2e/test/scenarios/dashboard-filters-2/shared/dashboard-filters-query-stages.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/shared/dashboard-filters-query-stages.ts
@@ -724,6 +724,7 @@ export function getPopoverItem(name: string, index = 0) {
    * Without scrollIntoView() the popover may scroll automatically to a different
    * place when clicking the item (unclear why).
    */
+  // eslint-disable-next-line no-unsafe-element-filtering
   return cy.findAllByText(name).eq(index).scrollIntoView();
 }
 
@@ -853,6 +854,7 @@ export function verifyDashcardCellValues({
   for (let valueIndex = 0; valueIndex < values.length; ++valueIndex) {
     const value = values[valueIndex];
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.getDashboardCard(dashcardIndex)
       .findByTestId("table-row")
       .findAllByTestId("cell-data")
@@ -869,6 +871,7 @@ export function verifyDashcardCellValues({
     const value = values[valueIndex];
     const cellIndex = valueIndex + values.length; // values.length to skip header row
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByTestId("cell-data").eq(cellIndex).should("have.text", value);
   }
 }

--- a/e2e/test/scenarios/dashboard-filters/dashboard-chained-filters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-chained-filters.cy.spec.js
@@ -111,6 +111,7 @@ describe("scenarios > dashboard > chained filter", () => {
 
       H.filterWidget().contains("AK").click();
 
+      // eslint-disable-next-line no-unsafe-element-filtering
       H.popover()
         .last()
         .within(() => {
@@ -144,6 +145,7 @@ describe("scenarios > dashboard > chained filter", () => {
       }
 
       H.filterWidget().contains("GA").click();
+      // eslint-disable-next-line no-unsafe-element-filtering
       H.popover()
         .last()
         .within(() => {

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-wiring.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-wiring.cy.spec.js
@@ -796,7 +796,9 @@ function getTableCell(columnName, rowIndex) {
     const columnHeaderIndex = $columnHeaders
       .toArray()
       .findIndex($columnHeader => $columnHeader.textContent === columnName);
+    // eslint-disable-next-line no-unsafe-element-filtering
     const row = cy.findAllByTestId("table-row").eq(rowIndex);
+    // eslint-disable-next-line no-unsafe-element-filtering
     row.findAllByTestId("cell-data").eq(columnHeaderIndex).as("cellData");
   });
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
@@ -35,6 +35,7 @@ describe("scenarios > dashboard > filters > date", () => {
     // Go through each of the filters and make sure they work individually
     Object.entries(DASHBOARD_DATE_FILTERS).forEach(
       ([filter, { value, representativeResult }], index) => {
+        // eslint-disable-next-line no-unsafe-element-filtering
         H.filterWidget().eq(index).click();
 
         dateFilterSelector({

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-location.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-location.cy.spec.js
@@ -30,6 +30,7 @@ describe("scenarios > dashboard > filters > location", () => {
 
     Object.entries(DASHBOARD_LOCATION_FILTERS).forEach(
       ([filter, { value, representativeResult }], index) => {
+        // eslint-disable-next-line no-unsafe-element-filtering
         H.filterWidget().eq(index).click();
         addWidgetStringFilter(value);
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-number-source.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-number-source.cy.spec.js
@@ -159,6 +159,7 @@ const filterDashboard = ({ isLabeled = false, isDropdown = false } = {}) => {
 
   if (isLabeled) {
     H.popover().first().findByPlaceholderText("Enter a number").type("T");
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.popover().last().findByText("Twenty").click();
     H.popover().first().button("Add filter").click();
     return;

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
@@ -49,6 +49,7 @@ describe("scenarios > dashboard > filters > number", () => {
 
     DASHBOARD_NUMBER_FILTERS.forEach(
       ({ operator, value, representativeResult }, index) => {
+        // eslint-disable-next-line no-unsafe-element-filtering
         H.filterWidget().eq(index).click();
         addWidgetNumberFilter(value);
         cy.wait("@dashboardData");

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-reset-clear.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-reset-clear.cy.spec.ts
@@ -1101,6 +1101,7 @@ function addRangeFilter(
 ) {
   filter(label).click();
   H.popover().findAllByRole("textbox").first().clear().type(firstValue).blur();
+  // eslint-disable-next-line no-unsafe-element-filtering
   H.popover().findAllByRole("textbox").last().clear().type(secondValue).blur();
   H.popover().button("Add filter").click();
 }
@@ -1112,6 +1113,7 @@ function updateRangeFilter(
 ) {
   filter(label).click();
   H.popover().findAllByRole("textbox").first().clear().type(firstValue).blur();
+  // eslint-disable-next-line no-unsafe-element-filtering
   H.popover().findAllByRole("textbox").last().clear().type(secondValue).blur();
   H.popover().button("Update filter").click();
 }

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-source.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-source.cy.spec.js
@@ -510,6 +510,7 @@ function setSearchFilter(label) {
     H.fieldValuesInput().type(label);
   });
 
+  // eslint-disable-next-line no-unsafe-element-filtering
   H.popover().last().findByText(label).click();
   H.popover().within(() => {
     H.fieldValuesValue(0).should("be.visible").should("contain", label);

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-date.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-date.cy.spec.js
@@ -40,6 +40,7 @@ describe("scenarios > dashboard > filters > SQL > date", () => {
 
     Object.entries(DASHBOARD_SQL_DATE_FILTERS).forEach(
       ([filter, { value, representativeResult }], index) => {
+        // eslint-disable-next-line no-unsafe-element-filtering
         H.filterWidget().eq(index).click();
         dateFilterSelector({
           filterType: filter,

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-location.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-location.cy.spec.js
@@ -39,6 +39,7 @@ describe("scenarios > dashboard > filters > location", () => {
 
     Object.entries(DASHBOARD_SQL_LOCATION_FILTERS).forEach(
       ([filter, { value, representativeResult }], index) => {
+        // eslint-disable-next-line no-unsafe-element-filtering
         H.filterWidget().eq(index).click();
         addWidgetStringFilter(value);
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-number.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-number.cy.spec.js
@@ -41,6 +41,7 @@ describe("scenarios > dashboard > filters > SQL > text/category", () => {
 
     Object.entries(DASHBOARD_SQL_NUMBER_FILTERS).forEach(
       ([filter, { value, representativeResult }], index) => {
+        // eslint-disable-next-line no-unsafe-element-filtering
         H.filterWidget().eq(index).click();
         addWidgetNumberFilter(value);
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-text-category.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-text-category.cy.spec.js
@@ -40,6 +40,7 @@ describe("scenarios > dashboard > filters > SQL > text/category", () => {
 
     Object.entries(DASHBOARD_SQL_TEXT_FILTERS).forEach(
       ([filter, { value, representativeResult }], index) => {
+        // eslint-disable-next-line no-unsafe-element-filtering
         H.filterWidget().eq(index).click();
         applyFilterByType(filter, value);
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
@@ -80,9 +80,11 @@ describe("scenarios > dashboard > filters > text/category", () => {
         { operator, value, representativeResult, single, negativeAssertion },
         index,
       ) => {
+        // eslint-disable-next-line no-unsafe-element-filtering
         H.filterWidget().eq(index).click();
         applyFilterByType(operator, value);
         waitDashboardCardQuery();
+        // eslint-disable-next-line no-unsafe-element-filtering
         H.filterWidget()
           .eq(index)
           .contains(single ? value.replace(/"/g, "") : /\d selections/);

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -68,6 +68,7 @@ describe("scenarios > dashboard > parameters", () => {
     // After typing "Ga", you should see this name!
     H.popover().within(() => cy.findByPlaceholderText("Search").type("Ga"));
     cy.wait("@dashboard");
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.popover().last().contains("Gabrielle Considine");
 
     // Continue typing a "d" and you see "Gadget"
@@ -76,6 +77,7 @@ describe("scenarios > dashboard > parameters", () => {
       .within(() => cy.findByPlaceholderText("Search").type("d"));
     cy.wait("@dashboard");
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.popover()
       .last()
       .within(() => {
@@ -90,6 +92,7 @@ describe("scenarios > dashboard > parameters", () => {
 
     cy.location("search").should("eq", "?text=Gadget");
     cy.findAllByTestId("dashcard-container").first().should("contain", "0");
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByTestId("dashcard-container").last().should("contain", "4,939");
   });
 

--- a/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
@@ -770,6 +770,7 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
       cy.log("add a temporal unit parameter");
       addTemporalUnitParameter();
       H.selectDashboardFilter(H.getDashboardCard(1), "Created At");
+      // eslint-disable-next-line no-unsafe-element-filtering
       H.undoToastList().last().button("Auto-connect").click();
       H.saveDashboard();
 

--- a/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
@@ -575,6 +575,7 @@ describe("Dashboard > Dashboard Questions", () => {
       // remove the card saved inside the dashboard
       H.editDashboard();
       H.dashboardCards().findByText("Total Orders").realHover();
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.icon("close").last().click();
       H.undoToast().findByText("Removed card");
       H.saveDashboard();

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1607,6 +1607,7 @@ describe("scenarios > dashboard > permissions", () => {
 });
 
 function validateIFrame(src, index = 0) {
+  // eslint-disable-next-line no-unsafe-element-filtering
   H.getDashboardCards()
     .get("iframe")
     .eq(index)

--- a/e2e/test/scenarios/dashboard/title-drill.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/title-drill.cy.spec.js
@@ -336,6 +336,7 @@ describe("scenarios > dashboard > title drill", () => {
         H.queryBuilderMain().findByText("53").should("be.visible");
 
         // make sure the unset id parameter works
+        // eslint-disable-next-line no-unsafe-element-filtering
         H.filterWidget().last().click();
         H.popover().within(() => {
           H.fieldValuesInput().type("5");

--- a/e2e/test/scenarios/embedding/embedding-questions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-questions.cy.spec.js
@@ -122,6 +122,7 @@ describe("scenarios > embedding > questions", () => {
     H.echartsContainer().should("contain", "60");
 
     // Check the tooltip for the last point on the line
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.cartesianChartCircle().last().trigger("mousemove");
 
     H.assertEChartsTooltip({

--- a/e2e/test/scenarios/embedding/embedding-snippets.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-snippets.cy.spec.js
@@ -53,6 +53,7 @@ features.forEach(feature => {
         .and("contain", "Python")
         .and("contain", "Clojure");
 
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.get(".ace_content").last().should("have.text", IFRAME_CODE);
 
       H.modal()

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -879,6 +879,7 @@ describe("issue 19494", () => {
   function connectFilterToCard({ filterName, cardPosition }) {
     cy.findByText(filterName).find(".Icon-gear").click();
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByText("Select…").eq(cardPosition).click();
 
     H.popover().contains("Category").click();
@@ -3613,9 +3614,11 @@ describe("issue 34955", () => {
 
       H.saveDashboard();
 
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.findAllByTestId("column-header")
         .eq(-2)
         .should("have.text", "Created At");
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.findAllByTestId("column-header").eq(-1).should("have.text", ccName);
       cy.findAllByTestId("cell-data")
         .filter(":contains(May 15, 2024, 8:04 AM)")
@@ -3627,6 +3630,7 @@ describe("issue 34955", () => {
     cy.get("@dashboardId").then(dashboard_id => {
       // Apply filter through URL to prevent the typing flakes
       cy.visit(`/dashboard/${dashboard_id}?on=&between=2024-01-01~2024-03-01`);
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.findAllByTestId("field-set-content")
         .last()
         .should("contain", "January 1, 2024 - March 1, 2024");

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-with-question-revert.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-with-question-revert.cy.spec.js
@@ -288,6 +288,7 @@ function connectFilterToColumn(column, index = 0) {
   });
 
   H.popover().within(() => {
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByText(column).eq(index).click();
   });
 }

--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -46,6 +46,7 @@ describe.skip("issue 12496", () => {
   });
 
   const datePickerInput = (picker, input) =>
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy
       .findAllByTestId("specific-date-picker")
       .eq(picker)
@@ -359,6 +360,7 @@ describe("issue 22230", () => {
   });
 
   it("should be able to filter on an aggregation (metabase#22230)", () => {
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByTestId("action-buttons").last().findByText("Filter").click();
 
     H.popover().within(() => {
@@ -566,6 +568,7 @@ describe("issue 25378", () => {
   });
 
   it("should be able to use relative date filter on a breakout after the aggregation (metabase#25378)", () => {
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByTestId("action-buttons").last().findByText("Filter").click();
 
     H.popover().within(() => {
@@ -710,6 +713,7 @@ describe("issue 25994", () => {
   });
 
   it("should be possible to use 'between' dates filter after aggregation (metabase#25994)", () => {
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByTestId("action-buttons").last().findByText("Filter").click();
 
     H.popover().within(() => {
@@ -1459,6 +1463,7 @@ describe("issue 47887", () => {
     });
 
     cy.findByTestId("notebook-button").click();
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByTestId("action-buttons").last().findByText("Filter").click();
 
     H.popover().within(() => {
@@ -1489,6 +1494,7 @@ describe("Issue 48851", () => {
       cy.findByText("Is").click();
     });
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.popover().last().findByText("Contains").click();
     H.popover()
       .first()
@@ -1512,6 +1518,7 @@ describe("issue 49321", () => {
       cy.findByText("Title").click();
       cy.findByText("Is").click();
     });
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.popover().last().findByText("Contains").click();
 
     H.popover().then($popover => {
@@ -1595,6 +1602,7 @@ describe("issue 44665", () => {
 
   it("should use the correct widget for the default value picker (metabase#44665)", () => {
     H.startNewNativeQuestion().type("select * from {{param");
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.sidebar()
       .last()
       .within(() => {
@@ -1608,6 +1616,7 @@ describe("issue 44665", () => {
       cy.button("Done").click();
     });
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.sidebar().last().findByText("Enter a default value…").click();
     H.popover().within(() => {
       cy.findByPlaceholderText("Enter a default value…")
@@ -1620,6 +1629,7 @@ describe("issue 44665", () => {
       cy.findByText("baz").should("not.exist");
     });
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.sidebar()
       .last()
       .within(() => {

--- a/e2e/test/scenarios/filters/filter-bulk.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter-bulk.cy.spec.js
@@ -101,6 +101,7 @@ describe("scenarios > filters > bulk filtering", () => {
         .eq(1)
         .should("include.text", "Discount");
 
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.findAllByTestId(/filter-column-/)
         .last()
         .should("include.text", "ID");

--- a/e2e/test/scenarios/filters/filter-sources.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter-sources.cy.spec.js
@@ -645,6 +645,7 @@ describe("scenarios > filters > filter sources", () => {
 });
 
 function addNewFilter() {
+  // eslint-disable-next-line no-unsafe-element-filtering
   cy.findAllByTestId("action-buttons").last().findByText("Filter").click();
 }
 

--- a/e2e/test/scenarios/filters/filter.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter.cy.spec.js
@@ -316,11 +316,13 @@ describe("scenarios > question > filter", () => {
 
     H.enterCustomColumnDetails({ formula: "[", blur: false });
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.popover().last().findByText("Body");
 
     cy.get("@formula").type("p");
 
     // only "P" (of Products etc) should be highlighted, and not "Pr"
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.popover()
       .last()
       .within(() => {
@@ -849,6 +851,7 @@ describe("scenarios > question > filter", () => {
       // See: https://github.com/metabase/metabase/pull/16209#discussion_r638129099
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/^Total/);
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.icon("add").last().click();
       H.popover().findByText(/^ID$/i).click();
       cy.findByPlaceholderText("Enter an ID").type("1");
@@ -879,6 +882,7 @@ describe("scenarios > question > filter", () => {
       });
 
       // cy.findByText(/^Total/);
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.icon("add").last().click();
       H.popover().findByText(/^ID$/i).click();
       cy.findByPlaceholderText("Enter an ID").type("1");

--- a/e2e/test/scenarios/filters/relative-datetime.cy.spec.js
+++ b/e2e/test/scenarios/filters/relative-datetime.cy.spec.js
@@ -268,6 +268,7 @@ const addStartingFrom = () => {
 
 const setRelativeDatetimeUnit = unit => {
   cy.findByLabelText("Unit").click();
+  // eslint-disable-next-line no-unsafe-element-filtering
   cy.findAllByText(unit).last().click();
 };
 
@@ -277,6 +278,7 @@ const setRelativeDatetimeValue = value => {
 
 const setStartingFromUnit = unit => {
   cy.findByLabelText("Starting from unit").click();
+  // eslint-disable-next-line no-unsafe-element-filtering
   cy.findAllByText(unit).last().click();
 };
 

--- a/e2e/test/scenarios/filters/view.cy.spec.js
+++ b/e2e/test/scenarios/filters/view.cy.spec.js
@@ -90,6 +90,7 @@ describe("scenarios > question > view", () => {
         cy.findByText("Add filter").click();
       });
 
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.findAllByTestId("run-button").last().click();
 
       cy.findAllByText("Widget");
@@ -125,6 +126,7 @@ describe("scenarios > question > view", () => {
           .type("Widget");
         cy.findByText("Add filter").click();
       });
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.findAllByTestId("run-button").last().click();
 
       cy.get(".test-TableInteractive-cellWrapper--firstColumn").should(

--- a/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
@@ -195,6 +195,7 @@ describe("issue 15342", { tags: "@external" }, () => {
     H.getNotebookStep("join").findByLabelText("Right column").click();
     H.popover().findByText("Product ID").click();
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.icon("join_left_outer").last().click();
     H.entityPickerModal().within(() => {
       H.entityPickerModalTab("Tables").click();
@@ -351,6 +352,7 @@ describe("issue 17968", () => {
       .click();
     H.popover().findByText("Created At").click();
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByTestId("action-buttons").last().button("Join data").click();
     H.entityPickerModal().within(() => {
       H.entityPickerModalTab("Tables").click();
@@ -647,6 +649,7 @@ describe("issue 20519", () => {
 
   // Tightly related issue: metabase#17767
   it("should allow subsequent joins and nested query after summarizing on the implicit joins (metabase#20519)", () => {
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByLabelText("Custom column").last().click();
 
     H.enterCustomColumnDetails({
@@ -846,10 +849,12 @@ describe("issue 23293", () => {
         "contain",
         "Product → Category is Doohickey",
       );
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.findAllByTestId("header-cell")
         .last()
         .should("have.text", "Product → Category");
 
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.findAllByRole("grid")
         .last()
         .as("tableResults")
@@ -889,6 +894,7 @@ describe("issue 27380", () => {
     );
 
     // Doesn't really matter which 'circle" we click on the graph
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.cartesianChartCircle().last().click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("See this month by week").click();
@@ -1224,6 +1230,7 @@ describe.skip("issue 27521", () => {
   });
 
   function assertTableHeader(index, name) {
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByTestId("header-cell").eq(index).should("have.text", name);
   }
 });

--- a/e2e/test/scenarios/joins/joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins.cy.spec.js
@@ -241,6 +241,7 @@ describe("scenarios > question > joined questions", () => {
     H.addSummaryField({ metric: "Count of rows" });
     H.addSummaryGroupingField({ table: "Products", field: "ID" });
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByTestId("action-buttons").last().button("Join data").click();
     H.joinTable("Reviews");
     H.visualize();
@@ -289,6 +290,7 @@ describe("scenarios > question > joined questions", () => {
 
     cy.findByLabelText("Right column").click();
     H.popover().findByText("by month").click({ force: true });
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.popover().last().findByText("Week").click();
 
     assertJoinColumnName("left", "Created At: Week");
@@ -298,6 +300,7 @@ describe("scenarios > question > joined questions", () => {
 
     cy.findByLabelText("Right column").click();
     H.popover().findByText("by week").click({ force: true });
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.popover().last().findByText("Day").click();
 
     assertJoinColumnName("left", "Created At: Day");

--- a/e2e/test/scenarios/metrics/browse.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/browse.cy.spec.ts
@@ -445,6 +445,7 @@ function findMetric(name: string) {
 }
 
 function getMetricsTableItem(index: number) {
+  // eslint-disable-next-line no-unsafe-element-filtering
   return metricsTable().findAllByTestId("metric-name").eq(index);
 }
 

--- a/e2e/test/scenarios/metrics/metrics-collection.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-collection.cy.spec.js
@@ -170,6 +170,7 @@ describe("scenarios > metrics > collection", () => {
     H.getUnpinnedSection()
       .findByText(ORDERS_TIMESERIES_METRIC.name)
       .should("not.exist");
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.undoToastList().last().findByText("Trashed metric").should("be.visible");
 
     openArchive();
@@ -178,6 +179,7 @@ describe("scenarios > metrics > collection", () => {
     H.getUnpinnedSection()
       .findByText(ORDERS_TIMESERIES_METRIC.name)
       .should("not.exist");
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.undoToastList()
       .last()
       .findByText(`${ORDERS_TIMESERIES_METRIC.name} has been restored.`)
@@ -191,6 +193,7 @@ describe("scenarios > metrics > collection", () => {
     H.popover().findByText("Delete permanently").click();
     H.modal().button("Delete permanently").click();
     H.getUnpinnedSection().should("not.exist");
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.undoToastList()
       .last()
       .findByText("This item has been permanently deleted.")

--- a/e2e/test/scenarios/metrics/metrics-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-dashboard.cy.spec.js
@@ -199,6 +199,7 @@ describe("scenarios > metrics > dashboard", () => {
       cy.findByText("Metrics").click();
       cy.findByText(ORDERS_SCALAR_METRIC.name).click();
     });
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.undoToastList()
       .last()
       .findByText("Question replaced")
@@ -213,6 +214,7 @@ describe("scenarios > metrics > dashboard", () => {
       cy.findByText("Questions").click();
       cy.findByText("Orders").click();
     });
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.undoToastList().last().findByText("Metric replaced").should("be.visible");
     H.getDashboardCard().findByText("Orders").should("be.visible");
   });

--- a/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
@@ -511,6 +511,7 @@ function getActionButton(title) {
 }
 
 function getPlusButton() {
+  // eslint-disable-next-line no-unsafe-element-filtering
   return cy.findAllByTestId("notebook-cell-item").last();
 }
 
@@ -587,6 +588,7 @@ function addBreakout({ tableName, columnName, bucketName, stageIndex }) {
   }
   if (bucketName) {
     H.popover().findByLabelText(columnName).findByText("by month").click();
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.popover().last().findByText(bucketName).click();
   } else {
     H.popover().findByText(columnName).click();

--- a/e2e/test/scenarios/models/helpers/e2e-models-helpers.js
+++ b/e2e/test/scenarios/models/helpers/e2e-models-helpers.js
@@ -103,6 +103,7 @@ export function turnIntoModel() {
 }
 
 export function selectFromDropdown(option, clickOpts) {
+  // eslint-disable-next-line no-unsafe-element-filtering
   popover().last().findByText(option).click(clickOpts);
 }
 

--- a/e2e/test/scenarios/models/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.js
@@ -879,6 +879,7 @@ describe("issue 28193", () => {
 
   function assertOnColumns() {
     cy.findAllByText("2.07").should("be.visible").and("have.length", 2);
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByTestId("header-cell")
       .should("be.visible")
       .last()
@@ -1220,6 +1221,7 @@ describe("issue 29951", { requestTimeout: 10000, viewportWidth: 1600 }, () => {
     cy.button("Get Answer").should("be.visible");
     H.saveMetadataChanges();
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByTestId("header-cell").last().should("have.text", "CC1");
 
     dragColumn(0, 100);
@@ -1663,6 +1665,7 @@ describe("issue 37009", () => {
       .button("Save")
       .should("be.enabled")
       .click();
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.modal()
       .last()
       .within(() => {

--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -39,6 +39,7 @@ describe("issue 29943", () => {
   }
 
   function getHeaderCell(columnIndex: number, name: string) {
+    // eslint-disable-next-line no-unsafe-element-filtering
     return cy
       .findAllByTestId("header-cell")
       .eq(columnIndex)
@@ -535,6 +536,7 @@ describe.skip("issue 40635", () => {
   }
 
   function assertTableHeader(index: number, name: string) {
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByTestId("header-cell").eq(index).should("have.text", name);
   }
 
@@ -1195,6 +1197,7 @@ describe.skip("issues 28270, 33708", () => {
     H.tableHeaderClick("Title");
     H.popover().findByText("Filter by this column").click();
     H.popover().findByLabelText("Filter operator").click();
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.popover().last().findByText("Contains").click();
     H.popover().findByLabelText("Filter value").type("a,");
     H.popover().button("Add filter").click();

--- a/e2e/test/scenarios/native-filters/helpers/e2e-field-filter-helpers.js
+++ b/e2e/test/scenarios/native-filters/helpers/e2e-field-filter-helpers.js
@@ -162,6 +162,7 @@ function addBetweenFilter([low, high] = [], buttonLabel = "Add filter") {
   popover().within(() => {
     cy.get("input").first().type(`${low}{enter}`);
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.get("input").last().type(`${high}{enter}`);
   });
 

--- a/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
@@ -83,6 +83,7 @@ describe("issue 11480", () => {
 describe("issue 11580", () => {
   function assertVariablesOrder() {
     cy.get("@variableLabels").first().should("have.text", "foo");
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.get("@variableLabels").last().should("have.text", "bar");
   }
 
@@ -1221,6 +1222,7 @@ describe("issue 49577", () => {
 
   it("should not show the values initially when using a single select search box (metabase#49577)", () => {
     H.startNewNativeQuestion().type("select * from {{param");
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.sidebar()
       .last()
       .within(() => {
@@ -1246,6 +1248,7 @@ describe("issue 49577", () => {
       cy.findByText("foo").should("be.visible");
     });
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.sidebar().last().findByText("Dropdown list").click();
 
     H.filterWidget().click();

--- a/e2e/test/scenarios/native-filters/sql-filters-source.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-filters-source.cy.spec.js
@@ -513,7 +513,9 @@ describe("scenarios > filters > sql filters > values source", () => {
       FieldFilter.openEntryForm();
 
       H.fieldValuesInput().type("Custom Label");
+      // eslint-disable-next-line no-unsafe-element-filtering
       H.popover().last().findByText("1018947080336").should("not.exist");
+      // eslint-disable-next-line no-unsafe-element-filtering
       H.popover().last().findByText("Custom Label").click();
       H.fieldValuesValue(0)
         .should("be.visible")
@@ -536,7 +538,9 @@ describe("scenarios > filters > sql filters > values source", () => {
       FieldFilter.openEntryForm();
 
       H.fieldValuesInput().type("Custom Label");
+      // eslint-disable-next-line no-unsafe-element-filtering
       H.popover().last().findByText("1018947080336").should("not.exist");
+      // eslint-disable-next-line no-unsafe-element-filtering
       H.popover().last().findByText("Custom Label").click();
       H.fieldValuesValue(0)
         .should("be.visible")
@@ -559,7 +563,9 @@ describe("scenarios > filters > sql filters > values source", () => {
       FieldFilter.openEntryForm();
 
       H.fieldValuesInput().type("Custom Label");
+      // eslint-disable-next-line no-unsafe-element-filtering
       H.popover().last().findByText("1018947080336").should("not.exist");
+      // eslint-disable-next-line no-unsafe-element-filtering
       H.popover().last().findByText("Custom Label").click();
       H.fieldValuesValue(0)
         .should("be.visible")
@@ -721,6 +727,7 @@ describe("scenarios > filters > sql filters > values source > number parameter",
       H.fieldValuesInput().type("Tw");
       checkFilterValueNotInList("10");
       checkFilterValueNotInList("20");
+      // eslint-disable-next-line no-unsafe-element-filtering
       H.popover().last().findByText("Twenty").click();
       H.popover().button("Add filter").click();
 
@@ -748,6 +755,7 @@ describe("scenarios > filters > sql filters > values source > number parameter",
       checkFilterValueNotInList("10");
       checkFilterValueNotInList("20");
 
+      // eslint-disable-next-line no-unsafe-element-filtering
       H.popover().last().findByText("Twenty").click();
       H.popover().button("Add filter").click();
 
@@ -774,6 +782,7 @@ describe("scenarios > filters > sql filters > values source > number parameter",
       checkFilterValueNotInList("10");
       checkFilterValueNotInList("20");
 
+      // eslint-disable-next-line no-unsafe-element-filtering
       H.popover().last().findByText("Twenty").click();
       H.popover().button("Add filter").click();
 
@@ -800,6 +809,7 @@ describe("scenarios > filters > sql filters > values source > number parameter",
       FieldFilter.openEntryForm();
 
       H.multiAutocompleteInput().type("Tw");
+      // eslint-disable-next-line no-unsafe-element-filtering
       H.popover().last().findByText("Twenty").click();
 
       H.multiAutocompleteValue(0)
@@ -828,6 +838,7 @@ describe("scenarios > filters > sql filters > values source > number parameter",
       FieldFilter.openEntryForm();
 
       H.multiAutocompleteInput().type("Tw");
+      // eslint-disable-next-line no-unsafe-element-filtering
       H.popover().last().findByText("Twenty").click();
       H.multiAutocompleteValue(0)
         .should("be.visible")
@@ -1063,6 +1074,7 @@ const updateQuestion = () => {
 };
 
 const checkFilterValueInList = value => {
+  // eslint-disable-next-line no-unsafe-element-filtering
   H.popover()
     .last()
     .within(() => {
@@ -1071,6 +1083,7 @@ const checkFilterValueInList = value => {
 };
 
 const checkFilterValueNotInList = value => {
+  // eslint-disable-next-line no-unsafe-element-filtering
   H.popover()
     .last()
     .within(() => {

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -143,6 +143,7 @@ describe("command palette", () => {
         const results = response.body.data;
 
         results.forEach((result, index) => {
+          // eslint-disable-next-line no-unsafe-element-filtering
           cy.findAllByRole("option")
             .eq(index + 2)
             .should("contain.text", result.name);

--- a/e2e/test/scenarios/onboarding/reference/databases.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/reference/databases.cy.spec.js
@@ -99,6 +99,7 @@ describe("scenarios > reference > databases", () => {
 
 function checkReferenceDatabasesOrder() {
   cy.get("[class*=Card]").as("databaseCard").first().should("have.text", "a");
+  // eslint-disable-next-line no-unsafe-element-filtering
   cy.get("@databaseCard").last().should("have.text", "Sample Database");
 }
 
@@ -111,6 +112,7 @@ function checkQuestionSourceDatabasesOrder() {
   H.popover().within(() => {
     cy.findByText("Raw Data").click();
     cy.get(selector).as("databaseName").eq(1).should("have.text", "a");
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.get("@databaseName")
       .eq(lastDatabaseIndex)
       .should("have.text", "Sample Database");

--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -295,15 +295,19 @@ describe("scenarios > setup", () => {
     skipLicenseStepOnEE();
 
     // usage data
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.get("section")
       .last()
       .findByText(/certain data about product usage/);
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.get("section").last().button("Finish").click();
 
     // done
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.get("section")
       .last()
       .findByText(/You're all set up/);
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.get("section")
       .last()
       .findByRole("link", { name: "Take me to Metabase" })
@@ -359,13 +363,16 @@ describe("scenarios > setup", () => {
         "not.exist",
       );
 
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.get("section")
         .last()
         .findByText(/certain data about product usage/);
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.get("section").last().button("Finish").click();
 
       // Finish & Subscribe
       cy.intercept("GET", "/api/session/properties").as("properties");
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.get("section")
         .last()
         .findByRole("link", { name: "Take me to Metabase" })

--- a/e2e/test/scenarios/permissions/view-data.cy.spec.js
+++ b/e2e/test/scenarios/permissions/view-data.cy.spec.js
@@ -41,6 +41,7 @@ H.describeEE("scenarios > admin > permissions > view data > blocked", () => {
     cy.log(
       "assert that user properly sees native query warning related to table level blocking",
     );
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.getPermissionRowPermissions("All Users")
       .eq(DATA_ACCESS_PERM_IDX)
       .findByLabelText("warning icon")
@@ -340,6 +341,7 @@ H.describeEE(
       H.saveImpersonationSettings();
       H.savePermissions();
 
+      // eslint-disable-next-line no-unsafe-element-filtering
       H.getPermissionRowPermissions("QA Postgres12")
         .eq(DATA_ACCESS_PERM_IDX)
         .findByLabelText("warning icon")

--- a/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
@@ -235,6 +235,7 @@ describe("issue 27104", () => {
   });
 
   it("should correctly format the filter operator after the aggregation (metabase#27104)", () => {
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByTestId("action-buttons").last().findByText("Filter").click();
     H.popover().findByText("Count").click();
     // The following line is the main assertion.

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -509,6 +509,7 @@ describe("issue 40435", () => {
     H.getNotebookStep("data").button("Pick columns").click();
     H.popover().findByText("Product ID").click();
     H.queryBuilderHeader().findByText("Save").click();
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.modal().last().findByText("Save").click();
     cy.wait("@updateCard");
     H.visualize();
@@ -672,6 +673,7 @@ describe("issue 42244", () => {
       cy.findByText(COLUMN_NAME).realHover();
       cy.findByText("by month").should("be.visible").click();
     });
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.popover().last().findByText("Year").click();
     H.getNotebookStep("summarize")
       .findByText(`${COLUMN_NAME}: Year`)
@@ -1166,6 +1168,7 @@ describe("issue 31960", () => {
     );
 
     H.getDashboardCard().within(() => {
+      // eslint-disable-next-line no-unsafe-element-filtering
       H.cartesianChartCircle().eq(dotIndex).realHover();
     });
     H.assertEChartsTooltip({
@@ -1175,6 +1178,7 @@ describe("issue 31960", () => {
       ],
     });
     H.getDashboardCard().within(() => {
+      // eslint-disable-next-line no-unsafe-element-filtering
       H.cartesianChartCircle().eq(dotIndex).click({ force: true });
     });
 
@@ -1486,6 +1490,7 @@ describe("issue 44668", () => {
 
     H.openNotebook();
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByTestId("action-buttons").last().button("Custom column").click();
     H.enterCustomColumnDetails({
       formula: 'concat("abc_", [Count])',

--- a/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
@@ -84,6 +84,7 @@ describe("issue 39487", () => {
     H.popover().findByText("Filter by this column").click();
     H.popover().findByText("Specific dates…").click();
     H.popover().findAllByRole("textbox").first().clear().type("2024/05/01");
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.popover().findAllByRole("textbox").last().clear().type("2024/06/01");
     previousButton().click();
     checkDateRangeFilter();

--- a/e2e/test/scenarios/question/column-compare.cy.spec.ts
+++ b/e2e/test/scenarios/question/column-compare.cy.spec.ts
@@ -291,6 +291,7 @@ describe.skip("scenarios > question", () => {
         );
 
         H.openNotebook();
+        // eslint-disable-next-line no-unsafe-element-filtering
         H.getNotebookStep("summarize")
           .findAllByTestId("aggregate-step")
           .last()
@@ -329,6 +330,7 @@ describe.skip("scenarios > question", () => {
         );
 
         H.openNotebook();
+        // eslint-disable-next-line no-unsafe-element-filtering
         H.getNotebookStep("summarize")
           .findAllByTestId("aggregate-step")
           .last()
@@ -345,6 +347,7 @@ describe.skip("scenarios > question", () => {
           cy.findByLabelText("Unit").click();
         });
 
+        // eslint-disable-next-line no-unsafe-element-filtering
         H.popover().last().findByText("Weeks").click();
 
         H.popover().within(() => {
@@ -1081,6 +1084,7 @@ describe.skip("scenarios > question", () => {
         );
 
         H.openNotebook();
+        // eslint-disable-next-line no-unsafe-element-filtering
         H.getNotebookStep("summarize")
           .findAllByTestId("aggregate-step")
           .last()
@@ -1097,6 +1101,7 @@ describe.skip("scenarios > question", () => {
           cy.findByLabelText("Unit").click();
         });
 
+        // eslint-disable-next-line no-unsafe-element-filtering
         H.popover().last().findByText("Week").click();
 
         H.popover().within(() => {
@@ -1913,6 +1918,7 @@ function verifyPlusButtonText(options: CheckTextOpts) {
 
 function verifyNotebookText(options: CheckTextOpts) {
   H.openNotebook();
+  // eslint-disable-next-line no-unsafe-element-filtering
   H.getNotebookStep("summarize")
     .findAllByTestId("aggregate-step")
     .last()

--- a/e2e/test/scenarios/question/multiple-column-breakouts.cy.spec.ts
+++ b/e2e/test/scenarios/question/multiple-column-breakouts.cy.spec.ts
@@ -306,6 +306,7 @@ describe("scenarios > question > multiple column breakouts", () => {
             .findByLabelText(columnName)
             .findByLabelText(bucketLabel)
             .click();
+          // eslint-disable-next-line no-unsafe-element-filtering
           H.popover().last().findByText(bucket1Name).click();
           H.getNotebookStep("summarize")
             .findByTestId("breakout-step")
@@ -315,6 +316,7 @@ describe("scenarios > question > multiple column breakouts", () => {
             .findByLabelText(columnName)
             .findByLabelText(bucketLabel)
             .click();
+          // eslint-disable-next-line no-unsafe-element-filtering
           H.popover().last().findByText(bucket2Name).click();
           H.visualize();
           cy.wait("@dataset");
@@ -518,6 +520,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           .should("contain.text", "All time")
           .click();
         H.popover().findByDisplayValue("All time").click();
+        // eslint-disable-next-line no-unsafe-element-filtering
         H.popover().last().findByText("On").click();
         H.popover().within(() => {
           cy.findByLabelText("Date").clear().type("August 14, 2023");
@@ -1800,11 +1803,13 @@ function tableHeaderClick(
   columnName: string,
   { columnIndex = 0 }: { columnIndex?: number } = {},
 ) {
+  // eslint-disable-next-line no-unsafe-element-filtering
   H.tableInteractive()
     .findAllByText(columnName)
     .eq(columnIndex)
     .trigger("mousedown");
 
+  // eslint-disable-next-line no-unsafe-element-filtering
   H.tableInteractive()
     .findAllByText(columnName)
     .eq(columnIndex)

--- a/e2e/test/scenarios/question/nested.cy.spec.js
+++ b/e2e/test/scenarios/question/nested.cy.spec.js
@@ -395,6 +395,7 @@ describe("scenarios > question > nested", () => {
     });
 
     it("Count of rows AND Sum of VAL by CAT (metabase#15725-1)", () => {
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.icon("add").last().click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/^Sum of/).click();

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -705,6 +705,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
         horizontal,
         vertical,
       });
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.findAllByTestId("notebook-cell-item")
         .eq(index)
         .should("have.text", name);
@@ -744,6 +745,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
           vertical,
         });
       });
+      // eslint-disable-next-line no-unsafe-element-filtering
       H.getNotebookStep(type)
         .findAllByTestId("notebook-cell-item")
         .eq(index)
@@ -910,6 +912,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
             .should("eq", "Revenue");
         });
 
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.get("@table")
         .last()
         .as("tableBody")
@@ -944,6 +947,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       .findByText("by month")
       .click();
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.popover()
       .last()
       .within(() => {
@@ -959,6 +963,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       .findByText("Auto bin")
       .click();
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.popover()
       .last()
       .within(() => {
@@ -1079,6 +1084,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     H.joinTable("Reviews", "Product ID", "Product ID");
     H.addSummaryField({ metric: "Count of rows" });
     H.addSummaryGroupingField({ field: "Created At" });
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByRole("button", { name: "Join data" }).last().click();
     H.joinTable("Reviews", "Created At: Month", "Created At");
     cy.button("Summarize").click();

--- a/e2e/test/scenarios/question/offset.cy.spec.ts
+++ b/e2e/test/scenarios/question/offset.cy.spec.ts
@@ -172,6 +172,7 @@ describe("scenarios > question > offset", () => {
       const columnIndex = 9;
       const columnsCount = 10;
       const cellIndex = rowIndex * columnsCount + columnIndex;
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.findAllByRole("gridcell").eq(cellIndex).click();
       cy.get(H.POPOVER_ELEMENT).should("not.exist");
 
@@ -547,6 +548,7 @@ describe("scenarios > question > offset", () => {
         table: "Product",
         field: "Category",
       });
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.findAllByLabelText("Custom column").last().click();
 
       H.enterCustomColumnDetails({
@@ -555,6 +557,7 @@ describe("scenarios > question > offset", () => {
       });
       H.popover().findByText("Done").click();
 
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.findAllByTestId("action-buttons").last().icon("filter").click();
       H.popover().findByText("Custom Expression").click();
 
@@ -563,6 +566,7 @@ describe("scenarios > question > offset", () => {
       });
       H.popover().findByText("Done").click();
 
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.findAllByTestId("action-buttons").last().icon("sort").click();
       H.popover().findByText(OFFSET_SUM_TOTAL_AGGREGATION_NAME).click();
       H.getNotebookStep("sort", { stage: 1, index: 0 })
@@ -1346,6 +1350,7 @@ function verifyTableContent(rows: string[][]) {
 }
 
 function verifyTableCellContent(index: number, text: string) {
+  // eslint-disable-next-line no-unsafe-element-filtering
   cy.findAllByRole("gridcell").eq(index).should("have.text", text);
 }
 
@@ -1415,6 +1420,7 @@ function addCustomColumn({
   if (actionButtonsGroup === "first") {
     cy.findAllByTestId("action-buttons").first().icon("add_data").click();
   } else {
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByTestId("action-buttons").last().icon("add_data").click();
   }
 

--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -53,6 +53,7 @@ describe("scenarios > question > saved", () => {
     cy.button("Not now").click();
 
     // Add a filter in order to be able to save question again
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByTestId("action-buttons").last().findByText("Filter").click();
 
     H.popover().findByText("Total: Auto binned").click();

--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -199,6 +199,7 @@ describe("scenarios > question > settings", () => {
        */
 
       function findColumnAtIndex(column_name, index) {
+        // eslint-disable-next-line no-unsafe-element-filtering
         return getVisibleSidebarColumns().eq(index).contains(column_name);
       }
     });

--- a/e2e/test/scenarios/question/summarization.cy.spec.js
+++ b/e2e/test/scenarios/question/summarization.cy.spec.js
@@ -203,6 +203,7 @@ describe("scenarios > question > summarize sidebar", () => {
       cy.findByLabelText("Temporal bucket").click();
     });
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.popover()
       .last()
       .within(() => {

--- a/e2e/test/scenarios/search/recently-viewed.cy.spec.js
+++ b/e2e/test/scenarios/search/recently-viewed.cy.spec.js
@@ -152,8 +152,10 @@ H.describeEE("search > recently viewed > enterprise features", () => {
 });
 
 const assertRecentlyViewedItem = (index, title, type) => {
+  // eslint-disable-next-line no-unsafe-element-filtering
   cy.findAllByTestId("recently-viewed-item-title")
     .eq(index)
     .should("have.text", title);
+  // eslint-disable-next-line no-unsafe-element-filtering
   cy.findAllByTestId("result-link-wrapper").eq(index).should("have.text", type);
 };

--- a/e2e/test/scenarios/sharing/alert/alert-permissions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/alert-permissions.cy.spec.js
@@ -113,6 +113,7 @@ function createBasicAlert({ firstAlert, includeNormal } = {}) {
   }
 
   if (includeNormal) {
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findByText("Email alerts to:").parent().children().last().click();
     cy.findByText(H.getFullName(normal)).click();
   }

--- a/e2e/test/scenarios/sharing/sharing-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/sharing-reproductions.cy.spec.js
@@ -563,6 +563,7 @@ describe("issue 25473", () => {
   };
 
   function assertOnResults() {
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByTestId("column-header").last().should("have.text", ccName);
     cy.findAllByText("xavier").should("have.length", 2);
 

--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -668,6 +668,7 @@ describe("scenarios > dashboard > subscriptions", () => {
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Emailed hourly").click();
 
+        // eslint-disable-next-line no-unsafe-element-filtering
         cy.findAllByText("Corbin Mertz").last().click();
         H.popover().within(() => {
           H.fieldValuesInput().type("Bob");
@@ -675,6 +676,7 @@ describe("scenarios > dashboard > subscriptions", () => {
         });
         H.popover().contains("Update filter").click();
 
+        // eslint-disable-next-line no-unsafe-element-filtering
         cy.findAllByText("Text 1").last().click();
         H.popover().findByText("Gizmo").click();
         H.popover().contains("Add filter").click();

--- a/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
@@ -793,6 +793,7 @@ describe("scenarios > visualizations > bar chart", () => {
       H.popover()
         .findByTestId("graph-other-category-aggregation-fn-picker")
         .click();
+      // eslint-disable-next-line no-unsafe-element-filtering
       H.popover().last().findByText(fnName).click();
     }
 

--- a/e2e/test/scenarios/visualizations-charts/legend.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/legend.cy.spec.js
@@ -564,6 +564,7 @@ describe("scenarios > visualizations > legend", () => {
 });
 
 function hideSeries(legendItemIndex) {
+  // eslint-disable-next-line no-unsafe-element-filtering
   cy.findAllByTestId("legend-item")
     .eq(legendItemIndex)
     .findByLabelText("Hide series")
@@ -571,6 +572,7 @@ function hideSeries(legendItemIndex) {
 }
 
 function showSeries(legendItemIndex) {
+  // eslint-disable-next-line no-unsafe-element-filtering
   cy.findAllByTestId("legend-item")
     .eq(legendItemIndex)
     .findByLabelText("Show series")

--- a/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
@@ -1078,11 +1078,13 @@ function resetHoverState() {
 
 function showTooltipForCircleInSeries(seriesColor, index = 0) {
   resetHoverState();
+  // eslint-disable-next-line no-unsafe-element-filtering
   H.cartesianChartCircleWithColor(seriesColor).eq(index).realHover();
 }
 
 function showTooltipForBarInSeries(seriesColor, index = 0) {
   resetHoverState();
+  // eslint-disable-next-line no-unsafe-element-filtering
   H.chartPathWithFillColor(seriesColor).eq(index).realHover();
 }
 

--- a/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
@@ -307,6 +307,7 @@ describe("scenarios > visualizations > pie chart", () => {
 
     H.openVizSettingsSidebar();
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByTestId("chartsettings-field-picker")
       .last()
       .within(() => {
@@ -318,6 +319,7 @@ describe("scenarios > visualizations > pie chart", () => {
       ["Affiliate", "Facebook", "Google", "Organic", "Twitter"],
     );
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByTestId("chartsettings-field-picker")
       .last()
       .within(() => {
@@ -694,6 +696,7 @@ function confirmSliceClickBehavior(sliceLabel, value, elementIndex) {
     if (elementIndex == null) {
       cy.findByText(sliceLabel).click({ force: true });
     } else {
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.findAllByText(sliceLabel).eq(elementIndex).click({ force: true });
     }
   });

--- a/e2e/test/scenarios/visualizations-charts/rows.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/rows.cy.spec.js
@@ -89,6 +89,7 @@ describe("scenarios > visualizations > rows", () => {
           .realHover()
           .invoke("width")
           .then(newWidth => {
+            // eslint-disable-next-line no-unsafe-element-filtering
             expect(prevWidth).eq(newWidth);
           });
       });

--- a/e2e/test/scenarios/visualizations-charts/scatter.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/scatter.cy.spec.js
@@ -240,6 +240,7 @@ function triggerPopoverForBubble(index = 13, force = false) {
     cy.findByLabelText("Switch to visualization").click(); // ... and then back to the scatter visualization (that now seems to be stable enough to make assertions about)
   });
 
+  // eslint-disable-next-line no-unsafe-element-filtering
   H.cartesianChartCircle()
     .eq(index) // Random bubble
     .trigger("mousemove", { force });

--- a/e2e/test/scenarios/visualizations-charts/trendline.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/trendline.cy.spec.js
@@ -37,6 +37,7 @@ describe("scenarios > question > trendline", () => {
     // Remove sum of total
     H.leftSidebar().within(() => {
       cy.findByText("Data").click();
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.icon("close").last().click({ force: true });
       cy.findByText("Done").click();
     });

--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
@@ -97,6 +97,7 @@ describe("issue 16170", { tags: "@mongo" }, () => {
 
       assertOnTheYAxis();
 
+      // eslint-disable-next-line no-unsafe-element-filtering
       H.cartesianChartCircle().eq(-2).trigger("mousemove");
 
       H.assertEChartsTooltip({
@@ -162,6 +163,7 @@ describe("issue 17524", () => {
 
       cy.get("polygon");
 
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.icon("play").last().click();
 
       cy.get("polygon");
@@ -725,6 +727,7 @@ describe("issue 25007", () => {
   };
 
   const clickLineDot = ({ index } = {}) => {
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.cartesianChartCircle().eq(index).click({ force: true });
   };
 
@@ -947,6 +950,7 @@ describe("issue 27427", () => {
 
 const addCountGreaterThan2Filter = () => {
   H.openNotebook();
+  // eslint-disable-next-line no-unsafe-element-filtering
   cy.findAllByTestId("action-buttons").last().button("Filter").click();
   H.popover().findByText("Count").click();
   H.selectFilterOperator("Greater than");

--- a/e2e/test/scenarios/visualizations-charts/waterfall.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/waterfall.cy.spec.js
@@ -48,6 +48,7 @@ describe("scenarios > visualizations > waterfall", () => {
     H.sidebar().findAllByPlaceholderText("Select a field").first().click();
     H.popover().findByText("X").click();
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.sidebar().findAllByPlaceholderText("Select a field").last().click();
     H.popover().findByText("Y").click();
 
@@ -72,6 +73,7 @@ describe("scenarios > visualizations > waterfall", () => {
     H.sidebar().findAllByPlaceholderText("Select a field").first().click();
     H.popover().findByText("X").click();
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.sidebar().findAllByPlaceholderText("Select a field").last().click();
     H.popover().findByText("Y").click();
 
@@ -223,6 +225,7 @@ describe("scenarios > visualizations > waterfall", () => {
     H.sidebar().findAllByPlaceholderText("Select a field").first().click();
     H.popover().findByText("Created At: Year").click();
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.sidebar().findAllByPlaceholderText("Select a field").last().click();
     H.popover().findByText("Count").click();
 
@@ -266,12 +269,14 @@ describe("scenarios > visualizations > waterfall", () => {
       },
     });
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     getWaterfallDataLabels()
       .as("labels")
       .eq(-3)
       .invoke("text")
       .should("eq", "0");
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.get("@labels").last().invoke("text").should("eq", "0.1");
   });
 
@@ -295,6 +300,7 @@ describe("scenarios > visualizations > waterfall", () => {
     // the null data label which should exist at index -3
     // should now display no label. so the label at index -3 should be the label
     // before the null data point
+    // eslint-disable-next-line no-unsafe-element-filtering
     getWaterfallDataLabels()
       .as("labels")
       .eq(-3)
@@ -304,12 +310,14 @@ describe("scenarios > visualizations > waterfall", () => {
     // but the x-axis label and area should still be shown for the null data point
     H.echartsContainer().findByText("f");
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     getWaterfallDataLabels()
       .as("labels")
       .eq(-2)
       .invoke("text")
       .should("eq", "(2)");
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.get("@labels").last().invoke("text").should("eq", "0.1");
   });
 

--- a/e2e/test/scenarios/visualizations-tabular/column-shortcuts.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-tabular/column-shortcuts.cy.spec.ts
@@ -332,11 +332,13 @@ function extractColumnAndCheck({
 
   cy.wait(`@${requestAlias}`);
 
+  // eslint-disable-next-line no-unsafe-element-filtering
   cy.findAllByRole("columnheader")
     .last()
     .should("have.text", newColumn)
     .should("be.visible");
 
+  // eslint-disable-next-line no-unsafe-element-filtering
   cy.findAllByRole("columnheader").last().should("have.text", newColumn);
   if (value) {
     cy.findByRole("gridcell", { name: value }).should("be.visible");
@@ -372,6 +374,7 @@ H.describeWithSnowplow("scenarios > visualizations > combine shortcut", () => {
 
     cy.wait(`@${requestAlias}`);
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByRole("columnheader")
       .last()
       .should("have.text", newColumn)
@@ -383,7 +386,9 @@ H.describeWithSnowplow("scenarios > visualizations > combine shortcut", () => {
   }
 
   function selectColumn(index: number, name: string) {
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.popover().findAllByTestId("column-input").eq(index).click();
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.popover().last().findByText(name).click();
   }
 

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/chart_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/chart_drill.cy.spec.js
@@ -293,6 +293,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     cy.contains("January 2025");
 
     // drill into a recent week
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.get(".dot").eq(-4).click({ force: true });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("See these Orders").click();
@@ -665,6 +666,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       H.visitQuestionAdhoc(questionDetails);
 
       // Drill-through the last bar (Widget)
+      // eslint-disable-next-line no-unsafe-element-filtering
       H.chartPathWithFillColor("#509EE3").last().click();
       H.popover().findByTextEnsureVisible("See these Products").click();
     });

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/column_extract_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/column_extract_drill.cy.spec.js
@@ -311,6 +311,7 @@ function extractColumnAndCheck({
   H.popover().findByText(option).click();
   cy.wait(`@${requestAlias}`);
 
+  // eslint-disable-next-line no-unsafe-element-filtering
   cy.findAllByRole("columnheader")
     .last()
     .should("have.text", newColumn)

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/combine-column.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/combine-column.cy.spec.ts
@@ -43,6 +43,7 @@ H.describeWithSnowplow(
         cy.findByText("ID").click();
       });
 
+      // eslint-disable-next-line no-unsafe-element-filtering
       H.popover().last().findByText("Name").click();
 
       H.popover().within(() => {
@@ -59,12 +60,14 @@ H.describeWithSnowplow(
           "email@example.com__text__12345",
         );
 
+        // eslint-disable-next-line no-unsafe-element-filtering
         cy.findAllByRole("textbox").last().clear();
         cy.findByTestId("combine-example").should(
           "have.text",
           "email@example.com__text12345",
         );
 
+        // eslint-disable-next-line no-unsafe-element-filtering
         cy.findAllByRole("textbox").last().clear().type("+");
         cy.findByTestId("combine-example").should(
           "have.text",
@@ -74,6 +77,7 @@ H.describeWithSnowplow(
         cy.findByText("Done").click();
       });
 
+      // eslint-disable-next-line no-unsafe-element-filtering
       cy.findAllByTestId("header-cell")
         .last()
         .should("have.text", "Combined Email, Name, ID");

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/table_drills.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/table_drills.cy.spec.js
@@ -386,6 +386,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills > nulls", ()
     const CANCELLED_AT_INDEX = 9;
 
     H.openTable({ table: ACCOUNTS_ID, limit: 1 });
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByRole("gridcell")
       .eq(CANCELLED_AT_INDEX)
       .should("have.text", "")
@@ -401,6 +402,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills > nulls", ()
       "have.text",
       "Canceled At is not empty",
     );
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findAllByRole("gridcell")
       .eq(CANCELLED_AT_INDEX)
       .should("not.have.text", "");

--- a/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
@@ -302,6 +302,7 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
     drillPK({ id: 2 });
     cy.url().should("contain", "objectId=2");
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findByTestId("object-detail")
       .findAllByText("Domenica Williamson")
       .last()

--- a/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
@@ -1066,6 +1066,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
       const leftHeaderColHandle = cy
         .findAllByTestId("pivot-table-resize-handle")
         .first();
+      // eslint-disable-next-line no-unsafe-element-filtering
       const totalHeaderColHandle = cy
         .findAllByTestId("pivot-table-resize-handle")
         .last();
@@ -1519,6 +1520,7 @@ function sortColumnResults(column, direction) {
 }
 
 function getPivotTableBodyCell(index) {
+  // eslint-disable-next-line no-unsafe-element-filtering
   return cy
     .findByLabelText("pivot-table-body-grid")
     .findAllByTestId("pivot-table-cell")

--- a/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
@@ -208,6 +208,7 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
 
     cy.button("Add comparison").should("be.disabled");
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.findByTestId("comparison-list")
       .children()
       .last()

--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -18,6 +18,7 @@ describe("scenarios > visualizations > table", () => {
   }
 
   function selectFromDropdown(option, clickOpts) {
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.popover().last().findByText(option).click(clickOpts);
   }
 
@@ -39,6 +40,7 @@ describe("scenarios > visualizations > table", () => {
       cy.findByText("Column title").click();
     });
     // click somewhere else to close the popover
+    // eslint-disable-next-line no-unsafe-element-filtering
     headerCells().last().click();
     headerCells().findAllByText("ID updated").should("have.length", 1);
   });

--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -122,6 +122,7 @@ describe("issue 11435", () => {
     },
   };
   const hoverLineDot = ({ index } = {}) => {
+    // eslint-disable-next-line no-unsafe-element-filtering
     H.cartesianChartCircle().eq(index).realHover();
   };
 
@@ -332,16 +333,19 @@ describe.skip("issue 19373", () => {
     cy.findAllByRole("grid").eq(2).as("tableCells");
 
     // Sanity check before we start asserting on this column
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.get("@columnTitles")
       .findAllByTestId("pivot-table-cell")
       .eq(ROW_TOTALS_INDEX)
       .should("contain", "Row totals");
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.get("@rowTitles")
       .findAllByTestId("pivot-table-cell")
       .eq(GRAND_TOTALS_INDEX)
       .should("contain", "Grand totals");
 
+    // eslint-disable-next-line no-unsafe-element-filtering
     cy.get("@tableCells")
       .findAllByTestId("pivot-table-cell")
       .eq(ROW_TOTALS_INDEX)

--- a/frontend/lint/eslint-rules/no-unsafe-element-filtering.js
+++ b/frontend/lint/eslint-rules/no-unsafe-element-filtering.js
@@ -1,0 +1,113 @@
+// eslint-disable-next-line import/no-commonjs
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "require .last() and .eq(<0) to be preceded by a length assertion",
+      category: "Possible Errors",
+      recommended: false,
+    },
+    schema: [],
+    messages: {
+      unexpected:
+        'Using .last() or .eq(<0) without checking collection length can lead to flaky tests. Please add .should("have.length", n) or other appropriate assertions before using these methods',
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (isCallingRiskyMethod(node) && !isPreviousALengthAssertion(node)) {
+          context.report({ node, messageId: "unexpected" });
+        }
+      },
+    };
+  },
+};
+
+function getPreviousInChain(node) {
+  if (
+    node.callee.type !== "MemberExpression" ||
+    node.callee.object.type !== "CallExpression"
+  ) {
+    return null;
+  }
+
+  return node.callee.object;
+}
+
+function isCallingRiskyMethod(node) {
+  if (
+    node.callee.type !== "MemberExpression" ||
+    node.callee.property.type !== "Identifier"
+  ) {
+    return false;
+  }
+
+  const methodName = node.callee.property.name;
+
+  // Check for last method only
+  if (methodName === "last") {
+    return true;
+  }
+
+  // Special handling for eq method
+  if (methodName === "eq") {
+    // Only consider eq risky if it's in a Cypress chain context
+    const isCypressChain = node.callee.object.type === "CallExpression";
+    if (!isCypressChain) {
+      return false;
+    }
+
+    // Only consider eq risky if the argument is negative
+    if (node.arguments.length > 0 && node.arguments[0].type === "Literal") {
+      const index = node.arguments[0].value;
+      return index < 0; // Only risky if index is negative
+    }
+    return true; // Consider risky if argument is not a literal (dynamic index)
+  }
+
+  return false;
+}
+
+function isPreviousALengthAssertion(node) {
+  let current = node;
+  while (current) {
+    current = getPreviousInChain(current);
+
+    if (!current) {
+      break;
+    }
+
+    if (
+      current.callee.type === "MemberExpression" &&
+      (current.callee.property.name === "should" ||
+        current.callee.property.name === "expect")
+    ) {
+      const args = current.arguments;
+      if (args.length >= 2) {
+        const assertion = args[0].value;
+        // Check for various length assertion patterns
+        const lengthAssertions = [
+          "have.length",
+          "have.lengthOf",
+          "have.length.of",
+          "have.length.at.least",
+          "have.length.gte",
+          "have.length.at.most",
+          "have.length.lte",
+          "have.length.above",
+          "have.length.gt",
+          "have.length.below",
+          "have.length.lt",
+          "have.length.within",
+        ];
+        if (lengthAssertions.some(pattern => assertion === pattern)) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}

--- a/frontend/lint/eslint-rules/no-unsafe-element-filtering.js
+++ b/frontend/lint/eslint-rules/no-unsafe-element-filtering.js
@@ -45,16 +45,16 @@ function isCallingRiskyMethod(node) {
   }
 
   const methodName = node.callee.property.name;
+  // Only consider methods risky if they're in a Cypress chain context
+  const isCypressChain = node.callee.object.type === "CallExpression";
 
-  // Check for last method only
+  // Check for last method
   if (methodName === "last") {
-    return true;
+    return isCypressChain;
   }
 
   // Special handling for eq method
   if (methodName === "eq") {
-    // Only consider eq risky if it's in a Cypress chain context
-    const isCypressChain = node.callee.object.type === "CallExpression";
     if (!isCypressChain) {
       return false;
     }

--- a/frontend/lint/tests/no-unsafe-element-filtering.unit.spec.js
+++ b/frontend/lint/tests/no-unsafe-element-filtering.unit.spec.js
@@ -1,0 +1,59 @@
+import { RuleTester } from "eslint";
+
+import rule from "../eslint-rules/no-unsafe-element-filtering";
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } });
+
+const unsafeError = {
+  messageId: "unexpected",
+};
+
+const blockTypes = ["it", "before", "beforeEach", "it.only"];
+
+const blockWrapper = (content, blockType = "it") => `
+  ${blockType}('should test something', () => {
+    ${content}
+  });
+`;
+
+const validCases = [
+  `cy.get('.list').should('have.length', 3).last();`,
+  `cy.get('.items').should('have.length.gt', 0).last();`,
+  `cy.get('.items').should('have.length.gte', 1).last();`,
+  `cy.get('.items').should('have.length', 5).eq(-1);`,
+  `cy.get('.items').should('have.length.at.least', 1).last();`,
+  `cy.get('.items').should('have.length.above', 0).last();`,
+  `cy.get('.items').should('have.lengthOf', 3).last();`,
+  `cy.get('.items').should('have.length.within', 1, 5).last();`,
+  `cy.get('.items').eq(1);`, // positive indices are fine
+  `cy.get('.items').first();`, // first() is fine
+  // Non-Cypress contexts should be ignored
+  `const array = [1, 2, 3]; array.last(); array.eq(-1);`,
+];
+
+const invalidCases = [
+  `cy.get('.list').last();`,
+  `cy.get('.items').last().click();`,
+  `cy.get('.items').eq(-1);`,
+  `cy.get('.items').eq(-2).click();`,
+  `cy.get('.items').find('div').last();`,
+  `cy.get('.items').find('div').eq(-1);`,
+  // Dynamic indices should be caught
+  `cy.get('.items').eq(someVariable);`,
+  `cy.get('.items').eq(getIndex());`,
+];
+
+ruleTester.run("no-unsafe-element-filtering", rule, {
+  valid: blockTypes.flatMap(blockType =>
+    validCases.map(testCase => ({
+      code: blockWrapper(testCase, blockType),
+    })),
+  ),
+
+  invalid: blockTypes.flatMap(blockType =>
+    invalidCases.map(testCase => ({
+      code: blockWrapper(testCase, blockType),
+      errors: [unsafeError],
+    })),
+  ),
+});


### PR DESCRIPTION
Closes https://linear.app/metabase-inc/issue/DEVX-58/add-eslint-rule-for-flaky-usage-of-last-and-eq-commands

### Description

Using cy.get('elem').last() is risky, because Cypress will select an element as soon as it finds one. This can lead to flaky results, because selected elements might not render all at once. At least a soft assertion should be required, or element should be properly targeted. This PR adds a rule that will throw a warning when either `.last()` or `.eq()` with negative  is used.

### How to verify

1. Checkout this branch
2. Restart Eslint server if needed
3. Open any test that uses `.last()` command to see eslint warning or run lint

### More details
there are certain situations where this rule might come off as annoying, but as described above, it’s quite necessary to make sure that we target the right element when multiple are present. One case where the rule might feel awkward could be in helpers. Let’s say you have a helper like this:

```js
getNotebookStep("summarize", { stage, index })
    .findByTestId("aggregate-step")
    .findAllByTestId("notebook-cell-item")
    .last()
    .click();
```

this triggers the eslint rule even in cases where we might be looking for the first element. we still want to be safe and prevent a flaky usage. the rewriting of this helper might look like this:

```diff
getNotebookStep("summarize", { stage, index })
    .findByTestId("aggregate-step")
    .findAllByTestId("notebook-cell-item")
+ .should('have.length.at.least', index + 1)
    .last()
    .click();
```
