### PR TITLE
fix flaky helper causing flakes

### DIFF
--- a/e2e/support/helpers/e2e-permissions-helpers.js
+++ b/e2e/support/helpers/e2e-permissions-helpers.js
@@ -134,7 +134,7 @@ export function assertSameBeforeAndAfterSave(assertionCallback) {
 export function assertDatasetReqIsSandboxed(options = {}) {
   const { requestAlias = "@dataset", columnId, columnAssertion } = options;
 
-  cy.get(requestAlias).then(({ response }) => {
+  cy.get(requestAlias).should(({ response }) => {
     // check if data is reporting itself as sandboxed
     const { data } = response.body;
     expect(data.is_sandboxed).to.equal(true);


### PR DESCRIPTION
Closes https://linear.app/metabase-inc/issue/ENG-9478/flaky-test-issue-24966-should-correctly-fetch-field-values-for-a

### Description

The test was flaking essentially because of a bug in Cypress. the `assertDatasetReqIsSandboxed` helper is using a combination of `cy.get()` and `cy.then()` commands. `cy.then()` does not have retryability mechanisms that most of Cypress commands have. This is by design and it’s not necessarily a bug. Usually you would use `.then()` if you want to test something that is already finished doing it’s thing. for example `cy.request().then()` makes complete sense, because `.then()` will only execute once response comes back.

The problem in this test was that because of the nature of `.then()` command, what `cy.get()` would return in the `assertDatasetReqIsSandboxed` helper would be `undefined`. This is no big deal when using `cy.get()` for the common use case such as getting elements on page, because `cy.get()` will either retry itself when searching for a DOM element, or is re-called when an assertion or other query command is not satisfied. 

in this particular use case, we are trying to `cy.get()` an alias which for some reason is not present at the very first moment of `cy.get()` being called. this will pass `undefined` to `.then()` function. 

### Resolution
We simply need to substitute `.then()` with a `.should()` command. in case of `cy.get()` not having a value, `.should()` will prompt it to try again, until fetching the alias is successful

### Stress test

https://github.com/metabase/metabase/actions/runs/13052951031/job/36417108649
