### PR TITLE
[refs] Split core table+card metadata functions into new and old

### DIFF
--- a/src/metabase/lib/common.cljc
+++ b/src/metabase/lib/common.cljc
@@ -99,3 +99,11 @@
                                      argvec)]]
             `([~@argvec]
               (defop-create ~(keyword op-name) ~arglist-expr))))))
+
+(def ^:dynamic *use-new-refs*
+  "Dynamically controls whether functions which use metadata are calling the `foo:new-refs` or `foo:old-refs` variants.
+
+  **This must be a clean break!** Old code calls old code only; new code calls new code only.
+
+  Defaults to false (ie. `foo:old-refs`) while the `foo:new-refs` code is under development."
+  false)

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -16,6 +16,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.metadata.ident :as lib.metadata.ident]
+   [metabase.lib.metadata.overhaul :as-alias lib.metadata.overhaul]
    [metabase.lib.options :as lib.options]
    [metabase.lib.query :as lib.query]
    [metabase.lib.ref :as lib.ref]
@@ -153,6 +154,10 @@
     :metadata/column
     (u/assoc-dissoc field-or-join ::join-alias join-alias)
 
+    ::lib.metadata.overhaul/column
+    (throw (ex-info "Can't happen: with-join-alias is too raw; we can't convert a random column into one from a join it didn't come from!"
+                    {}))
+
     :mbql/join
     (with-join-alias-update-join field-or-join join-alias)
 
@@ -288,7 +293,9 @@
                                                              :include-implicitly-joinable? false})))
         (:joins (lib.util/query-stage query stage-number))))
 
-(mu/defn all-joins-expected-columns :- lib.metadata.calculation/ColumnsWithUniqueAliases
+(mu/defn all-joins-expected-columns :- [:or
+                                        lib.metadata.calculation/ColumnsWithUniqueAliases
+                                        [:maybe [:sequential {:min 1} ::lib.metadata.overhaul/column]]]
   "Convenience for calling [[lib.metadata.calculation/returned-columns-method]] on all the joins in a query stage."
   [query        :- ::lib.schema/query
    stage-number :- :int

--- a/src/metabase/lib/join/util.cljc
+++ b/src/metabase/lib/join/util.cljc
@@ -3,6 +3,7 @@
   (:require
    [metabase.lib.dispatch :as lib.dispatch]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.metadata.overhaul :as lib.metadata.overhaul]
    [metabase.lib.options :as lib.options]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.common :as lib.schema.common]
@@ -30,6 +31,7 @@
   "A field in a join, either `:metabase.lib.schema.metadata/column` or a `:field` ref."
   [:or
    [:ref ::lib.schema.metadata/column]
+   [:ref ::lib.metadata.overhaul/column]
    [:ref :mbql.clause/field]])
 
 (def FieldOrPartialJoin
@@ -90,3 +92,12 @@
                           (implicit-join-name query field-metadata))]
     (joined-field-desired-alias join-alias (:name field-metadata))
     (:name field-metadata)))
+
+(mu/defn join-ident->alias :- :string
+  "Finds the join clause with the given `:ident` and returns its alias."
+  [query      :- ::lib.schema/query
+   join-ident :- :string]
+  (first (for [stage (:stages query)
+               join  (:joins stage)
+               :when (= (:ident join) join-ident)]
+           (:alias join))))

--- a/src/metabase/lib/metadata/overhaul.cljc
+++ b/src/metabase/lib/metadata/overhaul.cljc
@@ -1,0 +1,183 @@
+(ns metabase.lib.metadata.overhaul
+  "Helpers and utilities during the transition to the new world for `:ident`-based refs."
+  (:require
+   [malli.core :as mc]
+   [metabase.lib.schema.common :as lib.schema.common]
+   [metabase.lib.schema.id :as lib.schema.id]
+   [metabase.util.malli :as mu]
+   [metabase.util.malli.registry :as mr]))
+
+(def ^:dynamic *overhaul-selector*
+  "Enumerated setting that controls whether we're using old refs and metadata, or new refs and metadata.
+
+  **DO NOT** test this directly - use [[new-refs?]] or [[old-refs?]] instead.
+  This is only exported so it can be overridden in tests.
+
+  - `:old-only` and `:new-only` are self-explanatory.
+  - `:old-wins` runs **both** versions, but returns the old version's output.
+  - `:new-wins` is the reverse.
+
+  Current default is `:old-only`."
+  :old-only)
+
+(defn new-refs?
+  "Returns true if the library is operating in **new refs** mode.
+
+  Note that queries are not compatible between modes! The mode must be consistent for the entire life of a query."
+  []
+  (= *overhaul-selector* :new-only))
+
+(defn old-refs?
+  "Returns true if the library is operating in **old refs** mode.
+
+  Note that queries are not compatible between modes! The mode must be consistent for the entire life of a query."
+  []
+  (= *overhaul-selector* :old-only))
+
+(defn old-new
+  "Given two functions `old-fn` and `new-fn` with the same arguments, this returns the appropriate function based on
+  the current [[*overhaul-selector*]]."
+  [old-fn new-fn]
+  (if (new-refs?)
+    new-fn
+    old-fn))
+
+(mr/def ::common
+  "These are the parts which are universal, common to all columns whatever their source."
+  [:map
+   ;; TODO: Using this variant type is temporary; it should take over `:metadata/column` eventually.
+   [:lib/type            [:= ::column]]
+   [:column/ident        ::lib.schema.common/non-blank-string]
+
+   ;; NOTE: Some databases seem to allow blank column names!? `:column/name` should be set to `""` if it's blank.
+   ;; TODO: It seems from the original discussion that this is an accident of metadata fetching, and may no longer
+   ;; really happen. Investigate that and see if we can bring back `non-blank-string` for names.
+   ;; See https://metaboat.slack.com/archives/C04DN5VRQM6/p1686841551319789
+   ;; TODO: Even more radical, but - why do we need :name on general columns? Nobody should be using it!
+   ;; We do need display names, but those can be generated (and disambiguated) on the fly.
+   ;; I'm going to omit this for now and see how far we can go with it...
+   #_[:column/name         :string]
+   [:column/display-name {:optional true} ::lib.schema.common/non-blank-string]
+
+   ;; Deliberately combining `:effective-type` and `:base-type` under one label.
+   ;; This is the type of this column as it should be treated in Metabase.
+   ;; If the *representation* differs from the *value*, eg. a datetime encoded as an ISO string, this should be
+   ;; `:type/DateTime` and other properties (not currently defined) will specify the underlying representation and/or
+   ;; the coercion being applied.
+   [:column/type         ::lib.schema.common/base-type]
+
+   ;; If present, this is the :ident of a target column, typically the PK of another table.
+   ;; Using an ident here is strictly more flexible than an ID, since it could target eg. a column on a model.
+   [:column/fk-target-ident {:optional true} ::lib.schema.common/non-blank-string]])
+
+;; **On some "missing" metadata keys
+;; - source-alias and desired-alias are missing; these are SQL-level concerns and can be ignored by the library.
+;;   - :idents can be used instead to refer uniquely to columns
+;;   - :name might not be unique!
+
+(mr/def ::source-extras
+  "**Source** columns are those that come from some source external to our query: tables or cards. Sources return not
+  a *set* of columns but a *list*, with a defined order. Hence `:column.source/position` is defined on such cards."
+  [:map
+   [:column.source/position [:int {:min 0}]]])
+
+(mr/def ::field-specific
+  "Proper Fields that live in the user's data warehouse have these keys."
+  [:map
+   [:field/id       ::lib.schema.id/field]
+   [:field/table-id ::lib.schema.id/table]
+   ;; Fields have names, but columns don't necessarily.
+   ;; TODO: I'm leaving this out too until something actually needs it.
+   #_[:field/name     ::lib.schema.common/non-blank-string]])
+
+(mr/def ::card-extras
+  "When a column comes from a card, we include the ID of that card so that we can fetch the card's details for use in
+  `display-info`, display names, etc."
+  [:merge
+   ::source-extras
+   [:map
+    [:column/card-id ::lib.schema.id/card]]])
+
+(mr/def ::field
+  "Schema for a proper Field from the user's DWH.
+
+  Fields have a few specific properties, and are also *source columns*."
+  [:merge ::common ::field-specific ::source-extras])
+
+(mr/def ::column
+  "Schema for a proper Field from the user's DWH. Merging `::common` and `::field-specific`."
+  [:ref ::common])
+
+(mr/def ::column-from-card
+  "Schema for a proper Field from the user's DWH. Merging `::common` and `::field-specific`."
+  [:merge ::common ::card-extras])
+
+(def ^:private field-keys
+  (let [the-keys (-> (mr/schema ::field-specific) mc/explicit-keys)]
+    (when-not (some #{:field/id} the-keys)
+      (throw (ex-info "Could not calculate field-keys - make sure the schema is being extracted properly"
+                      {:schema (mr/schema ::field-specific)
+                       :keys   the-keys})))
+    the-keys))
+
+(defn- validate-column-metadata [column]
+  (when-let [err (or (mr/explain ::common column)
+                     (when (some column field-keys)
+                       (mr/explain ::field-specific column)))]
+    (throw (ex-info "bad new-refs column!" {:error err}))))
+
+(defn- validated-column:old-refs [column]
+  column)
+
+(defn- validated-column:new-refs [column]
+  (validate-column-metadata column)
+  column)
+
+(comment
+  ;; Preserving this handful of validators for now - not sure they'll be useful.
+  validated-column:old-refs
+  validated-column:new-refs)
+
+(def ^:private global-column-cache
+  (atom {:ident->col {}
+         :id->ident  {}}))
+
+(defn- register [cache {:keys [column/ident field/id] :as column}]
+  (when-not ident
+    (throw (ex-info "Cannot register! a column with no ident" {:column column})))
+  (cond-> (assoc-in cache [:ident->col ident] column)
+    id (assoc-in [:id->ident id] ident)))
+
+(mu/defn register! :- ::column
+  "Registers a new style column into the global column cache.
+
+  Idempotent, so call it whenever a column might have changed.
+
+  **Returns the column itself, for easy chaining.**"
+  [column :- ::column]
+  (swap! global-column-cache register column)
+  column)
+
+(mu/defn register-all! :- [:sequential ::column]
+  "Registers a seq of columns into the global column cache.
+
+  Like [[register!]], but it only updates the atom once.
+
+  **Returns the original `columns` list, for easy chaining.**"
+  [columns :- [:sequential ::column]]
+  (swap! global-column-cache #(reduce register % columns))
+  columns)
+
+(mu/defn lookup-ident :- [:maybe ::column]
+  "Looks up a column in the global column cache by its ident.
+
+  Returns nil if not found."
+  [ident :- :string]
+  (get-in @global-column-cache [:ident->col ident]))
+
+(mu/defn ident->id :- [:maybe ::lib.schema.id/field]
+  "Looks up the Field ID for the given ident.
+
+  Returns nil if (1) the ident is unknown, or (2) that column is not a plain Field."
+  [ident :- :string]
+  (-> ident lookup-ident :field/id))

--- a/src/metabase/query_processor/middleware/binning.clj
+++ b/src/metabase/query_processor/middleware/binning.clj
@@ -72,7 +72,7 @@
       (throw (ex-info (tru "Cannot update binned field: query is missing source-metadata")
                       {:field field-name})))
     ;; try to find field in source-metadata with matching name
-    (let [mlv2-metadatas (lib.card/->card-metadata-columns (qp.store/metadata-provider) source-metadata)]
+    (let [mlv2-metadatas (lib.card/->card-metadata-columns:old-refs (qp.store/metadata-provider) source-metadata)]
       (or
        (lib.equality/find-matching-column
         [:field {:lib/uuid (str (random-uuid)), :base-type :type/*} field-name]

--- a/src/metabase/util/memoize/impl/js.cljs
+++ b/src/metabase/util/memoize/impl/js.cljs
@@ -67,7 +67,8 @@
 (defn- args-fn
   "Returns a function's argument transformer."
   [x]
-  (or (::args-fn (meta x)) identity))
+  (or (:clojure.core.memoize/args-fn (meta x))
+      identity))
 
 (defn- through*
   "The basic hit/miss logic for the cache system based on `cache/through`.

--- a/test/metabase/lib/test_util/macros.cljs
+++ b/test/metabase/lib/test_util/macros.cljs
@@ -1,5 +1,6 @@
 (ns metabase.lib.test-util.macros
   (:require
+   metabase.lib.metadata.overhaul
    metabase.lib.test-util.macros.impl
    metabase.test.data.mbql-query-impl)
   (:require-macros [metabase.lib.test-util.macros]))

--- a/test/metabase/lib/types/isa_test.cljc
+++ b/test/metabase/lib/types/isa_test.cljc
@@ -61,7 +61,7 @@
                 :semantic-type :type/PK
                 :effective-type :type/BigInteger}]
               (columns-of-type :Relation/*))))
-    (testing "experssions"
+    (testing "expressions"
       (is (=? [{:name "ID"
                 :lib/desired-column-alias "ID"
                 :semantic-type :type/PK

--- a/test/metabase/query_processor/middleware/auto_bucket_datetimes_test.clj
+++ b/test/metabase/query_processor/middleware/auto_bucket_datetimes_test.clj
@@ -4,6 +4,7 @@
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.metadata.overhaul :as lib.metadata.overhaul]
    [metabase.lib.normalize :as lib.normalize]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
@@ -274,7 +275,8 @@
     (is (= {:source-table 1
             :breakout     [[:field Integer/MAX_VALUE nil]]
             :breakout-idents {0 "ZT7n35j6KY0m_NPIEa7Ut"}}
-           (binding [lib.metadata/*enforce-idents* false]
+           (binding [lib.metadata/*enforce-idents* false
+                     lib.metadata.overhaul/*overhaul-selector* :old-only]
              (auto-bucket-mbql
               {:source-table 1
                :breakout     [[:field Integer/MAX_VALUE nil]]


### PR DESCRIPTION
Closes QUE-650.

### Description

Begin the process of forking the library to work with new `:ident`-powered refs, and new metadata formats.

`foo:old-refs` is the new name for the original code; `foo:new-refs` is the new code. Some of them are just stubs that throw in this PR. `foo` is the common entry point, and uses `lib.metadata.overhaul/old-new` to choose between the two versions on demand.

The master control is a `^:dynamic` variable `metabase.lib.metadata.overhaul/*overhaul-selector*`. You should **not** need to manipulate it directly.

Calls to "distant" lib functions should generally use `foo`; calls to "nearby" functions should call `:new-refs` or `:old-refs` directly.

Some new test helper macros make it easy to write tests for either approach, or for both:
- `lib.tu/with-new-refs` runs the test body with new refs only
- `lib.tu/with-old-refs` runs the test body with old refs only
- `lib.tu/with-refs-overhaul` runs the test body with both old and new refs
    - You can use `lib.metadata.overhaul/old-new` inside this if there are only small differences in the setup or expectations.
    - If there are substantial differences, separate `with-new-refs` and `with-old-refs` are probably easier to read.

### How to verify

The app doesn't really work with `*overhaul-selector*` set to `:new-only`!

But it defaults to `:old-only`, which has not changed at all. All tests are passing.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
