### PR TITLE
Convert nil values to :null in dimension-contexts

### DIFF
--- a/src/metabase/lib/drill_thru.cljc
+++ b/src/metabase/lib/drill_thru.cljc
@@ -75,7 +75,9 @@
   [{:keys [dimensions], :as context} :- ::lib.schema.drill-thru/context]
   (not-empty
    (for [dimension dimensions]
-     (merge context dimension))))
+     (-> (merge context dimension)
+         ;; Drills expect nil :values to be converted to :null. See docstring in [[lib.js.available-drill-thrus]].
+         (update :value lib.drill-thru.common/js->drill-value)))))
 
 (mu/defn- context-with-dimensions-or-row-dimensions :- ::lib.schema.drill-thru/context
   "Return an updated `context` with either the existing `dimensions` or dimensions constructed from the `row`."

--- a/src/metabase/lib/drill_thru/common.cljc
+++ b/src/metabase/lib/drill_thru/common.cljc
@@ -44,9 +44,14 @@
   (> (count (lib.metadata.calculation/primary-keys query)) 1))
 
 (defn drill-value->js
-  "Convert a drill value to a JS value"
+  "Convert a drill value to a JS value."
   [value]
   (if (= value :null) nil value))
+
+(defn js->drill-value
+  "Convert a JS value to a drill value."
+  [value]
+  (if (nil? value) :null value))
 
 (defn dimensions-from-breakout-columns
   "Convert `row` data into dimensions for `column`s that come from an aggregation in a previous stage."

--- a/src/metabase/lib/drill_thru/zoom_in_bins.cljc
+++ b/src/metabase/lib/drill_thru/zoom_in_bins.cljc
@@ -92,7 +92,7 @@
   [query                                 :- ::lib.schema/query
    _stage-number                         :- :int
    {:keys [column value], :as _context}  :- ::lib.schema.drill-thru/context]
-  (when (and column value)
+  (when (and column value (not= value :null))
     (when-let [existing-breakout (first (lib.breakout/existing-breakouts query
                                                                          (lib.underlying/top-level-stage-number query)
                                                                          column))]

--- a/src/metabase/lib/drill_thru/zoom_in_geographic.cljc
+++ b/src/metabase/lib/drill_thru/zoom_in_geographic.cljc
@@ -194,7 +194,7 @@
   [query                        :- ::lib.schema/query
    _stage-number                :- :int
    {:keys [value], :as context} :- ::lib.schema.drill-thru/context]
-  (when value
+  (when (and value (not= value :null))
     (when-let [context (context-with-lat-lon query (lib.underlying/top-level-stage-number query) context)]
       (some (fn [f]
               (f context))

--- a/test/metabase/lib/drill_thru/column_filter_test.cljc
+++ b/test/metabase/lib/drill_thru/column_filter_test.cljc
@@ -170,6 +170,15 @@
                     :initial-op {:short :=}
                     :column     {:operators number-ops}}})))
 
+(deftest ^:parallel column-filter-not-returned-for-nil-dimension-test
+  (testing "column-filter should not be returned for nil dimension values (#49740, #51741)"
+    (lib.drill-thru.tu/test-drill-not-returned
+     {:drill-type  :drill-thru/column-filter
+      :click-type  :cell
+      :query-type  :aggregated
+      :column-name "max"
+      :custom-row  #(assoc % "CREATED_AT" nil)})))
+
 (deftest ^:parallel aggregation-adds-extra-stage-test
   (testing "filtering an aggregation column adds an extra stage"
     (let [query       (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))

--- a/test/metabase/lib/drill_thru_test.cljc
+++ b/test/metabase/lib/drill_thru_test.cljc
@@ -838,5 +838,27 @@
 (deftest ^:parallel drill-value->js-test
   (testing "should convert :null to nil"
     (doseq [[input expected] [[:null nil]
-                              [nil nil]]]
+                              [nil nil]
+                              [0 0]
+                              ["" ""]
+                              ["a" "a"]
+                              [{} {}]
+                              [[] []]]]
       (is (= expected (lib.drill-thru.common/drill-value->js input))))))
+
+(deftest ^:parallel js->drill-value-test
+  (testing "should convert nil to :null"
+    (doseq [[input expected] [[nil :null]
+                              [0 0]
+                              ["" ""]
+                              ["a" "a"]
+                              [{} {}]
+                              [[] []]]]
+      (is (= expected (lib.drill-thru.common/js->drill-value input))))))
+
+(deftest ^:parallel js->drill-value->js-test
+  (testing "should round trip js->drill-value -> drill-value->js"
+    (doseq [input [nil 0 1 "" "a" {} [] {"a" "b"} [nil "a" "b"]]]
+      (is (= input (-> input
+                       lib.drill-thru.common/js->drill-value
+                       lib.drill-thru.common/drill-value->js))))))

--- a/test/metabase/lib/drill_thru_test.cljc
+++ b/test/metabase/lib/drill_thru_test.cljc
@@ -835,6 +835,29 @@
                       {:type            :drill-thru/sort
                        :sort-directions [:asc :desc]}]})))
 
+(deftest ^:parallel available-drill-thrus-no-column-drills-for-nil-dimension-values-test
+  (testing (str "column header drills should not be returned when dimensions have nil values (#49740, #51741)")
+    (lib.drill-thru.tu/test-available-drill-thrus
+     {:click-type  :cell
+      :query-type  :aggregated
+      :column-name "count"
+      :custom-row  #(assoc % "CREATED_AT" nil)
+      ;; Expect the same set of drills as [[available-drill-thrus-test-9]] above, but without zoom-in.timeseries
+      ;; since "CREATED_AT" is nil.
+      :expected    [{:type :drill-thru/automatic-insights
+                     :dimensions [{:column {:name "PRODUCT_ID"}}
+                                  {:column {:name "CREATED_AT"}}]}
+                    {:type      :drill-thru/quick-filter
+                     :operators [{:name "<"}
+                                 {:name ">"}
+                                 {:name "="}
+                                 {:name "≠"}]}
+                    {:type       :drill-thru/underlying-records
+                     :row-count  77
+                     :table-name "Orders"}]
+      ;; Underlying records and automatic insights are not supported for native.
+      :native-drills #{:drill-thru/quick-filter}})))
+
 (deftest ^:parallel drill-value->js-test
   (testing "should convert :null to nil"
     (doseq [[input expected] [[:null nil]


### PR DESCRIPTION
Closes #49740

### Description

Convert `nil` dimension values to `:null` in [`lib.drill-thru/dimension-contexts`](https://github.com/metabase/metabase/blob/1c63f624318f76111c421d8bab22e79dfcd32f4a/src/metabase/lib/drill_thru.cljc#L70) to match the conversion in [`lib.js/available-drill-thrus`](https://github.com/metabase/metabase/blob/1c63f624318f76111c421d8bab22e79dfcd32f4a/src/metabase/lib/js.cljs#L2159).

In [`lib.drill-thru/available-drill-thrus`](https://github.com/metabase/metabase/blob/1c63f624318f76111c421d8bab22e79dfcd32f4a/src/metabase/lib/drill_thru.cljc#L113C73-L113C102), certain drills wind up being applied to their dimensions rather than the original context supplied by the FE (`return-drills-for-dimensions?`) and therefore did not have their `nil` values converted to `:null`. This caused confusion for drills like `column-filter`, `distribution`, `sort`, etc., which check `(nil? value)` to ensure they are only available in "column header" click contexts.

Add a new function `js->drill-value` to match the existing `drill-value->js` in `lib.drill-thru.common` and call it to convert the dimension values in `dimension-contexts`.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> Analytic Events
2. Summarize: Count by Button Label
3. Click on the `(empty)` bar
4. "Filter by this column" drill should not appear in the context menu

See also similar repro steps in #49740, but for table viz and the Accounts table.

### Demo

repro described above

![Screenshot 2025-01-20 at 11 35 41 AM](https://github.com/user-attachments/assets/5f8e2354-03a7-4c5a-b650-77e7b8c36fbe)

repro from #49740

![Screenshot 2025-01-24 at 12 20 40 PM](https://github.com/user-attachments/assets/74425638-38ba-485a-a616-27b63217c0de)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR