### PR TITLE
Hash id in core_session table

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -512,10 +512,13 @@
           metabase.server.middleware.json
           metabase.server.middleware.session
           metabase.server.streaming-response}
-   :uses #{analytics api config core db driver models premium-features public-settings request util enterprise/sso}}
+   :uses #{analytics api config core db driver models premium-features public-settings session request util enterprise/sso}}
 
   session
-  {:api  #{metabase.session.api metabase.session.init metabase.session.models.session}
+  {:api  #{metabase.session.core
+           metabase.session.api
+           metabase.session.init
+           metabase.session.models.session}
    :uses #{api channel config db driver events login-history models public-settings request sso task util}}
 
   setup

--- a/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
@@ -75,12 +75,12 @@
           (t2/query-one {:select [:u.email :u.sso_source]
                          :from   [[:core_user :u]]
                          :join   [[:core_session :session] [:= :u.id :session.user_id]]
-                         :where  [:or [:= metabase-session-key-hashed :key_hashed] [:= metabase-session-key :id]]})]
+                         :where  [:or [:= :key_hashed metabase-session-key-hashed] [:= :session.id metabase-session-key]]})]
       ;; If a user doesn't have SLO setup on their IdP,
       ;; they will never hit "/handle_slo" so we must delete the session here:
       ;; NOTE: Only safe to compare the plaintext session-key to core_session.id because of the call to `validate-session-key` above
       (let [deleted-rows (when-not (sso-settings/saml-slo-enabled)
-        (t2/delete! :model/Session {:where [:or [:= metabase-session-key-hashed :key_hashed] [:= metabase-session-key :id]]})]
+        (t2/delete! :model/Session {:where [:or [:= :key_hashed metabase-session-key-hashed] [:= :id metabase-session-key]]})]
         (api/check-404 (> deleted-rows 0))))
       {:saml-logout-url
        (when (and (sso-settings/saml-slo-enabled)

--- a/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
@@ -8,7 +8,6 @@
    [metabase-enterprise.sso.integrations.jwt]
    [metabase-enterprise.sso.integrations.saml]
    [metabase-enterprise.sso.integrations.sso-settings :as sso-settings]
-   [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.request.core :as request]
    [metabase.session.core :as session]

--- a/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
@@ -78,14 +78,13 @@
     ;; If a user doesn't have SLO setup on their IdP,
     ;; they will never hit "/handle_slo" so we must delete the session here:
     ;; NOTE: Only safe to compare the plaintext session-key to core_session.id because of the call to `validate-session-key` above
-    (let [deleted-rows (when-not (sso-settings/saml-slo-enabled)
-        (t2/delete! :model/Session {:where [:or [:= :key_hashed metabase-session-key-hashed] [:= :id metabase-session-key]]})]
-      (api/check-404 (> deleted-rows 0))))
+    (when-not (sso-settings/saml-slo-enabled)
+      (t2/delete! :model/Session {:where [:or [:= :key_hashed metabase-session-key-hashed] [:= :id metabase-session-key]]}))
     {:saml-logout-url
      (when (and (sso-settings/saml-slo-enabled)
                 (= sso_source "saml"))
        (saml/logout-redirect-location
-          :credential (metabase-enterprise.sso.integrations.saml/sp-cert-keystore-details)
+        :credential (metabase-enterprise.sso.integrations.saml/sp-cert-keystore-details)
         :idp-url (sso-settings/saml-identity-provider-slo-uri)
         :issuer (sso-settings/saml-application-name)
         :user-email email

--- a/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
@@ -75,7 +75,7 @@
           (t2/query-one {:select [:u.email :u.sso_source]
                          :from   [[:core_user :u]]
                          :join   [[:core_session :session] [:= :u.id :session.user_id]]
-                         :where  [:= :session.id metabase-session-key]})]
+                         :where  [:or [:= metabase-session-key-hashed :key_hashed] [:= metabase-session-key :id]]})]
       ;; If a user doesn't have SLO setup on their IdP,
       ;; they will never hit "/handle_slo" so we must delete the session here:
       ;; NOTE: Only safe to compare the plaintext session-key to core_session.id because of the call to `validate-session-key` above

--- a/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
@@ -10,9 +10,9 @@
    [metabase-enterprise.sso.integrations.sso-settings :as sso-settings]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
-   [metabase.models.session :as session]
    [metabase.request.core :as request]
    [metabase.util :as u]
+   [metabase.util.encryption :as encryption]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.urls :as urls]
@@ -69,7 +69,7 @@
   "Logout."
   [_route-params _query-params _body {cookies :cookies, :as _request}]
   (let [metabase-session-key (get-in cookies [request/metabase-session-cookie :value])
-        metabase-session-key-hashed (session/hash-session-key metabase-session-key)]
+        metabase-session-key-hashed (encryption/hash-session-key metabase-session-key)]
     (let [{:keys [email sso_source]}
           (t2/query-one {:select [:u.email :u.sso_source]
                          :from   [[:core_user :u]]

--- a/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
@@ -70,7 +70,6 @@
   [_route-params _query-params _body {cookies :cookies, :as _request}]
   (let [metabase-session-key (get-in cookies [request/metabase-session-cookie :value])
         metabase-session-key-hashed (session/hash-session-key metabase-session-key)]
-    (api/validate-session-key metabase-session-key)
     (let [{:keys [email sso_source]}
           (t2/query-one {:select [:u.email :u.sso_source]
                          :from   [[:core_user :u]]

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -131,7 +131,7 @@
                :status-code 402}))
     (response/response
      {:status :ok
-      :id     (:id session)
+      :id     (:key session)
       :exp    (:exp jwt-data)
       :iat    (:iat jwt-data)})))
 

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -42,6 +42,7 @@
    [metabase.session.models.session :as session]
    [metabase.sso.core :as sso]
    [metabase.util :as u]
+   [metabase.util.encryption :as encryption]
    [metabase.util.i18n :refer [trs tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -240,7 +241,7 @@
                                           :response-validators [:signature :require-authenticated :issuer]})]
       (if-let [metabase-session-key (and (saml/logout-success? response)(get-in cookies [request/metabase-session-cookie :value]))]
         (do
-          (t2/delete! :model/Session {:where [:or [:= (session/hash-session-key metabase-session-key) :key_hashed] [:= metabase-session-key :id]]})
+          (t2/delete! :model/Session {:where [:or [:= (encryption/hash-session-key metabase-session-key) :key_hashed] [:= metabase-session-key :id]]})
           (request/clear-session-cookie (response/redirect (urls/site-url))))
         {:status 500 :body "SAML logout failed."}))
     (log/warn "SAML SLO is not enabled, not continuing Single Log Out flow.")))

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -238,7 +238,7 @@
                                          {:idp-cert idp-cert
                                           :issuer (sso-settings/saml-identity-provider-issuer)
                                           :response-validators [:signature :require-authenticated :issuer]})]
-      (if-let [metabase-session-key (and (saml/logout-success? response)(get-in cookies [request/metabase-session-cookie :value]))]
+      (if-let [metabase-session-key (and (saml/logout-success? response) (get-in cookies [request/metabase-session-cookie :value]))]
         (do
           (t2/delete! :model/Session {:where [:or [:= (session/hash-session-key metabase-session-key) :key_hashed] [:= metabase-session-key :id]]})
           (request/clear-session-cookie (response/redirect (urls/site-url))))

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -39,10 +39,9 @@
    [metabase.premium-features.core :as premium-features]
    [metabase.public-settings :as public-settings]
    [metabase.request.core :as request]
-   [metabase.session.models.session :as session]
+   [metabase.session.core :as session]
    [metabase.sso.core :as sso]
    [metabase.util :as u]
-   [metabase.util.encryption :as encryption]
    [metabase.util.i18n :refer [trs tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -241,7 +240,7 @@
                                           :response-validators [:signature :require-authenticated :issuer]})]
       (if-let [metabase-session-key (and (saml/logout-success? response)(get-in cookies [request/metabase-session-cookie :value]))]
         (do
-          (t2/delete! :model/Session {:where [:or [:= (encryption/hash-session-key metabase-session-key) :key_hashed] [:= metabase-session-key :id]]})
+          (t2/delete! :model/Session {:where [:or [:= (session/hash-session-key metabase-session-key) :key_hashed] [:= metabase-session-key :id]]})
           (request/clear-session-cookie (response/redirect (urls/site-url))))
         {:status 500 :body "SAML logout failed."}))
     (log/warn "SAML SLO is not enabled, not continuing Single Log Out flow.")))

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -78,7 +78,7 @@
                                    (group-names->ids group-names)
                                    (all-mapped-group-ids)))))
 
-(mu/defn- fetch-or-create-user! :- [:maybe [:map [:id ms/UUIDString]]]
+(mu/defn- fetch-or-create-user! :- [:maybe [:map [:key ms/UUIDString]]]
   "Returns a Session for the given `email`. Will create the user if needed."
   [{:keys [first-name last-name email group-names user-attributes device-info]}]
   (when-not (sso-settings/saml-enabled)

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -238,10 +238,11 @@
                                          {:idp-cert idp-cert
                                           :issuer (sso-settings/saml-identity-provider-issuer)
                                           :response-validators [:signature :require-authenticated :issuer]})]
-      (if-let [metabase-session-id (and (saml/logout-success? response)
-                                        (get-in cookies [request/metabase-session-cookie :value]))]
+      (if-let [metabase-session-key (and (saml/logout-success? response)(get-in cookies [request/metabase-session-cookie :value]))]
         (do
-          (t2/delete! :model/Session :id (session/hash-session-id metabase-session-id))
+          (api/validate-session-key metabase-session-key)
+          ;; NOTE: Only safe to compare the plaintext session-key to core_session.id because of the call to `validate-session-key` above
+          (t2/delete! :model/Session {:where [:or [:= (session/hash-session-key metabase-session-key) :key_hashed] [:= metabase-session-key :id]]})
           (request/clear-session-cookie (response/redirect (urls/site-url))))
         {:status 500 :body "SAML logout failed."}))
     (log/warn "SAML SLO is not enabled, not continuing Single Log Out flow.")))

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -240,8 +240,6 @@
                                           :response-validators [:signature :require-authenticated :issuer]})]
       (if-let [metabase-session-key (and (saml/logout-success? response)(get-in cookies [request/metabase-session-cookie :value]))]
         (do
-          (api/validate-session-key metabase-session-key)
-          ;; NOTE: Only safe to compare the plaintext session-key to core_session.id because of the call to `validate-session-key` above
           (t2/delete! :model/Session {:where [:or [:= (session/hash-session-key metabase-session-key) :key_hashed] [:= metabase-session-key :id]]})
           (request/clear-session-cookie (response/redirect (urls/site-url))))
         {:status 500 :body "SAML logout failed."}))

--- a/enterprise/backend/test/metabase_enterprise/sso/api/sso_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/api/sso_test.clj
@@ -3,7 +3,9 @@
    [clojure.test :refer :all]
    [metabase.http-client :as client]
    [metabase.request.core :as request]
-   [metabase.test :as mt]))
+   [metabase.session.core :as session]
+   [metabase.test :as mt]
+   [metabase.util.string :as string]))
 
 (deftest saml-logout
   (testing "with slo enabled and configured"
@@ -21,7 +23,7 @@
           (with-redefs [random-uuid (constantly "66d96ab4-9834-40db-a3cd-42b361503ab9")]
             (binding [client/*url-prefix* ""]
               (mt/with-temp [:model/User user {:email "saml_test@metabase.com" :sso_source "saml"}
-                             :model/Session {session-id :id} {:user_id (:id user) :id (str (random-uuid))}]
+                             :model/Session {session-id :id} {:user_id (:id user) :id (session/generate-session-id) :key_hashed (session/hash-session-key (session/generate-session-key))}]
                 (let [req-options (assoc-in {} [:request-options :cookies request/metabase-session-cookie :value] session-id)]
                   (testing "logout is redirected to idp"
                     (let [response  (client/client :post "/auth/sso/logout" req-options)]

--- a/enterprise/backend/test/metabase_enterprise/sso/api/sso_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/api/sso_test.clj
@@ -4,8 +4,7 @@
    [metabase.http-client :as client]
    [metabase.request.core :as request]
    [metabase.session.core :as session]
-   [metabase.test :as mt]
-   [metabase.util.string :as string]))
+   [metabase.test :as mt]))
 
 (deftest saml-logout
   (testing "with slo enabled and configured"

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -460,7 +460,7 @@
                                                         :jwt   jwt-payload)]
           (is
            (=?
-            {:id  (mt/malli=? ms/NonBlankString)
+            {:id  (mt/malli=? ms/UUIDString)
              :iat jwt-iat-time
              :exp jwt-exp-time}
             (:body result)))))))

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -14,6 +14,7 @@
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
+   [metabase.util.encryption :as encryption]
    [ring.util.codec :as codec]
    [saml20-clj.core :as saml]
    [toucan2.core :as t2])
@@ -727,7 +728,7 @@
   (testing "Successful SAML SLO logouts should delete the user's session, when saml-slo-enabled."
     (with-other-sso-types-disabled!
       (let [session-key (session/generate-session-key)
-              session-key-hashed (session/hash-session-key session-key)]
+              session-key-hashed (encryption/hash-session-key session-key)]
           (mt/with-temp [:model/User user {:email "saml_test@metabase.com" :sso_source "saml"}
                          :model/Session _ {:user_id (:id user) :id (session/generate-session-id) :key_hashed session-key-hashed}]
           (with-saml-default-setup!
@@ -751,7 +752,7 @@
     (with-other-sso-types-disabled!
       (mt/with-temporary-setting-values [saml-slo-enabled false]
         (let [session-key (session/generate-session-key)
-              session-key-hashed (session/hash-session-key session-key)]
+              session-key-hashed (encryption/hash-session-key session-key)]
           (mt/with-temp [:model/User user {:email "saml_test@metabase.com" :sso_source "saml"}
                          :model/Session _ {:user_id (:id user) :id (session/generate-session-id) :key_hashed session-key-hashed}]
             (with-saml-default-setup!
@@ -772,7 +773,7 @@
     (with-other-sso-types-disabled!
       (mt/with-temporary-setting-values [saml-slo-enabled false]
         (let [session-key (session/generate-session-key)
-            session-key-hashed (session/hash-session-key session-key)]
+            session-key-hashed (encryption/hash-session-key session-key)]
         (mt/with-temp [:model/User user {:email "saml_test@metabase.com" :sso_source "saml"}
                        :model/Session _ {:user_id (:id user) :id (session/generate-session-id) :key_hashed session-key-hashed}]
             (is (t2/exists? :model/Session :key_hashed session-key-hashed))

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -727,9 +727,9 @@
   (testing "Successful SAML SLO logouts should delete the user's session, when saml-slo-enabled."
     (with-other-sso-types-disabled!
       (let [session-key (session/generate-session-key)
-              session-key-hashed (session/hash-session-key session-key)]
-          (mt/with-temp [:model/User user {:email "saml_test@metabase.com" :sso_source "saml"}
-                         :model/Session _ {:user_id (:id user) :id (session/generate-session-id) :key_hashed session-key-hashed}]
+            session-key-hashed (session/hash-session-key session-key)]
+        (mt/with-temp [:model/User user {:email "saml_test@metabase.com" :sso_source "saml"}
+                       :model/Session _ {:user_id (:id user) :id (session/generate-session-id) :key_hashed session-key-hashed}]
           (with-saml-default-setup!
             (mt/with-temporary-setting-values [saml-slo-enabled true
                                                saml-identity-provider-issuer "http://localhost:9090/realms/master"
@@ -772,9 +772,9 @@
     (with-other-sso-types-disabled!
       (mt/with-temporary-setting-values [saml-slo-enabled false]
         (let [session-key (session/generate-session-key)
-            session-key-hashed (session/hash-session-key session-key)]
-        (mt/with-temp [:model/User user {:email "saml_test@metabase.com" :sso_source "saml"}
-                       :model/Session _ {:user_id (:id user) :id (session/generate-session-id) :key_hashed session-key-hashed}]
+              session-key-hashed (session/hash-session-key session-key)]
+          (mt/with-temp [:model/User user {:email "saml_test@metabase.com" :sso_source "saml"}
+                         :model/Session _ {:user_id (:id user) :id (session/generate-session-id) :key_hashed session-key-hashed}]
             (is (t2/exists? :model/Session :key_hashed session-key-hashed))
             (let [req-options (assoc-in {} [:request-options :cookies request/metabase-session-cookie :value] session-key)]
               (client/client :post "/auth/sso/logout" req-options)

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -726,56 +726,56 @@
 (deftest logout-should-delete-session-test-slo-enabled
   (testing "Successful SAML SLO logouts should delete the user's session, when saml-slo-enabled."
     (with-other-sso-types-disabled!
-      (let [session-id (str (random-uuid))
-              session-id-hashed (session/hash-session-id session-id)]
+      (let [session-key (session/generate-session-key)
+              session-key-hashed (session/hash-session-key session-key)]
           (mt/with-temp [:model/User user {:email "saml_test@metabase.com" :sso_source "saml"}
-                         :model/Session _ {:user_id (:id user) :id session-id-hashed}]
+                         :model/Session _ {:user_id (:id user) :id (session/generate-session-id) :key_hashed session-key-hashed}]
           (with-saml-default-setup!
             (mt/with-temporary-setting-values [saml-slo-enabled true
                                                saml-identity-provider-issuer "http://localhost:9090/realms/master"
                                                saml-identity-provider-certificate slo-idp-cert]
-              (is (t2/exists? :model/Session :id session-id-hashed))
+              (is (t2/exists? :model/Session :key_hashed session-key-hashed))
               (let [req-options (-> (saml-post-request-options
                                      (saml-slo-test-response)
                                      default-redirect-uri)
                               ;; Client sends their session cookie during the SLO request redirect from the IDP.
-                                    (assoc-in [:request-options :cookies request/metabase-session-cookie :value] session-id))
+                                    (assoc-in [:request-options :cookies request/metabase-session-cookie :value] session-key))
                     response    (client/client-real-response :post 302 "/auth/sso/handle_slo" req-options)]
                 (is (str/blank? (get-in response [:cookies request/metabase-session-cookie :value]))
                     "After a successful log-out, you don't have a session")
-                (is (not (t2/exists? :model/Session :id session-id-hashed))
+                (is (not (t2/exists? :model/Session :key_hashed session-key-hashed))
                     "After a successful log-out, the session is deleted")))))))))
 
 (deftest logout-should-delete-session-test-slo-disabled
   (testing "Successful SAML SLO logouts should not delete the user's session, when not saml-slo-enabled."
     (with-other-sso-types-disabled!
       (mt/with-temporary-setting-values [saml-slo-enabled false]
-        (let [session-id (str (random-uuid))
-              session-id-hashed (session/hash-session-id session-id)]
+        (let [session-key (session/generate-session-key)
+              session-key-hashed (session/hash-session-key session-key)]
           (mt/with-temp [:model/User user {:email "saml_test@metabase.com" :sso_source "saml"}
-                         :model/Session _ {:user_id (:id user) :id session-id-hashed}]
+                         :model/Session _ {:user_id (:id user) :id (session/generate-session-id) :key_hashed session-key-hashed}]
             (with-saml-default-setup!
-              (is (t2/exists? :model/Session :id session-id-hashed))
+              (is (t2/exists? :model/Session :key_hashed session-key-hashed))
               (let [req-options (-> (saml-post-request-options
                                      (saml-slo-test-response)
                                      default-redirect-uri)
                                   ;; Client sends their session cookie during the SLO request redirect from the IDP.
-                                    (assoc-in [:request-options :cookies request/metabase-session-cookie :value] session-id))
+                                    (assoc-in [:request-options :cookies request/metabase-session-cookie :value] session-key))
                     response    (client/client-real-response :post 403 "/auth/sso/handle_slo" req-options)]
                 (is (str/blank? (get-in response [:cookies request/metabase-session-cookie :value]))
                     "After a successful log-out, you don't have a session")
-                (is (t2/exists? :model/Session :id session-id-hashed)
+                (is (t2/exists? :model/Session :key_hashed session-key-hashed)
                     "After a successful log-out, the session is deleted")))))))))
 
 (deftest logout-should-delete-session-when-idp-slo-conf-missing-test
   (testing "Missing SAML SLO config logouts should still delete the user's session."
     (with-other-sso-types-disabled!
       (mt/with-temporary-setting-values [saml-slo-enabled false]
-        (let [session-id (str (random-uuid))
-            session-id-hashed (session/hash-session-id session-id)]
+        (let [session-key (session/generate-session-key)
+            session-key-hashed (session/hash-session-key session-key)]
         (mt/with-temp [:model/User user {:email "saml_test@metabase.com" :sso_source "saml"}
-                       :model/Session _ {:user_id (:id user) :id session-id-hashed}]
-            (is (t2/exists? :model/Session :id session-id-hashed))
-            (let [req-options (assoc-in {} [:request-options :cookies request/metabase-session-cookie :value] session-id)]
+                       :model/Session _ {:user_id (:id user) :id (session/generate-session-id) :key_hashed session-key-hashed}]
+            (is (t2/exists? :model/Session :key_hashed session-key-hashed))
+            (let [req-options (assoc-in {} [:request-options :cookies request/metabase-session-cookie :value] session-key)]
               (client/client :post "/auth/sso/logout" req-options)
-              (is (not (t2/exists? :model/Session :id session-id-hashed))))))))))
+              (is (not (t2/exists? :model/Session :key_hashed session-key-hashed))))))))))

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -6,15 +6,14 @@
    [metabase-enterprise.sso.integrations.saml :as saml.mt]
    [metabase-enterprise.sso.integrations.sso-settings :as sso-settings]
    [metabase.http-client :as client]
-   [metabase.models.session :as session]
    [metabase.premium-features.token-check :as token-check]
    [metabase.public-settings :as public-settings]
    [metabase.request.core :as request]
+   [metabase.session.core :as session]
    [metabase.sso.init]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
-   [metabase.util.encryption :as encryption]
    [ring.util.codec :as codec]
    [saml20-clj.core :as saml]
    [toucan2.core :as t2])
@@ -728,7 +727,7 @@
   (testing "Successful SAML SLO logouts should delete the user's session, when saml-slo-enabled."
     (with-other-sso-types-disabled!
       (let [session-key (session/generate-session-key)
-              session-key-hashed (encryption/hash-session-key session-key)]
+              session-key-hashed (session/hash-session-key session-key)]
           (mt/with-temp [:model/User user {:email "saml_test@metabase.com" :sso_source "saml"}
                          :model/Session _ {:user_id (:id user) :id (session/generate-session-id) :key_hashed session-key-hashed}]
           (with-saml-default-setup!
@@ -752,7 +751,7 @@
     (with-other-sso-types-disabled!
       (mt/with-temporary-setting-values [saml-slo-enabled false]
         (let [session-key (session/generate-session-key)
-              session-key-hashed (encryption/hash-session-key session-key)]
+              session-key-hashed (session/hash-session-key session-key)]
           (mt/with-temp [:model/User user {:email "saml_test@metabase.com" :sso_source "saml"}
                          :model/Session _ {:user_id (:id user) :id (session/generate-session-id) :key_hashed session-key-hashed}]
             (with-saml-default-setup!
@@ -773,7 +772,7 @@
     (with-other-sso-types-disabled!
       (mt/with-temporary-setting-values [saml-slo-enabled false]
         (let [session-key (session/generate-session-key)
-            session-key-hashed (encryption/hash-session-key session-key)]
+            session-key-hashed (session/hash-session-key session-key)]
         (mt/with-temp [:model/User user {:email "saml_test@metabase.com" :sso_source "saml"}
                        :model/Session _ {:user_id (:id user) :id (session/generate-session-id) :key_hashed session-key-hashed}]
             (is (t2/exists? :model/Session :key_hashed session-key-hashed))

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10532,6 +10532,8 @@ databaseChangeLog:
 
   - changeSet:
       id: v53.2025-02-21T20:43:40
+  - changeSet:
+      id: v52.2025-02-05T20:43:40
       author: nvoxland
       comment: Delete everything from the core_session table because checks are now assuming a hashed session id
       changes:
@@ -10540,6 +10542,7 @@ databaseChangeLog:
       rollback:
         - delete:
             tableName: core_session
+
 
   - changeSet:
       id: v54.2025-01-30T16:10:55

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10530,35 +10530,6 @@ databaseChangeLog:
             );
       rollback: # not needed, these are created on startup using deserialization
 
-  - changeSet:
-      id: v53.2025-02-21T20:43:40
-      author: nvoxland
-      comment: Replacing storing the session key in the "id" column in favor of storing a new hashed version
-      preConditions:
-      changes:
-        - addColumn:
-            tableName: core_session
-            columns:
-              - column:
-                  name: key_hashed
-                  type: varchar(254)
-                  value: "upgrade placeholder"
-                  remarks: Hashed version of the session key
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v53.2025-02-21T21:21:04
-      author: nvoxland
-      comment: Creating index on the hashed session key
-      preConditions:
-      changes:
-        - createIndex:
-            tableName: core_session
-            columns:
-              - column:
-                  name: key_hashed
-            indexName: idx_core_session_key_hashed
 
   - changeSet:
       id: v54.2025-01-30T16:10:55
@@ -10832,6 +10803,36 @@ databaseChangeLog:
             dbms: h2
             path: instance_analytics_views/alerts/v1/h2-alerts.sql
             relativeToChangelogFile: true
+
+  - changeSet:
+      id: v54.2025-03-06T16:55:15
+      author: nvoxland
+      comment: Replacing storing the session key in the "id" column in favor of storing a new hashed version
+      preConditions:
+      changes:
+        - addColumn:
+            tableName: core_session
+            columns:
+              - column:
+                  name: key_hashed
+                  type: varchar(254)
+                  value: "upgrade placeholder"
+                  remarks: Hashed version of the session key
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v54.2025-03-06T16:55:16
+      author: nvoxland
+      comment: Creating index on the hashed session key
+      preConditions:
+      changes:
+        - createIndex:
+            tableName: core_session
+            columns:
+              - column:
+                  name: key_hashed
+            indexName: idx_core_session_key_hashed
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10531,7 +10531,7 @@ databaseChangeLog:
       rollback: # not needed, these are created on startup using deserialization
 
   - changeSet:
-      id: v53.2025-02-05T20:43:40
+      id: v53.2025-02-21T20:43:40
       author: nvoxland
       comment: Replacing storing the session key in the "id" column in favor of storing a new hashed version
       preConditions:
@@ -10548,7 +10548,7 @@ databaseChangeLog:
                     nullable: false
 
   - changeSet:
-      id: v53.2025-02-10T15:21:04
+      id: v53.2025-02-21T15:21:04
       author: nvoxland
       comment: Creating index on the hashed session key
       preConditions:

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10548,7 +10548,7 @@ databaseChangeLog:
                     nullable: false
 
   - changeSet:
-      id: v53.2025-02-21T15:21:04
+      id: v53.2025-02-21T21:21:04
       author: nvoxland
       comment: Creating index on the hashed session key
       preConditions:

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10530,6 +10530,16 @@ databaseChangeLog:
             );
       rollback: # not needed, these are created on startup using deserialization
 
+  - changeSet:
+      id: v53.2025-02-21T20:43:40
+      author: nvoxland
+      comment: Delete everything from the core_session table because checks are now assuming a hashed session id
+      changes:
+        - delete:
+            tableName: core_session
+      rollback:
+        - delete:
+            tableName: core_session
 
   - changeSet:
       id: v54.2025-01-30T16:10:55

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10532,17 +10532,18 @@ databaseChangeLog:
 
   - changeSet:
       id: v53.2025-02-21T20:43:40
-  - changeSet:
-      id: v52.2025-02-05T20:43:40
       author: nvoxland
-      comment: Delete everything from the core_session table because checks are now assuming a hashed session id
+      preConditions:
       changes:
-        - delete:
+        - addColumn:
             tableName: core_session
-      rollback:
-        - delete:
-            tableName: core_session
-
+            columns:
+              - column:
+                  name: key_hashed
+                  type: varchar(254)
+                  value: "upgrade placeholder"
+                  constraints:
+                    nullable: false
 
   - changeSet:
       id: v54.2025-01-30T16:10:55

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10533,6 +10533,7 @@ databaseChangeLog:
   - changeSet:
       id: v53.2025-02-21T20:43:40
       author: nvoxland
+      comment: Replacing storing the session key in the "id" column in favor of storing a new hashed version
       preConditions:
       changes:
         - addColumn:
@@ -10542,6 +10543,7 @@ databaseChangeLog:
                   name: key_hashed
                   type: varchar(254)
                   value: "upgrade placeholder"
+                  remarks: Hashed version of the session key
                   constraints:
                     nullable: false
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10531,7 +10531,7 @@ databaseChangeLog:
       rollback: # not needed, these are created on startup using deserialization
 
   - changeSet:
-      id: v53.2025-02-21T20:43:40
+      id: v53.2025-02-05T20:43:40
       author: nvoxland
       comment: Replacing storing the session key in the "id" column in favor of storing a new hashed version
       preConditions:
@@ -10546,6 +10546,19 @@ databaseChangeLog:
                   remarks: Hashed version of the session key
                   constraints:
                     nullable: false
+
+  - changeSet:
+      id: v53.2025-02-10T15:21:04
+      author: nvoxland
+      comment: Creating index on the hashed session key
+      preConditions:
+      changes:
+        - createIndex:
+            tableName: core_session
+            columns:
+              - column:
+                  name: key_hashed
+            indexName: idx_core_session_key_hashed
 
   - changeSet:
       id: v54.2025-01-30T16:10:55
@@ -10819,19 +10832,6 @@ databaseChangeLog:
             dbms: h2
             path: instance_analytics_views/alerts/v1/h2-alerts.sql
             relativeToChangelogFile: true
-
-  - changeSet:
-      id: v53.2025-02-10T15:21:04
-      author: nvoxland
-      comment: Creating index on the hashed session key
-      preConditions:
-      changes:
-        - createIndex:
-            tableName: core_session
-            columns:
-              - column:
-                  name: key_hashed
-            indexName: idx_core_session_key_hashed
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10820,6 +10820,19 @@ databaseChangeLog:
             path: instance_analytics_views/alerts/v1/h2-alerts.sql
             relativeToChangelogFile: true
 
+  - changeSet:
+      id: v53.2025-02-10T15:21:04
+      author: nvoxland
+      comment: Creating index on the hashed session key
+      preConditions:
+      changes:
+        - createIndex:
+            tableName: core_session
+            columns:
+              - column:
+                  name: key_hashed
+            indexName: idx_core_session_key_hashed
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -86,6 +86,7 @@
    [metabase.util.i18n :as i18n :refer [deferred-tru tru]]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
+   [metabase.util.string :as string]
    [potemkin :as p]
    [toucan2.core :as t2]))
 
@@ -202,6 +203,14 @@
   [tst field-name message]
   (when-not tst
     (throw-invalid-param-exception (str field-name) message)))
+
+(defn validate-session-key
+  "Validates that the given session-key looks like it could be a session id. Returns a 403 if it does not.
+
+  SECURITY NOTE: This needs to be called in any function that will directly compare the session-key against the core_session.id table for backwards-compatibility reasons
+  If this is NOT called before queries against core_session.id, attackers with access to the database can impersonate users by passing the core_session.id as their session cookie"
+  [session-key]
+  (check-403 (string/valid-uuid? session-key)))
 
 ;;; ---------------------------------------------- api-let, api->, etc. ----------------------------------------------
 

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -86,7 +86,6 @@
    [metabase.util.i18n :as i18n :refer [deferred-tru tru]]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
-   [metabase.util.string :as string]
    [potemkin :as p]
    [toucan2.core :as t2]))
 
@@ -203,14 +202,6 @@
   [tst field-name message]
   (when-not tst
     (throw-invalid-param-exception (str field-name) message)))
-
-(defn validate-session-key
-  "Validates that the given session-key looks like it could be a session id. Returns a 403 if it does not.
-
-  SECURITY NOTE: This needs to be called in any function that will directly compare the session-key against the core_session.id table for backwards-compatibility reasons
-  If this is NOT called before queries against core_session.id, attackers with access to the database can impersonate users by passing the core_session.id as their session cookie"
-  [session-key]
-  (check-403 (string/valid-uuid? session-key)))
 
 ;;; ---------------------------------------------- api-let, api->, etc. ----------------------------------------------
 

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -530,9 +530,9 @@
     (user/set-password! id password)
     ;; after a successful password update go ahead and offer the client a new session that they can use
     (when (= id api/*current-user-id*)
-      (let [{session-uuid :id, :as session} (session/create-session! :password user (request/device-info request))
+      (let [{session-key :key, :as session} (session/create-session! :password user (request/device-info request))
             response                        {:success    true
-                                             :session_id (str session-uuid)}]
+                                             :session_id (str session-key)}]
         (request/set-session-cookies request response session (t/zoned-date-time (t/zone-id "GMT")))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/login_history/models/login_history.clj
+++ b/src/metabase/login_history/models/login_history.clj
@@ -45,11 +45,11 @@
 
 (mu/defn record-login-history!
   "Record a login event in the LoginHistory table."
-  [session-id :- uuid?
+  [session-id-hash :- [:not uuid?]
    user-id :- ms/PositiveInt
    device-info :- request/DeviceInfo]
   (let [login-history (merge {:user_id    user-id
-                              :session_id (str session-id)}
+                              :session_id session-id-hash}
                              (dissoc device-info :embedded))]
     (t2/insert! :model/LoginHistory login-history)
     login-history))

--- a/src/metabase/login_history/models/login_history.clj
+++ b/src/metabase/login_history/models/login_history.clj
@@ -45,11 +45,11 @@
 
 (mu/defn record-login-history!
   "Record a login event in the LoginHistory table."
-  [session-id-hash :- [:not uuid?]
+  [session-id :- [:not uuid?]
    user-id :- ms/PositiveInt
    device-info :- request/DeviceInfo]
   (let [login-history (merge {:user_id    user-id
-                              :session_id session-id-hash}
+                              :session_id session-id}
                              (dissoc device-info :embedded))]
     (t2/insert! :model/LoginHistory login-history)
     login-history))

--- a/src/metabase/login_history/record.clj
+++ b/src/metabase/login_history/record.clj
@@ -30,7 +30,7 @@
 
 (mu/defn record-login-history!
   "Record login history for a user, and send them an email if this is their first time logging in from this device."
-  [session-id  :- uuid?
+  [session-id  :- string?
    user        :- [:map
                    {:description ":model/User"}
                    [:id pos-int?]

--- a/src/metabase/request/cookies.clj
+++ b/src/metabase/request/cookies.clj
@@ -212,12 +212,12 @@
   "Add the appropriate cookies to the `response` for the Session."
   [request
    response
-   {session-uuid :id
+   {session-key :key
     session-type :type
     anti-csrf-token :anti_csrf_token
-    :as _session-instance} :- [:map [:id [:or
-                                          uuid?
-                                          [:re u/uuid-regex]]]]
+    :as _session-instance} :- [:map [:key [:or
+                                           uuid?
+                                           [:re u/uuid-regex]]]]
    request-time]
   (let [cookie-options (merge
                         (default-session-cookie-attributes session-type request)
@@ -239,4 +239,4 @@
         (cond-> (= session-type :full-app-embed)
           (assoc-in [:headers anti-csrf-token-header] anti-csrf-token))
         (set-session-timeout-cookie request session-type request-time)
-        (response/set-cookie (session-cookie-name session-type) (str session-uuid) cookie-options))))
+        (response/set-cookie (session-cookie-name session-type) (str session-key) cookie-options))))

--- a/src/metabase/server/handler.clj
+++ b/src/metabase/server/handler.clj
@@ -59,9 +59,9 @@
    #'mw.misc/maybe-set-site-url                 ; set the value of `site-url` if it hasn't been set yet
    #'mw.session/reset-session-timeout           ; Resets the timeout cookie for user activity to [[metabase.request.cookies/session-timeout]]
    #'mw.session/bind-current-user               ; Binds *current-user* and *current-user-id* if :metabase-user-id is non-nil
-   #'mw.session/wrap-current-user-info          ; looks for :metabase-session-id and sets :metabase-user-id and other info if Session ID is valid
+   #'mw.session/wrap-current-user-info          ; looks for :metabase-session-key and sets :metabase-user-id and other info if Session ID is valid
    #'analytics/embedding-mw                     ; reads sdk client headers, binds them to *client* and *version*, and tracks sdk-response metrics
-   #'mw.session/wrap-session-id                 ; looks for a Metabase Session ID and assoc as :metabase-session-id
+   #'mw.session/wrap-session-key                 ; looks for a Metabase Session ID and assoc as :metabase-session-key
    #'mw.auth/wrap-static-api-key                ; looks for a static Metabase API Key on the request and assocs as :metabase-api-key
    #'wrap-cookies                               ; Parses cookies in the request map and assocs as :cookies
    #'mw.misc/add-content-type                   ; Adds a Content-Type header for any response that doesn't already have one

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -149,6 +149,7 @@
   "Return User ID and superuser status for Session with `session-key` if it is valid and not expired."
   [session-key anti-csrf-token]
   (when (and session-key (init-status/complete?))
+    (api/validate-session-key session-key)
     (let [sql    (session-with-id-query (mdb/db-type)
                                         (config/config-int :max-session-age)
                                         (if (seq anti-csrf-token) :full-app-embed :normal)

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -35,50 +35,50 @@
 (set! *warn-on-reflection* true)
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
-;;; |                                                wrap-session-id                                                 |
+;;; |                                                wrap-session-key                                                 |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (def ^:private ^String metabase-session-header "x-metabase-session")
 
-(defmulti ^:private wrap-session-id-with-strategy
-  "Attempt to add `:metabase-session-id` to `request` based on a specific strategy. Return modified request if
+(defmulti ^:private wrap-session-key-with-strategy
+  "Attempt to add `:metabase-session-key` to `request` based on a specific strategy. Return modified request if
   successful or `nil` if we should try another strategy."
   {:arglists '([strategy request])}
   (fn [strategy _]
     strategy))
 
-(defmethod wrap-session-id-with-strategy :embedded-cookie
+(defmethod wrap-session-key-with-strategy :embedded-cookie
   [_ {:keys [cookies headers], :as request}]
   (when-let [session (get-in cookies [request/metabase-embedded-session-cookie :value])]
     (when-let [anti-csrf-token (get headers request/anti-csrf-token-header)]
-      (assoc request :metabase-session-id session, :anti-csrf-token anti-csrf-token :metabase-session-type :full-app-embed))))
+      (assoc request :metabase-session-key session, :anti-csrf-token anti-csrf-token :metabase-session-type :full-app-embed))))
 
-(defmethod wrap-session-id-with-strategy :normal-cookie
+(defmethod wrap-session-key-with-strategy :normal-cookie
   [_ {:keys [cookies], :as request}]
   (when-let [session (get-in cookies [request/metabase-session-cookie :value])]
     (when (seq session)
-      (assoc request :metabase-session-id session :metabase-session-type :normal))))
+      (assoc request :metabase-session-key session :metabase-session-type :normal))))
 
-(defmethod wrap-session-id-with-strategy :header
+(defmethod wrap-session-key-with-strategy :header
   [_ {:keys [headers], :as request}]
   (when-let [session (get headers metabase-session-header)]
     (when (seq session)
-      (assoc request :metabase-session-id session))))
+      (assoc request :metabase-session-key session))))
 
-(defmethod wrap-session-id-with-strategy :best
+(defmethod wrap-session-key-with-strategy :best
   [_ request]
   (some
    (fn [strategy]
-     (wrap-session-id-with-strategy strategy request))
+     (wrap-session-key-with-strategy strategy request))
    [:embedded-cookie :normal-cookie :header]))
 
-(defn wrap-session-id
-  "Middleware that sets the `:metabase-session-id` keyword on the request if a session id can be found.
+(defn wrap-session-key
+  "Middleware that sets the `:metabase-session-key` keyword on the request if a session id can be found.
   We first check the request :cookies for `metabase.SESSION`, then if no cookie is found we look in the http headers
   for `X-METABASE-SESSION`. If neither is found then no keyword is bound to the request."
   [handler]
   (fn [request respond raise]
-    (let [request (or (wrap-session-id-with-strategy :best request)
+    (let [request (or (wrap-session-key-with-strategy :best request)
                       request)]
       (handler request respond raise))))
 
@@ -100,7 +100,7 @@
                 :left-join [[:core_user :user] [:= :session.user_id :user.id]]
                 :where     [:and
                             [:= :user.is_active true]
-                            [:= :session.id [:raw "?"]]
+                            [:or [:= :session.id [:raw "?"]] [:= :session.key_hashed [:raw "?"]]]
                             (let [oldest-allowed [:inline (sql.qp/add-interval-honeysql-form db-type
                                                                                              :%now
                                                                                              (- max-age-minutes)
@@ -146,14 +146,14 @@
                                                  [:is :pgm.is_group_manager true]]))))))))
 
 (defn- current-user-info-for-session
-  "Return User ID and superuser status for Session with `session-id` if it is valid and not expired."
-  [session-id anti-csrf-token]
-  (when (and session-id (init-status/complete?))
+  "Return User ID and superuser status for Session with `session-key` if it is valid and not expired."
+  [session-key anti-csrf-token]
+  (when (and session-key (init-status/complete?))
     (let [sql    (session-with-id-query (mdb/db-type)
                                         (config/config-int :max-session-age)
                                         (if (seq anti-csrf-token) :full-app-embed :normal)
                                         (premium-features/enable-advanced-permissions?))
-          params (concat [(session/hash-session-id session-id)]
+          params (concat [session-key (session/hash-session-key session-key)]
                          (when (seq anti-csrf-token)
                            [anti-csrf-token]))]
       (some-> (t2/query-one (cons sql params))
@@ -188,10 +188,10 @@
         (dissoc user-data :api-key)))))
 
 (defn- merge-current-user-info
-  [{:keys [metabase-session-id anti-csrf-token], {:strs [x-metabase-locale x-api-key]} :headers, :as request}]
+  [{:keys [metabase-session-key anti-csrf-token], {:strs [x-metabase-locale x-api-key]} :headers, :as request}]
   (merge
    request
-   (or (current-user-info-for-session metabase-session-id anti-csrf-token)
+   (or (current-user-info-for-session metabase-session-key anti-csrf-token)
        (current-user-info-for-api-key x-api-key))
    (when x-metabase-locale
      (log/tracef "Found X-Metabase-Locale header: using %s as user locale" (pr-str x-metabase-locale))

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -25,7 +25,7 @@
    [metabase.models.user :as user]
    [metabase.premium-features.core :as premium-features]
    [metabase.request.core :as request]
-   [metabase.util.encryption :as encryption]
+   [metabase.session.core :as session]
    [metabase.util.i18n :as i18n]
    [metabase.util.log :as log]
    [metabase.util.password :as u.password]
@@ -162,7 +162,7 @@
                                         (config/config-int :max-session-age)
                                         (if (seq anti-csrf-token) :full-app-embed :normal)
                                         (premium-features/enable-advanced-permissions?))
-          params (concat [session-key (encryption/hash-session-key session-key)]
+          params (concat [session-key (session/hash-session-key session-key)]
                          (when (seq anti-csrf-token)
                            [anti-csrf-token]))]
       (some-> (t2/query-one (cons sql params))

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -22,6 +22,7 @@
    [metabase.db :as mdb]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.models.api-key :as api-key]
+   [metabase.models.session :as session]
    [metabase.models.user :as user]
    [metabase.premium-features.core :as premium-features]
    [metabase.request.core :as request]
@@ -152,7 +153,7 @@
                                         (config/config-int :max-session-age)
                                         (if (seq anti-csrf-token) :full-app-embed :normal)
                                         (premium-features/enable-advanced-permissions?))
-          params (concat [session-id]
+          params (concat [(session/hash-session-id session-id)]
                          (when (seq anti-csrf-token)
                            [anti-csrf-token]))]
       (some-> (t2/query-one (cons sql params))

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -22,10 +22,10 @@
    [metabase.db :as mdb]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.models.api-key :as api-key]
-   [metabase.models.session :as session]
    [metabase.models.user :as user]
    [metabase.premium-features.core :as premium-features]
    [metabase.request.core :as request]
+   [metabase.util.encryption :as encryption]
    [metabase.util.i18n :as i18n]
    [metabase.util.log :as log]
    [metabase.util.password :as u.password]
@@ -162,7 +162,7 @@
                                         (config/config-int :max-session-age)
                                         (if (seq anti-csrf-token) :full-app-embed :normal)
                                         (premium-features/enable-advanced-permissions?))
-          params (concat [session-key (session/hash-session-key session-key)]
+          params (concat [session-key (encryption/hash-session-key session-key)]
                          (when (seq anti-csrf-token)
                            [anti-csrf-token]))]
       (some-> (t2/query-one (cons sql params))

--- a/src/metabase/session/api.clj
+++ b/src/metabase/session/api.clj
@@ -146,7 +146,6 @@
   "Logout."
   ;; `metabase-session-key` gets added automatically by the [[metabase.server.middleware.session]] middleware
   [_route-params _query-params _body {:keys [metabase-session-key], :as _request}]
-  (api/validate-session-key metabase-session-key)
   (let [session-key-hashed (session/hash-session-key metabase-session-key)]
     (let [rows-deleted (t2/delete! :model/Session {:where [:or [:= :key_hashed session-key-hashed] [:= :id metabase-session-key]]})]
       (api/check-404 (> rows-deleted 0))

--- a/src/metabase/session/api.clj
+++ b/src/metabase/session/api.clj
@@ -15,7 +15,6 @@
    [metabase.session.models.session :as session]
    [metabase.sso.core :as sso]
    [metabase.util :as u]
-   [metabase.util.encryption :as encryption]
    [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -147,7 +146,7 @@
   "Logout."
   ;; `metabase-session-key` gets added automatically by the [[metabase.server.middleware.session]] middleware
   [_route-params _query-params _body {:keys [metabase-session-key], :as _request}]
-  (let [session-key-hashed (encryption/hash-session-key metabase-session-key)]
+  (let [session-key-hashed (session/hash-session-key metabase-session-key)]
     (let [rows-deleted (t2/delete! :model/Session {:where [:or [:= :key_hashed session-key-hashed] [:= :id metabase-session-key]]})]
       (api/check-404 (> rows-deleted 0))
       (request/clear-session-cookie api/generic-204-no-content))))

--- a/src/metabase/session/api.clj
+++ b/src/metabase/session/api.clj
@@ -44,7 +44,7 @@
 (def ^:private fake-salt "ee169694-5eb6-4010-a145-3557252d7807")
 (def ^:private fake-hashed-password "$2a$10$owKjTym0ZGEEZOpxM0UyjekSvt66y1VvmOJddkAaMB37e0VAIVOX2")
 
-(mu/defn- ldap-login :- [:maybe [:map [:id ms/UUIDString]]]
+(mu/defn- ldap-login :- [:maybe [:map [:key ms/UUIDString]]]
   "If LDAP is enabled and a matching user exists return a new Session for them, or `nil` if they couldn't be
   authenticated."
   [username password device-info :- request/DeviceInfo]
@@ -67,7 +67,7 @@
       (catch LDAPSDKException e
         (log/error e "Problem connecting to LDAP server, will fall back to local authentication")))))
 
-(mu/defn- email-login :- [:maybe [:map [:id ms/UUIDString]]]
+(mu/defn- email-login :- [:maybe [:map [:key ms/UUIDString]]]
   "Find a matching `User` if one exists and return a new Session for them, or `nil` if they couldn't be authenticated."
   [username    :- ms/NonBlankString
    password    :- [:maybe ms/NonBlankString]

--- a/src/metabase/session/api.clj
+++ b/src/metabase/session/api.clj
@@ -15,6 +15,7 @@
    [metabase.session.models.session :as session]
    [metabase.sso.core :as sso]
    [metabase.util :as u]
+   [metabase.util.encryption :as encryption]
    [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -146,7 +147,7 @@
   "Logout."
   ;; `metabase-session-key` gets added automatically by the [[metabase.server.middleware.session]] middleware
   [_route-params _query-params _body {:keys [metabase-session-key], :as _request}]
-  (let [session-key-hashed (session/hash-session-key metabase-session-key)]
+  (let [session-key-hashed (encryption/hash-session-key metabase-session-key)]
     (let [rows-deleted (t2/delete! :model/Session {:where [:or [:= :key_hashed session-key-hashed] [:= :id metabase-session-key]]})]
       (api/check-404 (> rows-deleted 0))
       (request/clear-session-cookie api/generic-204-no-content))))

--- a/src/metabase/session/api.clj
+++ b/src/metabase/session/api.clj
@@ -146,10 +146,10 @@
   "Logout."
   ;; `metabase-session-key` gets added automatically by the [[metabase.server.middleware.session]] middleware
   [_route-params _query-params _body {:keys [metabase-session-key], :as _request}]
-  (let [session-key-hashed (session/hash-session-key metabase-session-key)]
-    (let [rows-deleted (t2/delete! :model/Session {:where [:or [:= :key_hashed session-key-hashed] [:= :id metabase-session-key]]})]
-      (api/check-404 (> rows-deleted 0))
-      (request/clear-session-cookie api/generic-204-no-content))))
+  (let [session-key-hashed (session/hash-session-key metabase-session-key)
+        rows-deleted (t2/delete! :model/Session {:where [:or [:= :key_hashed session-key-hashed] [:= :id metabase-session-key]]})]
+    (api/check-404 (> rows-deleted 0))
+    (request/clear-session-cookie api/generic-204-no-content)))
 
 ;; Reset tokens: We need some way to match a plaintext token with the a user since the token stored in the DB is
 ;; hashed. So we'll make the plaintext token in the format USER-ID_RANDOM-UUID, e.g.

--- a/src/metabase/session/core.clj
+++ b/src/metabase/session/core.clj
@@ -1,0 +1,16 @@
+(ns metabase.session.core
+  (:require
+   [metabase.session.models.session :as session]
+   [potemkin :as p]))
+
+(comment session/keep-me)
+
+(p/import-vars
+ [session
+  create-session!
+  generate-session-key
+  generate-session-id
+  hash-session-key])
+
+
+

--- a/src/metabase/session/core.clj
+++ b/src/metabase/session/core.clj
@@ -11,6 +11,3 @@
   generate-session-key
   generate-session-id
   hash-session-key])
-
-
-

--- a/src/metabase/session/models/session.clj
+++ b/src/metabase/session/models/session.clj
@@ -45,8 +45,8 @@
     (assoc session :type session-type)))
 
 (def ^{:arglists '([session-id])} hash-session-id
-    "Hash the session-id for storage in the database"
-  (memo/lru (fn [session-id] (codecs/bytes->hex (buddy-hash/sha512 session-id))) {} :lru/threshold 100))
+  "Hash the session-id for storage in the database"
+  (memo/lru (fn [session-id] (codecs/bytes->hex (buddy-hash/sha512 (str session-id)))) {} :lru/threshold 100))
 
 (def ^:private CreateSessionUserInfo
   [:map

--- a/src/metabase/session/models/session.clj
+++ b/src/metabase/session/models/session.clj
@@ -44,13 +44,9 @@
   (let [session-type (if anti-csrf-token :full-app-embed :normal)]
     (assoc session :type session-type)))
 
-(def ^:private hash-session-id-cache
+(def ^{:arglists '([session-id])} hash-session-id
+    "Hash the session-id for storage in the database"
   (memo/lru (fn [session-id] (codecs/bytes->hex (buddy-hash/sha512 session-id))) {} :lru/threshold 100))
-
-(defn hash-session-id
-  "Hash the session-id for storage in the database"
-  [session-id]
-  (hash-session-id-cache (str session-id)))
 
 (def ^:private CreateSessionUserInfo
   [:map

--- a/src/metabase/session/models/session.clj
+++ b/src/metabase/session/models/session.clj
@@ -70,7 +70,7 @@
 
 (def ^{:arglists '([session-key])} hash-session-key
   "Hash the session-key for storage in the database"
-  (memo/lru (fn [session-key] (codecs/bytes->hex (buddy-hash/sha512 (.getBytes session-key java.nio.charset.StandardCharsets/US_ASCII)))) {} :lru/threshold 100))
+  (memo/lru (fn [^String session-key] (codecs/bytes->hex (buddy-hash/sha512 (.getBytes session-key java.nio.charset.StandardCharsets/US_ASCII)))) {} :lru/threshold 100))
 
 (defn generate-session-key
   "Generate a new session key."

--- a/src/metabase/session/models/session.clj
+++ b/src/metabase/session/models/session.clj
@@ -48,7 +48,7 @@
 
 (def ^{:arglists '([session-key])} hash-session-key
   "Hash the session-key for storage in the database"
-  (memo/lru (fn [session-key] (codecs/bytes->hex (buddy-hash/sha512 (str session-key)))) {} :lru/threshold 100))
+  (memo/lru (fn [session-key] (codecs/bytes->hex (buddy-hash/sha512 (.getBytes session-key java.nio.charset.StandardCharsets/US_ASCII)))) {} :lru/threshold 100))
 
 (def ^:private CreateSessionUserInfo
   [:map

--- a/src/metabase/setup/api.clj
+++ b/src/metabase/setup/api.clj
@@ -147,7 +147,7 @@
       (when-not (:last_login superuser)
         (events/publish-event! :event/user-joined {:user-id user-id}))
       ;; return response with session ID and set the cookie as well
-      (request/set-session-cookies request {:key session-key} session (t/zoned-date-time (t/zone-id "GMT"))))))
+      (request/set-session-cookies request {:id session-key} session (t/zoned-date-time (t/zone-id "GMT"))))))
 
 ;;; Admin Checklist
 

--- a/src/metabase/setup/api.clj
+++ b/src/metabase/setup/api.clj
@@ -141,13 +141,13 @@
                 ;; this because there is `io!` in this block
                 (setting.cache/restore-cache!)
                 (throw e))))]
-    (let [{:keys [user-id session-id session]} (create!)
+    (let [{:keys [user-id session-key session]} (create!)
           superuser (t2/select-one :model/User :id user-id)]
       (events/publish-event! :event/user-login {:user-id user-id})
       (when-not (:last_login superuser)
         (events/publish-event! :event/user-joined {:user-id user-id}))
       ;; return response with session ID and set the cookie as well
-      (request/set-session-cookies request {:id session-id} session (t/zoned-date-time (t/zone-id "GMT"))))))
+      (request/set-session-cookies request {:key session-key} session (t/zoned-date-time (t/zone-id "GMT"))))))
 
 ;;; Admin Checklist
 

--- a/src/metabase/setup/api.clj
+++ b/src/metabase/setup/api.clj
@@ -65,7 +65,7 @@
     ;; then we create a session right away because we want our new user logged in to continue the setup process
     (let [session (session/create-session! :password new-user device-info)]
       ;; return user ID, session ID, and the Session object itself
-      {:session-id (:id session), :user-id user-id, :session session})))
+      {:session-key (:key session), :user-id user-id, :session session})))
 
 (defn- setup-maybe-create-and-invite-user! [{:keys [email] :as user}, invitor]
   (when email

--- a/src/metabase/util/encryption.clj
+++ b/src/metabase/util/encryption.clj
@@ -5,10 +5,8 @@
    [buddy.core.bytes :as bytes]
    [buddy.core.codecs :as codecs]
    [buddy.core.crypto :as crypto]
-   [buddy.core.hash :as buddy-hash]
    [buddy.core.kdf :as kdf]
    [buddy.core.nonce :as nonce]
-   [clojure.core.memoize :as memo]
    [clojure.string :as str]
    [environ.core :as env]
    [metabase.util :as u]
@@ -248,7 +246,3 @@
 
           :else
           v)))
-
-(def ^{:arglists '([session-key])} hash-session-key
-  "Hash the session-key for storage in the database"
-  (memo/lru (fn [session-key] (codecs/bytes->hex (buddy-hash/sha512 (.getBytes session-key java.nio.charset.StandardCharsets/US_ASCII)))) {} :lru/threshold 100))

--- a/src/metabase/util/encryption.clj
+++ b/src/metabase/util/encryption.clj
@@ -5,8 +5,10 @@
    [buddy.core.bytes :as bytes]
    [buddy.core.codecs :as codecs]
    [buddy.core.crypto :as crypto]
+   [buddy.core.hash :as buddy-hash]
    [buddy.core.kdf :as kdf]
    [buddy.core.nonce :as nonce]
+   [clojure.core.memoize :as memo]
    [clojure.string :as str]
    [environ.core :as env]
    [metabase.util :as u]
@@ -246,3 +248,7 @@
 
           :else
           v)))
+
+(def ^{:arglists '([session-key])} hash-session-key
+  "Hash the session-key for storage in the database"
+  (memo/lru (fn [session-key] (codecs/bytes->hex (buddy-hash/sha512 (.getBytes session-key java.nio.charset.StandardCharsets/US_ASCII)))) {} :lru/threshold 100))

--- a/src/metabase/util/string.clj
+++ b/src/metabase/util/string.clj
@@ -64,6 +64,8 @@
     s))
 
 (defn random-string
-  "Returns a string of `n` random alphanumeric characters."
+  "Returns a string of `n` random alphanumeric characters.
+
+  NOTE: this is not a cryptographically secure random string."
   [n]
   (apply str (take n (repeatedly #(rand-nth "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")))))

--- a/src/metabase/util/string.clj
+++ b/src/metabase/util/string.clj
@@ -62,3 +62,8 @@
   (if (> (count s) max-length)
     (str (subs s 0 (- max-length 3)) "...")
     s))
+
+(defn random-string
+  "Returns a string of `n` random alphanumeric characters."
+  [n]
+  (apply str (take n (repeatedly #(rand-nth "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")))))

--- a/test/metabase/login_history/api_test.clj
+++ b/test/metabase/login_history/api_test.clj
@@ -15,17 +15,18 @@
 
 (deftest login-history-test
   (testing "GET /api/login-history/current"
-    (let [session-id (str (random-uuid))
+    (let [session-key (session/generate-session-key)
+          session-id (session/generate-session-id)
           device-id  "e9b49ec7-bc64-4a83-9b1a-ecd3ae26ba9d"
-          session-id-hashed (session/hash-session-id session-id)]
+          session-key-hashed (session/hash-session-key session-key)]
       (mt/with-temp [:model/User         user {}
-                     :model/Session      _    {:id session-id-hashed, :user_id (u/the-id user)}
+                     :model/Session      _    {:id session-id :key_hashed session-key-hashed, :user_id (u/the-id user)}
                      :model/LoginHistory _    {:timestamp          #t "2021-03-18T19:52:41.808482Z"
                                                :user_id            (u/the-id user)
                                                :device_id          device-id
                                                :device_description windows-user-agent
                                                :ip_address         "185.233.100.23"
-                                               :session_id         session-id-hashed}
+                                               :session_id         session-id}
                      :model/LoginHistory _    {:timestamp          #t "2021-03-18T20:04:24.727300Z"
                                                :user_id            (u/the-id user)
                                                :device_id          device-id
@@ -89,4 +90,4 @@
                       [:active             [:= false]]
                       [:location           [:maybe [:re "Virginia, United States"]]]
                       [:timezone           [:maybe [:= "ET"]]]]]
-                    (mt/client session-id :get 200 "login-history/current")))))))
+                    (mt/client session-key :get 200 "login-history/current")))))))

--- a/test/metabase/login_history/api_test.clj
+++ b/test/metabase/login_history/api_test.clj
@@ -1,10 +1,9 @@
 (ns metabase.login-history.api-test
   (:require
    [clojure.test :refer :all]
-   [metabase.models.session :as session]
+   [metabase.session.core :as session]
    [metabase.test :as mt]
-   [metabase.util :as u]
-   [metabase.util.encryption :as encryption]))
+   [metabase.util :as u]))
 
 (set! *warn-on-reflection* true)
 
@@ -19,7 +18,7 @@
     (let [session-key (session/generate-session-key)
           session-id (session/generate-session-id)
           device-id  "e9b49ec7-bc64-4a83-9b1a-ecd3ae26ba9d"
-          session-key-hashed (encryption/hash-session-key session-key)]
+          session-key-hashed (session/hash-session-key session-key)]
       (mt/with-temp [:model/User         user {}
                      :model/Session      _    {:id session-id :key_hashed session-key-hashed, :user_id (u/the-id user)}
                      :model/LoginHistory _    {:timestamp          #t "2021-03-18T19:52:41.808482Z"

--- a/test/metabase/login_history/api_test.clj
+++ b/test/metabase/login_history/api_test.clj
@@ -3,7 +3,8 @@
    [clojure.test :refer :all]
    [metabase.models.session :as session]
    [metabase.test :as mt]
-   [metabase.util :as u]))
+   [metabase.util :as u]
+   [metabase.util.encryption :as encryption]))
 
 (set! *warn-on-reflection* true)
 
@@ -18,7 +19,7 @@
     (let [session-key (session/generate-session-key)
           session-id (session/generate-session-id)
           device-id  "e9b49ec7-bc64-4a83-9b1a-ecd3ae26ba9d"
-          session-key-hashed (session/hash-session-key session-key)]
+          session-key-hashed (encryption/hash-session-key session-key)]
       (mt/with-temp [:model/User         user {}
                      :model/Session      _    {:id session-id :key_hashed session-key-hashed, :user_id (u/the-id user)}
                      :model/LoginHistory _    {:timestamp          #t "2021-03-18T19:52:41.808482Z"

--- a/test/metabase/login_history/api_test.clj
+++ b/test/metabase/login_history/api_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.login-history.api-test
   (:require
    [clojure.test :refer :all]
+   [metabase.models.session :as session]
    [metabase.test :as mt]
    [metabase.util :as u]))
 
@@ -15,15 +16,16 @@
 (deftest login-history-test
   (testing "GET /api/login-history/current"
     (let [session-id (str (random-uuid))
-          device-id  "e9b49ec7-bc64-4a83-9b1a-ecd3ae26ba9d"]
+          device-id  "e9b49ec7-bc64-4a83-9b1a-ecd3ae26ba9d"
+          session-id-hashed (session/hash-session-id session-id)]
       (mt/with-temp [:model/User         user {}
-                     :model/Session      _    {:id session-id, :user_id (u/the-id user)}
+                     :model/Session      _    {:id session-id-hashed, :user_id (u/the-id user)}
                      :model/LoginHistory _    {:timestamp          #t "2021-03-18T19:52:41.808482Z"
                                                :user_id            (u/the-id user)
                                                :device_id          device-id
                                                :device_description windows-user-agent
                                                :ip_address         "185.233.100.23"
-                                               :session_id         session-id}
+                                               :session_id         session-id-hashed}
                      :model/LoginHistory _    {:timestamp          #t "2021-03-18T20:04:24.727300Z"
                                                :user_id            (u/the-id user)
                                                :device_id          device-id

--- a/test/metabase/models/user_test.clj
+++ b/test/metabase/models/user_test.clj
@@ -24,6 +24,7 @@
    [metabase.test.data.users :as test.users]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
+   [metabase.util.encryption :as encryption]
    [metabase.util.password :as u.password]
    [toucan2.core :as t2]))
 
@@ -413,7 +414,7 @@
       (mt/with-temp [:model/User {user-id :id} {}]
         (dotimes [_ 2]
           (t2/insert! :model/Session {:id (session/generate-session-id)
-                                      :key_hashed (session/hash-session-key (session/generate-session-key)),
+                                      :key_hashed (encryption/hash-session-key (session/generate-session-key)),
                                       :user_id user-id}))
         (letfn [(session-count [] (t2/count :model/Session :user_id user-id))]
           (is (= 2

--- a/test/metabase/models/user_test.clj
+++ b/test/metabase/models/user_test.clj
@@ -412,10 +412,9 @@
     (testing "should clear out all existing Sessions"
       (mt/with-temp [:model/User {user-id :id} {}]
         (dotimes [_ 2]
-          (t2/insert! :model/Session {
-              :id (session/generate-session-id)
-              :key_hashed (session/hash-session-key (session/generate-session-key)),
-              :user_id user-id}))
+          (t2/insert! :model/Session {:id (session/generate-session-id)
+                                      :key_hashed (session/hash-session-key (session/generate-session-key)),
+                                      :user_id user-id}))
         (letfn [(session-count [] (t2/count :model/Session :user_id user-id))]
           (is (= 2
                  (session-count)))

--- a/test/metabase/models/user_test.clj
+++ b/test/metabase/models/user_test.clj
@@ -10,6 +10,7 @@
    [metabase.models.collection :as collection]
    [metabase.models.collection-test :as collection-test]
    [metabase.models.serialization :as serdes]
+   [metabase.models.session :as session]
    [metabase.models.setting :as setting]
    [metabase.models.user :as user]
    [metabase.notification.test-util :as notification.tu]
@@ -411,7 +412,7 @@
     (testing "should clear out all existing Sessions"
       (mt/with-temp [:model/User {user-id :id} {}]
         (dotimes [_ 2]
-          (t2/insert! :model/Session {:id (str (random-uuid)), :user_id user-id}))
+          (t2/insert! :model/Session {:id (session/hash-session-id  (str (random-uuid))), :user_id user-id}))
         (letfn [(session-count [] (t2/count :model/Session :user_id user-id))]
           (is (= 2
                  (session-count)))

--- a/test/metabase/models/user_test.clj
+++ b/test/metabase/models/user_test.clj
@@ -10,7 +10,6 @@
    [metabase.models.collection :as collection]
    [metabase.models.collection-test :as collection-test]
    [metabase.models.serialization :as serdes]
-   [metabase.models.session :as session]
    [metabase.models.setting :as setting]
    [metabase.models.user :as user]
    [metabase.notification.test-util :as notification.tu]
@@ -18,13 +17,13 @@
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.permissions.models.permissions-test :as perms-test]
    [metabase.request.core :as request]
+   [metabase.session.core :as session]
    [metabase.sso.init]
    [metabase.sso.ldap-test-util :as ldap.test]
    [metabase.test :as mt]
    [metabase.test.data.users :as test.users]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
-   [metabase.util.encryption :as encryption]
    [metabase.util.password :as u.password]
    [toucan2.core :as t2]))
 
@@ -414,7 +413,7 @@
       (mt/with-temp [:model/User {user-id :id} {}]
         (dotimes [_ 2]
           (t2/insert! :model/Session {:id (session/generate-session-id)
-                                      :key_hashed (encryption/hash-session-key (session/generate-session-key)),
+                                      :key_hashed (session/hash-session-key (session/generate-session-key)),
                                       :user_id user-id}))
         (letfn [(session-count [] (t2/count :model/Session :user_id user-id))]
           (is (= 2

--- a/test/metabase/models/user_test.clj
+++ b/test/metabase/models/user_test.clj
@@ -412,7 +412,10 @@
     (testing "should clear out all existing Sessions"
       (mt/with-temp [:model/User {user-id :id} {}]
         (dotimes [_ 2]
-          (t2/insert! :model/Session {:id (session/hash-session-id  (str (random-uuid))), :user_id user-id}))
+          (t2/insert! :model/Session {
+              :id (session/generate-session-id)
+              :key_hashed (session/hash-session-key (session/generate-session-key)),
+              :user_id user-id}))
         (letfn [(session-count [] (t2/count :model/Session :user_id user-id))]
           (is (= 2
                  (session-count)))

--- a/test/metabase/request/cookies_test.clj
+++ b/test/metabase/request/cookies_test.clj
@@ -2,10 +2,10 @@
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]
-   [metabase.models.session :as session]
    [metabase.public-settings :as public-settings]
    [metabase.request.cookies :as request.cookies]
    [metabase.request.core :as request]
+   [metabase.session.models.session :as session]
    [metabase.test :as mt]
    [metabase.util.json :as json]))
 

--- a/test/metabase/server/middleware/auth_test.clj
+++ b/test/metabase/server/middleware/auth_test.clj
@@ -2,14 +2,13 @@
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]
-   [metabase.models.session :as session]
    [metabase.request.core :as request]
    [metabase.server.middleware.auth :as mw.auth]
    [metabase.server.middleware.session :as mw.session]
+   [metabase.session.core :as session]
    [metabase.test :as mt]
    [metabase.test.data.users :as test.users]
    [metabase.test.fixtures :as fixtures]
-   [metabase.util.encryption :as encryption]
    [ring.mock.request :as ring.mock]
    [toucan2.core :as t2]))
 
@@ -37,7 +36,7 @@
   (testing "Valid requests should add `metabase-user-id` to requests with valid session info"
     (let [session-id (session/generate-session-id)
           session-key (session/generate-session-key)
-          session-key-hashed (encryption/hash-session-key session-key)]
+          session-key-hashed (session/hash-session-key session-key)]
       (try
         (t2/insert! :model/Session {:id         session-id
                                     :key_hashed session-key-hashed
@@ -58,7 +57,7 @@
       ;; expiration
       (let [session-id (session/generate-session-id)
             session-key (session/generate-session-key)
-            session-key-hashed (encryption/hash-session-key session-key)]
+            session-key-hashed (session/hash-session-key session-key)]
         (try
           (t2/insert! :model/Session {:id      session-id
                                       :key_hashed session-key-hashed
@@ -75,7 +74,7 @@
       ;; NOTE that :trashbird is our INACTIVE test user
       (let [session-id (session/generate-session-id)
             session-key (session/generate-session-key)
-            session-key-hashed (encryption/hash-session-key session-key)]
+            session-key-hashed (session/hash-session-key session-key)]
         (try
           (t2/insert! :model/Session {:id         session-id
                                       :key_hashed session-key-hashed

--- a/test/metabase/server/middleware/auth_test.clj
+++ b/test/metabase/server/middleware/auth_test.clj
@@ -9,6 +9,7 @@
    [metabase.test :as mt]
    [metabase.test.data.users :as test.users]
    [metabase.test.fixtures :as fixtures]
+   [metabase.util.encryption :as encryption]
    [ring.mock.request :as ring.mock]
    [toucan2.core :as t2]))
 
@@ -36,7 +37,7 @@
   (testing "Valid requests should add `metabase-user-id` to requests with valid session info"
     (let [session-id (session/generate-session-id)
           session-key (session/generate-session-key)
-          session-key-hashed (session/hash-session-key session-key)]
+          session-key-hashed (encryption/hash-session-key session-key)]
       (try
         (t2/insert! :model/Session {:id         session-id
                                     :key_hashed session-key-hashed
@@ -57,7 +58,7 @@
       ;; expiration
       (let [session-id (session/generate-session-id)
             session-key (session/generate-session-key)
-            session-key-hashed (session/hash-session-key session-key)]
+            session-key-hashed (encryption/hash-session-key session-key)]
         (try
           (t2/insert! :model/Session {:id      session-id
                                       :key_hashed session-key-hashed
@@ -74,7 +75,7 @@
       ;; NOTE that :trashbird is our INACTIVE test user
       (let [session-id (session/generate-session-id)
             session-key (session/generate-session-key)
-            session-key-hashed (session/hash-session-key session-key)]
+            session-key-hashed (encryption/hash-session-key session-key)]
         (try
           (t2/insert! :model/Session {:id         session-id
                                       :key_hashed session-key-hashed

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -16,8 +16,7 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.secret :as u.secret]
    [ring.mock.request :as ring.mock]
-   [toucan2.core :as t2])
-  (:import (clojure.lang ExceptionInfo)))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -13,6 +13,7 @@
    [metabase.request.core :as request]
    [metabase.server.middleware.session :as mw.session]
    [metabase.test :as mt]
+   [metabase.util.encryption :as encryption]
    [metabase.util.i18n :as i18n]
    [metabase.util.secret :as u.secret]
    [ring.mock.request :as ring.mock]
@@ -24,7 +25,7 @@
 (def ^:private session-timeout-cookie request/metabase-session-timeout-cookie)
 
 (def ^:private test-session-key "092797dd-a82a-4748-b393-697d7bb9ab65")
-(def ^:private test-session-key-hashed (session/hash-session-key test-session-key))
+(def ^:private test-session-key-hashed (encryption/hash-session-key test-session-key))
 (def ^:private test-session-id "abcd1234")
 
 (deftest session-expired-test
@@ -40,7 +41,7 @@
           (mt/with-temp [:model/User {user-id :id}]
             (let [session-id (session/generate-session-id)
                   session-key (str (random-uuid))
-                  session-key-hashed (session/hash-session-key session-key)]
+                  session-key-hashed (encryption/hash-session-key session-key)]
               (t2/insert! (t2/table-name :model/Session) {:id session-id :key_hashed session-key-hashed, :user_id user-id, :created_at created-at})
               (let [session (#'mw.session/current-user-info-for-session session-key nil)]
                 (if expected
@@ -355,7 +356,7 @@
         (mt/with-temp [:model/User {user-id :id}]
           (let [session-id (session/generate-session-id)
                 session-key (str (random-uuid))
-                session-key-hashed (session/hash-session-key session-key)]
+                session-key-hashed (encryption/hash-session-key session-key)]
             (t2/insert! :model/Session {:id session-id :key_hashed session-key-hashed, :user_id user-id})
             (is (= nil
                    (session-locale session-key)))
@@ -368,7 +369,7 @@
         (mt/with-temp [:model/User {user-id :id} {:locale "es-MX"}]
           (let [session-id (session/generate-session-id)
                 session-key (str (random-uuid))
-                session-key-hashed (session/hash-session-key session-key)]
+                session-key-hashed (encryption/hash-session-key session-key)]
             (t2/insert! :model/Session {:id session-id :key_hashed session-key-hashed, :user_id user-id, :created_at :%now})
             (is (= "es_MX"
                    (session-locale session-key)))

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -8,6 +8,7 @@
    [metabase.core.initialization-status :as init-status]
    [metabase.db :as mdb]
    [metabase.driver.sql.query-processor :as sql.qp]
+   [metabase.models.session :as session]
    [metabase.premium-features.core :as premium-features]
    [metabase.request.core :as request]
    [metabase.server.middleware.session :as mw.session]
@@ -23,6 +24,7 @@
 (def ^:private session-timeout-cookie request/metabase-session-timeout-cookie)
 
 (def ^:private test-uuid #uuid "092797dd-a82a-4748-b393-697d7bb9ab65")
+(def ^:private test-uuid-hashed (session/hash-session-id test-uuid))
 
 (deftest session-expired-test
   (init-status/set-complete!)
@@ -35,8 +37,9 @@
                [(sql.qp/add-interval-honeysql-form (mdb/db-type) :%now -59 :second) false "session that is 59 seconds old"]]]
         (testing (format "\n%s %s be expired." msg (if expected "SHOULD" "SHOULD NOT"))
           (mt/with-temp [:model/User {user-id :id}]
-            (let [session-id (str (random-uuid))]
-              (t2/insert! (t2/table-name :model/Session) {:id session-id, :user_id user-id, :created_at created-at})
+            (let [session-id (str (random-uuid))
+                  session-id-hashed (session/hash-session-id session-id)]
+              (t2/insert! (t2/table-name :model/Session) {:id session-id-hashed, :user_id user-id, :created_at created-at})
               (let [session (#'mw.session/current-user-info-for-session session-id nil)]
                 (if expected
                   (is (nil? session))
@@ -177,20 +180,20 @@
     ;; for some reason Toucan seems to be busted with models with non-integer IDs and `with-temp` doesn't seem to work
     ;; the way we'd expect :/
     (try
-      (t2/insert! :model/Session {:id (str test-uuid), :user_id (mt/user->id :lucky)})
+      (t2/insert! :model/Session {:id test-uuid-hashed, :user_id (mt/user->id :lucky)})
       (is (= {:metabase-user-id (mt/user->id :lucky), :is-superuser? false, :is-group-manager? false, :user-locale nil}
              (#'mw.session/current-user-info-for-session (str test-uuid) nil)))
       (finally
-        (t2/delete! :model/Session :id (str test-uuid))))))
+        (t2/delete! :model/Session :id test-uuid-hashed)))))
 
 (deftest current-user-info-for-session-test-2
   (testing "superusers should come back as `:is-superuser?`"
     (try
-      (t2/insert! :model/Session {:id (str test-uuid), :user_id (mt/user->id :crowberto)})
+      (t2/insert! :model/Session {:id test-uuid-hashed, :user_id (mt/user->id :crowberto)})
       (is (= {:metabase-user-id (mt/user->id :crowberto), :is-superuser? true, :is-group-manager? false, :user-locale nil}
              (#'mw.session/current-user-info-for-session (str test-uuid) nil)))
       (finally
-        (t2/delete! :model/Session :id (str test-uuid))))))
+        (t2/delete! :model/Session :id test-uuid-hashed)))))
 
 (deftest current-user-info-for-session-test-3
   (testing "If user is a group manager of at least one group, `:is-group-manager?` "
@@ -200,7 +203,7 @@
                                user    [group-1 group-2]]
         (t2/update! :model/PermissionsGroupMembership {:user_id (:id user), :group_id (:id group-2)}
                     {:is_group_manager true})
-        (t2/insert! :model/Session {:id      (str test-uuid)
+        (t2/insert! :model/Session {:id      test-uuid-hashed
                                     :user_id (:id user)})
         (testing "is `false` if advanced-permisison is disabled"
           (mt/with-premium-features #{}
@@ -214,69 +217,69 @@
             (is (= true
                    (:is-group-manager? (#'mw.session/current-user-info-for-session (str test-uuid) nil)))))))
       (finally
-        (t2/delete! :model/Session :id (str test-uuid))))))
+        (t2/delete! :model/Session :id test-uuid-hashed)))))
 
 (deftest current-user-info-for-session-test-4
   (testing "full-app-embed sessions shouldn't come back if we don't explicitly specifiy the anti-csrf token"
     (try
-      (t2/insert! :model/Session {:id              (str test-uuid)
+      (t2/insert! :model/Session {:id              test-uuid-hashed
                                   :user_id         (mt/user->id :lucky)
                                   :anti_csrf_token test-anti-csrf-token})
       (is (= nil
              (#'mw.session/current-user-info-for-session (str test-uuid) nil)))
       (finally
-        (t2/delete! :model/Session :id (str test-uuid))))
+        (t2/delete! :model/Session :id test-uuid-hashed)))
 
     (testing "...but if we do specifiy the token, they should come back"
       (try
-        (t2/insert! :model/Session {:id              (str test-uuid)
+        (t2/insert! :model/Session {:id              test-uuid-hashed
                                     :user_id         (mt/user->id :lucky)
                                     :anti_csrf_token test-anti-csrf-token})
         (is (= {:metabase-user-id (mt/user->id :lucky), :is-superuser? false, :is-group-manager? false, :user-locale nil}
                (#'mw.session/current-user-info-for-session (str test-uuid) test-anti-csrf-token)))
         (finally
-          (t2/delete! :model/Session :id (str test-uuid))))
+          (t2/delete! :model/Session :id test-uuid-hashed)))
 
       (testing "(unless the token is wrong)"
         (try
-          (t2/insert! :model/Session {:id              (str test-uuid)
+          (t2/insert! :model/Session {:id              test-uuid-hashed
                                       :user_id         (mt/user->id :lucky)
                                       :anti_csrf_token test-anti-csrf-token})
           (is (= nil
                  (#'mw.session/current-user-info-for-session (str test-uuid) (str/join (reverse test-anti-csrf-token)))))
           (finally
-            (t2/delete! :model/Session :id (str test-uuid))))))))
+            (t2/delete! :model/Session :id test-uuid-hashed)))))))
 
 (deftest current-user-info-for-session-test-5
   (testing "if we specify an anti-csrf token we shouldn't get back a session without that token"
     (try
-      (t2/insert! :model/Session {:id      (str test-uuid)
+      (t2/insert! :model/Session {:id      test-uuid-hashed
                                   :user_id (mt/user->id :lucky)})
       (is (= nil
              (#'mw.session/current-user-info-for-session (str test-uuid) test-anti-csrf-token)))
       (finally
-        (t2/delete! :model/Session :id (str test-uuid))))))
+        (t2/delete! :model/Session :id test-uuid-hashed)))))
 
 (deftest current-user-info-for-session-test-6
   (testing "shouldn't fetch expired sessions"
     (try
-      (t2/insert! :model/Session {:id      (str test-uuid)
+      (t2/insert! :model/Session {:id      test-uuid-hashed
                                   :user_id (mt/user->id :lucky)})
         ;; use low-level `execute!` because updating is normally disallowed for Sessions
-      (t2/query-one {:update :core_session, :set {:created_at (t/instant 1000)}, :where [:= :id (str test-uuid)]})
+      (t2/query-one {:update (t2/table-name :model/Session), :set {:created_at (t/instant 1000)}, :where [:= :id test-uuid-hashed]})
       (is (= nil
              (#'mw.session/current-user-info-for-session (str test-uuid) nil)))
       (finally
-        (t2/delete! :model/Session :id (str test-uuid))))))
+        (t2/delete! :model/Session :id test-uuid-hashed)))))
 
 (deftest current-user-info-for-session-test-7
   (testing "shouldn't fetch sessions for inactive users"
     (try
-      (t2/insert! :model/Session {:id (str test-uuid), :user_id (mt/user->id :trashbird)})
+      (t2/insert! :model/Session {:id test-uuid-hashed, :user_id (mt/user->id :trashbird)})
       (is (= nil
              (#'mw.session/current-user-info-for-session (str test-uuid) nil)))
       (finally
-        (t2/delete! :model/Session :id (str test-uuid))))))
+        (t2/delete! :model/Session :id test-uuid-hashed)))))
 
 ;; create a simple example of our middleware wrapped around a handler that simply returns our bound variables for users
 (defn- user-bound-handler [request]
@@ -328,8 +331,9 @@
     (testing "w/ Session"
       (testing "for user with no `:locale`"
         (mt/with-temp [:model/User {user-id :id}]
-          (let [session-id (str (random-uuid))]
-            (t2/insert! :model/Session {:id session-id, :user_id user-id})
+          (let [session-id (str (random-uuid))
+                session-id-hashed (session/hash-session-id session-id)]
+            (t2/insert! :model/Session {:id session-id-hashed, :user_id user-id})
             (is (= nil
                    (session-locale session-id)))
 
@@ -339,8 +343,9 @@
 
       (testing "for user *with* `:locale`"
         (mt/with-temp [:model/User {user-id :id} {:locale "es-MX"}]
-          (let [session-id (str (random-uuid))]
-            (t2/insert! :model/Session {:id session-id, :user_id user-id, :created_at :%now})
+          (let [session-id (str (random-uuid))
+                session-id-hashed (session/hash-session-id session-id)]
+            (t2/insert! :model/Session {:id session-id-hashed, :user_id user-id, :created_at :%now})
             (is (= "es_MX"
                    (session-locale session-id)))
 

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -23,8 +23,9 @@
 (def ^:private session-cookie request/metabase-session-cookie)
 (def ^:private session-timeout-cookie request/metabase-session-timeout-cookie)
 
-(def ^:private test-uuid #uuid "092797dd-a82a-4748-b393-697d7bb9ab65")
-(def ^:private test-uuid-hashed (session/hash-session-id test-uuid))
+(def ^:private test-session-key "092797dd-a82a-4748-b393-697d7bb9ab65")
+(def ^:private test-session-key-hashed (session/hash-session-key test-session-key))
+(def ^:private test-session-id "abcd1234")
 
 (deftest session-expired-test
   (init-status/set-complete!)
@@ -37,52 +38,53 @@
                [(sql.qp/add-interval-honeysql-form (mdb/db-type) :%now -59 :second) false "session that is 59 seconds old"]]]
         (testing (format "\n%s %s be expired." msg (if expected "SHOULD" "SHOULD NOT"))
           (mt/with-temp [:model/User {user-id :id}]
-            (let [session-id (str (random-uuid))
-                  session-id-hashed (session/hash-session-id session-id)]
-              (t2/insert! (t2/table-name :model/Session) {:id session-id-hashed, :user_id user-id, :created_at created-at})
-              (let [session (#'mw.session/current-user-info-for-session session-id nil)]
+            (let [session-id (session/generate-session-id)
+                  session-key (str (random-uuid))
+                  session-key-hashed (session/hash-session-key session-key)]
+              (t2/insert! (t2/table-name :model/Session) {:id session-id :key_hashed session-key-hashed, :user_id user-id, :created_at created-at})
+              (let [session (#'mw.session/current-user-info-for-session session-key nil)]
                 (if expected
                   (is (nil? session))
                   (is (some? session)))))))))))
 
-;;; ---------------------------------------- TEST wrap-session-id middleware -----------------------------------------
+;;; ---------------------------------------- TEST wrap-session-key middleware -----------------------------------------
 
 (def ^:private session-header @#'mw.session/metabase-session-header)
 
 ;; create a simple example of our middleware wrapped around a handler that simply returns the request
 ;; this works in this case because the only impact our middleware has is on the request
 (defn- wrapped-handler [request]
-  ((mw.session/wrap-session-id
+  ((mw.session/wrap-session-key
     (fn [request respond _] (respond request)))
    request
    identity
    (fn [e] (throw e))))
 
-(deftest ^:parallel no-session-id-in-request-test
-  (testing "no session-id in the request"
+(deftest ^:parallel no-session-key-in-request-test
+  (testing "no session-key in the request"
     (is (= nil
            (-> (wrapped-handler (ring.mock/request :get "/anyurl"))
-               :metabase-session-id)))))
+               :metabase-session-key)))))
 
 (deftest ^:parallel header-test
-  (testing "extract session-id from header"
+  (testing "extract session-key from header"
     (is (= "foobar"
-           (:metabase-session-id
+           (:metabase-session-key
             (wrapped-handler
              (ring.mock/header (ring.mock/request :get "/anyurl") session-header "foobar")))))))
 
 (deftest ^:parallel cookie-test
-  (testing "extract session-id from cookie"
+  (testing "extract session-key from cookie"
     (is (= "cookie-session"
-           (:metabase-session-id
+           (:metabase-session-key
             (wrapped-handler
              (assoc (ring.mock/request :get "/anyurl")
                     :cookies {session-cookie {:value "cookie-session"}})))))))
 
 (deftest ^:parallel both-header-and-cookie-test
-  (testing "if both header and cookie session-ids exist, then we expect the cookie to take precedence"
+  (testing "if both header and cookie session-keys exist, then we expect the cookie to take precedence"
     (is (= "cookie-session"
-           (:metabase-session-id
+           (:metabase-session-key
             (wrapped-handler
              (assoc (ring.mock/header (ring.mock/request :get "/anyurl") session-header "foobar")
                     :cookies {session-cookie {:value "cookie-session"}})))))))
@@ -90,15 +92,15 @@
 (def ^:private test-anti-csrf-token "84482ddf1bb178186ed9e1c0b1e05a2d")
 
 (deftest ^:parallel anti-csrf-headers-test
-  (testing "`wrap-session-id` should handle anti-csrf headers they way we'd expect"
+  (testing "`wrap-session-key` should handle anti-csrf headers they way we'd expect"
     (let [request (-> (ring.mock/request :get "/anyurl")
-                      (assoc :cookies {request/metabase-embedded-session-cookie {:value (str test-uuid)}})
+                      (assoc :cookies {request/metabase-embedded-session-cookie {:value test-session-key}})
                       (assoc-in [:headers request/anti-csrf-token-header] test-anti-csrf-token))]
       (is (= {:anti-csrf-token     "84482ddf1bb178186ed9e1c0b1e05a2d"
               :cookies             {request/metabase-embedded-session-cookie {:value "092797dd-a82a-4748-b393-697d7bb9ab65"}}
-              :metabase-session-id "092797dd-a82a-4748-b393-697d7bb9ab65"
+              :metabase-session-key "092797dd-a82a-4748-b393-697d7bb9ab65"
               :uri                 "/anyurl"}
-             (select-keys (wrapped-handler request) [:anti-csrf-token :cookies :metabase-session-id :uri]))))))
+             (select-keys (wrapped-handler request) [:anti-csrf-token :cookies :metabase-session-key :uri]))))))
 
 (deftest current-user-info-for-api-key-test
   (mt/with-temp [:model/ApiKey _ {:name          "An API Key"
@@ -180,20 +182,24 @@
     ;; for some reason Toucan seems to be busted with models with non-integer IDs and `with-temp` doesn't seem to work
     ;; the way we'd expect :/
     (try
-      (t2/insert! :model/Session {:id test-uuid-hashed, :user_id (mt/user->id :lucky)})
+      (t2/insert! :model/Session {:id         test-session-id
+                                  :key_hashed test-session-key-hashed
+                                  :user_id    (mt/user->id :lucky)})
       (is (= {:metabase-user-id (mt/user->id :lucky), :is-superuser? false, :is-group-manager? false, :user-locale nil}
-             (#'mw.session/current-user-info-for-session (str test-uuid) nil)))
+             (#'mw.session/current-user-info-for-session test-session-key nil)))
       (finally
-        (t2/delete! :model/Session :id test-uuid-hashed)))))
+        (t2/delete! :model/Session :id test-session-id)))))
 
 (deftest current-user-info-for-session-test-2
   (testing "superusers should come back as `:is-superuser?`"
     (try
-      (t2/insert! :model/Session {:id test-uuid-hashed, :user_id (mt/user->id :crowberto)})
+      (t2/insert! :model/Session {:id         test-session-id
+                                  :key_hashed test-session-key-hashed
+                                  :user_id    (mt/user->id :crowberto)})
       (is (= {:metabase-user-id (mt/user->id :crowberto), :is-superuser? true, :is-group-manager? false, :user-locale nil}
-             (#'mw.session/current-user-info-for-session (str test-uuid) nil)))
+             (#'mw.session/current-user-info-for-session test-session-key nil)))
       (finally
-        (t2/delete! :model/Session :id test-uuid-hashed)))))
+        (t2/delete! :model/Session :id test-session-id)))))
 
 (deftest current-user-info-for-session-test-3
   (testing "If user is a group manager of at least one group, `:is-group-manager?` "
@@ -203,83 +209,89 @@
                                user    [group-1 group-2]]
         (t2/update! :model/PermissionsGroupMembership {:user_id (:id user), :group_id (:id group-2)}
                     {:is_group_manager true})
-        (t2/insert! :model/Session {:id      test-uuid-hashed
-                                    :user_id (:id user)})
+        (t2/insert! :model/Session {:id         test-session-id
+                                    :key_hashed test-session-key-hashed
+                                    :user_id    (:id user)})
         (testing "is `false` if advanced-permisison is disabled"
           (mt/with-premium-features #{}
             (is (= false
-                   (:is-group-manager? (#'mw.session/current-user-info-for-session (str test-uuid) nil))))))
+                   (:is-group-manager? (#'mw.session/current-user-info-for-session test-session-key nil))))))
 
         (testing "is `true` if advanced-permisison is enabled"
           ;; a trick to run this test in OSS because even if advanced-permisison is enabled but EE ns is not evailable
           ;; `enable-advanced-permissions?` will still return false
           (with-redefs [premium-features/enable-advanced-permissions? (fn [& _args] true)]
             (is (= true
-                   (:is-group-manager? (#'mw.session/current-user-info-for-session (str test-uuid) nil)))))))
+                   (:is-group-manager? (#'mw.session/current-user-info-for-session test-session-key nil)))))))
       (finally
-        (t2/delete! :model/Session :id test-uuid-hashed)))))
+        (t2/delete! :model/Session :id test-session-id)))))
 
 (deftest current-user-info-for-session-test-4
   (testing "full-app-embed sessions shouldn't come back if we don't explicitly specifiy the anti-csrf token"
     (try
-      (t2/insert! :model/Session {:id              test-uuid-hashed
+      (t2/insert! :model/Session {:id              test-session-id
+                                  :key_hashed      test-session-key-hashed
                                   :user_id         (mt/user->id :lucky)
                                   :anti_csrf_token test-anti-csrf-token})
       (is (= nil
-             (#'mw.session/current-user-info-for-session (str test-uuid) nil)))
+             (#'mw.session/current-user-info-for-session test-session-key nil)))
       (finally
-        (t2/delete! :model/Session :id test-uuid-hashed)))
+        (t2/delete! :model/Session :id test-session-id)))
 
     (testing "...but if we do specifiy the token, they should come back"
       (try
-        (t2/insert! :model/Session {:id              test-uuid-hashed
+        (t2/insert! :model/Session {:id              test-session-id
+                                    :key_hashed      test-session-key-hashed
                                     :user_id         (mt/user->id :lucky)
                                     :anti_csrf_token test-anti-csrf-token})
         (is (= {:metabase-user-id (mt/user->id :lucky), :is-superuser? false, :is-group-manager? false, :user-locale nil}
-               (#'mw.session/current-user-info-for-session (str test-uuid) test-anti-csrf-token)))
+               (#'mw.session/current-user-info-for-session test-session-key test-anti-csrf-token)))
         (finally
-          (t2/delete! :model/Session :id test-uuid-hashed)))
+          (t2/delete! :model/Session :id test-session-id)))
 
       (testing "(unless the token is wrong)"
         (try
-          (t2/insert! :model/Session {:id              test-uuid-hashed
+          (t2/insert! :model/Session {:id              test-session-id
+                                      :key_hashed      test-session-key-hashed
                                       :user_id         (mt/user->id :lucky)
                                       :anti_csrf_token test-anti-csrf-token})
           (is (= nil
-                 (#'mw.session/current-user-info-for-session (str test-uuid) (str/join (reverse test-anti-csrf-token)))))
+                 (#'mw.session/current-user-info-for-session test-session-key (str/join (reverse test-anti-csrf-token)))))
           (finally
-            (t2/delete! :model/Session :id test-uuid-hashed)))))))
+            (t2/delete! :model/Session :id test-session-id)))))))
 
 (deftest current-user-info-for-session-test-5
   (testing "if we specify an anti-csrf token we shouldn't get back a session without that token"
     (try
-      (t2/insert! :model/Session {:id      test-uuid-hashed
-                                  :user_id (mt/user->id :lucky)})
+      (t2/insert! :model/Session {:id         test-session-id
+                                  :key_hashed test-session-key-hashed
+                                  :user_id    (mt/user->id :lucky)})
       (is (= nil
-             (#'mw.session/current-user-info-for-session (str test-uuid) test-anti-csrf-token)))
+             (#'mw.session/current-user-info-for-session test-session-key test-anti-csrf-token)))
       (finally
-        (t2/delete! :model/Session :id test-uuid-hashed)))))
+        (t2/delete! :model/Session :id test-session-id)))))
 
 (deftest current-user-info-for-session-test-6
   (testing "shouldn't fetch expired sessions"
     (try
-      (t2/insert! :model/Session {:id      test-uuid-hashed
-                                  :user_id (mt/user->id :lucky)})
-        ;; use low-level `execute!` because updating is normally disallowed for Sessions
-      (t2/query-one {:update (t2/table-name :model/Session), :set {:created_at (t/instant 1000)}, :where [:= :id test-uuid-hashed]})
+      (t2/insert! :model/Session {:id         test-session-id
+                                  :key_hashed test-session-key-hashed
+                                  :user_id    (mt/user->id :lucky)})
+      ;; use low-level `execute!` because updating is normally disallowed for Sessions
+      (t2/query-one {:update (t2/table-name :model/Session), :set {:created_at (t/instant 1000)}, :where [:= :id test-session-id]})
       (is (= nil
-             (#'mw.session/current-user-info-for-session (str test-uuid) nil)))
+             (#'mw.session/current-user-info-for-session test-session-key nil)))
       (finally
-        (t2/delete! :model/Session :id test-uuid-hashed)))))
+        (t2/delete! :model/Session :id test-session-id)))))
 
 (deftest current-user-info-for-session-test-7
   (testing "shouldn't fetch sessions for inactive users"
     (try
-      (t2/insert! :model/Session {:id test-uuid-hashed, :user_id (mt/user->id :trashbird)})
+      (t2/insert! :model/Session {:id test-session-id :key_hashed test-session-key-hashed, :user_id (mt/user->id :trashbird)})
       (is (= nil
-             (#'mw.session/current-user-info-for-session (str test-uuid) nil)))
+             (#'mw.session/current-user-info-for-session test-session-key nil)))
       (finally
-        (t2/delete! :model/Session :id test-uuid-hashed)))))
+        (t2/delete! :model/Session :id test-session-id)))))
 
 ;; create a simple example of our middleware wrapped around a handler that simply returns our bound variables for users
 (defn- user-bound-handler [request]
@@ -319,9 +331,9 @@
                              (respond i18n/*user-locale*))
                            mw.session/bind-current-user
                            mw.session/wrap-current-user-info)
-        session-locale (fn [session-id & {:as more}]
+        session-locale (fn [session-key & {:as more}]
                          (handler
-                          (merge {:metabase-session-id session-id} more)
+                          (merge {:metabase-session-key session-key} more)
                           identity
                           (fn [e] (throw e))))]
     (testing "No Session"
@@ -331,31 +343,33 @@
     (testing "w/ Session"
       (testing "for user with no `:locale`"
         (mt/with-temp [:model/User {user-id :id}]
-          (let [session-id (str (random-uuid))
-                session-id-hashed (session/hash-session-id session-id)]
-            (t2/insert! :model/Session {:id session-id-hashed, :user_id user-id})
+          (let [session-id (session/generate-session-id)
+                session-key (str (random-uuid))
+                session-key-hashed (session/hash-session-key session-key)]
+            (t2/insert! :model/Session {:id session-id :key_hashed session-key-hashed, :user_id user-id})
             (is (= nil
-                   (session-locale session-id)))
+                   (session-locale session-key)))
 
             (testing "w/ X-Metabase-Locale header"
               (is (= "es_MX"
-                     (session-locale session-id :headers {"x-metabase-locale" "es-mx"})))))))
+                     (session-locale session-key :headers {"x-metabase-locale" "es-mx"})))))))
 
       (testing "for user *with* `:locale`"
         (mt/with-temp [:model/User {user-id :id} {:locale "es-MX"}]
-          (let [session-id (str (random-uuid))
-                session-id-hashed (session/hash-session-id session-id)]
-            (t2/insert! :model/Session {:id session-id-hashed, :user_id user-id, :created_at :%now})
+          (let [session-id (session/generate-session-id)
+                session-key (str (random-uuid))
+                session-key-hashed (session/hash-session-key session-key)]
+            (t2/insert! :model/Session {:id session-id :key_hashed session-key-hashed, :user_id user-id, :created_at :%now})
             (is (= "es_MX"
-                   (session-locale session-id)))
+                   (session-locale session-key)))
 
             (testing "w/ X-Metabase-Locale header"
               (is (= "en_GB"
-                     (session-locale session-id :headers {"x-metabase-locale" "en-GB"}))))))))))
+                     (session-locale session-key :headers {"x-metabase-locale" "en-GB"}))))))))))
 
 (deftest session-timeout-test
   (let [request-time (t/zoned-date-time "2022-01-01T00:00:00.000Z")
-        session-id   "8df268ab-00c0-4b40-9413-d66b966b696a"
+        session-key   "8df268ab-00c0-4b40-9413-d66b966b696a"
         response     {:body    "some body",
                       :cookies {}}]
     (testing "non-nil `session-timeout-seconds` should set the expiry of the timeout cookie relative to the request time"
@@ -364,7 +378,7 @@
         (testing "with normal sessions"
           (let [request {:cookies               {request/metabase-session-cookie         {:value "8df268ab-00c0-4b40-9413-d66b966b696a"}
                                                  request/metabase-session-timeout-cookie {:value "alive"}}
-                         :metabase-session-id   session-id
+                         :metabase-session-key   session-key
                          :metabase-session-type :normal}]
             (is (= {:body    "some body",
                     :cookies {session-timeout-cookie {:value     "alive"
@@ -376,7 +390,7 @@
         (testing "with embedded sessions"
           (let [request {:cookies               {request/metabase-embedded-session-cookie {:value "8df268ab-00c0-4b40-9413-d66b966b696a"}
                                                  request/metabase-session-timeout-cookie  {:value "alive"}}
-                         :metabase-session-id   session-id
+                         :metabase-session-key   session-key
                          :metabase-session-type :full-app-embed}]
             (is (= {:body    "some body",
                     :cookies {session-timeout-cookie {:value     "alive"

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -8,12 +8,11 @@
    [metabase.core.initialization-status :as init-status]
    [metabase.db :as mdb]
    [metabase.driver.sql.query-processor :as sql.qp]
-   [metabase.models.session :as session]
    [metabase.premium-features.core :as premium-features]
    [metabase.request.core :as request]
    [metabase.server.middleware.session :as mw.session]
+   [metabase.session.core :as session]
    [metabase.test :as mt]
-   [metabase.util.encryption :as encryption]
    [metabase.util.i18n :as i18n]
    [metabase.util.secret :as u.secret]
    [ring.mock.request :as ring.mock]
@@ -25,7 +24,7 @@
 (def ^:private session-timeout-cookie request/metabase-session-timeout-cookie)
 
 (def ^:private test-session-key "092797dd-a82a-4748-b393-697d7bb9ab65")
-(def ^:private test-session-key-hashed (encryption/hash-session-key test-session-key))
+(def ^:private test-session-key-hashed (session/hash-session-key test-session-key))
 (def ^:private test-session-id "abcd1234")
 
 (deftest session-expired-test
@@ -41,7 +40,7 @@
           (mt/with-temp [:model/User {user-id :id}]
             (let [session-id (session/generate-session-id)
                   session-key (str (random-uuid))
-                  session-key-hashed (encryption/hash-session-key session-key)]
+                  session-key-hashed (session/hash-session-key session-key)]
               (t2/insert! (t2/table-name :model/Session) {:id session-id :key_hashed session-key-hashed, :user_id user-id, :created_at created-at})
               (let [session (#'mw.session/current-user-info-for-session session-key nil)]
                 (if expected
@@ -356,7 +355,7 @@
         (mt/with-temp [:model/User {user-id :id}]
           (let [session-id (session/generate-session-id)
                 session-key (str (random-uuid))
-                session-key-hashed (encryption/hash-session-key session-key)]
+                session-key-hashed (session/hash-session-key session-key)]
             (t2/insert! :model/Session {:id session-id :key_hashed session-key-hashed, :user_id user-id})
             (is (= nil
                    (session-locale session-key)))
@@ -369,7 +368,7 @@
         (mt/with-temp [:model/User {user-id :id} {:locale "es-MX"}]
           (let [session-id (session/generate-session-id)
                 session-key (str (random-uuid))
-                session-key-hashed (encryption/hash-session-key session-key)]
+                session-key-hashed (session/hash-session-key session-key)]
             (t2/insert! :model/Session {:id session-id :key_hashed session-key-hashed, :user_id user-id, :created_at :%now})
             (is (= "es_MX"
                    (session-locale session-key)))

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -184,8 +184,7 @@
       (t2/insert! :model/Session {:id         test-session-id
                                   :key_hashed test-session-key-hashed
                                   :user_id    (mt/user->id :lucky)})
-      (is (thrown? ExceptionInfo
-                   (#'mw.session/current-user-info-for-session test-session-id nil)))
+      (is (= nil (#'mw.session/current-user-info-for-session test-session-id nil)))
       (finally
         (t2/delete! :model/Session :id test-session-id)))))
 

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -185,10 +185,9 @@
                                   :key_hashed test-session-key-hashed
                                   :user_id    (mt/user->id :lucky)})
       (is (thrown? ExceptionInfo
-            (#'mw.session/current-user-info-for-session test-session-id nil)))
+                   (#'mw.session/current-user-info-for-session test-session-id nil)))
       (finally
         (t2/delete! :model/Session :id test-session-id)))))
-
 
 (deftest current-user-info-for-session-test
   (testing "make sure the `current-user-info-for-session` logic is working correctly"

--- a/test/metabase/session/api_test.clj
+++ b/test/metabase/session/api_test.clj
@@ -36,7 +36,7 @@
 
 (def ^:private SessionResponse
   [:map
-   [:id ms/UUIDString]])
+   [:key ms/UUIDString]])
 
 (def ^:private session-cookie request/metabase-session-cookie)
 

--- a/test/metabase/session/api_test.clj
+++ b/test/metabase/session/api_test.clj
@@ -6,7 +6,6 @@
    [medley.core :as m]
    [metabase.driver.h2 :as h2]
    [metabase.http-client :as client]
-   [metabase.models.session :as session]
    [metabase.models.setting :as setting :refer [defsetting]]
    [metabase.public-settings :as public-settings]
    [metabase.request.core :as request]
@@ -16,6 +15,7 @@
    [metabase.test.data.users :as test.users]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
+   [metabase.util.encryption :as encryption]
    [metabase.util.json :as json]
    [metabase.util.malli.schema :as ms]
    [metabase.util.string :as string]
@@ -60,7 +60,7 @@
                        [:device_description ms/NonBlankString]
                        [:ip_address         ms/NonBlankString]
                        [:active             [:= true]]]
-                      (t2/select-one :model/LoginHistory :user_id (mt/user->id :rasta), :session_id (t2/select-one-fn :id :model/Session :key_hashed (session/hash-session-key (:id response)))))))))
+                      (t2/select-one :model/LoginHistory :user_id (mt/user->id :rasta), :session_id (t2/select-one-fn :id :model/Session :key_hashed (encryption/hash-session-key (:id response)))))))))
     (testing "Test that 'remember me' checkbox sets Max-Age attribute on session cookie"
       (let [body (assoc (mt/user->credentials :rasta) :remember true)
             response (mt/client-real-response :post 200 "session" body)]
@@ -197,7 +197,7 @@
       ;; Session
       (test.users/clear-cached-session-tokens!)
       (let [session-key       (client/authenticate (test.users/user->credentials :rasta))
-            session-key-hashed (session/hash-session-key session-key)
+            session-key-hashed (encryption/hash-session-key session-key)
             login-history-id (t2/select-one-pk :model/LoginHistory :session_id (t2/select-one-pk :model/Session :key_hashed session-key-hashed))]
         (testing "LoginHistory should have been recorded"
           (is (integer? login-history-id)))

--- a/test/metabase/session/api_test.clj
+++ b/test/metabase/session/api_test.clj
@@ -60,7 +60,7 @@
                        [:device_description ms/NonBlankString]
                        [:ip_address         ms/NonBlankString]
                        [:active             [:= true]]]
-                      (t2/select-one :model/LoginHistory :user_id (mt/user->id :rasta), :session_id (session/hash-session-id (:id response))))))))
+                      (t2/select-one :model/LoginHistory :user_id (mt/user->id :rasta), :session_id (t2/select-one-fn :id :model/Session :key_hashed (session/hash-session-key (:id response)))))))))
     (testing "Test that 'remember me' checkbox sets Max-Age attribute on session cookie"
       (let [body (assoc (mt/user->credentials :rasta) :remember true)
             response (mt/client-real-response :post 200 "session" body)]
@@ -196,17 +196,17 @@
       ;; clear out cached session tokens so next time we make an API request it log in & we'll know we have a valid
       ;; Session
       (test.users/clear-cached-session-tokens!)
-      (let [session-id       (client/authenticate (test.users/user->credentials :rasta))
-            session-id-hashed (session/hash-session-id session-id)
-            login-history-id (t2/select-one-pk :model/LoginHistory :session_id session-id-hashed)]
+      (let [session-key       (client/authenticate (test.users/user->credentials :rasta))
+            session-key-hashed (session/hash-session-key session-key)
+            login-history-id (t2/select-one-pk :model/LoginHistory :session_id (t2/select-one-pk :model/Session :key_hashed session-key-hashed))]
         (testing "LoginHistory should have been recorded"
           (is (integer? login-history-id)))
         ;; Ok, calling the logout endpoint should delete the Session in the DB. Don't worry, `test-users` will log back
         ;; in on the next API call
-        (client/client session-id :delete 204 "session")
+        (client/client session-key :delete 204 "session")
         ;; check whether it's still there -- should be GONE
         (is (= nil
-               (t2/select-one :model/Session :id session-id-hashed)))
+               (t2/select-one :model/Session :key_hashed session-key-hashed)))
         (testing "LoginHistory item should still exist, but session_id should be set to nil (active = false)"
           (is (malli= [:map
                        [:id                 ms/PositiveInt]

--- a/test/metabase/session/api_test.clj
+++ b/test/metabase/session/api_test.clj
@@ -60,7 +60,7 @@
                        [:device_description ms/NonBlankString]
                        [:ip_address         ms/NonBlankString]
                        [:active             [:= true]]]
-                      (t2/select-one :model/LoginHistory :user_id (mt/user->id :rasta), :session_id (:id response)))))))
+                      (t2/select-one :model/LoginHistory :user_id (mt/user->id :rasta), :session_id (session/hash-session-id (:id response))))))))
     (testing "Test that 'remember me' checkbox sets Max-Age attribute on session cookie"
       (let [body (assoc (mt/user->credentials :rasta) :remember true)
             response (mt/client-real-response :post 200 "session" body)]

--- a/test/metabase/session/api_test.clj
+++ b/test/metabase/session/api_test.clj
@@ -10,12 +10,12 @@
    [metabase.public-settings :as public-settings]
    [metabase.request.core :as request]
    [metabase.session.api :as api.session]
+   [metabase.session.models.session :as session]
    [metabase.sso.ldap-test-util :as ldap.test]
    [metabase.test :as mt]
    [metabase.test.data.users :as test.users]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
-   [metabase.util.encryption :as encryption]
    [metabase.util.json :as json]
    [metabase.util.malli.schema :as ms]
    [metabase.util.string :as string]
@@ -60,7 +60,7 @@
                        [:device_description ms/NonBlankString]
                        [:ip_address         ms/NonBlankString]
                        [:active             [:= true]]]
-                      (t2/select-one :model/LoginHistory :user_id (mt/user->id :rasta), :session_id (t2/select-one-fn :id :model/Session :key_hashed (encryption/hash-session-key (:id response)))))))))
+                      (t2/select-one :model/LoginHistory :user_id (mt/user->id :rasta), :session_id (t2/select-one-fn :id :model/Session :key_hashed (session/hash-session-key (:id response)))))))))
     (testing "Test that 'remember me' checkbox sets Max-Age attribute on session cookie"
       (let [body (assoc (mt/user->credentials :rasta) :remember true)
             response (mt/client-real-response :post 200 "session" body)]
@@ -197,7 +197,7 @@
       ;; Session
       (test.users/clear-cached-session-tokens!)
       (let [session-key       (client/authenticate (test.users/user->credentials :rasta))
-            session-key-hashed (encryption/hash-session-key session-key)
+            session-key-hashed (session/hash-session-key session-key)
             login-history-id (t2/select-one-pk :model/LoginHistory :session_id (t2/select-one-pk :model/Session :key_hashed session-key-hashed))]
         (testing "LoginHistory should have been recorded"
           (is (integer? login-history-id)))

--- a/test/metabase/session/api_test.clj
+++ b/test/metabase/session/api_test.clj
@@ -36,7 +36,7 @@
 
 (def ^:private SessionResponse
   [:map
-   [:key ms/UUIDString]])
+   [:id ms/UUIDString]])
 
 (def ^:private session-cookie request/metabase-session-cookie)
 

--- a/test/metabase/session/models/session_test.clj
+++ b/test/metabase/session/models/session_test.clj
@@ -152,9 +152,11 @@
 
     (mt/with-temp [:model/User {user-id :id} {}
                    :model/Session old-session {:id         "a"
+                                               :key_hashed "a1"
                                                :user_id    user-id
                                                :created_at (t/minus (t/local-date-time) (t/days 2))}
                    :model/Session new-session {:id         "b"
+                                               :key_hashed "b1"
                                                :user_id    user-id
                                                :created_at (t/minus (t/local-date-time) (t/hours 5))}]
       (testing "session-cleanup deletes old sessions and keeps new enough ones"

--- a/test/metabase/session/models/session_test.clj
+++ b/test/metabase/session/models/session_test.clj
@@ -158,3 +158,8 @@
         (session/cleanup-sessions!)
         (is (not (t2/exists? :model/Session :id (:id old-session))))
         (is (t2/exists? :model/Session :id (:id new-session)))))))
+
+(deftest hash-session-id-test
+  (is (= "ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff" (session/hash-session-id "test")))
+  (is (= "ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff" (session/hash-session-id "test")))
+  (is (= "6d201beeefb589b08ef0672dac82353d0cbd9ad99e1642c83a1601f3d647bcca003257b5e8f31bdc1d73fbec84fb085c79d6e2677b7ff927e823a54e789140d9" (session/hash-session-id "test2"))))

--- a/test/metabase/session/models/session_test.clj
+++ b/test/metabase/session/models/session_test.clj
@@ -10,7 +10,6 @@
    [metabase.test :as mt]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
-   [metabase.util.encryption :as encryption]
    [metabase.util.malli.schema :as ms]
    [metabase.util.string :as string]
    [toucan2.core :as t2]))
@@ -23,14 +22,14 @@
 (defn- new-session! []
   (let [session-id test-id]
     (try
-      (first (t2/insert-returning-instances! :model/Session {:id session-id :key_hashed (encryption/hash-session-key (str test-uuid)), :user_id (mt/user->id :trashbird)}))
+      (first (t2/insert-returning-instances! :model/Session {:id session-id :key_hashed (session/hash-session-key (str test-uuid)), :user_id (mt/user->id :trashbird)}))
       (finally
         (t2/delete! :model/Session :id test-id)))))
 
 (deftest new-session-include-test-test
   (testing "when creating a new Session, it should come back with an added `:type` key"
     (is (=? {:id              test-id
-             :key_hashed      (encryption/hash-session-key "092797dd-a82a-4748-b393-697d7bb9ab65")
+             :key_hashed      (session/hash-session-key "092797dd-a82a-4748-b393-697d7bb9ab65")
              :user_id         (mt/user->id :trashbird)
              :anti_csrf_token nil
              :type            :normal}
@@ -41,7 +40,7 @@
     (request/with-current-request {:headers {"x-metabase-embedded" "true"}}
       (with-redefs [session/random-anti-csrf-token (constantly "315c1279c6f9f873bf1face7afeee420")]
         (is (=? {:id              test-id
-                 :key_hashed      (encryption/hash-session-key "092797dd-a82a-4748-b393-697d7bb9ab65")
+                 :key_hashed      (session/hash-session-key "092797dd-a82a-4748-b393-697d7bb9ab65")
                  :user_id         (mt/user->id :trashbird)
                  :anti_csrf_token "315c1279c6f9f873bf1face7afeee420"
                  :type            :full-app-embed}
@@ -126,7 +125,7 @@
                                                                        :embedded           true
                                                                        :ip_address         "0:0:0:0:0:0:0:1"})]
       (is (string/valid-uuid? (:key session)))
-      (is (= (encryption/hash-session-key (:key session)) (t2/select-one-fn :key_hashed :model/Session :user_id user-id))))))
+      (is (= (session/hash-session-key (:key session)) (t2/select-one-fn :key_hashed :model/Session :user_id user-id))))))
 
 (deftest email-depending-on-embedded
   (let [email-sent (atom false)]
@@ -142,10 +141,10 @@
       (testing "do send email if not an embedded login"
         (reset! email-sent false)
         (mt/with-temp [:model/User {user-id :id}]
-          (session/create-session! :sso {:id user-id :last_login nil} {:device_id          "129d39d1-6758-4d2c-a751-35b860007002"
-                                                                       :device_description "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.72 Safari/537.36"
-                                                                       :embedded           false
-                                                                       :ip_address         "0:0:0:0:0:0:0:1"})
+          0          (session/create-session! :sso {:id user-id :last_login nil} {:device_id          "129d39d1-6758-4d2c-a751-35b860007002"
+                                                                                  :device_description "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.72 Safari/537.36"
+                                                                                  :embedded           false
+                                                                                  :ip_address         "0:0:0:0:0:0:0:1"})
           (is (true? @email-sent)))))))
 
 (deftest clean-sessions-test ()
@@ -165,3 +164,8 @@
         (session/cleanup-sessions!)
         (is (not (t2/exists? :model/Session :id (:id old-session))))
         (is (t2/exists? :model/Session :id (:id new-session)))))))
+
+(deftest hash-session-key-test
+  (is (= "ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff" (session/hash-session-key "test")))
+  (is (= "ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff" (session/hash-session-key "test")))
+  (is (= "6d201beeefb589b08ef0672dac82353d0cbd9ad99e1642c83a1601f3d647bcca003257b5e8f31bdc1d73fbec84fb085c79d6e2677b7ff927e823a54e789140d9" (session/hash-session-key "test2"))))

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -186,11 +186,12 @@
     (do
       (fetch-user user)
       (apply client-fn the-client user args))
-    (let [user-id (u/the-id user)]
+    (let [user-id (u/the-id user)
+          session-id (str (random-uuid))]
       (when-not (t2/exists? :model/User :id user-id)
         (throw (ex-info "User does not exist" {:user user})))
       #_{:clj-kondo/ignore [:discouraged-var]}
-      (t2.with-temp/with-temp [:model/Session {session-id :id} {:id      (session/hash-session-id (str (random-uuid)))
+      (t2.with-temp/with-temp [:model/Session _ {:id      (session/hash-session-id session-id)
                                                                 :user_id user-id}]
         (apply the-client session-id args)))))
 

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -5,11 +5,10 @@
    [medley.core :as m]
    [metabase.db :as mdb]
    [metabase.http-client :as client]
-   [metabase.models.session :as session]
    [metabase.request.core :as request]
+   [metabase.session.core :as session]
    [metabase.test.initialize :as initialize]
    [metabase.util :as u]
-   [metabase.util.encryption :as encryption]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]
@@ -139,7 +138,7 @@
   "Create a new `:model/Session` for one of the test users."
   [username :- TestUserName]
   (let [session-key (session/generate-session-key)]
-    (t2/insert! :model/Session {:id (session/generate-session-id) :key_hashed (encryption/hash-session-key session-key), :user_id (user->id username)})
+    (t2/insert! :model/Session {:id (session/generate-session-id) :key_hashed (session/hash-session-key session-key), :user_id (user->id username)})
     session-key))
 
 (mu/defn username->token :- ms/UUIDString
@@ -193,7 +192,7 @@
         (throw (ex-info "User does not exist" {:user user})))
       #_{:clj-kondo/ignore [:discouraged-var]}
       (t2.with-temp/with-temp [:model/Session _ {:id (session/generate-session-id)
-                                                 :key_hashed (encryption/hash-session-key session-key)
+                                                 :key_hashed (session/hash-session-key session-key)
                                                  :user_id user-id}]
         (apply the-client session-key args)))))
 

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -5,6 +5,7 @@
    [medley.core :as m]
    [metabase.db :as mdb]
    [metabase.http-client :as client]
+   [metabase.models.session :as session]
    [metabase.request.core :as request]
    [metabase.test.initialize :as initialize]
    [metabase.util :as u]
@@ -137,7 +138,7 @@
   "Create a new `:model/Session` for one of the test users."
   [username :- TestUserName]
   (let [session-token (str (random-uuid))]
-    (t2/insert! :model/Session {:id session-token, :user_id (user->id username)})
+    (t2/insert! :model/Session {:id (session/hash-session-id session-token), :user_id (user->id username)})
     session-token))
 
 (mu/defn username->token :- ms/UUIDString
@@ -189,7 +190,7 @@
       (when-not (t2/exists? :model/User :id user-id)
         (throw (ex-info "User does not exist" {:user user})))
       #_{:clj-kondo/ignore [:discouraged-var]}
-      (t2.with-temp/with-temp [:model/Session {session-id :id} {:id      (str (random-uuid))
+      (t2.with-temp/with-temp [:model/Session {session-id :id} {:id      (session/hash-session-id (str (random-uuid)))
                                                                 :user_id user-id}]
         (apply the-client session-id args)))))
 

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -192,7 +192,7 @@
         (throw (ex-info "User does not exist" {:user user})))
       #_{:clj-kondo/ignore [:discouraged-var]}
       (t2.with-temp/with-temp [:model/Session _ {:id      (session/hash-session-id session-id)
-                                                                :user_id user-id}]
+                                                 :user_id user-id}]
         (apply the-client session-id args)))))
 
 (def ^{:arglists '([test-user-name-or-user-or-id method expected-status-code? endpoint

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -9,6 +9,7 @@
    [metabase.request.core :as request]
    [metabase.test.initialize :as initialize]
    [metabase.util :as u]
+   [metabase.util.encryption :as encryption]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]
@@ -138,7 +139,7 @@
   "Create a new `:model/Session` for one of the test users."
   [username :- TestUserName]
   (let [session-key (session/generate-session-key)]
-    (t2/insert! :model/Session {:id (session/generate-session-id) :key_hashed (session/hash-session-key session-key), :user_id (user->id username)})
+    (t2/insert! :model/Session {:id (session/generate-session-id) :key_hashed (encryption/hash-session-key session-key), :user_id (user->id username)})
     session-key))
 
 (mu/defn username->token :- ms/UUIDString
@@ -192,7 +193,7 @@
         (throw (ex-info "User does not exist" {:user user})))
       #_{:clj-kondo/ignore [:discouraged-var]}
       (t2.with-temp/with-temp [:model/Session _ {:id (session/generate-session-id)
-                                                 :key_hashed (session/hash-session-key session-key)
+                                                 :key_hashed (encryption/hash-session-key session-key)
                                                  :user_id user-id}]
         (apply the-client session-key args)))))
 

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -1573,11 +1573,6 @@
   [expected actual]
   (=?/=?-diff (seq expected) (seq actual)))
 
-(defn random-string
-  "Returns a string of `n` random alphanumeric characters."
-  [n]
-  (apply str (take n (repeatedly #(rand-nth "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")))))
-
 (defmacro with-prometheus-system!
   "Run tests with a prometheus web server and registry. Provide binding symbols in a tuple of [port system]. Port will
   be bound to the random port used for the metrics endpoint and system will be a [[PrometheusSystem]] which has a

--- a/test/metabase/util/encryption_test.clj
+++ b/test/metabase/util/encryption_test.clj
@@ -164,8 +164,3 @@
     (testing "When secret is not set, it does not encrypt the stream"
       (let [encrypted (encryption/maybe-encrypt-for-stream nil (codecs/to-bytes "test string"))]
         (is (= "test string" (codecs/bytes->str encrypted)))))))
-
-(deftest hash-session-key-test
-  (is (= "ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff" (encryption/hash-session-key "test")))
-  (is (= "ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff" (encryption/hash-session-key "test")))
-  (is (= "6d201beeefb589b08ef0672dac82353d0cbd9ad99e1642c83a1601f3d647bcca003257b5e8f31bdc1d73fbec84fb085c79d6e2677b7ff927e823a54e789140d9" (encryption/hash-session-key "test2"))))

--- a/test/metabase/util/encryption_test.clj
+++ b/test/metabase/util/encryption_test.clj
@@ -7,8 +7,8 @@
    [metabase.models.setting.cache :as setting.cache]
    [metabase.test :as mt]
    [metabase.test.initialize :as initialize]
-   [metabase.test.util :as tu]
-   [metabase.util.encryption :as encryption])
+   [metabase.util.encryption :as encryption]
+   [metabase.util.string :as string])
   (:import (java.io ByteArrayInputStream)
            (org.apache.commons.io IOUtils)))
 
@@ -137,7 +137,7 @@
                   decrypted-stream (encryption/maybe-decrypt-stream secret encrypted-stream)]
         (is (= "test string" (slurp decrypted-stream))))))
   (testing "Can encrypt and decrypt a large stream"
-    (let [data (tu/random-string 100000)
+    (let [data (string/random-string 100000)
           input-stream (ByteArrayInputStream. (codecs/to-bytes data))]
       (with-open [encrypted-stream (encryption/encrypt-stream secret input-stream)
                   decrypted-stream (encryption/maybe-decrypt-stream secret encrypted-stream)]
@@ -151,7 +151,7 @@
       (with-open [decrypted-stream (encryption/maybe-decrypt-stream secret input-stream)]
         (is (= -1 (.read decrypted-stream))))))
   (testing "Long unencrypted streams come back as-is"
-    (let [data (tu/random-string 100000)
+    (let [data (string/random-string 100000)
           input-stream (ByteArrayInputStream. (codecs/to-bytes data))]
       (with-open [decrypted-stream (encryption/maybe-decrypt-stream secret input-stream)]
         (is (= data (codecs/bytes->str (IOUtils/toByteArray decrypted-stream))))))))

--- a/test/metabase/util/encryption_test.clj
+++ b/test/metabase/util/encryption_test.clj
@@ -164,3 +164,8 @@
     (testing "When secret is not set, it does not encrypt the stream"
       (let [encrypted (encryption/maybe-encrypt-for-stream nil (codecs/to-bytes "test string"))]
         (is (= "test string" (codecs/bytes->str encrypted)))))))
+
+(deftest hash-session-key-test
+  (is (= "ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff" (encryption/hash-session-key "test")))
+  (is (= "ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff" (encryption/hash-session-key "test")))
+  (is (= "6d201beeefb589b08ef0672dac82353d0cbd9ad99e1642c83a1601f3d647bcca003257b5e8f31bdc1d73fbec84fb085c79d6e2677b7ff927e823a54e789140d9" (encryption/hash-session-key "test2"))))

--- a/test/metabase/util/string_test.clj
+++ b/test/metabase/util/string_test.clj
@@ -29,6 +29,11 @@
       (is (= "ab...ra"
              (u.str/mask "abracadabra" 2 2))))))
 
-(deftest elide-test
+(deftest ^:parallel elide-test
   (is (= "short" (u.str/elide "short" 5)))
   (is (= "lo..." (u.str/elide "longer string" 5))))
+
+(deftest ^:parallel random-string
+  (is 10 (count (u.str/random-string 10)))
+  (is 20 (count (u.str/random-string 20)))
+  (is (not= (u.str/random-string 10) (u.str/random-string 10))))


### PR DESCRIPTION
### Description

Stores a hashed version of the session-id in the database rather than the plain version to improve security.

**NOTE**: To support upgrade without logging out existing users, the hashed keys will be stored in a new `core_session.key_hashed` column rather than continuing to use the `core_session.id` column. This allows us to continue to check the core_session.id column plain-text (IF AND NOLY IF the session cookie is a UUID) for legacy sessions and hashed_key for the hashed version. New records generate a random id string for the id value.

Making the `core_session.id` be a random value also allows us to have foreign keys to the session without including even the hashed key value in other tables, further improving security.

**NOTE:** If anyone downgrades to a version prior to this change, the existing sessions will become invalid because of the `id` checked by old versions will no longer have the session ids in them.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Log into the app and check that the core_session table does not contain a UUID-formatted id in either the id or key_hashed column.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
