### PR TITLE
ci: Fix SDK cross-version testing failure after test util refactor when cutting 54 (future)

### DIFF
--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -165,12 +165,8 @@ jobs:
 
       - name: Move tests from the release commit into the repo
         run: |
-          # remove this line after we release a new SDK 0.53.x, since it will already contain the fixed version then.
-          mv ./e2e/support/component-webpack.config.js .
-
           rm -rf ./e2e/support/*
           mv ./sdk-release-e2e/e2e/support/* ./e2e/support
-          mv ./component-webpack.config.js ./e2e/support
 
           rm -rf ./e2e/test-component/*
           mv ./sdk-release-e2e/e2e/test-component/* ./e2e/test-component

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -165,8 +165,13 @@ jobs:
 
       - name: Move tests from the release commit into the repo
         run: |
-          rm -rf ./e2e/support/helpers/*
-          mv ./sdk-release-e2e/e2e/support/helpers/* ./e2e/support/helpers
+          # remove this line after we release a new SDK 0.53.x, since it will already contain the fixed version then.
+          mv ./e2e/support/component-webpack.config.js .
+
+          rm -rf ./e2e/support/*
+          mv ./sdk-release-e2e/e2e/support/* ./e2e/support
+          mv ./component-webpack.config.js ./e2e/support
+
           rm -rf ./e2e/test-component/*
           mv ./sdk-release-e2e/e2e/test-component/* ./e2e/test-component
         shell: bash


### PR DESCRIPTION
This PR port #52900 to master. So by the time we cut 54, we won't encounter the same problem again.

View inline comment for more details.

This PR isn't backporting because the original fix already targets 53.