### PR TITLE
Add some nice logging about skipping snapshots

### DIFF
--- a/e2e/runner/run_cypress_local.ts
+++ b/e2e/runner/run_cypress_local.ts
@@ -97,6 +97,9 @@ const init = async () => {
 
     printBold("⏳ Generating snapshots");
     await runCypress("snapshot", cleanup);
+  } else {
+    printBold("Skipping snapshot generation, beware of stale snapshot caches");
+    shell("echo 'Existing snapshots:' && ls -1 e2e/snapshots");
   }
 
   const isFrontendRunning = shell("lsof -ti:8080 || echo ''", { quiet: true });


### PR DESCRIPTION
Small follow up to #53095 and #53576

We save e2e db snapshots as sql files in e2e/snapshots, so if you have generated them once, you need not re-generate them every time you start up cypress. This can make running cypress with a custom backend MUCH faster.

_However_, if these snapshots are stale, they could cause really nasty, hard-to-debug test failures. So refreshing snapshots will remain on by default, and retains the spirit of our local e2e testing ethos: everything should work properly out of the box, but you can customize and optimize as much as you want.

So, for many engineers who are running with h2 dbs, and already have local snapshot data: this e2e command will be _very_ fast for local development:
```
BACKEND_PORT=3000 GENERATE_SNAPSHOTS=false yarn test-cypress
```
But comes at the risk of (a) blowing away your h2 db, and (b) loading stale cache data that could make some tests error/fail
