### PR TITLE
Fix - Empty tooltip shown when save button is disabled

### DIFF
--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -169,8 +169,13 @@ describe("issue 49454", () => {
     });
   });
 
-  it("should be possible to use metrics in native queries (metabase#49454)", () => {
+  it("should be possible to use metrics in native queries (metabase#49454, metabase#51035)", () => {
     H.startNewNativeQuestion();
+
+    cy.log("should not show empty tooltip (metabase#51035)");
+    cy.button("Save").realHover();
+    H.tooltip().should("not.exist");
+
     H.NativeEditor.type("select * from {{ #test");
 
     H.NativeEditor.completions().within(() => {

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ViewTitleHeaderRightSide/ViewTitleHeaderRightSide.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ViewTitleHeaderRightSide/ViewTitleHeaderRightSide.tsx
@@ -136,7 +136,9 @@ export function ViewTitleHeaderRightSide({
   const canSave = Lib.canSave(question.query(), question.type());
   const isSaveDisabled = !canSave;
   const isBrandNew = !isSaved && !result && queryBuilderMode === "notebook";
-  const disabledSaveTooltip = getDisabledSaveTooltip(isEditable);
+  const disabledSaveTooltip = isSaveDisabled
+    ? getDisabledSaveTooltip(isEditable)
+    : undefined;
 
   return (
     <Flex
@@ -222,7 +224,11 @@ export function ViewTitleHeaderRightSide({
         />
       )}
       {hasSaveButton && (
-        <Tooltip label={disabledSaveTooltip} disabled={canSave} position="left">
+        <Tooltip
+          disabled={!disabledSaveTooltip}
+          label={disabledSaveTooltip}
+          position="left"
+        >
           <Button
             className={ViewTitleHeaderS.SaveButton}
             data-testid="qb-save-button"


### PR DESCRIPTION
Fixes #51035

### How to verify

1. New > SQL Query
2. Hover "Save" button

"Save" button should be disabled and it should have no tooltip.
