### PR TITLE
fix(sdk): Use 53-stable tag in `master` release workflow

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -13,6 +13,7 @@ on:
           - master
           - release-x.51.x
           - release-x.52.x
+          - release-x.53.x
 
 concurrency:
   # We want to ensure only one job is running at a time per branch because
@@ -260,10 +261,10 @@ jobs:
         run: |
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
           # Please keep the value in sync with `inputs.branch`'s release branch
-          npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable", "release-x.52.x": "52-stable"}')[inputs.branch]}}
+          npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable", "release-x.52.x": "52-stable", "release-x.53.x": "53-stable"}')[inputs.branch]}}
 
-      - name: Add `latest` tag to the latest release branch (`release-x.52.x`) deployment
-        if: ${{ inputs.branch == 'release-x.52.x' }}
+      - name: Add `latest` tag to the latest release branch (`release-x.53.x`) deployment
+        if: ${{ inputs.branch == 'release-x.53.x' }}
         working-directory: sdk
         run: |
           npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -263,8 +263,8 @@ jobs:
           # Please keep the value in sync with `inputs.branch`'s release branch
           npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable", "release-x.52.x": "52-stable", "release-x.53.x": "53-stable"}')[inputs.branch]}}
 
-      - name: Add `latest` tag to the latest release branch (`release-x.53.x`) deployment
-        if: ${{ inputs.branch == 'release-x.53.x' }}
+      - name: Add `latest` tag to the latest release branch (`release-x.52.x`) deployment
+        if: ${{ inputs.branch == 'release-x.52.x' }}
         working-directory: sdk
         run: |
           npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest


### PR DESCRIPTION
Adds `release-x.53.x` to the list of possible tags