### PR TITLE
fix test flake on pie chart

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
@@ -107,7 +107,16 @@ describe("scenarios > visualizations > pie chart", () => {
       display: "pie",
     });
 
-    cy.findByTestId("chart-legend").findByText("Doohickey").realHover();
+    // flakiness prevention
+    cy.findByTestId("chart-container").findByText("TOTAL").should("be.visible");
+    cy.findByTestId("view-footer")
+      .findByText("Showing 4 rows")
+      .should("be.visible");
+
+    cy.findByTestId("chart-legend")
+      .findByText("Doohickey")
+      .trigger("mouseover");
+
     [
       ["Doohickey", "true"],
       ["Gadget", "false"],


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/DEV-49/flaky-test-scenarios-question-object-details-handles-browsing-records

### Description

The test was flaking because of a layout shift on loading and usage of `.realHover()` command. While `.realHover()` command solves a problem with missing hover state, it’s not the most stable command. Mostly because the way it works is that it tries to interact with an element by calculating coordinates of an element and then triggering a Chrome DevTools protocol event on those coordinates. If the layout shifts during that, you are out of luck. That’s exactly what was happening in our test

### Resolution

Substituting `.realHover()` with `.trigger('mouseover')` works really well here, since this command will interact directly with the element and not with the whole page. this makes it immune to layout shifts. Since the pie chart uses js events for making changes on the page anyway it is much more precise approach than going with mouse hovering.