### PR TITLE
Error explicitly when sandboxing/impersonation configs conflict

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -341,6 +341,7 @@
     medley.core                                                   m
     metabase-enterprise.audit-app.pages.common                    common
     metabase-enterprise.sandbox.api.table                         table
+    metabase-enterprise.sandbox.api.util                          sandbox.api.util
     metabase-enterprise.test                                      met
     metabase.analytics.sdk                                        sdk
     metabase.analytics.stats                                      stats

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -594,7 +594,7 @@
            metabase-enterprise.advanced-permissions.api.util
            metabase-enterprise.advanced-permissions.common
            metabase-enterprise.advanced-permissions.models.permissions.group-manager}
-   :uses #{api audit driver lib models permissions premium-features query-processor util}}
+   :uses #{api audit driver lib models permissions premium-features query-processor util enterprise/sandbox}}
 
   enterprise/airgap
   {:api  #{}

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
@@ -69,7 +69,7 @@
   (when (and database-or-id (not api/*is-superuser?*))
     (let [conn-impersonations  (enforced-impersonations-for-db database-or-id)
           role-attributes      (set (map :attribute conn-impersonations))
-          conflicting-sandbox? (sandbox.api.util/sandboxed-user-for-db? (u/id database-or-id))]
+          conflicting-sandbox? (when api/*current-user-id* (sandbox.api.util/sandboxed-user-for-db? (u/id database-or-id)))]
       (when conflicting-sandbox?
         (throw (ex-info (tru "Conflicting sandboxing and impersonation policies found.")
                         {:user-id api/*current-user-id*

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
@@ -61,7 +61,7 @@
                (enforce-impersonations? db-or-id conn-impersonations group-ids))
       conn-impersonations)))
 
-(defn connection-impersonation-role
+(defn- connection-impersonation-role
   "Fetches the database role that should be used for the current user, if connection impersonation is in effect.
   Returns `nil` if connection impersonation should not be used for the current user. Throws an exception if multiple
   conflicting connection impersonation policies are found, or the role is not a single string."

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
+   [metabase-enterprise.sandbox.api.util :as sandbox.api.util]
    [metabase.api.common :as api]
    [metabase.driver :as driver]
    [metabase.driver.sql :as driver.sql]
@@ -66,8 +67,13 @@
   conflicting connection impersonation policies are found, or the role is not a single string."
   [database-or-id]
   (when (and database-or-id (not api/*is-superuser?*))
-    (let [conn-impersonations (enforced-impersonations-for-db database-or-id)
-          role-attributes     (set (map :attribute conn-impersonations))]
+    (let [conn-impersonations  (enforced-impersonations-for-db database-or-id)
+          role-attributes      (set (map :attribute conn-impersonations))
+          conflicting-sandbox? (sandbox.api.util/sandboxed-user-for-db? (u/id database-or-id))]
+      (when conflicting-sandbox?
+        (throw (ex-info (tru "Conflicting sandboxing and impersonation policies found.")
+                        {:user-id api/*current-user-id*
+                         :database-id (u/id database-or-id)})))
       (when conn-impersonations
         (when (> (count role-attributes) 1)
           (throw (ex-info (tru "Multiple conflicting connection impersonation policies found for current user")
@@ -115,7 +121,7 @@
         (when (and enabled? (not default-role))
           (throw (ex-info (tru "Connection impersonation is enabled for this database, but no default role is found")
                           {:user-id api/*current-user-id*
-                           :database-id (u/the-id database)})))
+                           :database-id (u/id database)})))
         (when-let [role (or impersonation-role default-role)]
           ;; If impersonation is not enabled for any groups but we have a default role, we should still set it, just
           ;; in case impersonation used to be enabled and the connection still uses an impersonated role.

--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
@@ -5,7 +5,7 @@
   (:require
    [clojure.core.memoize :as memoize]
    [medley.core :as m]
-   [metabase-enterprise.sandbox.api.util :as sandbox.api.u]
+   [metabase-enterprise.sandbox.api.util :as sandbox.api.util]
    [metabase-enterprise.sandbox.models.group-table-access-policy :as gtap]
    [metabase.api.common :as api :refer [*current-user* *current-user-id*]]
    [metabase.db :as mdb]
@@ -66,7 +66,7 @@
 
 (defn- tables->sandboxes [table-ids]
   (qp.store/cached [*current-user-id* table-ids]
-    (let [enforced-sandboxes (sandbox.api.u/enforced-sandboxes-for-tables table-ids)]
+    (let [enforced-sandboxes (sandbox.api.util/enforced-sandboxes-for-tables table-ids)]
       (when (seq enforced-sandboxes)
         (assert-one-gtap-per-table enforced-sandboxes)
         enforced-sandboxes))))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
@@ -5,7 +5,7 @@
   (:require
    [clojure.core.memoize :as memoize]
    [medley.core :as m]
-   [metabase-enterprise.sandbox.api.util :as mt.api.u]
+   [metabase-enterprise.sandbox.api.util :as sandbox.api.u]
    [metabase-enterprise.sandbox.models.group-table-access-policy :as gtap]
    [metabase.api.common :as api :refer [*current-user* *current-user-id*]]
    [metabase.db :as mdb]
@@ -66,7 +66,7 @@
 
 (defn- tables->sandboxes [table-ids]
   (qp.store/cached [*current-user-id* table-ids]
-    (let [enforced-sandboxes (mt.api.u/enforced-sandboxes-for-tables table-ids)]
+    (let [enforced-sandboxes (sandbox.api.u/enforced-sandboxes-for-tables table-ids)]
       (when (seq enforced-sandboxes)
         (assert-one-gtap-per-table enforced-sandboxes)
         enforced-sandboxes))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
@@ -82,9 +82,9 @@
 
 (deftest connection-impersonation-role-test-9
   (testing "Throws an exception if sandboxing policies are also defined for the current user on the DB"
-    (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                 :attributes     {"impersonation_attr" "impersonation_role"}}
-      (met/with-gtaps! {:gtaps {:venues {:query (mt/mbql-query venues)}}}
+    (met/with-gtaps! {:gtaps {:venues {:query (mt/mbql-query venues)}}}
+      (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                   :attributes     {"impersonation_attr" "impersonation_role"}}
         (mt/with-test-user :rasta
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
@@ -85,10 +85,11 @@
     (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
                                                  :attributes     {"impersonation_attr" "impersonation_role"}}
       (met/with-gtaps! {:gtaps {:venues {:query (mt/mbql-query venues)}}}
-        (is (thrown-with-msg?
-             clojure.lang.ExceptionInfo
-             #"Conflicting sandboxing and impersonation policies found."
-             (@#'impersonation/connection-impersonation-role (mt/db))))))))
+        (mt/with-test-user :rasta
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo
+               #"Conflicting sandboxing and impersonation policies found."
+               (@#'impersonation/connection-impersonation-role (mt/db)))))))))
 
 (deftest conn-impersonation-test-postgres
   (mt/test-driver :postgres

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
@@ -18,7 +18,8 @@
 
 (deftest ^:parallel connection-impersonation-role-test
   (testing "Returns nil when no impersonations are in effect"
-    (is (nil? (@#'impersonation/connection-impersonation-role (mt/db))))))
+    (mt/with-test-user :rasta
+      (is (nil? (@#'impersonation/connection-impersonation-role (mt/db)))))))
 
 (deftest connection-impersonation-role-test-2
   (testing "Correctly fetches the impersonation when one is in effect"
@@ -73,7 +74,7 @@
 (deftest connection-impersonation-role-test-8
   (testing "Throws an exception if impersonation should be enforced, but the user's attribute is not a single string"
     (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                 :attributes     {"impersonation_attr" "impersonation_role"}}
+                                                 :attributes     {"impersonation_attr" ["one" "two" "three"]}}
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
            #"Connection impersonation attribute is invalid: role must be a single non-empty string."
@@ -82,7 +83,7 @@
 (deftest connection-impersonation-role-test-9
   (testing "Throws an exception if sandboxing policies are also defined for the current user on the DB"
     (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                 :attributes     {"impersonation_attr" ["one" "two" "three"]}}
+                                                 :attributes     {"impersonation_attr" "impersonation_role"}}
       (met/with-gtaps! {:gtaps {:venues {:query (mt/mbql-query venues)}}}
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/util_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/util_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.advanced-permissions.api.util-test :as advanced-perms.api.tu]
-   [metabase-enterprise.sandbox.api.util :as mt.api.u]
+   [metabase-enterprise.sandbox.api.util :as sandbox.api.u]
    [metabase-enterprise.test :as met]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.test :as mt]
@@ -21,23 +21,23 @@
 
         ;; subsequent calls should still use the cache, and not hit the DB at all
         (t2/with-call-count [call-count]
-          (is (mt.api.u/sandboxed-user?))
+          (is (sandbox.api.u/sandboxed-user?))
           (is (zero? (call-count)))
 
-          (is (= 1 (count (mt.api.u/enforced-sandboxes-for-tables [(mt/id :venues)]))))
+          (is (= 1 (count (sandbox.api.u/enforced-sandboxes-for-tables [(mt/id :venues)]))))
           (is (zero? (call-count))))))))
 
 (deftest enforce-sandbox?-test
   (testing "If a user is in a single group with a sandbox, the sandbox should be enforced"
     (mt/with-temp [:model/User user {}]
       (met/with-gtaps-for-user! (u/the-id user) {:gtaps {:venues {}}}
-        (is (mt.api.u/sandboxed-user?)))))
+        (is (sandbox.api.u/sandboxed-user?)))))
 
   (testing "If a user is in another group with view data access, the sandbox should not be enforced"
     (mt/with-temp [:model/User user {}]
       (met/with-gtaps-for-user! (u/the-id user) {:gtaps {:venues {}}}
         (mt/with-full-data-perms-for-all-users!
-          (is (not (mt.api.u/sandboxed-user?)))))))
+          (is (not (sandbox.api.u/sandboxed-user?)))))))
 
   (testing "If a user is in another group with another sandbox defined on the table, the user should be considered sandboxed"
     ;; This (conflicting sandboxes) is an invalid state for the QP but `enforce-sandbox?` should return true in order
@@ -45,7 +45,7 @@
     (mt/with-temp [:model/User user {}]
       (met/with-gtaps-for-user! (u/the-id user) {:gtaps {:venues {}}}
         (met/with-gtaps-for-user! (u/the-id user) {:gtaps {:venues {}}}
-          (is (mt.api.u/sandboxed-user?))))))
+          (is (sandbox.api.u/sandboxed-user?))))))
 
   (testing "If a user is in another group with an impersonation policy defined on the table, the user should be considered sandboxed"
     ;; Similar to above, this is also an unsupported configuration for querying, but we want to treat this user as
@@ -58,7 +58,7 @@
         (mt/with-temp [:model/ConnectionImpersonation _ {:db_id (mt/id)
                                                          :group_id group-id
                                                          :attribute "test-attribute"}]
-          (is (mt.api.u/sandboxed-user?))))))
+          (is (sandbox.api.u/sandboxed-user?))))))
 
   (testing "If a user is in two groups with conflicting sandboxes, *and* a third group that grants full access to the table,
             neither sandbox is enforced"
@@ -66,12 +66,12 @@
       (met/with-gtaps-for-user! (u/the-id user) {:gtaps {:venues {}}}
         (met/with-gtaps-for-user! (u/the-id user) {:gtaps {:venues {}}}
           (mt/with-full-data-perms-for-all-users!
-            (is (not (mt.api.u/sandboxed-user?)))))))))
+            (is (not (sandbox.api.u/sandboxed-user?)))))))))
 
 (defn- has-segmented-perms-when-segmented-db-exists?! [user-kw]
   (testing "User is sandboxed when they are not in any other groups that provide unrestricted access"
     (met/with-gtaps-for-user! user-kw {:gtaps {:venues {}}}
-      (mt.api.u/sandboxed-user?))))
+      (sandbox.api.u/sandboxed-user?))))
 
 (deftest never-segment-admins-test
   (testing "Admins should not be classified as segmented users -- enterprise #147"


### PR DESCRIPTION
This came up on Slack a while back but got a bit lost since then. We don't currently support layering sandboxing + impersonation (doesn't work, and was never spec'd by product) so we should detect this case and return an explicit error message, similar to when two sandboxing policies are conflicting.