### PR TITLE
Keep Metabot palette item stable between query changes

### DIFF
--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -124,8 +124,7 @@ export const useCommandPalette = ({
     showDocsAction,
   ]);
 
-  const metabotActions =
-    PLUGIN_METABOT.useMetabotPalletteActions(debouncedSearchText);
+  const metabotActions = PLUGIN_METABOT.useMetabotPalletteActions(trimmedQuery);
   useRegisterActions(metabotActions, [metabotActions]);
 
   const searchResultActions = useMemo<PaletteAction[]>(() => {


### PR DESCRIPTION
Use 'trimmedQuery` instead of `debouncedSearchText` so that Metabot palette item doesn't disappear when the query changes.
