### PR TITLE
Include query in request to ai-service

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/envelope.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/envelope.clj
@@ -50,18 +50,11 @@
       (dissoc :structured-content)
       (assoc :content (stringified-content msg))))
 
-(defn- maybe-remove-query [msg]
-  (cond-> msg
-    (and (is-tool-call-response? msg)
-         (is-query? (:structured-content msg)))
-    (update :structured-content dissoc :query)))
-
 (defn- llm-message
   "Formats a message for the LLM. Removes things we don't want the LLM to see (e.g. `query`) and stringifies structured
   content."
   [msg]
   (-> msg
-      maybe-remove-query
       stringify-content))
 
 (defn llm-history


### PR DESCRIPTION
## Context

We currently pass the results of querying tools (also dummy tools that set up the initial context of the conversation) in the tool call result message. These MBQL queries are used for some of the tool invocations (e.g. the LLM wants to find outliers for a query result by providing us with a `query_id` -> we need to know the query to run). 
Up until now, the BE was using those queries but made sure to remove them from the tool call result before sending it to the ai-service. 

For running the agent-loop (+ tool calls) in the ai-service, we need these queries (especially the ones generated by dummy tool calls). Until we create and endpoint that allows the ai-service to generate the dummy tool calls from whatever the user is currently viewing, we need to pass the queries over to the ai-service.

The ai-service is already capable of [automatically loading and removing](https://github.com/metabase/ai-service/blob/main/ai_service/agent/types.py#L148-L163) the queries from the tool calls. This allows us to re-add the query to the tool results that we send to ai-service.

