### PR TITLE
[CI] Fix flaky dashboard tab test v2

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.ts
+++ b/e2e/support/helpers/e2e-dashboard-helpers.ts
@@ -90,6 +90,8 @@ export function saveDashboard({
     "saveDashboard-saveDashboardCards",
   );
   cy.intercept("GET", "/api/dashboard/*").as("saveDashboard-getDashboard");
+
+  cy.findByText(editBarText).should("be.visible");
   cy.button(buttonLabel).click();
 
   if (awaitRequest) {

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1242,7 +1242,7 @@ describe("scenarios > dashboard", () => {
       createNewDashboard();
       H.createNewTab();
       assertPreventLeave();
-      H.saveDashboard({ waitMs: 250 }); // editing immediately after saving can cause flaky test behavior, add a wait step first
+      H.saveDashboard();
 
       // move tab
       H.editDashboard();
@@ -1251,19 +1251,19 @@ describe("scenarios > dashboard", () => {
       cy.findAllByRole("tab").eq(0).should("have.text", "Tab 2");
       cy.findAllByRole("tab").eq(1).should("have.text", "Tab 1");
       assertPreventLeave();
-      H.saveDashboard({ waitMs: 250 }); // editing immediately after saving can cause flaky test behavior, add a wait step first
+      H.saveDashboard();
 
       // duplicate tab
       H.editDashboard();
       H.duplicateTab("Tab 1");
       assertPreventLeave();
-      H.saveDashboard({ waitMs: 250 }); // editing immediately after saving can cause flaky test behavior, add a wait step first
+      H.saveDashboard();
 
       // remove tab
       H.editDashboard();
       H.deleteTab("Copy of Tab 1");
       assertPreventLeave();
-      H.saveDashboard({ waitMs: 250 }); // editing immediately after saving can cause flaky test behavior, add a wait step first
+      H.saveDashboard();
 
       // rename tab
       H.editDashboard();

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1235,45 +1235,41 @@ describe("scenarios > dashboard", () => {
       assertPreventLeave();
     });
 
-    it(
-      "should warn a user before leaving after adding, removed, moving, or duplicating a tab",
-      { tags: "@flaky" },
-      () => {
-        cy.visit("/");
+    it("should warn a user before leaving after adding, removed, moving, or duplicating a tab", () => {
+      cy.visit("/");
 
-        // add tab
-        createNewDashboard();
-        H.createNewTab();
-        assertPreventLeave();
-        H.saveDashboard();
+      // add tab
+      createNewDashboard();
+      H.createNewTab();
+      assertPreventLeave();
+      H.saveDashboard({ waitMs: 250 }); // editing immediately after saving can cause flaky test behavior, add a wait step first
 
-        // move tab
-        H.editDashboard();
-        dragOnXAxis(cy.findByRole("tab", { name: "Tab 2" }), -200);
-        // assert tab order is now correct and ui has caught up to result of dragging the tab
-        cy.findAllByRole("tab").eq(0).should("have.text", "Tab 2");
-        cy.findAllByRole("tab").eq(1).should("have.text", "Tab 1");
-        assertPreventLeave();
-        H.saveDashboard();
+      // move tab
+      H.editDashboard();
+      dragOnXAxis(cy.findByRole("tab", { name: "Tab 2" }), -200);
+      // assert tab order is now correct and ui has caught up to result of dragging the tab
+      cy.findAllByRole("tab").eq(0).should("have.text", "Tab 2");
+      cy.findAllByRole("tab").eq(1).should("have.text", "Tab 1");
+      assertPreventLeave();
+      H.saveDashboard({ waitMs: 250 }); // editing immediately after saving can cause flaky test behavior, add a wait step first
 
-        // duplicate tab
-        H.editDashboard();
-        H.duplicateTab("Tab 1");
-        assertPreventLeave();
-        H.saveDashboard();
+      // duplicate tab
+      H.editDashboard();
+      H.duplicateTab("Tab 1");
+      assertPreventLeave();
+      H.saveDashboard({ waitMs: 250 }); // editing immediately after saving can cause flaky test behavior, add a wait step first
 
-        // remove tab
-        H.editDashboard();
-        H.deleteTab("Copy of Tab 1");
-        assertPreventLeave();
-        H.saveDashboard();
+      // remove tab
+      H.editDashboard();
+      H.deleteTab("Copy of Tab 1");
+      assertPreventLeave();
+      H.saveDashboard({ waitMs: 250 }); // editing immediately after saving can cause flaky test behavior, add a wait step first
 
-        // rename tab
-        H.editDashboard();
-        H.renameTab("Tab 2", "Foo tab");
-        assertPreventLeave();
-      },
-    );
+      // rename tab
+      H.editDashboard();
+      H.renameTab("Tab 2", "Foo tab");
+      assertPreventLeave();
+    });
 
     function createNewDashboard() {
       H.newButton("Dashboard").click();


### PR DESCRIPTION
### Description

My last flake fix (#53267) turned out to not be the only flake within the test. It appears there's an issue where when you go to edit the dashboard immediately after saving it can make the click on the pencil icon do nothing. Saving a dashboard has been a source of flakes in the past and we understand there's race conditions here where we can't be certain the page has settled after save. This PR adds a wait to try to avoid issue, but it certainly isn't an ideal fix.

This passes with [a 50 run stress test](https://github.com/metabase/metabase/actions/runs/13185476197/job/36806422201) but my last "fix" also passed stress testing, so I'm unsure how much value we can place in this.

I tried running the whole `e2e/test/scenarios/dashboard/dashboard.cy.spec.js` spec 10x, but it failed / ran out of memory. This leads me to believe that my test failing has more to do with constrained resources rather than any issue with the test itself. https://github.com/metabase/metabase/actions/runs/13185459816/job/36806370629
