### PR TITLE
[refs] Don't randomized `entity_id`s for databases, tables or fields

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
@@ -29,11 +29,6 @@
         (is (= (set known-models)
                (set (map name (v2.entity-ids/toucan-models)))))))))
 
-(def ^:private dual-entity-id-exceptions
-  "Databases, Tables and Fields have a custom [[serdes/entity-id]] based on their names, but also have randomized
-  `entity_id` columns used by column metadata."
-  #{"Database" "Table" "Field"})
-
 (deftest ^:parallel every-model-is-supported-test-2
   (testing "Serialization support\n"
     (let [should-have-entity-id (set (concat serdes.models/data-model serdes.models/content))
@@ -48,12 +43,9 @@
           ;; we're not checking inline-models for anything here, since some of them have (and use) entity_id, like
           ;; dashcards, and some (ParameterCard) do not
           (when (contains? should-have-entity-id (name model))
-            (if (contains? dual-entity-id-exceptions (name model))
-              (testing (str "Certain models have *both* entity_id and hash key: " (name model))
-                (is (= true custom-entity-id? random-entity-id?)))
-              (testing (str "Model should either have entity_id or a hash key: " (name model))
-                ;; `not=` is effectively `xor`
-                (is (not= custom-entity-id? random-entity-id?)))))
+            (testing (str "Model should either have entity_id or a hash key: " (name model))
+              ;; `not=` is effectively `xor`
+              (is (not= custom-entity-id? random-entity-id?))))
           (when (contains? excluded (name model))
             (testing (str "Model shouldn't have entity_id defined: " (name model))
               (is (not custom-entity-id?))

--- a/src/metabase/api/embed/common.clj
+++ b/src/metabase/api/embed/common.clj
@@ -298,7 +298,6 @@
    :dashboard         :model/Dashboard
    :dashboard-card    :model/DashboardCard
    :dashboard-tab     :model/DashboardTab
-   :database          :model/Database
    :dataset           :model/Card
    :dimension         :model/Dimension
    :metric            :model/Card
@@ -308,7 +307,6 @@
    :pulse-channel     :model/PulseChannel
    :segment           :model/Segment
    :snippet           :model/NativeQuerySnippet
-   :table             :model/Table
    :timeline          :model/Timeline
    :user              :model/User})
 

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -58,7 +58,10 @@
 (doto :model/Database
   (derive :metabase/model)
   (derive :hook/timestamped?)
-  (derive :hook/entity-id))
+  ;; Deliberately **not** deriving from `:hook/entity-id` because we should not be randomizing the `entity_id`s on
+  ;; databases, tables or fields. Since the sync process can create them in multiple instances, randomizing them would
+  ;; cause duplication rather than good matching if the two instances are later linked by serdes.
+  #_(derive :hook/entity-id))
 
 (methodical/defmethod t2.with-temp/do-with-temp* :before :model/Database
   [_model _explicit-attributes f]

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -117,7 +117,10 @@
 (doto :model/Field
   (derive :metabase/model)
   (derive :hook/timestamped?)
-  (derive :hook/entity-id))
+  ;; Deliberately **not** deriving from `:hook/entity-id` because we should not be randomizing the `entity_id`s on
+  ;; databases, tables or fields. Since the sync process can create them in multiple instances, randomizing them would
+  ;; cause duplication rather than good matching if the two instances are later linked by serdes.
+  #_(derive :hook/entity-id))
 
 (t2/define-after-select :model/Field
   [field]

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -40,7 +40,10 @@
   (derive ::mi/read-policy.full-perms-for-perms-set)
   (derive ::mi/write-policy.full-perms-for-perms-set)
   (derive :hook/timestamped?)
-  (derive :hook/entity-id))
+  ;; Deliberately **not** deriving from `:hook/entity-id` because we should not be randomizing the `entity_id`s on
+  ;; databases, tables or fields. Since the sync process can create them in multiple instances, randomizing them would
+  ;; cause duplication rather than good matching if the two instances are later linked by serdes.
+  #_(derive :hook/entity-id))
 
 (t2/deftransforms :model/Table
   {:entity_type     mi/transform-keyword

--- a/test/metabase/sync/sync_test.clj
+++ b/test/metabase/sync/sync_test.clj
@@ -118,7 +118,7 @@
     :db_id       true
     :entity_type :entity/GenericTable
     :id          true
-    :entity_id   true
+    :entity_id   false
     :updated_at  true}))
 
 (defn- field-defaults []
@@ -130,7 +130,7 @@
     :fk_target_field_id  false
     :database_is_auto_increment false
     :id                  true
-    :entity_id           true
+    :entity_id           false
     :last_analyzed       false
     :parent_id           false
     :position            0


### PR DESCRIPTION
Part of #53048.

### Description

#53076 added `entity_id` columns to databases, tables and fields, and used the `:hook/entity-id` helper to randomize them.
We actually don't want to randomize these, since it can make the sync process create duplicates between instances.

Instead, these `entity_id`s should always be based on the hashes, which will be done in a follow-up.

### How to verify

- Newly created databases, tables and fields should not get `entity_id` values populated.

### Checklist

- ~~Tests have been added/updated to cover changes in this PR~~
