### PR TITLE
Dev 344 remove flaky tag from tests that are stable

### DIFF
--- a/e2e/.eslintrc
+++ b/e2e/.eslintrc
@@ -46,7 +46,8 @@
       }
     ],
     "no-direct-helper-import": 2,
-    "no-unsafe-element-filtering": ["warn"]
+    "no-unsafe-element-filtering": ["warn"],
+    "no-unordered-test-helpers": 2
   },
   "env": {
     "cypress/globals": true,

--- a/e2e/test/scenarios/metrics/metrics-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-dashboard.cy.spec.js
@@ -116,32 +116,28 @@ describe("scenarios > metrics > dashboard", () => {
     );
   });
 
-  it(
-    "should be possible to add metrics to a dashboard",
-    { tags: "@flaky" },
-    () => {
-      H.createQuestion(ORDERS_SCALAR_METRIC);
-      H.createQuestion(ORDERS_TIMESERIES_METRIC);
-      H.visitDashboard(ORDERS_DASHBOARD_ID);
-      H.editDashboard();
-      H.openQuestionsSidebar();
-      cy.findByTestId("add-card-sidebar").within(() => {
-        cy.findByText(ORDERS_SCALAR_METRIC.name).click();
-        cy.findByPlaceholderText("Search…").type(ORDERS_TIMESERIES_METRIC.name);
-        cy.wait("@search");
-        cy.findByText(ORDERS_SCALAR_METRIC.name).should("not.exist");
-        cy.findByText(ORDERS_TIMESERIES_METRIC.name).click();
-      });
-      H.getDashboardCard(1).within(() => {
-        cy.findByText(ORDERS_SCALAR_METRIC.name).should("be.visible");
-        cy.findByText("18,760").should("be.visible");
-      });
-      H.getDashboardCard(2).within(() => {
-        cy.findByText(ORDERS_TIMESERIES_METRIC.name).should("be.visible");
-        H.echartsContainer().should("be.visible");
-      });
-    },
-  );
+  it("should be possible to add metrics to a dashboard", () => {
+    H.createQuestion(ORDERS_SCALAR_METRIC);
+    H.createQuestion(ORDERS_TIMESERIES_METRIC);
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.editDashboard();
+    H.openQuestionsSidebar();
+    cy.findByTestId("add-card-sidebar").within(() => {
+      cy.findByText(ORDERS_SCALAR_METRIC.name).click();
+      cy.findByPlaceholderText("Search…").type(ORDERS_TIMESERIES_METRIC.name);
+      cy.wait("@search");
+      cy.findByText(ORDERS_SCALAR_METRIC.name).should("not.exist");
+      cy.findByText(ORDERS_TIMESERIES_METRIC.name).click();
+    });
+    H.getDashboardCard(1).within(() => {
+      cy.findByText(ORDERS_SCALAR_METRIC.name).should("be.visible");
+      cy.findByText("18,760").should("be.visible");
+    });
+    H.getDashboardCard(2).within(() => {
+      cy.findByText(ORDERS_TIMESERIES_METRIC.name).should("be.visible");
+      H.echartsContainer().should("be.visible");
+    });
+  });
 
   it("should be able to add a filter and drill thru", () => {
     H.createDashboardWithQuestions({

--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -80,33 +80,29 @@ describe("scenarios > models metadata", () => {
         .and("not.contain", "Pre-tax");
     });
 
-    it(
-      "clears custom metadata when a model is turned back into a question",
-      { tags: "@flaky" },
-      () => {
-        H.openQuestionActions();
-        H.popover().findByTextEnsureVisible("Edit metadata").click();
+    it("clears custom metadata when a model is turned back into a question", () => {
+      H.openQuestionActions();
+      H.popover().findByTextEnsureVisible("Edit metadata").click();
 
-        H.openColumnOptions("Subtotal");
-        H.renameColumn("Subtotal", "Pre-tax");
-        H.setColumnType("No special type", "Cost");
-        H.saveMetadataChanges();
+      H.openColumnOptions("Subtotal");
+      H.renameColumn("Subtotal", "Pre-tax");
+      H.setColumnType("No special type", "Cost");
+      H.saveMetadataChanges();
 
-        cy.findAllByTestId("header-cell")
-          .should("contain", "Pre-tax ($)")
-          .and("not.contain", "Subtotal");
+      cy.findAllByTestId("header-cell")
+        .should("contain", "Pre-tax ($)")
+        .and("not.contain", "Subtotal");
 
-        H.openQuestionActions();
-        H.popover()
-          .findByTextEnsureVisible("Turn back to saved question")
-          .click();
-        cy.wait("@cardQuery");
+      H.openQuestionActions();
+      H.popover()
+        .findByTextEnsureVisible("Turn back to saved question")
+        .click();
+      cy.wait("@cardQuery");
 
-        cy.findAllByTestId("header-cell")
-          .should("contain", "Subtotal")
-          .and("not.contain", "Pre-tax ($)");
-      },
-    );
+      cy.findAllByTestId("header-cell")
+        .should("contain", "Subtotal")
+        .and("not.contain", "Pre-tax ($)");
+    });
   });
 
   it("should edit native model metadata", () => {

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -13,7 +13,7 @@ describe("command palette", () => {
     cy.signInAsAdmin();
   });
 
-  it("should render a searchable command palette", { tags: "@flaky" }, () => {
+  it("should render a searchable command palette", () => {
     // //Add a description for a check
     cy.request("PUT", `/api/card/${ORDERS_COUNT_QUESTION_ID}`, {
       description: "The best question",
@@ -24,7 +24,14 @@ describe("command palette", () => {
     cy.visit("/");
 
     cy.findByRole("button", { name: /Search/ }).click();
+    H.commandPalette().should("be.visible");
+    cy.findByRole("option", { name: "Orders in a dashboard" }).should(
+      "have.attr",
+      "aria-selected",
+      "true",
+    );
     H.closeCommandPalette();
+    H.commandPalette().should("not.exist");
 
     cy.log("open the command palette with keybinding");
     H.openCommandPalette();

--- a/e2e/test/scenarios/question-reproductions/reproductions-1.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-1.cy.spec.js
@@ -827,7 +827,7 @@ describe("issue 18207", () => {
   });
 });
 
-describe("issues 11914, 18978, 18977, 23857", { tags: "@flaky" }, () => {
+describe("issues 11914, 18978, 18977, 23857", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/visualizations-charts/waterfall.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/waterfall.cy.spec.js
@@ -466,7 +466,7 @@ describe("scenarios > visualizations > waterfall", () => {
       H.echartsContainer().get("text").contains("Total").should("exist");
     });
 
-    it("should allow toggling of value labels", { tags: "@flaky" }, () => {
+    it("should allow toggling of value labels", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Display").click();
 

--- a/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
@@ -190,30 +190,26 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
       .and("contain", "koss-ella@hotmail.com");
   });
 
-  it(
-    "handles browsing records by FKs (metabase#21756)",
-    { tags: "@flaky" },
-    () => {
-      H.openOrdersTable();
+  it("handles browsing records by FKs (metabase#21756)", () => {
+    H.openOrdersTable();
 
-      drillFK({ id: 1 });
+    drillFK({ id: 1 });
 
-      assertUserDetailView({ id: 1, name: "Hudson Borer" });
-      getPreviousObjectDetailButton().should("not.exist");
-      getNextObjectDetailButton().should("not.exist");
+    assertUserDetailView({ id: 1, name: "Hudson Borer" });
+    getPreviousObjectDetailButton().should("not.exist");
+    getNextObjectDetailButton().should("not.exist");
 
-      cy.go("back");
-      cy.go("back");
-      cy.wait("@dataset");
+    cy.go("back");
+    cy.go("back");
+    cy.wait("@dataset");
 
-      changeSorting("User ID", "desc");
-      drillFK({ id: 2500 });
+    changeSorting("User ID", "desc");
+    drillFK({ id: 2500 });
 
-      assertUserDetailView({ id: 2500, name: "Kenny Schmidt" });
-      getPreviousObjectDetailButton().should("not.exist");
-      getNextObjectDetailButton().should("not.exist");
-    },
-  );
+    assertUserDetailView({ id: 2500, name: "Kenny Schmidt" });
+    getPreviousObjectDetailButton().should("not.exist");
+    getNextObjectDetailButton().should("not.exist");
+  });
 
   it("handles opening a filtered out record", () => {
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");

--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -617,7 +617,7 @@ describe("issue 30039", () => {
   });
 });
 
-describe("issue 37726", { tags: "@flaky" }, () => {
+describe("issue 37726", () => {
   const PIVOT_QUESTION = {
     name: "Pivot table with custom column width",
     display: "pivot",
@@ -679,7 +679,7 @@ describe("issue 37726", { tags: "@flaky" }, () => {
     // along with the rest of the pivot table, would not appear.
     // Instead, you got a nice ⚠️ icon and a "Something's gone wrong" tooltip.
     H.main().within(() => {
-      cy.findByText("Product → Category");
+      cy.findByText("Product → Category", { timeout: 8000 });
     });
   });
 });

--- a/frontend/lint/eslint-rules/no-unordered-test-helpers.js
+++ b/frontend/lint/eslint-rules/no-unordered-test-helpers.js
@@ -1,0 +1,64 @@
+/**
+ * @fileoverview Rule to enforce H.restore() must come before H.resetTestTable()
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const ERROR_MESSAGE = "H.restore() must come before H.resetTestTable()";
+
+// eslint-disable-next-line import/no-commonjs
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Enforce H.restore() must be called before H.resetTestTable()",
+    },
+    schema: [], // no options
+  },
+  create(context) {
+    const stack = [{ hasRestore: false }];
+
+    return {
+      // Push new scope for describe blocks
+      "CallExpression[callee.name='describe']"() {
+        stack.push({ hasRestore: stack[stack.length - 1].hasRestore });
+      },
+
+      // Pop scope when leaving describe blocks
+      "CallExpression[callee.name='describe']:exit"() {
+        stack.pop();
+      },
+
+      CallExpression(node) {
+        if (
+          node.callee.type === "MemberExpression" &&
+          node.callee.object.name === "H"
+        ) {
+          const currentScope = stack[stack.length - 1];
+
+          if (node.callee.property.name === "restore") {
+            currentScope.hasRestore = true;
+          } else if (node.callee.property.name === "resetTestTable") {
+            const hasRestoreInHierarchy = stack.some(scope => scope.hasRestore);
+
+            if (!hasRestoreInHierarchy) {
+              context.report({
+                node,
+                message: ERROR_MESSAGE,
+              });
+            }
+          }
+        }
+      },
+
+      // Reset state for each test file
+      Program() {
+        stack.length = 1;
+        stack[0] = { hasRestore: false };
+      },
+    };
+  },
+};

--- a/frontend/lint/tests/no-unordered-test-helpers.unit.spec.js
+++ b/frontend/lint/tests/no-unordered-test-helpers.unit.spec.js
@@ -1,0 +1,88 @@
+import { RuleTester } from "eslint";
+
+import rule from "../eslint-rules/no-unordered-test-helpers";
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } });
+
+const orderError = {
+  message: "H.restore() must come before H.resetTestTable()",
+};
+
+const blockTypes = ["it", "before", "beforeEach", "describe"];
+
+const blockWrapper = (content, blockType = "it") => `
+  ${blockType}('should test something', () => {
+    ${content}
+  });
+`;
+
+const validCases = [
+  // Simple case - restore before reset
+  `H.restore();
+   H.resetTestTable();`,
+
+  // Multiple resets after restore
+  `H.restore();
+   H.resetTestTable();
+   H.resetTestTable();`,
+
+  // Nested describe with inherited restore
+  `describe('outer', () => {
+    before(() => {
+      H.restore();
+    });
+
+    describe('inner', () => {
+      it('test', () => {
+        H.resetTestTable();
+      });
+    });
+  });`,
+
+  // Restore in before hook
+  `before(() => {
+    H.restore();
+  });
+
+  it('test', () => {
+    H.resetTestTable();
+  });`,
+];
+
+const invalidCases = [
+  // Reset before restore
+  `H.resetTestTable();
+   H.restore();`,
+
+  // Reset without restore
+  `H.resetTestTable();`,
+
+  // Reset in nested describe without restore
+  `describe('outer', () => {
+    describe('inner', () => {
+      it('test', () => {
+        H.resetTestTable();
+      });
+    });
+  });`,
+
+  // Reset in before without restore
+  `before(() => {
+    H.resetTestTable();
+  });`,
+];
+
+ruleTester.run("no-unordered-test-helpers", rule, {
+  valid: blockTypes.flatMap(blockType =>
+    validCases.map(testCase => ({
+      code: blockWrapper(testCase, blockType),
+    })),
+  ),
+
+  invalid: blockTypes.flatMap(blockType =>
+    invalidCases.map(testCase => ({
+      code: blockWrapper(testCase, blockType),
+      errors: [orderError],
+    })),
+  ),
+});


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/DEV-344/remove-flaky-tag-from-tests-that-are-stable

### Description

Remove `@flaky` tags from tests that are no longer flaky

### Stress tests
`e2e/test/scenarios/metrics/browse.cy.spec.ts` -> [stress test](https://github.com/metabase/metabase/actions/runs/13309358033) (some tests still `@flaky`)
`e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js` -> [stress test](https://github.com/metabase/metabase/actions/runs/13309897256)
`e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js` -> [stress test](https://github.com/metabase/metabase/actions/runs/13310070346) (fixed)
`e2e/test/scenarios/question-reproductions/reproductions-1.cy.spec.js` -> [stress test](https://github.com/metabase/metabase/actions/runs/13325626020)
`e2e/test/scenarios/onboarding/command-palette.cy.spec.js` -> [stress test](https://github.com/metabase/metabase/actions/runs/13326957600) (fixed)
`e2e/test/scenarios/visualizations-charts/waterfall.cy.spec.js` -> [stress test](https://github.com/metabase/metabase/actions/runs/13327239480)
`e2e/test/scenarios/models/models-metadata.cy.spec.js` -> [stress test](https://github.com/metabase/metabase/actions/runs/13327403153)
`e2e/test/scenarios/metrics/metrics-dashboard.cy.spec.js` -> [stress test](https://github.com/metabase/metabase/actions/runs/13327564282)

This brings down the flaky test count to:
## 13