### PR TITLE
Fetch permissions for all databases when looking up db permissions

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -82,6 +82,7 @@
   native queries, but not to create new ones. With the advent of what is currently being called 'Space-Age
   Permissions', all Cards' permissions are based on their parent Collection, removing the need for native read perms."
   [dbs :- [:maybe [:sequential :map]]]
+  (perms/prime-db-cache (map :id dbs))
   (for [db dbs]
     (assoc db
            :native_permissions

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -23,6 +23,7 @@
   full-schema-permission-for-user
   most-permissive-database-permission-for-user
   permissions-for-user
+  prime-db-cache
   schema-permission-for-user
   set-database-permission!
   set-new-database-permissions!

--- a/src/metabase/permissions/models/data_permissions.clj
+++ b/src/metabase/permissions/models/data_permissions.clj
@@ -95,10 +95,9 @@
 
 ;;; ---------------------------------------- Caching ------------------------------------------------------------------
 
-(defn- relevant-db-permissions-for-user
-  "Returns all relevant rows for permissions for the user, excluding permissions for deactivated tables.
-  For performance reasons, includes all databases so we cache all db permissions for the user in one request."
-  [user-id]
+(defn- relevant-permissions-for-user-and-dbs
+  "Returns all relevant rows for permissions for the user, excluding permissions for deactivated tables for the given sequence of database ids."
+  [user-id db-ids]
   (t2/select :model/DataPermissions
              {:select [:p.* [:pgm.user_id :user_id]]
               :from [[:permissions_group_membership :pgm]]
@@ -107,10 +106,10 @@
               :left-join [[:metabase_table :mt] [:= :mt.id :p.table_id]]
               :where [:and
                       [:= :pgm.user_id user-id]
+                      [:in :p.db_id db-ids]
                       [:or
                        [:= :p.table_id nil]
-                       [:= :mt.active true]]]
-              :order-by [:p.db_id]}))
+                       [:= :mt.active true]]]}))
 
 (defn- relevant-permissions-for-user-perm-and-db
   "Returns all relevant rows for a given user, permission type, and db_id, excluding permissions for deactivated
@@ -139,6 +138,22 @@
 
   When checking permissions, if a DB has not been fetched, it will be added to the cache before the check returns."
   (atom {:db-ids #{} :perms {}}))
+
+(defn prime-db-cache
+  "Prime the permissions cache for a given user and database IDs.
+  This can be called directly prior to checking the permissions for a large number of databases to improve performance"
+  [db-ids]
+  (let [{cached-db-ids :db-ids perms :perms} @*permissions-for-user*
+        filtered-ids (filter #(not (some #{%} cached-db-ids)) db-ids)]
+    (when (seq filtered-ids)
+      (let [fetched-perm-rows (relevant-permissions-for-user-and-dbs api/*current-user-id* filtered-ids)
+            new-cache (reduce (fn [m {:keys [user_id perm_type db_id] :as row}]
+                                (update-in m [user_id perm_type db_id] u/conjv row))
+                              perms
+                              fetched-perm-rows)]
+        (reset! *permissions-for-user*
+                {:db-ids (into (or cached-db-ids #{}) db-ids)
+                 :perms  new-cache})))))
 
 (defenterprise enforced-sandboxes-for-user
   "Given a user-id, returns the set of sandboxes that should be enforced for the provided user ID. This result is
@@ -174,18 +189,9 @@
   (if (or (= user-id api/*current-user-id*)
           (not *use-perms-cache?*))
     ;; Use the cache if we can; if not, add perms to the cache for this DB
-    (let [{:keys [db-ids perms]} @*permissions-for-user*]
-      (if (db-ids db-id)
-        (get-in perms [user-id perm-type db-id])
-        (let [fetched-perm-rows (relevant-db-permissions-for-user user-id)
-              new-cache         (reduce (fn [m {:keys [user_id perm_type db_id] :as row}]
-                                          (update-in m [user_id perm_type db_id] u/conjv row))
-                                        perms
-                                        fetched-perm-rows)]
-          (reset! *permissions-for-user*
-                  {:db-ids (set (map :db_id fetched-perm-rows))
-                   :perms  new-cache})
-          (get-in new-cache [user-id perm-type db-id]))))
+    (do
+      (prime-db-cache [db-id])
+      (get-in (:perms @*permissions-for-user*) [user-id perm-type db-id]))
     ;; If we're checking permissions for a *different* user than ourselves, fetch it straight from the DB
     (relevant-permissions-for-user-perm-and-db user-id perm-type db-id)))
 

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -873,6 +873,27 @@
               (is (= expected-keys
                      (set (keys db)))))))))))
 
+(deftest ^:parallel databases-caching
+  (testing "GET /api/database"
+    (testing "Testing that listing all databases does not make excessive queries with multiple databases"
+        (mt/with-temp [:model/Database _ {:engine ::test-driver}
+                       :model/Database _ {:engine ::test-driver}
+                       :model/Database _ {:engine ::test-driver}
+                       :model/Database _ {:engine ::test-driver}
+                       :model/Database _ {:engine ::test-driver}
+                       :model/Database _ {:engine ::test-driver}
+                       :model/Database _ {:engine ::test-driver}
+                       :model/Database _ {:engine ::test-driver}
+                       :model/Database _ {:engine ::test-driver}
+                       :model/Database _ {:engine ::test-driver}
+                       :model/Database _ {:engine ::test-driver}
+                       :model/Database _ {:engine ::test-driver}
+                       :model/Database _ {:engine ::test-driver}
+                       :model/Database _ {:engine ::test-driver}]
+          (t2/with-call-count [call-count]
+            (mt/user-http-request :rasta :get 200 "database")
+            (is (> 10 (call-count))))))))
+
 (deftest ^:parallel databases-list-test-2
   (testing "GET /api/database"
     (testing "Test that we can get all the DBs (ordered by name, then driver)"

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -876,23 +876,23 @@
 (deftest ^:parallel databases-caching
   (testing "GET /api/database"
     (testing "Testing that listing all databases does not make excessive queries with multiple databases"
-        (mt/with-temp [:model/Database _ {:engine ::test-driver}
-                       :model/Database _ {:engine ::test-driver}
-                       :model/Database _ {:engine ::test-driver}
-                       :model/Database _ {:engine ::test-driver}
-                       :model/Database _ {:engine ::test-driver}
-                       :model/Database _ {:engine ::test-driver}
-                       :model/Database _ {:engine ::test-driver}
-                       :model/Database _ {:engine ::test-driver}
-                       :model/Database _ {:engine ::test-driver}
-                       :model/Database _ {:engine ::test-driver}
-                       :model/Database _ {:engine ::test-driver}
-                       :model/Database _ {:engine ::test-driver}
-                       :model/Database _ {:engine ::test-driver}
-                       :model/Database _ {:engine ::test-driver}]
-          (t2/with-call-count [call-count]
-            (mt/user-http-request :rasta :get 200 "database")
-            (is (< (call-count) 10)))))))
+      (mt/with-temp [:model/Database _ {:engine ::test-driver}
+                     :model/Database _ {:engine ::test-driver}
+                     :model/Database _ {:engine ::test-driver}
+                     :model/Database _ {:engine ::test-driver}
+                     :model/Database _ {:engine ::test-driver}
+                     :model/Database _ {:engine ::test-driver}
+                     :model/Database _ {:engine ::test-driver}
+                     :model/Database _ {:engine ::test-driver}
+                     :model/Database _ {:engine ::test-driver}
+                     :model/Database _ {:engine ::test-driver}
+                     :model/Database _ {:engine ::test-driver}
+                     :model/Database _ {:engine ::test-driver}
+                     :model/Database _ {:engine ::test-driver}
+                     :model/Database _ {:engine ::test-driver}]
+        (t2/with-call-count [call-count]
+          (mt/user-http-request :rasta :get 200 "database")
+          (is (< (call-count) 10)))))))
 
 (deftest ^:parallel databases-list-test-2
   (testing "GET /api/database"

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -892,7 +892,7 @@
                        :model/Database _ {:engine ::test-driver}]
           (t2/with-call-count [call-count]
             (mt/user-http-request :rasta :get 200 "database")
-            (is (> 10 (call-count))))))))
+            (is (< (call-count) 10)))))))
 
 (deftest ^:parallel databases-list-test-2
   (testing "GET /api/database"


### PR DESCRIPTION
### Description

Bullet 1 in #48674 found that calls to /api/database make individual calls to the permission tables for each database in the system -- which can be a lot

This PR changes the "what is the permissions for a database" query to fetch the permissions for all databases and fill the permission cache with them.

### How to verify

1. With log tracing on, hit /api/database as a non-admin user
2. See only one query to the permissions tables

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
