### PR TITLE
Convert /public endpoints to defendpoint 2, second try

### DIFF
--- a/dev/src/dev/rewrite_defendpoint_1.clj
+++ b/dev/src/dev/rewrite_defendpoint_1.clj
@@ -509,11 +509,3 @@
         (with-open [w (java.io.FileWriter. filename)]
           (print-root w))
         (print-root *out*)))))
-
-(comment
-  #_{:clj-kondo/ignore [:unresolved-namespace]}
-  (defn- files []
-    (->> (metabase.util.files/files-seq (metabase.util.files/get-path "src/metabase/api/"))
-         (map str)
-         (filter #(str/ends-with? % ".clj"))
-         sort)))

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -1,7 +1,6 @@
 (ns metabase.api.public
   "Metabase API endpoints for viewing publicly-accessible Cards and Dashboards."
   (:require
-   [compojure.core :refer [GET]]
    [medley.core :as m]
    [metabase.actions.core :as actions]
    [metabase.analytics.snowplow :as snowplow]
@@ -11,6 +10,7 @@
    [metabase.api.dashboard :as api.dashboard]
    [metabase.api.dataset :as api.dataset]
    [metabase.api.field :as api.field]
+   [metabase.api.macros :as api.macros]
    [metabase.db.query :as mdb.query]
    [metabase.events :as events]
    [metabase.lib.schema.id :as lib.schema.id]
@@ -92,12 +92,11 @@
 
 (defn- card-with-uuid [uuid] (public-card :public_uuid uuid))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/card/:uuid"
+(api.macros/defendpoint :get "/card/:uuid"
   "Fetch a publicly-accessible Card an return query results as well as `:card` information. Does not require auth
    credentials. Public sharing must be enabled."
-  [uuid]
-  {uuid ms/UUIDString}
+  [{:keys [uuid]} :- [:map
+                      [:uuid ms/UUIDString]]]
   (validation/check-public-sharing-enabled)
   (u/prog1 (card-with-uuid uuid)
     (events/publish-event! :event/card-read {:object-id (:id <>), :user-id api/*current-user-id*, :context :question})))
@@ -175,25 +174,25 @@
   (let [card-id (api/check-404 (t2/select-one-pk :model/Card :public_uuid uuid, :archived false))]
     (apply process-query-for-card-with-id card-id export-format parameters options)))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/card/:uuid/query"
+(api.macros/defendpoint :get "/card/:uuid/query"
   "Fetch a publicly-accessible Card an return query results as well as `:card` information. Does not require auth
    credentials. Public sharing must be enabled."
-  [uuid parameters]
-  {uuid       ms/UUIDString
-   parameters [:maybe ms/JSONString]}
+  [{:keys [uuid]} :- [:map
+                      [:uuid ms/UUIDString]]
+   {:keys [parameters]} :- [:map
+                            [:parameters {:optional true} [:maybe ms/JSONString]]]]
   (process-query-for-card-with-public-uuid uuid :api (json/decode+kw parameters)))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/card/:uuid/query/:export-format"
+(api.macros/defendpoint :get "/card/:uuid/query/:export-format"
   "Fetch a publicly-accessible Card and return query results in the specified format. Does not require auth
   credentials. Public sharing must be enabled."
-  [uuid export-format :as {{:keys [parameters format_rows pivot_results]} :params}]
-  {uuid          ms/UUIDString
-   export-format api.dataset/ExportFormat
-   format_rows   [:maybe :boolean]
-   pivot_results [:maybe :boolean]
-   parameters    [:maybe ms/JSONString]}
+  [{:keys [uuid export-format]} :- [:map
+                                    [:uuid          ms/UUIDString]
+                                    [:export-format api.dataset/ExportFormat]]
+   {:keys [parameters format_rows pivot_results]} :- [:map
+                                                      [:format_rows   {:default false} :boolean]
+                                                      [:pivot_results {:default false} :boolean]
+                                                      [:parameters    {:optional true} [:maybe ms/JSONString]]]]
   (process-query-for-card-with-public-uuid
    uuid
    export-format
@@ -201,8 +200,8 @@
    :constraints nil
    :middleware {:process-viz-settings? true
                 :js-int-to-string?     false
-                :format-rows?          (or format_rows false)
-                :pivot?                (or pivot_results false)}))
+                :format-rows?          format_rows
+                :pivot?                pivot_results}))
 
 ;;; ----------------------------------------------- Public Dashboards ------------------------------------------------
 
@@ -252,11 +251,10 @@
 
 (defn- dashboard-with-uuid [uuid] (public-dashboard :public_uuid uuid))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/dashboard/:uuid"
+(api.macros/defendpoint :get "/dashboard/:uuid"
   "Fetch a publicly-accessible Dashboard. Does not require auth credentials. Public sharing must be enabled."
-  [uuid]
-  {uuid ms/UUIDString}
+  [{:keys [uuid]} :- [:map
+                      [:uuid ms/UUIDString]]]
   (validation/check-public-sharing-enabled)
   (u/prog1 (dashboard-with-uuid uuid)
     (events/publish-event! :event/dashboard-read {:object-id (:id <>), :user-id api/*current-user-id*})))
@@ -290,15 +288,15 @@
     (request/as-admin
       (m/mapply qp.dashboard/process-query-for-dashcard options))))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/dashboard/:uuid/dashcard/:dashcard-id/card/:card-id"
+(api.macros/defendpoint :get "/dashboard/:uuid/dashcard/:dashcard-id/card/:card-id"
   "Fetch the results for a Card in a publicly-accessible Dashboard. Does not require auth credentials. Public
    sharing must be enabled."
-  [uuid card-id dashcard-id parameters]
-  {uuid        ms/UUIDString
-   dashcard-id ms/PositiveInt
-   card-id     ms/PositiveInt
-   parameters  [:maybe ms/JSONString]}
+  [{:keys [uuid dashcard-id card-id]} :- [:map
+                                          [:uuid        ms/UUIDString]
+                                          [:dashcard-id ms/PositiveInt]
+                                          [:card-id     ms/PositiveInt]]
+   {:keys [parameters]} :- [:map
+                            [:parameters {:optional true} [:maybe ms/JSONString]]]]
   (validation/check-public-sharing-enabled)
   (api/check-404 (t2/select-one-pk :model/Card :id card-id :archived false))
   (let [dashboard-id (api/check-404 (t2/select-one-pk :model/Dashboard :public_uuid uuid, :archived false))]
@@ -310,18 +308,19 @@
               :parameters    parameters)
       (events/publish-event! :event/card-read {:object-id card-id, :user-id api/*current-user-id*, :context :dashboard}))))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint POST ["/dashboard/:uuid/dashcard/:dashcard-id/card/:card-id/:export-format"
-                       :export-format api.dataset/export-format-regex]
-  "Fetch the results of running a publicly-accessible Card belonging to a Dashboard and return the data in one of the export formats. Does not require auth credentials. Public sharing must be enabled."
-  [uuid card-id dashcard-id parameters export-format :as {{:keys [format_rows pivot_results]} :params}]
-  {uuid          ms/UUIDString
-   dashcard-id   ms/PositiveInt
-   card-id       ms/PositiveInt
-   parameters    [:maybe ms/JSONString]
-   format_rows   [:maybe ms/BooleanValue]
-   pivot_results [:maybe ms/BooleanValue]
-   export-format (into [:enum] api.dataset/export-formats)}
+(api.macros/defendpoint :post ["/dashboard/:uuid/dashcard/:dashcard-id/card/:card-id/:export-format"
+                               :export-format api.dataset/export-format-regex]
+  "Fetch the results of running a publicly-accessible Card belonging to a Dashboard and return the data in one of the
+  export formats. Does not require auth credentials. Public sharing must be enabled."
+  [{:keys [uuid dashcard-id card-id export-format]} :- [:map
+                                                        [:uuid          ms/UUIDString]
+                                                        [:dashcard-id   ms/PositiveInt]
+                                                        [:card-id       ms/PositiveInt]
+                                                        [:export-format (into [:enum] api.dataset/export-formats)]]
+   {:keys [format_rows pivot_results parameters]} :- [:map
+                                                      [:parameters    {:optional true} [:maybe ms/JSONString]]
+                                                      [:format_rows   {:default false} ms/BooleanValue]
+                                                      [:pivot_results {:default false} ms/BooleanValue]]]
   (validation/check-public-sharing-enabled)
   (api/check-404 (t2/select-one-pk :model/Card :id card-id :archived false))
   (let [dashboard-id (api/check-404 (t2/select-one-pk :model/Dashboard :public_uuid uuid, :archived false))]
@@ -333,16 +332,16 @@
               :parameters    parameters
               :constraints   nil
               :middleware    {:process-viz-settings? true
-                              :format-rows?          (or format_rows false)
-                              :pivot?                (or pivot_results false)}))))
+                              :format-rows?          format_rows
+                              :pivot?                pivot_results}))))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/dashboard/:uuid/dashcard/:dashcard-id/execute"
+(api.macros/defendpoint :get "/dashboard/:uuid/dashcard/:dashcard-id/execute"
   "Fetches the values for filling in execution parameters. Pass PK parameters and values to select."
-  [uuid dashcard-id parameters]
-  {uuid        ms/UUIDString
-   dashcard-id ms/PositiveInt
-   parameters  ms/JSONString}
+  [{:keys [uuid dashcard-id]} :- [:map
+                                  [:uuid        ms/UUIDString]
+                                  [:dashcard-id ms/PositiveInt]]
+   {:keys [parameters]} :- [:map
+                            [:parameters ms/JSONString]]]
   (validation/check-public-sharing-enabled)
   (api/check-404 (t2/select-one-pk :model/Dashboard :public_uuid uuid :archived false))
   (actions/fetch-values
@@ -351,15 +350,16 @@
 
 (def ^:private dashcard-execution-throttle (throttle/make-throttler :dashcard-id :attempts-threshold 5000))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint POST "/dashboard/:uuid/dashcard/:dashcard-id/execute"
+(api.macros/defendpoint :post "/dashboard/:uuid/dashcard/:dashcard-id/execute"
   "Execute the associated Action in the context of a `Dashboard` and `DashboardCard` that includes it.
 
    `parameters` should be the mapped dashboard parameters with values."
-  [uuid dashcard-id :as {{:keys [parameters], :as _body} :body}]
-  {uuid        ms/UUIDString
-   dashcard-id ms/PositiveInt
-   parameters  [:maybe [:map-of :keyword :any]]}
+  [{:keys [uuid dashcard-id]} :- [:map
+                                  [:uuid        ms/UUIDString]
+                                  [:dashcard-id ms/PositiveInt]]
+   _query-params
+   {:keys [parameters], :as _body} :- [:map
+                                       [:parameters {:optional true} [:maybe [:map-of :keyword :any]]]]]
   (let [throttle-message (try
                            (throttle/check dashcard-execution-throttle dashcard-id)
                            nil
@@ -381,31 +381,32 @@
             ;; Undo middleware string->keyword coercion
             (actions/execute-dashcard! dashboard-id dashcard-id (update-keys parameters name))))))))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/oembed"
+(api.macros/defendpoint :get "/oembed"
   "oEmbed endpoint used to retreive embed code and metadata for a (public) Metabase URL."
-  [url format maxheight maxwidth]
-  ;; the format param is not used by the API, but is required as part of the oEmbed spec: http://oembed.com/#section2
-  ;; just return an error if `format` is specified and it's anything other than `json`.
-  {url       ms/NonBlankString
-   format    [:maybe [:enum "json"]]
-   maxheight [:maybe ms/IntString]
-   maxwidth  [:maybe ms/IntString]}
-  (let [height (if maxheight (Integer/parseInt maxheight) default-embed-max-height)
-        width  (if maxwidth  (Integer/parseInt maxwidth)  default-embed-max-width)]
-    {:version "1.0"
-     :type    "rich"
-     :width   width
-     :height  height
-     :html    (embed/iframe url width height)}))
+  [_route-params
+   {:keys [url maxheight maxwidth]}
+   :- [:map
+       [:url       ms/NonBlankString]
+       [:format    {:optional true} [:maybe
+                                     {:description (str "The format param is not used by the API, but is required as"
+                                                        " part of the oEmbed spec: http://oembed.com/#section2 just"
+                                                        " return an error if `format` is specified and it's anything"
+                                                        " other than `json`.")}
+                                     [:enum "json"]]]
+       [:maxheight {:default default-embed-max-height} pos-int?]
+       [:maxwidth  {:default default-embed-max-width}  pos-int?]]]
+  {:version "1.0"
+   :type    "rich"
+   :width   maxwidth
+   :height  maxheight
+   :html    (embed/iframe url maxwidth maxheight)})
 
 ;;; ----------------------------------------------- Public Action ------------------------------------------------
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/action/:uuid"
+(api.macros/defendpoint :get "/action/:uuid"
   "Fetch a publicly-accessible Action. Does not require auth credentials. Public sharing must be enabled."
-  [uuid]
-  {uuid ms/UUIDString}
+  [{:keys [uuid]} :- [:map
+                      [:uuid ms/UUIDString]]]
   (validation/check-public-sharing-enabled)
   (let [action (api/check-404 (action/select-action :public_uuid uuid :archived false))]
     (actions/check-actions-enabled! action)
@@ -473,12 +474,11 @@
   (check-field-is-referenced-by-card field-id card-id)
   (api.field/field->values (t2/select-one :model/Field :id field-id)))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/card/:uuid/field/:field-id/values"
+(api.macros/defendpoint :get "/card/:uuid/field/:field-id/values"
   "Fetch FieldValues for a Field that is referenced by a public Card."
-  [uuid field-id]
-  {uuid     ms/UUIDString
-   field-id ms/PositiveInt}
+  [{:keys [uuid field-id]} :- [:map
+                               [:uuid     ms/UUIDString]
+                               [:field-id ms/PositiveInt]]]
   (validation/check-public-sharing-enabled)
   (let [card-id (t2/select-one-pk :model/Card :public_uuid uuid, :archived false)]
     (card-and-field-id->values card-id field-id)))
@@ -490,12 +490,11 @@
   (check-field-is-referenced-by-dashboard field-id dashboard-id)
   (api.field/field->values (t2/select-one :model/Field :id field-id)))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/dashboard/:uuid/field/:field-id/values"
+(api.macros/defendpoint :get "/dashboard/:uuid/field/:field-id/values"
   "Fetch FieldValues for a Field that is referenced by a Card in a public Dashboard."
-  [uuid field-id]
-  {uuid     ms/UUIDString
-   field-id ms/PositiveInt}
+  [{:keys [uuid field-id]} :- [:map
+                               [:uuid     ms/UUIDString]
+                               [:field-id ms/PositiveInt]]]
   (validation/check-public-sharing-enabled)
   (let [dashboard-id (api/check-404 (t2/select-one-pk :model/Dashboard :public_uuid uuid, :archived false))]
     (dashboard-and-field-id->values dashboard-id field-id)))
@@ -518,28 +517,28 @@
   (check-search-field-is-allowed field-id search-id)
   (api.field/search-values (t2/select-one :model/Field :id field-id) (t2/select-one :model/Field :id search-id) value limit))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/card/:uuid/field/:field-id/search/:search-field-id"
+(api.macros/defendpoint :get "/card/:uuid/field/:field-id/search/:search-field-id"
   "Search for values of a Field that is referenced by a public Card."
-  [uuid field-id search-field-id value limit]
-  {uuid            ms/UUIDString
-   field-id        ms/PositiveInt
-   search-field-id ms/PositiveInt
-   value           ms/NonBlankString
-   limit           [:maybe ms/PositiveInt]}
+  [{:keys [uuid field-id search-field-id]} :- [:map
+                                               [:uuid            ms/UUIDString]
+                                               [:field-id        ms/PositiveInt]
+                                               [:search-field-id ms/PositiveInt]]
+   {:keys [value limit]} :- [:map
+                             [:value ms/NonBlankString]
+                             [:limit {:optional true} [:maybe ms/PositiveInt]]]]
   (validation/check-public-sharing-enabled)
   (let [card-id (t2/select-one-pk :model/Card :public_uuid uuid, :archived false)]
     (search-card-fields card-id field-id search-field-id value limit)))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/dashboard/:uuid/field/:field-id/search/:search-field-id"
+(api.macros/defendpoint :get "/dashboard/:uuid/field/:field-id/search/:search-field-id"
   "Search for values of a Field that is referenced by a Card in a public Dashboard."
-  [uuid field-id search-field-id value limit]
-  {uuid            ms/UUIDString
-   field-id        ms/PositiveInt
-   search-field-id ms/PositiveInt
-   value           ms/NonBlankString
-   limit           [:maybe ms/PositiveInt]}
+  [{:keys [uuid field-id search-field-id]} :- [:map
+                                               [:uuid            ms/UUIDString]
+                                               [:field-id        ms/PositiveInt]
+                                               [:search-field-id ms/PositiveInt]]
+   {:keys [value limit]} :- [:map
+                             [:value ms/NonBlankString]
+                             [:limit {:optional true} [:maybe ms/PositiveInt]]]]
   (validation/check-public-sharing-enabled)
   (let [dashboard-id (api/check-404 (t2/select-one-pk :model/Dashboard :public_uuid uuid, :archived false))]
     (search-dashboard-fields dashboard-id field-id search-field-id value limit)))
@@ -566,75 +565,73 @@
   (check-field-is-referenced-by-dashboard field-id dashboard-id)
   (field-remapped-values field-id remapped-field-id value-str))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/card/:uuid/field/:field-id/remapping/:remapped-id"
+(api.macros/defendpoint :get "/card/:uuid/field/:field-id/remapping/:remapped-id"
   "Fetch remapped Field values. This is the same as `GET /api/field/:id/remapping/:remapped-id`, but for use with public
   Cards."
-  [uuid field-id remapped-id value]
-  {uuid        ms/UUIDString
-   field-id    ms/PositiveInt
-   remapped-id ms/PositiveInt
-   value       ms/NonBlankString}
+  [{:keys [uuid field-id remapped-id]} :- [:map
+                                           [:uuid        ms/UUIDString]
+                                           [:field-id    ms/PositiveInt]
+                                           [:remapped-id ms/PositiveInt]]
+   {:keys [value]} :- [:map
+                       [:value ms/NonBlankString]]]
   (validation/check-public-sharing-enabled)
   (let [card-id (api/check-404 (t2/select-one-pk :model/Card :public_uuid uuid, :archived false))]
     (card-field-remapped-values card-id field-id remapped-id value)))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/dashboard/:uuid/field/:field-id/remapping/:remapped-id"
+(api.macros/defendpoint :get "/dashboard/:uuid/field/:field-id/remapping/:remapped-id"
   "Fetch remapped Field values. This is the same as `GET /api/field/:id/remapping/:remapped-id`, but for use with public
   Dashboards."
-  [uuid field-id remapped-id value]
-  {uuid        ms/UUIDString
-   field-id    ms/PositiveInt
-   remapped-id ms/PositiveInt
-   value       ms/NonBlankString}
+  [{:keys [uuid field-id remapped-id]} :- [:map
+                                           [:uuid        ms/UUIDString]
+                                           [:field-id    ms/PositiveInt]
+                                           [:remapped-id ms/PositiveInt]]
+   {:keys [value]} :- [:map
+                       [:value ms/NonBlankString]]]
   (validation/check-public-sharing-enabled)
   (let [dashboard-id (t2/select-one-pk :model/Dashboard :public_uuid uuid, :archived false)]
     (dashboard-field-remapped-values dashboard-id field-id remapped-id value)))
 
 ;;; ------------------------------------------------ Param Values -------------------------------------------------
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/card/:uuid/params/:param-key/values"
+(api.macros/defendpoint :get "/card/:uuid/params/:param-key/values"
   "Fetch values for a parameter on a public card."
-  [uuid param-key]
-  {uuid      ms/UUIDString
-   param-key ms/NonBlankString}
+  [{:keys [uuid param-key]} :- [:map
+                                [:uuid      ms/UUIDString]
+                                [:param-key ms/NonBlankString]]]
   (validation/check-public-sharing-enabled)
   (let [card (t2/select-one :model/Card :public_uuid uuid, :archived false)]
     (request/as-admin
       (api.card/param-values card param-key))))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/card/:uuid/params/:param-key/search/:query"
+(api.macros/defendpoint :get "/card/:uuid/params/:param-key/search/:query"
   "Fetch values for a parameter on a public card containing `query`."
-  [uuid param-key query]
-  {uuid      ms/UUIDString
-   param-key ms/NonBlankString
-   query     ms/NonBlankString}
+  [{:keys [uuid param-key query]} :- [:map
+                                      [:uuid      ms/UUIDString]
+                                      [:param-key ms/NonBlankString]
+                                      [:query     ms/NonBlankString]]]
   (validation/check-public-sharing-enabled)
   (let [card (t2/select-one :model/Card :public_uuid uuid, :archived false)]
     (request/as-admin
       (api.card/param-values card param-key query))))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/dashboard/:uuid/params/:param-key/values"
+(api.macros/defendpoint :get "/dashboard/:uuid/params/:param-key/values"
   "Fetch filter values for dashboard parameter `param-key`."
-  [uuid param-key :as {constraint-param-key->value :query-params}]
-  {uuid      ms/UUIDString
-   param-key ms/NonBlankString}
+  [{:keys [uuid param-key]} :- [:map
+                                [:uuid      ms/UUIDString]
+                                [:param-key ms/NonBlankString]]
+   constraint-param-key->value]
   (let [dashboard (dashboard-with-uuid uuid)]
     (request/as-admin
       (binding [qp.perms/*param-values-query* true]
         (api.dashboard/param-values dashboard param-key constraint-param-key->value)))))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/dashboard/:uuid/params/:param-key/search/:query"
+(api.macros/defendpoint :get "/dashboard/:uuid/params/:param-key/search/:query"
   "Fetch filter values for dashboard parameter `param-key`, containing specified `query`."
-  [uuid param-key query :as {constraint-param-key->value :query-params}]
-  {uuid      ms/UUIDString
-   param-key ms/NonBlankString
-   query     ms/NonBlankString}
+  [{:keys [uuid param-key query]} :- [:map
+                                      [:uuid      ms/UUIDString]
+                                      [:param-key ms/NonBlankString]
+                                      [:query     ms/NonBlankString]]
+   constraint-param-key->value]
   (let [dashboard (dashboard-with-uuid uuid)]
     (request/as-admin
       (binding [qp.perms/*param-values-query* true]
@@ -643,25 +640,25 @@
 ;;; ----------------------------------------------------- Pivot Tables -----------------------------------------------
 
 ;; TODO -- why do these endpoints START with `/pivot/` whereas the version in Dash
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/pivot/card/:uuid/query"
+(api.macros/defendpoint :get "/pivot/card/:uuid/query"
   "Fetch a publicly-accessible Card an return query results as well as `:card` information. Does not require auth
    credentials. Public sharing must be enabled."
-  [uuid parameters]
-  {uuid       ms/UUIDString
-   parameters [:maybe ms/JSONString]}
+  [{:keys [uuid]} :- [:map
+                      [:uuid ms/UUIDString]]
+   {:keys [parameters]} :- [:map
+                            [:parameters {:optional true} [:maybe ms/JSONString]]]]
   (process-query-for-card-with-public-uuid uuid :api (json/decode+kw parameters)
                                            :qp qp.pivot/run-pivot-query))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint GET "/pivot/dashboard/:uuid/dashcard/:dashcard-id/card/:card-id"
+(api.macros/defendpoint :get "/pivot/dashboard/:uuid/dashcard/:dashcard-id/card/:card-id"
   "Fetch the results for a Card in a publicly-accessible Dashboard. Does not require auth credentials. Public
   sharing must be enabled."
-  [uuid card-id dashcard-id parameters]
-  {uuid        ms/UUIDString
-   card-id     ms/PositiveInt
-   dashcard-id ms/PositiveInt
-   parameters  [:maybe ms/JSONString]}
+  [{:keys [uuid dashcard-id card-id]} :- [:map
+                                          [:uuid        ms/UUIDString]
+                                          [:card-id     ms/PositiveInt]
+                                          [:dashcard-id ms/PositiveInt]]
+   {:keys [parameters]} :- [:map
+                            [:parameters {:optional true} [:maybe ms/JSONString]]]]
   (validation/check-public-sharing-enabled)
   (api/check-404 (t2/select-one-pk :model/Card :id card-id :archived false))
   (let [dashboard-id (api/check-404 (t2/select-one-pk :model/Dashboard :public_uuid uuid, :archived false))]
@@ -684,14 +681,15 @@
                            :attempt-ttl-ms 1000
                            :delay-exponent 1))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint POST "/action/:uuid/execute"
+(api.macros/defendpoint :post "/action/:uuid/execute"
   "Execute the Action.
 
    `parameters` should be the mapped dashboard parameters with values."
-  [uuid :as {{:keys [parameters], :as _body} :body}]
-  {uuid       ms/UUIDString
-   parameters [:maybe [:map-of :keyword any?]]}
+  [{:keys [uuid]} :- [:map
+                      [:uuid ms/UUIDString]]
+   _query-params
+   {:keys [parameters], :as _body} :- [:map
+                                       [:parameters {:optional true} [:maybe [:map-of :keyword any?]]]]]
   (let [throttle-message (try
                            (throttle/check action-execution-throttle uuid)
                            nil


### PR DESCRIPTION
Last time I did this I messed something up and it broke `master` (these endpoints are undertested), so we had to revert it. This time I am fairly sure I fixed my mistakes, and also I think someone added some more tests for these endpoints now. At any rate stats isn't tracking master any more so if I break stuff no one will know until it's too late