### PR TITLE
auto cljfmt on commit hook

### DIFF
--- a/bin/cljfmt_staged.sh
+++ b/bin/cljfmt_staged.sh
@@ -19,10 +19,8 @@ if [ "${#STAGED_FILES}" -gt 0 ]; then
 
   output=$(clojure -T:cljfmt fix "{:paths [${args[*]}]}" 2>&1)
 
-  ## Return a non-zero error code if any files were formatted since this will cause the commit to abort
   if [ -n "$output" ]; then
     echo $output
-    exit 1
   else
     echo "All staged clj, cljc, or cljs formatted correctly"
   fi

--- a/package.json
+++ b/package.json
@@ -470,6 +470,9 @@
       "eslint --rulesdir frontend/lint/eslint-rules --max-warnings 0 --fix",
       "prettier --write"
     ],
+    "**/*.{clj,cljc,cljs,bb}": [
+      "./bin/cljfmt_staged.sh"
+    ],
     "e2e/test/scenarios/*/{*.(js|ts),!(helpers|shared)/*.(js|ts)}": [
       "node e2e/validate-e2e-test-files.js"
     ],


### PR DESCRIPTION
resolves https://linear.app/metabase/issue/DEV-354/cljfmt-should-be-applied-automatically

We had almost everything in place to _automatically_ reformat clojure files just before they get commited by `lint-staged`. I modified the `bin/cljfmt_staged.sh` script to exit 0 if it fixed something, which makes the commited content reformatted instead of having it block your commit.

Also has the script run during lint-staged with:

```
+    "**/*.{clj,cljc,cljs,bb}": [
+      "./bin/cljfmt_staged.sh"
+    ],
```