### PR TITLE
XLSX Export truncate String cells to 32767 chars [Clone PR to run CI]

### DIFF
--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -346,7 +346,7 @@
 
 (defmethod set-cell! String
   [^Cell cell value _styles _typed-styles]
-  (.setCellValue cell ^String value))
+  (.setCellValue cell ^String (if (> (count value) 32767) (subs value 0 32767) value)))
 
 (defmethod set-cell! Number
   [^Cell cell value styles typed-styles]

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -346,7 +346,7 @@
 
 (def ^:dynamic *number-of-characters-cell*
   "Total number of characters that a cell can contain, 32767 is the maximum number supported by the cell."
-  ;;See https://support.microsoft.com/en-us/office/excel-specifications-and-limits-1672b34d-7043-467e-8e27-269d656771c3
+  ;; See https://support.microsoft.com/en-us/office/excel-specifications-and-limits-1672b34d-7043-467e-8e27-269d656771c3
   32767)
 
 (defmethod set-cell! String

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -344,9 +344,14 @@
   [^Cell cell t styles typed-styles]
   (set-cell! cell (t/offset-date-time t) styles typed-styles))
 
+(def ^:dynamic *number-of-characters-cell*
+  "Total number of characters that a cell can contain, 32767 is the maximum number supported by the cell."
+  ;;See https://support.microsoft.com/en-us/office/excel-specifications-and-limits-1672b34d-7043-467e-8e27-269d656771c3
+  32767)
+
 (defmethod set-cell! String
   [^Cell cell value _styles _typed-styles]
-  (.setCellValue cell ^String (if (> (count value) 32767) (subs value 0 32767) value)))
+  (.setCellValue cell ^String (u/truncate value *number-of-characters-cell*)))
 
 (defmethod set-cell! Number
   [^Cell cell value styles typed-styles]

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -779,4 +779,4 @@
   (testing "When the number of characters exceeds *number-of-characters-cell*, the excess part will be truncated."
     (binding [qp.xlsx/*number-of-characters-cell* 5]
       (is (= ["abcde"]
-           (second (xlsx-export [{:id 0, :name "Col"}] {} [["abcdefghijklmnopqrstuvwxyz"]])))))))
+             (second (xlsx-export [{:id 0, :name "Col"}] {} [["abcdefghijklmnopqrstuvwxyz"]])))))))

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -774,3 +774,9 @@
       (do-export)
       ;; Should always allocate less than 100Mb.
       (is (< (- (get-allocated-bytes) start-bytes) (* 100 1024 1024))))))
+
+(deftest number-of-characters-cell-test
+  (testing "When the number of characters exceeds *number-of-characters-cell*, the excess part will be truncated."
+    (binding [qp.xlsx/*number-of-characters-cell* 5]
+      (is (= ["abcde"]
+           (second (xlsx-export [{:id 0, :name "Col"}] {} [["abcdefghijklmnopqrstuvwxyz"]])))))))


### PR DESCRIPTION
Clone of https://github.com/metabase/metabase/pull/51706