### PR TITLE
Do not ignore full_stacktrace on import

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/api.clj
@@ -267,7 +267,8 @@
                   report
                   callback]} (unpack&import (:tempfile file)
                                             {:size              (:size file)
-                                             :continue-on-error continue_on_error})
+                                             :continue-on-error continue_on_error
+                                             :full-stacktrace   full_stacktrace})
           imported           (into (sorted-set) (map (comp :model last)) (:seen report))]
       (snowplow/track-event! ::snowplow/serialization
                              {:event         :serialization


### PR DESCRIPTION

### Description

The `full_stacktrace` parameter to `/api/ee/serialization/import` did not work. It was not passed through to the `unpack&import` call. This PR passes it

No test as unsure whether worth it in this instance. Please comment if you'd like a test? (I'd imagine something that makes an api call, with-redef an exception, check logs for stack frames)