### PR TITLE
fix(sdk): Bump `package.template.json` to 54

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk/package.template.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabase/embedding-sdk-react",
-  "version": "0.53.1-nightly",
+  "version": "0.54.0-nightly",
   "description": "Metabase Embedding SDK for React",
   "bin": "./dist/cli.js",
   "repository": {


### PR DESCRIPTION
Updates the package.template.json to 54 for master. This should _not_ be backported