### PR TITLE
[mbql] Use more efficient keywordize-keys during normalization

### DIFF
--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -282,10 +282,12 @@
   [metadata]
   ;; TODO -- can we make this whole thing a lazy seq?
   (when-let [metadata (not-empty (json-out-with-keywordization metadata))]
-    (seq (->> (map mbql.normalize/normalize-source-metadata metadata)
-              ;; This is necessary, because in the wild, there may be cards created prior to this change.
-              (map lib.temporal-bucket/ensure-temporal-unit-in-display-name)
-              (map lib.binning/ensure-binning-in-display-name)))))
+    (not-empty (mapv #(-> %
+                          mbql.normalize/normalize-source-metadata
+                          ;; This is necessary, because in the wild, there may be cards created prior to this change.
+                          lib.temporal-bucket/ensure-temporal-unit-in-display-name
+                          lib.binning/ensure-binning-in-display-name)
+                     metadata))))
 
 (def transform-result-metadata
   "Transform for card.result_metadata like columns."

--- a/src/metabase/util/performance.clj
+++ b/src/metabase/util/performance.clj
@@ -184,3 +184,94 @@
   (let [its (mapv #(.iterator ^Iterable %) coll-of-colls)]
     (mapv (fn [_] (mapv #(.next ^Iterator %) its))
           (first coll-of-colls))))
+
+;; clojure.walk reimplementation. Partially adapted from https://github.com/tonsky/clojure-plus.
+
+(defn- editable? [coll]
+  (instance? clojure.lang.IEditableCollection coll))
+
+(defn- transient? [coll]
+  (instance? clojure.lang.ITransientCollection coll))
+
+(defn- assoc+ [coll key value]
+  (cond
+    (transient? coll) (assoc! coll key value)
+    (editable? coll)  (assoc! (transient coll) key value)
+    :else             (assoc  coll key value)))
+
+(defn- dissoc+ [coll key]
+  (cond
+    (transient? coll) (dissoc! coll key)
+    (editable? coll)  (dissoc! (transient coll) key)
+    :else             (dissoc  coll key)))
+
+(defn- maybe-persistent! [coll]
+  (cond-> coll
+    (transient? coll) persistent!))
+
+(defn walk
+  "Like `clojure.walk/walk`, but optimized for efficiency and has the following behavior differences:
+  - Doesn't walk over map entries. When descending into a map, walks keys and values separately.
+  - Uses transients and reduce where possible and tries to return the same input `form` if no changes were made."
+  [inner outer form]
+  (cond
+    (map? form)
+    (let [new-keys (volatile! (transient #{}))]
+      (-> (reduce-kv (fn [m k v]
+                       (let [k' (inner k)
+                             v' (inner v)]
+                         (if (identical? k' k)
+                           (if (identical? v' v)
+                             m
+                             (assoc+ m k' v'))
+                           (do (vswap! new-keys conj! k')
+                               (if (contains? @new-keys k)
+                                 (assoc+ m k' v')
+                                 (-> m (dissoc+ k) (assoc+ k' v')))))))
+                     form form)
+          maybe-persistent!
+          (with-meta (meta form))
+          outer))
+
+    (vector? form)
+    (-> (reduce-kv (fn [v idx el]
+                     (let [el' (inner el)]
+                       (if (identical? el' el)
+                         v
+                         (assoc+ v idx el'))))
+                   form form)
+        maybe-persistent!
+        (with-meta (meta form))
+        outer)
+
+    ;; Don't care much about optimizing seq and generic coll cases. When efficiency is required, use vectors.
+    (seq? form) (outer (with-meta (seq (mapv inner form)) (meta form))) ;;
+    (coll? form) (outer (with-meta (into (empty form) (map inner) form) (meta form)))
+    :else (outer form)))
+
+(defn prewalk
+  "Like `clojure.walk/prewalk`, but uses a more efficient `metabase.util.performance/walk` underneath."
+  [f form]
+  (walk (partial prewalk f) identity (f form)))
+
+(defn postwalk
+  "Like `clojure.walk/postwalk`, but uses a more efficient `metabase.util.performance/walk` underneath."
+  [f form]
+  (walk (partial postwalk f) f form))
+
+(defn keywordize-keys
+  "Like `clojure.walk/keywordize-keys`, but uses a more efficient `metabase.util.performance/walk` underneath and
+  preserves original metadata on the transformed maps."
+  [m]
+  (postwalk
+   (fn [form]
+     (if (map? form)
+       (-> (reduce-kv (fn [m k v]
+                        (if (string? k)
+                          (-> m (dissoc+ k) (assoc+ (keyword k) v))
+                          m))
+                      form form)
+           maybe-persistent!
+           (with-meta (meta form)))
+       form))
+   m))

--- a/test/metabase/util/performance_test.clj
+++ b/test/metabase/util/performance_test.clj
@@ -3,6 +3,8 @@
    [clojure.test :refer :all]
    [metabase.util.performance :as perf]))
 
+(set! *warn-on-reflection* true)
+
 (deftest ^:parallel concat-test
   (is (= [1 2 3 4 5] (perf/concat [1] [] [2] [3 4] nil '(5))))
   (is (= [] (perf/concat [] [])))
@@ -33,3 +35,53 @@
   (is (= [[1 2 3 4 5] [1 2 3 4 5] [1 2 3 4 5] [1 2 3 4 5] [1 2 3 4 5]]
          (perf/transpose [[1 1 1 1 1] [2 2 2 2 2] [3 3 3 3 3] [4 4 4 4 4] [5 5 5 5 5]])
          (apply mapv vector [[1 1 1 1 1] [2 2 2 2 2] [3 3 3 3 3] [4 4 4 4 4] [5 5 5 5 5]]))))
+
+(deftest ^:parallel test-postwalk
+  (are [before after] (= after (perf/postwalk #(cond-> %
+                                                 (number? %) inc)
+                                              before))
+
+    (list 1 2 3 :a "b" nil 4 5 6)
+    (list 2 3 4 :a "b" nil 5 6 7)
+
+    [1 2 3 :a "b" nil 4 5 6]
+    [2 3 4 :a "b" nil 5 6 7]
+
+    #{1 2 3 :a "b" nil 4 5 6}
+    #{2 3 4 :a "b" nil 5 6 7}
+
+    ;; new keys overriding past keys
+    {1 "1" 2 "2" 3 "3"}
+    {2 "1" 3 "2" 4 "3"}
+
+    {3 "3" 2 "2" 1 "1"}
+    {2 "1" 3 "2" 4 "3"}
+
+    {1 2 3 :a "b" 4 nil nil}
+    {2 3 4 :a "b" 5 nil nil}
+
+    {:a {:b {:c {:d [1 2 {:e 3}]}}}}
+    {:a {:b {:c {:d [2 3 {:e 4}]}}}}))
+
+(defrecord Foo [a b c])
+
+(deftest test-walk
+  (let [colls ['(1 2 3)
+               [1 2 3]
+               #{1 2 3}
+               (sorted-set-by > 1 2 3)
+               {:a 1, :b 2, :c 3}
+               (sorted-map-by > 1 10, 2 20, 3 30)
+               (->Foo 1 2 3)
+               (map->Foo {:a 1 :b 2 :c 3 :extra 4})]]
+    (doseq [c colls]
+      (let [walked (perf/walk identity identity c)]
+        (is (= c walked))
+        (if (map? c)
+          (is (= (perf/walk #(cond-> % (number? %) inc) #(reduce + (vals %)) c)
+                 (reduce + (map (comp inc val) c))))
+          (is (= (perf/walk inc #(reduce + %) c)
+                 (reduce + (map inc c)))))
+        (when (instance? clojure.lang.Sorted c)
+          (is (= (.comparator ^clojure.lang.Sorted c)
+                 (.comparator ^clojure.lang.Sorted walked))))))))


### PR DESCRIPTION
This PR introduces a custom `walk` and `keywordize-keys` implementation that tries to preserve the original objects as much as possible if the transforming function didn't change the leaf nodes. The idea and implementation is mostly borrowed from https://github.com/tonsky/clojure-plus/, but I also removed some unnecessary parts and made some changes to it, so it's easier to ship as a vendored code instead of adding a dependency.

The exact place where the new `keywordize-keys` is used is `normalize-source-metadata` function. This function takes significant time during MBQL pre-processing in the synthetic pulse notification benchmark (see https://github.com/metabase/metabase/issues/51708). The result is ~10% reduced allocations and execution time: https://flamebin.dev/Jnn4YL.

Since `normalize-source-metadata` lives in a CLJC file, the optimized walked is only used in the CLJ case; CLJS variant continues to use the basic clojure.walk-based implementation.