### PR TITLE
Take the :type of implicit action parameters from the table field, not what is saved in the database

### DIFF
--- a/src/metabase/actions/models.clj
+++ b/src/metabase/actions/models.clj
@@ -262,7 +262,14 @@
               action-kind     (:kind action)
               implicit-params (cond->> (get model-id->implicit-parameters model-id)
                                 :always
-                                (map (fn [param] (merge param (get saved-params (:id param)))))
+                                (map (fn [param]
+                                       (let [saved-param  (saved-params (:id param))
+                                             ;; we ignore the saved type, to allow schema changes (type changes) to be
+                                             ;; reflected in the field presentation
+                                             ;; this also fixes #39101 and avoids us making awkward changes to
+                                             ;; :parameter transforms for QueryActions.
+                                             saved-param' (dissoc saved-param :type)]
+                                         (merge param saved-param'))))
 
                                 (= "row/delete" action-kind)
                                 (filter ::pk?)

--- a/test/metabase/actions/models_test.clj
+++ b/test/metabase/actions/models_test.clj
@@ -297,11 +297,9 @@
             (testing "if the column type is varied after an update to the action, it is reflected in the parameters"
               (let [action (action/select-action action-id)]
                 (action/update! (assoc action :name "create foo2") action)
-                (->> ["ALTER TABLE \"FOO\" ALTER COLUMN \"name\" TEXT;"]
-                     (jdbc/execute! one-off-dbs/*conn*))
+                (exec! "ALTER TABLE \"FOO\" ALTER COLUMN \"name\" TEXT;")
                 (sync/sync-database! (mt/db))
-                ;; desired behaviour, broken #39101.
-                #_(is (= [["name" :type/Text]] (map (juxt :id :type) (:parameters (action/select-action action-id))))))))
+                (is (= [["name" :type/Text]] (map (juxt :id :type) (:parameters (action/select-action action-id))))))))
           (testing "if a column added, the model column set is used, not the table"
             (exec! "ALTER TABLE \"FOO\" ADD COLUMN \"name2\" BIGINT;")
             (is (= ["name"] (map :id (:parameters (action/select-action action-id))))))
@@ -313,4 +311,3 @@
               (is (= {"name" true}  (hide-state (action/select-action action-id))))
               (exec! "ALTER TABLE \"FOO\" ALTER COLUMN \"name\" BIGINT;")
               (is (= {"name" true}  (hide-state (action/select-action action-id)))))))))))
-

--- a/test/metabase/actions/models_test.clj
+++ b/test/metabase/actions/models_test.clj
@@ -273,3 +273,44 @@
             (is (some? (->> (action/select-action :id action-id)
                             :parameters
                             (filter #(= "uuid" (:id %))))))))))))
+
+(deftest implicit-action-parameters-schema-change-test
+  (one-off-dbs/with-blank-db
+    (doseq [statement ["CREATE USER IF NOT EXISTS GUEST PASSWORD 'guest';"
+                       "SET DB_CLOSE_DELAY -1;"
+                       "CREATE TABLE \"FOO\" (\"id\" IDENTITY PRIMARY KEY, \"name\" TEXT);"
+                       "GRANT ALL ON \"FOO\" TO GUEST;"]]
+      (jdbc/execute! one-off-dbs/*conn* [statement]))
+    (sync/sync-database! (mt/db))
+    (mt/with-actions-enabled
+      (mt/with-actions [{model-id :id} {:type :model, :dataset_query (mt/mbql-query foo)}]
+        (let [action-data {:type     :implicit
+                           :kind     "row/create"
+                           :name     "create foo"
+                           :model_id model-id}
+              action-id   (action/insert! action-data)
+              exec!       #(do (jdbc/execute! one-off-dbs/*conn* [%])
+                               (sync/sync-database! (mt/db)))]
+          (testing "if a column type is varied the parameter types are updated on select-action"
+            (exec! "ALTER TABLE \"FOO\" ALTER COLUMN \"name\" BIGINT;")
+            (is (= [["name" :type/BigInteger]] (map (juxt :id :type) (:parameters (action/select-action action-id)))))
+            (testing "if the column type is varied after an update to the action, it is reflected in the parameters"
+              (let [action (action/select-action action-id)]
+                (action/update! (assoc action :name "create foo2") action)
+                (->> ["ALTER TABLE \"FOO\" ALTER COLUMN \"name\" TEXT;"]
+                     (jdbc/execute! one-off-dbs/*conn*))
+                (sync/sync-database! (mt/db))
+                ;; desired behaviour, broken #39101.
+                #_(is (= [["name" :type/Text]] (map (juxt :id :type) (:parameters (action/select-action action-id))))))))
+          (testing "if a column added, the model column set is used, not the table"
+            (exec! "ALTER TABLE \"FOO\" ADD COLUMN \"name2\" BIGINT;")
+            (is (= ["name"] (map :id (:parameters (action/select-action action-id))))))
+          (testing "viz settings are kept after a schema change (for hiding fields)"
+            (let [action     (action/select-action action-id)
+                  hide-state #(-> % :visualization_settings :fields (update-vals :hidden))]
+              (is (= {"name" false} (hide-state action)))
+              (action/update! (assoc-in action [:visualization_settings :fields "name" :hidden] true) action)
+              (is (= {"name" true}  (hide-state (action/select-action action-id))))
+              (exec! "ALTER TABLE \"FOO\" ALTER COLUMN \"name\" BIGINT;")
+              (is (= {"name" true}  (hide-state (action/select-action action-id)))))))))))
+


### PR DESCRIPTION
Fixes an issue where type information could be lost when updating basic actions such as create or update, causing incorrect field handling.

Fixes an issue where if a schema change alters the type of a column, crud action fields for update/create did not reflect the new type of the column.

Closes https://github.com/metabase/metabase/issues/39101

Closes ENG-7925

### Description

Implicit (a.k.a Basic) action parameters have a `:type` key, that maps to a base type (like `:type/Boolean`). When saving actions back to the database through a `PUT` request, mbql1 normalization lower cases the `:type` resulting in `"type/boolean"` being saved to the database. 

My understanding is that this normalization was intended for QueryAction parameters, which as sql placeholders work like question params, having lower case types like `:category`.

Unfortunately in the case of implicit actions, the lower case type causes the frontend to present a text box by default instead of a type specialised field (such as a slider for booleans).

Ideas I considered and threw out:
- changing the toucan2 transforms for implicit actions to not apply normalization
   * I would want to be careful to only change the behaviour for implicit actions (and not query actions), but toucan transforms do not allow the transform behaviour to depend on other values in the row (e.g the `type` column).
- not saving parameters at all for implicit actions
   * chestertons fence: there is code for merging saved parameters with derived which suggests saving back of implicit parameters is intentional: [L261 actions/models.clj](https://github.com/metabase/metabase/blob/869d810773e5b5de184be3ec220c354a43647e12/src/metabase/actions/models.clj#L261)

The least risky and most surgical approach I could think of was to prefer the field derived `:type` over what is in the database when returning actions to the frontend. 

If any actions were saved to user appdbs and were corrupted in this way, they should be fixed after updating metabase to include this patch.

Incidently this fixes an issue where if the type of a field changed, e.g from text to a number, the crud action field would still show a text box.

### How to verify

- Create a table with a boolean column. I used postgres: `CREATE TABLE foo (id BIGSERIAL PRIMARY KEY, b BOOLEAN)`
- Create a model for the table
- Create basic actions (model > more info > actions tab > create basic actions)
- Observe that if you execute the create action, the field will be a slider
- Edit the create action, click the settings icon, change the success message, save the action
- Execute the action again, the field will remain a slider

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
