### PR TITLE
fix: Mongodb handle let with alias with space

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -410,6 +410,7 @@
                               :set-timezone                    true
                               :standard-deviation-aggregations true
                               :test/jvm-timezone-setting       false
+                              :identifiers-with-spaces         true
                               :index-info                      true}]
   (defmethod driver/database-supports? [:mongo feature] [_driver _feature _db] supported?))
 

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -932,7 +932,8 @@
         mapping (map (fn [f] (let [alias (-> (format "let_%s_" (->lvalue f))
                                              ;; ~ in let aliases provokes a parse error in Mongo. For correct function,
                                              ;; aliases should also contain no . characters (#32182).
-                                             (str/replace #"~|\." "_")
+                                             ;; - Spaces are allowed in columns and need to be replaced in let (#52807)
+                                             (str/replace #"[~\. ]" "_")
                                              (str "__" (next-alias-index)))]
                                {:field f, :rvalue (->rvalue f), :alias alias}))
                      own-fields)]


### PR DESCRIPTION
Fixes #52807 

The issue is with spaces in let aliases as can be seen by the linked error message. This is tested by `metabase.query-processor-test.nested-queries-test/space-names-test` requires correctly setting mongo as `identifiers-with-spaces`.

Tested on latest mongo.