### PR TITLE
fix a test

### DIFF
--- a/e2e/test/scenarios/metrics/browse.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/browse.cy.spec.ts
@@ -346,7 +346,7 @@ describe("scenarios > browse > metrics", () => {
     });
   });
 
-  describe("verified metrics", { tags: "@flaky" }, () => {
+  describe("verified metrics", () => {
     beforeEach(() => {
       cy.signInAsAdmin();
       H.setTokenFeatures("all");
@@ -355,6 +355,8 @@ describe("scenarios > browse > metrics", () => {
     it("should not the verified metrics filter when there are no verified metrics", () => {
       createMetrics();
       cy.visit("/browse/metrics");
+
+      cy.findByLabelText("Table of metrics").should("be.visible");
 
       cy.findByLabelText("Filters").should("not.exist");
     });


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/DEV-352/stabilize-flaky-tests-verified-metrics

### Description

Not much changed here, there was a test that wasn’t really testing anything, just removed the `@flaky` flag

here’s a stress test: https://github.com/metabase/metabase/actions/runs/13387795974