### PR TITLE
Exclude DQs from DQ candidate endpoint

### DIFF
--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -1063,7 +1063,10 @@
   "Implementation for the `dashboard-question-candidates` endpoints."
   [collection-id :- [:maybe ms/PositiveInt]]
   (api/check-403 api/*is-superuser?*)
-  (let [all-cards-in-collection (t2/hydrate (t2/select :model/Card {:where [:= :collection_id collection-id]}) :in_dashboards)]
+  (let [all-cards-in-collection (t2/hydrate (t2/select :model/Card {:where [:and
+                                                                            [:= :collection_id collection-id]
+                                                                            [:= :dashboard_id nil]]})
+                                            :in_dashboards)]
     (filter
      (fn [card]
        (and
@@ -1072,9 +1075,7 @@
         (card/sole-dashboard-id card)
         ;; - that one dashboard is in the same collection
         (= (:collection_id card)
-           (-> card :in_dashboards first :collection_id))
-        ;; - ... and we're not already a DQ in that dashboard
-        (nil? (:dashboard_id card))))
+           (-> card :in_dashboards first :collection_id))))
      all-cards-in-collection)))
 
 (mu/defn- present-dashboard-question-candidate

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -1063,8 +1063,19 @@
   "Implementation for the `dashboard-question-candidates` endpoints."
   [collection-id :- [:maybe ms/PositiveInt]]
   (api/check-403 api/*is-superuser?*)
-  (let [cards-in-collection (t2/hydrate (t2/select :model/Card {:where [:= :collection_id collection-id]}) :in_dashboards)]
-    (filter card/sole-dashboard-id cards-in-collection)))
+  (let [all-cards-in-collection (t2/hydrate (t2/select :model/Card {:where [:= :collection_id collection-id]}) :in_dashboards)]
+    (filter
+     (fn [card]
+       (and
+        ;; we're a good candidate if:
+        ;; - we're only in one dashboard
+        (card/sole-dashboard-id card)
+        ;; - that one dashboard is in the same collection
+        (= (:collection_id card)
+           (-> card :in_dashboards first :collection_id))
+        ;; - ... and we're not already a DQ in that dashboard
+        (nil? (:dashboard_id card))))
+     all-cards-in-collection)))
 
 (mu/defn- present-dashboard-question-candidate
   [{:keys [in_dashboards] :as card}]

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -1210,8 +1210,6 @@
                     {:card-id (:id card)})))
   (let [[dashboard :as dashboards] (:in_dashboards card)]
     (when (and (= 1 (count dashboards))
-               (= (:collection_id card)
-                  (:collection_id dashboard))
                (not (:archived dashboard))
                (not (:archived card)))
       (:id dashboard))))

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -1618,6 +1618,16 @@
                     (map :id)
                     (into #{}))))))))
 
+(deftest get-dashboard-question-candidates-excludes-existing-dashboard-questions
+  (testing "GET /api/collection/:id/dashboard-question-candidates"
+    (testing "Existing DQs are excluded"
+      (mt/with-temp [:model/Collection {coll-id :id} {}
+                     :model/Dashboard {dash-id :id} {:collection_id coll-id}
+                     :model/Card {card-id :id} {:dashboard_id dash-id}
+                     :model/DashboardCard _ {:dashboard_id dash-id :card_id card-id}]
+        (is (= {:data [] :count 0}
+               (mt/user-http-request :crowberto :get 200 (str "collection/" coll-id "/dashboard-question-candidates"))))))))
+
 (deftest get-root-dashboard-question-candidates-single-dashboard-card
   (testing "GET /api/collection/root/dashboard-question-candidates"
     (testing "Card is in single dashboard"


### PR DESCRIPTION
... oops

I also moved the `(= (:collection_id card) (:collection_id dashboard))` check out of `card/sole-dashboard-id`, since it's not really part of being a sole dashboard.