### PR TITLE
Fix blank eid not creating a new entity on load

### DIFF
--- a/docs/installation-and-operation/serialization.md
+++ b/docs/installation-and-operation/serialization.md
@@ -333,7 +333,7 @@ Metabase relies on [Entity IDs](#metabase-uses-entity-ids-to-identify-and-refere
 
   In particular, this means that if you export a question, then make a change in an exported YAML file — like rename a question by directly editing the `name` field — and then import the edited file back, Metabase will try to apply the changes you made to the YAML.
 
-- If you import an item with blank `entity_id` (and blank `serdes/meta → id`), Metabase will create a new item.
+- If you import an item with a blank `entity_id`, Metabase will create a new item. Any `serdes/meta → id` will be ignored in this case.
 
 - All items and data sources referenced in YAML must either exist in the target Metabase already, or be included in the import.
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50106

### Description

The documentation https://www.metabase.com/docs/latest/installation-and-operation/serialization#how-import-works suggests a 'blank' entity_id should result in a new entity being created. 

This lead to issue #50106 in which multiple repeated imports of the same entity (having a null entity_id) would on the 3rd import result in a constraint violation exception.

After discussing with @piranha - I have confirmed the desired behaviour is as documented, additionally we do not think the requirement for removing the `:id` from the `:serdes/meta` is necessary.

Previous behaviour: 

- Import 1
   - the existing entity matched, despite the null entity_id - as looking up the previous entity is based on the `:serdes/meta` `:id`. 
  -  the existing entity is updated to have a null entity_id.
- Import 2 
     - backfill runs, the null entity id is replaced with the identity-hash of the entity.
     - the new entity `:serdes/meta` does not match what is in the app db, so a new entity is created (with a null entity_id)
- Import 3
     - backfill runs, spots the null entity_id and tries again to replace with the identity-hash - failing because the hash already exists.

### How to verify

1. Import a serialized entity containing a null entity_id. 
2. Observe the entity is created
3. Repeat a further 2 or 3 times, you should expect to see new entities be created.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
