### PR TITLE
fix(entity-id): show 404 for entity id that starts with digits

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1698,24 +1698,24 @@ describe("scenarios > dashboard > entity id support", () => {
   });
 
   it("when loading `/dashboard/entity/${non existing entity id}`, it should show a 404 page", () => {
-    const invalidSlug = "x".repeat(21);
-    cy.visit(`/dashboard/entity/${invalidSlug}`);
+    const nonExistingEntityId = "x".repeat(21);
+    cy.visit(`/dashboard/entity/${nonExistingEntityId}`);
 
     H.main().findByText("We're a little lost...").should("be.visible");
   });
 
   it("when loading `/dashboard/entity/${non existing entity id}`, it should show a 404 page even if the entity id starts with a number", () => {
     const nonExistingEntityId = "12".padEnd(21, "x");
-    cy.visit(
-      `/dashboard/entity/${ORDERS_DASHBOARD_ENTITY_ID}?tab=${nonExistingEntityId}`,
-    );
+    cy.visit(`/dashboard/entity/${nonExistingEntityId}`);
 
     H.main().findByText("We're a little lost...").should("be.visible");
   });
 
-  it("when loading `/dashboard/entity/${existing entity id}?tab=${non existing tab entity id}`, it should show a 404 page even if the entity id starts with a number", () => {
-    const invalidSlug = "12".padEnd(21, "x");
-    cy.visit(`/dashboard/entity/${invalidSlug}`);
+  it("when loading `/dashboard/entity/${entity id}?tab=${non existing tab entity id}`, it should show a 404 page even if the entity id starts with a number", () => {
+    const nonExistingEntityId = "12".padEnd(21, "x");
+    cy.visit(
+      `/dashboard/entity/${ORDERS_DASHBOARD_ENTITY_ID}?tab=${nonExistingEntityId}`,
+    );
 
     H.main().findByText("We're a little lost...").should("be.visible");
   });

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1705,47 +1705,19 @@ describe("scenarios > dashboard > entity id support", () => {
   });
 
   it("when loading `/dashboard/entity/${non existing entity id}`, it should show a 404 page even if the entity id starts with a number", () => {
-    const invalidSlug = "12".padEnd(21, "x");
-    cy.visit(`/dashboard/entity/${invalidSlug}`);
+    const nonExistingEntityId = "12".padEnd(21, "x");
+    cy.visit(
+      `/dashboard/entity/${ORDERS_DASHBOARD_ENTITY_ID}?tab=${nonExistingEntityId}`,
+    );
 
     H.main().findByText("We're a little lost...").should("be.visible");
   });
 
-  it("when loading `/dashboard/entity/${entity-id}?tab=${non-existing-tab-entity-id}`, it should still load the dashboard correctly", () => {
-    const nonExistingTabEntityId = "x".repeat(21);
-    H.createDashboardWithTabs({
-      name: "Dashboard with 2 tabs",
-      tabs: [
-        { name: "Tab 1", id: -1 },
-        { name: "Tab 2", id: -2 },
-      ],
-      dashcards: [],
-    }).then(dashboard => {
-      cy.visit(
-        `/dashboard/entity/${dashboard.entity_id}?tab=${nonExistingTabEntityId}`,
-      );
-      cy.url().should("contain", `/dashboard/${dashboard.id}`);
-      H.main().findByText("Dashboard with 2 tabs").should("be.visible");
-      cy.url().should("not.contain", `tab=${nonExistingTabEntityId}`);
-    });
-  });
+  it("when loading `/dashboard/entity/${existing entity id}?tab=${non existing tab entity id}`, it should show a 404 page even if the entity id starts with a number", () => {
+    const invalidSlug = "12".padEnd(21, "x");
+    cy.visit(`/dashboard/entity/${invalidSlug}`);
 
-  it("when loading `/dashboard/entity/${entity-id}?tab=${tab-slug of 21 chars}`, it should still load the dashboard correctly", () => {
-    H.createDashboardWithTabs({
-      name: "Dashboard with 2 tabs",
-      tabs: [
-        { name: "Tab 1", id: -1 },
-        { name: "Tab 2", id: -2 },
-      ],
-      dashcards: [],
-    }).then(dashboard => {
-      const tabId = dashboard.tabs[1].id;
-      const tabSlug = `${tabId}`.padEnd(21, "x");
-      cy.visit(`/dashboard/entity/${dashboard.entity_id}?tab=${tabSlug}`);
-      cy.url().should("contain", `/dashboard/${dashboard.id}`);
-      H.main().findByText("Dashboard with 2 tabs").should("be.visible");
-      cy.url().should("contain", `tab=${tabId}`);
-    });
+    H.main().findByText("We're a little lost...").should("be.visible");
   });
 });
 

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1704,6 +1704,13 @@ describe("scenarios > dashboard > entity id support", () => {
     H.main().findByText("We're a little lost...").should("be.visible");
   });
 
+  it("when loading `/dashboard/entity/${non existing entity id}`, it should show a 404 page even if the entity id starts with a number", () => {
+    const invalidSlug = "12".padEnd(21, "x");
+    cy.visit(`/dashboard/entity/${invalidSlug}`);
+
+    H.main().findByText("We're a little lost...").should("be.visible");
+  });
+
   it("when loading `/dashboard/entity/${entity-id}?tab=${non-existing-tab-entity-id}`, it should still load the dashboard correctly", () => {
     const nonExistingTabEntityId = "x".repeat(21);
     H.createDashboardWithTabs({

--- a/e2e/test/scenarios/question/questions-entity-id.cy.spec.ts
+++ b/e2e/test/scenarios/question/questions-entity-id.cy.spec.ts
@@ -41,6 +41,9 @@ describe("scenarios > questions > entity id support", () => {
     // await the entity id request to make sure the "wrong" request had its time to get fired
     cy.wait("@entityIdRequest");
 
+    // it should render a 404 page as that entity id doesn't exist
+    H.main().findByText("We're a little lost...").should("be.visible");
+
     cy.get("@wrongCardRequest.all").should("have.length", 0);
   });
 });

--- a/frontend/src/metabase/routes-stable-id-aware.tsx
+++ b/frontend/src/metabase/routes-stable-id-aware.tsx
@@ -131,14 +131,12 @@ function handleResults({
       if (mappedEntityId?.id) {
         shouldRedirect = true;
         url = url.replace(value, String(mappedEntityId.id));
-      } else if (!canBeNormalId(value)) {
-        // if it's found and cannot be a normal slug (ie: it doesn't start with a number)
-        if (required) {
-          // if it's required, then we show an error, this is needed because at this time some endpoints
-          // become stuck in infinite loading if they fail to parse the numeric id from the slug
-          notFound = true;
-        } else {
-          // if it's not required then we remove it from the url
+      } else if (required) {
+        // if it's not found and it's required, then we render a not found
+        notFound = true;
+      } else {
+        // if it's not found and can't be a normal slug, but wasn't required, then we remove it from the url
+        if (!canBeNormalId(value)) {
           url = url.replace(value, "");
         }
       }

--- a/frontend/src/metabase/routes-stable-id-aware.tsx
+++ b/frontend/src/metabase/routes-stable-id-aware.tsx
@@ -20,11 +20,9 @@ type ParamConfig = {
   name: string;
   type: ParamType;
   resourceType: ResourceType;
-  required?: boolean;
 };
 
 type ParamWithValue = {
-  required: boolean;
   value: string;
   name: string;
   type: ParamType;
@@ -52,7 +50,6 @@ export const EntityIdRedirect = ({
         .exhaustive();
       return {
         ...config,
-        required: config.required ?? true,
         value,
       };
     });
@@ -124,21 +121,16 @@ function handleResults({
   let shouldRedirect = false;
   let url = currentUrl;
   let notFound = false;
-  for (const { value, required } of paramsWithValues) {
+  for (const { value } of paramsWithValues) {
     if (isBaseEntityID(value)) {
       const mappedEntityId = entity_ids?.[value];
       // if the entity id is found, we replace it with the numeric id
       if (mappedEntityId?.id) {
         shouldRedirect = true;
         url = url.replace(value, String(mappedEntityId.id));
-      } else if (required) {
-        // if it's not found and it's required, then we render a not found
-        notFound = true;
       } else {
-        // if it's not found and can't be a normal slug, but wasn't required, then we remove it from the url
-        if (!canBeNormalId(value)) {
-          url = url.replace(value, "");
-        }
+        // if it's not found we show a 404
+        notFound = true;
       }
     }
   }
@@ -160,9 +152,4 @@ export function createEntityIdRedirect(config: {
 
 export const canBeEntityId = (id: string): id is BaseEntityId => {
   return isBaseEntityID(id);
-};
-
-export const canBeNormalId = (id: string) => {
-  const parts = id.split("-");
-  return !isNaN(parseInt(parts[0]));
 };

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -190,7 +190,6 @@ export const getRoutes = store => {
                   name: "tab",
                   resourceType: "dashboard-tab",
                   type: "search",
-                  required: false,
                 },
               ],
             })}


### PR DESCRIPTION
There was a bug caused by my just re-using the old logic with the new routes.

The old logic had to support slugs/sequential ids, and therefore if the entity id was not found it was supposed to just pass the "slug" to the normal route which would either load the page or display the 404 page.

The new routes don't fallback to anything, as they either do the redirect if they find the entity id or they show a 404.

We also don't need to support slugs, neither for the dashboard/question/collection nor for the tab (see [slack thread](https://metaboat.slack.com/archives/C063Q3F1HPF/p1738169092434949) where alberto confirmed it).

This PR removes the un-needed logic and simplifies the code, it also updates the tests to check that we show the 404 page for both a missing dashboard and tab