### PR TITLE
Speed up saml e2e tests

### DIFF
--- a/e2e/test/scenarios/admin-2/sso/saml.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/sso/saml.cy.spec.js
@@ -116,6 +116,13 @@ const enterSamlSettings = () => {
       /SAML Identity Provider URL/,
       "https://example.test",
     );
-    H.typeAndBlurUsingLabel(/SAML Identity Provider Certificate/, certificate);
+    // paste this long value to not waste time typing
+    cy.findByLabelText(/SAML Identity Provider Certificate/)
+      .click()
+      .invoke("val", certificate);
+    // do a little typing to invoke the blur event
+    cy.findByLabelText(/SAML Identity Provider Certificate/)
+      .type("a{backspace}")
+      .blur();
   });
 };


### PR DESCRIPTION
I ran across these tests where we were slowly typing a 1073 character SAML cert multiple times. This instead changes it to pasting, which saves a lot of time.