### PR TITLE
[cleanup] Delete `lib.metadata/stage` and `stage-column`

### DIFF
--- a/src/metabase/lib/metadata.cljc
+++ b/src/metabase/lib/metadata.cljc
@@ -3,7 +3,6 @@
    [metabase.lib.metadata.ident :as lib.metadata.ident]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.schema :as lib.schema]
-   [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.util :as lib.util]
@@ -98,43 +97,6 @@
   ([metadata-providerable :- ::lib.schema.metadata/metadata-providerable
     setting-key           :- [:or string? keyword?]]
    (lib.metadata.protocols/setting (->metadata-provider metadata-providerable) setting-key)))
-
-;;;; Stage metadata
-
-(mu/defn stage :- [:maybe ::lib.schema.metadata/stage]
-  "Get metadata associated with a particular `stage-number` of the query, if any. `stage-number` can be a negative
-  index.
-
-  Currently, only returns metadata if it is explicitly attached to a stage; in the future we will probably dynamically
-  calculate this stuff if possible based on DatabaseMetadata and previous stages. Stay tuned!"
-  [query        :- :map
-   stage-number :- :int]
-  (:lib/stage-metadata (lib.util/query-stage query stage-number)))
-
-(mu/defn stage-column :- [:maybe ::lib.schema.metadata/column]
-  "Metadata about a specific column returned by a specific stage of the query, e.g. perhaps the first stage of the
-  query has an expression `num_cans`, then
-
-    (lib.metadata/stage-column query stage \"num_cans\")
-
-  should return something like
-
-    {:name \"num_cans\", :base-type :type/Integer, ...}
-
-  This is currently a best-effort thing and will only return information about columns if stage metadata is attached
-  to a particular stage. In the near term future this should be better about calculating that metadata dynamically and
-  returning correct info here."
-  ([query       :- :map
-    column-name :- ::lib.schema.common/non-blank-string]
-   (stage-column query -1 column-name))
-
-  ([query        :- :map
-    stage-number :- :int
-    column-name  :- ::lib.schema.common/non-blank-string]
-   (some (fn [column]
-           (when (= (:name column) column-name)
-             column))
-         (:columns (stage query stage-number)))))
 
 (mu/defn card :- [:maybe ::lib.schema.metadata/card]
   "Get metadata for a Card, aka Saved Question, with `card-id`, if it can be found."

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -28,17 +28,6 @@
                       (binding [lib.card/*force-broken-card-refs* false]
                         (thunk))))
 
-(deftest ^:parallel field-from-results-metadata-test
-  (let [field-metadata (lib.metadata/stage-column (lib.tu/query-with-stage-metadata-from-card
-                                                   meta/metadata-provider
-                                                   (:venues (lib.tu/mock-cards)))
-                                                  "ID")]
-    (is (=? {:lib/type :metadata/column
-             :name     "ID"}
-            field-metadata))
-    (is (=? [:field {:base-type :type/BigInteger, :lib/uuid string?} "ID"]
-            (lib/ref field-metadata)))))
-
 (defn- grandparent-parent-child-id [field]
   (+ (meta/id :venues :id)
      (case field

--- a/test/metabase/lib/filter_test.cljc
+++ b/test/metabase/lib/filter_test.cljc
@@ -8,7 +8,6 @@
    [metabase.lib.expression :as lib.expression]
    [metabase.lib.filter :as lib.filter]
    [metabase.lib.filter.operator :as lib.filter.operator]
-   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.options :as lib.options]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
@@ -29,7 +28,8 @@
         venues-name-metadata        (meta/field-metadata :venues :name)
         venues-latitude-metadata    (meta/field-metadata :venues :latitude)
         venues-longitude-metadata   (meta/field-metadata :venues :longitude)
-        categories-id-metadata      (lib.metadata/stage-column q2 -1 "ID")
+        categories-id-metadata      (m/find-first #(= (:id %) (meta/id :categories :id))
+                                                  (lib/visible-columns q2))
         checkins-date-metadata      (meta/field-metadata :checkins :date)]
     (testing "comparisons"
       (doseq [[op f] [[:=  lib/=]
@@ -42,7 +42,10 @@
          [op
           {:lib/uuid string?}
           [:field {:lib/uuid string?} (meta/id :venues :category-id)]
-          [:field {:base-type :type/BigInteger, :lib/uuid string?} "ID"]]
+          [:field {:base-type    :type/BigInteger
+                   :lib/uuid     string?
+                   :source-field (meta/id :venues :category-id)}
+           (meta/id :categories :id)]]
          f
          venues-category-id-metadata
          categories-id-metadata)))
@@ -53,7 +56,10 @@
         {:lib/uuid string?}
         [:field {:lib/uuid string?} (meta/id :venues :category-id)]
         42
-        [:field {:base-type :type/BigInteger, :lib/uuid string?} "ID"]]
+        [:field {:base-type    :type/BigInteger
+                 :lib/uuid     string?
+                 :source-field (meta/id :venues :category-id)}
+         (meta/id :categories :id)]]
        lib/between
        venues-category-id-metadata
        42

--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -136,7 +136,8 @@
           q2                          (lib.tu/query-with-stage-metadata-from-card meta/metadata-provider
                                                                                   (:venues (lib.tu/mock-cards)))
           venues-category-id-metadata (meta/field-metadata :venues :category-id)
-          categories-id-metadata      (lib.metadata/stage-column q2 "ID")]
+          categories-id-metadata      (m/find-first #(= (:id %) (meta/id :categories :id))
+                                                    (lib/visible-columns q2))]
 
       (let [clause (lib/join-clause q2 [(lib/= categories-id-metadata venues-category-id-metadata)])]
         (is (=? {:lib/type    :mbql/join
@@ -145,7 +146,10 @@
                                 :source-table (meta/id :venues)}]
                  :conditions  [[:=
                                 {:lib/uuid string?}
-                                [:field {:base-type :type/BigInteger, :lib/uuid string?} "ID"]
+                                [:field {:base-type    :type/BigInteger
+                                         :lib/uuid     string?
+                                         :source-field (meta/id :venues :category-id)}
+                                 (meta/id :categories :id)]
                                 [:field {:lib/uuid string?} (meta/id :venues :category-id)]]]}
                 clause)))
       (is (=? {:database (meta/id)
@@ -160,7 +164,7 @@
                                                            {:base-type :type/BigInteger
                                                             :lib/uuid string?
                                                             :join-alias absent-key-marker}
-                                                           "ID"]
+                                                           (meta/id :categories :id)]
                                                           [:field
                                                            {:lib/uuid string?
                                                             :join-alias "Venues"}

--- a/test/metabase/lib/metadata_test.cljc
+++ b/test/metabase/lib/metadata_test.cljc
@@ -19,28 +19,6 @@
            (meta/field-metadata :venues :category-id))
           (lib.metadata/field meta/metadata-provider (meta/id :venues :category-id)))))
 
-(deftest ^:parallel stage-metadata-test
-  (let [query (lib.tu/query-with-stage-metadata-from-card meta/metadata-provider (:venues (lib.tu/mock-cards)))]
-    (is (=? {:columns [{:name "ID"}
-                       {:name "NAME"}
-                       {:name "CATEGORY_ID"}
-                       {:name "LATITUDE"}
-                       {:name "LONGITUDE"}
-                       {:name "PRICE"}]}
-            (lib.metadata/stage query -1)))))
-
-(deftest ^:parallel stage-column-metadata-test
-  (let [query (lib.tu/query-with-stage-metadata-from-card meta/metadata-provider (:venues (lib.tu/mock-cards)))]
-    (are [x] (=? {:lib/type       :metadata/column
-                  :display-name   "Category ID"
-                  :name           "CATEGORY_ID"
-                  :base-type      :type/Integer
-                  :effective-type :type/Integer
-                  :semantic-type  :type/FK}
-                 x)
-      (lib.metadata/stage-column query "CATEGORY_ID")
-      (lib.metadata/stage-column query -1 "CATEGORY_ID"))))
-
 (deftest ^:parallel display-name-from-name-test
   (testing "Use the 'simple humanization' logic to calculate a display name for a Field that doesn't have one"
     (is (= "Venue ID"


### PR DESCRIPTION
### Description

Pre-work for #49182.

These functions date from the beginnings of the `metabase.lib` codebase,
and are unused outside of a couple of tests.

I deleted the tests for these functions specifically, and updated a few
other tests that used these functions to retrieve columns on a query.

### How to verify

BE unit tests still passing. No user-visible impact.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
