### PR TITLE
Remove an empty query stage after a drill from dashboards

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
@@ -398,7 +398,7 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
         .should("contain.text", multiBreakoutQuestionDetails.name);
       H.tableInteractive().within(() => {
         cy.findByText("Created At: Year").should("be.visible");
-        cy.findByText("Product → Created At: Week").should("be.visible");
+        cy.findByText("April 24, 2022").should("be.visible");
       });
     });
 

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -4158,3 +4158,72 @@ describe("issue 40396", { tags: "@external " }, () => {
     H.getDashboardCard().findAllByText("beta").should("have.length.gte", 1);
   });
 });
+
+describe("issue 52627", () => {
+  const questionDetails = {
+    display: "bar",
+    query: {
+      "source-table": ORDERS_ID,
+      aggregation: [
+        ["avg", ["field", ORDERS.TOTAL, null]],
+        ["avg", ["field", ORDERS.DISCOUNT, null]],
+      ],
+      breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }]],
+    },
+  };
+
+  const parameterDetails = {
+    name: "Category",
+    slug: "category",
+    id: "b6ed2d71",
+    type: "string/=",
+    sectionId: "string",
+    default: ["Gadget"],
+  };
+
+  const parameterTarget = [
+    "dimension",
+    ["field", PRODUCTS.CATEGORY, { "source-field": ORDERS.PRODUCT_ID }],
+    { "stage-number": 0 },
+  ];
+
+  const dashboardDetails = {
+    parameters: [parameterDetails],
+  };
+
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    cy.intercept("POST", "/api/dataset").as("dataset");
+  });
+
+  it("should remove an empty query stage after a dashboard drill-thru (metabase#52627)", () => {
+    H.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
+      ({ body: { id, card_id, dashboard_id } }) => {
+        H.addOrUpdateDashboardCard({
+          dashboard_id,
+          card_id,
+          card: {
+            id,
+            parameter_mappings: [
+              {
+                card_id: card_id,
+                parameter_id: parameterDetails.id,
+                target: parameterTarget,
+              },
+            ],
+          },
+        });
+        H.visitDashboard(dashboard_id);
+      },
+    );
+    H.chartPathWithFillColor("#A989C5").first().click();
+    H.popover().findByText("See this month by week").click();
+    cy.wait("@dataset");
+    cy.findByTestId("qb-filters-panel").findByText(
+      "Product → Category is Gadget",
+    );
+    H.summarize();
+    H.rightSidebar().findByText("Average of Total").should("be.visible");
+  });
+});

--- a/frontend/src/metabase-lib/v1/Question.ts
+++ b/frontend/src/metabase-lib/v1/Question.ts
@@ -771,24 +771,30 @@ class Question {
       return this;
     }
 
-    const newQuery = this.parameters().reduce((query, parameter) => {
+    // Pivot tables cannot work when there is an extra stage added on top of breakouts and aggregations
+    const queryWithExtraStage =
+      this.display() !== "pivot" ? Lib.ensureFilterStage(query) : query;
+    const queryWithFilters = this.parameters().reduce((newQuery, parameter) => {
       const stageIndex =
         isDimensionTarget(parameter.target) && !isComposed
           ? getParameterDimensionTargetStageIndex(parameter.target)
           : -1;
       return applyParameter(
-        query,
+        newQuery,
         stageIndex,
         parameter.type,
         parameter.target,
         parameter.value,
       );
-    }, query);
-    const newQuestion = this.setQuery(newQuery)
+    }, queryWithExtraStage);
+    const queryWithFiltersWithoutExtraStage =
+      Lib.dropEmptyStages(queryWithFilters);
+
+    const newQuestion = this.setQuery(queryWithFiltersWithoutExtraStage)
       .setParameters(undefined)
       .setParameterValues(undefined);
 
-    const hasQueryBeenAltered = query !== newQuery;
+    const hasQueryBeenAltered = queryWithExtraStage !== queryWithFilters;
     return hasQueryBeenAltered ? newQuestion.markDirty() : newQuestion;
 
     function getParameterDimensionTargetStageIndex(

--- a/frontend/src/metabase-lib/v1/Question.ts
+++ b/frontend/src/metabase-lib/v1/Question.ts
@@ -771,7 +771,8 @@ class Question {
       return this;
     }
 
-    // Pivot tables cannot work when there is an extra stage added on top of breakouts and aggregations
+    // If the query is composed (models or metrics) we cannot add filters to the underlying query since that query is used for data source.
+    // Pivot tables cannot work when there is an extra stage added on top of breakouts and aggregations.
     const queryWithExtraStage =
       !isComposed && this.display() !== "pivot"
         ? Lib.ensureFilterStage(query)

--- a/frontend/src/metabase-lib/v1/Question.ts
+++ b/frontend/src/metabase-lib/v1/Question.ts
@@ -773,7 +773,9 @@ class Question {
 
     // Pivot tables cannot work when there is an extra stage added on top of breakouts and aggregations
     const queryWithExtraStage =
-      this.display() !== "pivot" ? Lib.ensureFilterStage(query) : query;
+      !isComposed && this.display() !== "pivot"
+        ? Lib.ensureFilterStage(query)
+        : query;
     const queryWithFilters = this.parameters().reduce((newQuery, parameter) => {
       const stageIndex =
         isDimensionTarget(parameter.target) && !isComposed

--- a/frontend/src/metabase/dashboard/actions/getNewCardUrl.ts
+++ b/frontend/src/metabase/dashboard/actions/getNewCardUrl.ts
@@ -50,16 +50,7 @@ export const getNewCardUrl = ({
   let nextQuestion: Question | undefined = undefined;
 
   if (isEditable) {
-    nextQuestion = new Question(cardAfterClick, metadata);
-
-    // Pivot tables cannot work when there is an extra stage added on top of breakouts and aggregations
-    if (nextQuestion.display() !== "pivot") {
-      nextQuestion = nextQuestion.setQuery(
-        Lib.ensureFilterStage(nextQuestion.query()),
-      );
-    }
-
-    nextQuestion = nextQuestion
+    nextQuestion = new Question(cardAfterClick, metadata)
       .setDisplay(cardAfterClick.display || previousCard.display)
       .setSettings(dashcard.card.visualization_settings)
       .lockDisplay();

--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -3,6 +3,7 @@ import { parse } from "url";
 
 import { createMockMetadata } from "__support__/metadata";
 import { deserializeCardFromUrl } from "metabase/lib/card";
+import * as Lib from "metabase-lib";
 import Question from "metabase-lib/v1/Question";
 import NativeQuery from "metabase-lib/v1/queries/NativeQuery";
 import StructuredQuery from "metabase-lib/v1/queries/StructuredQuery";
@@ -808,6 +809,7 @@ describe("Question", () => {
         isComposed: false,
       });
 
+      expect(Lib.stageCount(questionWithFilters.query())).toBe(1);
       expect(questionWithFilters.datasetQuery().query.filter).toEqual([
         "starts-with",
         [


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/52627

How to verify:
- Follow the steps from the issue. Create a question, add it to a dashboard, and drill-thru.
- Open the summarize sidebar straight away after drilling. You see aggregations for stage number 0; the extra empty stage should be dropped.