### PR TITLE
Destroy DB in count of grouping tests

### DIFF
--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -1254,6 +1254,8 @@
       (binding [*recreate-db-if-stale?* false]
         (log/infof "DB for %s is stale! Deleteing and running test again\n" dataset)
         (t2/delete! :model/Database :id (mt/id))
+        (tx/destroy-db! driver/*driver* (tx/get-dataset-definition dataset)) 
+        (Thread/sleep 50)
         (apply count-of-grouping dataset field-grouping relative-datetime-args))
       (let [results (mt/run-mbql-query checkins
                       {:aggregation [[:count]]

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -1255,7 +1255,7 @@
         (log/infof "DB for %s is stale! Deleteing and running test again\n" dataset)
         (t2/delete! :model/Database :id (mt/id))
         (tx/destroy-db! driver/*driver* (tx/get-dataset-definition dataset)) 
-        (Thread/sleep 50)
+        ;; (Thread/sleep 1000)
         (apply count-of-grouping dataset field-grouping relative-datetime-args))
       (let [results (mt/run-mbql-query checkins
                       {:aggregation [[:count]]

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -1255,7 +1255,6 @@
         (log/infof "DB for %s is stale! Deleteing and running test again\n" dataset)
         (t2/delete! :model/Database :id (mt/id))
         (tx/destroy-db! driver/*driver* (tx/get-dataset-definition dataset)) 
-        ;; (Thread/sleep 1000)
         (apply count-of-grouping dataset field-grouping relative-datetime-args))
       (let [results (mt/run-mbql-query checkins
                       {:aggregation [[:count]]

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -1254,7 +1254,7 @@
       (binding [*recreate-db-if-stale?* false]
         (log/infof "DB for %s is stale! Deleteing and running test again\n" dataset)
         (t2/delete! :model/Database :id (mt/id))
-        (tx/destroy-db! driver/*driver* (tx/get-dataset-definition dataset)) 
+        (tx/destroy-db! driver/*driver* (tx/get-dataset-definition dataset))
         (apply count-of-grouping dataset field-grouping relative-datetime-args))
       (let [results (mt/run-mbql-query checkins
                       {:aggregation [[:count]]


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/DRI-116/talk-to-materialize-about-tests-exclusions

### Description

The DBs used in the `count-of-grouping` tests rely on relative time but we are not properly destroying and recreating them when they become stale. 

### How to verify

1. Run the `count-of-grouping-test` test once
2. Wait 5 minutes
3. Run it again
4. It should pass

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
