### PR TITLE
ci(sdk): skip flaky tooltip test on ci

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/tooltip-reproductions.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/tooltip-reproductions.cy.spec.tsx
@@ -59,7 +59,8 @@ describeEE("scenarios > embedding-sdk > tooltip-reproductions", () => {
     );
   });
 
-  it("should render tooltips below the screen's height", () => {
+  // This is flaking on CI but not locally :()
+  it.skip("should render tooltips below the screen's height (metabase#51904)", () => {
     cy.get("@dashboardId").then(dashboardId => {
       mountSdkContent(<InteractiveDashboard dashboardId={dashboardId} />);
     });


### PR DESCRIPTION
I ran this test locally 20+ times and it never flaked, and it is flaking on CI for some reason.

> My disappointment is immeasurable and my day is ruined :(
