### PR TITLE
Re-enable the filter-records tool

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
@@ -207,4 +207,4 @@
 
 (mu/defmethod metabot-v3.tools.interface/*tool-applicable?* :metabot.tool/filter-records
   [_tool-name _context]
-  false)
+  true)


### PR DESCRIPTION
It turns out that a fair number of our test cases rely on this tool, and they worked before, so it might be stable enough.
