### PR TITLE
Fix quick filter drill for trend charts

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
@@ -496,4 +496,44 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
     cy.icon("warning").should("not.exist");
     H.cartesianChartCircle().should("have.length", 3);
   });
+
+  it("should support quick-filter drill thru (metabase#46168)", () => {
+    H.createQuestion(
+      {
+        name: "46168",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: AGGREGATIONS,
+          breakout: [
+            ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+          ],
+        },
+        display: "smartscalar",
+      },
+      { visitQuestion: true },
+    );
+
+    cy.findByTestId("scalar-period")
+      .findByText("Apr 2026")
+      .should("be.visible");
+    cy.findByTestId("scalar-container").findByText("344").click();
+
+    H.popover().within(() => {
+      // Validate expected filter options
+      cy.findByText("Filter by this value").should("be.visible");
+      cy.findByText(">").should("be.visible");
+      cy.findByText("<").should("be.visible");
+      cy.findByText("=").should("be.visible");
+      cy.findByText("≠").should("be.visible");
+
+      // Apply the drill
+      cy.findByText(">").click();
+    });
+
+    // Validate that the filter was applied
+    cy.findByTestId("scalar-period")
+      .findByText("Mar 2026")
+      .should("be.visible");
+    cy.findByTestId("scalar-container").findByText("527").should("be.visible");
+  });
 });

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.js
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.js
@@ -204,7 +204,7 @@ function getCurrentMetricData({ series, insights, settings }) {
 
   const clicked = {
     value,
-    column: cols[dimensionColIndex],
+    column: cols[metricColIndex],
     dimensions: [
       {
         value: rows[latestRowIndex][dimensionColIndex],


### PR DESCRIPTION
Closes #46168

### Description

Fix the quick filter drill for SmartScalar trend charts.

The `clicked` object returned by `getCurrentMetricData` had the `value` from the aggregation cell, but the `column` from the date dimension, which breaks the quick filter drill (and probably others).

Instead, return the `column` that corresponds to the aggregation `value`.

### How to verify

1. Create a GUI question "Count of Orders by Created At"
2. Switch to Trend chart
3. Click on the big number
4. Select one of the "Filter by this value" operators (e.g. `>`)

Should add the appropriate filter and display the results.

### Demo

![Screenshot 2025-02-03 at 12 07 49 PM](https://github.com/user-attachments/assets/d76ea81a-190e-4e8f-ade0-fd99d5a719a5)
![Screenshot 2025-02-03 at 12 08 06 PM](https://github.com/user-attachments/assets/752a0816-ef01-4617-915f-a13bdb47c2f4)

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
