### PR TITLE
[refs] Make `lib.tu/*` into functions, not top-level defs

### DIFF
--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -350,10 +350,10 @@
 
 (defn native-stage?
   "Is this query stage a native stage?"
-  [query stage-number]
-  (-> (query-stage query stage-number)
-      :lib/type
-      (= :mbql.stage/native)))
+  ([stage]
+   (= (:lib/type stage) :mbql.stage/native))
+  ([query stage-number]
+   (native-stage? (query-stage query stage-number))))
 
 (mu/defn ensure-mbql-final-stage :- ::lib.schema/query
   "Convert query to a pMBQL (pipeline) query, and make sure the final stage is an `:mbql` one."

--- a/test/metabase/driver/common/parameters/values_test.clj
+++ b/test/metabase/driver/common/parameters/values_test.clj
@@ -582,7 +582,7 @@
   (testing "Parsing a Card reference should return a `ReferencedCardQuery` record that includes its parameters (#12236)"
     (qp.store/with-metadata-provider (lib.tu/mock-metadata-provider
                                       meta/metadata-provider
-                                      {:cards [(assoc (lib.tu/mock-cards :orders)
+                                      {:cards [(assoc ((lib.tu/mock-cards) :orders)
                                                       :id 1
                                                       :dataset-query (lib.tu.macros/mbql-query orders
                                                                        {:filter      [:between $total 30 60]

--- a/test/metabase/lib/card_test.cljc
+++ b/test/metabase/lib/card_test.cljc
@@ -20,7 +20,7 @@
 
 (deftest ^:parallel source-card-infer-metadata-test
   (testing "We should be able to calculate metadata for a Saved Question missing results_metadata"
-    (let [query lib.tu/query-with-source-card]
+    (let [query (lib.tu/query-with-source-card)]
       (is (=? [{:id                       (meta/id :checkins :user-id)
                 :name                     "USER_ID"
                 :lib/source               :source/card
@@ -55,11 +55,11 @@
                   (lib/display-info query col))))))))
 
 (deftest ^:parallel card-source-query-metadata-test
-  (doseq [metadata [(:venues lib.tu/mock-cards)
+  (doseq [metadata [(:venues (lib.tu/mock-cards))
                     ;; in some cases [the FE unit tests are broken] the FE is transforming the metadata like this, not
                     ;; sure why but handle it anyway
                     ;; (#29739)
-                    (set/rename-keys (:venues lib.tu/mock-cards) {:result-metadata :fields})]]
+                    (set/rename-keys (:venues (lib.tu/mock-cards)) {:result-metadata :fields})]]
     (testing (str "metadata = \n" (u/pprint-to-str metadata))
       (let [query {:lib/type     :mbql/query
                    :lib/metadata (lib.tu/mock-metadata-provider
@@ -67,7 +67,7 @@
                    :database     (meta/id)
                    :stages       [{:lib/type    :mbql.stage/mbql
                                    :source-card (:id metadata)}]}]
-        (is (=? (for [col (get-in lib.tu/mock-cards [:venues :result-metadata])]
+        (is (=? (for [col (get-in (lib.tu/mock-cards) [:venues :result-metadata])]
                   (-> col
                       (assoc :lib/source :source/card)
                       (dissoc :fk-target-field-id)))
@@ -75,7 +75,7 @@
 
 (deftest ^:parallel card-results-metadata-merge-metadata-provider-metadata-test
   (testing "Merge metadata from the metadata provider into result-metadata (#30046)"
-    (let [query lib.tu/query-with-source-card-with-result-metadata]
+    (let [query (lib.tu/query-with-source-card-with-result-metadata)]
       (is (=? [{:lib/type                 :metadata/column
                 :id                       (meta/id :checkins :user-id)
                 :table-id                 (meta/id :checkins)
@@ -101,11 +101,11 @@
     (let [venues-query (lib/query
                         (lib.tu/mock-metadata-provider
                          meta/metadata-provider
-                         {:cards [(assoc (:orders lib.tu/mock-cards) :dataset-query lib.tu/venues-query)]})
-                        (:orders lib.tu/mock-cards))]
+                         {:cards [(assoc (:orders (lib.tu/mock-cards)) :dataset-query (lib.tu/venues-query))]})
+                        (:orders (lib.tu/mock-cards)))]
       (is (=? (->> (cols-of :orders)
                    sort-cols)
-              (sort-cols (get-in lib.tu/mock-cards [:orders :result-metadata]))))
+              (sort-cols (get-in (lib.tu/mock-cards) [:orders :result-metadata]))))
 
       (is (=? (->> (concat (from :source/card (cols-of :orders))
                            (from :source/implicitly-joinable (cols-of :people))
@@ -213,8 +213,8 @@
 
 (deftest ^:parallel display-name-of-joined-cards-is-clean-test
   (testing "We get proper field names rather than ids (#27323)"
-    (let [query (lib/query lib.tu/metadata-provider-with-mock-cards (:products lib.tu/mock-cards))
-          people-card (:people lib.tu/mock-cards)
+    (let [query (lib/query (lib.tu/metadata-provider-with-mock-cards) (:products (lib.tu/mock-cards)))
+          people-card (:people (lib.tu/mock-cards))
           lhs (m/find-first (comp #{"ID"} :name) (lib/join-condition-lhs-columns query 0 people-card nil nil))
           rhs (m/find-first (comp #{"ID"} :name) (lib/join-condition-rhs-columns query 0 people-card nil nil))
           join-clause (lib/join-clause people-card [(lib/= lhs rhs)])

--- a/test/metabase/lib/column_group_test.cljc
+++ b/test/metabase/lib/column_group_test.cljc
@@ -13,7 +13,7 @@
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 
 (deftest ^:parallel basic-test
-  (let [query   lib.tu/venues-query
+  (let [query   (lib.tu/venues-query)
         columns (lib/orderable-columns query)
         groups  (lib/group-columns columns)]
     (is (not (mr/explain [:sequential @#'lib.column-group/ColumnGroup] groups)))
@@ -49,7 +49,7 @@
              (mapcat lib/columns-group-columns groups))))))
 
 (deftest ^:parallel aggregation-and-breakout-test
-  (let [query   (-> lib.tu/venues-query
+  (let [query   (-> (lib.tu/venues-query)
                     (lib/aggregate (lib/sum (meta/field-metadata :venues :id)))
                     (lib/breakout (meta/field-metadata :venues :name)))
         columns (lib/orderable-columns query)
@@ -70,7 +70,7 @@
              (mapcat lib/columns-group-columns groups))))))
 
 (deftest ^:parallel multi-stage-test
-  (let [query   (-> lib.tu/venues-query
+  (let [query   (-> (lib.tu/venues-query)
                     (lib/aggregate (lib/sum (meta/field-metadata :venues :id)))
                     (lib/breakout (meta/field-metadata :venues :name))
                     (lib/append-stage))
@@ -92,7 +92,7 @@
              (mapcat lib/columns-group-columns groups))))))
 
 (deftest ^:parallel source-card-test
-  (let [query   lib.tu/query-with-source-card
+  (let [query   (lib.tu/query-with-source-card)
         columns (lib/orderable-columns query)
         groups  (lib/group-columns columns)]
     (is (=? [{::lib.column-group/group-type :group-type/main
@@ -128,7 +128,7 @@
              (mapcat lib/columns-group-columns groups))))))
 
 (deftest ^:parallel joins-test
-  (let [query   lib.tu/query-with-join
+  (let [query   (lib.tu/query-with-join)
         columns (lib/orderable-columns query)
         groups  (lib/group-columns columns)]
     (is (=? [{::lib.column-group/group-type :group-type/main
@@ -159,7 +159,7 @@
              (mapcat lib/columns-group-columns groups))))))
 
 (deftest ^:parallel expressions-test
-  (let [query   lib.tu/query-with-expression
+  (let [query   (lib.tu/query-with-expression)
         columns (lib/orderable-columns query)
         groups  (lib/group-columns columns)]
     (is (=? [{::lib.column-group/group-type :group-type/main
@@ -191,7 +191,7 @@
              (mapcat lib/columns-group-columns groups))))))
 
 (deftest ^:parallel source-card-with-expressions-test
-  (let [query   (-> lib.tu/query-with-source-card
+  (let [query   (-> (lib.tu/query-with-source-card)
                     (lib/expression "expr" (lib/absolute-datetime "2020" :month)))
         columns (lib/orderable-columns query)
         groups  (lib/group-columns columns)]
@@ -229,7 +229,7 @@
              (mapcat lib/columns-group-columns groups))))))
 
 (deftest ^:parallel native-query-test
-  (let [query  lib.tu/native-query
+  (let [query  (lib.tu/native-query)
         groups (lib/group-columns (lib/orderable-columns query))]
     (is (=? [{::lib.column-group/group-type :group-type/main
               ::lib.column-group/columns    [{:display-name "another Field", :lib/source :source/native}
@@ -243,7 +243,7 @@
                 (lib/display-info query group)))))))
 
 (deftest ^:parallel native-source-query-test
-  (let [query  (-> lib.tu/native-query
+  (let [query  (-> (lib.tu/native-query)
                    lib/append-stage)
         groups (lib/group-columns (lib/orderable-columns query))]
     (is (=? [{::lib.column-group/group-type :group-type/main
@@ -268,10 +268,11 @@
 
 (deftest ^:parallel join-condition-rhs-columns-group-columns-join-test
   (testing "#32509 with an existing join"
-    (let [[join] (lib/joins lib.tu/query-with-join)]
+    (let [query  (lib.tu/query-with-join)
+          [join] (lib/joins query)]
       (is (=? {:lib/type :mbql/join}
               join))
-      (let [cols   (rhs-columns lib.tu/query-with-join join)
+      (let [cols   (rhs-columns query join)
             groups (lib/group-columns cols)]
         (testing `lib/group-columns
           (is (=? [{:lib/type                     :metadata/column-group
@@ -289,11 +290,11 @@
                     :display-name "Categories"
                     :is-from-join true}]
                   (for [group groups]
-                    (lib/display-info lib.tu/query-with-join group)))))))))
+                    (lib/display-info query group)))))))))
 
 (deftest ^:parallel join-condition-rhs-columns-group-columns-table-test
   (testing "#32509 when building a join against a Table"
-    (let [cols   (rhs-columns lib.tu/venues-query (meta/table-metadata :categories))
+    (let [cols   (rhs-columns (lib.tu/venues-query) (meta/table-metadata :categories))
           groups (lib/group-columns cols)]
       (testing `lib/group-columns
         (is (=? [{:lib/type                     :metadata/column-group
@@ -307,19 +308,19 @@
                   :display-name "Categories"
                   :is-from-join true}]
                 (for [group groups]
-                  (lib/display-info lib.tu/venues-query group))))))))
+                  (lib/display-info (lib.tu/venues-query) group))))))))
 
 (deftest ^:parallel join-condition-rhs-columns-group-columns-card-test
   (testing "#32509 when building a join against a Card"
     (doseq [{:keys [message card metadata-provider]}
             [{:message           "MBQL Card"
-              :card              (:categories lib.tu/mock-cards)
-              :metadata-provider lib.tu/metadata-provider-with-mock-cards}
+              :card              (:categories (lib.tu/mock-cards))
+              :metadata-provider (lib.tu/metadata-provider-with-mock-cards)}
              {:message           "Native Card"
-              :card              (lib.tu/mock-cards :categories/native)
-              :metadata-provider lib.tu/metadata-provider-with-mock-cards}]]
+              :card              ((lib.tu/mock-cards) :categories/native)
+              :metadata-provider (lib.tu/metadata-provider-with-mock-cards)}]]
       (testing message
-        (let [cols   (rhs-columns lib.tu/venues-query card)
+        (let [cols   (rhs-columns (lib.tu/venues-query) card)
               groups (lib/group-columns cols)]
           (testing `lib/group-columns
             (is (=? [{:lib/type                     :metadata/column-group
@@ -333,9 +334,9 @@
               (is (=? [{:display-name (str "Question " (:id card))
                         :is-from-join true}]
                       (for [group groups]
-                        (lib/display-info lib.tu/venues-query group)))))
+                        (lib/display-info (lib.tu/venues-query) group)))))
             (testing "Card *is* present in MetadataProvider"
-              (let [query  (assoc lib.tu/venues-query :lib/metadata metadata-provider)
+              (let [query  (assoc (lib.tu/venues-query) :lib/metadata metadata-provider)
                     groups (lib/group-columns (rhs-columns query card))]
                 (is (=? [{:name         "Mock categories card"
                           :display-name "Mock Categories Card"
@@ -393,8 +394,8 @@
 
 (deftest ^:parallel self-joined-cards-duplicate-implicit-columns-test
   (testing "Duplicate columns from different foreign key paths should get grouped separately (#34742)"
-    (let [card (:orders lib.tu/mock-cards)
-          query (lib/query lib.tu/metadata-provider-with-mock-cards card)
+    (let [card (:orders (lib.tu/mock-cards))
+          query (lib/query (lib.tu/metadata-provider-with-mock-cards) card)
           clause (lib/join-clause card [(lib/= (first (lib/join-condition-lhs-columns query card nil nil))
                                                (first (lib/join-condition-rhs-columns query card nil nil)))])
 

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -886,7 +886,7 @@
 
 (deftest ^:parallel legacy-ref->pMBQL-field-test
   (are [legacy-ref] (=? [:field {:lib/uuid string?} (meta/id :venues :name)]
-                        (lib.convert/legacy-ref->pMBQL lib.tu/venues-query legacy-ref))
+                        (lib.convert/legacy-ref->pMBQL (lib.tu/venues-query) legacy-ref))
     [:field (meta/id :venues :name) nil]
     [:field (meta/id :venues :name) {}]
     ;; should work with refs that need normalization
@@ -898,12 +898,12 @@
   #?(:cljs
      (is (=? [:field {:base-type :type/Integer, :lib/uuid string?} (meta/id :venues :name)]
              (lib.convert/legacy-ref->pMBQL
-              lib.tu/venues-query
+              (lib.tu/venues-query)
               #js ["field" (meta/id :venues :name) #js {"base-type" "type/Integer"}])))))
 
 (deftest ^:parallel legacy-ref->pMBQL-expression-test
   (are [legacy-ref] (=? [:expression {:lib/uuid string?} "expr"]
-                        (lib.convert/legacy-ref->pMBQL lib.tu/query-with-expression legacy-ref))
+                        (lib.convert/legacy-ref->pMBQL (lib.tu/query-with-expression) legacy-ref))
     [:expression "expr"]
     ["expression" "expr"]
     ["expression" "expr" nil]
@@ -913,7 +913,7 @@
          #js ["expression" "expr" #js {}]])))
 
 (deftest ^:parallel legacy-ref->pMBQL-aggregation-test
-  (let [query (-> lib.tu/venues-query
+  (let [query (-> (lib.tu/venues-query)
                   (lib/aggregate (lib/count)))
         [ag]  (lib/aggregations query)]
     (are [legacy-ref] (=? [:aggregation {:lib/uuid string?} (lib.options/uuid ag)]

--- a/test/metabase/lib/database_test.cljc
+++ b/test/metabase/lib/database_test.cljc
@@ -9,9 +9,9 @@
 (deftest ^:parallel database-id-test
   (testing "Normal query with a source Table"
     (is (= (meta/id)
-           (lib/database-id lib.tu/venues-query))))
+           (lib/database-id (lib.tu/venues-query)))))
   (testing "Query with source Card"
-    (let [query lib.tu/query-with-source-card]
+    (let [query (lib.tu/query-with-source-card)]
       (testing "and normal Database ID"
         (is (= (meta/id)
                (lib/database-id query))))

--- a/test/metabase/lib/drill_thru/underlying_records_test.cljc
+++ b/test/metabase/lib/drill_thru/underlying_records_test.cljc
@@ -71,9 +71,9 @@
     :query-type   :aggregated
     :query-kinds [:mbql]
     :column-name  "count"
-    :custom-query (-> (lib/query lib.tu/metadata-provider-with-mock-cards (lib.tu/mock-cards :orders))
+    :custom-query (-> (lib/query (lib.tu/metadata-provider-with-mock-cards) ((lib.tu/mock-cards) :orders))
                       (lib/aggregate (lib/count))
-                      (lib/breakout (lib.metadata/field lib.tu/metadata-provider-with-mock-cards
+                      (lib/breakout (lib.metadata/field (lib.tu/metadata-provider-with-mock-cards)
                                                         (meta/id :orders :created-at))))
     :custom-row   {"CREATED_AT" "2023-12-01"
                    "count"      9}
@@ -375,7 +375,7 @@
   (testing "should use the default row count for aggregations with negative values (#36143)"
     (let [query     (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
                         (lib/aggregate (lib/count))
-                        (lib/breakout (lib.metadata/field lib.tu/metadata-provider-with-mock-cards
+                        (lib/breakout (lib.metadata/field (lib.tu/metadata-provider-with-mock-cards)
                                                           (meta/id :orders :created-at))))
           count-col (m/find-first #(= (:name %) "count")
                                   (lib/returned-columns query))

--- a/test/metabase/lib/equality_test.cljc
+++ b/test/metabase/lib/equality_test.cljc
@@ -267,7 +267,7 @@
 
 (deftest ^:parallel find-matching-column-by-id-test
   (testing "find-matching-column should find columns based on matching ID (#31482) (#33453)"
-    (let [query lib.tu/query-with-join
+    (let [query (lib.tu/query-with-join)
           cols  (lib/returned-columns query)
           refs  (map lib.ref/ref cols)
           a-ref [:field {:lib/uuid (str (random-uuid))
@@ -288,7 +288,7 @@
              (lib.equality/find-matching-column query -1 a-ref cols))))))
 
 (deftest ^:parallel find-matching-column-from-column-test
-  (let [query (-> lib.tu/venues-query
+  (let [query (-> (lib.tu/venues-query)
                   (lib/breakout (meta/field-metadata :venues :id)))
         filterable-cols (lib/filterable-columns query)
         matched-from-col (lib.equality/find-matching-column query -1 (m/find-first :breakout-positions (lib/breakoutable-columns query)) filterable-cols)
@@ -304,7 +304,7 @@
 
 (deftest ^:parallel find-matching-column-by-name-test
   (testing "find-matching-column should find columns based on matching name"
-    (let [query    (lib/append-stage lib.tu/query-with-join)
+    (let [query    (lib/append-stage (lib.tu/query-with-join))
           cols     (lib/returned-columns query)
           refs     (map lib.ref/ref cols)
           cat-name [:field {:lib/uuid (str (random-uuid))
@@ -339,7 +339,7 @@
 
 (deftest ^:parallel find-matching-column-self-join-test
   (testing "find-matching-column with a self join"
-    (let [query     lib.tu/query-with-self-join
+    (let [query     (lib.tu/query-with-self-join)
           cols      (for [col (meta/fields :orders)]
                       (meta/field-metadata :orders col))
           table-col #(assoc % :lib/source :source/table-defaults)
@@ -379,7 +379,7 @@
 
 (deftest ^:parallel find-matching-column-self-join-with-fields-test
   (testing "find-matching-column works with a tricky case taken from an e2e test"
-    (let [base   (-> lib.tu/query-with-self-join
+    (let [base   (-> (lib.tu/query-with-self-join)
                      (lib/with-fields [(meta/field-metadata :orders :id)
                                        (meta/field-metadata :orders :tax)]))
           [join] (lib/joins base)
@@ -488,7 +488,7 @@
                     (lib.equality/find-column-indexes-for-refs just-3 -1 refs ret-3)))))))))
 
 (deftest ^:parallel find-matching-column-aggregation-test
-  (let [query (-> lib.tu/venues-query
+  (let [query (-> (lib.tu/venues-query)
                   (lib/aggregate (lib/count)))
         [ag]  (lib/aggregations query)]
     (testing "without passing query"
@@ -523,47 +523,43 @@
   (is (=? {:name "expr", :lib/source :source/expressions}
           (lib.equality/find-matching-column
            [:expression {:lib/uuid (str (random-uuid))} "expr"]
-           (lib/visible-columns lib.tu/query-with-expression)))))
+           (lib/visible-columns (lib.tu/query-with-expression))))))
 
 (deftest ^:parallel find-column-for-legacy-ref-field-test
-  (are [legacy-ref] (=? {:name "NAME", :id (meta/id :venues :name)}
-                        (lib/find-column-for-legacy-ref
-                         lib.tu/venues-query
-                         legacy-ref
-                         (lib/visible-columns lib.tu/venues-query)))
-    [:field (meta/id :venues :name) nil]
-    [:field (meta/id :venues :name) {}]
-    ;; should work with refs that need normalization
-    ["field" (meta/id :venues :name) nil]
-    ["field" (meta/id :venues :name)]
-    #?@(:cljs
-        [#js ["field" (meta/id :venues :name) nil]
-         #js ["field" (meta/id :venues :name) #js {}]])))
+  (let [query (lib.tu/venues-query)]
+    (are [legacy-ref] (=? {:name "NAME", :id (meta/id :venues :name)}
+                          (lib/find-column-for-legacy-ref query legacy-ref (lib/visible-columns query)))
+      [:field (meta/id :venues :name) nil]
+      [:field (meta/id :venues :name) {}]
+      ;; should work with refs that need normalization
+      ["field" (meta/id :venues :name) nil]
+      ["field" (meta/id :venues :name)]
+      #?@(:cljs
+          [#js ["field" (meta/id :venues :name) nil]
+           #js ["field" (meta/id :venues :name) #js {}]]))))
 
 (deftest ^:parallel find-column-for-legacy-ref-match-by-name-test
   (testing "Make sure fallback matching by name works correctly"
     (is (=? {:name "NAME"}
             (lib/find-column-for-legacy-ref
-             lib.tu/venues-query
+             (lib.tu/venues-query)
              [:field (meta/id :venues :name) nil]
              [(dissoc (meta/field-metadata :venues :name) :id :table-id)])))))
 
 (deftest ^:parallel find-column-for-legacy-ref-expression-test
-  (are [legacy-ref] (=? {:name "expr", :lib/source :source/expressions}
-                        (lib/find-column-for-legacy-ref
-                         lib.tu/query-with-expression
-                         legacy-ref
-                         (lib/visible-columns lib.tu/query-with-expression)))
-    [:expression "expr"]
-    ["expression" "expr"]
-    ["expression" "expr" nil]
-    ["expression" "expr" {}]
-    #?@(:cljs
-        [#js ["expression" "expr"]
-         #js ["expression" "expr" #js {}]])))
+  (let [query (lib.tu/query-with-expression)]
+    (are [legacy-ref] (=? {:name "expr", :lib/source :source/expressions}
+                          (lib/find-column-for-legacy-ref query legacy-ref (lib/visible-columns query)))
+      [:expression "expr"]
+      ["expression" "expr"]
+      ["expression" "expr" nil]
+      ["expression" "expr" {}]
+      #?@(:cljs
+          [#js ["expression" "expr"]
+           #js ["expression" "expr" #js {}]]))))
 
 (deftest ^:parallel find-column-for-legacy-ref-aggregation-test
-  (let [query (-> lib.tu/venues-query
+  (let [query (-> (lib.tu/venues-query)
                   (lib/aggregate (lib/count)))]
     (are [legacy-ref] (=? {:name           "count"
                            :effective-type :type/Integer
@@ -657,7 +653,7 @@
                          :base-type :type/Text
                          :join-alias "Cat"}
                  (meta/id :categories :name)]
-          query (-> lib.tu/query-with-join
+          query (-> (lib.tu/query-with-join)
                     (lib/expression "Joied Name" a-ref))
           cols  (lib/returned-columns query)]
       (is (=? {:name "NAME"

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -27,7 +27,7 @@
                      :expressions [[:+ {:lib/uuid string? :lib/expression-name "myadd"}
                                     1
                                     [:field {:base-type :type/Integer, :lib/uuid string?} (meta/id :venues :category-id)]]]}]}
-          (-> lib.tu/venues-query
+          (-> (lib.tu/venues-query)
               (lib/expression "myadd" (lib/+ 1 (meta/field-metadata :venues :category-id)))
               (dissoc :lib/metadata)))))
 
@@ -80,7 +80,7 @@
                          (lib/upper string-field) :type/Text
                          (lib/lower string-field) :type/Text])]
       (testing (str "expression: " (pr-str expr))
-        (let [query (-> lib.tu/venues-query
+        (let [query (-> (lib.tu/venues-query)
                         (lib/expression "myexpr" expr))
               resolved (lib.expression/resolve-expression query 0 "myexpr")]
           (testing (pr-str resolved)
@@ -94,7 +94,7 @@
            :display-name "double-price"
            :lib/source   :source/expressions}
           (lib/metadata
-           (-> lib.tu/venues-query
+           (-> (lib.tu/venues-query)
                (lib/expression "double-price"
                                (lib/* (lib.tu/field-clause :venues :price {:base-type :type/Integer}) 2)))
            -1
@@ -122,12 +122,12 @@
                 -1
                 :day]]
     (is (= "DATE_minus_1_day"
-           (lib/column-name lib.tu/venues-query -1 clause)))
+           (lib/column-name (lib.tu/venues-query) -1 clause)))
     (is (= "Date - 1 day"
-           (lib/display-name lib.tu/venues-query -1 clause)))))
+           (lib/display-name (lib.tu/venues-query) -1 clause)))))
 
 (deftest ^:parallel expression-reference-names-test
-  (let [query (-> lib.tu/venues-query
+  (let [query (-> (lib.tu/venues-query)
                   (lib/expression "double-price"
                                   (lib/*
                                    (lib.tu/field-clause :venues :price {:base-type :type/Integer})
@@ -143,14 +143,14 @@
 (deftest ^:parallel coalesce-names-test
   (let [clause [:coalesce {} (lib.tu/field-clause :venues :name) "<Venue>"]]
     (is (= "NAME"
-           (lib/column-name lib.tu/venues-query -1 clause)))
+           (lib/column-name (lib.tu/venues-query) -1 clause)))
     (is (= "Name"
-           (lib/display-name lib.tu/venues-query -1 clause)))))
+           (lib/display-name (lib.tu/venues-query) -1 clause)))))
 
 (defn- infer-first
   [expr]
   (lib/metadata
-   (-> lib.tu/venues-query
+   (-> (lib.tu/venues-query)
        (lib/expression "expr" expr))
    -1
    [:expression {:lib/uuid (str (random-uuid))} "expr"]))
@@ -197,7 +197,7 @@
            :display-name "last-login-plus-2"
            :lib/source   :source/expressions}
           (lib/metadata
-           (-> lib.tu/venues-query
+           (-> (lib.tu/venues-query)
                (lib/expression "last-login-plus-2"
                                [:datetime-add
                                 {:lib/uuid (str (random-uuid))}
@@ -213,7 +213,7 @@
          #?(:clj Throwable :cljs js/Error)
          #"No expression named \"double-price\""
          (lib/metadata
-          (-> lib.tu/venues-query
+          (-> (lib.tu/venues-query)
               (lib/expression "one-hundred" (lib/+ 100 0)))
           -1
           [:expression {:lib/uuid (str (random-uuid))} "double-price"])))))
@@ -232,7 +232,7 @@
           (is (= (condp = arg-2
                    1   :type/Integer
                    1.0 :type/Float)
-                 (lib/type-of lib.tu/venues-query clause)))))
+                 (lib/type-of (lib.tu/venues-query) clause)))))
       (testing "/ should always return type/Float"
         (doseq [arg-2 [1 1.0]
                 :let  [clause [:/ {:lib/uuid (str (random-uuid))} field arg-2]]]
@@ -240,21 +240,21 @@
             (is (= :type/Float
                    (lib.schema.expression/type-of clause)))
             (is (= :type/Float
-                   (lib/type-of lib.tu/venues-query clause)))))))))
+                   (lib/type-of (lib.tu/venues-query) clause)))))))))
 
 (deftest ^:parallel expressions-names-test
   (testing "expressions should include the original expression name"
     (is (=? [{:name         "expr"
               :display-name "expr"}]
-            (-> lib.tu/venues-query
+            (-> (lib.tu/venues-query)
                 (lib/expression "expr" (lib/absolute-datetime "2020" :month))
                 lib/expressions-metadata)))
     (is (=? [{:display-name "expr"
               :named? true}]
-            (-> lib.tu/venues-query
+            (-> (lib.tu/venues-query)
                 (lib/expression "expr" (lib/absolute-datetime "2020" :month))
                 lib/expressions
-                (->> (map (fn [expr] (lib/display-info lib.tu/venues-query expr))))))))
+                (->> (map (fn [expr] (lib/display-info (lib.tu/venues-query) expr))))))))
   ;; TODO: This logic was removed as part of fixing #39059. We might want to bring it back for collisions with other
   ;; expressions in the same stage; probably not with tables or earlier stages. De-duplicating names is supported by the
   ;; QP code, and it should be powered by MLv2 in due course.
@@ -278,15 +278,15 @@
             :name "expr",
             :display-name "expr",
             :lib/source :source/expressions}]
-          (-> lib.tu/venues-query
+          (-> (lib.tu/venues-query)
               (lib/expression "expr" 100)
               (lib/expressions-metadata))))
   (is (=? [[:value {:lib/expression-name "expr", :effective-type :type/Integer, :ident string?} 100]]
-          (-> lib.tu/venues-query
+          (-> (lib.tu/venues-query)
               (lib/expression "expr" 100)
               (lib/expressions))))
   (is (=? [[:value {:lib/expression-name "expr", :effective-type :type/Text, :ident string?} "value"]]
-          (-> lib.tu/venues-query
+          (-> (lib.tu/venues-query)
               (lib/expression "expr" "value")
               (lib/expressions)))))
 
@@ -308,7 +308,7 @@
 
 (deftest ^:parallel expressionable-columns-exclude-expressions-containing-offset
   (testing "expressionable-columns should filter out expressions which contain :offset"
-    (let [query (-> lib.tu/venues-query
+    (let [query (-> (lib.tu/venues-query)
                     (lib/order-by (meta/field-metadata :venues :id) :asc)
                     (lib/expression "Offset col"    (lib/offset (meta/field-metadata :venues :price) -1))
                     (lib/expression "Nested Offset"
@@ -326,7 +326,7 @@
 
 (deftest ^:parallel infix-display-name-with-expressions-test
   (testing "#32063"
-    (let [query (lib/query lib.tu/metadata-provider-with-mock-cards (:orders lib.tu/mock-cards))
+    (let [query (lib/query (lib.tu/metadata-provider-with-mock-cards) (:orders (lib.tu/mock-cards)))
           query (-> query
                     (lib/expression "Unit price" (lib//
                                                   (lib.tu/field-literal-ref query "SUBTOTAL")
@@ -340,7 +340,7 @@
     (testing "various pemutations on venues"
       (let [query (reduce (fn [query [label expr]]
                             (lib/expression query -1 label expr))
-                          lib.tu/venues-query
+                          (lib.tu/venues-query)
                           [["name+price" (lib/concat (meta/field-metadata :venues :name)
                                                      (meta/field-metadata :venues :price))]
                            ["$price"     (lib/concat "$" (meta/field-metadata :venues :price))]
@@ -387,7 +387,7 @@
         (is (empty? (lib/expressions dropped)))))))
 
 (deftest ^:parallel with-expression-name-test
-  (let [query         (-> lib.tu/venues-query
+  (let [query         (-> (lib.tu/venues-query)
                           (lib/expression "expr" (lib/absolute-datetime "2020" :month))
                           (lib/aggregate (lib/count))
                           (lib/filter (lib/< (meta/field-metadata :venues :price) 4)))
@@ -459,12 +459,12 @@
     (let [expr (lib/with-expression-name 0 "zero")]
       (is (=? [:value {:name "zero", :display-name "zero", :effective-type :type/Integer} 0]
               expr))
-      (is (= "zero" (lib/display-name lib.tu/venues-query expr))))))
+      (is (= "zero" (lib/display-name (lib.tu/venues-query) expr))))))
 
 (deftest ^:parallel diagnose-expression-test
   (testing "correct expression are accepted silently"
     (are [mode expr] (nil? (lib.expression/diagnose-expression
-                            lib.tu/venues-query 0 mode
+                            (lib.tu/venues-query) 0 mode
                             (lib.convert/->pMBQL expr)
                             #?(:clj nil :cljs js/undefined)))
       :expression  [:/ [:field 1 nil] 100]
@@ -477,7 +477,7 @@
       (binding [lib.schema.expression/*suppress-expression-type-check?* false]
         (are [mode expr] (=? {:message #"Type error: .*"}
                              (lib.expression/diagnose-expression
-                              lib.tu/venues-query 0 mode
+                              (lib.tu/venues-query) 0 mode
                               (lib.convert/->pMBQL expr)
                               #?(:clj nil :cljs js/undefined)))
           :expression  [:/ [:field 1 {:base-type :type/Address}] 100]
@@ -501,7 +501,7 @@
                                lib.convert/->pMBQL)
             query (reduce-kv (fn [query expr-name expr]
                                (lib/expression query 0 expr-name expr))
-                             lib.tu/venues-query
+                             (lib.tu/venues-query)
                              exprs)
             expressions (lib/expressions query)
             c-pos (some (fn [[i e]]

--- a/test/metabase/lib/fe_util_test.cljc
+++ b/test/metabase/lib/fe_util_test.cljc
@@ -121,11 +121,11 @@
                    :name "ID"
                    :display-name "ID"}
                   1]}
-          (lib/expression-parts lib.tu/venues-query -1 (lib/= (lib/ref (meta/field-metadata :products :id))
-                                                              1)))))
+          (lib/expression-parts (lib.tu/venues-query) -1 (lib/= (lib/ref (meta/field-metadata :products :id))
+                                                                1)))))
 
 (deftest ^:parallel string-filter-parts-test
-  (let [query  lib.tu/venues-query
+  (let [query  (lib.tu/venues-query)
         column (meta/field-metadata :venues :name)]
     (testing "clause to parts roundtrip"
       (doseq [[clause parts] {(lib.filter/is-empty column)
@@ -186,7 +186,7 @@
         (lib.filter/and (lib.filter/= column "A") true)))))
 
 (deftest ^:parallel number-filter-parts-test
-  (let [query  lib.tu/venues-query
+  (let [query  (lib.tu/venues-query)
         column (meta/field-metadata :venues :price)]
     (testing "clause to parts roundtrip"
       (doseq [[clause parts] {(lib.filter/is-null column)       {:operator :is-null, :column column}
@@ -272,7 +272,7 @@
         (lib.filter/and (lib.filter/= lat-column 10) true)))))
 
 (deftest ^:parallel boolean-filter-parts-test
-  (let [query  (-> lib.tu/venues-query
+  (let [query  (-> (lib.tu/venues-query)
                    (lib.expression/expression "Boolean"
                                               (lib.filter/is-empty (meta/field-metadata :venues :name))))
         column (m/find-first #(= (:name %) "Boolean") (lib.filter/filterable-columns query))]
@@ -300,7 +300,7 @@
           (fn [values] (mapv #(u.time/format-for-base-type % (if with-time? :type/DateTime :type/Date)) values))))
 
 (deftest ^:parallel specific-date-filter-parts-test
-  (let [query  lib.tu/venues-query
+  (let [query  (lib.tu/venues-query)
         column (meta/field-metadata :checkins :date)]
     (testing "clause to parts roundtrip"
       (doseq [[clause parts] {(lib.filter/= column "2024-11-28")
@@ -365,7 +365,7 @@
         (lib.filter/and (lib.filter/< column "2024-11-28") true)))))
 
 (deftest ^:parallel relative-date-filter-parts-test
-  (let [query  lib.tu/venues-query
+  (let [query  (lib.tu/venues-query)
         column (meta/field-metadata :checkins :date)]
     (testing "clause to parts roundtrip"
       (doseq [[clause parts] {(lib.filter/time-interval column :current :day)
@@ -417,7 +417,7 @@
         (lib.filter/and (lib.filter/time-interval column -10 :month) true)))))
 
 (deftest ^:parallel exclude-date-filter-parts-test
-  (let [query  lib.tu/venues-query
+  (let [query  (lib.tu/venues-query)
         column (meta/field-metadata :checkins :date)]
     (testing "clause to parts roundtrip"
       (doseq [[clause parts] {(lib.filter/is-null column)
@@ -503,7 +503,7 @@
   (update parts :values (fn [values] (mapv #(u.time/format-for-base-type % :type/Time) values))))
 
 (deftest ^:parallel time-filter-parts-test
-  (let [query  lib.tu/venues-query
+  (let [query  (lib.tu/venues-query)
         column (assoc (meta/field-metadata :checkins :date)
                       :base-type      :type/Time
                       :effective-type :type/Time)]
@@ -550,7 +550,7 @@
         (lib.filter/and (lib.filter/> column "10:20") true)))))
 
 (deftest ^:parallel default-filter-parts-test
-  (let [query  lib.tu/venues-query
+  (let [query  (lib.tu/venues-query)
         column (meta/field-metadata :venues :price)]
     (testing "clause to parts roundtrip"
       (doseq [[clause parts] {(lib.filter/is-null column)       {:operator :is-null, :column column}
@@ -571,7 +571,7 @@
         date-arg-1 "2023-11-02"
         date-arg-2 "2024-01-03"
         datetime-arg "2024-12-05T22:50:27"]
-    (are [expected clause] (=? expected (lib/filter-args-display-name lib.tu/venues-query -1 clause))
+    (are [expected clause] (=? expected (lib/filter-args-display-name (lib.tu/venues-query) -1 clause))
       "4 AM" (lib/= (lib/get-hour created-at) 4)
       "Excludes 12 PM" (lib/!= (lib/get-hour created-at) 12)
       "Mondays" (lib/= (lib.expression/get-day-of-week created-at :iso) 1)
@@ -618,34 +618,34 @@
                       {:type :table,    :id (meta/id :venues)}
                       {:type :table,    :id (meta/id :categories)}]
                      (lib/dependent-metadata query nil :question))
-      lib.tu/venues-query
-      (lib/append-stage lib.tu/venues-query)))
+      (lib.tu/venues-query)
+      (lib/append-stage (lib.tu/venues-query))))
   (testing "join query"
     (are [query] (=? [{:type :database, :id (meta/id)}
                       {:type :schema,   :id (meta/id)}
                       {:type :table,    :id (meta/id :venues)}
                       {:type :table,    :id (meta/id :categories)}]
                      (lib/dependent-metadata query nil :question))
-      lib.tu/query-with-join
-      (lib/append-stage lib.tu/query-with-join)))
+      (lib.tu/query-with-join)
+      (lib/append-stage (lib.tu/query-with-join))))
   (testing "source card based query"
     (are [query] (=? [{:type :database, :id (meta/id)}
                       {:type :schema,   :id (meta/id)}
                       {:type :table,    :id "card__1"}
                       {:type :table,    :id (meta/id :users)}]
                      (lib/dependent-metadata query nil :question))
-      lib.tu/query-with-source-card
-      (lib/append-stage lib.tu/query-with-source-card)))
+      (lib.tu/query-with-source-card)
+      (lib/append-stage (lib.tu/query-with-source-card))))
   (testing "source card based query with result metadata"
     (are [query] (=? [{:type :database, :id (meta/id)}
                       {:type :schema,   :id (meta/id)}
                       {:type :table,    :id "card__1"}
                       {:type :table,    :id (meta/id :users)}]
                      (lib/dependent-metadata query nil :question))
-      lib.tu/query-with-source-card-with-result-metadata
-      (lib/append-stage lib.tu/query-with-source-card-with-result-metadata)))
+      (lib.tu/query-with-source-card-with-result-metadata)
+      (lib/append-stage (lib.tu/query-with-source-card-with-result-metadata))))
   (testing "model based query"
-    (let [query (assoc lib.tu/query-with-source-card :lib/metadata lib.tu/metadata-provider-with-model)]
+    (let [query (assoc (lib.tu/query-with-source-card) :lib/metadata lib.tu/metadata-provider-with-model)]
       (are [query] (=? [{:type :database, :id (meta/id)}
                         {:type :schema,   :id (meta/id)}
                         {:type :table,    :id "card__1"}
@@ -654,7 +654,7 @@
         query
         (lib/append-stage query))))
   (testing "metric based query"
-    (let [query (assoc lib.tu/query-with-source-card :lib/metadata lib.tu/metadata-provider-with-metric)]
+    (let [query (assoc (lib.tu/query-with-source-card) :lib/metadata lib.tu/metadata-provider-with-metric)]
       (are [query] (=? [{:type :database, :id (meta/id)}
                         {:type :schema,   :id (meta/id)}
                         {:type :table,    :id "card__1"}

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -31,7 +31,7 @@
 (deftest ^:parallel field-from-results-metadata-test
   (let [field-metadata (lib.metadata/stage-column (lib.tu/query-with-stage-metadata-from-card
                                                    meta/metadata-provider
-                                                   (:venues lib.tu/mock-cards))
+                                                   (:venues (lib.tu/mock-cards)))
                                                   "ID")]
     (is (=? {:lib/type :metadata/column
              :name     "ID"}
@@ -159,7 +159,7 @@
              :base-type     :type/Integer
              :semantic-type :type/FK}
             (lib/metadata
-             lib.tu/native-query
+             (lib.tu/native-query)
              -1
              [:field {:lib/uuid (str (random-uuid)), :base-type :type/Integer} "sum"])))))
 
@@ -415,7 +415,7 @@
 
 (deftest ^:parallel available-binning-strategies-expressions-test
   (testing "There should be no binning strategies for expressions as they are not supported (#31367)"
-    (let [query (-> lib.tu/venues-query
+    (let [query (-> (lib.tu/venues-query)
                     (lib/expression "myadd" (lib/+ 1 (meta/field-metadata :venues :category-id))))]
       (is (empty? (->> (lib/returned-columns query)
                        (m/find-first (comp #{"myadd"} :name))
@@ -484,11 +484,11 @@
       (is (= ::lib.schema.expression/type.unknown
              (lib.schema.expression/type-of clause)))
       (is (= :type/BigInteger
-             (lib/type-of lib.tu/venues-query clause))))))
+             (lib/type-of (lib.tu/venues-query) clause))))))
 
 (deftest ^:parallel implicitly-joinable-field-display-name-test
   (testing "Should be able to calculate a display name for an implicitly joinable Field"
-    (let [query           lib.tu/venues-query
+    (let [query           (lib.tu/venues-query)
           categories-name (m/find-first #(= (:id %) (meta/id :categories :name))
                                         (lib/orderable-columns query))]
       (are [style expected] (= expected
@@ -516,7 +516,7 @@
 (deftest ^:parallel source-card-table-display-info-test
   ;; this uses a legacy `card__<id>` `:table-id` intentionally; we don't currently have logic that parses this to
   ;; something like `:card-id` for Column Metadata yet. Make sure it works correctly.
-  (let [query (assoc lib.tu/venues-query :lib/metadata lib.tu/metadata-provider-with-card)
+  (let [query (assoc (lib.tu/venues-query) :lib/metadata lib.tu/metadata-provider-with-card)
         field (lib/metadata query (assoc (lib.metadata/field query (meta/id :venues :name))
                                          :table-id "card__1"))]
     (is (=? {:name           "NAME"
@@ -559,7 +559,7 @@
               (lib/returned-columns query))))))
 
 (deftest ^:parallel with-fields-test
-  (let [query           (-> lib.tu/venues-query
+  (let [query           (-> (lib.tu/venues-query)
                             (lib/expression "myadd" (lib/+ 1 (meta/field-metadata :venues :category-id)))
                             (lib/with-fields [(meta/field-metadata :venues :id) (meta/field-metadata :venues :name)]))
         fields-metadata (fn [query]
@@ -589,7 +589,7 @@
               (is (not (has-fields? query'))))))))))
 
 (deftest ^:parallel with-fields-plus-expression-test
-  (let [query           (-> lib.tu/venues-query
+  (let [query           (-> (lib.tu/venues-query)
                             (lib/with-fields [(meta/field-metadata :venues :id)])
                             (lib/expression "myadd" (lib/+ 1 (meta/field-metadata :venues :category-id))))
         fields-metadata (fn [query]
@@ -609,7 +609,7 @@
              {:lib/desired-column-alias "LATITUDE", :selected? true}
              {:lib/desired-column-alias "LONGITUDE", :selected? true}
              {:lib/desired-column-alias "PRICE", :selected? true}]
-            (lib/fieldable-columns lib.tu/venues-query)))))
+            (lib/fieldable-columns (lib.tu/venues-query))))))
 
 (deftest ^:parallel fieldable-columns-query-with-fields-test
   (testing "query with :fields"
@@ -619,7 +619,7 @@
              {:lib/desired-column-alias "LATITUDE", :selected? false}
              {:lib/desired-column-alias "LONGITUDE", :selected? false}
              {:lib/desired-column-alias "PRICE", :selected? false}]
-            (-> lib.tu/venues-query
+            (-> (lib.tu/venues-query)
                 (lib/with-fields [(meta/field-metadata :venues :id)
                                   (meta/field-metadata :venues :name)])
                 lib/fieldable-columns)))))
@@ -671,7 +671,7 @@
               [:field {:lib/uuid "aa0e13af-29b3-4c27-a880-a10c33e55a3e", :base-type :type/Text} 4]))))))
 
 (deftest ^:parallel ref-to-joined-column-from-previous-stage-test
-  (let [query (-> lib.tu/venues-query
+  (let [query (-> (lib.tu/venues-query)
                   (lib/join (-> (lib/join-clause
                                  (meta/table-metadata :categories)
                                  [(lib/=
@@ -787,7 +787,7 @@
                       fields-of)))))))
 
   (testing "sourced from another card"
-    (let [query   lib.tu/query-with-source-card]
+    (let [query   (lib.tu/query-with-source-card)]
       (testing "starts with no :fields"
         (is (nil? (-> query (lib.util/query-stage -1) :fields))))
       (testing "populates correctly"
@@ -1249,7 +1249,7 @@
 
 (deftest ^:parallel add-remove-fields-source-card-test
   (testing "query with a source card"
-    (let [query   lib.tu/query-with-source-card
+    (let [query   (lib.tu/query-with-source-card)
           columns (lib/visible-columns query)]
       (testing "allows removing each of the fields"
         (is (=? [[:field {} "USER_ID"]]
@@ -1309,7 +1309,7 @@
 
 (deftest ^:parallel add-remove-fields-native-query-test
   (testing "native query"
-    (let [native-query   lib.tu/native-query
+    (let [native-query   (lib.tu/native-query)
           native-columns (lib/visible-columns native-query)]
       (testing "throws when editing fields directly"
         (is (thrown-with-msg? #?(:cljs :default :clj Exception) #"Fields cannot be adjusted on native queries"
@@ -1357,14 +1357,14 @@
     (doseq [query-var [#'lib.tu/query-with-expression
                        #'lib.tu/query-with-join-with-explicit-fields
                        #'lib.tu/query-with-source-card]
-            :let [query @query-var]
+            :let [query (@query-var)]
             col (lib/visible-columns query)
             :let [col-ref (lib/ref col)]]
       (testing (str "ref " col-ref " of " (symbol query-var))
         (is (= (dissoc col :lib/source-uuid)
                (dissoc (lib/find-visible-column-for-ref query col-ref) :lib/source-uuid))))))
   (testing "reference by ID instead of name"
-    (let [query lib.tu/query-with-source-card
+    (let [query (lib.tu/query-with-source-card)
           col-ref [:field
                    {:lib/uuid "ae24a9b0-cbb5-40b6-bace-c8a5ac6a7e42"
                     :base-type :type/Integer
@@ -1603,7 +1603,7 @@
                :lib/source-uuid string?
                :name            "12345"
                :display-name    "12345"}
-              (lib.metadata.calculation/metadata lib.tu/venues-query -1 [:field {:lib/uuid (str (random-uuid))} 12345]))))))
+              (lib.metadata.calculation/metadata (lib.tu/venues-query) -1 [:field {:lib/uuid (str (random-uuid))} 12345]))))))
 
 (deftest ^:parallel field-values-search-info-test
   (testing "type/PK field remapped to a type/Name field within the same table"
@@ -1668,7 +1668,7 @@
     (is (= {:field-id nil :search-field-id nil :has-field-values :none}
            (lib.field/field-values-search-info
             meta/metadata-provider
-            (-> lib.tu/native-query
+            (-> (lib.tu/native-query)
                 lib/visible-columns
                 first))))
     (is (= {:field-id nil :search-field-id nil :has-field-values :none}
@@ -1676,7 +1676,7 @@
             meta/metadata-provider
             (-> (lib.tu/query-with-stage-metadata-from-card
                  meta/metadata-provider
-                 (:venues/native lib.tu/mock-cards))
+                 (:venues/native (lib.tu/mock-cards)))
                 lib/visible-columns
                 first))))
     (is (= {:field-id nil :search-field-id nil :has-field-values :none}
@@ -1684,7 +1684,7 @@
             meta/metadata-provider
             (-> (lib.tu/query-with-stage-metadata-from-card
                  meta/metadata-provider
-                 (:venues/native lib.tu/mock-cards))
+                 (:venues/native (lib.tu/mock-cards)))
                 lib/append-stage
                 lib/visible-columns
                 first)))))
@@ -1692,7 +1692,7 @@
     (is (= {:field-id 1 :search-field-id 1 :has-field-values :search}
            (lib.field/field-values-search-info
             meta/metadata-provider
-            (-> (update-in lib.tu/native-query [:stages 0 :lib/stage-metadata :columns] conj
+            (-> (update-in (lib.tu/native-query) [:stages 0 :lib/stage-metadata :columns] conj
                            {:lib/type :metadata/column
                             :id 1
                             :name "search"
@@ -1703,7 +1703,7 @@
     (is (= {:field-id 1 :search-field-id nil :has-field-values :none}
            (lib.field/field-values-search-info
             meta/metadata-provider
-            (-> (update-in lib.tu/native-query [:stages 0 :lib/stage-metadata :columns] conj
+            (-> (update-in (lib.tu/native-query) [:stages 0 :lib/stage-metadata :columns] conj
                            {:lib/type :metadata/column
                             :id 1
                             :name "num"

--- a/test/metabase/lib/filter_test.cljc
+++ b/test/metabase/lib/filter_test.cljc
@@ -24,7 +24,7 @@
           (apply f args))))
 
 (deftest ^:parallel general-filter-clause-test
-  (let [q2                          (lib.tu/query-with-stage-metadata-from-card meta/metadata-provider (:venues lib.tu/mock-cards))
+  (let [q2                          (lib.tu/query-with-stage-metadata-from-card meta/metadata-provider (:venues (lib.tu/mock-cards)))
         venues-category-id-metadata (meta/field-metadata :venues :category-id)
         venues-name-metadata        (meta/field-metadata :venues :name)
         venues-latitude-metadata    (meta/field-metadata :venues :latitude)
@@ -118,7 +118,7 @@
 
 (deftest ^:parallel filter-test
   (let [q1                          (lib/query meta/metadata-provider (meta/table-metadata :categories))
-        q2                          (lib.tu/query-with-stage-metadata-from-card meta/metadata-provider (:venues lib.tu/mock-cards))
+        q2                          (lib.tu/query-with-stage-metadata-from-card meta/metadata-provider (:venues (lib.tu/mock-cards)))
         venues-category-id-metadata (meta/field-metadata :venues :category-id)
         original-filter
         [:between
@@ -214,7 +214,7 @@
   (testing "#29947"
     (is (= "Name ends with t"
            (lib/display-name
-            lib.tu/venues-query
+            (lib.tu/venues-query)
             [:ends-with
              {:lib/uuid "953597df-a96d-4453-a57b-665e845abc69"}
              [:field {:lib/uuid "be28f393-538a-406b-90da-bac5f8ef565e"} (meta/id :venues :name)]
@@ -285,7 +285,7 @@
 
 (deftest ^:parallel filterable-columns-excludes-offset-expressions-test
   (testing "filterable-columns should exclude expressions which contain :offset"
-    (let [query (-> lib.tu/venues-query
+    (let [query (-> (lib.tu/venues-query)
                     (lib/order-by (meta/field-metadata :venues :id) :asc)
                     (lib/expression "Offset col"    (lib/offset (meta/field-metadata :venues :price) -1))
                     (lib/expression "Nested Offset"
@@ -313,7 +313,7 @@
                 (lib/filter new-filter)
                 lib/filters))))
   (testing "standalone clause"
-    (let [query lib.tu/venues-query
+    (let [query (lib.tu/venues-query)
           [id-col] (lib/filterable-columns query)
           [eq-op] (lib/filterable-column-operators id-col)
           filter-clause (lib/filter-clause eq-op id-col 123)]
@@ -466,7 +466,7 @@
                (lib/find-filter-for-legacy-filter query (lib.convert/->legacy-MBQL (first filter-clauses))))))))))
 
 (deftest ^:parallel find-filterable-column-for-legacy-ref-test
-  (let [query (lib/filter lib.tu/venues-query (lib/= (meta/field-metadata :venues :name) "BBQ"))]
+  (let [query (lib/filter (lib.tu/venues-query) (lib/= (meta/field-metadata :venues :name) "BBQ"))]
     (are [legacy-ref] (=? {:name      "NAME"
                            :id        (meta/id :venues :name)
                            :operators seq}

--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -21,7 +21,7 @@
 (def ^:private absent-key-marker (symbol "nil #_\"key is not present.\""))
 
 (deftest ^:parallel resolve-join-test
-  (let [query       lib.tu/venues-query
+  (let [query       (lib.tu/venues-query)
         join-clause (-> (lib/join-clause
                          (meta/table-metadata :categories)
                          [(lib/=
@@ -53,7 +53,7 @@
                                                         :join-alias "Categories"}
                                                        (meta/id :categories :id)]]]
                                        :fields      :all}]}]}
-          (let [q lib.tu/venues-query
+          (let [q (lib.tu/venues-query)
                 j (lib/query meta/metadata-provider (meta/table-metadata :categories))]
             (lib/join q (lib/join-clause j [{:lib/type :lib/external-op
                                              :operator :=
@@ -70,7 +70,7 @@
             (lib/join-clause (meta/table-metadata :orders)))))
   (testing "Should allow specifying the join strategy when creating a join clause"
     (is (= [:left-join :right-join :inner-join]
-           (let [query lib.tu/query-with-join
+           (let [query (lib.tu/query-with-join)
                  product-table (meta/table-metadata :products)
                  products-id (meta/id :products :id)
                  orders-product-id (meta/id :orders :product-id)
@@ -82,21 +82,21 @@
                    join-strategies)))))
   (testing "source-card"
     (let [query {:lib/type :mbql/query
-                 :lib/metadata lib.tu/metadata-provider-with-mock-cards
+                 :lib/metadata (lib.tu/metadata-provider-with-mock-cards)
                  :database (meta/id)
                  :stages [{:lib/type :mbql.stage/mbql
-                           :source-card (:id (lib.tu/mock-cards :orders))}]}
-          product-card (lib.tu/mock-cards :products)
+                           :source-card (:id ((lib.tu/mock-cards) :orders))}]}
+          product-card ((lib.tu/mock-cards) :products)
           [_ orders-product-id] (lib/join-condition-lhs-columns query product-card nil nil)
           [products-id] (lib/join-condition-rhs-columns query product-card orders-product-id nil)]
       (is (=? {:stages [{:joins [{:stages [{:source-card (:id product-card)}]}]}]}
               (lib/join query (lib/join-clause product-card [(lib/= orders-product-id products-id)]))))))
   (testing "source-table"
     (let [query {:lib/type :mbql/query
-                 :lib/metadata lib.tu/metadata-provider-with-mock-cards
+                 :lib/metadata (lib.tu/metadata-provider-with-mock-cards)
                  :database (meta/id)
                  :stages [{:lib/type :mbql.stage/mbql
-                           :source-card (:id (lib.tu/mock-cards :orders))}]}
+                           :source-card (:id ((lib.tu/mock-cards) :orders))}]}
           product-table (meta/table-metadata :products)
           [_ orders-product-id] (lib/join-condition-lhs-columns query product-table nil nil)
           [products-id] (lib/join-condition-rhs-columns query product-table orders-product-id nil)]
@@ -125,7 +125,7 @@
                                                        (meta/id :venues :category-id)]]]}]}]}
           (-> (lib/query meta/metadata-provider (meta/table-metadata :categories))
               (lib/join (lib/join-clause
-                         (lib.tu/query-with-stage-metadata-from-card meta/metadata-provider (:venues lib.tu/mock-cards))
+                         (lib.tu/query-with-stage-metadata-from-card meta/metadata-provider (:venues (lib.tu/mock-cards)))
                          [(lib/= (meta/field-metadata :categories :id)
                                  (meta/field-metadata :venues :category-id))]))
               (dissoc :lib/metadata)))))
@@ -133,9 +133,11 @@
 (deftest ^:parallel join-condition-field-metadata-test
   (testing "Should be able to use raw Field metadatas in the join condition"
     (let [q1                          (lib/query meta/metadata-provider (meta/table-metadata :categories))
-          q2                          (lib.tu/query-with-stage-metadata-from-card meta/metadata-provider (:venues lib.tu/mock-cards))
+          q2                          (lib.tu/query-with-stage-metadata-from-card meta/metadata-provider
+                                                                                  (:venues (lib.tu/mock-cards)))
           venues-category-id-metadata (meta/field-metadata :venues :category-id)
           categories-id-metadata      (lib.metadata/stage-column q2 "ID")]
+
       (let [clause (lib/join-clause q2 [(lib/= categories-id-metadata venues-category-id-metadata)])]
         (is (=? {:lib/type    :mbql/join
                  :lib/options {:lib/uuid string?}
@@ -264,7 +266,7 @@
            (lib.join/joined-thing query join)))))
 
 (deftest ^:parallel joins-source-and-desired-aliases-test
-  (let [query (-> lib.tu/venues-query
+  (let [query (-> (lib.tu/venues-query)
                   (lib/join (-> (lib/join-clause
                                  (meta/table-metadata :categories)
                                  [(lib/=
@@ -375,7 +377,7 @@
             (lib/returned-columns query)))))
 
 (deftest ^:parallel join-strategy-test
-  (let [query  lib.tu/query-with-join
+  (let [query  (lib.tu/query-with-join)
         [join] (lib/joins query)]
     (testing "join without :strategy"
       (is (= :left-join
@@ -402,7 +404,7 @@
                                                          (meta/id :categories :id)]]]
                                           :strategy :right-join
                                           :alias "Categories"}]}]}
-                      (-> lib.tu/venues-query
+                      (-> (lib.tu/venues-query)
                           (lib/join (-> (lib/join-clause (meta/table-metadata :categories)
                                                          [(lib/=
                                                            (meta/field-metadata :venues :category-id)
@@ -415,16 +417,16 @@
   (is (= [{:lib/type :option/join.strategy, :strategy :left-join, :default true}
           {:lib/type :option/join.strategy, :strategy :right-join}
           {:lib/type :option/join.strategy, :strategy :inner-join}]
-         (lib/available-join-strategies lib.tu/query-with-join))))
+         (lib/available-join-strategies (lib.tu/query-with-join)))))
 
 (deftest ^:parallel join-strategy-display-name-test
-  (let [query lib.tu/query-with-join]
+  (let [query (lib.tu/query-with-join)]
     (is (= ["Left outer join" "Right outer join" "Inner join"]
            (map (partial lib/display-name query)
                 (lib/available-join-strategies query))))))
 
 (deftest ^:parallel join-strategy-display-info-test
-  (let [query lib.tu/query-with-join]
+  (let [query (lib.tu/query-with-join)]
     (is (= [{:short-name "left-join", :display-name "Left outer join", :default true}
             {:short-name "right-join", :display-name "Right outer join"}
             {:short-name "inner-join", :display-name "Inner join"}]
@@ -433,7 +435,7 @@
 
 (deftest ^:parallel with-join-alias-update-fields-test
   (testing "with-join-alias should update the alias of columns in :fields"
-    (let [query  lib.tu/query-with-join-with-explicit-fields
+    (let [query  (lib.tu/query-with-join-with-explicit-fields)
           [join] (lib/joins query)]
       (is (=? {:alias  "Cat"
                :fields [[:field {:join-alias "Cat"} (meta/id :categories :name)]]}
@@ -445,7 +447,7 @@
 
 (deftest ^:parallel with-join-alias-update-condition-rhs-test
   (testing "with-join-alias should update the alias of the RHS column(s) in the condition(s)"
-    (let [query  lib.tu/query-with-join
+    (let [query  (lib.tu/query-with-join)
           [join] (lib/joins query)]
       (is (=? {:conditions [[:= {}
                              [:field {} (meta/id :venues :category-id)]
@@ -461,7 +463,7 @@
 
 (deftest ^:parallel with-join-alias-update-condition-rhs-set-alias-for-first-time-test
   (testing "with-join-alias should set the alias of the RHS column(s) when setting the alias for the first time"
-    (let [query  lib.tu/query-with-join
+    (let [query  (lib.tu/query-with-join)
           [join] (lib/joins query)
           join   (-> join
                      (dissoc :alias)
@@ -482,7 +484,7 @@
                 join'))))))
 
 (deftest ^:parallel with-join-conditions-empty-test
-  (let [query  lib.tu/query-with-join
+  (let [query  (lib.tu/query-with-join)
         [join] (lib/joins query)]
     (are [new-conditions] (nil? (lib/join-conditions (lib/with-join-conditions join new-conditions)))
       nil
@@ -490,7 +492,7 @@
 
 (deftest ^:parallel with-join-conditions-add-alias-test
   (testing "with-join-conditions should add join alias to RHS of conditions (#32558)"
-    (let [query      lib.tu/query-with-join
+    (let [query      (lib.tu/query-with-join)
           [join]     (lib/joins query)
           conditions (lib/join-conditions join)]
       (is (=? [[:= {}
@@ -523,7 +525,7 @@
 
 (deftest ^:parallel with-join-conditions-do-not-add-alias-when-already-present-test
   (testing "with-join-conditions should not replace an existing join alias (don't second guess explicit aliases)"
-    (let [query  lib.tu/query-with-join
+    (let [query  (lib.tu/query-with-join)
           [join] (lib/joins query)
           new-conditions [(lib/=
                            (meta/field-metadata :venues :id)
@@ -536,7 +538,7 @@
 
 (deftest ^:parallel with-join-conditions-join-has-no-alias-yet-test
   (testing "with-join-conditions should work if join doesn't yet have an alias"
-    (let [query  lib.tu/query-with-join
+    (let [query  (lib.tu/query-with-join)
           [join] (lib/joins query)
           join   (lib/with-join-alias join nil)]
       (is (nil? (lib.join.util/current-join-alias join)))
@@ -557,7 +559,7 @@
 
 (deftest ^:parallel with-join-conditions-do-not-add-alias-to-complex-conditions
   (testing "with-join-conditions should not add aliases to non-binary filter clauses"
-    (let [query  lib.tu/query-with-join
+    (let [query  (lib.tu/query-with-join)
           [join] (lib/joins query)]
       (testing :between
         (let [new-conditions [(lib/between
@@ -591,7 +593,7 @@
 
 (defn- test-with-join-fields [input expected]
   (testing (pr-str (list 'with-join-fields 'query input))
-    (let [query (-> lib.tu/venues-query
+    (let [query (-> (lib.tu/venues-query)
                     (lib/join (-> (lib/join-clause
                                    (meta/table-metadata :categories)
                                    [(lib/=
@@ -643,7 +645,7 @@
        {:fields [(lib/with-join-alias categories-id "Cat")]}))))
 
 (deftest ^:parallel join-condition-lhs-columns-test
-  (let [query lib.tu/venues-query]
+  (let [query (lib.tu/venues-query)]
     (doseq [rhs [nil (lib/with-join-alias (lib.metadata/field query (meta/id :venues :category-id)) "Cat")]]
       (testing (str "rhs = " (pr-str rhs))
         ;; sort PKs then FKs then everything else
@@ -657,7 +659,7 @@
 
 (deftest ^:parallel join-condition-lhs-columns-with-previous-join-test
   (testing "Include columns from previous join(s)"
-    (let [query lib.tu/query-with-join-with-explicit-fields]
+    (let [query (lib.tu/query-with-join-with-explicit-fields)]
       (doseq [rhs [nil (lib/with-join-alias (lib.metadata/field query (meta/id :users :id)) "User")]]
         (testing (str "rhs = " (pr-str rhs))
           (is (=? [{:lib/desired-column-alias "ID"}
@@ -674,7 +676,7 @@
 
 (deftest ^:parallel join-condition-lhs-columns-exclude-columns-from-existing-join-test
   (testing "Ignore columns added by a join or any subsequent joins (#32005)"
-    (let [query                  (-> lib.tu/query-with-join
+    (let [query                  (-> (lib.tu/query-with-join)
                                      (lib.tu/add-joins "C2" "C3"))
           [join-1 join-2 join-3] (lib/joins query)]
       (is (=? {:lib/type :mbql/join
@@ -701,7 +703,7 @@
         ["ID" "Cat__ID" "C2__ID" "CATEGORY_ID" "NAME" "LATITUDE" "LONGITUDE" "PRICE" "Cat__NAME" "C2__NAME"]))))
 
 (def ^:private join-for-query-with-join
-  (first (lib/joins lib.tu/query-with-join)))
+  (first (lib/joins (lib.tu/query-with-join))))
 
 (def ^:private condition-for-query-with-join
   (first (lib/join-conditions join-for-query-with-join)))
@@ -724,22 +726,23 @@
 
 (deftest ^:parallel join-condition-lhs-columns-mark-selected-test
   (testing "#32438"
-    (is (=? [{:long-display-name "ID"}
-             {:long-display-name "Category ID", :selected true}
-             {:long-display-name "Name"}
-             {:long-display-name "Latitude"}
-             {:long-display-name "Longitude"}
-             {:long-display-name "Price"}]
-            (map (partial lib/display-info lib.tu/query-with-join)
-                 (lib/join-condition-lhs-columns lib.tu/query-with-join
-                                                 join-for-query-with-join
-                                                 lhs-for-query-with-join
-                                                 rhs-for-query-with-join))))))
+    (let [query (lib.tu/query-with-join)]
+      (is (=? [{:long-display-name "ID"}
+               {:long-display-name "Category ID", :selected true}
+               {:long-display-name "Name"}
+               {:long-display-name "Latitude"}
+               {:long-display-name "Longitude"}
+               {:long-display-name "Price"}]
+              (map (partial lib/display-info query)
+                   (lib/join-condition-lhs-columns query
+                                                   join-for-query-with-join
+                                                   lhs-for-query-with-join
+                                                   rhs-for-query-with-join)))))))
 
 (deftest ^:parallel join-condition-rhs-columns-join-table-test
   (testing "RHS columns when building a join against a Table"
-    (doseq [query [lib.tu/venues-query
-                   lib.tu/query-with-join]]
+    (doseq [query [(lib.tu/venues-query)
+                   (lib.tu/query-with-join)]]
       (let [cols (lib/join-condition-rhs-columns query (meta/table-metadata :categories) nil nil)]
         (is (=? [{:display-name "ID", :lib/source :source/joins, :table-id (meta/id :categories)}
                  {:display-name "Name", :lib/source :source/joins, :table-id (meta/id :categories)}]
@@ -751,10 +754,11 @@
 
 (deftest ^:parallel join-condition-rhs-columns-join-card-test
   (testing "RHS columns when building a join against"
-    (doseq [query            [lib.tu/venues-query
-                              lib.tu/query-with-join]
-            [card-type card] {"Native" (:categories/native lib.tu/mock-cards)
-                              "MBQL"   (:categories lib.tu/mock-cards)}]
+    (doseq [query            [(lib.tu/venues-query)
+                              (lib.tu/query-with-join)]
+            :let [cards (lib.tu/mock-cards)]
+            [card-type card] {"Native" (:categories/native cards)
+                              "MBQL"   (:categories cards)}]
       (testing (str "a " card-type " Card")
         (let [cols (lib/join-condition-rhs-columns query card nil nil)]
           (is (=? [{:display-name "ID", :lib/source :source/joins, :lib/card-id (:id card)}
@@ -767,7 +771,7 @@
 
 (deftest ^:parallel join-condition-rhs-columns-existing-join-test
   (testing "RHS columns for existing join"
-    (let [cols (lib/join-condition-rhs-columns lib.tu/query-with-join join-for-query-with-join nil nil)]
+    (let [cols (lib/join-condition-rhs-columns (lib.tu/query-with-join) join-for-query-with-join nil nil)]
       (is (=? [{:display-name "ID",   :lib/source :source/joins, ::lib.join/join-alias "Cat"}
                {:display-name "Name", :lib/source :source/joins, ::lib.join/join-alias "Cat"}]
               cols))
@@ -775,13 +779,13 @@
         (is (=? [{:display-name "ID", :is-from-join true}
                  {:display-name "Name", :is-from-join true}]
                 (for [col cols]
-                  (lib/display-info lib.tu/query-with-join col))))))))
+                  (lib/display-info (lib.tu/query-with-join) col))))))))
 
 (deftest ^:parallel join-condition-rhs-columns-test-2
-  (let [query lib.tu/venues-query]
+  (let [query (lib.tu/venues-query)]
     (doseq [lhs          [nil (lib.metadata/field query (meta/id :venues :id))]
             joined-thing [(meta/table-metadata :venues)
-                          (:venues lib.tu/mock-cards)]]
+                          (:venues (lib.tu/mock-cards))]]
       (testing (str "lhs = " (pr-str lhs)
                     "\njoined-thing = " (pr-str joined-thing))
         (is (=? [{:lib/desired-column-alias "ID"}
@@ -794,28 +798,29 @@
 
 (deftest ^:parallel join-condition-rhs-columns-mark-selected-test
   (testing "#32438"
-    (is (=? [{:display-name "ID", :selected true}
-             {:display-name "Name"}]
-            (map (partial lib/display-info lib.tu/query-with-join)
-                 (lib/join-condition-rhs-columns lib.tu/query-with-join
-                                                 join-for-query-with-join
-                                                 lhs-for-query-with-join
-                                                 rhs-for-query-with-join))))))
+    (let [query (lib.tu/query-with-join)]
+      (is (=? [{:display-name "ID", :selected true}
+               {:display-name "Name"}]
+              (map (partial lib/display-info query)
+                   (lib/join-condition-rhs-columns query
+                                                   join-for-query-with-join
+                                                   lhs-for-query-with-join
+                                                   rhs-for-query-with-join)))))))
 
 (deftest ^:parallel join-condition-operators-test
   ;; just make sure that this doesn't barf and returns the expected output given any combination of LHS or RHS fields
   ;; for now until we actually implement filtering there
-  (let [query lib.tu/venues-query]
+  (let [query (lib.tu/venues-query)]
     (doseq [lhs [nil (lib.metadata/field query (meta/id :categories :id))]
             rhs [nil (lib.metadata/field query (meta/id :venues :category-id))]]
-      (testing (pr-str (list `lib/join-condition-operators `lib.tu/venues-query lhs rhs))
+      (testing (pr-str (list `lib/join-condition-operators `(lib.tu/venues-query) lhs rhs))
         (is (=? [{:short :=, :default true}
                  {:short :>}
                  {:short :<}
                  {:short :>=}
                  {:short :<=}
                  {:short :!=}]
-                (lib/join-condition-operators lib.tu/venues-query lhs rhs)))
+                (lib/join-condition-operators query lhs rhs)))
         (is (=? [{:short-name "=", :display-name "=", :long-display-name "Is"}
                  {:short-name ">", :display-name ">", :long-display-name "Greater than"}
                  {:short-name "<", :display-name "<", :long-display-name "Less than"}
@@ -823,9 +828,9 @@
                  {:short-name "<=", :display-name "≤", :long-display-name "Less than or equal to"}
                  {:short-name "!=", :display-name "≠", :long-display-name "Is not"}]
                 (map (partial lib/display-info query)
-                     (lib/join-condition-operators lib.tu/venues-query lhs rhs))))
-        (is (= (lib/join-condition-operators lib.tu/venues-query lhs rhs)
-               (lib/join-condition-operators lib.tu/venues-query -1 lhs rhs))))
+                     (lib/join-condition-operators query lhs rhs))))
+        (is (= (lib/join-condition-operators query lhs rhs)
+               (lib/join-condition-operators query -1 lhs rhs))))
       (testing `lib/display-info
         (is (=? [{:short-name "=", :default true}
                  {:short-name ">"}
@@ -834,7 +839,7 @@
                  {:short-name "<="}
                  {:short-name "!="}]
                 (map (partial lib/display-info query)
-                     (lib/join-condition-operators lib.tu/venues-query lhs rhs))))))))
+                     (lib/join-condition-operators query lhs rhs))))))))
 
 (deftest ^:parallel join-alias-single-table-multiple-times-test
   (testing "joining the same table twice results in different join aliases"
@@ -861,10 +866,10 @@
                       query
                       (meta/table-metadata :categories)))
       ;; plain query
-      lib.tu/venues-query
+      (lib.tu/venues-query)
 
       ;; query with an aggregation (FK column is not exported, but is still "visible")
-      (-> lib.tu/venues-query
+      (-> (lib.tu/venues-query)
           (lib/aggregate (lib/count))))))
 
 (deftest ^:parallel suggested-join-conditions-pk->fk-test
@@ -1131,7 +1136,7 @@
                   (sort-conditions (lib/suggested-join-conditions query order)))))))))
 
 (deftest ^:parallel join-conditions-test
-  (let [joins (lib/joins lib.tu/query-with-join)]
+  (let [joins (lib/joins (lib.tu/query-with-join))]
     (is (= 1
            (count joins)))
     (is (=? [[:=
@@ -1147,12 +1152,12 @@
                             {:lib/type :metadata/column, :name "LATITUDE"}
                             {:lib/type :metadata/column, :name "LONGITUDE"}
                             {:lib/type :metadata/column, :name "PRICE"}]
-                           (lib/joinable-columns lib.tu/venues-query -1 table-or-card))
+                           (lib/joinable-columns (lib.tu/venues-query) -1 table-or-card))
     (meta/table-metadata :venues)
-    (:venues lib.tu/mock-cards)))
+    (:venues (lib.tu/mock-cards))))
 
 (deftest ^:parallel joinable-columns-join-test
-  (let [query           lib.tu/query-with-join
+  (let [query           (lib.tu/query-with-join)
         [original-join] (lib/joins query)]
     (is (=? {:lib/type :mbql/join, :alias "Cat", :fields :all}
             original-join))
@@ -1208,14 +1213,14 @@
                     (lib/with-join-fields join cols)))))))))
 
 (deftest ^:parallel join-lhs-display-name-test
-  (doseq [[source-table? query]                {true  lib.tu/venues-query
-                                                false lib.tu/query-with-source-card}
+  (doseq [[source-table? query]                {true  (lib.tu/venues-query)
+                                                false (lib.tu/query-with-source-card)}
           [num-existing-joins query]           {0 query
                                                 1 (lib.tu/add-joins query "J1")
                                                 2 (lib.tu/add-joins query "J1" "J2")}
           [first-join? join? join-or-joinable] (list*
                                                 [(zero? num-existing-joins) false (meta/table-metadata :venues)]
-                                                [(zero? num-existing-joins) false (:venues lib.tu/mock-cards)]
+                                                [(zero? num-existing-joins) false (:venues (lib.tu/mock-cards))]
                                                 [(zero? num-existing-joins) false nil]
                                                 (when-let [[first-join & more] (not-empty (lib/joins query))]
                                                   (cons [true true first-join]
@@ -1431,7 +1436,7 @@
 (deftest ^:parallel suggested-name-include-joins-test
   (testing "Include the names of joined tables in suggested query names (#24703)"
     (is (= "Venues + Categories"
-           (lib/suggested-name lib.tu/query-with-join)))))
+           (lib/suggested-name (lib.tu/query-with-join))))))
 
 (deftest ^:parallel suggested-join-conditions-with-position-test
   (testing "when editing the _i_th join, columns from that and later joins should not be suggested"

--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -138,7 +138,7 @@
 
 (deftest ^:parallel available-join-strategies-test
   (testing "available-join-strategies returns an array of opaque strategy objects (#32089)"
-    (let [strategies (lib.js/available-join-strategies lib.tu/query-with-join -1)]
+    (let [strategies (lib.js/available-join-strategies (lib.tu/query-with-join) -1)]
       (is (array? strategies))
       (is (= [{:lib/type :option/join.strategy, :strategy :left-join, :default true}
               {:lib/type :option/join.strategy, :strategy :right-join}
@@ -208,7 +208,7 @@
 
 (deftest ^:parallel expression-clause-<->-legacy-expression-test
   (testing "conversion works both ways, even with aggregations (#34830, #36087)"
-    (let [query (-> lib.tu/venues-query
+    (let [query (-> (lib.tu/venues-query)
                     (lib/expression "double-price" (lib/* (meta/field-metadata :venues :price) 2))
                     (lib/aggregate (lib/sum [:expression {:lib/uuid (str (random-uuid))} "double-price"])))
           agg-uuid (-> query lib/aggregations first lib.options/uuid)
@@ -232,7 +232,7 @@
       (testing "from pMBQL filter"
         (is (= (js->clj legacy-filter) (js->clj legacy-filter'))))))
   (testing "conversion drops aggregation-options (#36120)"
-    (let [query (-> lib.tu/venues-query
+    (let [query (-> (lib.tu/venues-query)
                     (lib/aggregate (lib.options/update-options (lib/sum (meta/field-metadata :venues :price))
                                                                assoc :display-name "price sum")))
           agg-expr (-> query lib/aggregations first)
@@ -240,14 +240,14 @@
           legacy-agg-expr' (lib.js/legacy-expression-for-expression-clause query -1 agg-expr)]
       (is (= (js->clj legacy-agg-expr) (js->clj legacy-agg-expr')))))
   (testing "legacy expressions are converted properly (#36120)"
-    (let [query (-> lib.tu/venues-query
+    (let [query (-> (lib.tu/venues-query)
                     (lib/aggregate (lib/count)))
           agg-expr (-> query lib/aggregations first)
           legacy-agg-expr #js ["count"]
           legacy-agg-expr' (lib.js/legacy-expression-for-expression-clause query -1 agg-expr)]
       (is (= (js->clj legacy-agg-expr) (js->clj legacy-agg-expr')))))
   (testing "simple values can be converted properly (#36459)"
-    (let [query lib.tu/venues-query
+    (let [query (lib.tu/venues-query)
           legacy-expr 0
           expr (lib.js/expression-clause-for-legacy-expression query 0 legacy-expr)
           legacy-expr' (lib.js/legacy-expression-for-expression-clause query 0 expr)
@@ -258,7 +258,7 @@
       (is (= legacy-expr expr legacy-expr' legacy-expr-from-query))
       (is (= "named" (lib/display-name query named-expr)))))
   (testing "simple expressions can be converted properly (#37173)"
-    (let [query lib.tu/venues-query
+    (let [query (lib.tu/venues-query)
           legacy-expr #js ["+" 1 2]
           expr (lib.js/expression-clause-for-legacy-expression query 0 legacy-expr)
           legacy-expr' (lib.js/legacy-expression-for-expression-clause query 0 expr)
@@ -274,7 +274,7 @@
         (is (=? {:stages [{:expressions [[:+ {:lib/expression-name "expr"} 1 2]]}]}
                 (lib/expression query -1 "expr" expr))))))
   (testing "filters from queries can be converted to legacy clauses (#37173, #44584)"
-    (let [query (lib/filter lib.tu/venues-query (lib/< (meta/field-metadata :venues :price) 3))
+    (let [query (lib/filter (lib.tu/venues-query) (lib/< (meta/field-metadata :venues :price) 3))
           expr (first (lib/filters query))
           legacy-expr (lib.js/legacy-expression-for-expression-clause query 0 expr)
           price-id (meta/id :venues :price)]
@@ -332,7 +332,7 @@
         metric-id 101
 
         metric-definition
-        (-> lib.tu/venues-query
+        (-> (lib.tu/venues-query)
             (lib/filter (lib/= (meta/field-metadata :venues :price) 4))
             (lib/aggregate (lib/sum (meta/field-metadata :venues :price)))
             lib.convert/->legacy-MBQL)
@@ -405,16 +405,16 @@
 (deftest ^:parallel source-table-or-card-id-test
   (testing "returns the table-id as a number"
     (are [query] (= (meta/id :venues) (lib.js/source-table-or-card-id query))
-      lib.tu/venues-query
-      (lib/append-stage lib.tu/venues-query)))
+      (lib.tu/venues-query)
+      (lib/append-stage (lib.tu/venues-query))))
   (testing "returns the card-id in the legacy string form"
     (are [query] (= "card__1" (lib.js/source-table-or-card-id query))
-      lib.tu/query-with-source-card
-      (lib/append-stage lib.tu/query-with-source-card)))
+      (lib.tu/query-with-source-card)
+      (lib/append-stage (lib.tu/query-with-source-card))))
   (testing "returns nil for questions starting from a native query"
     (are [query] (nil? (lib.js/source-table-or-card-id query))
-      lib.tu/native-query
-      (lib/append-stage lib.tu/native-query))))
+      (lib.tu/native-query)
+      (lib/append-stage (lib.tu/native-query)))))
 
 (deftest ^:parallel expression-clause-normalization-test
   (are [x y] (do
@@ -618,7 +618,7 @@
                            lib.convert/->pMBQL)
         query (reduce-kv (fn [query expr-name expr]
                            (lib/expression query 0 expr-name expr))
-                         lib.tu/venues-query
+                         (lib.tu/venues-query)
                          exprs)
         c-pos (some (fn [[i e]]
                       (when (= (-> e lib.options/options :lib/expression-name) "c")

--- a/test/metabase/lib/limit_test.cljc
+++ b/test/metabase/lib/limit_test.cljc
@@ -11,7 +11,7 @@
 (deftest ^:parallel limit-test
   (letfn [(limit [query]
             (get-in query [:stages 0 :limit] ::not-found))]
-    (let [query (-> lib.tu/venues-query
+    (let [query (-> (lib.tu/venues-query)
                     (lib/limit 100))]
       (is (= 100
              (limit query)))
@@ -25,7 +25,7 @@
 
 (deftest ^:parallel current-limit-test
   (testing "Last stage"
-    (let [query lib.tu/venues-query]
+    (let [query (lib.tu/venues-query)]
       (is (nil? (lib/current-limit query)))
       (is (nil? (lib/current-limit query -1)))
       (is (= 100 (lib/current-limit (lib/limit query 100))))

--- a/test/metabase/lib/metadata_test.cljc
+++ b/test/metabase/lib/metadata_test.cljc
@@ -20,7 +20,7 @@
           (lib.metadata/field meta/metadata-provider (meta/id :venues :category-id)))))
 
 (deftest ^:parallel stage-metadata-test
-  (let [query (lib.tu/query-with-stage-metadata-from-card meta/metadata-provider (:venues lib.tu/mock-cards))]
+  (let [query (lib.tu/query-with-stage-metadata-from-card meta/metadata-provider (:venues (lib.tu/mock-cards)))]
     (is (=? {:columns [{:name "ID"}
                        {:name "NAME"}
                        {:name "CATEGORY_ID"}
@@ -30,7 +30,7 @@
             (lib.metadata/stage query -1)))))
 
 (deftest ^:parallel stage-column-metadata-test
-  (let [query (lib.tu/query-with-stage-metadata-from-card meta/metadata-provider (:venues lib.tu/mock-cards))]
+  (let [query (lib.tu/query-with-stage-metadata-from-card meta/metadata-provider (:venues (lib.tu/mock-cards)))]
     (are [x] (=? {:lib/type       :metadata/column
                   :display-name   "Category ID"
                   :name           "CATEGORY_ID"
@@ -44,8 +44,8 @@
 (deftest ^:parallel display-name-from-name-test
   (testing "Use the 'simple humanization' logic to calculate a display name for a Field that doesn't have one"
     (is (= "Venue ID"
-           (lib/display-name lib.tu/venues-query -1 {:lib/type :metadata/column
-                                                     :name     "venue_id"})))))
+           (lib/display-name (lib.tu/venues-query) -1 {:lib/type :metadata/column
+                                                       :name     "venue_id"})))))
 
 (deftest ^:parallel table-or-card-test
   (are [id expected] (=? expected
@@ -65,7 +65,7 @@
      ;; now.
      :cljs
      ;; `Integer/MAX_VALUE`, but I don't know what the Cljs way to do this
-     (is (nil? (lib.metadata/table-or-card lib.tu/metadata-provider-with-card 2147483647)))))
+     (is (nil? (lib.metadata/table-or-card lib.tu/metadata-provider-with-card js/Number.MAX_SAFE_INT)))))
 
 (deftest ^:parallel bulk-metadata-preserve-order-test
   (testing "bulk-metadata should return things in the same order as the IDs passed in"
@@ -78,7 +78,7 @@
       ["PEOPLE" "ORDERS" "VENUES"])))
 
 (deftest ^:parallel editable?-test
-  (let [query          lib.tu/query-with-join
+  (let [query          (lib.tu/query-with-join)
         metadata       ^SimpleGraphMetadataProvider (:lib/metadata query)
         metadata-graph (.-metadata-graph metadata)
         restricted-metadata-graph (update metadata-graph :tables #(into [] (remove (comp #{"CATEGORIES"} :name)) %))

--- a/test/metabase/lib/metric_test.cljc
+++ b/test/metabase/lib/metric_test.cljc
@@ -17,7 +17,7 @@
 (def ^:private second-metric-id 101)
 
 (def ^:private metric-definition
-  (-> lib.tu/venues-query
+  (-> (lib.tu/venues-query)
       (lib/filter (lib/= (meta/field-metadata :venues :price) 4))
       (lib/aggregate (lib/sum (meta/field-metadata :venues :price)))
       lib.convert/->legacy-MBQL))
@@ -54,7 +54,7 @@
   (lib.tu/mock-metadata-provider meta/metadata-provider multiple-metrics-db))
 
 (def ^:private metadata-provider-with-cards
-  (lib.tu/mock-metadata-provider lib.tu/metadata-provider-with-mock-cards metrics-db))
+  (lib.tu/mock-metadata-provider (lib.tu/metadata-provider-with-mock-cards) metrics-db))
 
 (def ^:private metric-clause
   [:metric {:lib/uuid (str (random-uuid))} metric-id])
@@ -68,7 +68,7 @@
 
 (deftest ^:parallel uses-metric?-test
   (is (lib/uses-metric? query-with-metric metric-id))
-  (is (not (lib/uses-metric? lib.tu/venues-query metric-id))))
+  (is (not (lib/uses-metric? (lib.tu/venues-query) metric-id))))
 
 (deftest ^:parallel query-suggested-name-test
   (is (= "Venues, Sum of Cans"
@@ -135,7 +135,7 @@
 
 (deftest ^:parallel display-info-unselected-metric-test
   (testing "Include `:selected false` in display info for Metrics not in aggregations"
-    (are [metric] (not (:selected (lib/display-info lib.tu/venues-query metric)))
+    (are [metric] (not (:selected (lib/display-info (lib.tu/venues-query) metric)))
       metric-clause
       metric-metadata)))
 
@@ -269,6 +269,6 @@
       (is (nil? (lib.metric/available-metrics query)))))
   (testing "query based on a card -- don't return Metrics"
     (doseq [card-key [:venues :venues/native]]
-      (let [query (lib/query metadata-provider-with-cards (card-key lib.tu/mock-cards))]
+      (let [query (lib/query metadata-provider-with-cards (card-key (lib.tu/mock-cards)))]
         (is (not (lib/uses-metric? query metric-id)))
         (is (nil? (lib.metric/available-metrics (lib/append-stage query))))))))

--- a/test/metabase/lib/native_test.cljc
+++ b/test/metabase/lib/native_test.cljc
@@ -148,7 +148,7 @@
   add it to `data.results_metadata.columns` in QP results, and add it here as well, so we can start moving toward a
   world where we don't have two versions of the metadata in query responses."
   {:lib/type :metadata/results
-   :columns  (get-in lib.tu/mock-cards [:venues :result-metadata])})
+   :columns  (get-in (lib.tu/mock-cards) [:venues :result-metadata])})
 
 (deftest ^:parallel native-query-test
   (is (=? {:lib/type :mbql/query
@@ -189,7 +189,7 @@
     (is (thrown-with-msg?
          #?(:clj Throwable :cljs :default)
          #"Must be a native query"
-         (-> lib.tu/venues-query
+         (-> (lib.tu/venues-query)
              (lib/with-native-query "foobar"))))))
 
 (deftest ^:parallel with-template-tags-test
@@ -213,7 +213,7 @@
     (is (thrown-with-msg?
          #?(:clj Throwable :cljs :default)
          #"Must be a native query"
-         (-> lib.tu/venues-query
+         (-> (lib.tu/venues-query)
              (lib/with-template-tags {"myid" (assoc (get original-tags "myid") :display-name "My ID")}))))))
 
 (defn ^:private metadata-provider-requiring-collection []
@@ -254,7 +254,7 @@
     (is (thrown-with-msg?
          #?(:clj Throwable :cljs :default)
          #"Must be a native query"
-         (-> lib.tu/venues-query
+         (-> (lib.tu/venues-query)
              (lib/with-different-database meta/metadata-provider))))))
 
 (deftest ^:parallel with-native-collection-test
@@ -290,7 +290,7 @@
     (is (thrown-with-msg?
          #?(:clj Throwable :cljs :default)
          #"Must be a native query"
-         (lib/has-write-permission lib.tu/venues-query)))))
+         (lib/has-write-permission (lib.tu/venues-query))))))
 
 (deftest ^:parallel can-run-native-test
   (is (lib/can-run (lib/with-template-tags
@@ -302,7 +302,7 @@
                              :display-name "foo"
                              :dimension [:field {:lib/uuid (str (random-uuid))} 1]}})
                    :question))
-  (is (lib/can-run lib.tu/venues-query :question))
+  (is (lib/can-run (lib.tu/venues-query) :question))
   (mu/disable-enforcement
     (is (not (lib/can-run (lib/native-query meta/metadata-provider "") :question)))
     (is (not (lib/can-run (lib/with-template-tags
@@ -318,10 +318,10 @@
                           :question)))))
 
 (deftest ^:parallel engine-test
-  (is (= :h2 (lib/engine lib.tu/native-query))))
+  (is (= :h2 (lib/engine (lib.tu/native-query)))))
 
 (deftest ^:parallel template-tag-card-ids-test
-  (let [query (lib/query lib.tu/metadata-provider-with-mock-cards
+  (let [query (lib/query (lib.tu/metadata-provider-with-mock-cards)
                          {:database (meta/id)
                           :type     :native
                           :native   {:query         {}
@@ -336,7 +336,7 @@
 
 (deftest ^:parallel template-tags-referenced-cards-test
   (testing "returns Card instances from raw query"
-    (let [query (lib/query lib.tu/metadata-provider-with-mock-cards
+    (let [query (lib/query (lib.tu/metadata-provider-with-mock-cards)
                            {:database (meta/id)
                             :type     :native
                             :native   {:query         {}

--- a/test/metabase/lib/remove_replace_test.cljc
+++ b/test/metabase/lib/remove_replace_test.cljc
@@ -17,7 +17,7 @@
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 
 (deftest ^:parallel remove-clause-order-bys-test
-  (let [query (-> lib.tu/venues-query
+  (let [query (-> (lib.tu/venues-query)
                   (lib/order-by (meta/field-metadata :venues :name))
                   (lib/order-by (meta/field-metadata :venues :price)))
         order-bys (lib/order-bys query)]
@@ -49,7 +49,7 @@
 
 (deftest ^:parallel remove-clause-join-conditions-test
   (testing "directly removing the final join condition throws an exception"
-    (let [query (-> lib.tu/venues-query
+    (let [query (-> (lib.tu/venues-query)
                     (lib/join (lib/join-clause (lib/query meta/metadata-provider (meta/table-metadata :categories))
                                                [(lib/= (meta/field-metadata :venues :price) 4)
                                                 (lib/= (meta/field-metadata :venues :name) "x")])))
@@ -94,7 +94,7 @@
               (lib/remove-clause query 0 (first (lib/breakouts query 0))))))))
 
 (deftest ^:parallel remove-clause-breakout-test
-  (let [query (-> lib.tu/venues-query
+  (let [query (-> (lib.tu/venues-query)
                   (lib/aggregate (lib/count))
                   (lib/breakout (meta/field-metadata :venues :id))
                   (lib/breakout (meta/field-metadata :venues :name)))
@@ -136,7 +136,7 @@
                     (lib/breakouts 0)))))))
 
 (deftest ^:parallel remove-clause-fields-test
-  (let [query (-> lib.tu/venues-query
+  (let [query (-> (lib.tu/venues-query)
                   (lib/expression "myadd" (lib/+ 1 (meta/field-metadata :venues :category-id)))
                   (lib/with-fields [(meta/field-metadata :venues :id) (meta/field-metadata :venues :name)]))
         fields (lib/fields query)]
@@ -173,7 +173,7 @@
 
 (deftest ^:parallel remove-clause-join-fields-test
   (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :categories))
-                  (lib/join (-> (lib/join-clause lib.tu/venues-query
+                  (lib/join (-> (lib/join-clause (lib.tu/venues-query)
                                                  [(lib/= (meta/field-metadata :venues :price) 4)])
                                 (lib/with-join-fields [(meta/field-metadata :venues :price)
                                                        (meta/field-metadata :venues :id)]))))
@@ -210,7 +210,7 @@
     (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :categories))
                     (lib/breakout (meta/field-metadata :categories :id))
                     (lib/aggregate (lib/sum (meta/field-metadata :categories :id)))
-                    (lib/join (-> (lib/join-clause lib.tu/venues-query
+                    (lib/join (-> (lib/join-clause (lib.tu/venues-query)
                                                    [(lib/= (meta/field-metadata :venues :category-id)
                                                            (meta/field-metadata :categories :id))])
                                   (lib/with-join-fields :all))))
@@ -234,7 +234,7 @@
                                   (lib/avg (lib/length (meta/field-metadata :categories :name)))))))))
 
 (deftest ^:parallel remove-clause-aggregation-test
-  (let [query (-> lib.tu/venues-query
+  (let [query (-> (lib.tu/venues-query)
                   (lib/aggregate (lib/sum (meta/field-metadata :venues :id)))
                   (lib/aggregate (lib/sum (meta/field-metadata :venues :price))))
         aggregations (lib/aggregations query)]
@@ -322,7 +322,7 @@
                 (lib/remove-clause query 0 a0-ref)))))))
 
 (deftest ^:parallel remove-clause-expression-test
-  (let [query (-> lib.tu/venues-query
+  (let [query (-> (lib.tu/venues-query)
                   (lib/expression "a" (meta/field-metadata :venues :id))
                   (lib/expression "b" (meta/field-metadata :venues :price)))
         [expr-a expr-b :as expressions] (lib/expressions query)]
@@ -346,7 +346,7 @@
 
 (deftest ^:parallel replace-clause-order-by-test
   (binding [lib.schema.expression/*suppress-expression-type-check?* true]
-    (let [query (-> lib.tu/venues-query
+    (let [query (-> (lib.tu/venues-query)
                     (lib/filter (lib/= "myvenue" (meta/field-metadata :venues :name)))
                     (lib/order-by (meta/field-metadata :venues :name))
                     (lib/order-by (meta/field-metadata :venues :price)))
@@ -362,7 +362,7 @@
         (is (= (second order-bys) (second replaced-order-bys)))))))
 
 (deftest ^:parallel replace-clause-filters-test
-  (let [query (-> lib.tu/venues-query
+  (let [query (-> (lib.tu/venues-query)
                   (lib/filter (lib/= (meta/field-metadata :venues :name) "myvenue"))
                   (lib/filter (lib/= (meta/field-metadata :venues :price) 2)))
         filters (lib/filters query)]
@@ -377,7 +377,7 @@
       (is (= (second filters) (second replaced-filters))))))
 
 (deftest ^:parallel replace-clause-join-conditions-test
-  (let [query (-> lib.tu/venues-query
+  (let [query (-> (lib.tu/venues-query)
                   (lib/join (lib/join-clause (lib/query meta/metadata-provider (meta/table-metadata :categories))
                                              [(lib/= (meta/field-metadata :venues :price) 4)])))
         conditions (lib/join-conditions (first (lib/joins query)))]
@@ -395,7 +395,7 @@
                (:ident (first (lib/joins replaced)))))))))
 
 (deftest ^:parallel replace-clause-join-fields-test
-  (let [query (-> lib.tu/venues-query
+  (let [query (-> (lib.tu/venues-query)
                   (lib/join
                    (-> (lib/join-clause (lib/query meta/metadata-provider (meta/table-metadata :categories))
                                         [(lib/= (meta/field-metadata :venues :price) 4)])
@@ -416,7 +416,7 @@
                (:ident (first (lib/joins replaced)))))))))
 
 (deftest ^:parallel replace-clause-breakout-test
-  (let [query (-> lib.tu/venues-query
+  (let [query (-> (lib.tu/venues-query)
                   (lib/breakout (meta/field-metadata :venues :id))
                   (lib/breakout (meta/field-metadata :venues :name)))
         breakouts (lib/breakouts query)
@@ -447,7 +447,7 @@
     (testing "should ignore duplicate breakouts"
       (let [id-column    (meta/field-metadata :venues :id)
             price-column (meta/field-metadata :venues :price)
-            query        (-> lib.tu/venues-query
+            query        (-> (lib.tu/venues-query)
                              (lib/breakout id-column)
                              (lib/breakout price-column))
             breakouts    (lib/breakouts query)]
@@ -468,7 +468,7 @@
                                          (lib/with-temporal-bucket column :month))))))))
 
 (deftest ^:parallel replace-clause-fields-test
-  (let [query (-> lib.tu/venues-query
+  (let [query (-> (lib.tu/venues-query)
                   (lib/with-fields [(meta/field-metadata :venues :id) (meta/field-metadata :venues :name)]))
         fields (lib/fields query)
         replaced (-> query
@@ -494,7 +494,7 @@
                            (lib/fields 0)))))))
 
 (deftest ^:parallel replace-clause-aggregation-test
-  (let [query (-> lib.tu/venues-query
+  (let [query (-> (lib.tu/venues-query)
                   (lib/aggregate (lib/sum (meta/field-metadata :venues :id)))
                   (lib/aggregate (lib/distinct (meta/field-metadata :venues :name))))
         aggregations (lib/aggregations query)
@@ -548,7 +548,7 @@
                                        :database-id (meta/id)
                                        :table-id    (meta/id :venues)
                                        :dataset-query
-                                       (-> lib.tu/venues-query
+                                       (-> (lib.tu/venues-query)
                                            (lib/filter (lib/= (meta/field-metadata :venues :price) 4))
                                            (lib/aggregate (lib/sum (meta/field-metadata :venues :price)))
                                            lib.convert/->legacy-MBQL)
@@ -598,7 +598,7 @@
                (second (lib/available-segments query))))))))
 
 (deftest ^:parallel replace-clause-expression-test
-  (let [query (-> lib.tu/venues-query
+  (let [query (-> (lib.tu/venues-query)
                   (lib/expression "a" (meta/field-metadata :venues :id))
                   (lib/expression "b" (meta/field-metadata :venues :name)))
         [expr-a expr-b :as expressions] (lib/expressions query)
@@ -633,7 +633,7 @@
                   (lib/replace-clause 0 expr-a 999)))))))
 
 (deftest ^:parallel replace-clause-expression-used-in-breakout-test
-  (let [query    (-> lib.tu/venues-query
+  (let [query    (-> (lib.tu/venues-query)
                      (lib/expression "a" (lib/+ (meta/field-metadata :venues :name) 7))
                      (as-> $q (lib/breakout $q -1 (lib/expression-ref $q -1 "a"))))
         [before] (lib/breakouts query)
@@ -667,7 +667,7 @@
         (is (= :day (:temporal-unit (second (last (first (lib/order-bys q3)))))))
         (is (= :month (:temporal-unit (second (last (first (lib/order-bys q4)))))))))
     (testing "Binning should keep in order-by in sync"
-      (let [query lib.tu/venues-query
+      (let [query (lib.tu/venues-query)
             breakout-col (->> (lib/breakoutable-columns query)
                               (m/find-first (comp #{"PRICE"} :name)))
             ten (->> (lib/available-binning-strategies query breakout-col)
@@ -686,7 +686,7 @@
         (is (= 100 (:num-bins (:binning (second (last (first (lib/order-bys q3))))))))
         (is (= 10 (:num-bins (:binning (second (last (first (lib/order-bys q4))))))))))
     (testing "Replace the correct order-by bin when there are multiple"
-      (let [query lib.tu/venues-query
+      (let [query (lib.tu/venues-query)
             breakout-col (->> (lib/breakoutable-columns query)
                               (m/find-first (comp #{"PRICE"} :name)))
             ten (->> (lib/available-binning-strategies query breakout-col)
@@ -723,7 +723,7 @@
                          (lib/replace-clause ten-breakout fiddy)
                          lib/order-bys))))))
     (testing "Replacing with a new field should remove the order by"
-      (let [query lib.tu/venues-query
+      (let [query (lib.tu/venues-query)
             breakout-col (->> (lib/breakoutable-columns query)
                               (m/find-first (comp #{"PRICE"} :name)))
             new-breakout-col (->> (lib/breakoutable-columns query)
@@ -742,7 +742,7 @@
                  (lib/replace-clause ten-breakout new-breakout-col)
                  lib/order-bys)))))
     (testing "Removing a breakout should remove the order by"
-      (let [query lib.tu/venues-query
+      (let [query (lib.tu/venues-query)
             breakout-col (->> (lib/breakoutable-columns query)
                               (m/find-first (comp #{"PRICE"} :name)))
             q2 (-> query
@@ -1041,7 +1041,7 @@
       (is (nil? (lib/joins (lib/remove-clause query 0 (first (lib/joins query 0)))))))))
 
 (deftest ^:parallel replace-join-test
-  (let [query             lib.tu/query-with-join
+  (let [query             (lib.tu/query-with-join)
         expected-original {:stages [{:joins [{:lib/type :mbql/join, :alias "Cat", :fields :all}]}]}
         [original-join]   (lib/joins query)
         original-ident    (:ident original-join)
@@ -1157,7 +1157,7 @@
 
 (deftest ^:parallel removing-aggregation-leaves-breakouts
   (testing "Removing aggregation leaves breakouts (#28609)"
-    (let [query (-> lib.tu/venues-query
+    (let [query (-> (lib.tu/venues-query)
                     (lib/aggregate (lib/count)))
           query (reduce lib/breakout
                         query
@@ -1169,7 +1169,7 @@
 
 (deftest ^:parallel removing-last-aggregation-brings-back-all-fields-on-joins
   (testing "Removing the last aggregation puts :fields :all on join clauses"
-    (let [base   (-> lib.tu/venues-query
+    (let [base   (-> (lib.tu/venues-query)
                      (lib/join (lib/join-clause (meta/table-metadata :products)
                                                 [(lib/= (meta/field-metadata :orders :product-id)
                                                         (meta/field-metadata :products :id))])))
@@ -1182,7 +1182,7 @@
 
 (deftest ^:parallel removing-last-breakout-brings-back-all-fields-on-joins
   (testing "Removing the last breakout puts :fields :all on join clauses"
-    (let [base   (-> lib.tu/venues-query
+    (let [base   (-> (lib.tu/venues-query)
                      (lib/join (lib/join-clause (meta/table-metadata :products)
                                                 [(lib/= (meta/field-metadata :orders :product-id)
                                                         (meta/field-metadata :products :id))])))
@@ -1264,7 +1264,7 @@
             (lib/replace-clause query 0 orig-agg new-agg)))))
 
 (deftest ^:parallel replace-clause-uses-custom-expression-name-test
-  (let [query (-> lib.tu/venues-query
+  (let [query (-> (lib.tu/venues-query)
                   (lib/expression "expr" (lib/+ 1 1)))
         expr  (first (lib/expressions query))]
     (is (=? [[:+ {:lib/expression-name "expr"} 1 1]]
@@ -1281,7 +1281,7 @@
 
 (deftest ^:parallel normalize-fields-clauses-test
   (testing "queries with no :fields clauses should not be changed"
-    (are [query] (= query (lib.remove-replace/normalize-fields-clauses query))
+    (are [query-fn] (let [q (query-fn)] (= q (lib.remove-replace/normalize-fields-clauses q)))
       lib.tu/query-with-join
       lib.tu/query-with-self-join
       lib.tu/venues-query))
@@ -1363,7 +1363,7 @@
   (m/find-first #(= (:name %) col-name) columns))
 
 (def ^:private multi-stage-query-with-expressions
-  (-> lib.tu/venues-query
+  (-> (lib.tu/venues-query)
       (lib/expression "double price" (lib/* (meta/field-metadata :venues :price) 2))
       (lib/expression "name length" (lib/length (meta/field-metadata :venues :name)))
       (as-> q

--- a/test/metabase/lib/segment_test.cljc
+++ b/test/metabase/lib/segment_test.cljc
@@ -30,7 +30,7 @@
   (lib.tu/mock-metadata-provider meta/metadata-provider segments-db))
 
 (def ^:private metadata-provider-with-cards
-  (lib.tu/mock-metadata-provider lib.tu/metadata-provider-with-mock-cards segments-db))
+  (lib.tu/mock-metadata-provider (lib.tu/metadata-provider-with-mock-cards) segments-db))
 
 (def ^:private segment-clause
   [:segment {:lib/uuid (str (random-uuid))} segment-id])
@@ -115,7 +115,7 @@
       (is (nil? (lib/available-segments query)))))
   (testing "query based on a card -- don't return Segments"
     (doseq [card-key [:venues :venues/native]]
-      (let [query (lib/query metadata-provider-with-cards (card-key lib.tu/mock-cards))]
+      (let [query (lib/query metadata-provider-with-cards (card-key (lib.tu/mock-cards)))]
         (is (not (lib/uses-segment? query segment-id)))
         (is (nil? (lib/available-segments (lib/append-stage query))))))))
 

--- a/test/metabase/lib/table_test.cljc
+++ b/test/metabase/lib/table_test.cljc
@@ -12,7 +12,7 @@
 
 (deftest ^:parallel join-table-metadata-test
   (testing "You should be able to pass :metadata/table to lib/join INDIRECTLY VIA join-clause"
-    (let [query (-> lib.tu/venues-query
+    (let [query (-> (lib.tu/venues-query)
                     (lib/join (-> (lib/join-clause (meta/table-metadata :categories))
                                   (lib/with-join-alias "Cat")
                                   (lib/with-join-fields :all)

--- a/test/metabase/lib/temporal_bucket_test.cljc
+++ b/test/metabase/lib/temporal_bucket_test.cljc
@@ -211,14 +211,14 @@
 
 (deftest ^:parallel option-raw-temporal-bucket-test
   (let [option (m/find-first #(= (:unit %) :month)
-                             (lib.temporal-bucket/available-temporal-buckets lib.tu/venues-query (meta/field-metadata :checkins :date)))]
+                             (lib.temporal-bucket/available-temporal-buckets (lib.tu/venues-query) (meta/field-metadata :checkins :date)))]
     (is (=? {:lib/type :option/temporal-bucketing}
             option))
     (is (= :month
            (lib.temporal-bucket/raw-temporal-bucket option)))))
 
 (deftest ^:parallel short-name-display-info-test
-  (let [query lib.tu/venues-query]
+  (let [query (lib.tu/venues-query)]
     (is (= {"minute"          false
             "hour"            false
             "day"             false

--- a/test/metabase/lib/test_util.cljc
+++ b/test/metabase/lib/test_util.cljc
@@ -37,12 +37,13 @@
  [providers.mock              mock-metadata-provider]
  [providers.remap             remap-metadata-provider])
 
-(def venues-query
-  "A mock query against the `VENUES` test data table."
+(defn venues-query
+  "Returns a mock query against the `VENUES` test data table."
+  []
   (lib/query meta/metadata-provider (meta/table-metadata :venues)))
 
 (defn venues-query-with-last-stage [m]
-  (let [query (update-in venues-query [:stages 0] merge m)]
+  (let [query (update-in (venues-query) [:stages 0] merge m)]
     (is (mr/validate ::lib.schema/query query))
     query))
 
@@ -86,14 +87,11 @@
    (providers.mock/mock-metadata-provider
     (assoc-in cards [:cards 0 :type] :metric))))
 
-(def query-with-source-card
-  "A query against `:source-card 1`, with a metadata provider that has that Card. Card's name is `My Card`. Card
-  'exports' two columns, `USER_ID` and `count`."
-  {:lib/type     :mbql/query
-   :lib/metadata metadata-provider-with-card
-   :database     (meta/id)
-   :stages       [{:lib/type    :mbql.stage/mbql
-                   :source-card 1}]})
+(defn query-with-source-card
+  "Returns a query against `:source-card 1`, with a metadata provider that has that Card. Card's name is `My Card`.
+  Card 'exports' two columns, `USER_ID` and `count`."
+  []
+  (lib/query metadata-provider-with-card (lib.metadata/card metadata-provider-with-card 1)))
 
 (def ^:private metadata-provider-with-card-with-result-metadata
   "[[meta/metadata-provider]], but with a Card with results metadata as ID 1."
@@ -136,14 +134,12 @@
                                  :field_ref      [:aggregation 0]
                                  :effective_type :type/BigInteger}]}]})))
 
-(def query-with-source-card-with-result-metadata
-  "A query with a `card__<id>` source Table and a metadata provider that has a Card with `:result_metadata`."
-  {:lib/type     :mbql/query
-   :lib/metadata metadata-provider-with-card-with-result-metadata
-   :type         :pipeline
-   :database     (meta/id)
-   :stages       [{:lib/type    :mbql.stage/mbql
-                   :source-card 1}]})
+(defn query-with-source-card-with-result-metadata
+  "Returns a query with a `card__<id>` source Table and a metadata provider that has a Card with `:result_metadata`."
+  []
+  (lib/query metadata-provider-with-card-with-result-metadata
+             {:lib/type    :mbql.stage/mbql
+              :source-card 1}))
 
 (defn- add-join
   [query join-alias]
@@ -161,14 +157,16 @@
   [query & join-aliases]
   (reduce add-join query join-aliases))
 
-(def query-with-join
-  "A query against `VENUES` with an explicit join against `CATEGORIES`."
-  (add-joins venues-query "Cat"))
+(defn query-with-join
+  "Returns a query against `VENUES` with an explicit join against `CATEGORIES`."
+  []
+  (add-joins (venues-query) "Cat"))
 
-(def query-with-join-with-explicit-fields
+(defn query-with-join-with-explicit-fields
   "A query against `VENUES` with an explicit join against `CATEGORIES`, that includes explicit `:fields` including just
   `CATEGORIES.NAME`."
-  (-> venues-query
+  []
+  (-> (venues-query)
       (lib/join (-> (lib/join-clause (meta/table-metadata :categories))
                     (lib/with-join-conditions [(lib/= (meta/field-metadata :venues :category-id)
                                                       (-> (meta/field-metadata :categories :id)
@@ -177,20 +175,23 @@
                     (lib/with-join-fields [(-> (meta/field-metadata :categories :name)
                                                (lib/with-join-alias "Cat"))])))))
 
-(def query-with-self-join
+(defn query-with-self-join
   "A query against `ORDERS` joined to `ORDERS` by ID."
+  []
   (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
       (lib/join (lib/join-clause (meta/table-metadata :orders)
                                  [(lib/= (lib/ref (meta/field-metadata :orders :id))
                                          (lib/ref (meta/field-metadata :orders :id)))]))))
 
-(def query-with-expression
+(defn query-with-expression
   "A query with an expression."
-  (-> venues-query
+  []
+  (-> (venues-query)
       (lib/expression "expr" (lib/absolute-datetime "2020" :month))))
 
-(def native-query
+(defn native-query
   "A sample native query."
+  []
   {:lib/type     :mbql/query
    :lib/metadata meta/metadata-provider
    :database     (meta/id)
@@ -262,8 +263,8 @@
                                                   {:base-type :type/Integer
                                                    :join-alias "Reviews"}]]}]}}}}))
 
-(def mock-cards
-  "Map of mock MBQL query Card against the test tables. There are three versions of the Card for each table:
+(defn mock-cards
+  "Returns a map of mock MBQL query Card against the test tables. There are three versions of the Card for each table:
 
   * `:venues`, a Card WITH `:result-metadata`
   * `:venues/no-metadata`, a Card WITHOUT `:result-metadata`
@@ -271,6 +272,7 @@
 
   There are also some specialized mock cards used for corner cases:
   * `:model/products-and-reviews`, a model joining products to reviews"
+  []
   (merge (make-mock-cards meta/metadata-provider (map (juxt identity (comp :id meta/table-metadata)) (meta/tables)))
          (make-mock-cards-special-cases meta/metadata-provider)))
 
@@ -299,12 +301,13 @@
                                   (sort-by :id))}
            card-details))))
 
-(def metadata-provider-with-mock-cards
+(defn metadata-provider-with-mock-cards
   "A metadata provider with all of the [[mock-cards]]. Composed with the normal [[meta/metadata-provider]]."
+  []
   (lib/composed-metadata-provider
    meta/metadata-provider
    (providers.mock/mock-metadata-provider
-    {:cards (vals mock-cards)})))
+    {:cards (vals (mock-cards))})))
 
 (mu/defn field-literal-ref :- ::lib.schema.ref/field.literal
   "Get a `:field` 'literal' ref (a `:field` ref that uses a string column name rather than an integer ID) for a column
@@ -348,4 +351,4 @@
                                                {:dataset-query   {:database (meta/id)
                                                                   :type     :native
                                                                   :native   {:query "SELECT * FROM VENUES;"}}
-                                                :result-metadata (get-in mock-cards [:venues :result-metadata])}))))
+                                                :result-metadata (get-in (mock-cards) [:venues :result-metadata])}))))

--- a/test/metabase/lib/test_util/macros.clj
+++ b/test/metabase/lib/test_util/macros.clj
@@ -57,21 +57,21 @@
                    (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
                        (lib/join (lib/join-clause (lib.tu/query-with-stage-metadata-from-card
                                                    meta/metadata-provider
-                                                   (lib.tu/mock-cards :people))
+                                                   (:people (lib.tu/mock-cards)))
                                                   [(lib/= (meta/field-metadata :orders :user-id)
                                                           (meta/field-metadata :people :id))]))
                        (lib/join (lib/join-clause (lib.tu/query-with-stage-metadata-from-card
                                                    meta/metadata-provider
-                                                   (lib.tu/mock-cards :products))
+                                                   (:products (lib.tu/mock-cards)))
                                                   [(lib/= (meta/field-metadata :orders :product-id)
                                                           (meta/field-metadata :products :id))]))
                        (lib/append-stage))
                    :query-with-source-card-joins
-                   (-> (lib/query lib.tu/metadata-provider-with-mock-cards (meta/table-metadata :orders))
-                       (lib/join (lib/join-clause (lib.tu/mock-cards :people)
+                   (-> (lib/query (lib.tu/metadata-provider-with-mock-cards) (meta/table-metadata :orders))
+                       (lib/join (lib/join-clause (:people (lib.tu/mock-cards))
                                                   [(lib/= (meta/field-metadata :orders :user-id)
                                                           (meta/field-metadata :people :id))]))
-                       (lib/join (lib/join-clause (lib.tu/mock-cards :products)
+                       (lib/join (lib/join-clause (:products (lib.tu/mock-cards))
                                                   [(lib/= (meta/field-metadata :orders :product-id)
                                                           (meta/field-metadata :products :id))]))
                        (lib/append-stage))]]

--- a/test/metabase/lib/types/isa_test.cljc
+++ b/test/metabase/lib/types/isa_test.cljc
@@ -32,7 +32,7 @@
               :type/Text)))))
 
 (deftest ^:parallel column-isa-test
-  (let [query (-> lib.tu/venues-query
+  (let [query (-> (lib.tu/venues-query)
                   (lib/expression "myadd" (lib/+ 1 (meta/field-metadata :venues :category-id))))
         orderable-columns (lib/orderable-columns query)
         columns-of-type (fn [typ] (filter #(lib.types.isa/isa? % typ)

--- a/test/metabase/query_processor/middleware/fetch_source_query_test.clj
+++ b/test/metabase/query_processor/middleware/fetch_source_query_test.clj
@@ -137,7 +137,7 @@
   (testing "make sure that the `resolve-source-cards` middleware correctly resolves native queries"
     (qp.store/with-metadata-provider (lib.tu/metadata-provider-with-cards-for-queries
                                       meta/metadata-provider
-                                      [(:dataset-query (lib.tu/mock-cards :venues/native))])
+                                      [(:dataset-query (:venues/native (lib.tu/mock-cards)))])
       (is (=? (assoc (default-result-with-inner-query
                       {:aggregation  [[:count]]
                        :breakout     [[:field "price" {:base-type :type/Integer}]]

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -303,8 +303,9 @@
          (adjust query)))))
 
 (deftest ^:parallel adjust-mixed-multi-source-test
-  (let [[first-metric mp] (mock-metric lib.tu/metadata-provider-with-mock-cards
-                                       (-> (lib/query lib.tu/metadata-provider-with-mock-cards (:products lib.tu/mock-cards))
+  (let [mp                (lib.tu/metadata-provider-with-mock-cards)
+        [first-metric mp] (mock-metric mp
+                                       (-> (lib/query mp (:products (lib.tu/mock-cards)))
                                            (lib/aggregate (update (lib/avg (meta/field-metadata :products :rating)) 1 assoc :name (u/slugify "Mock metric")))
                                            (lib/filter (lib/> (meta/field-metadata :products :price) 1))))
         [second-metric mp] (mock-metric mp (-> (lib/query mp first-metric)
@@ -433,7 +434,7 @@
 (deftest ^:parallel metric-question-on-native-model-test
   (let [mp meta/metadata-provider
         sum-pred (comp #{"sum"} :name)
-        query lib.tu/native-query
+        query (lib.tu/native-query)
         question (model-based-metric-question mp query sum-pred)]
     (is (=? {:stages
              [{:lib/type :mbql.stage/native,


### PR DESCRIPTION
### Description

Future work on the refs overhaul #49182 changes how queries are
represented. To enable testing that new behaviour at a per-test level,
we can't let global queries like `lib.tu/venues-query` be defined once
and reused forever: in that case, tests of the new refs would see global
queries defined under old refs, and vice versa.

This change transforms the global queries, cards and other helpers in
`lib.test-util` from static `def`s to functions, so they build the
queries etc. in the context of the current test.

(If this introduces a performance hit for the lib tests, we can update
the functions to cache the two versions up front and choose between them
at runtime. So far it does not seem to have made a significant impact.)

### How to verify

BE unit tests still pass. No user-visible impact.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
