### PR TITLE
Mark browse metrics flakes as flaky

### DIFF
--- a/e2e/test/scenarios/metrics/browse.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/browse.cy.spec.ts
@@ -120,7 +120,7 @@ describe("scenarios > browse > metrics", () => {
     });
   });
 
-  describe("multiple metrics", () => {
+  describe("multiple metrics", { tags: "@flaky" }, () => {
     it("can browse metrics", () => {
       createMetrics(ALL_METRICS);
       cy.visit("/browse/metrics");
@@ -231,7 +231,7 @@ describe("scenarios > browse > metrics", () => {
     });
   });
 
-  describe("dot menu", () => {
+  describe("dot menu", { tags: "@flaky" }, () => {
     it("should be possible to bookmark a metrics from the dot menu", () => {
       createMetrics([ORDERS_SCALAR_METRIC]);
 
@@ -346,7 +346,7 @@ describe("scenarios > browse > metrics", () => {
     });
   });
 
-  describe("verified metrics", () => {
+  describe("verified metrics", { tags: "@flaky" }, () => {
     H.describeEE("on enterprise", () => {
       beforeEach(() => {
         cy.signInAsAdmin();


### PR DESCRIPTION
related to DEVX-130

Marking these tests as flaky. The flake is intermittent, and is related to async search indexing. Some percentage of the time, the search index has just not caught up with newly created metrics and can't find any metrics in these tests.

