### PR TITLE
Prevent Dashboard from reloading when clicking move, duplicate, and trash options in context menu

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardActionMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardActionMenu.tsx
@@ -11,7 +11,7 @@ import { PLUGIN_MODERATION } from "metabase/plugins";
 import { Icon, Menu } from "metabase/ui";
 
 // Fixes this bug: https://github.com/mantinedev/mantine/issues/5571#issue-2082430353
-// Hover states get wierd when using Link directly. Since Link does not take the standard
+// Hover states get weird when using Link directly. Since Link does not take the standard
 // `ref` prop, we have to manually forward it to the correct prop name to hover work as expected.
 const ForwardRefLink = forwardRef((props: LinkProps, ref) => (
   // @ts-expect-error - innerRef not in prop types but it is a valid prop. docs can be found here: https://github.com/remix-run/react-router/blob/v3.2.6/docs/API.md#innerref

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardActionMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardActionMenu.tsx
@@ -12,7 +12,7 @@ import { Icon, Menu } from "metabase/ui";
 
 // Fixes this bug: https://github.com/mantinedev/mantine/issues/5571#issue-2082430353
 // Hover states get weird when using Link directly. Since Link does not take the standard
-// `ref` prop, we have to manually forward it to the correct prop name to hover work as expected.
+// `ref` prop, we have to manually forward it to the correct prop name to make hover work as expected.
 const ForwardRefLink = forwardRef((props: LinkProps, ref) => (
   // @ts-expect-error - innerRef not in prop types but it is a valid prop. docs can be found here: https://github.com/remix-run/react-router/blob/v3.2.6/docs/API.md#innerref
   <Link {...props} innerRef={ref} />

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardActionMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardActionMenu.tsx
@@ -12,8 +12,7 @@ import { Icon, Menu } from "metabase/ui";
 
 // Fixes this bug: https://github.com/mantinedev/mantine/issues/5571#issue-2082430353
 // Hover states get wierd when using Link directly. Since Link does not take the standard
-// `ref` prop, we have to manually forward it to the correct prop name to make hover states.
-// work as expected.
+// `ref` prop, we have to manually forward it to the correct prop name to hover work as expected.
 const ForwardRefLink = forwardRef((props: LinkProps, ref) => (
   // @ts-expect-error - innerRef not in prop types but it is a valid prop. docs can be found here: https://github.com/remix-run/react-router/blob/v3.2.6/docs/API.md#innerref
   <Link {...props} innerRef={ref} />

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardActionMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardActionMenu.tsx
@@ -1,5 +1,5 @@
-import { type JSX, type MouseEvent, useState } from "react";
-import { withRouter } from "react-router";
+import { type JSX, type MouseEvent, forwardRef, useState } from "react";
+import { Link, type LinkProps, withRouter } from "react-router";
 import type { WithRouterProps } from "react-router/lib/withRouter";
 import { c, t } from "ttag";
 
@@ -9,6 +9,17 @@ import type { HeaderButtonProps } from "metabase/dashboard/components/DashboardH
 import { useRefreshDashboard } from "metabase/dashboard/hooks";
 import { PLUGIN_MODERATION } from "metabase/plugins";
 import { Icon, Menu } from "metabase/ui";
+
+// Fixes this bug: https://github.com/mantinedev/mantine/issues/5571#issue-2082430353
+// Hover states get wierd when using Link directly. Since Link does not take the standard
+// `ref` prop, we have to manually forward it to the correct prop name to make hover states.
+// work as expected.
+const ForwardRefLink = forwardRef((props: LinkProps, ref) => (
+  // @ts-expect-error - innerRef not in prop types but it is a valid prop. docs can be found here: https://github.com/remix-run/react-router/blob/v3.2.6/docs/API.md#innerref
+  <Link {...props} innerRef={ref} />
+));
+// @ts-expect-error - must set a displayName + this works
+ForwardRefLink.displayName = "ForwardRefLink";
 
 const DashboardActionMenuInner = ({
   canResetFilters,
@@ -81,16 +92,16 @@ const DashboardActionMenuInner = ({
 
             <Menu.Item
               icon={<Icon name="move" />}
-              component="a"
-              href={`${location?.pathname}/move`}
+              component={ForwardRefLink}
+              to={`${location?.pathname}/move`}
             >{c("A verb, not a noun").t`Move`}</Menu.Item>
           </>
         )}
 
         <Menu.Item
           icon={<Icon name="clone" />}
-          component="a"
-          href={`${location?.pathname}/copy`}
+          component={ForwardRefLink}
+          to={`${location?.pathname}/copy`}
         >{c("A verb, not a noun").t`Duplicate`}</Menu.Item>
 
         {canEdit && (
@@ -98,8 +109,8 @@ const DashboardActionMenuInner = ({
             <Menu.Divider />
             <Menu.Item
               icon={<Icon name="trash" />}
-              component="a"
-              href={`${location?.pathname}/archive`}
+              component={ForwardRefLink}
+              to={`${location?.pathname}/archive`}
             >{t`Move to trash`}</Menu.Item>
           </>
         )}


### PR DESCRIPTION
### Description

**Issue:**
Fixes a bug that was introduced in #51229 causing the page to reload when clicking on the "Move", "Duplicate", and "Move to trash" options in the dashboard's context menu.

**Repro:**
https://metaboat.slack.com/archives/C064EB1UE5P/p1737474757635759?thread_ts=1737474488.248789&cid=C064EB1UE5P

**Fix:**
This PR uses our react router `Link` instead of a native `a` tag to avoid doing a page refresh.

Note: Some extra work had to go into forwarding refs correctly to make Mantine hover states work correctly.
