### PR TITLE
Embed releases  page in settings

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/VersionUpdateNotice/VersionUpdateNotice.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/VersionUpdateNotice/VersionUpdateNotice.tsx
@@ -5,14 +5,12 @@ import {
   getCurrentVersion,
   getLatestVersion,
 } from "metabase/admin/settings/selectors";
-import { useSetting } from "metabase/common/hooks";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import ButtonsS from "metabase/css/components/buttons.module.css";
 import CS from "metabase/css/core/index.css";
 import { useSelector } from "metabase/lib/redux";
 import { newVersionAvailable, versionIsLatest } from "metabase/lib/utils";
 import { getIsHosted } from "metabase/setup/selectors";
-import type { VersionInfoRecord } from "metabase-types/api";
 
 import {
   NewVersionContainer,
@@ -71,11 +69,7 @@ function DefaultUpdateMessage({ currentVersion }: { currentVersion: string }) {
 }
 
 function NewVersionAvailable({ currentVersion }: { currentVersion: string }) {
-  const versionInfo = useSetting("version-info");
-  const updateChannel = useSetting("update-channel");
   const latestVersion = useSelector(getLatestVersion);
-
-  const lastestVersionInfo = versionInfo?.[updateChannel];
 
   return (
     <div>
@@ -112,48 +106,12 @@ function NewVersionAvailable({ currentVersion }: { currentVersion: string }) {
         </ExternalLink>
       </NewVersionContainer>
 
-      {versionInfo && (
-        <div
-          className={cx(
-            CS.textMedium,
-            CS.bordered,
-            CS.rounded,
-            CS.p2,
-            CS.mt2,
-            CS.overflowYScroll,
-          )}
-          style={{ height: 330 }}
-        >
-          <h3 className={cx(CS.pb3, CS.textUppercase)}>{t`What's Changed:`}</h3>
-
-          {lastestVersionInfo && <Version version={lastestVersionInfo} />}
-
-          {versionInfo.older &&
-            versionInfo.older.map((version, index) => (
-              <Version key={index} version={version} />
-            ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function Version({ version }: { version: VersionInfoRecord }) {
-  if (!version) {
-    return null;
-  }
-
-  return (
-    <div className={CS.pb3}>
-      <h3 className={CS.textMedium}>{formatVersion(version.version)}</h3>
-      <ul style={{ listStyleType: "disc", listStylePosition: "inside" }}>
-        {version.highlights &&
-          version.highlights.map((highlight, index) => (
-            <li key={index} style={{ lineHeight: "1.5" }} className={CS.pl1}>
-              {highlight}
-            </li>
-          ))}
-      </ul>
+      <iframe
+        width="100%"
+        height="400px"
+        src="https://metabase.com/releases"
+        style={{ border: "none", marginTop: "1rem" }}
+      ></iframe>
     </div>
   );
 }


### PR DESCRIPTION

### Description

Our existing data-based way of getting information about new versions into the admin settings is limited. Let's just embed our own webpage that we can update at will.

![Screen Shot 2025-01-24 at 8 20 41 AM](https://github.com/user-attachments/assets/5a50cc9a-5438-4d03-a9e5-971753634334)
