### PR TITLE
Don't cast dates when doing a dateadd on h2

### DIFF
--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -277,7 +277,7 @@
   ((get-method driver/execute-write-query! :sql-jdbc) driver query))
 
 (defn- dateadd [unit amount expr]
-  (let [expr (h2x/cast-unless-type-in "datetime" #{"datetime" "timestamp" "timestamp with time zone"} expr)]
+  (let [expr (h2x/cast-unless-type-in "datetime" #{"datetime" "timestamp" "timestamp with time zone" "date"} expr)]
     (-> [:dateadd
          (h2x/literal unit)
          (if (number? amount)

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -208,6 +208,16 @@
                       "ORDER BY ATTEMPTS.DATE ASC")
                  (some-> (qp.compile/compile query) :query pretty-sql))))))))
 
+(deftest ^:parallel do-not-cast-to-date-binned-by-week-to-datetime
+  (mt/test-driver :h2
+    (testing "Don't cast date binned by week"
+      (mt/dataset attempted-murders
+        (let [query (mt/mbql-query attempts
+                      {:aggregation [[:count]]
+                       :breakout    [!week.date]})
+              compiled (some-> (qp.compile/compile query) :query pretty-sql)]
+          (is (not (re-find #"CAST\([^)]+\s+AS\s+datetime\)" compiled))))))))
+
 (deftest ^:parallel check-action-commands-test
   (mt/test-driver :h2
     (are [query] (= true (#'h2/every-command-allowed-for-actions? (#'h2/classify-query (u/the-id (mt/db)) query)))


### PR DESCRIPTION
### Description

Date fields binned by week were being cast to datetime, which messed up drill-down options. For instance, you shouldn't be able to drill down a date by hour or minute. So if you did a brush filter on a date field binned by week, you'd get something similar to [#48608](https://github.com/metabase/metabase/issues/48608).

Here is a screenshot of the SQL when a date field is binned by week. Notice the CAST.
![screenshot_2025-01-28_at_9 19 15___pm](https://github.com/user-attachments/assets/595bf600-1ae8-47d1-9157-ce522797cf33)

The h2 driver was adding dates, and this `dateadd` function was doing the cast. I added a bit to avoid a cast if it was a date. It was already avoiding a cast if it was a datetime.


### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> People
2. Sumarize by "Cumulative count", Birth Date by week
3. Show SQL
4. Note that the cast is gone.

<img width="451" alt="Screenshot 2025-01-29 at 3 50 54 PM" src="https://github.com/user-attachments/assets/0a6ac641-0c7f-49f7-9a95-9095c865ea40" />

Related to [#48608](https://github.com/metabase/metabase/issues/48608)
