### PR TITLE
Add e2e tests checking high-visibility pages in top locales

### DIFF
--- a/e2e/test/scenarios/i18n/i18n.cy.spec.ts
+++ b/e2e/test/scenarios/i18n/i18n.cy.spec.ts
@@ -1,37 +1,45 @@
 const { H } = cy;
 
-const locales = {
-  "Portuguese (Brazil)": {
-    "/": /Início/,
-    "/getting-started": /Comece a visualizar seus dados/,
-    "/browse/models": /Descrição/,
-    "/browse/metrics": /Crie métricas/,
-    "/trash": /Nada aqui/,
-  },
-  // "Chinese (China)": { "/": "你好，鲍比！" },
-  // "Chinese (Taiwan)": { "/": "哈囉，鮑比！" },
-  // French: { "/": "Accueil" },
-  // German: { "/": "Hallo, Bobby!" },
-  // Italian: { "/": "Ciao, Bobby!" },
-  // Japanese: { "/": "こんにちは、ボビー！" },
-  // Korean: { "/": "안녕, 바비!" },
-  // Russian: { "/": "Привет, Бобби!" },
-  // Spanish: { "/": "Hola, Bobby!" },
-};
+const paths = [
+  "/",
+  "/getting-started",
+  "/collection/root",
+  "/browse/models",
+  "/browse/databases",
+  "/browse/metrics",
+  "/trash",
+  "/admin",
+];
 
-describe("Test that high-visibility pages work in popular locales", () => {
+const locales = [
+  "Chinese (China)",
+  "Chinese (Taiwan)",
+  "Chinese",
+  "French",
+  "German",
+  "Italian",
+  "Japanese",
+  "Korean",
+  "Portuguese (Brazil)",
+  "Russian",
+  "Spanish",
+];
+
+describe("Pages accessible within one click from the homepage should work in popular locales", () => {
+  before(H.restore);
+
   beforeEach(() => {
-    H.restore();
     cy.signInAsNormalUser();
     cy.intercept("PUT", "/api/user/*").as("updateUserSettings");
   });
 
-  Object.entries(locales).forEach(([localeName, pathToExpectedString]) => {
-    it(`Tour works in ${localeName}`, () => {
+  locales.forEach(localeName => {
+    it(`Pages should be reachable when locale is ${localeName}`, () => {
       selectLocale(localeName);
-      Object.entries(pathToExpectedString).forEach(([path, expectedString]) => {
+      paths.forEach(path => {
         cy.visit(path);
-        cy.findByText(expectedString);
+        cy.findByRole("main");
+        cy.findAllByTestId("error-boundary").should("not.exist");
       });
     });
   });
@@ -40,9 +48,9 @@ describe("Test that high-visibility pages work in popular locales", () => {
 const selectLocale = (localeName: string) => {
   cy.visit("/account/profile");
 
-  cy.findByTestId("user-profile-form").findByText("Use site default").click();
+  cy.findByTestId("user-locale-select").click();
   H.popover().within(() => cy.findByText(localeName).click());
 
-  cy.button("Update").click();
+  cy.get("[type=submit]").click();
   cy.wait("@updateUserSettings");
 };

--- a/e2e/test/scenarios/i18n/i18n.cy.spec.ts
+++ b/e2e/test/scenarios/i18n/i18n.cy.spec.ts
@@ -1,0 +1,48 @@
+const { H } = cy;
+
+const locales = {
+  "Portuguese (Brazil)": {
+    "/": /Início/,
+    "/getting-started": /Comece a visualizar seus dados/,
+    "/browse/models": /Descrição/,
+    "/browse/metrics": /Crie métricas/,
+    "/trash": /Nada aqui/,
+  },
+  // "Chinese (China)": { "/": "你好，鲍比！" },
+  // "Chinese (Taiwan)": { "/": "哈囉，鮑比！" },
+  // French: { "/": "Accueil" },
+  // German: { "/": "Hallo, Bobby!" },
+  // Italian: { "/": "Ciao, Bobby!" },
+  // Japanese: { "/": "こんにちは、ボビー！" },
+  // Korean: { "/": "안녕, 바비!" },
+  // Russian: { "/": "Привет, Бобби!" },
+  // Spanish: { "/": "Hola, Bobby!" },
+};
+
+describe("Test that high-visibility pages work in popular locales", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+    cy.intercept("PUT", "/api/user/*").as("updateUserSettings");
+  });
+
+  Object.entries(locales).forEach(([localeName, pathToExpectedString]) => {
+    it(`Tour works in ${localeName}`, () => {
+      selectLocale(localeName);
+      Object.entries(pathToExpectedString).forEach(([path, expectedString]) => {
+        cy.visit(path);
+        cy.findByText(expectedString);
+      });
+    });
+  });
+});
+
+const selectLocale = (localeName: string) => {
+  cy.visit("/account/profile");
+
+  cy.findByTestId("user-profile-form").findByText("Use site default").click();
+  H.popover().within(() => cy.findByText(localeName).click());
+
+  cy.button("Update").click();
+  cy.wait("@updateUserSettings");
+};

--- a/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.tsx
+++ b/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.tsx
@@ -82,11 +82,13 @@ const UserProfileForm = ({
               />
             </>
           )}
-          <FormSelect
-            name="locale"
-            title={t`Language`}
-            options={localeOptions}
-          />
+          <div data-testid="user-locale-select">
+            <FormSelect
+              name="locale"
+              title={t`Language`}
+              options={localeOptions}
+            />
+          </div>
           <FormSubmitButton title={t`Update`} disabled={!dirty} primary />
           <FormErrorMessage />
         </Form>

--- a/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.tsx
+++ b/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.tsx
@@ -59,7 +59,7 @@ const UserProfileForm = ({
       onSubmit={handleSubmit}
     >
       {({ dirty }) => (
-        <Form disabled={!dirty} data-testid="user-profile-form">
+        <Form disabled={!dirty}>
           {!isSsoUser && (
             <>
               <FormInput

--- a/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.tsx
+++ b/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.tsx
@@ -59,7 +59,7 @@ const UserProfileForm = ({
       onSubmit={handleSubmit}
     >
       {({ dirty }) => (
-        <Form disabled={!dirty}>
+        <Form disabled={!dirty} data-testid="user-profile-form">
           {!isSsoUser && (
             <>
               <FormInput


### PR DESCRIPTION
Last year we had a P1 where a high-visibility page in Brazilian Portuguese was broken. Let's add some basic e2e tests that check high-visibility admin/webapp pages (accessible in one click from the homepage) in our most popular locales.