### PR TITLE
Fix the code blocks in README.md to facilitate the copy feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,29 +45,29 @@ In order to spin up a development environment, you need to start the front end a
 
 The following command will install the Javascript dependencies:
 
-```
-$ yarn install
+```bash
+yarn install
 ```
 
 To build and run without watching changes:
 
-```
-$ yarn build
+```bash
+yarn build
 ```
 
 To build and run with hot-reload:
 
-```
-$ yarn build-hot
+```bash
+yarn build-hot
 ```
 
 ### Backend  quick setup
 
 In order to run the backend, you'll need to build the drivers first, and then start the backend:
 
-```
-$ ./bin/build-drivers.sh
-$ clojure -M:run
+```bash
+./bin/build-drivers.sh
+clojure -M:run
 ```
 
 For a more detailed setup of a dev environment for Metabase, check out our [Developers Guide](./docs/developers-guide/start.md).


### PR DESCRIPTION
I removed the `$` button and added the syntax declaration for the code block so the copy button will not copy the `$` symbol which causes errors when the users run the command in shell.

### Description

When the users ran the command with a `$` symbol, the shell did not recognize the command so the copy button of the code block was useless.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Go to the project's `README.md` file.
2. Find the code blocks.
3. Click on the copy button to copy the command.
4. Paste it directly into the shell and it works fine.

### Demo

-
### Checklist

-