### PR TITLE
Perf & correctness fixes for preemptive caching

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/task/cache.clj
+++ b/enterprise/backend/src/metabase_enterprise/task/cache.clj
@@ -59,8 +59,7 @@
   [refresh-defs]
   (fn []
     (let [card-ids    (into #{} (map :card-id refresh-defs))
-          cards       (t2/select :model/Card :id [:in card-ids])
-          cards-by-id (group-by :id cards)]
+          cards-by-id (t2/select-pk->fn identity :model/Card :id [:in card-ids])]
       (doseq [{:keys [card-id dashboard-id queries]} refresh-defs]
         ;; Annotate the query with its cache strategy in the format expected by the QP
         (let [cache-strategy (strategies/cache-strategy (first (get cards-by-id card-id)) dashboard-id)]

--- a/enterprise/backend/test/metabase_enterprise/task/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/task/cache_test.clj
@@ -12,7 +12,7 @@
    [metabase.test.fixtures :as fixtures]
    [toucan2.core :as t2]))
 
-(use-fixtures :once (fixtures/initialize :db))
+(use-fixtures :once (fixtures/initialize :db :test-users))
 
 (set! *warn-on-reflection* true)
 
@@ -271,8 +271,10 @@
                 (is (= [nil param-val-2] (map param-vals (to-rerun card-id))))))))))))
 
 (deftest duration-base-queries-to-rerun-edge-cases-test
-  (let [query-1        {:database 1}
-        query-2        {:database 2}]
+  (let [query-1            {:database 1}
+        query-2            {:database 2}
+        query-1-cache-hash (qp.util/query-hash query-1)
+        query-2-cache-hash (qp.util/query-hash query-2)]
     (mt/with-temp [:model/Dashboard {dashboard-id :id} {:name "Dashboard"}
                    :model/Card {card-id-1 :id} {:name "Cached card 1"
                                                 :dataset_query query-1}
@@ -297,22 +299,25 @@
                                          :results    (.getBytes "cache contents" "UTF-8")}]
       (let [question-cache-config-1 {:model "question" :model_id card-id-1 :config {:duration 1 :unit "hours"}}
             question-cache-config-2 {:model "question" :model_id card-id-2 :config {:duration 1 :unit "hours"}}
-            dashboard-cache-config  {:model "dashboard" :model_id dashboard-id :config {:duration 1 :unit "hours"}}]
+            dashboard-cache-config  {:model "dashboard" :model_id dashboard-id :config {:duration 1 :unit "hours"}}
+            query-1-rerun-def       {:query query-1 :card-id card-id-1 :dashboard-id nil :count 1 :cache-hash (vec query-1-cache-hash)}
+            query-2-rerun-def       {:query query-2 :card-id card-id-2 :dashboard-id nil :count 1 :cache-hash (vec query-2-cache-hash)}]
         (testing "Happy path: we find all queries and card IDs that should be rerun"
           (testing "Cache configs on cards"
             (mt/with-temp [:model/QueryExecution {} (merge (query-execution-defaults query-1)
                                                            {:card_id card-id-1})]
-              (is (= [{:query query-1 :card-id card-id-1 :dashboard-id nil :count 1}]
-                     (t2/select :model/Query (@#'task.cache/duration-queries-to-rerun-honeysql
-                                              [question-cache-config-1] false))))
+              (is (= [query-1-rerun-def]
+                     (->> (t2/select :model/Query (@#'task.cache/duration-queries-to-rerun-honeysql
+                                                   [question-cache-config-1] false))
+                          (map #(update % :cache-hash vec)))))
 
               (mt/with-temp [:model/QueryExecution {} (merge (query-execution-defaults query-2)
                                                              {:card_id card-id-2})]
-                (is (= (->> [{:query query-1 :card-id card-id-1 :dashboard-id nil :count 1}
-                             {:query query-2 :card-id card-id-2 :dashboard-id nil :count 1}]
+                (is (= (->> [query-1-rerun-def query-2-rerun-def]
                             (sort-by :card-id))
                        (->> (t2/select :model/Query (@#'task.cache/duration-queries-to-rerun-honeysql
                                                      [question-cache-config-1 question-cache-config-2] false))
+                            (map #(update % :cache-hash vec))
                             (sort-by :card-id)))))))
 
           (testing "Cache configs on dashboards"
@@ -320,19 +325,12 @@
                                                            {:card_id card-id-1 :dashboard_id dashboard-id})
                            :model/QueryExecution {} (merge (query-execution-defaults query-2)
                                                            {:card_id card-id-2 :dashboard_id dashboard-id})]
-              (def res
-                (->> (t2/select :model/Query (@#'task.cache/duration-queries-to-rerun-honeysql
-                                              [dashboard-cache-config] false))
-                     (sort-by :card-id)))
-              (def expected
-                (->> [{:query query-1 :card-id card-id-1 :dashboard-id dashboard-id :count 1}
-                      {:query query-2 :card-id card-id-2 :dashboard-id dashboard-id :count 1}]
-                     (sort-by :card-id)))
-              (is (= (->> [{:query query-1 :card-id card-id-1 :dashboard-id dashboard-id :count 1}
-                           {:query query-2 :card-id card-id-2 :dashboard-id dashboard-id :count 1}]
+              (is (= (->> [(assoc query-1-rerun-def :dashboard-id dashboard-id)
+                           (assoc query-2-rerun-def :dashboard-id dashboard-id)]
                           (sort-by :card-id))
                      (->> (t2/select :model/Query (@#'task.cache/duration-queries-to-rerun-honeysql
                                                    [dashboard-cache-config] false))
+                          (map #(update % :cache-hash vec))
                           (sort-by :card-id)))))))
 
         (testing "We don't rerun a query execution older than 30 days"
@@ -364,8 +362,10 @@
                                                [question-cache-config-1] false))))))))))
 
 (deftest duration-parameterized-queries-to-rerun-edge-cases-test
-  (let [query-1 {:database 1}
-        query-2 {:database 2}]
+  (let [query-1            {:database 1}
+        query-2            {:database 2}
+        query-1-cache-hash (qp.util/query-hash query-1)
+        query-2-cache-hash (qp.util/query-hash query-2)]
     (mt/with-temp [:model/Dashboard {dashboard-id :id} {:name "Dashboard"}
                    :model/Card {card-id-1 :id} {:name "Cached card 1"
                                                 :dataset_query query-1}
@@ -390,26 +390,30 @@
                                          :results    (.getBytes "cache contents" "UTF-8")}]
       (let [question-cache-config-1 {:model "question" :model_id card-id-1 :config {:duration 1 :unit "hours"}}
             question-cache-config-2 {:model "question" :model_id card-id-2 :config {:duration 1 :unit "hours"}}
-            dashboard-cache-config  {:model "dashboard" :model_id dashboard-id :config {:duration 1 :unit "hours"}}]
+            dashboard-cache-config  {:model "dashboard" :model_id dashboard-id :config {:duration 1 :unit "hours"}}
+            query-1-rerun-def       {:query query-1 :card-id card-id-1 :dashboard-id nil :count 1 :cache-hash (vec query-1-cache-hash)}
+            query-2-rerun-def       {:query query-2 :card-id card-id-2 :dashboard-id nil :count 1 :cache-hash (vec query-2-cache-hash)}]
         (testing "Happy path: we find all parameterized queries and card IDs that should be rerun"
           (testing "Cache configs on cards"
             (mt/with-temp [:model/QueryExecution {} (merge (query-execution-defaults query-1)
                                                            {:card_id card-id-1
                                                             :cache_hit true
                                                             :parameterized true})]
-              (is (= [{:query query-1 :card-id card-id-1 :dashboard-id nil :count 1}]
-                     (t2/select :model/Query (@#'task.cache/duration-queries-to-rerun-honeysql
-                                              [question-cache-config-1] true))))
+              (is (= [query-1-rerun-def]
+                     (->> (t2/select :model/Query (@#'task.cache/duration-queries-to-rerun-honeysql
+                                                   [question-cache-config-1] true))
+                          (map #(update % :cache-hash vec)))))
 
               (mt/with-temp [:model/QueryExecution {} (merge (query-execution-defaults query-2)
                                                              {:card_id card-id-2
                                                               :cache_hit true
                                                               :parameterized true})]
-                (is (= (->> [{:query query-1 :card-id card-id-1 :dashboard-id nil :count 1}
-                             {:query query-2 :card-id card-id-2 :dashboard-id nil :count 1}]
+                (is (= (->> [query-1-rerun-def query-2-rerun-def]
                             (sort-by :card-id))
+
                        (->> (t2/select :model/Query (@#'task.cache/duration-queries-to-rerun-honeysql
                                                      [question-cache-config-1 question-cache-config-2] true))
+                            (map #(update % :cache-hash vec))
                             (sort-by :card-id)))))))
 
           (testing "Cache configs on dashboards"
@@ -423,11 +427,12 @@
                                                             :dashboard_id dashboard-id
                                                             :cache_hit true
                                                             :parameterized true})]
-              (is (= (->> [{:query query-1 :card-id card-id-1 :dashboard-id dashboard-id :count 1}
-                           {:query query-2 :card-id card-id-2 :dashboard-id dashboard-id :count 1}]
+              (is (= (->> [(assoc query-1-rerun-def :dashboard-id dashboard-id)
+                           (assoc query-2-rerun-def :dashboard-id dashboard-id)]
                           (sort-by :card-id))
                      (->> (t2/select :model/Query (@#'task.cache/duration-queries-to-rerun-honeysql
                                                    [dashboard-cache-config] true))
+                          (map #(update % :cache-hash vec))
                           (sort-by :card-id)))))))
 
         (testing "We don't rerun a query execution older than 30 days"

--- a/enterprise/backend/test/metabase_enterprise/task/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/task/cache_test.clj
@@ -49,7 +49,8 @@
 
 (defn- most-recent-cache-entry
   []
-  (t2/select-one :model/QueryCache {:order-by [[:updated_at :desc]]}))
+  (t2/select-one :model/QueryCache {:order-by [[:updated_at :desc]]
+                                    :limit 1}))
 
 (defn- expire-most-recent-cache-entry!
   "Manually expire the most recently updated cache entry by setting its updated_at back by 24 hours"

--- a/src/metabase/query_processor/middleware/cache_backend/db.clj
+++ b/src/metabase/query_processor/middleware/cache_backend/db.clj
@@ -103,13 +103,14 @@
   creating a new entry."
   [^bytes query-hash ^bytes results]
   (log/debugf "Caching results for query with hash %s." (pr-str (i/short-hex-hash query-hash)))
-  (let [final-results (encryption/maybe-encrypt-for-stream results)]
+  (let [final-results (encryption/maybe-encrypt-for-stream results)
+        timestamp     (t/offset-date-time)]
     (try
       (or (pos? (t2/update! :model/QueryCache {:query_hash query-hash}
-                            {:updated_at (t/offset-date-time)
+                            {:updated_at timestamp
                              :results    final-results}))
           (first (t2/insert-returning-instances! :model/QueryCache
-                                                 :updated_at (t/offset-date-time)
+                                                 :updated_at timestamp
                                                  :query_hash query-hash
                                                  :results final-results)))
       (catch Throwable e


### PR DESCRIPTION
This PR is a basket of edge case fixes for preemptive caching which arose out of the demos & a Slack conversation last week: https://metaboat.slack.com/archives/C064EB1UE5P/p1738858427761589

The main changes are
* A `discarding-rff` when running refresh queries which doesn't accumulate results in memory
* For duration-based caches, we wipe the previous cached results before running the refresh query to ensure that the next task run doesn't try to re-run the query again if it hasn't finished yet
* Explicitly adding `cache-strategy` to refresh queries in the format required by the QP. This was causing a couple of the e2e tests to fail locally but not in CI... still trying to figure out why that is 
* Mild test & code refactors 