### PR TITLE
fix mantine viz settings widgets

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingRadio.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingRadio.tsx
@@ -1,18 +1,20 @@
 import { useMemo } from "react";
 
 import { Radio, Stack, Text } from "metabase/ui";
-
-const NULL_VALUE = "\0_null" as const;
+import {
+  decodeWidgetValue,
+  encodeWidgetValue,
+} from "metabase/visualizations/lib/settings/widgets";
 
 interface ChartSettingRadioProps {
   options: { name: string; value: string | null }[];
   value: string | null;
   className?: string;
-  onChange: (value: string | null) => void;
+  onChange: (value: unknown) => void;
 }
 
 export const ChartSettingRadio = ({
-  value: rawValue,
+  value,
   onChange,
   options: rawOptions = [],
   className,
@@ -20,18 +22,15 @@ export const ChartSettingRadio = ({
   const options: { name: string; value: string }[] = useMemo(() => {
     return rawOptions.map(({ name, value }) => ({
       name,
-      value: value ?? NULL_VALUE,
+      value: encodeWidgetValue(value),
     }));
   }, [rawOptions]);
 
-  // Some properties of visualization settings that are controlled by radio buttons can have a value of `null`
-  const value = rawValue === null ? NULL_VALUE : rawValue;
-
   return (
     <Radio.Group
-      value={value}
+      value={encodeWidgetValue(value)}
       className={className}
-      onChange={value => onChange(value === NULL_VALUE ? null : value)}
+      onChange={value => onChange(decodeWidgetValue(value))}
     >
       <Stack gap="xs">
         {options.map(({ name, value: optionValue }) => (

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.jsx
@@ -3,17 +3,10 @@ import cx from "classnames";
 
 import CS from "metabase/css/core/index.css";
 import { Select, Stack } from "metabase/ui";
-
-// Some properties of visualization settings that are controlled by selects can have a value of `true` or `false`
-const VALUE_OVERRIDE = val => {
-  if (val === true) {
-    return "\0_true";
-  } else if (val === false || val === "") {
-    return "\0_false";
-  } else {
-    return val;
-  }
-};
+import {
+  decodeWidgetValue,
+  encodeWidgetValue,
+} from "metabase/visualizations/lib/settings/widgets";
 
 export const ChartSettingSelect = ({
   // Use null if value is undefined. If we pass undefined, Select will create an
@@ -43,7 +36,7 @@ export const ChartSettingSelect = ({
 
   const data = options.map(({ name, value }) => ({
     label: name,
-    value: VALUE_OVERRIDE(value) || "",
+    value: encodeWidgetValue(value) || "",
   }));
 
   const dropdownComponent =
@@ -63,9 +56,9 @@ export const ChartSettingSelect = ({
       data={data}
       dropdownComponent={dropdownComponent}
       disabled={disabled}
-      value={VALUE_OVERRIDE(value)}
+      value={encodeWidgetValue(value)}
       //Mantine V7 select onChange has 2 arguments passed. This breaks the assumption in visualizations/lib/settings.js where the onChange function is defined
-      onChange={v => onChange(v)}
+      onChange={v => onChange(decodeWidgetValue(v))}
       placeholder={options.length === 0 ? placeholderNoOptions : placeholder}
       initiallyOpened={isInitiallyOpen}
       searchable={!!searchProp}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.unit.spec.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.unit.spec.jsx
@@ -1,0 +1,136 @@
+import userEvent from "@testing-library/user-event";
+
+import { render, screen } from "__support__/ui";
+
+import { ChartSettingSelect } from "./ChartSettingSelect";
+
+const options = [
+  { name: "Option 1", value: "value1" },
+  { name: "Option 2", value: "value2" },
+  { name: "Boolean True", value: true },
+  { name: "Boolean False", value: false },
+  { name: "No value", value: null },
+];
+
+const selectOption = async optionText => {
+  const select = screen.getByTestId("chart-setting-select");
+  await userEvent.click(select);
+  const option = screen.getByText(optionText);
+  await userEvent.click(option);
+};
+
+describe("ChartSettingSelect", () => {
+  beforeAll(() => {
+    // Mock scrollIntoView since it's not implemented in JSDOM
+    Element.prototype.scrollIntoView = jest.fn();
+  });
+
+  it("should render all options", async () => {
+    render(
+      <ChartSettingSelect
+        options={options}
+        value="value1"
+        onChange={() => undefined}
+      />,
+    );
+
+    const select = screen.getByTestId("chart-setting-select");
+    await userEvent.click(select);
+
+    expect(screen.getByText("Option 1")).toBeInTheDocument();
+    expect(screen.getByText("Option 2")).toBeInTheDocument();
+    expect(screen.getByText("Boolean True")).toBeInTheDocument();
+    expect(screen.getByText("Boolean False")).toBeInTheDocument();
+    expect(screen.getByText("No value")).toBeInTheDocument();
+  });
+
+  it("should handle string value selection", async () => {
+    const onChange = jest.fn();
+    render(
+      <ChartSettingSelect
+        options={options}
+        value="value1"
+        onChange={onChange}
+      />,
+    );
+
+    await selectOption("Option 2");
+    expect(onChange).toHaveBeenCalledWith("value2");
+  });
+
+  it("should handle boolean value selection", async () => {
+    const onChange = jest.fn();
+    render(
+      <ChartSettingSelect
+        options={options}
+        value="value1"
+        onChange={onChange}
+      />,
+    );
+
+    await selectOption("Boolean True");
+    expect(onChange).toHaveBeenCalledWith(true);
+
+    await selectOption("Boolean False");
+    expect(onChange).toHaveBeenCalledWith(false);
+  });
+
+  it("should handle null value selection", async () => {
+    const onChange = jest.fn();
+    render(
+      <ChartSettingSelect
+        options={options}
+        value="value1"
+        onChange={onChange}
+      />,
+    );
+
+    await selectOption("No value");
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it("should show correct option as selected", () => {
+    const { rerender } = render(
+      <ChartSettingSelect
+        options={options}
+        value={null}
+        onChange={jest.fn()}
+      />,
+    );
+    expect(screen.getByText("No value")).toBeInTheDocument();
+
+    rerender(
+      <ChartSettingSelect
+        options={options}
+        value={true}
+        onChange={jest.fn()}
+      />,
+    );
+    expect(screen.getByText("Boolean True")).toBeInTheDocument();
+
+    rerender(
+      <ChartSettingSelect
+        options={options}
+        value={false}
+        onChange={jest.fn()}
+      />,
+    );
+    expect(screen.getByText("Boolean False")).toBeInTheDocument();
+  });
+
+  it("should disable select when there are no options", () => {
+    render(<ChartSettingSelect options={[]} onChange={jest.fn()} />);
+    expect(screen.getByTestId("chart-setting-select")).toBeDisabled();
+  });
+
+  it("should disable select when there is only one option matching the current value", () => {
+    render(
+      <ChartSettingSelect
+        options={[{ name: "Option 1", value: "value1" }]}
+        value="value1"
+        onChange={jest.fn()}
+      />,
+    );
+    expect(screen.getByTestId("chart-setting-select")).toBeDisabled();
+  });
+});

--- a/frontend/src/metabase/visualizations/lib/settings/widgets.ts
+++ b/frontend/src/metabase/visualizations/lib/settings/widgets.ts
@@ -1,0 +1,22 @@
+const PREFIX = "\0_";
+
+// Encode boolean/null values to strings for Mantine form widgets (Select, Radio, etc), , needed for settings like "graph.x_axis.axis_enabled"
+const toWidgetValue = new Map<unknown, string>([
+  [true, `${PREFIX}true`],
+  [false, `${PREFIX}false`],
+  [null, `${PREFIX}null`],
+]);
+
+const fromWidgetValue = new Map<string, unknown>(
+  Array.from(toWidgetValue.entries()).map(([key, value]) => [value, key]),
+);
+
+export const encodeWidgetValue = (value: unknown): string => {
+  const mapped = toWidgetValue.get(value);
+  return mapped ?? String(value);
+};
+
+export const decodeWidgetValue = (value: string): unknown => {
+  const decoded = fromWidgetValue.get(value);
+  return decoded !== undefined ? decoded : value;
+};


### PR DESCRIPTION
### Description

Fixes viz settings Select widget after migration to Mantine. The problem was that the Mantine Select component supports only strings as values, however, some of our visualization settings can use the mix of booleans and strings. An example of that would be x-axis "Show lines and marks" line chart setting:
```
"graph.x_axis.axis_enabled"?: true | false | "compact" | "rotate-45" | "rotate-90";
```
This is already existing contract, there are many saved questions in app dbs that use these values so we cannot just change the contract to only string valus without a migration.

Before this change, if you set "Show lines and marks" to "hide", it would've saved `"graph.x_axis.axis_enabled":"\u0000_false"` to the viz settings which is not correct.

### How to verify

- Create a line chart
- Set "Show lines and marks" axis setting to "Hide"
- Save the question
- Ensure boolean `false` is set to `graph.x_axis.axis_enabled` setting

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
