### PR TITLE
chore: remove suppressNextjsWarning() call from mantine

### DIFF
--- a/patches/@mantine+core+7.16.3.patch
+++ b/patches/@mantine+core+7.16.3.patch
@@ -1,3 +1,16 @@
+diff --git a/node_modules/@mantine/core/cjs/core/MantineProvider/MantineProvider.cjs b/node_modules/@mantine/core/cjs/core/MantineProvider/MantineProvider.cjs
+index d0006e5..49e2259 100644
+--- a/node_modules/@mantine/core/cjs/core/MantineProvider/MantineProvider.cjs
++++ b/node_modules/@mantine/core/cjs/core/MantineProvider/MantineProvider.cjs
+@@ -13,7 +13,7 @@ var suppressNextjsWarning = require('./suppress-nextjs-warning.cjs');
+ var useProviderColorScheme = require('./use-mantine-color-scheme/use-provider-color-scheme.cjs');
+ var useRespectReduceMotion = require('./use-respect-reduce-motion/use-respect-reduce-motion.cjs');
+ 
+-suppressNextjsWarning.suppressNextjsWarning();
++// suppressNextjsWarning.suppressNextjsWarning();
+ function MantineProvider({
+   theme,
+   children,
 diff --git a/node_modules/@mantine/core/esm/core/MantineProvider/MantineProvider.mjs b/node_modules/@mantine/core/esm/core/MantineProvider/MantineProvider.mjs
 index e928597..08a9360 100644
 --- a/node_modules/@mantine/core/esm/core/MantineProvider/MantineProvider.mjs

--- a/patches/@mantine+core+7.16.3.patch
+++ b/patches/@mantine+core+7.16.3.patch
@@ -1,5 +1,18 @@
+diff --git a/node_modules/@mantine/core/esm/core/MantineProvider/MantineProvider.mjs b/node_modules/@mantine/core/esm/core/MantineProvider/MantineProvider.mjs
+index e928597..08a9360 100644
+--- a/node_modules/@mantine/core/esm/core/MantineProvider/MantineProvider.mjs
++++ b/node_modules/@mantine/core/esm/core/MantineProvider/MantineProvider.mjs
+@@ -11,7 +11,7 @@ import { suppressNextjsWarning } from './suppress-nextjs-warning.mjs';
+ import { useProviderColorScheme } from './use-mantine-color-scheme/use-provider-color-scheme.mjs';
+ import { useRespectReduceMotion } from './use-respect-reduce-motion/use-respect-reduce-motion.mjs';
+ 
+-suppressNextjsWarning();
++// suppressNextjsWarning();
+ function MantineProvider({
+   theme,
+   children,
 diff --git a/node_modules/@mantine/core/styles.css b/node_modules/@mantine/core/styles.css
-index 9a363c6..bd4c8aa 100644
+index d440fbf..dc78ac1 100644
 --- a/node_modules/@mantine/core/styles.css
 +++ b/node_modules/@mantine/core/styles.css
 @@ -1,34 +1,4 @@


### PR DESCRIPTION
https://metaboat.slack.com/archives/C063Q3F1HPF/p1739454483688469
Closes EMB-133

Mantine wraps all the console.error calls and changes the file:line that shows up in this function
https://github.com/mantinedev/mantine/blob/3f1b82458a82d9f1e83ef9b59a3c9422e069ee00/packages/%40mantine/core/src/core/MantineProvider/suppress-nextjs-warning.ts

This PR patches the file where they call that function, as they don't allow to opt out (it's called un-conditionally in the root level of the module of the provider)

example from storybook (see the filename on the right):
Before
<img width="481" alt="image" src="https://github.com/user-attachments/assets/8c083822-38f7-4e78-9a20-a06c21b8608f" />


After
<img width="501" alt="image" src="https://github.com/user-attachments/assets/9ae1e154-6bef-4561-be8d-d8eef2ac170a" />
