### PR TITLE
Keep old Search Engine for 53 gold release

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -51,6 +51,7 @@ jobs:
       MB_EXPERIMENTAL_SEARCH_BLOCK_ON_QUEUE: true
       MB_SNOWPLOW_AVAILABLE: true
       MB_SNOWPLOW_URL: "http://localhost:9090" # Snowplow micro
+      MB_SEARCH_ENGINE: "appdb"
       TZ: US/Pacific # to make node match the instance tz
       CYPRESS_CI: true
       CYPRESS_QA_DB_MONGO: ${{ inputs.name == 'mongo' }}

--- a/e2e/runner/cypress-runner-backend.js
+++ b/e2e/runner/cypress-runner-backend.js
@@ -70,10 +70,10 @@ const CypressBackend = {
         [...javaFlags, "-jar", "target/uberjar/metabase.jar"],
         {
           env: {
+            ...process.env,
             ...metabaseConfig,
             ...userDefaults,
             ...snowplowConfig,
-            PATH: process.env.PATH,
           },
           stdio:
             process.env["DISABLE_LOGGING"] ||

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -1072,7 +1072,7 @@ See [fonts](../configuring-metabase/fonts.md).")
   (deferred-tru "Which engine to use when performing search. Supported values are :in-place and :appdb")
   :visibility :internal
   :export?    false
-  :default    :appdb
+  :default    :in-place
   :type       :keyword)
 
 (defsetting experimental-search-weight-overrides


### PR DESCRIPTION
Given the issues we've seen during Cloud rollout, I think it's prudent to delay making this engine the default.