### PR TITLE
[Dashboards] Mark dashboard as dirty if tabs are edited

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.ts
+++ b/e2e/support/helpers/e2e-dashboard-helpers.ts
@@ -234,6 +234,14 @@ export function duplicateTab(tabName: string) {
   });
 }
 
+export function renameTab(tabName: string, newTabName: string) {
+  cy.findByRole("tab", { name: tabName }).findByRole("button").click();
+  popover().within(() => {
+    cy.findByText("Rename").click();
+  });
+  cy.findByRole("tab", { name: tabName }).type(newTabName + "{Enter}");
+}
+
 export function goToTab(tabName: string) {
   cy.findByRole("tab", { name: tabName }).click();
 }

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1187,7 +1187,8 @@ describe("scenarios > dashboard", () => {
 
       // add
       createNewDashboard();
-      addCard();
+      cy.findByTestId("dashboard-header").icon("add").click();
+      cy.findByTestId("add-card-sidebar").findByText("Orders").click();
       assertPreventLeave({ openSidebar: false });
       H.saveDashboard();
 
@@ -1246,12 +1247,6 @@ describe("scenarios > dashboard", () => {
         cy.findByLabelText("Name").type("Test");
         cy.findByRole("button", { name: "Create" }).click();
       });
-    }
-
-    function addCard() {
-      cy.log("test adding a card");
-      cy.findByTestId("dashboard-header").icon("add").click();
-      cy.findByTestId("add-card-sidebar").findByText("Orders").click();
     }
 
     function dragRight(el, distance) {

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1197,7 +1197,7 @@ describe("scenarios > dashboard", () => {
       const card = cy
         .findAllByTestId("dashcard-container", { scrollBehavior: false })
         .eq(0);
-      dragRight(card, 100);
+      dragOnXAxis(card, 100);
       assertPreventLeave();
       H.saveDashboard();
 
@@ -1218,7 +1218,7 @@ describe("scenarios > dashboard", () => {
 
       // move tab
       H.editDashboard();
-      dragRight(cy.findByRole("tab", { name: "Tab 2" }), -200);
+      dragOnXAxis(cy.findByRole("tab", { name: "Tab 2" }), -200);
       H.openQuestionsSidebar();
       assertPreventLeave();
       H.saveDashboard();
@@ -1249,7 +1249,7 @@ describe("scenarios > dashboard", () => {
       });
     }
 
-    function dragRight(el, distance) {
+    function dragOnXAxis(el, distance) {
       el.trigger("mousedown", { clientX: 0 })
         .trigger("mousemove", { clientX: distance })
         .trigger("mouseup");

--- a/frontend/src/metabase/dashboard/actions/tabs.ts
+++ b/frontend/src/metabase/dashboard/actions/tabs.ts
@@ -459,7 +459,7 @@ export const tabsReducer = createReducer<DashboardState>(
       },
     );
 
-    builder.addCase(renameTab, (state, { payload: { tabId, name } }) => {
+    builder.addCase(renameTab, (state, { type, payload: { tabId, name } }) => {
       const { prevTabs } = getPrevDashAndTabs({ state });
       const tabToRenameIndex = prevTabs.findIndex(({ id }) => id === tabId);
 
@@ -468,6 +468,8 @@ export const tabsReducer = createReducer<DashboardState>(
           `RENAME_TAB was dispatched but tabToRenameIndex (${tabToRenameIndex}) is invalid`,
         );
       }
+
+      markDashboardDirty(type, state);
 
       prevTabs[tabToRenameIndex].name = name;
     });

--- a/frontend/src/metabase/dashboard/actions/tabs.ts
+++ b/frontend/src/metabase/dashboard/actions/tabs.ts
@@ -367,10 +367,11 @@ export const tabsReducer = createReducer<DashboardState>(
           };
 
           // We don't have card (question) data for virtual dashcards (text, heading, link, action)
+          // @ts-expect-error - possibly infinite type error
           if (isVirtualDashCard(sourceDashCard)) {
             return;
           }
-          // @ts-expect-error - possibly infinite type error
+
           if (sourceDashCard.card_id == null) {
             throw Error("sourceDashCard is non-virtual yet has null card_id");
           }

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
@@ -244,13 +244,18 @@ function DashCardActionsPanelInner({
       <DashCardActionButton
         onClick={handleRemoveCard}
         tooltip={t`Remove and trash`}
+        key="remove"
       >
         <DashCardActionButton.Icon name="trash" />
       </DashCardActionButton>,
     );
   } else {
     buttons.push(
-      <DashCardActionButton onClick={handleRemoveCard} tooltip={t`Remove`}>
+      <DashCardActionButton
+        onClick={handleRemoveCard}
+        tooltip={t`Remove`}
+        key="remove"
+      >
         <DashCardActionButton.Icon name="close" />
       </DashCardActionButton>,
     );


### PR DESCRIPTION
Related to ENG-14565

### Description

A recent internal bug report had some odd experiences around editing a dashboard. Initially this was believed to be related to the recent cards in dashboards changes, but really these were bugs that existed already but users were more likely to encounter now that we actively encourage them to leave a dashboard during the edit flow.

**This PR makes it so that adding, moving, removing, renaming, and duplicating a tab marks the dashboard as dirty.** While users are able to save tab only changes, they wouldn't be prevented from leaving the dashboard or asked to save their changes as if they had made an edit to card. You can see the bug here:

https://github.com/user-attachments/assets/f82bb802-73cc-4ce7-a761-488fef6d345f

This PR also:
- adds e2e coverage for leaving a dashboard if cards are edited
- adds a missing key prop to a component I noticed react was warning about in the console

### Demo

https://github.com/user-attachments/assets/fa49eff7-4a98-4f99-bfef-49526b7a6fcc

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
