### PR TITLE
feat(sdk): abort cli with message when react version is unsupported

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
@@ -27,8 +27,12 @@ export const MISSING_REACT_DEPENDENCY = `
 `;
 
 export const UNSUPPORTED_REACT_VERSION = `
-  Your package.json file contains an unsupported React version.
-  Please make sure your package.json file contains a dependency for React 18.
+  Your app uses a version of React that is not supported.
+  See https://metaba.se/sdk-docs
+
+  Try downloading and running one of our samples instead:
+  - React: https://metaba.se/sdk-sample-react
+  - Next.js: https://metaba.se/sdk-sample-next
 `;
 
 export const DELETE_CONTAINER_MESSAGE = `Please delete the container with "docker rm -f ${CONTAINER_NAME}" and try again.`;

--- a/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
@@ -32,7 +32,7 @@ export const UNSUPPORTED_REACT_VERSION = `
 
   Try downloading and running one of our samples instead:
   - React: https://metaba.se/sdk-sample-react
-  - Next.js: https://metaba.se/sdk-sample-next
+  - Next.js: https://metaba.se/sdk-sample-nextjs
 `;
 
 export const DELETE_CONTAINER_MESSAGE = `Please delete the container with "docker rm -f ${CONTAINER_NAME}" and try again.`;

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/check-if-react-project.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/check-if-react-project.ts
@@ -12,7 +12,6 @@ import {
   getPackageVersions,
   hasPackageJson,
 } from "../utils/get-package-version";
-import { showWarningAndAskToContinue } from "../utils/show-warning-prompt";
 
 const isReactVersionSupported = (version: string) =>
   semver.satisfies(semver.coerce(version)!, "18.x");
@@ -37,22 +36,24 @@ export const checkIfReactProject: CliStepMethod = async state => {
     isReactVersionSupported(reactDep) &&
     isReactVersionSupported(reactDomDep);
 
-  let warningMessage: string | null = null;
+  let errorMessage: string | null = null;
 
   if (!hasReactDependency) {
-    warningMessage = MISSING_REACT_DEPENDENCY;
+    errorMessage = MISSING_REACT_DEPENDENCY;
   } else if (!hasSupportedReactVersion) {
-    warningMessage = UNSUPPORTED_REACT_VERSION;
+    errorMessage = UNSUPPORTED_REACT_VERSION;
   }
 
-  if (warningMessage) {
+  if (errorMessage) {
     spinner.fail();
 
-    const shouldContinue = await showWarningAndAskToContinue(warningMessage);
-
-    if (!shouldContinue) {
-      return [{ type: "error", message: "Canceled." }, state];
-    }
+    return [
+      {
+        type: "error",
+        message: errorMessage,
+      },
+      state,
+    ];
   } else {
     spinner.succeed(`React ${reactDep} and React DOM ${reactDomDep} found`);
   }


### PR DESCRIPTION
Closes EMB-131

Improves the message shown when the CLI encounters an unsupported React version

![image](https://github.com/user-attachments/assets/f3e35f3f-f900-4c96-b7d9-2c87e54e6b46)
