### PR TITLE
Delete indexed model search entries using cascade

### DIFF
--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -156,12 +156,16 @@
          [:updated_at :timestamp-with-time-zone :not-null]]
         (keep (fn [[k t]]
                 (when t
-                  (into [(->db-column k) (->db-type t)]
-                        (concat
-                         (when (not-null k)
-                           [:not-null])
-                         (when-some [d (default k)]
-                           [[:default d]]))))))
+                  (if (= :model-index-id k)
+                   [(->db-column k) :int
+                    [:references :model_index :id]
+                    :on-delete :cascade]
+                    (into [(->db-column k) (->db-type t)]
+                          (concat
+                           (when (not-null k)
+                             [:not-null])
+                           (when-some [d (default k)]
+                             [[:default d]])))))))
         search.spec/attr-types))
 
 (defn create-table!

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -157,9 +157,9 @@
         (keep (fn [[k t]]
                 (when t
                   (if (= :model-index-id k)
-                   [(->db-column k) :int
-                    [:references :model_index :id]
-                    :on-delete :cascade]
+                    [(->db-column k) :int
+                     [:references :model_index :id]
+                     :on-delete :cascade]
                     (into [(->db-column k) (->db-type t)]
                           (concat
                            (when (not-null k)

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -175,6 +175,7 @@
       (sql.helpers/with-columns (specialization/table-schema base-schema))
       t2/query)
   (let [table-name (name table-name)]
+    (t2/query (format "CREATE INDEX IF NOT EXISTS %s_model_index ON %s(model_index_id)" table-name table-name))
     (doseq [stmt (specialization/post-create-statements table-name table-name)]
       (t2/query stmt))))
 

--- a/src/metabase/search/spec.clj
+++ b/src/metabase/search/spec.clj
@@ -48,6 +48,7 @@
    :last-edited-at      :timestamp
    :last-editor-id      :pk
    :last-viewed-at      :timestamp
+   :model-index-id      :pk
    :name                :text
    :native-query        nil
    :official-collection :boolean
@@ -72,6 +73,7 @@
          :dashboard-id
          :dashboardcard-count
          :last-viewed-at
+         :model-index-id
          :pinned
          :verified                                          ;;  in addition to being a filter, this is also a ranker
          :view-count


### PR DESCRIPTION
Currently we synchronously update the searchable entities when models are indexed, but the entries are left there if we turn off indexing.

Since there may be millions of these records, its not practical to queue up all their ids, but we can leverage the fact that our index is in the same database.

This won't work for future engines, but we can cross that bridge when we get to it. One idea is to update `search/delete!` to take an arbitrary attr rather than assuming its the id. 