### PR TITLE
Fix search index update job restart issue

### DIFF
--- a/src/metabase/task/search_index.clj
+++ b/src/metabase/task/search_index.clj
@@ -11,7 +11,7 @@
   (:import
    (java.time Instant)
    (java.util Date)
-   (org.quartz DisallowConcurrentExecution JobDetail Trigger)))
+   (org.quartz DisallowConcurrentExecution JobExecutionException)))
 
 (set! *warn-on-reflection* true)
 
@@ -74,26 +74,23 @@
 (defn- update-index! []
   (when (search/supports-index?)
     (log/info "Starting Realtime Search Index Update worker")
-    (while true
-      (try
-        (let [batch    (search/get-next-batch! Long/MAX_VALUE 100)
-              _        (log/trace "Processing batch" batch)
-              timer    (u/start-timer)
-              report   (search/bulk-ingest! batch)
-              duration (u/since-ms timer)]
-          (when (seq report)
-            (report->prometheus! duration report)
-            (log/debugf "Indexed search entries in %.0fms %s" duration (sort-by (comp - val) report))))
-        (catch Exception e
-          (prometheus/inc! :metabase-search/index-error)
-          (throw e))))))
-
-(defn- force-scheduled-task! [^JobDetail job ^Trigger trigger]
-  ;; For some reason, using the schedule-task! with a non-durable job causes it to only fire on the first trigger.
-  #_(task/schedule-task! job trigger)
-  (task/delete-task! (.getKey job) (.getKey trigger))
-  (task/add-job! job)
-  (task/add-trigger! trigger))
+    (try
+      (while true
+        (try
+          (let [batch    (search/get-next-batch! Long/MAX_VALUE 100)
+                _        (log/trace "Processing batch" batch)
+                timer    (u/start-timer)
+                report   (search/bulk-ingest! batch)
+                duration (u/since-ms timer)]
+            (when (seq report)
+              (report->prometheus! duration report)
+              (log/debugf "Indexed search entries in %.0fms %s" duration (sort-by (comp - val) report))))
+          (catch Exception e
+            (prometheus/inc! :metabase-search/index-error)
+            (throw e))))
+      (catch Exception e
+        (log/error e "Updating search index failed")
+        (throw (JobExecutionException. "Updating search index failed" e true))))))
 
 (jobs/defjob ^{:doc "Ensure a Search Index exists"}
   SearchIndexInit [_ctx]
@@ -135,16 +132,13 @@
 (defmethod task/init! ::SearchIndexUpdate [_]
   (let [job         (jobs/build
                      (jobs/of-type SearchIndexUpdate)
-                     (jobs/store-durably)
                      (jobs/with-identity update-job-key))
         trigger-key (triggers/key (str update-stem ".trigger"))
         trigger     (triggers/build
                      (triggers/with-identity trigger-key)
                      (triggers/for-job update-job-key)
-                     (triggers/start-now)
-                     ;; This schedule is only here to restart the task if it dies for some reason.
-                     (triggers/with-schedule (simple/schedule (simple/with-interval-in-seconds 1))))]
-    (force-scheduled-task! job trigger)))
+                     (triggers/start-now))]
+    (task/schedule-task! job trigger)))
 
 (comment
   (task/job-exists? reindex-job-key)


### PR DESCRIPTION
This fixes the issue where the job throws an exception and is never restarted.

It hopefully also fixed the less deterministic issue where some pods don't start the job and others do, which I think has to do with the job being durable and having triggers get deleted and recreated.

This needs to be backported all the way to v52.

Refs ENG-14667
Closes ENG-14668