### PR TITLE
feat: use liquibase session lock instead of transaction lock

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -40,6 +40,7 @@
   com.fasterxml.woodstox/woodstox-core      {:mvn/version "7.1.0"}              ; trans dep of commons-codec
   ; Detect the charset in uploaded CSV files
   com.github.albfernandez/juniversalchardet {:mvn/version "2.5.0"}
+  com.github.blagerweij/liquibase-sessionlock {:mvn/version "1.6.9"}            ; session lock for liquibase migrations
   com.github.jknack/handlebars              ^:antq/exclude                      ; 4.4.0 requires java 17+
                                             {:mvn/version "4.3.1"}              ; templating engine
   com.github.seancorfield/honeysql          {:mvn/version "2.6.1270"}           ; Honey SQL 2. SQL generation from Clojure data maps

--- a/resources/migrations/000_legacy_migrations.yaml
+++ b/resources/migrations/000_legacy_migrations.yaml
@@ -5829,16 +5829,14 @@ databaseChangeLog:
   - changeSet:
         id: 109
         author: camsaul
-        comment: Added 0.34.2
+        comment: Added 0.34.2, but not necessary anymore with the liquibase session lock
         failOnError: false
         preConditions:
           - onFail: MARK_RAN
           - onSqlOutput: FAIL
           - or:
               - dbms:
-                    type: mysql
-              - dbms:
-                    type: mariadb
+                    type: none
         changes:
           - sql:
                 sql: ALTER TABLE `DATABASECHANGELOGLOCK` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/test/metabase/db/general_schema_tests.clj
+++ b/test/metabase/db/general_schema_tests.clj
@@ -10,11 +10,10 @@
 (deftest ^:parallel no-tiny-int-columns
   (when (= (mdb/db-type) :mysql)
     (testing "All boolean columns in mysql, mariadb should be bit(1)"
-      (is (= [{:table_name "DATABASECHANGELOGLOCK" :column_name "LOCKED"}] ;; outlier because this is liquibase's table
-             (t2/query
-              (format "SELECT table_name, column_name FROM information_schema.columns WHERE data_type LIKE 'tinyint%%' AND table_schema = '%s';"
-                      (with-open [conn (-> (mdb/app-db) .getConnection)]
-                        (.getCatalog conn)))))))))
+      (is (= [] (t2/query
+                 (format "SELECT table_name, column_name FROM information_schema.columns WHERE data_type LIKE 'tinyint%%' AND table_schema = '%s';"
+                         (with-open [conn (-> (mdb/app-db) .getConnection)]
+                           (.getCatalog conn)))))))))
 
 (deftest ^:parallel fks-are-indexed-test
   (when (= (mdb/db-type) :postgres)

--- a/test/metabase/db/liquibase_test.clj
+++ b/test/metabase/db/liquibase_test.clj
@@ -4,6 +4,7 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [metabase.db :as mdb]
    [metabase.db.liquibase :as liquibase]
    [metabase.db.test-util :as mdb.test-util]
    [metabase.driver :as driver]
@@ -12,7 +13,10 @@
    [metabase.test :as mt]
    [metabase.util.yaml :as u.yaml]
    [next.jdbc :as next.jdbc]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2])
+  (:import
+   (liquibase Liquibase)
+   (liquibase.lockservice LockServiceFactory)))
 
 (set! *warn-on-reflection* true)
 
@@ -128,3 +132,24 @@
             (deliver released true)
             (testing "The lock was released before the migration finished"
               (is (not @locked?)))))))))
+
+(deftest auto-release-session-lock-test
+  (mt/test-drivers #{:mysql :postgres}
+    (testing "Session lock is released on conn close"
+      ;; Session lock provided automatically by the com.github.blagerweij/liquibase-sessionlock dependency
+      (mt/with-temp-empty-app-db [_conn driver/*driver*]
+        (let [;; use data-source so with-liquibase opens and closes the conn itself
+              data-source (mdb/data-source)
+              lock        (fn [^Liquibase liquibase]
+                            (->> liquibase
+                                 .getDatabase
+                                 (.getLockService (LockServiceFactory/getInstance))
+                                 .acquireLock))]
+          (liquibase/with-liquibase [liquibase1 data-source]
+            (is (lock liquibase1) "Can initially acquire session lock")
+            (is (lock liquibase1) "Can require acquire session lock on same liquibase")
+            (liquibase/with-liquibase [liquibase2 data-source]
+              (is (not (lock liquibase2)) "Cannot acquire session lock on a different liquibase while it is taken")))
+          (liquibase/with-liquibase [liquibase3 data-source]
+            ;; This will fail if the com.github.blagerweij/liquibase-sessionlock dep is not present
+            (is (lock liquibase3) "Can acquire session lock when conn closed without lock release")))))))

--- a/test/metabase/db/liquibase_test.clj
+++ b/test/metabase/db/liquibase_test.clj
@@ -53,9 +53,7 @@
   "Read a liquibase migration file and returns all the migration id that is applied to `db-type`.
   Ids are orderer in the order it's defined in migration file."
   [file-path db-type]
-  (let [content (u.yaml/from-file (io/resource file-path))
-        ;; 109 is a DATABASECHANGELOGLOCK alter that isn't used anymore and does not fail on error
-        migration-lock-changeset? (fn [id] (and (#{:mysql :mariadb} db-type) (#{"109"} id)))]
+  (let [content (u.yaml/from-file (io/resource file-path))]
     (->> (:databaseChangeLog content)
          ;; if the changelog has filter by dbms, remove the ones that doens't apply for the current db-type
          (remove (fn [{{:keys [dbms]} :changeSet}] (and (not (str/blank? dbms))
@@ -63,7 +61,6 @@
          ;; remove ignored changeSets
          (remove #(get-in % [:changeSet :ignore]))
          (map #(str (get-in % [:changeSet :id])))
-         (remove migration-lock-changeset?)
          (remove str/blank?))))
 
 (deftest consolidate-liquibase-changesets-test

--- a/test/metabase/db/liquibase_test.clj
+++ b/test/metabase/db/liquibase_test.clj
@@ -110,7 +110,7 @@
               (is (= :done (liquibase/wait-for-all-locks sleep-ms timeout-ms))))))))))
 
 (deftest release-all-locks-if-needed!-test
-  (mt/test-drivers #{:h2 :mysql :postgres}
+  (mt/test-drivers #{:h2}
     (mt/with-temp-empty-app-db [conn driver/*driver*]
       (liquibase/with-liquibase [liquibase conn]
         (testing "When we release the locks from outside the migration...\n"


### PR DESCRIPTION
Prevent the migration lock class of errors in non-h2 dbs by using a liquibase session lock instead of a transaction lock.
This type of lock would clear automatically when the connection closes for any reason.

Using this approach there is no need for the metabase release lock command except with h2.
The force migration command still is applicable though, as it does more things than just release the lock.

See https://github.com/blagerweij/liquibase-sessionlock

Fix https://github.com/metabase/metabase/issues/50212

Other related issues and PRs: https://github.com/metabase/metabase/issues/50364, https://github.com/metabase/metabase/issues/45298, https://github.com/metabase/metabase/issues/45125, https://github.com/metabase/metabase/issues/44577, https://github.com/metabase/metabase/issues/34486, https://github.com/metabase/metabase/issues/37872, https://github.com/metabase/metabase/issues/37866, https://github.com/metabase/metabase/issues/34551, https://github.com/metabase/metabase/issues/10651
