### PR TITLE
Allow private slack channels to be returned for alerts/subscriptions

### DIFF
--- a/docs/configuring-metabase/slack.md
+++ b/docs/configuring-metabase/slack.md
@@ -53,6 +53,7 @@ oauth_config:
       - chat:write
       - chat:write.customize
       - chat:write.public
+      - groups:read
 ```
 
 The manifest just take cares of some settings for your app and helps speed things along.
@@ -83,7 +84,7 @@ In order to send subscriptions and alerts to private Slack channels, you must fi
 
 In Slack, go to the private channel and mention the Metabase app. For example, if you called your Slack app "Metabase", you'd just type `@Metabase`. Slack will ask you if you want to invite your app to your channel, which you should.
 
-Once your Metabase app is added to the private channel, you'll need to type out the private channel's name in the subscription or alert. Make sure to spell the channel's name correctly, or Metabase won't be able to send the notification.
+Once your Metabase app is added to the private channel you'll need to type out the private channel's name in the subscription or alert. Make sure to spell the channel's name correctly, or Metabase won't be able to send the notification.
 
 ## Further reading
 

--- a/docs/configuring-metabase/slack.md
+++ b/docs/configuring-metabase/slack.md
@@ -84,7 +84,17 @@ In order to send subscriptions and alerts to private Slack channels, you must fi
 
 In Slack, go to the private channel and mention the Metabase app. For example, if you called your Slack app "Metabase", you'd just type `@Metabase`. Slack will ask you if you want to invite your app to your channel, which you should.
 
-Once your Metabase app is added to the private channel you'll need to type out the private channel's name in the subscription or alert. Make sure to spell the channel's name correctly, or Metabase won't be able to send the notification.
+### Metabase not listing your private channel?
+
+It can take a little time for metabase to see all the channels the app has been invited to. New channels may not appear in listings for up to 10 minutes after inviting the app to the channel.
+
+In order for metabase to see private channels, the app must have the `groups:read` oauth scope. Although this scope should be granted when setting up the app through metabase, older installations might not have this scope. 
+If you think this might be the case [visit the app settings in slack](https://api.slack.com/apps/):
+- Click on the metabase app in the app listing.
+- Click on **OAuth & Permissions** in the sidebar.
+- Under **Scopes** add the `groups:read` scope.
+- The app will the need to be reinstalled to the workspace
+  by clicking the **Reinstall** button under **OAuth Tokens**.
 
 ## Further reading
 

--- a/resources/slack-manifest.yaml
+++ b/resources/slack-manifest.yaml
@@ -18,3 +18,4 @@ oauth_config:
       - chat:write
       - chat:write.customize
       - chat:write.public
+      - groups:read

--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -138,11 +138,11 @@
                                       " update your integration in Admin Settings -> Slack."))))
     (throw (ex-info message error))))
 
-(defn- handle-response [{:keys [status body]}]
+(defn- handle-response [{:keys [headers status body]}]
   (with-open [reader (io/reader body)]
     (let [body (json/decode+kw reader)]
       (if (and (= 200 status) (:ok body))
-        body
+        (assoc body ::headers headers)
         (handle-error body)))))
 
 (defn- do-slack-request [request-fn endpoint request]
@@ -175,6 +175,13 @@
   "Make a POST request to the Slack API."
   [endpoint body]
   (do-slack-request http/post endpoint body))
+
+(defn- oauth-scopes
+  "Returns the set of scopes associated with the current token"
+  []
+  (let [{::keys [headers]} (GET "auth.test")
+        {:strs [x-oauth-scopes]} headers]
+    (set (str/split x-oauth-scopes #","))))
 
 (defn- next-cursor
   "Get a cursor for the next page of results in a Slack API response, if one exists."
@@ -217,8 +224,11 @@
   "Calls Slack API `conversations.list` and returns list of available 'conversations' (channels and direct messages).
   By default only fetches channels, and returns them with their # prefix. Note the call to [[paged-list-request]] will
   only fetch the first [[max-list-results]] items."
-  [& {:as query-parameters}]
-  (let [params (merge {:exclude_archived true, :types "public_channel"} query-parameters)]
+  [& {:keys [oauth-scopes query-parameters]}]
+  (let [types  (if (contains? oauth-scopes "groups:read")
+                 "public_channel,private_channel"
+                 "public_channel")
+        params (merge {:exclude_archived true, :types types} query-parameters)]
     (paged-list-request "conversations.list"
                         ;; response -> channel names
                         #(->> % :channels (map channel-transform))
@@ -285,7 +295,7 @@
   (when (slack-configured?)
     (log/info "Refreshing slack channels and usernames.")
     (let [users (future (vec (users-list)))
-          conversations (future (vec (conversations-list)))]
+          conversations (future (vec (conversations-list {:oauth-scopes (oauth-scopes)})))]
       (slack-cached-channels-and-usernames! {:channels (concat @conversations @users)})
       (slack-channels-and-usernames-last-updated! (t/zoned-date-time)))))
 

--- a/test/metabase/integrations/slack_test.clj
+++ b/test/metabase/integrations/slack_test.clj
@@ -100,7 +100,9 @@
                 (fn [req]
                   (reset! request req)
                   (mock-200-response (mock-conversations-response-body req)))}
-               (slack/conversations-list opts))
+               (tu/with-temporary-setting-values [slack-token "test-token"
+                                                  slack-app-token nil]
+                 (slack/conversations-list opts)))
              (let [{:keys [query-string]} @request
                    {:keys [types]}        (parse-query-string query-string)]
                (= conversation-types types)))

--- a/test/metabase/integrations/slack_test.clj
+++ b/test/metabase/integrations/slack_test.clj
@@ -92,7 +92,7 @@
   (testing "conversations-list"
     (test-auth! conversations-endpoint slack/conversations-list)
 
-    (testing "private_channel is only requested if the groups:read scope is available"
+    (testing ":private_channel flag determines the \"types\" param sent to slack"
       (are [opts conversation-types]
            (let [request (atom nil)]
              (http-fake/with-fake-routes
@@ -106,9 +106,9 @@
              (let [{:keys [query-string]} @request
                    {:keys [types]}        (parse-query-string query-string)]
                (= conversation-types types)))
-        {}                               "public_channel"
-        {:oauth-scopes #{}}              "public_channel"
-        {:oauth-scopes #{"groups:read"}} "public_channel,private_channel"))
+        {}                        "public_channel"
+        {:private-channels false} "public_channel"
+        {:private-channels true}  "public_channel,private_channel"))
 
     (testing "should be able to fetch channels and paginate"
       (http-fake/with-fake-routes {conversations-endpoint (comp mock-200-response mock-conversations-response-body)}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/44798

Users can now send notifications to private channels. With the caveat that existing connections to slack will need to be granted an additional oauth scope, for which I've provided guidance in the docs here: [docs/configuring-metabase/slack.md](https://github.com/metabase/metabase/pull/53128/files#diff-e0ce4eb74e73749598c8abd003d02aafa2873d7917a120e54767c96dc3f3a6d5R87).

### Description

Makes it possible for the `conversation.list` call to request private channels, which are then used to populate the drop down box when selecting a channel for an alert.

The `groups:read` oauth scope is needed to list private channels. 

- New slack installations will get this by default, as we have added the scope to the `manifest.yaml`. 
- Existing installations can be reinstalled with the scope (in slack app settings), metabase will then start to request private channels, once the conversations cache is cleared (10mins TTL)
- Installations that do not have the required scope work as before, they do not request private channels.

> **note** the image channel must still be public, otherwise the previews do not appear correctly in slack. Will raise a new issue, as this seems surprising

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a slack workspace or use the metabase workspace
2. Create a private channel
3. Add the slack integration (admin settings -> notification channels -> slack) 
4. Invite the slack app to your new private channel
5. Go to a question (I used `/question/37-aerodynamic-copper-knife-trend`)
6. Setup alerts (share icon -> create alert)
7. The slack channel list should also list private channels the slack bot has been invited to

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
