### PR TITLE
Fix recents in the entity picker for tables in joins

### DIFF
--- a/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
@@ -188,12 +188,18 @@ describe("issue 15342", { tags: "@external" }, () => {
     });
 
     cy.icon("join_left_outer").click();
-    H.entityPickerModal().findByText("Orders").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
+      cy.findByText("Orders").click();
+    });
     H.getNotebookStep("join").findByLabelText("Right column").click();
     H.popover().findByText("Product ID").click();
 
     cy.icon("join_left_outer").last().click();
-    H.entityPickerModal().findByText("Products").click();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
+      cy.findByText("Products").click();
+    });
     H.getNotebookStep("join").icon("join_left_outer").click();
     H.popover().findByText("Inner join").click();
 

--- a/frontend/src/metabase-types/api/activity.ts
+++ b/frontend/src/metabase-types/api/activity.ts
@@ -33,15 +33,17 @@ export type BaseRecentItem = {
   timestamp: string;
 };
 
+export type RecentTableDatabaseInfo = {
+  id: number;
+  name: string;
+  initial_sync_status: InitialSyncStatus;
+};
+
 export type RecentTableItem = BaseRecentItem & {
   model: "table";
   display_name: string;
   table_schema: string;
-  database: {
-    id: number;
-    name: string;
-    initial_sync_status: InitialSyncStatus;
-  };
+  database: RecentTableDatabaseInfo;
 };
 
 export type RecentCollectionItem = BaseRecentItem & {

--- a/frontend/src/metabase-types/api/mocks/activity.ts
+++ b/frontend/src/metabase-types/api/mocks/activity.ts
@@ -1,30 +1,35 @@
 import type {
   PopularItem,
   RecentCollectionItem,
-  RecentItem,
+  RecentTableDatabaseInfo,
   RecentTableItem,
 } from "metabase-types/api";
 
 export const createMockRecentTableItem = (
   opts?: Partial<RecentTableItem>,
-): RecentItem => ({
+): RecentTableItem => ({
   id: 1,
   model: "table",
   name: "my_cool_table",
   display_name: "My Cool Table",
   timestamp: "2021-03-01T00:00:00.000Z",
   table_schema: "PUBLIC",
-  database: {
-    id: 1,
-    name: "My Cool Database",
-    initial_sync_status: "complete",
-  },
+  database: createMockRecentTableDatabaseInfo(),
+  ...opts,
+});
+
+export const createMockRecentTableDatabaseInfo = (
+  opts?: Partial<RecentTableDatabaseInfo>,
+): RecentTableDatabaseInfo => ({
+  id: 1,
+  name: "My Cool Database",
+  initial_sync_status: "complete",
   ...opts,
 });
 
 export const createMockRecentCollectionItem = (
   opts?: Partial<RecentCollectionItem>,
-): RecentItem => ({
+): RecentCollectionItem => ({
   id: 1,
   model: "card",
   name: "My Cool Question",

--- a/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
@@ -29,6 +29,7 @@ import type {
 import {
   createQuestionPickerItemSelectHandler,
   createShouldShowItem,
+  getRecentItemDatabaseId,
   isCollectionItem,
   isTableItem,
   isValueItem,
@@ -122,7 +123,7 @@ export const DataPickerModal = ({
     (recentItems: RecentItem[]) => {
       if (databaseId) {
         return recentItems.filter(
-          item => "database_id" in item && item.database_id === databaseId,
+          item => getRecentItemDatabaseId(item) === databaseId,
         );
       }
 

--- a/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.unit.spec.tsx
@@ -1,0 +1,131 @@
+import {
+  setupRecentViewsAndSelectionsEndpoints,
+  setupSearchEndpoints,
+} from "__support__/server-mocks";
+import { renderWithProviders, screen } from "__support__/ui";
+import type { DatabaseId, RecentItem, SearchResult } from "metabase-types/api";
+import {
+  createMockRecentCollectionItem,
+  createMockRecentTableDatabaseInfo,
+  createMockRecentTableItem,
+  createMockSearchResult,
+} from "metabase-types/api/mocks";
+
+import type { DataPickerValue } from "../types";
+
+import { DataPickerModal } from "./DataPickerModal";
+
+type SetupOpts = {
+  title?: string;
+  value?: DataPickerValue;
+  databaseId?: DatabaseId;
+  recentItems?: RecentItem[];
+  searchItems?: SearchResult[];
+};
+
+function setup({
+  title = "Pick your starting data",
+  value,
+  databaseId,
+  recentItems = [],
+  searchItems = [],
+}: SetupOpts = {}) {
+  const onChange = jest.fn();
+  const onClose = jest.fn();
+
+  setupRecentViewsAndSelectionsEndpoints(recentItems, ["selections"]);
+  setupSearchEndpoints(searchItems);
+
+  renderWithProviders(
+    <DataPickerModal
+      title={title}
+      value={value}
+      databaseId={databaseId}
+      onChange={onChange}
+      onClose={onClose}
+    />,
+  );
+
+  return { onChange, onClose };
+}
+
+describe("DataPickerModal", () => {
+  describe("recents", () => {
+    const recentItems = [
+      createMockRecentTableItem({
+        id: 10,
+        name: "db_1_table",
+        display_name: "DB 1 table",
+        database: createMockRecentTableDatabaseInfo({
+          id: 1,
+        }),
+      }),
+      createMockRecentTableItem({
+        id: 20,
+        name: "db_2_table",
+        display_name: "DB 2 table",
+        database: createMockRecentTableDatabaseInfo({
+          id: 2,
+        }),
+      }),
+      createMockRecentCollectionItem({
+        id: 30,
+        name: "DB 1 question",
+        database_id: 1,
+      }),
+      createMockRecentCollectionItem({
+        id: 40,
+        name: "DB 2 question",
+        database_id: 2,
+      }),
+    ];
+
+    const searchItems = [
+      createMockSearchResult({
+        id: 10,
+        model: "table",
+      }),
+      createMockSearchResult({
+        id: 20,
+        model: "table",
+      }),
+      createMockSearchResult({
+        id: 30,
+        model: "card",
+      }),
+      createMockSearchResult({
+        id: 40,
+        model: "card",
+      }),
+    ];
+
+    it("should show tables and cards for all databases in recent items if the database is not specified", async () => {
+      setup({
+        recentItems,
+        searchItems,
+      });
+      expect(
+        await screen.findByRole("tab", { name: /Recents/ }),
+      ).toBeInTheDocument();
+      expect(await screen.findByText("DB 1 table")).toBeInTheDocument();
+      expect(screen.getByText("DB 1 question")).toBeInTheDocument();
+      expect(screen.getByText("DB 2 table")).toBeInTheDocument();
+      expect(screen.getByText("DB 2 question")).toBeInTheDocument();
+    });
+
+    it("should show tables and cards for the selected database in recent items (metabase#52523)", async () => {
+      setup({
+        databaseId: 1,
+        recentItems,
+        searchItems,
+      });
+      expect(
+        await screen.findByRole("tab", { name: /Recents/ }),
+      ).toBeInTheDocument();
+      expect(await screen.findByText("DB 1 table")).toBeInTheDocument();
+      expect(screen.getByText("DB 1 question")).toBeInTheDocument();
+      expect(screen.queryByText("DB 2 table")).not.toBeInTheDocument();
+      expect(screen.queryByText("DB 2 question")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/metabase/common/components/DataPicker/utils.ts
+++ b/frontend/src/metabase/common/components/DataPicker/utils.ts
@@ -7,6 +7,7 @@ import type {
   CollectionItemModel,
   Database,
   DatabaseId,
+  RecentItem,
   SchemaName,
   Table,
   TableId,
@@ -212,3 +213,11 @@ export const createQuestionPickerItemSelectHandler = (
     onItemSelect(item);
   };
 };
+
+export function getRecentItemDatabaseId(item: RecentItem) {
+  if (item.model === "table") {
+    return item.database.id;
+  } else {
+    return item.database_id;
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/52523

How to verify:
- New -> Question
- See that in the entity picker there are recent items
- Pick any table
- Click on join
- Verify that there are tables in the join entity picker as well