### PR TITLE
Always run insights in middleware

### DIFF
--- a/src/metabase/query_processor/middleware/results_metadata.clj
+++ b/src/metabase/query_processor/middleware/results_metadata.clj
@@ -89,8 +89,8 @@
   "Post-processing middleware that records metadata about the columns returned when running the query. Returns an rff."
   [{{:keys [skip-results-metadata?]} :middleware, :as query} :- ::qp.schema/query
    rff                                                       :- ::qp.schema/rff]
-  (if skip-results-metadata?
-    rff
-    (let [record! (partial record-metadata! query)]
-      (fn record-and-return-metadata!-rff* [metadata]
-        (insights-xform metadata record! (rff metadata))))))
+  (let [record! (if skip-results-metadata?
+                  (partial record-metadata! query)
+                  (fn [_metadata] (log/debug "skipping recording metadata")))]
+    (fn record-and-return-metadata!-rff* [metadata]
+      (insights-xform metadata record! (rff metadata)))))


### PR DESCRIPTION
we conditionally run insights and save metadata. We definitely want to conditionally save metadata because we only save model metadata if we can preserve any user edits.

But we want to always run the insights middleware because we want insights.

I want to think through the implications and hope tests might guide us towards any other reliant behavior.
