### PR TITLE
Filter personal recent dashboards for the "Add to Dashboard" modal

### DIFF
--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -536,7 +536,6 @@ describe("scenarios > question > new", () => {
 
       H.entityPickerModal().within(() => {
         cy.findByText("Add this question to a dashboard").should("be.visible");
-        H.entityPickerModalTab("Dashboards").click();
         cy.findByText(/bobby tables's personal collection/i).should(
           "be.visible",
         );

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.tsx
@@ -1,13 +1,17 @@
+import { useCallback } from "react";
 import { t } from "ttag";
 
 import { DashboardPickerModal } from "metabase/common/components/DashboardPicker";
 import { LoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper";
 import { ROOT_COLLECTION } from "metabase/entities/collections";
+import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
-import type { Card, Dashboard } from "metabase-types/api";
+import { getUserPersonalCollectionId } from "metabase/selectors/user";
+import type { Card, Dashboard, RecentItem } from "metabase-types/api";
 
 import { useMostRecentlyViewedDashboard } from "./hooks";
 import {
+  filterPersonalRecents,
   filterWritableDashboards,
   filterWritableRecents,
   shouldDisableItem,
@@ -40,6 +44,8 @@ export const AddToDashSelectDashModal = ({
   onClose,
   onChangeLocation,
 }: AddToDashSelectDashModalProps) => {
+  const personalCollectionId = useSelector(getUserPersonalCollectionId);
+
   const {
     data: mostRecentlyViewedDashboard,
     isLoading,
@@ -59,10 +65,6 @@ export const AddToDashSelectDashModal = ({
     }
   };
 
-  if (isLoading || error) {
-    return <LoadingAndErrorWrapper loading={isLoading} error={error} />;
-  }
-
   const questionCollection = card.collection ?? ROOT_COLLECTION;
   const isQuestionInPersonalCollection = !!questionCollection.is_personal;
   const isRecentDashboardInPersonalCollection =
@@ -73,6 +75,23 @@ export const AddToDashSelectDashModal = ({
   const showRecentDashboard =
     mostRecentlyViewedDashboard?.id &&
     (!isQuestionInPersonalCollection || isRecentDashboardInPersonalCollection);
+
+  const recentsFilter = useCallback(
+    (items: RecentItem[]) => {
+      const writableRecents = filterWritableRecents(items);
+
+      if (isQuestionInPersonalCollection && personalCollectionId) {
+        return filterPersonalRecents(writableRecents, personalCollectionId);
+      } else {
+        return writableRecents;
+      }
+    },
+    [isQuestionInPersonalCollection, personalCollectionId],
+  );
+
+  if (isLoading || error) {
+    return <LoadingAndErrorWrapper loading={isLoading} error={error} />;
+  }
 
   return (
     <DashboardPickerModal
@@ -97,7 +116,7 @@ export const AddToDashSelectDashModal = ({
       }}
       shouldDisableItem={shouldDisableItem}
       searchFilter={filterWritableDashboards}
-      recentFilter={filterWritableRecents}
+      recentFilter={recentsFilter}
     />
   );
 };

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/utils.ts
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/utils.ts
@@ -51,3 +51,14 @@ export const filterWritableDashboards = (
 export const filterWritableRecents = (dashes: RecentItem[]) => {
   return dashes.filter(dash => dash.model !== "table" && dash.can_write);
 };
+
+export const filterPersonalRecents = (
+  dashes: RecentItem[],
+  personalCollectionId: CollectionId,
+) => {
+  return dashes.filter(
+    dash =>
+      dash.model !== "table" &&
+      dash.parent_collection.id === personalCollectionId,
+  );
+};


### PR DESCRIPTION
Closes Eng-8407

### Description
Adds a check to the `recentsFilter` on the Add to Dashboard modal. If the card that is being added is in a personal collection, then we do additional filtering of the list to ensure that the recent items are in the same folder as the card

### How to verify

1. Create a dashboard your personal folder
2. Create a question your personal folder
3. In the question, open the menu and select `Add to dashboard`
4. In the recents tab of the entity picker, you should only see dashboards in your personal folder. 

### Demo
![Code_HuWCnOd1Hi](https://github.com/user-attachments/assets/02cdd7ff-b948-4f46-9053-572e40f74051)

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
