### PR TITLE
chore: clean js dist folder before the build

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -14,6 +14,8 @@
 
 set -euo pipefail
 
+yarn clean-dev:js
+
 # switch to project root directory if we're not already there
 script_directory=`dirname "${BASH_SOURCE[0]}"`
 cd "$script_directory/.."

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -323,7 +323,6 @@ if (shouldEnableHotRefresh) {
     // tweak stats to make the output in the console more legible
     devMiddleware: {
       stats: { preset: "errors-warnings", timings: true },
-      writeToDisk: true,
       // if webpack doesn't reload UI after code change in development
       // watchOptions: {
       //     aggregateTimeout: 300,

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -323,6 +323,7 @@ if (shouldEnableHotRefresh) {
     // tweak stats to make the output in the console more legible
     devMiddleware: {
       stats: { preset: "errors-warnings", timings: true },
+      writeToDisk: true,
       // if webpack doesn't reload UI after code change in development
       // watchOptions: {
       //     aggregateTimeout: 300,


### PR DESCRIPTION
[context](https://metaboat.slack.com/archives/C084XNEPH6K/p1737737162137859)

### Description

clean the dist folder before building uberjar

+ do not save hot files to the disk