### PR TITLE
Support BigInteger in filter display names

### DIFF
--- a/e2e/test/scenarios/filters/filter-bigint.cy.spec.ts
+++ b/e2e/test/scenarios/filters/filter-bigint.cy.spec.ts
@@ -126,7 +126,7 @@ SELECT CAST('${positiveDecimalValue}' AS DECIMAL) AS NUMBER`,
       testFilter({
         filterOperator: "Equal to",
         setFilterValue: () => cy.findByLabelText("Filter value").type(maxValue),
-        filterDisplayName: `NUMBER is equal to "${maxValue}"`,
+        filterDisplayName: `NUMBER is equal to ${maxValue}`,
         filteredRowCount: 1,
       });
 
@@ -134,7 +134,7 @@ SELECT CAST('${positiveDecimalValue}' AS DECIMAL) AS NUMBER`,
       testFilter({
         filterOperator: "Not equal to",
         setFilterValue: () => cy.findByLabelText("Filter value").type(minValue),
-        filterDisplayName: `NUMBER is not equal to "${minValue}"`,
+        filterDisplayName: `NUMBER is not equal to ${minValue}`,
         filteredRowCount: 2,
       });
 
@@ -142,7 +142,7 @@ SELECT CAST('${positiveDecimalValue}' AS DECIMAL) AS NUMBER`,
       testFilter({
         filterOperator: "Greater than",
         setFilterValue: () => cy.findByLabelText("Filter value").type(minValue),
-        filterDisplayName: `NUMBER is greater than "${minValue}"`,
+        filterDisplayName: `NUMBER is greater than ${minValue}`,
         filteredRowCount: 2,
       });
 
@@ -150,7 +150,7 @@ SELECT CAST('${positiveDecimalValue}' AS DECIMAL) AS NUMBER`,
       testFilter({
         filterOperator: "Greater than or equal to",
         setFilterValue: () => cy.findByLabelText("Filter value").type(minValue),
-        filterDisplayName: `NUMBER is greater than or equal to "${minValue}"`,
+        filterDisplayName: `NUMBER is greater than or equal to ${minValue}`,
         filteredRowCount: 3,
       });
 
@@ -158,7 +158,7 @@ SELECT CAST('${positiveDecimalValue}' AS DECIMAL) AS NUMBER`,
       testFilter({
         filterOperator: "Less than",
         setFilterValue: () => cy.findByLabelText("Filter value").type(maxValue),
-        filterDisplayName: `NUMBER is less than "${maxValue}"`,
+        filterDisplayName: `NUMBER is less than ${maxValue}`,
         filteredRowCount: 2,
       });
 
@@ -166,7 +166,7 @@ SELECT CAST('${positiveDecimalValue}' AS DECIMAL) AS NUMBER`,
       testFilter({
         filterOperator: "Less than or equal to",
         setFilterValue: () => cy.findByLabelText("Filter value").type(maxValue),
-        filterDisplayName: `NUMBER is less than or equal to "${maxValue}"`,
+        filterDisplayName: `NUMBER is less than or equal to ${maxValue}`,
         filteredRowCount: 3,
       });
 
@@ -177,7 +177,7 @@ SELECT CAST('${positiveDecimalValue}' AS DECIMAL) AS NUMBER`,
           cy.findByPlaceholderText("Min").type(minValue);
           cy.findByPlaceholderText("Max").type("0");
         },
-        filterDisplayName: `NUMBER is between "${minValue}" and 0`,
+        filterDisplayName: `NUMBER is between ${minValue} and 0`,
         filteredRowCount: 2,
       });
 
@@ -188,7 +188,7 @@ SELECT CAST('${positiveDecimalValue}' AS DECIMAL) AS NUMBER`,
           cy.findByPlaceholderText("Min").type("0");
           cy.findByPlaceholderText("Max").type(maxValue);
         },
-        filterDisplayName: `NUMBER is between 0 and "${maxValue}"`,
+        filterDisplayName: `NUMBER is between 0 and ${maxValue}`,
         filteredRowCount: 2,
       });
 
@@ -530,7 +530,7 @@ SELECT CAST('${positiveDecimalValue}' AS DECIMAL) AS NUMBER`,
         parameterName: "Equal to",
         setParameterValue: () =>
           cy.findByPlaceholderText("Enter a number").type(maxValue),
-        filterDisplayName: `NUMBER is equal to "${maxValue}"`,
+        filterDisplayName: `NUMBER is equal to ${maxValue}`,
         filterArgsDisplayName: maxValue,
         filteredRowCount: 1,
       });
@@ -540,7 +540,7 @@ SELECT CAST('${positiveDecimalValue}' AS DECIMAL) AS NUMBER`,
         parameterName: "Not equal to",
         setParameterValue: () =>
           cy.findByPlaceholderText("Enter a number").type(minValue),
-        filterDisplayName: `NUMBER is not equal to "${minValue}"`,
+        filterDisplayName: `NUMBER is not equal to ${minValue}`,
         filterArgsDisplayName: minValue,
         filteredRowCount: 2,
       });
@@ -550,7 +550,7 @@ SELECT CAST('${positiveDecimalValue}' AS DECIMAL) AS NUMBER`,
         parameterName: "Greater than or equal to",
         setParameterValue: () =>
           cy.findByPlaceholderText("Enter a number").type(minValue),
-        filterDisplayName: `NUMBER is greater than or equal to "${minValue}"`,
+        filterDisplayName: `NUMBER is greater than or equal to ${minValue}`,
         filterArgsDisplayName: minValue,
         filteredRowCount: 3,
       });
@@ -560,7 +560,7 @@ SELECT CAST('${positiveDecimalValue}' AS DECIMAL) AS NUMBER`,
         parameterName: "Less than or equal to",
         setParameterValue: () =>
           cy.findByPlaceholderText("Enter a number").type(maxValue),
-        filterDisplayName: `NUMBER is less than or equal to "${maxValue}"`,
+        filterDisplayName: `NUMBER is less than or equal to ${maxValue}`,
         filterArgsDisplayName: maxValue,
         filteredRowCount: 3,
       });
@@ -572,7 +572,7 @@ SELECT CAST('${positiveDecimalValue}' AS DECIMAL) AS NUMBER`,
           cy.findAllByPlaceholderText("Enter a number").eq(0).type(minValue);
           cy.findAllByPlaceholderText("Enter a number").eq(1).type("0");
         },
-        filterDisplayName: `NUMBER is between "${minValue}" and 0`,
+        filterDisplayName: `NUMBER is between ${minValue} and 0`,
         filterArgsDisplayName: "2 selections",
         filteredRowCount: 2,
       });
@@ -584,7 +584,7 @@ SELECT CAST('${positiveDecimalValue}' AS DECIMAL) AS NUMBER`,
           cy.findAllByPlaceholderText("Enter a number").eq(0).type("0");
           cy.findAllByPlaceholderText("Enter a number").eq(1).type(maxValue);
         },
-        filterDisplayName: `NUMBER is between 0 and "${maxValue}"`,
+        filterDisplayName: `NUMBER is between 0 and ${maxValue}`,
         filterArgsDisplayName: "2 selections",
         filteredRowCount: 2,
       });

--- a/frontend/src/metabase/querying/parameters/utils/query.unit.spec.ts
+++ b/frontend/src/metabase/querying/parameters/utils/query.unit.spec.ts
@@ -199,7 +199,7 @@ describe("applyParameter", () => {
         target: getFilterColumnTarget("ORDERS", "ID"),
         value: "9223372036854775807",
         expectedDisplayName:
-          'ID is greater than or equal to "9223372036854775807"',
+          "ID is greater than or equal to 9223372036854775807",
       },
       {
         type: "number/<=",
@@ -211,8 +211,7 @@ describe("applyParameter", () => {
         type: "number/<=",
         target: getFilterColumnTarget("ORDERS", "ID"),
         value: "9223372036854775807",
-        expectedDisplayName:
-          'ID is less than or equal to "9223372036854775807"',
+        expectedDisplayName: "ID is less than or equal to 9223372036854775807",
       },
       {
         type: "number/between",
@@ -224,13 +223,13 @@ describe("applyParameter", () => {
         type: "number/between",
         target: getFilterColumnTarget("ORDERS", "ID"),
         value: [1, "9223372036854775807"],
-        expectedDisplayName: 'ID is between 1 and "9223372036854775807"',
+        expectedDisplayName: "ID is between 1 and 9223372036854775807",
       },
       {
         type: "number/between",
         target: getFilterColumnTarget("ORDERS", "ID"),
         value: ["-9223372036854775808", 1],
-        expectedDisplayName: 'ID is between "-9223372036854775808" and 1',
+        expectedDisplayName: "ID is between -9223372036854775808 and 1",
       },
       {
         type: "number/between",

--- a/src/metabase/lib/filter.cljc
+++ b/src/metabase/lib/filter.cljc
@@ -26,6 +26,7 @@
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
+   [metabase.util.number :as u.number]
    [metabase.util.time :as u.time]))
 
 (doseq [tag [:and :or]]
@@ -61,6 +62,10 @@
    (for [clause subclauses]
      (lib.metadata.calculation/display-name query stage-number clause style))))
 
+(defn- ->maybe-bigint
+  [x]
+  (clojure.core/or (when (string? x) (u.number/parse-bigint x)) x))
+
 (defmethod lib.metadata.calculation/display-name-method ::varargs
   [query stage-number expr style]
   (let [->display-name #(lib.metadata.calculation/display-name query stage-number % style)
@@ -78,6 +83,7 @@
                        (temporal? a)
                        (lib.util/clause? a)
                        (clojure.core/contains? units (:temporal-unit (second a)))))))
+        ->number-display-name #(-> % ->maybe-bigint ->display-name)
         ->unbucketed-display-name #(-> %
                                        (update 1 dissoc :temporal-unit)
                                        ->display-name)
@@ -86,7 +92,6 @@
                            :temporal-unit
                            lib.temporal-bucket/describe-temporal-unit
                            u/lower-case-en)
-
         ->unit {:get-hour :hour-of-day
                 :get-month :month-of-year
                 :get-quarter :quarter-of-year}]
@@ -139,7 +144,7 @@
                 (-> f ->unit lib.temporal-bucket/describe-temporal-unit u/lower-case-en))
 
       [(_ :guard #{:= :in}) _ (a :guard numeric?) b]
-      (i18n/tru "{0} is equal to {1}" (->display-name a) (->display-name b))
+      (i18n/tru "{0} is equal to {1}" (->display-name a) (->number-display-name b))
 
       [(_ :guard #{:= :in}) _ (a :guard (unit-is lib.schema.temporal-bucketing/datetime-truncation-units)) (b :guard string?)]
       (i18n/tru "{0} is {1}" (->unbucketed-display-name a) (u.time/format-relative-date-range b 0 (:temporal-unit (second a)) nil nil {:include-current true}))
@@ -151,7 +156,7 @@
       (i18n/tru "{0} is on {1}" (->display-name a) (->temporal-name a b))
 
       [(_ :guard #{:!= :not-in}) _ (a :guard numeric?) b]
-      (i18n/tru "{0} is not equal to {1}" (->display-name a) (->display-name b))
+      (i18n/tru "{0} is not equal to {1}" (->display-name a) (->number-display-name b))
 
       [(_ :guard #{:!= :not-in}) _ (a :guard (unit-is :day-of-week)) (b :guard (some-fn int? string?))]
       (i18n/tru "{0} excludes {1}" (->unbucketed-display-name a) (inflections/plural (->temporal-name a b)))
@@ -234,6 +239,7 @@
 (defmethod lib.metadata.calculation/display-name-method ::binary
   [query stage-number expr style]
   (let [->display-name #(lib.metadata.calculation/display-name query stage-number % style)
+        ->number-display-name #(-> % ->maybe-bigint ->display-name)
         ->temporal-name #(u.time/format-unit % nil)
         temporal? #(lib.util/original-isa? % :type/Temporal)]
     (lib.util.match/match-one expr
@@ -241,23 +247,24 @@
       (i18n/tru "{0} is before {1}"                   (->display-name x) (->temporal-name y))
 
       [:< _ x y]
-      (i18n/tru "{0} is less than {1}"                (->display-name x) (->display-name y))
+      (i18n/tru "{0} is less than {1}"                (->number-display-name x) (->number-display-name y))
 
       [:<= _ x y]
-      (i18n/tru "{0} is less than or equal to {1}"    (->display-name x) (->display-name y))
+      (i18n/tru "{0} is less than or equal to {1}"    (->number-display-name x) (->number-display-name y))
 
       [:> _ (x :guard temporal?) (y :guard string?)]
       (i18n/tru "{0} is after {1}"                    (->display-name x) (->temporal-name y))
 
       [:> _ x y]
-      (i18n/tru "{0} is greater than {1}"             (->display-name x) (->display-name y))
+      (i18n/tru "{0} is greater than {1}"             (->number-display-name x) (->number-display-name y))
 
       [:>= _ x y]
-      (i18n/tru "{0} is greater than or equal to {1}" (->display-name x) (->display-name y)))))
+      (i18n/tru "{0} is greater than or equal to {1}" (->number-display-name x) (->number-display-name y)))))
 
 (defmethod lib.metadata.calculation/display-name-method :between
   [query stage-number expr style]
   (let [->display-name #(lib.metadata.calculation/display-name query stage-number % style)
+        ->number-display-name #(-> % ->maybe-bigint ->display-name)
         ->unbucketed-display-name #(-> %
                                        (update 1 dissoc :temporal-unit)
                                        ->display-name)]
@@ -287,9 +294,9 @@
 
       [:between _ x y z]
       (i18n/tru "{0} is between {1} and {2}"
-                (->display-name x)
-                (->display-name y)
-                (->display-name z)))))
+                (->number-display-name x)
+                (->number-display-name y)
+                (->number-display-name z)))))
 
 (defmethod lib.metadata.calculation/display-name-method :during
   [query stage-number [_tag _opts expr value unit] style]

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -24,6 +24,7 @@
    [metabase.util.log :as log]
    [metabase.util.memoize :as memoize]
    [metabase.util.namespaces :as u.ns]
+   [metabase.util.number :as u.number]
    [metabase.util.polyfills]
    [nano-id.core :as nano-id]
    [net.cgrand.macrovich :as macros]
@@ -840,20 +841,20 @@
   off of `type` in pure Clojure."
   [x]
   (cond
-    (nil? x)        :dispatch-type/nil
-    (boolean? x)    :dispatch-type/boolean
-    (string? x)     :dispatch-type/string
-    (keyword? x)    :dispatch-type/keyword
-    (integer? x)    :dispatch-type/integer
-    (number? x)     :dispatch-type/number
-    (map? x)        :dispatch-type/map
-    (sequential? x) :dispatch-type/sequential
-    (set? x)        :dispatch-type/set
-    (symbol? x)     :dispatch-type/symbol
-    (fn? x)         :dispatch-type/fn
-    (regexp? x)     :dispatch-type/regex
+    (nil? x)              :dispatch-type/nil
+    (boolean? x)          :dispatch-type/boolean
+    (string? x)           :dispatch-type/string
+    (keyword? x)          :dispatch-type/keyword
+    (u.number/integer? x) :dispatch-type/integer
+    (number? x)           :dispatch-type/number
+    (map? x)              :dispatch-type/map
+    (sequential? x)       :dispatch-type/sequential
+    (set? x)              :dispatch-type/set
+    (symbol? x)           :dispatch-type/symbol
+    (fn? x)               :dispatch-type/fn
+    (regexp? x)           :dispatch-type/regex
     ;; we should add more mappings here as needed
-    :else           :dispatch-type/*))
+    :else                 :dispatch-type/*))
 
 (defn assoc-dissoc
   "Called like `(assoc m k v)`, this does [[assoc]] if `(some? v)`, and [[dissoc]] if not.

--- a/src/metabase/util/number.cljc
+++ b/src/metabase/util/number.cljc
@@ -3,7 +3,6 @@
   Most of the implementations are in the split CLJ/CLJS files [[metabase.util.number.impl]]."
   (:refer-clojure :exclude [bigint integer?])
   (:require
-   [clojure.core :as core]
    [metabase.util.namespaces :as shared.ns]
    [metabase.util.number.impl :as internal]))
 

--- a/src/metabase/util/number.cljc
+++ b/src/metabase/util/number.cljc
@@ -1,15 +1,17 @@
 (ns metabase.util.number
   "Number parsing helper functions.
   Most of the implementations are in the split CLJ/CLJS files [[metabase.util.number.impl]]."
-  (:refer-clojure :exclude [bigint])
+  (:refer-clojure :exclude [bigint integer?])
   (:require
+   [clojure.core :as core]
    [metabase.util.namespaces :as shared.ns]
    [metabase.util.number.impl :as internal]))
 
 (shared.ns/import-fns
  [internal
   bigint
-  bigint?])
+  bigint?
+  integer?])
 
 (defn parse-bigint
   "Parses a string as a BigInt. If the string cannot be parsed, returns `nil`."

--- a/src/metabase/util/number/impl.clj
+++ b/src/metabase/util/number/impl.clj
@@ -1,7 +1,7 @@
 (ns metabase.util.number.impl
   "CLJ implementation of the number utilities.
   See [[metabase.util.number]] for the public interface."
-  (:refer-clojure :exclude [bigint])
+  (:refer-clojure :exclude [bigint integer?])
   (:require
    [clojure.core :as core]))
 
@@ -14,3 +14,8 @@
   "Checks if the passed value is a BigInt instance."
   [x]
   (instance? clojure.lang.BigInt x))
+
+(defn integer?
+  "Checks if the passed value is an integer. [[clojure.core/integer?]] does not take BigInt into account on CLJS."
+  [x]
+  (core/integer? x))

--- a/src/metabase/util/number/impl.cljs
+++ b/src/metabase/util/number/impl.cljs
@@ -1,7 +1,9 @@
 (ns metabase.util.number.impl
   "CLJS implementation of the number utilities.
   See [[metabase.util.number]] for the public interface."
-  (:refer-clojure :exclude [bigint]))
+  (:refer-clojure :exclude [bigint integer?])
+  (:require
+   [clojure.core :as core]))
 
 (defn bigint
   "Coerce a number or a string to BigInt. Throws if coercion cannot be made."
@@ -12,3 +14,8 @@
   "Checks if the passed value is a BigInt instance."
   [x]
   (= (type x) js/BigInt))
+
+(defn integer?
+  "Checks if the passed value is an integer. [[clojure.core/integer?]] does not take BigInt into account on CLJS."
+  [x]
+  (or (core/integer? x) (bigint? x)))

--- a/test/metabase/lib/filter_test.cljc
+++ b/test/metabase/lib/filter_test.cljc
@@ -747,9 +747,9 @@
       {:clause [:not-null tax], :name "Tax is not empty"}])))
 
 (deftest ^:parallel bigint-frontend-filter-display-names-test
-  (let [id       (meta/field-metadata :orders :id)
-        value1    "9223372036854775808"
-        value2    "9223372036854775809"]
+  (let [id     (meta/field-metadata :orders :id)
+        value1  "9223372036854775808"
+        value2 "9223372036854775809"]
     (check-display-names
      [{:clause [:= id value1], :name (format "ID is %" value1)}]
      [{:clause [:!= id value1], :name (format "ID is not equal to %s" value1)}]

--- a/test/metabase/lib/filter_test.cljc
+++ b/test/metabase/lib/filter_test.cljc
@@ -14,7 +14,8 @@
    [metabase.lib.test-util.matrix :as matrix]
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.util :as lib.util]
-   [metabase.util :as u]))
+   [metabase.util :as u]
+   [metabase.util.number :as u.number]))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 
@@ -744,6 +745,19 @@
       {:clause [:<= tax 1], :name "Tax is less than or equal to 1"}
       {:clause [:is-null tax], :name "Tax is empty"}
       {:clause [:not-null tax], :name "Tax is not empty"}])))
+
+(deftest ^:parallel bigint-frontend-filter-display-names-test
+  (let [id       (meta/field-metadata :orders :id)
+        value1    "9223372036854775808"
+        value2    "9223372036854775809"]
+    (check-display-names
+     [{:clause [:= id value1], :name (format "ID is %" value1)}]
+     [{:clause [:!= id value1], :name (format "ID is not equal to %s" value1)}]
+     [{:clause [:> id value1], :name (format "ID is greater than %s" value1)}]
+     [{:clause [:>= id value1], :name (format "ID is greater than or equal to %s" value1)}]
+     [{:clause [:< id value1], :name (format "ID is less than %s" value1)}]
+     [{:clause [:<= id value1], :name (format "ID is less than or equal to %s" value1)}]
+     [{:clause [:between id value1 value2], :name (format "ID is between %s and %" value1 value2)}])))
 
 (deftest ^:parallel relative-datetime-frontend-filter-display-names-test
   (let [created-at (meta/field-metadata :products :created-at)]

--- a/test/metabase/lib/filter_test.cljc
+++ b/test/metabase/lib/filter_test.cljc
@@ -748,16 +748,18 @@
 
 (deftest ^:parallel bigint-frontend-filter-display-names-test
   (let [id     (meta/field-metadata :orders :id)
-        value1 "9223372036854775808"
-        value2 "9223372036854775809"]
+        pos-value "9223372036854775808"
+        neg-value "-9223372036854775809"]
     (check-display-names
-     [{:clause [:= id value1], :name (format "ID is %" value1)}]
-     [{:clause [:!= id value1], :name (format "ID is not equal to %s" value1)}]
-     [{:clause [:> id value1], :name (format "ID is greater than %s" value1)}]
-     [{:clause [:>= id value1], :name (format "ID is greater than or equal to %s" value1)}]
-     [{:clause [:< id value1], :name (format "ID is less than %s" value1)}]
-     [{:clause [:<= id value1], :name (format "ID is less than or equal to %s" value1)}]
-     [{:clause [:between id value1 value2], :name (format "ID is between %s and %" value1 value2)}])))
+     [{:clause [:= id pos-value], :name (format "ID is %s" pos-value)}
+      {:clause [:!= id pos-value], :name (format "ID is not %s" pos-value)}
+      {:clause [:> id pos-value], :name (format "ID is greater than %s" pos-value)}
+      {:clause [:>= id pos-value], :name (format "ID is greater than or equal to %s" pos-value)}
+      {:clause [:< id pos-value], :name (format "ID is less than %s" pos-value)}
+      {:clause [:<= id pos-value], :name (format "ID is less than or equal to %s" pos-value)}
+      {:clause [:between id 0 pos-value], :name (format "ID is between 0 and %s" pos-value)}
+      {:clause [:between id neg-value 0], :name (format "ID is between %s and 0" neg-value)}
+      {:clause [:between id neg-value pos-value], :name (format "ID is %s – %s" neg-value pos-value)}])))
 
 (deftest ^:parallel relative-datetime-frontend-filter-display-names-test
   (let [created-at (meta/field-metadata :products :created-at)]

--- a/test/metabase/lib/filter_test.cljc
+++ b/test/metabase/lib/filter_test.cljc
@@ -14,8 +14,7 @@
    [metabase.lib.test-util.matrix :as matrix]
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.util :as lib.util]
-   [metabase.util :as u]
-   [metabase.util.number :as u.number]))
+   [metabase.util :as u]))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 

--- a/test/metabase/lib/filter_test.cljc
+++ b/test/metabase/lib/filter_test.cljc
@@ -747,19 +747,19 @@
       {:clause [:not-null tax], :name "Tax is not empty"}])))
 
 (deftest ^:parallel bigint-frontend-filter-display-names-test
-  (let [id     (meta/field-metadata :orders :id)
+  (let [id        (meta/field-metadata :orders :id)
         pos-value "9223372036854775808"
         neg-value "-9223372036854775809"]
     (check-display-names
-     [{:clause [:= id pos-value], :name (format "ID is %s" pos-value)}
-      {:clause [:!= id pos-value], :name (format "ID is not %s" pos-value)}
-      {:clause [:> id pos-value], :name (format "ID is greater than %s" pos-value)}
-      {:clause [:>= id pos-value], :name (format "ID is greater than or equal to %s" pos-value)}
-      {:clause [:< id pos-value], :name (format "ID is less than %s" pos-value)}
-      {:clause [:<= id pos-value], :name (format "ID is less than or equal to %s" pos-value)}
-      {:clause [:between id 0 pos-value], :name (format "ID is between 0 and %s" pos-value)}
-      {:clause [:between id neg-value 0], :name (format "ID is between %s and 0" neg-value)}
-      {:clause [:between id neg-value pos-value], :name (format "ID is %s – %s" neg-value pos-value)}])))
+     [{:clause [:= id pos-value], :name (str "ID is " pos-value)}
+      {:clause [:!= id pos-value], :name (str "ID is not " pos-value)}
+      {:clause [:> id pos-value], :name (str "ID is greater than " pos-value)}
+      {:clause [:>= id pos-value], :name (str "ID is greater than or equal to " pos-value)}
+      {:clause [:< id pos-value], :name (str "ID is less than " pos-value)}
+      {:clause [:<= id pos-value], :name (str "ID is less than or equal to " pos-value)}
+      {:clause [:between id 0 pos-value], :name (str "ID is between 0 and " pos-value)}
+      {:clause [:between id neg-value 0], :name (str "ID is between " neg-value " and 0")}
+      {:clause [:between id neg-value pos-value], :name (str "ID is " neg-value " – " pos-value)}])))
 
 (deftest ^:parallel relative-datetime-frontend-filter-display-names-test
   (let [created-at (meta/field-metadata :products :created-at)]

--- a/test/metabase/lib/filter_test.cljc
+++ b/test/metabase/lib/filter_test.cljc
@@ -748,7 +748,7 @@
 
 (deftest ^:parallel bigint-frontend-filter-display-names-test
   (let [id     (meta/field-metadata :orders :id)
-        value1  "9223372036854775808"
+        value1 "9223372036854775808"
         value2 "9223372036854775809"]
     (check-display-names
      [{:clause [:= id value1], :name (format "ID is %" value1)}]

--- a/test/metabase/util/number_test.cljc
+++ b/test/metabase/util/number_test.cljc
@@ -18,6 +18,19 @@
       false 10
       false "9007199254740993")))
 
+(deftest integer?-test
+  (testing "should check if the value is an integer"
+    (are [exp value] (= exp (u.number/integer? value))
+      true  0
+      true  10
+      true  -10
+      true  (u.number/bigint 10)
+      true  (u.number/bigint "9223372036854775808")
+      true  (u.number/bigint "-9223372036854775808")
+      false 10.1
+      false -10.1
+      false "9223372036854775808")))
+
 (deftest parse-bigint-test
   (testing "should parse the value as a bigint"
     (are [exp value] (= exp (u.number/parse-bigint value))

--- a/test/metabase/util_test.cljc
+++ b/test/metabase/util_test.cljc
@@ -9,7 +9,8 @@
    [clojure.test.check.generators :as gen]
    [clojure.test.check.properties :as prop]
    [flatland.ordered.map :refer [ordered-map]]
-   [metabase.util :as u])
+   [metabase.util :as u]
+   [metabase.util.number :as u.number])
   #?(:clj (:import [java.time DayOfWeek Month])))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -359,6 +360,7 @@
     "x"                                   :dispatch-type/string
     :x                                    :dispatch-type/keyword
     1                                     :dispatch-type/integer
+    (u.number/bigint "10")                :dispatch-type/integer
     1.1                                   :dispatch-type/number
     {:a 1}                                :dispatch-type/map
     [1]                                   :dispatch-type/sequential


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/QUE-619/[mbql-lib]-support-biginteger-in-display-info-for-filters

How to verify:
- Try to add filters for numeric columns with bigint values, i.e. `9223372036854775808`
- Make sure there are no string quotes for all operators

Note that, depending on the column type or DB, the value can be rejected. In the sample DB `ID` columns are `BigInteger` and support large integers, while `Quantity` does not and the query would fail.

<img width="554" alt="Screenshot 2025-02-18 at 11 37 31" src="https://github.com/user-attachments/assets/4f6a30a3-e132-4684-9289-a75c94bbcd14" />
