### PR TITLE
rename enable embedding sdk alignment migration id

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10217,6 +10217,46 @@ databaseChangeLog:
             columnNames: engine, version, status
 
   - changeSet:
+      id: v52.2025-01-05T00:00:01
+      author: escherize
+      comment: set enable-embedding-sdk false when embedding-app-origins-sdk value exists
+      preConditions:
+        - onFail: MARK_RAN
+        - or:
+            - and:
+                - dbms:
+                    type: postgresql
+                - sqlCheck:
+                    expectedResult: 0
+                    sql: SELECT count(*) FROM setting WHERE key = 'embedding-app-origins-sdk';
+            - and:
+                - dbms:
+                    type: mysql,mariadb
+                - sqlCheck:
+                    expectedResult: 0
+                    sql: SELECT count(*) FROM setting WHERE `key` = 'embedding-app-origins-sdk';
+            - and:
+                - dbms:
+                    type: h2
+                - sqlCheck:
+                    expectedResult: 0
+                    sql: SELECT count(*) FROM setting WHERE "KEY" = 'embedding-app-origins-sdk';
+      changes:
+        - sql:
+            dbms: postgresql
+            sql: >-
+              update setting set value = 'false' where key = 'enable-embedding-sdk';
+        - sql:
+            dbms: mysql,mariadb
+            sql: >-
+              UPDATE setting set `value` = 'false' where `key` = 'enable-embedding-sdk';
+        - sql:
+            dbms: h2
+            sql: >-
+              UPDATE setting set "VALUE" = 'false' where "KEY" = 'enable-embedding-sdk';
+      rollback: # not needed
+
+  - changeSet:
       id: v53.2024-12-02T16:21:15
       author: noahmoss
       comment: Add cache_config.refresh_automatically column
@@ -10468,47 +10508,6 @@ databaseChangeLog:
                   name: deactivated_at
                   type: ${timestamp_type}
                   remarks: The timestamp at which a user was deactivated
-
-  - changeSet:
-      id: v52.2025-01-05T00:00:01
-      author: escherize
-      comment: set enable-embedding-sdk false when embedding-app-origins-sdk value exists
-      preConditions:
-        - onFail: MARK_RAN
-        - or:
-            - and:
-                - dbms:
-                    type: postgresql
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM setting WHERE key = 'embedding-app-origins-sdk';
-            - and:
-                - dbms:
-                    type: mysql,mariadb
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM setting WHERE `key` = 'embedding-app-origins-sdk';
-            - and:
-                - dbms:
-                    type: h2
-                - sqlCheck:
-                    expectedResult: 0
-                    sql: SELECT count(*) FROM setting WHERE "KEY" = 'embedding-app-origins-sdk';
-
-      changes:
-        - sql:
-            dbms: postgresql
-            sql: >-
-              update setting set value = 'false' where key = 'enable-embedding-sdk';
-        - sql:
-            dbms: mysql,mariadb
-            sql: >-
-              UPDATE setting set `value` = 'false' where `key` = 'enable-embedding-sdk';
-        - sql:
-            dbms: h2
-            sql: >-
-              UPDATE setting set "VALUE" = 'false' where "KEY" = 'enable-embedding-sdk';
-      rollback: # not needed
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10470,7 +10470,7 @@ databaseChangeLog:
                   remarks: The timestamp at which a user was deactivated
 
   - changeSet:
-      id: v53.2025-01-05T00:00:01
+      id: v52.2025-01-05T00:00:01
       author: escherize
       comment: set enable-embedding-sdk false when embedding-app-origins-sdk value exists
       preConditions:


### PR DESCRIPTION
# Migration ID Change
Changing migration ID from `v53.2025-01-05T00:00:01` to `v52.2025-01-05T00:00:01` to match the earliest release version where this migration appears.

## Motivation
- This migration needs to get backported to v52
- Per our changelog documentation, migrations should be numbered based on the lowest version they will be released in
- Having consistent IDs across versions prevents double-execution during upgrades

## Safety Considerations
1. This change affects a migration that is already in master
2. Developers and staging environments may have already run this migration under the v53 ID
3. When the ID changes, Liquibase's changeset fingerprinting will see this as a completely different migration

## Migration Plan
For environments that have already run the v53 version:
- The v53 migration record will remain in their databasechangelog table
- Liquibase will run the v52 version (same content, different ID) 
- This is safe because the migration is idempotent

## Verified:
- [x] Fresh install works
- [x] Upgrade from pre-migration state works
