### PR TITLE
Disable drill thrus for native queries with template-tag variables 

### DIFF
--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -288,6 +288,7 @@
  [lib.native
   engine
   extract-template-tags
+  has-template-tag-variables?
   has-write-permission
   native-extras
   native-query

--- a/src/metabase/lib/drill_thru.cljc
+++ b/src/metabase/lib/drill_thru.cljc
@@ -22,6 +22,7 @@
    [metabase.lib.drill-thru.zoom-in-timeseries :as lib.drill-thru.zoom-in-timeseries]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
+   [metabase.lib.native :as lib.native]
    [metabase.lib.query :as lib.query]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
@@ -104,7 +105,8 @@
     context      :- ::lib.schema.drill-thru/context]
    (try
      (into []
-           (when (lib.metadata/editable? query)
+           (when (and (lib.metadata/editable? query)
+                      (not (lib.native/has-template-tag-variables? query)))
              (let [{:keys [query stage-number]} (lib.query/wrap-native-query-with-mbql
                                                  query stage-number (:card-id context))
                    context                      (context-with-dimensions-or-row-dimensions query context)

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -239,6 +239,16 @@
      (lib.metadata/card query card-id))
    (template-tag-card-ids query)))
 
+(mu/defn has-template-tag-variables? :- :boolean
+  "Tests whether `query` has any template-tag variables.
+
+  That is, any `:template-tags` values with `:type` other than `:snippet` or `:card`."
+  [query :- ::lib.schema/query]
+  (not (every? #{:snippet :card}
+               (some->> (template-tags query)
+                        vals
+                        (map :type)))))
+
 (mu/defn has-write-permission :- :boolean
   "Returns whether the database has native write permissions.
    This is only filled in by [[metabase.api.database/add-native-perms-info]]

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -244,10 +244,9 @@
 
   That is, any `:template-tags` values with `:type` other than `:snippet` or `:card`."
   [query :- ::lib.schema/query]
-  (not (every? #{:snippet :card}
-               (some->> (template-tags query)
-                        vals
-                        (map :type)))))
+  (letfn [(variable-tag? [{tag-type :type}]
+            (not (#{:snippet :card} tag-type)))]
+    (boolean (some variable-tag? (vals (template-tags query))))))
 
 (mu/defn has-write-permission :- :boolean
   "Returns whether the database has native write permissions.

--- a/test/metabase/lib/drill_thru_test.cljc
+++ b/test/metabase/lib/drill_thru_test.cljc
@@ -642,7 +642,9 @@
                    :many-pks? false}]}))
 
 (deftest ^:parallel available-drill-thrus-test-3
-  (lib.drill-thru.tu/test-available-drill-thrus
+  (lib.drill-thru.tu/test-drill-variants-with-merged-args
+   lib.drill-thru.tu/test-available-drill-thrus
+   "unaggregated cell click on numeric column"
    {:click-type  :cell
     :query-type  :unaggregated
     :column-name "SUBTOTAL"
@@ -652,7 +654,14 @@
                   {:type :drill-thru/quick-filter, :operators [{:name "<"}
                                                                {:name ">"}
                                                                {:name "="}
-                                                               {:name "≠"}]}]}))
+                                                               {:name "≠"}]}]}
+
+   "drill thrus are disabled for native queries with template-tag variables"
+   {:custom-native #(lib/with-native-query % "SELECT * FROM orders WHERE product_id = {{mytag}}")
+    :native-drills #{}}
+
+   "snippets and card tags are allowed"
+   {:custom-native #(lib/with-native-query % "SELECT * FROM {{#123-mycard}} WHERE {{snippet:mysnip}}")}))
 
 (deftest ^:parallel available-drill-thrus-test-4
   (lib.drill-thru.tu/test-available-drill-thrus
@@ -677,14 +686,23 @@
                   {:type :drill-thru/summarize-column, :aggregations [:distinct]}]}))
 
 (deftest ^:parallel available-drill-thrus-test-6
-  (lib.drill-thru.tu/test-available-drill-thrus
+  (lib.drill-thru.tu/test-drill-variants-with-merged-args
+   lib.drill-thru.tu/test-available-drill-thrus
+   "unaggregated header click on fk column"
    {:click-type  :header
     :query-type  :unaggregated
     :column-name "PRODUCT_ID"
     :expected    [{:type :drill-thru/column-filter, :initial-op {:short :=}}
                   {:type :drill-thru/distribution}
                   {:type :drill-thru/sort, :sort-directions [:asc :desc]}
-                  {:type :drill-thru/summarize-column, :aggregations [:distinct]}]}))
+                  {:type :drill-thru/summarize-column, :aggregations [:distinct]}]}
+
+   "drill thrus are disabled for native queries with template-tag variables"
+   {:custom-native #(lib/with-native-query % "SELECT * FROM orders WHERE product_id = {{mytag}}")
+    :native-drills #{}}
+
+   "snippets and card tags are allowed"
+   {:custom-native #(lib/with-native-query % "SELECT * FROM {{#123-mycard}} WHERE {{snippet:mysnip}}")}))
 
 (deftest ^:parallel available-drill-thrus-test-7
   (lib.drill-thru.tu/test-available-drill-thrus
@@ -715,7 +733,9 @@
   (testing (str "fk-filter should not get returned for non-fk column (#34440) "
                 "fk-details should not get returned for non-fk column (#34441) "
                 "underlying-records should only get shown once for aggregated query (#34439)"))
-  (lib.drill-thru.tu/test-available-drill-thrus
+  (lib.drill-thru.tu/test-drill-variants-with-merged-args
+   lib.drill-thru.tu/test-available-drill-thrus
+   "aggregated cell click on count column"
    {:click-type  :cell
     :query-type  :aggregated
     :column-name "count"
@@ -734,7 +754,15 @@
                    :type         :drill-thru/zoom-in.timeseries}]
     ;; Underlying records and automatic insights are not supported for native.
     ;; zoom-in.timeseries can't be because we don't know what unit (if any) it's currently bucketed by.
-    :native-drills #{:drill-thru/quick-filter}}))
+    :native-drills #{:drill-thru/quick-filter}}
+
+   "drill thrus are disabled for native queries with template-tag variables"
+   {:custom-native #(lib/with-native-query %
+                      "SELECT COUNT(*) FROM orders GROUP BY product_id HAVING product_id > {{mytag}}")
+    :native-drills #{}}
+
+   "snippets and card tags are allowed"
+   {:custom-native #(lib/with-native-query % "SELECT COUNT(*) FROM {{#123-mycard}} GROUP BY {{snippet:mysnip}}")}))
 
 (deftest ^:parallel available-drill-thrus-test-10
   (testing (str "fk-filter should not get returned for non-fk column (#34440) "


### PR DESCRIPTION
Closes #49051

### Description

Disable drill thrus in `lib.drill-thru/available-drill-thus` if the query has `:template-tag` variables attached. Template tags of type `:snippet` and `:card` are still allowed.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New SQL query -> Sample Database -> `SELECT * FROM ORDERS WHERE TOTAL > {{Total}}`
2. Run and save the question
3. Click on one of the cell values or column headers in table viz
4. No drill thrus should appear
5. Edit the query to remove the template tag variable.
6. Optionally add snippets or card references like so:
    * `SELECT * FROM {{#123-my-card}} WHERE {{snippet:my snippet}}`
7. Save and run the query
8. Drill thrus should now be available

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
