### PR TITLE
Adjust Smoke Tests

### DIFF
--- a/.github/workflows/e2e-matrix-builder.yml
+++ b/.github/workflows/e2e-matrix-builder.yml
@@ -44,7 +44,7 @@ jobs:
             // see config.js function getSplittableSpecs for logic that excludes some tests from auto splitting
             const specialTests = [
               { name: "embedding-sdk", specs: "./e2e/test/scenarios/embedding-sdk/**.cy.spec.*" },
-              { name: "oss-subset", edition: 'oss', tags: "@OSS+@smoke", specs: allSpecs },
+              { name: "oss-subset", edition: 'oss', tags: "@OSS,@smoke", specs: allSpecs },
               { name: "mongo", tags: "@mongo", specs: allSpecs },
             ];
 

--- a/.github/workflows/e2e-matrix-builder.yml
+++ b/.github/workflows/e2e-matrix-builder.yml
@@ -44,7 +44,7 @@ jobs:
             // see config.js function getSplittableSpecs for logic that excludes some tests from auto splitting
             const specialTests = [
               { name: "embedding-sdk", specs: "./e2e/test/scenarios/embedding-sdk/**.cy.spec.*" },
-              { name: "oss-subset", edition: 'oss', tags: "@OSS @smoke", specs: allSpecs },
+              { name: "oss-subset", edition: 'oss', tags: "@OSS @smoke+-@EE", specs: allSpecs },
               { name: "mongo", tags: "@mongo", specs: allSpecs },
             ];
 

--- a/.github/workflows/e2e-matrix-builder.yml
+++ b/.github/workflows/e2e-matrix-builder.yml
@@ -44,7 +44,7 @@ jobs:
             // see config.js function getSplittableSpecs for logic that excludes some tests from auto splitting
             const specialTests = [
               { name: "embedding-sdk", specs: "./e2e/test/scenarios/embedding-sdk/**.cy.spec.*" },
-              { name: "oss-subset", edition: 'oss', tags: "@OSS", specs: allSpecs },
+              { name: "oss-subset", edition: 'oss', tags: "@OSS+@smoke", specs: allSpecs },
               { name: "mongo", tags: "@mongo", specs: allSpecs },
             ];
 

--- a/.github/workflows/e2e-matrix-builder.yml
+++ b/.github/workflows/e2e-matrix-builder.yml
@@ -44,7 +44,7 @@ jobs:
             // see config.js function getSplittableSpecs for logic that excludes some tests from auto splitting
             const specialTests = [
               { name: "embedding-sdk", specs: "./e2e/test/scenarios/embedding-sdk/**.cy.spec.*" },
-              { name: "oss-subset", edition: 'oss', tags: "@OSS,@smoke", specs: allSpecs },
+              { name: "oss-subset", edition: 'oss', tags: "@OSS @smoke", specs: allSpecs },
               { name: "mongo", tags: "@mongo", specs: allSpecs },
             ];
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -168,10 +168,17 @@ jobs:
         run: |
           jar xf metabase.jar version.properties
           mv version.properties resources/
+
+      - name: Run Metabase
+        run: node e2e/runner/run_cypress_ci.js start
+
+      - name: Make app db snapshot
+        run: node e2e/runner/run_cypress_ci.js snapshot --browser ${{ steps.cypress-prep.outputs.chrome-path }}
+
       - name: Run a few important Cypress tests as sanity check
         run: |
           mkdir -p ./target/uberjar && cp metabase.jar ./target/uberjar/metabase.jar
-          yarn test-cypress-run \
+          node e2e/runner/run_cypress_ci.js e2e \
             --env grepTags="@smoke",grepOmitFiltered=true \
             --spec './e2e/test/scenarios/**/*.cy.spec.(js|ts)' \
             --browser ${{ steps.cypress-prep.outputs.chrome-path }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -169,17 +169,28 @@ jobs:
           jar xf metabase.jar version.properties
           mv version.properties resources/
 
+      - name: Move jar
+        run: mkdir -p ./target/uberjar && cp metabase.jar ./target/uberjar/metabase.jar
+
       - name: Run Metabase
         run: node e2e/runner/run_cypress_ci.js start
 
       - name: Make app db snapshot
-        run: node e2e/runner/run_cypress_ci.js snapshot --browser ${{ steps.cypress-prep.outputs.chrome-path }}
+        run: node e2e/runner/run_cypress_ci.js snapshot
 
-      - name: Run a few important Cypress tests as sanity check
+      - name: Run a few important OSS Cypress tests as sanity check
+        if: ${{ matrix.edition == 'oss' }}
         run: |
-          mkdir -p ./target/uberjar && cp metabase.jar ./target/uberjar/metabase.jar
           node e2e/runner/run_cypress_ci.js e2e \
-            --env grepTags="@smoke",grepOmitFiltered=true \
+            --env grepTags="@smoke+-@EE",grepOmitFiltered=true \
+            --spec './e2e/test/scenarios/**/*.cy.spec.(js|ts)' \
+            --browser ${{ steps.cypress-prep.outputs.chrome-path }}
+
+      - name: Run a few important EE Cypress tests as sanity check
+        if: ${{ matrix.edition == 'ee' }}
+        run: |
+          node e2e/runner/run_cypress_ci.js e2e \
+            --env grepTags="@smoke+-@OSS",grepOmitFiltered=true \
             --spec './e2e/test/scenarios/**/*.cy.spec.(js|ts)' \
             --browser ${{ steps.cypress-prep.outputs.chrome-path }}
 

--- a/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
@@ -17,6 +17,7 @@ const MB = 1024 * 1024;
 
 describe("formatting > whitelabel", () => {
   beforeEach(() => {
+    cy.skipOn(Cypress.env("MB_EDITION") === "oss");
     H.restore();
     cy.signInAsAdmin();
     H.setTokenFeatures("all");

--- a/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
@@ -15,9 +15,8 @@ function checkLogo() {
 
 const MB = 1024 * 1024;
 
-describe("formatting > whitelabel", () => {
+describe("formatting > whitelabel", { tags: "@EE" }, () => {
   beforeEach(() => {
-    cy.skipOn(Cypress.env("MB_EDITION") === "oss");
     H.restore();
     cy.signInAsAdmin();
     H.setTokenFeatures("all");

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -708,7 +708,6 @@ describe(
   { tags: ["@OSS", "@smoke"] },
   () => {
     beforeEach(() => {
-      cy.skipOn(Cypress.env("MB_EDITION") !== "oss");
       H.restore("without-models");
       cy.signInAsAdmin();
     });

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -708,6 +708,7 @@ describe(
   { tags: ["@OSS", "@smoke"] },
   () => {
     beforeEach(() => {
+      cy.skipOn(Cypress.env("MB_EDITION") !== "oss");
       H.restore("without-models");
       cy.signInAsAdmin();
     });


### PR DESCRIPTION
Closes DEV-71

because of https://github.com/metabase/metabase/pull/53240, pre-release tests were failing.

- Adjust our regular OSS e2e test group to always run the `@smoke` tagged tests regularly so we know if they're failing _before_ we release.
- Adjust the test running commands in our e2e job to use our new ci-only test running commands and run the right sets of tests in EE vs OSS tests