### PR TITLE
feat(sdk): show clarification messages upon running the cli

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/cli/constants/config.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/constants/config.ts
@@ -2,7 +2,7 @@ export const IMAGE_NAME = "metabase/metabase-enterprise:latest";
 export const CONTAINER_NAME = "metabase-enterprise-embedding";
 export const SITE_NAME = "Metabase Embedding SDK Demo";
 export const SDK_PACKAGE_NAME = "@metabase/embedding-sdk-react";
-export const SDK_NPM_LINK = `https://npm.im/package/${SDK_PACKAGE_NAME}`;
+export const SDK_DOCS_LINK = "https://metaba.se/sdk";
 export const SAMPLE_CREDENTIALS_FILE_NAME = "METABASE_LOGIN.json";
 
 /**

--- a/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
@@ -9,9 +9,11 @@ import {
 export const SHOW_ON_STARTUP_MESSAGE = `
   This tool will spin up a local Metabase instance via Docker and help you get
   an embedded dashboard in your app.
-  
+
   - You can't use this tool to connect to an existing Metabase instance.
-  - The tool's default setup (which uses API keys) won’t work in production. It's only intended for you to quickly try out the SDK on your local machine. A production setup requires a Pro/Enterprise license and SSO with JWT.
+  - The tool's default setup (which uses API keys) won’t work in production.
+    It's only intended for you to quickly try out the SDK on your local machine.
+    A production setup requires a Pro/Enterprise license and SSO with JWT.
 `;
 
 export const PACKAGE_JSON_NOT_FOUND_MESSAGE = `

--- a/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
@@ -6,6 +6,16 @@ import {
   SDK_NPM_LINK,
 } from "./config";
 
+export const SHOW_ON_STARTUP_MESSAGE = `
+  This will spin up a local Metabase instance via Docker and help you get
+  an embedded dashboard in your app. You cannot connect to an existing
+  Metabase instance using this tool.
+
+  Note that the default setup with API keys won’t work in production.
+  It's only intended for you to quickly try out the SDK on your local machine.
+  A production setup requires a Pro/Enterprise license and SSO with JWT.
+`;
+
 export const PACKAGE_JSON_NOT_FOUND_MESSAGE = `
   Could not find a package.json file in the current directory.
   Please run this command from the root of your project.

--- a/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
@@ -3,7 +3,7 @@ import { blue, green, yellow } from "chalk";
 import {
   CONTAINER_NAME,
   SAMPLE_CREDENTIALS_FILE_NAME,
-  SDK_NPM_LINK,
+  SDK_DOCS_LINK,
 } from "./config";
 
 export const SHOW_ON_STARTUP_MESSAGE = `
@@ -98,7 +98,7 @@ export const SETUP_PRO_LICENSE_MESSAGE = `
 `;
 
 export const SDK_LEARN_MORE_MESSAGE = `All done! 🚀 Learn more about the SDK here: ${green(
-  SDK_NPM_LINK,
+  SDK_DOCS_LINK,
 )}`;
 
 export const CONTINUE_SETUP_ON_WARNING_MESSAGE = `Do you want to continue setup?`;

--- a/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
@@ -7,13 +7,11 @@ import {
 } from "./config";
 
 export const SHOW_ON_STARTUP_MESSAGE = `
-  This will spin up a local Metabase instance via Docker and help you get
-  an embedded dashboard in your app. You cannot connect to an existing
-  Metabase instance using this tool.
-
-  Note that the default setup with API keys won’t work in production.
-  It's only intended for you to quickly try out the SDK on your local machine.
-  A production setup requires a Pro/Enterprise license and SSO with JWT.
+  This tool will spin up a local Metabase instance via Docker and help you get
+  an embedded dashboard in your app.
+  
+  - You can't use this tool to connect to an existing Metabase instance.
+  - The tool's default setup (which uses API keys) won’t work in production. It's only intended for you to quickly try out the SDK on your local machine. A production setup requires a Pro/Enterprise license and SSO with JWT.
 `;
 
 export const PACKAGE_JSON_NOT_FOUND_MESSAGE = `

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/generate-credentials.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/generate-credentials.ts
@@ -16,7 +16,7 @@ import {
 
 export const generateCredentials: CliStepMethod = async state => {
   printEmptyLines();
-  printWithPadding("Setting up a local Metabase instance.");
+  printWithPadding("Setting up a local Metabase instance via Docker.");
 
   const email = await input({
     message: "What is the email address you want to use for the admin user?",

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/show-metabase-cli-title.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/show-metabase-cli-title.ts
@@ -1,4 +1,4 @@
-import { SDK_PACKAGE_NAME } from "embedding-sdk/cli/constants/config";
+import { SDK_DOCS_LINK } from "embedding-sdk/cli/constants/config";
 
 import { SHOW_ON_STARTUP_MESSAGE } from "../constants/messages";
 import type { CliStepMethod } from "../types/cli";
@@ -6,7 +6,7 @@ import { printEmptyLines, printTitle, printWithPadding } from "../utils/print";
 
 export const showMetabaseCliTitle: CliStepMethod = state => {
   printTitle(`Welcome to the Metabase Embedding SDK CLI`);
-  printTitle(`View docs at https://npm.im/${SDK_PACKAGE_NAME}`);
+  printTitle(`View docs at ${SDK_DOCS_LINK}`);
   printEmptyLines();
 
   printWithPadding(SHOW_ON_STARTUP_MESSAGE.trim());

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/show-metabase-cli-title.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/show-metabase-cli-title.ts
@@ -1,11 +1,15 @@
 import { SDK_PACKAGE_NAME } from "embedding-sdk/cli/constants/config";
 
+import { SHOW_ON_STARTUP_MESSAGE } from "../constants/messages";
 import type { CliStepMethod } from "../types/cli";
-import { printEmptyLines, printTitle } from "../utils/print";
+import { printEmptyLines, printTitle, printWithPadding } from "../utils/print";
 
 export const showMetabaseCliTitle: CliStepMethod = state => {
   printTitle(`Welcome to the Metabase Embedding SDK CLI`);
   printTitle(`View docs at https://npm.im/${SDK_PACKAGE_NAME}`);
+  printEmptyLines();
+
+  printWithPadding(SHOW_ON_STARTUP_MESSAGE.trim());
   printEmptyLines();
 
   return [{ type: "success" }, state];


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/51384

### Description

Show clarification messages to the CLI so people know they can't connect to an existing Metabase instance, and that API keys does not work on production.

### Demo

![CleanShot 2568-02-11 at 10 08 53@2x](https://github.com/user-attachments/assets/0db57ab6-61d4-41d3-971b-b287f74902a8)
