### PR TITLE
improve rules around unscoped-selectors rule

### DIFF
--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -62,7 +62,6 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
     });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Save changes").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("button", "Yes").click();
 
     // see error modal

--- a/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
@@ -935,7 +935,6 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("is less than or equal to").click();
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("[data-testid=pivot-table-cell]", "65.09").should(
       "have.css",
       "background-color",

--- a/frontend/lint/tests/no-unscoped-text-selectors.unit.spec.js
+++ b/frontend/lint/tests/no-unscoped-text-selectors.unit.spec.js
@@ -30,6 +30,10 @@ const validCases = [
     cy.contains('my string of text').click();
   });`,
   `cy.get('#my-div').contains('my string of text').click();`,
+  `cy.contains('#my-div', 'foo')`,
+  `cy.get('#my-div').contains('foo')`,
+  `cy.get('#my-div').find('.elem').contains('foo')`,
+  `cy.get('#my-div').within(() => { cy.contains('foo') })`,
 ];
 
 const invalidCases = [
@@ -40,6 +44,7 @@ const invalidCases = [
   }).click().clack();`,
   "cy.contains('foobar');",
   "cy.contains('foobar').click();",
+  `cy.contains('#my-div', {timeout: 10000})`,
 ];
 
 ruleTester.run("no-unscoped-text-selectors", rule, {


### PR DESCRIPTION
Closes https://linear.app/metabase-inc/issue/DEVX-71/improve-eslint-rules-around-unscoped-selectors

### Description

In general, I think the rule is great, but it could be improved. Current no-unscoped-text-selectors disallows some usage that should be allowed. 

Examples:

```js
cy.contains('.selector', 'text')           // two-argument contains is allowed
cy.get('.selector').contains('text')       // chained contains is allowed
cy.within(() => cy.contains('text'))       // scoped contains is allowed
cy.within(() => cy.findByText('text'))     // scoped findByText is allowed
```

I wrote a [whole blog](https://filiphric.com/contains-an-overlooked-gem-in-cypress) on why cy.contains() gives you selecting superpowers, I think we could utilize them for more stable tests

All in all, this does not soften the rules, we are still scoping our text selector.

### How to verify

1. Open VS code, restart eslint server and try some of the examples above

### Demo
![Screenshot 2025-01-22 at 11 27 12](https://github.com/user-attachments/assets/0b5c8d79-df28-4ea0-adbc-4bc2084a5051)
