### PR TITLE
Fix rerun workflow again

### DIFF
--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -2,9 +2,9 @@ name: Re-run Flaky Workflows
 
 on:
   workflow_run:
-    workflows: [run-tests]
+    workflows: [Run tests]
     types: [completed]
-    branches: [master, 'release-x.**', 'backport-**']
+    # branches: [master, 'release-x.**', 'backport-**'] # FIXME for testing
 
 jobs:
   rerun-on-failure:

--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: [Run tests]
     types: [completed]
-    # branches: [master, 'release-x.**', 'backport-**'] # FIXME for testing
+    branches: [master, 'release-x.**', 'backport-**']
 
 jobs:
   rerun-on-failure:


### PR DESCRIPTION
I guess we need to use the workflow name instead of id. Workflow events only trigger off the main branch, so there's no way to test this except in master.