### PR TITLE
Remove blue color from identifiers in the ACE editor

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/AceEditor/AceEditor.module.css
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/AceEditor/AceEditor.module.css
@@ -44,7 +44,6 @@
         color: var(--mb-color-saturated-purple);
       }
 
-      .ace_identifier,
       .ace_function,
       .ace_variable {
         color: var(--mb-color-saturated-blue);


### PR DESCRIPTION
Fixes an unwanted change in the syntax highlighting of SQL in the native editor on v53.

### Before 
<img width="395" alt="Screenshot 2025-02-10 at 19 57 28" src="https://github.com/user-attachments/assets/1d9c1b30-d1c2-491b-8ea5-8084d6a96b38" />

### After
<img width="424" alt="Screenshot 2025-02-10 at 20 00 26" src="https://github.com/user-attachments/assets/d2e2c512-b95d-4ce7-97b9-087dd919f6fc" />
