### PR TITLE
fix(sdk): Use scoped css reset for svg elements

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentStylesWrapper.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentStylesWrapper.tsx
@@ -33,10 +33,6 @@ const PublicComponentStylesWrapperInner = styled.div`
   transition: var(--transition-theme-change);
 
   ${saveDomImageStyles}
-
-  :where(svg) {
-    display: inline;
-  }
 `;
 
 export const PublicComponentStylesWrapper = (
@@ -71,5 +67,9 @@ export const SCOPED_CSS_RESET = css`
   :where(.mb-wrapper) *:where(ul) {
     padding: 0;
     margin: 0;
+  }
+
+  :where(.mb-wrapper) *:where(svg) {
+    display: inline;
   }
 `;


### PR DESCRIPTION
Fixes the global CSS reset for svg elements
It happens both in master, v53, v52

Fixes https://github.com/metabase/metabase/issues/53895

![image](https://github.com/user-attachments/assets/5031648a-1363-449d-88a9-b1aea35c12ad)

How to verify:
- build SDK locally
- add local version to shoppy/client: `rm -rf node_modules/.vite && yarn add file:../metabase/resources/embedding-sdk`
- launch shoppy: `yarn dev`
- visit http://localhost:3004/admin/analytics/new/dashboard
- create a new dashboard from a modal
- check the icon 