### PR TITLE
Use features instead of hard-coded driver names in tests

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -4,6 +4,10 @@ title: Driver interface changelog
 
 # Driver Interface Changelog
 
+## Metabase 0.53.0 
+
+- Added the multi-method `bad-connection-details` to allow mocking bad connection parameters for tests.
+
 ## Metabase 0.52.0
 
 - The Docker image for Metabase 0.52.0 now uses Java 21 instead of Java 11. Please make sure to test your driver

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -717,7 +717,12 @@
     ;; Whether the driver supports loading dynamic test datasets on each test run. Eg. datasets with names like
     ;; `checkins:4-per-minute` are created dynamically in each test run. This should be truthy for every driver we test
     ;; against except for Athena and Databricks which currently require test data to be loaded separately.
-    :test/dynamic-dataset-loading})
+    :test/dynamic-dataset-loading
+    :test/creates-db-on-connect
+    :test/details-name-is-db
+    :test/details-name-is-service-name
+    :test/details-name-is-catalog
+    :test/cannot-destroy-db})
 
 (defmulti database-supports?
   "Does this driver and specific instance of a database support a certain `feature`?

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -719,9 +719,6 @@
     ;; against except for Athena and Databricks which currently require test data to be loaded separately.
     :test/dynamic-dataset-loading
     :test/creates-db-on-connect
-    :test/details-name-is-db
-    :test/details-name-is-service-name
-    :test/details-name-is-catalog
     :test/cannot-destroy-db})
 
 (defmulti database-supports?

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -718,7 +718,13 @@
     ;; `checkins:4-per-minute` are created dynamically in each test run. This should be truthy for every driver we test
     ;; against except for Athena and Databricks which currently require test data to be loaded separately.
     :test/dynamic-dataset-loading
+
+    ;; Some DBs allow you to connect to a DB that doesn't exist by creating it for you. 
+    ;; This is to allow such DBs to opt out of tests that rely on not being able to connect to non-existent DBs.
     :test/creates-db-on-connect
+
+    ;; For some cloud DBs the test database is never created, and can't or shouldn't be destroyed. 
+    ;; This is to allow avoiding destroying the test DBs of such cloud DBs.
     :test/cannot-destroy-db})
 
 (defmulti database-supports?

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -719,11 +719,11 @@
     ;; against except for Athena and Databricks which currently require test data to be loaded separately.
     :test/dynamic-dataset-loading
 
-    ;; Some DBs allow you to connect to a DB that doesn't exist by creating it for you. 
+    ;; Some DBs allow you to connect to a DB that doesn't exist by creating it for you.
     ;; This is to allow such DBs to opt out of tests that rely on not being able to connect to non-existent DBs.
     :test/creates-db-on-connect
 
-    ;; For some cloud DBs the test database is never created, and can't or shouldn't be destroyed. 
+    ;; For some cloud DBs the test database is never created, and can't or shouldn't be destroyed.
     ;; This is to allow avoiding destroying the test DBs of such cloud DBs.
     :test/cannot-destroy-db})
 

--- a/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
@@ -756,7 +756,7 @@
          (is (= #{{:type :normal-column-index :value "id"}}
                 (describe-table-indexes (t2/select-one :model/Table (mt/id :conditional_index))))))))))
 
-(defmethod driver/database-supports? [::driver/driver ::materialized-view-fields]
+(defmethod driver/database-supports? [::driver/driver ::describe-materialized-view-fields]
   [_driver _feature _database]
   true)
 

--- a/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
@@ -783,7 +783,8 @@
                 :mongo
                 :sparksql
                 :sqlite
-                :athena]]
+                :athena
+                :vertica]]
   (defmethod driver/database-supports? [driver ::describe-materialized-view-fields]
     [_driver _feature _database]
     false))

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -84,9 +84,30 @@
                          :field-definitions [{:field-name "foo", :base-type :type/Text}]
                          :rows              [["bar"]]}]}))
 
+(doseq [driver [:redshift :snowflake :oracle]]
+        (defmethod driver/database-supports? [driver :test/details-name-is-db]
+          [_driver _feature _database]
+          true))
+
+(doseq [driver [:oracle]]
+        (defmethod driver/database-supports? [driver :test/details-name-is-service-name]
+          [_driver _feature _database]
+          true))
+
+(doseq [driver [:presto-jdbc]]
+        (defmethod driver/database-supports? [driver :test/details-name-is-catalog]
+          [_driver _feature _database]
+          true))
+
+(doseq [driver [:redshift :snowflake :vertica :presto-jdbc :oracle]]
+        (defmethod driver/database-supports? [driver :test/cannot-destroy-db]
+          [_driver _feature _database]
+          true))
+
 (deftest can-connect-with-destroy-db-test
   (testing "driver/can-connect? should fail or throw after destroying a database"
-    (mt/test-drivers (mt/normal-drivers-with-feature :test/dynamic-dataset-loading)
+    (mt/test-drivers (set/difference (mt/normal-drivers-with-feature :test/dynamic-dataset-loading)
+                                     (mt/normal-drivers-with-feature :test/creates-db-on-connect))
       (let [database-name (mt/random-name)
             dbdef         (basic-db-definition database-name)]
         (mt/dataset dbdef
@@ -100,11 +121,15 @@
             (testing "after deleting a database, can-connect? should return false or throw an exception"
               (let [;; in the case of some cloud databases, the test database is never created, and can't or shouldn't be destroyed.
                     ;; so fake it by changing the database details
-                    details (case driver/*driver*
-                              (:redshift :snowfake :vertica) (assoc details :db (mt/random-name))
-                              :oracle                        (assoc details :service-name (mt/random-name))
-                              :presto-jdbc                   (assoc details :catalog (mt/random-name))
+                    details (cond
+                              (driver/database-supports? driver/*driver* :test/details-name-is-db (mt/db))
+                              (assoc details :db (mt/random-name))
+                              (driver/database-supports? driver/*driver* :test/details-name-is-service-name (mt/db))
+                              (assoc details :service-name (mt/random-name))
+                              (driver/database-supports? driver/*driver* :test/details-name-is-catalog (mt/db))
+                              (assoc details :catalog (mt/random-name))
                               ;; otherwise destroy the db and use the original details
+                              :else
                               (do
                                 (tx/destroy-db! driver/*driver* dbdef)
                                 details))]
@@ -118,7 +143,8 @@
 
 (deftest check-can-connect-before-sync-test
   (testing "Database sync should short-circuit and fail if the database at the connection has been deleted (metabase#7526)"
-    (mt/test-drivers (mt/normal-drivers-with-feature :test/dynamic-dataset-loading)
+    (mt/test-drivers (set/difference (mt/normal-drivers-with-feature :test/dynamic-dataset-loading)
+                                     (mt/normal-drivers-with-feature :test/creates-db-on-connect))
       (let [database-name (mt/random-name)
             dbdef         (basic-db-definition database-name)]
         (mt/dataset dbdef
@@ -142,14 +168,17 @@
             ;; release db resources like connection pools so we don't have to wait to finish syncing before destroying the db
             (driver/notify-database-updated driver/*driver* db)
             ;; destroy the db
-            (if (contains? #{:redshift :snowflake :vertica :presto-jdbc :oracle} driver/*driver*)
+            (if (driver/database-supports? driver/*driver* :test/cannot-destroy-db (mt/db))
               ;; in the case of some cloud databases, the test database is never created, and can't or shouldn't be destroyed.
               ;; so fake it by changing the database details
               (let [details     (:details (mt/db))
-                    new-details (case driver/*driver*
-                                  (:redshift :snowflake :vertica) (assoc details :db (mt/random-name))
-                                  :oracle                         (assoc details :service-name (mt/random-name))
-                                  :presto-jdbc                    (assoc details :catalog (mt/random-name)))]
+                    new-details (cond
+                                  (driver/database-supports? driver/*driver* :test/details-name-is-db (mt/db))
+                                  (assoc details :db (mt/random-name))
+                                  (driver/database-supports? driver/*driver* :test/details-name-is-service-name (mt/db))
+                                  (assoc details :service-name (mt/random-name))
+                                  (driver/database-supports? driver/*driver* :test/details-name-is-catalog (mt/db))
+                                  (assoc details :catalog (mt/random-name)))]
                 (t2/update! :model/Database (u/the-id db) {:details new-details}))
               ;; otherwise destroy the db and use the original details
               (tx/destroy-db! driver/*driver* dbdef))

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -92,17 +92,17 @@
 (doseq [driver [:redshift :snowflake :vertica]]
   (defmethod bad-connection-details driver
     [_driver]
-    :db))
+    {:db (mt/random-name)}))
 
 (doseq [driver [:oracle]]
   (defmethod bad-connection-details driver
     [_driver]
-    :service-name))
+    {:service-name (mt/random-name)}))
 
 (doseq [driver [:presto-jdbc]]
   (defmethod bad-connection-details driver
     [_driver]
-    :catalog))
+    {:catalog (mt/random-name)}))
 
 (doseq [driver [:redshift :snowflake :vertica :presto-jdbc :oracle]]
   (defmethod driver/database-supports? [driver :test/cannot-destroy-db]
@@ -127,7 +127,7 @@
               (let [;; in the case of some cloud databases, the test database is never created, and can't or shouldn't be destroyed.
                     ;; so fake it by changing the database details
                     details (if (driver/database-supports? driver/*driver* :test/cannot-destroy-db (mt/db))
-                              (assoc details (bad-connection-details driver/*driver*) (mt/random-name))
+                              (merge details (bad-connection-details driver/*driver*))
                               ;; otherwise destroy the db and use the original details
                               (do
                                 (tx/destroy-db! driver/*driver* dbdef)
@@ -171,7 +171,7 @@
               ;; in the case of some cloud databases, the test database is never created, and can't or shouldn't be destroyed.
               ;; so fake it by changing the database details
               (let [details     (:details (mt/db))
-                    new-details (assoc details (bad-connection-details driver/*driver*) (mt/random-name))]
+                    new-details (merge details (bad-connection-details driver/*driver*))]
                 (t2/update! :model/Database (u/the-id db) {:details new-details}))
               ;; otherwise destroy the db and use the original details
               (tx/destroy-db! driver/*driver* dbdef))

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -84,7 +84,7 @@
                          :field-definitions [{:field-name "foo", :base-type :type/Text}]
                          :rows              [["bar"]]}]}))
 
-(doseq [driver [:redshift :snowflake :oracle]]
+(doseq [driver [:redshift :snowflake :vertica]]
   (defmethod driver/database-supports? [driver :test/details-name-is-db]
     [_driver _feature _database]
     true))

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -85,24 +85,24 @@
                          :rows              [["bar"]]}]}))
 
 (doseq [driver [:redshift :snowflake :oracle]]
-        (defmethod driver/database-supports? [driver :test/details-name-is-db]
-          [_driver _feature _database]
-          true))
+  (defmethod driver/database-supports? [driver :test/details-name-is-db]
+    [_driver _feature _database]
+    true))
 
 (doseq [driver [:oracle]]
-        (defmethod driver/database-supports? [driver :test/details-name-is-service-name]
-          [_driver _feature _database]
-          true))
+  (defmethod driver/database-supports? [driver :test/details-name-is-service-name]
+    [_driver _feature _database]
+    true))
 
 (doseq [driver [:presto-jdbc]]
-        (defmethod driver/database-supports? [driver :test/details-name-is-catalog]
-          [_driver _feature _database]
-          true))
+  (defmethod driver/database-supports? [driver :test/details-name-is-catalog]
+    [_driver _feature _database]
+    true))
 
 (doseq [driver [:redshift :snowflake :vertica :presto-jdbc :oracle]]
-        (defmethod driver/database-supports? [driver :test/cannot-destroy-db]
-          [_driver _feature _database]
-          true))
+  (defmethod driver/database-supports? [driver :test/cannot-destroy-db]
+    [_driver _feature _database]
+    true))
 
 (deftest can-connect-with-destroy-db-test
   (testing "driver/can-connect? should fail or throw after destroying a database"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/52045
Closes https://linear.app/metabase-inc/issue/ENG-9513/feature-exclusion-for-materialize

### Description

Adds features that can be used to modify test behaviour instead of using hard-coded driver names. 

`:test/creates-db-on-connect`

Materialize allows you to connect to a DB that does not exist, so this feature provides a way to opt out of the `can-connect-with-destroy-db-test` and `check-can-connect-before-sync-test` tests which check for failure after attempting to connect to a DB that does not exist. 

---

`:test/cannot-destroy-db`

`[:redshift :snowflake :vertica :presto-jdbc :oracle]` cannot have their DBs destroyed because they are cloud DBs. This feature gives a way for drivers to specify that their DBs should not be destroyed during tests. 

---

`:test/details-name-is-db`, `:test/details-name-is-service-name`, `:test/details-name-is-catalog`

Because we can't destroy the DBs for all drivers, we mock the failed connection attempt by overwriting a connection detail with an invalid name. These features give a way to specify which connection detail should be overwritten for each driver. 

### How to verify

The tests should pass and not reference specific drivers in the tests. 

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
