### PR TITLE
Update elliptic to ^6.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -341,7 +341,7 @@
     "cookie": "^0.7.0",
     "cross-spawn": "^7.0.5",
     "d3-color": "^3.1.0",
-    "elliptic": "^6.6.0",
+    "elliptic": "^6.6.1",
     "debug": "^4.3.4",
     "follow-redirects": "^1.15.5",
     "jsdom": "^22.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9173,10 +9173,10 @@ electron-to-chromium@^1.5.73:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.83.tgz#3f74078f0c83e24bf7e692eaa855a998d1bec34f"
   integrity sha512-LcUDPqSt+V0QmI47XLzZrz5OqILSMGsPFkDYus22rIbgorSvBYEFqq854ltTmUdHkY92FSdAAvsh4jWEULMdfQ==
 
-elliptic@^6.5.3, elliptic@^6.5.4, elliptic@^6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.0.tgz#5919ec723286c1edf28685aa89261d4761afa210"
-  integrity sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==
+elliptic@^6.5.3, elliptic@^6.5.4, elliptic@^6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.1.tgz#3b8ffb02670bf69e382c7f65bf524c97c5405c06"
+  integrity sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==
   dependencies:
     bn.js "^4.11.9"
     brorand "^1.1.0"


### PR DESCRIPTION
Fixes a [dependabot alert](https://github.com/metabase/metabase/security/dependabot/179)