### PR TITLE
Make public dashcards download endpoint match FE expectations

### DIFF
--- a/src/metabase/api/macros.clj
+++ b/src/metabase/api/macros.clj
@@ -546,7 +546,9 @@
 (mu/defn- request-body
   [request :- :map]
   (or (some-> (not-empty (:form-params request)) (update-keys keyword))
-      (:body request)))
+      (when-let [body (:body request)]
+        (when-not (instance? org.eclipse.jetty.server.HttpInput body)
+          body))))
 
 (mu/defn- middleware-forms
   "Middleware to apply to base handler. Currently the only option is middleware for handling multipart requests, applied

--- a/src/metabase/api/macros.clj
+++ b/src/metabase/api/macros.clj
@@ -543,6 +543,11 @@
     :route (:route-params request)
     :query (some-> (:query-params request) (update-keys keyword))))
 
+(mu/defn- request-body
+  [request :- :map]
+  (or (some-> (not-empty (:form-params request)) (update-keys keyword))
+      (:body request)))
+
 (mu/defn- middleware-forms
   "Middleware to apply to base handler. Currently the only option is middleware for handling multipart requests, applied
   if the handler metadata contains
@@ -564,13 +569,13 @@
                   (fn async-handler [request respond raise]
                     (let [route-params (defendpoint-params request :route)
                           query-params (defendpoint-params request :query)
-                          body-params  (:body request)]
+                          body-params  (request-body request)]
                       (core-fn respond raise route-params query-params body-params request)))
                   (fn handler [request respond raise]
                     (try
                       (let [route-params (defendpoint-params request :route)
                             query-params (defendpoint-params request :query)
-                            body-params  (:body request)]
+                            body-params  (request-body request)]
                         (respond (core-fn route-params query-params body-params request)))
                       (catch Throwable e
                         (raise e)))))]

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -324,7 +324,7 @@
                                                                                          (fn [x]
                                                                                            (cond-> x
                                                                                              (string? x) json/decode+kw))}
-                                                                                        :map]]
+                                                                                        [:sequential :map]]]
                                                       [:format_rows   {:default false} ms/BooleanValue]
                                                       [:pivot_results {:default false} ms/BooleanValue]]]
   (validation/check-public-sharing-enabled)

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -317,8 +317,14 @@
                                                         [:dashcard-id   ms/PositiveInt]
                                                         [:card-id       ms/PositiveInt]
                                                         [:export-format (into [:enum] api.dataset/export-formats)]]
+   _query-parameters
    {:keys [format_rows pivot_results parameters]} :- [:map
-                                                      [:parameters    {:optional true} [:maybe ms/JSONString]]
+                                                      [:parameters    {:optional true} [:maybe
+                                                                                        {:decode/api
+                                                                                         (fn [x]
+                                                                                           (cond-> x
+                                                                                             (string? x) json/decode+kw))}
+                                                                                        :map]]
                                                       [:format_rows   {:default false} ms/BooleanValue]
                                                       [:pivot_results {:default false} ms/BooleanValue]]]
   (validation/check-public-sharing-enabled)

--- a/test/metabase/api/downloads_exports_test.clj
+++ b/test/metabase/api/downloads_exports_test.clj
@@ -57,7 +57,8 @@
   [pivot export-format results]
   (when (seq results)
     (case export-format
-      :csv  (csv/read-csv results)
+      :csv  (cond-> results
+              (not (map? results)) csv/read-csv)
       :xlsx (read-xlsx pivot results)
       :json (tabulate-maps results))))
 
@@ -126,8 +127,8 @@
               (->> (mt/user-http-request :crowberto :post 200
                                          (format "public/dashboard/%s/dashcard/%d/card/%d/%s"
                                                  public-uuid dashcard-id card-id (name export-format))
-                                         :format_rows   format-rows
-                                         :pivot_results pivot)
+                                         {:format_rows   format-rows
+                                          :pivot_results pivot})
                    (process-results pivot export-format)))]
       (if (= :model/DashboardCard (t2/model card-or-dashcard))
         (mt/with-temp [:model/Dashboard {dashboard-id :id} {:public_uuid public-uuid}]

--- a/test/metabase/http_client.clj
+++ b/test/metabase/http_client.clj
@@ -77,6 +77,9 @@
       (= "multipart/form-data" content-type)
       (peridot.multipart/build http-body)
 
+      (= "application/x-www-form-urlencoded" content-type)
+      {:body (ByteArrayInputStream. (.getBytes ^String (codec/form-encode http-body) "UTF-8"))}
+
       :else
       (throw (ex-info "If you want this content-type to work, improve me"
                       {:content-type content-type})))))

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -354,6 +354,7 @@
                                                       :format_rows true)]
                     ((-> assertions export-format) results))
 
+                  ;; TODO -- what about the public dashcard endpoint???
                   :public
                   (let [results (mt/user-http-request user :get 200
                                                       (format "public/card/%s/query/%s?format_rows=true" public-uuid (name export-format))


### PR DESCRIPTION
While working on getting some of my other PRs green and[ wrapping my head around how things work](https://metaboat.slack.com/archives/C010L1Z4F9S/p1738003606875659) I realized that the public dashcards download endpoint does not match the shape the frontend uses here.

https://github.com/metabase/metabase/blob/d304dae6686ab52c876b758659ef7792be631514/frontend/src/metabase/redux/downloads.ts#L182-L189

Before `defendpoint` 2 it accepted stuff like `format_rows` in either query params **or** request body, the backend tests assumed query params but the FE prod code used request bodies; when I converted to `defendpoint` 2 I followed the backend tests. There are no FE e2e tests around this.

This PR adjusts the endpoint to match FE code and updates BE tests.

I already raised the issue that there are no e2e tests around this separately, but in the meantime I can fix the endpoint and make sure it matches FE expectations.
