### PR TITLE
Do not :return-drills-for-dimensions? for column header drills

### DIFF
--- a/src/metabase/lib/drill_thru.cljc
+++ b/src/metabase/lib/drill_thru.cljc
@@ -52,15 +52,15 @@
   ignore that column and return drills for all of the columns specified in `:dimensions`.
   `:return-drills-for-dimensions?` specifies which type we have."
   [{:f #'lib.drill-thru.automatic-insights/automatic-insights-drill,             :return-drills-for-dimensions? false}
-   {:f #'lib.drill-thru.column-filter/column-filter-drill,                       :return-drills-for-dimensions? true}
-   {:f #'lib.drill-thru.distribution/distribution-drill,                         :return-drills-for-dimensions? true}
+   {:f #'lib.drill-thru.column-filter/column-filter-drill,                       :return-drills-for-dimensions? false}
+   {:f #'lib.drill-thru.distribution/distribution-drill,                         :return-drills-for-dimensions? false}
    {:f #'lib.drill-thru.fk-filter/fk-filter-drill,                               :return-drills-for-dimensions? false}
    {:f #'lib.drill-thru.object-details/object-detail-drill,                      :return-drills-for-dimensions? false}
    {:f #'lib.drill-thru.pivot/pivot-drill,                                       :return-drills-for-dimensions? false}
    {:f #'lib.drill-thru.quick-filter/quick-filter-drill,                         :return-drills-for-dimensions? false}
-   {:f #'lib.drill-thru.sort/sort-drill,                                         :return-drills-for-dimensions? true}
-   {:f #'lib.drill-thru.summarize-column/summarize-column-drill,                 :return-drills-for-dimensions? true}
-   {:f #'lib.drill-thru.summarize-column-by-time/summarize-column-by-time-drill, :return-drills-for-dimensions? true}
+   {:f #'lib.drill-thru.sort/sort-drill,                                         :return-drills-for-dimensions? false}
+   {:f #'lib.drill-thru.summarize-column/summarize-column-drill,                 :return-drills-for-dimensions? false}
+   {:f #'lib.drill-thru.summarize-column-by-time/summarize-column-by-time-drill, :return-drills-for-dimensions? false}
    {:f #'lib.drill-thru.column-extract/column-extract-drill,                     :return-drills-for-dimensions? false}
    {:f #'lib.drill-thru.combine-columns/combine-columns-drill,                   :return-drills-for-dimensions? false}
    {:f #'lib.drill-thru.underlying-records/underlying-records-drill,             :return-drills-for-dimensions? false}

--- a/src/metabase/lib/schema/drill_thru.cljc
+++ b/src/metabase/lib/schema/drill_thru.cljc
@@ -331,6 +331,19 @@
 ;;;    | "Aggregated" Cell   | ✔      | ✔     | ✔   | ✔          |
 ;;;    | Pivot Cell          |        | ✔     | ✔   | ✔          |
 ;;;    | Legend Item         |        |       |     | ✔          |
+;;;
+;;; Testing shows that the above table is still mostly correct, with the exception of Pivot Cell clicks, which instead
+;;; have the following shapes, where `Pivot "Dim" Cell` means one of the Row/Column cells of the pivoted table,
+;;; corresponding to the breakout dimensions of the query, and `Pivot "Agg" Cell` means one of the
+;;; aggregated "measure" cells of the pivoted table.
+;;;
+;;; TODO: are these differences a bug in the pivot table implementation, or is the above table just out of date?
+;;;
+;;;
+;;;    | Drill Context Shape | column | value | row | dimensions |
+;;;    |---------------------|--------|-------|-----|------------|
+;;;    | Pivot "Dim" Cell    | ✔      | ✔     | ✔   |            |
+;;;    | Pivot "Agg" Cell    |        |       | ✔   | ✔          |
 
 (mr/def ::context.row.value
   [:map


### PR DESCRIPTION
Closes #49740

### Description

This is an alternate fix for #49740. See #52692 for another approach. Either of these PRs fix the bug, and I think both should be merged, but I feel less sure about the fix in this one, hence broke it out into a separate PR in case I'm overlooking something.

Do you know of any context where these drills need to be applied to their dimensions via `:return-drills-for-dimensions?`

AFAICT there are none, since dimensions never have "missing" values, and all of these drills are column-header-only drills, i.e. only meant to be available when the user clicks on a table viz column header and the resulting drill context has a `(nil? value)`. In addition, when initiated by a column-header click, AFAICT dimensions are never provided to the drill (though they are provided from other click contexts).

Even if it did happen that dimension values could be missing, it's not clear that applying any of these drills to the dimensions is what you'd want. As @alexyarosh notes in #49740, it's strange to click on a cell value in column A and get the option to apply a `sort` or `column-filter` drill for some other column B which happens to be a breakout dimension for the query (but only if the dimension's value is DB `NULL`).

On the other hand, one would assume these drills were marked `:return-drills-for-dimensions?` for a reason. Maybe they used to require it and no longer do, or maybe I'm missing something.

### How to verify

See repro steps in #49740 and/or #52692.

### Demo

column header click (sort and column-filter available)
![Screenshot 2025-01-24 at 2 38 34 PM](https://github.com/user-attachments/assets/a639bc28-1ef7-47fc-81de-40953cbf49c6)

cell value click (no sort or column-filter)
![Screenshot 2025-01-24 at 12 20 40 PM](https://github.com/user-attachments/assets/22c65cab-7228-4167-a8b0-6094551dd498)

legend click on dimension with null value
![Screenshot 2025-01-24 at 3 06 04 PM](https://github.com/user-attachments/assets/913ef69b-5c01-4a14-8430-8ef778c1ff05)

pivot table click
![Screenshot 2025-01-24 at 3 08 55 PM](https://github.com/user-attachments/assets/53580045-c164-47a5-81c8-154fb37fa59a)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
