### PR TITLE
Send email when notification failed to send WIP

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
@@ -5,8 +5,8 @@
    [metabase.api.common :as api]
    [metabase.channel.email.messages :as messages]
    [metabase.events :as events]
-   [metabase.events.notification :as events.notification]
    [metabase.integrations.common :as integrations.common]
+   [metabase.notification.core :as notification]
    [metabase.public-settings :as public-settings]
    [metabase.util :as u]
    [metabase.util.i18n :refer [trs tru]]
@@ -63,7 +63,7 @@
       (log/infof "New SSO user created: %s (%s)" (:common_name <>) (:email <>))
       ;; publish user-invited event for audit logging
       ;; skip sending user invited emails for sso users
-      (binding [events.notification/*skip-sending-notification?* true]
+      (binding [notification/*skip-sending-notification?* true]
         (events/publish-event! :event/user-invited {:object (assoc <> :sso_source (:sso_source user))}))
       ;; send an email to everyone including the site admin if that's set
       (when (integrations.common/send-new-sso-user-admin-email?)

--- a/src/metabase/channel/email/notification_send_failed.hbs
+++ b/src/metabase/channel/email/notification_send_failed.hbs
@@ -1,3 +1,12 @@
 {{> metabase/channel/email/_header.hbs }}
-Your {{#if (equals payload.event_info.payload_type "notification/card")}}alert{{else}}dashboard subscription{{/if}} of <a href="{{#if (equals payload.event_info.payload_type "notification/card")}}{{{card-url payload.event_info.alert.card_id}}}{{else}}{{{dashboard-url payload.dashboard_subscription.dashboard_id}}}{{/if}}">{{#if (equals payload.event_info.payload_type "notification/card")}}{{payload.event_info.alert.card.name}}{{else}}{{payload.event_info.dashboard_subscription.dashboard.name}}{{/if}}</a> failed to send with the following error: {{payload.event_info.error-message}}
+
+{{#with payload.event_info}}
+  Your {{#if (equals payload_type "notification/card")}}
+    alert of <a href="{{{card-url alert.card_id}}}">{{alert.card.name}}</a>
+  {{else}}
+    dashboard subscription of <a href="{{{dashboard-url dashboard_subscription.dashboard_id}}}">{{dashboard_subscription.dashboard.name}}</a>
+  {{/if}}
+  failed to send with the following error: {{error-message}}
+{{/with}}
+
 {{> metabase/channel/email/_footer.hbs }}

--- a/src/metabase/channel/email/notification_send_failed.hbs
+++ b/src/metabase/channel/email/notification_send_failed.hbs
@@ -1,0 +1,3 @@
+{{> metabase/channel/email/_header.hbs }}
+Your {{#if (equals payload.event_info.payload_type "notification/card")}}alert{{else}}dashboard subscription{{/if}} of <a href="{{#if (equals payload.event_info.payload_type "notification/card")}}{{{card-url payload.event_info.alert.card_id}}}{{else}}{{{dashboard-url payload.dashboard_subscription.dashboard_id}}}{{/if}}">{{#if (equals payload.event_info.payload_type "notification/card")}}{{payload.event_info.alert.card.name}}{{else}}{{payload.event_info.dashboard_subscription.dashboard.name}}{{/if}}</a> failed to send with the following error: {{payload.event_info.error-message}}
+{{> metabase/channel/email/_footer.hbs }}

--- a/src/metabase/events/notification.clj
+++ b/src/metabase/events/notification.clj
@@ -52,8 +52,6 @@
 (defn maybe-hydrate-event-info
   "Hydrate event-info if the topic has a schema."
   [topic event-info]
-  (def topic topic)
-  (def event-info event-info)
   (cond->> event-info
     (some? (events/topic->schema topic))
     (hydrate! (events/topic->schema topic))))
@@ -64,15 +62,9 @@
   (when (supported-topics topic)
     (models.notification/notifications-for-event topic)))
 
-(def ^:dynamic *skip-sending-notification?*
-  "Used as a hack for when we need to skip sending notifications for certain events.
-
-  It's an escape hatch until we implement conditional notifications."
-  false)
-
 (defn- maybe-send-notification-for-topic!
   [topic event-info]
-  (when-not *skip-sending-notification?*
+  (when-not notification/*skip-sending-notification?*
     (when-let [notifications (notifications-for-topic topic)]
       (task-history/with-task-history {:task         "notification-trigger"
                                        :task_details {:trigger_type     :notification-subscription/system-event

--- a/src/metabase/events/schema.clj
+++ b/src/metabase/events/schema.clj
@@ -31,6 +31,9 @@
 (def ^:private card-hydrate
   [:model/Card :name :description])
 
+(def ^:private dashboard-hydrate
+  [:model/Dashboard :name :description])
+
 (let [default-schema (mc/schema
                       [:map {:closed true}
                        [:user-id  pos-int?]
@@ -191,7 +194,10 @@
                                          (with-hydrate :creator user-hydrate))
                                      [:alert {:optional true}
                                       [:map (-> [:card_id pos-int?]
-                                                (with-hydrate :card card-hydrate))]]])})
+                                                (with-hydrate :card card-hydrate))]]
+                                     [:dashboard_subscription {:optional true}
+                                      [:map (-> [:dashboard_id pos-int?]
+                                                (with-hydrate :dashboard dashboard-hydrate))]]])})
 
 (def topic->schema
   "Returns the schema for an event topic."

--- a/src/metabase/events/schema.clj
+++ b/src/metabase/events/schema.clj
@@ -28,6 +28,9 @@
 (def ^:private user-hydrate
   [:model/User :first_name :last_name :email])
 
+(def ^:private card-hydrate
+  [:model/Card :name :description])
+
 (let [default-schema (mc/schema
                       [:map {:closed true}
                        [:user-id  pos-int?]
@@ -179,6 +182,17 @@
                                         [:user-id [:maybe pos-int?]]
                                         [:model [:or :keyword :string]]])}))
 
+;; notification events
+
+(def ^:private notification-events
+  {:event/notification-send-failed (mc/schema
+                                    [:map
+                                     (-> [:creator_id pos-int?]
+                                         (with-hydrate :creator user-hydrate))
+                                     [:alert {:optional true}
+                                      [:map (-> [:card_id pos-int?]
+                                                (with-hydrate :card card-hydrate))]]])})
+
 (def topic->schema
   "Returns the schema for an event topic."
   (merge alert-schema
@@ -187,6 +201,7 @@
          dashboard-events-schemas
          database-events
          metric-related-schema
+         notification-events
          permission-failure-events
          pulse-schemas
          table-events

--- a/src/metabase/notification/core.clj
+++ b/src/metabase/notification/core.clj
@@ -18,7 +18,9 @@
   Notification
   NotificationPayload]
  [notification.seed
-  seed-notification!])
+  seed-notification!]
+ [notification.send
+  *skip-sending-notification?*])
 
 (def ^:private Options
   [:map

--- a/src/metabase/notification/seed.clj
+++ b/src/metabase/notification/seed.clj
@@ -101,7 +101,23 @@
                             :recipients   [{:type    :notification-recipient/template
                                             :details {:pattern "{{context.admin_email}}" :is_optional true}}
                                            {:type                 :notification-recipient/group
-                                            :permissions_group_id (:id (perms/admin-group))}]}]}]))
+                                            :permissions_group_id (:id (perms/admin-group))}]}]}
+          {:internal_id   "system-event/notification-send-failed"
+           :active        true
+           :payload_type  :notification/system-event
+           :subscriptions [{:type       :notification-subscription/system-event
+                            :event_name :event/notification-send-failed}]
+           :handlers      [{:active       true
+                            :channel_type :channel/email
+                            :channel_id   nil
+                            :template     {:name         "Notification Failed Email template"
+                                           :channel_type "channel/email"
+                                           :details      {:type "email/handlebars-resource"
+                                                          :subject "Your notification failed to send"
+                                                          :path "metabase/channel/email/notification_send_failed.hbs"
+                                                          :recipient-type "cc"}}
+                            :recipients   [{:type    :notification-recipient/template
+                                            :details {:pattern "{{payload.event_info.creator.email}}"}}]}]}]))
 
 (defn- cleanup-notification!
   [internal-id existing-row]

--- a/test/metabase/notification/send_test.clj
+++ b/test/metabase/notification/send_test.clj
@@ -141,6 +141,5 @@
                                                               (select-keys x [:payload_type :id]))
                                                          (throw (Exception. "test-exception"))
                                                          (original-payload x)))]
-            (pulse.send/send-pulse! (t2/select-one :model/Pulse pulse-id))
-            #_(notification.tu/with-captured-channel-send!
-                (pulse.send/send-pulse! (t2/select-one :model/Pulse pulse-id)))))))))
+            (notification.tu/with-captured-channel-send!
+              (pulse.send/send-pulse! (t2/select-one :model/Pulse pulse-id)))))))))

--- a/test/metabase/pulse/test_util.clj
+++ b/test/metabase/pulse/test_util.clj
@@ -73,7 +73,7 @@
      ~@body))
 
 (def png-attachment
-  {:type         :inline
+{:type         :inline
    :content-id   true
    :content-type "image/png"
    :content      java.net.URL})


### PR DESCRIPTION
Closes https://linear.app/metabase-inc/issue/ENG-14638/send-an-error-when-subscription-rendering-fails


The current copy is quite simple, would love product's eyes on this

![Screenshot 2025-02-04 at 22 44 27](https://github.com/user-attachments/assets/152a169f-d6e5-4a6c-a0fa-a7f2c51e6605)
