### PR TITLE
fix: allow google auth when throttling is disabled

### DIFF
--- a/src/metabase/session/api.clj
+++ b/src/metabase/session/api.clj
@@ -275,22 +275,24 @@
   (when-not (sso/google-auth-client-id)
     (throw (ex-info "Google Auth is disabled." {:status-code 400})))
   ;; Verify the token is valid with Google
-  (if throttling-disabled?
-    (sso/do-google-auth request)
+  (letfn [(do-login []
+            (let [user (sso/do-google-auth request)
+                  {session-uuid :id, :as session} (session/create-session! :sso user (request/device-info request))
+                  response {:id (str session-uuid)}
+                  user (t2/select-one [:model/User :id :is_active], :email (:email user))]
+              (if (and user (:is_active user))
+                (request/set-session-cookies request
+                                             response
+                                             session
+                                             (t/zoned-date-time (t/zone-id "GMT")))
+                (throw (ex-info (str disabled-account-message)
+                                {:status-code 401
+                                 :errors      {:account disabled-account-snippet}})))))]
     (http-401-on-error
-      (throttle/with-throttling [(login-throttlers :ip-address) (request/ip-address request)]
-        (let [user (sso/do-google-auth request)
-              {session-uuid :id, :as session} (session/create-session! :sso user (request/device-info request))
-              response {:id (str session-uuid)}
-              user (t2/select-one [:model/User :id :is_active], :email (:email user))]
-          (if (and user (:is_active user))
-            (request/set-session-cookies request
-                                         response
-                                         session
-                                         (t/zoned-date-time (t/zone-id "GMT")))
-            (throw (ex-info (str disabled-account-message)
-                            {:status-code 401
-                             :errors      {:account disabled-account-snippet}}))))))))
+      (if throttling-disabled?
+        (do-login)
+        (throttle/with-throttling [(login-throttlers :ip-address) (request/ip-address request)]
+          (do-login))))))
 
 (defn- +log-all-request-failures [handler]
   (open-api/handler-with-open-api-spec

--- a/test/metabase/session/api_test.clj
+++ b/test/metabase/session/api_test.clj
@@ -502,8 +502,13 @@
                                                  "\"first_name\":\"test\","
                                                  "\"last_name\":\"user\","
                                                  "\"email\":\"test@metabase.com\"}")})]
-            (is (malli= SessionResponse
-                        (mt/client :post 200 "session/google_auth" {:token "foo"}))))))
+            (testing "with throttling enabled"
+              (is (malli= SessionResponse
+                          (mt/client :post 200 "session/google_auth" {:token "foo"}))))
+            (testing "with throttling disabled"
+              (with-redefs [api.session/throttling-disabled? true]
+                (is (malli= SessionResponse
+                            (mt/client :post 200 "session/google_auth" {:token "foo"}))))))))
       (testing "Google auth throws exception for a disabled account"
         (mt/with-temp [:model/User _ {:email "test@metabase.com" :is_active false}]
           (with-redefs [http/post (constantly


### PR DESCRIPTION
### Description

If a metabase instance has login throttling disabled google auth will not work to authenticate with this metabase instance. We will verify the oidc token, but then not create a session for that user. 

### How to verify

1. Supply a google client_id for your metabase instance
2. Attempt to authenticate using the sign-in with google button

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
