### PR TITLE
Fix env vars in embedding quickstart doc

### DIFF
--- a/docs/embedding/sdk/quickstart.md
+++ b/docs/embedding/sdk/quickstart.md
@@ -116,15 +116,15 @@ In the sample app's main directory, copy the `.env.example` template to `.env`.
 cp .env.example .env
 ```
 
-In `.env`, make sure `REACT_APP_METABASE_INSTANCE_URL` and `METABASE_INSTANCE_URL` point to your Metabase instance URL, e.g., `http://localhost:3000`.
+In `.env`, make sure `VITE_METABASE_INSTANCE_URL` and `METABASE_INSTANCE_URL` point to your Metabase instance URL, e.g., `http://localhost:3000`.
 
 Your `.env` will look something like:
 
 ```txt
 # FRONTEND
 PORT=3100
-REACT_APP_METABASE_INSTANCE_URL="http://localhost:3000"
-REACT_APP_AUTH_PROVIDER_URI="http://localhost:9090/sso/metabase"
+VITE_METABASE_INSTANCE_URL="http://localhost:3000"
+VITE_AUTH_PROVIDER_URI="http://localhost:9090/sso/metabase"
 
 # BACKEND
 BACKEND_PORT=9090

--- a/e2e/support/helpers/e2e-permissions-helpers.js
+++ b/e2e/support/helpers/e2e-permissions-helpers.js
@@ -48,7 +48,7 @@ export function getPermissionRowPermissions(item) {
     .find("tbody > tr")
     .contains(item)
     .closest("tr")
-    .findAllByTestId("permissions-select");
+    .asdf("permissions-select");
 }
 
 export function assertPermissionTable(rows) {

--- a/e2e/support/helpers/e2e-permissions-helpers.js
+++ b/e2e/support/helpers/e2e-permissions-helpers.js
@@ -48,7 +48,7 @@ export function getPermissionRowPermissions(item) {
     .find("tbody > tr")
     .contains(item)
     .closest("tr")
-    .asdf("permissions-select");
+    .findAllByTestId("permissions-select");
 }
 
 export function assertPermissionTable(rows) {


### PR DESCRIPTION
We're now using `VITE_METABASE_INSTANCE_URL` and `VITE_AUTH_PROVIDER_URI`: https://github.com/metabase/metabase-nodejs-react-sdk-embedding-sample/blob/main/.env.example