### PR TITLE
Test: Oracle compares dates (no time) correctly

### DIFF
--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -563,3 +563,42 @@
         (is (=? {:effective_type :type/DateTime}
                 (m/find-first (comp #{"created_at"} :name)
                               (mt/cols (qp/process-query query)))))))))
+
+(deftest date-filter-variable
+  (testing "Date filter variables work against date-times"
+    (mt/test-driver
+        :oracle
+      (mt/dataset
+          date-cols-with-datetime-values
+        (let [query (mt/native-query
+                      {:query "SELECT *
+                               FROM \"mb_test\".\"date_cols_with_datetime_values_dates_with_time\"
+                               WHERE {{date_filter}}"
+                       :template-tags {"date_filter"
+                                       {:name         "date_filter"
+                                        :display-name "Date Filter"
+                                        :type         :dimension
+                                        :dimension    [:field (mt/id :date_cols_with_datetime_values_dates_with_time :date_with_time) nil]
+                                        :widget-type  :date/single}}})
+              query (assoc query :parameters [{:type   :date/single
+                                               :target [:dimension [:template-tag "date_filter"]]
+                                               :value  "2024-11-06"}])]
+          (is (= [[2M "2024-11-06T13:13:13Z"]]
+                 (mt/rows
+                  (qp/process-query query))))
+         (let [query (mt/native-query
+                      {:query "SELECT *
+                               FROM \"mb_test\".\"date_cols_with_datetime_values_dates_with_time\"
+                               WHERE {{date_filter}}"
+                       :template-tags {"date_filter"
+                                       {:name         "date_filter"
+                                        :display-name "Date Filter"
+                                        :type         :dimension
+                                        :dimension    [:field (mt/id :date_cols_with_datetime_values_dates_with_time :date_with_time) nil]
+                                        :widget-type  :date/all-options}}})
+              query (assoc query :parameters [{:type   :date/all-options
+                                               :target [:dimension [:template-tag "date_filter"]]
+                                               :value  "2024-11-06"}])]
+          (is (= [[2M "2024-11-06T13:13:13Z"]]
+                 (mt/rows
+                  (qp/process-query query))))))))))

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -567,9 +567,9 @@
 (deftest date-filter-variable
   (testing "Date filter variables work against date-times"
     (mt/test-driver
-        :oracle
+      :oracle
       (mt/dataset
-          date-cols-with-datetime-values
+        date-cols-with-datetime-values
         (let [query (mt/native-query
                       {:query "SELECT *
                                FROM \"mb_test\".\"date_cols_with_datetime_values_dates_with_time\"
@@ -586,19 +586,19 @@
           (is (= [[2M "2024-11-06T13:13:13Z"]]
                  (mt/rows
                   (qp/process-query query))))
-         (let [query (mt/native-query
-                      {:query "SELECT *
+          (let [query (mt/native-query
+                        {:query "SELECT *
                                FROM \"mb_test\".\"date_cols_with_datetime_values_dates_with_time\"
                                WHERE {{date_filter}}"
-                       :template-tags {"date_filter"
-                                       {:name         "date_filter"
-                                        :display-name "Date Filter"
-                                        :type         :dimension
-                                        :dimension    [:field (mt/id :date_cols_with_datetime_values_dates_with_time :date_with_time) nil]
-                                        :widget-type  :date/all-options}}})
-              query (assoc query :parameters [{:type   :date/all-options
-                                               :target [:dimension [:template-tag "date_filter"]]
-                                               :value  "2024-11-06"}])]
-          (is (= [[2M "2024-11-06T13:13:13Z"]]
-                 (mt/rows
-                  (qp/process-query query))))))))))
+                         :template-tags {"date_filter"
+                                         {:name         "date_filter"
+                                          :display-name "Date Filter"
+                                          :type         :dimension
+                                          :dimension    [:field (mt/id :date_cols_with_datetime_values_dates_with_time :date_with_time) nil]
+                                          :widget-type  :date/all-options}}})
+                query (assoc query :parameters [{:type   :date/all-options
+                                                 :target [:dimension [:template-tag "date_filter"]]
+                                                 :value  "2024-11-06"}])]
+            (is (= [[2M "2024-11-06T13:13:13Z"]]
+                   (mt/rows
+                    (qp/process-query query))))))))))

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -570,22 +570,7 @@
       :oracle
       (mt/dataset
         date-cols-with-datetime-values
-        (let [query (mt/native-query
-                      {:query "SELECT *
-                               FROM \"mb_test\".\"date_cols_with_datetime_values_dates_with_time\"
-                               WHERE {{date_filter}}"
-                       :template-tags {"date_filter"
-                                       {:name         "date_filter"
-                                        :display-name "Date Filter"
-                                        :type         :dimension
-                                        :dimension    [:field (mt/id :date_cols_with_datetime_values_dates_with_time :date_with_time) nil]
-                                        :widget-type  :date/single}}})
-              query (assoc query :parameters [{:type   :date/single
-                                               :target [:dimension [:template-tag "date_filter"]]
-                                               :value  "2024-11-06"}])]
-          (is (= [[2M "2024-11-06T13:13:13Z"]]
-                 (mt/rows
-                  (qp/process-query query))))
+        (doseq [widget-type [:date/single :date/all-options]]
           (let [query (mt/native-query
                         {:query "SELECT *
                                FROM \"mb_test\".\"date_cols_with_datetime_values_dates_with_time\"
@@ -595,10 +580,10 @@
                                           :display-name "Date Filter"
                                           :type         :dimension
                                           :dimension    [:field (mt/id :date_cols_with_datetime_values_dates_with_time :date_with_time) nil]
-                                          :widget-type  :date/all-options}}})
-                query (assoc query :parameters [{:type   :date/all-options
-                                                 :target [:dimension [:template-tag "date_filter"]]
-                                                 :value  "2024-11-06"}])]
+                                          :widget-type  widget-type}}})
+                query-with-params (assoc query :parameters [{:type   widget-type
+                                                             :target [:dimension [:template-tag "date_filter"]]
+                                                             :value  "2024-11-06"}])]
             (is (= [[2M "2024-11-06T13:13:13Z"]]
                    (mt/rows
-                    (qp/process-query query))))))))))
+                    (qp/process-query query-with-params))))))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/49878

### Description

Issue https://github.com/metabase/metabase/issues/49878, back in November, was that Oracle was not comparing date-times correctly when compared to a single date without time. I was able to reproduce it in `v0.51.3` (reported in issue), but could not reproduce on master.

Just to be safe, I created tests that fail on `v0.51.3` that now pass on master. The tests cover two cases with field filters in native SQL queries that compare a datetime to a single date:

* Single Date
* All Options

### Note

Since this is a test only, I recommend not backporting because the test will fail on some prior releases.