### PR TITLE
remove all instances of describeEE, onlyOnEE and onlyOnOSS

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -107,8 +107,7 @@ module.exports = {
           "And",
           "When",
           "Then",
-          "describeWithSnowplow",
-          "describeEE",
+          "describeWithSnowplow"
         ],
       },
     ],

--- a/docs/developers-guide/e2e-tests.md
+++ b/docs/developers-guide/e2e-tests.md
@@ -219,7 +219,7 @@ The example of the artifacts for a failed test in "Onboarding" directory:
 
 ## Running Cypress tests against Metabase® Enterprise Edition™
 
-Prior to running Cypress against Metabase® Enterprise Edition™, set `MB_EDITION=ee` environment variable. We have a special `describe` block called `describeEE` that will conditionally skip or run tests based on the edition.
+Prior to running Cypress against Metabase® Enterprise Edition™, set `MB_EDITION=ee` environment variable.
 
 **Enterprise instance will start without a premium token!**
 
@@ -235,7 +235,6 @@ MB_EDITION=ee CYPRESS_ALL_FEATURES_TOKEN=xxxxxx CYPRESS_NO_FEATURES_TOKEN=xxxxxx
 
 If you navigate to the `/admin/settings/license` page, the license input field should display the active token. Be careful when sharing screenshots!
 
-- If tests under `describeEE` block are greyed out and not running, make sure you spun up Metabase® Enterprise Edition™.
 - If tests start running but the enterprise features are missing: make sure that the token you use has corresponding feature flags enabled.
 - If everything with the token seems to be okay, go nuclear and destroy all Java processes: run `killall java` and restart Cypress.
 

--- a/e2e/support/cypress.js
+++ b/e2e/support/cypress.js
@@ -155,3 +155,19 @@ if (isCI) {
   // Ensure that after plugin installation is after the afterEach handling the integration.
   require("cypress-terminal-report/src/installLogsCollector")(options);
 }
+
+beforeEach(function () {
+  const isCurrentTesOss =
+    this.currentTest._testConfig.unverifiedTestConfig.tags === "@OSS";
+  const isBuildOss = Cypress.env("MB_EDITION") === "oss";
+  const testName = this.currentTest.title;
+  if (Cypress.config("isInteractive") && isCurrentTesOss && !isBuildOss) {
+    console.log(
+      "%cSkipping test because it is tagged with @OSS:",
+      "color: red;",
+    );
+    console.log(`test name: ${testName}\n\n"this test should be ran against OSS jar. Make sure you have MB_EDITION=oss set and go to e2e/support/cypress.js and temporarily remove the skipOn(true) to run the test"
+    `);
+    cy.skipOn(true);
+  }
+});

--- a/e2e/support/helpers/e2e-enterprise-helpers.js
+++ b/e2e/support/helpers/e2e-enterprise-helpers.js
@@ -2,31 +2,16 @@
  * Just because an instance is using an Enterprise artifact (jar or Docker image),
  * doesn't mean that the token is active or that it has all feature flags enabled.
  *
- * `isEE` means enterprise instance without a token and `isOSS` means open-source instance.
+ * `IS_ENTERPRISE` means enterprise instance without a token and `isOSS` means open-source instance.
  */
-export const isEE = Cypress.env("IS_ENTERPRISE");
-export const isOSS = !isEE;
-
-/** run only if the test is running on an EE jar */
-export const onlyOnEE = () => cy.onlyOn(isEE);
-
-/** run only if the test is running on an OSS jar */
-export const onlyOnOSS = () => cy.onlyOn(isOSS);
-
-/**
- *
- * @param {boolean} cond
- */
-export const conditionalDescribe = cond => (cond ? describe : describe.skip);
-
-export const describeEE = conditionalDescribe(isEE);
+const { IS_ENTERPRISE } = Cypress.env();
 
 /**
  *
  * @param {("all"|"none")} featuresScope
  */
 export const setTokenFeatures = featuresScope => {
-  if (!isEE) {
+  if (!IS_ENTERPRISE) {
     throw new Error(
       "You must run Metabase® Enterprise Edition™ for token to make sense.\nMake sure you have `MB_EDITION=ee` in your environment variables.",
     );
@@ -66,7 +51,7 @@ export const setTokenFeatures = featuresScope => {
 };
 
 export const deleteToken = () => {
-  if (!isEE) {
+  if (!IS_ENTERPRISE) {
     throw new Error(
       "You must run Metabase® Enterprise Edition™ for token to make sense.\nMake sure you have `MB_EDITION=ee` in your environment variables.",
     );

--- a/e2e/support/helpers/e2e-snowplow-helpers.js
+++ b/e2e/support/helpers/e2e-snowplow-helpers.js
@@ -1,7 +1,8 @@
 import _ from "underscore";
 
-import { isEE, updateSetting } from "e2e/support/helpers";
+import { updateSetting } from "e2e/support/helpers";
 
+const { IS_ENTERPRISE } = Cypress.env();
 const HAS_SNOWPLOW = Cypress.env("HAS_SNOWPLOW_MICRO");
 const SNOWPLOW_URL = Cypress.env("SNOWPLOW_MICRO_URL");
 const SNOWPLOW_INTERVAL = 100;
@@ -9,7 +10,7 @@ const SNOWPLOW_TIMEOUT = 1000;
 
 export const describeWithSnowplow = HAS_SNOWPLOW ? describe : describe.skip;
 export const describeWithSnowplowEE =
-  HAS_SNOWPLOW && isEE ? describe : describe.skip;
+  HAS_SNOWPLOW && IS_ENTERPRISE ? describe : describe.skip;
 
 export const enableTracking = () => {
   updateSetting("anon-tracking-enabled", true);

--- a/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
@@ -7,7 +7,6 @@ import {
 } from "e2e/support/cypress_sample_instance_data";
 import {
   createQuestion,
-  describeEE,
   entityPickerModal,
   entityPickerModalTab,
   modal,
@@ -21,7 +20,7 @@ import {
 import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 import { Flex } from "metabase/ui";
 
-describeEE("scenarios > embedding-sdk > create-question", () => {
+describe("scenarios > embedding-sdk > create-question", () => {
   beforeEach(() => {
     signInAsAdminAndEnableEmbeddingSdk();
   });

--- a/e2e/test-component/scenarios/embedding-sdk/dashboard-click-behavior.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/dashboard-click-behavior.cy.spec.tsx
@@ -5,7 +5,6 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   POPOVER_ELEMENT,
   cartesianChartCircle,
-  describeEE,
   popover,
 } from "e2e/support/helpers";
 import {
@@ -17,7 +16,7 @@ import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
-describeEE("scenarios > embedding-sdk > dashboard-click-behavior", () => {
+describe("scenarios > embedding-sdk > dashboard-click-behavior", () => {
   beforeEach(() => {
     signInAsAdminAndEnableEmbeddingSdk();
 

--- a/e2e/test-component/scenarios/embedding-sdk/editable-dashboard.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/editable-dashboard.cy.spec.tsx
@@ -1,6 +1,6 @@
 import { EditableDashboard } from "@metabase/embedding-sdk-react";
 
-import { createDashboard, describeEE } from "e2e/support/helpers";
+import { createDashboard } from "e2e/support/helpers";
 import {
   mockAuthProviderAndJwtSignIn,
   mountSdkContent,
@@ -8,7 +8,7 @@ import {
 } from "e2e/support/helpers/component-testing-sdk";
 import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 
-describeEE("scenarios > embedding-sdk > editable-dashboard", () => {
+describe("scenarios > embedding-sdk > editable-dashboard", () => {
   beforeEach(() => {
     signInAsAdminAndEnableEmbeddingSdk();
 

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-dashboard.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-dashboard.cy.spec.tsx
@@ -7,11 +7,7 @@ import {
   ORDERS_DASHBOARD_DASHCARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  createDashboard,
-  describeEE,
-  getTextCardDetails,
-} from "e2e/support/helpers";
+import { createDashboard, getTextCardDetails } from "e2e/support/helpers";
 import {
   mockAuthProviderAndJwtSignIn,
   mountSdkContent,
@@ -20,7 +16,7 @@ import {
 import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 import { Stack } from "metabase/ui";
 
-describeEE("scenarios > embedding-sdk > interactive-dashboard", () => {
+describe("scenarios > embedding-sdk > interactive-dashboard", () => {
   beforeEach(() => {
     signInAsAdminAndEnableEmbeddingSdk();
 

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question-map.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question-map.cy.spec.tsx
@@ -1,5 +1,5 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { createQuestion, describeEE, mapPinIcon } from "e2e/support/helpers";
+import { createQuestion, mapPinIcon } from "e2e/support/helpers";
 import {
   METABASE_INSTANCE_URL,
   mockAuthProviderAndJwtSignIn,
@@ -10,7 +10,7 @@ import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 
 const { PEOPLE_ID } = SAMPLE_DATABASE;
 
-describeEE("scenarios > embedding-sdk > interactive-question-map", () => {
+describe("scenarios > embedding-sdk > interactive-question-map", () => {
   beforeEach(() => {
     signInAsAdminAndEnableEmbeddingSdk();
 

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question-native.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question-native.cy.spec.tsx
@@ -1,7 +1,6 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   createNativeQuestion,
-  describeEE,
   tableInteractiveBody,
 } from "e2e/support/helpers";
 import {
@@ -13,7 +12,7 @@ import type { DatasetColumn } from "metabase-types/api";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
-describeEE("scenarios > embedding-sdk > interactive-question > native", () => {
+describe("scenarios > embedding-sdk > interactive-question > native", () => {
   beforeEach(() => {
     signInAsAdminAndEnableEmbeddingSdk();
 

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question-theming.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question-theming.cy.spec.tsx
@@ -5,7 +5,7 @@ import {
 import Color from "color";
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { createQuestion, describeEE } from "e2e/support/helpers";
+import { createQuestion } from "e2e/support/helpers";
 import {
   mockAuthProviderAndJwtSignIn,
   mountSdkContent,
@@ -22,7 +22,7 @@ const darken = (color: string | undefined, amount: number) =>
 const lighten = (color: string | undefined, amount: number) =>
   Color(color).lighten(amount).rgb().toString();
 
-describeEE(
+describe(
   "scenarios > embedding-sdk > interactive-question > theming",
   // realHover color check is flaky 10% of the time so a retry is added
   { retries: { runMode: 2, openMode: 2 } },

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
@@ -12,7 +12,6 @@ import {
 } from "e2e/support/cypress_sample_instance_data";
 import {
   createQuestion,
-  describeEE,
   popover,
   tableAllFieldsHiddenImage,
   tableHeaderClick,
@@ -34,7 +33,7 @@ const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
 type InteractiveQuestionProps = ComponentProps<typeof InteractiveQuestion>;
 
-describeEE("scenarios > embedding-sdk > interactive-question", () => {
+describe("scenarios > embedding-sdk > interactive-question", () => {
   beforeEach(() => {
     signInAsAdminAndEnableEmbeddingSdk();
 

--- a/e2e/test-component/scenarios/embedding-sdk/locale-on-provider.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/locale-on-provider.cy.spec.tsx
@@ -4,7 +4,6 @@ import {
 } from "@metabase/embedding-sdk-react";
 
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
-import { describeEE } from "e2e/support/helpers";
 import {
   AUTH_PROVIDER_URL,
   METABASE_INSTANCE_URL,
@@ -31,7 +30,7 @@ function setup({ locale }: { locale: string }) {
   });
 }
 
-describeEE("scenarios > embedding-sdk > locale set on MetabaseProvider", () => {
+describe("scenarios > embedding-sdk > locale set on MetabaseProvider", () => {
   beforeEach(() => {
     signInAsAdminAndEnableEmbeddingSdk();
 

--- a/e2e/test-component/scenarios/embedding-sdk/redux-provider-clash.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/redux-provider-clash.cy.spec.tsx
@@ -6,7 +6,6 @@ import { configureStore, createSlice } from "@reduxjs/toolkit";
 import { Provider, useDispatch, useSelector } from "react-redux";
 
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
-import { describeEE } from "e2e/support/helpers";
 import {
   AUTH_PROVIDER_URL,
   METABASE_INSTANCE_URL,
@@ -15,61 +14,54 @@ import {
 } from "e2e/support/helpers/component-testing-sdk";
 import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 
-describeEE(
-  "scenarios > embedding-sdk > the redux provider context should not clash with the host app",
-  () => {
-    beforeEach(() => {
-      signInAsAdminAndEnableEmbeddingSdk();
+describe("scenarios > embedding-sdk > the redux provider context should not clash with the host app", () => {
+  beforeEach(() => {
+    signInAsAdminAndEnableEmbeddingSdk();
 
-      cy.signOut();
+    cy.signOut();
 
-      mockAuthProviderAndJwtSignIn();
-    });
+    mockAuthProviderAndJwtSignIn();
+  });
 
-    it("the host app redux logic should work normally even inside MetabaseProvider", () => {
-      cy.mount(
-        <Provider store={customerStore}>
-          <div data-testid="outside-metabase-provider">
+  it("the host app redux logic should work normally even inside MetabaseProvider", () => {
+    cy.mount(
+      <Provider store={customerStore}>
+        <div data-testid="outside-metabase-provider">
+          <CounterButton />
+        </div>
+        <MetabaseProvider
+          authConfig={{
+            authProviderUri: AUTH_PROVIDER_URL,
+            metabaseInstanceUrl: METABASE_INSTANCE_URL,
+          }}
+        >
+          <div data-testid="inside-metabase-provider">
             <CounterButton />
           </div>
-          <MetabaseProvider
-            authConfig={{
-              authProviderUri: AUTH_PROVIDER_URL,
-              metabaseInstanceUrl: METABASE_INSTANCE_URL,
-            }}
-          >
-            <div data-testid="inside-metabase-provider">
-              <CounterButton />
-            </div>
-            <StaticDashboard dashboardId={ORDERS_DASHBOARD_ID} withDownloads />
-          </MetabaseProvider>
-        </Provider>,
-      );
+          <StaticDashboard dashboardId={ORDERS_DASHBOARD_ID} withDownloads />
+        </MetabaseProvider>
+      </Provider>,
+    );
 
-      // the button should render and access the correct redux state both inside and outside the MetabaseProvider
-      cy.findByTestId("outside-metabase-provider")
-        .findByText("0")
-        .should("exist");
-      cy.findByTestId("inside-metabase-provider")
-        .findByText("0")
-        .should("exist");
+    // the button should render and access the correct redux state both inside and outside the MetabaseProvider
+    cy.findByTestId("outside-metabase-provider")
+      .findByText("0")
+      .should("exist");
+    cy.findByTestId("inside-metabase-provider").findByText("0").should("exist");
 
-      // sanity check that it's actually working and actions work
-      cy.findByTestId("inside-metabase-provider").findByText("0").click();
-      cy.findByTestId("outside-metabase-provider")
-        .findByText("1")
-        .should("exist");
-      cy.findByTestId("inside-metabase-provider")
-        .findByText("1")
-        .should("exist");
+    // sanity check that it's actually working and actions work
+    cy.findByTestId("inside-metabase-provider").findByText("0").click();
+    cy.findByTestId("outside-metabase-provider")
+      .findByText("1")
+      .should("exist");
+    cy.findByTestId("inside-metabase-provider").findByText("1").should("exist");
 
-      // also make sure the sdk is working, most data goes through redux so if it renders
-      // it means it's working
-      getSdkRoot().findByText("Orders in a dashboard").should("exist");
-      getSdkRoot().findByText("Product ID").should("exist");
-    });
-  },
-);
+    // also make sure the sdk is working, most data goes through redux so if it renders
+    // it means it's working
+    getSdkRoot().findByText("Orders in a dashboard").should("exist");
+    getSdkRoot().findByText("Product ID").should("exist");
+  });
+});
 
 // sample code for customer app
 const slice = createSlice({

--- a/e2e/test-component/scenarios/embedding-sdk/static-dashboard.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/static-dashboard.cy.spec.tsx
@@ -4,11 +4,7 @@ import {
   ORDERS_DASHBOARD_DASHCARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import {
-  createDashboard,
-  describeEE,
-  getTextCardDetails,
-} from "e2e/support/helpers";
+import { createDashboard, getTextCardDetails } from "e2e/support/helpers";
 import {
   mockAuthProviderAndJwtSignIn,
   mountSdkContent,
@@ -16,7 +12,7 @@ import {
 } from "e2e/support/helpers/component-testing-sdk";
 import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 
-describeEE("scenarios > embedding-sdk > static-dashboard", () => {
+describe("scenarios > embedding-sdk > static-dashboard", () => {
   beforeEach(() => {
     signInAsAdminAndEnableEmbeddingSdk();
 

--- a/e2e/test-component/scenarios/embedding-sdk/static-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/static-question.cy.spec.tsx
@@ -1,5 +1,5 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { createQuestion, describeEE } from "e2e/support/helpers";
+import { createQuestion } from "e2e/support/helpers";
 import {
   mockAuthProviderAndJwtSignIn,
   mountStaticQuestion,
@@ -9,7 +9,7 @@ import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
-describeEE("scenarios > embedding-sdk > static-question", () => {
+describe("scenarios > embedding-sdk > static-question", () => {
   beforeEach(() => {
     signInAsAdminAndEnableEmbeddingSdk();
 

--- a/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
@@ -6,7 +6,7 @@ import {
 } from "@metabase/embedding-sdk-react";
 
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
-import { describeEE, modal, updateSetting } from "e2e/support/helpers";
+import { modal, updateSetting } from "e2e/support/helpers";
 import {
   DEFAULT_SDK_AUTH_PROVIDER_CONFIG,
   mockAuthProviderAndJwtSignIn,
@@ -14,7 +14,7 @@ import {
 } from "e2e/support/helpers/component-testing-sdk";
 import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 
-describeEE("scenarios > embedding-sdk > styles", () => {
+describe("scenarios > embedding-sdk > styles", () => {
   beforeEach(() => {
     signInAsAdminAndEnableEmbeddingSdk();
 

--- a/e2e/test-component/scenarios/embedding-sdk/tooltip-reproductions.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/tooltip-reproductions.cy.spec.tsx
@@ -2,7 +2,6 @@ import { InteractiveDashboard } from "@metabase/embedding-sdk-react";
 
 const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { describeEE } from "e2e/support/helpers";
 import {
   mockAuthProviderAndJwtSignIn,
   mountSdkContent,
@@ -12,7 +11,7 @@ import { isFixedPositionElementVisible } from "e2e/support/helpers/e2e-element-v
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
-describeEE("scenarios > embedding-sdk > tooltip-reproductions", () => {
+describe("scenarios > embedding-sdk > tooltip-reproductions", () => {
   beforeEach(() => {
     signInAsAdminAndEnableEmbeddingSdk();
 

--- a/e2e/test/scenarios/admin-2/authentication.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/authentication.cy.spec.ts
@@ -11,8 +11,6 @@ describe("scenarios > admin > settings > authentication", () => {
   describe("page layout", () => {
     describe("oss", { tags: "@OSS" }, () => {
       it("should implement a tab layout for oss customers", () => {
-        H.onlyOnOSS();
-
         cy.visit("/admin/settings/authentication");
 
         cy.log(
@@ -35,7 +33,7 @@ describe("scenarios > admin > settings > authentication", () => {
       });
     });
 
-    H.describeEE("ee", () => {
+    describe("ee", () => {
       it("should implement a tab layout for enterprise customers", () => {
         H.setTokenFeatures("all");
 
@@ -78,7 +76,6 @@ describe("scenarios > admin > settings > user provisioning", () => {
 
   describe("oss", { tags: "@OSS" }, () => {
     it("user provisioning page should not be availble for OSS customers", () => {
-      H.onlyOnOSS();
       cy.visit("/admin/settings/authentication/user-provisioning");
       H.main().within(() => {
         cy.findByText("We're a little lost...");
@@ -86,7 +83,7 @@ describe("scenarios > admin > settings > user provisioning", () => {
     });
   });
 
-  H.describeEE("scim settings management", () => {
+  describe("scim settings management", () => {
     beforeEach(() => {
       H.setTokenFeatures("all");
     });

--- a/e2e/test/scenarios/admin-2/people.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/people.cy.spec.js
@@ -521,7 +521,7 @@ describe("scenarios > admin > people", () => {
   });
 });
 
-H.describeEE("scenarios > admin > people", () => {
+describe("scenarios > admin > people", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
@@ -605,7 +605,7 @@ H.describeEE("scenarios > admin > people", () => {
   });
 });
 
-H.describeEE("scenarios > admin > people > group managers", () => {
+describe("scenarios > admin > people > group managers", () => {
   function confirmLosingAbilityToManageGroup() {
     H.modal().within(() => {
       cy.findByText(
@@ -787,7 +787,7 @@ H.describeEE("scenarios > admin > people > group managers", () => {
   });
 });
 
-H.describeEE("issue 23689", () => {
+describe("issue 23689", () => {
   function findUserByFullName(user) {
     const { first_name, last_name } = user;
     return cy.findByText(`${first_name} ${last_name}`);

--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -1,4 +1,5 @@
 const { H } = cy;
+const { IS_ENTERPRISE } = Cypress.env();
 import {
   SAMPLE_DB_ID,
   SAMPLE_DB_SCHEMA_ID,
@@ -21,7 +22,6 @@ H.describeWithSnowplow("scenarios > admin > settings", () => {
     "should prompt admin to migrate to a hosted instance",
     { tags: "@OSS" },
     () => {
-      H.onlyOnOSS();
       cy.visit("/admin/settings/setup");
 
       cy.findByTestId("upsell-card").findByText(/Migrate to Metabase Cloud/);
@@ -279,9 +279,9 @@ H.describeWithSnowplow("scenarios > admin > settings", () => {
     "should display the order of the settings items consistently between OSS/EE versions (metabase#15441)",
     { tags: "@OSS" },
     () => {
-      H.isEE && H.setTokenFeatures("all");
+      IS_ENTERPRISE && H.setTokenFeatures("all");
 
-      const lastItem = H.isOSS ? "Cloud" : "Appearance";
+      const lastItem = !IS_ENTERPRISE ? "Cloud" : "Appearance";
 
       cy.visit("/admin/settings/setup");
       cy.findByTestId("admin-list-settings-items").within(() => {
@@ -339,7 +339,6 @@ H.describeWithSnowplow("scenarios > admin > settings", () => {
 
 describe("scenarios > admin > settings (OSS)", { tags: "@OSS" }, () => {
   beforeEach(() => {
-    H.onlyOnOSS();
     H.restore();
     cy.signInAsAdmin();
   });
@@ -353,7 +352,7 @@ describe("scenarios > admin > settings (OSS)", { tags: "@OSS" }, () => {
   });
 });
 
-H.describeEE("scenarios > admin > settings (EE)", () => {
+describe("scenarios > admin > settings (EE)", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
@@ -688,7 +687,7 @@ describe("scenarios > admin > license and billing", () => {
     cy.signInAsAdmin();
   });
 
-  H.describeEE("store info", () => {
+  describe("store info", () => {
     it("should show the user a link to the store for an unlincensed enterprise instance", () => {
       cy.visit("/admin/settings/license");
       cy.findByTestId("license-and-billing-content")

--- a/e2e/test/scenarios/admin-2/sso/jwt.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/sso/jwt.cy.spec.js
@@ -7,7 +7,7 @@ import {
 } from "./shared/group-mappings-widget";
 import { getSuccessUi, getUserProvisioningInput } from "./shared/helpers";
 
-H.describeEE("scenarios > admin > settings > SSO > JWT", () => {
+describe("scenarios > admin > settings > SSO > JWT", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/admin-2/sso/ldap.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/sso/ldap.cy.spec.js
@@ -154,7 +154,7 @@ describe(
   },
 );
 
-H.describeEE(
+describe(
   "scenarios > admin > settings > SSO > LDAP",
   { tags: "@external" },
   () => {

--- a/e2e/test/scenarios/admin-2/sso/saml.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/sso/saml.cy.spec.js
@@ -11,7 +11,7 @@ import {
   setupSaml,
 } from "./shared/helpers";
 
-H.describeEE("scenarios > admin > settings > SSO > SAML", () => {
+describe("scenarios > admin > settings > SSO > SAML", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
@@ -15,7 +15,7 @@ function checkLogo() {
 
 const MB = 1024 * 1024;
 
-H.describeEE("formatting > whitelabel", () => {
+describe("formatting > whitelabel", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/admin/databases.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases.cy.spec.js
@@ -1,4 +1,5 @@
 const { H } = cy;
+const { IS_ENTERPRISE } = Cypress.env();
 import {
   QA_MONGO_PORT,
   QA_MYSQL_PORT,
@@ -115,7 +116,7 @@ describe("admin > database > add", () => {
     describe("postgres", () => {
       beforeEach(() => {
         H.popover().within(() => {
-          if (H.isEE) {
+          if (IS_ENTERPRISE) {
             // EE should ship with Oracle and Vertica as options
             cy.findByText("Oracle");
             cy.findByText("Vertica");
@@ -529,13 +530,13 @@ describe("scenarios > admin > databases > exceptions", () => {
   it("should handle a failure to `GET` the list of all databases (metabase#20471)", () => {
     const errorMessage = "Lorem ipsum dolor sit amet, consectetur adip";
 
-    H.isEE && H.setTokenFeatures("all");
+    IS_ENTERPRISE && H.setTokenFeatures("all");
 
     cy.intercept(
       {
         method: "GET",
         pathname: "/api/database",
-        query: H.isEE
+        query: IS_ENTERPRISE
           ? {
               exclude_uneditable_details: "true",
             }

--- a/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
@@ -441,7 +441,7 @@ describe("scenarios > admin > datamodel > editor", () => {
     });
   });
 
-  H.describeEE("data model permissions", () => {
+  describe("data model permissions", () => {
     beforeEach(() => {
       H.restore();
       cy.signInAsAdmin();

--- a/e2e/test/scenarios/admin/performance/dashboardsAndQuestions.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/dashboardsAndQuestions.cy.spec.ts
@@ -122,7 +122,7 @@ describe(
   "Cache invalidation for dashboards and questions",
   { tags: "@external" },
   () => {
-    H.describeEE("ee", () => {
+    describe("ee", () => {
       beforeEach(() => {
         resetServerTime();
         interceptPerformanceRoutes();

--- a/e2e/test/scenarios/admin/performance/schedule.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/schedule.cy.spec.ts
@@ -18,7 +18,7 @@ import {
  * that configuring the schedule strategy causes the cache to be invalidated at
  * the appointed time. Nor do they check that the cron expression retrieved
  * from the API is displayed in the UI. */
-H.describeEE("scenarios > admin > performance > schedule strategy", () => {
+describe("scenarios > admin > performance > schedule strategy", () => {
   beforeEach(() => {
     H.restore();
     interceptPerformanceRoutes();

--- a/e2e/test/scenarios/admin/performance/strategyForm.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/strategyForm.cy.spec.ts
@@ -117,7 +117,7 @@ describe("scenarios > admin > performance > strategy form", () => {
     });
   });
 
-  H.describeEE("ee", () => {
+  describe("ee", () => {
     beforeEach(() => {
       H.restore();
       interceptPerformanceRoutes();

--- a/e2e/test/scenarios/admin/query-validator.cy.spec.js
+++ b/e2e/test/scenarios/admin/query-validator.cy.spec.js
@@ -6,7 +6,7 @@ import { createNativeQuestion } from "../../../support/helpers/api/createNativeQ
 const SCOREBOARD_TABLE = "scoreboard_actions";
 const COLORS_TABLE = "colors27745";
 
-H.describeEE("query validator", { tags: "@external" }, () => {
+describe("query validator", { tags: "@external" }, () => {
   describe("feature disabled", () => {
     beforeEach(() => {
       H.restore("postgres-writable");
@@ -181,7 +181,6 @@ H.describeEE("query validator", { tags: "@external" }, () => {
 
 describe("OSS", { tags: "@OSS" }, () => {
   beforeEach(() => {
-    H.onlyOnOSS();
     H.restore();
     cy.signInAsAdmin();
   });

--- a/e2e/test/scenarios/admin/troubleshooting.cy.spec.js
+++ b/e2e/test/scenarios/admin/troubleshooting.cy.spec.js
@@ -20,8 +20,6 @@ describe("scenarios > admin > troubleshooting > help", () => {
 
 describe("scenarios > admin > troubleshooting > help", { tags: "@OSS" }, () => {
   beforeEach(() => {
-    H.onlyOnOSS();
-
     H.restore();
     cy.signInAsAdmin();
   });
@@ -42,7 +40,7 @@ describe("scenarios > admin > troubleshooting > help", { tags: "@OSS" }, () => {
   });
 });
 
-H.describeEE("scenarios > admin > troubleshooting > help (EE)", () => {
+describe("scenarios > admin > troubleshooting > help (EE)", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
@@ -228,8 +226,6 @@ describe("admin > tools > erroring questions ", { tags: "@quarantine" }, () => {
 
   describe.skip("when feature enabled", () => {
     beforeEach(() => {
-      H.onlyOnEE();
-
       H.restore();
       cy.signInAsAdmin();
       H.setTokenFeatures("all");
@@ -316,8 +312,6 @@ describe("admin > tools > erroring questions ", { tags: "@quarantine" }, () => {
 
   describe("when feature disabled", () => {
     beforeEach(() => {
-      H.onlyOnEE();
-
       H.restore();
       cy.signInAsAdmin();
     });

--- a/e2e/test/scenarios/collections/cleanup.cy.spec.js
+++ b/e2e/test/scenarios/collections/cleanup.cy.spec.js
@@ -17,7 +17,6 @@ describe("scenarios > collections > clean up", () => {
 
   describe("oss", { tags: "@OSS" }, () => {
     beforeEach(() => {
-      H.onlyOnOSS();
       cy.signInAsAdmin();
     });
 
@@ -30,8 +29,8 @@ describe("scenarios > collections > clean up", () => {
     });
   });
 
-  H.describeEE("ee", () => {
-    H.describeEE("action menu", () => {
+  describe("ee", () => {
+    describe("action menu", () => {
       it("should show in proper contexts", () => {
         cy.signInAsAdmin();
         H.setTokenFeatures("all");

--- a/e2e/test/scenarios/collections/collections-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections-reproductions.cy.spec.js
@@ -109,7 +109,7 @@ describe("issue 24660", () => {
   });
 });
 
-H.describeEE("issue 30235", () => {
+describe("issue 30235", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/collections/instance-analytics.cy.spec.js
+++ b/e2e/test/scenarios/collections/instance-analytics.cy.spec.js
@@ -9,7 +9,7 @@ const CUSTOM_REPORTS_COLLECTION_NAME = "Custom reports";
 const PEOPLE_MODEL_NAME = "People";
 const METRICS_DASHBOARD_NAME = "Metabase metrics";
 
-H.describeEE("scenarios > Metabase Analytics Collection (AuditV2) ", () => {
+describe("scenarios > Metabase Analytics Collection (AuditV2) ", () => {
   describe("admin", () => {
     beforeEach(() => {
       cy.intercept("GET", "/api/field/*/values").as("fieldValues");
@@ -282,9 +282,8 @@ H.describeEE("scenarios > Metabase Analytics Collection (AuditV2) ", () => {
 });
 
 describe("question and dashboard links", () => {
-  H.describeEE("ee", () => {
+  describe("ee", () => {
     beforeEach(() => {
-      H.onlyOnEE();
       H.restore();
       cy.signInAsAdmin();
       H.setTokenFeatures("all");
@@ -366,7 +365,6 @@ describe("question and dashboard links", () => {
 
   describe("oss", { tags: "@OSS" }, () => {
     beforeEach(() => {
-      H.onlyOnOSS();
       H.restore();
       cy.signInAsAdmin();
     });

--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -124,7 +124,7 @@ const URL_WITH_FILLED_PARAMS = URL_WITH_PARAMS.replace(
   .replace(`{{${CREATED_AT_COLUMN_ID}}}`, POINT_CREATED_AT)
   .replace(`{{${DASHBOARD_FILTER_TEXT.slug}}}`, FILTER_VALUE);
 
-H.describeEE("scenarios > dashboard > dashboard cards > click behavior", () => {
+describe("scenarios > dashboard > dashboard cards > click behavior", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-source.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-source.cy.spec.js
@@ -367,7 +367,7 @@ describe(
   },
 );
 
-H.describeEE("scenarios > dashboard > filters", () => {
+describe("scenarios > dashboard > filters", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
@@ -641,7 +641,7 @@ describe("issue 28756", () => {
   });
 });
 
-H.describeEE("issue 29076", () => {
+describe("issue 29076", () => {
   beforeEach(() => {
     H.restore();
 

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1561,7 +1561,7 @@ describe("LOCAL TESTING ONLY > dashboard", () => {
   });
 });
 
-H.describeEE("scenarios > dashboard > caching", () => {
+describe("scenarios > dashboard > caching", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/embedding-sdk/static-dashboard-cors.cy.spec.js
+++ b/e2e/test/scenarios/embedding-sdk/static-dashboard-cors.cy.spec.js
@@ -16,7 +16,7 @@ import {
 
 const STORYBOOK_ID = "embeddingsdk-cypressstaticdashboardwithcors--default";
 
-H.describeEE("scenarios > embedding-sdk > static-dashboard", () => {
+describe("scenarios > embedding-sdk > static-dashboard", () => {
   beforeEach(() => {
     H.restore();
     cy.signIn("admin", { skipCache: true });

--- a/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -661,7 +661,7 @@ describe("scenarios > embedding > dashboard parameters with defaults", () => {
   });
 });
 
-H.describeEE("scenarios > embedding > dashboard appearance", () => {
+describe("scenarios > embedding > dashboard appearance", () => {
   const originalBaseUrl = Cypress.config("baseUrl");
 
   beforeEach(() => {

--- a/e2e/test/scenarios/embedding/embedding-questions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-questions.cy.spec.js
@@ -215,7 +215,7 @@ describe("scenarios > embedding > questions", () => {
   });
 });
 
-H.describeEE("scenarios [EE] > embedding > questions", () => {
+describe("scenarios [EE] > embedding > questions", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
@@ -289,7 +289,7 @@ function assertOnXYAxisLabels({ xLabel, yLabel } = {}) {
   H.echartsContainer().get("text").contains(yLabel);
 }
 
-H.describeEE("scenarios > embedding > questions > downloads", () => {
+describe("scenarios > embedding > questions > downloads", () => {
   const questionDetails = {
     name: "Simple SQL Query for Embedding",
     native: {

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -650,7 +650,7 @@ describe("issue 27643", { tags: "@external" }, () => {
   });
 });
 
-H.describeEE("issue 30535", () => {
+describe("issue 30535", () => {
   const questionDetails = {
     name: "3035",
     query: {
@@ -1008,7 +1008,7 @@ describe.skip("issue 49142", () => {
   });
 });
 
-H.describeEE("issue 8490", () => {
+describe("issue 8490", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -17,7 +17,7 @@ import {
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 const { ALL_USERS_GROUP } = USER_GROUPS;
 
-H.describeEE("scenarios > embedding > full app", () => {
+describe("scenarios > embedding > full app", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/metrics/browse.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/browse.cy.spec.ts
@@ -347,7 +347,7 @@ describe("scenarios > browse > metrics", () => {
   });
 
   describe("verified metrics", { tags: "@flaky" }, () => {
-    H.describeEE("on enterprise", () => {
+    describe("on enterprise", () => {
       beforeEach(() => {
         cy.signInAsAdmin();
         H.setTokenFeatures("all");

--- a/e2e/test/scenarios/models/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.js
@@ -156,7 +156,6 @@ describe("issue 19776", { tags: "@OSS" }, () => {
   }
 
   beforeEach(() => {
-    H.onlyOnOSS();
     H.restore();
     cy.signInAsAdmin();
   });

--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -857,7 +857,7 @@ describe("issue 45924", () => {
   });
 });
 
-H.describeEE("issue 43088", () => {
+describe("issue 43088", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/native-filters/sql-filters-source.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-filters-source.cy.spec.js
@@ -577,7 +577,7 @@ describe("scenarios > filters > sql filters > values source", () => {
   });
 });
 
-H.describeEE("scenarios > filters > sql filters > values source", () => {
+describe("scenarios > filters > sql filters > values source", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/native/snippets.cy.spec.js
+++ b/e2e/test/scenarios/native/snippets.cy.spec.js
@@ -153,7 +153,6 @@ describe("scenarios > question > snippets", () => {
 
 describe("scenarios > question > snippets (OSS)", { tags: "@OSS" }, () => {
   beforeEach(() => {
-    H.onlyOnOSS();
     H.restore();
   });
 
@@ -171,7 +170,7 @@ describe("scenarios > question > snippets (OSS)", { tags: "@OSS" }, () => {
   });
 });
 
-H.describeEE("scenarios > question > snippets (EE)", () => {
+describe("scenarios > question > snippets (EE)", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/navigation/navbar.cy.spec.js
+++ b/e2e/test/scenarios/navigation/navbar.cy.spec.js
@@ -127,7 +127,7 @@ describe("scenarios > navigation > navbar", () => {
     });
   });
 
-  H.describeEE("EE", () => {
+  describe("EE", () => {
     beforeEach(() => {
       H.restore();
       cy.signInAsAdmin();

--- a/e2e/test/scenarios/onboarding/auth/sso.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/auth/sso.cy.spec.js
@@ -69,7 +69,7 @@ describe("scenarios > auth > signin > SSO", () => {
     });
   });
 
-  H.describeEE("EE", () => {
+  describe("EE", () => {
     beforeEach(() => {
       H.setTokenFeatures("all");
       // Disable password log-in

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -4,7 +4,6 @@ import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_DASHBOARD_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import { describeEE } from "e2e/support/helpers";
 
 const { admin } = USERS;
 
@@ -210,7 +209,7 @@ describe("command palette", () => {
       });
     });
 
-    describeEE("with advanced permissions", () => {
+    describe("with advanced permissions", () => {
       it("should render links for non-admins that have specific privileges", () => {
         // setup
         cy.log("setup permissions");

--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -171,7 +171,7 @@ describe("scenarios > home > homepage", () => {
     });
 
     // TODO: popular items endpoint is currently broken in OSS. Re-enable test once endpoint has been fixed.
-    H.describeEE("EE", () => {
+    describe("EE", () => {
       it("should display popular items for a new user", () => {
         cy.signInAsAdmin();
         // Setting this to true so that displaying popular items for new users works.

--- a/e2e/test/scenarios/onboarding/onboarding-checklist.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/onboarding-checklist.cy.spec.ts
@@ -71,7 +71,7 @@ describe("Onboarding checklist page", () => {
   });
 });
 
-H.describeEE("Inaccessible Onboarding checklist", () => {
+describe("Inaccessible Onboarding checklist", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -1,4 +1,5 @@
 const { H } = cy;
+const { IS_ENTERPRISE } = Cypress.env();
 import { USERS } from "e2e/support/cypress_data";
 import { SUBSCRIBE_URL } from "metabase/setup/constants";
 
@@ -222,7 +223,6 @@ describe("scenarios > setup", () => {
   });
 
   it("should pre-fill user info for hosted instances (infra-frontend#1109)", () => {
-    H.onlyOnEE();
     H.setTokenFeatures("none");
     H.mockSessionProperty("is-hosted?", true);
 
@@ -402,7 +402,7 @@ describe("scenarios > setup", () => {
   });
 });
 
-H.describeEE("scenarios > setup (EE)", () => {
+describe("scenarios > setup (EE)", () => {
   beforeEach(() => H.restore("blank"));
 
   it("should ask for a license token on self-hosted", () => {
@@ -519,7 +519,7 @@ H.describeWithSnowplow("scenarios > setup", () => {
       });
 
       // This step is only visile on EE builds
-      if (H.isEE) {
+      if (IS_ENTERPRISE) {
         goodEvents++; // 10/11 - setup/step_seen "commercial_license"
         H.expectGoodSnowplowEvent({
           event: "step_seen",
@@ -538,7 +538,7 @@ H.describeWithSnowplow("scenarios > setup", () => {
       goodEvents++; // 11/12 - setup/step_seen "data_usage"
       H.expectGoodSnowplowEvent({
         event: "step_seen",
-        step_number: H.isEE ? 6 : 5,
+        step_number: IS_ENTERPRISE ? 6 : 5,
         step: "data_usage",
       });
 
@@ -548,7 +548,7 @@ H.describeWithSnowplow("scenarios > setup", () => {
       goodEvents++; // 13/14- setup/step_seen "completed"
       H.expectGoodSnowplowEvent({
         event: "step_seen",
-        step_number: H.isEE ? 7 : 6,
+        step_number: IS_ENTERPRISE ? 7 : 6,
         step: "completed",
       });
 
@@ -636,7 +636,7 @@ const fillUserAndContinue = ({
 };
 
 const skipLicenseStepOnEE = () => {
-  if (H.isEE) {
+  if (IS_ENTERPRISE) {
     cy.findByText("Activate your commercial license").should("exist");
     cy.button("Skip").click();
   }

--- a/e2e/test/scenarios/organization/content-verification.cy.spec.js
+++ b/e2e/test/scenarios/organization/content-verification.cy.spec.js
@@ -4,7 +4,7 @@ import {
   ORDERS_DASHBOARD_ID,
 } from "e2e/support/cypress_sample_instance_data";
 
-H.describeEE(
+describe(
   "scenarios > premium > content verification",
   { tags: "@flaky" },
   () => {

--- a/e2e/test/scenarios/organization/official-collections.cy.spec.js
+++ b/e2e/test/scenarios/organization/official-collections.cy.spec.js
@@ -11,7 +11,7 @@ const TEST_QUESTION_QUERY = {
   breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "hour-of-day" }]],
 };
 
-H.describeEE("official collections", () => {
+describe("official collections", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -14,8 +14,6 @@ const NATIVE_QUERIES_PERMISSION_INDEX = 0;
 
 describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
   beforeEach(() => {
-    H.onlyOnOSS();
-
     H.restore();
     cy.signInAsAdmin();
   });
@@ -434,7 +432,7 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
   });
 });
 
-H.describeEE("scenarios > admin > permissions", () => {
+describe("scenarios > admin > permissions", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/permissions/application-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/application-permissions.cy.spec.js
@@ -13,7 +13,7 @@ const SUBSCRIPTIONS_INDEX = 2;
 
 const NORMAL_USER_ID = 2;
 
-H.describeEE("scenarios > admin > permissions > application", () => {
+describe("scenarios > admin > permissions > application", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/permissions/data-model-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/data-model-permissions.cy.spec.js
@@ -7,7 +7,7 @@ const { ORDERS_ID } = SAMPLE_DATABASE;
 const DATA_ACCESS_PERMISSION_INDEX = 0;
 const DATA_MODEL_PERMISSION_INDEX = 3;
 
-H.describeEE("scenarios > admin > permissions", () => {
+describe("scenarios > admin > permissions", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/permissions/database-details-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/database-details-permissions.cy.spec.js
@@ -3,71 +3,68 @@ import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 
 const DETAILS_PERMISSION_INDEX = 4;
 
-H.describeEE(
-  "scenarios > admin > permissions > database details permissions",
-  () => {
-    beforeEach(() => {
-      H.restore();
-      cy.signInAsAdmin();
-      H.setTokenFeatures("all");
+describe("scenarios > admin > permissions > database details permissions", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.setTokenFeatures("all");
+  });
+
+  it("allows database managers to see and edit database details but not to delete a database (metabase#22293)", () => {
+    // As an admin, grant database details permissions to all users
+    cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
+    H.modifyPermission("All Users", DETAILS_PERMISSION_INDEX, "Yes");
+
+    cy.button("Save changes").click();
+
+    H.modal().within(() => {
+      cy.findByText("Save permissions?");
+      cy.findByText("Are you sure you want to do this?");
+      cy.button("Yes").click();
     });
 
-    it("allows database managers to see and edit database details but not to delete a database (metabase#22293)", () => {
-      // As an admin, grant database details permissions to all users
-      cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
-      H.modifyPermission("All Users", DETAILS_PERMISSION_INDEX, "Yes");
+    H.assertPermissionForItem("All Users", DETAILS_PERMISSION_INDEX, "Yes");
 
-      cy.button("Save changes").click();
+    // Normal user should now have the ability to manage databases
+    cy.signInAsNormalUser();
 
-      H.modal().within(() => {
-        cy.findByText("Save permissions?");
-        cy.findByText("Are you sure you want to do this?");
-        cy.button("Yes").click();
-      });
+    cy.visit("/");
+    cy.icon("gear").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.findByText("Admin settings").should("be.visible").click();
 
-      H.assertPermissionForItem("All Users", DETAILS_PERMISSION_INDEX, "Yes");
+    cy.location("pathname").should("eq", "/admin/databases");
 
-      // Normal user should now have the ability to manage databases
-      cy.signInAsNormalUser();
+    cy.get("nav")
+      .should("contain", "Databases")
+      .and("not.contain", "Settings")
+      .and("not.contain", "Data Model");
 
-      cy.visit("/");
-      cy.icon("gear").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Admin settings").should("be.visible").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.findByText("Sample Database").click();
 
-      cy.location("pathname").should("eq", "/admin/databases");
+    cy.findByTestId("database-actions-panel")
+      .should("contain", "Sync database schema now")
+      .and("contain", "Re-scan field values now")
+      .and("contain", "Discard saved field values")
+      .and("not.contain", "Remove this database");
 
-      cy.get("nav")
-        .should("contain", "Databases")
-        .and("not.contain", "Settings")
-        .and("not.contain", "Data Model");
-
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Sample Database").click();
-
-      cy.findByTestId("database-actions-panel")
-        .should("contain", "Sync database schema now")
-        .and("contain", "Re-scan field values now")
-        .and("contain", "Discard saved field values")
-        .and("not.contain", "Remove this database");
-
-      cy.request({
-        method: "DELETE",
-        url: `/api/database/${SAMPLE_DB_ID}`,
-        failOnStatusCode: false,
-      }).then(({ status }) => {
-        expect(status).to.eq(403);
-      });
-
-      cy.log(
-        "should not allow access to the database/create page (metabase-private#236)",
-      );
-      cy.visit("/admin/databases/create");
-      cy.findByRole("img", { name: /key/ }).should("exist");
-      cy.findByRole("status").should(
-        "contain.text",
-        "Sorry, you don’t have permission to see that.",
-      );
+    cy.request({
+      method: "DELETE",
+      url: `/api/database/${SAMPLE_DB_ID}`,
+      failOnStatusCode: false,
+    }).then(({ status }) => {
+      expect(status).to.eq(403);
     });
-  },
-);
+
+    cy.log(
+      "should not allow access to the database/create page (metabase-private#236)",
+    );
+    cy.visit("/admin/databases/create");
+    cy.findByRole("img", { name: /key/ }).should("exist");
+    cy.findByRole("status").should(
+      "contain.text",
+      "Sorry, you don’t have permission to see that.",
+    );
+  });
+});

--- a/e2e/test/scenarios/permissions/downgrade-ee-to-oss.cy.spec.js
+++ b/e2e/test/scenarios/permissions/downgrade-ee-to-oss.cy.spec.js
@@ -6,7 +6,7 @@ const { ALL_USERS_GROUP } = USER_GROUPS;
 const EE_DATA_ACCESS_PERMISSION_INDEX = 0;
 const OSS_NATIVE_QUERIES_PERMISSION_INDEX = 0;
 
-H.describeEE("scenarios > admin > permissions > downgrade ee to oss", () => {
+describe("scenarios > admin > permissions > downgrade ee to oss", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/permissions/download-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/download-permissions.cy.spec.js
@@ -22,7 +22,7 @@ const {
 const DATA_ACCESS_PERMISSION_INDEX = 0;
 const DOWNLOAD_PERMISSION_INDEX = 2;
 
-H.describeEE("scenarios > admin > permissions > data > downloads", () => {
+describe("scenarios > admin > permissions > data > downloads", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/permissions/impersonated.cy.spec.js
+++ b/e2e/test/scenarios/permissions/impersonated.cy.spec.js
@@ -5,7 +5,7 @@ const { ALL_USERS_GROUP, COLLECTION_GROUP } = USER_GROUPS;
 
 const PG_DB_ID = 2;
 
-H.describeEE("impersonated permission", { tags: "@external" }, () => {
+describe("impersonated permission", { tags: "@external" }, () => {
   describe("admins", () => {
     beforeEach(() => {
       H.restore("postgres-12");

--- a/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.js
@@ -74,7 +74,7 @@ describe.skip("issue 13347", { tags: "@external" }, () => {
   });
 });
 
-H.describeEE("postgres > user > query", { tags: "@external" }, () => {
+describe("postgres > user > query", { tags: "@external" }, () => {
   beforeEach(() => {
     H.restore("postgres-12");
     cy.signInAsAdmin();
@@ -212,7 +212,7 @@ describe("issue 19603", () => {
   });
 });
 
-H.describeEE("issue 20436", () => {
+describe("issue 20436", () => {
   const url = `/admin/permissions/data/group/${ALL_USERS_GROUP}`;
 
   function changePermissions(from, to) {
@@ -317,8 +317,6 @@ describe("UI elements that make no sense for users without data permissions (met
   });
 
   it("should not show visualization or question settings to users with block data permissions", () => {
-    H.onlyOnEE();
-
     cy.signInAsAdmin();
     H.setTokenFeatures("all");
     cy.updatePermissionsGraph({
@@ -390,7 +388,7 @@ describe("issue 22473", () => {
   });
 });
 
-H.describeEE("issue 22695 ", () => {
+describe("issue 22695 ", () => {
   function assert() {
     cy.visit("/");
 
@@ -548,7 +546,7 @@ describe("issue 23981", () => {
   });
 });
 
-H.describeEE("issue 24966", () => {
+describe("issue 24966", () => {
   const sandboxingQuestion = {
     name: "geadsfasd",
     native: {

--- a/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
@@ -22,7 +22,7 @@ const { ALL_USERS_GROUP, DATA_GROUP, COLLECTION_GROUP } = USER_GROUPS;
 
 const VIEW_DATA_PERMISSION_INDEX = 0;
 
-H.describeEE("formatting > sandboxes", () => {
+describe("formatting > sandboxes", () => {
   describe("admin", () => {
     beforeEach(() => {
       H.restore();

--- a/e2e/test/scenarios/permissions/view-data.cy.spec.js
+++ b/e2e/test/scenarios/permissions/view-data.cy.spec.js
@@ -12,7 +12,7 @@ const DOWNLOAD_PERM_IDX = 2;
 
 // EDITOR RELATED TESTS
 
-H.describeEE("scenarios > admin > permissions > view data > blocked", () => {
+describe("scenarios > admin > permissions > view data > blocked", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
@@ -135,7 +135,7 @@ describe("scenarios > admin > permissions > view data > granular", () => {
   });
 });
 
-H.describeEE("scenarios > admin > permissions > view data > granular", () => {
+describe("scenarios > admin > permissions > view data > granular", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
@@ -250,7 +250,7 @@ H.describeEE("scenarios > admin > permissions > view data > granular", () => {
   });
 });
 
-H.describeEE(
+describe(
   "scenarios > admin > permissions > view data > impersonated",
   { tags: "@external" },
   () => {
@@ -446,107 +446,104 @@ H.describeEE(
   },
 );
 
-H.describeEE(
-  "scenarios > admin > permissions > view data > legacy no self-service",
-  () => {
-    beforeEach(() => {
-      H.restore();
-      cy.signInAsAdmin();
-      H.setTokenFeatures("all");
-    });
+describe("scenarios > admin > permissions > view data > legacy no self-service", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.setTokenFeatures("all");
+  });
 
-    it("'no self service' should only be an option if it is the current value in the permissions graph", () => {
-      // load the page like normal w/o legacy value in the graph
-      // and test that it does not exist
-      cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
+  it("'no self service' should only be an option if it is the current value in the permissions graph", () => {
+    // load the page like normal w/o legacy value in the graph
+    // and test that it does not exist
+    cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
 
-      H.selectPermissionRow("Sample Database", DATA_ACCESS_PERM_IDX);
-      H.popover().should("not.contain", "No self-service (Deprecated)");
+    H.selectPermissionRow("Sample Database", DATA_ACCESS_PERM_IDX);
+    H.popover().should("not.contain", "No self-service (Deprecated)");
 
-      H.selectPermissionRow("Sample Database", CREATE_QUERIES_PERM_IDX);
-      H.isPermissionDisabled(CREATE_QUERIES_PERM_IDX, "No", false);
+    H.selectPermissionRow("Sample Database", CREATE_QUERIES_PERM_IDX);
+    H.isPermissionDisabled(CREATE_QUERIES_PERM_IDX, "No", false);
 
-      // load the page w/ legacy value in the graph and test that it does exist
-      cy.reload();
-      cy.intercept("GET", `/api/permissions/graph/group/${ALL_USERS_GROUP}`, {
-        statusCode: 200,
-        body: {
-          revision: 1,
-          groups: {
+    // load the page w/ legacy value in the graph and test that it does exist
+    cy.reload();
+    cy.intercept("GET", `/api/permissions/graph/group/${ALL_USERS_GROUP}`, {
+      statusCode: 200,
+      body: {
+        revision: 1,
+        groups: {
+          1: {
             1: {
-              1: {
-                "view-data": "legacy-no-self-service",
-                "create-queries": "no",
-                download: { schemas: "full" },
-              },
+              "view-data": "legacy-no-self-service",
+              "create-queries": "no",
+              download: { schemas: "full" },
             },
           },
         },
-      });
-
-      H.assertPermissionTable([
-        [
-          "Sample Database",
-          "No self-service (Deprecated)",
-          "No",
-          "1 million rows",
-          "No",
-          "No",
-        ],
-      ]);
-
-      // User should not be able to modify Create queries permission while set to legacy-no-self-service
-      H.isPermissionDisabled(CREATE_QUERIES_PERM_IDX, "No", true);
-
-      H.modifyPermission("Sample Database", DATA_ACCESS_PERM_IDX, "Can view");
-
-      H.modifyPermission(
-        "Sample Database",
-        CREATE_QUERIES_PERM_IDX,
-        "Query builder and native",
-      );
-
-      H.modifyPermission(
-        "Sample Database",
-        DATA_ACCESS_PERM_IDX,
-        "No self-service (Deprecated)",
-      );
-
-      // change something else so we can save
-      H.modifyPermission("Sample Database", DOWNLOAD_PERM_IDX, "No");
-
-      // User setting the value back to legacy-no-self-service should result in Create queries going back to No
-      const finalExpectedRows = [
-        [
-          "Sample Database",
-          "No self-service (Deprecated)",
-          "No",
-          "No",
-          "No",
-          "No",
-        ],
-      ];
-      H.assertPermissionTable(finalExpectedRows);
-
-      cy.intercept("PUT", "/api/permissions/graph").as("saveGraph");
-
-      cy.button("Save changes").click();
-
-      H.modal().within(() => {
-        cy.findByText("Save permissions?");
-        cy.button("Yes").click();
-      });
-
-      cy.wait("@saveGraph").then(({ response }) => {
-        expect(response.statusCode).to.equal(200);
-      });
-
-      H.assertPermissionTable(finalExpectedRows);
+      },
     });
-  },
-);
 
-H.describeEE("scenarios > admin > permissions > view data > sandboxed", () => {
+    H.assertPermissionTable([
+      [
+        "Sample Database",
+        "No self-service (Deprecated)",
+        "No",
+        "1 million rows",
+        "No",
+        "No",
+      ],
+    ]);
+
+    // User should not be able to modify Create queries permission while set to legacy-no-self-service
+    H.isPermissionDisabled(CREATE_QUERIES_PERM_IDX, "No", true);
+
+    H.modifyPermission("Sample Database", DATA_ACCESS_PERM_IDX, "Can view");
+
+    H.modifyPermission(
+      "Sample Database",
+      CREATE_QUERIES_PERM_IDX,
+      "Query builder and native",
+    );
+
+    H.modifyPermission(
+      "Sample Database",
+      DATA_ACCESS_PERM_IDX,
+      "No self-service (Deprecated)",
+    );
+
+    // change something else so we can save
+    H.modifyPermission("Sample Database", DOWNLOAD_PERM_IDX, "No");
+
+    // User setting the value back to legacy-no-self-service should result in Create queries going back to No
+    const finalExpectedRows = [
+      [
+        "Sample Database",
+        "No self-service (Deprecated)",
+        "No",
+        "No",
+        "No",
+        "No",
+      ],
+    ];
+    H.assertPermissionTable(finalExpectedRows);
+
+    cy.intercept("PUT", "/api/permissions/graph").as("saveGraph");
+
+    cy.button("Save changes").click();
+
+    H.modal().within(() => {
+      cy.findByText("Save permissions?");
+      cy.button("Yes").click();
+    });
+
+    cy.wait("@saveGraph").then(({ response }) => {
+      expect(response.statusCode).to.equal(200);
+    });
+
+    H.assertPermissionTable(finalExpectedRows);
+  });
+});
+
+describe("scenarios > admin > permissions > view data > sandboxed", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
@@ -727,34 +724,67 @@ H.describeEE("scenarios > admin > permissions > view data > sandboxed", () => {
   });
 });
 
-H.describeEE(
-  "scenarios > admin > permissions > view data > reproductions",
-  () => {
-    it("should allow you to sandbox view permissions and also edit the create queries permissions and saving should persist both (metabase#46450)", () => {
-      H.restore();
+describe("scenarios > admin > permissions > view data > reproductions", () => {
+  it("should allow you to sandbox view permissions and also edit the create queries permissions and saving should persist both (metabase#46450)", () => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.setTokenFeatures("all");
+
+    cy.intercept("PUT", "/api/permissions/graph").as("saveGraph");
+    cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
+
+    cy.get("a").contains("Sample Database").click();
+
+    H.modifyPermission("Orders", DATA_ACCESS_PERM_IDX, "Sandboxed");
+
+    H.modal().within(() => {
+      cy.findByText("Restrict access to this table");
+      cy.button("Save").should("be.disabled");
+      cy.findByText("Pick a column").click();
+    });
+
+    H.popover().findByText("User ID").click();
+    H.modal().findByText("Pick a user attribute").click();
+    H.popover().findByText("attr_uid").click();
+    H.modal().button("Save").click();
+
+    H.modifyPermission("Orders", CREATE_QUERIES_PERM_IDX, "Query builder only");
+
+    H.savePermissions();
+
+    cy.wait("@saveGraph").then(({ response }) => {
+      expect(response.statusCode).to.equal(200);
+    });
+
+    H.assertPermissionForItem("Orders", DATA_ACCESS_PERM_IDX, "Sandboxed");
+    H.assertPermissionForItem(
+      "Orders",
+      CREATE_QUERIES_PERM_IDX,
+      "Query builder only",
+    );
+  });
+
+  it(
+    "should allow you to impersonate view permissions and also edit the create queries permissions and saving should persist both (metabase#46450)",
+    { tags: "@external" },
+    () => {
+      H.restore("postgres-12");
+      H.createTestRoles({ type: "postgres" });
       cy.signInAsAdmin();
       H.setTokenFeatures("all");
 
       cy.intercept("PUT", "/api/permissions/graph").as("saveGraph");
+
       cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
 
-      cy.get("a").contains("Sample Database").click();
+      // Set impersonated access on Postgres database
+      H.modifyPermission("QA Postgres12", DATA_ACCESS_PERM_IDX, "Impersonated");
 
-      H.modifyPermission("Orders", DATA_ACCESS_PERM_IDX, "Sandboxed");
-
-      H.modal().within(() => {
-        cy.findByText("Restrict access to this table");
-        cy.button("Save").should("be.disabled");
-        cy.findByText("Pick a column").click();
-      });
-
-      H.popover().findByText("User ID").click();
-      H.modal().findByText("Pick a user attribute").click();
-      H.popover().findByText("attr_uid").click();
-      H.modal().button("Save").click();
+      H.selectImpersonatedAttribute("role");
+      H.saveImpersonationSettings();
 
       H.modifyPermission(
-        "Orders",
+        "QA Postgres12",
         CREATE_QUERIES_PERM_IDX,
         "Query builder only",
       );
@@ -765,147 +795,98 @@ H.describeEE(
         expect(response.statusCode).to.equal(200);
       });
 
-      H.assertPermissionForItem("Orders", DATA_ACCESS_PERM_IDX, "Sandboxed");
       H.assertPermissionForItem(
-        "Orders",
+        "QA Postgres12",
+        DATA_ACCESS_PERM_IDX,
+        "Impersonated",
+      );
+      H.assertPermissionForItem(
+        "QA Postgres12",
         CREATE_QUERIES_PERM_IDX,
         "Query builder only",
       );
+    },
+  );
+});
+
+describe("scenarios > admin > permissions > view data > unrestricted", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.setTokenFeatures("all");
+  });
+
+  it("should allow perms to be set to from 'can view' to 'block' and back from database view", () => {
+    cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
+
+    H.modifyPermission("All Users", DATA_ACCESS_PERM_IDX, "Blocked");
+
+    cy.intercept("PUT", "/api/permissions/graph").as("saveGraph");
+
+    cy.button("Save changes").click();
+
+    H.modal().within(() => {
+      cy.findByText("Save permissions?");
+      cy.button("Yes").click();
     });
 
-    it(
-      "should allow you to impersonate view permissions and also edit the create queries permissions and saving should persist both (metabase#46450)",
-      { tags: "@external" },
-      () => {
-        H.restore("postgres-12");
-        H.createTestRoles({ type: "postgres" });
-        cy.signInAsAdmin();
-        H.setTokenFeatures("all");
-
-        cy.intercept("PUT", "/api/permissions/graph").as("saveGraph");
-
-        cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
-
-        // Set impersonated access on Postgres database
-        H.modifyPermission(
-          "QA Postgres12",
-          DATA_ACCESS_PERM_IDX,
-          "Impersonated",
-        );
-
-        H.selectImpersonatedAttribute("role");
-        H.saveImpersonationSettings();
-
-        H.modifyPermission(
-          "QA Postgres12",
-          CREATE_QUERIES_PERM_IDX,
-          "Query builder only",
-        );
-
-        H.savePermissions();
-
-        cy.wait("@saveGraph").then(({ response }) => {
-          expect(response.statusCode).to.equal(200);
-        });
-
-        H.assertPermissionForItem(
-          "QA Postgres12",
-          DATA_ACCESS_PERM_IDX,
-          "Impersonated",
-        );
-        H.assertPermissionForItem(
-          "QA Postgres12",
-          CREATE_QUERIES_PERM_IDX,
-          "Query builder only",
-        );
-      },
-    );
-  },
-);
-H.describeEE(
-  "scenarios > admin > permissions > view data > unrestricted",
-  () => {
-    beforeEach(() => {
-      H.restore();
-      cy.signInAsAdmin();
-      H.setTokenFeatures("all");
+    cy.wait("@saveGraph").then(({ response }) => {
+      expect(response.statusCode).to.equal(200);
     });
 
-    it("should allow perms to be set to from 'can view' to 'block' and back from database view", () => {
-      cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
+    H.modifyPermission("All Users", DATA_ACCESS_PERM_IDX, "Can view");
 
-      H.modifyPermission("All Users", DATA_ACCESS_PERM_IDX, "Blocked");
+    cy.button("Save changes").click();
 
-      cy.intercept("PUT", "/api/permissions/graph").as("saveGraph");
-
-      cy.button("Save changes").click();
-
-      H.modal().within(() => {
-        cy.findByText("Save permissions?");
-        cy.button("Yes").click();
-      });
-
-      cy.wait("@saveGraph").then(({ response }) => {
-        expect(response.statusCode).to.equal(200);
-      });
-
-      H.modifyPermission("All Users", DATA_ACCESS_PERM_IDX, "Can view");
-
-      cy.button("Save changes").click();
-
-      H.modal().within(() => {
-        cy.findByText("Save permissions?");
-        cy.button("Yes").click();
-      });
-
-      cy.wait("@saveGraph").then(({ response }) => {
-        expect(response.statusCode).to.equal(200);
-      });
+    H.modal().within(() => {
+      cy.findByText("Save permissions?");
+      cy.button("Yes").click();
     });
-  },
-);
+
+    cy.wait("@saveGraph").then(({ response }) => {
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+});
 
 // ENFORMCENT RELATED TESTS
 
-H.describeEE(
-  "scenarios > admin > permissions > view data > blocked (enforcement)",
-  () => {
-    beforeEach(() => {
-      H.restore();
-      cy.signInAsAdmin();
-      H.setTokenFeatures("all");
-    });
+describe("scenarios > admin > permissions > view data > blocked (enforcement)", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.setTokenFeatures("all");
+  });
 
-    it("should deny view access to a query builder question that makes use of a blocked table", () => {
-      assertCollectionGroupUserHasAccess(ORDERS_QUESTION_ID, true);
+  it("should deny view access to a query builder question that makes use of a blocked table", () => {
+    assertCollectionGroupUserHasAccess(ORDERS_QUESTION_ID, true);
+    cy.visit(
+      `/admin/permissions/data/database/${SAMPLE_DB_ID}/schema/PUBLIC/table/${ORDERS_ID}`,
+    );
+    removeCollectionGroupPermissions();
+    assertCollectionGroupHasNoAccess(ORDERS_QUESTION_ID, true);
+  });
+
+  it("should deny view access to a query builder question that makes use of a blocked database", () => {
+    assertCollectionGroupUserHasAccess(ORDERS_QUESTION_ID, true);
+    cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
+    removeCollectionGroupPermissions();
+    assertCollectionGroupHasNoAccess(ORDERS_QUESTION_ID, true);
+  });
+
+  it("should deny view access to any native question if the user has blocked view data for any table or database", () => {
+    H.createNativeQuestion({
+      native: { query: "select 1" },
+    }).then(({ body: { id: nativeQuestionId } }) => {
+      assertCollectionGroupUserHasAccess(nativeQuestionId, false);
       cy.visit(
         `/admin/permissions/data/database/${SAMPLE_DB_ID}/schema/PUBLIC/table/${ORDERS_ID}`,
       );
       removeCollectionGroupPermissions();
-      assertCollectionGroupHasNoAccess(ORDERS_QUESTION_ID, true);
+      assertCollectionGroupHasNoAccess(nativeQuestionId, false);
     });
-
-    it("should deny view access to a query builder question that makes use of a blocked database", () => {
-      assertCollectionGroupUserHasAccess(ORDERS_QUESTION_ID, true);
-      cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
-      removeCollectionGroupPermissions();
-      assertCollectionGroupHasNoAccess(ORDERS_QUESTION_ID, true);
-    });
-
-    it("should deny view access to any native question if the user has blocked view data for any table or database", () => {
-      H.createNativeQuestion({
-        native: { query: "select 1" },
-      }).then(({ body: { id: nativeQuestionId } }) => {
-        assertCollectionGroupUserHasAccess(nativeQuestionId, false);
-        cy.visit(
-          `/admin/permissions/data/database/${SAMPLE_DB_ID}/schema/PUBLIC/table/${ORDERS_ID}`,
-        );
-        removeCollectionGroupPermissions();
-        assertCollectionGroupHasNoAccess(nativeQuestionId, false);
-      });
-    });
-  },
-);
+  });
+});
 
 function lackPermissionsView(isQbQuestion, shouldExist) {
   if (isQbQuestion) {

--- a/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
@@ -156,7 +156,6 @@ describe("issue 25016", () => {
 // this is only testable in OSS because EE always has models from auditv2
 describe("issue 25144", { tags: "@OSS" }, () => {
   beforeEach(() => {
-    H.onlyOnOSS();
     H.restore("setup");
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/card").as("createCard");

--- a/e2e/test/scenarios/question/caching.cy.spec.js
+++ b/e2e/test/scenarios/question/caching.cy.spec.js
@@ -10,7 +10,7 @@ import {
   questionSettingsSidesheet,
 } from "../admin/performance/helpers/e2e-strategy-form-helpers";
 
-H.describeEE("scenarios > question > caching", () => {
+describe("scenarios > question > caching", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -708,7 +708,6 @@ describe(
   { tags: ["@OSS", "@smoke"] },
   () => {
     beforeEach(() => {
-      H.onlyOnOSS();
       H.restore("without-models");
       cy.signInAsAdmin();
     });

--- a/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
@@ -21,7 +21,6 @@ describe("scenarios > notebook > data source", () => {
       "should display tables from the only existing database by default",
       { tags: "@OSS" },
       () => {
-        H.onlyOnOSS();
         cy.visit("/");
         cy.findByTestId("app-bar").findByText("New").click();
         H.popover().findByTextEnsureVisible("Question").click();
@@ -336,7 +335,6 @@ describe("scenarios > notebook > data source", () => {
 
 describe("scenarios > notebook > data source", { tags: "@OSS" }, () => {
   beforeEach(() => {
-    H.onlyOnOSS();
     H.restore("setup");
     cy.signInAsAdmin();
   });
@@ -450,7 +448,6 @@ describe("issue 28106", () => {
 // Needs to be OSS because EE will always have models due to instance analytics
 describe("issue 32252", { tags: "@OSS" }, () => {
   beforeEach(() => {
-    H.onlyOnOSS();
     H.restore("setup");
     cy.signInAsAdmin();
 

--- a/e2e/test/scenarios/question/notebook-link-to-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-link-to-data-source.cy.spec.ts
@@ -467,7 +467,7 @@ describe("scenarios > notebook > link to data source", () => {
       });
     });
 
-    H.describeEE("sandboxing", () => {
+    describe("sandboxing", () => {
       beforeEach(() => {
         H.setTokenFeatures("all");
 

--- a/e2e/test/scenarios/search/recently-viewed.cy.spec.js
+++ b/e2e/test/scenarios/search/recently-viewed.cy.spec.js
@@ -125,7 +125,7 @@ describe("Recently Viewed > Entity Picker", () => {
   });
 });
 
-H.describeEE("search > recently viewed > enterprise features", () => {
+describe("search > recently viewed > enterprise features", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/search/search-filters.cy.spec.js
+++ b/e2e/test/scenarios/search/search-filters.cy.spec.js
@@ -858,7 +858,7 @@ describe("scenarios > search", () => {
       });
     });
 
-    H.describeEE("verified filter", () => {
+    describe("verified filter", () => {
       beforeEach(() => {
         H.setTokenFeatures("all");
         H.createModerationReview({

--- a/e2e/test/scenarios/search/search-snowplow.cy.spec.js
+++ b/e2e/test/scenarios/search/search-snowplow.cy.spec.js
@@ -456,7 +456,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
       });
     });
 
-    H.describeEE("verified filter", () => {
+    describe("verified filter", () => {
       beforeEach(() => {
         H.setTokenFeatures("all");
       });

--- a/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
@@ -308,7 +308,7 @@ describe("scenarios > public > dashboard", () => {
   });
 });
 
-H.describeEE("scenarios [EE] > public > dashboard", () => {
+describe("scenarios [EE] > public > dashboard", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/sharing/public-question.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-question.cy.spec.js
@@ -238,7 +238,7 @@ describe("scenarios > question > public link with extension", () => {
   );
 });
 
-H.describeEE("scenarios [EE] > public > question", () => {
+describe("scenarios [EE] > public > question", () => {
   beforeEach(() => {
     cy.intercept("GET", "/api/public/card/*/query?*").as("publicQuery");
 

--- a/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
@@ -173,7 +173,7 @@ describe("embed modal display", () => {
     });
   });
 
-  H.describeEE("when the user has a paid instance", () => {
+  describe("when the user has a paid instance", () => {
     it("should display a disabled state and a link to the Interactive embedding settings", () => {
       H.setTokenFeatures("all");
       H.visitDashboard("@dashboardId");
@@ -522,7 +522,7 @@ describe("#39152 sharing an unsaved question", () => {
           }
         });
 
-        H.describeEE("Pro/EE instances", () => {
+        describe("Pro/EE instances", () => {
           beforeEach(() => {
             H.setTokenFeatures("all");
           });

--- a/e2e/test/scenarios/sharing/public-sharing.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-sharing.cy.spec.js
@@ -266,7 +266,7 @@ describe("scenarios > admin > settings > public sharing", () => {
   });
 });
 
-H.describeEE(
+describe(
   "scenarios > sharing > approved domains (EE)",
   { tags: "@external" },
   () => {

--- a/e2e/test/scenarios/sharing/sharing-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/sharing-reproductions.cy.spec.js
@@ -157,7 +157,7 @@ describe("issue 18352", { tags: "@external" }, () => {
   });
 });
 
-H.describeEE("issue 18669", { tags: "@external" }, () => {
+describe("issue 18669", { tags: "@external" }, () => {
   const questionDetails = {
     name: "Product count",
     database: SAMPLE_DB_ID,
@@ -416,7 +416,7 @@ describe("issue 22524", () => {
   });
 });
 
-H.describeEE("issue 24223", () => {
+describe("issue 24223", () => {
   const questionDetails = {
     name: "24223",
     query: {
@@ -636,7 +636,7 @@ describe("issue 25473", () => {
   });
 });
 
-H.describeEE("issue 26988", () => {
+describe("issue 26988", () => {
   beforeEach(() => {
     H.restore();
     cy.intercept("GET", "/api/preview_embed/dashboard/*").as(

--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -485,7 +485,6 @@ describe("scenarios > dashboard > subscriptions", () => {
 
   describe("OSS email subscriptions", { tags: ["@OSS", "external"] }, () => {
     beforeEach(() => {
-      H.onlyOnOSS();
       cy.visit(`/dashboard/${ORDERS_DASHBOARD_ID}`);
       H.setupSMTP();
     });
@@ -547,7 +546,7 @@ describe("scenarios > dashboard > subscriptions", () => {
     });
   });
 
-  H.describeEE("EE email subscriptions", { tags: "@external" }, () => {
+  describe("EE email subscriptions", { tags: "@external" }, () => {
     beforeEach(() => {
       H.setTokenFeatures("all");
       H.setupSMTP();

--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
@@ -1186,7 +1186,7 @@ describe("issue 43077", () => {
   });
 });
 
-H.describeEE("issue 49160", () => {
+describe("issue 49160", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/DEV-22/remove-describeee-and-onlyonoss-blocks

### Description

Removes pesky describeEE, onlyOnOss and onlyOnEE helpers. after some talks with @iethree, we concluded that `describeEE` blocks only add noise to the repo. Tests are ran on enterprise by default, and oss tests ar ran by using `@oss` grep tag.  this renders `onlyOnOss` pretty much useless, with the exception of running locally.

to avoid confusion when running locally, I added a helper to `cypresss/support/cypress.js` file that will automatically skip all the `@oss` tagged tests when in interactive mode with instructions on how to run these tests.

hopefully I’m not forgetting anything, but the logic seems to be exactly the same as before, unless there’s some black swan I’m unaware of.