### PR TITLE
Redirect user when navigate_to property is present in agent response

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/envelope.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/envelope.clj
@@ -95,7 +95,7 @@
   [e]
   (:context e))
 
-(defn- message->reaction
+(defn- message->reactions
   [msg]
   (let [message-reaction {:type :metabot.reaction/message
                           :repl/message-color :green
@@ -103,7 +103,7 @@
                           :message (:content msg)}
         navigate-reaction (when-let [nav-path (:navigate-to msg)]
                             {:type :metabot.reaction/redirect
-                             :url (str nav-path)})]
+                             :url nav-path})]
     (filter some? [message-reaction navigate-reaction])))
 
 (defn reactions
@@ -118,7 +118,7 @@
                                    (drop (inc last-user-msg-idx))
                                    (filter #(= (:role %) :assistant))
                                    (filter #(not-empty (:content %)))
-                                   (mapcat message->reaction)
+                                   (mapcat message->reactions)
                                    (into []))]
     (into [] (concat llm-message-reactions (:reactions e) (metabot-v3.context/create-reactions (:context e))))))
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/envelope.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/envelope.clj
@@ -97,10 +97,14 @@
 
 (defn- message->reaction
   [msg]
-  {:type :metabot.reaction/message
-   :repl/message-color :green
-   :repl/message-emoji "🤖"
-   :message (:content msg)})
+  (let [message-reaction {:type :metabot.reaction/message
+                          :repl/message-color :green
+                          :repl/message-emoji "🤖"
+                          :message (:content msg)}
+        navigate-reaction (when-let [nav-path (:navigate-to msg)]
+                            {:type :metabot.reaction/redirect
+                             :url (str nav-path)})]
+    (filter some? [message-reaction navigate-reaction])))
 
 (defn reactions
   "Gets the reactions from the envelope. Includes messages from the LLM itself if applicable."
@@ -114,7 +118,7 @@
                                    (drop (inc last-user-msg-idx))
                                    (filter #(= (:role %) :assistant))
                                    (filter #(not-empty (:content %)))
-                                   (map message->reaction)
+                                   (mapcat message->reaction)
                                    (into []))]
     (into [] (concat llm-message-reactions (:reactions e) (metabot-v3.context/create-reactions (:context e))))))
 


### PR DESCRIPTION
### Description

For migrating the tools over to the ai-service, we needed a way to redirect the user to specific pages from the ai-service response. In order to do so, we [discussed](https://metaboat.slack.com/archives/C07SJT1P0ET/p1739207510118999) to add a `navigate_to` property to the assistant message response that will be turned into a frontend reaction in the BE.

This PR adds processing for the navigate-to property to the message reactions and turns it into a redirect reaction if present.

