### PR TITLE
Fix parameter popover width when the datepicker changes its width

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -4241,6 +4241,7 @@ describe("issue 52918", () => {
       cy.findByText("Specific dates…").click();
       cy.findByText("Between").should("be.visible");
     });
+    cy.log("check that there is no overflow in the popover");
     H.popover().then(([element]) => {
       expect(element.offsetWidth).to.gte(element.scrollWidth);
     });

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -4242,7 +4242,7 @@ describe("issue 52918", () => {
       cy.findByText("Between").should("be.visible");
     });
     cy.log("check that there is no overflow in the popover");
-    H.popover().then(([element]) => {
+    H.popover().should(([element]) => {
       expect(element.offsetWidth).to.gte(element.scrollWidth);
     });
   });

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -4225,3 +4225,24 @@ describe("issue 52627", () => {
     H.rightSidebar().findByText("Average of Total").should("be.visible");
   });
 });
+
+describe("issue 52918", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should re-position the parameter dropdown when its size changes (metabase#52918)", () => {
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.editDashboard();
+    H.setFilter("Date picker", "All Options");
+    H.sidebar().findByLabelText("No default").click();
+    H.popover().within(() => {
+      cy.findByText("Specific dates…").click();
+      cy.findByText("Between").should("be.visible");
+    });
+    H.popover().then(([element]) => {
+      expect(element.offsetWidth).to.gte(element.scrollWidth);
+    });
+  });
+});

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.tsx
@@ -284,6 +284,7 @@ export const ParameterValueWidget = ({
       </Popover.Target>
       <Popover.Dropdown
         // Removes `maxWidth` so that `floating-ui` can detect the new element size. See metabase#52918 for details.
+        // Use `size` middleware options when we upgrade to mantine v7.
         maw={isDateParameter(parameter) ? "100vw !important" : undefined}
         data-testid="parameter-value-dropdown"
       >

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.tsx
@@ -282,7 +282,11 @@ export const ParameterValueWidget = ({
           </Sortable>
         </Box>
       </Popover.Target>
-      <Popover.Dropdown data-testid="parameter-value-dropdown">
+      <Popover.Dropdown
+        // Removes `maxWidth` so that `floating-ui` can detect the new element size. See metabase#52918 for details.
+        maw={isDateParameter(parameter) ? "100vw !important" : undefined}
+        data-testid="parameter-value-dropdown"
+      >
         <ParameterDropdownWidget
           parameter={parameter}
           parameters={parameters}


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/52918

The problem is that `usePopover` sets `maxWidth` on the popover dropdown to prevent overflow, which causes issues when the dropdown size changes. It's not possible to configure middlewares with mantine v6, but with mantine v7 we could set different `size` middleware options. 

How to verify:
- Add a date parameter to a dashboard
- Change its default value. Click on the default value picker, then `Specific dates`. The popover should be repositioned to stay inside the window without overflow. 

<img width="401" alt="Screenshot 2025-01-30 at 12 54 57" src="https://github.com/user-attachments/assets/2ea8549a-3489-4e1f-983d-c16622b1a0b1" />
<img width="638" alt="Screenshot 2025-01-30 at 12 55 06" src="https://github.com/user-attachments/assets/7946b9e6-eb28-4fd2-80f6-fd73284186dd" />
<img width="392" alt="Screenshot 2025-01-30 at 12 55 11" src="https://github.com/user-attachments/assets/9b37673d-d74d-461c-bc00-4e4d00f44088" />

E2E - before:
<img width="1327" alt="Screenshot 2025-01-30 at 14 16 48" src="https://github.com/user-attachments/assets/53a6767f-21dc-4dce-a331-c61f4bacaeac" />

E2E - after:
<img width="1322" alt="Screenshot 2025-01-30 at 14 17 02" src="https://github.com/user-attachments/assets/08709826-54c6-4d05-b156-699701d0d0a2" />
