### PR TITLE
fix(sdk): filter out @types/react from the generated package.json

### DIFF
--- a/bin/embedding-sdk/generate-sdk-package-files.js
+++ b/bin/embedding-sdk/generate-sdk-package-files.js
@@ -4,7 +4,12 @@
 const fs = require("fs");
 const path = require("path");
 
-const IGNORED_PACKAGES = ["react", "react-dom"];
+const IGNORED_PACKAGES = [
+  "react",
+  "react-dom",
+  "@types/react",
+  "@types/react-dom",
+];
 const SDK_DIST_DIR = path.resolve("./resources/embedding-sdk");
 
 function filterOutReactDependencies(object) {


### PR DESCRIPTION
https://metaboat.slack.com/archives/C063Q3F1HPF/p1739533605834869?thread_ts=1739530363.089089&cid=C063Q3F1HPF

We shouldn't have any reference to the react types in the package.json of the sdk


This may close https://github.com/metabase/metabase/issues/53767