### PR TITLE
[refs] Include `parent_id` when hashing Fields to be unique

### DIFF
--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -180,7 +180,7 @@
 
 (defmethod serdes/hash-fields :model/Field
   [_field]
-  [:name (serdes/hydrated-hash :table :table_id)])
+  [:name (serdes/hydrated-hash :table :table_id) (serdes/hydrated-hash :parent :parent_id)])
 
 ;;; ---------------------------------------------- Hydration / Util Fns ----------------------------------------------
 
@@ -344,6 +344,15 @@
   {:arglists '([field])}
   [{:keys [table_id]}]
   (t2/select-one 'Table, :id table_id))
+
+(methodical/defmethod t2/batched-hydrate [:model/Field :parent]
+  [_model k fields]
+  (mi/instances-with-hydrated-data
+   fields k
+   #(t2/select-fn->fn :id identity
+                      :model/Field
+                      :id [:in (map :parent_id fields)])
+   :parent_id))
 
 ;;; ------------------------------------------------- Serialization -------------------------------------------------
 

--- a/test/metabase/models/dimension_test.clj
+++ b/test/metabase/models/dimension_test.clj
@@ -18,6 +18,6 @@
                      :model/Dimension dim    {:field_id                (:id field1)
                                               :human_readable_field_id (:id field2)
                                               :created_at              now}]
-        (is (= "c52f8889"
+        (is (= "0f5162d3"
                (serdes/raw-hash [(serdes/identity-hash field1) (serdes/identity-hash field2) now])
                (serdes/identity-hash dim)))))))

--- a/test/metabase/models/field_test.clj
+++ b/test/metabase/models/field_test.clj
@@ -37,13 +37,13 @@
              field))))))
 
 (deftest identity-hash-test
-  (testing "Field hashes are composed of the name and the table's identity-hash"
+  (testing "Field hashes are composed of the name, the table's identity-hash, and the parent's identity-hash"
     (mt/with-temp [:model/Database db    {:name "field-db" :engine :h2}
                    :model/Table    table {:schema "PUBLIC" :name "widget" :db_id (:id db)}
                    :model/Field    field {:name "sku" :table_id (:id table)}]
       (let [table-hash (serdes/identity-hash table)]
-        (is (= "dfd77225"
-               (serdes/raw-hash ["sku" table-hash])
+        (is (= "edc06d97"
+               (serdes/raw-hash ["sku" table-hash "<none>"])
                (serdes/identity-hash field)))))))
 
 (deftest nested-field-names->field-id-test
@@ -64,3 +64,34 @@
     (testing "return nothing if field does not exist"
       (is (= nil
              (field/nested-field-names->field-id table-id ["top" "nested" "not-exists"]))))))
+
+(deftest nested-fields-with-duplicate-names-test
+  (mt/with-temp
+    [:model/Database {db-id :id} {:name "field-db", :engine :h2}
+     :model/Table    table       {:schema  "PUBLIC"
+                                  :name    "widget"
+                                  :db_id   db-id}
+     :model/Field    parent1     {:name    "parent1"
+                                  :table_id (:id table)}
+     :model/Field    parent2     {:name    "parent2"
+                                  :table_id (:id table)}
+     ;; These two have the same name but different parents.
+     :model/Field    child1      {:name      "child"
+                                  :table_id  (:id table)
+                                  :parent_id (:id parent1)}
+     :model/Field    child2      {:name      "child"
+                                  :table_id  (:id table)
+                                  :parent_id (:id parent2)}]
+    (testing "nested fields with the same name and different parents have unique identity-hashes"
+      (is (= "204a7209"
+             (serdes/raw-hash ["parent1" (serdes/identity-hash table) "<none>"])
+             (serdes/identity-hash parent1)))
+      (is (= "be1bb68e"
+             (serdes/raw-hash ["parent2" (serdes/identity-hash table) "<none>"])
+             (serdes/identity-hash parent2)))
+      (is (= "7f203b41"
+             (serdes/raw-hash ["child" (serdes/identity-hash table) (serdes/identity-hash parent1)])
+             (serdes/identity-hash child1)))
+      (is (= "913269d5"
+             (serdes/raw-hash ["child" (serdes/identity-hash table) (serdes/identity-hash parent2)])
+             (serdes/identity-hash child2))))))

--- a/test/metabase/models/field_values_test.clj
+++ b/test/metabase/models/field_values_test.clj
@@ -443,7 +443,7 @@
                    :model/Table       table {:schema "PUBLIC" :name "widget" :db_id (:id db)}
                    :model/Field       field {:name "sku" :table_id (:id table)}
                    :model/FieldValues fv    {:field_id (:id field)}]
-      (is (= "6f5bb4ba"
+      (is (= "cb0ff8ea"
              (serdes/raw-hash [(serdes/identity-hash field)])
              (serdes/identity-hash fv))))))
 


### PR DESCRIPTION
### Description

Nested fields (Mongo, Postgres JSON unfolding, etc.) can have the same
name within one table, if their parent paths are different.

Including the parent (if any) as part of a Field's `serdes/hash-fields`
makes the hashes truly unique.

### How to verify

Call `serdes/backfill-entity-id` on two columns which are from the same table and
have the same name, but have different sub-field paths.

There are some tests for this case.

### Checklist

- ~~Tests have been added/updated to cover changes in this PR~~
