### PR TITLE
Fix - Can't edit field descriptions from the edit mode of "learn about my data"

### DIFF
--- a/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
@@ -1,7 +1,10 @@
 const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { ORDERS_MODEL_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  ORDERS_MODEL_ID,
+  ORDERS_QUESTION_ID,
+} from "e2e/support/cypress_sample_instance_data";
 
 const { PRODUCTS_ID } = SAMPLE_DATABASE;
 
@@ -315,5 +318,51 @@ H.describeWithSnowplowEE("scenarios > browse (EE)", () => {
       cy.icon("model").should("exist");
       cy.icon("model_with_badge").should("not.exist");
     });
+  });
+});
+
+describe("issue 37907", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    cy.intercept("PUT", "/api/field/*").as("fieldUpdate");
+  });
+
+  it("allows to change field descriptions in data reference page (metabase#37907)", () => {
+    cy.visit("/");
+    H.browseDatabases().click();
+    cy.findByRole("link", { name: /Learn about our data/ }).click();
+    cy.findByTestId("data-reference-list-item").click();
+    cy.findByRole("link", { name: /Tables in Sample Database/ }).click();
+    cy.findAllByTestId("data-reference-list-item").findByText("Orders").click();
+    cy.findByRole("link", { name: /Fields in this table/ }).click();
+    cy.button(/Edit/).realClick(); // click() does not work
+    cy.findAllByPlaceholderText("No column description yet")
+      .eq(0)
+      .clear()
+      .type("My ID column");
+    cy.findAllByPlaceholderText("No column description yet")
+      .eq(5)
+      .focus()
+      .type(" Updated.");
+    cy.button(/Save/).realClick(); // click() does not work
+    cy.wait(["@fieldUpdate", "@fieldUpdate"]);
+
+    cy.get("main").within(() => {
+      cy.findByText("My ID column").should("be.visible");
+      cy.findByText("The total billed amount. Updated.").should("be.visible");
+      cy.findByText("Discount amount.").should("be.visible");
+    });
+
+    H.visitQuestion(ORDERS_QUESTION_ID);
+
+    H.tableInteractive().findByTextEnsureVisible("ID").realHover();
+    H.popover().should("include.text", "My ID column");
+
+    H.tableInteractive().findByTextEnsureVisible("Total").realHover();
+    H.popover().should("include.text", "The total billed amount. Updated.");
+
+    H.tableInteractive().findByTextEnsureVisible("Discount ($)").realHover();
+    H.popover().should("include.text", "Discount amount.");
   });
 });

--- a/frontend/src/metabase/reference/components/Field.jsx
+++ b/frontend/src/metabase/reference/components/Field.jsx
@@ -1,6 +1,5 @@
 /* eslint "react/prop-types": "warn" */
 import cx from "classnames";
-import type { FieldInputProps, FieldMetaProps } from "formik";
 import { getIn } from "icepick";
 import PropTypes from "prop-types";
 import { memo } from "react";
@@ -11,45 +10,12 @@ import S from "metabase/components/List/List.module.css";
 import Select from "metabase/core/components/Select";
 import CS from "metabase/css/core/index.css";
 import * as MetabaseCore from "metabase/lib/core";
-import { Icon, type IconName } from "metabase/ui";
+import { Icon } from "metabase/ui";
 import { isTypeFK } from "metabase-lib/v1/types/utils/isa";
-import type { Field as FieldType } from "metabase-types/api";
 
 import F from "./Field.module.css";
 
-type FormField<Value> = FieldMetaProps<Value | undefined> &
-  FieldInputProps<Value | undefined>;
-
-interface NestedFormField {
-  display_name: FormField<string>;
-  semantic_type: FormField<string>;
-  fk_target_field_id: FormField<string>;
-}
-
-interface Props {
-  field: FieldType;
-  formField: NestedFormField;
-  foreignKeys: Record<
-    string,
-    {
-      id: string;
-      name: string;
-      description: string;
-    }
-  >;
-  icon: IconName;
-  isEditing: boolean;
-  url: string;
-}
-
-const Field = ({
-  field,
-  foreignKeys,
-  url,
-  icon,
-  isEditing,
-  formField,
-}: Props) => (
+const Field = ({ field, foreignKeys, url, icon, isEditing, formField }) => (
   <div className={cx(S.item, CS.py1, CS.borderTop)}>
     <div
       className={cx(S.itemBody, CS.flexColumn)}

--- a/frontend/src/metabase/reference/components/Field.jsx
+++ b/frontend/src/metabase/reference/components/Field.jsx
@@ -4,6 +4,7 @@ import { getIn } from "icepick";
 import PropTypes from "prop-types";
 import { memo } from "react";
 import { Link } from "react-router";
+import { P, match } from "ts-pattern";
 import { t } from "ttag";
 
 import S from "metabase/components/List/List.module.css";
@@ -25,7 +26,7 @@ const Field = ({ field, foreignKeys, url, icon, isEditing, formField }) => (
         <div className={cx(S.itemTitle, F.fieldName)}>
           {isEditing ? (
             <input
-              className={F.fieldNameTextInput}
+              className={F.fieldTextInput}
               type="text"
               placeholder={field.name}
               {...formField.display_name}
@@ -86,13 +87,14 @@ const Field = ({ field, foreignKeys, url, icon, isEditing, formField }) => (
         </div>
         <div className={F.fieldDataType}>{field.base_type}</div>
       </div>
-      <div className={cx(S.itemSubtitle, { [CS.mt1]: true })}>
+      <div className={S.itemSubtitle}>
         <div className={F.fieldForeignKey}>
           {isEditing
             ? (isTypeFK(formField.semantic_type.value) ||
                 (isTypeFK(field.semantic_type) &&
                   formField.semantic_type.value === undefined)) && (
                 <Select
+                  className={CS.mt1}
                   name={formField.fk_target_field_id.name}
                   placeholder={t`Select a target`}
                   value={
@@ -105,16 +107,30 @@ const Field = ({ field, foreignKeys, url, icon, isEditing, formField }) => (
                 />
               )
             : isTypeFK(field.semantic_type) && (
-                <span>
+                <span className={CS.mt1}>
                   {getIn(foreignKeys, [field.fk_target_field_id, "name"])}
                 </span>
               )}
         </div>
-        {field.description && (
-          <div className={cx(S.itemSubtitle, CS.mb2, { [CS.mt1]: isEditing })}>
-            {field.description}
-          </div>
-        )}
+
+        {match({ description: field.description, isEditing })
+          .with({ isEditing: true }, () => {
+            return (
+              <input
+                className={cx(F.fieldTextInput, CS.mb2, CS.mt1)}
+                type="text"
+                placeholder="Description"
+                {...formField.description}
+                defaultValue={field.description ?? ""}
+              />
+            );
+          })
+          .with({ description: P.not(P.nullish) }, () => (
+            <div className={cx(F.fieldDescription, CS.mb2, CS.mt1)}>
+              {field.description}
+            </div>
+          ))
+          .otherwise(() => null)}
       </div>
     </div>
   </div>

--- a/frontend/src/metabase/reference/components/Field.jsx
+++ b/frontend/src/metabase/reference/components/Field.jsx
@@ -119,7 +119,7 @@ const Field = ({ field, foreignKeys, url, icon, isEditing, formField }) => (
               <input
                 className={cx(F.fieldTextInput, CS.mb2, CS.mt1)}
                 type="text"
-                placeholder={t`Description`}
+                placeholder={t`No column description yet`}
                 {...formField.description}
                 defaultValue={field.description ?? ""}
               />

--- a/frontend/src/metabase/reference/components/Field.jsx
+++ b/frontend/src/metabase/reference/components/Field.jsx
@@ -119,7 +119,7 @@ const Field = ({ field, foreignKeys, url, icon, isEditing, formField }) => (
               <input
                 className={cx(F.fieldTextInput, CS.mb2, CS.mt1)}
                 type="text"
-                placeholder="Description"
+                placeholder={t`Description`}
                 {...formField.description}
                 defaultValue={field.description ?? ""}
               />

--- a/frontend/src/metabase/reference/components/Field.module.css
+++ b/frontend/src/metabase/reference/components/Field.module.css
@@ -16,7 +16,7 @@
   composes: fieldNameTitle;
 }
 
-.fieldNameTextInput {
+.fieldTextInput {
   composes: input p1 from "style";
   color: var(--title-color);
   width: 100%;
@@ -48,9 +48,17 @@
 }
 
 .fieldForeignKey {
-  composes: fieldType;
+  composes: textMedium from "style";
+  flex: 0.25;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .fieldOther {
   composes: fieldDataType;
+}
+
+.fieldDescription {
+  color: var(--subtitle-color);
+  font-size: 14px;
 }

--- a/frontend/src/metabase/reference/components/Field.tsx
+++ b/frontend/src/metabase/reference/components/Field.tsx
@@ -1,5 +1,6 @@
 /* eslint "react/prop-types": "warn" */
 import cx from "classnames";
+import type { FieldInputProps, FieldMetaProps } from "formik";
 import { getIn } from "icepick";
 import PropTypes from "prop-types";
 import { memo } from "react";
@@ -10,12 +11,45 @@ import S from "metabase/components/List/List.module.css";
 import Select from "metabase/core/components/Select";
 import CS from "metabase/css/core/index.css";
 import * as MetabaseCore from "metabase/lib/core";
-import { Icon } from "metabase/ui";
+import { Icon, type IconName } from "metabase/ui";
 import { isTypeFK } from "metabase-lib/v1/types/utils/isa";
+import type { Field as FieldType } from "metabase-types/api";
 
 import F from "./Field.module.css";
 
-const Field = ({ field, foreignKeys, url, icon, isEditing, formField }) => (
+type FormField<Value> = FieldMetaProps<Value | undefined> &
+  FieldInputProps<Value | undefined>;
+
+interface NestedFormField {
+  display_name: FormField<string>;
+  semantic_type: FormField<string>;
+  fk_target_field_id: FormField<string>;
+}
+
+interface Props {
+  field: FieldType;
+  formField: NestedFormField;
+  foreignKeys: Record<
+    string,
+    {
+      id: string;
+      name: string;
+      description: string;
+    }
+  >;
+  icon: IconName;
+  isEditing: boolean;
+  url: string;
+}
+
+const Field = ({
+  field,
+  foreignKeys,
+  url,
+  icon,
+  isEditing,
+  formField,
+}: Props) => (
   <div className={cx(S.item, CS.py1, CS.borderTop)}>
     <div
       className={cx(S.itemBody, CS.flexColumn)}

--- a/frontend/src/metabase/reference/databases/FieldList.jsx
+++ b/frontend/src/metabase/reference/databases/FieldList.jsx
@@ -107,6 +107,7 @@ const FieldList = props => {
 
   const getNestedFormField = id => ({
     display_name: getFormField(`${id}.display_name`),
+    description: getFormField(`${id}.description`),
     semantic_type: getFormField(`${id}.semantic_type`),
     fk_target_field_id: getFormField(`${id}.fk_target_field_id`),
   });
@@ -142,7 +143,7 @@ const FieldList = props => {
             <div className={CS.wrapper}>
               <div
                 className={cx(
-                  CS.pl4,
+                  CS.px4,
                   CS.pb2,
                   CS.mb4,
                   CS.bgWhite,


### PR DESCRIPTION
Closes #37907

### Description

No design for this. I naively added the description input to make it look similar to [the UI in data model page](https://github.com/user-attachments/assets/5b05f196-ac13-4e7a-88ef-b8298c95dbc6) while preserving existing look and feel of the data reference page (`max-width: 600px` on input container).

It also [adds padding](https://github.com/user-attachments/assets/f268ca1d-da91-4285-bf44-e2f11ecc0c7a) on the right-hand side of the fields list, to make the horizontal line look sane.

### How to verify

1. Sidebar > Databases
2. Click "Learn about our data"
3. Click "Sample Database"
4. Click "Tables in Sample Database"
5. Click any table
6. Click "Fields in this table"
7. Click "Edit"
8. You should be able to edit descriptions of all fields - change some
9. Click "Save"

Verify that field description has been updated (e.g. browse the table and hover over column header to see updated descriptions).

### Demo

[before](https://github.com/user-attachments/assets/2db8ed0e-27c8-42e4-ac01-bf5464755d63) vs [after](https://github.com/user-attachments/assets/8a50b9b3-4a41-43c8-b01e-74a218f293d3)
