### PR TITLE
stop using circleci/postgres:latest

### DIFF
--- a/.github/workflows/cross-branch-migrations.yml
+++ b/.github/workflows/cross-branch-migrations.yml
@@ -60,7 +60,7 @@ jobs:
       MB_DB_USER: circle_test
     services:
       postgres:
-        image: circleci/postgres:latest
+        image: postgres:latest
         ports:
           - "5432:5432"
         env:

--- a/.github/workflows/drivers-stress-test.yml
+++ b/.github/workflows/drivers-stress-test.yml
@@ -470,7 +470,7 @@ jobs:
       MB_POSTGRES_SSL_TEST_SSL_ROOT_CERT_PATH: 'test-resources/certificates/us-east-2-bundle.pem'
     services:
       postgres:
-        image: circleci/postgres:latest
+        image: postgres:latest
         ports:
           - "5432:5432"
         env:


### PR DESCRIPTION
aka POSTGRES 13 because `circleci/` docker images are no longer kept up to date