### PR TITLE
Manual backport  "ci: find css variables that are used but never defined (#52910)"

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -44,6 +44,8 @@ jobs:
           m2-cache-key: "cljs"
       - name: Compile CLJS
         run: yarn build-pure:cljs
+      - name: Find CSS variables that are used but never defined
+        run: yarn find-never-defined-css-variables
       - name: Run Prettier formatting linter
         run: yarn run lint-prettier-pure
       - name: Run ESLint linter

--- a/bin/find-never-defined-css-variables/find-never-defined-css-variables.ts
+++ b/bin/find-never-defined-css-variables/find-never-defined-css-variables.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env tsx
+/* eslint-disable no-console */
+import { readFileSync } from "fs";
+
+import { glob } from "glob";
+
+/**
+ * This script finds css variables that are used but *never* defined in our codebase.
+ * Its goal isn't to find usages of variables in contexts where that variable is not defined,
+ * as that would be a lot harder.
+ * Its goal is to prevent typos and wrong usages created by conflicts and backports.
+ * The most common thing this should catch and prevent is backporting a fix or feature that uses a css variable
+ * that doesn't exist in the release branch.
+ */
+
+const shouldWhiteList = (_variable: string) => {
+  // Use this for whitelisting some variables if we know they're defined by a 3rd party, such as mantine
+  // Note: Be sure not to backport changes to this function that would whitelist variables not on the release branch
+  return false;
+};
+
+interface UsageMap {
+  // variable : files
+  [variable: string]: string[];
+}
+
+const findFiles = (): string[] => {
+  return glob.sync(
+    "{frontend,enterprise/frontend}/**/*.{css,module.css,js,jsx,ts,tsx}",
+  );
+};
+
+const extractVariableDefinitions = (filePath: string): Set<string> => {
+  const fileContent = readFileSync(filePath, "utf8");
+  return extractVariableDefinitionsFromFileContent(fileContent);
+};
+
+export const extractVariableDefinitionsFromFileContent = (
+  fileContent: string,
+): Set<string> => {
+  const patterns = [
+    /--[a-zA-Z0-9-]+:/g, // css files: --my-css-variable: blue
+    /['"`]--[a-zA-Z0-9-]+['"`]\s*:/g, // css-in-js: "--my-css-variable-in-emotion": blue
+  ];
+
+  const matches = patterns.flatMap(pattern => {
+    const found = fileContent.match(pattern) || [];
+    return found.map(match => {
+      const cleaned = match.replace(/['"`{}:,\s]/g, "");
+
+      return cleaned;
+    });
+  });
+
+  return new Set(matches);
+};
+
+const extractVariableUsages = (filePath: string): Set<string> => {
+  const content = readFileSync(filePath, "utf8");
+  return extractVariableUsagesFromFileContent(content);
+};
+
+export const extractVariableUsagesFromFileContent = (
+  content: string,
+): Set<string> => {
+  const pattern = /var\((--[a-zA-Z0-9-]+)\)/g;
+  const matches = Array.from(content.matchAll(pattern)).map(match => match[1]);
+
+  return new Set(matches);
+};
+
+const main = () => {
+  const files = findFiles();
+
+  const allDefinitions = new Set<string>();
+  const allUsages = new Set<string>();
+  const usageLocations: UsageMap = {};
+
+  // Find all variable definitions
+  files.forEach(file => {
+    const definitions = extractVariableDefinitions(file);
+    definitions.forEach(def => allDefinitions.add(def));
+  });
+
+  // Find all variable usages
+  files.forEach(file => {
+    const usages = extractVariableUsages(file);
+    usages.forEach(usage => {
+      allUsages.add(usage);
+      if (!usageLocations[usage]) {
+        usageLocations[usage] = [];
+      }
+      usageLocations[usage].push(file);
+    });
+  });
+
+  // Filter out defined or whitelisted variables
+  const undefinedVars = Array.from(allUsages)
+    .filter(usage => !allDefinitions.has(usage) && !shouldWhiteList(usage))
+    .sort();
+
+  if (undefinedVars.length > 0) {
+    console.log("Found undefined CSS variables:\n");
+    undefinedVars.forEach(variable => {
+      console.log(`${variable} used in:`);
+      usageLocations[variable].forEach(location => {
+        console.log(`  - ${location}`);
+      });
+      console.log("");
+    });
+
+    const filesWithUndefinedVars = new Set(
+      undefinedVars.map(variable => usageLocations[variable]).flat(),
+    );
+
+    console.log(
+      `Found ${undefinedVars.length} CSS variables that were used but never defined in ${filesWithUndefinedVars.size} files\n`,
+    );
+
+    console.log(
+      "See bin/find-never-defined-css-variables/find-never-defined-css-variables.ts for more details\n",
+    );
+
+    process.exit(1);
+  } else {
+    console.log("No undefined CSS variables found");
+    process.exit(0);
+  }
+};
+
+if (require.main === module) {
+  main();
+}

--- a/bin/find-never-defined-css-variables/find-never-defined-css-variables.unit.spec.ts
+++ b/bin/find-never-defined-css-variables/find-never-defined-css-variables.unit.spec.ts
@@ -1,0 +1,76 @@
+import {
+  extractVariableDefinitionsFromFileContent,
+  extractVariableUsagesFromFileContent,
+} from "./find-never-defined-css-variables";
+
+describe("extractVariableDefinitionsFromFileContent", () => {
+  it("should extract standard CSS variable definitions", () => {
+    const content = `
+      .my-class {
+        color: var(--should-not-be-extracted);
+        --color-brand: #509ee3;
+        --color-text: #000;
+      }
+    `;
+    const result = extractVariableDefinitionsFromFileContent(content);
+    expect(result).toEqual(new Set(["--color-brand", "--color-text"]));
+  });
+
+  it("should extract CSS-in-JS variable definitions", () => {
+    const content = `
+      const MyContainer1 = styled.div\`
+        color: var(--should-not-be-extracted);
+        --theme-primary: "blue",
+      \`;
+
+      const MyContainer2 = styled.div({
+        --theme-secondary: "#fff",
+      })
+    `;
+    const result = extractVariableDefinitionsFromFileContent(content);
+    expect(result).toEqual(new Set(["--theme-primary", "--theme-secondary"]));
+  });
+
+  it("should handle mixed quotes in definitions", () => {
+    const content = `
+      const theme = {
+        '--single-quote': 'value',
+        "--double-quote": "value",
+        \`--backtick\`: \`value\`,
+      };
+    `;
+    const result = extractVariableDefinitionsFromFileContent(content);
+    expect(result).toEqual(
+      new Set(["--single-quote", "--double-quote", "--backtick"]),
+    );
+  });
+});
+
+describe("extractVariableUsagesFromFileContent", () => {
+  it("should extract usage from css syntax", () => {
+    const content = `
+      .button {
+        --should-not-be-extracted: blue;
+        color: var(--color-brand);
+        background: var(--color-background);
+      }
+    `;
+    const result = extractVariableUsagesFromFileContent(content);
+    expect(result).toEqual(new Set(["--color-brand", "--color-background"]));
+  });
+
+  it("should extract usage from css-in-js syntax", () => {
+    const content = `
+      const MyDiv1 = styled.div\`
+        --should-not-be-extracted: blue;
+        color: var(--theme-color);
+      \`;
+
+      const MyDiv2 = styled.div({
+        background: var(--theme-background);
+      })
+    `;
+    const result = extractVariableUsagesFromFileContent(content);
+    expect(result).toEqual(new Set(["--theme-color", "--theme-background"]));
+  });
+});

--- a/enterprise/frontend/src/embedding-sdk/components/private/EditorViewControl/EditorViewControl.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/EditorViewControl/EditorViewControl.tsx
@@ -53,7 +53,7 @@ export const EditorViewControl = ({
         color: "var(--mb-color-brand)",
         "&[data-active]": {
           "&, &:hover": {
-            color: "var(--mb-color-white)",
+            color: "var(--mb-color-text-white)",
           },
         },
         // this really should be design token values

--- a/frontend/src/metabase/home/components/EmbedHomepage/Badge.ts
+++ b/frontend/src/metabase/home/components/EmbedHomepage/Badge.ts
@@ -9,7 +9,7 @@ const COLOR_VARIANTS = {
     background: "var(--mb-color-brand)",
   },
   gray: {
-    color: "var(--mb-color-text-black)",
+    color: "var(--mb-color-text-primary)",
     /* eslint-disable no-restricted-syntax -- we should find a way to use semantic colors here */
     background: "var(--mb-base-color-gray-20)",
   },

--- a/package.json
+++ b/package.json
@@ -394,6 +394,7 @@
     "embedding-sdk:generate-nextjs-compat": "tsx enterprise/frontend/src/embedding-sdk/bin/generate-nextjs-compat.ts",
     "embedding-sdk:test-unit": "yarn test-unit enterprise/frontend/src/embedding-sdk/",
     "eslint-fix": "yarn lint-eslint --fix",
+    "find-never-defined-css-variables": "tsx bin/find-never-defined-css-variables/find-never-defined-css-variables.ts",
     "generate-cypress-html-report": "mochawesome-merge cypress/reports/mochareports/*.json > cypress/reports/cypress-test-report.json && marge cypress/reports/cypress-test-report.json -o cypress/reports/mochareports --inline",
     "lint": "yarn lint-eslint && yarn lint-prettier && yarn lint-docs-links && yarn lint-yaml && yarn type-check",
     "lint-docs-links": "yarn && ./bin/verify-doc-links",


### PR DESCRIPTION
Manual backport of #52910,
It also cherrypicks part of https://github.com/metabase/metabase/pull/52808 as a couple of vars were missing here