### PR TITLE
chore: Prevent accidental console.log in unit tests

### DIFF
--- a/frontend/src/metabase/.eslintrc
+++ b/frontend/src/metabase/.eslintrc
@@ -37,12 +37,6 @@
   },
   "overrides": [
     {
-      "files": ["**/*.unit.spec.{js,jsx,ts,tsx}"],
-      "rules": {
-        "no-console": 0
-      }
-    },
-    {
       "files": ["**/*.stories.tsx"],
       "rules": {
         "import/no-default-export": 0,

--- a/frontend/src/metabase/dashboard/actions/utils.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/utils.unit.spec.ts
@@ -170,8 +170,6 @@ describe("dashboard > actions > utils", () => {
         createMockDashboardCard({ id: 2 }),
       ];
 
-      console.log(newCards, oldCards);
-
       expect(haveDashboardCardsChanged(newCards, oldCards)).toBe(false);
     });
 

--- a/frontend/src/metabase/lib/redux/utils.unit.spec.js
+++ b/frontend/src/metabase/lib/redux/utils.unit.spec.js
@@ -125,9 +125,7 @@ describe("Metadata", () => {
       });
 
       try {
-        const dataFail = await fetchData(argsFail).catch(error =>
-          console.log(error),
-        );
+        const dataFail = await fetchData(argsFail);
         expect(argsFail.dispatch).toHaveBeenCalledTimes(2);
         expect(dataFail).toEqual(args.existingData);
       } catch (error) {

--- a/frontend/test/.eslintrc
+++ b/frontend/test/.eslintrc
@@ -1,8 +1,7 @@
 {
   "rules": {
     "import/no-commonjs": 0,
-    "no-color-literals": 0,
-    "no-console": 0
+    "no-color-literals": 0
   },
   "env": {
     "node": true

--- a/frontend/test/jest-setup.js
+++ b/frontend/test/jest-setup.js
@@ -16,7 +16,6 @@ process.on("uncaughtException", err =>
 
 if (process.env["DISABLE_LOGGING"] || process.env["DISABLE_LOGGING_FRONTEND"]) {
   global.console = {
-    ...console.log,
     log: jest.fn(),
     debug: jest.fn(),
     info: jest.fn(),


### PR DESCRIPTION
[Context](https://metaboat.slack.com/archives/C505ZNNH4/p1739788724977029)

I found that we can still write `console.log` in unit tests and the linter won't catch it. I enable the rule again, so we would not left accidental `console.log` in our unit tests.
