### PR TITLE
Field select fix

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -519,7 +519,40 @@ describe("scenarios > visualizations > line chart", () => {
   });
 
   describe("color series", () => {
-    it("should allow changing a series' color", () => {
+    it("should allow drag and drop", () => {
+      const testQuery = {
+        type: "query",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"], ["sum", ["field", ORDERS.TOTAL, null]]],
+          breakout: [
+            ["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"],
+          ],
+        },
+        database: SAMPLE_DB_ID,
+      };
+
+      H.visitQuestionAdhoc({
+        dataset_query: testQuery,
+        display: "line",
+      });
+
+      H.openVizSettingsSidebar();
+
+      // making sure the grabber icon is there
+      cy.findAllByTestId("chart-setting-select")
+        .then($elements => {
+          for (const element of $elements) {
+            if (element.value === "Sum of Total") {
+              return cy.wrap(element);
+            }
+          }
+        })
+        .closest("[data-testid=chartsettings-field-picker]")
+        .icon("grabber");
+    });
+
+    it("should allow changing a series' color - #53735", () => {
       H.visitQuestionAdhoc({
         dataset_query: testQuery,
         display: "line",

--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -518,6 +518,33 @@ describe("scenarios > visualizations > line chart", () => {
     });
   });
 
+  describe("color series", () => {
+    it("should allow changing a series' color", () => {
+      H.visitQuestionAdhoc({
+        dataset_query: testQuery,
+        display: "line",
+      });
+
+      H.openVizSettingsSidebar();
+      H.openSeriesSettings("Count");
+
+      H.popover().within(() => {
+        cy.findByTestId("color-selector-button").button().click();
+      });
+
+      H.popover()
+        .should("have.length", 2)
+        .last()
+        .within(() => {
+          cy.findByLabelText("#EF8C8C").realClick();
+        });
+
+      cy.button("Done").click();
+
+      H.cartesianChartCircleWithColor("#EF8C8C");
+    });
+  });
+
   describe("tooltip of combined dashboard cards (multi-series) should show the correct column title (metabase#16249", () => {
     const RENAMED_FIRST_SERIES = "Foo";
     const RENAMED_SECOND_SERIES = "Bar";

--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -550,6 +550,17 @@ describe("scenarios > visualizations > line chart", () => {
         })
         .closest("[data-testid=chartsettings-field-picker]")
         .icon("grabber");
+
+      cy.log("Drag and drop the first y-axis field to the last position");
+      cy.findAllByTestId("chart-setting-select").then(initial => {
+        H.dragField(0, 1);
+
+        cy.findAllByTestId("chart-setting-select").should(content => {
+          expect(content[0].value).to.eq(initial[0].value); // Created At: Month
+          expect(content[1].value).to.eq(initial[2].value); // Sum of Total
+          expect(content[2].value).to.eq(initial[1].value); // Count
+        });
+      });
     });
 
     it("should allow changing a series' color - #53735", () => {

--- a/frontend/src/metabase/core/components/ColorSelector/ColorSelector.tsx
+++ b/frontend/src/metabase/core/components/ColorSelector/ColorSelector.tsx
@@ -17,18 +17,25 @@ export interface ColorSelectorProps extends ColorSelectorAttributes {
   colors: string[];
   pillSize?: PillSize;
   onChange?: (newValue: string) => void;
+  withinPortal?: boolean;
 }
 
 export const ColorSelector = ({
   value,
   colors,
   onChange,
+  withinPortal = true,
   ...props
 }: ColorSelectorProps) => {
   const [opened, { toggle, close }] = useDisclosure(false);
 
   return (
-    <Popover opened={opened} onClose={close} position="bottom-start">
+    <Popover
+      withinPortal={withinPortal}
+      opened={opened}
+      onClose={close}
+      position="bottom-start"
+    >
       <Popover.Target>
         <Center data-testid="color-selector-button">
           <ColorPill {...props} color={value} onClick={toggle} />
@@ -40,6 +47,7 @@ export const ColorSelector = ({
           colors={colors}
           onChange={onChange}
           onClose={close}
+          data-testid="color-selector-popover"
         />
       </Popover.Dropdown>
     </Popover>

--- a/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesSingle.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesSingle.tsx
@@ -41,6 +41,7 @@ const ChartNestedSettingsSeriesSingle = ({
     >
       <div className={cx(CS.flex, CS.alignCenter, CS.borderBottom, CS.pb2)}>
         <ColorSelector
+          withinPortal={false}
           value={computedSettings.color}
           colors={getAccentColors()}
           onChange={value => onChangeObjectSettings(object, { color: value })}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
@@ -98,7 +98,7 @@ export const ChartSettingFieldPicker = ({
         onChange={onChange}
         leftSection={
           hasLeftSection ? (
-            <Group wrap="nowrap" gap="sm" p="xs" ml="sm" align="start">
+            <Group wrap="nowrap" gap="xs" p="xs" ml="sm" mr="md" align="center">
               {showDragHandle && (
                 <GrabberHandle
                   name="grabber"
@@ -121,12 +121,20 @@ export const ChartSettingFieldPicker = ({
             </Group>
           ) : null
         }
-        leftSectionWidth="auto"
         placeholderNoOptions={t`No valid fields`}
         placeholder={t`Select a field`}
-        rightSectionWidth="auto"
+        rightSectionWidth="100px"
         rightSection={
-          <Group wrap="nowrap" gap="sm" p="xs" mr="sm">
+          <Group
+            wrap="nowrap"
+            gap="sm"
+            p="xs"
+            mr="sm"
+            miw={
+              [!disabled, !!menuWidgetInfo, !!onRemove].filter(Boolean).length *
+              42
+            }
+          >
             {!disabled && (
               <ActionIcon c="text-medium" size="sm" radius="xl" p={0}>
                 <Icon name="chevrondown" />
@@ -171,7 +179,7 @@ export const ChartSettingFieldPicker = ({
             border: "none",
             width: "100%",
             color: "var(--mb-color-text-primary)",
-            cursor: "inherit",
+            cursor: "pointer",
             pointerEvents: "unset",
           },
         }}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.jsx
@@ -31,7 +31,9 @@ export const ChartSettingSelect = ({
   iconWidth,
   pl,
   pr,
+  leftSection,
   rightSection,
+  rightSectionWidth,
   styles,
   w,
   footer,
@@ -69,7 +71,7 @@ export const ChartSettingSelect = ({
       placeholder={options.length === 0 ? placeholderNoOptions : placeholder}
       initiallyOpened={isInitiallyOpen}
       searchable={!!searchProp}
-      rightSectionWidth="10px"
+      rightSectionWidth={rightSectionWidth ?? "10px"}
       comboboxProps={{
         withinPortal: false,
         floatingStrategy: "fixed",
@@ -78,6 +80,7 @@ export const ChartSettingSelect = ({
       iconWidth={iconWidth}
       pl={pl}
       pr={pr}
+      leftSection={leftSection}
       rightSection={rightSection}
       styles={styles}
       w={w}


### PR DESCRIPTION
Closes #53735

### Description

Picking a color from within the field popover was broken. Also, the drag and drop grabber was not rendered properly.

### How to verify

  1. Reorder a column using the handle
  2. Pick a color using the color selector

<img width="1582" alt="image" src="https://github.com/user-attachments/assets/d6d6e276-a452-4163-9b25-4d9d3d39f172" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
