### PR TITLE
Disable query analysis (update e2e test)

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -48,7 +48,6 @@ jobs:
       CYPRESS_NO_FEATURES_TOKEN: ${{ secrets.E2E_STARTER_TOKEN }}
       CYPRESS_PULL_REQUEST_ID: ${{ github.event.pull_request.number || '' }}
       COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title || github.event.head_commit.message || github.event.head.sha }}
-      MB_QUERY_ANALYSIS_ENABLED: true
       MB_SNOWPLOW_AVAILABLE: true
       MB_SNOWPLOW_URL: "http://localhost:9090" # Snowplow micro
       TZ: US/Pacific # to make node match the instance tz

--- a/e2e/runner/cypress-runner-backend.js
+++ b/e2e/runner/cypress-runner-backend.js
@@ -70,10 +70,10 @@ const CypressBackend = {
         [...javaFlags, "-jar", "target/uberjar/metabase.jar"],
         {
           env: {
+            ...process.env,
             ...metabaseConfig,
             ...userDefaults,
             ...snowplowConfig,
-            PATH: process.env.PATH,
           },
           stdio:
             process.env["DISABLE_LOGGING"] ||

--- a/e2e/runner/cypress-runner-backend.js
+++ b/e2e/runner/cypress-runner-backend.js
@@ -70,10 +70,10 @@ const CypressBackend = {
         [...javaFlags, "-jar", "target/uberjar/metabase.jar"],
         {
           env: {
-            ...process.env,
             ...metabaseConfig,
             ...userDefaults,
             ...snowplowConfig,
+            PATH: process.env.PATH,
           },
           stdio:
             process.env["DISABLE_LOGGING"] ||

--- a/e2e/test/scenarios/admin/query-validator.cy.spec.js
+++ b/e2e/test/scenarios/admin/query-validator.cy.spec.js
@@ -7,7 +7,7 @@ const SCOREBOARD_TABLE = "scoreboard_actions";
 const COLORS_TABLE = "colors27745";
 
 H.describeEE("query validator", { tags: "@external" }, () => {
-  describe("feature disbaled", () => {
+  describe("feature disabled", () => {
     beforeEach(() => {
       H.restore("postgres-writable");
       cy.signInAsAdmin();
@@ -32,6 +32,7 @@ H.describeEE("query validator", { tags: "@external" }, () => {
       H.restore("postgres-writable");
       cy.signInAsAdmin();
       H.setTokenFeatures("all");
+      H.updateSetting("query-analysis-enabled", true);
     });
 
     it("enable query analysis setting", () => {


### PR DESCRIPTION
follow up to #52728 to fix tests

- Removes setting query analysis setting by environment variable, this breaks test that expect the setting to be toggle-able
- turn the setting on for tests that assume it is on