### PR TITLE
Remove color for codemirror identifier token

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.module.css
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.module.css
@@ -148,7 +148,6 @@
       color: var(--mb-color-saturated-purple);
     }
 
-    .cm-token-name,
     .cm-token-function,
     .cm-token-variable {
       color: var(--mb-color-saturated-blue);

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/language.ts
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/language.ts
@@ -3,6 +3,7 @@ import {
   MySQL,
   PLSQL,
   PostgreSQL,
+  SQLDialect,
   StandardSQL,
   sql,
 } from "@codemirror/lang-sql";
@@ -37,12 +38,19 @@ const engineToDialect = {
   mysql: MySQL,
   oracle: PLSQL,
   postgres: PostgreSQL,
+  h2: SQLDialect.define({
+    // @ts-expect-error: SQLDialect.dialect is an internal that is exposed
+    ...StandardSQL.dialect,
+    // @ts-expect-error: SQLDialect.dialect is an internal that is exposed
+    keywords: Object.keys(StandardSQL.dialect.words)
+      .join(" ")
+      .concat(" exclude"),
+  }),
   // TODO:
   // "presto-jdbc": "trino",
   // redshift: "redshift",
   // snowflake: "snowflake",
   // sparksql: "spark",
-  // h2: "h2",
 };
 
 const mongoKeywords = {


### PR DESCRIPTION
The CodeMirror counterpart of https://github.com/metabase/metabase/pull/53479 (since the broken style was copied in the conversion to CodeMirror).

Also adds `exclude` to the list of keywords for h2.

### Before 
<img width="395" alt="Screenshot 2025-02-10 at 19 57 28" src="https://github.com/user-attachments/assets/1d9c1b30-d1c2-491b-8ea5-8084d6a96b38" />

### After
<img width="384" alt="Screenshot 2025-02-10 at 20 23 20" src="https://github.com/user-attachments/assets/fe115ccc-e9ec-4706-bf40-ed89fdc9f1ca" />

