### PR TITLE
Convert expression popover to mantine to fix z-index issues

### DIFF
--- a/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
@@ -84,6 +84,29 @@ describe("scenarios > question > custom column > typing suggestion", () => {
     H.popover().findByLabelText("Name").focus();
     cy.findByTestId("expression-suggestions-list").should("not.exist");
   });
+
+  it("should always show the help text popover on top of the custom expression widget (metabase#52711)", () => {
+    addCustomColumn();
+    H.enterCustomColumnDetails({ formula: "endsWith(", blur: false });
+
+    /* It seems like cypress considers that this popover and its contents are visible,
+     * even when it's under its parent popover because it is in a portal, so technically it's not being clipped by any element.
+     * Weirdly enough, it refuses to click `Learn more` because it's covered, but should("be.visible") passes.
+     *
+     * So, the (hacky) solution for now is to click all 5 elements of the popover, and we will check if the
+     * popover is still there at the end. Since the popover has onClickOutside behavior, the popover will
+     * close if the user clicks on anything outside it, so we can use that to our advantage.
+     * */
+    cy.findByTestId("expression-helper-popover").within(() => {
+      cy.findByTestId("expression-helper-popover-structure").click();
+      cy.findByTestId("expression-helper-popover-arguments").click();
+      cy.findByText("Example").click();
+
+      // We want to trigger the "covered element" error if this is true without actually clicking the external link
+      cy.findByText("Learn more").trigger("mousemove");
+    });
+    cy.findByTestId("expression-helper-popover").should("exist");
+  });
 });
 
 const addCustomColumn = () => {

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/ExpressionEditorHelpText.stories.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/ExpressionEditorHelpText.stories.tsx
@@ -1,5 +1,4 @@
 import type { StoryFn } from "@storybook/react";
-import { useRef } from "react";
 
 import { createMockMetadata } from "__support__/metadata";
 import { checkNotNull } from "metabase/lib/types";
@@ -15,7 +14,6 @@ export default {
 };
 
 const Template: StoryFn<typeof ExpressionEditorHelpText> = () => {
-  const target = useRef(null);
   const database = createMockDatabase();
   const metadata = createMockMetadata({ databases: [database] });
 
@@ -25,8 +23,6 @@ const Template: StoryFn<typeof ExpressionEditorHelpText> = () => {
       checkNotNull(metadata.database(database.id)),
       "UTC",
     ),
-    width: 397,
-    target,
   };
 
   return <ExpressionEditorHelpText {...props} />;

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/ExpressionEditorHelpText.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/ExpressionEditorHelpText.tsx
@@ -1,10 +1,8 @@
 import cx from "classnames";
-import type { RefObject } from "react";
 import { Fragment } from "react";
 import { t } from "ttag";
 
 import { useDocsUrl } from "metabase/common/hooks";
-import TippyPopover from "metabase/components/Popover/TippyPopover";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import CS from "metabase/css/core/index.css";
 import { Box, Icon, Text } from "metabase/ui";
@@ -13,19 +11,13 @@ import type { HelpText } from "metabase-lib/v1/expressions/types";
 
 import ExpressionEditorHelpTextS from "./ExpressionEditorHelpText.module.css";
 
-export type ExpressionEditorHelpTextContentProps = {
+export type ExpressionEditorHelpTextProps = {
   helpText: HelpText | null | undefined;
 };
 
-export type ExpressionEditorHelpTextProps =
-  ExpressionEditorHelpTextContentProps & {
-    target: RefObject<HTMLElement>;
-    width: number | undefined;
-  };
-
-export const ExpressionEditorHelpTextContent = ({
+export const ExpressionEditorHelpText = ({
   helpText,
-}: ExpressionEditorHelpTextContentProps) => {
+}: ExpressionEditorHelpTextProps) => {
   const { url: docsUrl, showMetabaseLinks } = useDocsUrl(
     helpText ? getHelpDocsUrl(helpText) : "",
   );
@@ -117,25 +109,5 @@ export const ExpressionEditorHelpTextContent = ({
         )}
       </Box>
     </>
-  );
-};
-
-export const ExpressionEditorHelpText = ({
-  helpText,
-  width,
-  target,
-}: ExpressionEditorHelpTextProps) => {
-  if (!helpText) {
-    return null;
-  }
-
-  return (
-    <TippyPopover
-      maxWidth={width}
-      reference={target}
-      placement="bottom-start"
-      visible
-      content={<ExpressionEditorHelpTextContent helpText={helpText} />}
-    />
   );
 };

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/ExpressionEditorHelpText.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/ExpressionEditorHelpText.tsx
@@ -88,6 +88,7 @@ export const ExpressionEditorHelpText = ({
 
         <Box
           className={ExpressionEditorHelpTextS.BlockSubtitleText}
+          data-testid="argument-example"
         >{t`Example`}</Box>
         <Box
           className={cx(

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/index.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/index.ts
@@ -1,4 +1,1 @@
-export {
-  ExpressionEditorHelpText,
-  ExpressionEditorHelpTextContent,
-} from "./ExpressionEditorHelpText";
+export { ExpressionEditorHelpText } from "./ExpressionEditorHelpText";

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/tests/setup.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/tests/setup.tsx
@@ -1,6 +1,6 @@
 import { setupEnterprisePlugins } from "__support__/enterprise";
 import { mockSettings } from "__support__/settings";
-import { renderWithProviders, screen } from "__support__/ui";
+import { renderWithProviders } from "__support__/ui";
 import type { TokenFeatures } from "metabase-types/api";
 import { createMockTokenFeatures } from "metabase-types/api/mocks";
 import { createMockState } from "metabase-types/store/mocks";
@@ -21,12 +21,8 @@ export async function setup({
   hasEnterprisePlugins,
   tokenFeatures = {},
 }: SetupOpts) {
-  const target = { current: null };
-
   const props: ExpressionEditorHelpTextProps = {
     helpText,
-    width: 397,
-    target,
   };
 
   const state = createMockState({
@@ -43,9 +39,4 @@ export async function setup({
   renderWithProviders(<ExpressionEditorHelpText {...props} />, {
     storeInitialState: state,
   });
-
-  // have to wait for TippyPopover to render content
-  expect(
-    await screen.findByTestId("expression-helper-popover"),
-  ).toBeInTheDocument();
 }

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
@@ -34,7 +34,7 @@ import type {
 } from "metabase-lib/v1/expressions/suggest";
 import { GROUPS } from "metabase-lib/v1/expressions/suggest";
 
-import { ExpressionEditorHelpTextContent } from "../ExpressionEditorHelpText";
+import { ExpressionEditorHelpText } from "../ExpressionEditorHelpText";
 import type {
   SuggestionFooter,
   SuggestionShortcut,
@@ -301,7 +301,7 @@ function ExpressionEditorSuggestionsListItem({
         {helpText && (
           <InfoPopover
             position="right"
-            content={<ExpressionEditorHelpTextContent helpText={helpText} />}
+            content={<ExpressionEditorHelpText helpText={helpText} />}
             width={450}
           >
             <PopoverHoverTarget

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
@@ -12,7 +12,7 @@ import ExplicitSize from "metabase/components/ExplicitSize";
 import { connect } from "metabase/lib/redux";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
-import { Box, Flex, type IconName } from "metabase/ui";
+import { Box, Flex, type IconName, Popover } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import { isExpression } from "metabase-lib/v1/expressions";
 import {
@@ -779,60 +779,65 @@ class ExpressionEditorTextfieldInner extends React.Component<
     } = this.state;
 
     return (
-      <div ref={this.helpTextTarget}>
-        <ExpressionEditorSuggestions
-          query={query}
-          stageIndex={stageIndex}
-          suggestions={suggestions}
-          onSuggestionMouseDown={this.onSuggestionSelected}
-          highlightedIndex={highlightedSuggestionIndex}
-          onHighlightSuggestion={this.handleHighlightSuggestion}
-          open={isFocused}
-          ref={this.popupMenuTarget}
-        >
-          <Flex
-            className={cx(
-              "expression-editor-textfield",
-              ExpressionEditorTextfieldS.EditorContainer,
-              {
-                [ExpressionEditorTextfieldS.isFocused]: isFocused,
-                [ExpressionEditorTextfieldS.hasError]: errorMessage,
-              },
+      <Popover opened={!!helpText} position="bottom-start">
+        <Popover.Target>
+          <Box>
+            <ExpressionEditorSuggestions
+              query={query}
+              stageIndex={stageIndex}
+              suggestions={suggestions}
+              onSuggestionMouseDown={this.onSuggestionSelected}
+              highlightedIndex={highlightedSuggestionIndex}
+              onHighlightSuggestion={this.handleHighlightSuggestion}
+              open={isFocused}
+              ref={this.popupMenuTarget}
+            >
+              <Flex
+                className={cx(
+                  "expression-editor-textfield",
+                  ExpressionEditorTextfieldS.EditorContainer,
+                  {
+                    [ExpressionEditorTextfieldS.isFocused]: isFocused,
+                    [ExpressionEditorTextfieldS.hasError]: errorMessage,
+                  },
+                )}
+                ref={this.suggestionTarget}
+                data-testid="expression-editor-textfield"
+              >
+                <Box className={ExpressionEditorTextfieldS.EditorEqualsSign}>
+                  =
+                </Box>
+                <AceEditor
+                  commands={this.commands}
+                  mode="text"
+                  ref={this.input}
+                  value={source}
+                  markers={this.errorAsMarkers(errorMessage)}
+                  focus={true}
+                  highlightActiveLine={false}
+                  wrapEnabled={true}
+                  fontSize={12}
+                  onBlur={this.handleInputBlur}
+                  onFocus={this.handleFocus}
+                  setOptions={ACE_OPTIONS}
+                  onChange={this.handleExpressionChange}
+                  onCursorChange={this.handleCursorChange}
+                  width="100%"
+                />
+              </Flex>
+            </ExpressionEditorSuggestions>
+            {errorMessage && hasChanges && (
+              <Box className={ExpressionEditorTextfieldS.ErrorMessageContainer}>
+                {errorMessage.message}
+              </Box>
             )}
-            ref={this.suggestionTarget}
-            data-testid="expression-editor-textfield"
-          >
-            <Box className={ExpressionEditorTextfieldS.EditorEqualsSign}>=</Box>
-            <AceEditor
-              commands={this.commands}
-              mode="text"
-              ref={this.input}
-              value={source}
-              markers={this.errorAsMarkers(errorMessage)}
-              focus={true}
-              highlightActiveLine={false}
-              wrapEnabled={true}
-              fontSize={12}
-              onBlur={this.handleInputBlur}
-              onFocus={this.handleFocus}
-              setOptions={ACE_OPTIONS}
-              onChange={this.handleExpressionChange}
-              onCursorChange={this.handleCursorChange}
-              width="100%"
-            />
-          </Flex>
-        </ExpressionEditorSuggestions>
-        {errorMessage && hasChanges && (
-          <Box className={ExpressionEditorTextfieldS.ErrorMessageContainer}>
-            {errorMessage.message}
           </Box>
-        )}
-        <ExpressionEditorHelpText
-          target={this.helpTextTarget}
-          helpText={helpText}
-          width={width}
-        />
-      </div>
+        </Popover.Target>
+        {/* similar to overlays,  Mantine keeps overriding the max-width property on the `style` attribute */}
+        <Popover.Dropdown maw={`${width}px !important`}>
+          <ExpressionEditorHelpText helpText={helpText} />
+        </Popover.Dropdown>
+      </Popover>
     );
   }
 }


### PR DESCRIPTION
Convert the `ExpressionEditorTextfield` popover to mantine to fix z-index issues - on 52, it's hiding behind the parent popover. I've also added an E2E test that should ensure that this doesn't happen again - it's a weird one but it seems to work.


**On v53** - nothing should change
**On v52** - before, the expression editor help text is hidden behind the expression editor as shown in #52711. This will fix the problem when it is backported to 52.

Before (on `release-x.52.x`):
<img width="507" alt="image" src="https://github.com/user-attachments/assets/b917ef6e-7f52-4832-8466-66c8fa6075c9" />

After backporting:
<img width="533" alt="image" src="https://github.com/user-attachments/assets/d0bf81d2-b2cc-4935-b7c8-34cde2224fe1" />
