### PR TITLE
fix(sdk): dashboard not found when switching dashboards in cli

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/cli/snippets/analytics-dashboard-snippet.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/snippets/analytics-dashboard-snippet.ts
@@ -42,7 +42,7 @@ export const AnalyticsDashboard = () => {
             {isDashboard && (
               <select
                 className="dashboard-select"
-                onChange={(e) => setDashboardId(e.target.value)}
+                onChange={(e) => setDashboardId(Number(e.target.value))}
               >
                 {DASHBOARDS.map((dashboard) => (
                   <option key={dashboard.id} value={dashboard.id}>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/52796

When selecting "People" or "Products" table, there is an error that says `Dashboard 11 not found. Make sure you pass the correct ID.`. This was because the InteractiveDashboard component accepts either an integer id, or a string of entity ids. Casting the Dashboard ID in the click handler to an integer fixes the issue. We could also modify useValidatedEntityId to accept string ids but I'll leave that for later.

### How to verify

- Create a sample app (e.g. with Vite)
- Run the CLI in it. Use the following command: `docker rm -f metabase-enterprise-embedding && yarn add file:../metabase/resources/embedding-sdk && npx @metabase/embedding-sdk-react start`
  - If you are using Yarn 2, you need to specify the prefix to link it: `docker rm -f metabase-enterprise-embedding && yarn add "@metabase/embedding-sdk-react@file:../metabase/resources/embedding-sdk" && npx @metabase/embedding-sdk-react start` 
- Use the dropdown to switch between dropdowns
- No "Dashboard not found" error should show up