### PR TITLE
Remove the postcss-presets-env warning about the partially supported `end` value

### DIFF
--- a/frontend/src/metabase/nav/components/AppBar/AppBarLarge.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLarge.styled.tsx
@@ -32,7 +32,7 @@ export const AppBarRightContainer = styled.div`
   align-items: center;
   gap: 1rem;
   max-width: 32.5rem;
-  justify-content: end;
+  justify-content: flex-end;
 `;
 
 interface AppBarInfoContainerProps {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.module.css
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.module.css
@@ -35,7 +35,7 @@
       vertical-align: baseline;
       display: flex;
       align-items: center;
-      justify-content: end;
+      justify-content: flex-end;
 
       span[title="Fold line"] {
         position: relative;

--- a/frontend/src/metabase/query_builder/components/view/View/View/View.module.css
+++ b/frontend/src/metabase/query_builder/components/view/View/View/View.module.css
@@ -12,6 +12,6 @@
   position: relative;
 
   @media screen and (max-width: 40em) {
-    justify-content: end;
+    justify-content: flex-end;
   }
 }

--- a/frontend/src/metabase/querying/segments/components/SegmentEditor/ClauseStep/ClauseStep.module.css
+++ b/frontend/src/metabase/querying/segments/components/SegmentEditor/ClauseStep/ClauseStep.module.css
@@ -23,7 +23,7 @@
   &:last-child {
     flex-grow: 1;
     flex-shrink: 0;
-    justify-content: end;
+    justify-content: flex-end;
   }
 
   &:not(:last-child) {

--- a/frontend/src/metabase/timelines/common/components/EventForm/EventForm.styled.tsx
+++ b/frontend/src/metabase/timelines/common/components/EventForm/EventForm.styled.tsx
@@ -3,6 +3,6 @@ import styled from "@emotion/styled";
 export const EventFormFooter = styled.div`
   display: flex;
   align-items: center;
-  justify-content: end;
+  justify-content: flex-end;
   gap: 0.5rem;
 `;

--- a/frontend/src/metabase/timelines/common/components/TimelineForm/TimelineForm.styled.tsx
+++ b/frontend/src/metabase/timelines/common/components/TimelineForm/TimelineForm.styled.tsx
@@ -3,6 +3,6 @@ import styled from "@emotion/styled";
 export const TimelineFormFooter = styled.div`
   display: flex;
   align-items: center;
-  justify-content: end;
+  justify-content: flex-end;
   gap: 0.5rem;
 `;

--- a/frontend/src/metabase/visualizations/components/ChartSettings/ChartSettingsFooter/ChartSettingsFooter.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/ChartSettingsFooter/ChartSettingsFooter.styled.tsx
@@ -4,7 +4,7 @@ import Button from "metabase/core/components/Button";
 
 export const ChartSettingsFooterRoot = styled.div`
   display: flex;
-  justify-content: end;
+  justify-content: flex-end;
   padding: 1rem 2rem;
   ${Button} {
     margin-left: 1rem;


### PR DESCRIPTION
Should remove this warning
```
WARNING in
  ⚠ ModuleWarning: Warning
  │
  │ (38:7) postcss-preset-env: end value has mixed support, consider using flex-end instead
```
 
 ### How to verify?
 1. run `yarn build-hot`
 2. make sure the warning does not appear in logs