### PR TITLE
ci: Fix SDK cross-version testing failure after test util refactor

### DIFF
--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -165,8 +165,8 @@ jobs:
 
       - name: Move tests from the release commit into the repo
         run: |
-          rm -rf ./e2e/support/helpers/*
-          mv ./sdk-release-e2e/e2e/support/helpers/* ./e2e/support/helpers
+          rm -rf ./e2e/support/*
+          mv ./sdk-release-e2e/e2e/support/* ./e2e/support
           rm -rf ./e2e/test-component/*
           mv ./sdk-release-e2e/e2e/test-component/* ./e2e/test-component
         shell: bash

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -156,20 +156,20 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Needed to omit newly added tests for functionality that is not yet released
-      - name: Checkout tests from SDK release commit
+      - name: Sparse checkout tests from SDK release commit
         uses: actions/checkout@v4
         with:
           ref: embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }}
-          # path: sdk-release-e2e
-          # sparse-checkout: e2e
+          path: sdk-release-e2e
+          sparse-checkout: e2e
 
-      # - name: Move tests from the release commit into the repo
-      #   run: |
-      #     rm -rf ./e2e/support/helpers/*
-      #     mv ./sdk-release-e2e/e2e/support/helpers/* ./e2e/support/helpers
-      #     rm -rf ./e2e/test-component/*
-      #     mv ./sdk-release-e2e/e2e/test-component/* ./e2e/test-component
-      #   shell: bash
+      - name: Move tests from the release commit into the repo
+        run: |
+          rm -rf ./e2e/support/helpers/*
+          mv ./sdk-release-e2e/e2e/support/helpers/* ./e2e/support/helpers
+          rm -rf ./e2e/test-component/*
+          mv ./sdk-release-e2e/e2e/test-component/* ./e2e/test-component
+        shell: bash
 
       - name: Retrieve uberjar artifact for ee
         uses: actions/download-artifact@v4

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -160,7 +160,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }}
+          path: sdk-release-e2e
           sparse-checkout: e2e
+
+      - name: Move tests from the release commit into the repo
+        run: |
+          rm -rf ./e2e
+          mv ./sdk-release-e2e/e2e .
+        shell: bash
 
       - name: Retrieve uberjar artifact for ee
         uses: actions/download-artifact@v4

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -160,16 +160,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }}
-          path: sdk-release-e2e
           sparse-checkout: e2e
-
-      - name: Move tests from the release commit into the repo
-        run: |
-          rm -rf ./e2e/support/helpers/*
-          mv ./sdk-release-e2e/e2e/support/helpers/* ./e2e/support/helpers
-          rm -rf ./e2e/test-component/*
-          mv ./sdk-release-e2e/e2e/test-component/* ./e2e/test-component
-        shell: bash
 
       - name: Retrieve uberjar artifact for ee
         uses: actions/download-artifact@v4

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -156,20 +156,20 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Needed to omit newly added tests for functionality that is not yet released
-      - name: Sparse checkout tests from SDK release commit
+      - name: Checkout tests from SDK release commit
         uses: actions/checkout@v4
         with:
           ref: embedding-sdk-${{ needs.resolve-sdk-version.outputs.sdk_version }}
-          path: sdk-release-e2e
-          sparse-checkout: e2e
+          # path: sdk-release-e2e
+          # sparse-checkout: e2e
 
-      - name: Move tests from the release commit into the repo
-        run: |
-          rm -rf ./e2e/support/helpers/*
-          mv ./sdk-release-e2e/e2e/support/helpers/* ./e2e/support/helpers
-          rm -rf ./e2e/test-component/*
-          mv ./sdk-release-e2e/e2e/test-component/* ./e2e/test-component
-        shell: bash
+      # - name: Move tests from the release commit into the repo
+      #   run: |
+      #     rm -rf ./e2e/support/helpers/*
+      #     mv ./sdk-release-e2e/e2e/support/helpers/* ./e2e/support/helpers
+      #     rm -rf ./e2e/test-component/*
+      #     mv ./sdk-release-e2e/e2e/test-component/* ./e2e/test-component
+      #   shell: bash
 
       - name: Retrieve uberjar artifact for ee
         uses: actions/download-artifact@v4

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -165,8 +165,10 @@ jobs:
 
       - name: Move tests from the release commit into the repo
         run: |
-          rm -rf ./e2e
-          mv ./sdk-release-e2e/e2e .
+          rm -rf ./e2e/support/helpers/*
+          mv ./sdk-release-e2e/e2e/support/helpers/* ./e2e/support/helpers
+          rm -rf ./e2e/test-component/*
+          mv ./sdk-release-e2e/e2e/test-component/* ./e2e/test-component
         shell: bash
 
       - name: Retrieve uberjar artifact for ee

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -165,6 +165,7 @@ jobs:
 
       - name: Move tests from the release commit into the repo
         run: |
+          # remove this line after we release a new SDK 0.53.x, since it will already contain the fixed version then.
           mv ./e2e/support/component-webpack.config.js .
 
           rm -rf ./e2e/support/*

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -165,8 +165,12 @@ jobs:
 
       - name: Move tests from the release commit into the repo
         run: |
+          mv ./e2e/support/component-webpack.config.js .
+
           rm -rf ./e2e/support/*
           mv ./sdk-release-e2e/e2e/support/* ./e2e/support
+          mv ./component-webpack.config.js ./e2e/support
+
           rm -rf ./e2e/test-component/*
           mv ./sdk-release-e2e/e2e/test-component/* ./e2e/test-component
         shell: bash


### PR DESCRIPTION
[Reported on Slack
](https://metaboat.slack.com/archives/C5XHN8GLW/p1738153908445629)

The logic that we move tests + utils from the SDK release commit to the most recent release branch commit was from https://github.com/metabase/metabase/pull/51171.

This caused a problem where the tests somehow were out of sync with util files after we merged #52878.


Sooooooooooooooooo, finally the fix is to ensure we copy over everything under `e2e/support` with one caveat that we need to keep `component-webpack.config.js` from the release branch since that contains the latest fix necessary to run tests on the release 53 branch (https://github.com/metabase/metabase/pull/52800)

#### How to verify
This is [the run](https://github.com/metabase/metabase/actions/runs/13030469770/attempts/1) after merging the refactor https://github.com/metabase/metabase/pull/52878. Which has failed tests.

This is [the run](https://github.com/metabase/metabase/actions/runs/13036680731/job/36369310378#step:11:429) from this PR with ✅ ✅ ✅ ✅ ✅ 
