### PR TITLE
Allow disabling reading a setting from env vars

### DIFF
--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -283,6 +283,9 @@
    [:database-local LocalOption]
    [:user-local     LocalOption]
 
+   ;; should this setting be read from env vars?
+   [:can-read-from-env? :boolean]
+
    ;; called whenever setting value changes, whether from update-setting! or a cache refresh. used to handle cases
    ;; where a change to the cache necessitates a change to some value outside the cache, like when a change the
    ;; `:site-locale` setting requires a call to `java.util.Locale/setDefault`
@@ -393,6 +396,9 @@
    (not (database-local-only? setting))
    (not (user-local-only? setting))))
 
+(defn- allows-setting-via-env? [setting-definition-or-name]
+  (:can-read-from-env? (resolve-setting setting-definition-or-name)))
+
 (defn- site-wide-only? [setting]
   (and
    (not (allows-database-local-values? setting))
@@ -488,7 +494,8 @@
   environment variable `MB_FOO_BAR`."
   ^String [setting-definition-or-name]
   (let [setting (resolve-setting setting-definition-or-name)]
-    (when (allows-site-wide-values? setting)
+    (when (and (allows-site-wide-values? setting)
+               (allows-setting-via-env? setting))
       (let [v (env/env (setting-env-map-name setting))]
         (when (seq v)
           v)))))
@@ -1017,6 +1024,7 @@
                  :user-local     :never
                  :deprecated     nil
                  :enabled?       nil
+                 :can-read-from-env?       true
                  ;; Disable auditing by default for user- or database-local settings
                  :audit          (if (site-wide-only? setting) :no-value :never)}
                 (dissoc setting :name :type :default)))

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -124,6 +124,14 @@
   :encryption :when-encryption-key-set
   :feature    :test-feature)
 
+(defsetting test-setting-that-doesnt-allow-env
+  "Setting to test that a setting can be configured to disallow setting it via an environment variable."
+  :can-read-from-env? false
+  :visibility :internal
+  :type :string
+  :encryption :no
+  :default "the default value")
+
 ;; ## HELPER FUNCTIONS
 
 (defn db-fetch-setting
@@ -1603,3 +1611,12 @@
     (is (= :no (:encryption (setting/resolve-setting :test-boolean-setting)))))
   (testing "Boolean settings can be encrypted"
     (is (= :when-encryption-key-set (:encryption (setting/resolve-setting :test-boolean-encrypted-setting))))))
+
+(deftest settings-can-disallow-being-set-via-env-vars
+  (test-setting-that-doesnt-allow-env! nil)
+  (is (= "the default value" (test-setting-that-doesnt-allow-env)))
+  (with-redefs [env/env {:mb-test-setting-that-doesnt-allow-env "doesn't work"}]
+    (is (= "the default value" (test-setting-that-doesnt-allow-env))))
+  (testing "You can set them normally though"
+    (test-setting-that-doesnt-allow-env! "this works")
+    (is (= "this works" (test-setting-that-doesnt-allow-env)))))


### PR DESCRIPTION
Example:

```
(defsetting test-setting-that-doesnt-allow-env
  "Setting to test that a setting can be configured to disallow setting it via an environment variable."
  :can-read-from-env? false
  :visibility :internal
  :type :string
  :encryption :no
  :default "the default value")
```