### PR TITLE
[Cards in Dashboards] Use last selected collection for default save location if more recent than a dashboard

### DIFF
--- a/frontend/src/metabase/components/SaveQuestionForm/context.tsx
+++ b/frontend/src/metabase/components/SaveQuestionForm/context.tsx
@@ -94,7 +94,7 @@ export const SaveQuestionProvider = ({
       ? lastSelectedEntityModel
       : undefined;
 
-  const mostRecentDashboard =
+  const lastSelectedDashboard =
     lastSelectedEntityModel?.model === "dashboard"
       ? lastSelectedEntityModel
       : undefined;
@@ -105,12 +105,14 @@ export const SaveQuestionProvider = ({
   const initialDashboardId =
     question.type() === "question" &&
     !isAnalytics &&
-    mostRecentDashboard?.can_write
-      ? mostRecentDashboard?.id
+    lastSelectedDashboard?.can_write
+      ? lastSelectedDashboard?.id
       : undefined;
 
   const initialCollectionId =
-    (!isAnalytics ? mostRecentDashboard?.parent_collection.id : undefined) ??
+    (!isAnalytics
+      ? lastSelectedDashboard?.parent_collection.id
+      : defaultCollectionId) ??
     lastSelectedCollection?.id ??
     defaultCollectionId;
 

--- a/frontend/src/metabase/components/SaveQuestionForm/context.tsx
+++ b/frontend/src/metabase/components/SaveQuestionForm/context.tsx
@@ -14,7 +14,7 @@ import { isInstanceAnalyticsCollection } from "metabase/collections/utils";
 import { FormProvider } from "metabase/forms";
 import { isNotNull } from "metabase/lib/types";
 import type Question from "metabase-lib/v1/Question";
-import type { CollectionId, RecentCollectionItem } from "metabase-types/api";
+import type { CollectionId } from "metabase-types/api";
 
 import { SAVE_QUESTION_SCHEMA } from "./schema";
 import type { FormValues, SaveQuestionProps } from "./types";
@@ -82,23 +82,22 @@ export const SaveQuestionProvider = ({
     }
   }, [isLoading]);
 
-  const defaultDashboard = useMemo(() => {
-    if (!recentItems || recentItems.length === 0) {
-      return undefined;
-    }
-    const lastUsedDashboardIndex = recentItems?.findIndex(
-      item => item.model === "dashboard",
-    );
-    const lastUsedEntityModelIndex = recentItems?.findIndex(
+  const lastSelectedEntityModel = useMemo(() => {
+    return recentItems?.find(
       item => item.model === "collection" || item.model === "dashboard",
     );
-
-    if (lastUsedDashboardIndex === lastUsedEntityModelIndex) {
-      return recentItems[lastUsedDashboardIndex] as RecentCollectionItem;
-    } else {
-      return undefined;
-    }
   }, [recentItems]);
+
+  // we only care about the most recently select dashboard or collection
+  const lastSelectedCollection =
+    lastSelectedEntityModel?.model === "collection"
+      ? lastSelectedEntityModel
+      : undefined;
+
+  const mostRecentDashboard =
+    lastSelectedEntityModel?.model === "dashboard"
+      ? lastSelectedEntityModel
+      : undefined;
 
   // analytics questions should not default to saving in dashboard
   const isAnalytics = isInstanceAnalyticsCollection(question.collection());
@@ -106,13 +105,14 @@ export const SaveQuestionProvider = ({
   const initialDashboardId =
     question.type() === "question" &&
     !isAnalytics &&
-    defaultDashboard?.can_write
-      ? defaultDashboard?.id
+    mostRecentDashboard?.can_write
+      ? mostRecentDashboard?.id
       : undefined;
 
-  const initialCollectionId = isAnalytics
-    ? defaultCollectionId
-    : (defaultDashboard?.parent_collection.id ?? defaultCollectionId);
+  const initialCollectionId =
+    (!isAnalytics ? mostRecentDashboard?.parent_collection.id : undefined) ??
+    lastSelectedCollection?.id ??
+    defaultCollectionId;
 
   const initialValues: FormValues = useMemo(
     () =>

--- a/frontend/src/metabase/components/SaveQuestionForm/context.unit.spec.tsx
+++ b/frontend/src/metabase/components/SaveQuestionForm/context.unit.spec.tsx
@@ -1,0 +1,304 @@
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import {
+  defaultAuditInfo,
+  setupAuditEndpoints,
+  setupCollectionByIdEndpoint,
+  setupRecentViewsAndSelectionsEndpoints,
+} from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import Question from "metabase-lib/v1/Question";
+import type { Card } from "metabase-types/api";
+import {
+  createMockCard,
+  createMockCollection,
+  createMockRecentCollectionItem,
+  createMockTokenFeatures,
+  createMockUser,
+} from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { SaveQuestionProvider, useSaveQuestionContext } from "./context";
+
+const TestComponent = () => {
+  const { values } = useSaveQuestionContext();
+
+  return (
+    <div>
+      {values.collection_id && (
+        <div data-testid="collectionId">{values.collection_id}</div>
+      )}
+      {values.dashboard_id && (
+        <div data-testid="dashboardId">{values.dashboard_id}</div>
+      )}
+    </div>
+  );
+};
+
+interface setupProps {
+  question?: Question;
+  originalQuestion?: Question | null;
+}
+
+const setup = ({
+  question = new Question(
+    createMockCard({
+      collection_id: undefined,
+      collection: undefined,
+      dashboard_id: undefined,
+    }),
+  ),
+  originalQuestion = null,
+}: setupProps = {}) => {
+  const onCreate = jest.fn();
+  const onSave = jest.fn();
+
+  setupAuditEndpoints();
+
+  const settings = mockSettings({
+    "token-features": createMockTokenFeatures({
+      audit_app: true,
+    }),
+  });
+
+  setupEnterprisePlugins();
+
+  renderWithProviders(
+    <SaveQuestionProvider
+      question={question}
+      originalQuestion={originalQuestion}
+      onCreate={onCreate}
+      onSave={onSave}
+    >
+      <TestComponent />
+    </SaveQuestionProvider>,
+    {
+      storeInitialState: createMockState({
+        currentUser: createMockUser({
+          personal_collection_id: 1337,
+        }),
+        settings,
+      }),
+    },
+  );
+};
+
+describe("SaveQuestionContext", () => {
+  describe("Computing suggested save locations", () => {
+    describe("New Question", () => {
+      it("should suggest a dashboard if one has been recently selected", async () => {
+        setupRecentViewsAndSelectionsEndpoints(
+          [createMockRecentCollectionItem({ model: "dashboard", id: 10 })],
+          ["selections"],
+        );
+
+        setup();
+
+        expect(await screen.findByTestId("dashboardId")).toHaveTextContent(
+          "10",
+        );
+      });
+
+      it("should suggest a collection if one has been recently selected", async () => {
+        setupRecentViewsAndSelectionsEndpoints(
+          [createMockRecentCollectionItem({ model: "collection", id: 10 })],
+          ["selections"],
+        );
+
+        setup();
+
+        await waitFor(async () =>
+          expect(await screen.findByTestId("collectionId")).toHaveTextContent(
+            "10",
+          ),
+        );
+        expect(screen.queryByTestId("dashboardId")).not.toBeInTheDocument();
+      });
+
+      it("should suggest a default collection id if there are no valid recently selected items", async () => {
+        setupRecentViewsAndSelectionsEndpoints([], ["selections"]);
+
+        setup();
+
+        await waitFor(async () =>
+          expect(await screen.findByTestId("collectionId")).toHaveTextContent(
+            "1337", // Users personal collection id
+          ),
+        );
+        expect(screen.queryByTestId("dashboardId")).not.toBeInTheDocument();
+      });
+    });
+
+    describe("Updating an existing question", () => {
+      it("should suggest the existing questions dashboard over a recently selected dashboard", async () => {
+        setupRecentViewsAndSelectionsEndpoints(
+          [createMockRecentCollectionItem({ model: "dashboard", id: 10 })],
+          ["selections"],
+        );
+
+        setup({
+          question: new Question(
+            createMockCard({
+              collection_id: 11,
+              collection: createMockCollection({ id: 11 }),
+              dashboard_id: 20,
+            }),
+          ),
+        });
+
+        expect(await screen.findByTestId("dashboardId")).toHaveTextContent(
+          "20",
+        );
+      });
+
+      it("should suggest the existing questions collection over a recently selected collection", async () => {
+        setupRecentViewsAndSelectionsEndpoints(
+          [createMockRecentCollectionItem({ model: "collection", id: 10 })],
+          ["selections"],
+        );
+
+        setup({
+          question: new Question(
+            createMockCard({
+              collection_id: 20,
+              collection: createMockCollection({ id: 20 }),
+              dashboard_id: undefined,
+            }),
+          ),
+        });
+
+        await waitFor(async () =>
+          expect(await screen.findByTestId("collectionId")).toHaveTextContent(
+            "20",
+          ),
+        );
+        expect(screen.queryByTestId("dashboardId")).not.toBeInTheDocument();
+      });
+
+      it("should not suggest a dashboard if we are working with a model", async () => {
+        setupRecentViewsAndSelectionsEndpoints(
+          [createMockRecentCollectionItem({ model: "dashboard", id: 10 })],
+          ["selections"],
+        );
+
+        setup({
+          question: new Question(
+            createMockCard({
+              collection_id: 11,
+              collection: createMockCollection({ id: 11 }),
+              type: "model",
+            }),
+          ),
+        });
+
+        await waitFor(async () =>
+          expect(await screen.findByTestId("collectionId")).toHaveTextContent(
+            "11",
+          ),
+        );
+
+        expect(screen.queryByTestId("dashboardId")).not.toBeInTheDocument();
+      });
+
+      it("should suggest the custom reports collection when the original question is in the IA folder", async () => {
+        setupRecentViewsAndSelectionsEndpoints(
+          [createMockRecentCollectionItem({ model: "collection", id: 10 })],
+          ["selections"],
+        );
+
+        const IACollection = createMockCollection({
+          id: 20,
+          type: "instance-analytics",
+          can_write: false,
+        });
+
+        setupCollectionByIdEndpoint({
+          collections: [
+            IACollection,
+            createMockCollection({
+              id: defaultAuditInfo.custom_reports,
+              name: "custom reports",
+              can_write: true,
+            }),
+          ],
+        });
+
+        setup({
+          question: new Question(
+            createMockCard({
+              collection_id: 20,
+              collection: IACollection,
+              dashboard_id: undefined,
+            }),
+          ),
+          originalQuestion: new Question(
+            createMockCard({
+              collection_id: 20,
+              collection: IACollection,
+              dashboard_id: undefined,
+              can_write: false,
+            }),
+          ),
+        });
+
+        await waitFor(async () =>
+          expect(await screen.findByTestId("collectionId")).toHaveTextContent(
+            defaultAuditInfo.custom_reports.toString(),
+          ),
+        );
+      });
+    });
+
+    describe("Updating an existing question that is read only", () => {
+      const getProps = (opts?: Partial<Card>) => {
+        const card = {
+          collection_id: 11,
+          collection: createMockCollection({ id: 11 }),
+          ...opts,
+        };
+
+        const question = new Question(createMockCard(card));
+        const originalQuestion = new Question(
+          createMockCard({ ...card, can_write: false }),
+        );
+
+        return { question, originalQuestion };
+      };
+
+      beforeEach(() => {
+        setupCollectionByIdEndpoint({
+          collections: [createMockCollection({ id: 11 })],
+        });
+      });
+
+      it("should suggest a recently selected dashboard over the existing questions dashboard", async () => {
+        setupRecentViewsAndSelectionsEndpoints(
+          [createMockRecentCollectionItem({ model: "dashboard", id: 10 })],
+          ["selections"],
+        );
+
+        setup({ ...getProps({ dashboard_id: 20 }) });
+
+        expect(await screen.findByTestId("dashboardId")).toHaveTextContent(
+          "10",
+        );
+      });
+
+      it("should suggest a recently selected collection over the existing questions collection", async () => {
+        setupRecentViewsAndSelectionsEndpoints(
+          [createMockRecentCollectionItem({ model: "collection", id: 10 })],
+          ["selections"],
+        );
+
+        setup({ ...getProps() });
+
+        await waitFor(async () =>
+          expect(await screen.findByTestId("collectionId")).toHaveTextContent(
+            "10",
+          ),
+        );
+        expect(screen.queryByTestId("dashboardId")).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/frontend/src/metabase/components/SaveQuestionForm/util.ts
+++ b/frontend/src/metabase/components/SaveQuestionForm/util.ts
@@ -89,7 +89,7 @@ export const getInitialValues = (
   initialDashboardId: FormValues["dashboard_id"],
   initialDashboardTabId: FormValues["tab_id"],
 ): FormValues => {
-  const isNewQuestion = !originalQuestion;
+  const isNewQuestion = originalQuestion && question.card().type === "question";
   const isReadonly = originalQuestion != null && !originalQuestion.canWrite();
 
   const getOriginalNameModification = (originalQuestion: Question | null) =>
@@ -103,7 +103,9 @@ export const getInitialValues = (
       : question.dashboardId();
 
   const collectionId =
-    question.collectionId() === undefined || isReadonly || isNewQuestion
+    question.collectionId() === undefined ||
+    isReadonly ||
+    (isNewQuestion && question.collectionId() === undefined)
       ? initialCollectionId
       : question.collectionId();
 

--- a/frontend/src/metabase/components/SaveQuestionForm/util.ts
+++ b/frontend/src/metabase/components/SaveQuestionForm/util.ts
@@ -89,6 +89,7 @@ export const getInitialValues = (
   initialDashboardId: FormValues["dashboard_id"],
   initialDashboardTabId: FormValues["tab_id"],
 ): FormValues => {
+  const isNewQuestion = !originalQuestion;
   const isReadonly = originalQuestion != null && !originalQuestion.canWrite();
 
   const getOriginalNameModification = (originalQuestion: Question | null) =>
@@ -102,7 +103,7 @@ export const getInitialValues = (
       : question.dashboardId();
 
   const collectionId =
-    question.collectionId() === undefined || isReadonly
+    question.collectionId() === undefined || isReadonly || isNewQuestion
       ? initialCollectionId
       : question.collectionId();
 

--- a/frontend/test/__support__/server-mocks/audit.ts
+++ b/frontend/test/__support__/server-mocks/audit.ts
@@ -8,7 +8,7 @@ interface AuditInfo {
   custom_reports: CollectionId;
 }
 
-const defaultAuditInfo: AuditInfo = {
+export const defaultAuditInfo: AuditInfo = {
   dashboard_overview: 201,
   question_overview: 202,
   custom_reports: 203,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

[Flagged here](https://metaboat.slack.com/archives/C06RM2GEP5Z/p1739286775972919). I couldn't really find evidence of this existing before, but it's certainly frustrating nonetheless. This PR does what is says on the label.

Credit to @npfitz for the wonderful tests

### Demo

https://github.com/user-attachments/assets/f4243fe5-1828-4254-ab21-b811849c8773

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
