### PR TITLE
Initialize zeros for labeled counter metrics

### DIFF
--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -234,6 +234,7 @@
 
 (defmulti known-labels
   "Implement this for a given metric to initialize zeros for the given set of label values."
+  {:arglists '([metric]), :added "0.52.0"}
   identity)
 
 (defn- setup-metrics!

--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -45,7 +45,7 @@
 
 (defmethod prometheus/known-labels :metabase-search/index
   [_]
-  (for [model (keys (metabase.search.spec/specifications))]
+  (for [model (keys (search.spec/specifications))]
     {:model model}))
 
 (defn supports-index?

--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -1,6 +1,7 @@
 (ns metabase.search.core
   "NOT the API namespace for the search module!! See [[metabase.search]] instead."
   (:require
+   [metabase.analytics.prometheus :as prometheus]
    [metabase.search.appdb.core :as search.engines.appdb]
    [metabase.search.config :as search.config]
    [metabase.search.engine :as search.engine]
@@ -41,6 +42,11 @@
 
  [search.spec
   define-spec])
+
+(defmethod prometheus/known-labels :metabase-search/index
+  [_]
+  (for [model (keys (metabase.search.spec/specifications))]
+    {:model model}))
 
 (defn supports-index?
   "Does this instance support a search index, of any sort?"


### PR DESCRIPTION
Labelled counters only get created the first time we count something with their particular labels.

Since this typically means that a 0 value will never be scraped for them, the way Prometheus calculates increases means that we won't observe the initial delta.

![Screenshot 2025-01-28 at 18 56 35](https://github.com/user-attachments/assets/9dc0280d-ee49-47a2-afbc-c0b691e2abf2)

In the above example we see two counters, in green and light blue, and their corresponding "increase" time series in yellow and dark blue, respectively. The green counter has already been initialized, and we see a spike in its corresponding increase series when it is increased further. In contrast, when the blue counter is first "increased", there is no corresponding spike in its increase series. 

Initializing it with a zero prior to the first increase should fix our derived time series, except in the case where we subsequently increase it before it is first sampled. In that case, I don't think there is anything we can do. Luckily for search index metrics, we don't really care about missing data for small indexes that can be built that quickly.

### To verity that this works:

1. Set MB_PROMETHEUS_SERVER_PORT to 9999
2. Start up dev server
3. Go to `http://localhost:9999/metrics`
4. Confirm we see the expected counter values

```	
# HELP metabase_search_index_total Number of entries indexed for search
# TYPE metabase_search_index_total counter
metabase_search_index_total{model="card",} 0.0
metabase_search_index_total{model="dataset",} 0.0
metabase_search_index_total{model="indexed-entity",} 0.0
metabase_search_index_total{model="database",} 0.0
metabase_search_index_total{model="segment",} 0.0
metabase_search_index_total{model="collection",} 0.0
metabase_search_index_total{model="dashboard",} 0.0
metabase_search_index_total{model="action",} 0.0
metabase_search_index_total{model="metric",} 0.0
metabase_search_index_total{model="table",} 0.0
```

Bonus: I think this will get rid of that "blank" model entry.

Added bonus: We'll get zeros for models even when customers don't have any corresponding instances.
