### PR TITLE
Fix flaky bigint test

### DIFF
--- a/e2e/test/scenarios/filters/filter-bigint.cy.spec.ts
+++ b/e2e/test/scenarios/filters/filter-bigint.cy.spec.ts
@@ -492,6 +492,7 @@ SELECT CAST('${positiveDecimalValue}' AS DECIMAL) AS NUMBER`,
 
       const getQuestionDetails = (cardId: number): NativeQuestionDetails => {
         const cardTagName = `#${cardId}-sql-number`;
+        const cardTagDisplayName = `#${cardId} Sql Number`;
 
         return {
           name: "SQL",
@@ -501,7 +502,7 @@ SELECT CAST('${positiveDecimalValue}' AS DECIMAL) AS NUMBER`,
               [cardTagName]: {
                 id: "10422a0f-292d-10a3-fd90-407cc9e3e20e",
                 name: cardTagName,
-                "display-name": cardTagName,
+                "display-name": cardTagDisplayName,
                 type: "card",
                 "card-id": cardId,
               },

--- a/e2e/test/scenarios/filters/filter-bigint.cy.spec.ts
+++ b/e2e/test/scenarios/filters/filter-bigint.cy.spec.ts
@@ -21,6 +21,7 @@ UNION ALL
 SELECT 0 AS NUMBER
 UNION ALL
 SELECT ${maxBigIntValue} AS NUMBER`,
+      "template-tags": {},
     },
     display: "table",
   };
@@ -33,6 +34,7 @@ UNION ALL
 SELECT CAST(0 AS DECIMAL) AS NUMBER
 UNION ALL
 SELECT CAST('${positiveDecimalValue}' AS DECIMAL) AS NUMBER`,
+      "template-tags": {},
     },
     display: "table",
   };

--- a/e2e/test/scenarios/filters/filter-bigint.cy.spec.ts
+++ b/e2e/test/scenarios/filters/filter-bigint.cy.spec.ts
@@ -411,6 +411,7 @@ SELECT CAST('${positiveDecimalValue}' AS DECIMAL) AS NUMBER`,
     }) {
       const getQuestionDetails = (cardId: number): NativeQuestionDetails => {
         const cardTagName = `#${cardId}-sql-number`;
+        const cardTagDisplayName = `#${cardId} Sql Number`;
 
         return {
           name: "SQL",
@@ -420,7 +421,7 @@ SELECT CAST('${positiveDecimalValue}' AS DECIMAL) AS NUMBER`,
               [cardTagName]: {
                 id: "10422a0f-292d-10a3-fd90-407cc9e3e20e",
                 name: cardTagName,
-                "display-name": cardTagName,
+                "display-name": cardTagDisplayName,
                 type: "card",
                 "card-id": cardId,
               },


### PR DESCRIPTION
Stress test https://github.com/metabase/metabase/actions/runs/13342059544/job/37267950597

There was a wrong `display-name` for a card tag, so it got changed automatically, and an ad-hoc question was created when a saved question was opened. This is relevant code https://github.com/metabase/metabase/blob/7b4c298126b03755c832ee67e5e013f395646da7/frontend/src/metabase/query_builder/actions/core/initializeQB.ts#L234