### PR TITLE
Fix memoization of extensions in CodeMirror

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.tsx
@@ -213,13 +213,13 @@ export function useCardTagCompletion({ databaseId }: CardTagCompletionOptions) {
 }
 
 type ReferencedCardCompletionOptions = {
-  referencedQuestionIds: CardId[];
+  referencedCardIds: CardId[];
 };
 
 // Completes column names of cards referenced in the query through a
 // card tag (eg. `{{ #42-named-card-tag }}`)
 export function useReferencedCardCompletion({
-  referencedQuestionIds,
+  referencedCardIds,
 }: ReferencedCardCompletionOptions) {
   const [getCard] = useLazyGetCardQuery();
 
@@ -228,7 +228,7 @@ export function useReferencedCardCompletion({
   > => {
     const shouldCache = true;
     const data = await Promise.all(
-      referencedQuestionIds.map(id => getCard({ id }, shouldCache)),
+      referencedCardIds.map(id => getCard({ id }, shouldCache)),
     );
 
     return data
@@ -240,7 +240,7 @@ export function useReferencedCardCompletion({
           field,
         })),
       );
-  }, [referencedQuestionIds, getCard]);
+  }, [referencedCardIds, getCard]);
 
   return useCallback(
     async function completeReferencedCardIdentifiers(

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.unit.spec.tsx
@@ -564,7 +564,7 @@ describe("useReferencedCardCompletion", () => {
     }
 
     const complete = completer(() =>
-      useReferencedCardCompletion({ referencedQuestionIds: cardIds }),
+      useReferencedCardCompletion({ referencedCardIds: cardIds }),
     );
 
     return { complete, url };

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
@@ -39,14 +39,14 @@ import {
   useSnippetCompletion,
 } from "./completers";
 import { language } from "./language";
-import { referencedQuestionIds as getReferencedQuestionIds } from "./util";
+import { getReferencedCardIds } from "./util";
 
 export function useExtensions(query: Lib.Query): Extension[] {
-  const { databaseId, engine, referencedQuestionIds } = useMemo(
+  const { databaseId, engine, referencedCardIds } = useMemo(
     () => ({
       databaseId: Lib.databaseID(query),
       engine: Lib.engine(query),
-      referencedQuestionIds: getReferencedQuestionIds(query),
+      referencedCardIds: getReferencedCardIds(query),
     }),
     [query],
   );
@@ -55,7 +55,7 @@ export function useExtensions(query: Lib.Query): Extension[] {
   const snippetCompletion = useSnippetCompletion();
   const cardTagCompletion = useCardTagCompletion({ databaseId });
   const referencedCardCompletion = useReferencedCardCompletion({
-    referencedQuestionIds,
+    referencedCardIds,
   });
   const localsCompletion = useLocalsCompletion({ engine });
 

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/util.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/util.tsx
@@ -1,4 +1,6 @@
 import type { EditorState } from "@codemirror/state";
+import { createSelector } from "@reduxjs/toolkit";
+import { shallowEqual } from "react-redux";
 import { t } from "ttag";
 
 import { isNotNull } from "metabase/lib/types";
@@ -225,9 +227,12 @@ export function matchCardIdAtCursor(
   return parsedId;
 }
 
-export function getReferencedCardIds(query: Lib.Query): CardId[] {
-  return Object.values(Lib.templateTags(query) ?? {})
-    .filter(tag => tag.type === "card")
-    .map(tag => tag["card-id"])
-    .filter(isNotNull);
-}
+export const getReferencedCardIds = createSelector(
+  (query: Lib.Query) => Lib.templateTags(query),
+  tags =>
+    Object.values(tags)
+      .filter(tag => tag.type === "card")
+      .map(tag => tag["card-id"])
+      .filter(isNotNull),
+  { argsMemoizeOptions: { resultEqualityCheck: shallowEqual } },
+);

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/util.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/util.tsx
@@ -225,7 +225,7 @@ export function matchCardIdAtCursor(
   return parsedId;
 }
 
-export function referencedQuestionIds(query: Lib.Query): CardId[] {
+export function getReferencedCardIds(query: Lib.Query): CardId[] {
   return Object.values(Lib.templateTags(query) ?? {})
     .filter(tag => tag.type === "card")
     .map(tag => tag["card-id"])


### PR DESCRIPTION
Before https://www.loom.com/share/6eaf70ac468241b8af680e038b5a7a2e
After https://www.loom.com/share/a09be7d3559f41418e3b54985a713faf

As `referencedCardIds` is an array, it would be new every time by default, defeating `useMemo` memoization. 

How to verify:
- Add a console statement inside `useMemo` here https://github.com/metabase/metabase/blob/af091b360bbc6210c78c0988e50d90aa8185b704/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx#L66