### PR TITLE
Fix type failures from merge conflicts

### DIFF
--- a/frontend/src/metabase/ui/components/inputs/NumberInput/NumberInput.tsx
+++ b/frontend/src/metabase/ui/components/inputs/NumberInput/NumberInput.tsx
@@ -5,9 +5,9 @@ import type {
 import type { ChangeEvent, FocusEvent, Ref } from "react";
 import { forwardRef, useLayoutEffect, useState } from "react";
 
-import type { NumberValue } from "metabase/querying/filters/hooks/use-number-filter";
-
 import { TextInput } from "../TextInput";
+
+type NumberValue = number | "";
 
 export interface NumberInputProps
   extends Omit<
@@ -22,7 +22,7 @@ export interface NumberInputProps
   > {
   value: NumberValue;
   defaultValue?: NumberValue;
-  onChange?: (value: number | "") => void;
+  onChange?: (value: NumberValue) => void;
   vars?: TextInputProps["vars"];
   classNames?: TextInputProps["classNames"];
   styles?: TextInputProps["styles"];

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/PeriodsAgoMenuOption.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/PeriodsAgoMenuOption.tsx
@@ -2,13 +2,14 @@ import type { KeyboardEvent, MouseEvent } from "react";
 import { useCallback, useRef, useState } from "react";
 import { t } from "ttag";
 
-import type { NumberValue } from "metabase/querying/filters/hooks/use-number-filter";
 import { Box, Group, Text, rem } from "metabase/ui";
 import type { COMPARISON_TYPES } from "metabase/visualizations/visualizations/SmartScalar/constants";
 import type { SmartScalarComparisonPeriodsAgo } from "metabase-types/api";
 
 import { MenuItemStyled } from "./MenuItem.styled";
 import { NumberInputStyled } from "./PeriodsAgoMenuOption.styled";
+
+type NumberValue = number | "";
 
 type PeriodsAgoMenuOptionProps = {
   "aria-selected": boolean;


### PR DESCRIPTION
[Report 1](https://metaboat.slack.com/archives/C5XHN8GLW/p1739395279063069), [report 2](https://metaboat.slack.com/archives/C063Q3F1HPF/p1739431659939889)
This type error is caused by https://github.com/metabase/metabase/pull/51144 and https://github.com/metabase/metabase/pull/53607 getting merged roughly at the same time, and there were conflicts.

This PR fix, it so that we don't rely on Metabase Lib type on UI components, if you look at https://github.com/metabase/metabase/pull/53607, the new change doesn't affect files outside metabase lib and query builder.

### Backport note
No need to backport this since the 2 original PRs aren't backported.

### To verify
`yarn type-check` passes.
