### PR TITLE
Support bulk-fetching personal collection names to improve performance

### DIFF
--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -153,8 +153,7 @@
     ;; remove the :metabase.models.collection.root/is-root? tag since FE doesn't need it
     ;; and for personal collections we translate the name to user's locale
     (collection/personal-collections-with-ui-details  (for [collection collections]
-                                                        (-> collection
-                                                            (dissoc ::collection.root/is-root?))))))
+                                                        (dissoc collection ::collection.root/is-root?)))))
 
 (defn- shallow-tree-from-collection-id
   "Returns only a shallow Collection in the provided collection-id, e.g.

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -152,10 +152,9 @@
     (t2/hydrate collections :can_write :is_personal :can_delete)
     ;; remove the :metabase.models.collection.root/is-root? tag since FE doesn't need it
     ;; and for personal collections we translate the name to user's locale
-    (for [collection collections]
-      (-> collection
-          (dissoc ::collection.root/is-root?)
-          collection/personal-collection-with-ui-details))))
+    (collection/personal-collections-with-ui-details  (for [collection collections]
+                                                        (-> collection
+                                                            (dissoc ::collection.root/is-root?))))))
 
 (defn- shallow-tree-from-collection-id
   "Returns only a shallow Collection in the provided collection-id, e.g.

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -334,25 +334,40 @@
       (and first-name last-name) (trs "{0} {1}''s Personal Collection" first-name last-name)
       :else                      (trs "{0}''s Personal Collection" (or first-name last-name email)))))
 
+(mu/defn user->personal-collection-names :- ms/Map
+  "Come up with a nice name for the Personal Collection for the passed `user-or-ids`.
+  Returns a map of user-id -> name"
+  [user-or-ids user-or-site]
+  (let [ids (filter some? (map u/the-id user-or-ids))
+        rows (if (empty? ids)
+               []
+               (t2/select [:model/User :first_name :last_name :email :id]
+                          :id [:in ids]))]
+    (into {} (map (fn [{first-name :first_name last-name :last_name email :email id :id}]
+                    [id (format-personal-collection-name first-name last-name email user-or-site)]) rows))))
+
 (mu/defn user->personal-collection-name :- ms/NonBlankString
-  "Come up with a nice name for the Personal Collection for `user-or-id`."
+  "Calls `user->personal-collection-names` for a single user-id and returns the name"
   [user-or-id user-or-site]
-  (let [{first-name :first_name
-         last-name  :last_name
-         email      :email} (t2/select-one ['User :first_name :last_name :email]
-                                           :id (u/the-id user-or-id))]
-    (format-personal-collection-name first-name last-name email user-or-site)))
+  (first (vals (user->personal-collection-names [user-or-id] user-or-site))))
+
+(defn personal-collections-with-ui-details
+  "Like `personal-collection-with-ui-details`, but for a sequence of collections and returns a sequence of modified collections"
+  [collections]
+  (let [collection-names (user->personal-collection-names (filter some? (map :personal_owner_id collections)) :user)]
+    (map (fn [{:keys [personal_owner_id] :as collection}]
+           (if-not personal_owner_id
+             collection
+             (let [collection-name (get collection-names personal_owner_id)]
+               (assoc collection
+                      :name collection-name
+                      :slug (u/slugify collection-name))))) collections)))
 
 (defn personal-collection-with-ui-details
   "For Personal collection, we make sure the collection's name and slug is translated to user's locale
   This is only used for displaying purposes, For insertion or updating  the name, use site's locale instead"
-  [{:keys [personal_owner_id] :as collection}]
-  (if-not personal_owner_id
-    collection
-    (let [collection-name (user->personal-collection-name personal_owner_id :user)]
-      (assoc collection
-             :name collection-name
-             :slug (u/slugify collection-name)))))
+  [collection]
+  (first (personal-collections-with-ui-details [collection])))
 
 (def ^:private CollectionWithLocationAndPersonalOwnerID
   "Schema for a Collection instance that has a valid `:location`, and a `:personal_owner_id` key *present* (but not

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -338,13 +338,10 @@
   "Come up with a nice name for the Personal Collection for the passed `user-or-ids`.
   Returns a map of user-id -> name"
   [user-or-ids user-or-site]
-  (let [ids (filter some? (map u/the-id user-or-ids))
-        rows (if (empty? ids)
-               []
-               (t2/select [:model/User :first_name :last_name :email :id]
-                          :id [:in ids]))]
-    (into {} (map (fn [{first-name :first_name last-name :last_name email :email id :id}]
-                    [id (format-personal-collection-name first-name last-name email user-or-site)]) rows))))
+  (into {} (when-let [ids (seq (filter some? (map u/the-id user-or-ids)))]
+             (t2/select-pk->fn #(format-personal-collection-name (:first_name %) (:last_name %) (:email %) user-or-site)
+                               [:model/User :first_name :last_name :email :id]
+                               :id [:in ids]))))
 
 (mu/defn user->personal-collection-name :- ms/NonBlankString
   "Calls `user->personal-collection-names` for a single user-id and returns the name"

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -43,6 +43,45 @@
                                                                                       :site)))
              (var-get #'collection/collection-slug-max-length))))))
 
+(deftest user->personal-collection-name-test
+  (testing "test that we can get the name of a user's personal collection as :site"
+    (is (= "Lucky Pigeon's Personal Collection"
+           (collection/user->personal-collection-name (mt/user->id :lucky) :site))))
+  (testing "test that we can get the name of a user's personal collection as :user"
+    (is (= "Lucky Pigeon's Personal Collection"
+           (collection/user->personal-collection-name (mt/user->id :lucky) :user)))))
+
+(deftest user->personal-collection-names-test
+  (is (= {(mt/user->id :rasta) "Rasta Toucan's Personal Collection"
+          (mt/user->id :lucky) "Lucky Pigeon's Personal Collection"}
+         (collection/user->personal-collection-names [(mt/user->id :lucky) (mt/user->id :rasta)] :site))))
+
+(deftest personal-collection-with-ui-details-test
+  (testing "With personal_owner"
+    (is (= {:personal_owner_id (mt/user->id :lucky)
+            :name              "Lucky Pigeon's Personal Collection"
+            :slug              "lucky_pigeon_s_personal_collection"}
+           (collection/personal-collection-with-ui-details {:personal_owner_id (mt/user->id :lucky)})))
+    (testing "Without personal_owner"
+      (is (= {:other             "value"
+              :personal_owner_id nil}
+             (collection/personal-collection-with-ui-details {:other "value" :personal_owner_id nil}))))))
+
+(deftest personal-collections-with-ui-details-test
+  (is (= [{:personal_owner_id (mt/user->id :lucky)
+           :name              "Lucky Pigeon's Personal Collection"
+           :slug              "lucky_pigeon_s_personal_collection"}
+
+          {:personal_owner_id (mt/user->id :rasta)
+           :name              "Rasta Toucan's Personal Collection"
+           :slug              "rasta_toucan_s_personal_collection"}
+
+          {:personal_owner_id nil
+           :other             "No personal Id"}]
+         (collection/personal-collections-with-ui-details [{:personal_owner_id (mt/user->id :lucky)}
+                                                           {:personal_owner_id (mt/user->id :rasta)}
+                                                           {:personal_owner_id nil :other "No personal Id"}]))))
+
 (deftest ^:parallel create-collection-test
   (testing "test that we can create a new Collection with valid inputs"
     (mt/with-temp [:model/Collection collection {:name "My Favorite Cards"}]


### PR DESCRIPTION
Partly addresses #48674 

### Description

Bullet 2 in #48674 finds that `GET /api/collection/` does a separate query for every single user.

This PR queries all the users needed for the collections in a single request.

### How to verify

1. With SQL logging on and multiple users in the system, hit /api/collection with API and check that there is now only a single `SELECT "core_user"."first_name", "core_user"."last_name", "core_user"."email", "core_user"."id" FROM "core_user" WHERE "id" IN ($1, $2, $3)` type query

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
