### PR TITLE
fix: remove aria-expanded where it is not allowed

### DIFF
--- a/frontend/src/metabase/components/CollapseSection/CollapseSection.tsx
+++ b/frontend/src/metabase/components/CollapseSection/CollapseSection.tsx
@@ -60,7 +60,7 @@ const CollapseSection = ({
   );
 
   return (
-    <div className={className} role="tab" aria-expanded={isExpanded} {...props}>
+    <div className={className} role="tab" aria-selected={isExpanded} {...props}>
       <HeaderContainer
         className={headerClass}
         onClick={toggle}

--- a/frontend/src/metabase/components/tree/TreeNode.tsx
+++ b/frontend/src/metabase/components/tree/TreeNode.tsx
@@ -58,7 +58,6 @@ const BaseTreeNode = React.forwardRef<HTMLLIElement, TreeNodeProps>(
         {...props}
         depth={depth}
         isSelected={isSelected}
-        aria-selected={isSelected}
         aria-expanded={isExpanded}
         onKeyDown={handleKeyDown}
         ref={ref}

--- a/frontend/src/metabase/core/components/TabPanel/TabPanel.tsx
+++ b/frontend/src/metabase/core/components/TabPanel/TabPanel.tsx
@@ -24,7 +24,6 @@ const TabPanel = forwardRef(function TabPanel<T>(
       id={panelId}
       role="tabpanel"
       hidden={!isSelected}
-      aria-expanded={isSelected}
       aria-labelledby={tabId}
     >
       {isSelected && children}

--- a/frontend/src/metabase/databases/components/DatabaseEngineField/DatabaseEngineWidget.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseEngineField/DatabaseEngineWidget.tsx
@@ -137,7 +137,7 @@ const EngineSearch = ({
   );
 
   return (
-    <EngineSearchRoot role="combobox" aria-expanded="true">
+    <EngineSearchRoot role="combobox">
       <Input
         value={searchText}
         placeholder={t`Search for a database…`}


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/53270

### Description

Critical: Ensure an element's role supports its ARIA attributes
https://dequeuniversity.com/rules/axe/4.10/aria-allowed-attr?application=AxeChrome 

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Start the app
2. run axe devtools in Chrome

### Demo

![image](https://github.com/user-attachments/assets/f2b5e41b-f3a6-47fc-a38f-0d97a1177e2a)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
