### PR TITLE
feat(sdk): pro license setup in cli defaults to false

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/cli/steps/setup-license.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/setup-license.ts
@@ -22,7 +22,7 @@ export const setupLicense: CliStepMethod = async state => {
 
   const shouldSetupLicense = await toggle({
     message: "Do you want to set up a Pro license?",
-    default: true,
+    default: false,
   });
 
   if (!shouldSetupLicense) {


### PR DESCRIPTION
"Do you want to set up a Pro license?" step should default to false, as it is a lot easier to get started without multi-tenancy and SSO.