### PR TITLE
[Cards in Dashboards] Allow duplicating questions into dashboards

### DIFF
--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -285,6 +285,36 @@ describe("scenarios > models", () => {
     assertIsModel();
   });
 
+  it("allows duplicating a model", () => {
+    cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, { type: "model" });
+    cy.intercept("POST", "/api/card").as("cardCreate");
+    cy.visit(`/model/${ORDERS_QUESTION_ID}`);
+
+    H.openQuestionActions();
+    H.popover().within(() => {
+      cy.findByText("Duplicate").click();
+    });
+
+    H.modal().within(() => {
+      cy.findByLabelText("Name").should("have.value", "Orders - Duplicate");
+      cy.findByLabelText(/Where do you want to save this/).click();
+    });
+
+    H.entityPickerModal().within(() => {
+      cy.findByRole("tab", { name: /Collections/ }).click();
+
+      cy.findByText(/Select a collection$/).should("exist"); // title should not have trailing "or dashboard"
+      cy.findByText("Orders in a dashboard").should("not.exist"); // this dashboard would be present if dashboards were an allowed save target
+      cy.findByText("First collection").should("exist").click();
+      cy.findByRole("button", { name: "Select this collection" }).click();
+    });
+
+    H.modal().within(() => {
+      cy.findByText("Duplicate").click();
+      cy.wait("@cardCreate");
+    });
+  });
+
   it("shows 404 when opening a question with a /dataset URL", () => {
     cy.visit(`/model/${ORDERS_QUESTION_ID}`);
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -161,6 +161,7 @@ describe("scenarios > question > saved", () => {
     });
 
     H.entityPickerModal().within(() => {
+      cy.findByText("Select a collection or dashboard").should("exist");
       cy.findByText("Orders in a dashboard").click();
       cy.findByRole("button", { name: "Select this dashboard" }).click();
     });

--- a/frontend/src/metabase/collections/containers/FormCollectionAndDashboardPicker/FormCollectionAndDashboardPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionAndDashboardPicker/FormCollectionAndDashboardPicker.tsx
@@ -73,7 +73,7 @@ export function FormCollectionAndDashboardPicker({
   className,
   style,
   title,
-  placeholder = t`Select a collection or dashboard`,
+  placeholder,
   type = "collections",
   filterPersonalCollections,
   collectionPickerModalProps,
@@ -89,6 +89,10 @@ export function FormCollectionAndDashboardPicker({
   const dashboardField = useField(dashboardIdFieldName);
   const [dashboardIdInput, dashboardIdMeta, dashboardIdHelpers] =
     dashboardField;
+
+  const pickerTitle = collectionPickerModalProps?.models?.includes("dashboard")
+    ? t`Select a collection or dashboard`
+    : t`Select a collection`;
 
   const pickerValue = dashboardIdInput.value
     ? ({ id: dashboardIdInput.value, model: "dashboard" } as const)
@@ -202,13 +206,13 @@ export function FormCollectionAndDashboardPicker({
               type={type}
             />
           ) : (
-            placeholder
+            (placeholder ?? pickerTitle)
           )}
         </Button>
       </FormField>
       {isPickerOpen && (
         <CollectionPickerModal
-          title={t`Select a collection or dashboard`}
+          title={pickerTitle}
           value={pickerValue}
           onChange={handleChange}
           onClose={handleModalClose}

--- a/frontend/src/metabase/entities/containers/EntityCopyModal.tsx
+++ b/frontend/src/metabase/entities/containers/EntityCopyModal.tsx
@@ -64,6 +64,7 @@ const EntityCopyModal = ({
           onCancel={onClose}
           onSaved={onSaved}
           initialValues={initialValues}
+          model={entityObject?.type}
           {...props}
         />
       )}

--- a/frontend/src/metabase/questions/components/CopyQuestionForm.tsx
+++ b/frontend/src/metabase/questions/components/CopyQuestionForm.tsx
@@ -3,6 +3,7 @@ import { t } from "ttag";
 import * as Yup from "yup";
 
 import { FormCollectionAndDashboardPicker } from "metabase/collections/containers/FormCollectionAndDashboardPicker";
+import type { CollectionPickerModel } from "metabase/common/components/CollectionPicker";
 import { FormFooter } from "metabase/core/components/FormFooter";
 import {
   Form,
@@ -37,6 +38,7 @@ interface CopyQuestionFormProps {
   onCancel: () => void;
   onSubmit: (vals: CopyQuestionProperties) => Promise<Question>;
   onSaved: (newQuestion: Question) => void;
+  model?: string;
 }
 
 export const CopyQuestionForm = ({
@@ -44,6 +46,7 @@ export const CopyQuestionForm = ({
   onCancel,
   onSubmit,
   onSaved,
+  model,
 }: CopyQuestionFormProps) => {
   const computedInitialValues = useMemo<CopyQuestionProperties>(
     () => ({
@@ -57,6 +60,9 @@ export const CopyQuestionForm = ({
     const newQuestion = await onSubmit(vals);
     onSaved?.(newQuestion);
   };
+
+  const models: CollectionPickerModel[] =
+    model === "question" ? ["collection", "dashboard"] : ["collection"];
 
   return (
     <FormProvider
@@ -85,6 +91,15 @@ export const CopyQuestionForm = ({
           collectionIdFieldName="collection_id"
           dashboardIdFieldName="dashboard_id"
           title={t`Where do you want to save this?`}
+          collectionPickerModalProps={{
+            models,
+            recentFilter: items =>
+              items.filter(item => {
+                // narrow type and make sure it's a dashboard or
+                // collection that the user can write to
+                return item.model !== "table" && item.can_write;
+              }),
+          }}
         />
         <FormFooter>
           <FormErrorMessage inline />


### PR DESCRIPTION
[ENG-14403](https://linear.app/metabase-inc/issue/ENG-14403/duplicating-a-question-doesnt-allow-users-to-save-to-a-dashboard)

### Description

Allows duplicating a question into a dashboard. This action was overlooked in our initial implementation, so the same functionality for save has been brought over to duplicate.

### How to verify

- Visit a new question
- In the question menu, choose the "Duplicate" option
- Find a dashboard to save it in
- Save it to that dashboard

### Demo

https://github.com/user-attachments/assets/dd8458e0-765f-4785-a1eb-c5b68e0a8a94

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
