### PR TITLE
Register prometheus endpoint metrics

### DIFF
--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -8,6 +8,7 @@
   (:require
    [clojure.java.jmx :as jmx]
    [iapetos.collector :as collector]
+   [iapetos.collector.ring :as ring]
    [iapetos.collector.ring :as collector.ring]
    [iapetos.core :as prometheus]
    [metabase.models.setting :as setting :refer [defsetting]]
@@ -235,7 +236,8 @@
   [registry-name]
   (log/info "Starting prometheus metrics collector")
   (let [registry (prometheus/collector-registry registry-name)]
-    (apply prometheus/register registry
+    (apply prometheus/register
+           (ring/initialize registry)
            (concat (jvm-collectors)
                    (jetty-collectors)
                    [@c3p0-collector]

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -8,7 +8,6 @@
   (:require
    [clojure.java.jmx :as jmx]
    [iapetos.collector :as collector]
-   [iapetos.collector.ring :as ring]
    [iapetos.collector.ring :as collector.ring]
    [iapetos.core :as prometheus]
    [metabase.models.setting :as setting :refer [defsetting]]
@@ -237,7 +236,7 @@
   (log/info "Starting prometheus metrics collector")
   (let [registry (prometheus/collector-registry registry-name)]
     (apply prometheus/register
-           (ring/initialize registry)
+           (collector.ring/initialize registry)
            (concat (jvm-collectors)
                    (jetty-collectors)
                    [@c3p0-collector]


### PR DESCRIPTION
Without initializing these metrics, we're throwing hidden exceptions when scraping the endpoint. We're also flying blind as far as looking at these diagnostics.

### Before

```
2025-01-22 17:21:01,440 WARN server.HttpChannel :: /favicon.ico
java.lang.AssertionError: Assert failed: (instance? ExceptionCounterChild child)
	at iapetos.collector.exceptions$record_exception_BANG_.invokeStatic(exceptions.clj:70)
	at iapetos.collector.exceptions$record_exception_BANG_.invoke(exceptions.clj:70)
	at iapetos.collector.ring$run_instrumented.invokeStatic(ring.clj:133)
    ...
```

(this is logged even on succesful API calls, at least in dev)

### After

*crickets*

See: [prometheus wrapper docs](https://github.com/clj-commons/iapetos#ring-)