### PR TITLE
[csv-export] Follow-up optimizations to CSV pivotted export

### DIFF
--- a/src/metabase/util/performance.clj
+++ b/src/metabase/util/performance.clj
@@ -1,7 +1,8 @@
 (ns metabase.util.performance
   "Functions and utilities for faster processing."
   (:refer-clojure :exclude [reduce mapv run! some concat])
-  (:import (clojure.lang LazilyPersistentVector RT)))
+  (:import (clojure.lang LazilyPersistentVector RT)
+           java.util.Iterator))
 
 (set! *warn-on-reflection* true)
 
@@ -176,3 +177,10 @@
      (reduce conj! res f)
      (reduce (fn [res l] (reduce conj! res l)) res more)
      (persistent! res))))
+
+(defn transpose
+  "Like `(apply mapv vector coll-of-colls)`, but more efficient."
+  [coll-of-colls]
+  (let [its (mapv #(.iterator ^Iterable %) coll-of-colls)]
+    (mapv (fn [_] (mapv #(.next ^Iterator %) its))
+          (first coll-of-colls))))

--- a/test/metabase/util/performance_test.clj
+++ b/test/metabase/util/performance_test.clj
@@ -24,3 +24,11 @@
 (deftest run!-test
   (is (= [] (mapv-via-run! inc [])))
   (is (= [1 2 3 4 5] (mapv-via-run! inc (range 5)))))
+
+(deftest transpose-test
+  (is (= [[1 2 3 4] [1 2 3 4] [1 2 3 4] [1 2 3 4] [1 2 3 4]]
+         (perf/transpose [[1 1 1 1 1] [2 2 2 2 2] [3 3 3 3 3] [4 4 4 4 4]])
+         (apply mapv vector [[1 1 1 1 1] [2 2 2 2 2] [3 3 3 3 3] [4 4 4 4 4]])))
+  (is (= [[1 2 3 4 5] [1 2 3 4 5] [1 2 3 4 5] [1 2 3 4 5] [1 2 3 4 5]]
+         (perf/transpose [[1 1 1 1 1] [2 2 2 2 2] [3 3 3 3 3] [4 4 4 4 4] [5 5 5 5 5]])
+         (apply mapv vector [[1 1 1 1 1] [2 2 2 2 2] [3 3 3 3 3] [4 4 4 4 4] [5 5 5 5 5]]))))


### PR DESCRIPTION
A follow-up to #52551. That PR already did most of the work to fix the high memory watermark when generating CSV export with the pivot. This PR brings another ~2x improvement to seal the deal.

Notable changes:

1. `build-row`, the hottest function of the module, is rewritten to an explicit loop. This avoids lambda allocations that happen when nested `map` or `run!` loops are involved. Besides, the iterators are now also escape-analyzed away.
2. Cached intermediate values in auxiliary functions: `build-column-totals`, `build-grand-totals`.
3. Optimized the final mapv fo the `build-pivot-output`.
