### PR TITLE
fix flaky test

### DIFF
--- a/e2e/test/scenarios/admin-2/api-keys.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/api-keys.cy.spec.ts
@@ -89,24 +89,20 @@ describe("scenarios > admin > settings > API keys", () => {
     cy.findByTestId("api-keys-table").findByText(name);
   });
 
-  it(
-    "should show an error when a previously used key name is submitted",
-    { tags: "@flaky" },
-    () => {
-      const name = "New key";
-      const group = "Administrators";
-      H.visitApiKeySettings();
-      H.tryToCreateApiKeyViaModal({ name, group });
-      H.modal().button("Done").click();
-      H.tryToCreateApiKeyViaModal({ name, group }).then(({ response }) => {
-        expect(response?.statusCode).to.equal(400);
-      });
+  it("should show an error when a previously used key name is submitted", () => {
+    const name = "New key";
+    const group = "Administrators";
+    H.visitApiKeySettings();
+    H.tryToCreateApiKeyViaModal({ name, group });
+    cy.button("Done").click();
+    H.tryToCreateApiKeyViaModal({ name, group }).then(({ response }) => {
+      expect(response?.statusCode).to.equal(400);
+    });
 
-      cy.findByTestId("create-api-key-modal")
-        .findAllByRole("alert")
-        .contains("An API key with this name already exists.");
-    },
-  );
+    cy.findByTestId("create-api-key-modal")
+      .findAllByRole("alert")
+      .contains("An API key with this name already exists.");
+  });
 
   it("should allow deleting an API key", () => {
     H.createApiKey("Test API Key One", ALL_USERS_GROUP_ID);


### PR DESCRIPTION
Closes https://linear.app/metabase-inc/issue/ENG-14453/flaky-test-scenarios-admin-settings-api-keys-should-show-an-error-when

## Stress test
https://github.com/metabase/metabase/actions/runs/12986419889

### Description

The core of the problem seemed to be with how `H.modal` returns a scope in which `cy.button`  finds an element. there seems to be a break in retryability chain, and since `H.modal` can return either new or old modal, the flakiness happens when it is quick to find one of them, pass it on and then that modal disappears and UI shows the new one. `cy.button` then tries to search within invisible (or non-existent) element. I think an eslint rule for non-ambiguous elements might make sense here.

