### PR TITLE
Use max-content width for ClickActionsPopover

### DIFF
--- a/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsPopover.tsx
+++ b/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsPopover.tsx
@@ -134,7 +134,6 @@ export class ClickActionsPopover extends Component<
         opened={!!popoverAnchor}
         onClose={this.close}
         position="bottom-start"
-        width={700}
         offset={8}
         {...popoverAction?.popoverProps}
       >


### PR DESCRIPTION
The issue happens on v53 only.

Fixes https://github.com/metabase/metabase/issues/53891 ([linear](https://linear.app/metabase/issue/EMB-157/%5Bsdk%5D-drill-through-menus-container-width-is-very-wide))

Use max-content width for ClickActionsPopover, but limit max-width

This change is the same as Mantine v7 change (see image below)
![image](https://github.com/user-attachments/assets/a750572d-513f-42a6-ae85-6feaf16fec82)

When the `width` prop is removed, the `max-content` width is used

Before:
![image](https://github.com/user-attachments/assets/0c6843fc-8fd3-4022-b913-94160ab49b4c)

After:
![image](https://github.com/user-attachments/assets/45c8dd62-73ec-4398-972a-3371d8213b2a)


How to verify:
- checkout v53
- build SDK locally
- add local version to shoppy/client: rm -rf node_modules/.vite && yarn add file:../metabase/resources/embedding-sdk
- launch shoppy: yarn dev
- visit http://localhost:3004/admin/analytics/17
- click any dot in the `orders last 30 days` chart
- be sure that the default dropdown width is the same as max-width of its content
- via devtools adjust text on any menu item, make it really long
- be sure that max-width is 700px