### PR TITLE
Use env vars in backend process

### DIFF
--- a/e2e/runner/cypress-runner-backend.js
+++ b/e2e/runner/cypress-runner-backend.js
@@ -70,10 +70,10 @@ const CypressBackend = {
         [...javaFlags, "-jar", "target/uberjar/metabase.jar"],
         {
           env: {
+            ...process.env,
             ...metabaseConfig,
             ...userDefaults,
             ...snowplowConfig,
-            PATH: process.env.PATH,
           },
           stdio:
             process.env["DISABLE_LOGGING"] ||


### PR DESCRIPTION
Should fix `MB_EXPERIMENTAL_SEARCH_BLOCK_ON_QUEUE` being passed through... which might fix all the search flakes  🥐 🤞