### PR TITLE
fix missing pointer cursor on viz options action button

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ChartSettingsButton/ChartSettingsButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ChartSettingsButton/ChartSettingsButton.tsx
@@ -30,7 +30,6 @@ export function ChartSettingsButton({
   return (
     <>
       <DashCardActionButton
-        as="div"
         tooltip={t`Visualization options`}
         aria-label={t`Show visualization options`}
         onClick={open}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/53664

### Description

Dashcard `Visualization options` button has default cursor instead of pointer because of rendering it as div.

### How to verify

- Edit any dashboard with dashcards
- Over over `Visualization options` button, ensure its cursor is `pointer`

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
