### PR TITLE
Update rerun job to work with new master test workflow

### DIFF
--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -2,7 +2,7 @@ name: Re-run Flaky Workflows
 
 on:
   workflow_run:
-    workflows: [Backend, Driver Tests, E2E Tests, Frontend, Backend-Cloverage]
+    workflows: [run-tests]
     types: [completed]
     branches: [master, 'release-x.**', 'backport-**']
 


### PR DESCRIPTION
Updating the master testing workflow made it so that the rerun job (which also notifies us of broken branches) failed to ever trigger.