### PR TITLE
Highlight lines changed by SQL autofixing

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/ai-sql-fixer/components/FixSqlQueryButton/FixSqlQueryButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-sql-fixer/components/FixSqlQueryButton/FixSqlQueryButton.tsx
@@ -6,13 +6,14 @@ import type { FixSqlQueryButtonProps } from "metabase/plugins";
 import { Button, Icon } from "metabase/ui";
 import { useGetFixedSqlQueryQuery } from "metabase-enterprise/api";
 
-import { getFixRequest, getFixedQuery } from "./utils";
+import { getFixRequest, getFixedLineNumbers, getFixedQuery } from "./utils";
 
 export function FixSqlQueryButton({
   query,
   queryError,
   queryErrorType,
   onQueryFix,
+  onHighlightLines,
 }: FixSqlQueryButtonProps) {
   const request = getFixRequest(query, queryError, queryErrorType);
   const { data, error, isFetching } = useGetFixedSqlQueryQuery(
@@ -23,6 +24,16 @@ export function FixSqlQueryButton({
     if (data) {
       onQueryFix(getFixedQuery(query, data.fixes));
     }
+  };
+
+  const handleMouseEnter = () => {
+    if (data) {
+      onHighlightLines(getFixedLineNumbers(data.fixes));
+    }
+  };
+
+  const handleMouseLeave = () => {
+    onHighlightLines([]);
   };
 
   if (!request) {
@@ -44,5 +55,12 @@ export function FixSqlQueryButton({
       children: t`Metabot can't fix it`,
     }));
 
-  return <Button {...props} onClick={handleClick} />;
+  return (
+    <Button
+      {...props}
+      onClick={handleClick}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    />
+  );
 }

--- a/enterprise/frontend/src/metabase-enterprise/ai-sql-fixer/components/FixSqlQueryButton/FixSqlQueryButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-sql-fixer/components/FixSqlQueryButton/FixSqlQueryButton.tsx
@@ -22,7 +22,9 @@ export function FixSqlQueryButton({
 
   const handleClick = () => {
     if (data) {
-      onQueryFix(getFixedQuery(query, data.fixes));
+      const fixedQuery = getFixedQuery(query, data.fixes);
+      const fixedLineNumbers = getFixedLineNumbers(data.fixes);
+      onQueryFix(fixedQuery, fixedLineNumbers);
     }
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/ai-sql-fixer/components/FixSqlQueryButton/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/ai-sql-fixer/components/FixSqlQueryButton/utils.ts
@@ -44,3 +44,7 @@ export function getFixedQuery(query: Lib.Query, fixes: SqlQueryFix[]) {
   const newSql = newSqlLines.join("\n");
   return Lib.withNativeQuery(query, newSql);
 }
+
+export function getFixedLineNumbers(fixes: SqlQueryFix[]) {
+  return fixes.map(fix => fix.line_number);
+}

--- a/frontend/src/metabase-types/store/mocks/qb.ts
+++ b/frontend/src/metabase-types/store/mocks/qb.ts
@@ -33,8 +33,8 @@ export const createMockQueryBuilderUIControlsState = (
   modal: null,
   modalContext: null,
   dataReferenceStack: null,
-  highlightedSqlQueryLineNumbers: [],
-  isSqlQueryFixApplied: false,
+  isNativeQueryFixApplied: false,
+  highlightedNativeQueryLineNumbers: [],
   ...opts,
 });
 

--- a/frontend/src/metabase-types/store/mocks/qb.ts
+++ b/frontend/src/metabase-types/store/mocks/qb.ts
@@ -33,7 +33,8 @@ export const createMockQueryBuilderUIControlsState = (
   modal: null,
   modalContext: null,
   dataReferenceStack: null,
-  isNativeQueryFixApplied: false,
+  highlightedSqlQueryLineNumbers: [],
+  isSqlQueryFixApplied: false,
   ...opts,
 });
 

--- a/frontend/src/metabase-types/store/qb.ts
+++ b/frontend/src/metabase-types/store/qb.ts
@@ -50,8 +50,8 @@ export interface QueryBuilderUIControls {
   modal: QueryModalType | null;
   modalContext: TimelineEventId | null;
   dataReferenceStack: null;
-  highlightedSqlQueryLineNumbers: number[];
-  isSqlQueryFixApplied: boolean;
+  isNativeQueryFixApplied: boolean;
+  highlightedNativeQueryLineNumbers: number[];
 }
 
 export interface QueryBuilderLoadingControls {

--- a/frontend/src/metabase-types/store/qb.ts
+++ b/frontend/src/metabase-types/store/qb.ts
@@ -50,7 +50,8 @@ export interface QueryBuilderUIControls {
   modal: QueryModalType | null;
   modalContext: TimelineEventId | null;
   dataReferenceStack: null;
-  isNativeQueryFixApplied: boolean;
+  highlightedSqlQueryLineNumbers: number[];
+  isSqlQueryFixApplied: boolean;
 }
 
 export interface QueryBuilderLoadingControls {

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -581,6 +581,7 @@ export type FixSqlQueryButtonProps = {
   queryError: DatasetError;
   queryErrorType: DatasetErrorType | undefined;
   onQueryFix: (newQuery: Lib.Query) => void;
+  onHighlightLines: (lineNumbers: number[]) => void;
 };
 
 export type PluginAiSqlFixer = {

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -580,8 +580,8 @@ export type FixSqlQueryButtonProps = {
   query: Lib.Query;
   queryError: DatasetError;
   queryErrorType: DatasetErrorType | undefined;
-  onQueryFix: (newQuery: Lib.Query) => void;
-  onHighlightLines: (lineNumbers: number[]) => void;
+  onQueryFix: (fixedQuery: Lib.Query, fixedLineNumbers: number[]) => void;
+  onHighlightLines: (fixedLineNumbers: number[]) => void;
 };
 
 export type PluginAiSqlFixer = {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.module.css
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.module.css
@@ -193,5 +193,9 @@
         color: inherit;
       }
     }
+
+    .cm-highlight-line {
+      background-color: var(--mb-color-brand-alpha-04);
+    }
   }
 }

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.module.css
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.module.css
@@ -195,7 +195,7 @@
     }
 
     .cm-highlight-line {
-      background-color: var(--mb-color-brand-alpha-04);
+      background-color: var(--mb-color-brand-light);
     }
   }
 }

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
@@ -310,6 +310,7 @@ function highlightLines() {
 
       for (const effect of transaction.effects) {
         if (effect.is(highlightLinesEffect)) {
+          value = value.update({ filter: () => false });
           value = value.update({ add: effect.value });
         }
       }

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
@@ -322,11 +322,11 @@ function highlightLines() {
 
 export function useHighlightLines(
   editorRef: RefObject<ReactCodeMirrorRef>,
-  highlightedLineNumbers?: number[],
+  highlightedLineNumbers: number[] = [],
 ) {
   useEffect(() => {
     const view = editorRef.current?.view;
-    if (!view || !highlightedLineNumbers) {
+    if (!view) {
       return;
     }
 

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
@@ -21,10 +21,17 @@ import {
   keymap,
 } from "@codemirror/view";
 import { type Tag, tags } from "@lezer/highlight";
-import type { EditorState, Extension } from "@uiw/react-codemirror";
+import {
+  type EditorState,
+  type Extension,
+  type Range,
+  type ReactCodeMirrorRef,
+  StateEffect,
+  StateField,
+} from "@uiw/react-codemirror";
 import cx from "classnames";
 import { getNonce } from "get-nonce";
-import { useMemo } from "react";
+import { type RefObject, useEffect, useMemo } from "react";
 
 import { isNotNull } from "metabase/lib/types";
 import { monospaceFontFamily } from "metabase/styled-components/theme";
@@ -84,8 +91,9 @@ export function useExtensions(query: Lib.Query): Extension[] {
           keywordsCompletion,
         ],
       }),
-      highlighting(),
-      tagDecorator(),
+      highlightSyntax(),
+      highlightTags(),
+      highlightLines(),
       folds(),
       indentation(),
       disableCmdEnter(),
@@ -247,11 +255,11 @@ const metabaseStyle = HighlightStyle.define(
     })),
 );
 
-function highlighting() {
+function highlightSyntax() {
   return syntaxHighlighting(metabaseStyle);
 }
 
-function tagDecorator() {
+function highlightTags() {
   const decorator = new MatchDecorator({
     regexp: /\{\{([^\}]*)\}\}/g,
     decoration(match) {
@@ -285,4 +293,48 @@ function tagDecorator() {
       decorations: instance => instance.tags,
     },
   );
+}
+
+const highlightLinesEffect = StateEffect.define<Range<Decoration>[]>();
+const highlightLinesDecoration = Decoration.mark({
+  class: "cm-highlight-line",
+});
+
+function highlightLines() {
+  return StateField.define({
+    create() {
+      return Decoration.none;
+    },
+    update(value, transaction) {
+      value = value.map(transaction.changes);
+
+      for (const effect of transaction.effects) {
+        if (effect.is(highlightLinesEffect)) {
+          value = value.update({ add: effect.value });
+        }
+      }
+
+      return value;
+    },
+    provide: field => EditorView.decorations.from(field),
+  });
+}
+
+export function useHighlightLines(
+  editorRef: RefObject<ReactCodeMirrorRef>,
+  highlightedLineNumbers?: number[],
+) {
+  useEffect(() => {
+    const view = editorRef.current?.view;
+    if (!view || !highlightedLineNumbers) {
+      return;
+    }
+
+    const lines = highlightedLineNumbers.map(line => view.state.doc.line(line));
+    const lineRanges = lines.map(line =>
+      highlightLinesDecoration.range(line.from, line.to),
+    );
+
+    view.dispatch({ effects: highlightLinesEffect.of(lineRanges) });
+  }, [editorRef, highlightedLineNumbers]);
 }

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -52,6 +52,7 @@ type OwnProps = typeof NativeQueryEditor.defaultProps & {
   nativeEditorSelectedText?: string;
   modalSnippet?: NativeQuerySnippet;
   viewHeight: number;
+  highlightedLineNumbers?: number[];
 
   isOpen?: boolean;
   isInitiallyOpen?: boolean;
@@ -344,6 +345,7 @@ export class NativeQueryEditor extends Component<
       canChangeDatabase,
       setParameterValueToDefault,
       forwardedRef,
+      highlightedLineNumbers,
     } = this.props;
 
     const parameters = query.question().parameters();
@@ -419,6 +421,7 @@ export class NativeQueryEditor extends Component<
               ref={this.editor}
               query={question.query()}
               readOnly={readOnly}
+              highlightedLineNumbers={highlightedLineNumbers}
               onChange={this.onChange}
               onSelectionChange={setNativeEditorSelectedRange}
               onCursorMoveOverCardTag={openDataReferenceAtQuestion}

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
@@ -8,7 +8,7 @@ import LoadingSpinner from "metabase/components/LoadingSpinner";
 import CS from "metabase/css/core/index.css";
 import QueryBuilderS from "metabase/css/query_builder.module.css";
 import { useSelector } from "metabase/lib/redux";
-import { getisSqlQueryFixApplied } from "metabase/query_builder/selectors";
+import { getIsSqlQueryFixApplied } from "metabase/query_builder/selectors";
 import { getWhiteLabeledLoadingMessageFactory } from "metabase/selectors/whitelabel";
 import * as Lib from "metabase-lib";
 import { HARD_ROW_LIMIT } from "metabase-lib/v1/queries/utils";
@@ -34,7 +34,7 @@ export default function QueryVisualization(props) {
 
   const canRun = Lib.canRun(question.query(), question.type());
   const [warnings, setWarnings] = useState([]);
-  const isSqlQueryFixApplied = useSelector(getisSqlQueryFixApplied);
+  const isSqlQueryFixApplied = useSelector(getIsSqlQueryFixApplied);
 
   return (
     <div

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
@@ -8,7 +8,7 @@ import LoadingSpinner from "metabase/components/LoadingSpinner";
 import CS from "metabase/css/core/index.css";
 import QueryBuilderS from "metabase/css/query_builder.module.css";
 import { useSelector } from "metabase/lib/redux";
-import { getIsSqlQueryFixApplied } from "metabase/query_builder/selectors";
+import { getIsNativeQueryFixApplied } from "metabase/query_builder/selectors";
 import { getWhiteLabeledLoadingMessageFactory } from "metabase/selectors/whitelabel";
 import * as Lib from "metabase-lib";
 import { HARD_ROW_LIMIT } from "metabase-lib/v1/queries/utils";
@@ -34,7 +34,7 @@ export default function QueryVisualization(props) {
 
   const canRun = Lib.canRun(question.query(), question.type());
   const [warnings, setWarnings] = useState([]);
-  const isSqlQueryFixApplied = useSelector(getIsSqlQueryFixApplied);
+  const isNativeQueryFixApplied = useSelector(getIsNativeQueryFixApplied);
 
   return (
     <div
@@ -72,7 +72,7 @@ export default function QueryVisualization(props) {
         )}
         data-testid="query-visualization-root"
       >
-        {isSqlQueryFixApplied ? (
+        {isNativeQueryFixApplied ? (
           <VisualizationEmptyState className={CS.spread}>
             {t`Fixes applied. Run your query to view results.`}
           </VisualizationEmptyState>

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
@@ -8,7 +8,7 @@ import LoadingSpinner from "metabase/components/LoadingSpinner";
 import CS from "metabase/css/core/index.css";
 import QueryBuilderS from "metabase/css/query_builder.module.css";
 import { useSelector } from "metabase/lib/redux";
-import { getisNativeQueryFixApplied } from "metabase/query_builder/selectors";
+import { getisSqlQueryFixApplied } from "metabase/query_builder/selectors";
 import { getWhiteLabeledLoadingMessageFactory } from "metabase/selectors/whitelabel";
 import * as Lib from "metabase-lib";
 import { HARD_ROW_LIMIT } from "metabase-lib/v1/queries/utils";
@@ -34,7 +34,7 @@ export default function QueryVisualization(props) {
 
   const canRun = Lib.canRun(question.query(), question.type());
   const [warnings, setWarnings] = useState([]);
-  const isNativeQueryFixApplied = useSelector(getisNativeQueryFixApplied);
+  const isSqlQueryFixApplied = useSelector(getisSqlQueryFixApplied);
 
   return (
     <div
@@ -72,7 +72,7 @@ export default function QueryVisualization(props) {
         )}
         data-testid="query-visualization-root"
       >
-        {isNativeQueryFixApplied ? (
+        {isSqlQueryFixApplied ? (
           <VisualizationEmptyState className={CS.spread}>
             {t`Fixes applied. Run your query to view results.`}
           </VisualizationEmptyState>

--- a/frontend/src/metabase/query_builder/components/VisualizationError/VisualizationError.tsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationError/VisualizationError.tsx
@@ -47,15 +47,19 @@ export function VisualizationError({
   const showMetabaseLinks = useSelector(getShowMetabaseLinks);
   const dispatch = useDispatch();
 
-  const handleNativeQueryFix = (newQuery: Lib.Query) => {
+  const handleSqlQueryFix = (newQuery: Lib.Query) => {
     const newQuestion = question.setQuery(newQuery);
     dispatch(updateQuestion(newQuestion));
     dispatch(
       setUIControls({
         isNativeEditorOpen: true,
-        isNativeQueryFixApplied: true,
+        isSqlQueryFixApplied: true,
       }),
     );
+  };
+
+  const handleSqlQueryHighlight = (lineNumbers: number[]) => {
+    dispatch(setUIControls({ highlightedSqlQueryLineNumbers: lineNumbers }));
   };
 
   const isNative = question && Lib.queryDisplayInfo(query).isNative;
@@ -145,7 +149,8 @@ export function VisualizationError({
                 query={query}
                 queryError={error}
                 queryErrorType={errorType}
-                onQueryFix={handleNativeQueryFix}
+                onQueryFix={handleSqlQueryFix}
+                onHighlightLines={handleSqlQueryHighlight}
               />
             )}
           </Flex>

--- a/frontend/src/metabase/query_builder/components/VisualizationError/VisualizationError.tsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationError/VisualizationError.tsx
@@ -52,15 +52,15 @@ export function VisualizationError({
     dispatch(updateQuestion(newQuestion));
     dispatch(
       setUIControls({
-        highlightedSqlQueryLineNumbers: lineNumbers,
+        highlightedNativeQueryLineNumbers: lineNumbers,
         isNativeEditorOpen: true,
-        isSqlQueryFixApplied: true,
+        isNativeQueryFixApplied: true,
       }),
     );
   };
 
   const handleSqlQueryHighlight = (lineNumbers: number[]) => {
-    dispatch(setUIControls({ highlightedSqlQueryLineNumbers: lineNumbers }));
+    dispatch(setUIControls({ highlightedNativeQueryLineNumbers: lineNumbers }));
   };
 
   const isNative = question && Lib.queryDisplayInfo(query).isNative;

--- a/frontend/src/metabase/query_builder/components/VisualizationError/VisualizationError.tsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationError/VisualizationError.tsx
@@ -47,20 +47,25 @@ export function VisualizationError({
   const showMetabaseLinks = useSelector(getShowMetabaseLinks);
   const dispatch = useDispatch();
 
-  const handleSqlQueryFix = (newQuery: Lib.Query, lineNumbers: number[]) => {
-    const newQuestion = question.setQuery(newQuery);
+  const handleNativeQueryFix = (
+    fixedQuery: Lib.Query,
+    fixedLineNumbers: number[],
+  ) => {
+    const newQuestion = question.setQuery(fixedQuery);
     dispatch(updateQuestion(newQuestion));
     dispatch(
       setUIControls({
-        highlightedNativeQueryLineNumbers: lineNumbers,
+        highlightedNativeQueryLineNumbers: fixedLineNumbers,
         isNativeEditorOpen: true,
         isNativeQueryFixApplied: true,
       }),
     );
   };
 
-  const handleSqlQueryHighlight = (lineNumbers: number[]) => {
-    dispatch(setUIControls({ highlightedNativeQueryLineNumbers: lineNumbers }));
+  const handleNativeQueryHighlight = (fixedLineNumbers: number[]) => {
+    dispatch(
+      setUIControls({ highlightedNativeQueryLineNumbers: fixedLineNumbers }),
+    );
   };
 
   const isNative = question && Lib.queryDisplayInfo(query).isNative;
@@ -150,8 +155,8 @@ export function VisualizationError({
                 query={query}
                 queryError={error}
                 queryErrorType={errorType}
-                onQueryFix={handleSqlQueryFix}
-                onHighlightLines={handleSqlQueryHighlight}
+                onQueryFix={handleNativeQueryFix}
+                onHighlightLines={handleNativeQueryHighlight}
               />
             )}
           </Flex>

--- a/frontend/src/metabase/query_builder/components/VisualizationError/VisualizationError.tsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationError/VisualizationError.tsx
@@ -47,11 +47,12 @@ export function VisualizationError({
   const showMetabaseLinks = useSelector(getShowMetabaseLinks);
   const dispatch = useDispatch();
 
-  const handleSqlQueryFix = (newQuery: Lib.Query) => {
+  const handleSqlQueryFix = (newQuery: Lib.Query, lineNumbers: number[]) => {
     const newQuestion = question.setQuery(newQuery);
     dispatch(updateQuestion(newQuestion));
     dispatch(
       setUIControls({
+        highlightedSqlQueryLineNumbers: lineNumbers,
         isNativeEditorOpen: true,
         isSqlQueryFixApplied: true,
       }),

--- a/frontend/src/metabase/query_builder/components/view/View/ViewNativeQueryEditor/ViewNativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View/ViewNativeQueryEditor/ViewNativeQueryEditor.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import { useSelector } from "metabase/lib/redux";
 import NativeQueryEditor from "metabase/query_builder/components/NativeQueryEditor";
-import { getHighlightedSqlQueryLineNumbers } from "metabase/query_builder/selectors";
+import { getHighlightedNativeQueryLineNumbers } from "metabase/query_builder/selectors";
 import { Box } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
@@ -19,7 +19,9 @@ export const ViewNativeQueryEditor = props => {
   } = props;
 
   const legacyQuery = question.legacyQuery();
-  const highlightedLineNumbers = useSelector(getHighlightedSqlQueryLineNumbers);
+  const highlightedLineNumbers = useSelector(
+    getHighlightedNativeQueryLineNumbers,
+  );
 
   // Normally, when users open native models,
   // they open an ad-hoc GUI question using the model as a data source

--- a/frontend/src/metabase/query_builder/components/view/View/ViewNativeQueryEditor/ViewNativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View/ViewNativeQueryEditor/ViewNativeQueryEditor.jsx
@@ -1,5 +1,7 @@
 /* eslint-disable react/prop-types */
+import { useSelector } from "metabase/lib/redux";
 import NativeQueryEditor from "metabase/query_builder/components/NativeQueryEditor";
+import { getHighlightedSqlQueryLineNumbers } from "metabase/query_builder/selectors";
 import { Box } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
@@ -17,6 +19,7 @@ export const ViewNativeQueryEditor = props => {
   } = props;
 
   const legacyQuery = question.legacyQuery();
+  const highlightedLineNumbers = useSelector(getHighlightedSqlQueryLineNumbers);
 
   // Normally, when users open native models,
   // they open an ad-hoc GUI question using the model as a data source
@@ -36,6 +39,7 @@ export const ViewNativeQueryEditor = props => {
         {...props}
         query={legacyQuery}
         viewHeight={height}
+        highlightedLineNumbers={highlightedLineNumbers}
         isOpen={legacyQuery.isEmpty() || isDirty}
         isInitiallyOpen={isNativeEditorOpen}
         datasetQuery={card && card.dataset_query}

--- a/frontend/src/metabase/query_builder/defaults.ts
+++ b/frontend/src/metabase/query_builder/defaults.ts
@@ -31,8 +31,8 @@ export const DEFAULT_UI_CONTROLS: QueryBuilderUIControls = {
   showSidebarTitle: false,
   modal: null,
   modalContext: null,
-  highlightedSqlQueryLineNumbers: [],
-  isSqlQueryFixApplied: false,
+  isNativeQueryFixApplied: false,
+  highlightedNativeQueryLineNumbers: [],
 };
 
 export const DEFAULT_LOADING_CONTROLS: QueryBuilderLoadingControls = {

--- a/frontend/src/metabase/query_builder/defaults.ts
+++ b/frontend/src/metabase/query_builder/defaults.ts
@@ -31,7 +31,8 @@ export const DEFAULT_UI_CONTROLS: QueryBuilderUIControls = {
   showSidebarTitle: false,
   modal: null,
   modalContext: null,
-  isNativeQueryFixApplied: false,
+  highlightedSqlQueryLineNumbers: [],
+  isSqlQueryFixApplied: false,
 };
 
 export const DEFAULT_LOADING_CONTROLS: QueryBuilderLoadingControls = {

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -49,6 +49,7 @@ import {
   TOGGLE_DATA_REFERENCE,
   TOGGLE_SNIPPET_SIDEBAR,
   TOGGLE_TEMPLATE_TAGS_EDITOR,
+  UPDATE_QUESTION,
   ZOOM_IN_ROW,
   onCloseChartSettings,
   onCloseChartType,
@@ -118,6 +119,12 @@ export const uiControls = handleActions(
       },
     },
 
+    [UPDATE_QUESTION]: {
+      next: (state, { payload }) => ({
+        ...state,
+        highlightedSqlQueryLineNumbers: [],
+      }),
+    },
     [TOGGLE_DATA_REFERENCE]: {
       next: (state, { payload }) => ({
         ...state,

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -183,7 +183,7 @@ export const uiControls = handleActions(
     [RUN_QUERY]: state => ({
       ...state,
       isRunning: true,
-      isNativeQueryFixApplied: false,
+      isSqlQueryFixApplied: false,
     }),
     [CANCEL_QUERY]: {
       next: (state, { payload }) => ({ ...state, isRunning: false }),

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -184,6 +184,7 @@ export const uiControls = handleActions(
       ...state,
       isRunning: true,
       isSqlQueryFixApplied: false,
+      highlightedSqlQueryLineNumbers: [],
     }),
     [CANCEL_QUERY]: {
       next: (state, { payload }) => ({ ...state, isRunning: false }),

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -122,7 +122,9 @@ export const uiControls = handleActions(
     [UPDATE_QUESTION]: {
       next: (state, { payload }) => ({
         ...state,
-        highlightedSqlQueryLineNumbers: [],
+        highlightedNativeQueryLineNumbers: state.isNativeQueryFixApplied
+          ? DEFAULT_UI_CONTROLS.highlightedNativeQueryLineNumbers
+          : state.highlightedNativeQueryLineNumbers,
       }),
     },
     [TOGGLE_DATA_REFERENCE]: {
@@ -190,8 +192,9 @@ export const uiControls = handleActions(
     [RUN_QUERY]: state => ({
       ...state,
       isRunning: true,
-      isSqlQueryFixApplied: false,
-      highlightedSqlQueryLineNumbers: [],
+      isNativeQueryFixApplied: false,
+      highlightedNativeQueryLineNumbers:
+        DEFAULT_UI_CONTROLS.highlightedNativeQueryLineNumbers,
     }),
     [CANCEL_QUERY]: {
       next: (state, { payload }) => ({ ...state, isRunning: false }),

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -58,8 +58,8 @@ export const getIsShowingSnippetSidebar = state =>
   getUiControls(state).isShowingSnippetSidebar;
 export const getIsShowingDataReference = state =>
   getUiControls(state).isShowingDataReference;
-export const getHighlightedSqlQueryLineNumbers = state =>
-  getUiControls(state).highlightedSqlQueryLineNumbers;
+export const getHighlightedNativeQueryLineNumbers = state =>
+  getUiControls(state).highlightedNativeQueryLineNumbers;
 
 // This selector can be called from public questions / dashboards, which do not
 // have state.qb
@@ -766,9 +766,9 @@ const getNativeEditorSelectedRange = createSelector(
   uiControls => uiControls && uiControls.nativeEditorSelectedRange,
 );
 
-export const getIsSqlQueryFixApplied = createSelector(
+export const getIsNativeQueryFixApplied = createSelector(
   [getUiControls],
-  uiControls => uiControls && uiControls.isSqlQueryFixApplied,
+  uiControls => uiControls && uiControls.isNativeQueryFixApplied,
 );
 
 export const getIsTimeseries = createSelector(

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -766,7 +766,7 @@ const getNativeEditorSelectedRange = createSelector(
   uiControls => uiControls && uiControls.nativeEditorSelectedRange,
 );
 
-export const getisSqlQueryFixApplied = createSelector(
+export const getIsSqlQueryFixApplied = createSelector(
   [getUiControls],
   uiControls => uiControls && uiControls.isSqlQueryFixApplied,
 );

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -58,6 +58,8 @@ export const getIsShowingSnippetSidebar = state =>
   getUiControls(state).isShowingSnippetSidebar;
 export const getIsShowingDataReference = state =>
   getUiControls(state).isShowingDataReference;
+export const getHighlightedSqlQueryLineNumbers = state =>
+  getUiControls(state).highlightedSqlQueryLineNumbers;
 
 // This selector can be called from public questions / dashboards, which do not
 // have state.qb
@@ -764,9 +766,9 @@ const getNativeEditorSelectedRange = createSelector(
   uiControls => uiControls && uiControls.nativeEditorSelectedRange,
 );
 
-export const getisNativeQueryFixApplied = createSelector(
+export const getisSqlQueryFixApplied = createSelector(
   [getUiControls],
-  uiControls => uiControls && uiControls.isNativeQueryFixApplied,
+  uiControls => uiControls && uiControls.isSqlQueryFixApplied,
 );
 
 export const getIsTimeseries = createSelector(


### PR DESCRIPTION
Demo https://www.loom.com/share/72bad6b7eee94cc3a3f0a623393c8958

Highlights affected lines in the native query editor:
- When hovering over the button to fix the query
- After the fix is applied

Highlighting is removed either when:
- Any change is done to the query
- Query is run

How to verify:
- You need to have `ai-service` running locally. It's a separate repo with a README how to setup things.
- Run `yarn dev-ee`
- Run a SQL query with a typo