### PR TITLE
Renamed cleanup-session to cleanup-session!

### DIFF
--- a/src/metabase/models/session.clj
+++ b/src/metabase/models/session.clj
@@ -108,7 +108,7 @@
     (throw (ex-info (str (tru "Password login is disabled for this instance.")) {:status-code 400})))
   ((get-method create-session! :sso) session-type user device-info))
 
-(defn cleanup-sessions
+(defn cleanup-sessions!
   "Deletes sessions from the database which are no longer valid"
   []
   (let [oldest-allowed [:inline (sql.qp/add-interval-honeysql-form (mdb/db-type)

--- a/src/metabase/task/session_cleanup.clj
+++ b/src/metabase/task/session_cleanup.clj
@@ -14,7 +14,7 @@
 (jobs/defjob ^{:doc "Job that cleans up outdated sessions."}
   SessionCleanup
   [_]
-  (session/cleanup-sessions))
+  (session/cleanup-sessions!))
 
 (defmethod task/init! ::SessionCleanup [_]
   (let [job (jobs/build

--- a/test/metabase/models/session_test.clj
+++ b/test/metabase/models/session_test.clj
@@ -142,6 +142,6 @@
                                                :created_at (t/minus (t/local-date-time) (t/hours 5))}]
       (testing "session-cleanup deletes old sessions and keeps new enough ones"
         (is (t2/select-one :model/Session :id (old-session :id)))
-        (session/cleanup-sessions)
+        (session/cleanup-sessions!)
         (is (not (t2/exists? :model/Session :id (:id old-session))))
         (is (t2/exists? :model/Session :id (:id new-session)))))))


### PR DESCRIPTION
### Description

#53246 should have created the new method as `cleanup-session!` but the ! was missed. This fixes the code, no functionality changes.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
