### PR TITLE
feat(sdk): asks whether to add a db right before adding db connection in the cli

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/cli/run.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/run.ts
@@ -30,7 +30,6 @@ export const CLI_STEPS: CliStepConfig[] = [
   { id: "checkIfReactProject", executeStep: checkIfReactProject },
   { id: "checkSdkAvailable", executeStep: checkSdkAvailable },
   { id: "checkIsDockerRunning", executeStep: checkIsDockerRunning },
-  { id: "askIfHasDatabase", executeStep: askIfHasDatabase },
   { id: "generateCredentials", executeStep: generateCredentials },
   {
     id: "startLocalMetabaseContainer",
@@ -40,6 +39,7 @@ export const CLI_STEPS: CliStepConfig[] = [
   { id: "pollMetabaseInstance", executeStep: pollMetabaseInstance },
   { id: "setupMetabaseInstance", executeStep: setupMetabaseInstance },
   { id: "createApiKey", executeStep: createApiKey },
+  { id: "askIfHasDatabase", executeStep: askIfHasDatabase },
   { id: "addDatabaseConnection", executeStep: addDatabaseConnectionStep },
   { id: "pickDatabaseTables", executeStep: pickDatabaseTables },
   { id: "createModelsAndXrays", executeStep: createModelsAndXrays },


### PR DESCRIPTION
Moves the step that asks if you have a database to right before adding the credentials so it is more linear. See this discussion from Alex and Jeff for more context: https://github.com/metabase/metabase/pull/53628#discussion_r1953487276

> When the CLI asks me if I have a database or not, it does not immediately proceed to ask what database, and about connection details. That happens after Metabase is set up (so after the next step). I actually think this is confusing in the CLI UX itself, not just in docs. I'm not sure why we ask about database this early in the flow and not when we're actually ready to configure it.

> We frontloaded this db check back when the CLI didn't fall back to using the Sample Database. The rationale was that people would go through a long setup process only for the whole setup process to fail when they said they didn't have a db to connect to, so we wanted to fail earlier in that case. Now that the CLI works with OR without an external db, should we move this prompt so that the DB setup steps are sequential?

