### PR TITLE
Use more recent Ubuntu for SQLServer job

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -884,7 +884,7 @@ jobs:
 
   be-tests-sqlserver:
     if: ${{ !inputs.skip }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
       fail-fast: false


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/11101

> To raise awareness of the upcoming removal, we will temporarily fail jobs using Ubuntu 20.04

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/d908f406-3ce3-47f9-b47a-f8d548c5cd02" />
