### PR TITLE
CI driver job tweaks

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -916,7 +916,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-20.04
-    timeout-minutes: 60
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -768,7 +768,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         job:
           - name: Redshift Upload Tests

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -60,7 +60,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 60
     env:
       CI: 'true'
       DRIVERS: athena
@@ -96,7 +96,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 60
     env:
       CI: 'true'
       DRIVERS: bigquery-cloud-sdk
@@ -131,7 +131,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 60
     env:
       CI: 'true'
       DRIVERS: druid
@@ -167,7 +167,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 60
     env:
       CI: 'true'
       DRIVERS: databricks
@@ -202,7 +202,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 60
     env:
       CI: 'true'
       DRIVERS: druid-jdbc
@@ -238,7 +238,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -365,7 +365,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -418,7 +418,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -486,7 +486,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 60
     env:
       CI: 'true'
       DRIVERS: mongo
@@ -520,7 +520,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -592,7 +592,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -697,7 +697,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 60
     env:
       CI: 'true'
       DRIVERS: presto-jdbc
@@ -766,18 +766,20 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 60
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         job:
           - name: Redshift Upload Tests
             test-args: >-
               :only-tags [:mb/upload-tests]
+              :fail-fast? true
           - name: Redshift (Excluding Upload Tests)
             test-args: >-
               :only-tags [:mb/driver-tests]
               :exclude-tags [:mb/upload-tests]
+              :fail-fast? true
 
     env:
       CI: 'true'
@@ -811,7 +813,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 60
     env:
       CI: 'true'
       DRIVERS: snowflake
@@ -851,7 +853,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 60
     env:
       CI: 'true'
       DRIVERS: sparksql
@@ -885,7 +887,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 60
     env:
       CI: 'true'
       DRIVERS: sqlite
@@ -914,7 +916,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-20.04
-    timeout-minutes: 90
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -965,7 +967,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 60
     env:
       CI: 'true'
       DRIVERS: vertica


### PR DESCRIPTION
This is an attempt to make Redshift a little more stable by taking the load off of it a bit and having failing job runs fail quicker.

- Reduce Redshift timeout from 90 to 60 minutes. If it completes successfully, it does so in 10-30 minutes; if it starts taking longer than that's usually caught in 100% CPU land and will fail anyway.
  - By that logic I've also lowered the timeout for all other drivers to 60 minutes, and SQL Server to 30 --  SQL Server usually finishes in ~6 minutes but I've seen it randomly hang for the entire 90 minutes before. It would have been quicker to kill and retry it.
- Make Redshift jobs fail right away as soon as the first test fails -- if we get into 100% CPU based test failures this will start start reducing the load right away instead of letting several jobs thrash. This will also let us retry a little sooner.