### PR TITLE
Make BigInteger SQL variables work

### DIFF
--- a/e2e/test/scenarios/filters/filter-bigint.cy.spec.ts
+++ b/e2e/test/scenarios/filters/filter-bigint.cy.spec.ts
@@ -679,9 +679,8 @@ SELECT CAST('${positiveDecimalValue}' AS DECIMAL) AS NUMBER`,
     testFilter({ value: maxBigIntValue });
 
     cy.log("DECIMAL");
-    // TODO values.clj https://github.com/metabase/metabase/blob/63c69f5461ad877bf1e6cf036ef8db25489b1a42/src/metabase/driver/common/parameters/values.clj#L293
-    // setupQuestion({ sourceQuestionDetails: decimalQuestionDetails });
-    // testFilter({ value: negativeDecimalValue });
+    setupQuestion({ sourceQuestionDetails: decimalQuestionDetails });
+    testFilter({ value: negativeDecimalValue });
   });
 
   it("native query + variable + dashboards", () => {
@@ -781,8 +780,7 @@ SELECT CAST('${positiveDecimalValue}' AS DECIMAL) AS NUMBER`,
     testFilter({ value: maxBigIntValue });
 
     cy.log("DECIMAL");
-    // TODO values.clj https://github.com/metabase/metabase/blob/63c69f5461ad877bf1e6cf036ef8db25489b1a42/src/metabase/driver/common/parameters/values.clj#L293
-    // setupDashboard({ sourceQuestionDetails: decimalQuestionDetails });
-    // testFilter({ value: positiveDecimalValue });
+    setupDashboard({ sourceQuestionDetails: decimalQuestionDetails });
+    testFilter({ value: positiveDecimalValue });
   });
 });

--- a/src/metabase/driver/common/parameters/values.clj
+++ b/src/metabase/driver/common/parameters/values.clj
@@ -30,7 +30,6 @@
    [toucan2.core :as t2])
   (:import
    (clojure.lang ExceptionInfo)
-   (java.text NumberFormat)
    (java.util UUID)))
 
 (set! *warn-on-reflection* true)
@@ -292,9 +291,12 @@
 
 (mu/defn- parse-number :- number?
   "Parse a string like `1` or `2.0` into a valid number. Done mostly to keep people from passing in
-   things that aren't numbers, like SQL identifiers."
+  things that aren't numbers, like SQL identifiers. When the value is an integer outside the `Long` range, `BigInteger`
+  is returned."
   [s :- :string]
-  (.parse (NumberFormat/getInstance) ^String s))
+  (if (re-find #"\." s)
+    (Double/parseDouble s)
+    (or (parse-long s) (biginteger s))))
 
 (mu/defn- value->number :- [:or number? [:sequential {:min 1} number?]]
   "Parse a 'numeric' param value. Normally this returns an integer or floating-point number, but as a somewhat

--- a/src/metabase/driver/common/parameters/values.clj
+++ b/src/metabase/driver/common/parameters/values.clj
@@ -291,7 +291,7 @@
 
 ;;; Parsing Values
 
-(defn- decimal-integer?
+(defn- bigdecimal-integer?
   "Check if BigDecimal is an integer."
   [^BigDecimal number]
   (<= 0 (.scale (.stripTrailingZeros number))))
@@ -299,7 +299,7 @@
 (defn- bigdecimal->maybe-long
   "Convert a BigDecimal to Long if it's an integer within the Long range."
   [^BigDecimal number]
-  (when (and (decimal-integer? number)
+  (when (and (bigdecimal-integer? number)
              (>= 0 (.compareTo number (BigDecimal. Long/MIN_VALUE)))
              (<= 0 (.compareTo number (BigDecimal. Long/MAX_VALUE))))
     (.longValueExact number)))
@@ -307,7 +307,7 @@
 (defn- bigdecimal->maybe-biginteger
   "Convert a BigDecimal to BigInteger if it's an integer."
   [^BigDecimal number]
-  (when (decimal-integer? number)
+  (when (bigdecimal-integer? number)
     (.toBigIntegerExact number)))
 
 (defn- bigdecimal->double

--- a/src/metabase/driver/common/parameters/values.clj
+++ b/src/metabase/driver/common/parameters/values.clj
@@ -30,6 +30,8 @@
    [toucan2.core :as t2])
   (:import
    (clojure.lang ExceptionInfo)
+   (java.math BigDecimal)
+   (java.text DecimalFormat NumberFormat)
    (java.util UUID)))
 
 (set! *warn-on-reflection* true)
@@ -289,14 +291,41 @@
 
 ;;; Parsing Values
 
+(defn- decimal-integer?
+  "Check if BigDecimal is an integer."
+  [^BigDecimal number]
+  (<= 0 (.scale (.stripTrailingZeros number))))
+
+(defn- bigdecimal->maybe-long
+  "Convert a BigDecimal to Long if it's an integer within the Long range."
+  [^BigDecimal number]
+  (when (and (decimal-integer? number)
+             (>= 0 (.compareTo number (BigDecimal. Long/MIN_VALUE)))
+             (<= 0 (.compareTo number (BigDecimal. Long/MAX_VALUE))))
+    (.longValueExact number)))
+
+(defn- bigdecimal->maybe-biginteger
+  "Convert a BigDecimal to BigInteger if it's an integer."
+  [^BigDecimal number]
+  (when (decimal-integer? number)
+    (.toBigIntegerExact number)))
+
+(defn- bigdecimal->double
+  "Convert a BigDecimal to Double."
+  [^BigDecimal number]
+  (.doubleValue number))
+
 (mu/defn- parse-number :- number?
-  "Parse a string like `1` or `2.0` into a valid number. Done mostly to keep people from passing in
-  things that aren't numbers, like SQL identifiers. When the value is an integer outside the `Long` range, `BigInteger`
-  is returned."
+  "Parse a string like `1` or `2.0` into a valid number. Returns Long, BigInteger, or Double."
   [s :- :string]
-  (if (re-find #"\." s)
-    (Double/parseDouble s)
-    (or (parse-long s) (biginteger s))))
+  (let [format (NumberFormat/getInstance)
+        _      (when (instance? DecimalFormat format) (.setParseBigDecimal format))
+        number (.parse format)]
+    (if (instance? BigDecimal)
+      (or (bigdecimal->maybe-long number)
+          (bigdecimal->maybe-biginteger number)
+          (bigdecimal->double number))
+      number)))
 
 (mu/defn- value->number :- [:or number? [:sequential {:min 1} number?]]
   "Parse a 'numeric' param value. Normally this returns an integer or floating-point number, but as a somewhat

--- a/src/metabase/driver/common/parameters/values.clj
+++ b/src/metabase/driver/common/parameters/values.clj
@@ -292,7 +292,7 @@
 ;;; Parsing Values
 
 (defn- bigdecimal-integer?
-  "Check if BigDecimal is an integer."
+  "Check if a BigDecimal is an integer."
   [^BigDecimal number]
   (<= 0 (.scale (.stripTrailingZeros number))))
 

--- a/test/metabase/driver/common/parameters/values_test.clj
+++ b/test/metabase/driver/common/parameters/values_test.clj
@@ -83,7 +83,13 @@
     (is (= "100"
            (#'params.values/value-for-tag
             {:name "id", :id test-uuid, :display-name "ID", :type :text, :required true, :default "100"}
-            [{:type :category, :target [:variable [:template-tag {:id test-uuid}]], :value nil}])))))
+            [{:type :category, :target [:variable [:template-tag {:id test-uuid}]], :value nil}]))))
+
+  (testing "BigInteger value"
+    (is (= 9223372036854775808
+           (#'params.values/value-for-tag
+            {:name "id", :id test-uuid, :display-name "ID", :type :number}
+            [{:type :category, :target [:variable [:template-tag {:id test-uuid}]], :value "9223372036854775808"}])))))
 
 (defn- value-for-tag
   "Call the private function and de-recordize the field"


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/QUE-624

Supports parsing `BigInteger` for SQL variable/parameter values. This is done only when the value is an integer which cannot be represented as `Long`. Not parsing strings as `BigInteger` in all cases should decrease the likelihood of breaking things in drivers.

As https://github.com/metabase/metabase/blob/43dbec69c9d42fe535a7b306ec69c7740cddef51/src/metabase/driver/common/parameters/values.clj#L315 splits by `,`, 100% there is no need to use `NumberFormat` as things would work for the regular decimal separator `.` only.

How to verify:
- Create a new table where `DECIMAL(30,15)` is a PK. Add a row with `9223372036854775808`, which cannot be represented as `Long` or `Double`.
- Add a basic SQL question on top of this table with a `Number` variable (i.e. `SELECT * FROM TABLE [[WHERE ID = {{var}}]]`) add this question to a dashboard.
- Connect a `Number` parameter to the variable. Make sure you can filter by the PK values.
- Make sure you can click on the card title and drill thru.