### PR TITLE
Integrate Sample Apps e2e tests with CI

### DIFF
--- a/.github/workflows/e2e-sample-apps-embedding-sdk.yml
+++ b/.github/workflows/e2e-sample-apps-embedding-sdk.yml
@@ -1,0 +1,312 @@
+name: E2E Sample Apps compatibility with Embedding SDK testing
+
+on:
+  push:
+    branches:
+      - "master"
+      - "release-**"
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - "master"
+      - "release-**"
+
+env:
+  # we must support last two stable releases
+  SUPPORTED_RELEASES_COUNT: 2
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  files-changed:
+    name: Check which files changed
+    runs-on: ubuntu-22.04
+    timeout-minutes: 3
+    outputs:
+      e2e_all: ${{ steps.changes.outputs.e2e_all }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test which files changed
+        uses: dorny/paths-filter@v3.0.0
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-paths.yaml
+
+  # if this is a test on a release branch, we need to check the build requirements
+  get-build-requirements:
+    if: |
+      !cancelled() &&
+      contains(github.base_ref || github.ref, 'release-x')
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    outputs:
+      java_version: ${{ fromJson(steps.dependencies.outputs.result).java_version }}
+      node_version: ${{ fromJson(steps.dependencies.outputs.result).node_version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: release
+      - name: Prepare build scripts
+        run: cd ${{ github.workspace }}/release && yarn && yarn build
+      - name: Get build dependencies
+        uses: actions/github-script@v7
+        id: dependencies
+        with:
+          script: | # js
+            const {
+              getBuildRequirements,
+              getVersionFromReleaseBranch,
+            } = require('${{ github.workspace }}/release/dist/index.cjs');
+            const targetBranchName = '${{ github.base_ref || github.ref }}';
+
+            const version = getVersionFromReleaseBranch(targetBranchName);
+            const requirements = getBuildRequirements(version);
+
+            return {
+              java_version: requirements.java,
+              node_version: requirements.node,
+            };
+
+  get-sample-app-compatibility-data:
+    if: |
+      !cancelled()
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    outputs:
+      exclude_sample_app_names: ${{ fromJson(steps.build-sample-app-compatibility-data.outputs.result).exclude_sample_app_names }}
+      sample_app_branch_name: ${{ fromJson(steps.build-sample-app-compatibility-data.outputs.result).sample_app_branch_name }}
+      should_run_tests: ${{ fromJson(steps.build-sample-app-compatibility-data.outputs.result).should_run_tests }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build sample app compatibility data
+        uses: actions/github-script@v7
+        id: build-sample-app-compatibility-data
+        with:
+          script: | # js
+            const ref = process.env.GITHUB_BASE_REF || process.env.GITHUB_REF || "";
+            const branchName = ref.replace(/^refs\/heads\//, "");
+
+            const isMainBranchRef = branchName === 'master';
+            const isReleaseBranchRef = branchName.includes('release-x');
+
+            if (isMainBranchRef) {
+              return {
+                sample_app_branch_name: 'main',
+                should_run_tests: true,
+              };
+            }
+
+            if (isReleaseBranchRef) {
+              const currentLatestVersion = Number(${{ vars.CURRENT_VERSION }});
+              const versionRegexp = /release-x\.([0-9]+)\.x/;
+
+              const versionMatch = branchName.match(versionRegexp);
+              const currentBranchVersion = versionMatch ? versionMatch[1] : null;
+
+              const supportedReleasesCount = Number(${{env.SUPPORTED_RELEASES_COUNT}});
+
+              const shouldRunTestsForVersion = (currentLatestVersion - currentBranchVersion) <= (supportedReleasesCount - 1);
+
+              return {
+                exclude_sample_app_names: 'shoppy',
+                sample_app_branch_name: branchName,
+                should_run_tests: shouldRunTestsForVersion,
+              };
+            }
+
+            return {
+              sample_app_branch_name: '',
+              should_run_tests: false,
+            };
+
+  build:
+    needs: [files-changed, get-build-requirements, get-sample-app-compatibility-data]
+    if: |
+      !cancelled() &&
+      github.event.pull_request.draft == false &&
+      needs.files-changed.outputs.e2e_all == 'true' &&
+      needs.get-sample-app-compatibility-data.outputs.should_run_tests == 'true'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 25
+    env:
+      MB_EDITION: ee
+      INTERACTIVE: false
+      # make sure that builds on release branches get licenses, because we use them for releases
+      SKIP_LICENSES: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare front-end environment
+        uses: ./.github/actions/prepare-frontend
+        with:
+          node-version: "${{ needs.get-build-requirements.outputs.node_version }}"
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
+        with:
+          m2-cache-key: uberjar
+          java-version: "${{ needs.get-build-requirements.outputs.java_version || 21 }}"
+
+      - name: Build uberjar with ./bin/build.sh
+        run: ./bin/build.sh
+
+      - name: Prepare uberjar artifact
+        uses: ./.github/actions/prepare-uberjar-artifact
+        with:
+          name: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
+
+  reset-e2e-test-comment:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Remove test results comment
+        uses: actions/github-script@v7
+        with:
+          script: | # js
+            const { owner, repo } = context.repo;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number: context.issue.number,
+            }).catch(console.error);
+
+            if (!comments) {
+              return;
+            }
+
+            const comment = comments.find((comment) => comment.body.includes('## sample-apps-embedding-sdk-e2e failed on '));
+
+            if (comment) {
+              await github.rest.issues.deleteComment({
+                owner,
+                repo,
+                comment_id: comment.id,
+              });
+            }
+
+  e2e-tests:
+    needs: [get-build-requirements, get-sample-app-compatibility-data, build]
+    if: |
+      !cancelled() && needs.build.result == 'success'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+    name: e2e-sample-apps-embedding-sdk-tests
+    env:
+      MB_EDITION: ee
+      DISPLAY: ""
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+      HASH: ${{ github.event.pull_request.head.sha || github.sha }}-${{ github.run_attempt }}
+      # Any env starting with `CYPRESS_` will be available to all Cypress tests via `Cypress.env()`
+      # Example: you can get `CYPRESS_FOO` with `Cypress.env("FOO")`
+      CYPRESS_ALL_FEATURES_TOKEN: ${{ secrets.ENTERPRISE_TOKEN }}
+      CYPRESS_NO_FEATURES_TOKEN: ${{ secrets.E2E_STARTER_TOKEN }}
+      CYPRESS_PULL_REQUEST_ID: ${{ github.event.pull_request.number || '' }}
+      CYPRESS_IS_EMBEDDING_SDK: true
+      COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title || github.event.head_commit.message || github.event.head.sha }}
+      TZ: US/Pacific # to make node match the instance tz
+      CYPRESS_CI: true
+      # Sample Apps testing variables
+      EXCLUDE_SAMPLE_APP_NAMES: ${{ needs.get-sample-app-compatibility-data.outputs.exclude_sample_app_names }}
+      SAMPLE_APP_BRANCH_NAME: ${{ needs.get-sample-app-compatibility-data.outputs.sample_app_branch_name }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Retrieve uberjar artifact for ee
+        uses: actions/download-artifact@v4
+        with:
+          name: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
+
+      - name: Prepare front-end environment
+        uses: ./.github/actions/prepare-frontend
+
+      - name: Prepare JDK ${{ needs.get-build-requirements.outputs.java_version || 21 }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ needs.get-build-requirements.outputs.java_version || 21 }}
+          distribution: "temurin"
+
+      - name: Prepare Cypress environment
+        id: cypress-prep
+        uses: ./.github/actions/prepare-cypress
+
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
+        with:
+          m2-cache-key: "cljs"
+
+      - name: Compile CLJS
+        run: yarn build-pure:cljs
+        shell: bash
+
+      - name: Build Embedding SDK package
+        run: yarn build-embedding-sdk
+
+      - name: Run Metabase
+        run: node e2e/runner/run_cypress_ci.js start
+
+      - name: Make app db snapshot
+        run: node e2e/runner/run_cypress_ci.js snapshot --browser ${{ steps.cypress-prep.outputs.chrome-path }}
+
+      - name: Prepare and launch Sample Apps
+        run: npx tsx ./e2e/runner/run-sample-apps-for-embedding-sdk/run_ci.ts
+
+      - name: Run e2e tests for Sample Apps compatibility with Embedding SDK
+        id: run-e2e-tests
+        continue-on-error: true
+        run: node e2e/runner/run_cypress_ci.js sample-apps-embedding-sdk-e2e --browser ${{ steps.cypress-prep.outputs.chrome-path }}
+
+      - name: Upload Test Results
+        uses: ./.github/actions/upload-test-results
+        if: always()
+        with:
+          input-path: ./target/junit
+          output-name: e2e-sample-apps-embedding-sdk
+          bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+          aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+          trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+
+      - name: Upload Cypress Artifacts upon failure
+        uses: actions/upload-artifact@v4
+        if: ${{ steps.run-e2e-tests.outcome != 'success' }}
+        with:
+          name: cypress-recording-sample-apps-embedding-sdk-latest
+          path: |
+            ./cypress
+            ./logs/test.log
+          if-no-files-found: ignore
+
+      - name: Publish Summary
+        if: ${{ steps.run-e2e-tests.outcome != 'success' }}
+        uses: actions/github-script@v7
+        with:
+          script: | #js
+            const {
+               generateReport,
+               parseReport,
+               formatSummary
+             } = require("./.github/scripts/handle-mochawesome-report.js");
+
+             const report = await generateReport();
+             const results = parseReport(report);
+             const summary = formatSummary(results);
+
+             await core.summary.addRaw(summary).write();
+
+  e2e-tests-skipped-stub:
+    needs: [e2e-tests]
+    if: |
+      !cancelled() &&
+      needs.e2e-tests.result == 'skipped'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    name: e2e-sample-apps-embedding-sdk-tests
+    steps:
+      - run: |
+          echo "Didn't run due to conditional filtering"

--- a/.github/workflows/e2e-sample-apps-embedding-sdk.yml
+++ b/.github/workflows/e2e-sample-apps-embedding-sdk.yml
@@ -86,7 +86,7 @@ jobs:
         id: build-sample-app-compatibility-data
         with:
           script: | # js
-            const ref = process.env.GITHUB_BASE_REF || process.env.GITHUB_REF || "";
+            const ref = '${{ github.base_ref || github.ref }}';
             const branchName = ref.replace(/^refs\/heads\//, "");
 
             const isMainBranchRef = branchName === 'master';

--- a/e2e/runner/run-sample-apps-for-embedding-sdk/run.ts
+++ b/e2e/runner/run-sample-apps-for-embedding-sdk/run.ts
@@ -17,9 +17,10 @@ import type {
 import { SAMPLE_APP_NAMES } from "./config";
 
 const userOptions = {
-  EMBEDDING_SDK_VERSION: "",
+  EMBEDDING_SDK_VERSION: "local",
   SAMPLE_APP_NAMES: SAMPLE_APP_NAMES.join(","),
   EXCLUDE_SAMPLE_APP_NAMES: "",
+  SAMPLE_APP_BRANCH_NAME: "",
   ...booleanify(process.env),
 };
 
@@ -29,6 +30,7 @@ printBold(`Running Cypress Sample Apps Tests with options:
   - EMBEDDING_SDK_VERSION      : ${userOptions.EMBEDDING_SDK_VERSION}
   - SAMPLE_APP_NAMES           : ${userOptions.SAMPLE_APP_NAMES}
   - EXCLUDE_SAMPLE_APP_NAMES   : ${userOptions.EXCLUDE_SAMPLE_APP_NAMES}
+  - SAMPLE_APP_BRANCH_NAME     : ${userOptions.SAMPLE_APP_BRANCH_NAME}
 `);
 
 async function initSampleApp({
@@ -40,8 +42,15 @@ async function initSampleApp({
   setupConfig: SampleAppSetupConfig;
   embeddingSdkVersion: EmbeddingSdkVersion;
 }) {
-  const { subAppName, branch, env, startCommand, additionalSetup } =
-    setupConfig;
+  const {
+    subAppName,
+    defaultBranch,
+    env,
+    startCommand,
+    additionalSetup,
+  } = setupConfig;
+  const branch = userOptions.SAMPLE_APP_BRANCH_NAME ?? defaultBranch;
+
   const loggerPrefix = [appName, subAppName].filter(Boolean).join("/");
 
   const { rootPath, installationPath } = await fetchApp({

--- a/e2e/runner/run-sample-apps-for-embedding-sdk/run_ci.ts
+++ b/e2e/runner/run-sample-apps-for-embedding-sdk/run_ci.ts
@@ -1,0 +1,3 @@
+import { run as runSampleAppsForEmbeddingSdk } from "./run";
+
+runSampleAppsForEmbeddingSdk();

--- a/e2e/runner/run_cypress_ci.js
+++ b/e2e/runner/run_cypress_ci.js
@@ -5,11 +5,22 @@ const { printBold } = require("./cypress-runner-utils");
 
 const mode = process.argv?.[2]?.trim();
 
-const availableModes = ["start", "snapshot", "e2e", "component"];
+const availableModes = [
+  "start",
+  "snapshot",
+  "e2e",
+  "sample-apps-embedding-sdk-e2e",
+  "component",
+];
 
 if (!availableModes.includes(mode)) {
   console.error(`Invalid mode: ${mode}`);
   process.exit(FAILURE_EXIT_CODE);
+}
+
+// To read it in other places
+if (!process.env.TEST_SUITE) {
+  process.env.TEST_SUITE = mode;
 }
 
 const startServer = async () => {

--- a/e2e/runner/sample-apps-shared/constants/sample-app-setup-configs.ts
+++ b/e2e/runner/sample-apps-shared/constants/sample-app-setup-configs.ts
@@ -9,7 +9,7 @@ export const SAMPLE_APP_SETUP_CONFIGS: SampleAppSetupConfigs = {
   "metabase-nodejs-react-sdk-embedding-sample": [
     {
       subAppName: "client",
-      branch: "main",
+      defaultBranch: "main",
       env: {
         PORT: 4300,
         VITE_METABASE_INSTANCE_URL: METABASE_INSTANCE_URL,
@@ -21,7 +21,7 @@ export const SAMPLE_APP_SETUP_CONFIGS: SampleAppSetupConfigs = {
   "metabase-nextjs-sdk-embedding-sample": [
     {
       subAppName: "next-sample-pages-router",
-      branch: "main",
+      defaultBranch: "main",
       env: {
         PORT: 4301,
         NEXT_PUBLIC_METABASE_INSTANCE_URL: METABASE_INSTANCE_URL,
@@ -32,7 +32,7 @@ export const SAMPLE_APP_SETUP_CONFIGS: SampleAppSetupConfigs = {
     },
     {
       subAppName: "next-sample-app-router",
-      branch: "main",
+      defaultBranch: "main",
       env: {
         PORT: 4302,
         NEXT_PUBLIC_METABASE_INSTANCE_URL: METABASE_INSTANCE_URL,
@@ -44,7 +44,7 @@ export const SAMPLE_APP_SETUP_CONFIGS: SampleAppSetupConfigs = {
   ],
   shoppy: [
     {
-      branch: "main",
+      defaultBranch: "main",
       env: {
         PORT: 4303,
         // We have to reset API host for tests

--- a/e2e/runner/sample-apps-shared/helpers/start-app-in-background.ts
+++ b/e2e/runner/sample-apps-shared/helpers/start-app-in-background.ts
@@ -19,19 +19,23 @@ export function startAppInBackground({
     stdio: "ignore",
   });
 
-  ["exit", "SIGINT", "SIGTERM", "uncaughtException"].forEach(signal => {
-    process.on(signal, () => {
-      logWithPrefix(
-        `Parent received ${signal}, killing process with PID=${child.pid}...`,
-        loggerPrefix,
-      );
-      try {
-        if (child.pid) {
-          process.kill(child.pid);
-        }
-      } catch {}
+  if (process.env.CI) {
+    child.unref();
+  } else {
+    ["exit", "SIGINT", "SIGTERM", "uncaughtException"].forEach(signal => {
+      process.on(signal, () => {
+        logWithPrefix(
+          `Parent received ${signal}, killing process with PID=${child.pid}...`,
+          loggerPrefix,
+        );
+        try {
+          if (child.pid) {
+            process.kill(child.pid);
+          }
+        } catch {}
+      });
     });
-  });
+  }
 
   logWithPrefix(
     `Launched the process with PID=${child.pid} in background.`,

--- a/e2e/runner/sample-apps-shared/types.ts
+++ b/e2e/runner/sample-apps-shared/types.ts
@@ -7,7 +7,7 @@ export type EmbeddingSdkVersion = string | "local" | undefined;
 
 export type SampleAppSetupConfig = {
   subAppName?: string;
-  branch: string;
+  defaultBranch: string;
   env: Record<string, string | number>;
   additionalSetup?: (data: {
     installationPath: string;

--- a/e2e/support/ci_tasks.ts
+++ b/e2e/support/ci_tasks.ts
@@ -7,6 +7,7 @@ const {
   PR_NUMBER,
   GITHUB_REPOSITORY,
   JOB_NAME,
+  TEST_SUITE,
 } = process.env;
 
 const MAX_TEST_LENGTH = 10;
@@ -58,7 +59,7 @@ function getCommentText(tests: TestInfo[]) {
   }
 
   return `
-  ## e2e tests failed on \`${HASH ?? "hash"}\`
+  ## ${TEST_SUITE} tests failed on \`${HASH ?? "hash"}\`
 
   [e2e test run](https://github.com/metabase/metabase/actions/runs/${GITHUB_RUN_ID}?pr=${PR_NUMBER})
 
@@ -105,7 +106,7 @@ async function getComment(): Promise<{ body: string; id: string } | undefined> {
   }
 
   return comments.find((comment: { body: string; id: string }) =>
-    comment?.body?.includes("## e2e tests failed on"),
+    comment?.body?.includes(`## ${TEST_SUITE} tests failed on`),
   );
 }
 

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -266,6 +266,9 @@ const sampleAppsEmbeddingSdkE2eTestConfig = {
   specPattern: getSampleAppsEmbeddingSdkSpecFiles(
     "e2e/test/sample-apps-embedding-sdk-scenarios",
   ),
+  reporter: mainConfig.reporter,
+  reporterOptions: mainConfig.reporterOptions,
+  retries: mainConfig.retries,
 };
 
 module.exports = {


### PR DESCRIPTION
Integrate Sample Apps e2e tests with CI

We want to:
- run tests for all sample apps against their main branch when
	- a PR is targeting the master branch
	- it is the master branch
- run tests for all sample apps excluding Shoppy (see https://www.notion.so/metabase/SDK-sample-apps-and-MB-versions-19769354c901809390d6fa43489271bf?pvs=4#19869354c9018044b3fcd14fd9628c08) against their corresponding release branch N when
	- a PR is targeting a release branch N
	- a PR is the release branch N
	- ONLY for the last 2 stable release branches (52, 53)

How to verify:
- check this run against `master` sample apps https://github.com/metabase/metabase/actions/runs/13390059504/job/37396019613?pr=53748
- check this run against `release-x.53-x` branches of a sample app. It is failing, because we don't have such branches yet. https://github.com/metabase/metabase/actions/runs/13376678843/job/37357334365?pr=53847
- check some comments regarding failing specs in this PR like https://github.com/metabase/metabase/pull/53748#issuecomment-2660884747