### PR TITLE
add eslint rule that prevents incorrect order of helpers

### DIFF
--- a/e2e/.eslintrc
+++ b/e2e/.eslintrc
@@ -46,7 +46,8 @@
       }
     ],
     "no-direct-helper-import": 2,
-    "no-unsafe-element-filtering": ["warn"]
+    "no-unsafe-element-filtering": ["warn"],
+    "no-unordered-test-helpers": 2
   },
   "env": {
     "cypress/globals": true,

--- a/frontend/lint/eslint-rules/no-unordered-test-helpers.js
+++ b/frontend/lint/eslint-rules/no-unordered-test-helpers.js
@@ -1,0 +1,64 @@
+/**
+ * @fileoverview Rule to enforce H.restore() must come before H.resetTestTable()
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const ERROR_MESSAGE = "H.restore() must come before H.resetTestTable()";
+
+// eslint-disable-next-line import/no-commonjs
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Enforce H.restore() must be called before H.resetTestTable()",
+    },
+    schema: [], // no options
+  },
+  create(context) {
+    const stack = [{ hasRestore: false }];
+
+    return {
+      // Push new scope for describe blocks
+      "CallExpression[callee.name='describe']"() {
+        stack.push({ hasRestore: stack[stack.length - 1].hasRestore });
+      },
+
+      // Pop scope when leaving describe blocks
+      "CallExpression[callee.name='describe']:exit"() {
+        stack.pop();
+      },
+
+      CallExpression(node) {
+        if (
+          node.callee.type === "MemberExpression" &&
+          node.callee.object.name === "H"
+        ) {
+          const currentScope = stack[stack.length - 1];
+
+          if (node.callee.property.name === "restore") {
+            currentScope.hasRestore = true;
+          } else if (node.callee.property.name === "resetTestTable") {
+            const hasRestoreInHierarchy = stack.some(scope => scope.hasRestore);
+
+            if (!hasRestoreInHierarchy) {
+              context.report({
+                node,
+                message: ERROR_MESSAGE,
+              });
+            }
+          }
+        }
+      },
+
+      // Reset state for each test file
+      Program() {
+        stack.length = 1;
+        stack[0] = { hasRestore: false };
+      },
+    };
+  },
+};

--- a/frontend/lint/tests/no-unordered-test-helpers.unit.spec.js
+++ b/frontend/lint/tests/no-unordered-test-helpers.unit.spec.js
@@ -1,0 +1,88 @@
+import { RuleTester } from "eslint";
+
+import rule from "../eslint-rules/no-unordered-test-helpers";
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } });
+
+const orderError = {
+  message: "H.restore() must come before H.resetTestTable()",
+};
+
+const blockTypes = ["it", "before", "beforeEach", "describe"];
+
+const blockWrapper = (content, blockType = "it") => `
+  ${blockType}('should test something', () => {
+    ${content}
+  });
+`;
+
+const validCases = [
+  // Simple case - restore before reset
+  `H.restore();
+   H.resetTestTable();`,
+
+  // Multiple resets after restore
+  `H.restore();
+   H.resetTestTable();
+   H.resetTestTable();`,
+
+  // Nested describe with inherited restore
+  `describe('outer', () => {
+    before(() => {
+      H.restore();
+    });
+
+    describe('inner', () => {
+      it('test', () => {
+        H.resetTestTable();
+      });
+    });
+  });`,
+
+  // Restore in before hook
+  `before(() => {
+    H.restore();
+  });
+
+  it('test', () => {
+    H.resetTestTable();
+  });`,
+];
+
+const invalidCases = [
+  // Reset before restore
+  `H.resetTestTable();
+   H.restore();`,
+
+  // Reset without restore
+  `H.resetTestTable();`,
+
+  // Reset in nested describe without restore
+  `describe('outer', () => {
+    describe('inner', () => {
+      it('test', () => {
+        H.resetTestTable();
+      });
+    });
+  });`,
+
+  // Reset in before without restore
+  `before(() => {
+    H.resetTestTable();
+  });`,
+];
+
+ruleTester.run("no-unordered-test-helpers", rule, {
+  valid: blockTypes.flatMap(blockType =>
+    validCases.map(testCase => ({
+      code: blockWrapper(testCase, blockType),
+    })),
+  ),
+
+  invalid: blockTypes.flatMap(blockType =>
+    invalidCases.map(testCase => ({
+      code: blockWrapper(testCase, blockType),
+      errors: [orderError],
+    })),
+  ),
+});


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/DEV-91/write-lint-rule-to-prevent-writable-db-bugs

### Description

Add a rule that will prevent developers from accidentally writing our `H.restore()` and `H.resetTestTable()` helpers in a wrong order.

## Allowed usage

```
it('test', () => {
  H.restore();
  H.resetTestTable();
})
```

```
before(() => {
  H.restore();
})

it('test', () => {
  H.resetTestTable();
})
```

```
describe('group', () => {
  before(() => {
    H.restore();
  })

  it('test', () => {
    H.resetTestTable();
  })
})
```

```
describe('group', () => {
  before(() => {
    H.restore();
  })

  describe('subgroup', () => {
    it('test', () => {
      H.resetTestTable();
    })
  })
})
```

## Disallowed usage
```
it('test', () => {
  H.resetTestTable();
  H.restore();
})
```

```
// no H.restore() in test
it('test', () => {
  H.resetTestTable();
})
```

```
it('test #1',  () => {
  H.resetTestTable();
})

it('test #2', () => {
  H.restore();
})
```

```
before(() => {
  H.resetTestTable();
})
  
it('test', () => {
  H.restore();
})
```

```
describe('group', () => {
  it('test', () => {
    H.resetTestTable();
  })
})
```

```
describe('group', () => {
  before(() => {
    H.resetTestTable();
  })

  describe('subgroup', () => {
    it('test', () => {
      H.restore();
    })
  })
})
```