### PR TITLE
Auto reset data db for writable db tests

### DIFF
--- a/e2e/support/helpers/e2e-qa-databases-helpers.js
+++ b/e2e/support/helpers/e2e-qa-databases-helpers.js
@@ -221,6 +221,9 @@ export function resetWritableDb({ type = "postgres" }) {
   cy.task("resetWritableDb", { type });
 }
 
+/**
+ * Note: this function MUST come after the restore() function in the file, or it will get wiped out
+ */
 export function resetTestTable({ type, table }) {
   cy.task("resetTable", { type, table });
 }

--- a/e2e/support/helpers/e2e-qa-databases-helpers.js
+++ b/e2e/support/helpers/e2e-qa-databases-helpers.js
@@ -216,6 +216,11 @@ export function queryWritableDB(query, type = "postgres") {
   });
 }
 
+export function resetWritableDb({ type = "postgres" }) {
+  cy.log(`Resetting ${type} writable DB`);
+  cy.task("resetWritableDb", { type });
+}
+
 export function resetTestTable({ type, table }) {
   cy.task("resetTable", { type, table });
 }

--- a/e2e/support/helpers/e2e-setup-helpers.js
+++ b/e2e/support/helpers/e2e-setup-helpers.js
@@ -1,3 +1,5 @@
+import { resetWritableDb } from "./e2e-qa-databases-helpers";
+
 export function snapshot(name) {
   cy.request("POST", `/api/testing/snapshot/${name}`);
 }
@@ -21,5 +23,13 @@ export function restore(name = "default") {
   cy.skipOn(name.includes("mongo") && Cypress.env("QA_DB_MONGO") !== true);
 
   cy.log("Restore Data Set");
+
+  // automatically reset the data db if this is a test that uses a writable db
+  if (name.includes("-writable")) {
+    const dbType = name.includes("postgres") ? "postgres" : "mysql";
+
+    resetWritableDb({ type: dbType });
+  }
+
   return cy.request("POST", `/api/testing/restore/${name}`);
 }

--- a/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
@@ -27,8 +27,8 @@ describe(
         "prefetchValues",
       );
 
-      H.resetTestTable({ type: "postgres", table: WRITABLE_TEST_TABLE });
       H.restore("postgres-writable");
+      H.resetTestTable({ type: "postgres", table: WRITABLE_TEST_TABLE });
       asAdmin(() => {
         cy.updatePermissionsGraph({
           [ALL_USERS_GROUP]: {

--- a/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
@@ -35,8 +35,8 @@ const MODEL_NAME = "Test Action Model";
       H.describeWithSnowplow("adding and executing actions", () => {
         beforeEach(() => {
           H.resetSnowplow();
-          H.resetTestTable({ type: dialect, table: TEST_TABLE });
           H.restore(`${dialect}-writable`);
+          H.resetTestTable({ type: dialect, table: TEST_TABLE });
           cy.signInAsAdmin();
           H.enableTracking();
           H.resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: TEST_TABLE });
@@ -528,8 +528,8 @@ const MODEL_NAME = "Test Action Model";
 
       describe("Actions Data Types", () => {
         beforeEach(() => {
-          H.resetTestTable({ type: dialect, table: TEST_COLUMNS_TABLE });
           H.restore(`${dialect}-writable`);
+          H.resetTestTable({ type: dialect, table: TEST_COLUMNS_TABLE });
           cy.signInAsAdmin();
           H.resyncDatabase({
             dbId: WRITABLE_DB_ID,
@@ -902,8 +902,8 @@ const MODEL_NAME = "Test Action Model";
         );
 
         beforeEach(() => {
-          H.resetTestTable({ type: dialect, table: TEST_COLUMNS_TABLE });
           H.restore(`${dialect}-writable`);
+          H.resetTestTable({ type: dialect, table: TEST_COLUMNS_TABLE });
           cy.signInAsAdmin();
           H.resyncDatabase({
             dbId: WRITABLE_DB_ID,
@@ -1024,8 +1024,8 @@ const MODEL_NAME = "Test Action Model";
 
 describe("action error handling", { tags: ["@external", "@actions"] }, () => {
   beforeEach(() => {
-    H.resetTestTable({ type: "postgres", table: TEST_TABLE });
     H.restore("postgres-writable");
+    H.resetTestTable({ type: "postgres", table: TEST_TABLE });
     cy.signInAsAdmin();
     H.resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: TEST_TABLE });
     H.createModelFromTableName({
@@ -1096,8 +1096,8 @@ describe(
 
     describe("Inline action edit", () => {
       beforeEach(() => {
-        H.resetTestTable({ type: "postgres", table: TEST_TABLE });
         H.restore("postgres-writable");
+        H.resetTestTable({ type: "postgres", table: TEST_TABLE });
         cy.signInAsAdmin();
         H.resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: TEST_TABLE });
         H.createModelFromTableName({

--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -329,8 +329,8 @@ describe(
           "disableActionSharing",
         );
 
-        H.resetTestTable({ type: dialect, table: WRITABLE_TEST_TABLE });
         H.restore(`${dialect}-writable`);
+        H.resetTestTable({ type: dialect, table: WRITABLE_TEST_TABLE });
         cy.signInAsAdmin();
         H.resyncDatabase({
           dbId: WRITABLE_DB_ID,

--- a/e2e/test/scenarios/admin/admin-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/admin/admin-reproductions.cy.spec.js
@@ -68,8 +68,8 @@ describe("issue 41765", { tags: ["@external", "@flaky"] }, () => {
   const COLUMN_DISPLAY_NAME = "Another Column";
 
   beforeEach(() => {
-    H.resetTestTable({ type: "postgres", table: TEST_TABLE });
     H.restore("postgres-writable");
+    H.resetTestTable({ type: "postgres", table: TEST_TABLE });
     cy.signInAsAdmin();
 
     H.resyncDatabase({

--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.js
@@ -292,8 +292,8 @@ describe("Unfold JSON", { tags: "@external" }, () => {
   }
 
   beforeEach(() => {
-    H.resetTestTable({ type: "postgres", table: "many_data_types" });
     H.restore("postgres-writable");
+    H.resetTestTable({ type: "postgres", table: "many_data_types" });
     cy.signInAsAdmin();
     H.resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: "many_data_types" });
   });

--- a/e2e/test/scenarios/admin/datamodel/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/reproductions.cy.spec.js
@@ -196,8 +196,8 @@ describe("issue 15542", () => {
 
 describe("issue 52411", { tags: "@external" }, () => {
   beforeEach(() => {
-    H.resetTestTable({ type: "postgres", table: "multi_schema" });
     H.restore("postgres-writable");
+    H.resetTestTable({ type: "postgres", table: "multi_schema" });
     cy.signInAsAdmin();
     H.resyncDatabase({ dbId: WRITABLE_DB_ID });
   });

--- a/e2e/test/scenarios/admin/performance/dashboardsAndQuestions.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/dashboardsAndQuestions.cy.spec.ts
@@ -126,8 +126,8 @@ describe(
       beforeEach(() => {
         resetServerTime();
         interceptPerformanceRoutes();
-        H.resetTestTable({ type: "postgres", table: TEST_TABLE });
         H.restore("postgres-writable");
+        H.resetTestTable({ type: "postgres", table: TEST_TABLE });
         cy.signInAsAdmin();
         H.setTokenFeatures("all");
       });
@@ -264,8 +264,8 @@ describe(
       beforeEach(() => {
         resetServerTime();
         interceptPerformanceRoutes();
-        H.resetTestTable({ type: "postgres", table: TEST_TABLE });
         H.restore("postgres-writable");
+        H.resetTestTable({ type: "postgres", table: TEST_TABLE });
         cy.signInAsAdmin();
         cy.visit("/admin/performance");
         cacheStrategyForm();

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
@@ -19,8 +19,8 @@ describe("issue 18067", () => {
     () => {
       const dialect = "mysql";
       const TEST_TABLE = "many_data_types";
-      H.resetTestTable({ type: dialect, table: TEST_TABLE });
       H.restore(`${dialect}-writable`);
+      H.resetTestTable({ type: dialect, table: TEST_TABLE });
       cy.signInAsAdmin();
       H.resyncDatabase({
         dbId: WRITABLE_DB_ID,

--- a/e2e/test/scenarios/dashboard-filters/dashboard-chained-filters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-chained-filters.cy.spec.js
@@ -180,8 +180,8 @@ describe("scenarios > dashboard > chained filter", () => {
       const dialect = "postgres";
       const TEST_TABLE = "many_data_types";
 
-      H.resetTestTable({ type: dialect, table: TEST_TABLE });
       H.restore(`${dialect}-writable`);
+      H.resetTestTable({ type: dialect, table: TEST_TABLE });
       cy.signInAsAdmin();
       H.resyncDatabase({ tableName: TEST_TABLE, tableAlias: "testTable" });
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-source.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-source.cy.spec.js
@@ -288,8 +288,8 @@ describe(
     const TABLE_NAME = "ip_addresses";
 
     beforeEach(() => {
-      H.resetTestTable({ type: "postgres", table: TABLE_NAME });
       H.restore("postgres-writable");
+      H.resetTestTable({ type: "postgres", table: TABLE_NAME });
       cy.signInAsAdmin();
       H.resyncDatabase({
         dbId: WRITABLE_DB_ID,

--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -464,8 +464,8 @@ H.describeEE("scenarios > embedding > full app", () => {
         "should select a table when there are multiple schemas",
         { tags: "@external" },
         () => {
-          H.resetTestTable({ type: "postgres", table: "multi_schema" });
           H.restore("postgres-writable");
+          H.resetTestTable({ type: "postgres", table: "multi_schema" });
           cy.signInAsAdmin();
           H.resyncDatabase({ dbId: WRITABLE_DB_ID });
           startNewEmbeddingQuestion();

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -3920,8 +3920,8 @@ describe("issue 45670", { tags: ["@external"] }, () => {
   }
 
   beforeEach(() => {
-    H.resetTestTable({ type: dialect, table: tableName });
     H.restore(`${dialect}-writable`);
+    H.resetTestTable({ type: dialect, table: tableName });
     cy.signInAsAdmin();
     H.resyncDatabase({ dbId: WRITABLE_DB_ID, tableName });
     cy.intercept("PUT", "/api/card/*").as("updateCard");
@@ -4107,8 +4107,8 @@ describe("issue 40396", { tags: "@external " }, () => {
   const tableName = "many_data_types";
 
   beforeEach(() => {
-    H.resetTestTable({ type: "postgres", table: tableName });
     H.restore("postgres-writable");
+    H.resetTestTable({ type: "postgres", table: tableName });
     cy.signInAsAdmin();
     H.resyncDatabase({ dbId: WRITABLE_DB_ID });
     cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(

--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -1239,8 +1239,8 @@ describe("issue 40622", () => {
 
 describe("45252", { tags: "@external" }, () => {
   beforeEach(() => {
-    H.resetTestTable({ type: "postgres", table: "many_data_types" });
     H.restore("postgres-writable");
+    H.resetTestTable({ type: "postgres", table: "many_data_types" });
     cy.signInAsAdmin();
     H.resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: "many_data_types" });
     cy.intercept("POST", "/api/dataset").as("dataset");

--- a/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
+++ b/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
@@ -192,8 +192,8 @@ describe("scenarios > organization > entity picker", () => {
         "should search for tables when there are multiple databases",
         { tags: "@external" },
         () => {
-          H.resetTestTable({ type: "postgres", table: "multi_schema" });
           H.restore("postgres-writable");
+          H.resetTestTable({ type: "postgres", table: "multi_schema" });
           cy.signInAsAdmin();
           H.resyncDatabase({ dbId: WRITABLE_DB_ID });
 
@@ -252,8 +252,8 @@ describe("scenarios > organization > entity picker", () => {
         "should search for tables in a multi-schema database",
         { tags: "@external" },
         () => {
-          H.resetTestTable({ type: "postgres", table: "multi_schema" });
           H.restore("postgres-writable");
+          H.resetTestTable({ type: "postgres", table: "multi_schema" });
           cy.signInAsAdmin();
           H.resyncDatabase({ dbId: WRITABLE_DB_ID });
 

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -250,7 +250,6 @@ describe("issue 38354", { tags: "@external" }, () => {
   };
 
   beforeEach(() => {
-    H.restore();
     H.restore("postgres-12");
     cy.signInAsAdmin();
     H.createQuestion(QUESTION_DETAILS, { visitQuestion: true });

--- a/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
@@ -128,9 +128,9 @@ describe("scenarios > notebook > data source", () => {
         const schemaName = "Wild";
         const tableName = "Animals";
 
+        H.restore(`${dialect}-writable`);
         H.resetTestTable({ type: dialect, table: testTable1 });
         H.resetTestTable({ type: dialect, table: testTable2 });
-        H.restore(`${dialect}-writable`);
 
         cy.signInAsAdmin();
 
@@ -384,8 +384,8 @@ describe("issue 28106", () => {
   beforeEach(() => {
     const dialect = "postgres";
 
-    H.resetTestTable({ type: dialect, table: "many_schemas" });
     H.restore(`${dialect}-writable`);
+    H.resetTestTable({ type: dialect, table: "many_schemas" });
     cy.signInAsAdmin();
 
     H.resyncDatabase({ dbId: WRITABLE_DB_ID });

--- a/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
@@ -128,9 +128,9 @@ describe("scenarios > notebook > data source", () => {
         const schemaName = "Wild";
         const tableName = "Animals";
 
+        H.restore(`${dialect}-writable`);
         H.resetTestTable({ type: dialect, table: testTable1 });
         H.resetTestTable({ type: dialect, table: testTable2 });
-        H.restore(`${dialect}-writable`);
 
         cy.signInAsAdmin();
 

--- a/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
@@ -412,7 +412,7 @@ describe("issue 28106", () => {
         scrollAllTheWayDown();
 
         // assert scrolling worked and the last item is visible
-        H.entityPickerModalItem(1, "Public").should("be.visible");
+        H.entityPickerModalItem(1, "Schema Z").should("be.visible");
 
         // simulate scrolling up using mouse wheel 3 times
         for (let i = 0; i < 3; ++i) {
@@ -421,7 +421,7 @@ describe("issue 28106", () => {
         }
 
         // assert first item does not exist - this means the list has not been scrolled to the top
-        cy.findByText("Domestic").should("not.exist");
+        cy.findByText("Schema A").should("not.exist");
         cy.get("@schemasList").should(([$element]) => {
           expect($element.scrollTop).to.be.greaterThan(0);
         });

--- a/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
@@ -128,9 +128,9 @@ describe("scenarios > notebook > data source", () => {
         const schemaName = "Wild";
         const tableName = "Animals";
 
-        H.restore(`${dialect}-writable`);
         H.resetTestTable({ type: dialect, table: testTable1 });
         H.resetTestTable({ type: dialect, table: testTable2 });
+        H.restore(`${dialect}-writable`);
 
         cy.signInAsAdmin();
 

--- a/e2e/test/scenarios/search/search-pagination.cy.spec.js
+++ b/e2e/test/scenarios/search/search-pagination.cy.spec.js
@@ -25,7 +25,7 @@ describe("scenarios > search", () => {
     H.getSearchBar().type(" ");
   });
 
-  it("should allow users to paginate results", { tags: "@flaky" }, () => {
+  it("should allow users to paginate results", () => {
     generateQuestions(TOTAL_ITEMS);
 
     cy.visit("/");

--- a/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
@@ -429,8 +429,8 @@ function changeSorting(columnName, direction) {
       const TEST_TABLE = "composite_pk_table";
 
       beforeEach(() => {
-        H.resetTestTable({ type: dialect, table: TEST_TABLE });
         H.restore(`${dialect}-writable`);
+        H.resetTestTable({ type: dialect, table: TEST_TABLE });
         cy.signInAsAdmin();
         H.resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: TEST_TABLE });
       });
@@ -482,8 +482,8 @@ function changeSorting(columnName, direction) {
       const TEST_TABLE = "no_pk_table";
 
       beforeEach(() => {
-        H.resetTestTable({ type: dialect, table: TEST_TABLE });
         H.restore(`${dialect}-writable`);
+        H.resetTestTable({ type: dialect, table: TEST_TABLE });
         cy.signInAsAdmin();
         H.resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: TEST_TABLE });
       });

--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -443,8 +443,8 @@ describe("scenarios > visualizations > table > conditional formatting", () => {
 
   describe("operators", () => {
     beforeEach(() => {
-      H.resetTestTable({ type: "postgres", table: "many_data_types" });
       H.restore("postgres-writable");
+      H.resetTestTable({ type: "postgres", table: "many_data_types" });
       cy.signInAsAdmin();
       H.resyncDatabase({
         dbId: WRITABLE_DB_ID,


### PR DESCRIPTION
This does an auto drop for all tables + schema for any tests using the writable db.

This requires test tables to be created after the `.restore()` function, so most of the LoC change is just swapping line order around. There's a follow-up task to write a lint rule to help people not mess this up 😁 
