### PR TITLE
Fix no-unused-vars ESLint rule config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,7 @@ module.exports = {
       {
         vars: "all",
         args: "none",
-        varsIgnorePattern: "^_",
+        varsIgnorePattern: "^_.+$",
         ignoreRestSiblings: true,
       },
     ],
@@ -107,7 +107,7 @@ module.exports = {
           "And",
           "When",
           "Then",
-          "describeWithSnowplow"
+          "describeWithSnowplow",
         ],
       },
     ],
@@ -219,10 +219,10 @@ module.exports = {
         "@typescript-eslint/no-unused-vars": [
           "error",
           {
-            argsIgnorePattern: "^_",
-            varsIgnorePattern: "^_",
+            argsIgnorePattern: "^_.+$",
+            varsIgnorePattern: "^_.+$",
             ignoreRestSiblings: true,
-            destructuredArrayIgnorePattern: "^_",
+            destructuredArrayIgnorePattern: "^_.+$",
           },
         ],
         // This was introduced in 6.0.0

--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -1,13 +1,13 @@
 import { onlyOn } from "@cypress/skip-test";
-import _ from "underscore";
 
-const { H } = cy;
 import { USERS, USER_GROUPS } from "e2e/support/cypress_data";
 import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
+
+const { H } = cy;
 
 const PERMISSIONS = {
   curate: ["admin", "normal", "nodata"],

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Summarize/SummarizePicker/SummarizePicker.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Summarize/SummarizePicker/SummarizePicker.tsx
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import {
   AggregationPicker,
   type AggregationPickerProps,

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/routes.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/routes.jsx
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import { ModalRoute } from "metabase/hoc/ModalRoute";
 
 import UnsubscribeUserModal from "./containers/UnsubscribeUserModal/UnsubscribeUserModal";

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyFormLauncher.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyFormLauncher.unit.spec.tsx
@@ -1,3 +1,5 @@
+import _ from "underscore";
+
 import { setupEnterprisePlugins } from "__support__/enterprise";
 import { mockSettings } from "__support__/settings";
 import { createMockEntitiesState } from "__support__/store";
@@ -33,7 +35,7 @@ const defaultProps: Pick<
     { model: "database", model_id: 1, strategy: { type: "nocache" } },
   ],
   isFormDirty: false,
-  updateTargetId: (_: number | null, __: boolean) => {},
+  updateTargetId: _.noop,
 };
 
 const renderStrategyFormLauncher = (props: StrategyFormLauncherProps) => {

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionModal.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { withRouter } from "react-router";
 import { t } from "ttag";
-import _ from "underscore";
 
 import { skipToken } from "metabase/api";
 import { useUserSetting } from "metabase/common/hooks";

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionModalFilters.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionModalFilters.tsx
@@ -1,5 +1,4 @@
 import { c, t } from "ttag";
-import _ from "underscore";
 
 import { Flex, Icon, Select, Switch, Text } from "metabase/ui";
 

--- a/enterprise/frontend/src/metabase-enterprise/collections/components/CollectionAuthorityLevelIcon.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/collections/components/CollectionAuthorityLevelIcon.tsx
@@ -1,7 +1,5 @@
 /* eslint-disable react/prop-types */
 
-import _ from "underscore";
-
 import { color } from "metabase/lib/colors";
 import type { CollectionAuthorityLevelIcon as CollectionAuthorityLevelIconComponent } from "metabase/plugins/index";
 import { Icon } from "metabase/ui";

--- a/enterprise/frontend/src/metabase-enterprise/content_verification/metrics.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_verification/metrics.tsx
@@ -26,7 +26,7 @@ export const MetricFilterControls = ({
 }: MetricFilterControlsProps) => {
   const areAnyFiltersActive = Object.values(metricFilters).some(Boolean);
 
-  const [_, setUserSetting] = useUserSetting(USER_SETTING_KEY);
+  const [_userSetting, setUserSetting] = useUserSetting(USER_SETTING_KEY);
 
   const handleVerifiedFilterChange = useCallback(
     function (evt: ChangeEvent<HTMLInputElement>) {

--- a/enterprise/frontend/src/metabase-enterprise/content_verification/models.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_verification/models.tsx
@@ -26,7 +26,7 @@ export const ModelFilterControls = ({
 }: ModelFilterControlsProps) => {
   const areAnyFiltersActive = Object.values(modelFilters).some(Boolean);
 
-  const [_, setUserSetting] = useUserSetting(USER_SETTING_KEY);
+  const [_userSetting, setUserSetting] = useUserSetting(USER_SETTING_KEY);
 
   const handleVerifiedFilterChange = useCallback(
     function (evt: ChangeEvent<HTMLInputElement>) {

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewBanner/ModerationReviewBanner.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewBanner/ModerationReviewBanner.tsx
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import { getCurrentUser } from "metabase/admin/datamodel/selectors";
 import { skipToken, useGetUserQuery } from "metabase/api";
 import { alpha, color } from "metabase/lib/colors";

--- a/enterprise/frontend/src/metabase-enterprise/troubleshooting/components/QueryValidator.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/troubleshooting/components/QueryValidator.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from "react";
 import { Link } from "react-router";
 import { jt, t } from "ttag";
-import _ from "underscore";
 
 import { useGetCollectionQuery } from "metabase/api";
 import {

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ChartColorSettings/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ChartColorSettings/utils.ts
@@ -33,7 +33,7 @@ export const getAutoChartColors = (
 
   const newValues = groups
     .map(([name], index) => [name, newColors[index]?.hex()])
-    .filter(([_, value]) => value != null);
+    .filter(([_name, value]) => value != null);
 
   return { ...values, ...Object.fromEntries(newValues) };
 };
@@ -45,7 +45,7 @@ const getAutoColors = (
   const oldColor = oldColors.find(color => color != null);
 
   const autoColors: Color[] = [];
-  oldColors.forEach((_, index) => {
+  oldColors.forEach((_color, index) => {
     if (index === 0 && !oldColor) {
       autoColors.push(fallbackColor);
     } else if (index === 0 && oldColor) {

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/lib/loading-message.ts
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/lib/loading-message.ts
@@ -8,11 +8,11 @@ export const LOADING_MESSAGE_BY_SETTING = {
   },
   "running-query": {
     name: t`Running query...`,
-    value: (_: boolean) => t`Running query...`,
+    value: (_isSlow: boolean) => t`Running query...`,
   },
   "loading-results": {
     name: t`Loading results...`,
-    value: (_: boolean) => t`Loading results...`,
+    value: (_isSlow: boolean) => t`Loading results...`,
   },
 };
 

--- a/frontend/src/metabase-lib/v1/expressions/format.ts
+++ b/frontend/src/metabase-lib/v1/expressions/format.ts
@@ -107,7 +107,7 @@ function formatMetric([, metricId]: FieldReference, options: Options) {
   }
 
   const metric = Lib.availableMetrics(query, stageIndex).find(metric => {
-    const [_, availableMetricId] = Lib.legacyRef(query, stageIndex, metric);
+    const [_type, availableMetricId] = Lib.legacyRef(query, stageIndex, metric);
 
     return availableMetricId === metricId;
   });
@@ -129,7 +129,11 @@ function formatSegment([, segmentId]: FieldReference, options: Options) {
   }
 
   const segment = Lib.availableSegments(query, stageIndex).find(segment => {
-    const [_, availableSegmentId] = Lib.legacyRef(query, stageIndex, segment);
+    const [_type, availableSegmentId] = Lib.legacyRef(
+      query,
+      stageIndex,
+      segment,
+    );
 
     return availableSegmentId === segmentId;
   });

--- a/frontend/src/metabase-lib/v1/expressions/pratt/compiler.ts
+++ b/frontend/src/metabase-lib/v1/expressions/pratt/compiler.ts
@@ -259,7 +259,7 @@ function compileInfixOp(node: Node, opts: Options) {
   const text = node.token?.text;
   let left: any = leftFn(node.children[0], opts);
   if (Array.isArray(left) && left[0]?.toUpperCase() === text?.toUpperCase()) {
-    const [_, ...args] = left;
+    const [_first, ...args] = left;
     left = args;
   } else {
     left = [left];

--- a/frontend/src/metabase-types/api/mocks/entity-id.ts
+++ b/frontend/src/metabase-types/api/mocks/entity-id.ts
@@ -1,5 +1,4 @@
 import { nanoid } from "@reduxjs/toolkit";
-import _ from "underscore";
 
 import { type BaseEntityId, NANOID_LENGTH } from "../entity-id";
 

--- a/frontend/src/metabase/admin/datamodel/metadata/components/SemanticTypeAndTargetPicker/SemanticTypeAndTargetPicker.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/SemanticTypeAndTargetPicker/SemanticTypeAndTargetPicker.tsx
@@ -126,7 +126,7 @@ const SemanticTypeAndTargetPicker = ({
           searchProp="name"
           searchCaseSensitive={false}
         >
-          {currency.map(([_, c]: CurrencyOption[]) => (
+          {currency.map(([_symbol, c]: CurrencyOption[]) => (
             <Option name={c.name} value={c.code} key={c.code}>
               <span className={cx(CS.flex, CS.full, CS.alignCenter)}>
                 <span>{c.name}</span>

--- a/frontend/src/metabase/admin/permissions/permissions.js
+++ b/frontend/src/metabase/admin/permissions/permissions.js
@@ -1,7 +1,6 @@
 import { assocIn, merge } from "icepick";
 import { push } from "react-router-redux";
 import { t } from "ttag";
-import _ from "underscore";
 
 import {
   inferAndUpdateEntityPermissions,

--- a/frontend/src/metabase/admin/permissions/utils/graph/data-permissions/get.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/data-permissions/get.ts
@@ -1,5 +1,4 @@
 import { getIn } from "icepick";
-import _ from "underscore";
 
 import type {
   DatabaseEntityId,

--- a/frontend/src/metabase/admin/permissions/utils/graph/data-permissions/utils.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/data-permissions/utils.ts
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import { DataPermissionValue } from "metabase/admin/permissions/types";
 import { PLUGIN_ADVANCED_PERMISSIONS } from "metabase/plugins";
 

--- a/frontend/src/metabase/admin/permissions/utils/graph/partial-updates.unit.spec.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/partial-updates.unit.spec.ts
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import type { GroupsPermissions } from "metabase-types/api";
 
 import { DataPermission, DataPermissionValue } from "../../types";

--- a/frontend/src/metabase/admin/permissions/utils/metadata.ts
+++ b/frontend/src/metabase/admin/permissions/utils/metadata.ts
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type Table from "metabase-lib/v1/metadata/Table";
 import type { ConcreteTableId } from "metabase-types/api";

--- a/frontend/src/metabase/admin/settings/notifications/utils.ts
+++ b/frontend/src/metabase/admin/settings/notifications/utils.ts
@@ -34,7 +34,7 @@ export const channelToForm = ({ details }: NotificationChannel) => {
 
     if (encoded) {
       const decoded = atob(encoded);
-      const [_, username, password] = decoded.match(/(.*):(.*)/) || [];
+      const [_match, username, password] = decoded.match(/(.*):(.*)/) || [];
 
       if (username && password) {
         return {

--- a/frontend/src/metabase/admin/tasks/components/Logs/Logs.tsx
+++ b/frontend/src/metabase/admin/tasks/components/Logs/Logs.tsx
@@ -1,9 +1,8 @@
 import cx from "classnames";
-import { useMemo, useState } from "react";
 import * as React from "react";
+import { useMemo, useState } from "react";
 import reactAnsiStyle from "react-ansi-style";
 import { t } from "ttag";
-import _ from "underscore";
 
 import Select, { Option } from "metabase/core/components/Select";
 import CS from "metabase/css/core/index.css";

--- a/frontend/src/metabase/admin/tasks/components/Logs/hooks.ts
+++ b/frontend/src/metabase/admin/tasks/components/Logs/hooks.ts
@@ -2,7 +2,6 @@ import { useInterval } from "@mantine/hooks";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useMount, useUnmount } from "react-use";
 import { t } from "ttag";
-import _ from "underscore";
 
 import { UtilApi } from "metabase/services";
 import type { Log } from "metabase-types/api";

--- a/frontend/src/metabase/browse/models/utils.ts
+++ b/frontend/src/metabase/browse/models/utils.ts
@@ -1,5 +1,4 @@
 import { t } from "ttag";
-import _ from "underscore";
 
 import { getCollectionPathAsString } from "metabase/collections/utils";
 import { entityForObject } from "metabase/lib/schema";

--- a/frontend/src/metabase/collections/containers/FormAuthorityLevelFieldContainer.tsx
+++ b/frontend/src/metabase/collections/containers/FormAuthorityLevelFieldContainer.tsx
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import { useSelector } from "metabase/lib/redux";
 import { PLUGIN_COLLECTION_COMPONENTS } from "metabase/plugins";
 import { getUserIsAdmin } from "metabase/selectors/user";

--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -1,5 +1,4 @@
 import { t } from "ttag";
-import _ from "underscore";
 
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 import type {

--- a/frontend/src/metabase/common/components/CollectionPicker/components/NewCollectionDialog.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/NewCollectionDialog.unit.spec.tsx
@@ -40,7 +40,7 @@ describe("new collection dialog", () => {
     const apiCalls = fetchMock.calls("path:/api/collection");
     expect(apiCalls).toHaveLength(1);
 
-    const [_, options] = apiCalls[0];
+    const [_url, options] = apiCalls[0];
     const body = JSON.parse((await options?.body) as string);
     expect(body.parent_id).toBe(null);
   });
@@ -56,7 +56,7 @@ describe("new collection dialog", () => {
     const apiCalls = fetchMock.calls("path:/api/collection");
     expect(apiCalls).toHaveLength(1);
 
-    const [_, options] = apiCalls[0];
+    const [_url, options] = apiCalls[0];
     const body = JSON.parse((await options?.body) as string);
     expect(body.parent_id).toBe(12);
   });
@@ -72,7 +72,7 @@ describe("new collection dialog", () => {
     const apiCalls = fetchMock.calls("path:/api/collection");
     expect(apiCalls).toHaveLength(1);
 
-    const [_, options] = apiCalls[0];
+    const [_url, options] = apiCalls[0];
     const body = JSON.parse((await options?.body) as string);
     expect(body.parent_id).toBe(null);
   });

--- a/frontend/src/metabase/common/components/DashboardPicker/components/NewDashboardDialog.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/NewDashboardDialog.unit.spec.tsx
@@ -40,7 +40,7 @@ describe("new collection dialog", () => {
     const apiCalls = fetchMock.calls("path:/api/dashboard");
     expect(apiCalls).toHaveLength(1);
 
-    const [_, options] = apiCalls[0];
+    const [_url, options] = apiCalls[0];
     const body = JSON.parse((await options?.body) as string);
     expect(body.collection_id).toBe(null);
   });
@@ -56,7 +56,7 @@ describe("new collection dialog", () => {
     const apiCalls = fetchMock.calls("path:/api/dashboard");
     expect(apiCalls).toHaveLength(1);
 
-    const [_, options] = apiCalls[0];
+    const [_url, options] = apiCalls[0];
     const body = JSON.parse((await options?.body) as string);
     expect(body.collection_id).toBe(12);
   });
@@ -72,7 +72,7 @@ describe("new collection dialog", () => {
     const apiCalls = fetchMock.calls("path:/api/dashboard");
     expect(apiCalls).toHaveLength(1);
 
-    const [_, options] = apiCalls[0];
+    const [_url, options] = apiCalls[0];
     const body = JSON.parse((await options?.body) as string);
     expect(body.collection_id).toBe(null);
   });

--- a/frontend/src/metabase/components/Badge/Badge.tsx
+++ b/frontend/src/metabase/components/Badge/Badge.tsx
@@ -1,6 +1,5 @@
 import cx from "classnames";
 import type { PropsWithChildren } from "react";
-import _ from "underscore";
 
 import CS from "metabase/css/core/index.css";
 import type { IconName, IconProps } from "metabase/ui";

--- a/frontend/src/metabase/components/MetadataInfo/TableInfo/TableInfo.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfo/TableInfo.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import { t } from "ttag";
-import _ from "underscore";
 
 import Tables from "metabase/entities/tables";
 import { useSafeAsyncFunction } from "metabase/hooks/use-safe-async-function";

--- a/frontend/src/metabase/components/MoveQuestionsIntoDashboardsModal/ConfirmMoveDashboardQuestionCandidatesModal.tsx
+++ b/frontend/src/metabase/components/MoveQuestionsIntoDashboardsModal/ConfirmMoveDashboardQuestionCandidatesModal.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from "react";
 import { P, match } from "ts-pattern";
 import { msgid, ngettext, t } from "ttag";
-import _ from "underscore";
 
 import { Button, Flex, Icon, Loader, Modal, Text } from "metabase/ui";
 import type { GetCollectionDashboardQuestionCandidatesResult } from "metabase-types/api";

--- a/frontend/src/metabase/components/MoveQuestionsIntoDashboardsModal/MoveQuestionsIntoDashboardsInfoModal.tsx
+++ b/frontend/src/metabase/components/MoveQuestionsIntoDashboardsModal/MoveQuestionsIntoDashboardsInfoModal.tsx
@@ -1,5 +1,4 @@
 import { t } from "ttag";
-import _ from "underscore";
 
 import { Button, Flex, Icon, List, Modal } from "metabase/ui";
 

--- a/frontend/src/metabase/components/MoveQuestionsIntoDashboardsModal/MoveQuestionsIntoDashboardsModal.tsx
+++ b/frontend/src/metabase/components/MoveQuestionsIntoDashboardsModal/MoveQuestionsIntoDashboardsModal.tsx
@@ -4,7 +4,6 @@ import { useEffect } from "react";
 import { withRouter } from "react-router";
 import { replace } from "react-router-redux";
 import { t } from "ttag";
-import _ from "underscore";
 
 import {
   skipToken,

--- a/frontend/src/metabase/components/Schedule/constants.unit.spec.ts
+++ b/frontend/src/metabase/components/Schedule/constants.unit.spec.ts
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import { has24HourModeSetting } from "metabase/lib/time";
 
 import { getHours } from "./constants";

--- a/frontend/src/metabase/css/core/overlays/OverlaysDemo.tsx
+++ b/frontend/src/metabase/css/core/overlays/OverlaysDemo.tsx
@@ -220,7 +220,7 @@ export const OverlaysDemo = ({ enableNesting }: OverlaysDemoProps) => {
           <UndoToasts undoCount={undoCount} setUndoCount={setUndoCount} />
         </UndoListOverlay>
       )}
-      {Array.from({ length: actionToastCount }).map((_, index) => (
+      {Array.from({ length: actionToastCount }).map((_value, index) => (
         <BulkActionBarPortal
           key={`simple-bulk-action-bar-${index}`}
           opened
@@ -237,7 +237,7 @@ export const OverlaysDemo = ({ enableNesting }: OverlaysDemoProps) => {
           {enableNesting && <Launchers />}
         </BulkActionBarPortal>
       ))}
-      {Array.from({ length: toastCount }).map((_, index) => (
+      {Array.from({ length: toastCount }).map((_value, index) => (
         <Toaster
           key={`toaster-${index}`}
           message="Toaster-style toast text content"
@@ -292,7 +292,7 @@ export const OverlaysDemo = ({ enableNesting }: OverlaysDemoProps) => {
         </SimpleModal>
       ))}
       {Array.from({ length: mantineModalWithTitlePropCount }).map(
-        (_, index) => (
+        (_value, index) => (
           <MantineModal
             opened
             key={`mantine-modal-with-title-prop-${index}`}
@@ -304,7 +304,7 @@ export const OverlaysDemo = ({ enableNesting }: OverlaysDemoProps) => {
           </MantineModal>
         ),
       )}
-      {Array.from({ length: sidesheetCount }).map((_, index) => (
+      {Array.from({ length: sidesheetCount }).map((_value, index) => (
         <Sidesheet
           key={`sidesheet-${index}`}
           isOpen
@@ -315,7 +315,7 @@ export const OverlaysDemo = ({ enableNesting }: OverlaysDemoProps) => {
           {enableNesting && <Launchers />}
         </Sidesheet>
       ))}
-      {Array.from({ length: entityPickerCount }).map((_, index) => (
+      {Array.from({ length: entityPickerCount }).map((_value, index) => (
         <EntityPickerModal
           key={`entity-picker-${index}`}
           title={`Entity Picker content`}
@@ -325,7 +325,7 @@ export const OverlaysDemo = ({ enableNesting }: OverlaysDemoProps) => {
           onClose={() => {
             setEntityPickerCount(c => c - 1);
           }}
-          onItemSelect={(_: any) => {}}
+          onItemSelect={_.noop}
           onConfirm={() => {
             setEntityPickerCount(c => c - 1);
           }}
@@ -338,7 +338,7 @@ export const OverlaysDemo = ({ enableNesting }: OverlaysDemoProps) => {
           )}
         </EntityPickerModal>
       ))}
-      {Array.from({ length: commandPaletteCount }).map((_, index) => {
+      {Array.from({ length: commandPaletteCount }).map((_value, index) => {
         const modalTitleId = `command-palette-title-${index}`;
         return (
           <PaletteCard

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
@@ -1,7 +1,6 @@
 import type { MouseEvent } from "react";
 import { memo, useCallback, useState } from "react";
 import { t } from "ttag";
-import _ from "underscore";
 
 import { isActionDashCard } from "metabase/actions/utils";
 import { isLinkDashCard, isVirtualDashCard } from "metabase/dashboard/utils";

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapperContent.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapperContent.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import { useMount } from "react-use";
 import { t } from "ttag";
-import _ from "underscore";
 
 import { Ellipsified } from "metabase/core/components/Ellipsified";
 import CS from "metabase/css/core/index.css";

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardInfoSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardInfoSidebar.tsx
@@ -2,7 +2,6 @@ import type { FocusEvent } from "react";
 import { useCallback, useMemo, useState } from "react";
 import { useMount } from "react-use";
 import { t } from "ttag";
-import _ from "underscore";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
 import { isInstanceAnalyticsCollection } from "metabase/collections/utils";

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useMemo } from "react";
 import { t } from "ttag";
-import _ from "underscore";
 import * as Yup from "yup";
 
 import { useCreateDashboardMutation } from "metabase/api";

--- a/frontend/src/metabase/entities/containers/rtk-query/types/rtk.ts
+++ b/frontend/src/metabase/entities/containers/rtk-query/types/rtk.ts
@@ -32,7 +32,7 @@ type UseQuerySubscriptionResult<D extends QueryDefinition<any, any, any, any>> =
   Pick<QueryActionCreatorResult<D>, "refetch">;
 
 type UseQueryStateResult<
-  _ extends QueryDefinition<any, any, any, any>,
+  _D extends QueryDefinition<any, any, any, any>,
   R,
 > = TSHelpersNoInfer<R>;
 

--- a/frontend/src/metabase/forms/components/FormChipGroup/FormChipGroup.tsx
+++ b/frontend/src/metabase/forms/components/FormChipGroup/FormChipGroup.tsx
@@ -25,7 +25,7 @@ export const FormChipGroup = forwardRef(function FormChipGroup(
   }: FormChipGroupProps,
   ref: Ref<HTMLDivElement>,
 ) {
-  const [{ value }, _, { setValue }] = useField(name);
+  const [{ value }, _meta, { setValue }] = useField(name);
 
   const handleChange = useCallback(
     (newValue: string) => {

--- a/frontend/src/metabase/nav/components/CollectionBreadcrumbs/utils.ts
+++ b/frontend/src/metabase/nav/components/CollectionBreadcrumbs/utils.ts
@@ -16,7 +16,7 @@ export const getCollectionList = ({
 
   const ancestors = collection.effective_ancestors || [];
   const hasRoot = ancestors[0] && isRootCollection(ancestors[0]);
-  const [_, ...crumbsWithoutRoot] = ancestors;
+  const [_root, ...crumbsWithoutRoot] = ancestors;
 
   const baseIndex = baseCollectionId
     ? ancestors.findIndex(part => part.id === baseCollectionId)

--- a/frontend/src/metabase/nav/containers/CollectionBreadcrumbs/CollectionBreadcrumbs.tsx
+++ b/frontend/src/metabase/nav/containers/CollectionBreadcrumbs/CollectionBreadcrumbs.tsx
@@ -1,5 +1,4 @@
 import { useLocation } from "react-use";
-import _ from "underscore";
 
 import { useGetCollectionQuery } from "metabase/api";
 import { useSelector } from "metabase/lib/redux";

--- a/frontend/src/metabase/notifications/pulse/components/PulseEditChannels.tsx
+++ b/frontend/src/metabase/notifications/pulse/components/PulseEditChannels.tsx
@@ -2,7 +2,6 @@
 import cx from "classnames";
 import { assoc, updateIn } from "icepick";
 import { t } from "ttag";
-import _ from "underscore";
 
 import { useListChannelsQuery } from "metabase/api/channel";
 import CS from "metabase/css/core/index.css";

--- a/frontend/src/metabase/notifications/pulse/components/RecipientPicker.tsx
+++ b/frontend/src/metabase/notifications/pulse/components/RecipientPicker.tsx
@@ -1,6 +1,5 @@
 import cx from "classnames";
 import { t } from "ttag";
-import _ from "underscore";
 
 import { useSetting } from "metabase/common/hooks";
 import TokenField from "metabase/components/TokenField";

--- a/frontend/src/metabase/palette/components/test/PaletteResults/PaletteResults-ee.unit.spec.tsx
+++ b/frontend/src/metabase/palette/components/test/PaletteResults/PaletteResults-ee.unit.spec.tsx
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import { screen, within } from "__support__/ui";
 
 import { type CommonSetupProps, commonSetup } from "./setup";

--- a/frontend/src/metabase/palette/components/test/PaletteResults/PaletteResults-oss.unit.spec.tsx
+++ b/frontend/src/metabase/palette/components/test/PaletteResults/PaletteResults-oss.unit.spec.tsx
@@ -1,5 +1,4 @@
 import fetchMock from "fetch-mock";
-import _ from "underscore";
 
 import { screen, waitFor, within } from "__support__/ui";
 import {

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -1,3 +1,4 @@
+import type React from "react";
 import type {
   ComponentType,
   Dispatch,
@@ -5,9 +6,7 @@ import type {
   ReactNode,
   SetStateAction,
 } from "react";
-import type React from "react";
 import { t } from "ttag";
-import _ from "underscore";
 import type { AnySchema } from "yup";
 
 import noResultsSource from "assets/img/no_results.svg";
@@ -297,9 +296,9 @@ export const PLUGIN_COLLECTIONS = {
     [JSON.stringify(AUTHORITY_LEVEL_REGULAR.type)]: AUTHORITY_LEVEL_REGULAR,
   },
   REGULAR_COLLECTION: AUTHORITY_LEVEL_REGULAR,
-  isRegularCollection: (_: Partial<Collection> | Bookmark) => true,
+  isRegularCollection: (_data: Partial<Collection> | Bookmark) => true,
   getCollectionType: (
-    _: Partial<Collection>,
+    _collection: Partial<Collection>,
   ): CollectionAuthorityLevelConfig | CollectionInstanceAnaltyicsConfig =>
     AUTHORITY_LEVEL_REGULAR,
   useGetDefaultCollectionId: null as GetCollectionIdType | null,

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/SemanticTypePicker/SemanticTypePicker.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/SemanticTypePicker/SemanticTypePicker.jsx
@@ -30,7 +30,7 @@ function SemanticTypePicker({
   onChange,
   className,
 }) {
-  const [field, _, { setValue }] = useField(name);
+  const [field, _meta, { setValue }] = useField(name);
 
   const selectButtonRef = useRef();
 

--- a/frontend/src/metabase/query_builder/components/QuestionActivityTimeline.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActivityTimeline.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from "react";
-import _ from "underscore";
 
 import { Timeline } from "metabase/common/components/Timeline";
 import { getTimelineEvents } from "metabase/common/components/Timeline/utils";

--- a/frontend/src/metabase/query_builder/components/SyncedParametersList.tsx
+++ b/frontend/src/metabase/query_builder/components/SyncedParametersList.tsx
@@ -1,6 +1,5 @@
 import querystring from "querystring";
 import { useEffect, useMemo } from "react";
-import _ from "underscore";
 
 import { IS_EMBED_PREVIEW } from "metabase/lib/embed";
 import {

--- a/frontend/src/metabase/query_builder/components/chart-type-selector/use-question-visualization-state.ts
+++ b/frontend/src/metabase/query_builder/components/chart-type-selector/use-question-visualization-state.ts
@@ -72,7 +72,7 @@ export const getSensibleVisualizations = ({
   result,
 }: GetSensibleVisualizationsProps) => {
   const availableVizTypes = Array.from(visualizations.entries())
-    .filter(([_, config]) => !config.hidden)
+    .filter(([_display, config]) => !config.hidden)
     .map(([vizType]) => vizType)
     .filter(isCardDisplayType);
 

--- a/frontend/src/metabase/query_builder/components/dataref/TableInfoLoader.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/TableInfoLoader.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import _ from "underscore";
 
 import Tables from "metabase/entities/tables";
 import { useSafeAsyncFunction } from "metabase/hooks/use-safe-async-function";

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/DefaultRequiredValueControl.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/DefaultRequiredValueControl.tsx
@@ -1,5 +1,4 @@
 import { t } from "ttag";
-import _ from "underscore";
 
 import { RequiredParamToggle } from "metabase/parameters/components/RequiredParamToggle";
 import { Flex, Text } from "metabase/ui";

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.tsx
@@ -1,7 +1,6 @@
 import type { ChangeEvent } from "react";
 import { useRef, useState } from "react";
 import { t } from "ttag";
-import _ from "underscore";
 
 import { UploadInput } from "metabase/components/upload";
 import BookmarkToggle from "metabase/core/components/BookmarkToggle";

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar/ChartTypeSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar/ChartTypeSidebar.tsx
@@ -1,7 +1,6 @@
 import cx from "classnames";
 import { useMemo } from "react";
 import { t } from "ttag";
-import _ from "underscore";
 
 import CS from "metabase/css/core/index.css";
 import { useDispatch } from "metabase/lib/redux";

--- a/frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx
@@ -2,7 +2,6 @@
 import cx from "classnames";
 import { useMemo, useState } from "react";
 import { t } from "ttag";
-import _ from "underscore";
 
 import QuestionResultLoader from "metabase/containers/QuestionResultLoader";
 import Button from "metabase/core/components/Button";

--- a/frontend/src/metabase/querying/viz-settings/utils/sync-viz-settings.ts
+++ b/frontend/src/metabase/querying/viz-settings/utils/sync-viz-settings.ts
@@ -208,7 +208,7 @@ function syncColumnSettings(
     newColumns,
     oldColumns,
     getColumnName: ([key]) => getColumnNameFromKey(key),
-    setColumnName: ([_, setting], name) => [getColumnKey({ name }), setting],
+    setColumnName: ([_key, setting], name) => [getColumnKey({ name }), setting],
     createSetting: column => [getColumnKey(column), {}],
     shouldCreateSetting: () => false,
   });

--- a/frontend/src/metabase/static-viz/components/FunnelChart/utils/funnel.ts
+++ b/frontend/src/metabase/static-viz/components/FunnelChart/utils/funnel.ts
@@ -15,7 +15,7 @@ export const calculateFunnelSteps = (
   funnelHeight: number,
 ): FunnelStep[] => {
   return data.map((datum, index) => {
-    const [_, firstMeasure] = data[0];
+    const [_step, firstMeasure] = data[0];
     const [step, measure] = datum;
     const left = index * stepWidth;
     const height = (measure * funnelHeight) / firstMeasure;

--- a/frontend/src/metabase/static-viz/components/FunnelChart/utils/margin.ts
+++ b/frontend/src/metabase/static-viz/components/FunnelChart/utils/margin.ts
@@ -17,7 +17,7 @@ export const calculateMargin = (
   paddingLeft: number,
   settings: FunnelSettings,
 ) => {
-  const [_, measure] = firstStep;
+  const [_step, measure] = firstStep;
   const formattedFirstMeasure = formatNumber(
     measure,
     settings?.measure?.format,

--- a/frontend/src/metabase/static-viz/components/Legend/utils.ts
+++ b/frontend/src/metabase/static-viz/components/Legend/utils.ts
@@ -227,7 +227,7 @@ export const calculateLegendRowsWithColumns = ({
 
   const colWidth = Math.floor(availableTotalWidth / numCols);
   const rows: PositionedLegendItem[][] = [...Array(numRows).keys()].map(
-    _ => [],
+    () => [],
   );
 
   for (let colIndex = 0; colIndex < numCols; colIndex++) {

--- a/frontend/src/metabase/styled-components/theme/css-variables.ts
+++ b/frontend/src/metabase/styled-components/theme/css-variables.ts
@@ -48,7 +48,7 @@ function getSdkDesignSystemCssVariables(theme: MantineTheme) {
     /* Semantic colors */
     /* Dynamic colors from SDK */
     ${Object.entries(SDK_TO_MAIN_APP_COLORS_MAPPING).flatMap(
-      ([_, metabaseColorNames]) => {
+      ([_key, metabaseColorNames]) => {
         return metabaseColorNames.map(metabaseColorName => {
           /**
            * Prevent returning the primary color when color is not found,

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/EChartsTooltip/EChartsTooltip.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/EChartsTooltip/EChartsTooltip.tsx
@@ -1,6 +1,5 @@
 import cx from "classnames";
 import type React from "react";
-import _ from "underscore";
 
 import { isNotNull } from "metabase/lib/types";
 

--- a/frontend/src/metabase/visualizations/components/legend/LegendLayout.jsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendLayout.jsx
@@ -1,5 +1,4 @@
 import PropTypes from "prop-types";
-import _ from "underscore";
 
 import Legend from "./Legend";
 import LegendActions from "./LegendActions";

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingInput.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingInput.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import _ from "underscore";
 
 import { TextInput } from "metabase/ui";
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.tsx
@@ -1,5 +1,4 @@
 import { type ChangeEvent, useState } from "react";
-import _ from "underscore";
 
 import { TextInput } from "metabase/ui";
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/trend-line.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/trend-line.ts
@@ -1,5 +1,4 @@
 import Color from "color";
-import _ from "underscore";
 
 import { checkNumber, isNotNull } from "metabase/lib/types";
 import { X_AXIS_DATA_KEY } from "metabase/visualizations/echarts/cartesian/constants/dataset";

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/trend-line.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/trend-line.ts
@@ -1,5 +1,4 @@
 import type { LineSeriesOption } from "echarts/charts";
-import _ from "underscore";
 
 import { X_AXIS_DATA_KEY } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/scatter/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/scatter/option/series.ts
@@ -39,7 +39,7 @@ function getBubbleDiameterScale(
     // Then we plug the normalized value `t` into the `areaScale` to get the corrseponding area for that diameter.
     // We then take this area and convert it back to a diameter value
     // if area = π × (diameter ÷ 2)², then diameter = (2 × √area) ÷ π
-    .interpolate((_, _2) => t => (2 * Math.sqrt(areaScale(t))) / Math.PI)
+    .interpolate(() => t => (2 * Math.sqrt(areaScale(t))) / Math.PI)
     // Finally, D3 linearly maps that value into our defined min/max range.
     .range([MIN_BUBBLE_DIAMETER, MAX_BUBBLE_DIAMETER]);
 

--- a/frontend/src/metabase/visualizations/echarts/tooltip/index.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/tooltip/index.unit.spec.ts
@@ -1,7 +1,6 @@
 import { renderHook } from "@testing-library/react-hooks";
 import type { EChartsType } from "echarts/core";
 import type { MutableRefObject } from "react";
-import _ from "underscore";
 
 import {
   TOOLTIP_POINTER_MARGIN,

--- a/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
+++ b/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
@@ -1,5 +1,4 @@
 import { t } from "ttag";
-import _ from "underscore";
 
 import { DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_ID } from "metabase/dashboard/constants";
 import type { Dashboard } from "metabase-types/api";

--- a/frontend/src/metabase/visualizations/lib/settings/utils.js
+++ b/frontend/src/metabase/visualizations/lib/settings/utils.js
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import {
   columnsAreValid,
   getDefaultDimensionAndMetric,

--- a/frontend/src/metabase/visualizations/lib/timeseries.js
+++ b/frontend/src/metabase/visualizations/lib/timeseries.js
@@ -1,5 +1,4 @@
 import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
-import _ from "underscore";
 
 import { isDate } from "metabase-lib/v1/types/utils/isa";
 

--- a/frontend/src/metabase/visualizations/lib/trends.js
+++ b/frontend/src/metabase/visualizations/lib/trends.js
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 // mappings of allowed operators
 const EXPRESSION_OPERATORS = new Map([
   ["+", (...args) => args.reduce((x, y) => x + y)],

--- a/frontend/src/metabase/visualizations/visualizations/IFrameViz/IFrameViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/IFrameViz/IFrameViz.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useMemo } from "react";
 import { jt, t } from "ttag";
-import _ from "underscore";
 
 import { useDocsUrl, useSetting } from "metabase/common/hooks";
 import ExternalLink from "metabase/core/components/ExternalLink";

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/use-chart-events.ts
@@ -1,7 +1,6 @@
 import type { EChartsType } from "echarts/core";
 import { type MutableRefObject, useEffect, useMemo } from "react";
 import { t } from "ttag";
-import _ from "underscore";
 
 import { checkNotNull } from "metabase/lib/types";
 import { formatPercent } from "metabase/static-viz/lib/numbers";

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/SankeyChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/SankeyChart.tsx
@@ -1,6 +1,5 @@
 import type { EChartsType } from "echarts/core";
 import { useCallback, useMemo, useRef } from "react";
-import _ from "underscore";
 
 import { extractRemappings } from "metabase/visualizations";
 import { ResponsiveEChartsRenderer } from "metabase/visualizations/components/EChartsRenderer";

--- a/frontend/test/__support__/events.ts
+++ b/frontend/test/__support__/events.ts
@@ -20,6 +20,6 @@ export const callMockEvent: CallMockEventType = (
 
   mockEventListener.mock.calls
     .filter(([event]) => eventName === event)
-    .forEach(([_, callback]) => callback(mockEvent));
+    .forEach(([_event, callback]) => callback(mockEvent));
   return mockEvent;
 };


### PR DESCRIPTION
### Description

We've had a bunch of unused underscore imports throughout the code because the rule config allowed `_` identifier to be left unused.

### Demo
[before](https://github.com/user-attachments/assets/917c9a01-f639-46e8-9e21-d31be9434ffd) vs [after](https://github.com/user-attachments/assets/609b5f0f-2a14-4fff-9917-d44c42370aed)
