### PR TITLE
Allow duplicating dashboard but not with DQs

### DIFF
--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -229,14 +229,12 @@
 ;;; ### GENERIC RESPONSE HELPERS
 ;; These are basically the same as the `api-` versions but with RESPONSE-PAIR already bound
 
-;; #### GENERIC 400 RESPONSE HELPERS
-(def ^:private generic-400
-  [400 (deferred-tru "Invalid Request.")])
-
 (defn check-400
   "Throw a `400` if `arg` is `false` or `nil`, otherwise return as-is."
-  [arg]
-  (check arg generic-400))
+  ([arg]
+   (check-400 arg (deferred-tru "Invalid Request.")))
+  ([arg msg]
+   (check arg [400 msg])))
 
 ;; #### GENERIC 404 RESPONSE HELPERS
 (def ^:private generic-404

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -348,7 +348,8 @@
                          (cond
                            (or
                             (not (readable? parent-card))
-                            (not (readable? card)))
+                            (not (readable? card))
+                            (:archived card))
                            :discard
 
                            (or (:dashboard_id card)
@@ -460,6 +461,11 @@
                                               [:is_deep_copy        {:default false} [:maybe :boolean]]]]
   ;; if we're trying to save the new dashboard in a Collection make sure we have permissions to do that
   (collection/check-write-perms-for-collection collection_id)
+  (api/check-400 (not (and (= is_deep_copy false)
+                           (t2/exists? :model/Card
+                                       :dashboard_id from-dashboard-id
+                                       :archived false)))
+                 (deferred-tru "You cannot do a shallow copy of this dashboard because it contains Dashboard Questions."))
   (let [existing-dashboard (get-dashboard from-dashboard-id)
         dashboard-data {:name                (or name (:name existing-dashboard))
                         :description         (or description (:description existing-dashboard))


### PR DESCRIPTION
If you try to shallow-copy a dashboard but it has DQs, throw a 400.

(Also, when copying a dashboard, don't copy cards that are archived.)