### PR TITLE
Stop checking that parameter names are kebab-case

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/interface.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/interface.clj
@@ -18,10 +18,7 @@
                             (u/->snake_case_en (name x)))
     :decode/api-response  (fn [x]
                             (keyword (u/->kebab-case-en x)))}
-   :keyword
-   [:fn
-    {:error/message "PARSED parameter names should be kebab-case (in JSON files they should use camelCase)"}
-    #(= (u/->kebab-case-en %) %)]])
+   :keyword])
 
 (mr/def ::metadata.parameter
   [:and


### PR DESCRIPTION
Having different variants for the same parameter is a burden, because there are multiple places where conversions should happen. This PR enables snake case parameters, so dummy tool parameters don't have to be converted back and forth.
