### PR TITLE
fix (ci): Set longer timeout to ensure we get a successful connection attempt

### DIFF
--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -67,9 +67,10 @@
       (binding [h2/*allow-testing-h2-connections* true]
         (testing "successes"
           (mt/with-prometheus-system! [_ system]
-            (database/health-check-database! (mt/db))
-            (is (== 1 (mt/metric-value system :metabase-database/healthy {:driver driver/*driver*})) "healthy")
-            (is (== 0 (mt/metric-value system :metabase-database/unhealthy {:driver driver/*driver*})) "unhealthy")))
+            (mt/with-temporary-setting-values [db-connection-timeout-ms 30000]
+              (database/health-check-database! (mt/db))
+              (is (== 1 (mt/metric-value system :metabase-database/healthy {:driver driver/*driver*})) "healthy")
+              (is (== 0 (mt/metric-value system :metabase-database/unhealthy {:driver driver/*driver*})) "unhealthy"))))
 
         (testing "skip audit"
           (mt/with-prometheus-system! [_ system]
@@ -82,6 +83,13 @@
             (database/health-check-database! (:is_sample (mt/db)))
             (is (== 0 (mt/metric-value system :metabase-database/healthy {:driver driver/*driver*})) "healthy")
             (is (== 0 (mt/metric-value system :metabase-database/unhealthy {:driver driver/*driver*})) "unhealthy")))
+
+        (testing "failures for timeout"
+          (mt/with-prometheus-system! [_ system]
+            (mt/with-temporary-setting-values [db-connection-timeout-ms 0]
+              (database/health-check-database! (mt/db))
+              (is (== 0 (mt/metric-value system :metabase-database/healthy {:driver driver/*driver*})) "healthy")
+              (is (== 1 (mt/metric-value system :metabase-database/unhealthy {:driver driver/*driver*})) "unhealthy"))))
 
         (testing "failures for bad connections"
           (when-let [bad-conn (tx/bad-connection-details driver/*driver*)]


### PR DESCRIPTION
We expect the connection to be valid, but this value https://github.com/metabase/metabase/blob/master/src/metabase/driver/util.clj#L132-L134 in CI is not great for bigquery. Bigquery[ connection checks test the dataset filters](https://github.com/metabase/metabase/blob/master/src/metabase/driver/util.clj#L132-L134) and fetching all the datasets can be slow - I managed to hit the 10s timeout locally debugging this.