### PR TITLE
legacy expression refs aren't bad refs

### DIFF
--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -99,9 +99,11 @@
   [:sequential {:min 1} ::filterable])
 
 (defn- bad-ref-clause? [ref-type valid-ids x]
-  (and (vector? x)
-       (= ref-type (nth x 0 nil))
-       (not (contains? valid-ids (nth x 2 nil)))))
+  (when-let [[kind opts target] (and (vector? x) x)]
+    (and (= ref-type kind)
+         (map? opts)
+         (string? target)
+         (not (contains? valid-ids target)))))
 
 (defn- stage-with-joins-and-namespaced-keys-removed
   "For ref validation purposes we should ignore `:joins` and any namespaced keys that might be used to record additional

--- a/test/metabase/lib/schema_test.cljc
+++ b/test/metabase/lib/schema_test.cljc
@@ -177,6 +177,22 @@
                                                     {:lib/uuid (str (random-uuid))}
                                                     [:expression {:lib/uuid (str (random-uuid))} "price + 2"]]]}
                                    {:lib/type :mbql.stage/mbql, :lib/options {:lib/uuid (str (random-uuid))}}]}]}
+    nil
+
+    ;; parameters have *legacy* expression refs :sob:
+    {:expressions [[:field
+                    {:base-type :type/BigInteger,
+                     :ident (u/generate-nano-id)
+                     :lib/expression-name "foo_id",
+                     :lib/uuid (str (random-uuid))}
+                    9]],
+     :parameters [{:target [:dimension
+                            [:expression "foo_id" {:base-type :type/BigInteger}]
+                            {:stage-number 0}],
+                   :type :category,
+                   :value "1"}],
+     :source-table 2,
+     :lib/type :mbql.stage/mbql}
     nil))
 
 (defn- valid-join


### PR DESCRIPTION
Under `:parameters`, we have legacy field refs - I don't understand why, but that's what the spec says, so... in the case that we run into a legacy field ref, we shouldn't return that it's a bad ref.

There may be a better way to go about this, happy to consider better options.