### PR TITLE
stabilize flaky browse.cy.spec.ts tests

### DIFF
--- a/e2e/test/scenarios/metrics/browse.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/browse.cy.spec.ts
@@ -285,8 +285,12 @@ describe("scenarios > browse > metrics", () => {
         .should("be.visible");
 
       H.navigationSidebar().findByText("Trash").should("be.visible").click();
+      cy.intercept("/api/bookmark").as("bookmark"); // anti-flake guard
       cy.button("Actions").click();
       H.popover().findByText("Restore").should("be.visible").click();
+
+      H.main().findByText("Nothing here").should("be.visible");
+      cy.wait("@bookmark");
 
       H.navigationSidebar().findByText("Metrics").should("be.visible").click();
       metricsTable().findByText(ORDERS_SCALAR_METRIC.name).should("be.visible");


### PR DESCRIPTION
Closes https://linear.app/metabase-inc/issue/DEVX-130/multiple-metrics-flakes

### Description

The flakiness seemed to have happened mostly because of some sort of caching when switching between different views. When a metric was deleted and then restored, there seemed to have been a short time period that during which the data was not updated. This also seemed to contribute to all the other tests.

### Resolution
I added guard assertions for an API call and empty state (when restoring) so that the test does not proceed sooner than it should

### Stress test
https://github.com/metabase/metabase/actions/runs/13113255658/job/36581632129