### PR TITLE
[refs] Add `entity_id` columns to databases, tables, fields

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_app/audit.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/audit.clj
@@ -229,12 +229,20 @@
   "audit__rP75CiURKZ-0pq")
 
 (defn- entity-id-for-table [table]
-  (-> [audit-db-entity-id (:schema table "(no schema)") (:name table)]
+  (-> [audit-db-entity-id
+       ;; The hard-coded entity_ids saved in the serdes export used a schema of "public", so that's now hard-coded.
+       ;; The schema (and spelling) used for the AppDB tables varies by engine, so it should not influence the idents.
+       "public"
+       ;; We use inconsistent upper and lower case table and field names for audit across AppDB engines; this uses
+       ;; lower case everywhere to make the entity IDs effectively hard-coded.
+       (u/lower-case-en (:name table))]
       serdes/raw-hash
       u/generate-nano-id))
 
 (defn- entity-id-for-field [table-eid field]
-  (-> [table-eid (:name field)]
+  ;; We use inconsistent upper and lower case table and field names for audit across AppDB engines; this uses lower
+  ;; case to make the entity IDs effectively hard-coded.
+  (-> [table-eid (u/lower-case-en (:name field))]
       serdes/raw-hash
       u/generate-nano-id))
 

--- a/enterprise/backend/src/metabase_enterprise/audit_app/audit.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/audit.clj
@@ -259,8 +259,8 @@
 
   So we hard-code a NanoID for the audit Database, and then compute reproducible NanoIDs for all existing tables and
   fields by *seeding* [[u/generate-nano-id]] with the table and field names."
-  []
-  (when-let [db (t2/select-one :model/Database :is_audit true)]
+  [db]
+  (when db
     (t2/update! :model/Database (:id db) {:entity_id audit-db-entity-id})
     (let [tables (t2/select :model/Table :db_id (:id db))
           eids   (into {} (map (juxt :id (some-fn :entity_id entity-id-for-table))) tables)]
@@ -276,7 +276,7 @@
   []
   (let [audit-db (t2/select-one :model/Database :is_audit true)]
     (when audit-db
-      (backfill-entity-ids!))
+      (backfill-entity-ids! audit-db))
     (cond
       (nil? audit-db)
       (u/prog1 ::installed

--- a/enterprise/backend/test/metabase_enterprise/audit_app/audit_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/audit_test.clj
@@ -82,6 +82,72 @@
         (is (= ::ee-audit/no-op (ee-audit/ensure-audit-db-installed!)))
         (t2/update! :model/Database :is_audit true {:engine "h2"})))))
 
+(def ^:private audit-table-eids
+  {"v_alerts"        "qTuDhH4a4sSqVzZ47jJ8R"
+   "v_audit_log"     "tSCO5aQmgbiUf-SLSQVpi"
+   "v_content"       "p53BD8eTrMM1neH9_4eZx"
+   "v_dashboardcard" "S3ZF9KyTHqp7zj_N8x0KI"
+   "v_databases"     "Blz8U_EUpr3TKzZ__T3Wt"
+   "v_fields"        "IuKLQLGZin2wvJeZWlOam"
+   "v_group_members" "uGm59moVbiP8uHLIII-JN"
+   "v_query_log"     "5RKjPrEoH_ojdWK2ItOJa"
+   "v_subscriptions" "MXMK0SDjKjLlXKCGt4fei"
+   "v_tables"        "YvPPmCigBjeBH5QLSXzuH"
+   "v_tasks"         "t4AxH0GHZpxw6QNUIwwHd"
+   "v_users"         "VnUplpevdFkZyG2I9brb5"
+   "v_view_log"      "-G_OzovvQZlIm6xoipIL2"})
+
+(deftest audit-db-entity-ids-test
+  (mt/test-drivers #{:postgres :h2 :mysql}
+    (testing "Audit DB content has the hard-coded `:entity_id`s"
+      (testing "when freshly loaded:"
+        (t2/delete! :model/Database :is_audit true)
+        (audit/last-analytics-checksum! 0)
+        (is (= ::ee-audit/installed (ee-audit/ensure-audit-db-installed!)))
+        ;; Fresh install now complete.
+        (is (= [audit/audit-db-id] (t2/select-fn-vec :id 'Database {:where [:= :is_audit true]}))
+            "Audit DB is installed and unique.")
+        (testing "database has hard-coded audit/audit-db-entity-id"
+          (is (= "audit__rP75CiURKZ-0pq" (t2/select-one-fn :entity_id 'Database :is_audit true))))
+        (testing "tables have entity_ids derived from the fixed database entity_id"
+          (is (= audit-table-eids
+                 (into {} (map (juxt :name :entity_id))
+                       (t2/reducible-select 'Table :db_id audit/audit-db-id)))))
+        (testing "tables have entity_ids derived from the fixed database entity_id"
+          (doseq [table (t2/select ['Table :id :entity_id :name] :db_id audit/audit-db-id)
+                  field (t2/select ['Field :entity_id :name] :table_id (:id table))]
+            (is (= (#'ee-audit/entity-id-for-field (:entity_id table) field)
+                   (:entity_id field))))))
+
+      (testing "pre-existing with no entity_ids"
+        (t2/update! :model/Database audit/audit-db-id {:entity_id nil})
+        (let [table-ids (t2/update-returning-pks! :model/Table
+                                                  {:db_id audit/audit-db-id}
+                                                  {:entity_id nil})]
+          (t2/update! :model/Field {:table_id [:in table-ids]}
+                      {:entity_id nil})
+          (is (= [nil] (t2/select-fn-vec :entity_id :model/Database :is_audit true))
+              "Audit DB is installed and unique, but its entity_id was removed")
+          (is (= #{nil} (t2/select-fn-set :entity_id :model/Table :db_id audit/audit-db-id)))
+          (is (= #{nil} (t2/select-fn-set :entity_id :model/Field :table_id [:in table-ids]))))
+
+        ;; Installing the DB is a no-op, since it's already installed.
+        (is (= ::ee-audit/no-op (ee-audit/ensure-audit-db-installed!)))
+        ;; Audit DB has not been duplicated, but all the entity_ids are back.
+        (is (= [audit/audit-db-id] (t2/select-fn-vec :id 'Database {:where [:= :is_audit true]}))
+            "Audit DB is installed and unique.")
+        (testing "database has hard-coded audit/audit-db-entity-id"
+          (is (= ["audit__rP75CiURKZ-0pq"] (t2/select-fn-vec :entity_id 'Database :is_audit true))))
+        (testing "tables have entity_ids derived from the fixed database entity_id"
+          (is (= audit-table-eids
+                 (into {} (map (juxt :name :entity_id))
+                       (t2/reducible-select 'Table :db_id audit/audit-db-id)))))
+        (testing "tables have entity_ids derived from the fixed database entity_id"
+          (doseq [table (t2/select ['Table :id :entity_id :name] :db_id audit/audit-db-id)
+                  field (t2/select ['Field :entity_id :name] :table_id (:id table))]
+            (is (= (#'ee-audit/entity-id-for-field (:entity_id table) field)
+                   (:entity_id field)))))))))
+
 (deftest instance-analytics-content-is-copied-to-mb-plugins-dir-test
   (mt/with-temp-env-var-value! [mb-plugins-dir "card_catalogue_dir"]
     (try

--- a/enterprise/backend/test/metabase_enterprise/audit_app/audit_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/audit_test.clj
@@ -111,8 +111,8 @@
           (is (= "audit__rP75CiURKZ-0pq" (t2/select-one-fn :entity_id 'Database :is_audit true))))
         (testing "tables have entity_ids derived from the fixed database entity_id"
           (is (= audit-table-eids
-                 (into {} (map (juxt :name :entity_id))
-                       (t2/reducible-select 'Table :db_id audit/audit-db-id)))))
+                 (->> (t2/reducible-select 'Table :db_id audit/audit-db-id)
+                      (into {} (map (juxt (comp u/lower-case-en :name) :entity_id)))))))
         (testing "tables have entity_ids derived from the fixed database entity_id"
           (doseq [table (t2/select ['Table :id :entity_id :name] :db_id audit/audit-db-id)
                   field (t2/select ['Field :entity_id :name] :table_id (:id table))]
@@ -124,6 +124,8 @@
         (let [table-ids (t2/update-returning-pks! :model/Table
                                                   {:db_id audit/audit-db-id}
                                                   {:entity_id nil})]
+          (is (= (count audit-table-eids)
+                 (count table-ids)))
           (t2/update! :model/Field {:table_id [:in table-ids]}
                       {:entity_id nil})
           (is (= [nil] (t2/select-fn-vec :entity_id :model/Database :is_audit true))
@@ -140,8 +142,8 @@
           (is (= ["audit__rP75CiURKZ-0pq"] (t2/select-fn-vec :entity_id 'Database :is_audit true))))
         (testing "tables have entity_ids derived from the fixed database entity_id"
           (is (= audit-table-eids
-                 (into {} (map (juxt :name :entity_id))
-                       (t2/reducible-select 'Table :db_id audit/audit-db-id)))))
+                 (->> (t2/reducible-select 'Table :db_id audit/audit-db-id)
+                      (into {} (map (juxt (comp u/lower-case-en :name) :entity_id)))))))
         (testing "tables have entity_ids derived from the fixed database entity_id"
           (doseq [table (t2/select ['Table :id :entity_id :name] :db_id audit/audit-db-id)
                   field (t2/select ['Field :entity_id :name] :table_id (:id table))]

--- a/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
@@ -24,12 +24,12 @@
 
 (defn temp-field [from-field-id table-id]
   (-> (t2/select-one :model/Field :id from-field-id)
-      (dissoc :id)
+      (dissoc :id :entity_id)
       (assoc :table_id table-id)))
 
 (defn temp-table [from-tbl-id db-id]
   (-> (t2/select-one :model/Table :id from-tbl-id)
-      (dissoc :id)
+      (dissoc :id :entity_id)
       (update :display_name #(str "Temp " %))
       (assoc :db_id db-id)))
 
@@ -121,7 +121,7 @@
 
 (defn do-with-world [f]
   (with-temp-dpc [:model/Database   {db-id :id} (into {:name temp-db-name} (-> (data/db)
-                                                                               (dissoc :id :features :name)))
+                                                                               (dissoc :id :features :name :entity_id)))
                   :model/Table      {table-id :id :as table} (temp-table (data/id :venues) db-id)
                   :model/Table      {table-id-categories :id}  (temp-table (data/id :categories) db-id)
                   :model/Table      {table-id-users :id}       (temp-table (data/id :users) db-id)

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
@@ -29,6 +29,11 @@
         (is (= (set known-models)
                (set (map name (v2.entity-ids/toucan-models)))))))))
 
+(def ^:private dual-entity-id-exceptions
+  "Databases, Tables and Fields have a custom [[serdes/entity-id]] based on their names, but also have randomized
+  `entity_id` columns used by column metadata."
+  #{"Database" "Table" "Field"})
+
 (deftest ^:parallel every-model-is-supported-test-2
   (testing "Serialization support\n"
     (let [should-have-entity-id (set (concat serdes.models/data-model serdes.models/content))
@@ -43,9 +48,12 @@
           ;; we're not checking inline-models for anything here, since some of them have (and use) entity_id, like
           ;; dashcards, and some (ParameterCard) do not
           (when (contains? should-have-entity-id (name model))
-            (testing (str "Model should either have entity_id or a hash key: " (name model))
-              ;; `not=` is effectively `xor`
-              (is (not= custom-entity-id? random-entity-id?))))
+            (if (contains? dual-entity-id-exceptions (name model))
+              (testing (str "Certain models have *both* entity_id and hash key: " (name model))
+                (is (= true custom-entity-id? random-entity-id?)))
+              (testing (str "Model should either have entity_id or a hash key: " (name model))
+                ;; `not=` is effectively `xor`
+                (is (not= custom-entity-id? random-entity-id?)))))
           (when (contains? excluded (name model))
             (testing (str "Model shouldn't have entity_id defined: " (name model))
               (is (not custom-entity-id?))

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -866,7 +866,7 @@
         (try
           (let [synced-tables (t2/select :model/Table :db_id (mt/id))]
             (is (= 2 (count synced-tables)))
-            (t2/insert! :model/Table (map #(dissoc % :id :schema) synced-tables))
+            (t2/insert! :model/Table (map #(dissoc % :id :entity_id :schema) synced-tables))
             (sync/sync-database! (mt/db) {:scan :schema})
             (let [synced-tables (t2/select :model/Table :db_id (mt/id))]
               (is (partial= {true [{:name "messages"} {:name "users"}]

--- a/resources/instance_analytics/databases/Internal Metabase Database/Internal Metabase Database.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/Internal Metabase Database.yaml
@@ -7,3 +7,4 @@ serdes/meta:
   id: Internal Metabase Database
 initial_sync_status: complete
 is_audit: true
+entity_id: audit__rP75CiURKZ-0pq

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/alert_condition.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/alert_condition.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: BedPL8TCqvbUDtZbxWqNW

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/archived.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/archived.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: tnUqQqqEyWZbddo_oXKZh

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/card_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/card_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: pV0rAaGxBYl5lz67uF3ZY

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/card_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/card_qualified_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: xZoAsgUDy84UNk8-veVzB

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/created_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/created_at.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: UqdnqKH0HfnH8D9rzL7nI

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/creator_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/creator_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 2jeaFHB78kvOKZBMuqQQs

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/dashboard_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/dashboard_qualified_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 66uyvgzehUqpqYgZxftnc

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/entity_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/entity_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: JDJ5ebbKjA46VPnk6M_im

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/entity_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/entity_qualified_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 99Hj407aZtjB6fqjeAAHn

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/recipient_external.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/recipient_external.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: Yi9lwiEuDQJgKV6h1e5At

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/recipient_type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/recipient_type.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: yk_NuUjWpI6WkTkfk9M65

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/recipients.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/recipients.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: Cg1LX_7c8lhqhrzDEXQke

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/schedule_day.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/schedule_day.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 5os71MXtQUpQuDbdv5nlF

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/schedule_hour.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/schedule_hour.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: AR0cOHtDOwWBzfrmr4MDl

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/schedule_type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/schedule_type.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 0HEa0hittNoeYZcYLAcdn

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/updated_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/fields/updated_at.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: CgxYoxKKROMRW1HzwsEn1

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/v_alerts.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_alerts/v_alerts.yaml
@@ -21,3 +21,4 @@ serdes/meta:
 - id: v_alerts
   model: Table
 database_require_filter: null
+entity_id: qTuDhH4a4sSqVzZ47jJ8R

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/details.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/details.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: AQquzyiFkokkAJRvgBPih

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/end_timestamp.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/end_timestamp.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: vnUrRe2V4XFovrLygQy9c

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/entity_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/entity_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 4u04WG2-QJhf5NfLx6HKK

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/entity_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/entity_qualified_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: wq2mI_Iq-vCnHrCy4wWlz

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/entity_type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/entity_type.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: zlFPrntTppDFDH-TGxOX1

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: Qg33zoa2moVu8iaw_iD93

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/model.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/model.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: K0t8tB6hMDKVnlTfNMeHy

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/model_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/model_id.yaml
@@ -43,3 +43,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: KlnCdn9XWOX7wPqVZkfz1

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/timestamp.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/timestamp.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: gYXWfNhzbvE67Q-8l-WfL

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/topic.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/topic.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: cC4ZCtSObiEmPnlhFQz5L

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/user_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/fields/user_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: hw4zEJYZLEC7GCDOW9Ph1

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/v_audit_log.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_audit_log/v_audit_log.yaml
@@ -21,3 +21,4 @@ serdes/meta:
 - id: v_audit_log
   model: Table
 database_require_filter: null
+entity_id: tSCO5aQmgbiUf-SLSQVpi

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/action_model_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/action_model_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 0NhsHwA4bPlVptdN83-ws

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/action_type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/action_type.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: FRR3th-v_uiZavgR3HwZO

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/archived.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/archived.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: YOgMbUEyjpumObRloALsW

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/collection_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/collection_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: jFUh1SwDDhOwEMSqIi21x

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/collection_is_official.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/collection_is_official.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: HmPQe2rt0s7zz8DV8w8-t

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/collection_is_personal.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/collection_is_personal.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: qkacMLnJKycPTZvC5JOds

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/created_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/created_at.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: GZ063eHDIRwUK6-T5lWw-

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/creator_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/creator_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: ZxmEGrIzoCZXBw-EHiI3s

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/description.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/description.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: yYIeXOLzBOrXHLzWUKe-Z

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/entity_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/entity_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: SmdvrVnBYqSLboSNlbLLv

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/entity_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/entity_qualified_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: HN3BVl_a2DA5BI8kPKOV2

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/entity_type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/entity_type.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: f5_TqpbuzrnC-uEGRX3nA

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/event_timestamp.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/event_timestamp.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: qcgrblt4R9oi3sDXAeNIH

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: JD6OmL1rCaK59fU_opJQv

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/is_embedding_enabled.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/is_embedding_enabled.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: JlAwpCbpYjmNvQL9WPP52

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/made_public_by_user.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/made_public_by_user.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: Oxq6k_16JSL7syLJZknnr

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/name.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/name.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: bL2Rh1SGUiKbaZtokAOo7

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/question_database_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/question_database_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: CFnbXRBSEzx8_UyEd5BdC

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/question_is_native.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/question_is_native.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: M_7bluHZpmNnrXcw6jpBj

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/question_viz_type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/question_viz_type.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: uHFWboNvQO_hCqMXjeECt

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/updated_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/fields/updated_at.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: JsqEAXrf8jEl0VwkzIgum

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/v_content.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_content/v_content.yaml
@@ -21,3 +21,4 @@ serdes/meta:
 - id: v_content
   model: Table
 database_require_filter: null
+entity_id: p53BD8eTrMM1neH9_4eZx

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/card_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/card_qualified_id.yaml
@@ -43,3 +43,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: xtmIGdoIN_J34j3LCa1Lq

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/col.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/col.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: JFt-lb6owNaX_0zr9WWSi

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/created_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/created_at.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: MLZ6E44kxdYVW5wqNSpr7

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/dashboard_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/dashboard_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: Y36vPZAg-XXe2t-U3mEV2

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/dashboard_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/dashboard_qualified_id.yaml
@@ -43,3 +43,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 50mvl0crGV2YQIgfsdiWu

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/dashboardtab_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/dashboardtab_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: flLOYnPbjGXcjtV03JhX3

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/entity_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/entity_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: qaaohrBKavu8pDoZ5nzFf

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/entity_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/entity_qualified_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: BFZIzZDD4l6Bih0uLKmzl

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: lBBw7t427Jo24hA7Ax383

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/parameter_mappings.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/parameter_mappings.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: WW6RFmOppg2F1mOthHW3q

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/question_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/question_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: D2iJN8Hk5KSRsNJlFk4KM

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/row.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/row.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: WZxJ92ob_0uRdi-pP3sqn

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/size_x.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/size_x.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: -jsELTBWUYTBRpUkGVjoI

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/size_y.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/size_y.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: VajVlnNSJZLS0QE8vte7B

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/updated_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/updated_at.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: sC-DKCtn3RU7YQo5G3qKZ

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/visualization_settings.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/fields/visualization_settings.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: _jcth5BrKnhKqFZlcYbOa

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/v_dashboardcard.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_dashboardcard/v_dashboardcard.yaml
@@ -21,3 +21,4 @@ serdes/meta:
 - id: v_dashboardcard
   model: Table
 database_require_filter: null
+entity_id: S3ZF9KyTHqp7zj_N8x0KI

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/auto_run_queries.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/auto_run_queries.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: TY2INNIs58Xq74YFtxlQo

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/cache_field_values_schedule.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/cache_field_values_schedule.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: tXgihfYDy6_4nrSXQtv44

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/cache_ttl.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/cache_ttl.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: wQAwMQ8aWLUQB_xWEncmK

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/created_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/created_at.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: _5_1n1KeC2T1DBfQVMovL

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/creator_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/creator_id.yaml
@@ -43,3 +43,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: j_SkRcXOGFPgmMjaj1nCa

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/database_type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/database_type.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: NHVrSOvK78oxmOS9HjVKM

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/db_version.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/db_version.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: hEmtVh_AOWnHyFC22TJ2h

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/description.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/description.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: LVNnTBZ2I9jhwXPhp9eys

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/entity_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/entity_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: zdR38UaZYQR2fak5MvB3h

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/entity_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/entity_qualified_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: qjifLTteJPqp4CWKODJSo

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/is_on_demand.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/is_on_demand.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: oQRptvSst4-71rkCFDduj

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/metadata_sync_schedule.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/metadata_sync_schedule.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: vPps-CFrZvLzr5MbKnnAN

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/name.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/name.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: taMjwsZEtPiqdMV0-F1ww

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/timezone.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/timezone.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: ia-AXcINoMkgmzXoD8kLF

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/updated_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/fields/updated_at.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 5k8mldUmzt4Y2geCRILvp

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/v_databases.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_databases/v_databases.yaml
@@ -21,3 +21,4 @@ serdes/meta:
 - id: v_databases
   model: Table
 database_require_filter: null
+entity_id: Blz8U_EUpr3TKzZ__T3Wt

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/active.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/active.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: Avj5f1GOaDdu6H2etgScX

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/base_type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/base_type.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: mfzmZVFmhl4OUtsE9lLWP

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/created_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/created_at.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: tPAH1Bucu9DcTQj_rWI4l

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/description.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/description.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 1VB53VLOdYp9_461rg8pU

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/display_name.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/display_name.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: eoL8blC8u1weX2TWDcwBU

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/entity_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/entity_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 9rusgP-VrJo2MlaVp3T75

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/entity_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/entity_qualified_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: krAy_jV_jkc_fzF5zhnwv

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/fk_target_field_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/fk_target_field_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: kXZr3RggQkZwD7Ufwttge

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/has_field_values.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/has_field_values.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 68cbVsYrgFw0fezD0PTyz

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/name.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/name.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: PYFPoHM_3lSzVpPuj4c9u

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/table_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/table_id.yaml
@@ -43,3 +43,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: hs9ZnYDHpJMBvb3K0wYWF

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/updated_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/updated_at.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: YeqS89mCdWClYE1sqHPv9

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/visibility_type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/fields/visibility_type.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: zo9QNMeAQgs0Uv4kr6BkL

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/v_fields.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_fields/v_fields.yaml
@@ -21,3 +21,4 @@ serdes/meta:
 - id: v_fields
   model: Table
 database_require_filter: null
+entity_id: IuKLQLGZin2wvJeZWlOam

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_group_members/fields/group_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_group_members/fields/group_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: PmPFkn_DwiMjknNdLS8Ih

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_group_members/fields/group_name.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_group_members/fields/group_name.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 7frSatWYEs4CVkzSjb0tA

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_group_members/fields/user_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_group_members/fields/user_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: TBqW-L4WKyVy_pPzPeu_Z

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_group_members/v_group_members.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_group_members/v_group_members.yaml
@@ -21,3 +21,4 @@ serdes/meta:
 - id: v_group_members
   model: Table
 database_require_filter: null
+entity_id: uGm59moVbiP8uHLIII-JN

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/action_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/action_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: S68_rKXVZonlLuUMT7xmA

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/action_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/action_qualified_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: S36pc-OaIy_iAZdE3xH04

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/cache_hit.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/cache_hit.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: w5D5X2PzFwF_pc4vbR1iF

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/card_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/card_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: sBoGmM1G2AlbzN7uAJQ5G

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/card_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/card_qualified_id.yaml
@@ -43,3 +43,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 4BSRkYg9dYOXm8kBZ9Y0D

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/dashboard_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/dashboard_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: n_kLu2UN4mqnbORyPkJ2I

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/dashboard_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/dashboard_qualified_id.yaml
@@ -43,3 +43,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: ezMrjOJz714FacNav7zMJ

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/database_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/database_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: BhejLsvYD0iV-NTYOPDnd

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/database_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/database_qualified_id.yaml
@@ -43,3 +43,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 54Bf7ol8KJLuTV98Y_xGV

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/entity_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/entity_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: ub0K4DkdnTHP1R9bG9S4S

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/error.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/error.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: SC7WveyifHhUs3aqa6ngi

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/is_native.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/is_native.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: dOqpoU2AX8Ux2D9kDLiiU

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/pulse_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/pulse_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: p1TSm_sW9iyi8iymwvJdf

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/query.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/query.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: j9Yt5kdbzEtZj7EcBQNSm

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/query_source.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/query_source.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: wfSuAJ0rpx3wo4D3DCnfQ

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/result_rows.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/result_rows.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: Mc2dp6A5dc_kGmwYen8KZ

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/running_time_seconds.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/running_time_seconds.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: M56ScO0oEkjCA23Zvfmke

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/started_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/started_at.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: cvFWFdQRLaciIk8IsBQWn

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/user_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/fields/user_id.yaml
@@ -43,3 +43,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: mAq-NOPoEyyqKJmlP6R52

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/v_query_log.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_query_log/v_query_log.yaml
@@ -21,3 +21,4 @@ serdes/meta:
 - id: v_query_log
   model: Table
 database_require_filter: null
+entity_id: 5RKjPrEoH_ojdWK2ItOJa

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/archived.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/archived.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: r0CFTm1QhwFFYryh4Kz58

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/created_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/created_at.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: Hl-cwGU9UEai-P9DwL0Bc

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/creator_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/creator_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: cfeoDB_Qfm_mjce5Qx3mg

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/dashboard_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/dashboard_qualified_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: qngnGT9Ac8Ta-Zug4U3CQ

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/entity_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/entity_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: PUW0w9XPLBxoH44h_yJRB

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/entity_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/entity_qualified_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: mXWdE7k6g8kmRM8W8Fl1F

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/parameters.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/parameters.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: uwySw3HodSiogj6rhhrmB

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/recipient_external.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/recipient_external.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 3I04H_sH3Pyz6NPUpRsw8

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/recipient_type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/recipient_type.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: YkncE8aQPLdIGmVnSzRGz

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/recipients.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/recipients.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: dKvYa7XvRnfDVtj6aYvtN

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/schedule_day.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/schedule_day.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: EJDZ_mlJiYACLpB4CR412

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/schedule_hour.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/schedule_hour.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 5AWXwTpLApL5YJ7pMvRxr

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/schedule_type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/schedule_type.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 0GgGHquCuw_GWXGBFud4F

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/updated_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/fields/updated_at.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: fUjiV87skd2Df_7ykBAdJ

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/v_subscriptions.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_subscriptions/v_subscriptions.yaml
@@ -21,3 +21,4 @@ serdes/meta:
 - id: v_subscriptions
   model: Table
 database_require_filter: null
+entity_id: MXMK0SDjKjLlXKCGt4fei

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/active.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/active.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: NAsbtn0hU0GttfTOgUQw_

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/created_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/created_at.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: FrcXC57yP1jozLfwwLRDM

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/database_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/database_id.yaml
@@ -43,3 +43,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 9UvHB-pOc9YMq9wNdDOJw

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/description.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/description.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 0MlDo7OREJ0g2cKOVSmMM

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/display_name.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/display_name.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: y7Lbhr2tJD70YRex4e8ZQ

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/entity_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/entity_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: ovcW5yFVd6FAbyyIUbPJ3

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/entity_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/entity_qualified_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: zekAeSj-wq4Ds4ykVmF4V

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/is_upload.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/is_upload.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: oyslYgVmH351Z8-JbX91Z

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/name.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/name.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: rZZ0eDAUW4eNjp3RyHtVd

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/schema.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/schema.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: e1sFQSbcIg3irdEfvAuW6

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/updated_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/fields/updated_at.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: A134DFlJRJTZndclCdGd7

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/v_tables.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tables/v_tables.yaml
@@ -21,3 +21,4 @@ serdes/meta:
 - id: v_tables
   model: Table
 database_require_filter: null
+entity_id: YvPPmCigBjeBH5QLSXzuH

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/database_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/database_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: zrVCxUoLqP6ondz_vytIQ

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/database_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/database_qualified_id.yaml
@@ -43,3 +43,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: GiS4njKAxvFNjsBVHEF0h

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/details.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/details.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 7LrnqkQIr9cbQNxtGtwg6

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/duration_seconds.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/duration_seconds.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: Pw0TpOikkoqtvMvYqX4Gv

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/ended_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/ended_at.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: LovOuxfAwZp7G7VtV0rLp

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: qkSO0jYVSfsW0mE2JQRP-

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/started_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/started_at.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: Q28GjRphKmWyDQZ7vch_l

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/task.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/fields/task.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: E3HQyRSHOmIY_Hj-J3ysx

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/v_tasks.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_tasks/v_tasks.yaml
@@ -21,3 +21,4 @@ serdes/meta:
 - id: v_tasks
   model: Table
 database_require_filter: null
+entity_id: t4AxH0GHZpxw6QNUIwwHd

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/date_joined.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/date_joined.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: DGh3k7vmCw15VD5-pQtPx

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/email.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/email.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: oc3ouj8vkP6NCN5SYYLEX

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/entity_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/entity_qualified_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: nB00JHTIzcjsTas2Ncheu

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/first_name.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/first_name.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: aw3ki3H05YzD1MhRgSWCw

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/full_name.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/full_name.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: nOdyllT0-IcZK-IDaPbi4

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/is_active.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/is_active.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: Z5CnXh1_XyG6IhycmjNGj

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/is_admin.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/is_admin.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: duUrx_m1Tv76eOXiDr4Kr

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/last_login.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/last_login.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: dQWtUb6_wBFwziRdcYrAW

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/last_name.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/last_name.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: FLxqUSHMawI9J2bOC2w6t

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/locale.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/locale.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: Oi4A6YeO_-PfplLcJzGhq

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/sso_source.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/sso_source.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: kqBtt1GTYpB43_pXBPxue

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/type.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: rsIOX9T2bL_sh6ntSsoxS

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/updated_at.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/updated_at.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: ss3FfaX2kPGoeON_7jwCp

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/user_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/fields/user_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: jy7F-WTOwykLcC5c-L9dd

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/v_users.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_users/v_users.yaml
@@ -21,3 +21,4 @@ serdes/meta:
 - id: v_users
   model: Table
 database_require_filter: null
+entity_id: VnUplpevdFkZyG2I9brb5

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/details.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/details.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: jgaVbTwmldm-qqkvzQAh4

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/entity_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/entity_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: eV363UM1ZHSS6PaRefgZZ

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/entity_qualified_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/entity_qualified_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: N7qT14PEJ0e1rjjEEm3TF

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/entity_type.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/entity_type.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: SShvirdf0Pbfng3-2q5Tz

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: rTqMkr_LqI6qctQ69_dzl

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/timestamp.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/timestamp.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: H07rG7wgZ6ocycUgH93C3

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/user_id.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/fields/user_id.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: Kne9gRihTBUqPV1N7Ky1l

--- a/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/v_view_log.yaml
+++ b/resources/instance_analytics/databases/Internal Metabase Database/schemas/public/tables/v_view_log/v_view_log.yaml
@@ -21,3 +21,4 @@ serdes/meta:
 - id: v_view_log
   model: Table
 database_require_filter: null
+entity_id: -G_OzovvQZlIm6xoipIL2

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10509,6 +10509,72 @@ databaseChangeLog:
                   type: ${timestamp_type}
                   remarks: The timestamp at which a user was deactivated
 
+  - changeSet:
+      id: v54.2025-01-30T16:10:55
+      author: bshepherdson
+      comment: Add `entity_id` column to the `metabase_database` table
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: metabase_database
+                columnName: entity_id
+      changes:
+        - addColumn:
+            tableName: metabase_database
+            columns:
+              - column:
+                  remarks: Random NanoID tag for unique identity.
+                  name: entity_id
+                  type: char(21)
+                  constraints:
+                    nullable: true
+                    unique: true
+
+  - changeSet:
+      id: v54.2025-01-30T16:13:20
+      author: bshepherdson
+      comment: Add `entity_id` column to the `metabase_table` table
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: metabase_table
+                columnName: entity_id
+      changes:
+        - addColumn:
+            tableName: metabase_table
+            columns:
+              - column:
+                  remarks: Random NanoID tag for unique identity.
+                  name: entity_id
+                  type: char(21)
+                  constraints:
+                    nullable: true
+                    unique: true
+
+  - changeSet:
+      id: v54.2025-01-30T16:14:02
+      author: bshepherdson
+      comment: Add `entity_id` column to the `metabase_field` table
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: metabase_field
+                columnName: entity_id
+      changes:
+        - addColumn:
+            tableName: metabase_field
+            columns:
+              - column:
+                  remarks: Random NanoID tag for unique identity.
+                  name: entity_id
+                  type: char(21)
+                  constraints:
+                    nullable: true
+                    unique: true
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/api/embed/common.clj
+++ b/src/metabase/api/embed/common.clj
@@ -298,6 +298,7 @@
    :dashboard         :model/Dashboard
    :dashboard-card    :model/DashboardCard
    :dashboard-tab     :model/DashboardTab
+   :database          :model/Database
    :dataset           :model/Card
    :dimension         :model/Dimension
    :metric            :model/Card
@@ -307,6 +308,7 @@
    :pulse-channel     :model/PulseChannel
    :segment           :model/Segment
    :snippet           :model/NativeQuerySnippet
+   :table             :model/Table
    :timeline          :model/Timeline
    :user              :model/User})
 

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -243,7 +243,8 @@
   (when (contains? collection :location)
     (when-not (valid-location-path? location)
       (let [msg (tru "Invalid Collection location: path is invalid.")]
-        (throw (ex-info msg {:status-code 400, :errors {:location msg}}))))
+        (throw (ex-info msg {:status-code 400, :errors {:location msg}
+                             :collection collection}))))
     ;; if this is a Personal Collection it's only allowed to go in the Root Collection: you can't put it anywhere else!
     (when (:personal_owner_id collection)
       (when-not (= location "/")

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -58,7 +58,8 @@
 
 (doto :model/Database
   (derive :metabase/model)
-  (derive :hook/timestamped?))
+  (derive :hook/timestamped?)
+  (derive :hook/entity-id))
 
 (methodical/defmethod t2.with-temp/do-with-temp* :before :model/Database
   [_model _explicit-attributes f]
@@ -407,13 +408,12 @@
    json-generator))
 
 ;;; ------------------------------------------------ Serialization ----------------------------------------------------
-
 (defmethod serdes/make-spec "Database"
   [_model-name {:keys [include-database-secrets]}]
   {:copy      [:auto_run_queries :cache_field_values_schedule :caveats :dbms_version
-               :description :engine :is_audit :is_attached_dwh :is_full_sync :is_on_demand :is_sample :metadata_sync_schedule :name
-               :points_of_interest :refingerprint :settings :timezone :uploads_enabled :uploads_schema_name
-               :uploads_table_prefix]
+               :description :engine :entity_id :is_audit :is_attached_dwh :is_full_sync :is_on_demand :is_sample
+               :metadata_sync_schedule :name :points_of_interest :refingerprint :settings :timezone :uploads_enabled
+               :uploads_schema_name :uploads_table_prefix]
    :skip      [;; deprecated field
                :cache_ttl]
    :transform {:created_at          (serdes/date)

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -116,7 +116,8 @@
 
 (doto :model/Field
   (derive :metabase/model)
-  (derive :hook/timestamped?))
+  (derive :hook/timestamped?)
+  (derive :hook/entity-id))
 
 (t2/define-after-select :model/Field
   [field]
@@ -381,8 +382,8 @@
 (defmethod serdes/make-spec "Field" [_model-name opts]
   {:copy      [:active :base_type :caveats :coercion_strategy :custom_position :database_indexed
                :database_is_auto_increment :database_partitioned :database_position :database_required :database_type
-               :description :display_name :effective_type :has_field_values :is_defective_duplicate :json_unfolding
-               :name :nfc_path :points_of_interest :position :preview_display :semantic_type :settings
+               :description :display_name :effective_type :entity_id :has_field_values :is_defective_duplicate
+               :json_unfolding :name :nfc_path :points_of_interest :position :preview_display :semantic_type :settings
                :unique_field_helper :visibility_type]
    :skip      [:fingerprint :fingerprint_version :last_analyzed]
    :transform {:created_at         (serdes/date)

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -168,7 +168,9 @@
 
 (defn raw-hash
   "Hashes a Clojure value into an 8-character hex string, which is used as the identity hash.
-  Don't call this outside a test, use [[identity-hash]] instead."
+
+  Don't call this outside a test, use [[identity-hash]] instead. Exception: [[metabase-enterprise.audit-app.audit]]
+  uses this because it needs reproducible `:entity_id`s that differ from the usual [[hash-fields]] ones."
   [target]
   (when (sequential? target)
     (assert (seq target) "target cannot be an empty sequence"))

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -39,7 +39,8 @@
   (derive :metabase/model)
   (derive ::mi/read-policy.full-perms-for-perms-set)
   (derive ::mi/write-policy.full-perms-for-perms-set)
-  (derive :hook/timestamped?))
+  (derive :hook/timestamped?)
+  (derive :hook/entity-id))
 
 (t2/deftransforms :model/Table
   {:entity_type     mi/transform-keyword
@@ -278,7 +279,7 @@
 (defmethod serdes/make-spec "Table" [_model-name _opts]
   {:copy      [:name :description :entity_type :active :display_name :visibility_type :schema
                :points_of_interest :caveats :show_in_getting_started :field_order :initial_sync_status :is_upload
-               :database_require_filter]
+               :database_require_filter :entity_id]
    :skip      [:estimated_row_count :view_count]
    :transform {:created_at (serdes/date)
                :db_id      (serdes/fk :model/Database :name)}})

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -79,7 +79,7 @@
   ([{driver :engine, :as db}]
    (merge
     (mt/object-defaults :model/Database)
-    (select-keys db [:created_at :id :details :updated_at :timezone :name :dbms_version
+    (select-keys db [:created_at :id :entity_id :details :updated_at :timezone :name :dbms_version
                      :metadata_sync_schedule :cache_field_values_schedule :uploads_enabled])
     {:engine               (u/qualified-name (:engine db))
      :settings             {}
@@ -88,7 +88,7 @@
 
 (defn- table-details [table]
   (-> (merge (mt/obj->json->obj (mt/object-defaults :model/Table))
-             (select-keys table [:active :created_at :db_id :description :display_name :entity_type
+             (select-keys table [:active :created_at :db_id :description :display_name :entity_id :entity_type
                                  :id :name :rows :schema :updated_at :visibility_type :initial_sync_status]))
       (update :entity_type #(when % (str "entity/" (name %))))
       (update :visibility_type #(when % (name %)))
@@ -106,7 +106,8 @@
     {:target nil}
     (select-keys
      field
-     [:updated_at :id :created_at :last_analyzed :fingerprint :fingerprint_version :fk_target_field_id :position]))))
+     [:updated_at :id :entity_id :created_at :last_analyzed :fingerprint :fingerprint_version :fk_target_field_id
+      :position]))))
 
 (defn- card-with-native-query [card-name & {:as kvs}]
   (merge
@@ -632,7 +633,7 @@
                    :features      (map u/qualified-name (driver.u/features :h2 (mt/db)))
                    :tables        [(merge
                                     (mt/obj->json->obj (mt/object-defaults :model/Table))
-                                    (t2/select-one [:model/Table :created_at :updated_at] :id (mt/id :categories))
+                                    (t2/select-one [:model/Table :created_at :updated_at :entity_id] :id (mt/id :categories))
                                     {:schema              "PUBLIC"
                                      :name                "CATEGORIES"
                                      :display_name        "Categories"

--- a/test/metabase/api/field_test.clj
+++ b/test/metabase/api/field_test.clj
@@ -29,19 +29,22 @@
     :features      (mapv u/qualified-name (driver.u/features :h2 (mt/db)))
     :timezone      "UTC"
     :settings      {}}
-   (select-keys (mt/db) [:id :timezone :initial_sync_status :cache_field_values_schedule :metadata_sync_schedule])))
+   (select-keys (mt/db) [:id :entity_id :timezone :initial_sync_status :cache_field_values_schedule
+                         :metadata_sync_schedule])))
 
 (deftest ^:parallel get-field-test
   (testing "GET /api/field/:id"
     (is (= (-> (merge
                 (mt/object-defaults :model/Field)
                 (t2/select-one [:model/Field :created_at :updated_at :last_analyzed :fingerprint :fingerprint_version
-                                :database_position :database_required :database_is_auto_increment]
+                                :database_position :database_required :database_is_auto_increment :entity_id]
                                :id (mt/id :users :name))
                 {:table_id         (mt/id :users)
                  :table            (merge
                                     (mt/obj->json->obj (mt/object-defaults :model/Table))
-                                    (t2/select-one [:model/Table :created_at :updated_at :initial_sync_status :view_count] :id (mt/id :users))
+                                    (t2/select-one [:model/Table :created_at :updated_at :entity_id
+                                                    :initial_sync_status :view_count]
+                                                   :id (mt/id :users))
                                     {:description             nil
                                      :entity_type             "entity/UserTable"
                                      :visibility_type         nil

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -33,7 +33,7 @@
 
 (defn- db-details []
   (merge
-   (select-keys (mt/db) [:id :created_at :updated_at :timezone :creator_id :initial_sync_status :dbms_version
+   (select-keys (mt/db) [:id :entity_id :created_at :updated_at :timezone :creator_id :initial_sync_status :dbms_version
                          :cache_field_values_schedule :metadata_sync_schedule :uploads_enabled :uploads_schema_name
                          :uploads_table_prefix])
    {:engine                      "h2"
@@ -80,7 +80,7 @@
    (select-keys
     field
     [:created_at :fingerprint :fingerprint_version :fk_target_field_id :id :last_analyzed :updated_at
-     :database_required :database_is_auto_increment])))
+     :database_required :database_is_auto_increment :entity_id])))
 
 (defn- fk-field-details [field]
   (-> (field-details field)
@@ -155,7 +155,8 @@
   (testing "GET /api/table/:id"
     (is (= (merge
             (dissoc (table-defaults) :segments :field_values :metrics)
-            (t2/hydrate (t2/select-one [:model/Table :id :created_at :updated_at :initial_sync_status :view_count]
+            (t2/hydrate (t2/select-one [:model/Table :id :entity_id :created_at :updated_at :initial_sync_status
+                                        :view_count]
                                        :id (mt/id :venues))
                         :pk_field)
             {:schema       "PUBLIC"
@@ -175,7 +176,8 @@
                                                         :schema       nil}]
         (is (= (merge
                 (dissoc (table-defaults) :segments :field_values :metrics :db)
-                (t2/hydrate (t2/select-one [:model/Table :id :created_at :updated_at :initial_sync_status :view_count]
+                (t2/hydrate (t2/select-one [:model/Table :id :entity_id :created_at :updated_at :initial_sync_status
+                                            :view_count]
                                            :id table-id)
                             :pk_field)
                 {:schema       ""
@@ -216,7 +218,8 @@
     (testing "Sensitive fields are included"
       (is (= (merge
               (query-metadata-defaults)
-              (t2/select-one [:model/Table :created_at :updated_at :initial_sync_status :view_count] :id (mt/id :users))
+              (t2/select-one [:model/Table :created_at :updated_at :entity_id :initial_sync_status :view_count]
+                             :id (mt/id :users))
               {:schema       "PUBLIC"
                :name         "USERS"
                :display_name "Users"
@@ -299,7 +302,8 @@
     (testing "Sensitive fields should not be included"
       (is (= (merge
               (query-metadata-defaults)
-              (t2/select-one [:model/Table :created_at :updated_at :initial_sync_status :view_count] :id (mt/id :users))
+              (t2/select-one [:model/Table :created_at :updated_at :entity_id :initial_sync_status :view_count]
+                             :id (mt/id :users))
               {:schema       "PUBLIC"
                :name         "USERS"
                :display_name "Users"
@@ -390,7 +394,7 @@
               (-> (table-defaults)
                   (dissoc :segments :field_values :metrics :updated_at)
                   (update :db merge (select-keys (mt/db) [:details])))
-              (t2/hydrate (t2/select-one [:model/Table :id :schema :name :created_at :initial_sync_status] :id (u/the-id table)) :pk_field)
+              (t2/hydrate (t2/select-one [:model/Table :id :entity_id :schema :name :created_at :initial_sync_status] :id (u/the-id table)) :pk_field)
               {:description     "What a nice table!"
                :entity_type     nil
                :schema          ""
@@ -431,7 +435,7 @@
     (testing "Table should get synced when it gets unhidden"
       (mt/with-temp [:model/Database db    {:details (:details (mt/db))}
                      :model/Table    table (-> (t2/select-one :model/Table (mt/id :venues))
-                                               (dissoc :id)
+                                               (dissoc :id :entity_id)
                                                (assoc :db_id (:id db)))]
         (let [called (atom 0)
               ;; original is private so a var will pick up the redef'd. need contents of var before
@@ -519,7 +523,7 @@
                                             :table         (merge
                                                             (dissoc (table-defaults) :segments :field_values :metrics)
                                                             (t2/select-one [:model/Table
-                                                                            :id :created_at :updated_at
+                                                                            :id :entity_id :created_at :updated_at
                                                                             :initial_sync_status :view_count]
                                                                            :id (mt/id :checkins))
                                                             {:schema       "PUBLIC"
@@ -539,7 +543,7 @@
                                             :table            (merge
                                                                (dissoc (table-defaults) :db :segments :field_values :metrics)
                                                                (t2/select-one [:model/Table
-                                                                               :id :created_at :updated_at
+                                                                               :id :entity_id :created_at :updated_at
                                                                                :initial_sync_status :view_count]
                                                                               :id (mt/id :users))
                                                                {:schema       "PUBLIC"
@@ -555,7 +559,7 @@
   (testing "GET /api/table/:id/query_metadata"
     (is (= (merge
             (query-metadata-defaults)
-            (t2/select-one [:model/Table :created_at :updated_at :initial_sync_status] :id (mt/id :categories))
+            (t2/select-one [:model/Table :created_at :updated_at :initial_sync_status :entity_id] :id (mt/id :categories))
             {:schema       "PUBLIC"
              :name         "CATEGORIES"
              :display_name "Categories"

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -1065,7 +1065,9 @@
           ;; we're testing here, so let's override it to be a no-op. Other tests add DBs using the table name instead of
           ;; model name, so they don't hit the post-insert hook, but here we're relying on the transformations being
           ;; applied so we can't do that.
-          (with-redefs [database/set-new-database-permissions! (constantly nil)]
+          (with-redefs [database/set-new-database-permissions! (constantly nil)
+                        ;; The entity_id column doesn't exist on Databases until 54, but it will be set automatically.
+                        mi/add-entity-id                       identity]
             (impl/test-migrations ["v48.00-001" "v48.00-002"] [migrate!]
               (let [default-db                {:name       "DB"
                                                :engine     "postgres"

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -32,6 +32,7 @@
    [metabase.db.query :as mdb.query]
    [metabase.db.schema-migrations-test.impl :as impl]
    [metabase.models.collection :as collection]
+   [metabase.models.interface :as mi]
    [metabase.permissions.models.permissions :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.search.ingestion :as search.ingestion]
@@ -314,57 +315,58 @@
 (deftest ^:mb/old-migrations-test migrate-field-database-type-test
   (testing "Migration v47.00-001: set base-type to type/JSON for JSON database-types for postgres and mysql"
     (impl/test-migrations ["v47.00-001"] [migrate!]
-      (let [[pg-db-id
-             mysql-db-id] (t2/insert-returning-pks! (t2/table-name :model/Database)
-                                                    [{:name "PG Database"
-                                                      :engine "postgres"
-                                                      :created_at :%now
-                                                      :updated_at :%now
-                                                      :details "{}"}
-                                                     {:name "MySQL Database"
-                                                      :engine "mysql"
-                                                      :created_at :%now
-                                                      :updated_at :%now
-                                                      :details "{}"}])
-            [pg-table-id
-             mysql-table-id] (t2/insert-returning-pks! (t2/table-name :model/Table)
-                                                       [{:db_id pg-db-id
-                                                         :name "PG Table"
-                                                         :created_at :%now
-                                                         :updated_at :%now
-                                                         :active true}
-                                                        {:db_id mysql-db-id
-                                                         :name "MySQL Table"
-                                                         :created_at :%now
-                                                         :updated_at :%now
-                                                         :active true}])
-            [pg-field-1-id
-             pg-field-2-id
-             pg-field-3-id
-             mysql-field-1-id
-             mysql-field-2-id] (t2/insert-returning-pks! :model/Field [{:name "PG Field 1"    :table_id pg-table-id    :database_type "json"    :base_type :type/Structured}
-                                                                       {:name "PG Field 2"    :table_id pg-table-id    :database_type "JSONB"   :base_type :type/Structured}
-                                                                       {:name "PG Field 3"    :table_id pg-table-id    :database_type "varchar" :base_type :type/Text}
-                                                                       {:name "MySQL Field 1" :table_id mysql-table-id :database_type "json"    :base_type :type/SerializedJSON}
-                                                                       {:name "MySQL Field 2" :table_id mysql-table-id :database_type "varchar" :base_type :type/Text}])
-            _ (migrate!)
-            new-base-types (t2/select-pk->fn :base_type :model/Field)]
-        (are [field-id expected] (= expected (get new-base-types field-id))
-          pg-field-1-id :type/JSON
-          pg-field-2-id :type/JSON
-          pg-field-3-id :type/Text
-          mysql-field-1-id :type/JSON
-          mysql-field-2-id :type/Text)
-        ;; TODO: this is commented out temporarily because it flakes for MySQL (metabase#37884)
-        #_(testing "Rollback restores the original state"
-            (migrate! :down 46)
-            (let [new-base-types (t2/select-pk->fn :base_type Field)]
-              (are [field-id expected] (= expected (get new-base-types field-id))
-                pg-field-1-id :type/Structured
-                pg-field-2-id :type/Structured
-                pg-field-3-id :type/Text
-                mysql-field-1-id :type/SerializedJSON
-                mysql-field-2-id :type/Text)))))))
+      (with-redefs [mi/add-entity-id identity]
+        (let [[pg-db-id
+               mysql-db-id] (t2/insert-returning-pks! (t2/table-name :model/Database)
+                                                      [{:name "PG Database"
+                                                        :engine "postgres"
+                                                        :created_at :%now
+                                                        :updated_at :%now
+                                                        :details "{}"}
+                                                       {:name "MySQL Database"
+                                                        :engine "mysql"
+                                                        :created_at :%now
+                                                        :updated_at :%now
+                                                        :details "{}"}])
+              [pg-table-id
+               mysql-table-id] (t2/insert-returning-pks! (t2/table-name :model/Table)
+                                                         [{:db_id pg-db-id
+                                                           :name "PG Table"
+                                                           :created_at :%now
+                                                           :updated_at :%now
+                                                           :active true}
+                                                          {:db_id mysql-db-id
+                                                           :name "MySQL Table"
+                                                           :created_at :%now
+                                                           :updated_at :%now
+                                                           :active true}])
+              [pg-field-1-id
+               pg-field-2-id
+               pg-field-3-id
+               mysql-field-1-id
+               mysql-field-2-id] (t2/insert-returning-pks! :model/Field [{:name "PG Field 1"    :table_id pg-table-id    :database_type "json"    :base_type :type/Structured}
+                                                                         {:name "PG Field 2"    :table_id pg-table-id    :database_type "JSONB"   :base_type :type/Structured}
+                                                                         {:name "PG Field 3"    :table_id pg-table-id    :database_type "varchar" :base_type :type/Text}
+                                                                         {:name "MySQL Field 1" :table_id mysql-table-id :database_type "json"    :base_type :type/SerializedJSON}
+                                                                         {:name "MySQL Field 2" :table_id mysql-table-id :database_type "varchar" :base_type :type/Text}])
+              _ (migrate!)
+              new-base-types (t2/select-pk->fn :base_type :model/Field)]
+          (are [field-id expected] (= expected (get new-base-types field-id))
+            pg-field-1-id :type/JSON
+            pg-field-2-id :type/JSON
+            pg-field-3-id :type/Text
+            mysql-field-1-id :type/JSON
+            mysql-field-2-id :type/Text)
+          ;; TODO: this is commented out temporarily because it flakes for MySQL (metabase#37884)
+          #_(testing "Rollback restores the original state"
+              (migrate! :down 46)
+              (let [new-base-types (t2/select-pk->fn :base_type Field)]
+                (are [field-id expected] (= expected (get new-base-types field-id))
+                  pg-field-1-id :type/Structured
+                  pg-field-2-id :type/Structured
+                  pg-field-3-id :type/Text
+                  mysql-field-1-id :type/SerializedJSON
+                  mysql-field-2-id :type/Text))))))))
 
 (deftest ^:mb/old-migrations-test migrate-google-auth-test
   (testing "Migrations v47.00-009 and v47.00-012: migrate google_auth into sso_source"

--- a/test/metabase/models/params/chain_filter_test.clj
+++ b/test/metabase/models/params/chain_filter_test.clj
@@ -470,6 +470,7 @@
               :has_more_values false}
              (chain-filter-search venues.category_id {venues.price 4} "zzzzz"))))))
 
+;; Detail: Key (entity_id)=(6nmVTpCpKFRkZJigvqSVm) already exists.
 (deftest use-cached-field-values-test
   (testing "chain-filter should use cached FieldValues if applicable (#13832)"
     (let [field-id (mt/id :categories :name)]
@@ -499,7 +500,7 @@
         (testing "should search with the cached FieldValues when search without constraints"
           (mt/with-temp
             [:model/Field       field (-> (t2/select-one :model/Field (mt/id :categories :name))
-                                          (dissoc :id)
+                                          (dissoc :id :entity_id)
                                           (assoc :name "NAME2"))
              :model/FieldValues  _    {:field_id (:id field)
                                        :type     :full

--- a/test/metabase/sync/sync_test.clj
+++ b/test/metabase/sync/sync_test.clj
@@ -118,6 +118,7 @@
     :db_id       true
     :entity_type :entity/GenericTable
     :id          true
+    :entity_id   true
     :updated_at  true}))
 
 (defn- field-defaults []
@@ -129,6 +130,7 @@
     :fk_target_field_id  false
     :database_is_auto_increment false
     :id                  true
+    :entity_id           true
     :last_analyzed       false
     :parent_id           false
     :position            0

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -255,7 +255,10 @@
 (defn- copy-table-fields! [old-table-id new-table-id]
   (t2/insert! :model/Field
               (for [field (t2/select :model/Field :table_id old-table-id, :active true, {:order-by [[:id :asc]]})]
-                (-> field (dissoc :id :fk_target_field_id) (assoc :table_id new-table-id))))
+                (-> field
+                    (dissoc :id :fk_target_field_id)
+                    (assoc :table_id new-table-id
+                           :entity_id (u/generate-nano-id)))))
   ;; now copy the FieldValues as well.
   (let [old-field-id->name (t2/select-pk->fn :name :model/Field :table_id old-table-id :active true)
         new-field-name->id (t2/select-fn->pk :name :model/Field :table_id new-table-id :active true)
@@ -276,7 +279,10 @@
         new-table-ids (sort ; sorting by PK recovers the insertion order, because insert-returning-pks! doesn't guarantee this
                        (t2/insert-returning-pks! :model/Table
                                                  (for [table old-tables]
-                                                   (-> table (dissoc :id) (assoc :db_id new-db-id)))))]
+                                                   (-> table
+                                                       (dissoc :id)
+                                                       (assoc :db_id new-db-id
+                                                              :entity_id (u/generate-nano-id))))))]
     (doseq [[old-table-id new-table-id] (zipmap (map :id old-tables) new-table-ids)]
       (copy-table-fields! old-table-id new-table-id))))
 

--- a/test_resources/serialization_baseline/databases/My Database/My Database.yaml
+++ b/test_resources/serialization_baseline/databases/My Database/My Database.yaml
@@ -12,8 +12,8 @@ is_on_demand: false
 is_sample: false
 is_audit: false
 is_attached_dwh: false
-metadata_sync_schedule: 0 9 * * * ? *
-cache_field_values_schedule: 0 0 12 * * ? *
+metadata_sync_schedule: 0 57 * * * ? *
+cache_field_values_schedule: 0 0 7 * * ? *
 settings:
   database-source-dataset-name: test-data
 caveats: null
@@ -22,6 +22,7 @@ initial_sync_status: complete
 serdes/meta:
 - id: My Database
   model: Database
+entity_id: ykVHi-GHcd1td4Lvb62pr
 uploads_enabled: false
 uploads_schema_name: null
 uploads_table_prefix: null

--- a/test_resources/serialization_baseline/databases/My Database/tables/Schemaless Table/Schemaless Table.yaml
+++ b/test_resources/serialization_baseline/databases/My Database/tables/Schemaless Table/Schemaless Table.yaml
@@ -19,3 +19,4 @@ serdes/meta:
 - id: Schemaless Table
   model: Table
 database_require_filter: null
+entity_id: KhHJ3brgFTO9CIBiZA4uE

--- a/test_resources/serialization_baseline/databases/My Database/tables/Schemaless Table/fields/Some Field.yaml
+++ b/test_resources/serialization_baseline/databases/My Database/tables/Schemaless Table/fields/Some Field.yaml
@@ -37,3 +37,4 @@ serdes/meta:
   model: Field
 database_indexed: null
 database_partitioned: null
+entity_id: Ov5wwh7fYOdhiUFxS4ihN

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CATEGORIES/CATEGORIES.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CATEGORIES/CATEGORIES.yaml
@@ -21,3 +21,4 @@ serdes/meta:
 - id: CATEGORIES
   model: Table
 database_require_filter: null
+entity_id: fROOTcxZ8KNzW6frWxyBn

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CATEGORIES/fields/ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CATEGORIES/fields/ID.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
+entity_id: sBsHx24gA7l-4ghDzlzhF

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CATEGORIES/fields/NAME.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CATEGORIES/fields/NAME.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: jEZf_v-4ewNSY1QEWw0Se

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/CHECKINS.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/CHECKINS.yaml
@@ -21,3 +21,4 @@ serdes/meta:
 - id: CHECKINS
   model: Table
 database_require_filter: null
+entity_id: fLCYfgLenqruHqCo2_dvG

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/fields/DATE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/fields/DATE.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: RP5HLhoqRvCi2Y7tt6SiJ

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/fields/ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/fields/ID.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
+entity_id: cY9GKjimt9fkbwSmq3s2D

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/fields/USER_ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/fields/USER_ID.yaml
@@ -43,3 +43,4 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
+entity_id: aPH5xec5UYszHtsFWpmel

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/fields/VENUE_ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/CHECKINS/fields/VENUE_ID.yaml
@@ -43,3 +43,4 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
+entity_id: PCwnRlLbnPF8R4hzXmNGR

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/ORDERS.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/ORDERS.yaml
@@ -21,3 +21,4 @@ serdes/meta:
 - id: ORDERS
   model: Table
 database_require_filter: null
+entity_id: Xklmu-9-kSX8qWUU4gx8T

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/CREATED_AT.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/CREATED_AT.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 9ntDoLGY3AF3C4gD2TEzy

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/DISCOUNT.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/DISCOUNT.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: bJZMPrTpKh9du7t-BG67z

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/ID.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
+entity_id: IiIFClKQXRxRxACobQ0Hb

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/PRODUCT_ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/PRODUCT_ID.yaml
@@ -43,3 +43,4 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
+entity_id: HcBNIyo38ID7k3zRiaZZ7

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/QUANTITY.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/QUANTITY.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 0wAi4F3QofJo3rKLN0Tmc

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/SUBTOTAL.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/SUBTOTAL.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: Hk8HG908-1Yk3eatFXpqM

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/TAX.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/TAX.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: T8PChksd3ig-4V3cmUkX1

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/TOTAL.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/TOTAL.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: OzPJltpWAbCXnqBRDXETi

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/USER_ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/ORDERS/fields/USER_ID.yaml
@@ -43,3 +43,4 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
+entity_id: rNoeK7kIBWVuk-q-GXeXe

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/PEOPLE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/PEOPLE.yaml
@@ -21,3 +21,4 @@ serdes/meta:
 - id: PEOPLE
   model: Table
 database_require_filter: null
+entity_id: kzKpXesKBLetpfOfXeSsS

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/ADDRESS.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/ADDRESS.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 95on8mqct2RznafaiUYYN

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/BIRTH_DATE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/BIRTH_DATE.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: QTEhFM69RUzvOmN54uzW3

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/CITY.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/CITY.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 9B2UPC2I7yRIUQiJuZNrO

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/CREATED_AT.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/CREATED_AT.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: kVPl9EyIl3cKVtJT2boYc

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/EMAIL.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/EMAIL.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: NAoZKcsK9zzQ_vx6E9ioB

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/ID.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
+entity_id: qrQZFu3wq_jquvdj9Cykl

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/LATITUDE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/LATITUDE.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 4g80DtZISRLp5SCVUFdOw

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/LONGITUDE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/LONGITUDE.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: hZ92SH5RvNXAgQDTWhUaD

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/NAME.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/NAME.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: hyZGfYofxZluz3zEY06z1

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/PASSWORD.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/PASSWORD.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: H3sKKUFQJZjLnpv6Qzv4E

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/SOURCE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/SOURCE.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 2hnPlZ9z5Riq4qv_VSeTv

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/STATE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/STATE.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: sCwbkjXDJgQIAX3D3rbV5

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/ZIP.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PEOPLE/fields/ZIP.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 1dXHzmeh3xHHuQC1y51Dj

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/PRODUCTS.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/PRODUCTS.yaml
@@ -21,3 +21,4 @@ serdes/meta:
 - id: PRODUCTS
   model: Table
 database_require_filter: null
+entity_id: rKyV6tg0Gg8YKC-Rq24__

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/CATEGORY.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/CATEGORY.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: khmQ5iqqybZ9RL7rP7DVH

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/CREATED_AT.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/CREATED_AT.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: tlG2LL84pkkAcc6FLQhWU

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/EAN.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/EAN.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: MLCr2IuH9utdQxlXlH3hp

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/ID.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
+entity_id: pIVx08kb89oxIvq9ewtm_

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/PRICE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/PRICE.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: Zsxl1zcPTMPPJoHpaFMwC

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/RATING.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/RATING.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: lVeIH8wHGn6hBtTWcgvwV

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/TITLE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/TITLE.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: KcDM8frKUWvd0mC1KPJ-G

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/VENDOR.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/PRODUCTS/fields/VENDOR.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: plKu8ko8uSEu8t8rSyTNb

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/REVIEWS.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/REVIEWS.yaml
@@ -21,3 +21,4 @@ serdes/meta:
 - id: REVIEWS
   model: Table
 database_require_filter: null
+entity_id: imJMQOvUtLybVRNQu7MFu

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/BODY.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/BODY.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: nZQyMvxGygYomxrBfzoQk

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/CREATED_AT.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/CREATED_AT.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: VHTQLIUwNEI0PoLRogT8W

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/ID.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
+entity_id: LUbennMbPNtPzL9tKb8W9

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/PRODUCT_ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/PRODUCT_ID.yaml
@@ -43,3 +43,4 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
+entity_id: SSid-McZJwdk9QqJQbQ5a

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/RATING.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/RATING.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: i9kgOCMWRj9Zy8gXDioh-

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/REVIEWER.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/REVIEWS/fields/REVIEWER.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: s5SzrmXlHrLNSSU0pchfo

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/USERS.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/USERS.yaml
@@ -21,3 +21,4 @@ serdes/meta:
 - id: USERS
   model: Table
 database_require_filter: null
+entity_id: BM7Nnb4drPYip-uXrsxXs

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/fields/ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/fields/ID.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
+entity_id: b4rF_gcpmPwMBS1fEul7x

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/fields/LAST_LOGIN.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/fields/LAST_LOGIN.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: qELQSWKJkRMHmPZNn8-80

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/fields/NAME.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/fields/NAME.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: hYN1x8_S3RWiV9gyLlW8R

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/fields/PASSWORD.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/USERS/fields/PASSWORD.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: hT0OPv0YdJd3l56rFPYLy

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/VENUES.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/VENUES.yaml
@@ -21,3 +21,4 @@ serdes/meta:
 - id: VENUES
   model: Table
 database_require_filter: null
+entity_id: YeEoba5Ys1KUhghWWZteq

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/CATEGORY_ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/CATEGORY_ID.yaml
@@ -43,3 +43,4 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
+entity_id: 6d-rbYLMiBcMKBFBO3z2O

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/ID.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/ID.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: true
 database_partitioned: null
+entity_id: 5Ni7ZdMvZ5yqmbaRYVQ-q

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/LATITUDE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/LATITUDE.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: EPdF1g_aQzDZ0Z4cozcxg

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/LONGITUDE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/LONGITUDE.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: 9rX_BZ6VY24FA6H6qFuCs

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/NAME.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/NAME.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: cMgpuvb_X4Jkvf8_e0lp5

--- a/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/PRICE.yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/schemas/PUBLIC/tables/VENUES/fields/PRICE.yaml
@@ -39,3 +39,4 @@ serdes/meta:
   model: Field
 database_indexed: false
 database_partitioned: null
+entity_id: lqd08dVvYfpeB73LxjbQz

--- a/test_resources/serialization_baseline/databases/test-data (h2)/test-data (h2).yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/test-data (h2).yaml
@@ -17,8 +17,8 @@ is_on_demand: false
 is_sample: false
 is_audit: false
 is_attached_dwh: false
-metadata_sync_schedule: 0 3 * * * ? *
-cache_field_values_schedule: 0 0 11 * * ? *
+metadata_sync_schedule: 0 9 * * * ? *
+cache_field_values_schedule: 0 0 9 * * ? *
 settings:
   database-source-dataset-name: test-data
 caveats: null
@@ -27,6 +27,7 @@ initial_sync_status: complete
 serdes/meta:
 - id: test-data (h2)
   model: Database
+entity_id: ymbeYS8YN6P6Vltnq81Ib
 uploads_enabled: false
 uploads_schema_name: null
 uploads_table_prefix: null


### PR DESCRIPTION
Part of #53048.


### Description

These three entities have previously used their names as their serdes
keys. The names are still used for serdes but we want opaque, stable
`entity_id`s as well so that they can be used as `:ident`s in the field
refs overhaul. Then the name of a database, schema, table or field can
be changed without its `:ident` changing, and therefore without breaking
any questions that reference it.

The internal audit DB (EE feature) uses hardcoded `entity_id`s, since
it gets checked into git and the `entity_id`s need to be stable.

### How to verify

Databases, tables and fields have `entity_id`s now. They aren't necessarily
returned from API calls or `MetadataProvider`s yet; that will come in later PRs.

Tests are still passing.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
    - New test: loading a fresh audit DB
    - New test: backfilling a pre-existing audit DB without `entity_id`s at startup
