### PR TITLE
Fix e2e flake: 45252

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -1249,6 +1249,7 @@ describe("45252", { tags: "@external" }, () => {
     H.entityPickerModal().within(() => {
       H.entityPickerModalTab("Tables").click();
       cy.findByText("Writable Postgres12").click();
+      cy.findByText("Public").click();
       cy.findByText("Many Data Types").click();
     });
     H.getNotebookStep("filter")


### PR DESCRIPTION
This test could behave differently based on what schema exist in the db, which can be different from test to test. This adds an explicit schema selection rather than relying on "Public" always being selected