### PR TITLE
Log name of missing class when implicitly deleting job

### DIFF
--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -86,7 +86,9 @@
         (qs/get-job scheduler job-key)
         (catch JobPersistenceException e
           (when (instance? ClassNotFoundException (.getCause e))
-            (log/infof "Deleting job %s due to class not found" (.getName ^JobKey job-key))
+            (log/warnf "Deleting job %s due to class not found (%s)"
+                       (.getName ^JobKey job-key)
+                       (ex-message (.getCause e)))
             (qs/delete-job scheduler job-key)))))))
 
 (defn- init-scheduler!


### PR DESCRIPTION
Recently I had a heart attack seeing some [essential jobs get deleted](https://grafana.monitoring.metabase.com/d/Zjw_nJX7k/metabase-logs?orgId=1&var-cluster=staging-1&var-filter=Deleting%20job&var-namespace=All&var-dns_host=stats.metabase.com&var-pod=All&from=1738800000000&to=1738972799000). It turns out that their class name changed due to Clojure namespaces being moved around, and the jobs were still re-registered, but if I hadn't approved the corresponding PR this investigation may have taken some time.

I have also made this a warning so that it's more visible when doing investigations, we don't need to be worried about high volume. Well, if there is high volume we would definitely want to know about it.

```clojure
(try 
  (Class/forName "some.missing.Class")
  (catch ClassNotFoundException e
    (log/warnf "Deleting job %s due to class not found (%s)"
               "some.job.key"
               (ex-message e))))

;; WARN metabase.task :: Deleting job some.job.key due to class not found (some.missing.Class)
```