### PR TITLE
Allow users to format their durations

### DIFF
--- a/frontend/src/metabase/lib/formatting/numbers.tsx
+++ b/frontend/src/metabase/lib/formatting/numbers.tsx
@@ -1,5 +1,8 @@
 import * as d3 from "d3";
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
 import Humanize from "humanize-plus";
+dayjs.extend(duration);
 
 import { COMPACT_CURRENCY_OPTIONS, getCurrencySymbol } from "./currency";
 
@@ -80,6 +83,8 @@ export function formatNumber(
     return formatNumberCompact(number, options);
   } else if (options.number_style === "scientific") {
     return formatNumberScientific(number, options);
+  } else if (options.number_style === "duration") {
+    return formatDuration(number, options);
   } else {
     try {
       let nf;
@@ -282,6 +287,29 @@ function formatNumberScientific(
   } else {
     return exp;
   }
+}
+
+function formatDuration(value: number, _options: FormatNumberOptionsType) {
+  const duration = dayjs.duration(value);
+  let str = "";
+
+  if (duration.days() > 0) {
+    str += `${duration.days()}d `;
+  }
+
+  if (duration.hours() > 0) {
+    str += `${duration.hours()}h `;
+  }
+
+  if (duration.minutes() > 0) {
+    str += `${duration.minutes()}m `;
+  }
+
+  if (duration.seconds() > 0) {
+    str += `${duration.seconds()}s `;
+  }
+
+  return str.trim();
 }
 
 /**

--- a/frontend/src/metabase/lib/formatting/numbers.unit.spec.js
+++ b/frontend/src/metabase/lib/formatting/numbers.unit.spec.js
@@ -70,4 +70,24 @@ describe("formatNumber", () => {
     });
     expect(fullResult).toEqual("-$500,000.00");
   });
+
+  it("should work with durations", () => {
+    expect(
+      formatNumber(652000, {
+        number_style: "duration",
+      }),
+    ).toEqual("10m 52s");
+
+    expect(
+      formatNumber(10652000, {
+        number_style: "duration",
+      }),
+    ).toEqual("2h 57m 32s");
+
+    expect(
+      formatNumber(100620000, {
+        number_style: "duration",
+      }),
+    ).toEqual("1d 3h 57m");
+  });
 });

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -268,6 +268,7 @@ export const NUMBER_COLUMN_SETTINGS = {
         { name: t`Percent`, value: "percent" },
         { name: t`Scientific`, value: "scientific" },
         { name: t`Currency`, value: "currency" },
+        { name: t`Duration`, value: "duration" },
       ],
     },
     getDefault: getDefaultNumberStyle,
@@ -363,6 +364,7 @@ export const NUMBER_COLUMN_SETTINGS = {
       ],
     },
     getDefault: getDefaultNumberSeparators,
+    getHidden: (column, settings) => settings["number_style"] !== "duration",
   },
   decimals: {
     title: t`Number of decimal places`,
@@ -370,6 +372,7 @@ export const NUMBER_COLUMN_SETTINGS = {
     props: {
       placeholder: "1",
     },
+    getHidden: (column, settings) => settings["number_style"] !== "duration",
   },
   scale: {
     title: t`Multiply by a number`,

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -364,7 +364,7 @@ export const NUMBER_COLUMN_SETTINGS = {
       ],
     },
     getDefault: getDefaultNumberSeparators,
-    getHidden: (column, settings) => settings["number_style"] !== "duration",
+    getHidden: (column, settings) => settings["number_style"] === "duration",
   },
   decimals: {
     title: t`Number of decimal places`,
@@ -372,7 +372,7 @@ export const NUMBER_COLUMN_SETTINGS = {
     props: {
       placeholder: "1",
     },
-    getHidden: (column, settings) => settings["number_style"] !== "duration",
+    getHidden: (column, settings) => settings["number_style"] === "duration",
   },
   scale: {
     title: t`Multiply by a number`,


### PR DESCRIPTION
Closes _nothing_

### Description

Formats a value in milliseconds into a human-readable duration. Implementation is naive and not configurable at this point, but that's better than trying to compare raw durations.

### How to verify

<img width="1581" alt="image" src="https://github.com/user-attachments/assets/3bdbca07-976f-4ad6-bd1b-0116a0a3daa6" />
