### PR TITLE
[Dashboards] Prevent duplicate edit dashboard calls from breaking dashboard save

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -354,10 +354,10 @@ describe("scenarios > dashboard", () => {
 
       it("should save changes to a dashboard after using the 'Add a chart' button from an empty tab (metabase#53132)", () => {
         cy.log("add an existing card");
-        cy.findAllByTestId("dashboard-header").icon("pencil").click();
-        cy.findAllByTestId("dashboard-header").icon("add").click();
+        H.editDashboard();
+        cy.findByTestId("dashboard-header").icon("add").click();
         H.sidebar().findByText("Orders, Count").click();
-        cy.findAllByTestId("dashboard-header").icon("add").click();
+        cy.findByTestId("dashboard-header").icon("add").click();
 
         cy.log("create a tab to access emtpy state again");
         H.createNewTab();
@@ -371,13 +371,7 @@ describe("scenarios > dashboard", () => {
 
         cy.log("create a dashboard question");
         H.NativeEditor.focus().type("SELECT 1");
-        H.queryBuilderHeader().findByText("Save").click();
-        H.modal().within(() => {
-          cy.findByPlaceholderText(/name of your question/i).type(
-            "Foo question",
-          );
-          cy.findByRole("button", { name: "Save" }).click();
-        });
+        H.saveQuestion("Foo question");
 
         cy.log(
           "should have persisted changes from when dashboard was saved before creating a question",

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -352,6 +352,40 @@ describe("scenarios > dashboard", () => {
           .and("contain", "18,760");
       });
 
+      it("should save changes to a dashboard after using the 'Add a chart' button from an empty tab (metabase#53132)", () => {
+        cy.log("add an existing card");
+        cy.findAllByTestId("dashboard-header").icon("pencil").click();
+        cy.findAllByTestId("dashboard-header").icon("add").click();
+        H.sidebar().findByText("Orders, Count").click();
+        cy.findAllByTestId("dashboard-header").icon("add").click();
+
+        cy.log("create a tab to access emtpy state again");
+        H.createNewTab();
+        cy.findByTestId("dashboard-empty-state")
+          .findByText("Add a chart")
+          .click();
+
+        cy.log("save changes before leaving");
+        H.sidebar().findByText("New SQL query").click();
+        H.modal().findByRole("button", { name: "Save changes" }).click();
+
+        cy.log("create a dashboard question");
+        H.NativeEditor.focus().type("SELECT 1");
+        H.queryBuilderHeader().findByText("Save").click();
+        H.modal().within(() => {
+          cy.findByPlaceholderText(/name of your question/i).type(
+            "Foo question",
+          );
+          cy.findByRole("button", { name: "Save" }).click();
+        });
+
+        cy.log(
+          "should have persisted changes from when dashboard was saved before creating a question",
+        );
+        cy.findAllByRole("tab", { name: /Tab \d/ }).should("have.length", 2);
+        H.getDashboardCards().should("have.length", 2);
+      });
+
       it("should allow navigating to the notebook editor directly from a dashboard card", () => {
         H.visitDashboard(ORDERS_DASHBOARD_ID);
         H.showDashboardCardActions();

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -236,17 +236,18 @@ function Dashboard(props: DashboardProps) {
 
   const handleSetEditing = useCallback(
     (dashboard: IDashboard | null) => {
-      onRefreshPeriodChange(null);
-      setEditingDashboard(dashboard);
+      if (!isEditing) {
+        onRefreshPeriodChange(null);
+        setEditingDashboard(dashboard);
+      }
     },
-    [onRefreshPeriodChange, setEditingDashboard],
+    [isEditing, onRefreshPeriodChange, setEditingDashboard],
   );
 
   const handleAddQuestion = useCallback(() => {
-    onRefreshPeriodChange(null);
-    setEditingDashboard(dashboard);
+    handleSetEditing(dashboard);
     toggleSidebar(SIDEBAR_NAME.addQuestion);
-  }, [onRefreshPeriodChange, setEditingDashboard, dashboard, toggleSidebar]);
+  }, [handleSetEditing, dashboard, toggleSidebar]);
 
   const handleLoadDashboard = useCallback(
     async (dashboardId: DashboardId) => {

--- a/frontend/src/metabase/dashboard/reducers-typed.ts
+++ b/frontend/src/metabase/dashboard/reducers-typed.ts
@@ -145,9 +145,13 @@ export const editingDashboard = handleActions(
         // Only update the dashboard in the state if the new dashboard differs from the current one.
         // This prevents the case where this function is accidentally called with an edited/dirty dashboard,
         // preventing the diff logic in our save flow from properly detecting that were changes.
-        if (state?.id === payload?.id) {
+        if (payload !== null && state?.id === payload?.id) {
+          console.warn(
+            "The editingDashboard state should not be set to a newer version of the same dashboard. This can produce subtle bugs for detecting how dashboards have changed over time. Skipping updating state and using old editingDashboard state.",
+          );
           return state;
         }
+
         return payload ?? null;
       },
     },

--- a/frontend/src/metabase/dashboard/reducers-typed.ts
+++ b/frontend/src/metabase/dashboard/reducers-typed.ts
@@ -141,7 +141,15 @@ export const editingDashboard = handleActions(
   {
     [INITIALIZE]: { next: () => INITIAL_DASHBOARD_STATE.editingDashboard },
     [SET_EDITING_DASHBOARD]: {
-      next: (_state, { payload }) => payload ?? null,
+      next: (state, { payload }) => {
+        // Only update the dashboard in the state if the new dashboard differs from the current one.
+        // This prevents the case where this function is accidentally called with an edited/dirty dashboard,
+        // preventing the diff logic in our save flow from properly detecting that were changes.
+        if (state?.id === payload?.id) {
+          return state;
+        }
+        return payload ?? null;
+      },
     },
     [RESET]: { next: () => INITIAL_DASHBOARD_STATE.editingDashboard },
   },


### PR DESCRIPTION
### Description

Currently edits to a dashboard can be lost in a very particular set of steps:
1. the user makes edits to a dashboard
2. the user creates a new tab
3. the user hits the empty state's "Add a chart" button
4. the user then creates a "New question" or "New sql question" from the sidebar
![CleanShot 2025-02-03 at 12 18 29@2x](https://github.com/user-attachments/assets/edddc24c-fa31-48fb-bd0a-c21ad739ab0d)

This bug is in part a result of #52639, which introduce a new empty state to dashboards. The offending function is `handleAddQuestion` in `frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx`, which makes a call to `setEditingDashboard` with the current dashboard. If the user is in the edit state, this button sets the current edit dashboard state to the currently edited/dirty dashboard. This has downstream effects when the user goes to save, if the user hasn't made any changes since the last call to this function. Our `updateDashboardAndCards` function will skip submitting our dashboard edits to the server as it diffs that there were no changes before and after editing.

Ultimately the above mistake would be easy for anyone to accidentally make. In this PR, I do 3 things to fix this now and for future engineers:
1. Fix the improper call to `setEditingDashboard` if we're already in an edit state on the dashboard. In `Dashboard.tsx` I colocate the setting the edit state and make sure it only happens if we're currently not in the edit state.
2. Warn developers if they're setting the editing dashboard to a dashboard with the same id. Since the repro steps are quite specific in this case I wanted to avoid throwing an error. It seems likely developers would be able to create other edge cases similar to this in the future that we can't possibly predict. If we throw we'd be relying on users to report when they're noticing thrown errors (and praying that they submitted a decent set of steps to repro).
3. Continue to the use the old editing dashboard state when a dashboard with the same id is dispatched. Currently this is all we ever want the logic to be. I think in some future case where it's not what we want, it will be obvious to a developer that something is wrong before shipping a feature, which again I think makes this a better approach than throwing an error.

### Demo

Bug Repro
https://github.com/user-attachments/assets/19e1b13b-82de-4459-b37e-8d94dfb6fc35

Fix Demo (note: save to tab doesn't currently work, so it's expected new card is saved to tab 1)
https://github.com/user-attachments/assets/759f100b-961c-4e15-ba5b-cba79c5ac6cd

### Checklist

- [x] Tests have been added/updated to cover changes in this PR