### PR TITLE
add visibility check before saving dashboard

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -206,6 +206,7 @@ describe("scenarios > dashboard", () => {
       });
       H.entityPickerModal().button("Select").click();
 
+      cy.findByTestId("dashcard").should("be.visible");
       H.saveDashboard();
 
       cy.log(


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/DEV-21/flaky-test-scenarios-dashboard-create-adding-question-to-one-dashboard

### Description

The test occasionaly flaked when it was waiting for a certain API call to be made. This was another dead-click situation where dashboard would get saved too soon.

### Resolution
Simply waiting for elements to fully load and then proceed would make the test stable again

### Stress test

https://github.com/metabase/metabase/actions/runs/13178743160
