### PR TITLE
Add desc systematically + reporter info

### DIFF
--- a/e2e/test/scenarios/admin-2/error-reporting.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/error-reporting.cy.spec.ts
@@ -22,7 +22,7 @@ describe("error reporting modal", () => {
     cy.realPress(["Control", "F1"]);
 
     H.modal().within(() => {
-      cy.findByText("Download diagnostic information").should("be.visible");
+      cy.findByText("Gather diagnostic information").should("be.visible");
       cy.button(/Download/i).click();
     });
 
@@ -49,7 +49,7 @@ describe("error reporting modal", () => {
     H.commandPaletteInput().type("Error");
     H.commandPaletteAction(/Report an issue/).click();
 
-    cy.findByRole("dialog", { name: "Download diagnostic information" }).should(
+    cy.findByRole("dialog", { name: "Gather diagnostic information" }).should(
       "be.visible",
     );
   });
@@ -88,7 +88,7 @@ describe("error reporting modal", () => {
     cy.realPress(["Control", "F1"]);
 
     H.modal().within(() => {
-      cy.findByText("Download diagnostic information").should("be.visible");
+      cy.findByText("Gather diagnostic information").should("be.visible");
       cy.findByLabelText("Query results").should("not.be.checked");
       cy.button(/Download/i).click();
     });
@@ -109,7 +109,7 @@ describe("error reporting modal", () => {
     cy.realPress(["Control", "F1"]);
 
     H.modal().within(() => {
-      cy.findByText("Download diagnostic information").should("be.visible");
+      cy.findByText("Gather diagnostic information").should("be.visible");
       cy.findByLabelText("Query results").should("not.be.checked");
       cy.findByLabelText("Query results").click(); // off by default
       cy.findByLabelText("Query results").should("be.checked");
@@ -142,7 +142,7 @@ describe("error reporting modal", () => {
     cy.realPress(["Control", "F1"]);
 
     H.modal().within(() => {
-      cy.findByText("Download diagnostic information").should("be.visible");
+      cy.findByText("Gather diagnostic information").should("be.visible");
       cy.findByLabelText("Query results").should("not.be.checked");
       cy.findByLabelText("Query results").click(); // off by default
       cy.findByLabelText("Query results").should("be.checked");
@@ -169,7 +169,7 @@ describe("error reporting modal", () => {
 
     cy.realPress(["Control", "F1"]);
     H.modal().within(() => {
-      cy.findByText("Download diagnostic information").should("be.visible");
+      cy.findByText("Gather diagnostic information").should("be.visible");
       cy.findByLabelText("Dashboard definition").should("be.visible");
       cy.findByLabelText("Query results").should("not.exist");
       cy.findByLabelText(/server logs/i).should("not.exist");
@@ -192,7 +192,7 @@ describe("error reporting modal", () => {
 });
 
 function getDiagnosticInfoFile() {
-  cy.findByLabelText("Download diagnostic information").should("not.exist");
+  cy.findByLabelText("Gather diagnostic information").should("not.exist");
   return cy
     .verifyDownload("metabase-diagnostic-info-", {
       contains: true,

--- a/frontend/src/metabase-types/api/bug-report.ts
+++ b/frontend/src/metabase-types/api/bug-report.ts
@@ -16,6 +16,11 @@ export type ReportableEntityName =
 
 export type ErrorPayload = Partial<{
   url: string;
+  description: string;
+  reporter: {
+    name: string;
+    email: string;
+  };
   frontendErrors: string[];
   backendErrors: Log[];
   userLogs: Log[];

--- a/frontend/src/metabase/components/ErrorPages/BugReportModal.tsx
+++ b/frontend/src/metabase/components/ErrorPages/BugReportModal.tsx
@@ -49,6 +49,7 @@ export const BugReportModal = ({
       <FormProvider
         initialValues={{
           ...hiddenValues,
+          reporter: true,
           queryResults: false,
           entityInfo: true,
           frontendErrors: true,
@@ -61,10 +62,12 @@ export const BugReportModal = ({
       >
         {formik => (
           <Form>
-            <Text py="md">
-              {t`What were you trying to do, and what steps did you take? What was the expected result, and what happened instead?`}
-            </Text>
-            <FormTextArea name="description" autoFocus />
+            <Text py="md">{t`Could you provide us with a little context?`}</Text>
+            <FormTextArea
+              name="description"
+              autoFocus
+              placeholder={t`What were you trying to do, and what steps did you take? What was the expected result, and what happened instead?`}
+            />
             <Box
               bg={color("accent-gray-light")}
               p="lg"

--- a/frontend/src/metabase/components/ErrorPages/DiagnosticCheckboxes.tsx
+++ b/frontend/src/metabase/components/ErrorPages/DiagnosticCheckboxes.tsx
@@ -20,7 +20,8 @@ export const DiagnosticCheckboxes = ({
   <Stack spacing="md" pt="md">
     <FormCheckbox
       name="reporter"
-      label={c("This is part of the bug reporting modal").t`Your user details`}
+      label={c("This is part of the bug reporting modal")
+        .t`Your name and email`}
     />
     {canIncludeQueryData && (
       <FormCheckbox name="queryResults" label={t`Query results`} />

--- a/frontend/src/metabase/components/ErrorPages/DiagnosticCheckboxes.tsx
+++ b/frontend/src/metabase/components/ErrorPages/DiagnosticCheckboxes.tsx
@@ -18,6 +18,10 @@ export const DiagnosticCheckboxes = ({
   applicationName,
 }: DiagnosticCheckboxesProps) => (
   <Stack spacing="md" pt="md">
+    <FormCheckbox
+      name="reporter"
+      label={c("This is part of the bug reporting modal").t`Your user details`}
+    />
     {canIncludeQueryData && (
       <FormCheckbox name="queryResults" label={t`Query results`} />
     )}

--- a/frontend/src/metabase/components/ErrorPages/DownloadDiagnosticModal.tsx
+++ b/frontend/src/metabase/components/ErrorPages/DownloadDiagnosticModal.tsx
@@ -1,5 +1,6 @@
 import { c, t } from "ttag";
 
+import FormTextArea from "metabase/core/components/FormTextArea";
 import { Form, FormProvider, FormSubmitButton } from "metabase/forms";
 import { Modal, Text } from "metabase/ui";
 
@@ -31,12 +32,13 @@ export const DownloadDiagnosticModal = ({
   <Modal
     opened
     onClose={onClose}
-    title={t`Download diagnostic information`}
+    title={t`Gather diagnostic information`}
     size={550}
   >
     <FormProvider
       initialValues={{
         ...hiddenValues,
+        reporter: true,
         queryResults: false,
         entityInfo: true,
         frontendErrors: true,
@@ -48,7 +50,13 @@ export const DownloadDiagnosticModal = ({
       onSubmit={onSubmit}
     >
       <Form>
-        <Text py="md">
+        <Text py="md">{t`Could you provide us with a little context?`}</Text>
+        <FormTextArea
+          name="description"
+          autoFocus
+          placeholder={t`What were you trying to do, and what steps did you take? What was the expected result, and what happened instead?`}
+        />
+        <Text>
           {/* eslint-disable-next-line no-literal-metabase-strings -- this is a translation context string, not shown to users */}
           {c("{0} is the name of the application, usually 'Metabase'")
             .t`This information helps ${applicationName} figure out what exactly caused the issue`}

--- a/frontend/src/metabase/components/ErrorPages/DownloadDiagnosticModal.tsx
+++ b/frontend/src/metabase/components/ErrorPages/DownloadDiagnosticModal.tsx
@@ -10,9 +10,7 @@ import type { ErrorPayload } from "./types";
 interface DownloadDiagnosticModalProps {
   errorInfo: ErrorPayload;
   onClose: () => void;
-  onSubmit: (
-    values: Partial<Record<keyof Omit<ErrorPayload, "description">, boolean>>,
-  ) => void;
+  onSubmit: (values: Partial<Record<keyof ErrorPayload, boolean>>) => void;
   canIncludeQueryData: boolean;
   applicationName: string;
   hiddenValues: Record<

--- a/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.tsx
+++ b/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.tsx
@@ -31,8 +31,6 @@ interface ErrorDiagnosticModalProps {
   onClose: () => void;
 }
 
-type PayloadSelection = Partial<Record<keyof ErrorPayload, boolean>>;
-
 export const ErrorDiagnosticModal = ({
   errorInfo,
   loading,
@@ -75,15 +73,17 @@ export const ErrorDiagnosticModal = ({
     browserInfo: true,
   };
 
-  const handleSubmit = (values: PayloadSelection) => {
+  const handleSubmit = (values: Record<string, boolean | string>) => {
     trackErrorDiagnosticModalSubmitted("download-diagnostics");
-    const selectedKeys = Object.keys(values).filter(
-      key => values[key as keyof PayloadSelection],
+    const { description, ...diagnosticSelections } = values;
+
+    const selectedKeys = Object.keys(diagnosticSelections).filter(
+      key => diagnosticSelections[key],
     );
-    const selectedInfo: Partial<ErrorPayload> = _.pick(
-      errorInfo,
-      ...selectedKeys,
-    );
+    const selectedInfo = {
+      ..._.pick(errorInfo, ...selectedKeys),
+      description,
+    };
 
     downloadObjectAsJson(
       selectedInfo,
@@ -92,9 +92,7 @@ export const ErrorDiagnosticModal = ({
     onClose();
   };
 
-  const handleSlackSubmit = async (
-    values: Record<string, boolean | string>,
-  ) => {
+  const handleSlackSubmit = async (values: Record<string, any>) => {
     setIsSlackSending(true);
     const { description, ...diagnosticSelections } = values;
 
@@ -197,7 +195,7 @@ export const ErrorDiagnosticModalTrigger = () => {
           leftIcon={<Icon name="download" />}
           onClick={() => setModalOpen(true)}
         >
-          {t`Download diagnostic information`}
+          {t`Gather diagnostic information`}
         </Button>
       </Stack>
       <ErrorDiagnosticModalWrapper

--- a/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.unit.spec.tsx
+++ b/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.unit.spec.tsx
@@ -15,6 +15,10 @@ import type { ErrorPayload, ReportableEntityName } from "./types";
 
 const defaultErrorPayload: ErrorPayload = {
   url: "http://example.com/question/1",
+  reporter: {
+    name: "John McLane",
+    email: "diehard@metabase.com",
+  },
   frontendErrors: ["Frontend error 1", "Frontend error 2"],
   backendErrors: [
     {
@@ -91,7 +95,7 @@ describe("ErrorDiagnosticsModal", () => {
   it("should show diagnostic modal", () => {
     setup(defaultErrorPayload);
     expect(
-      screen.getByText("Download diagnostic information"),
+      screen.getByText("Gather diagnostic information"),
     ).toBeInTheDocument();
   });
 
@@ -105,6 +109,7 @@ describe("ErrorDiagnosticsModal", () => {
     "dashboard",
     "collection",
     "model",
+    "metric",
   ];
 
   entityNames.forEach(entityName => {
@@ -143,6 +148,15 @@ describe("ErrorDiagnosticsModal", () => {
       ...defaultErrorPayload,
       entityName: "model",
       localizedEntityName: "Model",
+    });
+    expect(screen.getByText(/query results/i)).toBeInTheDocument();
+  });
+
+  it("should show query results checkbox for metrics", () => {
+    setup({
+      ...defaultErrorPayload,
+      entityName: "metric",
+      localizedEntityName: "Metric",
     });
     expect(screen.getByText(/query results/i)).toBeInTheDocument();
   });
@@ -199,9 +213,7 @@ describe("ErrorDiagnosticsModal", () => {
 
     it("should show description textarea with correct label", () => {
       expect(
-        screen.getByText(
-          /what were you trying to do, and what steps did you take\? what was the expected result, and what happened instead\?/i,
-        ),
+        screen.getByText(/Could you provide us with a little context\?/i),
       ).toBeInTheDocument();
     });
 

--- a/frontend/src/metabase/components/ErrorPages/types.ts
+++ b/frontend/src/metabase/components/ErrorPages/types.ts
@@ -16,6 +16,11 @@ export type ReportableEntityName =
 
 export type ErrorPayload = {
   url: string;
+  reporter: {
+    name: string;
+    email: string;
+  };
+  description?: string;
   frontendErrors?: string[];
   backendErrors?: Log[];
   userLogs?: Log[];

--- a/frontend/src/metabase/components/ErrorPages/use-error-info.ts
+++ b/frontend/src/metabase/components/ErrorPages/use-error-info.ts
@@ -95,6 +95,10 @@ export const useErrorInfo = (
     const browserInfo = getBrowserInfo();
 
     const payload: ErrorPayload = {
+      reporter: {
+        name: `${currentUser.first_name} ${currentUser.last_name}`,
+        email: currentUser.email,
+      },
       url: location,
       entityInfo,
       entityName: entity,

--- a/frontend/src/metabase/components/ErrorPages/utils.ts
+++ b/frontend/src/metabase/components/ErrorPages/utils.ts
@@ -3,10 +3,10 @@ import Bowser from "bowser";
 import { b64url_to_utf8 } from "metabase/lib/encoding";
 import { CardApi, CollectionsApi, DashboardApi } from "metabase/services";
 
-import type { ErrorPayload, ReportableEntityName } from "./types";
+import type { ReportableEntityName } from "./types";
 
 export function downloadObjectAsJson(
-  exportObj: Partial<ErrorPayload>,
+  exportObj: Record<string, any>,
   exportName: string,
 ) {
   const dataStr =

--- a/src/metabase/api/slack.clj
+++ b/src/metabase/api/slack.clj
@@ -26,13 +26,18 @@
   [diagnostic-info file-info]
   (let [version-info (get-in diagnostic-info [:bugReportDetails :metabase-info :version])
         description (get diagnostic-info :description)
+        reporterEmail (get-in diagnostic-info [:reporter :email])
+        reporterName (get-in diagnostic-info [:reporter :name])
         file-url (if (string? file-info)
                    file-info
                    (:url file-info))]
     [{:type "rich_text"
       :elements [{:type "rich_text_section"
                   :elements [{:type "text"
-                              :text "New bug report"}
+                              :text "New bug report from "}
+                             {:type "link"
+                              :url (str "mailto:" reporterEmail)
+                              :text reporterName}
                              {:type "text"
                               :text "\n\nDescription:\n"
                               :style {:bold true}}

--- a/src/metabase/api/slack.clj
+++ b/src/metabase/api/slack.clj
@@ -26,8 +26,7 @@
   [diagnostic-info file-info]
   (let [version-info (get-in diagnostic-info [:bugReportDetails :metabase-info :version])
         description (get diagnostic-info :description)
-        reporterEmail (get-in diagnostic-info [:reporter :email])
-        reporterName (get-in diagnostic-info [:reporter :name])
+        reporter (get diagnostic-info :reporter)
         file-url (if (string? file-info)
                    file-info
                    (:url file-info))]
@@ -35,9 +34,12 @@
       :elements [{:type "rich_text_section"
                   :elements [{:type "text"
                               :text "New bug report from "}
-                             {:type "link"
-                              :url (str "mailto:" reporterEmail)
-                              :text reporterName}
+                             (if reporter
+                               {:type "link"
+                                :url (str "mailto:" (:email reporter))
+                                :text (:name reporter)}
+                               {:type "text"
+                                :text "anonymous user"})
                              {:type "text"
                               :text "\n\nDescription:\n"
                               :style {:bold true}}

--- a/test/metabase/api/slack_test.clj
+++ b/test/metabase/api/slack_test.clj
@@ -91,82 +91,82 @@
 (deftest bug-report-test
   (testing "POST /api/slack/bug-report"
     (let [diagnostic-info {:url "https://test.com"
-                          :description "Test description"
-                          :reporter {:name "John McLane"
-                                   :email "diehard@metabase.com"}
-                          :bugReportDetails
-                          {:metabase-info {:version {:date "2025-01-10"
-                                                   :tag "vUNKNOWN"
-                                                   :hash "68b5038"}}}}
+                           :description "Test description"
+                           :reporter {:name "John McLane"
+                                      :email "diehard@metabase.com"}
+                           :bugReportDetails
+                           {:metabase-info {:version {:date "2025-01-10"
+                                                      :tag "vUNKNOWN"
+                                                      :hash "68b5038"}}}}
           mock-file-info {:url "https://files.slack.com/files-pri/123/diagnostic.json"
-                         :id "F123ABC"
-                         :permalink_public "https://slack.com/files/123/diagnostic.json"}
+                          :id "F123ABC"
+                          :permalink_public "https://slack.com/files/123/diagnostic.json"}
           expected-blocks [{:type "rich_text"
-                          :elements [{:type "rich_text_section"
-                                    :elements [{:type "text"
-                                              :text "New bug report from "}
-                                             {:type "link"
-                                              :url "mailto:diehard@metabase.com"
-                                              :text "John McLane"}
-                                             {:type "text"
-                                              :text "\n\nDescription:\n"
-                                              :style {:bold true}}
-                                             {:type "text"
-                                              :text "Test description"}
-                                             {:type "text"
-                                              :text "\n\nURL:\n"
-                                              :style {:bold true}}
-                                             {:type "link"
-                                              :text "https://test.com"
-                                              :url "https://test.com"}
-                                             {:type "text"
-                                              :text "\n\nVersion info:\n"
-                                              :style {:bold true}}]}
-                                   {:type "rich_text_preformatted"
-                                    :border 0
-                                    :elements [{:type "text"
-                                              :text "{\n  \"date\" : \"2025-01-10\",\n  \"tag\" : \"vUNKNOWN\",\n  \"hash\" : \"68b5038\"\n}"}]}]}
-                         {:type "divider"}
-                         {:type "actions"
-                          :elements [{:type "button"
-                                    :text {:type "plain_text"
-                                          :text "Jump to debugger"
-                                          :emoji true}
-                                    :url "https://metabase-debugger.vercel.app/?fileId=F123ABC"
-                                    :style "primary"}
-                                   {:type "button"
-                                    :text {:type "plain_text"
-                                          :text "Download the report"
-                                          :emoji true}
-                                    :url "https://files.slack.com/files-pri/123/diagnostic.json"}]}]]
+                            :elements [{:type "rich_text_section"
+                                        :elements [{:type "text"
+                                                    :text "New bug report from "}
+                                                   {:type "link"
+                                                    :url "mailto:diehard@metabase.com"
+                                                    :text "John McLane"}
+                                                   {:type "text"
+                                                    :text "\n\nDescription:\n"
+                                                    :style {:bold true}}
+                                                   {:type "text"
+                                                    :text "Test description"}
+                                                   {:type "text"
+                                                    :text "\n\nURL:\n"
+                                                    :style {:bold true}}
+                                                   {:type "link"
+                                                    :text "https://test.com"
+                                                    :url "https://test.com"}
+                                                   {:type "text"
+                                                    :text "\n\nVersion info:\n"
+                                                    :style {:bold true}}]}
+                                       {:type "rich_text_preformatted"
+                                        :border 0
+                                        :elements [{:type "text"
+                                                    :text "{\n  \"date\" : \"2025-01-10\",\n  \"tag\" : \"vUNKNOWN\",\n  \"hash\" : \"68b5038\"\n}"}]}]}
+                           {:type "divider"}
+                           {:type "actions"
+                            :elements [{:type "button"
+                                        :text {:type "plain_text"
+                                               :text "Jump to debugger"
+                                               :emoji true}
+                                        :url "https://metabase-debugger.vercel.app/?fileId=F123ABC"
+                                        :style "primary"}
+                                       {:type "button"
+                                        :text {:type "plain_text"
+                                               :text "Download the report"
+                                               :emoji true}
+                                        :url "https://files.slack.com/files-pri/123/diagnostic.json"}]}]]
 
       (testing "should post bug report to Slack with correct blocks"
         (with-redefs [slack/upload-file! (constantly mock-file-info)
-                     slack/post-chat-message! (constantly nil)
-                     slack/channel-exists? (constantly true)]
+                      slack/post-chat-message! (constantly nil)
+                      slack/channel-exists? (constantly true)]
           (mt/with-temporary-setting-values [slack-files-channel "test-files"
-                                           slack-bug-report-channel "test-bugs"]
+                                             slack-bug-report-channel "test-bugs"]
             (let [response (mt/user-http-request :crowberto :post 200 "slack/bug-report"
-                                               {:diagnosticInfo diagnostic-info})]
+                                                 {:diagnosticInfo diagnostic-info})]
               (is (= expected-blocks (#'api.slack/create-slack-message-blocks diagnostic-info mock-file-info)))
               (is (= {:success true
-                     :file-url "https://slack.com/files/123/diagnostic.json"}
-                    response))))))
+                      :file-url "https://slack.com/files/123/diagnostic.json"}
+                     response))))))
 
       (testing "should handle anonymous reports"
         (with-redefs [slack/upload-file! (constantly mock-file-info)
-                     slack/post-chat-message! (constantly nil)
-                     slack/channel-exists? (constantly true)]
+                      slack/post-chat-message! (constantly nil)
+                      slack/channel-exists? (constantly true)]
           (mt/with-temporary-setting-values [slack-files-channel "test-files"
-                                           slack-bug-report-channel "test-bugs"]
+                                             slack-bug-report-channel "test-bugs"]
             (let [anonymous-info (dissoc diagnostic-info :reporter)
                   anonymous-blocks (update-in expected-blocks [0 :elements 0 :elements]
-                                            (fn [elements]
-                                              (map #(cond
-                                                    (and (= (:type %) "link")
-                                                         (str/starts-with? (:url %) "mailto:"))
-                                                    {:type "text" :text "anonymous user"}
+                                              (fn [elements]
+                                                (map #(cond
+                                                        (and (= (:type %) "link")
+                                                             (str/starts-with? (:url %) "mailto:"))
+                                                        {:type "text" :text "anonymous user"}
 
-                                                    :else %)
-                                                   elements)))]
+                                                        :else %)
+                                                     elements)))]
               (is (= anonymous-blocks (#'api.slack/create-slack-message-blocks anonymous-info mock-file-info))))))))))

--- a/test/metabase/api/slack_test.clj
+++ b/test/metabase/api/slack_test.clj
@@ -3,6 +3,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [java-time.api :as t]
+   [metabase.api.slack :as api.slack]
    [metabase.config :as config]
    [metabase.integrations.slack :as slack]
    [metabase.test :as mt]))
@@ -86,3 +87,86 @@
 
     (testing "A non-admin cannot fetch the Slack manifest"
       (mt/user-http-request :rasta :get 403 "slack/manifest"))))
+
+(deftest bug-report-test
+  (testing "POST /api/slack/bug-report"
+    (let [diagnostic-info {:url "https://test.com"
+                          :description "Test description"
+                          :reporter {:name "John McLane"
+                                   :email "diehard@metabase.com"}
+                          :bugReportDetails
+                          {:metabase-info {:version {:date "2025-01-10"
+                                                   :tag "vUNKNOWN"
+                                                   :hash "68b5038"}}}}
+          mock-file-info {:url "https://files.slack.com/files-pri/123/diagnostic.json"
+                         :id "F123ABC"
+                         :permalink_public "https://slack.com/files/123/diagnostic.json"}
+          expected-blocks [{:type "rich_text"
+                          :elements [{:type "rich_text_section"
+                                    :elements [{:type "text"
+                                              :text "New bug report from "}
+                                             {:type "link"
+                                              :url "mailto:diehard@metabase.com"
+                                              :text "John McLane"}
+                                             {:type "text"
+                                              :text "\n\nDescription:\n"
+                                              :style {:bold true}}
+                                             {:type "text"
+                                              :text "Test description"}
+                                             {:type "text"
+                                              :text "\n\nURL:\n"
+                                              :style {:bold true}}
+                                             {:type "link"
+                                              :text "https://test.com"
+                                              :url "https://test.com"}
+                                             {:type "text"
+                                              :text "\n\nVersion info:\n"
+                                              :style {:bold true}}]}
+                                   {:type "rich_text_preformatted"
+                                    :border 0
+                                    :elements [{:type "text"
+                                              :text "{\n  \"date\" : \"2025-01-10\",\n  \"tag\" : \"vUNKNOWN\",\n  \"hash\" : \"68b5038\"\n}"}]}]}
+                         {:type "divider"}
+                         {:type "actions"
+                          :elements [{:type "button"
+                                    :text {:type "plain_text"
+                                          :text "Jump to debugger"
+                                          :emoji true}
+                                    :url "https://metabase-debugger.vercel.app/?fileId=F123ABC"
+                                    :style "primary"}
+                                   {:type "button"
+                                    :text {:type "plain_text"
+                                          :text "Download the report"
+                                          :emoji true}
+                                    :url "https://files.slack.com/files-pri/123/diagnostic.json"}]}]]
+
+      (testing "should post bug report to Slack with correct blocks"
+        (with-redefs [slack/upload-file! (constantly mock-file-info)
+                     slack/post-chat-message! (constantly nil)
+                     slack/channel-exists? (constantly true)]
+          (mt/with-temporary-setting-values [slack-files-channel "test-files"
+                                           slack-bug-report-channel "test-bugs"]
+            (let [response (mt/user-http-request :crowberto :post 200 "slack/bug-report"
+                                               {:diagnosticInfo diagnostic-info})]
+              (is (= expected-blocks (#'api.slack/create-slack-message-blocks diagnostic-info mock-file-info)))
+              (is (= {:success true
+                     :file-url "https://slack.com/files/123/diagnostic.json"}
+                    response))))))
+
+      (testing "should handle anonymous reports"
+        (with-redefs [slack/upload-file! (constantly mock-file-info)
+                     slack/post-chat-message! (constantly nil)
+                     slack/channel-exists? (constantly true)]
+          (mt/with-temporary-setting-values [slack-files-channel "test-files"
+                                           slack-bug-report-channel "test-bugs"]
+            (let [anonymous-info (dissoc diagnostic-info :reporter)
+                  anonymous-blocks (update-in expected-blocks [0 :elements 0 :elements]
+                                            (fn [elements]
+                                              (map #(cond
+                                                    (and (= (:type %) "link")
+                                                         (str/starts-with? (:url %) "mailto:"))
+                                                    {:type "text" :text "anonymous user"}
+
+                                                    :else %)
+                                                   elements)))]
+              (is (= anonymous-blocks (#'api.slack/create-slack-message-blocks anonymous-info mock-file-info))))))))))


### PR DESCRIPTION
Closes https://linear.app/metabase-inc/issue/DEVX-113/adjust-the-slack-blocks-rendering-to-add-the-alias-to-the-reporter and https://linear.app/metabase-inc/issue/DEVX-111/fetch-currently-logged-in-user-and-add-to-diagnostics-in
Also closes #51297 and https://github.com/metabase/metabase-debugger/issues/22

### Description

Adds the currently logged-in user to the bug report, as well as to the Slack message whenever Slack bugs submission is available.

Also adds the description text area to the public facing diagnostics to make sure we can eventually gather appropriate details about bugs.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Launch without MB_BUG_REPORTING_ENABLED set
2. Pop the diagnostics modal using Cmd/Ctrl+F1
3. See the description field is there, fill it in
4. See that there's a new option to add the reporter's detail
5. Download diagnostics JSON and verify the description is present
6. Relaunch with MB_BUG_REPORTING_ENABLED=true
7. Pop the diagnostics modal using Cmd/Ctrl+F1
8. Add some description
9. Send to Slack
10. Check the issuer's name and email are present if ticked

### Demo

[Loom demo
](https://www.loom.com/share/26e9a7f9998d40f39ddf2800f901f800?sid=ce4f05bf-adec-4309-97c5-e68ceb1ad2a7)
