### PR TITLE
Fix webhook e2e test setup

### DIFF
--- a/e2e/support/helpers/e2e-notification-helpers.ts
+++ b/e2e/support/helpers/e2e-notification-helpers.ts
@@ -25,3 +25,12 @@ export const setupNotificationChannel = (
     ...opts,
   });
 };
+
+export const resetWebhookTester = () => {
+  cy.log("Reset webhook tester");
+  cy.request({
+    method: "DELETE",
+    url: `${WEBHOOK_TEST_HOST}/api/session/${WEBHOOK_TEST_SESSION_ID}/requests`,
+    failOnStatusCode: false, // returns 404 if no requests
+  });
+};

--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -1115,6 +1115,7 @@ describe("scenarios > admin > settings > map settings", () => {
 // docker run -p 9080:8080/tcp tarampampam/webhook-tester:1.1.0 serve --create-session 00000000-0000-0000-0000-000000000000
 describe("notifications", { tags: "@external" }, () => {
   beforeEach(() => {
+    H.resetWebhookTester();
     H.restore();
     cy.signInAsAdmin();
     cy.request({


### PR DESCRIPTION
### Description

This makes our webhook tests work no matter what order they execute. Previously, if we had 2 webhook tests on the same runner, the second would fail, because we assert on the number of webhook requests received.

![Screen Shot 2025-01-22 at 12 41 36 PM](https://github.com/user-attachments/assets/17e41d64-09ed-4658-94e3-bf406ecd0b74)

This adds a helper `H.resetWebhookTester()` that can be called before any webhook tests to get us back to a fresh state.