### PR TITLE
More /less e2e Parallelism

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,7 +15,7 @@ jobs:
   e2e-matrix-builder:
     uses: ./.github/workflows/e2e-matrix-builder.yml
     with:
-      chunks: 50
+      chunks: 60
 
   # if this is a test on a release branch, we need to check the build requirements
   get-build-requirements:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,7 +15,7 @@ jobs:
   e2e-matrix-builder:
     uses: ./.github/workflows/e2e-matrix-builder.yml
     with:
-      chunks: 60
+      chunks: 40
 
   # if this is a test on a release branch, we need to check the build requirements
   get-build-requirements:


### PR DESCRIPTION
Testing e2e CI speed 
- with 60 runners: 25:10
- with 40 runners: 25:20 