### PR TITLE
fix flaky test 

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions-1.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-1.cy.spec.js
@@ -517,41 +517,43 @@ describe("issue 17514", () => {
       });
     });
 
-    it(
-      "should not show the run overlay when we apply dashboard filter on a question with removed column and then click through its title (metabase#17514-1)",
-      { tags: "@flaky" },
-      () => {
-        H.editDashboard();
+    it("should not show the run overlay when we apply dashboard filter on a question with removed column and then click through its title (metabase#17514-1)", () => {
+      H.editDashboard();
 
-        openVisualizationOptions();
+      openVisualizationOptions();
 
-        hideColumn("Products → Ean");
+      hideColumn("Products → Ean");
 
-        closeModal();
+      closeModal();
 
-        H.saveDashboard();
+      H.saveDashboard();
 
-        H.filterWidget().click();
-        setAdHocFilter({ timeBucket: "years" });
+      H.filterWidget().click();
+      setAdHocFilter({ timeBucket: "years" });
 
-        cy.location("search").should("eq", "?date_filter=past30years");
-        cy.wait("@cardQuery");
+      cy.location("search").should("eq", "?date_filter=past30years");
+      cy.wait("@cardQuery");
 
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.findByText("Previous 30 Years");
+      cy.findByTestId("parameter-value-widget-target")
+        .findByText("Previous 30 Years")
+        .click();
 
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.findByText("17514").click();
-        cy.wait("@dataset");
-        cy.findByTextEnsureVisible("Subtotal");
+      cy.findByTestId("parameter-value-dropdown")
+        .findByText("Update filter")
+        .click();
 
-        // Cypress cannot click elements that are blocked by an overlay so this will immediately fail if the issue is not fixed
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.findByText("79.37").click();
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.findByText("Filter by this value");
-      },
-    );
+      cy.findByTestId("legend-caption").findByText("17514").click();
+      cy.wait("@dataset");
+      cy.findByTextEnsureVisible("Subtotal");
+
+      cy.findByTestId("view-footer")
+        .findByText("Showing first 2,000 rows")
+        .should("be.visible");
+
+      cy.findByTestId("query-builder-main").findByText("79.37").click();
+
+      cy.findByTestId("click-actions-view").findByText("Filter by this value");
+    });
   });
 
   describe("scenario 2", () => {


### PR DESCRIPTION
Closes https://linear.app/metabase-inc/issue/DEVX-61/[flaky-test]-scenario-1-issue-17514-scenario-1-should-not-show-the-run
Stress test: https://github.com/metabase/metabase/actions/runs/12907689916

### Description

The problem was actually quite simple, we were clicking on a cell item before the table was fully loaded. Adding an assertion on the table footer that shows number of displayed items fixed it.

I got rid of some eslint warnings in the process