### PR TITLE
Lofi quartz debugging for search-index.update task

### DIFF
--- a/src/metabase/task/search_index.clj
+++ b/src/metabase/task/search_index.clj
@@ -73,6 +73,7 @@
 
 (defn- update-index! []
   (when (search/supports-index?)
+    (log/info "Starting Realtime Search Index Update worker")
     (while true
       (try
         (let [batch    (search/get-next-batch! Long/MAX_VALUE 100)


### PR DESCRIPTION
Want to validate the theory that in-memory queue leaks correspond to the worker never starting for the relevant pod.