### PR TITLE
Cast column to float for Redshift and SQLServer `AVG`

### DIFF
--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -292,6 +292,10 @@
                    y))
                nil)))
 
+(defmethod sql.qp/->honeysql [:redshift :avg]
+  [driver [_ field]]
+  [:avg [:cast (sql.qp/->honeysql driver field) :float]])
+
 (defn- extract [unit temporal]
   [::h2x/extract (format "'%s'" (name unit)) temporal])
 

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -556,6 +556,10 @@
   [driver [_ arg power]]
   [:power (h2x/cast :float (sql.qp/->honeysql driver arg)) (sql.qp/->honeysql driver power)])
 
+(defmethod sql.qp/->honeysql [:sqlserver :avg]
+  [driver [_ field]]
+  [:avg [:cast (sql.qp/->honeysql driver field) :float]])
+
 (defn- format-approx-percentile-cont
   [_tag [expr p :as _args]]
   (let [[expr-sql & expr-args] (sql/format-expr expr {:nested true})

--- a/test/metabase/query_processor_test/expression_aggregations_test.clj
+++ b/test/metabase/query_processor_test/expression_aggregations_test.clj
@@ -57,14 +57,13 @@
                 {:aggregation [[:avg [:* $id $price]]]
                  :breakout    [$price]})))))))
 
-(deftest ^:parallel double-average-test
+(deftest ^:parallel non-int-avg-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
-    (testing "average is calculated correctly"
-      (is (> 0.01 (Math/abs (- 2.03
-                               (->> {:aggregation [[:avg $price]]}
-                                    (mt/run-mbql-query venues)
-                                    (mt/formatted-rows [double])
-                                    first first))))))))
+    (testing "integers with a non-integer average is calculated correctly"
+      (is (= [[2.03]]
+             (->> {:aggregation [[:avg $price]]}
+                  (mt/run-mbql-query venues)
+                  (mt/formatted-rows [2.0])))))))
 
 (deftest ^:parallel post-aggregation-math-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)

--- a/test/metabase/query_processor_test/expression_aggregations_test.clj
+++ b/test/metabase/query_processor_test/expression_aggregations_test.clj
@@ -60,10 +60,11 @@
 (deftest ^:parallel double-average-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
     (testing "average is calculated correctly"
-      (is (= [[2.03]]
-             (->> {:aggregation [[:avg $price]]}
-                  (mt/run-mbql-query venues)
-                  (mt/formatted-rows [double])))))))
+      (is (> 0.01 (Math/abs (- 2.03
+                               (->> {:aggregation [[:avg $price]]}
+                                    (mt/run-mbql-query venues)
+                                    (mt/formatted-rows [double])
+                                    first first))))))))
 
 (deftest ^:parallel post-aggregation-math-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)

--- a/test/metabase/query_processor_test/expression_aggregations_test.clj
+++ b/test/metabase/query_processor_test/expression_aggregations_test.clj
@@ -57,6 +57,14 @@
                 {:aggregation [[:avg [:* $id $price]]]
                  :breakout    [$price]})))))))
 
+(deftest ^:parallel double-average-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
+    (testing "average is calculated correctly"
+      (is (= [[2.03]]
+             (->> {:aggregation [[:avg $price]]}
+                  (mt/run-mbql-query venues)
+                  (mt/formatted-rows [double])))))))
+
 (deftest ^:parallel post-aggregation-math-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
     (testing "post-aggregation math"

--- a/test/metabase/query_processor_test/order_by_test.clj
+++ b/test/metabase/query_processor_test/order_by_test.clj
@@ -2,7 +2,6 @@
   "Tests for the `:order-by` clause."
   (:require
    [clojure.test :refer :all]
-   [metabase.driver :as driver]
    [metabase.test :as mt]))
 
 (deftest ^:parallel order-by-test

--- a/test/metabase/query_processor_test/order_by_test.clj
+++ b/test/metabase/query_processor_test/order_by_test.clj
@@ -92,15 +92,6 @@
                  :breakout    [$price]
                  :order-by    [[:asc [:aggregation 0]]]})))))))
 
-(defmethod driver/database-supports? [::driver/driver ::floors-average]
-  [_driver _feature _database]
-  false)
-
-(doseq [driver [:redshift :sqlserver]]
-  (defmethod driver/database-supports? [driver ::floors-average]
-    [_driver _feature _database]
-    true))
-
 (deftest ^:parallel order-by-aggregate-fields-test-4
   (mt/test-drivers (mt/normal-drivers)
     (testing :avg

--- a/test/metabase/query_processor_test/order_by_test.clj
+++ b/test/metabase/query_processor_test/order_by_test.clj
@@ -104,17 +104,16 @@
 (deftest ^:parallel order-by-aggregate-fields-test-4
   (mt/test-drivers (mt/normal-drivers)
     (testing :avg
-      (let [driver-floors-average? (driver/database-supports? driver/*driver* ::floors-average (mt/db))]
-        (is (= [[3 22.0]
-                [2 (if driver-floors-average? 28.0 28.3)]
-                [1 (if driver-floors-average? 32.0 32.8)]
-                [4 (if driver-floors-average? 53.0 53.5)]]
-               (mt/formatted-rows
-                [int 1.0]
-                (mt/run-mbql-query venues
-                  {:aggregation [[:avg $category_id]]
-                   :breakout    [$price]
-                   :order-by    [[:asc [:aggregation 0]]]}))))))))
+      (is (= [[3 22.0]
+              [2 28.3]
+              [1 32.8]
+              [4 53.5]]
+             (mt/formatted-rows
+              [int 1.0]
+              (mt/run-mbql-query venues
+                {:aggregation [[:avg $category_id]]
+                 :breakout    [$price]
+                 :order-by    [[:asc [:aggregation 0]]]})))))))
 
 (deftest ^:parallel order-by-aggregate-fields-test-5
   (mt/test-drivers (mt/normal-drivers-with-feature :standard-deviation-aggregations)


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/48173
Closes https://linear.app/metabase/issue/DRI-90/redshift-average-returns-integer-values-for-integer-columns

### Description

Redshift average function returns the same type of the column its given. So if you're calculating the average of an int column it returns an int, even though a user may expect the average to be a non-integer (e.g. avg(1, 2, 3, 4) should be 2.5 not 2). We can do this by casting the column to a float before calculating the average for Redshift.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Take the average of a Redshift integer column
2. It should be the correct decimal value, not the nearest integer.

### Demo

https://github.com/user-attachments/assets/32889339-c22d-4550-bb31-ceccffe4afae


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
