### PR TITLE
Add describe-database check to view tests

### DIFF
--- a/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
@@ -804,10 +804,9 @@
           (tx/drop-view! driver/*driver* (mt/db) view-name {:materialized? materialized?})
           (tx/create-view-of-table! driver/*driver* (mt/db) view-name table-name {:materialized? materialized?})
           (sync/sync-database! (mt/db) {:scan :schema})
-          (is (contains? (into #{} (map :name) (:tables (driver/describe-database driver/*driver* (mt/db))))
-                         view-name))
           (let [orders-id (:id (tx/metabase-instance (tx/map->TableDefinition {:table-name table-name}) (mt/db)))
-                orders-m-id (:id (tx/metabase-instance (tx/map->TableDefinition {:table-name view-name}) (mt/db)))
+                view-instance (tx/metabase-instance (tx/map->TableDefinition {:table-name view-name}) (mt/db))
+                orders-m-id (:id view-instance)
                 non-view-fields (t2/select-fn-vec
                                  (juxt (comp u/lower-case-en :name) :base_type :database_position)
                                  :model/Field
@@ -818,6 +817,8 @@
                              :model/Field
                              :table_id orders-m-id
                              {:order-by [:database_position]})]
+            (is (contains? (into #{} (map :name) (:tables (driver/describe-database driver/*driver* (mt/db))))
+                           (:name view-instance)))
             (is (some? orders-m-id))
             (is (some? orders-id))
             (is (= 9 (count view-fields)))

--- a/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
@@ -804,6 +804,8 @@
           (tx/drop-view! driver/*driver* (mt/db) view-name {:materialized? materialized?})
           (tx/create-view-of-table! driver/*driver* (mt/db) view-name table-name {:materialized? materialized?})
           (sync/sync-database! (mt/db) {:scan :schema})
+          (is (contains? (into #{} (map :name) (:tables (driver/describe-database driver/*driver* (mt/db))))
+                         view-name))
           (let [orders-id (:id (tx/metabase-instance (tx/map->TableDefinition {:table-name table-name}) (mt/db)))
                 orders-m-id (:id (tx/metabase-instance (tx/map->TableDefinition {:table-name view-name}) (mt/db)))
                 non-view-fields (t2/select-fn-vec


### PR DESCRIPTION
Looking at a databricks CI failure and noticed that describe-database output wasn't being tested for views.