### PR TITLE
API dox include session token

### DIFF
--- a/src/metabase/api/macros/defendpoint/open_api.clj
+++ b/src/metabase/api/macros/defendpoint/open_api.clj
@@ -142,7 +142,10 @@
           params                    (concat
                                      (for [param route-params]
                                        (assoc param :in :path))
-                                     query-params)
+                                     query-params
+                                     [{:name "X-Metabase-Session"
+                                       :in   :header
+                                       :$ref "#/components/headers/X-Metabase-Session"}])
           ctype                     (if (get-in form [:metadata :multipart])
                                       "multipart/form-data"
                                       "application/json")

--- a/src/metabase/api/open_api.clj
+++ b/src/metabase/api/open_api.clj
@@ -180,14 +180,16 @@
     [:object  ::parameter.schema.object]
     [:array   ::parameter.schema.array]]])
 
+(mr/def ::ref.string
+  [:re
+   {:description "string starting with '#/components/'"}
+   #"^#/components/(?:schemas)|(?:headers)/[^/]+$"])
+
 (mr/def ::parameter.schema.ref
   [:merge
    ::parameter.schema.common
    [:map
-
-    [:$ref [:re
-            {:description "string starting with '#/components/schemas/'"}
-            #"^#/components/schemas/[^/]+$"]]
+    [:$ref ::ref.string]
     [:definitions {:optional true} [:map-of :string [:ref ::parameter.schema]]]]])
 
 (mr/def ::parameter.schema.or
@@ -201,34 +203,29 @@
     [:merge
      ::parameter.schema.common
      [:map
-
       [:anyOf [:sequential [:ref ::parameter.schema]]]]]]
    [:oneOf
     [:merge
      ::parameter.schema.common
      [:map
-
       [:oneOf [:sequential [:ref ::parameter.schema]]]]]]])
 
 (mr/def ::parameter.schema.and
   [:merge
    ::parameter.schema.common
    [:map
-
     [:allOf [:sequential [:ref ::parameter.schema]]]]])
 
 (mr/def ::parameter.schema.const
   [:merge
    ::parameter.schema.common
    [:map
-
     [:const :any]]])
 
 (mr/def ::parameter.schema.untyped-enum
   [:merge
    ::parameter.schema.common
    [:map
-
     [:enum [:sequential :any]]]])
 
 (mr/def ::parameter.schema.empty
@@ -265,8 +262,9 @@
    [:name        string?]
    [:in          ::parameter.in]
    [:description {:optional true} :string]
-   [:required    :boolean]
-   [:schema      ::parameter.schema]])
+   [:required    {:optional true} :boolean]
+   [:schema      {:optional true} ::parameter.schema]
+   [:$ref        {:optional true} ::ref.string]])
 
 (mr/def ::path-item.request-body
   [:map


### PR DESCRIPTION
<img width="1278" alt="Screenshot 2025-02-19 at 9 20 41 AM" src="https://github.com/user-attachments/assets/6d591662-81b3-4218-bfbc-2af0b6cab2af" />

Populated with the session token from your session cookie. Lets you test out the API from the Scalar client. Needs a little more work so we don't include it in the static version. Also it would be nice to support API Tokens as an auth option