### PR TITLE
Dashcard titles no longer interactive when editing the dashboard

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartCaption.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartCaption.styled.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 
-import LegendCaption from "./legend/LegendCaption";
+import { LegendCaption } from "./legend/LegendCaption";
 
 export const ChartCaptionRoot = styled(LegendCaption)`
   margin: 0 0.5rem;

--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import PropTypes from "prop-types";
 import { useCallback, useState } from "react";
 
 import { Ellipsified } from "metabase/core/components/Ellipsified";
@@ -8,6 +7,7 @@ import Tooltip from "metabase/core/components/Tooltip";
 import CS from "metabase/css/core/index.css";
 import DashboardS from "metabase/css/dashboard.module.css";
 import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
+import type { IconProps } from "metabase/ui";
 
 import LegendActions from "./LegendActions";
 import {
@@ -18,18 +18,7 @@ import {
   LegendRightContent,
 } from "./LegendCaption.styled";
 
-const propTypes = {
-  className: PropTypes.string,
-  title: PropTypes.string,
-  description: PropTypes.string,
-  getHref: PropTypes.func,
-  icon: PropTypes.object,
-  actionButtons: PropTypes.node,
-  onSelectTitle: PropTypes.func,
-  width: PropTypes.number,
-};
-
-function shouldHideDescription(width) {
+function shouldHideDescription(width: number | undefined) {
   const HIDE_DESCRIPTION_THRESHOLD = 100;
   return width != null && width < HIDE_DESCRIPTION_THRESHOLD;
 }
@@ -41,7 +30,18 @@ function shouldHideDescription(width) {
  */
 const HREF_PLACEHOLDER = "#";
 
-const LegendCaption = ({
+interface LegendCaptionProps {
+  className?: string;
+  title: string;
+  description?: string;
+  getHref?: () => string | undefined;
+  icon?: IconProps;
+  actionButtons?: React.ReactNode;
+  onSelectTitle?: () => void;
+  width?: number;
+}
+
+export const LegendCaption = ({
   className,
   title,
   description,
@@ -50,7 +50,7 @@ const LegendCaption = ({
   actionButtons,
   onSelectTitle,
   width,
-}) => {
+}: LegendCaptionProps) => {
   /*
    * Optimization: lazy computing the href on title focus & mouseenter only.
    * Href computation uses getNewCardUrl, which makes a few MLv2 calls,
@@ -100,6 +100,7 @@ const LegendCaption = ({
             maxWidth="22em"
           >
             <LegendDescriptionIcon
+              name="info"
               className={cx(CS.hoverChild, CS.hoverChildSmooth)}
             />
           </Tooltip>
@@ -109,7 +110,3 @@ const LegendCaption = ({
     </LegendCaptionRoot>
   );
 };
-
-LegendCaption.propTypes = propTypes;
-
-export default LegendCaption;

--- a/frontend/src/metabase/visualizations/components/legend/LegendLabel.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendLabel.tsx
@@ -15,7 +15,7 @@ interface Props {
   children: ReactNode;
   className?: string;
   href?: LinkProps["to"];
-  onClick: MouseEventHandler;
+  onClick?: MouseEventHandler;
   onFocus: FocusEventHandler;
   onMouseEnter: MouseEventHandler;
 }
@@ -33,12 +33,12 @@ export const LegendLabel = ({
       // Prefer programmatic onClick handling over native browser's href handling.
       // This helps to avoid e.g. 2 tabs opening when ctrl + clicking the link.
       event.preventDefault();
-      onClick(event);
+      onClick?.(event);
     },
     [onClick],
   );
 
-  if (!href) {
+  if (!href || !onClick) {
     return (
       <div
         className={cx(S.text, className, {

--- a/frontend/src/metabase/visualizations/components/legend/LegendLabel.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendLabel.unit.spec.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { Route, Router, createMemoryHistory } from "react-router";
+
+import { screen } from "__support__/ui";
+
+import { LegendLabel } from "./LegendLabel";
+
+describe("LegendLabel", () => {
+  const setup = (props: Partial<ComponentProps<typeof LegendLabel>> = {}) => {
+    const onClick = jest.fn();
+    const onFocus = jest.fn();
+    const onMouseEnter = jest.fn();
+
+    const history = createMemoryHistory();
+    const component = () => {
+      return (
+        <LegendLabel
+          href="#hello"
+          onClick={onClick}
+          onFocus={onFocus}
+          onMouseEnter={onMouseEnter}
+          {...props}
+        >
+          Test
+        </LegendLabel>
+      );
+    };
+
+    render(
+      <Router history={history}>
+        <Route path="/" component={component} />
+      </Router>,
+    );
+
+    return { history, onClick, onFocus, onMouseEnter };
+  };
+
+  it("should be a link when onClick is defined", () => {
+    const { onClick } = setup();
+
+    expect(screen.getByText("Test")).toHaveAttribute("href", "#hello");
+
+    fireEvent.click(screen.getByText("Test"));
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it("should not be a link when onClick is not defined", () => {
+    const { history } = setup({ onClick: undefined });
+
+    expect(screen.getByText("Test")).not.toHaveAttribute("href");
+    fireEvent.click(screen.getByText("Test"));
+    expect(history.getCurrentLocation().pathname).toBe("/");
+    expect(history.getCurrentLocation().hash).toBe("");
+  });
+});

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -12,7 +12,7 @@ import { useSet } from "react-use";
 import { isDesktopSafari } from "metabase/lib/browser";
 import { ChartRenderingErrorBoundary } from "metabase/visualizations/components/ChartRenderingErrorBoundary";
 import { ResponsiveEChartsRenderer } from "metabase/visualizations/components/EChartsRenderer";
-import LegendCaption from "metabase/visualizations/components/legend/LegendCaption";
+import { LegendCaption } from "metabase/visualizations/components/legend/LegendCaption";
 import { getLegendItems } from "metabase/visualizations/echarts/cartesian/model/legend";
 import {
   useCartesianChartSeriesColorsClasses,

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.styled.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 
-import LegendCaption from "metabase/visualizations/components/legend/LegendCaption";
+import { LegendCaption } from "metabase/visualizations/components/legend/LegendCaption";
 import { LegendLayout } from "metabase/visualizations/components/legend/LegendLayout";
 import { getChartPadding } from "metabase/visualizations/visualizations/CartesianChart/padding";
 


### PR DESCRIPTION
Closes #47228 

### Description

The dashcard title should not look interactive when the dashboard is being edited.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a question (any) and add it to a new dashboard
2. Edit the dashboard
3. Add a filter and click to edit it
4. Hover over dashcard title
5. The title should not look like a link, and clicking on it should do nothing

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
