### PR TITLE
Remove Exasol and Ocient

### DIFF
--- a/.github/actions/build-ee-extra/action.yml
+++ b/.github/actions/build-ee-extra/action.yml
@@ -64,10 +64,7 @@ runs:
           const extraDrivers = {
             firebolt: getDriverUrl('firebolt'),
             starburst: getDriverUrl('starburst'),
-            exasol: getDriverUrl('exasol'),
-            exasol_jdbc: drivers.find(d => d.name === 'exasol').deps[0],
             clickhouse: getDriverUrl('clickhouse'),
-            ocient: getDriverUrl('ocient'),
             materialize: getDriverUrl('materialize'),
           };
 
@@ -84,20 +81,9 @@ runs:
         curl -OL ${{ fromJson(steps.drivers_registry.outputs.result).starburst }}
       shell: bash
       working-directory: modules
-    - name: Download Exasol driver
-      run: |
-        curl -OL ${{ fromJson(steps.drivers_registry.outputs.result).exasol }}
-        curl -OL ${{ fromJson(steps.drivers_registry.outputs.result).exasol_jdbc }}
-      shell: bash
-      working-directory: modules
     - name: Download Clickhouse driver
       run: |
         curl -OL ${{ fromJson(steps.drivers_registry.outputs.result).clickhouse }}
-      shell: bash
-      working-directory: modules
-    - name: Download Ocient driver
-      run: |
-        curl -OL ${{ fromJson(steps.drivers_registry.outputs.result).ocient }}
       shell: bash
       working-directory: modules
     - name: Download Materialize driver

--- a/docs/developers-guide/partner-and-community-drivers.md
+++ b/docs/developers-guide/partner-and-community-drivers.md
@@ -44,9 +44,7 @@ Current partner drivers:
 
 - [ClickHouse](https://github.com/ClickHouse/metabase-clickhouse-driver)
 - [DuckDB](https://github.com/MotherDuck-Open-Source/metabase_duckdb_driver) (for now, only available for self-hosted Metabases)
-- [Exasol](https://github.com/exasol/metabase-driver)
 - [Materialize](https://github.com/MaterializeInc/metabase-materialize-driver)
-- [Ocient](https://github.com/Xeograph/metabase-ocient-driver)
 - [Starburst (compatible with Trino)](https://github.com/starburstdata/metabase-driver)
 
 Partner drivers are available to Cloud customers out-of-the-box.

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -510,7 +510,7 @@
 
 (def partner-drivers
   "The set of other drivers in the partnership program"
-  #{"clickhouse" "exasol" "firebolt" "materialize" "ocient" "starburst"})
+  #{"clickhouse" "firebolt" "materialize" "starburst"})
 
 (defn driver-source
   "Return the source type of the driver: official, partner, or community"


### PR DESCRIPTION
These drivers are not part of the partnership program anymore.