### PR TITLE
[Cards in Dashboards] Trash UI when removing last dashcard for a dashboard question

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
@@ -541,6 +541,59 @@ describe("Dashboard > Dashboard Questions", () => {
       H.navigationSidebar().findByText("Orders").should("be.visible");
     });
 
+    it("shows trash action for the last dashcard for a dashboard question", () => {
+      H.createDashboard({
+        name: "Foo Dashboard",
+      }).then(({ body: dashboard }) => {
+        H.createQuestion({
+          name: "Foo dashboard question",
+          query: { "source-table": SAMPLE_DATABASE.ORDERS_ID, limit: 5 },
+          dashboard_id: dashboard.id,
+        }).then(({ body: card }) => {
+          H.addOrUpdateDashboardCard({
+            card_id: card.id,
+            dashboard_id: dashboard.id,
+            card: {
+              size_x: 6,
+              size_y: 6,
+            },
+          });
+
+          H.visitDashboard(dashboard.id);
+        });
+      });
+
+      H.editDashboard();
+
+      cy.log(
+        "should have trash option as only dashcard for dashboard question",
+      );
+      H.showDashboardCardActions(0);
+      cy.icon("trash").realHover();
+      H.tooltip().findByText("Remove and trash").should("exist");
+
+      cy.log(
+        "should have remove options if there's more than one dashcard for the dashboard question",
+      );
+      cy.icon("copy").click();
+      cy.findAllByTestId("dashcard").should("have.length", 2);
+      H.showDashboardCardActions(0);
+      cy.icon("trash").should("not.exist");
+      cy.icon("close").should("exist");
+
+      cy.log(
+        "should have the trash option if changes leave only one dashcard for a question",
+      );
+      cy.findAllByTestId("dashcard").eq(1).realHover().icon("close").click();
+      cy.findAllByTestId("dashcard").should("have.length", 1);
+      H.showDashboardCardActions(0);
+      cy.icon("trash").should("exist");
+
+      cy.log("should notify user that removal will also trash the card");
+      cy.icon("trash").click();
+      cy.findAllByTestId("dashcard").should("have.length", 0);
+    });
+
     it("can delete a question from a dashboard without deleting all of the questions in metabase", () => {
       H.createQuestion({
         name: "Total Orders",
@@ -579,8 +632,8 @@ describe("Dashboard > Dashboard Questions", () => {
       H.editDashboard();
       H.dashboardCards().findByText("Total Orders").realHover();
       // eslint-disable-next-line no-unsafe-element-filtering
-      cy.icon("close").last().click();
-      H.undoToast().findByText("Removed card");
+      cy.icon("trash").last().click();
+      H.undoToast().findByText("Trashed and removed card");
       H.saveDashboard();
 
       // check that we didn't accidentally delete everything

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -67,9 +67,11 @@ export interface DashCardProps {
   isXray?: boolean;
   withTitle?: boolean;
 
+  /** Bool if removing the dashcard will queue the card to be trashed on dashboard save */
+  isTrashedOnRemove: boolean;
+  onRemove: (dashcard: StoreDashcard) => void;
   onAddSeries: (dashcard: StoreDashcard) => void;
   onReplaceCard: (dashcard: StoreDashcard) => void;
-  onRemove: (dashcard: StoreDashcard) => void;
   markNewCardSeen: (dashcardId: DashCardId) => void;
   navigateToNewCardFromDashboard?: (
     opts: NavigateToNewCardFromDashboardOpts,
@@ -109,9 +111,10 @@ function DashCardInner({
   isEditingParameter,
   clickBehaviorSidebarDashcard,
   withTitle = true,
+  isTrashedOnRemove,
+  onRemove,
   onAddSeries,
   onReplaceCard,
-  onRemove,
   navigateToNewCardFromDashboard,
   markNewCardSeen,
   showClickBehaviorSidebar,
@@ -337,6 +340,7 @@ function DashCardInner({
             }
             showClickBehaviorSidebar={handleShowClickBehaviorSidebar}
             onPreviewToggle={handlePreviewToggle}
+            isTrashedOnRemove={isTrashedOnRemove}
           />
         )}
         <DashCardVisualization

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
@@ -34,6 +34,7 @@ interface Props {
   isLoading: boolean;
   isPreviewing: boolean;
   hasError: boolean;
+  isTrashedOnRemove: boolean;
   onRemove: (dashcard: DashboardCard) => void;
   onAddSeries: (dashcard: DashboardCard) => void;
   onReplaceCard: (dashcard: DashboardCard) => void;
@@ -58,6 +59,7 @@ function DashCardActionsPanelInner({
   isLoading,
   isPreviewing,
   hasError,
+  isTrashedOnRemove,
   onRemove,
   onAddSeries,
   onReplaceCard,
@@ -237,6 +239,23 @@ function DashCardActionsPanelInner({
     }
   }
 
+  if (isTrashedOnRemove) {
+    buttons.push(
+      <DashCardActionButton
+        onClick={handleRemoveCard}
+        tooltip={t`Remove and trash`}
+      >
+        <DashCardActionButton.Icon name="trash" />
+      </DashCardActionButton>,
+    );
+  } else {
+    buttons.push(
+      <DashCardActionButton onClick={handleRemoveCard} tooltip={t`Remove`}>
+        <DashCardActionButton.Icon name="close" />
+      </DashCardActionButton>,
+    );
+  }
+
   return (
     <>
       <DashCardActionsPanelContainer
@@ -247,9 +266,6 @@ function DashCardActionsPanelInner({
       >
         <DashCardActionButtonsContainer>
           {buttons}
-          <DashCardActionButton onClick={handleRemoveCard} tooltip={t`Remove`}>
-            <DashCardActionButton.Icon name="close" />
-          </DashCardActionButton>
         </DashCardActionButtonsContainer>
       </DashCardActionsPanelContainer>
     </>

--- a/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
@@ -81,6 +81,7 @@ function setup({
       {...props}
       onAddSeries={jest.fn()}
       onReplaceCard={onReplaceCard}
+      isTrashedOnRemove={false}
       onRemove={jest.fn()}
       markNewCardSeen={jest.fn()}
       navigateToNewCardFromDashboard={jest.fn()}

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -39,6 +39,7 @@ import type { QueryClickActionsMode } from "metabase/visualizations/types";
 import {
   type BaseDashboardCard,
   type Card,
+  type CardId,
   type DashCardId,
   type Dashboard,
   type DashboardCard,
@@ -98,6 +99,7 @@ interface DashboardGridState {
   replaceCardModalDashCard: BaseDashboardCard | null;
   isDragging: boolean;
   isAnimationPaused: boolean;
+  dashcardCountByCardId: Record<CardId, number>;
 }
 
 const mapStateToProps = (state: State) => ({
@@ -168,6 +170,9 @@ class DashboardGrid extends Component<DashboardGridProps, DashboardGridState> {
 
     this.state = {
       visibleCardIds,
+      dashcardCountByCardId: this.getDashcardCountByCardId(
+        props.dashboard.dashcards,
+      ),
       initialCardSizes: this.getInitialCardSizes(props.dashboard.dashcards),
       layouts: this.getLayouts(props.dashboard.dashcards),
       addSeriesModalDashCard: null,
@@ -196,6 +201,16 @@ class DashboardGrid extends Component<DashboardGridProps, DashboardGridState> {
   componentWillUnmount() {
     if (this._pauseAnimationTimer !== null) {
       clearTimeout(this._pauseAnimationTimer);
+    }
+  }
+
+  componentDidUpdate(prevProps: DashboardGridProps) {
+    if (prevProps.dashboard.dashcards !== this.props.dashboard.dashcards) {
+      this.setState({
+        dashcardCountByCardId: this.getDashcardCountByCardId(
+          this.props.dashboard.dashcards,
+        ),
+      });
     }
   }
 
@@ -350,6 +365,17 @@ class DashboardGrid extends Component<DashboardGridProps, DashboardGridState> {
       : tabCards.filter(card => visibleCardIds.has(card.id));
   };
 
+  getDashcardCountByCardId = (cards: BaseDashboardCard[]) =>
+    _.countBy(cards, "card_id");
+
+  getIsLastDashboardQuestionDashcard = (dc: BaseDashboardCard): boolean => {
+    return Boolean(
+      dc.card.dashboard_id !== null &&
+        dc.card_id &&
+        this.state.dashcardCountByCardId[dc.card_id] <= 1,
+    );
+  };
+
   getLayouts(cards: BaseDashboardCard[]) {
     const desktop = cards.map(this.getLayoutForDashCard);
     const mobile = generateMobileLayout(desktop);
@@ -484,7 +510,9 @@ class DashboardGrid extends Component<DashboardGridProps, DashboardGridState> {
     });
 
     this.props.addUndo({
-      message: t`Removed card`,
+      message: this.getIsLastDashboardQuestionDashcard(dc)
+        ? t`Trashed and removed card`
+        : t`Removed card`,
       undo: true,
       action: () =>
         this.props.undoRemoveCardFromDashboard({ dashcardId: dc.id }),
@@ -551,6 +579,7 @@ class DashboardGrid extends Component<DashboardGridProps, DashboardGridState> {
         clickBehaviorSidebarDashcard={this.props.clickBehaviorSidebarDashcard}
         downloadsEnabled={downloadsEnabled}
         autoScroll={shouldAutoScrollTo}
+        isTrashedOnRemove={this.getIsLastDashboardQuestionDashcard(dashcard)}
         reportAutoScrolledToDashcard={reportAutoScrolledToDashcard}
       />
     );


### PR DESCRIPTION
[ENG-14500](https://linear.app/metabase-inc/issue/ENG-14500/last-dashcard-for-a-dashboard-question-should-show-trash-ui)

### Description

Updates the dashboard actions so that the last dashcard for a dashboard question highlights the fact that it will also get trashed as part of being removed from the dashboard. Additionally, the undo toast's copy now reflects trash + removal.

### How to verify

- Go to a dashboard, add a new dashboard question to it
- The remove button for your new dashboard question should be a trash button
- Duplicate the dashcard
- Both dash cards should be the normal remove UI, neither should be a trash button
- Remove one of the dashcards, the other should have a trash button again
- Add a normal / non-dashboard question to your dashboard, it should never have a trash button

### Demo

https://github.com/user-attachments/assets/e5efcb41-3579-4cec-a0df-8649a0903ee6

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
