### PR TITLE
Slightly tweaked the font size in gauge to make sure middle label is always visible

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Gauge/Gauge.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Gauge/Gauge.jsx
@@ -41,7 +41,7 @@ const getArrowFillColor = () => color("text-medium");
 const getArrowStrokeColor = () => color("bg-white");
 
 // in ems, but within the scaled 100px SVG element
-const FONT_SIZE_SEGMENT_LABEL = 0.285;
+const FONT_SIZE_SEGMENT_LABEL = 0.28;
 const FONT_SIZE_CENTER_LABEL_MIN = 0.5;
 const FONT_SIZE_CENTER_LABEL_MAX = 0.7;
 


### PR DESCRIPTION
Closes #47937 

### Description

The gauge labels are sometimes hidden based on whether there's enough room or not for them. The font size would basically never allow for a label right in the middle of the gauge.

### How to verify

See https://metaboat.slack.com/archives/C01LQQ2UW03/p1726258978599119 for additional explanation and context.