### PR TITLE
Dont run redshift upload tests on PRs

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -802,7 +802,7 @@ jobs:
           ${{ matrix.job.test-args }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: ${{ !matrix.job.skip }} && always()
+      if: ${{ !matrix.job.skip }} && !cancelled()
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -802,7 +802,7 @@ jobs:
           ${{ matrix.job.test-args }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always()
+      if: always() && ${{ !matrix.job.skip }}
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -802,7 +802,7 @@ jobs:
           ${{ matrix.job.test-args }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: ${{ !matrix.job.skip }} && !cancelled()
+      if: ${{ !matrix.job.skip }}
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -794,7 +794,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Test ${{ matrix.job.name }}
-      if: ${{ matrix.job.skip != 'true' }}
+      if: ${{ !matrix.job.skip }}
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-redshift-ee'

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -802,7 +802,7 @@ jobs:
           ${{ matrix.job.test-args }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: ${{ !matrix.job.skip }}
+      if: ${{ !matrix.job.skip && !cancelled() }}
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -802,7 +802,7 @@ jobs:
           ${{ matrix.job.test-args }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always() && ${{ !matrix.job.skip }}
+      if: ${{ !matrix.job.skip }} && always()
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -772,10 +772,12 @@ jobs:
       matrix:
         job:
           - name: Redshift Upload Tests
+            skip: ${{ github.event_name == 'pull_request' }} # FIXME: temporary to alleviate pressure on redshift instances
             test-args: >-
               :only-tags [:mb/upload-tests]
               :fail-fast? true
           - name: Redshift (Excluding Upload Tests)
+            skip: false
             test-args: >-
               :only-tags [:mb/driver-tests]
               :exclude-tags [:mb/upload-tests]
@@ -792,6 +794,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Test ${{ matrix.job.name }}
+      if: ${{ matrix.job.skip != 'true' }}
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-redshift-ee'


### PR DESCRIPTION
Our redshift test infrastructure is getting overloaded for reasons that we don't fully understand yet. For now, let's only run the heaviest tests (the upload tests) on master and release branches.

follow up to remove this: [ENG-14636: Remove skipped redshift upload tests on PRs](https://linear.app/metabase-inc/issue/ENG-14636/remove-skipped-redshift-upload-tests-on-prs)