### PR TITLE
Allow passing aggregation functions to coalesce

### DIFF
--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -494,6 +494,7 @@
                        (is-clause? boolean-functions x)  :boolean-expression
                        (is-clause? numeric-functions x)  :numeric-expression
                        (is-clause? datetime-functions x) :datetime-expression
+                       (is-clause? aggregations x)       :aggregation
                        (string? x)                       :string
                        (is-clause? string-functions x)   :string-expression
                        (is-clause? :value x)             :value
@@ -503,6 +504,7 @@
    [:boolean-expression  BooleanExpression]
    [:numeric-expression  NumericExpression]
    [:datetime-expression DatetimeExpression]
+   [:aggregation         Aggregation]
    [:string              :string]
    [:string-expression   StringExpression]
    [:value               value]

--- a/test/metabase/legacy_mbql/schema_test.cljc
+++ b/test/metabase/legacy_mbql/schema_test.cljc
@@ -87,6 +87,23 @@
              #"keys in template tag map must match the :name of their values"
              (mbql.s/validate-query bad-query)))))))
 
+(deftest ^:parallel coalesce-aggregation-test
+  (testing "should be able to nest aggregation functions within a coalesce"
+    (let [query {:database 1,
+                 :type :query,
+                 :query
+                 {:source-table 5,
+                  :aggregation
+                  [[:aggregation-options
+                    [:/
+                     [:sum [:field 42 {:base-type :type/Float}]]
+                     [:coalesce [:sum [:field 36 {:base-type :type/Float}]] 1]]
+                    {:name "Avg discount", :display-name "Avg discount"}]],
+                  :aggregation-idents {0 "ZOn_HshYdSEeteY5ArmS9"}},
+                 :parameters []}]
+      (is (not (me/humanize (mr/explain mbql.s/Query query))))
+      (is (= query (mbql.s/validate-query query))))))
+
 (deftest ^:parallel aggregation-reference-test
   (are [schema] (nil? (me/humanize (mr/explain schema [:aggregation 0])))
     mbql.s/aggregation


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/19289

### Description

This was already legal-ish, as [:* 1 [:sum ...]] was a valid argument to coalesce.  However, you couldn't pass in the sum directly.  Under the hood, NumericExpressionArg allowed aggregations, but ExpressionArg didn't.  Presumably, the one is supposed to be a superset of the other, and this change made that actually be true.

### How to verify

Query the sample orders table and aggregate on the custom expression `Sum([Total]) / coalesce(Sum([Discount]), 1)`.  If you can actually run the query, the fix works.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
