### PR TITLE
update enable-embedding-sdk based on embedding-app-origins-sdk

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10469,6 +10469,24 @@ databaseChangeLog:
                   type: ${timestamp_type}
                   remarks: The timestamp at which a user was deactivated
 
+  - changeSet:
+      id: v53.2025-01-05T00:00:01
+      author: escherize
+      comment: update enable-embedding-sdk with (exists? embedding-app-origins-sdk)
+      preConditions:
+        - onFail: MARK_RAN
+      rollback: # not needed
+      changes:
+        - sql: >
+            UPDATE setting
+            SET value = 'true'
+            WHERE key = 'enable-embedding-sdk'
+            AND EXISTS (
+                  SELECT 1
+                  FROM setting
+                  WHERE key = 'embedding-app-origins-sdk'
+            )
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10475,30 +10475,40 @@ databaseChangeLog:
       comment: set enable-embedding-sdk false when embedding-app-origins-sdk value exists
       preConditions:
         - onFail: MARK_RAN
-      rollback: # not needed
+        - or:
+            - and:
+                - dbms:
+                    type: postgresql
+                - sqlCheck:
+                    expectedResult: 0
+                    sql: SELECT count(*) FROM setting WHERE key = 'embedding-app-origins-sdk';
+            - and:
+                - dbms:
+                    type: mysql,mariadb
+                - sqlCheck:
+                    expectedResult: 0
+                    sql: SELECT count(*) FROM setting WHERE `key` = 'embedding-app-origins-sdk';
+            - and:
+                - dbms:
+                    type: h2
+                - sqlCheck:
+                    expectedResult: 0
+                    sql: SELECT count(*) FROM setting WHERE "KEY" = 'embedding-app-origins-sdk';
+
       changes:
         - sql:
-            sql: >-
-              UPDATE setting
-              SET value = 'false'
-              WHERE key = 'enable-embedding-sdk'
-              AND 'embedding-app-origins-sdk' NOT IN (SELECT key FROM setting);
             dbms: postgresql
-        - sql:
             sql: >-
-              UPDATE setting
-              SET `value` = 'false'
-              WHERE `key` = 'enable-embedding-sdk'
-              AND 'embedding-app-origins-sdk' NOT IN (SELECT `key` FROM setting);
+              update setting set value = 'false' where key = 'enable-embedding-sdk';
+        - sql:
             dbms: mysql,mariadb
-        - sql:
             sql: >-
-              UPDATE setting
-              SET "VALUE" = 'false'
-              WHERE "KEY" = 'enable-embedding-sdk'
-              AND 'embedding-app-origins-sdk' NOT IN (SELECT "KEY" FROM setting);
+              UPDATE setting set `value` = 'false' where `key` = 'enable-embedding-sdk';
+        - sql:
             dbms: h2
-
+            sql: >-
+              UPDATE setting set "VALUE" = 'false' where "KEY" = 'enable-embedding-sdk';
+      rollback: # not needed
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10477,14 +10477,14 @@ databaseChangeLog:
         - onFail: MARK_RAN
       rollback: # not needed
       changes:
-        - sql: >
+        - sql: >-
             UPDATE setting
             SET value = 'false'
             WHERE key = 'enable-embedding-sdk'
             AND NOT EXISTS (
-                  SELECT 1
-                  FROM setting
-                  WHERE key = 'embedding-app-origins-sdk'
+              SELECT 1
+              FROM setting
+              WHERE key = 'embedding-app-origins-sdk'
             );
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10479,13 +10479,13 @@ databaseChangeLog:
       changes:
         - sql: >
             UPDATE setting
-            SET value = 'true'
+            SET value = 'false'
             WHERE key = 'enable-embedding-sdk'
-            AND EXISTS (
+            AND NOT EXISTS (
                   SELECT 1
                   FROM setting
                   WHERE key = 'embedding-app-origins-sdk'
-            )
+            );
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10481,11 +10481,7 @@ databaseChangeLog:
             UPDATE setting
             SET value = 'false'
             WHERE key = 'enable-embedding-sdk'
-            AND NOT EXISTS (
-              SELECT 1
-              FROM setting
-              WHERE key = 'embedding-app-origins-sdk'
-            );
+            AND 'embedding-app-origins-sdk' NOT IN (SELECT key FROM setting);
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10472,16 +10472,33 @@ databaseChangeLog:
   - changeSet:
       id: v53.2025-01-05T00:00:01
       author: escherize
-      comment: update enable-embedding-sdk with (exists? embedding-app-origins-sdk)
+      comment: set enable-embedding-sdk false when embedding-app-origins-sdk value exists
       preConditions:
         - onFail: MARK_RAN
       rollback: # not needed
       changes:
-        - sql: >-
-            UPDATE setting
-            SET value = 'false'
-            WHERE key = 'enable-embedding-sdk'
-            AND 'embedding-app-origins-sdk' NOT IN (SELECT key FROM setting);
+        - sql:
+            sql: >-
+              UPDATE setting
+              SET value = 'false'
+              WHERE key = 'enable-embedding-sdk'
+              AND 'embedding-app-origins-sdk' NOT IN (SELECT key FROM setting);
+            dbms: postgresql
+        - sql:
+            sql: >-
+              UPDATE setting
+              SET `value` = 'false'
+              WHERE `key` = 'enable-embedding-sdk'
+              AND 'embedding-app-origins-sdk' NOT IN (SELECT `key` FROM setting);
+            dbms: mysql,mariadb
+        - sql:
+            sql: >-
+              UPDATE setting
+              SET "VALUE" = 'false'
+              WHERE "KEY" = 'enable-embedding-sdk'
+              AND 'embedding-app-origins-sdk' NOT IN (SELECT "KEY" FROM setting);
+            dbms: h2
+
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 


### PR DESCRIPTION
resolves https://github.com/metabase/metabase/issues/53247

This will update existing enable-embedding-sdk settings in the following way:

```
|enable-embedding-sdk key exists? | then we:
|---------------------------------|---------
|false                            | no-op
|true                             | set enable-embedding-sdk to false when `embedding-app-origins-sdk` is not there
```

Said differently, if the `enable-embedding-sdk` is present and `embedding-app-origins-sdk` is not present on the setting table, then set `enable-embedding-sdk` to false.