### PR TITLE
Remove an external link from convert-timezone description

### DIFF
--- a/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
+++ b/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
@@ -1161,8 +1161,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
     name: "convert-timezone",
     structure: "convertTimezone",
     description: () => t`Convert timezone of a date or timestamp column.
-We support tz database time zone names.
-See the full list here: https://w.wiki/4Jx`,
+We support tz database time zone names.`,
     args: [
       {
         name: t`column`,

--- a/frontend/src/metabase-lib/v1/expressions/helper-text-strings.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/helper-text-strings.unit.spec.ts
@@ -40,6 +40,20 @@ describe("getHelpText", () => {
       );
       expect(helpText?.args).toHaveLength(2);
     });
+
+    it("convertTimezone", () => {
+      const { database } = setup();
+      const helpText = getHelpText(
+        "convert-timezone",
+        database,
+        reportTimezone,
+      );
+
+      expect(helpText?.structure).toEqual("convertTimezone");
+      expect(helpText?.description).toEqual(
+        expect.not.stringContaining("https"),
+      );
+    });
   });
 
   describe("help texts customized per database engine", () => {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/27184

How to verify:
- Add a DB that works with `convertTimezone`. Our QA instance of postgres would work.
- New -> Question -> Select a table from this DB
- Custom column -> `convertTimezone`
- See the description in the popover - there is no extra link now.

Before
<img width="441" alt="207141730-652d28a1-1e21-4c91-8a40-8806c6682b36" src="https://github.com/user-attachments/assets/ed6ca329-bb95-41df-ad1f-9554084278b0" />

After
<img width="555" alt="Screenshot 2025-01-23 at 10 44 06" src="https://github.com/user-attachments/assets/5e1bcf28-d95f-43f1-bcab-adf9e72156ef" />
