### PR TITLE
Remove settings access as a requirement to use the bug reporter

### DIFF
--- a/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.tsx
+++ b/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.tsx
@@ -3,7 +3,6 @@ import { c, t } from "ttag";
 import _ from "underscore";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
-import { getSlackSettings } from "metabase/admin/settings/slack/selectors";
 import { useSendBugReportMutation } from "metabase/api/bug-report";
 import { useSetting } from "metabase/common/hooks";
 import { useToggle } from "metabase/hooks/use-toggle";
@@ -42,13 +41,6 @@ export const ErrorDiagnosticModal = ({
   const isBugReportingEnabled = useSetting("bug-reporting-enabled");
   const [isSubmissionComplete, setIsSubmissionComplete] = useState(false);
   const applicationName = useSelector(getApplicationName);
-
-  const slackSettings = useSelector(getSlackSettings);
-  const enableBugReportField = Boolean(
-    slackSettings["slack-bug-report-channel"] &&
-      slackSettings["slack-app-token"] &&
-      isBugReportingEnabled,
-  );
 
   if (loading || !errorInfo) {
     return (
@@ -158,7 +150,7 @@ export const ErrorDiagnosticModal = ({
     );
   }
 
-  return enableBugReportField ? (
+  return isBugReportingEnabled ? (
     <BugReportModal
       errorInfo={errorInfo}
       onClose={onClose}

--- a/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.unit.spec.tsx
+++ b/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.unit.spec.tsx
@@ -191,10 +191,7 @@ describe("ErrorDiagnosticsModal", () => {
       const state = createMockState({
         settings: mockSettings({
           "enable-embedding": true,
-          "slack-app-token": "test-token",
-          "slack-bug-report-channel": "test-channel",
           "bug-reporting-enabled": true,
-          "slack-token-valid?": true,
         }),
       });
 


### PR DESCRIPTION
Follow up to https://github.com/metabase/metabase/pull/49875

In the interest of good UX, we were checking whether slack bug reports have been fully configured before showing the debugger. Unfortunately, this means that only users who had access to those settings (read: admins) could use the bug reporter.

![Screen Shot 2025-02-14 at 4 36 30 PM](https://github.com/user-attachments/assets/75d61597-a3f0-4b6e-8129-ac49ce5d7735)

Since this is a feature that can only be enabled by environment variable (MB_BUG_REPORTING_ENABLED=true), we can loosen up this check a bit, and allow it to be used so long as the feature has been enabled by env var, at the risk of showing a button that will not work if the feature hasn't been fully set up.