### PR TITLE
Allow dashes in hashes

### DIFF
--- a/e2e/support/ci_tasks.ts
+++ b/e2e/support/ci_tasks.ts
@@ -89,7 +89,7 @@ async function addOrUpdateComment({
 }
 
 function getExistingCommentSha(commentBody: string): string | undefined {
-  const hash = commentBody.match(/failed on `([a-f0-9]+)`/);
+  const hash = commentBody.match(/failed on `([a-f0-9\-]+)`/);
   return hash?.[1];
 }
 


### PR DESCRIPTION
Fixes the instant test update comment to show more than one test failure. There was a bug in the regex that didn't see `-` as a valid component of a hash - but the format for the hash in this context is actually `$HASH-$ATTEMPT` - so we gotta included `-` in the regex for it to detect the comment properly.