### PR TITLE
fix: hide sqlite from engines on cloud hosting

### DIFF
--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -277,11 +277,19 @@
              :when (supports? driver feature database)]
          feature)))
 
+(defn- supported-in-environment?
+  "Returns true if a driver is supported in the the current metabase environment. As implemented this just disallows the
+  sqlite driver on hosted metabase because hosted metabase does not support uploading a SQLite file for use."
+  [driver]
+  (or (not (premium-features/is-hosted?))
+      (not= :sqlite (keyword driver))))
+
 (defn available-drivers
   "Return a set of all currently available drivers."
   []
   (set (for [driver (descendants driver/hierarchy :metabase.driver/driver)
-             :when  (driver/available? driver)]
+             :when  (and (driver/available? driver)
+                         (supported-in-environment? driver))]
          driver)))
 
 (mu/defn semantic-version-gte :- :boolean

--- a/test/metabase/driver/util_test.clj
+++ b/test/metabase/driver/util_test.clj
@@ -5,6 +5,7 @@
    [clojure.test :refer :all]
    [metabase.driver :as driver]
    [metabase.driver.h2 :as h2]
+   [metabase.driver.impl :as driver.impl]
    [metabase.driver.util :as driver.u]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
@@ -294,8 +295,10 @@
                      (log-messages))))))))))
 
 (deftest sqlite-in-available-drivers
-  (testing "includes sqlite in non-hosted environment"
-    (is (contains? (driver.u/available-drivers) :sqlite)))
-  (mt/with-premium-features #{:hosting}
-    (testing "does not include sqlite in hosted environment"
-      (is (not (contains? (driver.u/available-drivers) :sqlite))))))
+  (with-redefs [driver.impl/hierarchy (->  (derive (make-hierarchy) :sqlite :metabase.driver/driver)
+                                           (derive :sqlite :metabase.driver.impl/concrete))]
+    (testing "includes sqlite in non-hosted environment"
+      (is (contains? (driver.u/available-drivers) :sqlite)))
+    (mt/with-premium-features #{:hosting}
+      (testing "does not include sqlite in hosted environment"
+        (is (not (contains? (driver.u/available-drivers) :sqlite)))))))

--- a/test/metabase/driver/util_test.clj
+++ b/test/metabase/driver/util_test.clj
@@ -292,3 +292,10 @@
               (is (false? (driver.u/supports? :test-driver feature db)))
               (is (= []
                      (log-messages))))))))))
+
+(deftest sqlite-in-available-drivers
+  (testing "includes sqlite in non-hosted environment"
+    (is (contains? (driver.u/available-drivers) :sqlite)))
+  (mt/with-premium-features #{:hosting}
+    (testing "does not include sqlite in hosted environment"
+      (is (not (contains? (driver.u/available-drivers) :sqlite))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/44233

### Description

sqlite is not a supported database in our cloud hosted environment because don't support uploading a sqlite file to metabase. This hides sqlite from the list of supported databases by checking if we are in a hosted environment with `is-hosted?` to remove sqlite from the list of available drivers. 

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Edit `defsetting is-hosted?` and change `:setter` to `(constantly true)`
2. Navigate to admin/databases/new no option for sqlite

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
