### PR TITLE
[refs] Use the new `entity_id` on Fields as their idents

### DIFF
--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -246,7 +246,7 @@
              {:error/message "Join must have an ident to determine column idents"}
              ::lib.schema.common/non-blank-string]]
    col  :- :map]
-  (update col :ident #(lib.metadata.ident/explicitly-joined-ident (:ident join) %)))
+  (update col :ident lib.metadata.ident/explicitly-joined-ident (:ident join)))
 
 (mu/defmethod lib.metadata.calculation/returned-columns-method :mbql/join
   [query

--- a/src/metabase/lib/metadata.cljc
+++ b/src/metabase/lib/metadata.cljc
@@ -1,6 +1,5 @@
 (ns metabase.lib.metadata
   (:require
-   [metabase.lib.metadata.ident :as lib.metadata.ident]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.id :as lib.schema.id]
@@ -46,10 +45,7 @@
   "Get metadata about all the Fields belonging to a specific Table."
   [metadata-providerable :- ::lib.schema.metadata/metadata-providerable
    table-id              :- ::lib.schema.id/table]
-  (let [prefix (lib.metadata.ident/table-prefix (:name (database metadata-providerable))
-                                                (table metadata-providerable table-id))]
-    (->> (lib.metadata.protocols/fields (->metadata-provider metadata-providerable) table-id)
-         (lib.metadata.ident/attach-idents (constantly prefix)))))
+  (lib.metadata.protocols/fields (->metadata-provider metadata-providerable) table-id))
 
 (mu/defn metadatas-for-table :- [:sequential [:or
                                               ::lib.schema.metadata/column
@@ -77,7 +73,8 @@
 
   Generally that is an error and we should throw, but there are a few tests explicitly checking broken fields that
   don't want to get hung up on this error."
-  true)
+  ;; TODO: Fix the metadata APIs to include `:ident` or `:entity_id` so the JS side has proper idents.
+  #?(:clj true :cljs false))
 
 (mu/defn field :- [:maybe ::lib.schema.metadata/column]
   "Get metadata about a specific Field in the Database we're querying."

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -629,7 +629,7 @@
                                 options        {:unique-name-fn               unique-name-fn
                                                 :include-implicitly-joinable? false}]
                             (for [field (visible-columns-method query stage-number table-metadata options)
-                                  :let  [ident (lib.metadata.ident/implicitly-joined-ident fk-ident (:ident field))
+                                  :let  [ident (lib.metadata.ident/implicitly-joined-ident (:ident field) fk-ident)
                                          field (assoc field
                                                       :ident                    ident
                                                       :fk-field-id              source-field-id

--- a/src/metabase/lib/metadata/ident.cljc
+++ b/src/metabase/lib/metadata/ident.cljc
@@ -1,64 +1,16 @@
 (ns metabase.lib.metadata.ident
-  "Helpers for working with `:ident` fields on columns."
-  (:require
-   [clojure.string :as str]))
-
-(defn table-prefix
-  "Given the DB name and a `table` with `:name` and optional `:schema`, returns a string prefix for the `:ident`s
-  of fields in this table."
-  [db-name {tbl-name :name, :keys [schema] :as _table}]
-  (str/join "__" ["field"
-                  db-name
-                  (or schema "!noschema!")
-                  tbl-name]))
-
-(defn ident-for-field
-  "Given a database name, table with `:name` and optional `:schema`, and column with `:name`, construct the `:ident`
-  for Fields from the user's DWH. (Other kinds of columns get randomly generated NanoIDs as `:ident`s.)"
-  ([prefix {col-name :name :as _column}]
-   (str prefix "__" col-name))
-  ([db-name table column]
-   (ident-for-field (table-prefix db-name table) column)))
-
-(defn attach-ident
-  "Generates and attaches an `:ident` to a column, if it doesn't already have one.
-
-  Either takes a prefix for the database, schema and table, or the DB name and table."
-  ([prefix-or-fn column]
-   (if (:ident column)
-     column
-     (let [prefix (if (ifn? prefix-or-fn)
-                    (prefix-or-fn column)
-                    prefix-or-fn)]
-       (assoc column :ident (ident-for-field prefix column)))))
-  ([db-name table column]
-   (cond-> column
-     (not (:ident column)) (assoc :ident (ident-for-field db-name table column)))))
-
-(defn attach-idents
-  "Generates and attaches an `:ident` to each of the `columns`, if it doesn't have one already.
-
-  2-arity version takes a function from table IDs to the `:ident` prefix for that table.
-
-  1-arity version takes the same function and returns a transducer.
-
-  If you want to memoize or cache the calls to `prefix-fn`, you need to handle that externally! Some callers just have
-  a map or constant value, so caching inside this function is redundant and wasteful."
-  ([prefix-fn]
-   (map #(attach-ident (prefix-fn (:table-id %)) %)))
-  ([prefix-fn columns]
-   (sequence (attach-idents prefix-fn) columns)))
+  "Helpers for working with `:ident` fields on columns.")
 
 (defn implicitly-joined-ident
   "Returns the ident for an implicitly joined column, given the idents of the foreign key column and the target column.
 
   Remember that `:ident` strings should never be parsed - they are opaque, but should be legible during debugging."
-  [fk-ident target-ident]
+  [target-ident fk-ident]
   (str "implicit_via__" fk-ident "__->__" target-ident))
 
 (defn explicitly-joined-ident
   "Returns the ident for an explicitly joined column, given the idents of the join clause and the target column.
 
   Remember that `:ident` strings should never be parsed - they are opaque, but should be legible during debugging."
-  [join-ident target-ident]
+  [target-ident join-ident]
   (str "join__" join-ident "__" target-ident))

--- a/src/metabase/lib/metadata/jvm.clj
+++ b/src/metabase/lib/metadata/jvm.clj
@@ -6,16 +6,16 @@
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [metabase.driver :as driver]
    [metabase.lib.metadata.cached-provider :as lib.metadata.cached-provider]
-   [metabase.lib.metadata.ident :as lib.metadata.ident]
    [metabase.lib.metadata.invocation-tracker :as lib.metadata.invocation-tracker]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.models.interface :as mi]
+   [metabase.models.serialization :as serdes]
    [metabase.models.setting :as setting]
    [metabase.util :as u]
-   [metabase.util.log :as log]
    [metabase.util.malli :as mu]
+   [metabase.util.memoize :as u.memo]
    [metabase.util.snake-hating-map :as u.snake-hating-map]
    [methodical.core :as methodical]
    [potemkin :as p]
@@ -32,18 +32,12 @@
   (or (qualified-keyword? k)
       (str/includes? k ".")))
 
-;; we spent a lot of time messing around with different ways of doing this and this seems to be the fastest. See
-;; https://metaboat.slack.com/archives/C04CYTEL9N2/p1702671632956539 -- Cam
-(let [cache      (java.util.concurrent.ConcurrentHashMap.)
-      mapping-fn (reify java.util.function.Function
-                   (apply [_this k]
-                     (u/->kebab-case-en k)))]
-  (defn- memoized-kebab-key
-    "Calculating the kebab-case version of a key every time is pretty slow (even with the LRU
-  caching [[u/->kebab-case-en]] has), since the keys here are static and finite we can just memoize them forever and
+(def ^{:private true
+       :arglists '([k])} memoized-kebab-key
+  "Calculating the kebab-case version of a key every time is pretty slow (even with the LRU caching
+  [[u/->kebab-case-en]] has), since the keys here are static and finite we can just memoize them forever and
   get a nice performance boost."
-    [k]
-    (.computeIfAbsent cache k mapping-fn)))
+  (u.memo/fast-memo u/->kebab-case-en))
 
 (defn instance->metadata
   "Convert a (presumably) Toucan 2 instance of an application database model with `snake_case` keys to a MLv2 style
@@ -108,8 +102,6 @@
 ;;;
 
 (derive :metadata/column :model/Field)
-
-(def ^:private ^:dynamic *table-idents* nil)
 
 (methodical/defmethod t2.model/resolve-model :metadata/column
   [model]
@@ -180,14 +172,15 @@
 
 (t2/define-after-select :metadata/column
   [field]
-  (let [field          (instance->metadata field :metadata/column)
+  (let [entity-id      (serdes/backfill-entity-id field)
+        field          (instance->metadata field :metadata/column)
         dimension-type (some-> (:dimension/type field) keyword)]
     (merge
      (dissoc field
+             :table
              :dimension/human-readable-field-id :dimension/id :dimension/name :dimension/type
              :values/human-readable-values :values/values)
-     (when-let [prefix (get *table-idents* (:table-id field))]
-       {:ident (lib.metadata.ident/ident-for-field prefix field)})
+     {:ident entity-id}
      (when (and (= dimension-type :external)
                 (:dimension/human-readable-field-id field))
        {:lib/external-remap {:lib/type :metadata.column.remapping/external
@@ -357,11 +350,10 @@
 (defn- metadatas-for-table [metadata-type table-id]
   (case metadata-type
     :metadata/column
-    (into [] (lib.metadata.ident/attach-idents #(get *table-idents* %))
-          (t2/select :metadata/column
-                     :table_id        table-id
-                     :active          true
-                     :visibility_type [:not-in #{"sensitive" "retired"}]))
+    (t2/select :metadata/column
+               :table_id        table-id
+               :active          true
+               :visibility_type [:not-in #{"sensitive" "retired"}])
 
     :metadata/metric
     (t2/select :metadata/metric :table_id table-id, :source_card_id [:= nil], :type :metric, :archived false)
@@ -374,47 +366,16 @@
     :metadata/metric
     (t2/select :metadata/metric :source_card_id card-id, :type :metric, :archived false)))
 
-(defn- database-name [database-id atom-db-name]
-  (if-let [db-name @atom-db-name]
-    db-name
-    (reset! atom-db-name (:name (database database-id)))))
-
-(defn- table-idents [db-name tbls]
-  (into {} (comp (filter identity)
-                 (map (juxt :id #(lib.metadata.ident/table-prefix db-name %))))
-        tbls))
-
-(defn- ensure-table-idents [table-idents-atom db-name table-ids]
-  (let [id->ident (or @table-idents-atom {})]
-    (or (when-let [missing-ids (not-empty (into #{} (remove id->ident) table-ids))]
-          (log/debugf "Fetching tables for their idents: %s" (pr-str missing-ids))
-          (let [tbls (t2/select :metadata/table :id [:in missing-ids])]
-            (swap! table-idents-atom merge (table-idents db-name tbls))))
-        id->ident)))
-
-(defn- attach-idents [table-idents-atom db-name columns]
-  (let [table-ids (into #{} (map :table-id) columns)
-        id->ident (ensure-table-idents table-idents-atom db-name table-ids)]
-    (lib.metadata.ident/attach-idents id->ident columns)))
-
-(p/deftype+ UncachedApplicationDatabaseMetadataProvider [database-id db-name-atom table-idents-atom]
+(p/deftype+ UncachedApplicationDatabaseMetadataProvider [database-id]
   lib.metadata.protocols/MetadataProvider
   (database [_this]
-    (let [db (database database-id)]
-      (reset! db-name-atom (:name db))
-      db))
+    (database database-id))
   (metadatas [_this metadata-type ids]
-    (let [ms (metadatas database-id metadata-type ids)]
-      (cond->> ms
-        (= metadata-type :metadata/column) (attach-idents table-idents-atom (database-name database-id db-name-atom)))))
+    (metadatas database-id metadata-type ids))
   (tables [_this]
-    (let [tbls (tables database-id)]
-      (swap! table-idents-atom merge (table-idents (database-name database-id db-name-atom) tbls))
-      tbls))
+    (tables database-id))
   (metadatas-for-table [_this metadata-type table-id]
-    (ensure-table-idents table-idents-atom (database-name database-id db-name-atom) [table-id])
-    (binding [*table-idents* @table-idents-atom]
-      (metadatas-for-table metadata-type table-id)))
+    (metadatas-for-table metadata-type table-id))
   (metadatas-for-card [_this metadata-type card-id]
     (metadatas-for-card metadata-type card-id))
   (setting [_this setting-name]
@@ -436,7 +397,7 @@
   Call [[application-database-metadata-provider]] instead, which wraps this inner function with optional, dynamically
   scoped caching, to allow reuse of `MetadataProvider`s across the life of an API request."
   [database-id]
-  (-> (->UncachedApplicationDatabaseMetadataProvider database-id (atom nil) (atom {}))
+  (-> (->UncachedApplicationDatabaseMetadataProvider database-id)
       lib.metadata.cached-provider/cached-metadata-provider
       lib.metadata.invocation-tracker/invocation-tracker-provider))
 

--- a/src/metabase/lib/schema/util.cljc
+++ b/src/metabase/lib/schema/util.cljc
@@ -74,12 +74,12 @@
                      options options)))))))
 
 (defn remove-randomized-idents
-  "Recursively remove all uuids and `:ident`s from x."
+  "Recursively remove all uuids, `:ident`s and `:entity_id`s from x."
   [x]
   (walk/postwalk
    (fn [x]
      (if (map? x)
-       (dissoc x :lib/uuid :ident)
+       (dissoc x :lib/uuid :ident :entity_id :entity-id)
        x))
    x))
 

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -180,7 +180,7 @@
 
 (defmethod serdes/hash-fields :model/Field
   [_field]
-  [:name (serdes/hydrated-hash :table)])
+  [:name (serdes/hydrated-hash :table :table_id)])
 
 ;;; ---------------------------------------------- Hydration / Util Fns ----------------------------------------------
 

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -210,16 +210,42 @@
   [s]
   (boolean (re-matches #"^[0-9a-fA-F]{8}$" s)))
 
+;; ## Memoizing `hydrated-hash`
+;;
+;; Hashing a Field requires its Table; hashing a Table requires its Database.
+;; Letting each of those hit the appdb for every Field lookup (when it lacks an `entity_id`) is too costly,
+;; so we cache any that have to be looked up right here.
+;;
+;; Memory use is not a serious concern here, for two reasons:
+;; 1. This is caching the `hydrated-hash` lookups, so it doesn't cache Fields but only Tables and Databases.
+;; 2. This is called only when [[backfill-entity-id]] needs to generate an `entity_id` by hashing. Once the background
+;;    job populates that column everywhere, this will always be empty.
+;;
+;; NOTE: To support Metabase upgrades where the new `entity_id`s might still be blank, this code will have to live on.
+;; But in practice once `entity_id`s are populated this cache will never be needed.
+(def ^:private hydrated-hash-cache
+  (atom {}))
+
 (defn hydrated-hash
   "Returns a function which accepts an entity and returns the identity hash of
    the value of the hydrated property under key k.
 
   This is a helper for writing [[hash-fields]] implementations."
-  [k]
-  (fn [entity]
-    (or
-     (some-> entity (t2/hydrate k) (get k) identity-hash)
-     "<none>")))
+  ([k]
+   (fn [entity]
+     (or
+      (some-> entity (t2/hydrate k) (get k) identity-hash)
+      "<none>")))
+  ([hydration-key cache-key]
+   (let [inner-fn (hydrated-hash hydration-key)]
+     (fn [entity]
+       (let [the-key (cache-key entity)
+             cached  (swap! hydrated-hash-cache
+                            (fn [cache]
+                              (cond-> cache
+                                (-> cache hydration-key (get the-key) not)
+                                (assoc-in [hydration-key the-key] (delay (inner-fn entity))))))]
+         (-> cached hydration-key (get the-key) deref))))))
 
 ;;; # Serdes paths and <tt>:serdes/meta</tt>
 ;;; The Clojure maps from extraction and ingestion always include a special key `:serdes/meta` giving some information

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -125,7 +125,7 @@
 
 (defmethod serdes/hash-fields :model/Table
   [_table]
-  [:schema :name (serdes/hydrated-hash :db)])
+  [:schema :name (serdes/hydrated-hash :db :db_id)])
 
 ;;; ------------------------------------------------ Field ordering -------------------------------------------------
 

--- a/test/metabase/lib/drill_thru/zoom_in_geographic_test.cljc
+++ b/test/metabase/lib/drill_thru/zoom_in_geographic_test.cljc
@@ -6,6 +6,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.metadata.ident :as lib.metadata.ident]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]))
 
@@ -559,14 +560,17 @@
                                   :column-ref (lib/ref state-col)
                                   :value      "MN"}]}
         drills     (lib/available-drill-thrus query -1 context)
+        [join]     (lib/joins query)
         zoom-in    (m/find-first #(= (:type %) :drill-thru/zoom-in.geographic) drills)]
     (is (=? {:lib/type  :metabase.lib.drill-thru/drill-thru
              :type      :drill-thru/zoom-in.geographic
              :subtype   :drill-thru.zoom-in.geographic/country-state-city->binned-lat-lon
              :column    state-col
-             :latitude  {:column    (meta/field-metadata :people :latitude)
+             :latitude  {:column    (update (meta/field-metadata :people :latitude)
+                                            :ident lib.metadata.ident/explicitly-joined-ident (:ident join))
                          :bin-width 1}
-             :longitude {:column    (meta/field-metadata :people :longitude)
+             :longitude {:column    (update (meta/field-metadata :people :longitude)
+                                            :ident lib.metadata.ident/explicitly-joined-ident (:ident join))
                          :bin-width 1}}
             zoom-in))
     (is (=? {:stages [{:filters [[:= {} [:field {} (meta/id :people :state)] "MN"]]

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -10,6 +10,7 @@
    [metabase.lib.field :as lib.field]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
+   [metabase.lib.metadata.ident :as lib.metadata.ident]
    [metabase.lib.options :as lib.options]
    [metabase.lib.schema.expression :as lib.schema.expression]
    [metabase.lib.schema.temporal-bucketing :as lib.schema.temporal-bucketing]
@@ -41,18 +42,21 @@
                      :name         "grandparent"
                      :display-name "Grandparent"
                      :id           (grandparent-parent-child-id :grandparent)
+                     :ident        (u/generate-nano-id)
                      :base-type    :type/Text}
         parent      {:lib/type     :metadata/column
                      :name         "parent"
                      :display-name "Parent"
                      :parent-id    (grandparent-parent-child-id :grandparent)
                      :id           (grandparent-parent-child-id :parent)
+                     :ident        (u/generate-nano-id)
                      :base-type    :type/Text}
         child       {:lib/type     :metadata/column
                      :name         "child"
                      :display-name "Child"
                      :parent-id    (grandparent-parent-child-id :parent)
                      :id           (grandparent-parent-child-id :child)
+                     :ident        (u/generate-nano-id)
                      :base-type    :type/Text}]
     (lib.tu/mock-metadata-provider
      {:database meta/database
@@ -1536,9 +1540,11 @@
           join-cols      [(-> (meta/field-metadata :products :category)
                               (assoc :lib/source :source/card
                                      :source-alias "Products")
+                              (update :ident lib.metadata.ident/explicitly-joined-ident (:ident join))
                               (dissoc :id :table-id))]
           implicit-cols  (for [col (meta/fields :people)]
                            (-> (meta/field-metadata :people col)
+                               (update :ident lib.metadata.ident/implicitly-joined-ident (meta/ident :orders :user-id))
                                (assoc :lib/source :source/implicitly-joinable)))
           sorted         #(sort-by (juxt :name :join-alias :id :table-id) %)]
       (is (=? (sorted (concat order-cols join-cols))

--- a/test/metabase/lib/js/metadata_test.cljs
+++ b/test/metabase/lib/js/metadata_test.cljs
@@ -18,6 +18,7 @@
 
 (def ^:private mock-field-metadata-with-external-remap
   #js {"id"               36
+       "ident"            "niM_yGvJuGyEZvPqUlgqk"
        "name"             "CATEGORY_ID"
        "has_field_values" "none"
        "dimensions"       #js [{"id"                      72
@@ -31,9 +32,7 @@
         metadata-provider (lib.js.metadata/metadata-provider 1 metadata)]
     (is (= {:lib/type           :metadata/column
             :id                 36
-            ;; This is a bit busted because of the partial metadata, but it's still there.
-            ;; No DB or table names, so those are blank.
-            :ident              "field____!noschema!____CATEGORY_ID"
+            :ident              "niM_yGvJuGyEZvPqUlgqk"
             :name               "CATEGORY_ID"
             :has-field-values   :none
             :lib/external-remap {:lib/type :metadata.column.remapping/external
@@ -44,6 +43,7 @@
 
 (def ^:private mock-field-metadata-with-internal-remap
   #js {"id"               33
+       "ident"            "cWYe4OhoaSgeCfIMJUDos"
        "name"             "ID"
        "has_field_values" "none"
        "dimensions"       #js [{"id"                      66
@@ -57,9 +57,7 @@
         metadata-provider (lib.js.metadata/metadata-provider 1 metadata)]
     (is (= {:lib/type           :metadata/column
             :id                 33
-            ;; This is a bit busted because of the partial metadata, but it's still there.
-            ;; No DB or table names, so those are blank.
-            :ident              "field____!noschema!____ID"
+            :ident              "cWYe4OhoaSgeCfIMJUDos"
             :name               "ID"
             :has-field-values   :none
             :lib/internal-remap {:lib/type :metadata.column.remapping/internal
@@ -79,16 +77,18 @@
                                 :schema "SomeSchema"
                                 :db_id  1
                                 :fields #js {}}}
-       :fields    #js {"600" #js {:id   600
+       :fields    #js {"600" #js {:id       600
                                   :table_id 6
+                                  :ident    "Pe-udJ-W6agr-C3yh_XMR"
                                   :name "one_field"}
-                       "700" #js {:id   700
+                       "700" #js {:id       700
                                   :table_id 7
-                                  :name "two_field"}}})
+                                  :ident    "cq16i_0gLWMyVf_fjSATF"
+                                  :name     "two_field"}}})
 
 (deftest ^:parallel idents-test
   (let [mp (lib.js.metadata/metadata-provider 1 mock-metadata-with-generic-tables-and-fields)]
-    (is (= "field__fake DB__!noschema!__basic_table__one_field"
+    (is (= "Pe-udJ-W6agr-C3yh_XMR"
            (:ident (lib.metadata/field mp 600))))
-    (is (= "field__fake DB__SomeSchema__another_table__two_field"
+    (is (= "cq16i_0gLWMyVf_fjSATF"
            (:ident (lib.metadata/field mp 700))))))

--- a/test/metabase/lib/metadata_test.cljc
+++ b/test/metabase/lib/metadata_test.cljc
@@ -68,7 +68,6 @@
 (deftest ^:parallel idents-test
   (doseq [table-key (meta/tables)
           field-key (meta/fields table-key)]
-    (let [table    (meta/table-metadata table-key)
-          field    (meta/field-metadata table-key field-key)]
-      (is (= (str "field__" (:name meta/database) "__" (:schema table) "__" (:name table) "__" (:name field))
+    (let [field (meta/field-metadata table-key field-key)]
+      (is (= (:ident field)
              (:ident (lib.metadata/field meta/metadata-provider (:id field))))))))

--- a/test/metabase/lib/test_metadata.cljc
+++ b/test/metabase/lib/test_metadata.cljc
@@ -177,6 +177,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :categories :id)
+   :ident               "PWWBk6ty2MHhRsyVxynoW"
    :position            0
    :visibility-type     :normal
    :target              nil
@@ -208,6 +209,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :categories :name)
+   :ident               "RDOjlMfV-Fg8UwZMPWiq3"
    :position            1
    :visibility-type     :normal
    :target              nil
@@ -266,6 +268,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :checkins :id)
+   :ident               "vWsH15xQSs3zTEAnBfBpg"
    :position            0
    :visibility-type     :normal
    :target              nil
@@ -297,6 +300,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :checkins :date)
+   :ident               "A9rzjV-n0z6b6UvRgVu8G"
    :position            1
    :visibility-type     :normal
    :target              nil
@@ -329,6 +333,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :checkins :user-id)
+   :ident               "lrJ9XAr6FRGHGafMQuxKJ"
    :position            2
    :visibility-type     :normal
    :target              nil
@@ -360,6 +365,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :checkins :venue-id)
+   :ident               "_99ifdCxbDKLesl4IkeUl"
    :position            3
    :visibility-type     :normal
    :target              nil
@@ -415,6 +421,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :users :id)
+   :ident               "Bo3W7NNZIr2tODiMTy4yN"
    :position            0
    :visibility-type     :normal
    :target              nil
@@ -446,6 +453,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :users :name)
+   :ident               "kB6mZwmTLfGs3t5zwibjn"
    :position            1
    :visibility-type     :normal
    :target              nil
@@ -483,6 +491,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :users :last-login)
+   :ident               "J8tIOKqMWIluDSAIk9Wvi"
    :position            2
    :visibility-type     :normal
    :target              nil
@@ -515,6 +524,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :users :password)
+   :ident               "UNtexw8AUjzvrQSshcY_J"
    :position            3
    :visibility-type     :sensitive
    :target              nil
@@ -576,6 +586,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :venues :id)
+   :ident               "aYXxJJkPa0GR3fc9uv6m2"
    :position            0
    :visibility-type     :normal
    :target              nil
@@ -607,6 +618,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :venues :name)
+   :ident               "5fzDTF0GuMRk21YLch7OQ"
    :position            1
    :visibility-type     :normal
    :target              nil
@@ -644,6 +656,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :venues :category-id)
+   :ident               "wOMa4NLLsgHe74Rj1okcc"
    :position            2
    :visibility-type     :normal
    :target              nil
@@ -675,6 +688,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :venues :latitude)
+   :ident               "FXhsCz8PYDMfikR2D3ccw"
    :position            3
    :visibility-type     :normal
    :target              nil
@@ -713,6 +727,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :venues :longitude)
+   :ident               "Z7YfJn_oH2E7QDqUlhXcF"
    :position            4
    :visibility-type     :normal
    :target              nil
@@ -753,6 +768,7 @@
    :nfc-path            nil
    :parent-id           nil
    :id                  (id :venues :price)
+   :ident               "oel2OtBaZRcjpBF4HkEOh"
    :position            5
    :visibility-type     :normal
    :target              nil
@@ -818,6 +834,7 @@
    :parent-id                  nil
    :id                         (id :products :id)
    :database-is-auto-increment true
+   :ident                      "zaFrUMrlem27YA4vX20PP"
    :position                   0
    :visibility-type            :normal
    :preview-display            true
@@ -849,6 +866,7 @@
    :parent-id                  nil
    :id                         (id :products :rating)
    :database-is-auto-increment false
+   :ident                      "orY0SwYoFpT0cp-NTwBtl"
    :position                   6
    :visibility-type            :normal
    :preview-display            true
@@ -886,6 +904,7 @@
    :parent-id                  nil
    :id                         (id :products :category)
    :database-is-auto-increment false
+   :ident                      "MvxP-c7scJi3Ypicz7Pko"
    :position                   3
    :visibility-type            :normal
    :preview-display            true
@@ -921,6 +940,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :products :price)
+   :ident                      "_Mw1CWXwjrjeEKI3Ixzil"
    :database-is-auto-increment false
    :position                   5
    :visibility-type            :normal
@@ -958,6 +978,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :products :title)
+   :ident                      "cy6cxdeEcrYTdx30bDZvI"
    :database-is-auto-increment false
    :position                   2
    :visibility-type            :normal
@@ -994,6 +1015,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :products :created-at)
+   :ident                      "Y_E2kCrZCo7htAwby4_m-"
    :database-is-auto-increment false
    :position                   7
    :visibility-type            :normal
@@ -1027,6 +1049,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :products :vendor)
+   :ident                      "SUw6OkR5bIL0MAYdN1KmV"
    :database-is-auto-increment false
    :position                   4
    :visibility-type            :normal
@@ -1063,6 +1086,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :products :ean)
+   :ident                      "j6KkODbzbivj5vQPjZyFv"
    :database-is-auto-increment false
    :position                   1
    :visibility-type            :normal
@@ -1125,6 +1149,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :orders :id)
+   :ident                      "YV9abw8AQ5pCVAQhaSMVO"
    :database-is-auto-increment true
    :position                   0
    :visibility-type            :normal
@@ -1156,6 +1181,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :orders :subtotal)
+   :ident                      "F31vad3vgquibQmIsVBK2"
    :database-is-auto-increment false
    :position                   3
    :visibility-type            :normal
@@ -1194,6 +1220,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :orders :total)
+   :ident                      "lMq_ks9eJgnASWwo-5UCE"
    :database-is-auto-increment false
    :position                   5
    :visibility-type            :normal
@@ -1232,6 +1259,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :orders :tax)
+   :ident                      "aHk-zDyLzTY8XYyESg8dl"
    :database-is-auto-increment false
    :position                   4
    :visibility-type            :normal
@@ -1270,6 +1298,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :orders :discount)
+   :ident                      "HjXFQSw4fNHOoyzyWLgPx"
    :database-is-auto-increment false
    :position                   6
    :visibility-type            :normal
@@ -1307,6 +1336,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :orders :quantity)
+   :ident                      "qe9EvBhTR7LKgx2wRrk3f"
    :database-is-auto-increment false
    :position                   8
    :visibility-type            :normal
@@ -1344,6 +1374,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :orders :created-at)
+   :ident                      "kLEi3k1-6i8GpgqsQ0-7k"
    :database-is-auto-increment false
    :position                   7
    :visibility-type            :normal
@@ -1377,6 +1408,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :orders :product-id)
+   :ident                      "V5NFZP_6JOWd6J7ULXCIs"
    :database-is-auto-increment false
    :position                   2
    :visibility-type            :normal
@@ -1408,6 +1440,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :orders :user-id)
+   :ident                      "w6egqJWAVTNypKmv7gemF"
    :database-is-auto-increment false
    :position                   1
    :visibility-type            :normal
@@ -1466,6 +1499,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :people :id)
+   :ident                      "SmYetbZtPKwwFfkjGcEm3"
    :database-is-auto-increment true
    :position                   0
    :visibility-type            :normal
@@ -1497,6 +1531,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :people :state)
+   :ident                      "M6zAelR060aOQEIcUjOLR"
    :database-is-auto-increment false
    :position                   7
    :visibility-type            :normal
@@ -1533,6 +1568,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :people :city)
+   :ident                      "WkzaKB-IvSHf6zZzT45vz"
    :database-is-auto-increment false
    :position                   5
    :visibility-type            :normal
@@ -1569,6 +1605,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :people :address)
+   :ident                      "nOD2ARIn9IGwSwc5_5_SM"
    :database-is-auto-increment false
    :position                   1
    :visibility-type            :normal
@@ -1605,6 +1642,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :people :name)
+   :ident                      "XNv5jtDfnuvp2KN8WhJex"
    :database-is-auto-increment false
    :position                   4
    :visibility-type            :normal
@@ -1641,6 +1679,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :people :source)
+   :ident                      "dU-riH8RvUl3nMmWxRCnO"
    :database-is-auto-increment false
    :position                   8
    :visibility-type            :normal
@@ -1677,6 +1716,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :people :zip)
+   :ident                      "oleh-os9rLmUjdWrjKkMP"
    :database-is-auto-increment false
    :position                   10
    :visibility-type            :normal
@@ -1713,6 +1753,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :people :latitude)
+   :ident                      "4mOOY4ru0ZDc0RAPiMcMI"
    :database-is-auto-increment false
    :position                   11
    :visibility-type            :normal
@@ -1750,6 +1791,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :people :password)
+   :ident                      "8FhaFSmfDk9wjOzNN-pcP"
    :database-is-auto-increment false
    :position                   3
    :visibility-type            :normal
@@ -1786,6 +1828,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :people :birth-date)
+   :ident                      "TbRRgbOjjSXfl7Q3RYjRn"
    :database-is-auto-increment false
    :position                   9
    :visibility-type            :normal
@@ -1819,6 +1862,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :people :longitude)
+   :ident                      "Ey0aDHLWUBQhEBcLtzgUi"
    :database-is-auto-increment false
    :position                   6
    :visibility-type            :normal
@@ -1856,6 +1900,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :people :email)
+   :ident                      "51mJbNKKAk9Fzu8NHE7Z_"
    :database-is-auto-increment false
    :position                   2
    :visibility-type            :normal
@@ -1892,6 +1937,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :people :created-at)
+   :ident                      "7x7cvFd0i_9hCtu8KK2Fm"
    :database-is-auto-increment false
    :position                   12
    :visibility-type            :normal
@@ -1956,6 +2002,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :reviews :id)
+   :ident                      "EvuypV2uqt8DJb7L8NKPi"
    :database-is-auto-increment true
    :position                   0
    :visibility-type            :normal
@@ -1987,6 +2034,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :reviews :created-at)
+   :ident                      "-2YPEvQPmJ5WiBX9rNEdG"
    :database-is-auto-increment false
    :position                   5
    :visibility-type            :normal
@@ -2020,6 +2068,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :reviews :rating)
+   :ident                      "TwyzncoirctxX4EvM567q"
    :database-is-auto-increment false
    :position                   3
    :visibility-type            :normal
@@ -2057,6 +2106,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :reviews :reviewer)
+   :ident                      "esBOudUYL1gyTl_WjmWwH"
    :database-is-auto-increment false
    :position                   2
    :visibility-type            :normal
@@ -2093,6 +2143,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :reviews :body)
+   :ident                      "-t7C0NJxK7bCX9nHSr6zL"
    :database-is-auto-increment false
    :position                   4
    :visibility-type            :normal
@@ -2129,6 +2180,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :reviews :product-id)
+   :ident                      "1Zp5Muev3k5mT4RvtpPQR"
    :database-is-auto-increment false
    :position                   1
    :visibility-type            :normal
@@ -2185,6 +2237,7 @@
    :parent-id                  nil
    :id                         (id :ic/accounts :id)
    :last-analyzed              nil
+   :ident                      "Lu7nMH_XdHH6hqsHaKW1m"
    :database-is-auto-increment false
    :json-unfolding             false
    :position                   0
@@ -2217,6 +2270,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :ic/accounts :name)
+   :ident                      "Wf7y6030q_c31L5mtCAK8"
    :database-is-auto-increment false
    :json-unfolding             false
    :position                   1
@@ -2275,6 +2329,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :ic/reports :id)
+   :ident                      "rN1WZzhva-9naWlhJOisG"
    :database-is-auto-increment false
    :json-unfolding             false
    :position                   0
@@ -2309,6 +2364,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :ic/reports :created-by)
+   :ident                      "_fSRZCC1h0FeFnyKBITuh"
    :database-is-auto-increment false
    :json-unfolding             false
    :position                   1
@@ -2341,6 +2397,7 @@
    :nfc-path                   nil
    :parent-id                  nil
    :id                         (id :ic/reports :updated-by)
+   :ident                      "dLX0Y18XnBwWkbw_SiADu"
    :database-is-auto-increment false
    :json-unfolding             false
    :position                   2
@@ -2385,6 +2442,7 @@
    :semantic-type              :type/PK
    :table-id                   (id :gh/issues)
    :id                         (id :gh/issues :id)
+   :ident                      "JKyXKw2V2cjoVVmvHvy_v"
    :name                       "ID"
    :coercion-strategy          nil
    :fingerprint-version        5
@@ -2418,6 +2476,7 @@
    :semantic-type              :type/FK
    :table-id                   (id :gh/issues)
    :id                         (id :gh/issues :reporter-id)
+   :ident                      "x-yxZZNE3c7LqZaxFEnWx"
    :name                       "REPORTER_ID"
    :display-name               "Reporter ID"
    :coercion-strategy          nil
@@ -2455,6 +2514,7 @@
    :semantic-type              :type/FK
    :table-id                   (id :gh/issues)
    :id                         (id :gh/issues :assignee-id)
+   :ident                      "9Wt9ogSynNeMVtsWuA6VX"
    :name                       "ASSIGNEE_ID"
    :display-name               "Assignee ID"
    :coercion-strategy          nil
@@ -2492,6 +2552,7 @@
    :semantic-type              :type/Category
    :table-id                   (id :gh/issues)
    :id                         (id :gh/issues :is-open)
+   :ident                      "tyoebOZRaf0QbfgpFzxnd"
    :name                       "IS_OPEN"
    :display-name               "Is Open"
    :coercion-strategy          nil
@@ -2526,6 +2587,7 @@
    :semantic-type              nil
    :table-id                   (id :gh/issues)
    :id                         (id :gh/issues :reported-at)
+   :ident                      "9f74xH4NWQeTmCHR0TOye"
    :name                       "REPORTED_AT"
    :display-name               "Reported At"
    :coercion-strategy          nil
@@ -2560,6 +2622,7 @@
    :semantic-type              nil
    :table-id                   (id :gh/issues)
    :id                         (id :gh/issues :closed-at)
+   :ident                      "iYumlBafrHPue9CLJLsSA"
    :name                       "CLOSED_AT"
    :display-name               "Closed At"
    :coercion-strategy          nil
@@ -2619,6 +2682,7 @@
    :semantic-type              :type/PK
    :table-id                   (id :gh/users)
    :id                         (id :gh/users :id)
+   :ident                      "kGAQfykjP7sNUuKklvX9E"
    :name                       "ID"
    :display-name               "Username"
    :coercion-strategy          nil
@@ -2656,6 +2720,7 @@
    :semantic-type              nil
    :table-id                   (id :gh/users)
    :id                         (id :gh/users :birthday)
+   :ident                      "AhzW2ts1iYLtnVsN8duI2"
    :name                       "BIRTHDAY"
    :display-name               "Birthday"
    :coercion-strategy          nil
@@ -2689,6 +2754,7 @@
    :semantic-type              :type/Email
    :table-id                   (id :gh/users)
    :id                         (id :gh/users :email)
+   :ident                      "hxVljG-mcCWR2yCyLDyfI"
    :name                       "EMAIL"
    :display-name               "Email"
    :coercion-strategy          nil
@@ -2748,6 +2814,7 @@
    :semantic-type              :type/PK
    :table-id                   (id :gh/comments)
    :id                         (id :gh/comments :id)
+   :ident                      "N9GPZG-iBB3fNJFw6k75L"
    :name                       "ID"
    :display-name               "ID"
    :coercion-strategy          nil
@@ -2781,6 +2848,7 @@
    :semantic-type              :type/FK
    :table-id                   (id :gh/comments)
    :id                         (id :gh/comments :author-id)
+   :ident                      "N8Zc29IeohSLcDhPlntTI"
    :name                       "AUTHOR_ID"
    :display-name               "Author ID"
    :coercion-strategy          nil
@@ -2818,6 +2886,7 @@
    :semantic-type              :type/CreationDate
    :table-id                   (id :gh/comments)
    :id                         (id :gh/comments :posted-at)
+   :ident                      "SFZiylJmurPdeucrYWBZO"
    :name                       "POSTED_AT"
    :display-name               "Posted At"
    :coercion-strategy          nil
@@ -2852,6 +2921,7 @@
    :semantic-type              :type/FK
    :table-id                   (id :gh/comments)
    :id                         (id :gh/comments :reply-to)
+   :ident                      "b1ng7KzofdPc2IuDEA8M2"
    :name                       "REPLY_TO"
    :display-name               "Reply To"
    :coercion-strategy          nil
@@ -2885,6 +2955,7 @@
    :semantic-type              nil
    :table-id                   (id :gh/comments)
    :id                         (id :gh/comments :body-markdown)
+   :ident                      "CidSifa32m1qX0mEeh46X"
    :name                       "BODY_MARKDOWN"
    :display-name               "Body Markdown"
    :coercion-strategy          nil
@@ -3046,3 +3117,9 @@
   [table-name :- :keyword
    field-name :- :keyword]
   (field-metadata-method table-name field-name))
+
+(mu/defn ident :- :string
+  "Convenience to get the `:ident` string for a given field, by its table and field keys."
+  [table-name :- :keyword
+   field-name :- :keyword]
+  (:ident (field-metadata table-name field-name)))

--- a/test/metabase/lib/test_util/matrix.cljc
+++ b/test/metabase/lib/test_util/matrix.cljc
@@ -7,7 +7,8 @@
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-metadata.graph-provider :as meta.graph-provider]
    [metabase.lib.test-util :as lib.tu]
-   [metabase.lib.test-util.metadata-providers.mock :as providers.mock]))
+   [metabase.lib.test-util.metadata-providers.mock :as providers.mock]
+   [metabase.util :as u]))
 
 (defn- metadata-with-column-of-type
   [column-type]
@@ -19,6 +20,7 @@
                      :database-required false
                      :table-id 1
                      :name "TEST_ME"
+                     :ident (u/generate-nano-id)
                      :coercion-strategy nil
                      :settings nil
                      :caveats nil
@@ -62,6 +64,7 @@
                        :database-required false,
                        :table-id 1,
                        :name "ID",
+                       :ident (u/generate-nano-id)
                        :coercion-strategy nil,
                        :settings nil,
                        :caveats nil,
@@ -116,6 +119,7 @@
                        :custom-position 0,
                        :active true,
                        :id 10,
+                       :ident (u/generate-nano-id)
                        :parent-id nil,
                        :points-of-interest nil,
                        :visibility-type :normal,
@@ -135,6 +139,7 @@
                        :database-required false
                        :table-id 10
                        :name "FK_ID"
+                       :ident (u/generate-nano-id)
                        :coercion-strategy nil
                        :settings nil
                        :caveats nil

--- a/test/metabase/lib/test_util/metadata_providers/merged_mock.cljc
+++ b/test/metabase/lib/test_util/metadata_providers/merged_mock.cljc
@@ -29,6 +29,10 @@
    [:metrics  {:optional true} [:maybe [:sequential [:map [:id ::lib.schema.id/metric]]]]]
    [:segments {:optional true} [:maybe [:sequential [:map [:id ::lib.schema.id/segment]]]]]])
 
+(defn- add-idents [field-skeletons]
+  (for [field field-skeletons]
+    (u/assoc-default field :ident (u/generate-nano-id))))
+
 (mu/defn- merged-metadata-map :- lib.tu.metadata-providers.mock/MockMetadata
   [parent-metadata-provider :- ::lib.schema.metadata/metadata-provider
    properties               :- MergeableProperties]
@@ -38,7 +42,7 @@
                 (case object-type
                   :database (merge (lib.metadata/database parent-metadata-provider) x)
                   :tables   (merge-metadatas parent-metadata-provider lib.metadata/table x)
-                  :fields   (merge-metadatas parent-metadata-provider lib.metadata/field x)
+                  :fields   (merge-metadatas parent-metadata-provider lib.metadata/field (add-idents x))
                   :cards    (merge-metadatas parent-metadata-provider lib.metadata/card x)
                   :metrics  (merge-metadatas parent-metadata-provider lib.metadata/metric x)
                   :segments (merge-metadatas parent-metadata-provider lib.metadata/segment x))]))


### PR DESCRIPTION
Closes #53048.


### Description

`entity_id` columns on Databases, Tables and Fields are new in #53076.

This PR uses `entity_id` on Fields as their `:ident` in the metadata,
rather than the concatenated names previously used.

The names were a bit too fragile, since occasionally people rename
Fields or Tables in the appdb to retain the identity of something that
got renamed in place in their data warehouse. (That isn't exactly
supported, but it's also not blocked.)

With random (or hashed and saved) `entity_id`s for Fields used as their
`:ident`s instead, references to fields will not need to be updated if
fields or tables are renamed but their `entity_id`s preserved.

**On memoization**

Since the `entity_id` is `NULL` for existing fields and they're only
being populated in the background, we need to populate them on demand
when reading metadata. Since fields depend on their tables and tables on
their databases, this meant a lot of extra appdb reads at first.

This change includes memoization added to `serdes/hydrated-hash`, such
that any table or database only gets read once, and memoized forever.
There's a big comment about the memory impact of this; in summary it
should be safe since this is on demand, and holds only DBs/tables
and not fields.

A later PR will add a background job as mentioned, that will populate
all the `entity_id` columns with hashed values. After that, the cache
will always be empty.

Note that this memoization is not going to work if a table or field is
renamed before the background job catches up! I consider this an
acceptable loss - renaming fields is an admin action that requires
editing the appdb. The guide for doing that can include making sure all
`entity_id` fields are populated first.


### How to verify

`:ident`s on fields are now NanoID strings, rather than concatenations of their database, schema,
table and field names. Should be invisible aside from inspecting the metadata.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
