### PR TITLE
Added Session Cleanup Job

### DIFF
--- a/src/metabase/task/init.clj
+++ b/src/metabase/task/init.clj
@@ -16,6 +16,7 @@
    [metabase.task.refresh-slack-channel-user-cache]
    [metabase.task.send-anonymous-stats]
    [metabase.task.send-pulses]
+   [metabase.task.session-cleanup]
    [metabase.task.task-history-cleanup]
    [metabase.task.truncate-audit-tables]
    [metabase.task.upgrade-checks]))

--- a/src/metabase/task/session_cleanup.clj
+++ b/src/metabase/task/session_cleanup.clj
@@ -1,0 +1,25 @@
+(ns metabase.task.session-cleanup
+  (:require [clojurewerkz.quartzite.jobs :as jobs]
+            [clojurewerkz.quartzite.schedule.cron :as cron]
+            [clojurewerkz.quartzite.triggers :as triggers]
+            [metabase.task :as task]))
+
+(def ^:private session-cleanup-job-key (jobs/key "metabase.task.session.cleanup.job"))
+(def ^:private session-cleanup-trigger-key (triggers/key "metabase.task.follow-up-emails.trigger"))
+
+(jobs/defjob ^{:doc "Triggers that cleans up outdated sessions."}
+  SessionCleanup
+  [context]
+  (println ("Running session cleanup job!!!"))
+
+(defmethod task/init! ::SessionCleanup [_]
+  (let [job     (jobs/build
+                  (jobs/of-type SessionCleanup)
+                  (jobs/with-identity session-cleanup-job-key))
+        trigger (triggers/build
+                  (triggers/with-identity session-cleanup-trigger-key)
+                  (triggers/start-now)
+                  (triggers/with-schedule
+                    ;; run once a day
+                    (cron/cron-schedule "* * * * * ? *")))]
+    (task/schedule-task! job trigger))))

--- a/src/metabase/task/session_cleanup.clj
+++ b/src/metabase/task/session_cleanup.clj
@@ -5,12 +5,14 @@
             [metabase.models.session :as session]
             [metabase.task :as task]))
 
+(set! *warn-on-reflection* true)
+
 (def ^:private session-cleanup-job-key (jobs/key "metabase.task.session-cleanup.job"))
 (def ^:private session-cleanup-trigger-key (triggers/key "metabase.task.session-cleanup.trigger"))
 
 (jobs/defjob ^{:doc "Job that cleans up outdated sessions."}
   SessionCleanup
-  [context]
+  [_]
   (session/cleanup-sessions))
 
 (defmethod task/init! ::SessionCleanup [_]
@@ -22,5 +24,5 @@
                  (triggers/start-now)
                  (triggers/with-schedule
                     ;; run once a day
-                   cron/cron-schedule "0 0 2 * * ? *"))]
+                  cron/cron-schedule "0 0 2 * * ? *"))]
     (task/schedule-task! job trigger)))

--- a/src/metabase/task/session_cleanup.clj
+++ b/src/metabase/task/session_cleanup.clj
@@ -24,5 +24,5 @@
                  (triggers/start-now)
                  (triggers/with-schedule
                     ;; run once a day
-                  cron/cron-schedule "0 0 2 * * ? *"))]
+                  (cron/cron-schedule "0 0 2 * * ? *")))]
     (task/schedule-task! job trigger)))

--- a/src/metabase/task/session_cleanup.clj
+++ b/src/metabase/task/session_cleanup.clj
@@ -2,24 +2,25 @@
   (:require [clojurewerkz.quartzite.jobs :as jobs]
             [clojurewerkz.quartzite.schedule.cron :as cron]
             [clojurewerkz.quartzite.triggers :as triggers]
+            [metabase.models.session :as session]
             [metabase.task :as task]))
 
-(def ^:private session-cleanup-job-key (jobs/key "metabase.task.session.cleanup.job"))
-(def ^:private session-cleanup-trigger-key (triggers/key "metabase.task.follow-up-emails.trigger"))
+(def ^:private session-cleanup-job-key (jobs/key "metabase.task.session-cleanup.job"))
+(def ^:private session-cleanup-trigger-key (triggers/key "metabase.task.session-cleanup.trigger"))
 
-(jobs/defjob ^{:doc "Triggers that cleans up outdated sessions."}
+(jobs/defjob ^{:doc "Job that cleans up outdated sessions."}
   SessionCleanup
   [context]
-  (println ("Running session cleanup job!!!"))
+  (session/cleanup-sessions))
 
 (defmethod task/init! ::SessionCleanup [_]
-  (let [job     (jobs/build
-                  (jobs/of-type SessionCleanup)
-                  (jobs/with-identity session-cleanup-job-key))
+  (let [job (jobs/build
+             (jobs/of-type SessionCleanup)
+             (jobs/with-identity session-cleanup-job-key))
         trigger (triggers/build
-                  (triggers/with-identity session-cleanup-trigger-key)
-                  (triggers/start-now)
-                  (triggers/with-schedule
+                 (triggers/with-identity session-cleanup-trigger-key)
+                 (triggers/start-now)
+                 (triggers/with-schedule
                     ;; run once a day
-                    (cron/cron-schedule "* * * * * ? *")))]
-    (task/schedule-task! job trigger))))
+                   cron/cron-schedule "0 0 2 * * ? *"))]
+    (task/schedule-task! job trigger)))

--- a/src/metabase/task/session_cleanup.clj
+++ b/src/metabase/task/session_cleanup.clj
@@ -1,9 +1,10 @@
 (ns metabase.task.session-cleanup
-  (:require [clojurewerkz.quartzite.jobs :as jobs]
-            [clojurewerkz.quartzite.schedule.cron :as cron]
-            [clojurewerkz.quartzite.triggers :as triggers]
-            [metabase.models.session :as session]
-            [metabase.task :as task]))
+  (:require
+   [clojurewerkz.quartzite.jobs :as jobs]
+   [clojurewerkz.quartzite.schedule.cron :as cron]
+   [clojurewerkz.quartzite.triggers :as triggers]
+   [metabase.models.session :as session]
+   [metabase.task :as task]))
 
 (set! *warn-on-reflection* true)
 

--- a/test/metabase/models/session_test.clj
+++ b/test/metabase/models/session_test.clj
@@ -139,7 +139,7 @@
                                              :user_id    user-id
                                              :created_at (t/minus (t/local-date) (t/days 1))}]
     (testing "session-cleanup deletes old sessions and keeps new enough ones"
-      (is (t2/select-one :model/Session :id "a"))
+      (is (t2/select-one :model/Session :id (old-session :id)))
       (session/cleanup-sessions)
-      (is (not (t2/select-one :model/Session :id "a")))
-      (is (t2/select-one :model/Session :id "b")))))
+      (is (not (t2/select-one :model/Session :id (old-session :id))))
+      (is (t2/select-one :model/Session :id (new-session :id))))))

--- a/test/metabase/models/session_test.clj
+++ b/test/metabase/models/session_test.clj
@@ -143,5 +143,5 @@
       (testing "session-cleanup deletes old sessions and keeps new enough ones"
         (is (t2/select-one :model/Session :id (old-session :id)))
         (session/cleanup-sessions)
-        (is (not (t2/select-one :model/Session :id (old-session :id))))
-        (is (t2/select-one :model/Session :id (new-session :id)))))))
+        (is (not (t2/exists? :model/Session :id (:id old-session))))
+        (is (t2/exists? :model/Session :id (:id new-session)))))))

--- a/test/metabase/models/session_test.clj
+++ b/test/metabase/models/session_test.clj
@@ -131,15 +131,17 @@
           (is (true? @email-sent)))))))
 
 (deftest clean-sessions-test ()
-  (mt/with-temp [:model/User {user-id :id} {}
-                 :model/Session old-session {:id         "a"
-                                             :user_id    user-id
-                                             :created_at (t/minus (t/local-date) (t/months 1))}
-                 :model/Session new-session {:id         "b"
-                                             :user_id    user-id
-                                             :created_at (t/minus (t/local-date) (t/days 1))}]
-    (testing "session-cleanup deletes old sessions and keeps new enough ones"
-      (is (t2/select-one :model/Session :id (old-session :id)))
-      (session/cleanup-sessions)
-      (is (not (t2/select-one :model/Session :id (old-session :id))))
-      (is (t2/select-one :model/Session :id (new-session :id))))))
+  (mt/with-temp-env-var-value! [:max-session-age (str (* 60 24))] ;; one day
+
+    (mt/with-temp [:model/User {user-id :id} {}
+                   :model/Session old-session {:id         "a"
+                                               :user_id    user-id
+                                               :created_at (t/minus (t/local-date-time) (t/days 2))}
+                   :model/Session new-session {:id         "b"
+                                               :user_id    user-id
+                                               :created_at (t/minus (t/local-date-time) (t/hours 5))}]
+      (testing "session-cleanup deletes old sessions and keeps new enough ones"
+        (is (t2/select-one :model/Session :id (old-session :id)))
+        (session/cleanup-sessions)
+        (is (not (t2/select-one :model/Session :id (old-session :id))))
+        (is (t2/select-one :model/Session :id (new-session :id)))))))


### PR DESCRIPTION
### Description

Sessions older than `max-session-age` cannot be used for authentication, but if users do not explicitly log out they linger in the `core_session` table.

This PR adds a daily quartz task to delete any sessions older than `max-session-age` 

NOTE: sessions older than `max-session-age` could never be used for authentication previously due to the query in `metabase/server/middleware/session.clj:103` used to check the session-id. So this is just removing rows that would never be selected anyway.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Have a database with `core_session` rows older than `max-session-age`
2. Wait for the job to trigger (2am) or manually run it
3. See that the old sessions are deleted

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
