### PR TITLE
Buckets for notification send duration ms histogram

### DIFF
--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -239,7 +239,9 @@
                         :labels [:payload-type]})
    (prometheus/histogram :metabase-notification/send-duration-ms
                          {:description "Duration of notification sends in milliseconds."
-                          :labels [:payload-type]})
+                          :labels [:payload-type]
+                          ;; 1ms -> 10minutes
+                          :buckets [1 10 50 100 500 1000 5000 10000 30000 60000 120000 300000 600000]})
    (prometheus/counter :metabase-notification/channel-send-ok
                        {:description "Number of successful channel sends."
                         :labels [:payload-type :channel-type]})

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -439,12 +439,12 @@
                ;; First, "decompose" the characters. e.g. replace 'LATIN CAPITAL LETTER A WITH ACUTE' with
                ;; 'LATIN CAPITAL LETTER A' + 'COMBINING ACUTE ACCENT'
                ;; See http://docs.oracle.com/javase/8/docs/api/java/text/Normalizer.html
-               (Normalizer/normalize s Normalizer$Form/NFD)
+              (Normalizer/normalize s Normalizer$Form/NFD)
                ;; next, remove the combining diacritical marks -- this SO answer explains what's going on here best:
                ;; http://stackoverflow.com/a/5697575/1198455 The closest thing to a relevant JavaDoc I could find was
                ;; http://docs.oracle.com/javase/7/docs/api/java/lang/Character.UnicodeBlock.html#COMBINING_DIACRITICAL_MARKS
-               #"\p{Block=CombiningDiacriticalMarks}+"
-               "")
+              #"\p{Block=CombiningDiacriticalMarks}+"
+              "")
        :cljs (-> s
                  (.normalize "NFKD")  ;; Renders accented characters as base + accent.
                  (.replace (js/RegExp. "[\u0300-\u036f]" "gu") ""))))) ;; Drops all the accents.

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -439,12 +439,12 @@
                ;; First, "decompose" the characters. e.g. replace 'LATIN CAPITAL LETTER A WITH ACUTE' with
                ;; 'LATIN CAPITAL LETTER A' + 'COMBINING ACUTE ACCENT'
                ;; See http://docs.oracle.com/javase/8/docs/api/java/text/Normalizer.html
-              (Normalizer/normalize s Normalizer$Form/NFD)
+               (Normalizer/normalize s Normalizer$Form/NFD)
                ;; next, remove the combining diacritical marks -- this SO answer explains what's going on here best:
                ;; http://stackoverflow.com/a/5697575/1198455 The closest thing to a relevant JavaDoc I could find was
                ;; http://docs.oracle.com/javase/7/docs/api/java/lang/Character.UnicodeBlock.html#COMBINING_DIACRITICAL_MARKS
-              #"\p{Block=CombiningDiacriticalMarks}+"
-              "")
+               #"\p{Block=CombiningDiacriticalMarks}+"
+               "")
        :cljs (-> s
                  (.normalize "NFKD")  ;; Renders accented characters as base + accent.
                  (.replace (js/RegExp. "[\u0300-\u036f]" "gu") ""))))) ;; Drops all the accents.


### PR DESCRIPTION
The default buckets for `notification-send-duration-ms` histogram range from 0.005 -> 10. Though I sure hope one day sending notifications take less than 10ms, but it's surely not that performant today. I've changed the buckets to range from 1ms -> 10minutes.

```
metabase_notification_send_duration_ms_bucket{payload_type="notification/card",le="1.0",} 0.0                                                                                      
metabase_notification_send_duration_ms_bucket{payload_type="notification/card",le="10.0",} 0.0                                                                                     
metabase_notification_send_duration_ms_bucket{payload_type="notification/card",le="50.0",} 0.0                                                                                     
metabase_notification_send_duration_ms_bucket{payload_type="notification/card",le="100.0",} 0.0                                                                                    
metabase_notification_send_duration_ms_bucket{payload_type="notification/card",le="500.0",} 0.0                                                                                    
metabase_notification_send_duration_ms_bucket{payload_type="notification/card",le="1000.0",} 5.0                                                                                   
metabase_notification_send_duration_ms_bucket{payload_type="notification/card",le="5000.0",} 6.0                                                                                   
metabase_notification_send_duration_ms_bucket{payload_type="notification/card",le="10000.0",} 6.0                                                                                  
metabase_notification_send_duration_ms_bucket{payload_type="notification/card",le="30000.0",} 6.0                                                                                  
metabase_notification_send_duration_ms_bucket{payload_type="notification/card",le="60000.0",} 6.0                                                                                  
metabase_notification_send_duration_ms_bucket{payload_type="notification/card",le="120000.0",} 6.0
metabase_notification_send_duration_ms_bucket{payload_type="notification/card",le="300000.0",} 6.0
metabase_notification_send_duration_ms_bucket{payload_type="notification/card",le="600000.0",} 6.0
metabase_notification_send_duration_ms_bucket{payload_type="notification/card",le="+Inf",} 6.0
```