### PR TITLE
add estimated size to Search Results virtual list in entity picker

### DIFF
--- a/frontend/src/metabase/common/components/EntityPicker/components/SearchTab/SearchResults.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/SearchTab/SearchResults.tsx
@@ -41,6 +41,7 @@ export const SearchResults = <
                 <ChunkyList>{children}</ChunkyList>
               </Box>
             )}
+            estimatedItemSize={66}
           >
             {searchResults?.map((item, index) => (
               <ResultItem


### PR DESCRIPTION
Closes ENG 8233

### Description
Adds an accurate estimated size for a `<ChunkyListItem>` in the search tab, which solves the issue of of weird scrolling

### How to verify
1. Open an entity picker (data picker is a good choice)
2. Perform a search that will return many results
3. grab the scroll bar in the search results, and drag down. the bar should follow your mouse

### Demo
Before (on stats):
![chrome_gVQ0ofNIVf](https://github.com/user-attachments/assets/36f433b1-b922-4f79-9eae-14a82a905e7c)

After: 
![chrome_S9FlcS6mii](https://github.com/user-attachments/assets/d8e2dda2-a414-4a17-862a-de38e75bf773)

### Checklist

- ~[ ] Tests have been added/updated to cover changes in this PR~

There was a reference in the original issue that points to a test that can be changed once this is fixed. However, that test has since changed, and doing a simple `scrollTo("bottom")` still results in weird behavior. I've confirmed the UX is better for real users, but cypress interactions still appear to be fussy
