### PR TITLE
Fix - Incorrect document title when query fails

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
@@ -284,3 +284,23 @@ describe("issue 47793", () => {
     },
   );
 });
+
+describe("issue 49270", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("document title should not indicate that loading takes place when query has errored (metabase#49270)", () => {
+    H.openOrdersTable();
+    cy.icon("sum").click();
+
+    cy.intercept("POST", "/api/dataset", request => {
+      request.reply({ statusCode: 500, delay: 1000 });
+    });
+
+    cy.button("Done").click();
+    cy.title().should("equal", "Doing science... · Metabase");
+    cy.title().should("equal", "Question · Metabase");
+  });
+});

--- a/frontend/src/metabase/query_builder/actions/querying.ts
+++ b/frontend/src/metabase/query_builder/actions/querying.ts
@@ -234,10 +234,11 @@ export const QUERY_ERRORED = "metabase/qb/QUERY_ERRORED";
 export const queryErrored = createThunkAction(
   QUERY_ERRORED,
   (startTime, error) => {
-    return async () => {
+    return async dispatch => {
       if (error && error.isCancelled) {
         return null;
       } else {
+        dispatch(setDocumentTitle(""));
         return { error: error, duration: Date.now() - startTime };
       }
     };

--- a/frontend/src/metabase/query_builder/actions/querying.ts
+++ b/frontend/src/metabase/query_builder/actions/querying.ts
@@ -41,8 +41,9 @@ const hideLoadingCompleteFavicon = createAction(
   () => false,
 );
 
-const LOAD_COMPLETE_UI_CONTROLS = "metabase/qb/LOAD_COMPLETE_UI_CONTROLS";
 const LOAD_START_UI_CONTROLS = "metabase/qb/LOAD_START_UI_CONTROLS";
+const LOAD_COMPLETE_UI_CONTROLS = "metabase/qb/LOAD_COMPLETE_UI_CONTROLS";
+const LOAD_ERROR_UI_CONTROLS = "metabase/qb/LOAD_ERROR_UI_CONTROLS";
 export const SET_DOCUMENT_TITLE_TIMEOUT_ID =
   "metabase/qb/SET_DOCUMENT_TITLE_TIMEOUT_ID";
 const setDocumentTitleTimeoutId = createAction(SET_DOCUMENT_TITLE_TIMEOUT_ID);
@@ -71,6 +72,15 @@ const loadCompleteUIControls = createThunkAction(
         dispatch(hideLoadingCompleteFavicon());
       }, 3000);
     }
+  },
+);
+
+const loadErrorUIControls = createThunkAction(
+  LOAD_ERROR_UI_CONTROLS,
+  () => (dispatch, getState) => {
+    const timeoutId = getTimeoutId(getState());
+    clearTimeout(timeoutId);
+    dispatch(setDocumentTitle(""));
   },
 );
 
@@ -146,9 +156,7 @@ export const runQuestionQuery = ({
       ignoreCache: ignoreCache,
       isDirty: isQueryDirty,
     })
-      .then(queryResults => {
-        return dispatch(queryCompleted(question, queryResults));
-      })
+      .then(queryResults => dispatch(queryCompleted(question, queryResults)))
       .catch(error => dispatch(queryErrored(startTime, error)));
 
     dispatch({ type: RUN_QUERY, payload: { cancelQueryDeferred } });
@@ -238,7 +246,8 @@ export const queryErrored = createThunkAction(
       if (error && error.isCancelled) {
         return null;
       } else {
-        dispatch(setDocumentTitle(""));
+        dispatch(loadErrorUIControls());
+
         return { error: error, duration: Date.now() - startTime };
       }
     };


### PR DESCRIPTION
Fixes #49270

### How to verify

1. Open orders table
2. Disable network
3. Summarize → Done

`document.title` should be "Question", not "Doing science..."

