### PR TITLE
fix: text color not being brand in embed modal

### DIFF
--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SharingPaneButton/SharingPaneButton.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SharingPaneButton/SharingPaneButton.tsx
@@ -69,7 +69,7 @@ export const SharingPaneButton = ({
             <Box
               ml="xs"
               component={Link}
-              variant="brand"
+              c="brand"
               to={disabledLink}
             >{t`Enable in admin settings`}</Box>
           </Text>


### PR DESCRIPTION
No need to backport, this is fine on the 53 release branch

Before
<img width="1296" alt="image" src="https://github.com/user-attachments/assets/36a7b6bc-7083-45e2-8171-3463298429a0" />


After
<img width="1292" alt="image" src="https://github.com/user-attachments/assets/7a0216e1-138c-4d01-882d-f7d1da15da29" />
