### PR TITLE
Revert discarding-rff for preemptive caching

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/task/cache.clj
+++ b/enterprise/backend/src/metabase_enterprise/task/cache.clj
@@ -45,14 +45,6 @@
   [refresh-task-fn]
   (.submit ^ExecutorService @pool ^Callable refresh-task-fn))
 
-(defn discarding-rff
-  "Returns a reducing function that discards result rows"
-  [_metadata]
-  (fn discarding-rf
-    ([] {:rows []})
-    ([result] result)
-    ([result _row] result)))
-
 (defn- refresh-task
   "Returns a function that serially reruns queries based on `refresh-defs`, and discards the results. Each refresh
   definition contains a card-id, an optional dashboard-id, and a list of queries to rerun."
@@ -73,8 +65,7 @@
                 {:executed-by  nil
                  :context      :cache-refresh
                  :card-id      card-id
-                 :dashboard-id dashboard-id})
-               discarding-rff)
+                 :dashboard-id dashboard-id}))
               (catch Exception e
                 (log/debugf "Error refreshing cache for card %s: %s" card-id (ex-message e))))))))))
 


### PR DESCRIPTION
Quick revert of the discarding-rff for preemptive caching. Causes issues because we need to accumulate results in memory to generate column metadata, apparently, and this is part of the data returned from the cache.

https://metaboat.slack.com/archives/C05MPF0TM3L/p1739388590172409