### PR TITLE
fix(sdk): make headers in generated cli components responsive

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/cli/snippets/analytics-css-snippet.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/snippets/analytics-css-snippet.ts
@@ -19,6 +19,13 @@ export const ANALYTICS_CSS_SNIPPET = `
   margin: 0 auto;
   min-height: 100vh;
   padding: 30px 0;
+  container-type: inline-size;
+}
+
+@container (max-width: 900px) {
+  .analytics-header {
+    flex-direction: column;
+  }
 }
 
 .analytics-header,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50095

### Description

Most React projects or even default starter kits comes with CSS that applies `max-width` to the project. If someone is trying it out the SDK for the first time, and we don't tell them anything about CSS in the CLI, it looks bad because the component expects to be rendered in full-screen.

We use a bit of container queries to make the headers

### How to verify

- Create a sample app (e.g. with Vite)
- Run the CLI in it. Use the following command: `docker rm -f metabase-enterprise-embedding && yarn add file:../metabase/resources/embedding-sdk && npx @metabase/embedding-sdk-react start`
  - If you are using Yarn 2, you need to specify the prefix to link it: `docker rm -f metabase-enterprise-embedding && yarn add "@metabase/embedding-sdk-react@file:../metabase/resources/embedding-sdk" && npx @metabase/embedding-sdk-react start` 
- If your sample app does not have a default CSS stylesheet, render this in your sample app to emulate them:

```tsx
    <div style={{ background: "#2d2d30" }}>
      <div style={{ maxWidth: "400px", margin: "0 auto" }}>
        <AnalyticsPage />
      </div>
    </div>
```

- Headers should be well-centered despite being in a container

### Demo

![CleanShot 2568-02-10 at 21 59 46@2x](https://github.com/user-attachments/assets/10c264fb-6572-468d-9d7c-937cbd796bb7)