### PR TITLE
Fix model native editor render loop

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.tsx
@@ -32,7 +32,7 @@ export interface CodeMirrorEditorRef {
 
 import S from "./CodeMirrorEditor.module.css";
 import { useExtensions } from "./extensions";
-import { convertIndexToPosition, matchCardIdAtCursor } from "./util";
+import { convertSelectionToRange, matchCardIdAtCursor } from "./util";
 
 export const CodeMirrorEditor = forwardRef<
   CodeMirrorEditorRef,
@@ -66,13 +66,21 @@ export const CodeMirrorEditor = forwardRef<
       // handle selection changes
       const value = update.state.doc.toString();
       if (onSelectionChange) {
-        onSelectionChange({
-          start: convertIndexToPosition(
-            value,
-            update.state.selection.main.from,
-          ),
-          end: convertIndexToPosition(value, update.state.selection.main.to),
-        });
+        const beforeRange = convertSelectionToRange(
+          update.startState.doc.toString(),
+          update.startState.selection.main,
+        );
+        const afterRange = convertSelectionToRange(
+          value,
+          update.state.selection.main,
+        );
+
+        if (
+          beforeRange.start !== afterRange.start ||
+          beforeRange.end !== afterRange.end
+        ) {
+          onSelectionChange(afterRange);
+        }
       }
       if (onCursorMoveOverCardTag) {
         const cardId = matchCardIdAtCursor(update.state);

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/util.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/util.tsx
@@ -1,4 +1,4 @@
-import type { EditorState } from "@codemirror/state";
+import type { EditorState, SelectionRange } from "@codemirror/state";
 import { createSelector } from "@reduxjs/toolkit";
 import { shallowEqual } from "react-redux";
 import { t } from "ttag";
@@ -7,7 +7,7 @@ import { isNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
 import type { CardId, CardType } from "metabase-types/api";
 
-import type { Location } from "../types";
+import type { Location, SelectionRange as Range } from "../types";
 
 export function convertIndexToPosition(value: string, index: number): Location {
   let row = 0;
@@ -26,6 +26,16 @@ export function convertIndexToPosition(value: string, index: number): Location {
   return {
     row,
     column,
+  };
+}
+
+export function convertSelectionToRange(
+  value: string,
+  selection: SelectionRange,
+): Range {
+  return {
+    start: convertIndexToPosition(value, selection.from),
+    end: convertIndexToPosition(value, selection.to),
   };
 }
 

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -167,7 +167,6 @@ export class NativeQueryEditor extends Component<
 
   componentDidMount() {
     document.addEventListener("keydown", this.handleKeyDown);
-    this.focus();
   }
 
   onChange = (queryText: string) => {


### PR DESCRIPTION
Fixes QUE-614.

The bug does not reproduce locally, so it's a bit of a guess whether or this will work.

I suspect the issue is that the native editor updates the selection range everytime it gets focussed and in focusses every time it rerenders, causing an infinite loop.

I'll write a reproduction once we verify the fix.