### PR TITLE
[CI] Fix flaky dashboard test

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1219,7 +1219,9 @@ describe("scenarios > dashboard", () => {
       // move tab
       H.editDashboard();
       dragOnXAxis(cy.findByRole("tab", { name: "Tab 2" }), -200);
-      H.openQuestionsSidebar();
+      // assert tab order is now correct and ui has caught up to result of dragging the tab
+      cy.findAllByRole("tab").eq(0).should("have.text", "Tab 2");
+      cy.findAllByRole("tab").eq(1).should("have.text", "Tab 1");
       assertPreventLeave();
       H.saveDashboard();
 


### PR DESCRIPTION
This PR fixes a race condition for the dashboard tabs PR I just added in #53204. Here's 20x run of the test to prove it works: https://github.com/metabase/metabase/actions/runs/13167590409/job/36751312115

When working on a refactor of the tests I had moved `H.openQuestionsSidebar()` calls into `assertPreventLeave` but this last usage went unnoticed and was actually making tests pass locally due to a timing issue where the first click on the `+` button was going unregistered. I've added an assert that the tabs have been correctly reordered in the UI which makes the test a bit more robust and causes cypress to wait for the UI to catch up to the result of the drag.

This test is also failing in the original PR's backport #53254. I'll cherry pick the changes from this PR into that backport once this is approved.