### PR TITLE
Fix v2 - Redundant GET `/api/action` request when viewing non-model object details

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
@@ -375,6 +375,22 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Item 1 of/i).should("be.visible");
   });
+
+  it("should not call GET /api/action endpoint for ad-hoc questions (metabase#50266)", () => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.intercept("GET", "/api/action", cy.spy().as("getActions"));
+
+    cy.visit("/");
+    H.browseDatabases().click();
+    cy.findByRole("heading", { name: "Sample Database" }).click();
+    cy.findByRole("heading", { name: "Orders" }).click();
+    cy.wait("@dataset");
+    cy.findAllByTestId("cell-data").eq(11).click();
+    H.popover().findByText("View details").click();
+    cy.wait(["@dataset", "@dataset", "@dataset"]); // object detail + Orders relationship + Reviews relationship
+
+    cy.get("@getActions").should("have.callCount", 0);
+  });
 });
 
 function drillPK({ id }) {

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailView.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailView.tsx
@@ -4,10 +4,8 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import { ActionExecuteModal } from "metabase/actions/containers/ActionExecuteModal";
-import {
-  useActionListQuery,
-  useDatabaseListQuery,
-} from "metabase/common/hooks";
+import { skipToken, useListActionsQuery } from "metabase/api";
+import { useDatabaseListQuery } from "metabase/common/hooks";
 import { NotFound } from "metabase/components/ErrorPages";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
 import Modal from "metabase/components/Modal";
@@ -244,16 +242,20 @@ export function ObjectDetailView({
     [zoomedRowID, followForeignKey],
   );
 
-  const areImplicitActionsEnabled =
+  const areImplicitActionsEnabled = Boolean(
     question &&
-    question.canWrite() &&
-    question.type() === "model" &&
-    question.supportsImplicitActions();
+      question.canWrite() &&
+      question.type() === "model" &&
+      question.supportsImplicitActions(),
+  );
 
-  const { data: actions = [] } = useActionListQuery({
-    enabled: areImplicitActionsEnabled,
-    query: { "model-id": question?.id() },
-  });
+  const modelId = question?.type() === "model" ? question.id() : undefined;
+
+  const { data: actions = [] } = useListActionsQuery(
+    areImplicitActionsEnabled && modelId != null
+      ? { "model-id": modelId }
+      : skipToken,
+  );
 
   const { data: databases = [] } = useDatabaseListQuery({
     enabled: areImplicitActionsEnabled,


### PR DESCRIPTION
Fixes #50266

### How to verify

1. Browse databases > Sample database > Orders
2. Click on "Product ID" cell in the first data row
3. Click "View details"

Observe network tab in dev tools - there should be no GET `/api/action` request
