### PR TITLE
unmark tests as flaky

### DIFF
--- a/e2e/test/scenarios/models/model-indexes.cy.spec.js
+++ b/e2e/test/scenarios/models/model-indexes.cy.spec.js
@@ -185,43 +185,39 @@ describe("scenarios > model indexes", () => {
     },
   );
 
-  it(
-    "should not reload the model for record in the same model",
-    { tags: "@flaky" },
-    () => {
-      createModelIndex({ modelId, pkName: "ID", valueName: "TITLE" });
+  it("should not reload the model for record in the same model", () => {
+    createModelIndex({ modelId, pkName: "ID", valueName: "TITLE" });
 
-      cy.visit("/");
+    cy.visit("/");
 
-      H.commandPaletteSearch("marble shoes", false);
-      H.commandPalette()
-        .findByRole("option", { name: "Small Marble Shoes" })
-        .click();
+    H.commandPaletteSearch("marble shoes", false);
+    H.commandPalette()
+      .findByRole("option", { name: "Small Marble Shoes" })
+      .click();
 
-      cy.wait("@dataset");
+    cy.wait("@dataset");
 
-      cy.findByTestId("object-detail").within(() => {
-        cy.findByRole("heading", { name: /Product/ });
-        cy.findByText("Small Marble Shoes");
-        cy.findByText("Doohickey");
-      });
+    cy.findByTestId("object-detail").within(() => {
+      cy.findByRole("heading", { name: /Product/ });
+      cy.findByText("Small Marble Shoes");
+      cy.findByText("Doohickey");
+    });
 
-      expectCardQueries(1);
+    expectCardQueries(1);
 
-      cy.get("body").type("{esc}");
+    cy.get("body").type("{esc}");
 
-      H.commandPaletteSearch("silk coat", false);
-      H.commandPalette()
-        .findByRole("option", { name: "Ergonomic Silk Coat" })
-        .click();
+    H.commandPaletteSearch("silk coat", false);
+    H.commandPalette()
+      .findByRole("option", { name: "Ergonomic Silk Coat" })
+      .click();
 
-      cy.findByTestId("object-detail").within(() => {
-        cy.findByText("Upton, Kovacek and Halvorson");
-      });
+    cy.findByTestId("object-detail").within(() => {
+      cy.findByText("Upton, Kovacek and Halvorson");
+    });
 
-      expectCardQueries(1);
-    },
-  );
+    expectCardQueries(1);
+  });
 });
 
 function editTitleMetadata() {

--- a/e2e/test/scenarios/models/model-indexes.cy.spec.js
+++ b/e2e/test/scenarios/models/model-indexes.cy.spec.js
@@ -123,28 +123,24 @@ describe("scenarios > model indexes", () => {
       .should("exist");
   });
 
-  it(
-    "should be able to search model index values and visit detail records",
-    { tags: "@flaky" },
-    () => {
-      createModelIndex({ modelId, pkName: "ID", valueName: "TITLE" });
+  it("should be able to search model index values and visit detail records", () => {
+    createModelIndex({ modelId, pkName: "ID", valueName: "TITLE" });
 
-      cy.visit("/");
+    cy.visit("/");
 
-      H.commandPaletteSearch("marble shoes", false);
-      H.commandPalette()
-        .findByRole("option", { name: "Small Marble Shoes" })
-        .click();
+    H.commandPaletteSearch("marble shoes", false);
+    H.commandPalette()
+      .findByRole("option", { name: "Small Marble Shoes" })
+      .click();
 
-      cy.wait("@dataset");
+    cy.wait("@dataset");
 
-      cy.findByTestId("object-detail").within(() => {
-        cy.findByRole("heading", { name: /Product/ });
-        cy.findByText("Small Marble Shoes");
-        cy.findByText("Doohickey");
-      });
-    },
-  );
+    cy.findByTestId("object-detail").within(() => {
+      cy.findByRole("heading", { name: /Product/ });
+      cy.findByText("Small Marble Shoes");
+      cy.findByText("Doohickey");
+    });
+  });
 
   it("should be able to see details of a record outside the first 2000", () => {
     H.createQuestion(

--- a/e2e/test/scenarios/models/model-indexes.cy.spec.js
+++ b/e2e/test/scenarios/models/model-indexes.cy.spec.js
@@ -146,44 +146,40 @@ describe("scenarios > model indexes", () => {
     },
   );
 
-  it(
-    "should be able to see details of a record outside the first 2000",
-    { tags: "@flaky" },
-    () => {
-      H.createQuestion(
-        {
-          name: "People Model",
-          query: { "source-table": PEOPLE_ID },
-          type: "model",
-        },
-        {
-          wrapId: true,
-          idAlias: "people_model_id",
-        },
-      );
+  it("should be able to see details of a record outside the first 2000", () => {
+    H.createQuestion(
+      {
+        name: "People Model",
+        query: { "source-table": PEOPLE_ID },
+        type: "model",
+      },
+      {
+        wrapId: true,
+        idAlias: "people_model_id",
+      },
+    );
 
-      cy.get("@people_model_id").then(peopleModelId => {
-        createModelIndex({
-          modelId: peopleModelId,
-          pkName: "ID",
-          valueName: "NAME",
-        });
+    cy.get("@people_model_id").then(peopleModelId => {
+      createModelIndex({
+        modelId: peopleModelId,
+        pkName: "ID",
+        valueName: "NAME",
       });
+    });
 
-      cy.visit("/");
+    cy.visit("/");
 
-      H.commandPaletteSearch("anais", false);
-      H.commandPalette().findByRole("option", { name: "Anais Zieme" }).click();
+    H.commandPaletteSearch("anais", false);
+    H.commandPalette().findByRole("option", { name: "Anais Zieme" }).click();
 
-      cy.wait("@dataset");
-      cy.wait("@dataset"); // second query gets the additional record
+    cy.wait("@dataset");
+    cy.wait("@dataset"); // second query gets the additional record
 
-      cy.findByTestId("object-detail").within(() => {
-        cy.findByText(/We're a little lost/i).should("not.exist");
-        cy.findAllByText("Anais Zieme").should("have.length", 2);
-      });
-    },
-  );
+    cy.findByTestId("object-detail").within(() => {
+      cy.findByText(/We're a little lost/i).should("not.exist");
+      cy.findAllByText("Anais Zieme").should("have.length", 2);
+    });
+  });
 
   it("should not reload the model for record in the same model", () => {
     createModelIndex({ modelId, pkName: "ID", valueName: "TITLE" });

--- a/e2e/test/scenarios/search/search-pagination.cy.spec.js
+++ b/e2e/test/scenarios/search/search-pagination.cy.spec.js
@@ -25,7 +25,7 @@ describe("scenarios > search", () => {
     H.getSearchBar().type(" ");
   });
 
-  it("should allow users to paginate results", { tags: "@flaky" }, () => {
+  it("should allow users to paginate results", () => {
     generateQuestions(TOTAL_ITEMS);
 
     cy.visit("/");

--- a/e2e/test/scenarios/search/search.cy.spec.js
+++ b/e2e/test/scenarios/search/search.cy.spec.js
@@ -148,7 +148,7 @@ describe("scenarios > search", () => {
         .should("not.exist");
     });
 
-    it("should not overflow container if results contain descriptions with large unborken strings", () => {
+    it("should not overflow container if results contain descriptions with large unbroken strings", () => {
       H.createQuestion({
         name: "Description Test",
         query: { "source-table": ORDERS_ID },


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/DEV-32/unmark-tests-as-flaky

### Description

Unmarking some issues as flaky
`scenarios > model indexes should not reload the model for record in the same model` [stress test](https://github.com/metabase/metabase/actions/runs/13180225476)
`scenarios > search should allow users to paginate results` [stress test](https://github.com/metabase/metabase/actions/runs/13180278403)
`scenarios > model indexes should be able to see details of a record outside the first 2000` [stress test](https://github.com/metabase/metabase/actions/runs/13180507174)
`scenarios > model indexes should be able to search model index values and visit detail records` [stress test](https://github.com/metabase/metabase/actions/runs/13180566904)