### PR TITLE
fix(sdk): remove error about stageIndex prop being passed to dom element

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Filter/FilterDropdown/FilterDropdown.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Filter/FilterDropdown/FilterDropdown.tsx
@@ -11,7 +11,6 @@ import type { UpdateQueryHookProps } from "metabase/query_builder/hooks";
 import { getFilterItems } from "metabase/querying/filters/components/FilterPanel/utils";
 import type { FilterColumnPickerProps } from "metabase/querying/filters/components/FilterPicker/FilterColumnPicker";
 import type { PopoverProps } from "metabase/ui";
-import type * as Lib from "metabase-lib";
 
 import { useInteractiveQuestionContext } from "../../../context";
 import { ToolbarButton } from "../../util/ToolbarButton";
@@ -24,7 +23,7 @@ const FilterDropdownInner = ({
   query,
   withColumnItemIcon,
   ...popoverProps
-}: UpdateQueryHookProps &
+}: Pick<UpdateQueryHookProps, "query"> &
   FilterProps &
   Omit<PopoverProps, "children" | "onClose" | "opened">) => {
   const filters = useMemo(() => getFilterItems(query), [query]);
@@ -92,21 +91,15 @@ const FilterDropdownInner = ({
 };
 
 export const FilterDropdown = ({ withColumnItemIcon }: FilterProps) => {
-  const { question, updateQuestion } = useInteractiveQuestionContext();
+  const { question } = useInteractiveQuestionContext();
 
   if (!question) {
     return null;
   }
 
-  const onQueryChange = (query: Lib.Query) => {
-    updateQuestion(question.setQuery(query), { run: true });
-  };
-
   return (
     <FilterDropdownInner
       query={question.query()}
-      stageIndex={-1}
-      onQueryChange={onQueryChange}
       withColumnItemIcon={withColumnItemIcon}
     />
   );


### PR DESCRIPTION

### Description

From my understanding of the code, `stageIndex` and `onQueryChange` were not used, but were passed down as attributes causing those longs errors in the browser console

### How to verify

Render a InteractiveQuestion component, http://localhost:6006/?path=/story/embeddingsdk-interactivequestion--default should be enough to verify that it doesn't show up anymore