### PR TITLE
Fix "Migrating to Metabase Cloud" for local dev instances

### DIFF
--- a/src/metabase/cloud_migration/settings.clj
+++ b/src/metabase/cloud_migration/settings.clj
@@ -62,7 +62,7 @@
   ;; a dump from that version, but it lets you test everything else up to that point works.
   :default    (when (-> (config/mb-version-info :tag)
                         (#(or (= % "vLOCAL_DEV") (str/ends-with? % "-SNAPSHOT"))))
-                "v0.52.0-RC1")
+                "v0.53.3")
   :doc        false
   :export?    false)
 

--- a/src/metabase/cloud_migration/settings.clj
+++ b/src/metabase/cloud_migration/settings.clj
@@ -61,7 +61,9 @@
   ;; This will cause the restore to fail on cloud unless you also set `migration-dump-file` to
   ;; a dump from that version, but it lets you test everything else up to that point works.
   :default    (when (-> (config/mb-version-info :tag)
-                        (#(or (= % "vLOCAL_DEV") (str/ends-with? % "-SNAPSHOT"))))
+                        (#(or (= % "vLOCAL_DEV")
+                              (= % "vUNKNOWN")
+                              (str/ends-with? % "-SNAPSHOT"))))
                 "v0.53.3")
   :doc        false
   :export?    false)

--- a/src/metabase/cloud_migration/settings.clj
+++ b/src/metabase/cloud_migration/settings.clj
@@ -53,6 +53,12 @@
   :doc        false
   :export?    false)
 
+(defn- is-invalid-mb-version?
+  "These variations are not valid Metabase versions that can be found in production. They are mostly used for local
+   development, or as fallback values if a :tag is missing altogether."
+  [version]
+  (or (= version "vLOCAL_DEV") (= version "vUNKNOWN") (str/ends-with? version "-SNAPSHOT")))
+
 (defsetting migration-dump-version
   (deferred-tru "Custom dump version for migrations.")
   :encryption :no
@@ -60,10 +66,7 @@
   ;; Use a known version on staging when there's no real version.
   ;; This will cause the restore to fail on cloud unless you also set `migration-dump-file` to
   ;; a dump from that version, but it lets you test everything else up to that point works.
-  :default    (when (-> (config/mb-version-info :tag)
-                        (#(or (= % "vLOCAL_DEV")
-                              (= % "vUNKNOWN")
-                              (str/ends-with? % "-SNAPSHOT"))))
+  :default    (when (is-invalid-mb-version? (config/mb-version-info :tag))
                 "v0.53.3")
   :doc        false
   :export?    false)

--- a/src/metabase/cloud_migration/settings.clj
+++ b/src/metabase/cloud_migration/settings.clj
@@ -1,5 +1,6 @@
 (ns metabase.cloud-migration.settings
   (:require
+   [clojure.string :as str]
    [metabase.config :as config]
    [metabase.models.setting :refer [defsetting]]
    [metabase.util.i18n :refer [deferred-tru]]))
@@ -59,7 +60,9 @@
   ;; Use a known version on staging when there's no real version.
   ;; This will cause the restore to fail on cloud unless you also set `migration-dump-file` to
   ;; a dump from that version, but it lets you test everything else up to that point works.
-  :default    (when (= (config/mb-version-info :tag) "vLOCAL_DEV") "v0.50.0-RC1")
+  :default    (when (-> (config/mb-version-info :tag)
+                        (#(or (= % "vLOCAL_DEV") (str/ends-with? % "-SNAPSHOT"))))
+                "v0.52.0-RC1")
   :doc        false
   :export?    false)
 


### PR DESCRIPTION
Resolves CLO-3616
Resolves CLO-3577

## About
This PR makes it possible to run a migration to cloud from a local dev instance. This was not possible previously unless you explicitly had `MB_MIGRATION_DUMP_VERSION` in your envs.

### How to test
1. Make sure you **don't** have the `MB_MIGRATION_DUMP_VERSION` env set up
2. Make sure you **don't** have the pro/enterprise token in your envs
3. Checkout this branch
4. Spin the local Metabase instance with `yarn dev`
5. Go to `/admin/settings/cloud`
6. Click on "Try for free" upsell cta button
7. Click on "Migrate now" button in the migration modal
8. The migration should start (you'll be redirected to the Metabase Store in a new browser tab)
9. If you go back to your local Metabase instance, you should see migration underway

![Screenshot 2025-02-19 at 16 59 37](https://github.com/user-attachments/assets/56ff6290-1c73-4850-9f5a-5c717e37bf5c)
