### PR TITLE
Simplify and shorten upload table names

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -49,7 +49,7 @@
   com.google.guava/guava                    {:mvn/version "33.3.1-jre"}         ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
   com.h2database/h2                         ^:antq/exclude                      ; https://metaboat.slack.com/archives/CKZEMT1MJ/p1727191010259979
                                             {:mvn/version "2.1.214"}            ; embedded SQL database
-  com.ibm.icu/icu4j                         {:mvn/version "72.1"}               ; Used to transliterate unicode characters into latin
+  com.ibm.icu/icu4j                         {:mvn/version "71.1"}               ; Used to transliterate unicode characters into latin
   com.mchange/c3p0                          {:mvn/version "0.10.1"}             ; DB connection pool
   com.snowplowanalytics/snowplow-java-tracker ^:antq/exclude                    ; 2+ depend on apache httpclient 5.x, but saml and clj-http depend on 4.x
                                             {:mvn/version "1.0.1"}              ; Snowplow analytics

--- a/deps.edn
+++ b/deps.edn
@@ -49,6 +49,7 @@
   com.google.guava/guava                    {:mvn/version "33.3.1-jre"}         ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
   com.h2database/h2                         ^:antq/exclude                      ; https://metaboat.slack.com/archives/CKZEMT1MJ/p1727191010259979
                                             {:mvn/version "2.1.214"}            ; embedded SQL database
+  com.ibm.icu/icu4j                         {:mvn/version "72.1"}               ; Used to transliterate unicode characters into latin
   com.mchange/c3p0                          {:mvn/version "0.10.1"}             ; DB connection pool
   com.snowplowanalytics/snowplow-java-tracker ^:antq/exclude                    ; 2+ depend on apache httpclient 5.x, but saml and clj-http depend on 4.x
                                             {:mvn/version "1.0.1"}              ; Snowplow analytics

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -146,7 +146,8 @@
                 (t/plus (t/seconds 1))
                 (t/truncate-to :seconds))))))
 
-(def ^:private transliterator (Transliterator/getInstance "Any-Latin; Latin-ASCII"))
+(def ^:private transliterator
+  (Transliterator/getInstance "Arabic-Latin; Bulgarian-Latin/BGN; Greek-Latin/BGN; Any-Latin; Latin-ASCII"))
 
 (defn- transliterate [s]
   (when-not (str/blank? s)
@@ -162,8 +163,7 @@
   ;; TODO we should not rely on the timestamp to make the filename unique
   ;; Ideally we would add an incrementing count, but it may be cheaper and easier to include some randomness.
   (let [time-format                 "_yyyyMMddHHmmss"
-        slugified-name               (transliterate table-name)
-        slugified-name               (if (str/blank? slugified-name) "blank" slugified-name)
+        slugified-name              (or (u/not-blank (transliterate table-name)) "blank")
         ;; since both the time-format and the slugified-name contain only ASCII characters, we can behave as if
         ;; [[driver/table-name-length-limit]] were defining a length in characters.
         max-length                  (- (min-safe (driver/table-name-length-limit driver)

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -154,7 +154,8 @@
     (-> (.transliterate ^Transliterator transliterator ^String s)
         (str/replace #"\s+" "_")
         (str/replace #"[^\w]+" "_")
-        (str/replace #"_{2,}" "_"))))
+        (str/replace #"_{2,}" "_")
+        (str/replace #"^_|_$" ""))))
 
 (defn- unique-table-name
   "Append the current datetime to the given name to create a unique table name. The resulting name will be short enough for the given driver (truncating the supplied `table-name` if necessary)."

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -146,7 +146,7 @@
                 (t/plus (t/seconds 1))
                 (t/truncate-to :seconds))))))
 
-(def transliterator (Transliterator/getInstance "Any-Latin; Latin-ASCII"))
+(def ^:private transliterator (Transliterator/getInstance "Any-Latin; Latin-ASCII"))
 
 (defn- transliterate [s]
   (when-not (str/blank? s)

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -149,8 +149,7 @@
 (def transliterator (Transliterator/getInstance "Any-Latin; Latin-ASCII"))
 
 (defn- transliterate [s]
-  (if (str/blank? s)
-    "blank"
+  (when-not (str/blank? s)
     (-> (.transliterate ^Transliterator transliterator ^String s)
         (str/replace #"\s+" "_")
         (str/replace #"[^\w]+" "_")
@@ -164,6 +163,7 @@
   ;; Ideally we would add an incrementing count, but it may be cheaper and easier to include some randomness.
   (let [time-format                 "_yyyyMMddHHmmss"
         slugified-name               (transliterate table-name)
+        slugified-name               (if (str/blank? slugified-name) "blank" slugified-name)
         ;; since both the time-format and the slugified-name contain only ASCII characters, we can behave as if
         ;; [[driver/table-name-length-limit]] were defining a length in characters.
         max-length                  (- (min-safe (driver/table-name-length-limit driver)

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -1202,3 +1202,8 @@
     (if res
       (assoc m k res)
       (dissoc m k))))
+
+(defn not-blank
+  "Like not-empty, but for strings"
+  [s]
+  (when-not (str/blank? s) s))

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -269,7 +269,7 @@
         (is (nil? (re-find #";" escaped)))
         (is (=? #"some_text_DROP_TABLE_csv_\d+" escaped))))
     (testing "transliteration"
-      (is (=? #"Geia_sou_Privet_alslam_lykm_Ola_\d+" (unique-table-name "¡Γειά σoυ! Пpивeт! السلام عليكم! Olá!"))))
+      (is (=? #"Geia_sou_Privet_alslam_lykm_Ola_\d+" (unique-table-name "¡Γειά σoυ! Пrивeт! السلام عليكم! Olá!"))))
     (testing "No collisions"
       (let [n 50
             names (repeatedly n (partial #'upload/unique-table-name driver/*driver* ""))]

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -258,6 +258,10 @@
 
 (deftest ^:parallel unique-table-name-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
+    (testing "Blank names"
+      (is (=? #"blank_\d+" (unique-table-name nil)))
+      (is (=? #"blank_\d+" (unique-table-name "")))
+      (is (=? #"blank_\d+" (unique-table-name " ! $ _ "))))
     (testing "File name is slugified"
       (is (=? #"my_file_name_\d+" (unique-table-name "my file name"))))
     (testing "semicolons are removed"

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -269,7 +269,7 @@
         (is (nil? (re-find #";" escaped)))
         (is (=? #"some_text_DROP_TABLE_csv_\d+" escaped))))
     (testing "transliteration"
-      (is (=? #"Geia_sou_Privet_alslam_lykm_Ola_\d+" (unique-table-name "¡Γειά σoυ! Пrивeт! السلام عليكم! Olá!"))))
+      (is (=? #"Geia_sou_Privet_alslam_lykm_Ola_\d+" (unique-table-name "¡Γειά σoυ! Пpивeт! السلام عليكم! Olá!"))))
     (testing "No collisions"
       (let [n 50
             names (repeatedly n (partial #'upload/unique-table-name driver/*driver* ""))]

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -258,7 +258,9 @@
     (testing "File name is slugified"
       (is (=? #"my_file_name_\d+" (@#'upload/unique-table-name driver/*driver* "my file name"))))
     (testing "semicolons are removed"
-      (is (nil? (re-find #";" (@#'upload/unique-table-name driver/*driver* "some text; -- DROP TABLE.csv")))))
+      (let [escaped (@#'upload/unique-table-name driver/*driver* "some text; -- DROP TABLE.csv")]
+        (is (nil? (re-find #";" escaped)))
+        (is (str/starts-with? escaped "some_text_DROP_TABLE_csv_"))))
     (testing "No collisions"
       (let [n 50
             names (repeatedly n (partial #'upload/unique-table-name driver/*driver* ""))]

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -269,7 +269,7 @@
         (is (nil? (re-find #";" escaped)))
         (is (=? #"some_text_DROP_TABLE_csv_\d+" escaped))))
     (testing "transliteration"
-      (is (=? #"Geia_sou_Privet_alslam_lykm_Ola_\d+" (unique-table-name "¡Γειά σoυ! Пpивeт! السلام عليكم! Olá!"))))
+      (is (=? #"Geia_sou_Privet_alslam_lykm_Ola_\d+" (unique-table-name "¡Γειά σου! Привет! السلام عليكم! Olá!"))))
     (testing "No collisions"
       (let [n 50
             names (repeatedly n (partial #'upload/unique-table-name driver/*driver* ""))]

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -451,7 +451,7 @@
                (fn [model]
                  (with-upload-table! [table (card->table model)]
                    (test-names-match table "出色的")
-                   (is (= (ddl.i/format-name driver/*driver* "%e5%87%ba%e8%89%b2%e7%9a%84_20240628000000")
+                   (is (= (ddl.i/format-name driver/*driver* "chu_se_de_20240628000000")
                           (:name table)))))))))
         (testing "The names should be truncated to the right size"
          ;; we can assume app DBs use UTF-8 encoding (metabase#11753)

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -269,7 +269,7 @@
         (is (nil? (re-find #";" escaped)))
         (is (=? #"some_text_DROP_TABLE_csv_\d+" escaped))))
     (testing "transliteration"
-      (is (=? #"Geia_sou_Privet_alslam_lykm_Ola_\d+" (unique-table-name "¡Γειά σου! Привет! السلام عليكم! Olá!"))))
+      (is (=? #"Geia_sou_Privet_alslam_lykm_Ola_\d+" (unique-table-name "¡Γειά σoυ! Пpивeт! السلام عليكم! Olá!"))))
     (testing "No collisions"
       (let [n 50
             names (repeatedly n (partial #'upload/unique-table-name driver/*driver* ""))]

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -455,7 +455,7 @@
                           (:name table)))))))))
         (testing "The names should be truncated to the right size"
          ;; we can assume app DBs use UTF-8 encoding (metabase#11753)
-          (let [max-bytes 50]
+          (let [max-bytes 15]
             (with-redefs [; redef this because the UNIX filename limit is 255 bytes, so we can't test it in CI
                           upload/max-bytes (constantly max-bytes)]
               (doseq [^String c ["a" "出"]]

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -269,7 +269,8 @@
         (is (nil? (re-find #";" escaped)))
         (is (=? #"some_text_DROP_TABLE_csv_\d+" escaped))))
     (testing "transliteration"
-      (is (=? #"Geia_sou_Privet_alslam_lykm_Ola_\d+" (unique-table-name "¡Γειά σου! Привет! السلام عليكم! Olá!"))))
+      ;; <skip lint>
+      (is (=? #"Yia_sou_Privet_alslam_lykm_Ola_\d+" (unique-table-name "¡Γειά σου! Привет! السلام عليكم! Olá!"))))
     (testing "No collisions"
       (let [n 50
             names (repeatedly n (partial #'upload/unique-table-name driver/*driver* ""))]


### PR DESCRIPTION
Closes: https://github.com/metabase/metabase/issues/52116

Note that of icu4j was already a dependency, via graalvm. 

We have just made it explicit now, ~~and updated to the latest version.~~ ([upgrading version breaks rendering](https://github.com/metabase/metabase/actions/runs/12926546646/job/36049844305?pr=52581))

```
org.graalvm.js/js 22.3.5
  . org.graalvm.regex/regex 22.3.5
    . org.graalvm.truffle/truffle-api 22.3.5
    . com.ibm.icu/icu4j 71.1
  . org.graalvm.truffle/truffle-api 22.3.5
    . org.graalvm.sdk/graal-sdk 22.3.5
  . org.graalvm.sdk/graal-sdk 22.3.5
  . com.ibm.icu/icu4j 71.1
```