### PR TITLE
Smooth out some rough edges for local e2e tests

### DIFF
--- a/e2e/runner/cypress-runner-backend.js
+++ b/e2e/runner/cypress-runner-backend.js
@@ -44,6 +44,8 @@ const CypressBackend = {
         MB_ENABLE_TEST_ENDPOINTS: "true",
         MB_DANGEROUS_UNSAFE_ENABLE_TESTING_H2_CONNECTIONS_DO_NOT_ENABLE: "true",
         MB_LAST_ANALYTICS_CHECKSUM: "-1",
+        MB_DB_CONNECTION_URI: "", // ignore connection URI in favor of the db file
+        MB_CONFIG_FILE_PATH: "", // ignore config.yml
       };
 
       /**

--- a/e2e/runner/cypress-runner-backend.js
+++ b/e2e/runner/cypress-runner-backend.js
@@ -32,9 +32,9 @@ const CypressBackend = {
         "-Djava.awt.headless=true", // when running on macOS prevent little Java icon from popping up in Dock
         "-Duser.timezone=US/Pacific",
         process.env.SHOW_BACKEND_LOGS === "true"
-          ? ""
+          ? null
           : `-Dlog4j.configurationFile=file:${__dirname}/../../frontend/test/__runner__/log4j2.xml`,
-      ];
+      ].filter(Boolean);
 
       const metabaseConfig = {
         MB_DB_TYPE: "h2",
@@ -45,7 +45,7 @@ const CypressBackend = {
         MB_DANGEROUS_UNSAFE_ENABLE_TESTING_H2_CONNECTIONS_DO_NOT_ENABLE: "true",
         MB_LAST_ANALYTICS_CHECKSUM: "-1",
         MB_DB_CONNECTION_URI: "", // ignore connection URI in favor of the db file
-        MB_CONFIG_FILE_PATH: "", // ignore config.yml
+        MB_CONFIG_FILE_PATH: "__cypress__", // ignore config.yml
       };
 
       /**

--- a/e2e/runner/run_cypress_local.ts
+++ b/e2e/runner/run_cypress_local.ts
@@ -85,7 +85,10 @@ const init = async () => {
     await CypressBackend.start();
   } else {
     printBold(
-      `Not building a jar, expecting metabase to be running on port ${options.BACKEND_PORT}`,
+      `Not building a jar, expecting metabase to be running on port ${options.BACKEND_PORT} make sure your metabase instance has
+      - MB_ENABLE_TEST_ENDPOINTS=true
+      - MB_DANGEROUS_UNSAFE_ENABLE_TESTING_H2_CONNECTIONS_DO_NOT_ENABLE=true
+    `,
     );
   }
 

--- a/e2e/runner/run_cypress_local.ts
+++ b/e2e/runner/run_cypress_local.ts
@@ -23,7 +23,6 @@ const userOptions = {
 };
 
 const derivedOptions = {
-  MB_PREMIUM_EMBEDDING_TOKEN: userOptions.ENTERPRISE_TOKEN,
   CYPRESS_ALL_FEATURES_TOKEN: userOptions.ENTERPRISE_TOKEN,
   QA_DB_ENABLED: userOptions.START_CONTAINERS,
   BUILD_JAR: userOptions.BACKEND_PORT === 4000,

--- a/e2e/runner/run_cypress_local.ts
+++ b/e2e/runner/run_cypress_local.ts
@@ -17,6 +17,7 @@ const userOptions = {
   BACKEND_PORT: 4000,
   OPEN_UI: true,
   SHOW_BACKEND_LOGS: false,
+  GENERATE_SNAPSHOTS: true,
   QUIET: false,
   ...booleanify(process.env),
 };
@@ -26,7 +27,6 @@ const derivedOptions = {
   CYPRESS_ALL_FEATURES_TOKEN: userOptions.ENTERPRISE_TOKEN,
   QA_DB_ENABLED: userOptions.START_CONTAINERS,
   BUILD_JAR: userOptions.BACKEND_PORT === 4000,
-  GENERATE_SNAPSHOTS: userOptions.BACKEND_PORT === 4000,
   CYPRESS_IS_EMBEDDING_SDK: userOptions.TEST_SUITE === "component",
   MB_SNOWPLOW_AVAILABLE: userOptions.START_CONTAINERS,
   MB_SNOWPLOW_URL: "http://localhost:9090",

--- a/e2e/runner/run_cypress_local.ts
+++ b/e2e/runner/run_cypress_local.ts
@@ -84,9 +84,9 @@ const init = async () => {
     await CypressBackend.start();
   } else {
     printBold(
-      `Not building a jar, expecting metabase to be running on port ${options.BACKEND_PORT} make sure your metabase instance has
-      - MB_ENABLE_TEST_ENDPOINTS=true
-      - MB_DANGEROUS_UNSAFE_ENABLE_TESTING_H2_CONNECTIONS_DO_NOT_ENABLE=true
+      `Not building a jar, expecting metabase to be running on port ${options.BACKEND_PORT}. Make sure your metabase instance is running with an h2 app db and the following environment variables:
+  - MB_ENABLE_TEST_ENDPOINTS=true
+  - MB_DANGEROUS_UNSAFE_ENABLE_TESTING_H2_CONNECTIONS_DO_NOT_ENABLE=true
     `,
     );
   }


### PR DESCRIPTION
Follow up to https://github.com/metabase/metabase/pull/53095

- make sure that `MB_DB_CONNECTION_URI` and `MB_CONFIG_FILE_PATH` do not interfere with setting a db file
- run snapshots even when you're running your own backend
- add console message reminding of required variables for running your own backend with cypress
- don't set MB_PREMIUM_EMBEDDING_TOKEN to allow for tests that want to set it programatically