### PR TITLE
Disable broken multi-arch container build

### DIFF
--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -227,6 +227,7 @@ jobs:
         sarif_file: 'trivy-results.sarif'
 
   containerize_multi_arch:
+    if: false # FIXME: get this to work with Java 21
     runs-on: ubuntu-22.04
     name: Containerize multi-arch ${{ matrix.edition }}
     needs: check_jar_health


### PR DESCRIPTION
[The Java 21](https://github.com/metabase/metabase/pull/48854) upgrade broke this job. 

In any event, it was only an experimental build, not something we're actually using right now.

one failed attempt to fix: https://github.com/metabase/metabase/pull/52761

