### PR TITLE
[Cards in Dashboards] Fix dashboard on the go bug

### DIFF
--- a/frontend/src/metabase/common/components/CollectionPicker/utils.ts
+++ b/frontend/src/metabase/common/components/CollectionPicker/utils.ts
@@ -124,7 +124,7 @@ export const getPathLevelForItem = (
   >,
   userPersonalCollectionId?: CollectionId,
 ): number => {
-  if (item.id === userPersonalCollectionId) {
+  if (item.model === "collection" && item.id === userPersonalCollectionId) {
     return 0;
   }
 


### PR DESCRIPTION
### Description

Fixes this failure we were getting in OSS runs of cypress
![scenarios  question  new -- should be able to save a question to a dashboard created on the go (failed)](https://github.com/user-attachments/assets/77992828-d660-412e-9351-7e79691e5752)
![Screen Shot 2025-01-28 at 7 55 12 AM](https://github.com/user-attachments/assets/d4c0246a-49d9-4070-a1ef-acde137e56e2)

We had a check that didn't first compare that models were the same, so if the user's personal collection id matched the exact id of the dashboard they were creating, they'd encounter the above error.

### How to verify

- Run cypress in OSS mode, test should pass now and fail before

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
