### PR TITLE
make links in slack bug report descriptions clickable

### DIFF
--- a/src/metabase/api/slack.clj
+++ b/src/metabase/api/slack.clj
@@ -41,9 +41,11 @@
                                 :text "anonymous user"})
                              {:type "text"
                               :text "\n\nDescription:\n"
-                              :style {:bold true}}
-                             {:type "text"
-                              :text (or description "N/A")}
+                              :style {:bold true}}]}]}
+     {:type "section" :text {:type "mrkdwn" :text (or description "N/A")}}
+     {:type "rich_text"
+      :elements [{:type "rich_text_section"
+                  :elements [
                              {:type "text"
                               :text "\n\nURL:\n"
                               :style {:bold true}}

--- a/src/metabase/api/slack.clj
+++ b/src/metabase/api/slack.clj
@@ -45,8 +45,7 @@
      {:type "section" :text {:type "mrkdwn" :text (or description "N/A")}}
      {:type "rich_text"
       :elements [{:type "rich_text_section"
-                  :elements [
-                             {:type "text"
+                  :elements [{:type "text"
                               :text "\n\nURL:\n"
                               :style {:bold true}}
                              {:type "link"


### PR DESCRIPTION
pulls description out into a mrkdwn block, which gets links parsed out automatically.

update tests
