### PR TITLE
fix(entity-id): don't call to the card endpoint if the entity id starts with digits

### DIFF
--- a/e2e/test/scenarios/question/questions-entity-id.cy.spec.ts
+++ b/e2e/test/scenarios/question/questions-entity-id.cy.spec.ts
@@ -26,4 +26,20 @@ describe("scenarios > questions > entity id support", () => {
 
     H.queryBuilderHeader().should("contain", "Orders");
   });
+
+  it("should not make requests to `/api/card/12` when the entity id starts with `12`", () => {
+    const entityId = "12".padEnd(21, "x");
+
+    // this is a request that could be made by mistake if some paths of the code think that the entity id is a slug of a question
+    cy.intercept("GET", "/api/card/12").as("wrongCardRequest");
+
+    cy.intercept("POST", "/api/util/entity_id").as("entityIdRequest");
+
+    cy.visit(`/question/entity/${entityId}`);
+
+    // await the entity id request to make sure the "wrong" request had its time to get fired
+    cy.wait("@entityIdRequest");
+
+    cy.get("@wrongCardRequest.all").should("have.length", 0);
+  });
 });

--- a/frontend/src/metabase/nav/containers/MainNavbar/getSelectedItems.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/getSelectedItems.ts
@@ -17,7 +17,11 @@ type Opts = {
 };
 
 export function isCollectionPath(pathname: string): boolean {
-  return pathname.startsWith("/collection");
+  return (
+    pathname.startsWith("/collection") &&
+    // `/${resource}/entity/${entity_id}` paths should only do a redirect, without triggering any other logic
+    !pathname.startsWith("/collection/entity/")
+  );
 }
 
 function isTrashPath(pathname: string): boolean {
@@ -44,7 +48,11 @@ function isUsersCollectionPath(pathname: string): boolean {
 }
 
 export function isQuestionPath(pathname: string): boolean {
-  return pathname.startsWith("/question");
+  return (
+    pathname.startsWith("/question") &&
+    // `/${resource}/entity/${entity_id}` paths should only do a redirect, without triggering any other logic
+    !pathname.startsWith("/question/entity/")
+  );
 }
 
 export function isModelPath(pathname: string): boolean {
@@ -56,7 +64,11 @@ export function isMetricPath(pathname: string): boolean {
 }
 
 function isDashboardPath(pathname: string): boolean {
-  return pathname.startsWith("/dashboard");
+  return (
+    pathname.startsWith("/dashboard") &&
+    // `/${resource}/entity/${entity_id}` paths should only do a redirect, without triggering any other logic
+    !pathname.startsWith("/dashboard/entity/")
+  );
 }
 
 function getSelectedItems({

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -149,11 +149,11 @@ export const getRoutes = store => {
           />
 
           <Route
-            path="collection/entity/:slug(**)"
+            path="collection/entity/:entity_id(**)"
             component={createEntityIdRedirect({
               parametersToTranslate: [
                 {
-                  name: "slug",
+                  name: "entity_id",
                   resourceType: "collection",
                   type: "param",
                 },
@@ -178,11 +178,11 @@ export const getRoutes = store => {
           </Route>
 
           <Route
-            path="dashboard/entity/:slug(**)"
+            path="dashboard/entity/:entity_id(**)"
             component={createEntityIdRedirect({
               parametersToTranslate: [
                 {
-                  name: "slug",
+                  name: "entity_id",
                   resourceType: "dashboard",
                   type: "param",
                 },
@@ -212,11 +212,11 @@ export const getRoutes = store => {
 
           <Route path="/question">
             <Route
-              path="/question/entity/:slug(**)"
+              path="/question/entity/:entity_id(**)"
               component={createEntityIdRedirect({
                 parametersToTranslate: [
                   {
-                    name: "slug",
+                    name: "entity_id",
                     resourceType: "card",
                     type: "param",
                   },


### PR DESCRIPTION
Note: I'm touching `frontend/src/metabase/nav/containers/MainNavbar/getSelectedItems.ts` and I wasn't sure who owns that so I asked for a review from the frontend team


# Description

https://metaboat.slack.com/archives/C5XHN8GLW/p1738149168742469?thread_ts=1738146001.638819&cid=C5XHN8GLW

Context: we implemented some paths that redirect from `/dashboard/entity/${entity_id}` to `/dashboard/${sequential_id}` with https://github.com/metabase/metabase/pull/52659

When I made the first implementation, the routes were supposed to be on the path `/question/:slug` and they should have figured out if it was an entity id or not.
When we decided to move the path to `/question/entity/:slug` I didn't rename the parameter so it staid `:slug`, even though it wasn't a slug.

That caused an unexpected behaviour where if the entity id started with digits, for example `/question/entity/12xx...`, a request was made to `/api/card/12`, I actually thing this would have happened even in the original plan.

This request doesn't have visible side-effects if you have access to that card so it was hard to detect, but in ci it happened that that request had a permission error, triggering an error state that made some tests fail.

The request starts from
https://github.com/metabase/metabase/blob/1d7d799d37ae0c669a8e8749a9a7602cc77044c7/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.tsx#L81-L88

Because `questionId` is being returned populated by 
https://github.com/metabase/metabase/blob/1d7d799d37ae0c669a8e8749a9a7602cc77044c7/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.tsx#L146-L154

Which only was returning true because it only checked if the path started with `/question`, which it was for `/question/entity/:xxx`
https://github.com/metabase/metabase/blob/1d7d799d37ae0c669a8e8749a9a7602cc77044c7/frontend/src/metabase/nav/containers/MainNavbar/getSelectedItems.ts#L46-L48

This PR changes the parameter to a more appropriate name, and also changes the functions to return false if the path is one of an entity id


# How to verify

Check that the test would fail with the old code.
Check that going to `http://localhost:3000/question/entity/8EdazRgPwfxdiltp7NCjS` doesn't make a request for `/api/card/8`.
At this moment, it will show a white page instead of a 404 page, I'll make a [separate PR](https://github.com/metabase/metabase/pull/52896) to address that too.