### PR TITLE
Migrations for database routing

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10804,6 +10804,105 @@ databaseChangeLog:
             path: instance_analytics_views/alerts/v1/h2-alerts.sql
             relativeToChangelogFile: true
 
+  - changeSet:
+      id: v54.2025-02-26T05:22:58
+      author: johnswanson
+      comment: Add `db_router` table
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: db_router
+      changes:
+        - createTable:
+            tableName: db_router
+            remarks: |
+              Configuration for Database Routers. Currently just holds which user attribute each
+              configured router database should use to choose a mirror database to route to.
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: database_id
+                  type: int
+                  remarks: 'The ID of the database this is for.'
+                  constraints:
+                    unique: true
+                    nullable: false
+                    referencedTableName: metabase_database
+                    referencedColumnNames: id
+                    foreignKeyName: fk_db_router_database_id
+              - column:
+                  name: user_attribute
+                  type: varchar(254)
+                  remarks: 'The user attribute used to redirect users to a different database.'
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v54.2025-02-26T05:23:06
+      author: johnswanson
+      comment: Add self-referential foreign key `router_database_id` to metabase_database
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: metabase_database
+                columnName: router_database_id
+      changes:
+        - addColumn:
+            tableName: metabase_database
+            columns:
+              - column:
+                  name: router_database_id
+                  type: int
+                  remarks: The ID of the primary database for this mirror database.
+                  constraints:
+                    unique: false
+                    nullable: true
+
+  - changeSet:
+      id: v54.2025-02-26T05:23:12
+      author: johnswanson
+      comment: Add foreign key for `router_database_id`
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+          - foreignKeyConstraintExists:
+            - foreignKeyName: fk_metabase_database_metabase_database_id
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: metabase_database
+            baseColumnNames: router_database_id
+            referencedTableName: metabase_database
+            referencedColumnNames: id
+            constraintName: fk_metabase_database_metabase_database_id
+            onDelete: RESTRICT
+
+  - changeSet:
+      id: v54.2025-02-26T05:23:15
+      author: johnswanson
+      comment: add an index for `metabase_database.router_database_id`
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: metabase_database
+                indexName: idx_metabase_database_router_database_id
+      rollback: # will be deleted when column is deleted
+      changes:
+        - createIndex:
+            tableName: metabase_database
+            columns:
+              - column:
+                  name: router_database_id
+            indexName: idx_metabase_database_router_database_id
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -451,6 +451,7 @@
                                          ::serdes/skip))
                                      :import identity}
                :creator_id          (serdes/fk :model/User)
+               :router_database_id (serdes/fk :model/Database)
                :initial_sync_status {:export identity :import (constantly "complete")}}})
 
 (defmethod serdes/entity-id "Database"

--- a/test/metabase/search/appdb/index_test.clj
+++ b/test/metabase/search/appdb/index_test.clj
@@ -513,7 +513,7 @@
    "report_card"       #{"action" "model_index_value" "report_card"}
    "report_dashboard"  #{"action" "model_index_value" "report_card"}})
 
-(deftest search-model-cascade-text
+(deftest search-model-cascade-test
   (is (= model->deleted-descendants
          (mt/with-empty-h2-app-db
            (let [table->children    (u.conn/app-db-cascading-deletes (mdb/app-db) (map t2/table-name (descendants :metabase/model)))

--- a/test_resources/serialization_baseline/databases/My Database/My Database.yaml
+++ b/test_resources/serialization_baseline/databases/My Database/My Database.yaml
@@ -26,3 +26,4 @@ entity_id: ykVHi-GHcd1td4Lvb62pr
 uploads_enabled: false
 uploads_schema_name: null
 uploads_table_prefix: null
+router_database_id: null

--- a/test_resources/serialization_baseline/databases/test-data (h2)/test-data (h2).yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/test-data (h2).yaml
@@ -31,3 +31,4 @@ entity_id: ymbeYS8YN6P6Vltnq81Ib
 uploads_enabled: false
 uploads_schema_name: null
 uploads_table_prefix: null
+router_database_id: null


### PR DESCRIPTION
Two changes here:

- add a self-referential foreign key, `metabase_database.router_database_id`, to allow marking a mirror database's primary database. Databases with this set are mirror databases, databases without it are primary databases.

- add a `db_router` table with only three columns:

  - `id`, primary ID,

  - `database_id`, the `metabase_database.id` of the primary database for this router, and

  - `user_attribute`, the user attribute used to map users to a particular mirror database.