### PR TITLE
Fix flaky date-string->range driver test

### DIFF
--- a/test/metabase/driver/common/parameters/dates_test.clj
+++ b/test/metabase/driver/common/parameters/dates_test.clj
@@ -458,9 +458,9 @@
       (gen/elements time-units)
       (gen/elements time-units)))))
 
-(defspec date-string->range-spec-test 1000
+(defspec ^:parallel date-string->range-spec-test 1000
   (prop/for-all [[tr tr+from-zero] time-range-generator]
-    (with-redefs [t/local-date-time (constantly (t/local-date-time))]
+    (mt/with-clock (t/zoned-date-time)
       (= (params.dates/date-string->range tr)
          (params.dates/date-string->range tr+from-zero)))))
 

--- a/test/metabase/driver/common/parameters/dates_test.clj
+++ b/test/metabase/driver/common/parameters/dates_test.clj
@@ -458,7 +458,7 @@
       (gen/elements time-units)
       (gen/elements time-units)))))
 
-(defspec ^:parallel date-string->range-spec-test 1000
+(defspec date-string->range-spec-test 1000
   (prop/for-all [[tr tr+from-zero] time-range-generator]
     (with-redefs [t/local-date-time (constantly (t/local-date-time))]
       (= (params.dates/date-string->range tr)

--- a/test/metabase/driver/common/parameters/dates_test.clj
+++ b/test/metabase/driver/common/parameters/dates_test.clj
@@ -4,6 +4,7 @@
    [clojure.test.check.clojure-test :refer [defspec]]
    [clojure.test.check.generators :as gen]
    [clojure.test.check.properties :as prop]
+   [java-time.api :as t]
    [metabase.driver.common.parameters.dates :as params.dates]
    [metabase.test :as mt]))
 
@@ -459,8 +460,9 @@
 
 (defspec ^:parallel date-string->range-spec-test 1000
   (prop/for-all [[tr tr+from-zero] time-range-generator]
-    (= (params.dates/date-string->range tr)
-       (params.dates/date-string->range tr+from-zero))))
+    (with-redefs [t/local-date-time (constantly (t/local-date-time))]
+      (= (params.dates/date-string->range tr)
+         (params.dates/date-string->range tr+from-zero)))))
 
 (deftest custom-start-of-week-test
   (testing "Relative filters should respect the custom `start-of-week` Setting (#14294)"


### PR DESCRIPTION
Closes https://linear.app/metabase-inc/issue/ENG-14350/investigate-date-string-range-flake

### Description

The `date-string->range` function calls `now (t/local-date-time)` itself. Both calls in a test are usually very close but once in a while they differ by enough that they round to different seconds:
```
; from date-string->range: #t "2025-01-23T13:05:52.712148"
; from date-string->range: #t "2025-01-23T13:05:53.603516"
; results: {:start 2025-01-23T13:05:53, :end 2025-01-23T13:06:50} {:start 2025-01-23T13:05:54, :end 2025-01-23T13:06:51}
; args: next58seconds next58seconds-from-0weeks
; FAIL
```
We can use `(mt/with-clock)` and then both calls in a test use the same time:
```
; from date-string->range: #t "2025-01-23T13:07:11.083553"
; from date-string->range: #t "2025-01-23T13:07:11.083553"
; results: {:start 2025-01-23T13:07:09, :end 2025-01-23T13:07:10} {:start 2025-01-23T13:07:09, :end 2025-01-23T13:07:10}
; args: past2seconds past2seconds-from-0years
```

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Run the `date-string->range-spec-test` test many times (i.e. 10,000,000) without the changes and observe a failure.
2. Run the `date-string->range-spec-test` test many times (i.e. 10,000,000) with the changes and observe no failures.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
