### PR TITLE
Backport: Don't cache query results for impersonated users

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/shared/dashboard-filters-date.js
+++ b/e2e/test/scenarios/dashboard-filters/shared/dashboard-filters-date.js
@@ -28,6 +28,6 @@ export const DASHBOARD_DATE_FILTERS = {
     value: {
       timeBucket: "years",
     },
-    representativeResult: "51.19", // this may change every year
+    representativeResult: "67.33", // this may change every year
   },
 };

--- a/e2e/test/scenarios/sharing/public-question.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-question.cy.spec.js
@@ -55,7 +55,7 @@ describe("scenarios > public > question", () => {
       H.visitQuestion(id);
 
       // Make sure metadata fully loaded before we continue
-      cy.get("[data-testid=cell-data]").contains("Winner");
+      cy.findByTestId("visualization-root").should("be.visible");
 
       H.openNewPublicLinkDropdown("card");
 
@@ -71,8 +71,6 @@ describe("scenarios > public > question", () => {
       H.filterWidget().contains("Affiliate");
 
       cy.wait("@publicQuery");
-      // Name of a city from the expected results
-      cy.get("[data-testid=cell-data]").contains("Winner");
 
       // Make sure we can download the public question (metabase#21993)
       cy.get("@uuid").then(publicUid => {
@@ -118,7 +116,7 @@ describe("scenarios > public > question", () => {
               H.filterWidget().contains("Previous 30 Years");
               H.filterWidget().contains("Affiliate");
 
-              cy.get("[data-testid=cell-data]").contains("Winner");
+              cy.findByTestId("visualization-root").should("be.visible");
             },
           );
         });

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -10,9 +10,11 @@
   (:require
    [java-time.api :as t]
    [medley.core :as m]
+   [metabase.api.common :as api]
    [metabase.config :as config]
    [metabase.lib.query :as lib.query]
    [metabase.public-settings :as public-settings]
+   [metabase.public-settings.premium-features :as premium-features]
    [metabase.query-processor.middleware.cache-backend.db :as backend.db]
    [metabase.query-processor.middleware.cache-backend.interface :as i]
    [metabase.query-processor.middleware.cache.impl :as impl]
@@ -218,6 +220,9 @@
 (defn- is-cacheable? {:arglists '([query])} [{:keys [cache-strategy]}]
   (and (public-settings/enable-query-caching)
        (some? cache-strategy)
+       ;; sometimes, e.g. on scheduled cache refresh, we don't have a user here
+       (or (nil? api/*current-user-id*)
+           (not (premium-features/impersonated-user?)))
        (not= (:type cache-strategy) :nocache)))
 
 (defn maybe-return-cached-results


### PR DESCRIPTION
#53489 

Also pulls in https://github.com/metabase/metabase/pull/51720 which fixed e2e tests and wasn't previously backported to v50.