### PR TITLE
Exclude `e2e-tests-result` from Slack notifications

### DIFF
--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -61,7 +61,7 @@ jobs:
               });
 
               const failedJobs = jobInfo.data.jobs
-                .filter(job => job.status === "completed" && job.conclusion === "failure");
+                .filter(job => job.status === "completed" && job.conclusion === "failure" && job.name !== "e2e-tests-result");
 
               // don't bother slack if only the flaky job failed
               if (failedJobs.every(job => job.name.toLowerCase().includes("flaky"))) {

--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -61,7 +61,7 @@ jobs:
               });
 
               const failedJobs = jobInfo.data.jobs
-                .filter(job => job.status === "completed" && job.conclusion === "failure" && !job.name.includes("-tests-result");
+                .filter(job => job.status === "completed" && job.conclusion === "failure" && !job.name.includes("-tests-result"));
 
               // don't bother slack if only the flaky job failed
               if (failedJobs.every(job => job.name.toLowerCase().includes("flaky"))) {

--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -61,7 +61,7 @@ jobs:
               });
 
               const failedJobs = jobInfo.data.jobs
-                .filter(job => job.status === "completed" && job.conclusion === "failure" && !job.name.includes("-tests-result") && !job.name.includes("Flaky"));
+                .filter(job => job.status === "completed" && job.conclusion === "failure" && !job.name.includes("-tests-result");
 
               // don't bother slack if only the flaky job failed
               if (failedJobs.every(job => job.name.toLowerCase().includes("flaky"))) {

--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -61,7 +61,7 @@ jobs:
               });
 
               const failedJobs = jobInfo.data.jobs
-                .filter(job => job.status === "completed" && job.conclusion === "failure" && job.name !== "e2e-tests-result");
+                .filter(job => job.status === "completed" && job.conclusion === "failure" && !job.name.includes("-tests-result") && !job.name.includes("Flaky"));
 
               // don't bother slack if only the flaky job failed
               if (failedJobs.every(job => job.name.toLowerCase().includes("flaky"))) {


### PR DESCRIPTION
Resolves [DEVX-74](https://linear.app/metabase-inc/issue/DEVX-74/exclude-tests-result-and-flaky-tests-from-ci-failure-notifications)