### PR TITLE
fix invalid pivot table columns in click behavior

### DIFF
--- a/frontend/src/metabase/dashboard/components/ClickMappings.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickMappings.jsx
@@ -7,7 +7,7 @@ import _ from "underscore";
 
 import Select from "metabase/core/components/Select";
 import CS from "metabase/css/core/index.css";
-import { getParameters } from "metabase/dashboard/selectors";
+import { getDashcardData, getParameters } from "metabase/dashboard/selectors";
 import { isPivotGroupColumn } from "metabase/lib/data_grid";
 import { connect } from "metabase/lib/redux";
 import MetabaseSettings from "metabase/lib/settings";
@@ -134,6 +134,7 @@ export const ClickMappingsConnected = _.compose(
     const { object, isDashboard, dashcard, clickBehavior } = props;
     let parameters = getParameters(state, props);
     const metadata = getMetadata(state);
+    const dashcardData = getDashcardData(state, dashcard.id);
     const question = new Question(dashcard.card, metadata);
 
     if (props.excludeParametersSources) {
@@ -156,8 +157,12 @@ export const ClickMappingsConnected = _.compose(
       ({ id }) =>
         getIn(clickBehavior, ["parameterMapping", id, "source"]) != null,
     );
+
+    const availableColumns =
+      Object.values(dashcardData).flatMap(dataset => dataset.data.cols) ?? [];
+
     const sourceOptions = {
-      column: dashcard.card.result_metadata?.filter(isMappableColumn) || [],
+      column: availableColumns.filter(isMappableColumn),
       parameter: parameters,
     };
     return { setTargets, unsetTargets, sourceOptions, question };


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/52339

### Description

The click behavior column mapping used `results_metadata.columns` to understand which columns of a dashcard can be mapped to the source. However, for pivot tables, it contains completely invalid set of columns due to https://github.com/metabase/metabase/issues/41896.

This PR makes mapping logic use dataset columns.

### How to verify

Follow repro steps from the original issue.

### Demo

Before
<img width="1724" alt="Screenshot 2025-01-31 at 4 04 10 PM" src="https://github.com/user-attachments/assets/e5789fb9-c8f0-4b10-9c9f-bc80f7afbdab" />

After
<img width="1728" alt="Screenshot 2025-01-31 at 4 03 31 PM" src="https://github.com/user-attachments/assets/e4de6001-7aa1-4205-b779-96ea99132e36" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
