### PR TITLE
fix: `<Text span` not being a span

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding/components/EmbeddingAppSameSiteCookieDescription/EmbeddingAppSameSiteCookieDescription.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding/components/EmbeddingAppSameSiteCookieDescription/EmbeddingAppSameSiteCookieDescription.tsx
@@ -47,7 +47,7 @@ function AuthorizedOriginsNote() {
       <SameSiteAlert variant="warning" hasBorder>
         <Center>
           <Text>{jt`You should probably change this setting to ${(
-            <Text key="inner" span fw="bold">
+            <Text key="inner" component="span" fw="bold">
               {t`None`}
             </Text>
           )}.`}</Text>

--- a/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettingsForm.tsx
+++ b/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettingsForm.tsx
@@ -305,7 +305,11 @@ const H2PersistenceWarning = ({ isHosted }: { isHosted: boolean }) => (
           multiline
           maw="30rem"
         >
-          <Text span td="underline" fw={700}>{t`Additional terms apply.`}</Text>
+          <Text
+            component="span"
+            td="underline"
+            fw={700}
+          >{t`Additional terms apply.`}</Text>
         </Tooltip>
       )}
     </Alert>

--- a/frontend/src/metabase/collections/components/CollectionBulkActions/QuestionMoveConfirmModal.tsx
+++ b/frontend/src/metabase/collections/components/CollectionBulkActions/QuestionMoveConfirmModal.tsx
@@ -145,7 +145,7 @@ export const QuestionMoveConfirmModal = ({
                 return (
                   <List.Item key={`card-${cd.card_id}`}>
                     <Text>{jt`${(
-                      <Text span fw={700}>
+                      <Text component="span" fw={700}>
                         {card?.name}
                       </Text>
                     )} will be removed from ${(
@@ -204,7 +204,7 @@ const DashboardNames = ({ names }: { names: string[] }) => {
     return null;
   } else if (names.length === 1) {
     return (
-      <Text span fw={700}>
+      <Text component="span" fw={700}>
         {names[0]}
       </Text>
     );
@@ -214,16 +214,16 @@ const DashboardNames = ({ names }: { names: string[] }) => {
 
     return [
       ...restOfNames.map((name, i, arr) => (
-        <Text span key={`dashboard-${name}`}>
-          <Text span fw={700}>
+        <Text component="span" key={`dashboard-${name}`}>
+          <Text component="span" fw={700}>
             {name}
           </Text>
           {i < arr.length - 1 ? ", " : ""}
         </Text>
       )),
-      <Text span key={`dashboard-${lastName}`}>
+      <Text component="span" key={`dashboard-${lastName}`}>
         {t` and `}
-        <Text span fw={700}>
+        <Text component="span" fw={700}>
           {lastName}
         </Text>
       </Text>,

--- a/frontend/src/metabase/components/PaginationControls/PaginationControls.tsx
+++ b/frontend/src/metabase/components/PaginationControls/PaginationControls.tsx
@@ -44,18 +44,18 @@ export const PaginationControls = ({
       role="navigation"
       {...props}
     >
-      <Text span mr="sm">
+      <Text component="span" mr="sm">
         {page * pageSize + 1} - {page * pageSize + itemsLength}
         {showTotal && (
           <>
-            <Text span c="text-light">
+            <Text component="span" c="text-light">
               &nbsp;
               {c(
                 "Appears in phrases like '1-10 of 100', referring to a page of results",
               ).t`of`}
               &nbsp;
             </Text>
-            <Text span data-testid="pagination-total">
+            <Text component="span" data-testid="pagination-total">
               {total}
             </Text>
           </>

--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/PublicEmbedCard.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/PublicEmbedCard.tsx
@@ -33,7 +33,7 @@ export const PublicEmbedCard = ({
     <Group gap="xs">
       <Text>
         {jt`Use ${(
-          <Text span fw="bold" key="bold">
+          <Text component="span" fw="bold" key="bold">
             {t`public embedding`}
           </Text>
         )} to add a publicly-visible iframe embed to your web page or blog

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/ParametersSettings.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/ParametersSettings.tsx
@@ -69,7 +69,7 @@ export const ParametersSettings = ({
               <h3>
                 {parameter.name}
                 {parameter.required && (
-                  <Text color="error" span>
+                  <Text color="error" component="span">
                     &nbsp;*
                   </Text>
                 )}

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/FieldMappingSelect.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/FieldMappingSelect.tsx
@@ -8,7 +8,6 @@ import type Table from "metabase-lib/v1/metadata/Table";
 import type { FieldId, TemplateTag } from "metabase-types/api";
 
 import { ContainerLabel, InputContainer } from "./TagEditorParam";
-
 export function FieldMappingSelect({
   tag,
   hasSelectedDimensionField,
@@ -33,7 +32,7 @@ export function FieldMappingSelect({
       <ContainerLabel>
         {t`Field to map to`}
         {tag.dimension == null && (
-          <Text c="error" span={true} ml="sm">
+          <Text c="error" component="span" ml="sm">
             {t`(required)`}
           </Text>
         )}

--- a/frontend/src/metabase/querying/fields/components/FieldPanel/FieldPanel.tsx
+++ b/frontend/src/metabase/querying/fields/components/FieldPanel/FieldPanel.tsx
@@ -84,7 +84,7 @@ export const FieldPanel = ({
                   label={
                     <Flex ml="0.25rem" align="center">
                       <Icon name={getColumnIcon(columnItem.column)} />
-                      <Text span ml="0.5rem" lh="1rem" fw={400}>
+                      <Text component="span" ml="0.5rem" lh="1rem" fw={400}>
                         {columnItem.displayName}
                       </Text>
                     </Flex>

--- a/frontend/src/metabase/search/components/InfoText/InfoTextEditedInfo.tsx
+++ b/frontend/src/metabase/search/components/InfoText/InfoTextEditedInfo.tsx
@@ -26,7 +26,7 @@ const LoadingText = () => (
 );
 
 const InfoTextSeparator = (
-  <Text span size="sm" mx="xs" c="text-medium">
+  <Text component="span" size="sm" mx="xs" c="text-medium">
     •
   </Text>
 );
@@ -92,7 +92,7 @@ export const InfoTextEditedInfo = ({
       const formattedDuration = timestamp && getRelativeTime(timestamp);
       return (
         <Tooltip tooltip={<LastEditedInfoTooltip {...lastEditedInfoData} />}>
-          <Text span size="sm" c="text-medium" truncate>
+          <Text component="span" size="sm" c="text-medium" truncate>
             {formattedDuration}
           </Text>
         </Tooltip>


### PR DESCRIPTION
Closes EMB-142

A default prop of `component="div"` was added to the [Text component](https://github.com/metabase/metabase/blob/df459b77dc9c1f570e28de477544ec22d8b50345/frontend/src/metabase/ui/components/typography/Text/Text.config.tsx#L13)

That is override the `span` prop, that should be a shortcut of `component="span"`.

This is causing issue on layouts as we usually use `<Text span` because we want `display:inline` and now it's `display:block` again.

In this PR I'm changing all instances I've found of `<Text span` to use `component="span"`


Before: (see text in the footer of the modal)
<img width="1316" alt="image" src="https://github.com/user-attachments/assets/8943c8b2-c4f1-4f41-b954-1972639d729e" />

After:
<img width="1309" alt="image" src="https://github.com/user-attachments/assets/c0b39a4f-f21d-4202-8e31-eb803554e4bc" />

