### PR TITLE
[WIP][Gentest] Various fixes

### DIFF
--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -821,7 +821,7 @@
                      "options" [:optional StringFilterOptions])
      ;; Multi-arg form
      (helpers/clause (keyword (name clause-keyword))
-                     "options" StringFilterOptions
+                     "options" [:maybe StringFilterOptions]
                      "field" StringExpressionArg
                      "string-or-field" StringExpressionArg
                      "second-string-or-field" StringExpressionArg

--- a/test/metabase/query_processor_test/filter_test.clj
+++ b/test/metabase/query_processor_test/filter_test.clj
@@ -509,6 +509,27 @@
                  :order-by [[:asc $id]]
                  :limit 3})))))))
 
+;;; --------------------------- starts-with, ends-with, contains, does-not-contain combined ---------------------------
+
+(deftest ^:parallel string-predicates-higher-arity-test
+  (mt/test-drivers
+   (mt/normal-drivers)
+   (doseq [f [:starts-with :ends-with :contains :does-not-contain]]
+     (testing (format "3+ incl. arity of `%s` should be fine with `nil` valued options" f)
+       (let [result (mt/run-mbql-query venues
+                                       {:filter   [f nil $name "Red Medicine" "Stout Burgers & Beers"]
+                                        :order-by [[:asc $id]]
+                                        :limit 2})]
+         (is (= :completed
+                (:status result)))
+         (if (= :does-not-contain f)
+           (is (= [[3 "The Apple Pan" 11 34.0406 -118.428 2]
+                   [4 "Wurstküche" 29 33.9997 -118.465 2]]
+                  (mt/formatted-rows :venues result)))
+           (is (= [[1 "Red Medicine" 4 10.0646 -165.374 3]
+                   [2 "Stout Burgers & Beers" 11 34.0996 -118.329 2]]
+                  (mt/formatted-rows :venues result)))))))))
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                             NESTED AND/OR CLAUSES                                              |
 ;;; +----------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
WIP

### StringFilterOptions schema fix, 1784144538647289715, qgen-milestone-1: 1ab194f3aa87d7e16456b3b90fd2b900bd07fe2a
Schema for multiarity string predicates was too strict. We explicitly `nil` empty maps in `metabase.legacy-mbql.normalize/remove-empty-clauses-in-sequence` during legacy query normalization (`metabase.legacy-mbql.normalize/normalize`). Hence, query containing one of string predicates (see the test) with more than 2 arguments and empty options map, when normalized, would not conform the legacy schema. This is reproducible through QBUI in dev mode. I'm not sure about prod, as I believe schema checks are limited there to some extent. (_Sidenote: ability to replay gentest enables analyzing WHY the options became nil_)