### PR TITLE
Hopefully fix e2e search flakes

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -48,6 +48,7 @@ jobs:
       CYPRESS_NO_FEATURES_TOKEN: ${{ secrets.E2E_STARTER_TOKEN }}
       CYPRESS_PULL_REQUEST_ID: ${{ github.event.pull_request.number || '' }}
       COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title || github.event.head_commit.message || github.event.head.sha }}
+      MB_EXPERIMENTAL_SEARCH_BLOCK_ON_QUEUE: true
       MB_SNOWPLOW_AVAILABLE: true
       MB_SNOWPLOW_URL: "http://localhost:9090" # Snowplow micro
       TZ: US/Pacific # to make node match the instance tz

--- a/deps.edn
+++ b/deps.edn
@@ -86,7 +86,11 @@
   io.prometheus/simpleclient_jetty          {:mvn/version "0.16.0"}             ; prometheus jetty collector
   javax.servlet/servlet-api                 {:mvn/version "2.5"}                ; used by ring's multipart-params (file upload)
   junegunn/grouper                          {:mvn/version "0.1.1"}              ; Batch processing helper
-  kixi/stats                                {:mvn/version "0.5.6"               ; Various statistic measures implemented as transducers
+  ;; Pinned to include fix for reflection warning, which can cause Eastwood to fail.
+  ;; Requested the release here: https://github.com/MastodonC/kixi.stats/issues/52
+  kixi/stats                                {;; :git/sha     "0.5.7"            ; Various statistic measures implemented as transducers
+                                             :git/sha     "6563dd32e2960f0a127244b3f43934f3cded5b80"
+                                             :git/url     "https://github.com/MastodonC/kixi.stats"
                                              :exclusions  [org.clojure/data.avl]}
   lambdaisland/uri                          {:mvn/version "1.19.155"}           ; Used by openai-clojure
   medley/medley                             {:mvn/version "1.4.0"}              ; lightweight lib of useful functions

--- a/e2e/test/scenarios/metrics/metrics-search.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-search.cy.spec.js
@@ -21,62 +21,50 @@ describe("scenarios > metrics > search", () => {
     cy.intercept("GET", "/api/search?q=*").as("search");
   });
 
-  it(
-    "should be able to search for metrics in global search",
-    { tags: "@flaky" },
-    () => {
-      H.createQuestion(ORDERS_SCALAR_METRIC);
-      cy.visit("/");
-      H.commandPaletteSearch(ORDERS_SCALAR_METRIC.name, false);
-      H.commandPalette()
-        .findByRole("option", { name: ORDERS_SCALAR_METRIC.name })
-        .click();
-      cy.wait("@dataset");
-      cy.findByTestId("scalar-container").should("be.visible");
-    },
-  );
+  it("should be able to search for metrics in global search", () => {
+    H.createQuestion(ORDERS_SCALAR_METRIC);
+    cy.visit("/");
+    H.commandPaletteSearch(ORDERS_SCALAR_METRIC.name, false);
+    H.commandPalette()
+      .findByRole("option", { name: ORDERS_SCALAR_METRIC.name })
+      .click();
+    cy.wait("@dataset");
+    cy.findByTestId("scalar-container").should("be.visible");
+  });
 
-  it(
-    "should be able to search for metrics on the search page",
-    { tags: "@flaky" },
-    () => {
-      H.createQuestion(ORDERS_SCALAR_METRIC);
-      cy.visit("/");
-      H.commandPaletteSearch(ORDERS_SCALAR_METRIC.name, true);
-      cy.wait("@search");
-      cy.findByTestId("search-app").within(() => {
-        cy.findByText(ORDERS_SCALAR_METRIC.name).should("be.visible");
-        cy.findByTestId("type-search-filter").click();
-      });
-      H.popover().within(() => {
-        cy.findByText("Metric").click();
-        cy.findByText("Apply").click();
-      });
-      cy.wait("@search");
-      cy.findByTestId("search-app").within(() => {
-        cy.findByText("1 result").should("be.visible");
-        cy.findByText(ORDERS_SCALAR_METRIC.name).click();
-      });
-      cy.wait("@dataset");
-      cy.findByTestId("scalar-container").should("be.visible");
-    },
-  );
+  it("should be able to search for metrics on the search page", () => {
+    H.createQuestion(ORDERS_SCALAR_METRIC);
+    cy.visit("/");
+    H.commandPaletteSearch(ORDERS_SCALAR_METRIC.name, true);
+    cy.wait("@search");
+    cy.findByTestId("search-app").within(() => {
+      cy.findByText(ORDERS_SCALAR_METRIC.name).should("be.visible");
+      cy.findByTestId("type-search-filter").click();
+    });
+    H.popover().within(() => {
+      cy.findByText("Metric").click();
+      cy.findByText("Apply").click();
+    });
+    cy.wait("@search");
+    cy.findByTestId("search-app").within(() => {
+      cy.findByText("1 result").should("be.visible");
+      cy.findByText(ORDERS_SCALAR_METRIC.name).click();
+    });
+    cy.wait("@dataset");
+    cy.findByTestId("scalar-container").should("be.visible");
+  });
 
-  it(
-    "should see metrics in recent items in global search",
-    { tags: "@flaky" },
-    () => {
-      H.createQuestion(ORDERS_SCALAR_METRIC).then(({ body: card }) => {
-        H.visitMetric(card.id);
-        cy.wait("@dataset");
-      });
-      H.navigationSidebar().findByText("Home").click();
-      H.commandPaletteSearch(ORDERS_SCALAR_METRIC.name, false);
-      H.commandPalette()
-        .findByRole("option", { name: ORDERS_SCALAR_METRIC.name })
-        .click();
+  it("should see metrics in recent items in global search", () => {
+    H.createQuestion(ORDERS_SCALAR_METRIC).then(({ body: card }) => {
+      H.visitMetric(card.id);
       cy.wait("@dataset");
-      cy.findByTestId("scalar-container").should("be.visible");
-    },
-  );
+    });
+    H.navigationSidebar().findByText("Home").click();
+    H.commandPaletteSearch(ORDERS_SCALAR_METRIC.name, false);
+    H.commandPalette()
+      .findByRole("option", { name: ORDERS_SCALAR_METRIC.name })
+      .click();
+    cy.wait("@dataset");
+    cy.findByTestId("scalar-container").should("be.visible");
+  });
 });

--- a/src/metabase/api/testing.clj
+++ b/src/metabase/api/testing.clj
@@ -22,6 +22,7 @@
    [toucan2.core :as t2])
   (:import
    (com.mchange.v2.c3p0 PoolBackedDataSource)
+   (java.util Queue)
    (java.util.concurrent.locks ReentrantReadWriteLock)))
 
 (set! *warn-on-reflection* true)
@@ -122,7 +123,7 @@
   "Restore a database snapshot for testing purposes."
   [{snapshot-name :name} :- [:map
                              [:name ms/NonBlankString]]]
-  (.clear @#'search.ingestion/queue)
+  (.clear ^Queue @#'search.ingestion/queue)
   (restore-snapshot! snapshot-name)
   (search/reindex!)
   nil)

--- a/src/metabase/api/testing.clj
+++ b/src/metabase/api/testing.clj
@@ -1,5 +1,7 @@
 (ns metabase.api.testing
   "Endpoints for testing."
+  ;; Allow direct access to search.ingestion here, as only our e2e tests need this coupling to our queue.
+  ^{:clj-kondo/ignore [:metabase/ns-module-checker]}
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
@@ -120,7 +122,7 @@
   "Restore a database snapshot for testing purposes."
   [{snapshot-name :name} :- [:map
                              [:name ms/NonBlankString]]]
-  (search.ingestion/clear-queue!)
+  (.clear @#'search.ingestion/queue)
   (restore-snapshot! snapshot-name)
   (search/reindex!)
   nil)

--- a/src/metabase/api/testing.clj
+++ b/src/metabase/api/testing.clj
@@ -11,6 +11,7 @@
    [metabase.config :as config]
    [metabase.db :as mdb]
    [metabase.search.core :as search]
+   [metabase.search.ingestion :as search.ingestion]
    [metabase.util.date-2 :as u.date]
    [metabase.util.files :as u.files]
    [metabase.util.json :as json]
@@ -119,6 +120,7 @@
   "Restore a database snapshot for testing purposes."
   [{snapshot-name :name} :- [:map
                              [:name ms/NonBlankString]]]
+  (search.ingestion/clear-queue!)
   (restore-snapshot! snapshot-name)
   (search/reindex!)
   nil)

--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -20,7 +20,8 @@
    [metabase.util.log :as log]
    [toucan2.core :as t2])
   (:import
-   (java.time OffsetDateTime)))
+   (java.time OffsetDateTime)
+   (java.util Queue)))
 
 ;; Register the multimethods for each specialization
 (comment
@@ -109,8 +110,9 @@
 
   (try
     (when (setting/string->boolean (:mb-experimental-search-block-on-queue env/env))
+      (throw (ex-info "testing" {}))
       ;; wait for a bit for the queue to be drained
-      (let [pending-updates #(.size @#'search.ingestion/queue)]
+      (let [pending-updates #(.size ^Queue @#'search.ingestion/queue)]
         (when-not (u/poll {:thunk       pending-updates
                            :done?       zero?
                            :timeout-ms  2000

--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -106,6 +106,13 @@
                        :index-metadata     (t2/select :model/SearchIndexMetadata :engine :appdb)}))))
 
   (try
+    ;; wait for a bit for queue to be drained
+    (when-not (u/poll {:thunk       (fn [] (.size #'search.ingestion/queue))
+                   :done        zero?
+                   :timeout-ms  2000
+                   :interval-ms 100})
+      (log/warn "Returning search results even though they may be stale"))
+
     (let [weights (search.config/weights search-ctx)
           scorers (search.scoring/scorers search-ctx)]
       (->> (search.index/search-query search-string search-ctx [:legacy_input])

--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -110,7 +110,6 @@
 
   (try
     (when (setting/string->boolean (:mb-experimental-search-block-on-queue env/env))
-      (throw (ex-info "testing" {}))
       ;; wait for a bit for the queue to be drained
       (let [pending-updates #(.size ^Queue @#'search.ingestion/queue)]
         (when-not (u/poll {:thunk       pending-updates

--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -108,9 +108,9 @@
   (try
     ;; wait for a bit for queue to be drained
     (when-not (u/poll {:thunk       (fn [] (.size #'search.ingestion/queue))
-                   :done        zero?
-                   :timeout-ms  2000
-                   :interval-ms 100})
+                       :done        zero?
+                       :timeout-ms  2000
+                       :interval-ms 100})
       (log/warn "Returning search results even though they may be stale"))
 
     (let [weights (search.config/weights search-ctx)

--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -107,12 +107,12 @@
 
   (try
     ;; wait for a bit for the queue to be drained
-    (let [pending-updates #(.size #'search.ingestion/queue)]
+    (let [pending-updates #(.size @#'search.ingestion/queue)]
       (when-not (u/poll {:thunk       pending-updates
-                         :done        zero?
+                         :done?       zero?
                          :timeout-ms  2000
                          :interval-ms 100})
-        (log/warn "Returning search results even though they may be stale. Queue size: " (pending-updates))))
+        (log/warn "Returning search results even though they may be stale. Queue size:" (pending-updates))))
 
     (let [weights (search.config/weights search-ctx)
           scorers (search.scoring/scorers search-ctx)]

--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -1,9 +1,11 @@
 (ns metabase.search.appdb.core
   (:require
    [clojure.string :as str]
+   [environ.core :as env]
    [honey.sql.helpers :as sql.helpers]
    [metabase.config :as config]
    [metabase.db :as mdb]
+   [metabase.models.setting :as setting]
    [metabase.public-settings :as public-settings]
    [metabase.search.appdb.index :as search.index]
    [metabase.search.appdb.scoring :as search.scoring]
@@ -106,13 +108,14 @@
                        :index-metadata     (t2/select :model/SearchIndexMetadata :engine :appdb)}))))
 
   (try
-    ;; wait for a bit for the queue to be drained
-    (let [pending-updates #(.size @#'search.ingestion/queue)]
-      (when-not (u/poll {:thunk       pending-updates
-                         :done?       zero?
-                         :timeout-ms  2000
-                         :interval-ms 100})
-        (log/warn "Returning search results even though they may be stale. Queue size:" (pending-updates))))
+    (when (setting/string->boolean (:mb-experimental-search-block-on-queue env/env))
+      ;; wait for a bit for the queue to be drained
+      (let [pending-updates #(.size @#'search.ingestion/queue)]
+        (when-not (u/poll {:thunk       pending-updates
+                           :done?       zero?
+                           :timeout-ms  2000
+                           :interval-ms 100})
+          (log/warn "Returning search results even though they may be stale. Queue size:" (pending-updates)))))
 
     (let [weights (search.config/weights search-ctx)
           scorers (search.scoring/scorers search-ctx)]

--- a/src/metabase/search/ingestion.clj
+++ b/src/metabase/search/ingestion.clj
@@ -138,6 +138,9 @@
 (defn- track-queue-size! []
   (prometheus/set! :metabase-search/queue-size (.size queue)))
 
+(defn clear-queue! []
+  (.clear queue))
+
 (defn get-next-batch!
   "Wait up for a batch to become ready, and take it off the queue.
   Used `first-delay-ms` to determine how long it will wait for any updates.

--- a/src/metabase/search/ingestion.clj
+++ b/src/metabase/search/ingestion.clj
@@ -138,9 +138,6 @@
 (defn- track-queue-size! []
   (prometheus/set! :metabase-search/queue-size (.size queue)))
 
-(defn clear-queue! []
-  (.clear queue))
-
 (defn get-next-batch!
   "Wait up for a batch to become ready, and take it off the queue.
   Used `first-delay-ms` to determine how long it will wait for any updates.


### PR DESCRIPTION
1. Clear the in-memory re-indexing queue whenever we load a fresh db snapshot.
2. Wait up to 2s for queue to be drained before performing search.

We almost certainly don't want to slow down search this much in production, so we'll either make that timeout a setting, or put this mechanism behind a non-documented environment variable.

I'm leaning towards the latter for now, to keep things zen.

Other ideas are adding this optional timeout setting to the API itself, or adding another API endpoint dedicated to polling the queue.