### PR TITLE
Stop drilling down past day in DateType

### DIFF
--- a/src/metabase/lib/filter/update.cljc
+++ b/src/metabase/lib/filter/update.cljc
@@ -98,6 +98,7 @@
    column-type :- :keyword]
   (let [next-unit (if (= column-type :type/Date)
                     unit->next-unit-date
+                    ;; should catch :type/DateTime and :type/DateTimeWithTZ
                     unit->next-unit-datetime)]
     (loop [unit unit]
       (let [num-points      (u.time/unit-diff unit start end)

--- a/src/metabase/lib/filter/update.cljc
+++ b/src/metabase/lib/filter/update.cljc
@@ -79,24 +79,33 @@
   only return 2 points, switch the unit to `:minute`."
   4)
 
-(def ^:private unit->next-unit
+(def ^:private unit->next-unit-datetime
   "E.g. the next unit after `:hour` is `:minute`."
   (let [units [:minute :hour :day :week :month :quarter :year]]
+    (zipmap units (cons nil units))))
+
+(def ^:private unit->next-unit-date
+  "E.g. the next unit after `:week` is `:day`."
+  (let [units [:day :week :month :quarter :year]]
     (zipmap units (cons nil units))))
 
 (mu/defn- temporal-filter-find-best-breakout-unit :- ::lib.schema.temporal-bucketing/unit.date-time.truncate
   "If the current breakout `unit` will not return at least [[temporal-filter-min-num-points]], find the largest unit
   that will."
-  [unit  :- ::lib.schema.temporal-bucketing/unit.date-time.truncate
-   start :- ::lib.schema.literal/temporal
-   end   :- ::lib.schema.literal/temporal]
-  (loop [unit unit]
-    (let [num-points      (u.time/unit-diff unit start end)
-          too-few-points? (< num-points temporal-filter-min-num-points)]
-      (if-let [next-largest-unit (when too-few-points?
-                                   (unit->next-unit unit))]
-        (recur next-largest-unit)
-        unit))))
+  [unit        :- ::lib.schema.temporal-bucketing/unit.date-time.truncate
+   start       :- ::lib.schema.literal/temporal
+   end         :- ::lib.schema.literal/temporal
+   column-type :- :keyword]
+  (let [next-unit (if (= column-type :type/Date)
+                    unit->next-unit-date
+                    unit->next-unit-datetime)]
+    (loop [unit unit]
+      (let [num-points      (u.time/unit-diff unit start end)
+            too-few-points? (< num-points temporal-filter-min-num-points)]
+        (if-let [next-largest-unit (when too-few-points?
+                                     (next-unit unit))]
+          (recur next-largest-unit)
+          unit)))))
 
 (mu/defn- temporal-filter-update-breakouts :- ::lib.schema/query
   "Update the first breakout against `column` so it uses `new-unit` rather than the original unit (if any); remove all
@@ -177,7 +186,7 @@
              start         (u.time/truncate (u.time/add start unit 1) unit)
              end           (u.time/truncate end unit)
              ;; update the breakout unit if appropriate.
-             breakout-unit (temporal-filter-find-best-breakout-unit unit start end)
+             breakout-unit (temporal-filter-find-best-breakout-unit unit start end (:effective-type temporal-column))
              query         (if (= unit breakout-unit)
                              query
                              (temporal-filter-update-breakouts query stage-number temporal-column breakout-unit))]

--- a/test/metabase/lib/filter/update_test.cljc
+++ b/test/metabase/lib/filter/update_test.cljc
@@ -141,6 +141,33 @@
 
 (deftest ^:parallel update-temporal-filter-existing-breakout-change-unit-test
   (testing "Update an existing query with breakout and filter against this column; update the breakout unit"
+    (doseq [[table field type] [[:users    :last-login :type/DateTime]
+                                [:products :created-at :type/DateTimeWithLocalTZ]]]
+      (testing (str type " column, specifically " table " " field)
+        (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :users))
+                        (lib/breakout (-> (meta/field-metadata table field)
+                                          (lib/with-temporal-bucket :day)))
+                        (lib/filter (lib/= (-> (meta/field-metadata table field)
+                                               (lib/with-temporal-bucket :day))
+                                           "2024-01-02T15:00")))]
+          (is (=? {:stages [{:breakout [[:field
+                                         ;; `:day` should have been changed to `:hour`, because there aren't enough days
+                                         ;; between `2024-01-02` and `2024-01-03`
+                                         {:temporal-unit :hour}
+                                         (meta/id table field)]]
+                             :filters  [[:between
+                                         {}
+                                         [:field {} (meta/id table field)]
+                                         "2024-01-02"
+                                         "2024-01-03"]]}]}
+                  (lib/update-temporal-filter query
+                                              (-> (meta/field-metadata table field)
+                                                  (lib/with-temporal-bucket :day))
+                                              "2024-01-01"
+                                              "2024-01-03"))))))))
+
+(deftest ^:parallel update-temporal-filter-existing-breakout-date-stop-drill-down
+  (testing "Update an existing query with breakout and filter against this column; update the breakout unit"
     (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :checkins))
                     (lib/breakout (-> (meta/field-metadata :checkins :date)
                                       (lib/with-temporal-bucket :day)))
@@ -148,9 +175,9 @@
                                            (lib/with-temporal-bucket :day))
                                        "2024-01-02T15:00")))]
       (is (=? {:stages [{:breakout [[:field
-                                     ;; `:day` should have been changed to `:hour`, because there aren't enough days
+                                     ;; `:day` should not change to `:hour` for `:type/Date`
                                      ;; between `2024-01-02` and `2024-01-03`
-                                     {:temporal-unit :hour}
+                                     {:temporal-unit :day}
                                      (meta/id :checkins :date)]]
                          :filters  [[:between
                                      {}
@@ -162,6 +189,7 @@
                                               (lib/with-temporal-bucket :day))
                                           "2024-01-01"
                                           "2024-01-03"))))))
+
 
 (deftest ^:parallel update-temporal-filter-equals-test
   (testing "If the resulting start and end values are the same then generate an := filter instead of :between"

--- a/test/metabase/lib/filter/update_test.cljc
+++ b/test/metabase/lib/filter/update_test.cljc
@@ -141,9 +141,9 @@
 
 (deftest ^:parallel update-temporal-filter-existing-breakout-change-unit-test
   (testing "Update an existing query with breakout and filter against this column; update the breakout unit"
-    (doseq [[table field type] [[:users    :last-login :type/DateTime]
-                                [:products :created-at :type/DateTimeWithLocalTZ]]]
-      (testing (str type " column, specifically " table " " field)
+    (doseq [[table field field-type] [[:users    :last-login :type/DateTime]
+                                      [:products :created-at :type/DateTimeWithLocalTZ]]]
+      (testing (str field-type " column, specifically " table " " field)
         (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :users))
                         (lib/breakout (-> (meta/field-metadata table field)
                                           (lib/with-temporal-bucket :day)))
@@ -189,7 +189,6 @@
                                               (lib/with-temporal-bucket :day))
                                           "2024-01-01"
                                           "2024-01-03"))))))
-
 
 (deftest ^:parallel update-temporal-filter-equals-test
   (testing "If the resulting start and end values are the same then generate an := filter instead of :between"


### PR DESCRIPTION

Closes https://github.com/metabase/metabase/issues/48608

### Description

Using a brush filter to drill down on a small time range was failing on Date types. It was trying to filter on time units (hour/minute/second) which was giving an error.

I added logic to distinguish Date as a special case, and I made the drilling down stop at day.

### How to verify



1. New question -> Sample Dataset -> People table
2. Summarize with Cumulative sum by Birth Date: month
3. Visualize
4. Select a small area of the graph.
5. Select a small area surrounding one point.
6. It should not give an error

### Demo

<img width="1705" alt="Screenshot 2025-01-28 at 9 15 35 PM" src="https://github.com/user-attachments/assets/aa043523-777a-440f-ab4d-bbd31087a0d7" />
<img width="1674" alt="Screenshot 2025-01-28 at 9 15 45 PM" src="https://github.com/user-attachments/assets/625f311b-7356-44e2-8757-6f56ac9c89a7" />
