### PR TITLE
fix(sdk): fixes `NotFoundError: Failed to execute 'removeChild' on 'Node'` on nextjs app router when a TableInteractive component is rendered

### DIFF
--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -170,7 +170,7 @@ class TableInteractive extends Component {
     );
   }
 
-  UNSAFE_componentWillMount() {
+  componentDidMount() {
     // for measuring cells:
     this._div = document.createElement("div");
     this._div.className = cx(TableS.TableInteractive, "test-TableInteractive");


### PR DESCRIPTION
Fixes: https://github.com/metabase/metabase/issues/51628

When a TableInteractive is rendered on a nextjs **app** router app via the sdk, it breaks.

I tried to figure out why this issue is only showing up on that specific scenario (it wasn't  showing up on pages router) but I wasn't lucky in that.

I was able to locate the issue to the `unmountRoot` call inside `onMeasureHeaderRender`:
https://github.com/metabase/metabase/blob/5cfecfc07a9dae84f2c97194782dd2c6b6156c8c/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx#L404

I tried a few things to fix it but ultimately the best thing was to just renamed the method from `UNSAFE_componentWillMount` to `componentDidMount`.

I didn't notice any delay/layout shifting compared to before the change

# How to verify

Core app: this should not affect anything. I tried to play around with it and I didn't see anything weird but I may have missed some performance detail.

SDK: This should have broken with both StaticQuestion or InteractiveQuestion, if they rendered a TableInteractive component, try to render one and it should not be broken now.