### PR TITLE
Better error messages when embedding against oss

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/api/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/routes.clj
@@ -10,6 +10,9 @@
 ;; directly?
 ;;
 ;; TODO -- we need to feature-flag this based on the `:sso-` feature flags
+
+;; NOTE: there is a wrapper in metabase.server.auth-wrapper to ensure that oss versions give nice error
+;; messages. These must be kept in sync manually since compojure are opaque functions.
 (compojure/defroutes ^{:doc "Ring routes for auth (SAML) API endpoints.", :arglists '([request] [request respond raise])} routes
   (compojure/context
     "/auth"

--- a/src/metabase/server/auth_wrapper.clj
+++ b/src/metabase/server/auth_wrapper.clj
@@ -1,0 +1,42 @@
+(ns metabase.server.auth-wrapper
+  (:require
+   [compojure.core :as compojure]
+   [metabase.config :as config]
+   [metabase.plugins.classloader :as classloader]
+   [ring.util.response :as response]))
+
+(when config/ee-available?
+  (classloader/require 'metabase-enterprise.sso.api.routes))
+
+(let [bad-req (response/bad-request {:message "The auth/sso endpoint only exists in enterprise builds"
+                                     :status "ee-build-required"})]
+  (defn- not-enabled
+    ([_req] bad-req)
+    ([_req respond _raise]
+     (respond bad-req))))
+
+(compojure/defroutes ^{:doc "Ring routes for auth (SAML) API endpoints.", :arglists '([request] [request respond raise])}
+  ee-missing-routes
+  ;; follows the same form as metabase-enterprise.sso.api.routes. Compojure is a bit opaque so need to manually keep
+  ;; them in sync.
+  (compojure/context
+    "/auth"
+    []
+    (compojure/routes
+     (compojure/context "/sso" [] not-enabled)))
+  (compojure/context
+    "/api"
+    []
+    (compojure/routes
+     (compojure/context "/saml" [] not-enabled))))
+
+;; This needs to be injected into [[metabase.server.routes/routes]] -- not [[metabase.api.routes/routes]] !!!
+;;
+;; TODO -- should we make a `metabase-enterprise.routes` namespace where this can live instead of injecting it
+;; directly?
+;;
+;; TODO -- we need to feature-flag this based on the `:sso-` feature flags
+(def routes
+  "Ring routes for auth (SAML) api endpoints. If enterprise is not present, will return a nicer message"
+  (or (some-> (resolve 'metabase-enterprise.sso.api.routes/routes) var-get)
+      ee-missing-routes))

--- a/test/metabase/server/auth_wrapper_test.clj
+++ b/test/metabase/server/auth_wrapper_test.clj
@@ -1,0 +1,23 @@
+(ns metabase.server.auth-wrapper-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.config :as config]
+   [metabase.http-client :as client]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]))
+
+(use-fixtures
+  :once
+  (fixtures/initialize :web-server :test-users))
+
+(deftest routes-test
+  (when-not config/ee-available?
+    (doseq [route ["auth/sso" "api/saml"]]
+      (testing (str route " route returns nice error message")
+        (binding [client/*url-prefix* ""] ; prevent automatic /api/auth/sso which is a 404
+          ;; it's possible that a post or get is the actual route that doesn't exist. The warning handler is simple
+          ;; and responds to any request with a helpful error message
+          (let [response (mt/user-http-request :rasta :post 400 route)]
+            (is (= {:message "The auth/sso endpoint only exists in enterprise builds"
+                    :status "ee-build-required"}
+                   response))))))))


### PR DESCRIPTION
Fixes #51972

Error message in oss:
```
❯ http get localhost:3000/auth/sso/ -pb
{
    "message": "The auth/sso endpoint only exists in enterprise builds",
    "status": "ee-build-required"
}
```

Working endpoint on ee (but an error message about what it needs)

```
❯ http post localhost:3000/auth/sso/logout -pb
{
    "errors": {
        "cookies": "map where {metabase.SESSION -> <map where {:value -> <value must be a non-blank string.>}>}"
    },
    "specific-errors": {
        "cookies": {
            "metabase.SESSION": [
                "missing required key, received: nil"
            ]
        }
    }
}
```

Running tests:

```
;; without enterprise on classpath
clj -X:dev:test :only metabase.server.auth-wrapper-test

Running tests in metabase.server.auth-wrapper-test
Ran 1 tests in 3.761 seconds
4 assertions, 0 failures, 0 errors.
{:test 1, :pass 4, :fail 0, :error 0, :type :summary, :duration 3760.932417, :single-threaded 1}
Ran 0 tests in parallel, 1 single-threaded.
All tests passed.

;; with enterprise on classpath
clj -X:dev:ee:test :only metabase.server.auth-wrapper-test
0 assertions, 0 failures, 0 errors.
{:test 1, :pass 0, :fail 0, :error 0, :type :summary, :duration 3705.00675, :single-threaded 1}
Ran 0 tests in parallel, 1 single-threaded.
All tests passed.
```

with enterprise has 0 assertions

But most importantly, when embedding against 0.52.5:
<img width="1507" alt="image" src="https://github.com/user-attachments/assets/a2d65015-b6a7-454c-9054-bb3cc09d5906" />
 And now after the change:
<img width="1507" alt="image" src="https://github.com/user-attachments/assets/7aab96c8-98a3-4e7f-a616-c77620b113d0" />

Screenshots from https://github.com/metabase/metabase-angular-react-sdk-embedding-sample
