### PR TITLE
Remove UNSAFE_componentWillReceiveProps from DashboardGrid

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -199,34 +199,44 @@ class DashboardGrid extends Component<DashboardGridProps, DashboardGridState> {
     }
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps: DashboardGridProps) {
-    const { dashboard, dashcardData, isEditing, selectedTabId } = nextProps;
+  componentDidUpdate(prevProps: DashboardGridProps) {
+    const { dashboard, dashcardData, isEditing, selectedTabId } = this.props;
 
-    const visibleCardIds = !isEditing
-      ? getVisibleCardIds(
-          dashboard.dashcards,
-          dashcardData,
-          this.state.visibleCardIds,
-        )
-      : new Set(dashboard.dashcards.map(card => card.id));
+    if (
+      prevProps.dashboard !== dashboard ||
+      prevProps.dashcardData !== dashcardData ||
+      prevProps.isEditing !== isEditing ||
+      prevProps.selectedTabId !== selectedTabId
+    ) {
+      const visibleCardIds = !isEditing
+        ? getVisibleCardIds(
+            dashboard.dashcards,
+            dashcardData,
+            this.state.visibleCardIds,
+          )
+        : new Set(dashboard.dashcards.map(card => card.id));
 
-    const cards = this.getVisibleCards(
-      dashboard.dashcards,
-      visibleCardIds,
-      isEditing,
-      selectedTabId,
-    );
+      const cards = this.getVisibleCards(
+        dashboard.dashcards,
+        visibleCardIds,
+        isEditing,
+        selectedTabId,
+      );
 
-    if (!isEditing || !_.isEqual(this.getVisibleCards(), cards)) {
-      this.setState({
-        initialCardSizes: this.getInitialCardSizes(cards),
-      });
+      const updates: Partial<DashboardGridState> = {
+        visibleCardIds,
+        layouts: this.getLayouts(cards),
+      };
+
+      if (
+        !isEditing ||
+        !_.isEqual(this.getVisibleCards(prevProps.dashboard.dashcards), cards)
+      ) {
+        updates.initialCardSizes = this.getInitialCardSizes(cards);
+      }
+
+      this.setState(updates);
     }
-
-    this.setState({
-      visibleCardIds,
-      layouts: this.getLayouts(cards),
-    });
   }
 
   getInitialCardSizes = (cards: BaseDashboardCard[]) => {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/48497

This PR combined with https://github.com/metabase/metabase/pull/52885 will close the above issue, but 52885 is more likely to get merged before this one

### Description

Removes the unsafe React lifecycle from the `<DashboardGrid />` component, which was causing console errors:

- Using UNSAFE_componentWillReceiveProps in strict mode is not recommended and may indicate bugs in your code

It does this by replacing `UNSAFE_componentWillReceiveProps` with `static getDerivedStateFromProps`, refer to https://github.com/metabase/metabase/pull/52885 for how that works

### How to verify

Verification with manual tests

- Run the SDK and render a InteractiveDashboard (which should render a DashboardGrid)
- The UNSAFE_componentWillReceiveProps should still be there, but come from other components (e.g. Table, TableInteractive, Link from react-router 3)

Verification with end-to-end tests

- Add a dummy UNSAFE_componentWillReceiveProps to DashboardGrid.jsx
- The SDK end-to-end test now errors due to unsafe lifecycle being in Visualization

