### PR TITLE
fix(sdk): fix minWidth console error in dashboard grid

### DIFF
--- a/frontend/src/metabase/dashboard/components/grid/utils.ts
+++ b/frontend/src/metabase/dashboard/components/grid/utils.ts
@@ -29,6 +29,7 @@ export function generateMobileLayout(desktopLayout: DashcardLayout[]) {
       y: sumVerticalSpace(mobile),
       h: getMobileHeight(card.display, item.h),
       w: 1,
+      minW: 1,
     });
   });
   return mobile;

--- a/frontend/src/metabase/dashboard/components/grid/utils.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/grid/utils.unit.spec.ts
@@ -92,7 +92,7 @@ describe("generateMobileLayout", () => {
       expect(result[2].y).toBe(5); // after action + scalar
     });
 
-    it("should set width=1 and x=0 for all cards", () => {
+    it("should set width=1, minWidth=1, and x=0 for all cards", () => {
       const result = generateMobileLayout([
         createMockDashcardLayout(10, "bar"),
         createMockDashcardLayout(10, "scalar"),
@@ -101,6 +101,9 @@ describe("generateMobileLayout", () => {
       result.forEach(layout => {
         expect(layout.w).toBe(1);
         expect(layout.x).toBe(0);
+
+        // minWidth must be >= width, otherwise GridLayout throws a prop type validation error
+        expect(layout.minW).toBe(1);
       });
     });
   });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/48499

Fixes the minWidth console error when rendering the DashboardGrid component (e.g. in the Embedding SDK). This is caused by the prop-type validation logic in the library we use:

```
    // All optional
    minW: function (props: Props, propName: string) {
      const value = props[propName];
      if (typeof value !== "number") return new Error("minWidth not Number");
      if (value > props.w || value > props.maxW)
        return new Error("minWidth larger than item width/maxWidth");
    },
```

As we forcibly sets all width (`w`) to `1` in the mobile layout, minW can be greater than w and cause the console error `Failed prop type: minWidth larger than item width/maxWidth` to show up.