### PR TITLE
Fix `all-indexes->field-ids` generating queries with too many parameters

### DIFF
--- a/src/metabase/sync/sync_metadata/indexes.clj
+++ b/src/metabase/sync/sync_metadata/indexes.clj
@@ -51,17 +51,17 @@
 
 (defn- all-indexes->field-ids
   [database-id indexes]
-  (let [get-indexes (fn [index-batch]
-                      (when (seq index-batch)
-                        (let [normal-indexes (map (juxt #(:table-schema % "__null__") :table-name :field-name) index-batch)
-                              query (t2/reducible-query {:select [[:f.id]]
-                                                         :from [[(t2/table-name :model/Field) :f]]
-                                                         :inner-join [[(t2/table-name :model/Table) :t] [:= :f.table_id :t.id]]
-                                                         :where [:and [:in [:composite [:coalesce :t.schema "__null__"] :t.name :f.name] normal-indexes]
-                                                                 [:= :t.db_id database-id]
-                                                                 [:= :parent_id nil]]})]
-                          (into #{} (keep :id) query))))]
-    (reduce set/union #{} (map get-indexes (partition-all 5000 indexes)))))
+  (let [get-index-ids (fn [index-batch]
+                        (when (seq index-batch)
+                          (let [normal-indexes (map (juxt #(:table-schema % "__null__") :table-name :field-name) index-batch)
+                                query (t2/reducible-query {:select [[:f.id]]
+                                                           :from [[(t2/table-name :model/Field) :f]]
+                                                           :inner-join [[(t2/table-name :model/Table) :t] [:= :f.table_id :t.id]]
+                                                           :where [:and [:in [:composite [:coalesce :t.schema "__null__"] :t.name :f.name] normal-indexes]
+                                                                   [:= :t.db_id database-id]
+                                                                   [:= :parent_id nil]]})]
+                            (into #{} (keep :id) query))))]
+    (reduce set/union #{} (map get-index-ids (partition-all 5000 indexes)))))
 
 (defn- sync-all-indexes!
   [database]

--- a/src/metabase/sync/sync_metadata/indexes.clj
+++ b/src/metabase/sync/sync_metadata/indexes.clj
@@ -1,7 +1,6 @@
 (ns metabase.sync.sync-metadata.indexes
   (:require
    [clojure.data :as data]
-   [clojure.set :as set]
    [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
    [metabase.models.field :as field]

--- a/src/metabase/sync/sync_metadata/indexes.clj
+++ b/src/metabase/sync/sync_metadata/indexes.clj
@@ -61,6 +61,8 @@
                                               [:= :parent_id nil]]})]
        (into accum (keep :id) query)))
    #{}
+   ;; break the indexes up in groups of 5000 to avoid max
+   ;; parameter limit of 65,535. See #52746 for details.
    (partition-all 5000 indexes)))
 
 (defn- sync-all-indexes!

--- a/src/metabase/sync/sync_metadata/indexes.clj
+++ b/src/metabase/sync/sync_metadata/indexes.clj
@@ -51,17 +51,18 @@
 
 (defn- all-indexes->field-ids
   [database-id indexes]
-  (let [get-index-ids (fn [index-batch]
-                        (when (seq index-batch)
-                          (let [normal-indexes (map (juxt #(:table-schema % "__null__") :table-name :field-name) index-batch)
-                                query (t2/reducible-query {:select [[:f.id]]
-                                                           :from [[(t2/table-name :model/Field) :f]]
-                                                           :inner-join [[(t2/table-name :model/Table) :t] [:= :f.table_id :t.id]]
-                                                           :where [:and [:in [:composite [:coalesce :t.schema "__null__"] :t.name :f.name] normal-indexes]
-                                                                   [:= :t.db_id database-id]
-                                                                   [:= :parent_id nil]]})]
-                            (into #{} (keep :id) query))))]
-    (reduce set/union #{} (map get-index-ids (partition-all 5000 indexes)))))
+  (reduce
+   (fn [accum index-batch]
+     (let [normal-indexes (map (juxt #(:table-schema % "__null__") :table-name :field-name) index-batch)
+           query (t2/reducible-query {:select [[:f.id]]
+                                      :from [[(t2/table-name :model/Field) :f]]
+                                      :inner-join [[(t2/table-name :model/Table) :t] [:= :f.table_id :t.id]]
+                                      :where [:and [:in [:composite [:coalesce :t.schema "__null__"] :t.name :f.name] normal-indexes]
+                                              [:= :t.db_id database-id]
+                                              [:= :parent_id nil]]})]
+       (into accum (keep :id) query)))
+   #{}
+   (partition-all 5000 indexes)))
 
 (defn- sync-all-indexes!
   [database]

--- a/test/metabase/sync/sync_metadata/indexes_test.clj
+++ b/test/metabase/sync/sync_metadata/indexes_test.clj
@@ -45,3 +45,13 @@
                    :model/Table    table {:db_id (:id db)}]
       (is (= @#'sync.indexes/empty-stats (sync.indexes/maybe-sync-indexes! db)))
       (is (= @#'sync.indexes/empty-stats (sync.indexes/maybe-sync-indexes-for-table! db table))))))
+
+(deftest all-indexes->fields-ids-many-indexes-test
+  (testing "no exception is thrown when there are very many indexes"
+    (is (try (#'sync.indexes/all-indexes->field-ids
+              (:id (mt/db))
+              (repeat 100000 {:table-schema "public",
+                              :table-name "serialization_stats",
+                              :field-name "id"}))
+             true
+             (catch Exception _e false)))))

--- a/test/metabase/sync/sync_metadata/indexes_test.clj
+++ b/test/metabase/sync/sync_metadata/indexes_test.clj
@@ -4,7 +4,6 @@
    [clojure.test :refer :all]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
-   [metabase.driver.util :as driver.u]
    [metabase.sync.core :as sync]
    [metabase.sync.sync-metadata.indexes :as sync.indexes]
    [metabase.test :as mt]
@@ -50,7 +49,7 @@
 (deftest all-indexes->fields-ids-many-indexes-test
   (testing "no exception is thrown when there are very many indexes"
     (mt/test-drivers (mt/normal-drivers-with-feature :describe-indexes)
-      (let [indexes (into [] (driver/describe-indexes (driver.u/database->driver (mt/db)) (mt/db)))
+      (let [indexes (into [] (driver/describe-indexes driver/*driver* (mt/db)))
             many-indexes (into indexes (repeat 100000 {:table-schema "public",
                                                        :table-name "fake_table",
                                                        :field-name "id"}))

--- a/test/metabase/sync/sync_metadata/indexes_test.clj
+++ b/test/metabase/sync/sync_metadata/indexes_test.clj
@@ -48,7 +48,7 @@
 
 (deftest all-indexes->fields-ids-many-indexes-test
   (testing "no exception is thrown when there are very many indexes"
-    (mt/test-drivers (mt/normal-drivers-with-feature :describe-indexes)
+    (mt/test-drivers (mt/normal-drivers-with-feature :describe-indexes :index-info)
       (let [indexes (into [] (driver/describe-indexes driver/*driver* (mt/db)))
             many-indexes (into indexes (repeat 100000 {:table-schema "public",
                                                        :table-name "fake_table",

--- a/test/metabase/sync/sync_metadata/indexes_test.clj
+++ b/test/metabase/sync/sync_metadata/indexes_test.clj
@@ -50,11 +50,9 @@
 (deftest all-indexes->fields-ids-many-indexes-test
   (testing "no exception is thrown when there are very many indexes"
     (mt/test-drivers (mt/normal-drivers-with-feature :describe-indexes)
-      (let [database (mt/db)
-            indexes (into [] (driver/describe-indexes (driver.u/database->driver database) database))
+      (let [indexes (into [] (driver/describe-indexes (driver.u/database->driver (mt/db)) (mt/db)))
             many-indexes (into indexes (repeat 100000 {:table-schema "public",
                                                        :table-name "fake_table",
                                                        :field-name "id"}))
-            field-ids (#'sync.indexes/all-indexes->field-ids (:id database) many-indexes)]
-        (println "number of field ids:" (count field-ids) "field ids" field-ids)
+            field-ids (#'sync.indexes/all-indexes->field-ids (:id (mt/db)) many-indexes)]
         (is (= 8 (count field-ids)))))))

--- a/test/metabase/sync/sync_metadata/indexes_test.clj
+++ b/test/metabase/sync/sync_metadata/indexes_test.clj
@@ -55,4 +55,4 @@
                                                        :table-name "fake_table",
                                                        :field-name "id"}))
             field-ids (#'sync.indexes/all-indexes->field-ids (:id (mt/db)) many-indexes)]
-        (is (= 8 (count field-ids)))))))
+        (is (seq field-ids))))))


### PR DESCRIPTION
Closes https://linear.app/metabase-inc/issue/ENG-14467/task-sync-indexes-can-throw-enormous-stacktraces

### Description

When `all-indexes->field-ids` is passed a large `indexes` list (> ~21k), it generates a SQL query with more than 65k parameters which throws an exception. Proposed solution is to batch the indexes list into smaller groups such that the number of parameters in a query will always be < 65k.

I initially tried a batch size of 20k, and then 10k, but both failed with `ERROR: stack depth limit exceeded`. A batch limit of 5k seems to work. This means we will be doing `(/ (count indexes) 5000)` queries now instead of 1. Not sure if this increase in queries is a concern or not in this case. I think? it would be small enough in practice to not be a concern.

### How to verify

From the repl:

```clojure
> (def indexes (repeat 100000 {:table-schema "public",
                             :table-name "serialization_stats",
                             :field-name "id"}))
> (def database-id 10)
> (all-indexes->field-ids database-id indexes)
#{}
```

There should be no exceptions.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
