### PR TITLE
Remove css vars on unit tests

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ChartSettingsButton/ChartSettingsButton.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ChartSettingsButton/ChartSettingsButton.unit.spec.tsx
@@ -71,7 +71,9 @@ describe("ChartSettingsButton", () => {
     setup();
     await userEvent.click(screen.getByLabelText("palette icon"));
 
-    expect(screen.getByTestId("chartsettings-sidebar")).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("chartsettings-sidebar"),
+    ).toBeInTheDocument();
     expect(screen.getByTestId("visualization-root")).toBeInTheDocument();
 
     await userEvent.click(screen.getByDisplayValue("Linear Interpolated"));

--- a/frontend/src/metabase/querying/notebook/components/Notebook/Notebook.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/Notebook/Notebook.unit.spec.tsx
@@ -417,7 +417,7 @@ const goToDataPickerTab = async ({
   name: string;
   iconName: IconName;
 }) => {
-  const tabsView = within(screen.getByTestId("tabs-view"));
+  const tabsView = within(await screen.findByTestId("tabs-view"));
 
   const tabButton = tabsView.getByRole("tab", {
     name: `${iconName} icon ${name}`,

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/PeriodsAgoMenuOption.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/PeriodsAgoMenuOption.tsx
@@ -9,8 +9,6 @@ import type { SmartScalarComparisonPeriodsAgo } from "metabase-types/api";
 import { MenuItemStyled } from "./MenuItem.styled";
 import { NumberInputStyled } from "./PeriodsAgoMenuOption.styled";
 
-type NumberValue = number | "";
-
 type PeriodsAgoMenuOptionProps = {
   "aria-selected": boolean;
   editedValue?: SmartScalarComparisonPeriodsAgo;

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -169,7 +169,10 @@ export function TestWrapper({
   return (
     <MetabaseReduxProvider store={store}>
       <MaybeDNDProvider hasDND={withDND}>
-        <ThemeProvider theme={theme}>
+        <ThemeProvider
+          theme={theme}
+          mantineProviderProps={{ withCssVariables: false }}
+        >
           <GlobalStylesForTest />
 
           <MaybeKBar hasKBar={withKBar}>
@@ -345,9 +348,18 @@ export function createMockClipboardData(
   return clipboardData as unknown as DataTransfer;
 }
 
+const ThemeProviderWrapper = ({
+  children,
+  ...props
+}: React.PropsWithChildren) => (
+  <ThemeProvider mantineProviderProps={{ withCssVariables: false }} {...props}>
+    {children}
+  </ThemeProvider>
+);
+
 export function renderWithTheme(children: React.ReactElement) {
   return testingLibraryRender(children, {
-    wrapper: ThemeProvider,
+    wrapper: ThemeProviderWrapper,
   });
 }
 


### PR DESCRIPTION
### Description
With the update to Mantine V7, a large style tag is applied to the root element of the DOM containing CSS variables. This is present in all unit tests that need to render react components, causing a lot of extra content in JSDom and slowing down tests. This PR removes those css variables when performing unit tests, which should improve testing speed. Locally, I'm able to complete the entire test suite in ~240 seconds with 10 threads.

There are also a couple small adjustments that should reduce a touch of flakiness

### How to verify

CI should be 📗 

