### PR TITLE
Query builder breadcrumbs can link back to archived models

### DIFF
--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -16,7 +16,7 @@ import {
   turnIntoModel,
 } from "./helpers/e2e-models-helpers";
 
-const { PRODUCTS, ORDERS_ID, PRODUCTS_ID } = SAMPLE_DATABASE;
+const { PRODUCTS, ORDERS_ID, PRODUCTS_ID, ACCOUNTS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > models", () => {
   beforeEach(() => {
@@ -37,6 +37,18 @@ describe("scenarios > models", () => {
   });
 
   it("allows to turn a GUI question into a model", () => {
+    H.createQuestion(
+      {
+        name: "Accounts Model",
+        query: { "source-table": ACCOUNTS_ID },
+        type: "model",
+      },
+      {
+        wrapId: true,
+        idAlias: "accountsModelId",
+      },
+    );
+
     cy.get("@productsQuestionId").then(id => {
       cy.request("PUT", `/api/card/${id}`, {
         name: "Products Model",
@@ -79,6 +91,37 @@ describe("scenarios > models", () => {
       getCollectionItemRow("Q1").icon("table2");
 
       cy.url().should("not.include", "/question/" + id);
+    });
+
+    cy.log(
+      "Question Lineage should show link to archived models (metabase#52071)",
+    );
+    cy.get("@accountsModelId").then(modelId => {
+      H.createQuestion(
+        {
+          name: "Accounts Model Quest",
+          query: { "source-table": `card__${modelId}` },
+        },
+        {
+          wrapId: true,
+          idAlias: "accountsQuestionId",
+        },
+      );
+
+      H.archiveQuestion(modelId);
+
+      cy.get("@accountsQuestionId").then(questionId => {
+        H.visitQuestion(questionId);
+        cy.findByTestId("qb-header-left-side").within(() => {
+          cy.icon("warning").should("exist");
+
+          cy.findByRole("link", { name: /accounts model/i }).should(
+            "have.attr",
+            "href",
+            `/model/${modelId}-accounts-model`,
+          );
+        });
+      });
     });
   });
 

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/SourceDatasetBreadcrumbs.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/SourceDatasetBreadcrumbs.tsx
@@ -2,9 +2,8 @@ import type { ReactElement } from "react";
 import { t } from "ttag";
 
 import { skipToken, useGetCollectionQuery } from "metabase/api";
-import Tooltip from "metabase/core/components/Tooltip";
-import { color } from "metabase/lib/colors";
 import * as Urls from "metabase/lib/urls";
+import { Box, Tooltip } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";
 
 import { HeadBreadcrumbs } from "../HeaderBreadcrumbs/HeaderBreadcrumbs";
@@ -46,16 +45,20 @@ export function SourceDatasetBreadcrumbs({
         question.isArchived() ? (
           <Tooltip
             key="dataset-name"
-            tooltip={t`This model is archived and shouldn't be used.`}
-            maxWidth="auto"
-            placement="bottom"
+            label={t`This model is archived and shouldn't be used.`}
+            maw="auto"
+            position="bottom"
           >
-            <HeadBreadcrumbs.Badge
-              inactiveColor="text-light"
-              icon={{ name: "warning", color: color("danger") }}
-            >
-              {question.displayName()}
-            </HeadBreadcrumbs.Badge>
+            {/* We use a box here for ref forwarding */}
+            <Box>
+              <HeadBreadcrumbs.Badge
+                inactiveColor="text-light"
+                icon={{ name: "warning", color: "var(--mb-color-danger)" }}
+                to={Urls.question(question.card())}
+              >
+                {question.displayName()}
+              </HeadBreadcrumbs.Badge>
+            </Box>
           </Tooltip>
         ) : (
           <HeadBreadcrumbs.Badge


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/52071

### Description
Enables linking back to archived models via question lineage in the query builder header

### How to verify

1. Create a new question based on a modal
2. Archive the source model
3. go to the created question and see the model name under the question name. It should be clickable

### Demo
![image](https://github.com/user-attachments/assets/9dc83deb-f8d1-42f9-8b10-4a91b53a7837)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
