### PR TITLE
Fix brush filters for longitudes that lie outside the normal -180 to 180 range

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
@@ -215,172 +215,105 @@ describe("scenarios > visualizations > maps", () => {
     });
   });
 
-  it("should apply brush filters by dragging map", () => {
-    cy.viewport(1280, 800);
-
-    H.visitQuestionAdhoc({
-      dataset_query: {
-        type: "query",
-        database: SAMPLE_DB_ID,
-        query: {
-          "source-table": PEOPLE_ID,
+  describe(
+    "Pin Map brush filters",
+    { viewportWidth: 1280, viewportHeight: 800 },
+    () => {
+      function pinMapSelectRegion(
+        x,
+        y,
+        moveX,
+        moveY,
+        visualization_settings = {
+          "map.center_latitude": 0,
+          "map.center_longitude": 0,
+          "map.zoom": 0,
+          "map.type": "pin",
+          "map.latitude_column": "LATITUDE",
+          "map.longitude_column": "LONGITUDE",
         },
-      },
-      display: "map",
-      visualization_settings: {
-        "map.region": "us_states",
-        "map.type": "pin",
-        "map.latitude_column": "LATITUDE",
-        "map.longitude_column": "LONGITUDE",
-      },
-    });
+      ) {
+        H.visitQuestionAdhoc({
+          dataset_query: {
+            type: "query",
+            database: SAMPLE_DB_ID,
+            query: {
+              "source-table": PEOPLE_ID,
+            },
+          },
+          display: "map",
+          visualization_settings,
+        });
 
-    cy.get(".CardVisualization").realHover();
-    cy.findByTestId("visualization-root")
-      .findByText("Draw box to filter")
-      .click();
+        cy.get(".CardVisualization").realHover();
+        cy.findByTestId("visualization-root")
+          .findByText("Draw box to filter")
+          .click();
 
-    cy.findByTestId("visualization-root")
-      .realMouseDown({ x: 600, y: 400 })
-      .realMouseMove(1200, 600)
-      .realMouseUp();
+        cy.findByTestId("visualization-root")
+          .realMouseDown({ x, y })
+          .realMouseMove(moveX, moveY)
+          .realMouseUp();
 
-    cy.wait("@dataset");
+        cy.wait("@dataset");
+      }
 
-    cy.get(".CardVisualization").should("exist");
-    // selecting area at the map provides different filter values, so the simplified assertion is used
-    cy.findAllByTestId("filter-pill").should("have.length", 1);
-  });
+      it("should apply brush filters by dragging map", () => {
+        pinMapSelectRegion(500, 500, 600, 600, {
+          "map.region": "us_states",
+          "map.type": "pin",
+          "map.latitude_column": "LATITUDE",
+          "map.longitude_column": "LONGITUDE",
+        });
+        cy.get(".CardVisualization").should("exist");
+        // selecting area at the map provides different filter values, so the simplified assertion is used
+        cy.findAllByTestId("filter-pill").should("have.length", 1);
+      });
 
-  it("should handle brush filters that exceed 360 deg of longitude", () => {
-    cy.viewport(1280, 800);
+      it("should apply brush filters by dragging map when zoomed out (metabase#41056)", () => {
+        pinMapSelectRegion(250, 150, 500, 250);
+        cy.get(".CardVisualization").should("exist");
+        cy.findAllByTestId("filter-pill").should("have.length", 1);
+      });
 
-    H.visitQuestionAdhoc({
-      dataset_query: {
-        type: "query",
-        database: SAMPLE_DB_ID,
-        query: {
-          "source-table": PEOPLE_ID,
-        },
-      },
-      display: "map",
-      visualization_settings: {
-        "map.center_latitude": 0,
-        "map.center_longitude": 0,
-        "map.zoom": 0,
-        "map.type": "pin",
-        "map.latitude_column": "LATITUDE",
-        "map.longitude_column": "LONGITUDE",
-      },
-    });
+      it("should handle brush filters that select zero data points (metabase#41056)", () => {
+        pinMapSelectRegion(10, 10, 20, 20);
+        cy.get(".CardVisualization").should("not.exist");
+        cy.findByTestId("question-row-count").findByText("Showing 0 rows");
+        cy.findAllByTestId("filter-pill").should("have.length", 1);
+      });
 
-    cy.get(".CardVisualization").realHover();
-    cy.findByTestId("visualization-root")
-      .findByText("Draw box to filter")
-      .click();
+      it("should handle brush filters that exceed 360 deg of longitude (metabase#41056)", () => {
+        pinMapSelectRegion(10, 10, 1270, 600);
+        cy.get(".CardVisualization").should("exist");
+        cy.findByTestId("question-row-count").findByText(
+          "Showing first 2,000 rows",
+        );
+        cy.findAllByTestId("filter-pill")
+          .should("have.length", 1)
+          .contains("Longitude is between -180 and 180");
+      });
 
-    cy.findByTestId("visualization-root")
-      .realMouseDown({ x: 10, y: 10 })
-      .realMouseMove(1270, 600)
-      .realMouseUp();
+      it("should handle brush filters that cross the 180th meridian (metabase#41056)", () => {
+        pinMapSelectRegion(100, 100, 200, 200);
 
-    cy.wait("@dataset");
+        cy.get(".CardVisualization").should("exist");
+        cy.findByTestId("question-row-count").findByText("Showing 9 rows");
 
-    cy.get(".CardVisualization").should("exist");
-    cy.findByTestId("question-row-count").findByText(
-      "Showing first 2,000 rows",
-    );
-    cy.findAllByTestId("filter-pill")
-      .should("have.length", 1)
-      .contains("Longitude is between -180 and 180");
-  });
+        // Exact value for these longitude bounds is not important.
+        const lngRegex = /\d+(\.\d+)?/.source;
 
-  it("should handle brush filters that cross the 180th meridian", () => {
-    cy.viewport(1280, 800);
-
-    H.visitQuestionAdhoc({
-      dataset_query: {
-        type: "query",
-        database: SAMPLE_DB_ID,
-        query: {
-          "source-table": PEOPLE_ID,
-        },
-      },
-      display: "map",
-      visualization_settings: {
-        "map.center_latitude": 0,
-        "map.center_longitude": 0,
-        "map.zoom": 0,
-        "map.type": "pin",
-        "map.latitude_column": "LATITUDE",
-        "map.longitude_column": "LONGITUDE",
-      },
-    });
-
-    cy.get(".CardVisualization").realHover();
-    cy.findByTestId("visualization-root")
-      .findByText("Draw box to filter")
-      .click();
-
-    cy.findByTestId("visualization-root")
-      .realMouseDown({ x: 100, y: 100 })
-      .realMouseMove(200, 200)
-      .realMouseUp();
-
-    cy.wait("@dataset");
-
-    const lngRegex = /\d+(\.\d+)?/.source;
-
-    cy.get(".CardVisualization").should("exist");
-    cy.findByTestId("question-row-count").findByText("Showing 9 rows");
-    cy.findAllByTestId("filter-pill")
-      .should("have.length", 1)
-      .contains(
-        new RegExp(
-          `(Latitude is between .*) and Longitude is between ${lngRegex} and 180` +
-            ` or \\1 and Longitude is between -180 and -${lngRegex}`,
-        ),
-      );
-  });
-
-  it("should handle brush filters that select zero data points", () => {
-    cy.viewport(1280, 800);
-
-    H.visitQuestionAdhoc({
-      dataset_query: {
-        type: "query",
-        database: SAMPLE_DB_ID,
-        query: {
-          "source-table": PEOPLE_ID,
-        },
-      },
-      display: "map",
-      visualization_settings: {
-        "map.center_latitude": 0,
-        "map.center_longitude": 0,
-        "map.zoom": 0,
-        "map.type": "pin",
-        "map.latitude_column": "LATITUDE",
-        "map.longitude_column": "LONGITUDE",
-      },
-    });
-
-    cy.get(".CardVisualization").realHover();
-    cy.findByTestId("visualization-root")
-      .findByText("Draw box to filter")
-      .click();
-
-    cy.findByTestId("visualization-root")
-      .realMouseDown({ x: 10, y: 10 })
-      .realMouseMove(20, 20)
-      .realMouseUp();
-
-    cy.wait("@dataset");
-
-    cy.get(".CardVisualization").should("not.exist");
-    cy.findByTestId("question-row-count").findByText("Showing 0 rows");
-    cy.findAllByTestId("filter-pill").should("have.length", 1);
-  });
+        cy.findAllByTestId("filter-pill")
+          .should("have.length", 1)
+          .contains(
+            new RegExp(
+              `(Latitude is between .*) and Longitude is between ${lngRegex} and 180` +
+                ` or \\1 and Longitude is between -180 and -${lngRegex}`,
+            ),
+          );
+      });
+    },
+  );
 });
 
 function toggleFieldSelectElement(field) {

--- a/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
@@ -241,15 +241,15 @@ describe("scenarios > visualizations > maps", () => {
       .click();
 
     cy.findByTestId("visualization-root")
-      .realMouseDown(500, 500)
-      .realMouseMove(600, 600)
-      .realMouseUp(600, 600);
+      .realMouseDown({ x: 600, y: 400 })
+      .realMouseMove(1200, 600)
+      .realMouseUp();
 
     cy.wait("@dataset");
 
     cy.get(".CardVisualization").should("exist");
     // selecting area at the map provides different filter values, so the simplified assertion is used
-    cy.findByTestId("filter-pill").should("have.length", 1);
+    cy.findAllByTestId("filter-pill").should("have.length", 1);
   });
 
   it("should handle brush filters that exceed 360 deg of longitude", () => {

--- a/frontend/src/metabase/visualizations/components/LeafletMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMap.jsx
@@ -181,8 +181,8 @@ export default class LeafletMap extends Component {
       const filterBounds = {
         north: bounds.getNorth(),
         south: bounds.getSouth(),
-        west: west,
-        east: east,
+        west,
+        east,
       };
       const updatedQuery = Lib.updateLatLonFilter(
         query,

--- a/frontend/src/metabase/visualizations/components/LeafletMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMap.jsx
@@ -174,9 +174,9 @@ export default class LeafletMap extends Component {
 
       // Longitudes should be wrapped to the canonical range [-180, 180]. If the delta is >= 360,
       // select the full range; otherwise, you wind up selecting only the overlapping portion.
-      const longDelta = Math.abs(bounds.getEast() - bounds.getWest());
-      const west = longDelta >= 360 ? -180 : bounds.getSouthWest().wrap().lng;
-      const east = longDelta >= 360 ? 180 : bounds.getNorthEast().wrap().lng;
+      const lngDelta = Math.abs(bounds.getEast() - bounds.getWest());
+      const west = lngDelta >= 360 ? -180 : bounds.getSouthWest().wrap().lng;
+      const east = lngDelta >= 360 ? 180 : bounds.getNorthEast().wrap().lng;
 
       const filterBounds = {
         north: bounds.getNorth(),

--- a/frontend/src/metabase/visualizations/components/LeafletMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMap.jsx
@@ -171,11 +171,18 @@ export default class LeafletMap extends Component {
     if (this.supportsFilter()) {
       const query = question.query();
       const stageIndex = -1;
+
+      // Longitudes should be wrapped to the canonical range [-180, 180]. If the delta is >= 360,
+      // select the full range; otherwise, you wind up selecting only the overlapping portion.
+      const longDelta = Math.abs(bounds.getEast() - bounds.getWest());
+      const west = longDelta >= 360 ? -180 : bounds.getSouthWest().wrap().lng;
+      const east = longDelta >= 360 ? 180 : bounds.getNorthEast().wrap().lng;
+
       const filterBounds = {
         north: bounds.getNorth(),
         south: bounds.getSouth(),
-        west: bounds.getWest(),
-        east: bounds.getEast(),
+        west: west,
+        east: east,
       };
       const updatedQuery = Lib.updateLatLonFilter(
         query,

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -2405,6 +2405,10 @@
 
   `bounds` is a JS object `{north: number, south: number, west: number, east: number}` giving the bounding rectangle.
 
+  This function expects that longitudes (west and east bounds) have been canonicalized into the range [-180, 180]. If
+  west > east, this indicates that the bounds cross the antimerdian, and so we must add two filter clauses, which are
+  ORed together. In such cases, the first clause covers the range [west, 180.0] and the second covers [-180.0, east].
+
   > **Code health:** Smelly; Single use. This is highly specialized in the UI, but should probably continue to exist.
   However, it should be adjusted to accept only MLv2 columns. Any legacy conversion should be done by the caller, and
   ideally refactored away."

--- a/test/metabase/lib/filter/update_test.cljc
+++ b/test/metabase/lib/filter/update_test.cljc
@@ -50,46 +50,133 @@
                                          (meta/field-metadata :venues :longitude)
                                          {:north 10, :south -10, :east 20, :west -20}))))))
 
-(deftest ^:parallel update-lat-lon-filter-remove-existing-test
-  (testing "Remove existing filter(s) against this column. Don't remove ones from a different source"
-    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
-                    (lib/join (-> (lib/join-clause (meta/table-metadata :venues))
-                                  (lib/with-join-conditions [(lib/= (meta/field-metadata :venues :id)
-                                                                    (-> (meta/field-metadata :venues :id)
-                                                                        (lib/with-join-alias "V2")))])
-                                  (lib/with-join-alias "V2")))
-                    (lib/filter (lib/= (meta/field-metadata :venues :latitude) 1))
-                    (lib/filter (lib/= (meta/field-metadata :venues :longitude) 2))
-                    (lib/filter (lib/= (lib/with-join-alias (meta/field-metadata :venues :latitude) "V2") 4)))]
-      (is (=? {:stages [{:filters [[:= {} [:field {:join-alias "V2"} (meta/id :venues :latitude)] 4]
-                                   [:inside
-                                    {}
-                                    [:field {} (meta/id :venues :latitude)]
-                                    [:field {} (meta/id :venues :longitude)]
-                                    10
-                                    -20
-                                    -10
-                                    20]]}]}
-              (lib/update-lat-lon-filter query
-                                         (meta/field-metadata :venues :latitude)
-                                         (meta/field-metadata :venues :longitude)
-                                         {:north 10, :south -10, :east 20, :west -20}))))))
-
-(deftest ^:parallel update-lat-lon-filter-fix-order-test
-  (testing "Fix lat/lon min/max if values are passed in backwards"
+(deftest ^:parallel update-lat-lon-filter-antimerdian-test
+  (testing "Add a new filter that crosses the antimeridian (metabase#41056)"
     (let [query (lib/query meta/metadata-provider (meta/table-metadata :venues))]
-      (is (=? {:stages [{:filters [[:inside
+      (is (=? {:stages [{:filters [[:or
                                     {}
-                                    [:field {} (meta/id :venues :latitude)]
-                                    [:field {} (meta/id :venues :longitude)]
-                                    10
-                                    -20
-                                    -10
-                                    20]]}]}
+                                    [:inside
+                                     {}
+                                     [:field {} (meta/id :venues :latitude)]
+                                     [:field {} (meta/id :venues :longitude)]
+                                     10
+                                     179
+                                     -10
+                                     180]
+                                    [:inside
+                                     {}
+                                     [:field {} (meta/id :venues :latitude)]
+                                     [:field {} (meta/id :venues :longitude)]
+                                     10
+                                     -180
+                                     -10
+                                     -179]]]}]}
               (lib/update-lat-lon-filter query
                                          (meta/field-metadata :venues :latitude)
                                          (meta/field-metadata :venues :longitude)
-                                         {:north -10, :south 10, :east -20, :west 20}))))))
+                                         {:north 10, :south -10, :east -179, :west 179}))))))
+
+(deftest ^:parallel update-lat-lon-filter-remove-existing-test
+  (testing "Remove existing filter(s) against this column. Don't remove ones from a different source.\n"
+    (let [base-query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+                         (lib/join (-> (lib/join-clause (meta/table-metadata :venues))
+                                       (lib/with-join-conditions [(lib/= (meta/field-metadata :venues :id)
+                                                                         (-> (meta/field-metadata :venues :id)
+                                                                             (lib/with-join-alias "V2")))])
+                                       (lib/with-join-alias "V2")))
+                         (lib/filter (lib/= (meta/field-metadata :venues :latitude) 1))
+                         (lib/filter (lib/= (meta/field-metadata :venues :longitude) 2))
+                         (lib/filter (lib/= (lib/with-join-alias (meta/field-metadata :venues :latitude) "V2") 4)))
+          query-lat-lon  (lib/update-lat-lon-filter base-query
+                                                    (meta/field-metadata :venues :latitude)
+                                                    (meta/field-metadata :venues :longitude)
+                                                    {:north 10, :south -10, :east 20, :west -20})]
+      (testing "First application of update-lat-lon-filter"
+        (is (=? {:stages [{:filters [[:= {} [:field {:join-alias "V2"} (meta/id :venues :latitude)] 4]
+                                     [:inside
+                                      {}
+                                      [:field {} (meta/id :venues :latitude)]
+                                      [:field {} (meta/id :venues :longitude)]
+                                      10
+                                      -20
+                                      -10
+                                      20]]}]}
+                query-lat-lon)))
+      (testing "Second application of update-lat-lon-filter"
+        (is (=? {:stages [{:filters [[:= {} [:field {:join-alias "V2"} (meta/id :venues :latitude)] 4]
+                                     [:inside
+                                      {}
+                                      [:field {} (meta/id :venues :latitude)]
+                                      [:field {} (meta/id :venues :longitude)]
+                                      11
+                                      -21
+                                      -11
+                                      21]]}]}
+                (lib/update-lat-lon-filter base-query
+                                           (meta/field-metadata :venues :latitude)
+                                           (meta/field-metadata :venues :longitude)
+                                           {:north 11, :south -11, :east 21, :west -21})))))))
+
+(deftest ^:parallel update-lat-lon-filter-remove-existing-antimerdian-test
+  (testing "Remove existing filter(s) that cross the antimerdian (metabase#41056).\n"
+    (let [base-query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+                         (lib/join (-> (lib/join-clause (meta/table-metadata :venues))
+                                       (lib/with-join-conditions [(lib/= (meta/field-metadata :venues :id)
+                                                                         (-> (meta/field-metadata :venues :id)
+                                                                             (lib/with-join-alias "V2")))])
+                                       (lib/with-join-alias "V2")))
+                         (lib/filter (lib/= (meta/field-metadata :venues :latitude) 1))
+                         (lib/filter (lib/= (meta/field-metadata :venues :longitude) 2))
+                         (lib/filter (lib/= (lib/with-join-alias (meta/field-metadata :venues :latitude) "V2") 4)))
+          query-lat-lon  (lib/update-lat-lon-filter base-query
+                                                    (meta/field-metadata :venues :latitude)
+                                                    (meta/field-metadata :venues :longitude)
+                                                    {:north 10, :south -10, :east -170, :west 170})]
+      (testing "First application of update-lat-lon-filter (metabase#41056)"
+        (is (=? {:stages [{:filters [[:= {} [:field {:join-alias "V2"} (meta/id :venues :latitude)] 4]
+                                     [:or
+                                      {}
+                                      [:inside
+                                       {}
+                                       [:field {} (meta/id :venues :latitude)]
+                                       [:field {} (meta/id :venues :longitude)]
+                                       10
+                                       170
+                                       -10
+                                       180]
+                                      [:inside
+                                       {}
+                                       [:field {} (meta/id :venues :latitude)]
+                                       [:field {} (meta/id :venues :longitude)]
+                                       10
+                                       -180
+                                       -10
+                                       -170]]]}]}
+                query-lat-lon)))
+      (testing "Second application of update-lat-lon-filter (metabase#41056)"
+        (is (=? {:stages [{:filters [[:= {} [:field {:join-alias "V2"} (meta/id :venues :latitude)] 4]
+                                     [:or
+                                      {}
+                                      [:inside
+                                       {}
+                                       [:field {} (meta/id :venues :latitude)]
+                                       [:field {} (meta/id :venues :longitude)]
+                                       11
+                                       171
+                                       -11
+                                       180]
+                                      [:inside
+                                       {}
+                                       [:field {} (meta/id :venues :latitude)]
+                                       [:field {} (meta/id :venues :longitude)]
+                                       11
+                                       -180
+                                       -11
+                                       -171]]]}]}
+                (lib/update-lat-lon-filter base-query
+                                           (meta/field-metadata :venues :latitude)
+                                           (meta/field-metadata :venues :longitude)
+                                           {:north 11, :south -11, :east -171, :west 171})))))))
 
 (deftest ^:parallel update-temporal-filter-test
   (testing "Add a new filter -- no unit"


### PR DESCRIPTION
Closes #41056

### Description

Fix brush filter for `LeafletMap.jsx` to allow selecting points anywhere on the map.

1. update `Leafletmap.jsx` to call `LatLng.wrap()` to wrap longitudes in `filterBounds` into the canonical range [-180, 180].
2. modify `update-lat-lon-filter` so that if the filter bounds cross the 180th meridian, the filter is split into two parts covering the east and west sides with separate `:inside` filters that are ORed together. 

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> People
2. Visualize
3. Change viz type to Pin Map
4. Scroll east or west a long ways (far enough to cross the 180th meridian)
5. Click `Draw box to filter` button
6. Draw a box
7. Filter should work
8. Zoom out
9. Scroll to the 180th meridian (either direction)
10. Click `Draw box to filter` button
11. Draw a filter box that crosses the 180th meridian.
12. Unless you modify your sample DB, you won't have any points near the meridian, but if you make your box large enough you can select some points in, e.g., Alaska.
13. Verify that a two-part filter is added that covers both the eastern and western hemisphere sides of your selection.
14. Get crazy. Zoom out and select a region > 360º.
15. Should filter to the range [-180,180].

### Demo

Loom demo posted to slack here

https://metaboat.slack.com/archives/C0645JP1W81/p1738960382927599

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
