### PR TITLE
Add metrics around default and active engines

### DIFF
--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -251,7 +251,7 @@
 
 (defmethod initial-value :default [_ _] 0)
 
-(defn initial-labelled-metric-values []
+(defn- initial-labelled-metric-values []
   (for [metric (keys (methods known-labels))
         labels (known-labels metric)]
     {:metric metric

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -251,6 +251,13 @@
 
 (defmethod initial-value :default [_ _] 0)
 
+(defn initial-labelled-metric-values []
+  (for [metric (keys (methods known-labels))
+        labels (known-labels metric)]
+    {:metric metric
+     :labels labels
+     :value  (initial-value metric labels)}))
+
 (defn- setup-metrics!
   "Instrument the application. Conditionally done when some setting is set. If [[prometheus-server-port]] is not set it
   will throw."
@@ -263,9 +270,7 @@
                                 (jetty-collectors)
                                 [@c3p0-collector]
                                 (product-collectors)))]
-    (doseq [metric (keys (methods known-labels))
-            labels (known-labels metric)
-            :let [value (initial-value metric labels)]]
+    (doseq [{:keys [metric labels value]} (initial-labelled-metric-values)]
       (prometheus/inc registry metric labels value))
     registry))
 

--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -49,7 +49,7 @@
     {:model model}))
 
 (defmethod prometheus/known-labels :metabase-search/engine-default
-  [_ {:keys [engine]}]
+  [_]
   (prometheus/known-labels :metabase-search/engine-active))
 
 (defmethod prometheus/known-labels :metabase-search/engine-active

--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -48,6 +48,19 @@
   (for [model (keys (search.spec/specifications))]
     {:model model}))
 
+(defmethod prometheus/known-labels :metabase-search/engine-active
+  [_]
+  (for [e (search.engine/known-engines)]
+    {:engine (name e)}))
+
+(defmethod prometheus/initial-value :metabase-search/engine-default
+  [_ {:keys [engine]}]
+  (if (= engine (name (search.impl/default-engine))) 1 0))
+
+(defmethod prometheus/initial-value :metabase-search/engine-active
+  [_ {:keys [engine]}]
+  (if (search.engine/supported-engine? (keyword "search.engine" engine)) 1 0))
+
 (defn supports-index?
   "Does this instance support a search index, of any sort?"
   []

--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -48,6 +48,10 @@
   (for [model (keys (search.spec/specifications))]
     {:model model}))
 
+(defmethod prometheus/known-labels :metabase-search/engine-default
+  [_ {:keys [engine]}]
+  (prometheus/known-labels :metabase-search/engine-active))
+
 (defmethod prometheus/known-labels :metabase-search/engine-active
   [_]
   (for [e (search.engine/known-engines)]

--- a/src/metabase/search/engine.clj
+++ b/src/metabase/search/engine.clj
@@ -57,6 +57,12 @@
   {:arglists '([engine])}
   identity)
 
+(defn known-engines
+  "List the possible search engines defined for this version, whether this instance supports them or not."
+  []
+  ;; If we end up with more "abstract" nodes, we may want a better way to filter them out.
+  (keys (dissoc (methods supported-engine?) :default)))
+
 (defn active-engines
   "List the search engines that are supported. Does not mention the legacy in-place engine."
   []

--- a/test/metabase/analytics/prometheus_test.clj
+++ b/test/metabase/analytics/prometheus_test.clj
@@ -196,7 +196,7 @@
       (is (approx= 1 (metric-value system :metabase-email/messages))))))
 
 (deftest search-engine-metrics-test
-  (let [metrics       (prometheus/initial-labelled-metric-values)
+  (let [metrics       (#'prometheus/initial-labelled-metric-values)
         engine->value (fn [metric] (u/index-by (comp :engine :labels) :value (filter (comp #{metric} :metric) metrics)))
         engines       (fn [metric] (keys (engine->value metric)))
         value         (fn [metric engine] (get (engine->value metric) (name engine)))

--- a/test/metabase/analytics/prometheus_test.clj
+++ b/test/metabase/analytics/prometheus_test.clj
@@ -197,8 +197,8 @@
 
 (deftest search-engine-metrics-test
   (let [metrics       (prometheus/initial-labelled-metric-values)
-        engines       (fn [metric] (map (comp :engine :labels) (filter (comp #{metric} :metric) metrics)))
         engine->value (fn [metric] (u/index-by (comp :engine :labels) :value (filter (comp #{metric} :metric) metrics)))
+        engines       (fn [metric] (keys (engine->value metric)))
         value         (fn [metric engine] (get (engine->value metric) (name engine)))
         sum           (fn [metric] (reduce + 0 (vals (engine->value metric))))]
     (testing "A consistent set of engines is enumerated"


### PR DESCRIPTION
These metrics will be useful to filter our dashboards and alarms during rollout.

They'll also be nice to track when deprecating engines.

For my local instance:

```
# HELP metabase_search_engine_active Whether a given engine is active. This does NOT mean that it is the default.
# TYPE metabase_search_engine_active gauge
metabase_search_engine_active{engine="in-place",} 1.0
metabase_search_engine_active{engine="appdb",} 1.0
...
# HELP metabase_search_engine_default Whether a given engine is being used as the default. User can override via cookie.
# TYPE metabase_search_engine_default gauge
metabase_search_engine_default{engine="in-place",} 0.0
metabase_search_engine_default{engine="appdb",} 1.0
```