### PR TITLE
Simple data picker UI

### DIFF
--- a/frontend/src/metabase/embedding-sdk/components/SimpleDataPicker/SimpleDataPicker.stories.tsx
+++ b/frontend/src/metabase/embedding-sdk/components/SimpleDataPicker/SimpleDataPicker.stories.tsx
@@ -10,10 +10,6 @@ const SHORT_OPTIONS = createOptions([
   "Analytic Events",
   "Feedback",
   "Invoices",
-  "Orders",
-  "People",
-  "Products",
-  "Reviews",
 ]);
 
 const LONG_OPTIONS = createOptions([
@@ -93,6 +89,12 @@ type Story = StoryObj<typeof SimpleDataPicker>;
 
 export const WithoutPopover: Story = {
   render: args => <SimpleDataPicker {...args} />,
+};
+
+export const NoOptions: Story = {
+  args: {
+    options: [],
+  },
 };
 
 export const ShortOptions: Story = {};

--- a/frontend/src/metabase/embedding-sdk/components/SimpleDataPicker/SimpleDataPicker.stories.tsx
+++ b/frontend/src/metabase/embedding-sdk/components/SimpleDataPicker/SimpleDataPicker.stories.tsx
@@ -97,6 +97,12 @@ export const WithoutPopover: Story = {
 
 export const ShortOptions: Story = {};
 
+export const SelectedOption: Story = {
+  args: {
+    selectedEntity: 3,
+  },
+};
+
 export const TenOptions: Story = {
   args: {
     options: LONG_OPTIONS.filter((_, index) => index < 10),

--- a/frontend/src/metabase/embedding-sdk/components/SimpleDataPicker/SimpleDataPicker.stories.tsx
+++ b/frontend/src/metabase/embedding-sdk/components/SimpleDataPicker/SimpleDataPicker.stories.tsx
@@ -1,0 +1,43 @@
+import { action } from "@storybook/addon-actions";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Popover } from "metabase/ui";
+
+import { SimpleDataPicker } from "./SimpleDataPicker";
+
+const meta: Meta<typeof SimpleDataPicker> = {
+  title: "embedding/SimpleDataPicker",
+  component: SimpleDataPicker,
+  args: {
+    onClick: action("on-click"),
+    options: [
+      {
+        id: 1,
+        display_name: "Accounts",
+      },
+      {
+        id: 2,
+        display_name: "Orders",
+      },
+    ],
+  },
+  render: args => {
+    return (
+      <Popover opened>
+        <Popover.Dropdown>
+          <SimpleDataPicker {...args} />
+        </Popover.Dropdown>
+      </Popover>
+    );
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SimpleDataPicker>;
+
+export const WithoutPopover: Story = {
+  render: args => <SimpleDataPicker {...args} />,
+};
+
+export const Primary: Story = {};

--- a/frontend/src/metabase/embedding-sdk/components/SimpleDataPicker/SimpleDataPicker.stories.tsx
+++ b/frontend/src/metabase/embedding-sdk/components/SimpleDataPicker/SimpleDataPicker.stories.tsx
@@ -5,25 +5,80 @@ import { Popover } from "metabase/ui";
 
 import { SimpleDataPicker } from "./SimpleDataPicker";
 
+const SHORT_OPTIONS = createOptions([
+  "Accounts",
+  "Analytic Events",
+  "Feedback",
+  "Invoices",
+  "Orders",
+  "People",
+  "Products",
+  "Reviews",
+]);
+
+const LONG_OPTIONS = createOptions([
+  "Accounts",
+  "Analytic Events",
+  "Feedback",
+  "Invoices",
+  "Orders",
+  "People",
+  "Products",
+  "Reviews",
+  "Accounts 2",
+  "Analytic Events 2",
+  "Feedback 2",
+  "Invoices 2",
+]);
+
+const SUPER_LONG_OPTIONS = createOptions([
+  "Accounts",
+  "Analytic Events",
+  "Feedback",
+  "Invoices",
+  "Orders",
+  "People",
+  "Products",
+  "Reviews",
+  "Accounts 2",
+  "Analytic Events 2",
+  "Feedback 2",
+  "Invoices 2",
+  "Orders 2",
+  "People 2",
+  "Products 2",
+  "Reviews 2",
+  "Accounts 3",
+  "Analytic Events 3",
+  "Feedback 3",
+  "Invoices 3",
+  "Orders 3",
+  "People 3",
+  "Products 3",
+  "Reviews 3",
+]);
+
+function createOptions(optionNames: string[]): Option[] {
+  return optionNames.map((name, index) => ({
+    id: index + 1,
+    display_name: name,
+  }));
+}
+interface Option {
+  id: number;
+  display_name: string;
+}
+
 const meta: Meta<typeof SimpleDataPicker> = {
   title: "embedding/SimpleDataPicker",
   component: SimpleDataPicker,
   args: {
     onClick: action("on-click"),
-    options: [
-      {
-        id: 1,
-        display_name: "Accounts",
-      },
-      {
-        id: 2,
-        display_name: "Orders",
-      },
-    ],
+    options: SHORT_OPTIONS,
   },
   render: args => {
     return (
-      <Popover opened>
+      <Popover opened trapFocus>
         <Popover.Dropdown>
           <SimpleDataPicker {...args} />
         </Popover.Dropdown>
@@ -40,4 +95,22 @@ export const WithoutPopover: Story = {
   render: args => <SimpleDataPicker {...args} />,
 };
 
-export const Primary: Story = {};
+export const ShortOptions: Story = {};
+
+export const TenOptions: Story = {
+  args: {
+    options: LONG_OPTIONS.filter((_, index) => index < 10),
+  },
+};
+
+export const LongOptions: Story = {
+  args: {
+    options: LONG_OPTIONS,
+  },
+};
+
+export const SuperLongOptions: Story = {
+  args: {
+    options: SUPER_LONG_OPTIONS,
+  },
+};

--- a/frontend/src/metabase/embedding-sdk/components/SimpleDataPicker/SimpleDataPicker.tsx
+++ b/frontend/src/metabase/embedding-sdk/components/SimpleDataPicker/SimpleDataPicker.tsx
@@ -2,8 +2,10 @@ import { useState } from "react";
 import { t } from "ttag";
 
 import { Icon, NavLink, Paper, ScrollArea, TextInput } from "metabase/ui";
+import type { TableId } from "metabase-types/api";
 
 interface SimpleDataPickerProps {
+  selectedEntity?: TableId;
   options: Options[];
   onClick: (option: any) => void;
 }
@@ -15,7 +17,11 @@ interface Options {
 
 const TEN_OPTIONS_HEIGHT = 10 * 33;
 
-export function SimpleDataPicker({ options, onClick }: SimpleDataPickerProps) {
+export function SimpleDataPicker({
+  selectedEntity,
+  options,
+  onClick,
+}: SimpleDataPickerProps) {
   const shouldShowSearchBar = options.length > 10;
   const [searchText, setSearchText] = useState("");
   function filterSearch(option: Options): boolean {
@@ -54,6 +60,7 @@ export function SimpleDataPicker({ options, onClick }: SimpleDataPickerProps) {
           return (
             <NavLink
               key={option.id}
+              active={selectedEntity === option.id}
               icon={<Icon c="var(--mb-color-icon-primary)" name="table" />}
               label={option.display_name}
               onClick={() => {

--- a/frontend/src/metabase/embedding-sdk/components/SimpleDataPicker/SimpleDataPicker.tsx
+++ b/frontend/src/metabase/embedding-sdk/components/SimpleDataPicker/SimpleDataPicker.tsx
@@ -63,9 +63,7 @@ export function SimpleDataPicker({
               active={selectedEntity === option.id}
               icon={<Icon c="var(--mb-color-icon-primary)" name="table" />}
               label={option.display_name}
-              onClick={() => {
-                onClick(option);
-              }}
+              onClick={() => onClick(option)}
               variant="default"
             />
           );

--- a/frontend/src/metabase/embedding-sdk/components/SimpleDataPicker/SimpleDataPicker.tsx
+++ b/frontend/src/metabase/embedding-sdk/components/SimpleDataPicker/SimpleDataPicker.tsx
@@ -57,11 +57,15 @@ export function SimpleDataPicker({
       {/* @ts-expect-error - I think the typing for ScrollArea.Autosize is wrong. This might be fixed in Mantine 7 */}
       <ScrollArea.Autosize mah={TEN_OPTIONS_HEIGHT} type="auto">
         {options.filter(filterSearch).map(option => {
+          const isSelected = selectedEntity === option.id;
+          const iconColor = isSelected
+            ? "--mb-color-text-white"
+            : "--mb-color-icon-primary";
           return (
             <NavLink
               key={option.id}
               active={selectedEntity === option.id}
-              icon={<Icon c="var(--mb-color-icon-primary)" name="table" />}
+              icon={<Icon color={`var(${iconColor})`} name="table" />}
               label={option.display_name}
               onClick={() => onClick(option)}
               variant="default"

--- a/frontend/src/metabase/embedding-sdk/components/SimpleDataPicker/SimpleDataPicker.tsx
+++ b/frontend/src/metabase/embedding-sdk/components/SimpleDataPicker/SimpleDataPicker.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
 import { t } from "ttag";
 
-import { Icon, NavLink, Paper, ScrollArea, TextInput } from "metabase/ui";
+import EmptyState from "metabase/components/EmptyState";
+import { CONTAINER_WIDTH } from "metabase/query_builder/components/DataSelector/constants";
+import { Flex, Icon, NavLink, Paper, ScrollArea, TextInput } from "metabase/ui";
 import type { TableId } from "metabase-types/api";
 
 interface SimpleDataPickerProps {
@@ -34,8 +36,26 @@ export function SimpleDataPicker({
     return true;
   }
 
+  if (options.length === 0) {
+    return (
+      <Paper w={CONTAINER_WIDTH} p="80px 60px">
+        <EmptyState
+          message={t`To pick some data, you'll need to add some first`}
+          icon="database"
+        />
+      </Paper>
+    );
+  }
+
+  const displayOptions = options.filter(filterSearch);
   return (
-    <Paper w="300px" p="sm">
+    <Paper
+      component={Flex}
+      w={CONTAINER_WIDTH}
+      p="sm"
+      mih="200px"
+      direction="column"
+    >
       {shouldShowSearchBar ? (
         <TextInput
           data-autofocus
@@ -54,25 +74,31 @@ export function SimpleDataPicker({
          */
         <span aria-hidden data-autofocus tabIndex={-1} />
       )}
-      {/* @ts-expect-error - I think the typing for ScrollArea.Autosize is wrong. This might be fixed in Mantine 7 */}
-      <ScrollArea.Autosize mah={TEN_OPTIONS_HEIGHT} type="auto">
-        {options.filter(filterSearch).map(option => {
-          const isSelected = selectedEntity === option.id;
-          const iconColor = isSelected
-            ? "--mb-color-text-white"
-            : "--mb-color-icon-primary";
-          return (
-            <NavLink
-              key={option.id}
-              active={selectedEntity === option.id}
-              icon={<Icon color={`var(${iconColor})`} name="table" />}
-              label={option.display_name}
-              onClick={() => onClick(option)}
-              variant="default"
-            />
-          );
-        })}
-      </ScrollArea.Autosize>
+      <Flex direction="column" justify="center" style={{ flex: 1 }}>
+        {displayOptions.length >= 1 ? (
+          // @ts-expect-error - I think the typing for ScrollArea.Autosize is wrong. This might be fixed in Mantine 7 */}
+          <ScrollArea.Autosize mah={TEN_OPTIONS_HEIGHT} type="auto" mb="auto">
+            {displayOptions.map(option => {
+              const isSelected = selectedEntity === option.id;
+              const iconColor = isSelected
+                ? "--mb-color-text-white"
+                : "--mb-color-icon-primary";
+              return (
+                <NavLink
+                  key={option.id}
+                  active={selectedEntity === option.id}
+                  icon={<Icon color={`var(${iconColor})`} name="table" />}
+                  label={option.display_name}
+                  onClick={() => onClick(option)}
+                  variant="default"
+                />
+              );
+            })}
+          </ScrollArea.Autosize>
+        ) : (
+          <EmptyState message={t`Nothing here`} />
+        )}
+      </Flex>
     </Paper>
   );
 }

--- a/frontend/src/metabase/embedding-sdk/components/SimpleDataPicker/SimpleDataPicker.tsx
+++ b/frontend/src/metabase/embedding-sdk/components/SimpleDataPicker/SimpleDataPicker.tsx
@@ -1,4 +1,7 @@
-import { Icon, NavLink, Paper } from "metabase/ui";
+import { useState } from "react";
+import { t } from "ttag";
+
+import { Icon, NavLink, Paper, ScrollArea, TextInput } from "metabase/ui";
 
 interface SimpleDataPickerProps {
   options: Options[];
@@ -10,22 +13,61 @@ interface Options {
   display_name: string;
 }
 
+const TEN_OPTIONS_HEIGHT = 10 * 33;
+
 export function SimpleDataPicker({ options, onClick }: SimpleDataPickerProps) {
+  const shouldShowSearchBar = options.length > 10;
+  const [searchText, setSearchText] = useState("");
+  function filterSearch(option: Options): boolean {
+    if (searchText) {
+      return normalizeString(option.display_name).includes(
+        normalizeString(searchText),
+      );
+    }
+
+    return true;
+  }
+
   return (
     <Paper w="300px" p="sm">
-      {options.map(option => {
-        return (
-          <NavLink
-            key={option.id}
-            icon={<Icon c="var(--mb-color-icon-primary)" name="table" />}
-            label={option.display_name}
-            onClick={() => {
-              onClick(option);
-            }}
-            variant="default"
-          />
-        );
-      })}
+      {shouldShowSearchBar ? (
+        <TextInput
+          data-autofocus
+          type="search"
+          icon={<Icon name="search" size={16} />}
+          mb="sm"
+          placeholder={t`Search…`}
+          onChange={e => setSearchText(e.target.value ?? "")}
+        />
+      ) : (
+        /**
+         * Behave like Mantine 7's `FocusTrap.InitialFocus`.
+         *
+         * This component disable the automatic focus on the first focusable element
+         * when there is no search bar.
+         */
+        <span aria-hidden data-autofocus tabIndex={-1} />
+      )}
+      {/* @ts-expect-error - I think the typing for ScrollArea.Autosize is wrong. This might be fixed in Mantine 7 */}
+      <ScrollArea.Autosize mah={TEN_OPTIONS_HEIGHT} type="auto">
+        {options.filter(filterSearch).map(option => {
+          return (
+            <NavLink
+              key={option.id}
+              icon={<Icon c="var(--mb-color-icon-primary)" name="table" />}
+              label={option.display_name}
+              onClick={() => {
+                onClick(option);
+              }}
+              variant="default"
+            />
+          );
+        })}
+      </ScrollArea.Autosize>
     </Paper>
   );
+}
+
+function normalizeString(input: string) {
+  return input.trim().toLowerCase();
 }

--- a/frontend/src/metabase/embedding-sdk/components/SimpleDataPicker/SimpleDataPicker.tsx
+++ b/frontend/src/metabase/embedding-sdk/components/SimpleDataPicker/SimpleDataPicker.tsx
@@ -1,0 +1,31 @@
+import { Icon, NavLink, Paper } from "metabase/ui";
+
+interface SimpleDataPickerProps {
+  options: Options[];
+  onClick: (option: any) => void;
+}
+
+interface Options {
+  id: number;
+  display_name: string;
+}
+
+export function SimpleDataPicker({ options, onClick }: SimpleDataPickerProps) {
+  return (
+    <Paper w="300px" p="sm">
+      {options.map(option => {
+        return (
+          <NavLink
+            key={option.id}
+            icon={<Icon c="var(--mb-color-icon-primary)" name="table" />}
+            label={option.display_name}
+            onClick={() => {
+              onClick(option);
+            }}
+            variant="default"
+          />
+        );
+      })}
+    </Paper>
+  );
+}

--- a/frontend/src/metabase/embedding-sdk/components/SimpleDataPicker/index.ts
+++ b/frontend/src/metabase/embedding-sdk/components/SimpleDataPicker/index.ts
@@ -1,0 +1,1 @@
+export { SimpleDataPicker } from "./SimpleDataPicker";

--- a/loki.config.js
+++ b/loki.config.js
@@ -4,7 +4,7 @@ module.exports = {
     "static-viz",
     "viz",
     "^visualizations/shared",
-    "^embed",
+    "^embed/",
     "^design system",
     "^Inputs/DatePicker Dates range",
     "^Parameters/DatePicker",


### PR DESCRIPTION
Epic: #52889

### Description

This PR implements the flattened list version of the data picker.

### How to verify
1. Run `yarn storybook`
2. Visit http://localhost:6006/?path=/story/embedding-simpledatapicker--without-popover and play with related stories.

### Demo
![image](https://github.com/user-attachments/assets/e056a587-3ed7-4070-a1b2-17fc4dc278f3)
![image](https://github.com/user-attachments/assets/c9d13361-9fec-4d21-a3c3-c54d40abc039)
![Screenshot 2025-02-04 at 7 48 41 PM](https://github.com/user-attachments/assets/59a2f0d7-61c4-447a-8fb3-bb2cc2efbbd5)
![Screenshot 2025-02-04 at 7 48 38 PM](https://github.com/user-attachments/assets/89a836c9-7bc0-43f9-af29-d3e5eaef121a)
![Screenshot 2025-02-04 at 7 48 44 PM](https://github.com/user-attachments/assets/04d3be24-d0b8-4618-a4e5-c953bf1ee440)

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~ this is just UI, so there are no tests yet. they'll be added later.
