### PR TITLE
Fix converting nested mongo questions to native

### DIFF
--- a/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
@@ -1,5 +1,3 @@
-import { onlyOn } from "@cypress/skip-test";
-
 import { H } from "e2e/support";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
@@ -255,7 +253,7 @@ describe("converting question to SQL (metabase#12651, metabase#21615, metabase#3
 });
 
 describe(
-  "converting question to a native query (metabase#15946, metabase#32121, metabase#38181)",
+  "converting question to a native query (metabase#15946, metabase#32121, metabase#38181, metabase#40557)",
   { tags: "@mongo" },
   () => {
     const MONGO_DB_NAME = "QA Mongo";
@@ -316,18 +314,12 @@ describe(
         cy.button("Convert this question to a native query").click();
       });
 
-      // FIXME: Remove `onlyOn` wrapper block once the issue #40557 is fixed
-      onlyOn(false, () => {
-        cy.log(
-          "Database and table should be pre-selected (metabase#15946 and/or metabase#40557)",
-        );
-        cy.findByTestId("selected-database").should("have.text", MONGO_DB_NAME);
-        cy.findByTestId("selected-table").should("have.text", "Products");
-        cy.get("[data-testid=cell-data]").should(
-          "contain",
-          "Small Marble Shoes",
-        );
-      });
+      cy.log(
+        "Database and table should be pre-selected (metabase#15946 and/or metabase#40557)",
+      );
+      cy.findByTestId("selected-database").should("have.text", MONGO_DB_NAME);
+      cy.findByTestId("selected-table").should("have.text", "Products");
+      cy.get("[data-testid=cell-data]").should("contain", "Small Marble Shoes");
     });
 
     it.skip("should work for a nested GUI question (metabase#40557)", () => {

--- a/frontend/src/metabase-types/api/dataset.ts
+++ b/frontend/src/metabase-types/api/dataset.ts
@@ -143,6 +143,7 @@ export interface ErrorEmbedDataset {
 export interface NativeQueryForm {
   params: unknown;
   query: string;
+  collection?: string;
 }
 
 export type SingleSeries = {

--- a/frontend/src/metabase-types/api/dataset.ts
+++ b/frontend/src/metabase-types/api/dataset.ts
@@ -136,14 +136,12 @@ export interface ErrorEmbedDataset {
   status: string;
 }
 
-/**
- * This is the type of the `POST /api/dataset/native` response.
- * We're mostly ignoring the `params` on the FE. It's added to the type only for completeness.
- */
-export interface NativeQueryForm {
-  params: unknown;
+export interface NativeDatasetResponse {
   query: string;
+  // some engines, e.g. mongo, require a "collection", which is the name of the source table
   collection?: string;
+  // not used, added to the type only for completeness
+  params: unknown;
 }
 
 export type SingleSeries = {

--- a/frontend/src/metabase/api/dataset.ts
+++ b/frontend/src/metabase/api/dataset.ts
@@ -2,7 +2,7 @@ import type {
   CardQueryMetadata,
   Dataset,
   DatasetQuery,
-  NativeQueryForm,
+  NativeDatasetResponse,
 } from "metabase-types/api";
 
 import { Api } from "./api";
@@ -26,7 +26,7 @@ export const datasetApi = Api.injectEndpoints({
       providesTags: metadata =>
         metadata ? provideAdhocQueryMetadataTags(metadata) : [],
     }),
-    getNativeDataset: builder.query<NativeQueryForm, DatasetQuery>({
+    getNativeDataset: builder.query<NativeDatasetResponse, DatasetQuery>({
       query: body => ({
         method: "POST",
         url: "/api/dataset/native",

--- a/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/NotebookNativePreview.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/NotebookNativePreview.tsx
@@ -4,7 +4,7 @@ import { t } from "ttag";
 import { useGetNativeDatasetQuery } from "metabase/api";
 import { DelayedLoadingSpinner } from "metabase/common/components/EntityPicker/components/LoadingSpinner";
 import { color } from "metabase/lib/colors";
-import { formatNativeQuery, getEngineNativeType } from "metabase/lib/engine";
+import { getEngineNativeType } from "metabase/lib/engine";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { checkNotNull } from "metabase/lib/types";
 import { setUIControls, updateQuestion } from "metabase/query_builder/actions";
@@ -12,8 +12,9 @@ import { Editor } from "metabase/query_builder/components/NativeQueryEditor/Edit
 import { getQuestion } from "metabase/query_builder/selectors";
 import { Box, Button, Flex, Icon, rem } from "metabase/ui";
 import * as Lib from "metabase-lib";
+import type NativeQuery from "metabase-lib/v1/queries/NativeQuery";
 
-import { createDatasetQuery, createNativeQuery } from "./utils";
+import { createNativeQuestion } from "./utils";
 
 const TITLE = {
   sql: t`SQL for this question`,
@@ -29,41 +30,27 @@ export const NotebookNativePreview = (): JSX.Element => {
   const dispatch = useDispatch();
   const question = checkNotNull(useSelector(getQuestion));
 
-  const engine = question.database()?.engine;
+  const database = question.database();
+  const engine = database?.engine;
   const engineType = getEngineNativeType(engine);
 
   const sourceQuery = question.query();
   const canRun = Lib.canRun(sourceQuery, question.type());
   const payload = Lib.toLegacyQuery(sourceQuery);
-  const {
-    data: nativeForm,
-    error,
-    isFetching,
-  } = useGetNativeDatasetQuery(payload);
+  const { data: data, error, isFetching } = useGetNativeDatasetQuery(payload);
 
   const showLoader = isFetching;
   const showError = !isFetching && canRun && !!error;
   const showQuery = !isFetching && canRun && !error;
   const showEmptySidebar = !canRun;
 
-  const formattedQuery = formatNativeQuery(nativeForm?.query, engine);
-  const query = createNativeQuery(question, formattedQuery);
+  const newQuestion = createNativeQuestion(question, data);
+  const newQuery = newQuestion.legacyQuery() as NativeQuery;
 
   const handleConvertClick = useCallback(() => {
-    if (!nativeForm || !formattedQuery) {
-      return;
-    }
-
-    const newDatasetQuery = createDatasetQuery(
-      question,
-      formattedQuery,
-      nativeForm,
-    );
-    const newQuestion = question.setDatasetQuery(newDatasetQuery);
-
     dispatch(updateQuestion(newQuestion, { shouldUpdateUrl: true, run: true }));
     dispatch(setUIControls({ isNativeEditorOpen: true }));
-  }, [question, dispatch, nativeForm, formattedQuery]);
+  }, [newQuestion, dispatch]);
 
   const getErrorMessage = (error: unknown) =>
     typeof error === "string" ? error : undefined;
@@ -105,7 +92,7 @@ export const NotebookNativePreview = (): JSX.Element => {
         )}
         {showQuery && (
           <div style={{ height: "100%", flex: 1 }}>
-            <Editor query={query} readOnly />
+            <Editor query={newQuery} readOnly />
           </div>
         )}
       </Box>

--- a/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/NotebookNativePreview.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/NotebookNativePreview.tsx
@@ -35,27 +35,35 @@ export const NotebookNativePreview = (): JSX.Element => {
   const sourceQuery = question.query();
   const canRun = Lib.canRun(sourceQuery, question.type());
   const payload = Lib.toLegacyQuery(sourceQuery);
-  const { data, error, isFetching } = useGetNativeDatasetQuery(payload);
+  const {
+    data: nativeForm,
+    error,
+    isFetching,
+  } = useGetNativeDatasetQuery(payload);
 
   const showLoader = isFetching;
   const showError = !isFetching && canRun && !!error;
   const showQuery = !isFetching && canRun && !error;
   const showEmptySidebar = !canRun;
 
-  const formattedQuery = formatNativeQuery(data?.query, engine);
+  const formattedQuery = formatNativeQuery(nativeForm?.query, engine);
   const query = createNativeQuery(question, formattedQuery);
 
   const handleConvertClick = useCallback(() => {
-    if (!formattedQuery) {
+    if (!nativeForm || !formattedQuery) {
       return;
     }
 
-    const newDatasetQuery = createDatasetQuery(formattedQuery, question);
+    const newDatasetQuery = createDatasetQuery(
+      question,
+      formattedQuery,
+      nativeForm,
+    );
     const newQuestion = question.setDatasetQuery(newDatasetQuery);
 
     dispatch(updateQuestion(newQuestion, { shouldUpdateUrl: true, run: true }));
     dispatch(setUIControls({ isNativeEditorOpen: true }));
-  }, [question, dispatch, formattedQuery]);
+  }, [question, dispatch, nativeForm, formattedQuery]);
 
   const getErrorMessage = (error: unknown) =>
     typeof error === "string" ? error : undefined;

--- a/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/NotebookNativePreview.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/NotebookNativePreview.tsx
@@ -37,7 +37,7 @@ export const NotebookNativePreview = (): JSX.Element => {
   const sourceQuery = question.query();
   const canRun = Lib.canRun(sourceQuery, question.type());
   const payload = Lib.toLegacyQuery(sourceQuery);
-  const { data: data, error, isFetching } = useGetNativeDatasetQuery(payload);
+  const { data, error, isFetching } = useGetNativeDatasetQuery(payload);
 
   const showLoader = isFetching;
   const showError = !isFetching && canRun && !!error;

--- a/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/utils.ts
+++ b/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/utils.ts
@@ -1,18 +1,16 @@
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 import NativeQuery from "metabase-lib/v1/queries/NativeQuery";
-import type { DatasetQuery } from "metabase-types/api";
+import type { DatasetQuery, NativeQueryForm } from "metabase-types/api";
 
 export function createDatasetQuery(
-  queryText: string,
   question: Question,
+  queryText: string,
+  { collection }: NativeQueryForm,
 ): DatasetQuery {
   const query = question.query();
   const databaseId = Lib.databaseID(query);
-  const tableId = Lib.sourceTableOrCardId(query);
-  const table = tableId ? Lib.tableOrCardMetadata(query, tableId) : undefined;
-  const tableName = table ? Lib.displayInfo(query, -1, table).name : undefined;
-  const extras = tableName ? { collection: tableName } : {};
+  const extras = collection ? { collection } : {};
 
   return {
     type: "native",

--- a/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/utils.ts
+++ b/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/utils.ts
@@ -4,17 +4,17 @@ import type { NativeDatasetResponse } from "metabase-types/api";
 
 export function createNativeQuestion(
   question: Question,
-  nativeForm: NativeDatasetResponse | undefined,
+  response: NativeDatasetResponse | undefined,
 ) {
   const database = question.database();
-  const query = formatNativeQuery(nativeForm?.query, database?.engine) ?? "";
+  const query = formatNativeQuery(response?.query, database?.engine) ?? "";
 
   return question.setDatasetQuery({
     type: "native",
     native: {
       query,
       "template-tags": {},
-      ...(nativeForm?.collection ? { collection: nativeForm.collection } : {}),
+      ...(response?.collection ? { collection: response.collection } : {}),
     },
     database: question.databaseId(),
   });

--- a/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/utils.ts
+++ b/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/utils.ts
@@ -7,23 +7,15 @@ export function createNativeQuestion(
   nativeForm: NativeQueryForm | undefined,
 ) {
   const database = question.database();
-  if (!database || !nativeForm) {
-    return question;
-  }
-
-  const { query, collection } = nativeForm;
-  const formattedQuery = formatNativeQuery(query, database.engine);
-  if (!formattedQuery) {
-    return question;
-  }
+  const query = formatNativeQuery(nativeForm?.query, database?.engine) ?? "";
 
   return question.setDatasetQuery({
     type: "native",
     native: {
-      query: formattedQuery,
+      query,
       "template-tags": {},
-      ...(collection ? { collection } : {}),
+      ...(nativeForm?.collection ? { collection: nativeForm.collection } : {}),
     },
-    database: database.id,
+    database: question.databaseId(),
   });
 }

--- a/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/utils.ts
+++ b/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/utils.ts
@@ -1,10 +1,10 @@
 import { formatNativeQuery } from "metabase/lib/engine";
 import type Question from "metabase-lib/v1/Question";
-import type { NativeQueryForm } from "metabase-types/api";
+import type { NativeDatasetResponse } from "metabase-types/api";
 
 export function createNativeQuestion(
   question: Question,
-  nativeForm: NativeQueryForm | undefined,
+  nativeForm: NativeDatasetResponse | undefined,
 ) {
   const database = question.database();
   const query = formatNativeQuery(nativeForm?.query, database?.engine) ?? "";

--- a/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/utils.ts
+++ b/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/utils.ts
@@ -7,7 +7,7 @@ export function createNativeQuestion(
   nativeForm: NativeQueryForm | undefined,
 ) {
   const database = question.database();
-  if (!database || nativeForm) {
+  if (!database || !nativeForm) {
     return question;
   }
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/40557

For mongo queries, we should have used the `collection` field returned by `/api/dataset/native` endpoint to set the mongo collection, and do not compute it ourselves. The previous approach only worked for queries based on raw tables. There was an existing E2E repro that I un-ignored. 