### PR TITLE
fix row chart font in pdf exports

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
@@ -139,7 +139,11 @@ const RowChartVisualization = ({
   );
   const goal = useMemo(() => getChartGoal(settings), [settings]);
   const stackOffset = getStackOffset(settings);
-  const theme = useRowChartTheme(fontFamily, isDashboard, isFullscreen);
+  const theme = useRowChartTheme(
+    `${fontFamily}, Arial, sans-serif`,
+    isDashboard,
+    isFullscreen,
+  );
 
   const chartWarnings = useMemo(
     () => getChartWarnings(chartColumns, data.rows),


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/53007

### Description

Adds `Arial, sans-serif` fallback to the Row chart font for PDF exports.

### How to verify

- Add a row chart to a dashboard
- Export it as a PDF
- Ensure labels use Arial instead of Times New Roman

### Demo

Before
<img width="866" alt="Screenshot 2025-01-31 at 11 53 55 AM" src="https://github.com/user-attachments/assets/d79bb9ba-3394-44d7-91cf-a2e47852d940" />

After
<img width="880" alt="Screenshot 2025-01-31 at 11 53 40 AM" src="https://github.com/user-attachments/assets/7f1acd3d-1640-40cc-afb4-dfc348de7cc5" />

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
