### PR TITLE
allow draft prs with label to run tests

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
         with:
-          m2-cache-key: 'kondo'
+          m2-cache-key: "kondo"
       - name: Run clj-kondo
         run: ./bin/kondo.sh
 
@@ -81,7 +81,7 @@ jobs:
     needs: [files-changed, static-viz-files-changed]
     if: |
       !cancelled() &&
-      github.event.pull_request.draft == false &&
+      (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) &&
       (needs.files-changed.outputs.backend_all == 'true' || needs.static-viz-files-changed.outputs.static_viz == 'true')
     runs-on: ubuntu-22.04
     timeout-minutes: 20
@@ -138,7 +138,7 @@ jobs:
     needs: [files-changed, static-viz-files-changed]
     if: |
       !cancelled() &&
-      github.event.pull_request.draft == false &&
+      (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) &&
       (needs.files-changed.outputs.backend_all == 'true' || needs.static-viz-files-changed.outputs.static_viz == 'true')
     runs-on: ubuntu-22.04
     timeout-minutes: 60
@@ -149,33 +149,33 @@ jobs:
         job:
           - name: Enterprise Tests
             edition: ee
-            build-static-viz: 'false'
+            build-static-viz: "false"
             test-args: >-
               :only '"enterprise/backend/test"'
           - name: EE App DB Tests (Part 1)
             edition: ee
-            build-static-viz: 'true'
+            build-static-viz: "true"
             test-args: >-
               :only '["test" ".clj-kondo/test"]'
               :partition/total 2
               :partition/index 0
           - name: EE App DB Tests (Part 2)
             edition: ee
-            build-static-viz: 'true'
+            build-static-viz: "true"
             test-args: >-
               :only '["test" ".clj-kondo/test"]'
               :partition/total 2
               :partition/index 1
           - name: OSS App DB Tests (Part 1)
             edition: oss
-            build-static-viz: 'true'
+            build-static-viz: "true"
             test-args: >-
               :only '["test" ".clj-kondo/test"]'
               :partition/total 2
               :partition/index 0
           - name: OSS App DB Tests (Part 2)
             edition: oss
-            build-static-viz: 'true'
+            build-static-viz: "true"
             test-args: >-
               :only '["test" ".clj-kondo/test"]'
               :partition/total 2
@@ -255,7 +255,7 @@ jobs:
     needs: [files-changed, static-viz-files-changed]
     if: |
       !cancelled() &&
-      github.event.pull_request.draft == false &&
+      (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) &&
       (needs.files-changed.outputs.backend_all == 'true' || needs.static-viz-files-changed.outputs.static_viz == 'true')
     runs-on: ubuntu-22.04
     timeout-minutes: 10
@@ -285,7 +285,7 @@ jobs:
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
         with:
-          m2-cache-key: 'cljfmt'
+          m2-cache-key: "cljfmt"
       - name: Run cljfmt
         run: clojure -T:cljfmt check
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -81,7 +81,7 @@ jobs:
     needs: [files-changed, static-viz-files-changed]
     if: |
       !cancelled() &&
-      (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) &&
+      (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-tests')) &&
       (needs.files-changed.outputs.backend_all == 'true' || needs.static-viz-files-changed.outputs.static_viz == 'true')
     runs-on: ubuntu-22.04
     timeout-minutes: 20
@@ -138,7 +138,7 @@ jobs:
     needs: [files-changed, static-viz-files-changed]
     if: |
       !cancelled() &&
-      (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) &&
+      (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-tests')) &&
       (needs.files-changed.outputs.backend_all == 'true' || needs.static-viz-files-changed.outputs.static_viz == 'true')
     runs-on: ubuntu-22.04
     timeout-minutes: 60
@@ -255,7 +255,7 @@ jobs:
     needs: [files-changed, static-viz-files-changed]
     if: |
       !cancelled() &&
-      (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) &&
+      (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-tests')) &&
       (needs.files-changed.outputs.backend_all == 'true' || needs.static-viz-files-changed.outputs.static_viz == 'true')
     runs-on: ubuntu-22.04
     timeout-minutes: 10

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -6,7 +6,7 @@ on:
       - "master"
       - "release-**"
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -3,8 +3,8 @@ name: Driver Tests
 on:
   push:
     branches:
-      - 'master'
-      - 'release-**'
+      - "master"
+      - "release-**"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
@@ -30,39 +30,39 @@ jobs:
 
   be-tests-h2:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
-      CI: 'true'
+      CI: "true"
     name: H2
     steps:
-    - uses: actions/checkout@v4
-    - name: Test H2 driver
-      uses: ./.github/actions/test-driver
-      with:
-        junit-name: 'be-tests-h2'
-        test-args: >-
-          :only-tags [:mb/driver-tests]
-    - name: Upload Test Results
-      uses: ./.github/actions/upload-test-results
-      if: always()
-      with:
-        input-path: ./target/junit/
-        output-name: ${{ github.job }}
-        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
-        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ vars.AWS_REGION }}
-        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+      - uses: actions/checkout@v4
+      - name: Test H2 driver
+        uses: ./.github/actions/test-driver
+        with:
+          junit-name: "be-tests-h2"
+          test-args: >-
+            :only-tags [:mb/driver-tests]
+      - name: Upload Test Results
+        uses: ./.github/actions/upload-test-results
+        if: always()
+        with:
+          input-path: ./target/junit/
+          output-name: ${{ github.job }}
+          bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+          aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+          trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
   be-tests-athena-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
-      CI: 'true'
+      CI: "true"
       DRIVERS: athena
       MB_ATHENA_TEST_REGION: us-east-1
       MB_ATHENA_TEST_ACCESS_KEY: ${{ secrets.MB_ATHENA_TEST_ACCESS_KEY }}
@@ -73,32 +73,32 @@ jobs:
       MB_ATHENA_TEST_WITHOUT_GET_TABLE_METADATA_SECRET_KEY: ${{ secrets.MB_ATHENA_TEST_WITHOUT_GET_TABLE_METADATA_SECRET_KEY }}
     name: Athena
     steps:
-    - uses: actions/checkout@v4
-    - name: Test Athena driver
-      uses: ./.github/actions/test-driver
-      with:
-        junit-name: 'be-tests-athena-ee'
-        test-args: >-
-          :only-tags [:mb/driver-tests]
-    - name: Upload Test Results
-      uses: ./.github/actions/upload-test-results
-      if: always()
-      with:
-        input-path: ./target/junit/
-        output-name: ${{ github.job }}
-        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
-        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ vars.AWS_REGION }}
-        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+      - uses: actions/checkout@v4
+      - name: Test Athena driver
+        uses: ./.github/actions/test-driver
+        with:
+          junit-name: "be-tests-athena-ee"
+          test-args: >-
+            :only-tags [:mb/driver-tests]
+      - name: Upload Test Results
+        uses: ./.github/actions/upload-test-results
+        if: always()
+        with:
+          input-path: ./target/junit/
+          output-name: ${{ github.job }}
+          bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+          aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+          trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
   be-tests-bigquery-cloud-sdk-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
-      CI: 'true'
+      CI: "true"
       DRIVERS: bigquery-cloud-sdk
       MB_BIGQUERY_TEST_PROJECT_ID: ${{ secrets.BIGQUERY_TEST_PROJECT_ID }}
       MB_BIGQUERY_TEST_CLIENT_ID: ${{ secrets.MB_BIGQUERY_TEST_CLIENT_ID }}
@@ -108,32 +108,32 @@ jobs:
       MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON: ${{ secrets.MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON }}
     name: BigQuery
     steps:
-    - uses: actions/checkout@v4
-    - name: Test BigQuery Cloud SDK driver
-      uses: ./.github/actions/test-driver
-      with:
-        junit-name: 'be-tests-bigquery-cloud-sdk-ee'
-        test-args: >-
-          :only-tags [:mb/driver-tests]
-    - name: Upload Test Results
-      uses: ./.github/actions/upload-test-results
-      if: always()
-      with:
-        input-path: ./target/junit/
-        output-name: ${{ github.job }}
-        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
-        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ vars.AWS_REGION }}
-        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+      - uses: actions/checkout@v4
+      - name: Test BigQuery Cloud SDK driver
+        uses: ./.github/actions/test-driver
+        with:
+          junit-name: "be-tests-bigquery-cloud-sdk-ee"
+          test-args: >-
+            :only-tags [:mb/driver-tests]
+      - name: Upload Test Results
+        uses: ./.github/actions/upload-test-results
+        if: always()
+        with:
+          input-path: ./target/junit/
+          output-name: ${{ github.job }}
+          bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+          aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+          trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
   be-tests-druid-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
-      CI: 'true'
+      CI: "true"
       DRIVERS: druid
     services:
       druid:
@@ -144,67 +144,67 @@ jobs:
           CLUSTER_SIZE: nano-quickstart
     name: Druid (Legacy)
     steps:
-    - uses: actions/checkout@v4
-    - name: Test Druid driver
-      uses: ./.github/actions/test-driver
-      with:
-        junit-name: 'be-tests-druid-ee'
-        test-args: >-
-          :only-tags [:mb/driver-tests]
-    - name: Upload Test Results
-      uses: ./.github/actions/upload-test-results
-      if: always()
-      with:
-        input-path: ./target/junit/
-        output-name: ${{ github.job }}
-        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
-        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ vars.AWS_REGION }}
-        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+      - uses: actions/checkout@v4
+      - name: Test Druid driver
+        uses: ./.github/actions/test-driver
+        with:
+          junit-name: "be-tests-druid-ee"
+          test-args: >-
+            :only-tags [:mb/driver-tests]
+      - name: Upload Test Results
+        uses: ./.github/actions/upload-test-results
+        if: always()
+        with:
+          input-path: ./target/junit/
+          output-name: ${{ github.job }}
+          bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+          aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+          trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
   be-tests-databricks-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
-      CI: 'true'
+      CI: "true"
       DRIVERS: databricks
       MB_DATABRICKS_TEST_HOST: ${{ secrets.MB_DATABRICKS_JDBC_TEST_HOST }}
       MB_DATABRICKS_TEST_HTTP_PATH: ${{ secrets.MB_DATABRICKS_JDBC_TEST_HTTP_PATH }}
       MB_DATABRICKS_TEST_TOKEN: ${{ secrets.MB_DATABRICKS_JDBC_TEST_TOKEN }}
-      MB_DATABRICKS_TEST_CATALOG: 'metabase_ci'
+      MB_DATABRICKS_TEST_CATALOG: "metabase_ci"
       MB_DATABRICKS_TEST_CLIENT_ID: ${{ secrets.MB_DATABRICKS_JDBC_TEST_CLIENT_ID }}
       MB_DATABRICKS_TEST_OAUTH_SECRET: ${{ secrets.MB_DATABRICKS_JDBC_TEST_OAUTH_SECRET }}
     name: Databricks
     steps:
-    - uses: actions/checkout@v4
-    - name: Test Databricks driver
-      uses: ./.github/actions/test-driver
-      with:
-        junit-name: 'be-tests-databricks-ee'
-        test-args: >-
-          :only-tags [:mb/driver-tests]
-    - name: Upload Test Results
-      uses: ./.github/actions/upload-test-results
-      if: always()
-      with:
-        input-path: ./target/junit/
-        output-name: ${{ github.job }}
-        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
-        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ vars.AWS_REGION }}
-        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+      - uses: actions/checkout@v4
+      - name: Test Databricks driver
+        uses: ./.github/actions/test-driver
+        with:
+          junit-name: "be-tests-databricks-ee"
+          test-args: >-
+            :only-tags [:mb/driver-tests]
+      - name: Upload Test Results
+        uses: ./.github/actions/upload-test-results
+        if: always()
+        with:
+          input-path: ./target/junit/
+          output-name: ${{ github.job }}
+          bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+          aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+          trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
   be-tests-druid-jdbc-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
-      CI: 'true'
+      CI: "true"
       DRIVERS: druid-jdbc
     services:
       druid:
@@ -215,28 +215,28 @@ jobs:
           CLUSTER_SIZE: nano-quickstart
     name: Druid (JDBC)
     steps:
-    - uses: actions/checkout@v4
-    - name: Test Druid JDBC driver
-      uses: ./.github/actions/test-driver
-      with:
-        junit-name: 'be-tests-druid-jdbc-ee'
-        test-args: >-
-          :only-tags [:mb/driver-tests]
-    - name: Upload Test Results
-      uses: ./.github/actions/upload-test-results
-      if: always()
-      with:
-        input-path: ./target/junit/
-        output-name: ${{ github.job }}
-        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
-        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ vars.AWS_REGION }}
-        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+      - uses: actions/checkout@v4
+      - name: Test Druid JDBC driver
+        uses: ./.github/actions/test-driver
+        with:
+          junit-name: "be-tests-druid-jdbc-ee"
+          test-args: >-
+            :only-tags [:mb/driver-tests]
+      - name: Upload Test Results
+        uses: ./.github/actions/upload-test-results
+        if: always()
+        with:
+          input-path: ./target/junit/
+          output-name: ${{ github.job }}
+          bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+          aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+          trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
   be-tests-mysql-mariadb:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     strategy:
@@ -247,22 +247,22 @@ jobs:
             junit-name: be-tests-mariadb-10-2-ee
             image: circleci/mariadb:10.2.23
             env:
-              enable-ssl-tests: 'false'
+              enable-ssl-tests: "false"
           - name: MariaDB Latest
             junit-name: be-tests-mariadb-latest-ee
             image: circleci/mariadb:latest
             env:
-              enable-ssl-tests: 'false'
+              enable-ssl-tests: "false"
           - name: MySQL 8.0
             junit-name: be-tests-mysql-8-0-ee
             image: cimg/mysql:8.0
             env:
-              enable-ssl-tests: 'false'
+              enable-ssl-tests: "false"
           - name: MySQL Latest
             junit-name: be-tests-mysql-latest-ee
             image: mysql:latest
             env:
-              enable-ssl-tests: 'true'
+              enable-ssl-tests: "true"
         job:
           - name: Driver Tests
             build-static-viz: false
@@ -272,21 +272,21 @@ jobs:
             build-static-viz: false
             test-args: >-
               :only '"enterprise/backend/test"'
-            exclude-tag: ':mb/driver-tests'
+            exclude-tag: ":mb/driver-tests"
           - name: EE App DB Tests (Part 1)
             build-static-viz: true
             test-args: >-
               :only '"test"'
               :partition/total 2
               :partition/index 0
-            exclude-tag: ':mb/driver-tests'
+            exclude-tag: ":mb/driver-tests"
           - name: EE App DB Tests (Part 2)
             build-static-viz: true
             test-args: >-
               :only '"test"'
               :partition/total 2
               :partition/index 1
-            exclude-tag: ':mb/driver-tests'
+            exclude-tag: ":mb/driver-tests"
 
     services:
       mysql:
@@ -313,7 +313,7 @@ jobs:
           ':mb/old-migrations-test'
         }}
       # actual serious env vars below
-      CI: 'true'
+      CI: "true"
       DRIVERS: mysql
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
@@ -331,7 +331,7 @@ jobs:
       # the MYSQL_RDS_SSL_INSTANCE vars are defined as secrets and can be altered
       MB_MYSQL_SSL_TEST_SSL: ${{ matrix.version.env.enable-ssl-tests }}
       MB_MYSQL_SSL_TEST_HOST: ${{ secrets.MYSQL_RDS_SSL_INSTANCE_HOST }}
-      MB_MYSQL_SSL_TEST_ADDITIONAL_OPTIONS: 'verifyServerCertificate=true'
+      MB_MYSQL_SSL_TEST_ADDITIONAL_OPTIONS: "verifyServerCertificate=true"
       # the contents of the ./resources/certificates/rds-combined-ca-bundle.pem file
       MB_MYSQL_SSL_TEST_SSL_CERT: ${{ secrets.MB_MYSQL_SSL_TEST_SSL_CERT }}
       MB_MYSQL_SSL_TEST_USER: metabase
@@ -363,7 +363,7 @@ jobs:
 
   be-tests-mongo:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     strategy:
@@ -380,7 +380,7 @@ jobs:
             junit-name: be-tests-mongo-latest-ee
             image: mongo:latest
     env:
-      CI: 'true'
+      CI: "true"
       DRIVERS: mongo
       MB_MONGO_TEST_USER: metabase
       MB_MONGO_TEST_PASSWORD: metasample123
@@ -394,29 +394,29 @@ jobs:
           MONGO_INITDB_ROOT_PASSWORD: metasample123
     name: ${{ matrix.version.name }}
     steps:
-    - uses: actions/checkout@v4
-    - name: Test ${{ matrix.version.name }}
-      uses: ./.github/actions/test-driver
-      with:
-        junit-name: ${{ matrix.version.junit-name }}
-        test-args: >-
-          :exclude-tags [:mongo-sharded-cluster-tests]
-          :only-tags [:mb/driver-tests]
-    - name: Upload Test Results
-      uses: ./.github/actions/upload-test-results
-      if: always()
-      with:
-        input-path: ./target/junit/
-        output-name: ${{ github.job }}
-        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
-        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ vars.AWS_REGION }}
-        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+      - uses: actions/checkout@v4
+      - name: Test ${{ matrix.version.name }}
+        uses: ./.github/actions/test-driver
+        with:
+          junit-name: ${{ matrix.version.junit-name }}
+          test-args: >-
+            :exclude-tags [:mongo-sharded-cluster-tests]
+            :only-tags [:mb/driver-tests]
+      - name: Upload Test Results
+        uses: ./.github/actions/upload-test-results
+        if: always()
+        with:
+          input-path: ./target/junit/
+          output-name: ${{ github.job }}
+          bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+          aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+          trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
   be-tests-mongo-ssl:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     strategy:
@@ -430,7 +430,7 @@ jobs:
             junit-name: be-tests-mongo-5-0-ssl-ee
             image: metabase/qa-databases:mongo-sample-5.0
     env:
-      CI: 'true'
+      CI: "true"
       DRIVERS: mongo
       MB_MONGO_TEST_USER: metabase
       MB_MONGO_TEST_PASSWORD: metasample123
@@ -484,11 +484,11 @@ jobs:
 
   be-tests-mongo-sharded-cluster-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
-      CI: 'true'
+      CI: "true"
       DRIVERS: mongo
     services:
       mongodb:
@@ -497,28 +497,28 @@ jobs:
           - "27017:17017"
     name: MongoDB Sharded Cluster
     steps:
-    - uses: actions/checkout@v4
-    - name: Test MongoDB driver (Sharded cluster)
-      uses: ./.github/actions/test-driver
-      with:
-        junit-name: 'be-tests-mongo-sharded-cluster-ee'
-        test-args: >-
-          :only metabase.driver.mongo.sharded-cluster-test
-    - name: Upload Test Results
-      uses: ./.github/actions/upload-test-results
-      if: always()
-      with:
-        input-path: ./target/junit/
-        output-name: ${{ github.job }}
-        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
-        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ vars.AWS_REGION }}
-        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+      - uses: actions/checkout@v4
+      - name: Test MongoDB driver (Sharded cluster)
+        uses: ./.github/actions/test-driver
+        with:
+          junit-name: "be-tests-mongo-sharded-cluster-ee"
+          test-args: >-
+            :only metabase.driver.mongo.sharded-cluster-test
+      - name: Upload Test Results
+        uses: ./.github/actions/upload-test-results
+        if: always()
+        with:
+          input-path: ./target/junit/
+          output-name: ${{ github.job }}
+          bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+          aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+          trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
   be-tests-oracle:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     strategy:
@@ -531,35 +531,35 @@ jobs:
             port: 1521
             env:
               user: system
-              password: 'password'
+              password: "password"
               enable-ssl-tests: false
           - name: Oracle 21.3
             junit-name: be-tests-oracle-21-3-ee
             image: metabase/qa-databases:oracle-xe-21.3
             port: 2484
             env:
-              user: ''
-              password: ''
+              user: ""
+              password: ""
               enable-ssl-tests: true
     env:
-      CI: 'true'
+      CI: "true"
       DRIVERS: oracle
       MB_ORACLE_TEST_HOST: localhost
-      MB_ORACLE_TEST_USER: '${{ matrix.version.env.user }}'
+      MB_ORACLE_TEST_USER: "${{ matrix.version.env.user }}"
       MB_ORACLE_TEST_SERVICE_NAME: XEPDB1
       # Only the non-SSL 18.4 tests specify password as an env var; the SSL 21.3 tests get it from the keystore I guess
-      MB_ORACLE_TEST_PASSWORD: '${{ matrix.version.env.password }}'
+      MB_ORACLE_TEST_PASSWORD: "${{ matrix.version.env.password }}"
       # These are ignored for the 18.4 tests which do not test SSL
       MB_ORACLE_TEST_SSL: ${{ matrix.version.env.enable-ssl-tests }}
       MB_ORACLE_SSL_TEST_SSL: ${{ matrix.version.env.enable-ssl-tests }}
       MB_ORACLE_TEST_SSL_USE_TRUSTSTORE: ${{ matrix.version.env.enable-ssl-tests }}
-      MB_ORACLE_TEST_SSL_TRUSTSTORE_PATH: './test_resources/ssl/oracle/truststore.p12'
+      MB_ORACLE_TEST_SSL_TRUSTSTORE_PATH: "./test_resources/ssl/oracle/truststore.p12"
       MB_ORACLE_TEST_SSL_TRUSTSTORE_OPTIONS: local
-      MB_ORACLE_TEST_SSL_TRUSTSTORE_PASSWORD_VALUE: 'PassworD_#1234'
+      MB_ORACLE_TEST_SSL_TRUSTSTORE_PASSWORD_VALUE: "PassworD_#1234"
       MB_ORACLE_TEST_SSL_USE_KEYSTORE: ${{ matrix.version.env.enable-ssl-tests }}
-      MB_ORACLE_TEST_SSL_KEYSTORE_PATH: './test_resources/ssl/oracle/keystore.p12'
+      MB_ORACLE_TEST_SSL_KEYSTORE_PATH: "./test_resources/ssl/oracle/keystore.p12"
       MB_ORACLE_TEST_SSL_KEYSTORE_OPTIONS: local
-      MB_ORACLE_TEST_SSL_KEYSTORE_PASSWORD_VALUE: 'PassworD_#1234'
+      MB_ORACLE_TEST_SSL_KEYSTORE_PASSWORD_VALUE: "PassworD_#1234"
     services:
       oracle:
         image: ${{ matrix.version.image }}
@@ -569,28 +569,28 @@ jobs:
           - "1521:${{ matrix.version.port }}"
     name: ${{ matrix.version.name }}
     steps:
-    - uses: actions/checkout@v4
-    - name: Test ${{ matrix.version.name }}
-      uses: ./.github/actions/test-driver
-      with:
-        junit-name: ${{ matrix.version.junit-name }}
-        test-args: >-
-          :only-tags [:mb/driver-tests]
-    - name: Upload Test Results
-      uses: ./.github/actions/upload-test-results
-      if: always()
-      with:
-        input-path: ./target/junit/
-        output-name: ${{ github.job }}
-        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
-        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ vars.AWS_REGION }}
-        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+      - uses: actions/checkout@v4
+      - name: Test ${{ matrix.version.name }}
+        uses: ./.github/actions/test-driver
+        with:
+          junit-name: ${{ matrix.version.junit-name }}
+          test-args: >-
+            :only-tags [:mb/driver-tests]
+      - name: Upload Test Results
+        uses: ./.github/actions/upload-test-results
+        if: always()
+        with:
+          input-path: ./target/junit/
+          output-name: ${{ github.job }}
+          bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+          aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+          trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
   be-tests-postgres:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     strategy:
@@ -601,12 +601,12 @@ jobs:
             junit-name: postgres-ee
             docker-image: postgres:12-alpine
             env:
-              enable-ssl-tests: 'false'
+              enable-ssl-tests: "false"
           - name: Postgres Latest
             junit-name: postgres-latest-ee
             docker-image: postgres:latest
             env:
-              enable-ssl-tests: 'true'
+              enable-ssl-tests: "true"
         job:
           - name: Driver Tests
             build-static-viz: false
@@ -616,7 +616,7 @@ jobs:
             build-static-viz: false
             test-args: >-
               :only '"enterprise/backend/test"'
-            exclude-tag: ':mb/driver-tests'
+            exclude-tag: ":mb/driver-tests"
           - name: EE App DB Tests (Part 1)
             build-static-viz: true
             test-args: >-
@@ -624,14 +624,14 @@ jobs:
               :exclude-tags [:mb/driver-tests]
               :partition/total 2
               :partition/index 0
-            exclude-tag: ':mb/driver-tests'
+            exclude-tag: ":mb/driver-tests"
           - name: EE App DB Tests (Part 2)
             build-static-viz: true
             test-args: >-
               :only '"test"'
               :partition/total 2
               :partition/index 1
-            exclude-tag: ':mb/driver-tests'
+            exclude-tag: ":mb/driver-tests"
     name: "${{ matrix.version.name }} ${{ matrix.job.name }}"
     env:
       # Only run old migrations tests on pushes to master or release branches. All other branches should skip tests
@@ -650,7 +650,7 @@ jobs:
           ':mb/old-migrations-test'
         }}
       # actual serious env vars below
-      CI: 'true'
+      CI: "true"
       DRIVERS: postgres
       MB_DB_TYPE: postgres
       MB_DB_PORT: 5432
@@ -661,7 +661,7 @@ jobs:
       # SSL tests are only enabled for the postgres-latest job.
       MB_POSTGRES_SSL_TEST_SSL: ${{ matrix.version.env.enable-ssl-tests }}
       MB_POSTGRES_SSL_TEST_SSL_MODE: verify-full
-      MB_POSTGRES_SSL_TEST_SSL_ROOT_CERT_PATH: 'test-resources/certificates/us-east-2-bundle.pem'
+      MB_POSTGRES_SSL_TEST_SSL_ROOT_CERT_PATH: "test-resources/certificates/us-east-2-bundle.pem"
     services:
       postgres:
         image: ${{ matrix.version.docker-image }}
@@ -677,7 +677,7 @@ jobs:
         uses: ./.github/actions/test-driver
         with:
           build-static-viz: ${{ matrix.job.build-static-viz }}
-          junit-name: 'be-tests-${{ matrix.version.junit-name }}'
+          junit-name: "be-tests-${{ matrix.version.junit-name }}"
           test-args: >-
             ${{ matrix.job.test-args }}
             :exclude-tags '[ ${{ matrix.job.exclude-tag }} ${{ env.__ADDITIONAL_EXCLUDED_TAG__ }}]'
@@ -695,11 +695,11 @@ jobs:
 
   be-tests-presto-jdbc-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
-      CI: 'true'
+      CI: "true"
       DRIVERS: presto-jdbc
       MB_PRESTO_JDBC_TEST_CATALOG: test_data
       MB_PRESTO_JDBC_TEST_HOST: localhost
@@ -708,7 +708,7 @@ jobs:
       MB_PRESTO_JDBC_TEST_USER: metabase
       MB_PRESTO_JDBC_TEST_PASSWORD: metabase
       MB_ENABLE_PRESTO_JDBC_DRIVER: true
-      MB_PRESTO_JDBC_TEST_ADDITIONAL_OPTIONS: 'SSLTrustStorePath=/tmp/cacerts-with-presto-ssl.jks&SSLTrustStorePassword=changeit'
+      MB_PRESTO_JDBC_TEST_ADDITIONAL_OPTIONS: "SSLTrustStorePath=/tmp/cacerts-with-presto-ssl.jks&SSLTrustStorePassword=changeit"
     name: Presto
     services:
       presto:
@@ -718,53 +718,53 @@ jobs:
         env:
           JAVA_TOOL_OPTIONS: "-Xmx2g"
     steps:
-    - uses: actions/checkout@v4
-    - uses: ./.github/actions/await-port
-      with:
-         port: ${{ env.MB_PRESTO_JDBC_TEST_PORT }}
-      timeout-minutes: 5
-    - name: Create temp cacerts file based on bundled JDK one
-      run: cp $JAVA_HOME/lib/security/cacerts /tmp/cacerts-with-presto-ssl.jks
-    - name: Capture Presto server self signed CA
-      run: |
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/await-port
+        with:
+          port: ${{ env.MB_PRESTO_JDBC_TEST_PORT }}
+        timeout-minutes: 5
+      - name: Create temp cacerts file based on bundled JDK one
+        run: cp $JAVA_HOME/lib/security/cacerts /tmp/cacerts-with-presto-ssl.jks
+      - name: Capture Presto server self signed CA
+        run: |
           while [[ ! -s /tmp/presto-ssl-ca.pem ]]; do
             echo "Waiting to capture SSL CA" \
               && openssl s_client -connect localhost:8443 2>/dev/null </dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > /tmp/presto-ssl-ca.pem \
               && sleep 1;
           done
-    - name: Convert Presto CA from PEM to DER
-      run: openssl x509 -outform der -in /tmp/presto-ssl-ca.pem -out /tmp/presto-ssl-ca.der
-    - name: Add write permission on cacerts file
-      run: chmod u+w /tmp/cacerts-with-presto-ssl.jks
-    - name: Import Presto CA into temp cacerts file
-      run: >-
-        keytool -noprompt -import
-        -alias presto
-        -keystore /tmp/cacerts-with-presto-ssl.jks
-        -storepass changeit
-        -file /tmp/presto-ssl-ca.der
-        -trustcacerts
-    - name: Test Presto JDBC driver
-      uses: ./.github/actions/test-driver
-      with:
-        junit-name: 'be-tests-presto-jdbc-ee'
-        test-args: >-
-          :only-tags [:mb/driver-tests]
-    - name: Upload Test Results
-      uses: ./.github/actions/upload-test-results
-      if: always()
-      with:
-        input-path: ./target/junit/
-        output-name: ${{ github.job }}
-        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
-        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ vars.AWS_REGION }}
-        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+      - name: Convert Presto CA from PEM to DER
+        run: openssl x509 -outform der -in /tmp/presto-ssl-ca.pem -out /tmp/presto-ssl-ca.der
+      - name: Add write permission on cacerts file
+        run: chmod u+w /tmp/cacerts-with-presto-ssl.jks
+      - name: Import Presto CA into temp cacerts file
+        run: >-
+          keytool -noprompt -import
+          -alias presto
+          -keystore /tmp/cacerts-with-presto-ssl.jks
+          -storepass changeit
+          -file /tmp/presto-ssl-ca.der
+          -trustcacerts
+      - name: Test Presto JDBC driver
+        uses: ./.github/actions/test-driver
+        with:
+          junit-name: "be-tests-presto-jdbc-ee"
+          test-args: >-
+            :only-tags [:mb/driver-tests]
+      - name: Upload Test Results
+        uses: ./.github/actions/upload-test-results
+        if: always()
+        with:
+          input-path: ./target/junit/
+          output-name: ${{ github.job }}
+          bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+          aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+          trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
   be-tests-redshift-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     strategy:
@@ -784,7 +784,7 @@ jobs:
               :fail-fast? true
 
     env:
-      CI: 'true'
+      CI: "true"
       DRIVERS: redshift
       MB_REDSHIFT_TEST_USER: metabase_ci
       MB_REDSHIFT_TEST_DB: testdb
@@ -792,33 +792,33 @@ jobs:
       MB_REDSHIFT_TEST_PASSWORD: ${{ secrets.MB_REDSHIFT_TEST_PASSWORD }}
     name: ${{ matrix.job.name }}
     steps:
-    - uses: actions/checkout@v4
-    - name: Test ${{ matrix.job.name }}
-      if: ${{ !matrix.job.skip }}
-      uses: ./.github/actions/test-driver
-      with:
-        junit-name: 'be-tests-redshift-ee'
-        test-args: >-
-          ${{ matrix.job.test-args }}
-    - name: Upload Test Results
-      uses: ./.github/actions/upload-test-results
-      if: ${{ !matrix.job.skip && !cancelled() }}
-      with:
-        input-path: ./target/junit/
-        output-name: ${{ github.job }}
-        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
-        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ vars.AWS_REGION }}
-        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+      - uses: actions/checkout@v4
+      - name: Test ${{ matrix.job.name }}
+        if: ${{ !matrix.job.skip }}
+        uses: ./.github/actions/test-driver
+        with:
+          junit-name: "be-tests-redshift-ee"
+          test-args: >-
+            ${{ matrix.job.test-args }}
+      - name: Upload Test Results
+        uses: ./.github/actions/upload-test-results
+        if: ${{ !matrix.job.skip && !cancelled() }}
+        with:
+          input-path: ./target/junit/
+          output-name: ${{ github.job }}
+          bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+          aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+          trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
   be-tests-snowflake-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
-      CI: 'true'
+      CI: "true"
       DRIVERS: snowflake
       MB_SNOWFLAKE_TEST_USER: METABASE CI
       MB_SNOWFLAKE_TEST_ACCOUNT: ${{ secrets.MB_SNOWFLAKE_TEST_ACCOUNT }}
@@ -833,32 +833,32 @@ jobs:
       MB_SNOWFLAKE_TEST_RSA_ROLE_TEST_DB: RSA_ROLE_TEST_DB
     name: Snowflake
     steps:
-    - uses: actions/checkout@v4
-    - name: Test Snowflake driver
-      uses: ./.github/actions/test-driver
-      with:
-        junit-name: 'be-tests-snowflake-ee'
-        test-args: >-
-          :only-tags [:mb/driver-tests]
-    - name: Upload Test Results
-      uses: ./.github/actions/upload-test-results
-      if: always()
-      with:
-        input-path: ./target/junit/
-        output-name: ${{ github.job }}
-        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
-        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ vars.AWS_REGION }}
-        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+      - uses: actions/checkout@v4
+      - name: Test Snowflake driver
+        uses: ./.github/actions/test-driver
+        with:
+          junit-name: "be-tests-snowflake-ee"
+          test-args: >-
+            :only-tags [:mb/driver-tests]
+      - name: Upload Test Results
+        uses: ./.github/actions/upload-test-results
+        if: always()
+        with:
+          input-path: ./target/junit/
+          output-name: ${{ github.job }}
+          bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+          aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+          trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
   be-tests-sparksql-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
-      CI: 'true'
+      CI: "true"
       DRIVERS: sparksql
     services:
       sparksql:
@@ -867,57 +867,57 @@ jobs:
           - "10000:10000"
     name: Spark SQL
     steps:
-    - uses: actions/checkout@v4
-    - name: Test Spark driver
-      uses: ./.github/actions/test-driver
-      with:
-        junit-name: 'be-tests-sparksql-ee'
-        test-args: >-
-          :only-tags [:mb/driver-tests]
-    - name: Upload Test Results
-      uses: ./.github/actions/upload-test-results
-      if: always()
-      with:
-        input-path: ./target/junit/
-        output-name: ${{ github.job }}
-        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
-        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ vars.AWS_REGION }}
-        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+      - uses: actions/checkout@v4
+      - name: Test Spark driver
+        uses: ./.github/actions/test-driver
+        with:
+          junit-name: "be-tests-sparksql-ee"
+          test-args: >-
+            :only-tags [:mb/driver-tests]
+      - name: Upload Test Results
+        uses: ./.github/actions/upload-test-results
+        if: always()
+        with:
+          input-path: ./target/junit/
+          output-name: ${{ github.job }}
+          bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+          aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+          trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
   be-tests-sqlite-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
-      CI: 'true'
+      CI: "true"
       DRIVERS: sqlite
     name: SQLite
     steps:
-    - uses: actions/checkout@v4
-    - name: Test SQLite driver
-      uses: ./.github/actions/test-driver
-      with:
-        junit-name: 'be-tests-sqlite-ee'
-        test-args: >-
-          :only-tags [:mb/driver-tests]
-    - name: Upload Test Results
-      uses: ./.github/actions/upload-test-results
-      if: always()
-      with:
-        input-path: ./target/junit/
-        output-name: ${{ github.job }}
-        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
-        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ vars.AWS_REGION }}
-        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+      - uses: actions/checkout@v4
+      - name: Test SQLite driver
+        uses: ./.github/actions/test-driver
+        with:
+          junit-name: "be-tests-sqlite-ee"
+          test-args: >-
+            :only-tags [:mb/driver-tests]
+      - name: Upload Test Results
+        uses: ./.github/actions/upload-test-results
+        if: always()
+        with:
+          input-path: ./target/junit/
+          output-name: ${{ github.job }}
+          bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+          aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+          trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
   be-tests-sqlserver:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     strategy:
@@ -931,10 +931,10 @@ jobs:
             junit-name: be-tests-sqlserver-2022-ee
             image: mcr.microsoft.com/mssql/server:2022-latest
     env:
-      CI: 'true'
+      CI: "true"
       DRIVERS: sqlserver
       MB_SQLSERVER_TEST_HOST: localhost
-      MB_SQLSERVER_TEST_PASSWORD: 'P@ssw0rd'
+      MB_SQLSERVER_TEST_PASSWORD: "P@ssw0rd"
       MB_SQLSERVER_TEST_USER: SA
     services:
       sqlserver:
@@ -943,36 +943,36 @@ jobs:
           - "1433:1433"
         env:
           ACCEPT_EULA: Y
-          SA_PASSWORD: 'P@ssw0rd'
+          SA_PASSWORD: "P@ssw0rd"
           MSSQL_MEMORY_LIMIT_MB: 1024
     name: ${{ matrix.version.name }}
     steps:
-    - uses: actions/checkout@v4
-    - name: Test ${{ matrix.version.name }}
-      uses: ./.github/actions/test-driver
-      with:
-        junit-name: ${{ matrix.version.junit-name }}
-        test-args: >-
-          :only-tags [:mb/driver-tests]
-    - name: Upload Test Results
-      uses: ./.github/actions/upload-test-results
-      if: always()
-      with:
-        input-path: ./target/junit/
-        output-name: ${{ github.job }}
-        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
-        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ vars.AWS_REGION }}
-        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+      - uses: actions/checkout@v4
+      - name: Test ${{ matrix.version.name }}
+        uses: ./.github/actions/test-driver
+        with:
+          junit-name: ${{ matrix.version.junit-name }}
+          test-args: >-
+            :only-tags [:mb/driver-tests]
+      - name: Upload Test Results
+        uses: ./.github/actions/upload-test-results
+        if: always()
+        with:
+          input-path: ./target/junit/
+          output-name: ${{ github.job }}
+          bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+          aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+          trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
   be-tests-vertica-ee:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
-      CI: 'true'
+      CI: "true"
       DRIVERS: vertica
     services:
       vertica:
@@ -981,26 +981,26 @@ jobs:
           - "5433:5433"
     name: Vertica
     steps:
-    - uses: actions/checkout@v4
-    - name: Make plugins directory
-      run: mkdir plugins
-    - name: Test Vertica driver
-      uses: ./.github/actions/test-driver
-      with:
-        junit-name: 'be-tests-vertica-ee'
-        test-args: >-
-          :only-tags [:mb/driver-tests]
-    - name: Upload Test Results
-      uses: ./.github/actions/upload-test-results
-      if: always()
-      with:
-        input-path: ./target/junit/
-        output-name: ${{ github.job }}
-        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
-        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ vars.AWS_REGION }}
-        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+      - uses: actions/checkout@v4
+      - name: Make plugins directory
+        run: mkdir plugins
+      - name: Test Vertica driver
+        uses: ./.github/actions/test-driver
+        with:
+          junit-name: "be-tests-vertica-ee"
+          test-args: >-
+            :only-tags [:mb/driver-tests]
+      - name: Upload Test Results
+        uses: ./.github/actions/upload-test-results
+        if: always()
+        with:
+          input-path: ./target/junit/
+          output-name: ${{ github.job }}
+          bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+          aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+          trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
   drivers-tests-result:
     needs:

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -30,7 +30,7 @@ jobs:
 
   be-tests-h2:
     needs: files-changed
-    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-tests')) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
@@ -58,7 +58,7 @@ jobs:
 
   be-tests-athena-ee:
     needs: files-changed
-    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-tests')) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
@@ -94,7 +94,7 @@ jobs:
 
   be-tests-bigquery-cloud-sdk-ee:
     needs: files-changed
-    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-tests')) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
@@ -129,7 +129,7 @@ jobs:
 
   be-tests-druid-ee:
     needs: files-changed
-    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-tests')) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
@@ -165,7 +165,7 @@ jobs:
 
   be-tests-databricks-ee:
     needs: files-changed
-    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-tests')) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
@@ -200,7 +200,7 @@ jobs:
 
   be-tests-druid-jdbc-ee:
     needs: files-changed
-    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-tests')) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
@@ -236,7 +236,7 @@ jobs:
 
   be-tests-mysql-mariadb:
     needs: files-changed
-    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-tests')) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     strategy:
@@ -363,7 +363,7 @@ jobs:
 
   be-tests-mongo:
     needs: files-changed
-    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-tests')) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     strategy:
@@ -416,7 +416,7 @@ jobs:
 
   be-tests-mongo-ssl:
     needs: files-changed
-    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-tests')) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     strategy:
@@ -484,7 +484,7 @@ jobs:
 
   be-tests-mongo-sharded-cluster-ee:
     needs: files-changed
-    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-tests')) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
@@ -518,7 +518,7 @@ jobs:
 
   be-tests-oracle:
     needs: files-changed
-    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-tests')) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     strategy:
@@ -590,7 +590,7 @@ jobs:
 
   be-tests-postgres:
     needs: files-changed
-    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-tests')) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     strategy:
@@ -695,7 +695,7 @@ jobs:
 
   be-tests-presto-jdbc-ee:
     needs: files-changed
-    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-tests')) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
@@ -764,7 +764,7 @@ jobs:
 
   be-tests-redshift-ee:
     needs: files-changed
-    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-tests')) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     strategy:
@@ -814,7 +814,7 @@ jobs:
 
   be-tests-snowflake-ee:
     needs: files-changed
-    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-tests')) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
@@ -854,7 +854,7 @@ jobs:
 
   be-tests-sparksql-ee:
     needs: files-changed
-    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-tests')) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
@@ -888,7 +888,7 @@ jobs:
 
   be-tests-sqlite-ee:
     needs: files-changed
-    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-tests')) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
@@ -917,7 +917,7 @@ jobs:
 
   be-tests-sqlserver:
     needs: files-changed
-    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-tests')) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     strategy:
@@ -968,7 +968,7 @@ jobs:
 
   be-tests-vertica-ee:
     needs: files-changed
-    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-tests')) && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -67,7 +67,7 @@ jobs:
     needs: [files-changed, get-build-requirements]
     if: |
       !cancelled() &&
-      github.event.pull_request.draft == false
+      (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests')))
     runs-on: ubuntu-22.04
     timeout-minutes: 25
     env:

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -67,7 +67,7 @@ jobs:
     needs: [files-changed, get-build-requirements]
     if: |
       !cancelled() &&
-      (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests')))
+      (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-tests'))
     runs-on: ubuntu-22.04
     timeout-minutes: 25
     env:

--- a/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - "release-**"
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
     branches:
       - "release-**"
 

--- a/.github/workflows/e2e-component-tests-embedding-sdk.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk.yml
@@ -6,7 +6,7 @@ on:
       - "master"
       - "release-**"
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}

--- a/.github/workflows/e2e-component-tests-embedding-sdk.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk.yml
@@ -67,7 +67,7 @@ jobs:
     needs: [files-changed, get-build-requirements]
     if: |
       !cancelled() &&
-      github.event.pull_request.draft == false &&
+      (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) &&
       needs.files-changed.outputs.e2e_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 25

--- a/.github/workflows/e2e-component-tests-embedding-sdk.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk.yml
@@ -67,7 +67,7 @@ jobs:
     needs: [files-changed, get-build-requirements]
     if: |
       !cancelled() &&
-      (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) &&
+      (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-tests')) &&
       needs.files-changed.outputs.e2e_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 25

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -6,7 +6,7 @@ on:
       - "master"
       - "release-**"
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -68,7 +68,7 @@ jobs:
     needs: [files-changed, get-build-requirements]
     if: |
       !cancelled() &&
-      github.event.pull_request.draft == false &&
+      (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) &&
       needs.files-changed.outputs.e2e_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 25
@@ -167,8 +167,8 @@ jobs:
 
   e2e-tests-result:
     needs:
-     - e2e-tests
-     - flaky-e2e-tests
+      - e2e-tests
+      - flaky-e2e-tests
     runs-on: ubuntu-latest
     timeout-minutes: 5
     name: e2e-tests-result

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -68,7 +68,7 @@ jobs:
     needs: [files-changed, get-build-requirements]
     if: |
       !cancelled() &&
-      (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) &&
+      (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-tests')) &&
       needs.files-changed.outputs.e2e_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 25

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -6,7 +6,7 @@ on:
       - "master"
       - "release-**"
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -71,7 +71,7 @@ jobs:
 
   fe-tests-unit:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.frontend_all == 'true'
+    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.frontend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
@@ -112,7 +112,7 @@ jobs:
 
   fe-tests-timezones:
     needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.frontend_all == 'true'
+    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.frontend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -71,7 +71,7 @@ jobs:
 
   fe-tests-unit:
     needs: files-changed
-    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.frontend_all == 'true'
+    if: (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-tests')) && needs.files-changed.outputs.frontend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
@@ -112,7 +112,7 @@ jobs:
 
   fe-tests-timezones:
     needs: files-changed
-    if: (github.event.pull_request.draft == false || (github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'run-tests'))) && needs.files-changed.outputs.frontend_all == 'true'
+    if: (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'run-tests')) && needs.files-changed.outputs.frontend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
This PR implements [this RFC](https://www.notion.so/metabase/111-Allow-tests-to-run-on-draft-PRs-with-a-label-11a69354c90180b0b2d9c66b33ff3ba9).


We'd want draft PR in addition to ready-for-review PRs to run tests, but only when there is a label `run-tests` in the PR.

I tested 3 scenarios
### 1. Draft PR with no `run-tests` label
There are a lot of skipped checks.
![Screenshot 2025-02-05 at 6 46 40 PM](https://github.com/user-attachments/assets/8a2f94b5-ca33-47f3-8d95-8c8384052897)


### 2. Draft PR with `run-tests` label
The number of skipped checks is comparable to the ready-for-review one. They're totally equal because the screenshot is captured at different stages and with different runners picking up the checks.

![Screenshot 2025-02-05 at 6 55 50 PM](https://github.com/user-attachments/assets/6c2df784-cf0e-43ef-8002-4bd25f034459)


### 3. Ready-for-review PR with no `run-tests` label
This makes sure that normal ready-for-review PRs would have tests run as usual, like this PR in the current state.
![Screenshot 2025-02-05 at 7 00 42 PM](https://github.com/user-attachments/assets/80a0c3b4-aa19-4b61-861c-c8f4e274b00c)

