### PR TITLE
Auto-rewrite even more defendpoints

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_config/api/logs.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/api/logs.clj
@@ -7,10 +7,10 @@
   keep logs externally for longer than this retention period."
   (:require
    [clojure.string :as str]
-   [compojure.core :refer [GET]]
    [malli.core :as mc]
    [malli.transform :as mtx]
    [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
    [metabase.db :as mdb]
    [metabase.util.i18n :refer [deferred-tru]]
    [metabase.util.malli :as mu]
@@ -32,13 +32,12 @@
                                          (date-part :month month)]})]
     results))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/query_execution/:yyyy-mm"
+(api.macros/defendpoint :get "/query_execution/:yyyy-mm"
   "Fetch rows for the month specified by `:yyyy-mm` from the query_execution logs table.
   Must be a superuser."
-  [yyyy-mm]
-  {yyyy-mm (mu/with-api-error-message [:re #"\d{4}-\d{2}"]
-                                      (deferred-tru "Must be a string like 2020-04 or 2222-11."))}
+  [{:keys [yyyy-mm]} :- [:map
+                         [:yyyy-mm (mu/with-api-error-message [:re #"\d{4}-\d{2}"]
+                                                              (deferred-tru "Must be a string like 2020-04 or 2222-11."))]]]
   (let [[year month] (mc/coerce [:tuple
                                  [:int {:title "year" :min 0 :max 9999}]
                                  [:int {:title "month" :min 0 :max 12}]] ; month 0 ???

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/api/application.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/api/application.clj
@@ -3,16 +3,15 @@
   Implements the Permissions routes needed for application permission - a class of permissions that control access to features
   like access Setting pages, access monitoring tools ... etc"
   (:require
-   [compojure.core :refer [GET PUT]]
    [metabase-enterprise.advanced-permissions.models.permissions.application-permissions :as a-perms]
    [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
    [metabase.models.application-permissions-revision :as a-perm-revision]
    [metabase.util.malli.schema :as ms]))
 
 (set! *warn-on-reflection* true)
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/graph"
+(api.macros/defendpoint :get "/graph"
   "Fetch a graph of Application Permissions."
   []
   (api/check-superuser)
@@ -35,20 +34,19 @@
   [graph]
   (update graph :groups dejsonify-groups))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint PUT "/graph"
+(api.macros/defendpoint :put "/graph"
   "Do a batch update of Application Permissions by passing a modified graph."
-  [:as {body :body
-        {skip-graph :skip-graph
-         force      :force} :params}]
-  {body       :map
-   skip-graph [:maybe ms/BooleanValue]
-   force      [:maybe ms/BooleanValue]}
+  [_route-params
+   {skip-graph? :skip-graph
+    force? :force} :- [:map
+                       [:skip-graph {:default false} [:maybe ms/BooleanValue]]
+                       [:force      {:default false} [:maybe ms/BooleanValue]]]
+   body :- :map]
   (api/check-superuser)
   (-> body
       dejsonify-graph
-      (a-perms/update-graph! force))
-  (if skip-graph
+      (a-perms/update-graph! force?))
+  (if skip-graph?
     {:revision (a-perm-revision/latest-id)}
     (a-perms/graph)))
 

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/api/impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/api/impersonation.clj
@@ -1,27 +1,26 @@
 (ns metabase-enterprise.advanced-permissions.api.impersonation
   (:require
-   [compojure.core :refer [GET]]
    [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/"
+(api.macros/defendpoint :get "/"
   "Fetch a list of all Impersonation policies currently in effect, or a single policy if both `group_id` and `db_id`
   are provided."
-  [group_id db_id]
-  {group_id [:maybe ms/PositiveInt]
-   db_id    [:maybe ms/PositiveInt]}
+  [_route-params
+   {:keys [group_id db_id]} :- [:map
+                                [:group_id {:optional true} [:maybe ms/PositiveInt]]
+                                [:db_id    {:optional true} [:maybe ms/PositiveInt]]]]
   (api/check-superuser)
   (if (and group_id db_id)
     (t2/select-one :model/ConnectionImpersonation :group_id group_id :db_id db_id)
     (t2/select :model/ConnectionImpersonation {:order-by [[:id :asc]]})))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint DELETE "/:id"
+(api.macros/defendpoint :delete "/:id"
   "Delete a Connection Impersonation entry."
-  [id]
-  {id ms/PositiveInt}
+  [{:keys [id]} :- [:map
+                    [:id ms/PositiveInt]]]
   (api/check-superuser)
   (api/check-404 (t2/select-one :model/ConnectionImpersonation :id id))
   (t2/delete! :model/ConnectionImpersonation :id id)

--- a/enterprise/backend/src/metabase_enterprise/audit_app/api/user.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/api/user.clj
@@ -1,9 +1,9 @@
 (ns metabase-enterprise.audit-app.api.user
   "`/api/ee/audit-app/user` endpoints. These only work if you have a premium token with the `:audit-app` feature."
   (:require
-   [compojure.core :refer [DELETE GET]]
    [metabase-enterprise.audit-app.audit :as ee-audit]
    [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
    [metabase.api.user :as api.user]
    [metabase.audit :as audit]
    [metabase.models.interface :as mi]
@@ -11,8 +11,7 @@
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/audit-info"
+(api.macros/defendpoint :get "/audit-info"
   "Gets audit info for the current user if he has permissions to access the audit collection.
   Otherwise return an empty map."
   []
@@ -27,12 +26,11 @@
        {(u/slugify (:name question-overview)) (:id question-overview)
         (u/slugify (:name dashboard-overview)) (:id dashboard-overview)}))))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint DELETE "/:id/subscriptions"
+(api.macros/defendpoint :delete "/:id/subscriptions"
   "Delete all Alert and DashboardSubscription subscriptions for a User (i.e., so they will no longer receive them).
   Archive all Alerts and DashboardSubscriptions created by the User. Only allowed for admins or for the current user."
-  [id]
-  {id ms/PositiveInt}
+  [{:keys [id]} :- [:map
+                    [:id ms/PositiveInt]]]
   (api.user/check-self-or-superuser id)
   ;; delete all `PulseChannelRecipient` rows for this User, which means they will no longer receive any
   ;; Alerts/DashboardSubscriptions

--- a/enterprise/backend/src/metabase_enterprise/billing/billing.clj
+++ b/enterprise/backend/src/metabase_enterprise/billing/billing.clj
@@ -4,9 +4,9 @@
    [clj-http.client :as http]
    [clojure.core.memoize :as memoize]
    [clojure.string :as str]
-   [compojure.core :refer [GET]]
    [java-time.api :as t]
    [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
    [metabase.premium-features.core :as premium-features]
    [metabase.util :as u]
    [metabase.util.date-2.parse :as u.date.parse]
@@ -53,8 +53,7 @@
                {:name "Token expiration date" :value (valid-thru) :format "string" :display "value"}
                {:name "Plan" :value "Enterprise Airgap" :format "string" :display "value"}]}))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/"
+(api.macros/defendpoint :get "/"
   "Get billing information. This acts as a proxy between `metabase-billing-info-url` and the client,
    using the embedding token and signed in user's email to fetch the billing information."
   []

--- a/enterprise/backend/src/metabase_enterprise/content_verification/api/moderation_review.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_verification/api/moderation_review.clj
@@ -1,21 +1,23 @@
 (ns metabase-enterprise.content-verification.api.moderation-review
   "`api/ee/moderation-review` routes."
   (:require
-   [compojure.core :refer [POST]]
    [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
    [metabase.models.moderation-review :as moderation-review]
    [metabase.moderation :as moderation]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint POST "/"
+(api.macros/defendpoint :post "/"
   "Create a new `ModerationReview`."
-  [:as {{:keys [text moderated_item_id moderated_item_type status]} :body}]
-  {text                [:maybe :string]
-   moderated_item_id   ms/PositiveInt
-   moderated_item_type moderation/moderated-item-types
-   status              [:maybe moderation-review/Statuses]}
+  [_route-params
+   _query-params
+   {:keys [text moderated_item_id moderated_item_type status]}
+   :- [:map
+       [:text                {:optional true} [:maybe :string]]
+       [:moderated_item_id   ms/PositiveInt]
+       [:moderated_item_type moderation/moderated-item-types]
+       [:status              {:optional true} [:maybe moderation-review/Statuses]]]]
   (api/check-superuser)
   (let [review-data {:text                text
                      :moderated_item_id   moderated_item_id

--- a/enterprise/backend/src/metabase_enterprise/llm/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/llm/api.clj
@@ -1,38 +1,36 @@
 (ns metabase-enterprise.llm.api
   (:require
-   [compojure.core :refer [GET POST]]
    [metabase-enterprise.llm.tasks.describe-dashboard :refer [describe-dashboard]]
    [metabase-enterprise.llm.tasks.describe-question :refer [describe-question]]
    [metabase.analyze.query-results :as qr]
    [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
    [metabase.util.malli.schema :as ms]))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint POST "/card/summarize"
+(api.macros/defendpoint :post "/card/summarize"
   "Summarize a question."
-  [:as {{:keys [collection_id collection_position dataset dataset_query description display
-                parameters parameter_mappings result_metadata visualization_settings cache_ttl]
-         :as   body} :body}]
-  {dataset                [:maybe :boolean]
-   dataset_query          ms/Map
-   parameters             [:maybe [:sequential ms/Parameter]]
-   parameter_mappings     [:maybe [:sequential ms/ParameterMapping]]
-   description            [:maybe ms/NonBlankString]
-   display                ms/NonBlankString
-   visualization_settings ms/Map
-   collection_id          [:maybe ms/PositiveInt]
-   collection_position    [:maybe ms/PositiveInt]
-   result_metadata        [:maybe qr/ResultsMetadata]
-   cache_ttl              [:maybe ms/PositiveInt]}
+  [_route-params
+   _query-params
+   body :- [:map
+            [:dataset                {:optional true} [:maybe :boolean]]
+            [:dataset_query          ms/Map]
+            [:parameters             {:optional true} [:maybe [:sequential ms/Parameter]]]
+            [:parameter_mappings     {:optional true} [:maybe [:sequential ms/ParameterMapping]]]
+            [:description            {:optional true} [:maybe ms/NonBlankString]]
+            [:display                ms/NonBlankString]
+            [:visualization_settings ms/Map]
+            [:collection_id          {:optional true} [:maybe ms/PositiveInt]]
+            [:collection_position    {:optional true} [:maybe ms/PositiveInt]]
+            [:result_metadata        {:optional true} [:maybe qr/ResultsMetadata]]
+            [:cache_ttl              {:optional true} [:maybe ms/PositiveInt]]]]
   ;; check that we have permissions to run the query that we're trying to save
-  ;(check-data-permissions-for-query dataset_query)
+                                        ;(check-data-permissions-for-query dataset_query)
   {:summary (describe-question body)})
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint POST "/dashboard/summarize/:id"
+(api.macros/defendpoint :post "/dashboard/summarize/:id"
   "Provide a summary of a dashboard."
-  [id]
-  {id ms/PositiveInt}
+  [{:keys [id]} :- [:map
+                    [:id ms/PositiveInt]]]
   {:summary (describe-dashboard id)})
 
 (api/define-routes)

--- a/enterprise/backend/src/metabase_enterprise/query_reference_validation/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/query_reference_validation/api.clj
@@ -1,8 +1,8 @@
 (ns metabase-enterprise.query-reference-validation.api
   (:require
-   [compojure.core :refer [GET]]
    [medley.core :as m]
    [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
    [metabase.models.collection :as collection]
    [metabase.models.query-analysis :as query-analysis]
@@ -98,8 +98,7 @@
            {:limit (request/limit)
             :offset (request/offset)})))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/invalid-cards"
+(api.macros/defendpoint :get "/invalid-cards"
   "List of cards that have an invalid reference in their query. Shape of each card is standard, with the addition of an
   `errors` key. Supports pagination (`offset` and `limit`), so it returns something in the shape:
 
@@ -109,10 +108,11 @@
      :limit  50
      :offset 100
   ```"
-  [sort_column sort_direction collection_id]
-  {sort_column    [:maybe (into [:enum] valid-sort-columns)]
-   sort_direction [:maybe (into [:enum] valid-sort-directions)]
-   collection_id  [:maybe ms/PositiveInt]}
+  [_route-params
+   {:keys [sort_column sort_direction collection_id]} :- [:map
+                                                          [:sort_column    {:optional true} [:maybe (into [:enum] valid-sort-columns)]]
+                                                          [:sort_direction {:optional true} [:maybe (into [:enum] valid-sort-directions)]]
+                                                          [:collection_id  {:optional true} [:maybe ms/PositiveInt]]]]
   (invalid-cards sort_column sort_direction collection_id))
 
 (defn +check-setting

--- a/enterprise/backend/src/metabase_enterprise/stale/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/stale/api.clj
@@ -126,10 +126,10 @@
   [{:keys [id]} :- [:map
                     [:id [:or ms/PositiveInt [:= :root]]]]
    {:keys [before_date is_recursive sort_column sort_direction]} :- [:map
-                                                                     [:before_date    {:optional true} [:maybe :string]]
-                                                                     [:is_recursive   [:boolean {:default false}]]
-                                                                     [:sort_column    {:optional true} [:maybe {:default :name} [:enum :name :last_used_at]]]
-                                                                     [:sort_direction {:optional true} [:maybe {:default :asc} [:enum :asc :desc]]]]]
+                                                                     [:before_date    {:optional true}  [:maybe :string]]
+                                                                     [:is_recursive   {:default false}  :boolean]
+                                                                     [:sort_column    {:default :name}  [:enum :name :last_used_at]]
+                                                                     [:sort_direction {:default :asc}   [:enum :asc :desc]]]]
   (premium-features/assert-has-feature :collection-cleanup (tru "Collection Cleanup"))
   (let [before-date    (if before_date
                          (try (t/local-date "yyyy-MM-dd" before_date)

--- a/enterprise/backend/src/metabase_enterprise/stale/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/stale/api.clj
@@ -117,7 +117,7 @@
        annotate-dashboard-with-collection-info
        present-collections))
 
-(api.macros/defendpoint :get "/:id"
+(api.macros/defendpoint :get ["/:id" :id #"(?:\d+)|(?:root)"]
   "A flexible endpoint that returns stale entities, in the same shape as collections/items, with the following options:
   - `before_date` - only return entities that were last edited before this date (default: 6 months ago)
   - `is_recursive` - if true, return entities from all children of the collection, not just the direct children (default: false)

--- a/enterprise/backend/src/metabase_enterprise/upload_management/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/upload_management/api.clj
@@ -1,7 +1,7 @@
 (ns metabase-enterprise.upload-management.api
   (:require
-   [compojure.core :refer [DELETE]]
    [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
    [metabase.models.interface :as mi]
    [metabase.upload :as upload]
@@ -9,8 +9,7 @@
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/tables"
+(api.macros/defendpoint :get "/tables"
   "Get all `Tables` visible to the current user which were created by uploading a file."
   []
   (as-> (t2/select :model/Table, :active true, :is_upload true, {:order-by [[:name :asc]]}) tables
@@ -18,12 +17,12 @@
     (map #(update % :schema str) tables)
     (filterv mi/can-read? tables)))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint DELETE "/tables/:id"
+(api.macros/defendpoint :delete "/tables/:id"
   "Delete the uploaded table from the database, optionally archiving cards for which it is the primary source."
-  [id archive-cards]
-  {id            ms/PositiveInt
-   archive-cards [:maybe {:default false} ms/BooleanValue]}
+  [{:keys [id]} :- [:map
+                    [:id ms/PositiveInt]]
+   {:keys [archive-cards]} :- [:map
+                               [:archive-cards {:optional true} [:maybe {:default false} ms/BooleanValue]]]]
   (try
     ;; To be idempotent, we do not check whether the table has already been deactivated.
     (let [table  (api/check-404 (t2/select-one :model/Table id))

--- a/enterprise/backend/test/metabase_enterprise/stale/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/stale/api_test.clj
@@ -139,10 +139,10 @@
                  (->> (mt/user-http-request :crowberto :get 200 "ee/stale/root"
                                             :is_recursive true)
                       :data
-                      (filter #(contains? #{(u/the-id card-a)
-                                            (u/the-id card-b)
-                                            (u/the-id dashboard-a)
-                                            (u/the-id dashboard-b)}
+                      (filter #(contains? (into #{} [(u/the-id card-a) ; there might be some duplicates here
+                                                     (u/the-id card-b)
+                                                     (u/the-id dashboard-a)
+                                                     (u/the-id dashboard-b)])
                                           (:id %)))
                       (map :name)
                       set))))))))

--- a/enterprise/backend/test/metabase_enterprise/stale/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/stale/api_test.clj
@@ -1,11 +1,12 @@
 (ns metabase-enterprise.stale.api-test
-  (:require  [clojure.test :refer [deftest testing is]]
-             [metabase.analytics.snowplow-test :as snowplow-test]
-             [metabase.models.collection :as collection]
-             [metabase.models.collection-test :refer [with-collection-hierarchy!]]
-             [metabase.stale-test :as stale.test]
-             [metabase.test :as mt]
-             [metabase.util :as u]))
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [metabase.analytics.snowplow-test :as snowplow-test]
+   [metabase.models.collection :as collection]
+   [metabase.models.collection-test :refer [with-collection-hierarchy!]]
+   [metabase.stale-test :as stale.test]
+   [metabase.test :as mt]
+   [metabase.util :as u]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/metabase/api/login_history.clj
+++ b/src/metabase/api/login_history.clj
@@ -1,7 +1,7 @@
 (ns metabase.api.login-history
   (:require
-   [compojure.core :refer [GET]]
    [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
    [metabase.models.login-history :as login-history]
    [metabase.util :as u]
    [toucan2.core :as t2]))
@@ -17,8 +17,7 @@
               :user_id (u/the-id user-or-id)
               {:order-by [[:timestamp :desc]]})))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/current"
+(api.macros/defendpoint :get "/current"
   "Fetch recent logins for the current user."
   []
   (login-history api/*current-user-id*))

--- a/src/metabase/api/premium_features.clj
+++ b/src/metabase/api/premium_features.clj
@@ -1,11 +1,10 @@
 (ns metabase.api.premium-features
   (:require
-   [compojure.core :refer [GET]]
    [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
    [metabase.premium-features.core :as premium-features]))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/token/status"
+(api.macros/defendpoint :get "/token/status"
   "Fetch info about the current Premium-Features premium features token including whether it is `valid`, a `trial` token, its
   `features`, when it is `valid-thru`, and the `status` of the account."
   []

--- a/src/metabase/api/tiles.clj
+++ b/src/metabase/api/tiles.clj
@@ -2,8 +2,8 @@
   "`/api/tiles` endpoints."
   (:require
    [clojure.set :as set]
-   [compojure.core :refer [GET]]
    [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
    [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.legacy-mbql.util :as mbql.u]
    [metabase.query-processor :as qp]
@@ -165,19 +165,19 @@
 ;;
 ;; TODO - this should reduce results from the QP in a streaming fashion instead of requiring them all to be in memory
 ;; at the same time
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/:zoom/:x/:y/:lat-field/:lon-field"
+(api.macros/defendpoint :get "/:zoom/:x/:y/:lat-field/:lon-field"
   "This endpoints provides an image with the appropriate pins rendered given a MBQL `query` (passed as a GET query
   string param). We evaluate the query and find the set of lat/lon pairs which are relevant and then render the
   appropriate ones. It's expected that to render a full map view several calls will be made to this endpoint in
   parallel."
-  [zoom x y lat-field lon-field query]
-  {zoom        ms/Int
-   x           ms/Int
-   y           ms/Int
-   lat-field   :string
-   lon-field   :string
-   query       ms/JSONString}
+  [{:keys [zoom x y lat-field lon-field]} :- [:map
+                                              [:zoom      ms/Int]
+                                              [:x         ms/Int]
+                                              [:y         ms/Int]
+                                              [:lat-field :string]
+                                              [:lon-field :string]]
+   {:keys [query]} :- [:map
+                       [:query ms/JSONString]]]
   (let [lat-field-ref (field-ref lat-field)
         lon-field-ref (field-ref lon-field)
 

--- a/src/metabase/sync/api/notify.clj
+++ b/src/metabase/sync/api/notify.clj
@@ -2,8 +2,8 @@
   "/api/notify/* endpoints which receive inbound etl server notifications."
   (:require
    [clojure.string :as str]
-   [compojure.core :refer [POST]]
    [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
    [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
    [metabase.sync.core :as sync]
@@ -16,19 +16,20 @@
 
 (set! *warn-on-reflection* true)
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint POST "/db/:id"
+(api.macros/defendpoint :post "/db/:id"
   "Notification about a potential schema change to one of our `Databases`.
   Caller can optionally specify a `:table_id` or `:table_name` in the body to limit updates to a single
   `Table`. Optional Parameter `:scan` can be `\"full\"` or `\"schema\"` for a full sync or a schema sync, available
   regardless if a `:table_id` or `:table_name` is passed.
   This endpoint is secured by an API key that needs to be passed as a `X-METABASE-APIKEY` header which needs to be defined in
   the `MB_API_KEY` [environment variable](https://www.metabase.com/docs/latest/configuring-metabase/environment-variables.html#mb_api_key)"
-  [id :as {{:keys [table_id table_name scan synchronous?]} :body}]
-  {id         ms/PositiveInt
-   table_id   [:maybe ms/PositiveInt]
-   table_name [:maybe ms/NonBlankString]
-   scan       [:maybe [:enum "full" "schema"]]}
+  [{:keys [id]} :- [:map
+                    [:id ms/PositiveInt]]
+   _query-params
+   {:keys [table_id table_name scan synchronous?]} :- [:map
+                                                       [:table_id   {:optional true} [:maybe ms/PositiveInt]]
+                                                       [:table_name {:optional true} [:maybe ms/NonBlankString]]
+                                                       [:scan       {:optional true} [:maybe [:enum "full" "schema"]]]]]
   (let [schema?       (when scan (#{"schema" :schema} scan))
         table-sync-fn (if schema? sync-metadata/sync-table-metadata! sync/sync-table!)
         db-sync-fn    (if schema? sync-metadata/sync-db-metadata! sync/sync-database!)]
@@ -66,17 +67,18 @@
                         :schema_name schema-name
                         :table_name  table-name}))))))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint POST "/db/attached_datawarehouse"
+(api.macros/defendpoint :post "/db/attached_datawarehouse"
   "Sync the attached datawarehouse. Can provide in the body:
   - table_name and schema_name: both strings. Will look for an existing table and sync it, otherwise will try to find a
   new table with that name and sync it. If it cannot find a table it will throw an error. If table_name is empty or
   blank, will sync the entire database.
   - synchronous?: is a boolean value to indicate if this should block on the result."
-  [:as {{:keys [table_name schema_name synchronous?]} :body}]
-  {table_name   [:maybe ms/NonBlankString]
-   schema_name  [:maybe string?]
-   synchronous? [:maybe ms/BooleanValue]}
+  [_route-params
+   _query-params
+   {:keys [table_name schema_name synchronous?]} :- [:map
+                                                     [:table_name   {:optional true} [:maybe ms/NonBlankString]]
+                                                     [:schema_name  {:optional true} [:maybe string?]]
+                                                     [:synchronous? {:default false} [:maybe ms/BooleanValue]]]]
   (api/let-404 [database (t2/select-one :model/Database :is_attached_dwh true)]
     (if (str/blank? table_name)
       (cond-> (future (sync-metadata/sync-db-metadata! database))
@@ -89,14 +91,15 @@
         (find-and-sync-new-table database table_name schema_name))))
   {:success true})
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint POST "/db/:id/new-table"
+(api.macros/defendpoint :post "/db/:id/new-table"
   "Sync a new table without running a full database sync. Requires `schema_name` and `table_name`. Will throw an error
   if the table already exists in Metabase or cannot be found."
-  [id :as {{:keys [schema_name table_name]} :body}]
-  {id          ms/PositiveInt
-   schema_name ms/NonBlankString
-   table_name  ms/NonBlankString}
+  [{:keys [id]} :- [:map
+                    [:id ms/PositiveInt]]
+   _query-params
+   {:keys [schema_name table_name]} :- [:map
+                                        [:schema_name ms/NonBlankString]
+                                        [:table_name  ms/NonBlankString]]]
   (api/let-404 [database (t2/select-one :model/Database :id id)]
     (if-not (t2/select-one :model/Table :db_id id :name table_name :schema schema_name)
       (find-and-sync-new-table database table_name schema_name)


### PR DESCRIPTION
Rewrite most of the stuff from namespaces with just one or two endpoint. Making 10 different PRs with one endpoint each seemed like too much work so I grouped them all together.