### PR TITLE
Avoid cartesian products in pivot csv exports

### DIFF
--- a/src/metabase/query_processor/pivot/postprocess.clj
+++ b/src/metabase/query_processor/pivot/postprocess.clj
@@ -6,7 +6,6 @@
   visually in the same way as in the app."
   (:refer-clojure :exclude [run!])
   (:require
-   [clojure.math.combinatorics :as math.combo]
    [clojure.set :as set]
    [clojure.string :as str]
    [flatland.ordered.map :as ordered-map]

--- a/test/metabase/api/downloads_exports_test.clj
+++ b/test/metabase/api/downloads_exports_test.clj
@@ -645,9 +645,7 @@
                (= [["B" "C" "3" "4" "Row totals"]
                    ["BA" "3" "1" "1" "2"]
                    ["BA" "4" "1" "1" "2"]
-                   ;; Without the fix in pr#50380, this would incorrectly look like:
-                   ;; ["Totals for BA"  "" "2" "[4 {:result 1}]"]
-                   ["Totals for BA"  "" "2" "2"]
+                   ["Totals for BA"  "" "2" "2" "4"]
                    ["Grand totals" "" "2" "2" "4"]]
                   result)))))))))
 
@@ -669,15 +667,12 @@
                                                 :pivot_results true)
                           csv/read-csv)]
           (is (= [["Created At: Month" "Category" "Sum of Price"]
-                  ["April, 2016" "Gadget" "49.54"]
-                  ["April, 2016" "Gizmo" "87.29"]
-                  ["Totals for April, 2016" "" "136.83"]
                   ["May, 2016" "Doohickey" "144.12"]
                   ["May, 2016" "Gadget" "81.58"]
                   ["May, 2016" "Gizmo" "75.09"]
                   ["May, 2016" "Widget" "90.21"]
                   ["Totals for May, 2016" "" "391"]]
-                 (take 9 result))))))))
+                 (take 6 result))))))))
 
 (deftest ^:parallel zero-row-pivot-tables-test
   (testing "Pivot tables with zero rows download correctly."
@@ -697,11 +692,10 @@
                                                 :pivot_results true)
                           csv/read-csv)]
           (is (= [["Category" "Doohickey" "Gadget" "Gizmo" "Widget" "Row totals"]
-                  ["" "2185.89" "3019.2" "2834.88" "3109.31" ""]
                   ["Grand totals" "2185.89" "3019.2" "2834.88" "3109.31" "11149.28"]]
                  result)))))))
 
-(deftest ^:parallel zero-column-multiple-meausres-pivot-tables-test
+(deftest ^:parallel zero-column-multiple-measures-pivot-tables-test
   (testing "Pivot tables with zero columns and multiple measures download correctly."
     (mt/dataset test-data
       (mt/with-temp [:model/Card {pivot-card-id :id}
@@ -1345,15 +1339,13 @@
         (let [named-cards {:one-scale-card one-scale-card
                            :two-scale-card zero-scale-card
                            :no-scale-card no-scale-card}]
+          ;; TODO: We don't support JSON for pivot tables, once we do, we should add them here
           (doseq [[c1-name c2-name export-format expected] [[:one-scale-card  :no-scale-card  :csv  true]
                                                             [:one-scale-card  :two-scale-card :csv  false]
                                                             [:no-scale-card   :two-scale-card :csv  false]
                                                             [:one-scale-card  :no-scale-card  :xlsx true]
                                                             [:one-scale-card  :two-scale-card :xlsx false]
-                                                            [:no-scale-card   :two-scale-card :xlsx false]
-                                                            ;; TODO: We don't support JSON for pivot tables, once we
-                                                            ;; do, we should add them here
-                                                            ]]
+                                                            [:no-scale-card   :two-scale-card :xlsx false]]]
             (testing (str "> " (name c1-name) " and " (name c2-name) " with export-format: '" (name export-format) "' should be " expected)
               (let [c1 (get named-cards c1-name)
                     c2 (get named-cards c2-name)
@@ -1435,7 +1427,7 @@
                                                   :columns []
                                                   :values  ["count" "sum" "sum_2"]}}
                         :dataset_query          (mt/mbql-query nil
-                                                  {:breakout     [[:field "MEASURE" {:base-type :type/Integer}]],
+                                                  {:breakout [[:field "MEASURE" {:base-type :type/Integer}]],
                                                    :aggregation
                                                    [[:count]
                                                     [:sum [:field "A" {:base-type :type/Integer}]]

--- a/test/metabase/query_processor/pivot/postprocess_test.clj
+++ b/test/metabase/query_processor/pivot/postprocess_test.clj
@@ -227,7 +227,8 @@
                         (:totals pivot-data)
                         true
                         (repeat 5 identity)
-                        (repeat 2 identity))))
+                        (repeat 2 identity)
+                        pivot-config)))
       (is (= ["Totals for 4" nil 3 4 7]
              (build-column-totals [4]
                                   [[3] [4]]
@@ -235,4 +236,5 @@
                                   (:totals pivot-data)
                                   true
                                   (repeat 5 identity)
-                                  (repeat 2 identity)))))))
+                                  [0 1]
+                                  [2]))))))

--- a/test/metabase/query_processor/pivot/postprocess_test.clj
+++ b/test/metabase/query_processor/pivot/postprocess_test.clj
@@ -1,6 +1,8 @@
 (ns metabase.query-processor.pivot.postprocess-test
   (:require
    [clojure.test :refer :all]
+   [flatland.ordered.map :as ordered-map]
+   [flatland.ordered.set :as ordered-set]
    [metabase.query-processor.pivot.postprocess :as process]))
 
 (def ^:private column-titles
@@ -10,6 +12,80 @@
   {:pivot-rows [2 3]
    :pivot-cols [0 1]
    :column-titles column-titles})
+
+(deftest assoc-in-path-tree-test
+  (testing "Values are correctly assoc'ed into a path tree, maintaining insertion order at every level"
+    (let [base-tree (#'process/assoc-in-path-tree (ordered-map/ordered-map) [:a :b :c] :d)]
+      ;; Assert on strings because direct map/set comparison doesn't preserve order, but strings do
+      (is (= "{:a {:b {:c #{:d}}}}" (str base-tree)))
+      (is (= "{:a {:b {:c #{:d :e}}}}"
+             (str (#'process/assoc-in-path-tree base-tree [:a :b :c] :e))))
+      (is (= "{:a {:b {:c #{:d :c}}}}"
+             (str (#'process/assoc-in-path-tree base-tree [:a :b :c] :c))))
+      (is (= "{:a {:b {:c #{:d}}, :e {:f #{:g}}}}"
+             (str (#'process/assoc-in-path-tree base-tree [:a :e :f] :g))))
+      (is (= "{:a {:b {:c #{:d}}, :a {:f #{:g}}}}"
+             (str (#'process/assoc-in-path-tree base-tree [:a :a :f] :g))))))
+
+  (testing "Assoc'ing a value with no key to an ordered map converts it to a top-level ordered set"
+    (let [new-tree (#'process/assoc-in-path-tree (ordered-map/ordered-map) [] :a)]
+      (is (= [:a] (seq new-tree))))
+
+    (let [new-tree (#'process/assoc-in-path-tree (ordered-set/ordered-set :b) [] :a)]
+      (is (= [:b :a] (seq new-tree))))))
+
+(deftest sort-path-tree-test
+  (testing "sort-path-tree with ascending and descending orders using integer indices in sort-orders"
+    (let [tree (ordered-map/ordered-map
+                :a (ordered-set/ordered-set 3 1 2)
+                :b (ordered-map/ordered-map
+                    :x (ordered-set/ordered-set 5 4 6)
+                    :y (ordered-set/ordered-set 8 7 9)))
+          sort-orders {0 :ascending
+                       1 :descending}
+          result (#'process/sort-path-tree tree [0 1] sort-orders)]
+      ;; Assert top-level keys are in ascending order
+      (is (= [:a :b] (keys result)))
+      ;; Assert second-level values in :a are in descending order
+      (is (= [3 2 1] (seq (get result :a))))
+      ;; Assert nested keys (:x, :y) in :b are in descending order
+      (is (= [:y :x] (keys (get result :b))))
+      ;; Assert :x and :y sets remain unsorted (no specific sort order provided for them)
+      (is (= [5 4 6] (seq (get-in result [:b :x]))))
+      (is (= [8 7 9] (seq (get-in result [:b :y]))))))
+
+  (testing "sort-path-tree with no sort order provided"
+    (let [tree (ordered-map/ordered-map
+                :a (ordered-set/ordered-set 3 1 2)
+                :b (ordered-map/ordered-map
+                    :x (ordered-set/ordered-set 5 4 6)))
+          sort-orders {}
+          result (#'process/sort-path-tree tree [0 1] sort-orders)]
+      ;; Ensure the original tree structure remains intact
+      (is (= (str tree) (str result)))))
+
+  (testing "sort-path-tree with nil input"
+    (is (nil? (#'process/sort-path-tree nil [] {})))))
+
+(deftest enumerate-paths-test
+  (testing "enumerate-paths with nested maps and sets"
+    (let [tree (ordered-map/ordered-map
+                :a (ordered-map/ordered-map
+                    :w (ordered-set/ordered-set 1 2)
+                    :x (ordered-set/ordered-set 2 1)))]
+      (is (= [[:a :w 1]
+              [:a :w 2]
+              [:a :x 2]
+              [:a :x 1]]
+             (#'process/enumerate-paths tree)))))
+
+  (testing "enumerate-paths with a single-level set"
+    (let [tree (ordered-set/ordered-set 1 2 3)]
+      (is (= [[1] [2] [3]]
+             (#'process/enumerate-paths tree)))))
+
+  (testing "enumerate-paths with empty input"
+    (is (= [] (#'process/enumerate-paths {})))))
 
 (deftest add-pivot-measures-test
   (testing "Given a `pivot-spec` without `:pivot-measures`, add them."
@@ -55,12 +131,13 @@
                       "bD" {3 {:result 1}}}}
                (:data pivot-data)))
 
-        ;; all distinct values encountered for each row/col index are stored
-        ;; this is necessary to construct the headers as well as the combinations
-        ;; that make up the 'paths' to get measure values for every cell in the pivot table
-        (is (= {:row-values {0 #{"aA" "aB"}}
-                :column-values {1 #{"bA" "bB" "bC" "bD"}}}
-               (select-keys pivot-data [:row-values :column-values])))
+        ;; Distinct values of rows and columns are built into a tree composed of ordered maps and sets. If there is only
+        ;; one row/col, it is stored as an ordered set at the top-level.
+        (is (= {:row-paths #{"aA" "aB"}
+                :col-paths #{"bA" "bB" "bC" "bD"}}
+               (select-keys pivot-data [:row-paths :col-paths])))
+        (is (= flatland.ordered.set.OrderedSet (type (:row-paths pivot-data))))
+        (is (= flatland.ordered.set.OrderedSet (type (:col-paths pivot-data))))
 
         ;; since everything is aggregated as a row is added, we can store all of the
         ;; relevant totals right away and use them to construct the pivot table totals

--- a/test/metabase/query_processor/pivot/postprocess_test.clj
+++ b/test/metabase/query_processor/pivot/postprocess_test.clj
@@ -15,23 +15,23 @@
 
 (deftest assoc-in-path-tree-test
   (testing "Values are correctly assoc'ed into a path tree, maintaining insertion order at every level"
-    (let [base-tree (#'process/assoc-in-path-tree (ordered-map/ordered-map) [:a :b :c] :d)]
+    (let [base-tree (#'process/add-to-path-tree (ordered-map/ordered-map) [:a :b :c :d])]
       ;; Assert on strings because direct map/set comparison doesn't preserve order, but strings do
       (is (= "{:a {:b {:c #{:d}}}}" (str base-tree)))
       (is (= "{:a {:b {:c #{:d :e}}}}"
-             (str (#'process/assoc-in-path-tree base-tree [:a :b :c] :e))))
+             (str (#'process/add-to-path-tree base-tree [:a :b :c :e]))))
       (is (= "{:a {:b {:c #{:d :c}}}}"
-             (str (#'process/assoc-in-path-tree base-tree [:a :b :c] :c))))
+             (str (#'process/add-to-path-tree base-tree [:a :b :c :c]))))
       (is (= "{:a {:b {:c #{:d}}, :e {:f #{:g}}}}"
-             (str (#'process/assoc-in-path-tree base-tree [:a :e :f] :g))))
+             (str (#'process/add-to-path-tree base-tree [:a :e :f :g]))))
       (is (= "{:a {:b {:c #{:d}}, :a {:f #{:g}}}}"
-             (str (#'process/assoc-in-path-tree base-tree [:a :a :f] :g))))))
+             (str (#'process/add-to-path-tree base-tree [:a :a :f :g]))))))
 
   (testing "Assoc'ing a value with no key to an ordered map converts it to a top-level ordered set"
-    (let [new-tree (#'process/assoc-in-path-tree (ordered-map/ordered-map) [] :a)]
+    (let [new-tree (#'process/add-to-path-tree (ordered-map/ordered-map) [:a])]
       (is (= [:a] (seq new-tree))))
 
-    (let [new-tree (#'process/assoc-in-path-tree (ordered-set/ordered-set :b) [] :a)]
+    (let [new-tree (#'process/add-to-path-tree (ordered-set/ordered-set :b) [:a])]
       (is (= [:b :a] (seq new-tree))))))
 
 (deftest sort-path-tree-test


### PR DESCRIPTION
Likely resolves https://github.com/metabase/metabase/issues/49977

This PR optimizes pivoted CSV exports by avoiding generating Cartesian products of all row and column values and instead building the result rows and columns as tree structures from the actual data. These are accumulated in the `:row-paths` and `:col-paths` keys in the pivot data structure returned by `init-pivot`.

This mirrors the approach taken by the frontend, which doesn't see equivalent performance issues as the backend: https://github.com/metabase/metabase/blob/abad978404a78c111f14414648c401636f0b7dad/frontend/src/metabase/lib/data_grid.js#L53-L55

The trees are built as nested `ordered-map`s (with `ordered-set`s to accumulate the leaf values) so that we don't lose the ordering from the original data, since this is the order of the output rows if no alternate ordering is provided. (I'm not sure if this is the best default behavior, since this ordering is pretty arbitrary, but for now I'm just trying to match the frontend).

Then, in `sort-path-tree` we traverse the tree and convert each level to a `sorted-map` or `sorted-set` as needed, based on the pivot settings. Finally, we enumerate every path from the root to a leaf to get the ultimate `row-combos` and `col-combos` which manifest as actual rows/columns in the CSV.

I've also made some tweaks to the surrounding code to ensure that column and row ordering is respected, and to handle some other edge cases. And I've added some unit tests for new helper functions, and tweaked the expected output of other tests to be more correct. There's a lot more cleanup and further optimization that can be done here but I'm trying to keep the changes relatively focused so that we can resolve the main source of perf problems.