### PR TITLE
Fix breakout by drill through context menu for multi-stage queries

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -221,10 +221,9 @@ describe("issue 18770", () => {
     H.popover().within(() => {
       cy.findByText("Filter by this value").should("be.visible");
       cy.findAllByRole("button")
-        .should("have.length", 5)
+        .should("have.length", 6)
         .and("contain", "See these Orders")
-        // TODO fix this drill thru and re-enable this check (metabase#52236)
-        // .and("contain", "Break out by")
+        .and("contain", "Break out by")
         .and("contain", "<")
         .and("contain", ">")
         .and("contain", "=")

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/table_drills.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/table_drills.cy.spec.js
@@ -1,7 +1,16 @@
 const { H } = cy;
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
-const { REVIEWS, REVIEWS_ID, ACCOUNTS_ID } = SAMPLE_DATABASE;
+const {
+  ORDERS,
+  ORDERS_ID,
+  PRODUCTS,
+  PRODUCTS_ID,
+  REVIEWS,
+  REVIEWS_ID,
+  ACCOUNTS_ID,
+} = SAMPLE_DATABASE;
 
 describe("scenarios > visualizations > drillthroughs > table_drills", () => {
   beforeEach(() => {
@@ -185,6 +194,99 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       cy.findByText("All time").should("be.visible");
       cy.findByText("by").should("be.visible");
       cy.findByText("Month").should("be.visible");
+    });
+  });
+
+  describe("pivot drill", () => {
+    const queryWithJoin = {
+      "source-table": ORDERS_ID,
+      aggregation: [["count"]],
+      breakout: [["field", PRODUCTS.CATEGORY, { "join-alias": "Products" }]],
+      joins: [
+        {
+          alias: "Products",
+          condition: [
+            "=",
+            ["field", ORDERS.PRODUCT_ID, null],
+            ["field", PRODUCTS.ID, { "join-alias": "Products" }],
+          ],
+          fields: "all",
+          "source-table": PRODUCTS_ID,
+        },
+      ],
+    };
+    const queryWithJoinThenFilter = {
+      "source-query": queryWithJoin,
+      filter: [">", ["field", "count", { "base-type": "type/Integer" }], 0],
+    };
+
+    function pivotDrillTest({
+      query,
+      drillCellText,
+      menuItems,
+      filterText,
+      resultText,
+    }) {
+      H.visitQuestionAdhoc({
+        name: "pivot drill query",
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          query: query,
+          type: "query",
+        },
+        display: "table",
+      });
+      cy.get("[data-testid=cell-data]").contains(drillCellText).first().click();
+      H.popover().within(() => {
+        cy.findByText("Break out by…").click();
+        menuItems.forEach(item => {
+          cy.findByText(item).click();
+        });
+      });
+      cy.findAllByTestId("filter-pill").first().should("have.text", filterText);
+      cy.get("[data-testid=cell-data]")
+        .contains(resultText)
+        .should("be.visible");
+    }
+
+    it("should allow category pivot drills on single-stage queries (metabase#52236)", () => {
+      pivotDrillTest({
+        query: queryWithJoin,
+        drillCellText: "4,939",
+        menuItems: ["Category", "Vendor"],
+        filterText: "Products → Category is Gadget",
+        resultText: "Barrows-Johns",
+      });
+    });
+
+    it("should allow category pivot drills on multi-stage queries (metabase#52236)", () => {
+      pivotDrillTest({
+        query: queryWithJoinThenFilter,
+        drillCellText: "4,939",
+        menuItems: ["Category", "Vendor"],
+        filterText: "Products → Category is Gadget",
+        resultText: "Barrows-Johns",
+      });
+    });
+
+    it("should allow timeseries pivot drills on single-stage queries (metabase#52236)", () => {
+      pivotDrillTest({
+        query: queryWithJoin,
+        drillCellText: "3,976",
+        menuItems: ["Time", "Products", "Created At"],
+        filterText: "Products → Category is Doohickey",
+        resultText: "July 31, 2022",
+      });
+    });
+
+    it("should allow timeseries pivot drills on multi-stage queries (metabase#52236)", () => {
+      pivotDrillTest({
+        query: queryWithJoinThenFilter,
+        drillCellText: "3,976",
+        menuItems: ["Time", "Products", "Created At"],
+        filterText: "Products → Category is Doohickey",
+        resultText: "July 31, 2022",
+      });
     });
   });
 

--- a/frontend/src/metabase-lib/drills.ts
+++ b/frontend/src/metabase-lib/drills.ts
@@ -59,10 +59,6 @@ export function pivotDrillDetails(drillThru: DrillThru): PivotDrillDetails {
   return ML.pivot_drill_details(drillThru);
 }
 
-export function pivotTypes(drillThru: DrillThru): PivotType[] {
-  return ML.pivot_types(drillThru);
-}
-
 export function pivotColumnsForType(
   drillThru: DrillThru,
   pivotType: PivotType,

--- a/frontend/src/metabase-lib/drills.ts
+++ b/frontend/src/metabase-lib/drills.ts
@@ -7,6 +7,7 @@ import type {
   ColumnMetadata,
   DrillThru,
   FilterDrillDetails,
+  PivotDrillDetails,
   PivotType,
   Query,
 } from "./types";
@@ -52,6 +53,10 @@ export function combineColumnDrillDetails(
   drillThru: DrillThru,
 ): FilterDrillDetails {
   return ML.combine_column_drill_details(drillThru);
+}
+
+export function pivotDrillDetails(drillThru: DrillThru): PivotDrillDetails {
+  return ML.pivot_drill_details(drillThru);
 }
 
 export function pivotTypes(drillThru: DrillThru): PivotType[] {

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -596,11 +596,12 @@ export type FilterDrillDetails = {
   column: ColumnMetadata;
 };
 
+export type PivotType = "category" | "location" | "time";
+
 export type PivotDrillDetails = {
+  pivotTypes: PivotType[];
   stageIndex: number;
 };
-
-export type PivotType = "category" | "location" | "time";
 
 export interface ClickObjectDimension {
   value: RowValue;

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -596,6 +596,10 @@ export type FilterDrillDetails = {
   column: ColumnMetadata;
 };
 
+export type PivotDrillDetails = {
+  stageIndex: number;
+};
+
 export type PivotType = "category" | "location" | "time";
 
 export interface ClickObjectDimension {

--- a/frontend/src/metabase/querying/drills/utils/pivot-drill.tsx
+++ b/frontend/src/metabase/querying/drills/utils/pivot-drill.tsx
@@ -29,8 +29,9 @@ const ACTIONS = {
   },
 } as const;
 
-export const pivotDrill: Drill = ({ query, stageIndex, drill, applyDrill }) => {
+export const pivotDrill: Drill = ({ query, drill, applyDrill }) => {
   const pivotTypes = Lib.pivotTypes(drill);
+  const { stageIndex } = Lib.pivotDrillDetails(drill);
 
   const actions = pivotTypes.map(pivotType =>
     getActionForType(query, stageIndex, drill, pivotType, applyDrill),

--- a/frontend/src/metabase/querying/drills/utils/pivot-drill.tsx
+++ b/frontend/src/metabase/querying/drills/utils/pivot-drill.tsx
@@ -30,8 +30,7 @@ const ACTIONS = {
 } as const;
 
 export const pivotDrill: Drill = ({ query, drill, applyDrill }) => {
-  const pivotTypes = Lib.pivotTypes(drill);
-  const { stageIndex } = Lib.pivotDrillDetails(drill);
+  const { pivotTypes, stageIndex } = Lib.pivotDrillDetails(drill);
 
   const actions = pivotTypes.map(pivotType =>
     getActionForType(query, stageIndex, drill, pivotType, applyDrill),

--- a/src/metabase/lib/drill_thru/pivot.cljc
+++ b/src/metabase/lib/drill_thru/pivot.cljc
@@ -148,7 +148,6 @@
   (select-keys drill-thru [:many-pks? :object-id :type]))
 
 ;; Note that pivot drills have specific public functions for accessing the nested pivoting options.
-;; Therefore the [[drill-thru-info-method]] is just the default `{:type :drill-thru/pivot}`.
 
 (mu/defn pivot-types :- [:sequential ::lib.schema.drill-thru/pivot-types]
   "A helper for the FE. Returns the set of pivot types (category, location, time) that apply to this drill-thru."

--- a/src/metabase/lib/drill_thru/pivot.cljc
+++ b/src/metabase/lib/drill_thru/pivot.cljc
@@ -132,9 +132,9 @@
                (-> (lib.aggregation/aggregations query stage-number) count pos?))
       (let [breakout-pivot-types (permitted-pivot-types query stage-number)
             pivots               (into {} (for [pivot-type breakout-pivot-types
-                                                :let       [pred    (get pivot-type-predicates pivot-type)
-                                                            columns (pivot-drill-pred query stage-number context pred)]
-                                                :when      (not-empty columns)]
+                                                :let [pred    (get pivot-type-predicates pivot-type)
+                                                      columns (pivot-drill-pred query stage-number context pred)]
+                                                :when (not-empty columns)]
                                             [pivot-type columns]))]
         (when-not (empty? pivots)
           {:lib/type     :metabase.lib.drill-thru/drill-thru

--- a/src/metabase/lib/drill_thru/pivot.cljc
+++ b/src/metabase/lib/drill_thru/pivot.cljc
@@ -129,20 +129,19 @@
                column
                (some? value)
                (lib.underlying/aggregation-sourced? query column)
-               ;; TODO fix this drill thru and remove this check (metabase#52236)
-               (not (lib.underlying/strictly-underlying-aggregation? query column))
                (-> (lib.aggregation/aggregations query stage-number) count pos?))
       (let [breakout-pivot-types (permitted-pivot-types query stage-number)
             pivots               (into {} (for [pivot-type breakout-pivot-types
-                                                :let [pred    (get pivot-type-predicates pivot-type)
-                                                      columns (pivot-drill-pred query stage-number context pred)]
-                                                :when (not-empty columns)]
+                                                :let       [pred    (get pivot-type-predicates pivot-type)
+                                                            columns (pivot-drill-pred query stage-number context pred)]
+                                                :when      (not-empty columns)]
                                             [pivot-type columns]))]
         (when-not (empty? pivots)
-          {:lib/type   :metabase.lib.drill-thru/drill-thru
-           :type       :drill-thru/pivot
-           :dimensions dimensions
-           :pivots     pivots})))))
+          {:lib/type     :metabase.lib.drill-thru/drill-thru
+           :type         :drill-thru/pivot
+           :dimensions   dimensions
+           :pivots       pivots
+           :stage-number stage-number})))))
 
 (defmethod lib.drill-thru.common/drill-thru-info-method :drill-thru/pivot
   [_query _stage-number drill-thru]
@@ -175,7 +174,9 @@
 ;;     b. Go through the breakouts, and remove any that match this dimension from the query.
 ;; 2. Add a new breakout for the selected column.
 (defmethod lib.drill-thru.common/drill-thru-method :drill-thru/pivot
-  [query _stage-number drill-thru & [column]]
-  (let [stage-number (lib.underlying/top-level-stage-number query)
-        filtered (reduce #(breakouts->filters %1 stage-number %2) query (:dimensions drill-thru))]
+  [query
+   _stage-number
+   {:keys [stage-number dimensions] :as _drill-thru}
+   & [column]]
+  (let [filtered (reduce #(breakouts->filters %1 stage-number %2) query dimensions)]
     (lib.breakout/breakout filtered stage-number column)))

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -2217,19 +2217,11 @@
   "Returns a JS object with the details needed to render the complex UI for `pivot` drills.
 
   > **Code health:** Single use. This is only here to support the context menu UI and should not be reused."
-  [{:keys [stage-number]}]
-  #js {"stageIndex" stage-number})
-
-(defn ^:export pivot-types
-  "Returns a JS array of pivot types that are available in `a-drill-thru`, which must be a `pivot` drill-thru.
-
-  The list contains a subset of the strings `\"category\"`, `\"location\"` and `\"time\"`.
-
-  > **Code health:** Single use. This is only here to support the context menu UI and should not be reused."
-  [a-drill-thru]
-  (->> (lib.core/pivot-types a-drill-thru)
-       (map name)
-       to-array))
+  [{:keys [stage-number] :as a-drill-thru}]
+  #js {"stageIndex" stage-number
+       "pivotTypes" (->> (lib.core/pivot-types a-drill-thru)
+                         (map name)
+                         to-array)})
 
 (defn ^:export pivot-columns-for-type
   "Returns a JS array of pivotable columns for `a-drill-thru`, given the selected `pivot-type`.

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -2213,6 +2213,13 @@
   [column-extract-drill]
   (to-array (lib.core/extractions-for-drill column-extract-drill)))
 
+(defn ^:export pivot-drill-details
+  "Returns a JS object with the details needed to render the complex UI for `pivot` drills.
+
+  > **Code health:** Single use. This is only here to support the context menu UI and should not be reused."
+  [{:keys [stage-number]}]
+  #js {"stageIndex" stage-number})
+
 (defn ^:export pivot-types
   "Returns a JS array of pivot types that are available in `a-drill-thru`, which must be a `pivot` drill-thru.
 

--- a/src/metabase/lib/schema/drill_thru.cljc
+++ b/src/metabase/lib/schema/drill_thru.cljc
@@ -126,7 +126,8 @@
    ::drill-thru.common
    [:map
     [:type   [:= :drill-thru/pivot]]
-    [:pivots [:map-of ::pivot-types [:sequential [:ref ::lib.schema.metadata/column]]]]]])
+    [:pivots [:map-of ::pivot-types [:sequential [:ref ::lib.schema.metadata/column]]]]
+    [:stage-number number?]]])
 
 (mr/def ::drill-thru.sort
   [:merge

--- a/test/metabase/lib/drill_thru/pivot_test.cljc
+++ b/test/metabase/lib/drill_thru/pivot_test.cljc
@@ -196,9 +196,8 @@
    "single-stage query"
    (merge (orders-count-with-breakouts [bv-date])
           (expecting ["CREATED_AT"] [:category :location]))
-   ;; TODO fix this drill thru and re-enable this check (metabase#52236)
-   #_"multi-stage query"
-   #_variant-with-count-filter-stage))
+   "multi-stage query"
+   variant-with-count-filter-stage))
 
 (deftest ^:parallel returns-pivot-test-2b-cat+loc-with-date+category
   (lib.drill-thru.tu/test-drill-variants-with-merged-args
@@ -206,9 +205,8 @@
    "single-stage query"
    (merge (orders-count-with-breakouts [bv-date bv-category1])
           (expecting ["CREATED_AT" "CATEGORY"] [:category :location]))
-   ;; TODO fix this drill thru and re-enable this check (metabase#52236)
-   #_"multi-stage query"
-   #_variant-with-count-filter-stage))
+   "multi-stage query"
+   variant-with-count-filter-stage))
 
 (deftest ^:parallel returns-pivot-test-3a-cat+time-with-address
   (lib.drill-thru.tu/test-drill-variants-with-merged-args
@@ -216,9 +214,8 @@
    "single-stage query"
    (merge (orders-count-with-breakouts [bv-address])
           (expecting ["STATE"] [:category :time]))
-   ;; TODO fix this drill thru and re-enable this check (metabase#52236)
-   #_"multi-stage query"
-   #_variant-with-count-filter-stage))
+   "multi-stage query"
+   variant-with-count-filter-stage))
 
 (deftest ^:parallel returns-pivot-test-3b-cat+time-with-category
   (lib.drill-thru.tu/test-drill-variants-with-merged-args
@@ -226,9 +223,8 @@
    "single-stage query"
    (merge (orders-count-with-breakouts [bv-category2])
           (expecting ["SOURCE"] [:category :time]))
-   ;; TODO fix this drill thru and re-enable this check (metabase#52236)
-   #_"multi-stage query"
-   #_variant-with-count-filter-stage))
+   "multi-stage query"
+   variant-with-count-filter-stage))
 
 (deftest ^:parallel returns-pivot-test-3c-cat+time-with-category+category
   (lib.drill-thru.tu/test-drill-variants-with-merged-args
@@ -236,9 +232,8 @@
    "single-stage query"
    (merge (orders-count-with-breakouts [bv-category2 bv-category1])
           (expecting ["SOURCE" "CATEGORY"] [:category :time]))
-   ;; TODO fix this drill thru and re-enable this check (metabase#52236)
-   #_"multi-stage query"
-   #_variant-with-count-filter-stage))
+   "multi-stage query"
+   variant-with-count-filter-stage))
 
 (deftest ^:parallel returns-pivot-test-4a-none-with-no-breakouts
   (lib.drill-thru.tu/test-drill-variants-with-merged-args
@@ -246,9 +241,8 @@
    "single-stage query"
    (merge (orders-count-with-breakouts [])
           (expecting [] [:category :location :time]))
-   ;; TODO fix this drill thru and re-enable this check (metabase#52236)
-   #_"multi-stage query"
-   #_variant-with-count-filter-stage))
+   "multi-stage query"
+   variant-with-count-filter-stage))
 
 (deftest ^:parallel pivot-application-test-1
   (lib.drill-thru.tu/test-drill-variants-with-merged-args
@@ -264,13 +258,12 @@
                                                   (get-in lib.drill-thru.tu/test-queries
                                                           ["ORDERS" :aggregated :row "CREATED_AT"])))
                                (lib/breakout (meta/field-metadata :products :category)))})
-   ;; TODO fix this drill thru and re-enable this check (metabase#52236)
-   #_"multi-stage query"
-   #_(fn [base-case]
-       {:custom-query (-> base-case
-                          :custom-query
-                          (lib.drill-thru.tu/append-filter-stage "count"))
-        :expected-query (-> base-case
-                            :expected-query
-                            (assoc-in [:stages 0 :filters 0 2 2] "CREATED_AT")
-                            (lib.drill-thru.tu/append-filter-stage-to-test-expectation "count"))})))
+   "multi-stage query"
+   (fn [base-case]
+     {:custom-query (-> base-case
+                        :custom-query
+                        (lib.drill-thru.tu/append-filter-stage "count"))
+      :expected-query (-> base-case
+                          :expected-query
+                          (assoc-in [:stages 0 :filters 0 2 2] "CREATED_AT")
+                          (lib.drill-thru.tu/append-filter-stage-to-test-expectation "count"))})))


### PR DESCRIPTION
Closes #52236
Related to: #51950

Slack thread: https://metaboat.slack.com/archives/C0645JP1W81/p1736970278902299

### Description

Add a new function `pivot-drill-details`, similar in spirit to the existing `filter-drill-details` and `combine-column-drill-details`, and call it in the FE to get the `stageIndex` to target for the `QueryColumnPicker` in the `DrillColumnPopover`.

This allows the column picker to work for queries with e.g. a filter stage after summarize, since the columns may come from an underlying stage (#51950).

### How to verify

See repro steps in #52236

### Demo

![Screenshot 2025-01-29 at 12 54 19 PM](https://github.com/user-attachments/assets/5ae34688-caca-4447-a3ad-110b41c9f817)

![Screenshot 2025-01-29 at 12 54 28 PM](https://github.com/user-attachments/assets/295a6f51-d256-4a49-a511-cb502eaa6c0d)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
