### PR TITLE
🍒 backported "Improve interactive embedding type clarity"

### DIFF
--- a/e2e/support/helpers/e2e-embedding-helpers.js
+++ b/e2e/support/helpers/e2e-embedding-helpers.js
@@ -306,7 +306,7 @@ export function createPublicDashboardLink(dashboardId) {
 /**
  * @param {Object} options
  * @param {string} options.url
- * @param {Object} options.qs
+ * @param {import("metabase-types/store").InteractiveEmbeddingOptions} options.qs
  * @param {Function} [options.onBeforeLoad]
  */
 export const visitFullAppEmbeddingUrl = ({ url, qs, onBeforeLoad }) => {

--- a/frontend/src/metabase-types/store/embed.ts
+++ b/frontend/src/metabase-types/store/embed.ts
@@ -1,4 +1,4 @@
-export interface EmbedOptions {
+export interface InteractiveEmbeddingOptions {
   font?: string;
   top_nav?: boolean;
   search?: boolean;
@@ -12,6 +12,6 @@ export interface EmbedOptions {
 }
 
 export interface EmbedState {
-  options: EmbedOptions;
+  options: InteractiveEmbeddingOptions;
   isEmbeddingSdk?: boolean;
 }

--- a/frontend/src/metabase-types/store/mocks/embed.ts
+++ b/frontend/src/metabase-types/store/mocks/embed.ts
@@ -1,6 +1,11 @@
-import type { EmbedOptions, EmbedState } from "metabase-types/store";
+import type {
+  EmbedState,
+  InteractiveEmbeddingOptions,
+} from "metabase-types/store";
 
-export const createMockEmbedOptions = (opts?: Partial<EmbedOptions>) => ({
+export const createMockEmbedOptions = (
+  opts?: Partial<InteractiveEmbeddingOptions>,
+) => ({
   ...opts,
 });
 

--- a/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
@@ -6,7 +6,7 @@ import { setupCollectionsEndpoints } from "__support__/server-mocks";
 import { renderWithProviders } from "__support__/ui";
 import { DEFAULT_EMBED_OPTIONS } from "metabase/redux/embed";
 import { createMockCard } from "metabase-types/api/mocks";
-import type { EmbedOptions } from "metabase-types/store";
+import type { InteractiveEmbeddingOptions } from "metabase-types/store";
 import {
   createMockAppState,
   createMockEmbedOptions,
@@ -166,7 +166,7 @@ describe("AppBar", () => {
   });
 });
 
-function setup(embedOptions: Partial<EmbedOptions>) {
+function setup(embedOptions: Partial<InteractiveEmbeddingOptions>) {
   setupCollectionsEndpoints({ collections: [] });
 
   return renderWithProviders(<Route path="*" component={AppBar} />, {

--- a/frontend/src/metabase/redux/embed.ts
+++ b/frontend/src/metabase/redux/embed.ts
@@ -2,9 +2,9 @@ import { type PayloadAction, createSlice } from "@reduxjs/toolkit";
 import { pick } from "underscore";
 
 import { parseSearchOptions } from "metabase/lib/browser";
-import type { EmbedOptions } from "metabase-types/store";
+import type { InteractiveEmbeddingOptions } from "metabase-types/store";
 
-export const DEFAULT_EMBED_OPTIONS: EmbedOptions = {
+export const DEFAULT_EMBED_OPTIONS: InteractiveEmbeddingOptions = {
   top_nav: true,
   side_nav: "default",
   search: false,
@@ -34,7 +34,7 @@ export const urlParameterToBoolean = (
 const interactiveEmbedSlice = createSlice({
   name: "interactiveEmbed",
   initialState: {
-    options: {} as EmbedOptions,
+    options: {} as InteractiveEmbeddingOptions,
     isEmbeddingSdk: false,
   },
   reducers: {
@@ -49,7 +49,10 @@ const interactiveEmbedSlice = createSlice({
         ...pick(searchOptions, allowedEmbedOptions),
       };
     },
-    setOptions: (state, action: PayloadAction<Partial<EmbedOptions>>) => {
+    setOptions: (
+      state,
+      action: PayloadAction<Partial<InteractiveEmbeddingOptions>>,
+    ) => {
       state.options = {
         ...state.options,
         ...action.payload,

--- a/frontend/src/metabase/selectors/embed.ts
+++ b/frontend/src/metabase/selectors/embed.ts
@@ -1,11 +1,11 @@
 import { isWithinIframe } from "metabase/lib/dom";
-import type { EmbedOptions, State } from "metabase-types/store";
+import type { InteractiveEmbeddingOptions, State } from "metabase-types/store";
 
 export const getIsEmbedded = (_state?: State): boolean => {
   return isWithinIframe();
 };
 
-export const getEmbedOptions = (state: State): EmbedOptions => {
+export const getEmbedOptions = (state: State): InteractiveEmbeddingOptions => {
   return state.embed.options;
 };
 


### PR DESCRIPTION
Manual backport of #53444 because it was merged with workflow version before #53201 landed, making it impossible to double backport automatically.

I also fixed the conflict on `frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx` manually.