### PR TITLE
Ignore result-columns for saved questions

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
@@ -72,7 +72,10 @@
   [id]
   (when-let [base (api.card/get-card id)]
     (let [mp (lib.metadata.jvm/application-database-metadata-provider (:database_id base))
-          card-query (lib/query mp (lib.metadata/card mp id))
+          card-metadata (lib.metadata/card mp id)
+          card-query (lib/query mp (cond-> card-metadata
+                                     ;; pivot questions have strange result-columns so we work with the dataset-query
+                                     (#{:question} (:type base)) (get :dataset-query)))
           cols (lib/returned-columns card-query)
           field-id-prefix (metabot-v3.tools.u/card-field-id-prefix id)]
       (-> {:id id

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
@@ -155,7 +155,9 @@
       (if-let [card (api.card/get-card report_id)]
         (let [mp (lib.metadata.jvm/application-database-metadata-provider (:database_id card))]
           [(metabot-v3.tools.u/card-field-id-prefix report_id)
-           (lib/query mp (lib.metadata/card mp report_id))])
+           (lib/query mp (cond-> (lib.metadata/card mp report_id)
+                           ;; pivot questions have strange result-columns so we work with the dataset-query
+                           (#{:question} (:type card)) (get :dataset-query)))])
         (throw (ex-info (str "No report found with report_id " report_id) {:agent-error? true
                                                                            :data_source data-source})))
 


### PR DESCRIPTION
Fixes #52521.

The result-columns of saved pivot questions are a mess, the names and the effective types don't match the values. Instead of using these columns, we generate the columns from the dataset-query field.

The assumption is that the result-columns for saved questions (but not for models) don't play an important role.
