### PR TITLE
chore: remove embedding team from codeowners on the release branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,6 @@
 # Before changing this file, make sure you have read how we use it:
 # https://www.notion.so/metabase/Pull-Request-Code-Review-Guide-374f05df889748b69d67af753f9bc9b8?pvs=4#36550c04ceab40b5a8b8bee6264b090c
 
-enterprise/frontend/src/embedding-sdk @metabase/embedding
-frontend/src/metabase/embedding-sdk @metabase/embedding
 frontend/src/metabase/ui @metabase/core-frontend-admin-webapp
 snowplow/* @metabase/data
 e2e @filiphric

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -125,8 +125,6 @@ test/metabase/driver @metabase/drivers
 src/metabase/eid_translation @metabase/core-backend-admin-webapp
 test/metabase/eid_translation @metabase/core-backend-admin-webapp
 
-src/metabase/embed @metabase/embedding
-test/metabase/embed @metabase/embedding
 
 src/metabase/events @metabase/devexp
 test/metabase/events @metabase/devexp


### PR DESCRIPTION
[Context](https://metaboat.slack.com/archives/C063Q3F1HPF/p1738931139748069)

this was triggering reviews for automated backports that are
auto-approved by the bot