### PR TITLE
Fix home page Metabot spacing on large screens

### DIFF
--- a/frontend/src/metabase/home/components/HomeGreeting/HomeGreeting.styled.tsx
+++ b/frontend/src/metabase/home/components/HomeGreeting/HomeGreeting.styled.tsx
@@ -8,15 +8,23 @@ export const GreetingRoot = styled.div`
   align-items: center;
 `;
 
-export const GreetingLogo = styled(MetabotLogo)<{ isCool: boolean }>`
+export const GreetingLogoContainer = styled.div`
+  position: relative;
+  width: 3.375rem;
   height: 2.5rem;
+  margin-inline-end: 0.5rem;
+
+  ${breakpointMinExtraLarge} {
+    width: 4rem;
+    height: 3rem;
+  }
+`;
+
+export const GreetingLogo = styled(MetabotLogo)<{ isCool: boolean }>`
+  width: 100%;
   position: absolute;
   top: 0;
   opacity: ${props => (props.isCool ? 1 : 0)};
-
-  ${breakpointMinExtraLarge} {
-    height: 3rem;
-  }
 `;
 
 interface GreetingMessageProps {

--- a/frontend/src/metabase/home/components/HomeGreeting/HomeGreeting.tsx
+++ b/frontend/src/metabase/home/components/HomeGreeting/HomeGreeting.tsx
@@ -5,12 +5,13 @@ import _ from "underscore";
 import styles from "metabase/css/core/animation.module.css";
 import { useSelector } from "metabase/lib/redux";
 import { getUser } from "metabase/selectors/user";
-import { Box, Tooltip } from "metabase/ui";
+import { Tooltip } from "metabase/ui";
 
 import { getHasMetabotLogo } from "../../selectors";
 
 import {
   GreetingLogo,
+  GreetingLogoContainer,
   GreetingMessage,
   GreetingRoot,
 } from "./HomeGreeting.styled";
@@ -83,14 +84,7 @@ const MetabotGreeting = () => {
       label={t`Don't tell anyone, but you're my favorite.`}
       position="bottom"
     >
-      <Box
-        style={{
-          position: "relative",
-          width: "54px",
-          height: "40px",
-          marginInlineEnd: "0.5rem",
-        }}
-      >
+      <GreetingLogoContainer>
         <GreetingLogo
           isCool={isCool}
           className={`${styles.SpinOut} ${isCooling ? styles.SpinOutActive : ""}`}
@@ -101,7 +95,7 @@ const MetabotGreeting = () => {
           className={`${styles.SpinOut} ${isCooling ? styles.SpinOutActive : ""}`}
           variant="happy"
         />
-      </Box>
+      </GreetingLogoContainer>
     </Tooltip>
   );
 };


### PR DESCRIPTION
Closes ENG-8921

### Description

Fixes spacing at larger screen sizes

### How to verify

- Expand a window over 1920px wide, see that the spacing looks correct
- Changes to other screen sizes to see spacing preserved at smaller sizes

### Demo

Before
![CleanShot 2025-01-29 at 12 26 15@2x](https://github.com/user-attachments/assets/fe256186-eb97-48d5-bd9a-2a6c1a2e42a8)
![CleanShot 2025-01-29 at 12 26 17@2x](https://github.com/user-attachments/assets/5e634d3a-42a2-4751-ad23-0b2b2bf18ebf)
![CleanShot 2025-01-29 at 12 26 29@2x](https://github.com/user-attachments/assets/157fd62f-ff9c-4ca2-96cd-8e7b31a76db2)

After
![CleanShot 2025-01-29 at 12 25 17@2x](https://github.com/user-attachments/assets/574de7e4-d0e6-4602-b7a9-c9d526b7ff09)
![CleanShot 2025-01-29 at 12 25 30@2x](https://github.com/user-attachments/assets/1051f4b8-ee57-4b87-81c5-b460dc84528e)
![CleanShot 2025-01-29 at 12 25 37@2x](https://github.com/user-attachments/assets/9a853a29-dae3-4aaa-b812-adf902a71443)