### PR TITLE
fix(sdk): better scope for SCOPED_CSS_RESET to fix transparent button bg

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentStylesWrapper.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentStylesWrapper.tsx
@@ -60,14 +60,15 @@ export const PublicComponentStylesWrapper = (
  * - this global css is loaded in the provider, before our other styles
  * - -> our other code with specificity (0,1,0) will override this as they're loaded after
  */
+// note: if we move this to  css.module, remember to add :global to .mb-wrapper
 export const SCOPED_CSS_RESET = css`
-  ${PublicComponentStylesWrapperInner} *:where(button) {
+  :where(.mb-wrapper) *:where(button) {
     border: 0;
     background-color: transparent;
   }
 
   // fonts.styled.ts has a reset for list padding and margin in the main app, so we need to do it here
-  ${PublicComponentStylesWrapperInner} *:where(ul) {
+  :where(.mb-wrapper) *:where(ul) {
     padding: 0;
     margin: 0;
   }


### PR DESCRIPTION
https://metaboat.slack.com/archives/C063Q3F1HPF/p1737991577557429

# How to verify:
With storybook, open the [interactive question story](http://localhost:6006/?path=/story/embeddingsdk-interactivequestion--default) and open the editor  (top right button)

Before:
Notice that transparent rule is at the top
<img width="1334" alt="image" src="https://github.com/user-attachments/assets/111d03ac-8d75-4d11-8f14-1b867706a9dd" />

After:
<img width="1320" alt="image" src="https://github.com/user-attachments/assets/bb942d2e-2081-451b-bef1-58a03660a7c0" />



TODO:
- [ ] backport to 52