### PR TITLE
[pulse] Optimize memory usage email notification rendering

### DIFF
--- a/src/metabase/channel/render/card.clj
+++ b/src/metabase/channel/render/card.clj
@@ -202,7 +202,7 @@
 (mu/defn render-pulse-section :- body/RenderedPartCard
   "Render a single Card section of a Pulse to a Hiccup form (representating HTML)."
   ([timezone-id part]
-   (render-pulse-section timezone-id part))
+   (render-pulse-section timezone-id part {}))
 
   ([timezone-id
     {card :card, dashcard :dashcard, result :result, :as _part}

--- a/src/metabase/util/performance.clj
+++ b/src/metabase/util/performance.clj
@@ -252,12 +252,12 @@
 (defn prewalk
   "Like `clojure.walk/prewalk`, but uses a more efficient `metabase.util.performance/walk` underneath."
   [f form]
-  (walk (partial prewalk f) identity (f form)))
+  (walk (fn prewalker [form] (walk prewalker identity (f form))) identity (f form)))
 
 (defn postwalk
   "Like `clojure.walk/postwalk`, but uses a more efficient `metabase.util.performance/walk` underneath."
   [f form]
-  (walk (partial postwalk f) f form))
+  (walk (fn postwalker [form] (walk postwalker f form)) f form))
 
 (defn keywordize-keys
   "Like `clojure.walk/keywordize-keys`, but uses a more efficient `metabase.util.performance/walk` underneath and


### PR DESCRIPTION
This is an attempt to further address the problem of high memory usage when sending out email reports. #51708 made sure that the data for individual cards is serialized to disk, so that they are not kept at the same time in memory. However, another source of OOMs comes from the fact that in order to render the full HTML report for all the cards, the code collected the Hiccup structures for all the cards altogether and then called `hiccup.core/html` on them. Those structures are really really heavy.

This PR changes the approach. Each card is converted to HTML separately. Then the strings are combined. Strings are much lighter than the corresponding Hiccup structures.

Additionally, I refactored some functions to reduce the number of times that the cumulative `dashboard_cards` is iterated. I couldn't make it single-pass for now but I got closer to that. In the future, that would be ideal – it would allow to skip freezing/thawing the card data to disk.

## Benchmark

I used the same benchmark as in #51708. After the fix, 300 dashboards perform fine within 1GB heap.