### PR TITLE
fix(sdk): fix save question form's cancel button height

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/test/storybook-themes.ts
+++ b/enterprise/frontend/src/embedding-sdk/test/storybook-themes.ts
@@ -195,7 +195,7 @@ const luminaraTheme: MetabaseTheme = {
     background: luminaraColors.background,
     "background-secondary": luminaraColors.background,
     "background-hover": luminaraColors.background,
-    "background-disabled": luminaraColors.green2,
+    "background-disabled": luminaraColors.background,
     charts: [
       luminaraColors.viz1,
       "#E09862",

--- a/frontend/src/metabase/components/SaveQuestionForm/SaveQuestionForm.tsx
+++ b/frontend/src/metabase/components/SaveQuestionForm/SaveQuestionForm.tsx
@@ -108,11 +108,7 @@ export const SaveQuestionForm = ({
       )}
       <FormFooter>
         <FormErrorMessage inline />
-        <Button
-          onClick={onCancel}
-          variant="subtle"
-          c="text-dark"
-        >{t`Cancel`}</Button>
+        <Button onClick={onCancel}>{t`Cancel`}</Button>
         <FormSubmitButton
           label={t`Save`}
           data-testid="save-question-button"

--- a/frontend/src/metabase/components/SaveQuestionForm/SaveQuestionForm.tsx
+++ b/frontend/src/metabase/components/SaveQuestionForm/SaveQuestionForm.tsx
@@ -3,7 +3,6 @@ import { t } from "ttag";
 import { FormCollectionAndDashboardPicker } from "metabase/collections/containers/FormCollectionAndDashboardPicker";
 import type { CollectionPickerModel } from "metabase/common/components/CollectionPicker";
 import { getPlaceholder } from "metabase/components/SaveQuestionForm/util";
-import Button from "metabase/core/components/Button";
 import FormErrorMessage from "metabase/core/components/FormErrorMessage";
 import { FormFooter } from "metabase/core/components/FormFooter";
 import FormInput from "metabase/core/components/FormInput";
@@ -12,6 +11,7 @@ import FormSelect from "metabase/core/components/FormSelect";
 import FormTextArea from "metabase/core/components/FormTextArea";
 import { Form, FormSubmitButton } from "metabase/forms";
 import { isNullOrUndefined } from "metabase/lib/types";
+import { Button } from "metabase/ui";
 import type { Dashboard } from "metabase-types/api";
 
 import CS from "./SaveQuestionForm.module.css";
@@ -108,7 +108,11 @@ export const SaveQuestionForm = ({
       )}
       <FormFooter>
         <FormErrorMessage inline />
-        <Button type="button" onClick={onCancel}>{t`Cancel`}</Button>
+        <Button
+          onClick={onCancel}
+          variant="subtle"
+          c="text-dark"
+        >{t`Cancel`}</Button>
         <FormSubmitButton
           label={t`Save`}
           data-testid="save-question-button"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50010

### Description

We are mixing the legacy buttons with Mantine buttons, so its height is slightly different. Using Mantine buttons for both fixes the issue. You can reproduce this by creating a questions in the dashboard, then hit "Save". You can see the height differs for Cancel and Save.

<img src="https://github.com/user-attachments/assets/4da0464e-07c6-402f-8593-71c5cbc0c123" width="300">

You can also reproduce this by going to the deployed Shoppy demo at https://embedded-analytics-sdk-demo.metabase.com/admin/analytics/new/from-template

<img src="https://github.com/user-attachments/assets/f4af9d41-b53e-4fc4-bd20-b4c169cda4fc" width="300">

### How to verify

On the main app:

- Create a questions in the dashboard, then hit "Save"
- Button height now looks the same.

<img src="https://github.com/user-attachments/assets/d845fa25-057e-45d0-8cbf-957cc1887355" width="300">
