### PR TITLE
ADM 174 create contextual menu and badge components

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/clean_up/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/index.tsx
@@ -1,11 +1,12 @@
 import { t } from "ttag";
 
 import { skipToken, useListCollectionItemsQuery } from "metabase/api";
+import { IndicatorMenu } from "metabase/core/components/IndicatorMenu";
 import { ForwardRefLink } from "metabase/core/components/Link";
 import { ModalRoute } from "metabase/hoc/ModalRoute";
 import * as Urls from "metabase/lib/urls";
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
-import { Badge, Icon, Menu } from "metabase/ui";
+import { Icon } from "metabase/ui";
 import { useListStaleCollectionItemsQuery } from "metabase-enterprise/api/collection";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
@@ -51,13 +52,15 @@ if (hasPremiumFeature("collection_cleanup")) {
 
     return {
       menuItems: [
-        <Menu.Item
+        <IndicatorMenu.ItemWithBadge
           key="collections-cleanup"
           leftSection={<Icon name="archive" />}
           component={ForwardRefLink}
           to={`${Urls.collection(collection)}/cleanup`}
-          rightSection={hasStaleItems && <Badge>Recommended</Badge>}
-        >{t`Clear out unused items`}</Menu.Item>,
+          badgeLabel={t`Recommended`}
+          showBadge={() => hasStaleItems}
+          userAckKey="clean-stale-items"
+        >{t`Clear out unused items`}</IndicatorMenu.ItemWithBadge>,
       ],
       showIndicator: hasStaleItems,
     };

--- a/frontend/src/metabase-types/api/user.ts
+++ b/frontend/src/metabase-types/api/user.ts
@@ -117,6 +117,7 @@ export type UpdateUserRequest = {
 
 export type UserKeyValue =
   | { namespace: "test"; key: string; value: any }
+  | { namespace: "indicator-menu"; key: string; value: string[] }
   | {
       namespace: "user_acknowledgement";
       key: string;

--- a/frontend/src/metabase/collections/components/CollectionHeader/tests/setup.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/tests/setup.tsx
@@ -44,8 +44,8 @@ export const setup = ({
   setupDashboardQuestionCandidatesEndpoint([]);
   setupUserKeyValueEndpoints({
     key: "collection-menu",
-    namespace: "user_acknowledgement",
-    value: true,
+    namespace: "indicator-menu",
+    value: [],
   });
   setupUserKeyValueEndpoints({
     key: "move-to-dashboard",

--- a/frontend/src/metabase/collections/components/CollectionMenu/CollectionMenu.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/CollectionMenu.tsx
@@ -7,11 +7,11 @@ import {
   isRootPersonalCollection,
 } from "metabase/collections/utils";
 import { useHasDashboardQuestionCandidates } from "metabase/components/MoveQuestionsIntoDashboardsModal/hooks";
+import { IndicatorMenu } from "metabase/core/components/IndicatorMenu";
 import { ForwardRefLink } from "metabase/core/components/Link";
-import { useUserAcknowledgement } from "metabase/hooks/use-user-acknowledgement";
 import * as Urls from "metabase/lib/urls";
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
-import { ActionIcon, Badge, Icon, Indicator, Menu, Tooltip } from "metabase/ui";
+import { ActionIcon, Icon, Tooltip } from "metabase/ui";
 import type { Collection } from "metabase-types/api";
 
 export interface CollectionMenuProps {
@@ -26,7 +26,7 @@ const mergeArrays = (arr: React.ReactNode[][]): React.ReactNode[] => {
   return filteredArr.length === 0
     ? []
     : filteredArr.reduce((acc, val, index) =>
-        acc.concat(<Menu.Divider key={`divider-${index}`} />, ...val),
+        acc.concat(<IndicatorMenu.Divider key={`divider-${index}`} />, ...val),
       );
 };
 
@@ -48,14 +48,6 @@ export const CollectionMenu = ({
   const canMove =
     !isRoot && !isPersonal && canWrite && !isInstanceAnalyticsCustom;
 
-  const [hasSeenMenu, { ack: ackHasSeenMenu }] = useUserAcknowledgement(
-    "collection-menu",
-    true,
-  );
-
-  const [hasSeenMoveToDashboard, { ack: ackHasMoveToDashboard }] =
-    useUserAcknowledgement("move-to-dashboard", true);
-
   const moveItems = [];
   const cleanupItems = [];
   const editItems = [];
@@ -63,12 +55,12 @@ export const CollectionMenu = ({
 
   if (canMove) {
     moveItems.push(
-      <Menu.Item
+      <IndicatorMenu.Item
         key="collection-move"
         leftSection={<Icon name="move" />}
         component={ForwardRefLink}
         to={`${url}/move`}
-      >{t`Move`}</Menu.Item>,
+      >{t`Move`}</IndicatorMenu.Item>,
     );
   }
 
@@ -83,41 +75,41 @@ export const CollectionMenu = ({
 
   if (isAdmin && !isPersonal && !isPersonalCollectionChild) {
     editItems.push(
-      <Menu.Item
+      <IndicatorMenu.Item
         key="collection-edit"
         leftSection={<Icon name="lock" />}
         component={ForwardRefLink}
         to={`${url}/permissions`}
-      >{t`Edit permissions`}</Menu.Item>,
+      >{t`Edit permissions`}</IndicatorMenu.Item>,
     );
   }
 
-  const { menuItems: cleanupMenuItems, showIndicator: showCleanupIndicator } =
+  const { menuItems: cleanupMenuItems } =
     PLUGIN_COLLECTIONS.useGetCleanUpMenuItems(collection);
 
   cleanupItems.push(...cleanupMenuItems);
 
   if (hasDqCandidates) {
     cleanupItems.push(
-      <Menu.Item
+      <IndicatorMenu.ItemWithBadge
         key="collection-move-to-dashboards"
         leftSection={<Icon name="add_to_dash" />}
         component={ForwardRefLink}
         to={`${url}/move-questions-dashboard`}
-        rightSection={!hasSeenMoveToDashboard && <Badge>New</Badge>}
-        onClick={() => !hasSeenMoveToDashboard && ackHasMoveToDashboard()}
-      >{t`Move questions into their dashboards`}</Menu.Item>,
+        userAckKey="move-to-dashboard"
+        badgeLabel={t`New`}
+      >{t`Move questions into their dashboards`}</IndicatorMenu.ItemWithBadge>,
     );
   }
 
   if (canMove) {
     trashItems.push(
-      <Menu.Item
+      <IndicatorMenu.Item
         key="collection-trash"
         leftSection={<Icon name="trash" />}
         component={ForwardRefLink}
         to={`${url}/archive`}
-      >{t`Move to trash`}</Menu.Item>,
+      >{t`Move to trash`}</IndicatorMenu.Item>,
     );
   }
 
@@ -127,34 +119,17 @@ export const CollectionMenu = ({
     return null;
   }
 
-  const showIndicator =
-    !hasSeenMenu &&
-    ((!hasSeenMoveToDashboard && hasDqCandidates) || showCleanupIndicator);
-
   return (
-    <Menu
-      position="bottom-end"
-      onChange={() => {
-        if (!hasSeenMenu && showIndicator) {
-          ackHasSeenMenu();
-        }
-      }}
-    >
-      <Menu.Target>
-        <Indicator
-          size={6}
-          disabled={!showIndicator}
-          label={<span data-testid="indicator" />}
-        >
-          <Tooltip label={t`Move, trash, and more...`} position="bottom">
-            <ActionIcon size={32} variant="viewHeader">
-              <Icon name="ellipsis" color="text-dark" />
-            </ActionIcon>
-          </Tooltip>
-        </Indicator>
-      </Menu.Target>
+    <IndicatorMenu position="bottom-end" menuKey="collection-menu">
+      <IndicatorMenu.Target>
+        <Tooltip label={t`Move, trash, and more...`} position="bottom">
+          <ActionIcon size={32} variant="viewHeader">
+            <Icon name="ellipsis" color="text-dark" />
+          </ActionIcon>
+        </Tooltip>
+      </IndicatorMenu.Target>
 
-      <Menu.Dropdown>{items}</Menu.Dropdown>
-    </Menu>
+      <IndicatorMenu.Dropdown>{items}</IndicatorMenu.Dropdown>
+    </IndicatorMenu>
   );
 };

--- a/frontend/src/metabase/collections/components/CollectionMenu/CollectionMenu.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/CollectionMenu.tsx
@@ -1,4 +1,4 @@
-import type React from "react";
+import { type ReactNode, useState } from "react";
 import { t } from "ttag";
 
 import {
@@ -21,7 +21,7 @@ export interface CollectionMenuProps {
   onUpdateCollection: (entity: Collection, values: Partial<Collection>) => void;
 }
 
-const mergeArrays = (arr: React.ReactNode[][]): React.ReactNode[] => {
+const mergeArrays = (arr: ReactNode[][]): ReactNode[] => {
   const filteredArr = arr.filter(v => v.length > 0);
   return filteredArr.length === 0
     ? []
@@ -36,6 +36,8 @@ export const CollectionMenu = ({
   isPersonalCollectionChild,
   onUpdateCollection,
 }: CollectionMenuProps): JSX.Element | null => {
+  const [menuOpen, setMenuOpen] = useState(false);
+
   const hasDqCandidates = useHasDashboardQuestionCandidates(collection.id);
 
   const url = Urls.collection(collection);
@@ -120,9 +122,18 @@ export const CollectionMenu = ({
   }
 
   return (
-    <IndicatorMenu position="bottom-end" menuKey="collection-menu">
+    <IndicatorMenu
+      position="bottom-end"
+      menuKey="collection-menu"
+      opened={menuOpen}
+      onChange={setMenuOpen}
+    >
       <IndicatorMenu.Target>
-        <Tooltip label={t`Move, trash, and more...`} position="bottom">
+        <Tooltip
+          label={t`Move, trash, and more...`}
+          position="bottom"
+          disabled={menuOpen}
+        >
           <ActionIcon size={32} variant="viewHeader">
             <Icon name="ellipsis" color="text-dark" />
           </ActionIcon>

--- a/frontend/src/metabase/collections/components/CollectionMenu/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/tests/common.unit.spec.tsx
@@ -1,7 +1,7 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
-import { getIcon, queryIcon, screen } from "__support__/ui";
+import { getIcon, queryIcon, screen, waitFor } from "__support__/ui";
 import { createMockCollection } from "metabase-types/api/mocks";
 
 import { setup } from "./setup";
@@ -163,19 +163,16 @@ describe("for your consideration", () => {
         isAdmin: true,
       });
 
-      expect(
-        fetchMock.called(
-          "http://localhost/api/user-key-value/namespace/user_acknowledgement/key/collection-menu",
-          { method: "PUT" },
-        ),
-      ).toBe(false);
-
-      expect(await screen.findByTestId("indicator")).toBeInTheDocument();
+      await waitFor(async () =>
+        expect(
+          await screen.findByTestId("menu-indicator-root"),
+        ).toHaveAttribute("data-show-indicator", "true"),
+      );
       await userEvent.click(getIcon("ellipsis"));
 
       expect(
         fetchMock.calls(
-          "http://localhost/api/user-key-value/namespace/user_acknowledgement/key/collection-menu",
+          "http://localhost/api/user-key-value/namespace/indicator-menu/key/collection-menu",
           { method: "PUT" },
         ),
       ).toHaveLength(1);
@@ -203,7 +200,10 @@ describe("for your consideration", () => {
         isAdmin: true,
       });
 
-      expect(screen.queryByTestId("indicator")).not.toBeInTheDocument();
+      expect(await screen.findByTestId("menu-indicator-root")).toHaveAttribute(
+        "data-show-indicator",
+        "false",
+      );
       await userEvent.click(getIcon("ellipsis"));
 
       expect(
@@ -219,10 +219,12 @@ describe("for your consideration", () => {
         collection: createMockCollection({ can_write: true }),
         dashboardQuestionCandidates: [dqCandidate],
         isAdmin: true,
-        collectionMenu: true,
       });
 
-      expect(screen.queryByTestId("indicator")).not.toBeInTheDocument();
+      expect(await screen.findByTestId("menu-indicator-root")).toHaveAttribute(
+        "data-show-indicator",
+        "false",
+      );
       await userEvent.click(getIcon("ellipsis"));
 
       expect(
@@ -244,7 +246,10 @@ describe("for your consideration", () => {
         isAdmin: false,
       });
 
-      expect(screen.queryByTestId("indicator")).not.toBeInTheDocument();
+      expect(await screen.findByTestId("menu-indicator-root")).toHaveAttribute(
+        "data-show-indicator",
+        "false",
+      );
       await userEvent.click(getIcon("ellipsis"));
 
       expect(
@@ -263,7 +268,10 @@ describe("for your consideration", () => {
         moveToDashboard: true,
       });
 
-      expect(screen.queryByTestId("indicator")).not.toBeInTheDocument();
+      expect(await screen.findByTestId("menu-indicator-root")).toHaveAttribute(
+        "data-show-indicator",
+        "false",
+      );
       await userEvent.click(getIcon("ellipsis"));
 
       expect(
@@ -279,11 +287,13 @@ describe("for your consideration", () => {
         collection: createMockCollection({ can_write: true }),
         dashboardQuestionCandidates: [dqCandidate],
         isAdmin: true,
-        collectionMenu: true,
         moveToDashboard: true,
       });
 
-      expect(screen.queryByTestId("indicator")).not.toBeInTheDocument();
+      expect(await screen.findByTestId("menu-indicator-root")).toHaveAttribute(
+        "data-show-indicator",
+        "false",
+      );
       await userEvent.click(getIcon("ellipsis"));
 
       expect(

--- a/frontend/src/metabase/collections/components/CollectionMenu/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/tests/premium.unit.spec.tsx
@@ -1,7 +1,7 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
-import { getIcon, screen } from "__support__/ui";
+import { getIcon, screen, waitFor } from "__support__/ui";
 import {
   createMockCollection,
   createMockTokenFeatures,
@@ -124,19 +124,16 @@ describe("CollectionMenu", () => {
         numberOfStaleItems: 10,
       });
 
-      expect(
-        fetchMock.called(
-          "http://localhost/api/user-key-value/namespace/user_acknowledgement/key/collection-menu",
-          { method: "PUT" },
-        ),
-      ).toBe(false);
-
-      expect(await screen.findByTestId("indicator")).toBeInTheDocument();
+      await waitFor(async () =>
+        expect(
+          await screen.findByTestId("menu-indicator-root"),
+        ).toHaveAttribute("data-show-indicator", "true"),
+      );
       await userEvent.click(getIcon("ellipsis"));
 
       expect(
         fetchMock.calls(
-          "http://localhost/api/user-key-value/namespace/user_acknowledgement/key/collection-menu",
+          "http://localhost/api/user-key-value/namespace/indicator-menu/key/collection-menu",
           { method: "PUT" },
         ),
       ).toHaveLength(1);
@@ -151,10 +148,12 @@ describe("CollectionMenu", () => {
         collection: createMockCollection({ can_write: true }),
         isAdmin: true,
         numberOfStaleItems: 10,
-        collectionMenu: true,
       });
 
-      expect(screen.queryByTestId("indicator")).not.toBeInTheDocument();
+      expect(await screen.findByTestId("menu-indicator-root")).toHaveAttribute(
+        "data-show-indicator",
+        "false",
+      );
       await userEvent.click(getIcon("ellipsis"));
 
       expect(
@@ -174,7 +173,6 @@ describe("CollectionMenu", () => {
         collection: createMockCollection({ can_write: true }),
         isAdmin: false,
         numberOfStaleItems: 10,
-        collectionMenu: true,
       });
 
       await userEvent.click(getIcon("ellipsis"));
@@ -191,7 +189,10 @@ describe("CollectionMenu", () => {
         numberOfStaleItems: 0,
       });
 
-      expect(screen.queryByTestId("indicator")).not.toBeInTheDocument();
+      expect(await screen.findByTestId("menu-indicator-root")).toHaveAttribute(
+        "data-show-indicator",
+        "false",
+      );
       await userEvent.click(getIcon("ellipsis"));
 
       expect(fetchMock.calls("express:/api/ee/stale/:id")).toHaveLength(1);
@@ -217,7 +218,10 @@ describe("CollectionMenu", () => {
         isAdmin: false,
       });
 
-      expect(screen.queryByTestId("indicator")).not.toBeInTheDocument();
+      expect(await screen.findByTestId("menu-indicator-root")).toHaveAttribute(
+        "data-show-indicator",
+        "false",
+      );
       await userEvent.click(getIcon("ellipsis"));
 
       expect(fetchMock.calls("path:/api/collection/1/items")).toHaveLength(0);
@@ -236,7 +240,10 @@ describe("CollectionMenu", () => {
         numberOfStaleItems: 0,
       });
 
-      expect(screen.queryByTestId("indicator")).not.toBeInTheDocument();
+      expect(await screen.findByTestId("menu-indicator-root")).toHaveAttribute(
+        "data-show-indicator",
+        "false",
+      );
       await userEvent.click(getIcon("ellipsis"));
 
       expect(fetchMock.calls("express:/api/ee/stale/:id")).toHaveLength(0);

--- a/frontend/src/metabase/collections/components/CollectionMenu/tests/setup.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/tests/setup.tsx
@@ -32,7 +32,6 @@ export interface SetupOpts {
   hasEnterprisePlugins?: boolean;
   dashboardQuestionCandidates?: DashboardQuestionCandidate[];
   moveToDashboard?: boolean;
-  collectionMenu?: boolean;
   numberOfCollectionItems?: number;
   numberOfStaleItems?: number;
 }
@@ -45,7 +44,6 @@ export const setup = ({
   hasEnterprisePlugins = false,
   dashboardQuestionCandidates = [],
   moveToDashboard = false,
-  collectionMenu = false,
   numberOfCollectionItems = 10,
   numberOfStaleItems = 0,
 }: SetupOpts) => {
@@ -56,14 +54,20 @@ export const setup = ({
   });
   setupDashboardQuestionCandidatesEndpoint(dashboardQuestionCandidates);
   setupUserKeyValueEndpoints({
-    namespace: "user_acknowledgement",
+    namespace: "indicator-menu",
     key: "collection-menu",
-    value: collectionMenu,
+    value: [],
   });
 
   setupUserKeyValueEndpoints({
     namespace: "user_acknowledgement",
     key: "move-to-dashboard",
+    value: moveToDashboard,
+  });
+
+  setupUserKeyValueEndpoints({
+    namespace: "user_acknowledgement",
+    key: "clean-stale-items",
     value: moveToDashboard,
   });
 

--- a/frontend/src/metabase/core/components/IndicatorMenu/IndicatorMenu.tsx
+++ b/frontend/src/metabase/core/components/IndicatorMenu/IndicatorMenu.tsx
@@ -1,0 +1,40 @@
+import { type PropsWithChildren, useContext } from "react";
+
+import { Menu, type MenuProps } from "metabase/ui";
+
+import {
+  IndicatorMenuContext,
+  IndicatorMenuProvider,
+} from "./IndicatorMenuContext";
+import { IndicatorMenuItem } from "./IndicatorMenuItem";
+import { IndicatorMenuTarget } from "./IndicatorMenuTarget";
+
+const _IndicatorMenu = (props: PropsWithChildren<MenuProps>) => {
+  const ctx = useContext(IndicatorMenuContext);
+
+  if (!ctx) {
+    throw new Error("Indicator Menu Context not found");
+  }
+
+  const handleOpen = () => {
+    props.onOpen?.();
+    ctx.handleOpen();
+  };
+
+  return <Menu {...props} keepMounted onOpen={handleOpen}></Menu>;
+};
+
+export const IndicatorMenu = ({
+  menuKey,
+  ...rest
+}: PropsWithChildren<MenuProps & { menuKey: string }>) => (
+  <IndicatorMenuProvider menuKey={menuKey}>
+    <_IndicatorMenu {...rest}></_IndicatorMenu>
+  </IndicatorMenuProvider>
+);
+
+IndicatorMenu.Divider = Menu.Divider;
+IndicatorMenu.Item = Menu.Item;
+IndicatorMenu.Dropdown = Menu.Dropdown;
+IndicatorMenu.ItemWithBadge = IndicatorMenuItem;
+IndicatorMenu.Target = IndicatorMenuTarget;

--- a/frontend/src/metabase/core/components/IndicatorMenu/IndicatorMenu.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/IndicatorMenu/IndicatorMenu.unit.spec.tsx
@@ -1,0 +1,148 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+import type React from "react";
+
+import {
+  setupUserAcknowledgementEndpoints,
+  setupUserKeyValueEndpoints,
+} from "__support__/server-mocks";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { ActionIcon, Icon } from "metabase/ui";
+
+import { IndicatorMenu } from "./IndicatorMenu";
+
+const setup = async ({
+  menuItems,
+  seen = [],
+}: {
+  menuItems: React.ReactNode[];
+  seen?: string[];
+}) => {
+  const { names } = setupUserKeyValueEndpoints({
+    namespace: "indicator-menu",
+    key: "collection-menu",
+    value: seen,
+  });
+
+  renderWithProviders(
+    <IndicatorMenu menuKey="collection-menu">
+      <IndicatorMenu.Target>
+        <ActionIcon>
+          <Icon name="ellipsis" />
+        </ActionIcon>
+      </IndicatorMenu.Target>
+      <IndicatorMenu.Dropdown>{menuItems}</IndicatorMenu.Dropdown>
+    </IndicatorMenu>,
+  );
+
+  await waitFor(() => {
+    expect(fetchMock.calls(names.get).length).toBeGreaterThanOrEqual(1);
+  });
+
+  return {
+    indicatorMenuCalls: names,
+  };
+};
+
+describe("IndicatorMenu", () => {
+  it("should show an indicator when a new badge key is present in the menu", async () => {
+    const { names } = setupUserAcknowledgementEndpoints({
+      key: "move-to-dashboard",
+      value: false,
+    });
+    const { indicatorMenuCalls } = await setup({
+      menuItems: [
+        <IndicatorMenu.ItemWithBadge
+          key="one"
+          userAckKey="move-to-dashboard"
+          badgeLabel="Bar"
+        >
+          Foo
+        </IndicatorMenu.ItemWithBadge>,
+      ],
+    });
+
+    await waitForUserAckRequest(names.get);
+    assertIndicatorShown(true);
+
+    await userEvent.click(screen.getByRole("button", { name: /ellipsis/i }));
+
+    expect(await screen.findByText("Foo")).toBeInTheDocument();
+    expect(await screen.findByText("Bar")).toBeInTheDocument();
+
+    // Assert that the menu updates has seen in the API
+    const updateHasSeenCall = fetchMock.lastCall(indicatorMenuCalls.put);
+    const payload = updateHasSeenCall && (await updateHasSeenCall[1]?.body);
+
+    expect(JSON.parse(payload as string)).toHaveValue(["move-to-dashboard"]);
+
+    // The indicator should go away
+    assertIndicatorShown(false);
+  });
+
+  it("should not show an indicator when the only badges in the menu have already been seen", async () => {
+    const { names } = setupUserAcknowledgementEndpoints({
+      key: "move-to-dashboard",
+      value: false,
+    });
+    setup({
+      menuItems: [
+        <IndicatorMenu.ItemWithBadge
+          key="move-to-dashboard"
+          userAckKey="move-to-dashboard"
+          badgeLabel="Bar"
+        >
+          Foo
+        </IndicatorMenu.ItemWithBadge>,
+      ],
+      seen: ["move-to-dashboard"],
+    });
+
+    await waitForUserAckRequest(names.get);
+    assertIndicatorShown(false);
+
+    await userEvent.click(screen.getByRole("button", { name: /ellipsis/i }));
+
+    expect(await screen.findByText("Foo")).toBeInTheDocument();
+    expect(await screen.findByText("Bar")).toBeInTheDocument();
+  });
+
+  it("should not show an indicator when the badge is not rendered for a menu item", async () => {
+    const { names } = setupUserAcknowledgementEndpoints({
+      key: "move-to-dashboard",
+      value: true,
+    });
+    setup({
+      menuItems: [
+        <IndicatorMenu.ItemWithBadge
+          key="move-to-dashboard"
+          userAckKey="move-to-dashboard"
+          badgeLabel="Bar"
+        >
+          Foo
+        </IndicatorMenu.ItemWithBadge>,
+      ],
+    });
+
+    await waitForUserAckRequest(names.get);
+    assertIndicatorShown(false);
+
+    await userEvent.click(screen.getByRole("button", { name: /ellipsis/i }));
+
+    expect(await screen.findByText("Foo")).toBeInTheDocument();
+    expect(screen.queryByText("Bar")).not.toBeInTheDocument();
+  });
+});
+
+const assertIndicatorShown = (shown: boolean) => {
+  expect(screen.getByTestId("menu-indicator-root")).toHaveAttribute(
+    "data-show-indicator",
+    `${shown}`,
+  );
+};
+
+const waitForUserAckRequest = async (name: string) => {
+  await waitFor(() =>
+    expect(fetchMock.calls(name).length).toBeGreaterThanOrEqual(1),
+  );
+};

--- a/frontend/src/metabase/core/components/IndicatorMenu/IndicatorMenuContext.tsx
+++ b/frontend/src/metabase/core/components/IndicatorMenu/IndicatorMenuContext.tsx
@@ -1,0 +1,76 @@
+import {
+  type PropsWithChildren,
+  createContext,
+  useCallback,
+  useMemo,
+  useState,
+} from "react";
+
+import { useUserKeyValue } from "metabase/hooks/use-user-key-value";
+
+export interface IndicatorMenuContextProps {
+  upsertBadge: ({ key, value }: { key: string; value: boolean }) => void;
+  removeBadge: ({ key }: { key: string }) => void;
+  handleOpen: () => void;
+  showIndicator: boolean;
+}
+
+export const IndicatorMenuContext =
+  createContext<IndicatorMenuContextProps | null>(null);
+
+export const IndicatorMenuProvider = ({
+  menuKey,
+  children,
+}: PropsWithChildren<{ menuKey: string }>) => {
+  const contextValue = useIndicatorMenu(menuKey);
+
+  return (
+    <IndicatorMenuContext.Provider value={contextValue}>
+      {children}
+    </IndicatorMenuContext.Provider>
+  );
+};
+
+const useIndicatorMenu = (menuKey: string) => {
+  const [badges, setBadges] = useState<[string, boolean][]>([]);
+
+  const upsertBadge = useCallback(
+    ({ value, key }: { value: boolean; key: string }) => {
+      setBadges(s => [...s.filter(([k]) => k !== key), [key, value]]);
+    },
+    [],
+  );
+  const removeBadge = useCallback(({ key }: { key: string }) => {
+    setBadges(s => [...s.filter(([k]) => k !== key)]);
+  }, []);
+
+  const { value: seenBadges, setValue: setSeenBadges } = useUserKeyValue({
+    namespace: "indicator-menu",
+    key: menuKey,
+    defaultValue: [],
+  });
+
+  const unseenBadges = useMemo(
+    () =>
+      badges.filter(([key]) => !seenBadges.includes(key)).map(([key]) => key),
+    [badges, seenBadges],
+  );
+
+  const handleOpen = useCallback(() => {
+    if (!unseenBadges.every(b => seenBadges.includes(b))) {
+      setSeenBadges(badges.map(([k]) => k));
+    }
+  }, [unseenBadges, badges, seenBadges, setSeenBadges]);
+
+  const showIndicator = unseenBadges.length > 0;
+
+  return useMemo(
+    () => ({
+      upsertBadge,
+      removeBadge,
+      showIndicator,
+      handleOpen,
+    }),
+    [showIndicator, upsertBadge, removeBadge, handleOpen],
+  );
+};

--- a/frontend/src/metabase/core/components/IndicatorMenu/IndicatorMenuItem.tsx
+++ b/frontend/src/metabase/core/components/IndicatorMenu/IndicatorMenuItem.tsx
@@ -1,0 +1,77 @@
+import type { PolymorphicComponentProps } from "@mantine/utils";
+import type React from "react";
+import { useContext, useEffect } from "react";
+
+import { useUserAcknowledgement } from "metabase/hooks/use-user-acknowledgement";
+import { Badge, Menu, type MenuItemProps } from "metabase/ui";
+
+import { IndicatorMenuContext } from "./IndicatorMenuContext";
+
+type IndicatorMenuItemProps = MenuItemProps & {
+  badgeLabel: React.ReactNode;
+  userAckKey: string;
+  showBadge?: (val: boolean) => boolean;
+};
+
+export const IndicatorMenuItem = <C = "button",>(
+  props: PolymorphicComponentProps<C, IndicatorMenuItemProps>,
+) => {
+  const {
+    userAckKey,
+    badgeLabel = "New",
+    children,
+    showBadge = (hasSeen: boolean) => !hasSeen,
+    ...rest
+  } = props;
+
+  //Keep TS Happy
+  const typeCastedRest = rest as MenuItemProps;
+
+  const ctx = useContext(IndicatorMenuContext);
+
+  if (!ctx) {
+    throw new Error(
+      "Indicator Menu Item must be used within an Indicator Menu",
+    );
+  }
+
+  const { removeBadge, upsertBadge } = ctx;
+
+  const [hasSeen, { ack, isLoading }] = useUserAcknowledgement(
+    userAckKey,
+    true,
+  );
+
+  const isShowingBadge = showBadge(hasSeen);
+
+  useEffect(() => {
+    if (!isLoading && isShowingBadge) {
+      upsertBadge({ key: userAckKey, value: hasSeen });
+
+      return () => removeBadge({ key: userAckKey });
+    }
+  }, [
+    userAckKey,
+    upsertBadge,
+    removeBadge,
+    hasSeen,
+    isShowingBadge,
+    isLoading,
+  ]);
+
+  const handleClick = () => {
+    ack();
+  };
+
+  return (
+    <Menu.Item
+      {...typeCastedRest}
+      rightSection={
+        isShowingBadge && <Badge variant="light">{badgeLabel}</Badge>
+      }
+      onClick={handleClick}
+    >
+      {children}
+    </Menu.Item>
+  );
+};

--- a/frontend/src/metabase/core/components/IndicatorMenu/IndicatorMenuItem.tsx
+++ b/frontend/src/metabase/core/components/IndicatorMenu/IndicatorMenuItem.tsx
@@ -1,9 +1,13 @@
-import type { PolymorphicComponentProps } from "@mantine/utils";
 import type React from "react";
 import { useContext, useEffect } from "react";
 
 import { useUserAcknowledgement } from "metabase/hooks/use-user-acknowledgement";
-import { Badge, Menu, type MenuItemProps } from "metabase/ui";
+import {
+  Badge,
+  Menu,
+  type MenuItemProps,
+  type PolymorphicComponentProps,
+} from "metabase/ui";
 
 import { IndicatorMenuContext } from "./IndicatorMenuContext";
 

--- a/frontend/src/metabase/core/components/IndicatorMenu/IndicatorMenuTarget.tsx
+++ b/frontend/src/metabase/core/components/IndicatorMenu/IndicatorMenuTarget.tsx
@@ -17,7 +17,12 @@ export const IndicatorMenuTarget = (props: PropsWithChildren) => {
 
   return (
     <Menu.Target>
-      <Indicator disabled={!showIndicator} size={6}>
+      <Indicator
+        data-show-indicator={showIndicator}
+        data-testid="menu-indicator-root"
+        disabled={!showIndicator}
+        size={6}
+      >
         {props.children}
       </Indicator>
     </Menu.Target>

--- a/frontend/src/metabase/core/components/IndicatorMenu/IndicatorMenuTarget.tsx
+++ b/frontend/src/metabase/core/components/IndicatorMenu/IndicatorMenuTarget.tsx
@@ -1,0 +1,25 @@
+import { type PropsWithChildren, useContext } from "react";
+
+import { Indicator, Menu } from "metabase/ui";
+
+import { IndicatorMenuContext } from "./IndicatorMenuContext";
+
+export const IndicatorMenuTarget = (props: PropsWithChildren) => {
+  const ctx = useContext(IndicatorMenuContext);
+
+  if (!ctx) {
+    throw new Error(
+      "Indicator Menu Target must be used within an Indicator Menu",
+    );
+  }
+
+  const { showIndicator } = ctx;
+
+  return (
+    <Menu.Target>
+      <Indicator disabled={!showIndicator} size={6}>
+        {props.children}
+      </Indicator>
+    </Menu.Target>
+  );
+};

--- a/frontend/src/metabase/core/components/IndicatorMenu/index.ts
+++ b/frontend/src/metabase/core/components/IndicatorMenu/index.ts
@@ -1,0 +1,1 @@
+export * from "./IndicatorMenu";

--- a/frontend/src/metabase/ui/index.ts
+++ b/frontend/src/metabase/ui/index.ts
@@ -6,6 +6,7 @@ export type {
   MantineStyleProps,
   FloatingPosition,
   MantineSize,
+  PolymorphicComponentProps,
 } from "@mantine/core";
 export { useHover } from "@mantine/hooks";
 export * from "./components";

--- a/frontend/test/__support__/server-mocks/user-key-value.ts
+++ b/frontend/test/__support__/server-mocks/user-key-value.ts
@@ -7,19 +7,44 @@ export const setupUserKeyValueEndpoints = ({
   key,
   value,
 }: UserKeyValue) => {
-  fetchMock.get(`path:/api/user-key-value/namespace/${namespace}/key/${key}`, {
-    status: 200,
-    body: value,
-  });
+  // Fetch Mock doesn't seem to work when you use calls(name) and name has underscores *sigh*
+  const name = `user-key-value-${namespace}-${key}`.replace("_", "-");
 
-  fetchMock.put(`path:/api/user-key-value/namespace/${namespace}/key/${key}`, {
-    status: 200,
-  });
+  const getName = `get-${name}`;
+  const putName = `put-${name}`;
+
+  fetchMock.get(
+    `path:/api/user-key-value/namespace/${namespace}/key/${key}`,
+    {
+      status: 200,
+      body: value,
+    },
+    {
+      name: getName,
+    },
+  );
+
+  fetchMock.put(
+    `path:/api/user-key-value/namespace/${namespace}/key/${key}`,
+    {
+      status: 200,
+    },
+    {
+      name: putName,
+    },
+  );
 
   fetchMock.delete(
     `path:/api/user-key-value/namespace/${namespace}/key/${key}`,
     { status: 200 },
   );
+
+  return {
+    names: {
+      get: getName,
+      put: putName,
+    },
+  };
 };
 
 export function setupGetUserKeyValueEndpoint(kv: UserKeyValue) {
@@ -52,4 +77,18 @@ export function setupDeleteUserKeyValueEndpoint(k: UserKeyValueKey) {
     { status: 200 },
     { overwriteRoutes: true },
   );
+}
+
+export function setupUserAcknowledgementEndpoints({
+  key,
+  value,
+}: {
+  key: string;
+  value: boolean;
+}) {
+  return setupUserKeyValueEndpoints({
+    namespace: "user_acknowledgement",
+    key,
+    value,
+  });
 }

--- a/resources/user_key_value_types/indicator-menu.edn
+++ b/resources/user_key_value_types/indicator-menu.edn
@@ -1,0 +1,2 @@
+[:map
+ [:value [:vector :string]]]


### PR DESCRIPTION
Closes ADM-174

### Description
Introduces a wrapper around the Menu component that uses context to compute and share whether an indicator belongs on a menu based on it's contents. This replaces the existing implementation that was simply a boolean stored in the user key value store. Now we store which items a user has seen, compare that against what items are in the list, and decide dynamically whether or not to show an indicator. In the future, adding new items with callouts should "just work", without us needing to fuss with migrations

This PR has the `no-backport` tag because there will be conflicts with how we do the testing with the indicator component. It will need to be manually backported, if that is something that we want to do

### How to verify
1. Go to a collection where you have items you can move to a dashboard. You should see an indicator on the collection menu
2. Open the menu, and the indicator should disappear. Refreshing the page, it should stay hidden
3. Go to another collection where you have stale items, and the indicator should re-appear
4. Opening the menu should dismiss the indicator again

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
