### PR TITLE
Order the query in `expression-using-aggregation-test`

### DIFF
--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -540,7 +540,8 @@
                                 :limit        3}
                  :expressions  {:price_range [:-
                                               [:field "max" {:base-type :type/Number}]
-                                              [:field "min" {:base-type :type/Number}]]}})))))))
+                                              [:field "min" {:base-type :type/Number}]]}
+                 :order-by     [[:asc [:field "name" {:base-type :type/Text}]]]})))))))
 
 (deftest ^:parallel expression-with-duplicate-column-name
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -530,18 +530,18 @@
       (is (= [["20th Century Cafe" 2 2 0]
               ["25°" 2 2 0]
               ["33 Taps" 2 2 0]]
-             (mt/formatted-rows
-              [str int int int]
-              (mt/run-mbql-query venues
-                {:source-query {:source-table (mt/id :venues)
-                                :aggregation  [[:min (mt/id :venues :price)]
-                                               [:max (mt/id :venues :price)]]
-                                :breakout     [[:field (mt/id :venues :name) nil]]
-                                :limit        3}
-                 :expressions  {:price_range [:-
-                                              [:field "max" {:base-type :type/Number}]
-                                              [:field "min" {:base-type :type/Number}]]}
-                 :order-by     [[:asc [:field "name" {:base-type :type/Text}]]]})))))))
+             (sort-by first
+                      (mt/formatted-rows
+                       [str int int int]
+                       (mt/run-mbql-query venues
+                         {:source-query {:source-table (mt/id :venues)
+                                         :aggregation  [[:min (mt/id :venues :price)]
+                                                        [:max (mt/id :venues :price)]]
+                                         :breakout     [[:field (mt/id :venues :name) nil]]
+                                         :limit        3}
+                          :expressions  {:price_range [:-
+                                                       [:field "max" {:base-type :type/Number}]
+                                                       [:field "min" {:base-type :type/Number}]]}}))))))))
 
 (deftest ^:parallel expression-with-duplicate-column-name
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)


### PR DESCRIPTION
Closes https://linear.app/metabase-inc/issue/ENG-14635/order-the-query-in-expression-using-aggregation-test

### Description

Sorts the returned rows to avoid relying on DBs preserving subquery order in outer queries, which doesn't necessarily happen.

### How to verify

The test should still pass, even for DBs that don't preserve subquery order like the partner DB Materialize.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
