### PR TITLE
fix(api-openapi): documentation responsivity

### DIFF
--- a/resources/openapi/index.html
+++ b/resources/openapi/index.html
@@ -2,6 +2,9 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1" />
     <title>Metabase API doc</title>
     <link href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,400;0,700;0,900;1,400;1,700&display=swap" rel="stylesheet" />
   </head>


### PR DESCRIPTION
### Description

currently the api documentation [as seen here](https://www.metabase.com/docs/latest/api) is not being displayed properly on mobile devices. this pr adds a missing meta viewport to `index.html` open api ressource.

### How to verify

1. Use mobile device
1. Navigate to Metabase api documentation

### Demo

| before | after |
| -------|------|
| <img width="312" alt="image" src="https://github.com/user-attachments/assets/8c57db04-d21e-46ae-97ef-1d0046a8c041" /> | <img width="312" alt="image" src="https://github.com/user-attachments/assets/04dedfc2-ac61-4b17-9d3e-3d2c1eab1ecc" /> |
| documentation not responsive on mobile | documentation responsive to mobile viewport | 
