### PR TITLE
fix(sdk): hide "New Question" in EditableDashboard sidebar

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/editable-dashboard.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/editable-dashboard.cy.spec.tsx
@@ -189,4 +189,17 @@ describe("scenarios > embedding-sdk > editable-dashboard", () => {
       });
     });
   });
+
+  it("should not show New Question button in sidebar (metabase#53896)", () => {
+    cy.get("@dashboardId").then(dashboardId => {
+      mountSdkContent(<EditableDashboard dashboardId={dashboardId} />);
+    });
+
+    getSdkRoot().within(() => {
+      cy.findByText("Add a chart").should("be.visible").click();
+
+      cy.findByText("New Question").should("not.exist");
+      cy.findByText("New SQL query").should("not.exist");
+    });
+  });
 });

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionPicker.tsx
@@ -11,6 +11,7 @@ import type { BaseSelectListItemProps } from "metabase/components/SelectList/Bas
 import Input from "metabase/core/components/Input";
 import { getDashboard } from "metabase/dashboard/selectors";
 import Collections, { ROOT_COLLECTION } from "metabase/entities/collections";
+import { isEmbeddingSdk } from "metabase/env";
 import { useDebouncedValue } from "metabase/hooks/use-debounced-value";
 import { getCrumbs } from "metabase/lib/collections";
 import { SEARCH_DEBOUNCE_DURATION } from "metabase/lib/constants";
@@ -108,7 +109,7 @@ function QuestionPickerInner({
         onChange={handleSearchTextChange}
       />
 
-      {(hasDataAccess || hasNativeWrite) && (
+      {(hasDataAccess || hasNativeWrite) && !isEmbeddingSdk && (
         <Flex gap="sm" mb="md" data-testid="new-button-bar">
           {hasDataAccess && (
             <Button


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/53896 (EMB-160)

Hides the "New Question" and "New SQL query" button from EditableDashboard's sidebar when in the Embedding SDK. See the issue for the previous incorrect behavior.

The rationale is that EditableDashboard does not have the ability to create new questions (that belongs to CreateQuestion or InteractiveQuestion), so for the time being we should hide it until we can find an implementation that makes sense in an embedding context.

![CleanShot 2568-02-18 at 21 55 39@2x](https://github.com/user-attachments/assets/20ebe7c0-a653-4363-9843-f1bd3055f8c4)