### PR TITLE
Update "Multiple domains for Google Sign-in"

### DIFF
--- a/docs/people-and-groups/google-sign-in.md
+++ b/docs/people-and-groups/google-sign-in.md
@@ -52,7 +52,7 @@ Note that Metabase accounts _created_ with Google Sign-In will not have password
 
 {% include plans-blockquote.html feature="Multiple domains for Google Sign-in" %}
 
-If you're on a [pro](https://www.metabase.com/product/pro) or [Enterprise](https://www.metabase.com/product/enterprise) plan, you can specify multiple domains in the **Domain** field, separated by a comma. For example, `mycompany.com,example.com.br,otherdomain.co.uk`.
+If you're on a [pro](https://www.metabase.com/product/pro) or [Enterprise](https://www.metabase.com/product/enterprise) plan, you can specify multiple domains from the same Google Workspace in the **Domain** field, separated by a comma. For example, `mycompany.com,example.com.br,otherdomain.co.uk`.
 
 ## Syncing user attributes with Google
 


### PR DESCRIPTION
Update the "Multiple domains for Google Sign-in" section to note that multiple domains must be in the same Google Workspace account.
We got a ticket asking why multiple domains weren’t working, ticket: https://app.usepylon.com/issues?conversationID=b5cbe6ab-ed1b-4a96-b264-3ae2e56eb42c 