### PR TITLE
chore: restore no-restricted-imports rules for enterprise folder

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,9 @@ module.exports = {
       },
     ],
     "no-empty": [1, { allowEmptyCatch: true }],
+    // Note: adding this rule to a eslint config file in a subfolder will remove
+    // *not* carry over the restricted imports from parent folders, you will
+    // need to copy them over
     "no-restricted-imports": [
       "error",
       {

--- a/e2e/.eslintrc
+++ b/e2e/.eslintrc
@@ -8,6 +8,9 @@
     "cypress/no-async-tests": "error",
     "cypress/no-pause": "error",
     "quotes": ["error", "double", { "avoidEscape": true }],
+    // Note: adding this rule to a eslint config file in a subfolder will remove
+    // *not* carry over the restricted imports from parent folders, you will
+    // need to copy them over
     "no-restricted-imports": [
       "error",
       {

--- a/enterprise/frontend/.eslintrc
+++ b/enterprise/frontend/.eslintrc
@@ -6,6 +6,10 @@
         "patterns": ["cljs/metabase.lib*"],
         "paths": [
           {
+            "name": "@mantine/core",
+            "message": "Please import from `metabase/ui` instead."
+          },
+          {
             "name": "moment",
             "message": "Moment is deprecated, please use dayjs"
           },
@@ -14,12 +18,16 @@
             "message": "Moment is deprecated, please use dayjs"
           },
           {
+            "name": "@storybook/testing-library",
+            "message": "Please use `testing-library/react` or `@testing-library/user-event`"
+          },
+          {
             "name": "react-redux",
             "importNames": ["useSelector", "useDispatch", "connect"],
             "message": "Please import from `metabase/lib/redux` instead."
           },
-        ]
-      }
-    ]
-  }
+        ],
+      },
+    ],
+  },
 }

--- a/enterprise/frontend/.eslintrc
+++ b/enterprise/frontend/.eslintrc
@@ -10,27 +10,27 @@
         "paths": [
           {
             "name": "@mantine/core",
-            "message": "Please import from `metabase/ui` instead."
+            "message": "Please import from `metabase/ui` instead.",
           },
           {
             "name": "moment",
-            "message": "Moment is deprecated, please use dayjs"
+            "message": "Moment is deprecated, please use dayjs",
           },
           {
             "name": "moment-timezone",
-            "message": "Moment is deprecated, please use dayjs"
+            "message": "Moment is deprecated, please use dayjs",
           },
           {
-            "name": "@storybook/testing-library",
-            "message": "Please use `testing-library/react` or `@testing-library/user-event`"
+            "name": "@storybook/test",
+            "message": "Please use `testing-library/react` or `@testing-library/user-event`",
           },
           {
             "name": "react-redux",
             "importNames": ["useSelector", "useDispatch", "connect"],
-            "message": "Please import from `metabase/lib/redux` instead."
-          }
-        ]
-      }
-    ]
-  }
+            "message": "Please import from `metabase/lib/redux` instead.",
+          },
+        ],
+      },
+    ],
+  },
 }

--- a/enterprise/frontend/.eslintrc
+++ b/enterprise/frontend/.eslintrc
@@ -1,5 +1,8 @@
 {
   "rules": {
+    // Note: adding this rule to a eslint config file in a subfolder will remove
+    // *not* carry over the restricted imports from parent folders, you will
+    // need to copy them over
     "no-restricted-imports": [
       "error",
       {
@@ -25,9 +28,9 @@
             "name": "react-redux",
             "importNames": ["useSelector", "useDispatch", "connect"],
             "message": "Please import from `metabase/lib/redux` instead."
-          },
-        ],
-      },
-    ],
-  },
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/enterprise/frontend/src/embedding-sdk/.eslintrc
+++ b/enterprise/frontend/src/embedding-sdk/.eslintrc
@@ -1,5 +1,8 @@
 {
   "rules": {
+    // Note: adding this rule to a eslint config file in a subfolder will remove
+    // *not* carry over the restricted imports from parent folders, you will
+    // need to copy them over
     "no-restricted-imports": [
       "error",
       {

--- a/enterprise/frontend/src/embedding-sdk/.eslintrc
+++ b/enterprise/frontend/src/embedding-sdk/.eslintrc
@@ -5,6 +5,22 @@
       {
         "paths": [
           {
+            "name": "@mantine/core",
+            "message": "Please import from `metabase/ui` instead."
+          },
+          {
+            "name": "moment",
+            "message": "Moment is deprecated, please use dayjs"
+          },
+          {
+            "name": "moment-timezone",
+            "message": "Moment is deprecated, please use dayjs"
+          },
+          {
+            "name": "@storybook/testing-library",
+            "message": "Please use `testing-library/react` or `@testing-library/user-event`"
+          },
+          {
             "name": "react-redux",
             "importNames": ["useSelector", "useDispatch", "connect"],
             "message": "Please use \"useSdkSelector\", \"useSdkDispatch\""

--- a/enterprise/frontend/src/embedding-sdk/.eslintrc
+++ b/enterprise/frontend/src/embedding-sdk/.eslintrc
@@ -9,41 +9,41 @@
         "paths": [
           {
             "name": "@mantine/core",
-            "message": "Please import from `metabase/ui` instead."
+            "message": "Please import from `metabase/ui` instead.",
           },
           {
             "name": "moment",
-            "message": "Moment is deprecated, please use dayjs"
+            "message": "Moment is deprecated, please use dayjs",
           },
           {
             "name": "moment-timezone",
-            "message": "Moment is deprecated, please use dayjs"
+            "message": "Moment is deprecated, please use dayjs",
           },
           {
-            "name": "@storybook/testing-library",
-            "message": "Please use `testing-library/react` or `@testing-library/user-event`"
+            "name": "@storybook/test",
+            "message": "Please use `testing-library/react` or `@testing-library/user-event`",
           },
           {
             "name": "react-redux",
             "importNames": ["useSelector", "useDispatch", "connect"],
-            "message": "Please use \"useSdkSelector\", \"useSdkDispatch\""
+            "message": "Please use \"useSdkSelector\", \"useSdkDispatch\"",
           },
           {
             "name": "metabase/lib/redux",
             "importNames": ["useStore", "useDispatch"],
-            "message": "Please use \"useSdkStore\", \"useSdkDispatch\""
-          }
-        ]
-      }
-    ]
+            "message": "Please use \"useSdkStore\", \"useSdkDispatch\"",
+          },
+        ],
+      },
+    ],
   },
   "overrides": [
     {
       "files": ["**/*.stories.tsx"],
       "rules": {
         "import/no-default-export": 0,
-        "no-restricted-imports": 0
-      }
-    }
-  ]
+        "no-restricted-imports": 0,
+      },
+    },
+  ],
 }

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Filter/DropdownFilterBadgeList.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Filter/DropdownFilterBadgeList.tsx
@@ -1,5 +1,6 @@
-import { Group, Popover } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
+
+import { Group, Popover } from "metabase/ui";
 
 import { BadgeListItem } from "../util/BadgeList/BadgeListItem";
 

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/util/BadgeList/AddBadgeListItem/AddBadgeListItem.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/util/BadgeList/AddBadgeListItem/AddBadgeListItem.tsx
@@ -1,10 +1,10 @@
-import { Badge, type BadgeProps } from "@mantine/core";
 import { type HTMLAttributes, type Ref, forwardRef } from "react";
 
 import CS from "metabase/css/core/index.css";
-import { ActionIcon, Icon } from "metabase/ui";
+import { ActionIcon, Badge, Icon } from "metabase/ui";
 
-type BadgeListItemRootProps = BadgeProps & HTMLAttributes<HTMLDivElement>;
+type BadgeListItemRootProps = React.ComponentProps<typeof Badge> &
+  HTMLAttributes<HTMLDivElement>;
 
 interface AddBadgeListItemProps extends BadgeListItemRootProps {
   name: string;

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/util/BadgeList/AddBadgeListItem/AddBadgeListItem.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/util/BadgeList/AddBadgeListItem/AddBadgeListItem.tsx
@@ -1,10 +1,9 @@
 import { type HTMLAttributes, type Ref, forwardRef } from "react";
 
 import CS from "metabase/css/core/index.css";
-import { ActionIcon, Badge, Icon } from "metabase/ui";
+import { ActionIcon, Badge, type BadgeProps, Icon } from "metabase/ui";
 
-type BadgeListItemRootProps = React.ComponentProps<typeof Badge> &
-  HTMLAttributes<HTMLDivElement>;
+type BadgeListItemRootProps = BadgeProps & HTMLAttributes<HTMLDivElement>;
 
 interface AddBadgeListItemProps extends BadgeListItemRootProps {
   name: string;

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/util/BadgeList/BadgeListItem/BadgeListItem.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/util/BadgeList/BadgeListItem/BadgeListItem.tsx
@@ -1,12 +1,12 @@
-import { Badge, type BadgeProps } from "@mantine/core";
 import { type HTMLAttributes, type Ref, forwardRef } from "react";
 
 import CS from "metabase/css/core/index.css";
-import { ActionIcon, Icon } from "metabase/ui";
+import { ActionIcon, Badge, Icon } from "metabase/ui";
 
 import S from "./BadgeListItem.module.css";
 
-type BadgeListItemRootProps = BadgeProps & HTMLAttributes<HTMLDivElement>;
+type BadgeListItemRootProps = React.ComponentProps<typeof Badge> &
+  HTMLAttributes<HTMLDivElement>;
 
 interface BadgeListItemProps extends BadgeListItemRootProps {
   onRemoveItem?: () => void;

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/util/BadgeList/BadgeListItem/BadgeListItem.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/util/BadgeList/BadgeListItem/BadgeListItem.tsx
@@ -1,12 +1,11 @@
 import { type HTMLAttributes, type Ref, forwardRef } from "react";
 
 import CS from "metabase/css/core/index.css";
-import { ActionIcon, Badge, Icon } from "metabase/ui";
+import { ActionIcon, Badge, type BadgeProps, Icon } from "metabase/ui";
 
 import S from "./BadgeListItem.module.css";
 
-type BadgeListItemRootProps = React.ComponentProps<typeof Badge> &
-  HTMLAttributes<HTMLDivElement>;
+type BadgeListItemRootProps = BadgeProps & HTMLAttributes<HTMLDivElement>;
 
 interface BadgeListItemProps extends BadgeListItemRootProps {
   onRemoveItem?: () => void;

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/EditableDashboard.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/EditableDashboard.unit.spec.tsx
@@ -1,4 +1,3 @@
-import { Box } from "@mantine/core";
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 import { indexBy } from "underscore";
@@ -20,6 +19,7 @@ import type { MetabaseProviderProps } from "embedding-sdk/components/public/Meta
 import { renderWithSDKProviders } from "embedding-sdk/test/__support__/ui";
 import { createMockAuthProviderUriConfig } from "embedding-sdk/test/mocks/config";
 import { setupSdkState } from "embedding-sdk/test/server-mocks/sdk-init";
+import { Box } from "metabase/ui";
 import {
   createMockCard,
   createMockCardQueryMetadata,

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/InteractiveDashboard.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/InteractiveDashboard.unit.spec.tsx
@@ -1,4 +1,3 @@
-import { Box } from "@mantine/core";
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 import { indexBy } from "underscore";
@@ -17,6 +16,7 @@ import type { MetabaseProviderProps } from "embedding-sdk/components/public/Meta
 import { renderWithSDKProviders } from "embedding-sdk/test/__support__/ui";
 import { createMockAuthProviderUriConfig } from "embedding-sdk/test/mocks/config";
 import { setupSdkState } from "embedding-sdk/test/server-mocks/sdk-init";
+import { Box } from "metabase/ui";
 import {
   createMockCard,
   createMockCardQueryMetadata,

--- a/enterprise/frontend/src/embedding-sdk/components/public/StaticDashboard/StaticDashboard.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/StaticDashboard/StaticDashboard.unit.spec.tsx
@@ -1,4 +1,3 @@
-import { Box } from "@mantine/core";
 import fetchMock from "fetch-mock";
 import { indexBy } from "underscore";
 
@@ -12,6 +11,7 @@ import type { MetabaseProviderProps } from "embedding-sdk/components/public/Meta
 import { renderWithSDKProviders } from "embedding-sdk/test/__support__/ui";
 import { createMockAuthProviderUriConfig } from "embedding-sdk/test/mocks/config";
 import { setupSdkState } from "embedding-sdk/test/server-mocks/sdk-init";
+import { Box } from "metabase/ui";
 import {
   createMockCard,
   createMockDashboard,

--- a/enterprise/frontend/src/embedding-sdk/test/__support__/ui.tsx
+++ b/enterprise/frontend/src/embedding-sdk/test/__support__/ui.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import type { MantineThemeOverride } from "@mantine/core";
 import type { Store } from "@reduxjs/toolkit";
 import { render } from "@testing-library/react";

--- a/enterprise/frontend/src/embedding-sdk/test/__support__/ui.tsx
+++ b/enterprise/frontend/src/embedding-sdk/test/__support__/ui.tsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line no-restricted-imports
-import type { MantineThemeOverride } from "@mantine/core";
 import type { Store } from "@reduxjs/toolkit";
 import { render } from "@testing-library/react";
 import type * as React from "react";
@@ -15,6 +13,7 @@ import type { SdkStoreState } from "embedding-sdk/store/types";
 import { createMockSdkState } from "embedding-sdk/test/mocks/state";
 import { Api } from "metabase/api";
 import { MetabaseReduxProvider } from "metabase/lib/redux";
+import type { MantineThemeOverride } from "metabase/ui";
 import type { State } from "metabase-types/store";
 import { createMockState } from "metabase-types/store/mocks";
 

--- a/frontend/src/metabase-lib/.eslintrc
+++ b/frontend/src/metabase-lib/.eslintrc
@@ -1,5 +1,8 @@
 {
   "rules": {
+    // Note: adding this rule to a eslint config file in a subfolder will remove
+    // *not* carry over the restricted imports from parent folders, you will
+    // need to copy them over
     "no-restricted-imports": [
       "error",
       {

--- a/frontend/src/metabase/.eslintrc
+++ b/frontend/src/metabase/.eslintrc
@@ -1,5 +1,8 @@
 {
   "rules": {
+    // Note: adding this rule to a eslint config file in a subfolder will remove
+    // *not* carry over the restricted imports from parent folders, you will
+    // need to copy them over
     "no-restricted-imports": [
       "error",
       {

--- a/frontend/src/metabase/.eslintrc
+++ b/frontend/src/metabase/.eslintrc
@@ -10,47 +10,47 @@
           "metabase-enterprise",
           "metabase-enterprise/*",
           "cljs/metabase.lib*",
-          "/embedding-sdk"
+          "/embedding-sdk",
         ],
         "paths": [
           {
             "name": "react-redux",
             "importNames": ["useSelector", "useDispatch", "connect"],
-            "message": "Please import from `metabase/lib/redux` instead."
+            "message": "Please import from `metabase/lib/redux` instead.",
           },
           {
             "name": "@mantine/core",
-            "message": "Please import from `metabase/ui` instead."
+            "message": "Please import from `metabase/ui` instead.",
           },
           {
             "name": "moment",
-            "message": "Moment is deprecated, please use dayjs"
+            "message": "Moment is deprecated, please use dayjs",
           },
           {
             "name": "moment-timezone",
-            "message": "Moment is deprecated, please use dayjs"
+            "message": "Moment is deprecated, please use dayjs",
           },
           {
-            "name": "@storybook/testing-library",
-            "message": "Please use `testing-library/react` or `@testing-library/user-event`"
-          }
-        ]
-      }
-    ]
+            "name": "@storybook/test",
+            "message": "Please use `testing-library/react` or `@testing-library/user-event`",
+          },
+        ],
+      },
+    ],
   },
   "overrides": [
     {
       "files": ["**/*.stories.tsx"],
       "rules": {
         "import/no-default-export": 0,
-        "no-restricted-imports": 0
-      }
+        "no-restricted-imports": 0,
+      },
     },
     {
       "files": ["lib/redux/hooks.ts"],
       "rules": {
-        "no-restricted-imports": 0
-      }
+        "no-restricted-imports": 0,
+      },
     },
     {
       "files": ["ui/**/*.{js,jsx,ts,tsx}"],
@@ -61,21 +61,21 @@
             "patterns": [
               "metabase-enterprise",
               "metabase-enterprise/*",
-              "cljs/metabase.lib*"
+              "cljs/metabase.lib*",
             ],
             "paths": [
               {
                 "name": "moment",
-                "message": "Moment is deprecated, please use dayjs"
+                "message": "Moment is deprecated, please use dayjs",
               },
               {
                 "name": "moment-timezone",
-                "message": "Moment is deprecated, please use dayjs"
-              }
-            ]
-          }
-        ]
-      }
-    }
-  ]
+                "message": "Moment is deprecated, please use dayjs",
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
 }

--- a/frontend/src/metabase/css/core/overlays/find-utils.tsx
+++ b/frontend/src/metabase/css/core/overlays/find-utils.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- this is only used in stories
 import { within } from "@storybook/test";
 
 import { EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID } from "metabase/embedding-sdk/config";

--- a/frontend/src/metabase/ui/components/data-display/Badge/Badge.config.tsx
+++ b/frontend/src/metabase/ui/components/data-display/Badge/Badge.config.tsx
@@ -1,4 +1,5 @@
 import { Badge } from "@mantine/core";
+export type { BadgeProps } from "@mantine/core";
 
 import BadgeStyles from "./Badge.module.css";
 

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -1,5 +1,4 @@
 import { Global } from "@emotion/react";
-import type { MantineThemeOverride } from "@mantine/core";
 import type { Reducer, Store } from "@reduxjs/toolkit";
 import type { MatcherFunction } from "@testing-library/dom";
 import type { ByRoleMatcher } from "@testing-library/react";
@@ -24,6 +23,7 @@ import { baseStyle } from "metabase/css/core/base.styled";
 import { MetabaseReduxProvider } from "metabase/lib/redux";
 import { mainReducers } from "metabase/reducers-main";
 import { publicReducers } from "metabase/reducers-public";
+import type { MantineThemeOverride } from "metabase/ui";
 import { ThemeProvider } from "metabase/ui";
 import type { State } from "metabase-types/store";
 import { createMockState } from "metabase-types/store/mocks";


### PR DESCRIPTION
# Description

Implement the basic version of [this RFC](https://www.notion.so/metabase/115-Fix-inconsistent-no-restricted-imports-eslint-rules-17669354c901809a8822eb05f49acf22)

It may not be the most awesome and perfect solution but I wanted to fix the rule for the sdk and enterprise folder, which could import for example from `@mantine/core` directly. Most of the times it shouldn't make a difference, but we do wrap some components with extra logic 





