### PR TITLE
Disable flaky tests for native editor

### DIFF
--- a/e2e/support/helpers/e2e-browser-helpers.ts
+++ b/e2e/support/helpers/e2e-browser-helpers.ts
@@ -1,0 +1,13 @@
+/**
+ * Clear the browser cache.
+ *
+ * Cypress clears the browser cache automatically when it start up, but it doesn't
+ * clear the cache between tests. Use this helper if you need to clear the cache.
+ */
+export function clearBrowserCache() {
+  cy.wrap(
+    Cypress.automation("remote:debugger:protocol", {
+      command: "Network.clearBrowserCache",
+    }),
+  );
+}

--- a/e2e/support/helpers/index.ts
+++ b/e2e/support/helpers/index.ts
@@ -7,6 +7,7 @@ export * from "./e2e-boolean-helpers";
 export * from "./e2e-cloud-helpers";
 export * from "./e2e-collection-helpers";
 export * from "./e2e-command-palette-helpers";
+export * from "./e2e-browser-helpers";
 export * from "./e2e-custom-column-helpers";
 export * from "./e2e-dashboard-helpers";
 export * from "./e2e-database-metadata-helpers";

--- a/e2e/test/scenarios/admin/admin-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/admin/admin-reproductions.cy.spec.js
@@ -55,7 +55,7 @@ describe("issue 21532", () => {
   });
 });
 
-describe("issue 41765", { tags: ["@external", "@flaky"] }, () => {
+describe("issue 41765", { tags: "@external" }, () => {
   // In this test we are testing the in-browser cache that metabase uses,
   // so we need to navigate by clicking trough the UI without reloading the page.
 

--- a/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
@@ -392,7 +392,7 @@ describe("Dashboard > Dashboard Questions", () => {
         .should("exist");
     });
 
-    it("can save a native question to a dashboard", { tags: "@flaky" }, () => {
+    it("can save a native question to a dashboard", () => {
       H.startNewNativeQuestion({ query: "SELECT 123" });
 
       // this reduces the flakiness

--- a/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
@@ -695,7 +695,7 @@ describe("issue 16756", () => {
   });
 });
 
-describe("issue 17019", { tags: "@flaky" }, () => {
+describe("issue 17019", () => {
   const question = {
     name: "17019",
     native: {

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.js
@@ -85,24 +85,20 @@ describe("issue 16886", () => {
     cy.signInAsAdmin();
   });
 
-  it(
-    "shouldn't remove parts of the query when choosing 'Run selected text' (metabase#16886)",
-    { tags: "@flaky" },
-    () => {
-      H.startNewNativeQuestion().as("editor");
-      H.NativeEditor.type(ORIGINAL_QUERY);
-      cy.realPress("Home");
-      Cypress._.range(SELECTED_TEXT.length).forEach(() =>
-        cy.realPress(["Shift", "ArrowRight"]),
-      );
+  it("shouldn't remove parts of the query when choosing 'Run selected text' (metabase#16886)", () => {
+    H.startNewNativeQuestion().as("editor");
+    H.NativeEditor.type(ORIGINAL_QUERY);
+    cy.realPress("Home");
+    Cypress._.range(SELECTED_TEXT.length).forEach(() =>
+      cy.realPress(["Shift", "ArrowRight"]),
+    );
 
-      cy.findByTestId("native-query-editor-container").icon("play").click();
+    cy.findByTestId("native-query-editor-container").icon("play").click();
 
-      cy.findByTestId("scalar-value").invoke("text").should("eq", "1");
+    cy.findByTestId("scalar-value").invoke("text").should("eq", "1");
 
-      cy.get("@editor").contains(ORIGINAL_QUERY);
-    },
-  );
+    cy.get("@editor").contains(ORIGINAL_QUERY);
+  });
 });
 
 describe("issue 16914", () => {
@@ -610,7 +606,7 @@ describe("issue 30680", () => {
   });
 });
 
-describe("issue 34330", { tags: "@flaky" }, () => {
+describe("issue 34330", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsNormalUser();

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -83,7 +83,7 @@ describe("scenarios > question > native", () => {
     });
   });
 
-  it("displays an error", { tags: "@flaky" }, () => {
+  it("displays an error", () => {
     H.startNewNativeQuestion();
     H.NativeEditor.type("select * from not_a_table");
 
@@ -92,7 +92,7 @@ describe("scenarios > question > native", () => {
     cy.contains('Table "NOT_A_TABLE" not found');
   });
 
-  it("displays an error when running selected text", { tags: "@flaky" }, () => {
+  it("displays an error when running selected text", () => {
     H.startNewNativeQuestion();
     H.NativeEditor.type("select * from orders");
 
@@ -105,7 +105,7 @@ describe("scenarios > question > native", () => {
     cy.contains('Table "ORD" not found');
   });
 
-  it("should handle template tags", { tags: "@flaky" }, () => {
+  it("should handle template tags", () => {
     H.startNewNativeQuestion();
     H.NativeEditor.type("select * from PRODUCTS where RATING > {{Stars}}");
 
@@ -144,7 +144,7 @@ describe("scenarios > question > native", () => {
     cy.findByText("Not now").click();
   });
 
-  it("can save a question with no rows", { tags: "@flaky" }, () => {
+  it("can save a question with no rows", () => {
     H.startNewNativeQuestion();
     H.NativeEditor.type("select * from people where false");
     runQuery();
@@ -225,30 +225,26 @@ describe("scenarios > question > native", () => {
     });
   });
 
-  it(
-    "should be able to add new columns after hiding some (metabase#15393)",
-    { tags: "@flaky" },
-    () => {
-      H.startNewNativeQuestion({ display: "table" }).as("editor");
-      H.NativeEditor.type("select 1 as visible, 2 as hidden");
-      cy.findByTestId("native-query-editor-container")
-        .icon("play")
-        .as("runQuery")
-        .click();
+  it("should be able to add new columns after hiding some (metabase#15393)", () => {
+    H.startNewNativeQuestion({ display: "table" }).as("editor");
+    H.NativeEditor.type("select 1 as visible, 2 as hidden");
+    cy.findByTestId("native-query-editor-container")
+      .icon("play")
+      .as("runQuery")
+      .click();
 
-      H.openVizSettingsSidebar();
-      cy.findByTestId("sidebar-left")
-        .as("sidebar")
-        .within(() => {
-          cy.findByTestId("draggable-item-HIDDEN")
-            .icon("eye_outline")
-            .click({ force: true });
-        });
-      H.NativeEditor.type("{movetoend}, 3 as added");
-      cy.get("@runQuery").click();
-      cy.get("@sidebar").contains(/added/i);
-    },
-  );
+    H.openVizSettingsSidebar();
+    cy.findByTestId("sidebar-left")
+      .as("sidebar")
+      .within(() => {
+        cy.findByTestId("draggable-item-HIDDEN")
+          .icon("eye_outline")
+          .click({ force: true });
+      });
+    H.NativeEditor.type("{movetoend}, 3 as added");
+    cy.get("@runQuery").click();
+    cy.get("@sidebar").contains(/added/i);
+  });
 
   it("should recognize template tags and save them as parameters", () => {
     H.startNewNativeQuestion();

--- a/e2e/test/scenarios/native/native_subquery.cy.spec.js
+++ b/e2e/test/scenarios/native/native_subquery.cy.spec.js
@@ -48,60 +48,56 @@ describe("scenarios > question > native subquery", () => {
     });
   });
 
-  it(
-    "autocomplete should complete question slugs inside template tags",
-    { tags: "@flaky" },
-    () => {
-      // Create a question and a model.
+  it("autocomplete should complete question slugs inside template tags", () => {
+    // Create a question and a model.
+    H.createNativeQuestion({
+      name: "A People Question",
+      native: {
+        query: "SELECT id FROM PEOPLE",
+      },
+    }).then(({ body: { id: questionId1 } }) => {
       H.createNativeQuestion({
-        name: "A People Question",
+        name: "A People Model",
         native: {
           query: "SELECT id FROM PEOPLE",
         },
-      }).then(({ body: { id: questionId1 } }) => {
-        H.createNativeQuestion({
-          name: "A People Model",
-          native: {
-            query: "SELECT id FROM PEOPLE",
-          },
-          type: "model",
-          collection_id: ADMIN_PERSONAL_COLLECTION_ID,
-        }).then(({ body: { id: questionId2 } }) => {
-          // Move question 2 to personal collection
-          cy.visit(`/question/${questionId2}`);
-          H.openQuestionActions();
-          cy.findByTestId("move-button").click();
-          H.entityPickerModal().within(() => {
-            cy.findByRole("tab", { name: /Collections/ }).click();
-            cy.findByText("Bobby Tables's Personal Collection").click();
-            cy.button("Move").click();
-          });
+        type: "model",
+        collection_id: ADMIN_PERSONAL_COLLECTION_ID,
+      }).then(({ body: { id: questionId2 } }) => {
+        // Move question 2 to personal collection
+        cy.visit(`/question/${questionId2}`);
+        H.openQuestionActions();
+        cy.findByTestId("move-button").click();
+        H.entityPickerModal().within(() => {
+          cy.findByRole("tab", { name: /Collections/ }).click();
+          cy.findByText("Bobby Tables's Personal Collection").click();
+          cy.button("Move").click();
+        });
 
-          H.startNewNativeQuestion();
-          cy.reload(); // Refresh the state, so previously created questions need to be loaded again.
-          H.NativeEditor.focus();
+        H.startNewNativeQuestion();
+        cy.reload(); // Refresh the state, so previously created questions need to be loaded again.
+        H.NativeEditor.focus();
 
-          cy.wait(200); // This reduces flakiness
+        cy.wait(200); // This reduces flakiness
 
-          H.NativeEditor.focus().type(" {{#people");
+        H.NativeEditor.focus().type(" {{#people");
 
-          // Wait until another explicit autocomplete is triggered
-          // (slightly longer than AUTOCOMPLETE_DEBOUNCE_DURATION)
-          // See https://github.com/metabase/metabase/pull/20970
-          cy.wait(1000);
+        // Wait until another explicit autocomplete is triggered
+        // (slightly longer than AUTOCOMPLETE_DEBOUNCE_DURATION)
+        // See https://github.com/metabase/metabase/pull/20970
+        cy.wait(1000);
 
-          H.NativeEditor.completions().within(() => {
-            H.NativeEditor.completion(`${questionId2}-a-`)
-              .should("be.visible")
-              .should("contain", "Model in Bobby Tables's Personal Collection");
-            H.NativeEditor.completion(`${questionId1}-a-`)
-              .should("be.visible")
-              .should("contain", "Question in Our analytics");
-          });
+        H.NativeEditor.completions().within(() => {
+          H.NativeEditor.completion(`${questionId2}-a-`)
+            .should("be.visible")
+            .should("contain", "Model in Bobby Tables's Personal Collection");
+          H.NativeEditor.completion(`${questionId1}-a-`)
+            .should("be.visible")
+            .should("contain", "Question in Our analytics");
         });
       });
-    },
-  );
+    });
+  });
 
   it("autocomplete should work for columns from referenced questions", () => {
     // Create two saved questions, the first will be referenced in the query when it is opened, and the second will be added to the query after it is opened.

--- a/e2e/test/scenarios/visualizations-charts/waterfall.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/waterfall.cy.spec.js
@@ -61,7 +61,7 @@ describe("scenarios > visualizations > waterfall", () => {
     verifyWaterfallRendering("X", "Y");
   });
 
-  it("should work with quantitative series", { tags: "@flaky" }, () => {
+  it("should work with quantitative series", () => {
     H.startNewNativeQuestion().type(
       "select 1 as X, 10 as Y union select 2 as X, -2 as Y",
     );


### PR DESCRIPTION
Removes the `@flaky` tag for tests that use the native editor, since the move to CodeMirror has made the tests more stable.

That's 12 out of 26 flaky tags, gone!

### Stress tests

##### `admin/admin-reproductions.cy.spec.js`
- [x] [`issue 41765`](https://github.com/metabase/metabase/actions/runs/13048636388)

##### `dashboard/dashboard-questions.cy.spec.js`
- [x] [`can save a native question to a dashboard`](https://github.com/metabase/metabase/actions/runs/13048573056)

##### `native-filters/native-filters-reproductions.cy.spec.js`
- [x] [`issue 17019`](https://github.com/metabase/metabase/actions/runs/13053794997)

##### `native/native-reproductions.cy.spec.js`
- [x] [`shouldn't remove parts of the query when choosing 'Run selected text' (metabase#16886)`](https://github.com/metabase/metabase/actions/runs/13048730502)
- [x] [`issue 34330`](https://github.com/metabase/metabase/actions/runs/13053000427)


##### `native/native.cy.spec.js`
- [x] [`displays an error`](https://github.com/metabase/metabase/actions/runs/13048787091)
- [x] [`displays an error when running selected text`](https://github.com/metabase/metabase/actions/runs/13048928104)
- [x] [`should handle template tags`](https://github.com/metabase/metabase/actions/runs/13048938939)
- [x] [`can save a question with no rows`](https://github.com/metabase/metabase/actions/runs/13048962335)
- [x] [`should be able to add new columns after hiding some (metabase#15393)`](https://github.com/metabase/metabase/actions/runs/13048971123)

##### `native/native_subquery.cy.spec.js`
- [x] [`autocomplete should complete question slugs inside template tags`](https://github.com/metabase/metabase/actions/runs/13048747573)

##### `visualizations-charts/waterfall.cy.spec.js`
- [x] [`should work with quantitative series`](https://github.com/metabase/metabase/actions/runs/13048761348)
