### PR TITLE
disable video recording on snapshots and delete videos on success

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -125,23 +125,6 @@ const defaultConfig = {
       signJwt,
     });
 
-    // this is an official workaround to keep recordings of the failed specs only
-    // https://docs.cypress.io/guides/guides/screenshots-and-videos#Delete-videos-for-specs-without-failing-or-retried-tests
-    on("after:spec", (spec, results) => {
-      if (results && results.video) {
-        // Do we have failures for any retry attempts?
-        const failures = results.tests.some(test =>
-          test.attempts.some(attempt => attempt.state === "failed"),
-        );
-        if (!failures) {
-          // delete the video if the spec passed and no tests retried
-          if (fs.existsSync(results.video)) {
-            fs.unlinkSync(results.video);
-          }
-        }
-      }
-    });
-
     /********************************************************************
      **                          CONFIG                                **
      ********************************************************************/
@@ -173,6 +156,18 @@ const defaultConfig = {
     if (isCI) {
       cypressSplit(on, config, getSplittableSpecs);
     }
+
+    // this is an official workaround to keep recordings of the failed specs only
+    // https://docs.cypress.io/guides/guides/screenshots-and-videos#Delete-videos-for-specs-without-failing-or-retried-tests
+    on("after:spec", (spec, results) => {
+      if (results && results.video) {
+        // Do we have test failures?
+        if (results && results.video && results.stats.failures === 0) {
+          // delete the video if the spec passed
+          fs.unlinkSync(results.video);
+        }
+      }
+    });
 
     return config;
   },
@@ -235,6 +230,7 @@ const mainConfig = {
 const snapshotsConfig = {
   ...defaultConfig,
   specPattern: "e2e/snapshot-creators/**/*.cy.snap.js",
+  video: false,
 };
 
 const crossVersionSourceConfig = {


### PR DESCRIPTION
### Description

I noticed that we compress videos even after successful specs. this is because our previous implementation of deleting videos would not delete videos if a test retried (using Cypress config.retries). This adds a ton of time, because every spec has that "compressing video" step happening. Since we don’t save artifacts of tests that flaked only of those that ultimately failed, there is no point of doing this compression.

Also, it seems like we have video enabled for snapshots creating, which as far as I know, nobody needs.

### How to verify

Hopefully some tests in the flaky category fail, so that we can see that videos are still being recorded, but I tested this locally and it works the way it should.

**EDIT:** Looks like I may have done some error, tests are still being recorded, so I’ll need to fix them
**EDIT2:** I needed to move the "after:spec" hook because as it turns out, it wasn’t getting triggered at all. everything should now be working as intended and we are shaving off some more seconds from the test run