### PR TITLE
ensure that the link abstracted from element is not empty

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
@@ -487,7 +487,7 @@ describe("Dashboard > Dashboard Questions", () => {
       H.dashboardCards().findAllByText("Orders").should("have.length", 1);
     });
 
-    it("can share a dashboard card via public link", { tags: "@flaky" }, () => {
+    it("can share a dashboard card via public link", () => {
       H.createQuestion(
         {
           name: "Total Orders",
@@ -504,6 +504,7 @@ describe("Dashboard > Dashboard Questions", () => {
       H.openSharingMenu("Create a public link");
       cy.findByTestId("public-link-input")
         .invoke("val")
+        .should("not.be.empty")
         .then(publicLink => {
           cy.signOut();
           cy.visit(publicLink);


### PR DESCRIPTION
Closes https://linear.app/metabase-inc/issue/ENG-14666/dashboard-questions-admin-can-share-a-dashboard-card-via-public-link

### Description

Test started flaking out because it could not find the right element. The reason why it could not be found is that the test ended on login screen. The reason for ending up on login screen was that the test was trying to open invalid URL. This URL was obtained from an element that would take a little while to load its value. If the test ran too early, it would copy an empty value, end up opening invalid link, ending up on login screen and not finding the right element

### Resolution

Before entering `.then()` block, we need to make sure that the copied link value is not empty:

```diff
cy.findByTestId("public-link-input")
        .invoke("val")
+       .should("not.be.empty")
        .then(publicLink => {
          cy.signOut();
          cy.visit(publicLink);
```

### Stress test
https://github.com/metabase/metabase/actions/runs/13134825374/job/36647760891