### PR TITLE
Fix nav bar highlighting when creating a new question

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -103,6 +103,19 @@ export function navigationSidebar() {
   return cy.findByTestId("main-navbar-root");
 }
 
+export function assertNavigationSidebarItemSelected(name, value = "true") {
+  navigationSidebar()
+    .findByRole("treeitem", { name })
+    .should("have.attr", "aria-selected", value);
+}
+
+export function assertNavigationSidebarBookmarkSelected(name, value = "true") {
+  navigationSidebar()
+    .findByRole("tab", { name: "Bookmarks" })
+    .findByRole("listitem", { name })
+    .should("have.attr", "aria-selected", value);
+}
+
 export function appBar() {
   return cy.findByLabelText("Navigation bar");
 }

--- a/e2e/test/scenarios/navigation/navbar.cy.spec.js
+++ b/e2e/test/scenarios/navigation/navbar.cy.spec.js
@@ -1,5 +1,11 @@
 import { H } from "e2e/support";
-import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import {
+  ORDERS_DASHBOARD_ID,
+  THIRD_COLLECTION_ID,
+} from "e2e/support/cypress_sample_instance_data";
+
+const { ORDERS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > navigation > navbar", () => {
   describe("Normal user", () => {
@@ -11,6 +17,38 @@ describe("scenarios > navigation > navbar", () => {
     it("should be open after logging in", () => {
       cy.visit("/");
       H.navigationSidebar().should("be.visible");
+    });
+
+    it("should highlight relevant entities when navigating", () => {
+      const questionName = "Bookmarked question";
+      H.createQuestion(
+        {
+          name: questionName,
+          collection_id: THIRD_COLLECTION_ID,
+          query: { "source-table": ORDERS_ID, aggregation: [["count"]] },
+        },
+        {
+          wrapId: true,
+        },
+      );
+
+      cy.get("@questionId").then(id => {
+        cy.request("POST", `/api/bookmark/card/${id}`);
+        H.visitQuestion(id);
+      });
+
+      H.openNavigationSidebar();
+      H.assertNavigationSidebarItemSelected(/Third collection/);
+      H.assertNavigationSidebarBookmarkSelected(questionName);
+
+      H.newButton().click();
+      H.popover()
+        .findByText(/SQL query/)
+        .click();
+
+      H.openNavigationSidebar();
+      H.assertNavigationSidebarItemSelected(/Third collection/, "false");
+      H.assertNavigationSidebarBookmarkSelected(questionName, "false");
     });
 
     it("should display error ui when data fetching fails", () => {

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.tsx
@@ -79,7 +79,7 @@ function MainNavbar({
   onChangeLocation,
   ...props
 }: Props) {
-  const { data: card } = useGetCardQuery(
+  const { currentData: card } = useGetCardQuery(
     questionId
       ? {
           id: questionId,
@@ -87,7 +87,7 @@ function MainNavbar({
       : skipToken,
   );
 
-  const { data: collection } = useGetCollectionQuery(
+  const { currentData: collection } = useGetCollectionQuery(
     collectionId ? { id: collectionId } : skipToken,
   );
 
@@ -109,7 +109,7 @@ function MainNavbar({
   }, [isOpen, openNavbar, closeNavbar]);
 
   const selectedItems = useMemo<SelectedItem[]>(() => {
-    const question = new Question(card);
+    const question = card && new Question(card);
 
     return getSelectedItems({
       pathname: location.pathname,


### PR DESCRIPTION
Closes #52809

### Description
The main fix here comes from our hook usage with RTK Query. When traversing from a Saved question to an ad hoc question page, the skip token would be passed to `useGetCardQuery`. This prevented us from running a new query, but it meant that `data` was still returning data from the previous query. Changing to `currentData` solved that issue. The second part of the fix was only passing a new `Question` object if `card` was defined. Otherwise, `getSelectedItems()` would return improper data

### How to verify

1. Bookmark a question, and navigate to it
2. Open the sidebar, and verify that the question, and it's collection, are highlighted in the navbar
3. click New -> SQL Query
4. Open the sidebar again. Nothing should be highlighted

### Demo
![chrome_eUjTrDHQUO](https://github.com/user-attachments/assets/16f60f24-d8b7-4121-91eb-a3a019e71994)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
