### PR TITLE
Fix search for queries with single backslashes

### DIFF
--- a/src/metabase/search/appdb/specialization/postgres.clj
+++ b/src/metabase/search/appdb/specialization/postgres.clj
@@ -88,7 +88,8 @@
            complete?      (not (str/ends-with? trimmed "\""))
            ;; TODO also only complete if the :context is appropriate
            maybe-complete (if complete? complete-last-word identity)]
-       (->> (split-preserving-quotes trimmed)
+       (->> (str/replace trimmed "\\" "\\\\")
+            split-preserving-quotes
             (remove str/blank?)
             (partition-by #{"or"})
             (remove #(= (first %) "or"))

--- a/test/metabase/search/appdb/specializations/postgres_test.clj
+++ b/test/metabase/search/appdb/specializations/postgres_test.clj
@@ -51,6 +51,10 @@
     (is (= "'you' & '<-' & 'pointing':*"
            (search-expr "you <- pointing"))))
 
+  (testing "backslash"
+    (is (= "'test\\\\':*" (search-expr "test\\"))))
+
   (testing "single quotes"
     (is (= "'you''re':*"
            (search-expr "you're")))))
+

--- a/test/metabase/search/appdb/specializations/postgres_test.clj
+++ b/test/metabase/search/appdb/specializations/postgres_test.clj
@@ -57,4 +57,3 @@
   (testing "single quotes"
     (is (= "'you''re':*"
            (search-expr "you're")))))
-


### PR DESCRIPTION
Fixes queries like this one: https://grafana.monitoring.metabase.com/d/Zjw_nJX7k/metabase-logs?orgId=1&var-cluster=metabase-1&var-filter=api%2Fsearch&var-namespace=All&var-dns_host=All&var-pod=All&from=1738796478000&to=1738811065000

We rely on quoting in our `tsquery` to handle special characters, but backslashes need special treatment as they can also escape quotes.

Our current dictionary strips out backslashes, and we let users escape their own quotes in the raw query, so there's no real reason to keep them, but this approach is more future-proof than simply removing them.