### PR TITLE
Don't normalize numbers to field ids

### DIFF
--- a/frontend/src/metabase-lib/v1/expressions/format.ts
+++ b/frontend/src/metabase-lib/v1/expressions/format.ts
@@ -23,6 +23,7 @@ import {
   isOptionsObject,
   isSegment,
   isStringLiteral,
+  isValue,
 } from "./index";
 
 export { DISPLAY_QUOTES, EDITOR_QUOTES } from "./config";
@@ -63,6 +64,8 @@ export function format(mbql: any, options: Options): string {
     return formatCaseOrIf(mbql, options);
   } else if (isNegativeFilter(mbql)) {
     return formatNegativeFilter(mbql, options);
+  } else if (isValue(mbql)) {
+    return formatValue(mbql, options);
   }
   throw new Error("Unknown MBQL clause " + JSON.stringify(mbql));
 }
@@ -251,4 +254,8 @@ function formatNegativeFilter(mbql: Filter, options: Options) {
   const [fn, ...args] = mbql;
   const baseFn = NEGATIVE_FILTERS[fn];
   return "NOT " + format([baseFn, ...args], options);
+}
+
+function formatValue([, value]: any[], options: Options) {
+  return format(value, options);
 }

--- a/frontend/src/metabase-lib/v1/expressions/index.ts
+++ b/frontend/src/metabase-lib/v1/expressions/index.ts
@@ -284,7 +284,8 @@ export function isExpression(expr: unknown): expr is Expression {
     isBooleanLiteral(expr) ||
     isMetric(expr) ||
     isSegment(expr) ||
-    isCaseOrIf(expr)
+    isCaseOrIf(expr) ||
+    isValue(expr)
   );
 }
 
@@ -302,6 +303,10 @@ export function isBooleanLiteral(expr: unknown): boolean {
 
 export function isNumberLiteral(expr: unknown): boolean {
   return typeof expr === "number";
+}
+
+export function isValue(expr: unknown): boolean {
+  return Array.isArray(expr) && expr[0] === "value" && isExpression(expr[1]);
 }
 
 export function isOperator(expr: unknown): boolean {

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -985,15 +985,15 @@
 ;;
 ;;    SUM(field_1 + field_2)
 
-(defclause ^{:requires-features #{:basic-aggregations}} avg,      field-or-expression [:ref ::FieldOrExpressionDef])
-(defclause ^{:requires-features #{:basic-aggregations}} cum-sum,  field-or-expression [:ref ::FieldOrExpressionDef])
-(defclause ^{:requires-features #{:basic-aggregations}} distinct, field-or-expression [:ref ::FieldOrExpressionDef])
-(defclause ^{:requires-features #{:basic-aggregations}} sum,      field-or-expression [:ref ::FieldOrExpressionDef])
-(defclause ^{:requires-features #{:basic-aggregations}} min,      field-or-expression [:ref ::FieldOrExpressionDef])
-(defclause ^{:requires-features #{:basic-aggregations}} max,      field-or-expression [:ref ::FieldOrExpressionDef])
+(defclause ^{:requires-features #{:basic-aggregations}} avg,      field-or-expression [:ref ::ExpressionArg])
+(defclause ^{:requires-features #{:basic-aggregations}} cum-sum,  field-or-expression [:ref ::ExpressionArg])
+(defclause ^{:requires-features #{:basic-aggregations}} distinct, field-or-expression [:ref ::ExpressionArg])
+(defclause ^{:requires-features #{:basic-aggregations}} sum,      field-or-expression [:ref ::ExpressionArg])
+(defclause ^{:requires-features #{:basic-aggregations}} min,      field-or-expression [:ref ::ExpressionArg])
+(defclause ^{:requires-features #{:basic-aggregations}} max,      field-or-expression [:ref ::ExpressionArg])
 
 (defclause ^{:requires-features #{:basic-aggregations}} sum-where
-  field-or-expression [:ref ::FieldOrExpressionDef], pred Filter)
+  field-or-expression [:ref ::ExpressionArg], pred Filter)
 
 (defclause ^{:requires-features #{:basic-aggregations}} count-where
   pred Filter)
@@ -1002,16 +1002,16 @@
   pred Filter)
 
 (defclause ^{:requires-features #{:standard-deviation-aggregations}} stddev
-  field-or-expression [:ref ::FieldOrExpressionDef])
+  field-or-expression [:ref ::ExpressionArg])
 
 (defclause ^{:requires-features #{:standard-deviation-aggregations}} [ag:var var]
-  field-or-expression [:ref ::FieldOrExpressionDef])
+  field-or-expression [:ref ::ExpressionArg])
 
 (defclause ^{:requires-features #{:percentile-aggregations}} median
-  field-or-expression [:ref ::FieldOrExpressionDef])
+  field-or-expression [:ref ::ExpressionArg])
 
 (defclause ^{:requires-features #{:percentile-aggregations}} percentile
-  field-or-expression [:ref ::FieldOrExpressionDef], percentile NumericExpressionArg)
+  field-or-expression [:ref ::ExpressionArg], percentile NumericExpressionArg)
 
 ;; Metrics are just 'macros' (placeholders for other aggregations with optional filter and breakout clauses) that get
 ;; expanded to other aggregations/etc. in the expand-macros middleware

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -2332,9 +2332,11 @@
   expression parser understand MLv2 expressions."
   [a-query stage-number legacy-expression]
   (lib.convert/with-aggregation-list (lib.core/aggregations a-query stage-number)
-    (let [expr (js->clj legacy-expression :keywordize-keys true)
-          expr (first (mbql.normalize/normalize-fragment [:query :aggregation] [expr]))]
-      (lib.core/normalize (lib.convert/->pMBQL expr)))))
+    (binding [mbql.normalize/*use-implicit-field-ids* false]
+      (let [expr (js->clj legacy-expression :keywordize-keys true)
+            _ (prn "js->clj" expr)
+            expr (first (mbql.normalize/normalize-fragment [:query :aggregation] [expr]))]
+        (lib.core/normalize (lib.convert/->pMBQL expr))))))
 
 (defn ^:export legacy-expression-for-expression-clause
   "Convert `an-expression-clause` into a legacy expression.

--- a/test/metabase/legacy_mbql/schema_test.cljc
+++ b/test/metabase/legacy_mbql/schema_test.cljc
@@ -104,6 +104,21 @@
       (is (not (me/humanize (mr/explain mbql.s/Query query))))
       (is (= query (mbql.s/validate-query query))))))
 
+(deftest ^:parallel aggregate-constant-test
+  (testing "should be able to nest aggregation functions within a coalesce"
+    (let [query {:database 1,
+                 :type :query,
+                 :query
+                 {:source-table 5,
+                  :aggregation
+                  [[:aggregation-options
+                    [:cum-sum 1]
+                    {:name "Avg discount", :display-name "Avg discount"}]],
+                  :aggregation-idents {0 "ZOn_HshYdSEeteY5ArmS9"}},
+                 :parameters []}]
+      (is (not (me/humanize (mr/explain mbql.s/Query query))))
+      (is (= query (mbql.s/validate-query query))))))
+
 (deftest ^:parallel aggregation-reference-test
   (are [schema] (nil? (me/humanize (mr/explain schema [:aggregation 0])))
     mbql.s/aggregation


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/27807

### Description

We currently normalize [:cum-sum 5] to [:cum-sum [:field 5 nil]], which means that you can't aggregate on a custom expression like "CumulativeSum(5)".  Removing that portion of the normalize code and updating the mbql schema to match fixes the issue and allows those expressions.
### How to verify

Create a custom aggregation like "CumulativeSum(1)" and see if it compiles

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
