### PR TITLE
Ensure CLJS/CLJC files get translations included in the FE bundle

### DIFF
--- a/bin/build/src/i18n/create_artifacts/frontend.clj
+++ b/bin/build/src/i18n/create_artifacts/frontend.clj
@@ -15,8 +15,7 @@
 (defn- frontend-message?
   "Whether this i18n `message` comes from a frontend source file."
   [{:keys [source-references]}]
-  (some #(str/includes? % "frontend")
-        source-references))
+  (some #(re-find #"frontend|cljs|cljc" %) source-references))
 
 (defn- ->ttag-reference
   "Replace an xgettext `{0}` style reference with a ttag `${ 0 }` style reference."

--- a/bin/build/test/i18n/create_artifacts/backend_test.clj
+++ b/bin/build/test/i18n/create_artifacts/backend_test.clj
@@ -1,7 +1,6 @@
 (ns i18n.create-artifacts.backend-test
   (:require
    [clojure.edn :as edn]
-   [clojure.string :as str]
    [clojure.test :refer :all]
    [i18n.create-artifacts.backend :as backend]
    [i18n.create-artifacts.test-common :as test-common]))

--- a/bin/build/test/i18n/create_artifacts/backend_test.clj
+++ b/bin/build/test/i18n/create_artifacts/backend_test.clj
@@ -1,5 +1,6 @@
 (ns i18n.create-artifacts.backend-test
   (:require
+   [clojure.edn :as edn]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [i18n.create-artifacts.backend :as backend]
@@ -7,28 +8,22 @@
 
 (deftest edn-test
   (#'backend/write-edn-file! test-common/po-contents "/tmp/out.edn")
-  (is (= ["{"
-          ":headers"
-          "{\"MIME-Version\" \"1.0\", \"Content-Type\" \"text/plain; charset=UTF-8\", \"Content-Transfer-Encoding\" \"8bit\", \"X-Generator\" \"POEditor.com\", \"Project-Id-Version\" \"Metabase\", \"Language\" \"es\", \"Plural-Forms\" \"nplurals=2; plural=(n != 1);\"}"
-          ""
-          ":messages"
-          "{"
-          "\"No table description yet\""
-          "\"No hay una descripción de la tabla\""
-          ""
-          "\"Count of {0}\""
-          "\"Número de {0}\""
-          ""
-          "\"{0} table\""
-          "[\"{0} tabla\" \"{0} tablas\"]"
-          ""
-          "\"{0} metric\""
-          "[\"{0} metrik\" \"\"]"
-          ""
-          "}"
-          "}"]
+  (is (= {:headers
+          {"MIME-Version"              "1.0"
+           "Content-Type"              "text/plain; charset=UTF-8"
+           "Content-Transfer-Encoding" "8bit"
+           "X-Generator"               "POEditor.com"
+           "Project-Id-Version"        "Metabase"
+           "Language"                  "es"
+           "Plural-Forms"              "nplurals=2; plural=(n != 1);"}
+          :messages
+          {"No table description yet" "No hay una descripción de la tabla"
+           "Count of {0}"             "Número de {0}"
+           "{0} table"                ["{0} tabla" "{0} tablas"]
+           "{0} metric"               ["{0} metrik" ""]
+           "Average of {0}"           "Average of {0}"}}
          (some-> (slurp "/tmp/out.edn")
-                 (str/split-lines)))))
+                 edn/read-string))))
 
 (deftest ^:parallel backend-message?
   (testing "messages present in any .clj and .cljc files are detected as backend messages"

--- a/bin/build/test/i18n/create_artifacts/frontend_test.clj
+++ b/bin/build/test/i18n/create_artifacts/frontend_test.clj
@@ -30,5 +30,11 @@
 
                           "${ 0 } metric"
                           {:msgid_plural "{0} metrics"
-                           :msgstr       ["${ 0 } metrik" ""]}}}}
+                           :msgstr       ["${ 0 } metrik" ""]}
+
+                          "Average of ${ 0 }"
+                          {:msgstr ["Average of ${ 0 }"]}
+
+                          "Median of ${ 0 }"
+                          {:msgstr ["Median of ${ 0 }"]}}}}
          (#'frontend/->i18n-map test-common/po-contents))))

--- a/bin/build/test/i18n/create_artifacts/test_common.clj
+++ b/bin/build/test/i18n/create_artifacts/test_common.clj
@@ -80,6 +80,26 @@
    :source-references ["src/metabase/automagic_dashboards/core.clj"]
    :comment           nil})
 
+(def ^:private cljc-message
+  {:id                "Average of {0}"
+   :id-plural         nil
+   :str               "Average of {0}"
+   :str-plural        nil
+   :fuzzy?            false
+   :plural?           false
+   :source-references ["src/metabase/lib/aggregation.cljc"]
+   :comment           nil})
+
+(def ^:private cljs-message
+  {:id                "Median of {0}"
+   :id-plural         nil
+   :str               "Median of {0}"
+   :str-plural        nil
+   :fuzzy?            false
+   :plural?           false
+   :source-references ["src/metabase/lib/aggregation.cljs"]
+   :comment           nil})
+
 (def ^:private messages
   [singular-message-frontend
    singular-message-backend
@@ -88,7 +108,9 @@
    plural-message-frontend
    plural-message-frontend-with-empty
    plural-message-backend
-   plural-message-backend-with-empty])
+   plural-message-backend-with-empty
+   cljc-message
+   cljs-message])
 
 (def po-contents
   "Contents of a `.po` file."

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -1,6 +1,7 @@
 const { H } = cy;
 import { SAMPLE_DB_ID, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { ADMIN_USER_ID } from "e2e/support/cypress_sample_instance_data";
 
 const { ORDERS, ORDERS_ID, PEOPLE, PEOPLE_ID, PRODUCTS, PRODUCTS_ID } =
   SAMPLE_DATABASE;
@@ -1138,6 +1139,30 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     H.addSummaryGroupingField({ field: "Total" });
     H.visualize();
     H.echartsContainer().should("contain.text", "Total: 8 bins");
+  });
+
+  it("Correctly translates aggregations", () => {
+    cy.request("PUT", `/api/user/${ADMIN_USER_ID}`, {
+      locale: "de",
+    });
+
+    H.openTable({
+      table: ORDERS_ID,
+      mode: "notebook",
+    });
+
+    cy.findByRole("button", { name: "Zusammenfassen" }).click();
+    H.popover().within(() => {
+      cy.findByText("Durchschnitt von...").click();
+      cy.findByText("Subtotal").click();
+    });
+
+    cy.findAllByText("Durchschnitt von Subtotal").should("exist");
+    cy.findAllByText("Average of Subtotal").should("not.exist");
+
+    cy.request("PUT", `/api/user/${ADMIN_USER_ID}`, {
+      locale: "en",
+    });
   });
 });
 

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/column_extract_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/column_extract_drill.cy.spec.js
@@ -237,7 +237,7 @@ H.describeWithSnowplow("extract action", () => {
         column: "Created At",
         option: "Tag der Woche",
         value: "Dienstag",
-        extraction: "Extract day, month…",
+        extraction: "Auszug Tag, Monat...",
       });
     });
   });


### PR DESCRIPTION
Slack investigation: https://metaboat.slack.com/archives/CKZEMT1MJ/p1739912764732399

Closes https://github.com/metabase/metabase/issues/53988

* Updates i18n build scripts to ensure that strings defined in `.cljs` and `.cljc` files are correctly included in the FE bundle (`cljc` files are also included in the BE) file
* Adds unit + e2e tests
