### PR TITLE
chore: remove embedding team from codeowners on the release branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,6 @@
 # Before changing this file, make sure you have read how we use it:
 # https://www.notion.so/metabase/Pull-Request-Code-Review-Guide-374f05df889748b69d67af753f9bc9b8?pvs=4#36550c04ceab40b5a8b8bee6264b090c
 
-enterprise/frontend/src/embedding-sdk @metabase/embedding
-frontend/src/metabase/embedding-sdk @metabase/embedding
 frontend/src/metabase/ui @metabase/core-frontend-admin-webapp
 snowplow/* @metabase/data
 e2e @filiphric


### PR DESCRIPTION
this was triggering reviews for automated backports that are auto-approved by the bot

https://metaboat.slack.com/archives/C063Q3F1HPF/p1738931139748069