### PR TITLE
Port native queries to MBQL lib

### DIFF
--- a/frontend/src/metabase-lib/native.ts
+++ b/frontend/src/metabase-lib/native.ts
@@ -27,13 +27,6 @@ export function templateTags(query: Query): TemplateTags {
   return ML.template_tags(query);
 }
 
-export function extractTemplateTags(
-  queryText: string,
-  existingTags?: TemplateTags,
-): TemplateTags {
-  return ML.extract_template_tags(queryText, existingTags);
-}
-
 export function hasWritePermission(query: Query): boolean {
   return ML.has_write_permission(query);
 }

--- a/frontend/src/metabase-lib/v1/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/v1/queries/NativeQuery.ts
@@ -221,6 +221,8 @@ export default class NativeQuery extends AtomicQuery {
   setParameterIndex(id: string, newIndex: number) {
     // NOTE: currently all NativeQuery parameters are implicitly generated from
     // template tags, and the order is determined by the key order
+    // NOTE 2: currently cannot be ported to MBQL lib because maps with keys in
+    // different order are considered equal.
     return new NativeQuery(
       this._originalQuestion,
       updateIn(

--- a/frontend/src/metabase-lib/v1/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/v1/queries/NativeQuery.ts
@@ -201,7 +201,8 @@ export default class NativeQuery extends AtomicQuery {
   }
 
   setQueryText(newQueryText: string): NativeQuery {
-    return this._setQuery(Lib.withNativeQuery(this._query(), newQueryText));
+    const newQuery = Lib.withNativeQuery(this._query(), newQueryText);
+    return this._setQuery(newQuery);
   }
 
   collection(): string | null | undefined {
@@ -210,9 +211,10 @@ export default class NativeQuery extends AtomicQuery {
   }
 
   setCollectionName(newCollection: string) {
-    return this._setQuery(
-      Lib.withNativeExtras(this._query(), { collection: newCollection }),
-    );
+    const newQuery = Lib.withNativeExtras(this._query(), {
+      collection: newCollection,
+    });
+    return this._setQuery(newQuery);
   }
 
   setParameterIndex(id: string, newIndex: number) {

--- a/frontend/src/metabase-lib/v1/queries/utils/native-query-table.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/queries/utils/native-query-table.unit.spec.ts
@@ -64,7 +64,12 @@ const cardWithCollection = createSavedNativeCard({
 const card = createSavedNativeCard({ id: 3 });
 
 const metadata = createMockMetadata({
-  databases: [createSampleDatabase(), SAVED_QUESTIONS_DB],
+  databases: [
+    createSampleDatabase({
+      features: ["native-requires-specified-collection"],
+    }),
+    SAVED_QUESTIONS_DB,
+  ],
   tables: [modelTable],
   questions: [model, card, cardWithCollection],
 });

--- a/frontend/src/metabase-types/api/database.ts
+++ b/frontend/src/metabase-types/api/database.ts
@@ -35,7 +35,8 @@ export type DatabaseFeature =
   | "nested-field-columns"
   | "advanced-math-expressions"
   | "connection-impersonation"
-  | "connection-impersonation-requires-role";
+  | "connection-impersonation-requires-role"
+  | "native-requires-specified-collection";
 
 export interface Database extends DatabaseData {
   id: DatabaseId;

--- a/frontend/test/metabase-lib/lib/queries/NativeQuery.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/NativeQuery.unit.spec.js
@@ -19,7 +19,12 @@ const metadata = createMockMetadata({
     createMockDatabase({
       id: MONGO_DB_ID,
       engine: "mongo",
-      features: ["basic-aggregations", "nested-fields", "dynamic-schema"],
+      features: [
+        "basic-aggregations",
+        "nested-fields",
+        "dynamic-schema",
+        "native-requires-specified-collection",
+      ],
     }),
   ],
 });
@@ -128,7 +133,7 @@ describe("NativeQuery", () => {
 
     describe("setCollectionName(newCollection) selects or updates a target table for you mongo native query", () => {
       it("allows you to update mongo collections", () => {
-        const fakeCollectionID = 9999;
+        const fakeCollectionID = "9999";
         const fakeMongoQuery =
           makeMongoQuery("").setCollectionName(fakeCollectionID);
         expect(fakeMongoQuery.collection()).toBe(fakeCollectionID);

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -1885,7 +1885,8 @@
 
   > **Code health:** Healthy"
   [a-query]
-  (clj->js (m/map-vals #(m/update-existing % :dimension ref->legacy-ref) (lib.core/template-tags a-query))))
+  (clj->js (m/map-vals #(m/update-existing % :dimension ref->legacy-ref) (lib.core/template-tags a-query))
+           :keyword-fn u/qualified-name))
 
 (defn ^:export required-native-extras
   "Returns a JS array of the extra keys that are required for this database's native queries.

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -1831,7 +1831,7 @@
 (defn- remove-undefined-properties
   [obj]
   (cond-> obj
-          (object? obj) (gobject/filter (fn [e _ _] (not (undefined? e))))))
+    (object? obj) (gobject/filter (fn [e _ _] (not (undefined? e))))))
 
 (defn- template-tags-js->cljs
   [tags]

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -1885,7 +1885,7 @@
 
   > **Code health:** Healthy"
   [a-query]
-  (clj->js (m/map-vals #(m/update-existing % :dimension ref->legacy-ref) (lib.core/template-tags a-query))
+  (clj->js (update-vals (lib.core/template-tags a-query) #(m/update-existing % :dimension ref->legacy-ref))
            :keyword-fn u/qualified-name))
 
 (defn ^:export required-native-extras

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -1833,11 +1833,6 @@
   (cond-> obj
           (object? obj) (gobject/filter (fn [e _ _] (not (undefined? e))))))
 
-(defn- remove-undefined-properties
-  [obj]
-  (cond-> obj
-          (object? obj) (gobject/filter (fn [e _ _] (not (undefined? e))))))
-
 (defn- template-tags-js->cljs
   [tags]
   (-> tags

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -1885,7 +1885,7 @@
 
   > **Code health:** Healthy"
   [a-query]
-  (clj->js (update-vals (lib.core/template-tags a-query) #(m/update-existing % :dimension ref->legacy-ref))
+  (clj->js (update-vals (lib.core/template-tags a-query) (fn [tag] (update tag :dimension #(some-> % ref->legacy-ref))))
            :keyword-fn u/qualified-name))
 
 (defn ^:export required-native-extras

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -89,15 +89,8 @@
 ;;; This ensures that all of metabase.lib.* is loaded, so all the `defmethod`s are properly registered.
 (comment lib.core/keep-me)
 
-(defn- remove-undefined-properties
-  [obj]
-  (cond-> obj
-    (object? obj) (gobject/filter (fn [e _ _] (not (undefined? e))))))
-
 (defn- convert-js-template-tags [tags]
   (-> tags
-      (gobject/map (fn [e _ _]
-                     (remove-undefined-properties e)))
       js->clj
       (update-vals #(-> %
                         (update-keys keyword)

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -1875,8 +1875,7 @@
 
   > **Code health:** Healthy"
   [a-query]
-  (-> (lib.core/template-tags a-query)
-      template-tags-cljs->js))
+  (template-tags-cljs->js (lib.core/template-tags a-query)))
 
 (defn ^:export required-native-extras
   "Returns a JS array of the extra keys that are required for this database's native queries.

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -212,7 +212,9 @@
    query 0
    (fn [{existing-tags :template-tags :as stage}]
      (assert-native-query! stage)
-     (assoc stage :template-tags tags))))
+     (let [valid-tags (keys existing-tags)]
+       (assoc stage :template-tags
+              (merge existing-tags (select-keys tags valid-tags)))))))
 
 (mu/defn raw-native-query :- ::common/non-blank-string
   "Returns the native query string"

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -212,9 +212,7 @@
    query 0
    (fn [{existing-tags :template-tags :as stage}]
      (assert-native-query! stage)
-     (let [valid-tags (keys existing-tags)]
-       (assoc stage :template-tags
-              (m/deep-merge existing-tags (select-keys tags valid-tags)))))))
+     (assoc stage :template-tags tags))))
 
 (mu/defn raw-native-query :- ::common/non-blank-string
   "Returns the native query string"

--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -183,21 +183,6 @@
       (is (test.js/= (clj->js snippets)
                      (lib.js/template-tags query))))))
 
-(deftest ^:parallel extract-template-tags-test
-  (testing "Undefined parameters are ignored (#34729)"
-    (let [tag-name "foo"
-          tags {tag-name {:type         :text
-                          :name         tag-name
-                          :display-name "Foo"
-                          :id           (str (random-uuid))}}]
-      (is (= {"bar" {"type"         "text"
-                     "name"         "bar"
-                     "display-name" "Bar"
-                     "id"           (get-in tags [tag-name :id])}}
-             (-> (lib.js/extract-template-tags "SELECT * FROM table WHERE {{bar}}"
-                                               (add-undefined-params (clj->js tags) tag-name))
-                 js->clj))))))
-
 (deftest ^:parallel is-column-metadata-test
   (is (true? (lib.js/is-column-metadata (meta/field-metadata :venues :id))))
   (is (false? (lib.js/is-column-metadata 1))))

--- a/test/metabase/lib/native_test.cljc
+++ b/test/metabase/lib/native_test.cljc
@@ -210,6 +210,23 @@
              (-> query
                  (lib/with-template-tags {"garbage" (assoc (get original-tags "myid") :name "garbage" :display-name "Foobar")})
                  lib/template-tags))))
+    (testing "Allows to remove template tag properties"
+      (let [template-tags     {"tag"
+                               {:default nil
+                                :dimension [:field {:lib/uuid (str (random-uuid))} 1]
+                                :display-name "Tag"
+                                :id "9ae1ea5e-ac33-4574-bc95-ff595b0ac1a7"
+                                :name "tag"
+                                :type :dimension
+                                :widget-type :date/range}}
+            query             (-> (lib/native-query meta/metadata-provider "select * from venues where {{tag}}")
+                                  (lib/with-template-tags template-tags))
+            new-template-tags {"tag"
+                               {:display-name "Tag"
+                                :id "9ae1ea5e-ac33-4574-bc95-ff595b0ac1a7"
+                                :name "tag"
+                                :type :text}}]
+        (is (= new-template-tags (lib/template-tags (lib/with-template-tags query new-template-tags))))))
     (is (thrown-with-msg?
          #?(:clj Throwable :cljs :default)
          #"Must be a native query"


### PR DESCRIPTION
Use MBQL lib under the hood for `NativeQuery` class. Mostly worked out of the box, but:
- `templateTags`  and `withTemplateTags` didn't have JS<->CLJS conversion implemented
- `withTemplateTags` had deep merge, preventing removing any properties from existing template tags
- reordering of template tags cannot be ported to MBQL lib because of caching issues, as in clojure maps with the same keys in different order are equal. We should probably refactor the FE to rely on the order of `parameters` instead.

In the future we should aim to get rid of `NativeQuery` class altogether. 

How to verify:
- Creating native questions via the native query editor should work
- It should be possible to use template tags of all different types. Pay special attention to changing template tag properties.