### PR TITLE
Close clause popovers when dnd is active

### DIFF
--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -710,6 +710,26 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
         .should("have.text", name);
     }
 
+    function verifyDragAndDrop() {
+      H.getNotebookStep("expression").within(() => {
+        moveElement({ name: "E1", horizontal: 100, index: 1 });
+      });
+      H.getNotebookStep("filter").within(() => {
+        moveElement({ name: "ID is 2", horizontal: -100, index: 0 });
+      });
+      H.getNotebookStep("summarize").within(() => {
+        cy.findByTestId("aggregate-step").within(() => {
+          moveElement({ name: "Count", vertical: 100, index: 4 });
+        });
+        cy.findByTestId("breakout-step").within(() => {
+          moveElement({ name: "ID", horizontal: 100, index: 1 });
+        });
+      });
+      H.getNotebookStep("sort").within(() => {
+        moveElement({ name: "Average of Total", horizontal: -100, index: 0 });
+      });
+    }
+
     function verifyPopoverDoesNotMoveElement({
       type,
       name,
@@ -728,6 +748,23 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
         .findAllByTestId("notebook-cell-item")
         .eq(index)
         .should("have.text", name);
+    }
+
+    function verifyPopoverIsClosedAfterDragAndDrop({
+      type,
+      name,
+      index,
+      horizontal,
+      vertical,
+    }) {
+      H.getNotebookStep(type).within(() => {
+        cy.findByText(name).click();
+      });
+      H.popover().should("be.visible");
+      H.getNotebookStep(type).within(() => {
+        moveElement({ name, horizontal, vertical, index });
+      });
+      cy.get(H.POPOVER_ELEMENT).should("not.exist");
     }
 
     const questionDetails = {
@@ -762,27 +799,17 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     };
     cy.createQuestion(questionDetails, { visitQuestion: true });
     H.openNotebook();
-    H.getNotebookStep("expression").within(() => {
-      moveElement({ name: "E1", horizontal: 100, index: 1 });
-    });
-    H.getNotebookStep("filter").within(() => {
-      moveElement({ name: "ID is 2", horizontal: -100, index: 0 });
-    });
-    H.getNotebookStep("summarize").within(() => {
-      cy.findByTestId("aggregate-step").within(() => {
-        moveElement({ name: "Count", vertical: 100, index: 4 });
-      });
-      cy.findByTestId("breakout-step").within(() => {
-        moveElement({ name: "ID", horizontal: 100, index: 1 });
-      });
-    });
-    H.getNotebookStep("sort").within(() => {
-      moveElement({ name: "Average of Total", horizontal: -100, index: 0 });
-    });
+    verifyDragAndDrop();
     verifyPopoverDoesNotMoveElement({
       type: "filter",
       name: "ID is 1",
       index: 1,
+      horizontal: -100,
+    });
+    verifyPopoverIsClosedAfterDragAndDrop({
+      type: "filter",
+      name: "ID is 1",
+      index: 0,
       horizontal: -100,
     });
   });

--- a/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.tsx
+++ b/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useState } from "react";
+import { useDndContext } from "@dnd-kit/core";
+import { useCallback, useLayoutEffect, useState } from "react";
 
 import { Popover } from "metabase/ui";
 
@@ -14,6 +15,7 @@ export function ClausePopover({
   renderPopover,
 }: ClausePopoverProps) {
   const [isOpen, setIsOpen] = useState(isInitiallyOpen);
+  const { active } = useDndContext();
 
   const handleOpen = useCallback(() => {
     setIsOpen(true);
@@ -22,6 +24,12 @@ export function ClausePopover({
   const handleClose = useCallback(() => {
     setIsOpen(false);
   }, []);
+
+  useLayoutEffect(() => {
+    if (active) {
+      setIsOpen(false);
+    }
+  }, [active]);
 
   return (
     <Popover


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/48922

How to verify:
- Open a question with multiple filters
- Go to notebook and click on one of the filters to open the filter pick
- Now reorder filter clauses with drag-n-drop without closing the popover
- The popover should be closed automatically