### PR TITLE
chore(ci): update sql server runner to ubuntu 22

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -884,7 +884,7 @@ jobs:
 
   be-tests-sqlserver:
     if: ${{ !inputs.skip }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
       fail-fast: false


### PR DESCRIPTION
### Description

I see warnings on my CI runs for an [upcoming brownout of ubuntu 20.04](https://github.com/actions/runner-images/issues/11101), which looks like it'll be unsupported on April 1st. It looks like the SQLServer jobs are using it because of a problem with [sqlserver-2017](https://metaboat.slack.com/archives/C5XHN8GLW/p1727077788250889). Possible whatever kernel issue was causing sqlserver to fail in September is fixed now and it seems like it'd be nice to get ahead having our CI randomly fail. 

### How to verify

Via CI

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
