### PR TITLE
No more super tiny remove button for condition rules with many columns

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx
@@ -273,6 +273,7 @@ const RulePreview = ({ rule, cols, onClick, onRemove }) => (
         <Icon
           name="close"
           className={cx(CS.cursorPointer, CS.textLight, CS.textMediumHover)}
+          style={{ minWidth: 16 }}
           onClick={e => {
             e.stopPropagation();
             onRemove();


### PR DESCRIPTION
Closes #49931 

### Description

Before:
<img width="1450" alt="image" src="https://github.com/user-attachments/assets/6ff835f0-37cc-4610-8963-9eb19aae8ccd" />


After:
<img width="1450" alt="image" src="https://github.com/user-attachments/assets/c1896a87-0032-4acb-be08-b1c000536fe6" />
