### PR TITLE
Point all hosting-related upsells to the main Cloud upsell

### DIFF
--- a/frontend/src/metabase/admin/upsells/UpsellCloud.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellCloud.tsx
@@ -5,7 +5,6 @@ import ExternalLink from "metabase/core/components/ExternalLink";
 
 import { UpsellBigCard } from "./components";
 import S from "./components/Upsells.module.css";
-import { CLOUD_URL } from "./constants";
 
 export const UpsellCloud = ({
   source,
@@ -33,7 +32,10 @@ export const UpsellCloud = ({
         .t`Get automatic backups, restores, and upgrades, built-in network monitoring, unlimited expert help from engineers and more.`}{" "}
       <strong>{t`All your dashboards and questions will be copied to your Cloud instance.`}</strong>{" "}
       {t`Get your first 14 days of Metabase Cloud for free.`}
-      <ExternalLink className={S.SecondaryCTALink} href={CLOUD_URL}>
+      <ExternalLink
+        className={S.SecondaryCTALink}
+        href="https://www.metabase.com/cloud"
+      >
         {t`Learn more`}
       </ExternalLink>
     </UpsellBigCard>

--- a/frontend/src/metabase/admin/upsells/UpsellHosting.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellHosting.tsx
@@ -5,10 +5,10 @@ import { useSelector } from "metabase/lib/redux";
 import { getIsHosted } from "metabase/setup/selectors";
 
 import { UpsellCard } from "./components";
-import { CLOUD_URL } from "./constants";
 
 // the default 200px width will break the title into two lines
 const UPSELL_CARD_WIDTH = 202;
+const CLOUD_PAGE = "/admin/settings/cloud";
 
 export const UpsellHosting = ({ source }: { source: string }) => {
   const isHosted = useSelector(getIsHosted);
@@ -22,7 +22,7 @@ export const UpsellHosting = ({ source }: { source: string }) => {
       title={t`Minimize maintenance`}
       campaign="hosting"
       buttonText={t`Learn more`}
-      buttonLink={CLOUD_URL}
+      internalLink={CLOUD_PAGE}
       illustrationSrc={RocketGlobeIllustrationSrc}
       source={source}
       maxWidth={UPSELL_CARD_WIDTH}
@@ -46,7 +46,7 @@ export const UpsellHostingUpdates = ({ source }: { source: string }) => {
       title={t`Get automatic updates`}
       campaign="hosting"
       buttonText={t`Learn more`}
-      buttonLink={CLOUD_URL}
+      internalLink={CLOUD_PAGE}
       illustrationSrc={RocketGlobeIllustrationSrc}
       source={source}
       maxWidth={UPSELL_CARD_WIDTH}

--- a/frontend/src/metabase/admin/upsells/components/UpsellCard.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellCard.tsx
@@ -2,7 +2,10 @@ import cx from "classnames";
 import { useMount } from "react-use";
 
 import ExternalLink from "metabase/core/components/ExternalLink";
+import Link from "metabase/core/components/Link";
 import { Box, Flex, Image, Stack, Text, Title } from "metabase/ui";
+
+import { UPGRADE_URL } from "../constants";
 
 import { UpsellGem } from "./UpsellGem";
 import { UpsellWrapper } from "./UpsellWrapper";
@@ -10,17 +13,7 @@ import S from "./Upsells.module.css";
 import { trackUpsellClicked, trackUpsellViewed } from "./analytics";
 import { useUpsellLink } from "./use-upsell-link";
 
-export type UpsellCardProps = {
-  title: string;
-  buttonText: string;
-  buttonLink: string;
-  campaign: string;
-  source: string;
-  illustrationSrc?: string;
-  children: React.ReactNode;
-  large?: boolean;
-  style?: React.CSSProperties;
-} & (
+type CardWidthProps =
   | {
       maxWidth?: never;
       fullWidth?: boolean;
@@ -28,8 +21,29 @@ export type UpsellCardProps = {
   | {
       maxWidth?: number;
       fullWidth?: never;
+    };
+
+type CardLinkProps =
+  | {
+      buttonLink: string;
+      internalLink?: never;
     }
-);
+  | {
+      internalLink: string;
+      buttonLink?: never;
+    };
+
+export type UpsellCardProps = {
+  title: string;
+  buttonText: string;
+  campaign: string;
+  source: string;
+  illustrationSrc?: string;
+  children: React.ReactNode;
+  large?: boolean;
+  style?: React.CSSProperties;
+} & CardWidthProps &
+  CardLinkProps;
 
 export const _UpsellCard: React.FC<UpsellCardProps> = ({
   title,
@@ -38,6 +52,7 @@ export const _UpsellCard: React.FC<UpsellCardProps> = ({
   campaign,
   source,
   illustrationSrc,
+  internalLink,
   children,
   fullWidth,
   maxWidth,
@@ -45,7 +60,7 @@ export const _UpsellCard: React.FC<UpsellCardProps> = ({
   ...props
 }: UpsellCardProps) => {
   const url = useUpsellLink({
-    url: buttonLink,
+    url: buttonLink ?? UPGRADE_URL,
     campaign,
     source,
   });
@@ -81,15 +96,24 @@ export const _UpsellCard: React.FC<UpsellCardProps> = ({
           <Text lh="1rem" px="1rem">
             {children}
           </Text>
-          <Box
-            component={ExternalLink}
-            onClickCapture={() => trackUpsellClicked({ source, campaign })}
-            href={url}
-            className={S.UpsellCTALink}
-            mx="md"
-            mb="lg"
-          >
-            {buttonText}
+          <Box mx="md" mb="lg">
+            {buttonLink ? (
+              <ExternalLink
+                onClickCapture={() => trackUpsellClicked({ source, campaign })}
+                href={url}
+                className={S.UpsellCTALink}
+              >
+                {buttonText}
+              </ExternalLink>
+            ) : (
+              <Link
+                onClickCapture={() => trackUpsellClicked({ source, campaign })}
+                to={internalLink as string}
+                className={S.UpsellCTALink}
+              >
+                {buttonText}
+              </Link>
+            )}
           </Box>
         </Stack>
       </Stack>

--- a/frontend/src/metabase/admin/upsells/components/UpsellCard.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellCard.tsx
@@ -97,7 +97,7 @@ export const _UpsellCard: React.FC<UpsellCardProps> = ({
             {children}
           </Text>
           <Box mx="md" mb="lg">
-            {buttonLink ? (
+            {buttonLink !== undefined ? (
               <ExternalLink
                 onClickCapture={() => trackUpsellClicked({ source, campaign })}
                 href={url}
@@ -108,7 +108,7 @@ export const _UpsellCard: React.FC<UpsellCardProps> = ({
             ) : (
               <Link
                 onClickCapture={() => trackUpsellClicked({ source, campaign })}
-                to={internalLink as string}
+                to={internalLink}
                 className={S.UpsellCTALink}
               >
                 {buttonText}

--- a/frontend/src/metabase/admin/upsells/constants.ts
+++ b/frontend/src/metabase/admin/upsells/constants.ts
@@ -1,2 +1,1 @@
-export const CLOUD_URL = "https://www.metabase.com/cloud";
 export const UPGRADE_URL = "https://www.metabase.com/upgrade";


### PR DESCRIPTION
Resolves CLO-3590

## About
The Product decision was to point all existing upsells (that were previously leading to `https://www.metabase.com/cloud`) to the existing, central Cloud upsell in the app. This is now possible after we merged #53632. This makes it easier to initiate the migration directly from the app.

> [!IMPORTANT]
> I double-checked with @trinya and she confirmed that all of the existing Snowplow analytics stays intact. Once a user lands on a "smaller" or "secondary" hosting upsell, the existing events still kick in: (1) visited + (2) clicked on the CTA. The user than lands on `/admin/settings/cloud` where we again have the same sequence of Snowplow events.