### PR TITLE
More reindexing up into the restore snapshot API

### DIFF
--- a/src/metabase/api/testing.clj
+++ b/src/metabase/api/testing.clj
@@ -88,8 +88,7 @@
       ;; parameterization doesn't work with view names. If someone maliciously named a table, this is bad. On the
       ;; other hand, this is not running in prod and you already had to have enough access to maliciously name the
       ;; table, so this is probably safe enough.
-      (jdbc/execute! {:connection conn} (format "ALTER VIEW %s RECOMPILE" table-name))
-      (search/reindex!))))
+      (jdbc/execute! {:connection conn} (format "ALTER VIEW %s RECOMPILE" table-name)))))
 
 (defn- restore-snapshot! [snapshot-name]
   (assert-h2 (mdb/app-db))
@@ -123,6 +122,7 @@
   [name]
   {name ms/NonBlankString}
   (restore-snapshot! name)
+  (search/reindex!)
   nil)
 
 #_{:clj-kondo/ignore [:deprecated-var]}


### PR DESCRIPTION
Fix minor bug in testing helper.

We want re-indexing to happen exactly once, but it was accidentally inside a loop. So it could be happen 0 or N times, not what we want.

Also moved it up to the API, as in our unit tests we run this function with an empty appdb, missing the search index metadata table.