### PR TITLE
fix: allow passing aggregation instead of expression

### DIFF
--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -1092,6 +1092,21 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       cy.findByText("Count").should("be.visible");
     });
   });
+
+  it("should allow using aggregation functions inside expressions in aggregation (metabase#52611)", () => {
+    cy.visit("/");
+    H.newButton("Question").click();
+    H.entityPickerModal().findByText("Orders").click();
+    H.addSummaryField({ metric: "Custom Expression" });
+    H.enterCustomColumnDetails({
+      formula: "case(Sum([Total]) > 10, Sum([Total]), Sum([Subtotal]))",
+      name: "conditional sum",
+    });
+    cy.button("Done").click();
+    H.addSummaryGroupingField({ field: "Total" });
+    H.visualize();
+    H.echartsContainer().should("contain.text", "Total: 8 bins");
+  });
 });
 
 function assertTableRowCount(expectedCount) {

--- a/frontend/src/metabase-lib/v1/expressions/resolver.js
+++ b/frontend/src/metabase-lib/v1/expressions/resolver.js
@@ -70,6 +70,10 @@ const isCompatible = (expectedType, inferredType) => {
   if (expectedType === "number" && inferredType === "aggregation") {
     return true;
   }
+  if (expectedType === "expression" && inferredType === "aggregation") {
+    return true;
+  }
+
   return false;
 };
 

--- a/frontend/test/metabase/lib/expressions/resolver.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/resolver.unit.spec.js
@@ -343,6 +343,11 @@ describe("metabase-lib/v1/expressions/resolve", () => {
       expect(() => expr(["case", [[X, ["*", 0.5, Y]]], def])).not.toThrow();
     });
 
+    it("should allow sum inside expression in aggregation", () => {
+      // CASE(SUM(A) > 10, B)
+      expect(() => expr(["case", [[[">", ["sum", A], 10], B]]])).not.toThrow();
+    });
+
     it("should accept IF as an alias for CASE", () => {
       expect(expr(["if", [[A, B]]]).segments).toEqual(["A"]);
       expect(expr(["if", [[A, B]]]).dimensions).toEqual(["B"]);


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/52611

### Description

Allows using aggregation functions inside expressions

### How to verify

- orders table
- enter expression `case(Sum([Total]) > 10, Sum([Total]), Sum([Subtotal]))` in summarize -> expression
- select Total in breakout

### Demo


https://github.com/user-attachments/assets/cd68b441-74e8-4b15-997b-987a7c3c8cf1




### Checklist

- [x] Tests have been added/updated to cover changes in this PR
