### PR TITLE
Add custom linter to make sure requires are on newlines

### DIFF
--- a/.clj-kondo/test/hooks/clojure/core_test.clj
+++ b/.clj-kondo/test/hooks/clojure/core_test.clj
@@ -109,3 +109,16 @@
                               {:arglists '([card x y])}
                               (fn [card _ _]
                                 (-> card :visualization first))))))))
+
+(deftest require-newlines-test
+  (let [findings (atom [])]
+    (with-redefs [hooks/reg-finding! (fn [node]
+                                       (swap! findings conj node))]
+      (hooks.clojure.core/lint-ns
+       {:node     (hooks/parse-string "
+(ns metabase.task.cache
+  (:require [metabase.task.bunny]
+            [metabase.task.rabbit]))")})
+      (is (=? [{:message "Put your requires on a newline from the :require keyword [:metabase/require-shape-checker]",
+                :type    :metabase/require-shape-checker}]
+              @findings)))))

--- a/bin/release-list/src/release_list/main.clj
+++ b/bin/release-list/src/release_list/main.clj
@@ -1,7 +1,8 @@
 ;; #!/usr/bin/env bb
 (ns release-list.main
-  (:require [babashka.process :refer [shell]]
-            [clojure.string  :as str]))
+  (:require
+   [babashka.process :refer [shell]]
+   [clojure.string  :as str]))
 
 (set! *warn-on-reflection* true)
 

--- a/bin/release-list/test/release_list/main_test.clj
+++ b/bin/release-list/test/release_list/main_test.clj
@@ -1,6 +1,7 @@
 (ns main-test
-  (:require [clojure.test :refer [deftest is testing]]
-            [release-list.main :as rl]))
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [release-list.main :as rl]))
 
 (deftest ^:parallel test-build-link
   (testing "Builds correct link as a list item."
@@ -20,7 +21,7 @@
             :hotfix 0}
            (rl/semver-map "0.9-final")))))
 
-(def release-link "- [v0.45.3](https://github.com/metabase/metabase/releases/tag/1.2.3)")
+(def ^:private release-link "- [v0.45.3](https://github.com/metabase/metabase/releases/tag/1.2.3)")
 
 (deftest ^:parallel test-get-version
   (testing "Gets a line containing release information, and returns a map of release info for sorting."
@@ -30,13 +31,15 @@
             :hotfix 0}
            (rl/get-version release-link)))))
 
-(def releases "Metabase v0.46.1 Latest  v0.46.1 about 21 days ago\nMetabase® Enterprise Edition™ v1.46.1 v1.46.1 about 21 days ago\nMetabase v0.45.3.1 v0.45.3.1 about 29 days ago\nMetabase® Enterprise Edition™ v1.45.3.1 v1.45.3.1 about 29 days ago")
+(def ^:private releases
+  "Metabase v0.46.1 Latest  v0.46.1 about 21 days ago\nMetabase® Enterprise Edition™ v1.46.1 v1.46.1 about 21 days ago\nMetabase v0.45.3.1 v0.45.3.1 about 29 days ago\nMetabase® Enterprise Edition™ v1.45.3.1 v1.45.3.1 about 29 days ago")
 
-(def release-list '("- [v1.46.1](https://github.com/metabase/metabase/releases/tag/v1.46.1)"
-                    "- [v0.46.1](https://github.com/metabase/metabase/releases/tag/v0.46.1)"
-                    "- [v1.45.3.1](https://github.com/metabase/metabase/releases/tag/v1.45.3.1)"
-                    "- [v0.45.3.1](https://github.com/metabase/metabase/releases/tag/v0.45.3.1)"))
+(def ^:private release-list
+  '("- [v1.46.1](https://github.com/metabase/metabase/releases/tag/v1.46.1)"
+    "- [v0.46.1](https://github.com/metabase/metabase/releases/tag/v0.46.1)"
+    "- [v1.45.3.1](https://github.com/metabase/metabase/releases/tag/v1.45.3.1)"
+    "- [v0.45.3.1](https://github.com/metabase/metabase/releases/tag/v0.45.3.1)"))
 
-(deftest test-prep-links
+(deftest ^:parallel test-prep-links
   (testing "Creates links to GitHub release pages, and sorts by release and edition. EE before OSS."
     (is (= (rl/prep-links releases) release-list))))

--- a/enterprise/backend/src/metabase_enterprise/airgap.clj
+++ b/enterprise/backend/src/metabase_enterprise/airgap.clj
@@ -1,13 +1,14 @@
 (ns metabase-enterprise.airgap
-  (:require [buddy.core.keys :as keys]
-            [buddy.sign.jwt :as jwt]
-            [clojure.java.io :as io]
-            [clojure.string :as str]
-            [java-time.api :as t]
-            [metabase.premium-features.core :as premium-features :refer [defenterprise]]
-            [metabase.util.i18n :refer [tru]]
-            [metabase.util.malli :as mu]
-            [metabase.util.malli.schema :as ms])
+  (:require
+   [buddy.core.keys :as keys]
+   [buddy.sign.jwt :as jwt]
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [java-time.api :as t]
+   [metabase.premium-features.core :as premium-features :refer [defenterprise]]
+   [metabase.util.i18n :refer [tru]]
+   [metabase.util.malli :as mu]
+   [metabase.util.malli.schema :as ms])
   (:import [java.io Reader]))
 
 (set! *warn-on-reflection* true)

--- a/enterprise/backend/src/metabase_enterprise/cache/config.clj
+++ b/enterprise/backend/src/metabase_enterprise/cache/config.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.cache.config
-  (:require [metabase.premium-features.core :refer [defenterprise]]))
+  (:require
+   [metabase.premium-features.core :refer [defenterprise]]))
 
 (defenterprise refreshable-states
   "States of `persisted_info` records which can be refreshed."

--- a/enterprise/backend/src/metabase_enterprise/stale.clj
+++ b/enterprise/backend/src/metabase_enterprise/stale.clj
@@ -1,12 +1,13 @@
 (ns metabase-enterprise.stale
-  (:require [malli.experimental.time]
-            [metabase.embed.settings :as embed.settings]
-            [metabase.models.setting :refer [defsetting]]
-            [metabase.public-settings :as public-settings]
-            [metabase.util.honey-sql-2 :as h2x]
-            [metabase.util.i18n :refer [deferred-tru]]
-            [metabase.util.malli :as mu]
-            [toucan2.core :as t2]))
+  (:require
+   [malli.experimental.time]
+   [metabase.embed.settings :as embed.settings]
+   [metabase.models.setting :refer [defsetting]]
+   [metabase.public-settings :as public-settings]
+   [metabase.util.honey-sql-2 :as h2x]
+   [metabase.util.i18n :refer [deferred-tru]]
+   [metabase.util.malli :as mu]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 

--- a/enterprise/backend/test/metabase_enterprise/airgap_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/airgap_test.clj
@@ -1,9 +1,10 @@
 (ns metabase-enterprise.airgap-test
-  (:require    [clojure.java.io :as io]
-               [clojure.string :as str]
-               [clojure.test :refer :all]
-               [metabase-enterprise.airgap :as airgap]
-               [metabase.premium-features.core :as premium-features]))
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase-enterprise.airgap :as airgap]
+   [metabase.premium-features.core :as premium-features]))
 
 (defn- test-fake-features! [& {:keys [token-fn pubk-fn]}]
   (with-redefs

--- a/enterprise/backend/test/metabase_enterprise/stale_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/stale_test.clj
@@ -1,17 +1,18 @@
 (ns metabase-enterprise.stale-test
-  (:require [clojure.test :refer [deftest is are testing]]
-            [metabase-enterprise.stale :as stale]
-            [metabase-enterprise.test :as met]
-            [metabase.models.collection :as collection]
-            [metabase.models.moderation-review :as moderation-review]
-            [metabase.stale-test :refer [with-stale-items
-                                         stale-dashboard
-                                         stale-card
-                                         date-months-ago
-                                         datetime-months-ago]]
-            [metabase.test :as mt]
-            [metabase.util :as u]
-            [toucan2.core :as t2])
+  (:require
+   [clojure.test :refer [deftest is are testing]]
+   [metabase-enterprise.stale :as stale]
+   [metabase-enterprise.test :as met]
+   [metabase.models.collection :as collection]
+   [metabase.models.moderation-review :as moderation-review]
+   [metabase.stale-test :refer [with-stale-items
+                                stale-dashboard
+                                stale-card
+                                date-months-ago
+                                datetime-months-ago]]
+   [metabase.test :as mt]
+   [metabase.util :as u]
+   [toucan2.core :as t2])
   (:import (java.time LocalDate)))
 
 (set! *warn-on-reflection* true)

--- a/modules/drivers/athena/test/metabase/driver/athena/hive_parser_test.clj
+++ b/modules/drivers/athena/test/metabase/driver/athena/hive_parser_test.clj
@@ -1,29 +1,19 @@
 (ns metabase.driver.athena.hive-parser-test
-  (:require [clojure.test :refer :all]
-            [metabase.driver.athena.hive-parser :refer [hive-schema->map]]))
+  (:require
+   [clojure.test :refer :all]
+   [metabase.driver.athena.hive-parser :refer [hive-schema->map]]))
 
-(deftest parser
+(deftest ^:parallel parser
   (testing "Parse schema"
-    (is (=
-         {:customerid "string" :prime "boolean" :productid "int"}
-         (hive-schema->map "struct<customerid:string,prime:boolean,productid:int>")))
-
-    (is (=
-         {:customerid "string" :m_field [{:key "string" :value "string"}]}
-         (hive-schema->map "struct<customerid:string,m_field:map<string,string>>")))
-
-    (is (=
-         {:grouperrors "string" :grouperrorsorder [] :fielderrors {:reviewtext {:field "string"} :title {:field "string"}} :fielderrorsorder []}
-         (hive-schema->map "struct<grouperrors:string,grouperrorsorder:array<string>,fielderrors:struct<reviewtext:struct<field:string>,title:struct<field:string>>,fielderrorsorder:array<string>>")))
-
-    (is (=
-         [{:customerid "string" :Order "bigint"}]
-         (hive-schema->map "array<struct<customerid:string,Order:bigint>>")))
-
-    (is (=
-         {:accredited_buyer_representative_abr "boolean"}
-         (hive-schema->map "struct<accredited_buyer_representative_abr: boolean>")))
-
-    (is (=
-         {:mediacategory "string" :mediakey "string" :mediaurl "string" :order "bigint"}
-         (hive-schema->map "struct<mediacategory: string, mediakey: string, mediaurl: string, order: bigint>")))))
+    (is (= {:customerid "string" :prime "boolean" :productid "int"}
+           (hive-schema->map "struct<customerid:string,prime:boolean,productid:int>")))
+    (is (= {:customerid "string" :m_field [{:key "string" :value "string"}]}
+           (hive-schema->map "struct<customerid:string,m_field:map<string,string>>")))
+    (is (= {:grouperrors "string" :grouperrorsorder [] :fielderrors {:reviewtext {:field "string"} :title {:field "string"}} :fielderrorsorder []}
+           (hive-schema->map "struct<grouperrors:string,grouperrorsorder:array<string>,fielderrors:struct<reviewtext:struct<field:string>,title:struct<field:string>>,fielderrorsorder:array<string>>")))
+    (is (= [{:customerid "string" :Order "bigint"}]
+           (hive-schema->map "array<struct<customerid:string,Order:bigint>>")))
+    (is (= {:accredited_buyer_representative_abr "boolean"}
+           (hive-schema->map "struct<accredited_buyer_representative_abr: boolean>")))
+    (is (= {:mediacategory "string" :mediakey "string" :mediaurl "string" :order "bigint"}
+           (hive-schema->map "struct<mediacategory: string, mediakey: string, mediaurl: string, order: bigint>")))))

--- a/modules/drivers/druid/src/metabase/driver/druid/js.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/js.clj
@@ -1,7 +1,8 @@
 (ns metabase.driver.druid.js
   "Util fns for creating Javascript functions."
   (:refer-clojure :exclude [+ - * / or])
-  (:require [clojure.string :as str]))
+  (:require
+   [clojure.string :as str]))
 
 (defn- ->js [x]
   {:pre [(not (coll? x))]}

--- a/modules/drivers/druid/test/metabase/driver/druid/execute_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid/execute_test.clj
@@ -1,11 +1,12 @@
 (ns ^:mb/driver-tests metabase.driver.druid.execute-test
-  (:require [clojure.java.io :as io]
-            [clojure.test :refer :all]
-            [metabase.driver.druid.execute :as druid.execute]
-            [metabase.test :as mt]
-            [metabase.timeseries-query-processor-test.util :as tqpt]
-            [metabase.util :as u]
-            [metabase.util.json :as json]))
+  (:require
+   [clojure.java.io :as io]
+   [clojure.test :refer :all]
+   [metabase.driver.druid.execute :as druid.execute]
+   [metabase.test :as mt]
+   [metabase.timeseries-query-processor-test.util :as tqpt]
+   [metabase.util :as u]
+   [metabase.util.json :as json]))
 
 (deftest results-order-test
   (mt/test-driver :druid

--- a/modules/drivers/druid/test/metabase/test/data/druid.clj
+++ b/modules/drivers/druid/test/metabase/test/data/druid.clj
@@ -1,9 +1,10 @@
 (ns metabase.test.data.druid
-  (:require [clojure.string :as str]
-            [metabase.driver.druid.client :as druid.client]
-            [metabase.test.data.impl :as data.impl]
-            [metabase.test.data.interface :as tx]
-            [metabase.util :as u]))
+  (:require
+   [clojure.string :as str]
+   [metabase.driver.druid.client :as druid.client]
+   [metabase.test.data.impl :as data.impl]
+   [metabase.test.data.interface :as tx]
+   [metabase.util :as u]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/metabase/analytics/sdk.clj
+++ b/src/metabase/analytics/sdk.clj
@@ -8,9 +8,10 @@
 
   then we can use the information on the tables to track information about the embedding client,
   and TODO: send it out in `summarize-execution`."
-  (:require [metabase.analytics.prometheus :as prometheus]
-            [metabase.util.log :as log]
-            [metabase.util.malli :as mu]))
+  (:require
+   [metabase.analytics.prometheus :as prometheus]
+   [metabase.util.log :as log]
+   [metabase.util.malli :as mu]))
 
 (def ^:dynamic *version* "Used to track information about the metabase embedding client version." nil)
 (def ^:dynamic *client* "Used to track information about the metabase embedding client." nil)

--- a/src/metabase/core/bootstrap.clj
+++ b/src/metabase/core/bootstrap.clj
@@ -1,6 +1,7 @@
 (ns metabase.core.bootstrap
   (:gen-class)
-  (:require [clojure.java.io :as io]))
+  (:require
+   [clojure.java.io :as io]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/metabase/lib/dispatch.cljc
+++ b/src/metabase/lib/dispatch.cljc
@@ -1,5 +1,6 @@
 (ns metabase.lib.dispatch
-  (:require [metabase.util :as u]))
+  (:require
+   [metabase.util :as u]))
 
 (defn- mbql-clause-type [x]
   (when (and (vector? x)

--- a/src/metabase/query_processor/context.clj
+++ b/src/metabase/query_processor/context.clj
@@ -1,5 +1,6 @@
 (ns ^{:deprecated "0.50.0"} metabase.query-processor.context
-  (:require [metabase.query-processor.pipeline :as qp.pipeline]))
+  (:require
+   [metabase.query-processor.pipeline :as qp.pipeline]))
 
 (defn canceled-chan
   "DEPRECATED: use [[metabase.query-processor.pipeline/*canceled-chan*]] directly instead."

--- a/src/metabase/server/middleware/request_id.clj
+++ b/src/metabase/server/middleware/request_id.clj
@@ -1,5 +1,6 @@
 (ns metabase.server.middleware.request-id
-  (:require [metabase.config :refer [*request-id*]]))
+  (:require
+   [metabase.config :refer [*request-id*]]))
 
 (defn wrap-request-id
   "Attach a unique request ID to the request"

--- a/src/metabase/task/cache.clj
+++ b/src/metabase/task/cache.clj
@@ -1,6 +1,7 @@
 (ns metabase.task.cache
-  (:require [metabase.premium-features.core :refer [defenterprise]]
-            [metabase.task :as task]))
+  (:require
+   [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.task :as task]))
 
 (defenterprise init-cache-task!
   "In OSS does nothing"

--- a/src/metabase/util/autoplace.clj
+++ b/src/metabase/util/autoplace.clj
@@ -2,7 +2,8 @@
   "NOTE: It's not SUPER high impact if it falls out of sync - hopefully both will place things in a reasonable spot - but
   ideally this namespace should be kept in sync with
   [the frontend version](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/lib/dashboard_grid.js)."
-  (:require [metabase.models.dashboard.constants :as dashboard.constants]))
+  (:require
+   [metabase.models.dashboard.constants :as dashboard.constants]))
 
 (def ^:constant default-grid-width
   "The default grid width."

--- a/src/metabase/util/connection.clj
+++ b/src/metabase/util/connection.clj
@@ -1,7 +1,8 @@
 (ns metabase.util.connection
-  (:require [clojure.set :as set]
-            [metabase.util :as u]
-            [toucan2.core :as t2])
+  (:require
+   [clojure.set :as set]
+   [metabase.util :as u]
+   [toucan2.core :as t2])
   (:import
    (java.sql Connection DatabaseMetaData ResultSet ResultSetMetaData)))
 

--- a/test/metabase/api/cards_test.clj
+++ b/test/metabase/api/cards_test.clj
@@ -1,9 +1,10 @@
 (ns metabase.api.cards-test
-  (:require [clojure.test :refer :all]
-            [metabase.permissions.models.permissions :as perms]
-            [metabase.permissions.models.permissions-group :as perms-group]
-            [metabase.test :as mt]
-            [toucan2.core :as t2]))
+  (:require
+   [clojure.test :refer :all]
+   [metabase.permissions.models.permissions :as perms]
+   [metabase.permissions.models.permissions-group :as perms-group]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
 
 (deftest dashboards-for-cards-works
   (mt/with-temp [:model/Card {card-id :id} {}

--- a/test/metabase/api/trash_test.clj
+++ b/test/metabase/api/trash_test.clj
@@ -1,8 +1,9 @@
 (ns metabase.api.trash-test
-  (:require  [clojure.test :refer [deftest testing is]]
-             [metabase.api.card-test :refer [card-with-name-and-query]]
-             [metabase.models.collection :as collection]
-             [metabase.test :as mt]))
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [metabase.api.card-test :refer [card-with-name-and-query]]
+   [metabase.models.collection :as collection]
+   [metabase.test :as mt]))
 
 (def dashboard-defaults {:name          "Dashboard"
                          :parameters    [{:id "abc123", :name "test", :type "date"}]

--- a/test/metabase/api/user_key_value_test.clj
+++ b/test/metabase/api/user_key_value_test.clj
@@ -1,7 +1,8 @@
 (ns metabase.api.user-key-value-test
-  (:require [clojure.test :refer :all]
-            [metabase.models.user-key-value.types :as user-kv.types]
-            [metabase.test :as mt]))
+  (:require
+   [clojure.test :refer :all]
+   [metabase.models.user-key-value.types :as user-kv.types]
+   [metabase.test :as mt]))
 
 (def ^:private test-types-dir
   "These schemas are only loaded in tests.

--- a/test/metabase/stale_test.clj
+++ b/test/metabase/stale_test.clj
@@ -1,6 +1,8 @@
 (ns metabase.stale-test
-  (:require [metabase.test :as mt])
-  (:import (java.time LocalDate LocalDateTime)))
+  (:require
+   [metabase.test :as mt])
+  (:import
+   (java.time LocalDate LocalDateTime)))
 
 (set! *warn-on-reflection* true)
 

--- a/test/metabase/util/autoplace_test.clj
+++ b/test/metabase/util/autoplace_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.util.autoplace-test
-  (:require [clojure.test :refer :all]
-            [metabase.util.autoplace :as autoplace]))
+  (:require
+   [clojure.test :refer :all]
+   [metabase.util.autoplace :as autoplace]))
 
 (def ^:private test-grid-width 6)
 (def ^:private test-card-width 2)

--- a/test/metabase/util/delay_test.clj
+++ b/test/metabase/util/delay_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.util.delay-test
-  (:require [clojure.test :refer :all]
-            [metabase.util.delay :as delay]))
+  (:require
+   [clojure.test :refer :all]
+   [metabase.util.delay :as delay]))
 
 (set! *warn-on-reflection* true)
 

--- a/test/metabase/util/performance_test.clj
+++ b/test/metabase/util/performance_test.clj
@@ -1,8 +1,9 @@
 (ns metabase.util.performance-test
-  (:require [clojure.test :refer :all]
-            [metabase.util.performance :as perf]))
+  (:require
+   [clojure.test :refer :all]
+   [metabase.util.performance :as perf]))
 
-(deftest concat-test
+(deftest ^:parallel concat-test
   (is (= [1 2 3 4 5] (perf/concat [1] [] [2] [3 4] nil '(5))))
   (is (= [] (perf/concat [] [])))
   (is (= [] (perf/concat [] [])))
@@ -25,7 +26,7 @@
   (is (= [] (mapv-via-run! inc [])))
   (is (= [1 2 3 4 5] (mapv-via-run! inc (range 5)))))
 
-(deftest transpose-test
+(deftest ^:parallel transpose-test
   (is (= [[1 2 3 4] [1 2 3 4] [1 2 3 4] [1 2 3 4] [1 2 3 4]]
          (perf/transpose [[1 1 1 1 1] [2 2 2 2 2] [3 3 3 3 3] [4 4 4 4 4]])
          (apply mapv vector [[1 1 1 1 1] [2 2 2 2 2] [3 3 3 3 3] [4 4 4 4 4]])))


### PR DESCRIPTION
99.9% of our namespaces follow this rule, but some don't. Add a linter to enforce it and fix the naughty namespaces.