### PR TITLE
Fix - Segment filter misaligned in filter modal

### DIFF
--- a/e2e/test/scenarios/filters/filter-bulk.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter-bulk.cy.spec.js
@@ -306,7 +306,7 @@ describe("scenarios > filters > bulk filtering", () => {
       H.visitQuestionAdhoc(rawQuestionDetails);
       H.filter();
 
-      // The entire H.modal().within(() => { ... }) block is the repro. The rest are regular tests.
+      // Only the H.modal().within(() => { ... }) block is the repro. The rest is a regular test.
       cy.log(
         "segment filter icon should be aligned with other filter icons (metabase#50734)",
       );

--- a/e2e/test/scenarios/filters/filter-bulk.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter-bulk.cy.spec.js
@@ -302,9 +302,30 @@ describe("scenarios > filters > bulk filtering", () => {
       });
     });
 
-    it("should apply and remove segment filter", () => {
+    it("should apply and remove segment filter (metabase#50734)", () => {
       H.visitQuestionAdhoc(rawQuestionDetails);
       H.filter();
+
+      H.modal().within(() => {
+        cy.log(
+          "segment filter icon should be aligned with other filter icons (metabase#50734)",
+        );
+        H.filterField("segments")
+          .findByRole("img")
+          .should("be.visible")
+          .then(([$segmentsIcon]) => {
+            const segmentsIconRect = $segmentsIcon.getBoundingClientRect();
+
+            H.filterField("Discount")
+              .findAllByRole("img")
+              .first()
+              .should(([$discountIcon]) => {
+                const discountIconRect = $discountIcon.getBoundingClientRect();
+                expect(segmentsIconRect.left).to.eq(discountIconRect.left);
+                expect(segmentsIconRect.right).to.eq(discountIconRect.right);
+              });
+          });
+      });
 
       H.modal().within(() => {
         H.filterField("segments").within(() =>

--- a/e2e/test/scenarios/filters/filter-bulk.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter-bulk.cy.spec.js
@@ -306,10 +306,11 @@ describe("scenarios > filters > bulk filtering", () => {
       H.visitQuestionAdhoc(rawQuestionDetails);
       H.filter();
 
+      // The entire H.modal().within(() => { ... }) block is the repro. The rest are regular tests.
+      cy.log(
+        "segment filter icon should be aligned with other filter icons (metabase#50734)",
+      );
       H.modal().within(() => {
-        cy.log(
-          "segment filter icon should be aligned with other filter icons (metabase#50734)",
-        );
         H.filterField("segments")
           .findByRole("img")
           .should("be.visible")

--- a/frontend/src/metabase/querying/filters/components/FilterModal/FilterModalBody/SegmentFilterItem/SegmentFilterItem.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterModal/FilterModalBody/SegmentFilterItem/SegmentFilterItem.tsx
@@ -19,12 +19,7 @@ export function SegmentFilterItem({ segmentItems }: SegmentFilterItemProps) {
   };
 
   return (
-    <FilterTabItem
-      component="li"
-      px="2rem"
-      py="1rem"
-      data-testid="filter-column-segments"
-    >
+    <FilterTabItem component="li" data-testid="filter-column-segments">
       <SegmentFilterEditor
         segmentItems={segmentItems}
         onChange={handleChange}

--- a/frontend/src/metabase/querying/filters/components/FilterModal/SegmentFilterEditor/SegmentFilterEditor.css
+++ b/frontend/src/metabase/querying/filters/components/FilterModal/SegmentFilterEditor/SegmentFilterEditor.css
@@ -1,0 +1,3 @@
+.icon {
+  flex-shrink: 0;
+}

--- a/frontend/src/metabase/querying/filters/components/FilterModal/SegmentFilterEditor/SegmentFilterEditor.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterModal/SegmentFilterEditor/SegmentFilterEditor.tsx
@@ -3,6 +3,8 @@ import { t } from "ttag";
 import type { SegmentItem } from "metabase/querying/filters/types";
 import { Flex, Grid, Icon, MultiSelect, Text } from "metabase/ui";
 
+import S from "./SegmentFilterEditor.css";
+
 interface SegmentFilterEditorProps {
   segmentItems: SegmentItem[];
   onChange: (newSegmentItems: SegmentItem[]) => void;
@@ -31,8 +33,8 @@ export function SegmentFilterEditor({
   return (
     <Grid grow>
       <Grid.Col span="auto">
-        <Flex h="100%" align="center" gap="sm">
-          <Icon name="filter" />
+        <Flex h="100%" align="center" gap="sm" pl="md">
+          <Icon className={S.icon} name="filter" />
           <Text color="text-dark" weight="bold">
             {t`Filter down to a segment`}
           </Text>


### PR DESCRIPTION
Fixes #50734

### How to verify

1. Create a Segment for Orders table
2. New > Question > Orders > Visualize
3. Open filter modal

Segment filter icon should be aligned with icons of other filters

4. Change viewport width to 500px or less

Segment filter icon should be of the same size as icons of other filters (should not shrink)

### Demo

Alignment: [before](https://github.com/user-attachments/assets/ab32ede5-148a-4657-bddd-34d372902916) vs [after](https://github.com/user-attachments/assets/4c119e81-deab-42dc-b6c8-70a31dde8949)
Icon: [before](https://github.com/user-attachments/assets/85830664-5587-4571-8906-76600080a7da) vs [after](https://github.com/user-attachments/assets/92ff1cb2-9796-456d-8b07-bcd801374b62)

