### PR TITLE
fix path in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,7 @@ frontend/src/metabase/ui @metabase/core-frontend-admin-webapp
 src/metabase/**/*permissions* @noahmoss
 src/metabase/integrations @noahmoss
 snowplow/* @metabase/data
-e2e/* @filiphric
+e2e @filiphric
 
 #
 # Backend modules <=> teams that own them


### PR DESCRIPTION
Closes https://linear.app/metabase-inc/issue/DEVX-116/fix-codeowners-reference

### Description

Previous path was not set up properly, see [github docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)

### How to verify

We can only verify this after the fact, but looking at the docs, this change shoul be safe