### PR TITLE
Force adding reindex trigger

### DIFF
--- a/src/metabase/task/search_index.clj
+++ b/src/metabase/task/search_index.clj
@@ -129,7 +129,7 @@
                       (simple/schedule
                        (simple/with-interval-in-hours 1)
                        (simple/repeat-forever))))]
-    (task/schedule-task! job trigger)))
+    (force-scheduled-task! job trigger)))
 
 (defmethod task/init! ::SearchIndexUpdate [_]
   (let [job         (jobs/build


### PR DESCRIPTION
Somehow the search `reindex` trigger stopped firing mid december. Nothing about the task has changed since november.

There is no trace of the trigger in the stats quartz tables.

We had a similar issue with the `update` task, so this copies the same brute force fix.