### PR TITLE
Fix json indentation

### DIFF
--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -372,6 +372,28 @@ describe("scenarios > question > native", () => {
       .get()
       .should("have.text", "\tSELECT\tFOO");
   });
+
+  it("should use the correct indentation for mongo", { tags: "@mongo" }, () => {
+    const MONGO_DB_NAME = "QA Mongo";
+
+    H.restore("mongo-5");
+    cy.signInAsAdmin();
+
+    H.startNewNativeQuestion();
+    cy.findByTestId("gui-builder-data").click();
+    cy.findByLabelText(MONGO_DB_NAME).click();
+
+    H.NativeEditor.type('[{enter}{ {enter}"foo": "bar",{enter}"baz"');
+
+    H.NativeEditor.get().should("be.visible").get(".cm-line").as("lines");
+
+    cy.get("@lines").eq(0).should("have.text", "[");
+    cy.get("@lines").eq(1).should("have.text", "  {");
+    cy.get("@lines").eq(2).should("have.text", '    "foo": "bar",');
+    cy.get("@lines").eq(3).should("have.text", '    "baz"');
+    cy.get("@lines").eq(4).should("have.text", "  }");
+    cy.get("@lines").eq(5).should("have.text", "]");
+  });
 });
 
 // causes error in cypress 13

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -394,6 +394,27 @@ describe("scenarios > question > native", () => {
     cy.get("@lines").eq(4).should("have.text", "  }");
     cy.get("@lines").eq(5).should("have.text", "]");
   });
+
+  it(
+    "it should insert a two spaces when pressing tab in json-like languages",
+    { tags: "@mongo" },
+    () => {
+      const MONGO_DB_NAME = "QA Mongo";
+
+      H.restore("mongo-5");
+      cy.signInAsAdmin();
+
+      H.startNewNativeQuestion();
+      cy.findByTestId("gui-builder-data").click();
+      cy.findByLabelText(MONGO_DB_NAME).click();
+
+      H.NativeEditor.type("{tab}");
+
+      H.NativeEditor.get().should("be.visible").get(".cm-line").as("lines");
+
+      cy.get("@lines").eq(0).should("have.text", "  ");
+    },
+  );
 });
 
 // causes error in cypress 13

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.module.css
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.module.css
@@ -175,6 +175,7 @@
       font-style: italic;
     }
 
+    .cm-token-brace,
     .cm-token-squareBracket {
       color: var(--mb-color-brand);
     }

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
@@ -7,6 +7,7 @@ import { indentMore } from "@codemirror/commands";
 import {
   HighlightStyle,
   foldService,
+  indentUnit,
   syntaxHighlighting,
 } from "@codemirror/language";
 import { Prec } from "@codemirror/state";
@@ -19,7 +20,11 @@ import {
   keymap,
 } from "@codemirror/view";
 import { type Tag, tags } from "@lezer/highlight";
-import type { EditorState, Extension } from "@uiw/react-codemirror";
+import type {
+  EditorState,
+  Extension,
+  Transaction,
+} from "@uiw/react-codemirror";
 import cx from "classnames";
 import { getNonce } from "get-nonce";
 import { useMemo } from "react";
@@ -115,7 +120,7 @@ function disableCmdEnter() {
       },
       {
         key: "Tab",
-        run: indentMore,
+        run: insertIndent,
       },
       {
         key: "Mod-j",
@@ -265,4 +270,27 @@ function tagDecorator() {
       decorations: instance => instance.tags,
     },
   );
+}
+
+export function insertIndent({
+  state,
+  dispatch,
+}: {
+  state: EditorState;
+  dispatch: (tr: Transaction) => void;
+}) {
+  if (state.selection.ranges.some(r => !r.empty)) {
+    return indentMore({ state, dispatch });
+  }
+
+  const indent = state.facet(indentUnit);
+
+  dispatch(
+    state.update(state.replaceSelection(indent), {
+      scrollIntoView: true,
+      userEvent: "input",
+    }),
+  );
+
+  return true;
 }

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
@@ -7,8 +7,6 @@ import { indentMore } from "@codemirror/commands";
 import {
   HighlightStyle,
   foldService,
-  indentService,
-  indentUnit,
   syntaxHighlighting,
 } from "@codemirror/language";
 import { Prec } from "@codemirror/state";
@@ -87,7 +85,6 @@ export function useExtensions(query: Lib.Query): Extension[] {
       highlighting(),
       tagDecorator(),
       folds(),
-      indentation(),
       disableCmdEnter(),
     ]
       .flat()
@@ -130,23 +127,6 @@ function disableCmdEnter() {
       },
     ]),
   );
-}
-
-function indentation() {
-  return [
-    // set indentation to tab
-    indentUnit.of("\t"),
-
-    // persist the indentation from the previous line
-    indentService.of((context, pos) => {
-      const previousLine = context.lineAt(pos, -1);
-      const previousLineText = previousLine.text.replaceAll(
-        "\t",
-        " ".repeat(context.state.tabSize),
-      );
-      return previousLineText.match(/^(\s)*/)?.[0].length ?? 0;
-    }),
-  ];
 }
 
 function nonce() {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/extensions.tsx
@@ -3,7 +3,7 @@ import {
   autocompletion,
   moveCompletionSelection,
 } from "@codemirror/autocomplete";
-import { insertTab } from "@codemirror/commands";
+import { indentMore } from "@codemirror/commands";
 import {
   HighlightStyle,
   foldService,
@@ -118,7 +118,7 @@ function disableCmdEnter() {
       },
       {
         key: "Tab",
-        run: insertTab,
+        run: indentMore,
       },
       {
         key: "Mod-j",


### PR DESCRIPTION
Improves native editor experience for json-based query languages like Druid and Mongo.

### To verify
1. New > Native query
2. Select MongoDB
3. type:
   ```
   [{enter}{"foo": 12
   ```

The indentation should be more palatable.

> [!WARNING]
> it is not possible to test this until https://github.com/metabase/metabase/issues/53299 is fixed.

#### Before
<img width="329" alt="Screenshot 2025-02-07 at 13 15 43" src="https://github.com/user-attachments/assets/996fb9d1-4e5a-45ad-8001-9bd2ed954824" />


#### After
<img width="320" alt="Screenshot 2025-02-07 at 13 15 09" src="https://github.com/user-attachments/assets/be8df21b-03a0-4045-a704-7d4aae0a0a1d" />
