### PR TITLE
Add legacy handling for snowflake password

### DIFF
--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -780,6 +780,16 @@
         (is (= {:account "my-instance.us-west-1"}
                (:details db)))))))
 
+(deftest ^:parallel normalize-use-password-test
+  (mt/test-driver :snowflake
+    (testing "details should be normalized coming out of the DB"
+      (mt/with-temp [:model/Database db {:name    "Legacy Snowflake DB"
+                                         :engine  :snowflake,
+                                         :details {:password (mt/random-name)}}]
+        (is (=? {:password string?
+                 :use-password true}
+                (:details db)))))))
+
 (deftest ^:parallel set-role-statement-test
   (testing "set-role-statement should return a USE ROLE command, with the role quoted if it contains special characters"
     ;; No special characters


### PR DESCRIPTION
Context: https://metaboat.slack.com/archives/C052ZBWRG3W/p1738620323941229

Fixes #53141 

When we added the toggle for snowflake password, we failed to see how it affected cloud hosted instances.