### PR TITLE
Use `gap` instead of `spacing` in Mantine components

### DIFF
--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/SettingsEditor.jsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/SettingsEditor.jsx
@@ -244,7 +244,7 @@ class SettingsEditor extends Component {
               to={"/admin/settings/" + slug}
               className={classes}
             >
-              <Group spacing="xs">
+              <Group gap="xs">
                 <span>{section.name}</span>
                 {section?.isUpsell && <UpsellGem />}
               </Group>

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.jsx
@@ -49,7 +49,7 @@ export const ChartSettingSelect = ({
   const dropdownComponent =
     footer &&
     (({ children }) => (
-      <Stack p={0} w="100%" spacing={0}>
+      <Stack p={0} w="100%" gap={0}>
         {children}
         {footer}
       </Stack>


### PR DESCRIPTION
@npfitz said https://www.notion.so/metabase/Things-to-Know-About-Mantine-v7-11969354c90180828a7df78a96277080?pvs=4#19769354c9018058b8a9c91cc91d8a30.