### PR TITLE
Drop `of our terms` from legalese copy

### DIFF
--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkLegaleseModal/EmbeddingSdkLegaleseModal.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkLegaleseModal/EmbeddingSdkLegaleseModal.tsx
@@ -48,7 +48,7 @@ export const EmbeddingSdkLegaleseModal = ({
           <Text>{t`Sharing Metabase accounts is a security risk. Even if you filter data on the client side, each user could use their token to view any data visible to that shared user account.`}</Text>
         </List.Item>
         <List.Item>
-          <Text>{t`That, and we consider shared accounts to be unfair usage of our terms. Fair usage of the SDK involves giving each end-user of the embedded analytics their own Metabase account.`}</Text>
+          <Text>{t`That, and we consider shared accounts to be unfair usage. Fair usage of the SDK involves giving each end-user of the embedded analytics their own Metabase account.`}</Text>
         </List.Item>
       </List>
       <Group position="right" mt="lg">


### PR DESCRIPTION
[Context](https://metaboat.slack.com/archives/C01R1JY03J4/p1738859312389669)

@metabase-bot backport release-x.52.x