### PR TITLE
Remove unused test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -442,7 +442,6 @@
     "test-unit-keep-cljs": "jest --maxWorkers=4",
     "test-unit-watch": "yarn test-unit --watch",
     "test-unit-watch:cljs": "yarn concurrently -n 'cljs,tests' 'yarn build-watch:cljs' 'yarn test-unit-keep-cljs --watch'",
-    "test-visual": "yarn build && ./bin/build-for-test && yarn test-visual-run",
     "test-visual:loki": "loki test --chromeFlags='--headless --disable-gpu'",
     "test-visual:loki-approve-diff": "ls .loki/difference | xargs -I _ find .loki/current -name _ | xargs -I _ cp _ .loki/reference/",
     "test-visual:loki-update": "loki update --chromeFlags='--headless --disable-gpu'",


### PR DESCRIPTION
`yarn test-visual-run` doesn't exist anymore, so `test-visual` doesn't do anything