### PR TITLE
Reject conflicting metrics

### DIFF
--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -41,8 +41,8 @@
   ;; localhost:<prometheus-server-port>/metrics. Nothing we need to do but shutdown.
   PrometheusActions
   (stop-web-server [_this]
-    (when-let [^Server web-server web-server]
-      (.stop web-server))))
+                   (when-let [^Server web-server web-server]
+                     (.stop web-server))))
 
 (defonce ^:private ^{:doc "Prometheus System for prometheus metrics"} ^PrometheusSystem system nil)
 
@@ -215,6 +215,8 @@
                        {:description "Number of error responses from SCIM endpoints"})
    (prometheus/counter :metabase-query-processor/metrics-adjust
                        {:description "Number of queries with metrics processed by the metrics adjust middleware."})
+   (prometheus/counter :metabase-query-processor/metrics-adjust-incompatible-rejections
+                       {:description "Number of queries rejected due to referencing incompatible metrics."})
    (prometheus/counter :metabase-query-processor/metrics-adjust-errors
                        {:description "Number of errors when processing metrics in the metrics adjust middleware."})
    (prometheus/counter :metabase-search/index

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -41,8 +41,8 @@
   ;; localhost:<prometheus-server-port>/metrics. Nothing we need to do but shutdown.
   PrometheusActions
   (stop-web-server [_this]
-                   (when-let [^Server web-server web-server]
-                     (.stop web-server))))
+    (when-let [^Server web-server web-server]
+      (.stop web-server))))
 
 (defonce ^:private ^{:doc "Prometheus System for prometheus metrics"} ^PrometheusSystem system nil)
 

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -238,6 +238,7 @@
   (lib.util.match/match-one query
     [:metric _ _] &match))
 
+;; operates on single filter -- not filters vector as returned from lib/filters
 (defn- equal-filter?
   [f1 f2]
   (let [f1 (cond-> f1 (lib.util/clause-of-type? f1 :value) (get 2))
@@ -250,7 +251,10 @@
       (and (= (first f1) (first f2))
            (= (count (nthnext f1 2)) (count (nthnext f2 2))))
       (every? #(apply equal-filter? %)
-              (map vector (nthnext f1 2) (nthnext f2 2))))))
+              (map vector (nthnext f1 2) (nthnext f2 2)))
+
+      :else
+      false)))
 
 (defn- filters-for-subset?
   "Check whether filter clause `f1` filters for subset of rows that filter clause `f2` filters for."

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -265,6 +265,7 @@
   [f1 f2]
   (every? #(m/find-first (partial equal-filter? %) f1) f2))
 
+;; Later will decide whether to go with this implementation
 (defn- assert-compatible-stage-filters
   "Assert that stage filteres are compatible with filterse of every referenced metric. Returns nil."
   [query stage-number metrics]
@@ -276,8 +277,8 @@
                 metric-query (get metrics metric-id)
                 metric-filters (lib/filters metric-query)]
             (when-not (filters-for-subset? query-filters metric-filters)
-              (throw (ex-info (format "Stage filter is not compatible with metric %d filter."
-                                      metric-id)
+              (throw (ex-info (tru "Stage filter is not compatible with metric {0} filter."
+                                   metric-id)
                               {:stage-filters query-filters
                                :metric-filters metric-filters}))))
           (recur (rest metric-ids))))))
@@ -359,9 +360,9 @@
               metric-query (get metrics metric-id)
               metric-filters (lib/filters metric-query)]
           (when-not (filters-map-1-1? base-filters metric-filters)
-            (throw (ex-info (format "Metrics %d and %d have incompatible filters."
-                                    base-metric-id
-                                    metric-id)
+            (throw (ex-info (tru "Metrics {0} and {1} have incompatible filters."
+                                 base-metric-id
+                                 metric-id)
                             {:base-filters base-filters
                              :metric-filters metric-filters}))))
         (recur (rest other-metric-ids)))))
@@ -402,7 +403,7 @@
     (when (seq stage-joins)
       (let [join (first stage-joins)]
         (when-not (is-join-compatible? query stage-number join)
-          (throw (ex-info "Incompatible join in a stage referencing a metric"
+          (throw (ex-info (tru "Incompatible join in a stage referencing a metric")
                           {:join join}))))
       (recur (rest stage-joins))))
   ;; check the metrics' joins
@@ -414,7 +415,7 @@
           (when (seq metric-joins)
             (let [metric-join (first metric-joins)]
               (when-not (is-join-compatible? metric-query -1 metric-join)
-                (throw (ex-info (format "Incompatible join in the metric %d" metric-id)
+                (throw (ex-info (tru "Incompatible join in the metric {0}" metric-id)
                                 {:join metric-join}))))
             (recur (rest metric-joins)))))
       (recur (rest metric-ids))))

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -18,24 +18,24 @@
     (let [columns (lib/visible-columns query stage-number)]
       (assoc-in query [:stages stage-number :aggregation]
                 (lib.util.match/replace aggregations
-                  [:metric _ metric-id]
-                  (if-let [{replacement :aggregation metric-name :name} (get lookup metric-id)]
+                                        [:metric _ metric-id]
+                                        (if-let [{replacement :aggregation metric-name :name} (get lookup metric-id)]
                     ;; We have to replace references from the source-metric with references appropriate for
                     ;; this stage (expression/aggregation -> field, field-id to string)
-                    (let [replacement (lib.util.match/replace replacement
-                                        [(tag :guard #{:expression :field :aggregation}) _ _]
-                                        (if-let [col (lib/find-matching-column &match columns)]
-                                          (lib/ref col)
+                                          (let [replacement (lib.util.match/replace replacement
+                                                                                    [(tag :guard #{:expression :field :aggregation}) _ _]
+                                                                                    (if-let [col (lib/find-matching-column &match columns)]
+                                                                                      (lib/ref col)
                                           ;; This is probably due to a field-id where it shouldn't be
-                                          &match))]
-                      (update (lib.util/fresh-uuids replacement)
-                              1
-                              #(merge
-                                %
-                                {:name metric-name}
-                                (select-keys % [:name :display-name])
-                                (select-keys (get &match 1) [:lib/uuid :name :display-name]))))
-                    (throw (ex-info "Incompatible metric" {:match &match :lookup lookup}))))))
+                                                                                      &match))]
+                                            (update (lib.util/fresh-uuids replacement)
+                                                    1
+                                                    #(merge
+                                                      %
+                                                      {:name metric-name}
+                                                      (select-keys % [:name :display-name])
+                                                      (select-keys (get &match 1) [:lib/uuid :name :display-name]))))
+                                          (throw (ex-info "Incompatible metric" {:match &match :lookup lookup}))))))
     query))
 
 (defn- find-metric-ids
@@ -101,8 +101,8 @@
 (defn- add-join-aliases
   [x source-field->join-alias]
   (lib.util.match/replace x
-    [:field (opts :guard (every-pred (comp source-field->join-alias :source-field) (complement :join-alias))) _]
-    (assoc-in &match [1 :join-alias] (-> opts :source-field source-field->join-alias))))
+                          [:field (opts :guard (every-pred (comp source-field->join-alias :source-field) (complement :join-alias))) _]
+                          (assoc-in &match [1 :join-alias] (-> opts :source-field source-field->join-alias))))
 
 (defn- include-implicit-joins
   [query agg-stage-index metric-query]
@@ -184,28 +184,28 @@
    replaced with the actual aggregation of the metric."
   [query stage-path expanded-stages last-metric-stage-number metric-metadata]
   (mu/disable-enforcement
-    (let [[pre-transition-stages [last-metric-stage _following-stage & following-stages]] (split-at last-metric-stage-number expanded-stages)
-          metric-name (:name metric-metadata)
-          metric-aggregation (-> last-metric-stage :aggregation first)
-          stage-query (temp-query-at-stage-path query stage-path)
-          stage-query (update-in stage-query
-                                 [:stages last-metric-stage-number]
-                                 (fn [stage]
-                                   (dissoc stage :breakout :order-by :aggregation :fields :lib/stage-metadata)))
+   (let [[pre-transition-stages [last-metric-stage _following-stage & following-stages]] (split-at last-metric-stage-number expanded-stages)
+         metric-name (:name metric-metadata)
+         metric-aggregation (-> last-metric-stage :aggregation first)
+         stage-query (temp-query-at-stage-path query stage-path)
+         stage-query (update-in stage-query
+                                [:stages last-metric-stage-number]
+                                (fn [stage]
+                                  (dissoc stage :breakout :order-by :aggregation :fields :lib/stage-metadata)))
           ;; Needed for field references to resolve further in the pipeline
-          stage-query (lib/with-fields stage-query last-metric-stage-number (lib/fieldable-columns stage-query last-metric-stage-number))
-          new-metric-stage (lib.util/query-stage stage-query last-metric-stage-number)
-          lookup {(:id metric-metadata)
-                  {:name metric-name :aggregation metric-aggregation}}
-          stage-query (replace-metric-aggregation-refs
-                       stage-query
-                       (inc last-metric-stage-number)
-                       lookup)
-          new-following-stage (lib.util/query-stage stage-query (inc last-metric-stage-number))
-          combined-stages (vec (remove nil? (concat pre-transition-stages
-                                                    [new-metric-stage new-following-stage]
-                                                    following-stages)))]
-      combined-stages)))
+         stage-query (lib/with-fields stage-query last-metric-stage-number (lib/fieldable-columns stage-query last-metric-stage-number))
+         new-metric-stage (lib.util/query-stage stage-query last-metric-stage-number)
+         lookup {(:id metric-metadata)
+                 {:name metric-name :aggregation metric-aggregation}}
+         stage-query (replace-metric-aggregation-refs
+                      stage-query
+                      (inc last-metric-stage-number)
+                      lookup)
+         new-following-stage (lib.util/query-stage stage-query (inc last-metric-stage-number))
+         combined-stages (vec (remove nil? (concat pre-transition-stages
+                                                   [new-metric-stage new-following-stage]
+                                                   following-stages)))]
+     combined-stages)))
 
 (defn- adjust-metric-stages
   "`expanded-stages` are the result of :stages from fetch-source-query.
@@ -236,9 +236,46 @@
 (defn- find-first-metric
   [query]
   (lib.util.match/match-one query
-    [:metric _ _] &match))
+                            [:metric _ _] &match))
 
 ;;;; Rejection of incompatible metrics ===============================================================================
+
+;; TODO: Do we have something else?
+;; TODO: Where this should live?
+(def ^:private commutative-ops
+  #{:+
+    :*
+    :=
+    :!=
+    :and
+    :or})
+
+(declare equal-filter?)
+
+(defn- equal-commutative-op?
+  [f1 f2]
+  (let [f1-args (vec (nthnext f1 2))
+        f2-args (vec (nthnext f2 2))]
+    (loop [f1-indices (range (count f1-args))
+           f2-indices (range (count f2-args))]
+      (cond
+        (and (empty? f1-indices)
+             (empty? f2-indices))
+        true
+
+        ;; I believe the following is redundant! This function is inner to equal-filter?
+        ;; (or (empty? f1-indices)
+        ;;     (empty? f2-indices))
+        ;; false
+
+        :else
+        (let [f1-index (first f1-indices)
+              f1-elm (nth f1-args f1-index)
+              matching (m/find-first #(equal-filter? f1-elm (nth f2-args %)) f2-indices)]
+          (if-not matching
+            false
+            (recur (next f1-indices)
+                   (disj f2-indices matching))))))))
 
 ;; Following fn operates on _single elements_ of filters vector (as returned from lib/filters).
 (defn- equal-filter?
@@ -254,8 +291,10 @@
            (lib.util/clause? f2)
            (= (first f1) (first f2))
            (= (count (nthnext f1 2)) (count (nthnext f2 2))))
-      (every? #(apply equal-filter? %)
-              (map vector (nthnext f1 2) (nthnext f2 2)))
+      (if ((comp commutative-ops first) f1)
+        (equal-commutative-op? f1 f2)
+        (every? #(apply equal-filter? %)
+                (map vector (nthnext f1 2) (nthnext f2 2))))
 
       :else
       false)))
@@ -289,6 +328,8 @@
 ;; (disj (set (metabase.lib.hierarchy/descendants :metabase.lib.schema.aggregation/aggregation-clause-tag))
 ;;                                                :metric :offset)
 ;; =>
+;;
+;; TODO: this should be turned into using the schema, and the following fuction should be adjusted.
 (def ^:private forbidden-aggregations #{:min
                                         :stddev
                                         :count-where
@@ -477,9 +518,9 @@
                        (when (= path-type :lib.walk/join)
                          (update stage-or-join :stages #(adjust-metric-stages query path %)))))]
           (u/prog1
-            (update query :stages #(adjust-metric-stages query nil %))
-            (when-let [metric (find-first-metric (:stages <>))]
-              (throw (ex-info "Failed to replace metric" {:metric metric})))))
+           (update query :stages #(adjust-metric-stages query nil %))
+           (when-let [metric (find-first-metric (:stages <>))]
+             (throw (ex-info "Failed to replace metric" {:metric metric})))))
         (catch Throwable e
           (analytics/inc! :metabase-query-processor/metrics-adjust-errors)
           (throw e))))))

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -18,24 +18,24 @@
     (let [columns (lib/visible-columns query stage-number)]
       (assoc-in query [:stages stage-number :aggregation]
                 (lib.util.match/replace aggregations
-                                        [:metric _ metric-id]
-                                        (if-let [{replacement :aggregation metric-name :name} (get lookup metric-id)]
+                  [:metric _ metric-id]
+                  (if-let [{replacement :aggregation metric-name :name} (get lookup metric-id)]
                     ;; We have to replace references from the source-metric with references appropriate for
                     ;; this stage (expression/aggregation -> field, field-id to string)
-                                          (let [replacement (lib.util.match/replace replacement
-                                                                                    [(tag :guard #{:expression :field :aggregation}) _ _]
-                                                                                    (if-let [col (lib/find-matching-column &match columns)]
-                                                                                      (lib/ref col)
+                    (let [replacement (lib.util.match/replace replacement
+                                        [(tag :guard #{:expression :field :aggregation}) _ _]
+                                        (if-let [col (lib/find-matching-column &match columns)]
+                                          (lib/ref col)
                                           ;; This is probably due to a field-id where it shouldn't be
-                                                                                      &match))]
-                                            (update (lib.util/fresh-uuids replacement)
-                                                    1
-                                                    #(merge
-                                                      %
-                                                      {:name metric-name}
-                                                      (select-keys % [:name :display-name])
-                                                      (select-keys (get &match 1) [:lib/uuid :name :display-name]))))
-                                          (throw (ex-info "Incompatible metric" {:match &match :lookup lookup}))))))
+                                          &match))]
+                      (update (lib.util/fresh-uuids replacement)
+                              1
+                              #(merge
+                                %
+                                {:name metric-name}
+                                (select-keys % [:name :display-name])
+                                (select-keys (get &match 1) [:lib/uuid :name :display-name]))))
+                    (throw (ex-info "Incompatible metric" {:match &match :lookup lookup}))))))
     query))
 
 (defn- find-metric-ids
@@ -101,8 +101,8 @@
 (defn- add-join-aliases
   [x source-field->join-alias]
   (lib.util.match/replace x
-                          [:field (opts :guard (every-pred (comp source-field->join-alias :source-field) (complement :join-alias))) _]
-                          (assoc-in &match [1 :join-alias] (-> opts :source-field source-field->join-alias))))
+    [:field (opts :guard (every-pred (comp source-field->join-alias :source-field) (complement :join-alias))) _]
+    (assoc-in &match [1 :join-alias] (-> opts :source-field source-field->join-alias))))
 
 (defn- include-implicit-joins
   [query agg-stage-index metric-query]
@@ -184,28 +184,28 @@
    replaced with the actual aggregation of the metric."
   [query stage-path expanded-stages last-metric-stage-number metric-metadata]
   (mu/disable-enforcement
-   (let [[pre-transition-stages [last-metric-stage _following-stage & following-stages]] (split-at last-metric-stage-number expanded-stages)
-         metric-name (:name metric-metadata)
-         metric-aggregation (-> last-metric-stage :aggregation first)
-         stage-query (temp-query-at-stage-path query stage-path)
-         stage-query (update-in stage-query
-                                [:stages last-metric-stage-number]
-                                (fn [stage]
-                                  (dissoc stage :breakout :order-by :aggregation :fields :lib/stage-metadata)))
+    (let [[pre-transition-stages [last-metric-stage _following-stage & following-stages]] (split-at last-metric-stage-number expanded-stages)
+          metric-name (:name metric-metadata)
+          metric-aggregation (-> last-metric-stage :aggregation first)
+          stage-query (temp-query-at-stage-path query stage-path)
+          stage-query (update-in stage-query
+                                 [:stages last-metric-stage-number]
+                                 (fn [stage]
+                                   (dissoc stage :breakout :order-by :aggregation :fields :lib/stage-metadata)))
           ;; Needed for field references to resolve further in the pipeline
-         stage-query (lib/with-fields stage-query last-metric-stage-number (lib/fieldable-columns stage-query last-metric-stage-number))
-         new-metric-stage (lib.util/query-stage stage-query last-metric-stage-number)
-         lookup {(:id metric-metadata)
-                 {:name metric-name :aggregation metric-aggregation}}
-         stage-query (replace-metric-aggregation-refs
-                      stage-query
-                      (inc last-metric-stage-number)
-                      lookup)
-         new-following-stage (lib.util/query-stage stage-query (inc last-metric-stage-number))
-         combined-stages (vec (remove nil? (concat pre-transition-stages
-                                                   [new-metric-stage new-following-stage]
-                                                   following-stages)))]
-     combined-stages)))
+          stage-query (lib/with-fields stage-query last-metric-stage-number (lib/fieldable-columns stage-query last-metric-stage-number))
+          new-metric-stage (lib.util/query-stage stage-query last-metric-stage-number)
+          lookup {(:id metric-metadata)
+                  {:name metric-name :aggregation metric-aggregation}}
+          stage-query (replace-metric-aggregation-refs
+                       stage-query
+                       (inc last-metric-stage-number)
+                       lookup)
+          new-following-stage (lib.util/query-stage stage-query (inc last-metric-stage-number))
+          combined-stages (vec (remove nil? (concat pre-transition-stages
+                                                    [new-metric-stage new-following-stage]
+                                                    following-stages)))]
+      combined-stages)))
 
 (defn- adjust-metric-stages
   "`expanded-stages` are the result of :stages from fetch-source-query.
@@ -236,7 +236,7 @@
 (defn- find-first-metric
   [query]
   (lib.util.match/match-one query
-                            [:metric _ _] &match))
+    [:metric _ _] &match))
 
 ;;;; Rejection of incompatible metrics ===============================================================================
 
@@ -488,9 +488,9 @@
                        (when (= path-type :lib.walk/join)
                          (update stage-or-join :stages #(adjust-metric-stages query path %)))))]
           (u/prog1
-           (update query :stages #(adjust-metric-stages query nil %))
-           (when-let [metric (find-first-metric (:stages <>))]
-             (throw (ex-info "Failed to replace metric" {:metric metric})))))
+            (update query :stages #(adjust-metric-stages query nil %))
+            (when-let [metric (find-first-metric (:stages <>))]
+              (throw (ex-info "Failed to replace metric" {:metric metric})))))
         (catch Throwable e
           (analytics/inc! :metabase-query-processor/metrics-adjust-errors)
           (throw e))))))

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -252,9 +252,9 @@
 
 (defn- equal-commutative-op?
   [f1 f2]
-  (let [f1-args (vec (nthnext f1 2))
-        f2-args (vec (nthnext f2 2))]
-    (loop [f1-indices (vec (range (count f1-args)))
+  (let [f1-args (subvec f1 2)
+        f2-args (subvec f2 2)]
+    (loop [f1-indices (range (count f1-args))
            f2-indices (set (range (count f2-args)))]
       (cond
         (and (empty? f1-indices)
@@ -267,8 +267,8 @@
 
         :else
         (let [f1-index (first f1-indices)
-              f1-elm (nth f1-args f1-index)
-              matching (m/find-first #(equal-filter? f1-elm (nth f2-args %)) f2-indices)]
+              f1-elm (f1-args f1-index)
+              matching (m/find-first #(equal-filter? f1-elm (f2-args %)) f2-indices)]
           (if-not matching
             false
             (recur (next f1-indices)

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -18,24 +18,24 @@
     (let [columns (lib/visible-columns query stage-number)]
       (assoc-in query [:stages stage-number :aggregation]
                 (lib.util.match/replace aggregations
-                                        [:metric _ metric-id]
-                                        (if-let [{replacement :aggregation metric-name :name} (get lookup metric-id)]
+                  [:metric _ metric-id]
+                  (if-let [{replacement :aggregation metric-name :name} (get lookup metric-id)]
                     ;; We have to replace references from the source-metric with references appropriate for
                     ;; this stage (expression/aggregation -> field, field-id to string)
-                                          (let [replacement (lib.util.match/replace replacement
-                                                                                    [(tag :guard #{:expression :field :aggregation}) _ _]
-                                                                                    (if-let [col (lib/find-matching-column &match columns)]
-                                                                                      (lib/ref col)
+                    (let [replacement (lib.util.match/replace replacement
+                                        [(tag :guard #{:expression :field :aggregation}) _ _]
+                                        (if-let [col (lib/find-matching-column &match columns)]
+                                          (lib/ref col)
                                           ;; This is probably due to a field-id where it shouldn't be
-                                                                                      &match))]
-                                            (update (lib.util/fresh-uuids replacement)
-                                                    1
-                                                    #(merge
-                                                      %
-                                                      {:name metric-name}
-                                                      (select-keys % [:name :display-name])
-                                                      (select-keys (get &match 1) [:lib/uuid :name :display-name]))))
-                                          (throw (ex-info "Incompatible metric" {:match &match :lookup lookup}))))))
+                                          &match))]
+                      (update (lib.util/fresh-uuids replacement)
+                              1
+                              #(merge
+                                %
+                                {:name metric-name}
+                                (select-keys % [:name :display-name])
+                                (select-keys (get &match 1) [:lib/uuid :name :display-name]))))
+                    (throw (ex-info "Incompatible metric" {:match &match :lookup lookup}))))))
     query))
 
 (defn- find-metric-ids
@@ -101,8 +101,8 @@
 (defn- add-join-aliases
   [x source-field->join-alias]
   (lib.util.match/replace x
-                          [:field (opts :guard (every-pred (comp source-field->join-alias :source-field) (complement :join-alias))) _]
-                          (assoc-in &match [1 :join-alias] (-> opts :source-field source-field->join-alias))))
+    [:field (opts :guard (every-pred (comp source-field->join-alias :source-field) (complement :join-alias))) _]
+    (assoc-in &match [1 :join-alias] (-> opts :source-field source-field->join-alias))))
 
 (defn- include-implicit-joins
   [query agg-stage-index metric-query]
@@ -184,28 +184,28 @@
    replaced with the actual aggregation of the metric."
   [query stage-path expanded-stages last-metric-stage-number metric-metadata]
   (mu/disable-enforcement
-   (let [[pre-transition-stages [last-metric-stage _following-stage & following-stages]] (split-at last-metric-stage-number expanded-stages)
-         metric-name (:name metric-metadata)
-         metric-aggregation (-> last-metric-stage :aggregation first)
-         stage-query (temp-query-at-stage-path query stage-path)
-         stage-query (update-in stage-query
-                                [:stages last-metric-stage-number]
-                                (fn [stage]
-                                  (dissoc stage :breakout :order-by :aggregation :fields :lib/stage-metadata)))
+    (let [[pre-transition-stages [last-metric-stage _following-stage & following-stages]] (split-at last-metric-stage-number expanded-stages)
+          metric-name (:name metric-metadata)
+          metric-aggregation (-> last-metric-stage :aggregation first)
+          stage-query (temp-query-at-stage-path query stage-path)
+          stage-query (update-in stage-query
+                                 [:stages last-metric-stage-number]
+                                 (fn [stage]
+                                   (dissoc stage :breakout :order-by :aggregation :fields :lib/stage-metadata)))
           ;; Needed for field references to resolve further in the pipeline
-         stage-query (lib/with-fields stage-query last-metric-stage-number (lib/fieldable-columns stage-query last-metric-stage-number))
-         new-metric-stage (lib.util/query-stage stage-query last-metric-stage-number)
-         lookup {(:id metric-metadata)
-                 {:name metric-name :aggregation metric-aggregation}}
-         stage-query (replace-metric-aggregation-refs
-                      stage-query
-                      (inc last-metric-stage-number)
-                      lookup)
-         new-following-stage (lib.util/query-stage stage-query (inc last-metric-stage-number))
-         combined-stages (vec (remove nil? (concat pre-transition-stages
-                                                   [new-metric-stage new-following-stage]
-                                                   following-stages)))]
-     combined-stages)))
+          stage-query (lib/with-fields stage-query last-metric-stage-number (lib/fieldable-columns stage-query last-metric-stage-number))
+          new-metric-stage (lib.util/query-stage stage-query last-metric-stage-number)
+          lookup {(:id metric-metadata)
+                  {:name metric-name :aggregation metric-aggregation}}
+          stage-query (replace-metric-aggregation-refs
+                       stage-query
+                       (inc last-metric-stage-number)
+                       lookup)
+          new-following-stage (lib.util/query-stage stage-query (inc last-metric-stage-number))
+          combined-stages (vec (remove nil? (concat pre-transition-stages
+                                                    [new-metric-stage new-following-stage]
+                                                    following-stages)))]
+      combined-stages)))
 
 (defn- adjust-metric-stages
   "`expanded-stages` are the result of :stages from fetch-source-query.
@@ -236,7 +236,7 @@
 (defn- find-first-metric
   [query]
   (lib.util.match/match-one query
-                            [:metric _ _] &match))
+    [:metric _ _] &match))
 
 ;;;; Rejection of incompatible metrics ===============================================================================
 
@@ -484,9 +484,9 @@
                        (when (= path-type :lib.walk/join)
                          (update stage-or-join :stages #(adjust-metric-stages query path %)))))]
           (u/prog1
-           (update query :stages #(adjust-metric-stages query nil %))
-           (when-let [metric (find-first-metric (:stages <>))]
-             (throw (ex-info "Failed to replace metric" {:metric metric})))))
+            (update query :stages #(adjust-metric-stages query nil %))
+            (when-let [metric (find-first-metric (:stages <>))]
+              (throw (ex-info "Failed to replace metric" {:metric metric})))))
         (catch Throwable e
           (analytics/inc! :metabase-query-processor/metrics-adjust-errors)
           (throw e))))))

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -18,24 +18,24 @@
     (let [columns (lib/visible-columns query stage-number)]
       (assoc-in query [:stages stage-number :aggregation]
                 (lib.util.match/replace aggregations
-                                        [:metric _ metric-id]
-                                        (if-let [{replacement :aggregation metric-name :name} (get lookup metric-id)]
+                  [:metric _ metric-id]
+                  (if-let [{replacement :aggregation metric-name :name} (get lookup metric-id)]
                     ;; We have to replace references from the source-metric with references appropriate for
                     ;; this stage (expression/aggregation -> field, field-id to string)
-                                          (let [replacement (lib.util.match/replace replacement
-                                                                                    [(tag :guard #{:expression :field :aggregation}) _ _]
-                                                                                    (if-let [col (lib/find-matching-column &match columns)]
-                                                                                      (lib/ref col)
+                    (let [replacement (lib.util.match/replace replacement
+                                        [(tag :guard #{:expression :field :aggregation}) _ _]
+                                        (if-let [col (lib/find-matching-column &match columns)]
+                                          (lib/ref col)
                                           ;; This is probably due to a field-id where it shouldn't be
-                                                                                      &match))]
-                                            (update (lib.util/fresh-uuids replacement)
-                                                    1
-                                                    #(merge
-                                                      %
-                                                      {:name metric-name}
-                                                      (select-keys % [:name :display-name])
-                                                      (select-keys (get &match 1) [:lib/uuid :name :display-name]))))
-                                          (throw (ex-info "Incompatible metric" {:match &match :lookup lookup}))))))
+                                          &match))]
+                      (update (lib.util/fresh-uuids replacement)
+                              1
+                              #(merge
+                                %
+                                {:name metric-name}
+                                (select-keys % [:name :display-name])
+                                (select-keys (get &match 1) [:lib/uuid :name :display-name]))))
+                    (throw (ex-info "Incompatible metric" {:match &match :lookup lookup}))))))
     query))
 
 (defn- find-metric-ids
@@ -101,8 +101,8 @@
 (defn- add-join-aliases
   [x source-field->join-alias]
   (lib.util.match/replace x
-                          [:field (opts :guard (every-pred (comp source-field->join-alias :source-field) (complement :join-alias))) _]
-                          (assoc-in &match [1 :join-alias] (-> opts :source-field source-field->join-alias))))
+    [:field (opts :guard (every-pred (comp source-field->join-alias :source-field) (complement :join-alias))) _]
+    (assoc-in &match [1 :join-alias] (-> opts :source-field source-field->join-alias))))
 
 (defn- include-implicit-joins
   [query agg-stage-index metric-query]
@@ -184,28 +184,28 @@
    replaced with the actual aggregation of the metric."
   [query stage-path expanded-stages last-metric-stage-number metric-metadata]
   (mu/disable-enforcement
-   (let [[pre-transition-stages [last-metric-stage _following-stage & following-stages]] (split-at last-metric-stage-number expanded-stages)
-         metric-name (:name metric-metadata)
-         metric-aggregation (-> last-metric-stage :aggregation first)
-         stage-query (temp-query-at-stage-path query stage-path)
-         stage-query (update-in stage-query
-                                [:stages last-metric-stage-number]
-                                (fn [stage]
-                                  (dissoc stage :breakout :order-by :aggregation :fields :lib/stage-metadata)))
+    (let [[pre-transition-stages [last-metric-stage _following-stage & following-stages]] (split-at last-metric-stage-number expanded-stages)
+          metric-name (:name metric-metadata)
+          metric-aggregation (-> last-metric-stage :aggregation first)
+          stage-query (temp-query-at-stage-path query stage-path)
+          stage-query (update-in stage-query
+                                 [:stages last-metric-stage-number]
+                                 (fn [stage]
+                                   (dissoc stage :breakout :order-by :aggregation :fields :lib/stage-metadata)))
           ;; Needed for field references to resolve further in the pipeline
-         stage-query (lib/with-fields stage-query last-metric-stage-number (lib/fieldable-columns stage-query last-metric-stage-number))
-         new-metric-stage (lib.util/query-stage stage-query last-metric-stage-number)
-         lookup {(:id metric-metadata)
-                 {:name metric-name :aggregation metric-aggregation}}
-         stage-query (replace-metric-aggregation-refs
-                      stage-query
-                      (inc last-metric-stage-number)
-                      lookup)
-         new-following-stage (lib.util/query-stage stage-query (inc last-metric-stage-number))
-         combined-stages (vec (remove nil? (concat pre-transition-stages
-                                                   [new-metric-stage new-following-stage]
-                                                   following-stages)))]
-     combined-stages)))
+          stage-query (lib/with-fields stage-query last-metric-stage-number (lib/fieldable-columns stage-query last-metric-stage-number))
+          new-metric-stage (lib.util/query-stage stage-query last-metric-stage-number)
+          lookup {(:id metric-metadata)
+                  {:name metric-name :aggregation metric-aggregation}}
+          stage-query (replace-metric-aggregation-refs
+                       stage-query
+                       (inc last-metric-stage-number)
+                       lookup)
+          new-following-stage (lib.util/query-stage stage-query (inc last-metric-stage-number))
+          combined-stages (vec (remove nil? (concat pre-transition-stages
+                                                    [new-metric-stage new-following-stage]
+                                                    following-stages)))]
+      combined-stages)))
 
 (defn- adjust-metric-stages
   "`expanded-stages` are the result of :stages from fetch-source-query.
@@ -236,7 +236,7 @@
 (defn- find-first-metric
   [query]
   (lib.util.match/match-one query
-                            [:metric _ _] &match))
+    [:metric _ _] &match))
 
 ;;;; Rejection of incompatible metrics ===============================================================================
 
@@ -260,29 +260,29 @@
       :else
       false)))
 
-(defn- filters-for-subset?
-  "Check whether filter clause `f1` filters for subset of rows that filter clause `f2` filters for."
-  [f1 f2]
-  (every? #(m/find-first (partial equal-filter? %) f1) f2))
+#_(defn- filters-for-subset?
+    "Check whether filter clause `f1` filters for subset of rows that filter clause `f2` filters for."
+    [f1 f2]
+    (every? #(m/find-first (partial equal-filter? %) f1) f2))
 
 ;; Later will decide whether to go with this implementation
-(defn- assert-compatible-stage-filters
-  "Assert that stage filteres are compatible with filterse of every referenced metric. Returns nil."
-  [query stage-number metrics]
-  (let [query-filters (lib/filters query stage-number)]
-    (when (seq query-filters)
-      (loop [metric-ids (keys metrics)]
-        (when (seq metric-ids)
-          (let [metric-id (first metric-ids)
-                metric-query (get metrics metric-id)
-                metric-filters (lib/filters metric-query)]
-            (when-not (filters-for-subset? query-filters metric-filters)
-              (throw (ex-info (tru "Stage filter is not compatible with metric {0} filter."
-                                   metric-id)
-                              {:stage-filters query-filters
-                               :metric-filters metric-filters}))))
-          (recur (rest metric-ids))))))
-  nil)
+#_(defn- assert-compatible-stage-filters
+    "Assert that stage filteres are compatible with filterse of every referenced metric. Returns nil."
+    [query stage-number metrics]
+    (let [query-filters (lib/filters query stage-number)]
+      (when (seq query-filters)
+        (loop [metric-ids (keys metrics)]
+          (when (seq metric-ids)
+            (let [metric-id (first metric-ids)
+                  metric-query (get metrics metric-id)
+                  metric-filters (lib/filters metric-query)]
+              (when-not (filters-for-subset? query-filters metric-filters)
+                (throw (ex-info (tru "Stage filter is not compatible with metric {0} filter."
+                                     metric-id)
+                                {:stage-filters query-filters
+                                 :metric-filters metric-filters}))))
+            (recur (rest metric-ids))))))
+    nil)
 
 ;; list of aggregation operators
 
@@ -477,9 +477,9 @@
                        (when (= path-type :lib.walk/join)
                          (update stage-or-join :stages #(adjust-metric-stages query path %)))))]
           (u/prog1
-           (update query :stages #(adjust-metric-stages query nil %))
-           (when-let [metric (find-first-metric (:stages <>))]
-             (throw (ex-info "Failed to replace metric" {:metric metric})))))
+            (update query :stages #(adjust-metric-stages query nil %))
+            (when-let [metric (find-first-metric (:stages <>))]
+              (throw (ex-info "Failed to replace metric" {:metric metric})))))
         (catch Throwable e
           (analytics/inc! :metabase-query-processor/metrics-adjust-errors)
           (throw e))))))

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -382,7 +382,7 @@
       (when-some [metric-ids (not-empty (set (lib.util.match/match aggregation
                                                [:metric opts id]
                                                id)))]
-        (let [metrics (-> (->> (lib.metadata/bulk-metadata query :metadata/card metric-ids)
+        (let [metrics (-> (->> (lib.metadata/bulk-metadata-or-throw query :metadata/card metric-ids)
                                (m/index-by :id))
                           (update-vals #(->> %
                                              :dataset-query
@@ -419,8 +419,8 @@
     query
     (do
       (analytics/inc! :metabase-query-processor/metrics-adjust)
-      (assert-compatible-metrics query)
       (try
+        (assert-compatible-metrics query)
         (let [query (lib.walk/walk
                      query
                      (fn [_query path-type path stage-or-join]

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -10,6 +10,7 @@
    [metabase.lib.util.match :as lib.util.match]
    [metabase.lib.walk :as lib.walk]
    [metabase.util :as u]
+   [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]))
 
 (defn- replace-metric-aggregation-refs [query stage-number lookup]
@@ -17,24 +18,24 @@
     (let [columns (lib/visible-columns query stage-number)]
       (assoc-in query [:stages stage-number :aggregation]
                 (lib.util.match/replace aggregations
-                  [:metric _ metric-id]
-                  (if-let [{replacement :aggregation metric-name :name} (get lookup metric-id)]
+                                        [:metric _ metric-id]
+                                        (if-let [{replacement :aggregation metric-name :name} (get lookup metric-id)]
                     ;; We have to replace references from the source-metric with references appropriate for
                     ;; this stage (expression/aggregation -> field, field-id to string)
-                    (let [replacement (lib.util.match/replace replacement
-                                        [(tag :guard #{:expression :field :aggregation}) _ _]
-                                        (if-let [col (lib/find-matching-column &match columns)]
-                                          (lib/ref col)
+                                          (let [replacement (lib.util.match/replace replacement
+                                                                                    [(tag :guard #{:expression :field :aggregation}) _ _]
+                                                                                    (if-let [col (lib/find-matching-column &match columns)]
+                                                                                      (lib/ref col)
                                           ;; This is probably due to a field-id where it shouldn't be
-                                          &match))]
-                      (update (lib.util/fresh-uuids replacement)
-                              1
-                              #(merge
-                                %
-                                {:name metric-name}
-                                (select-keys % [:name :display-name])
-                                (select-keys (get &match 1) [:lib/uuid :name :display-name]))))
-                    (throw (ex-info "Incompatible metric" {:match &match :lookup lookup}))))))
+                                                                                      &match))]
+                                            (update (lib.util/fresh-uuids replacement)
+                                                    1
+                                                    #(merge
+                                                      %
+                                                      {:name metric-name}
+                                                      (select-keys % [:name :display-name])
+                                                      (select-keys (get &match 1) [:lib/uuid :name :display-name]))))
+                                          (throw (ex-info "Incompatible metric" {:match &match :lookup lookup}))))))
     query))
 
 (defn- find-metric-ids
@@ -100,8 +101,8 @@
 (defn- add-join-aliases
   [x source-field->join-alias]
   (lib.util.match/replace x
-    [:field (opts :guard (every-pred (comp source-field->join-alias :source-field) (complement :join-alias))) _]
-    (assoc-in &match [1 :join-alias] (-> opts :source-field source-field->join-alias))))
+                          [:field (opts :guard (every-pred (comp source-field->join-alias :source-field) (complement :join-alias))) _]
+                          (assoc-in &match [1 :join-alias] (-> opts :source-field source-field->join-alias))))
 
 (defn- include-implicit-joins
   [query agg-stage-index metric-query]
@@ -183,28 +184,28 @@
    replaced with the actual aggregation of the metric."
   [query stage-path expanded-stages last-metric-stage-number metric-metadata]
   (mu/disable-enforcement
-    (let [[pre-transition-stages [last-metric-stage _following-stage & following-stages]] (split-at last-metric-stage-number expanded-stages)
-          metric-name (:name metric-metadata)
-          metric-aggregation (-> last-metric-stage :aggregation first)
-          stage-query (temp-query-at-stage-path query stage-path)
-          stage-query (update-in stage-query
-                                 [:stages last-metric-stage-number]
-                                 (fn [stage]
-                                   (dissoc stage :breakout :order-by :aggregation :fields :lib/stage-metadata)))
+   (let [[pre-transition-stages [last-metric-stage _following-stage & following-stages]] (split-at last-metric-stage-number expanded-stages)
+         metric-name (:name metric-metadata)
+         metric-aggregation (-> last-metric-stage :aggregation first)
+         stage-query (temp-query-at-stage-path query stage-path)
+         stage-query (update-in stage-query
+                                [:stages last-metric-stage-number]
+                                (fn [stage]
+                                  (dissoc stage :breakout :order-by :aggregation :fields :lib/stage-metadata)))
           ;; Needed for field references to resolve further in the pipeline
-          stage-query (lib/with-fields stage-query last-metric-stage-number (lib/fieldable-columns stage-query last-metric-stage-number))
-          new-metric-stage (lib.util/query-stage stage-query last-metric-stage-number)
-          lookup {(:id metric-metadata)
-                  {:name metric-name :aggregation metric-aggregation}}
-          stage-query (replace-metric-aggregation-refs
-                       stage-query
-                       (inc last-metric-stage-number)
-                       lookup)
-          new-following-stage (lib.util/query-stage stage-query (inc last-metric-stage-number))
-          combined-stages (vec (remove nil? (concat pre-transition-stages
-                                                    [new-metric-stage new-following-stage]
-                                                    following-stages)))]
-      combined-stages)))
+         stage-query (lib/with-fields stage-query last-metric-stage-number (lib/fieldable-columns stage-query last-metric-stage-number))
+         new-metric-stage (lib.util/query-stage stage-query last-metric-stage-number)
+         lookup {(:id metric-metadata)
+                 {:name metric-name :aggregation metric-aggregation}}
+         stage-query (replace-metric-aggregation-refs
+                      stage-query
+                      (inc last-metric-stage-number)
+                      lookup)
+         new-following-stage (lib.util/query-stage stage-query (inc last-metric-stage-number))
+         combined-stages (vec (remove nil? (concat pre-transition-stages
+                                                   [new-metric-stage new-following-stage]
+                                                   following-stages)))]
+     combined-stages)))
 
 (defn- adjust-metric-stages
   "`expanded-stages` are the result of :stages from fetch-source-query.
@@ -235,7 +236,7 @@
 (defn- find-first-metric
   [query]
   (lib.util.match/match-one query
-    [:metric _ _] &match))
+                            [:metric _ _] &match))
 
 ;;;; Rejection of incompatible metrics ===============================================================================
 
@@ -280,6 +281,49 @@
                               {:stage-filters query-filters
                                :metric-filters metric-filters}))))
           (recur (rest metric-ids))))))
+  nil)
+
+;; list of aggregation operators
+
+;; (disj (set (metabase.lib.hierarchy/descendants :metabase.lib.schema.aggregation/aggregation-clause-tag)) 
+;;                                                :metric :offset)
+;; =>
+(def ^:private forbidden-aggregations #{:min
+                                        :stddev
+                                        :count-where
+                                        :cum-count
+                                        :sum-where
+                                        :cum-sum
+                                        :distinct
+                                        :percentile
+                                        :var
+                                        :median
+                                        :share
+                                        :max
+                                        :count
+                                        :avg
+                                        :sum})
+
+(defn- non-metric-aggregation
+  [aggregation]
+  (when-let [[tag _opts & args] (and (vector? aggregation) aggregation)]
+    (or (and (forbidden-aggregations tag) aggregation)
+        (some non-metric-aggregation args))))
+
+(defn- assert-compatible-stage-filters-NUKE-THOSE-AGS
+  "Assert that stage filteres are compatible with filterse of every referenced metric. Returns nil."
+  [query stage-number metrics]
+  (when-some [non-metric-ag (m/find-first non-metric-aggregation (lib/aggregations query stage-number))]
+    (when-some [metric-id  (some (fn [[id metric-query]]
+                                   (when (seq (lib/filters metric-query))
+                                     id))
+                                 ;; assuming all those metrics are present in the `query`'s `stage-number`
+                                 metrics)]
+      (throw (ex-info (tru "It''s not allowed to combine metrics having filters with other aggregations")
+                      {:meric-id metric-id
+                       :metric-filter (lib/filters (metrics metric-id))
+                       :non-metric-aggregation non-metric-ag}))))
+
   nil)
 
 ;; Following fn operates on filter's vectors (as returned from lib/filters)
@@ -395,7 +439,8 @@
                                              (lib/query query))))]
           (assert-compatible-joins refq refq-stage-number metrics)
           (assert-compatible-filters-in-metrics metrics)
-          (assert-compatible-stage-filters refq refq-stage-number metrics)))))
+          (assert-compatible-stage-filters-NUKE-THOSE-AGS refq refq-stage-number metrics)
+          #_(assert-compatible-stage-filters refq refq-stage-number metrics)))))
   nil)
 
 (defn- assert-compatible-metrics
@@ -431,9 +476,9 @@
                        (when (= path-type :lib.walk/join)
                          (update stage-or-join :stages #(adjust-metric-stages query path %)))))]
           (u/prog1
-            (update query :stages #(adjust-metric-stages query nil %))
-            (when-let [metric (find-first-metric (:stages <>))]
-              (throw (ex-info "Failed to replace metric" {:metric metric})))))
+           (update query :stages #(adjust-metric-stages query nil %))
+           (when-let [metric (find-first-metric (:stages <>))]
+             (throw (ex-info "Failed to replace metric" {:metric metric})))))
         (catch Throwable e
           (analytics/inc! :metabase-query-processor/metrics-adjust-errors)
           (throw e))))))

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -1,6 +1,5 @@
 (ns metabase.query-processor.middleware.metrics
   (:require
-   [clojure.walk :as walk]
    [medley.core :as m]
    [metabase.analytics.core :as analytics]
    [metabase.lib.core :as lib]

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -18,24 +18,24 @@
     (let [columns (lib/visible-columns query stage-number)]
       (assoc-in query [:stages stage-number :aggregation]
                 (lib.util.match/replace aggregations
-                  [:metric _ metric-id]
-                  (if-let [{replacement :aggregation metric-name :name} (get lookup metric-id)]
+                                        [:metric _ metric-id]
+                                        (if-let [{replacement :aggregation metric-name :name} (get lookup metric-id)]
                     ;; We have to replace references from the source-metric with references appropriate for
                     ;; this stage (expression/aggregation -> field, field-id to string)
-                    (let [replacement (lib.util.match/replace replacement
-                                        [(tag :guard #{:expression :field :aggregation}) _ _]
-                                        (if-let [col (lib/find-matching-column &match columns)]
-                                          (lib/ref col)
+                                          (let [replacement (lib.util.match/replace replacement
+                                                                                    [(tag :guard #{:expression :field :aggregation}) _ _]
+                                                                                    (if-let [col (lib/find-matching-column &match columns)]
+                                                                                      (lib/ref col)
                                           ;; This is probably due to a field-id where it shouldn't be
-                                          &match))]
-                      (update (lib.util/fresh-uuids replacement)
-                              1
-                              #(merge
-                                %
-                                {:name metric-name}
-                                (select-keys % [:name :display-name])
-                                (select-keys (get &match 1) [:lib/uuid :name :display-name]))))
-                    (throw (ex-info "Incompatible metric" {:match &match :lookup lookup}))))))
+                                                                                      &match))]
+                                            (update (lib.util/fresh-uuids replacement)
+                                                    1
+                                                    #(merge
+                                                      %
+                                                      {:name metric-name}
+                                                      (select-keys % [:name :display-name])
+                                                      (select-keys (get &match 1) [:lib/uuid :name :display-name]))))
+                                          (throw (ex-info "Incompatible metric" {:match &match :lookup lookup}))))))
     query))
 
 (defn- find-metric-ids
@@ -101,8 +101,8 @@
 (defn- add-join-aliases
   [x source-field->join-alias]
   (lib.util.match/replace x
-    [:field (opts :guard (every-pred (comp source-field->join-alias :source-field) (complement :join-alias))) _]
-    (assoc-in &match [1 :join-alias] (-> opts :source-field source-field->join-alias))))
+                          [:field (opts :guard (every-pred (comp source-field->join-alias :source-field) (complement :join-alias))) _]
+                          (assoc-in &match [1 :join-alias] (-> opts :source-field source-field->join-alias))))
 
 (defn- include-implicit-joins
   [query agg-stage-index metric-query]
@@ -184,28 +184,28 @@
    replaced with the actual aggregation of the metric."
   [query stage-path expanded-stages last-metric-stage-number metric-metadata]
   (mu/disable-enforcement
-    (let [[pre-transition-stages [last-metric-stage _following-stage & following-stages]] (split-at last-metric-stage-number expanded-stages)
-          metric-name (:name metric-metadata)
-          metric-aggregation (-> last-metric-stage :aggregation first)
-          stage-query (temp-query-at-stage-path query stage-path)
-          stage-query (update-in stage-query
-                                 [:stages last-metric-stage-number]
-                                 (fn [stage]
-                                   (dissoc stage :breakout :order-by :aggregation :fields :lib/stage-metadata)))
+   (let [[pre-transition-stages [last-metric-stage _following-stage & following-stages]] (split-at last-metric-stage-number expanded-stages)
+         metric-name (:name metric-metadata)
+         metric-aggregation (-> last-metric-stage :aggregation first)
+         stage-query (temp-query-at-stage-path query stage-path)
+         stage-query (update-in stage-query
+                                [:stages last-metric-stage-number]
+                                (fn [stage]
+                                  (dissoc stage :breakout :order-by :aggregation :fields :lib/stage-metadata)))
           ;; Needed for field references to resolve further in the pipeline
-          stage-query (lib/with-fields stage-query last-metric-stage-number (lib/fieldable-columns stage-query last-metric-stage-number))
-          new-metric-stage (lib.util/query-stage stage-query last-metric-stage-number)
-          lookup {(:id metric-metadata)
-                  {:name metric-name :aggregation metric-aggregation}}
-          stage-query (replace-metric-aggregation-refs
-                       stage-query
-                       (inc last-metric-stage-number)
-                       lookup)
-          new-following-stage (lib.util/query-stage stage-query (inc last-metric-stage-number))
-          combined-stages (vec (remove nil? (concat pre-transition-stages
-                                                    [new-metric-stage new-following-stage]
-                                                    following-stages)))]
-      combined-stages)))
+         stage-query (lib/with-fields stage-query last-metric-stage-number (lib/fieldable-columns stage-query last-metric-stage-number))
+         new-metric-stage (lib.util/query-stage stage-query last-metric-stage-number)
+         lookup {(:id metric-metadata)
+                 {:name metric-name :aggregation metric-aggregation}}
+         stage-query (replace-metric-aggregation-refs
+                      stage-query
+                      (inc last-metric-stage-number)
+                      lookup)
+         new-following-stage (lib.util/query-stage stage-query (inc last-metric-stage-number))
+         combined-stages (vec (remove nil? (concat pre-transition-stages
+                                                   [new-metric-stage new-following-stage]
+                                                   following-stages)))]
+     combined-stages)))
 
 (defn- adjust-metric-stages
   "`expanded-stages` are the result of :stages from fetch-source-query.
@@ -236,7 +236,7 @@
 (defn- find-first-metric
   [query]
   (lib.util.match/match-one query
-    [:metric _ _] &match))
+                            [:metric _ _] &match))
 
 ;;;; Rejection of incompatible metrics ===============================================================================
 
@@ -446,9 +446,13 @@
                                              :dataset-query
                                              ((requiring-resolve 'metabase.query-processor.preprocess/preprocess))
                                              (lib/query query))))]
-          (assert-compatible-joins refq refq-stage-number metrics)
-          (assert-compatible-filters-in-metrics metrics)
-          (assert-compatible-stage-aggregations refq refq-stage-number metrics)))))
+          (try
+            (assert-compatible-joins refq refq-stage-number metrics)
+            (assert-compatible-filters-in-metrics metrics)
+            (assert-compatible-stage-aggregations refq refq-stage-number metrics)
+            (catch Throwable t
+              (analytics/inc! :metabase-query-processor/metrics-adjust-incompatible-rejections)
+              (throw t)))))))
   nil)
 
 (defn- assert-compatible-metrics
@@ -484,9 +488,9 @@
                        (when (= path-type :lib.walk/join)
                          (update stage-or-join :stages #(adjust-metric-stages query path %)))))]
           (u/prog1
-            (update query :stages #(adjust-metric-stages query nil %))
-            (when-let [metric (find-first-metric (:stages <>))]
-              (throw (ex-info "Failed to replace metric" {:metric metric})))))
+           (update query :stages #(adjust-metric-stages query nil %))
+           (when-let [metric (find-first-metric (:stages <>))]
+             (throw (ex-info "Failed to replace metric" {:metric metric})))))
         (catch Throwable e
           (analytics/inc! :metabase-query-processor/metrics-adjust-errors)
           (throw e))))))

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -286,7 +286,7 @@
 
 ;; list of aggregation operators
 
-;; (disj (set (metabase.lib.hierarchy/descendants :metabase.lib.schema.aggregation/aggregation-clause-tag)) 
+;; (disj (set (metabase.lib.hierarchy/descendants :metabase.lib.schema.aggregation/aggregation-clause-tag))
 ;;                                                :metric :offset)
 ;; =>
 (def ^:private forbidden-aggregations #{:min

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -318,8 +318,9 @@
     (or (and (forbidden-aggregations tag) aggregation)
         (some non-metric-aggregation args))))
 
-(defn- assert-compatible-stage-filters
-  "Assert that stage filters are compatible with filters of every referenced metric. Returns nil."
+(defn- assert-compatible-stage-aggregations
+  "Assert that stage, specifically its aggregations, are compatible with referenced metrics. If there is aggregating
+  function called on referencing stage directly, referenced metrics can not contain any filters."
   [query stage-number metrics]
   (when-some [non-metric-ag (m/find-first non-metric-aggregation (lib/aggregations query stage-number))]
     (when-some [metric-id  (some (fn [[id metric-query]]
@@ -447,7 +448,7 @@
                                              (lib/query query))))]
           (assert-compatible-joins refq refq-stage-number metrics)
           (assert-compatible-filters-in-metrics metrics)
-          (assert-compatible-stage-filters refq refq-stage-number metrics)))))
+          (assert-compatible-stage-aggregations refq refq-stage-number metrics)))))
   nil)
 
 (defn- assert-compatible-metrics

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -630,40 +630,40 @@
       (comment
         (testing "nested 1 level"
           (is (=? (lib.tu.macros/mbql-query nil
-                    {:source-query after})
+                                            {:source-query after})
                   (expand-macros (lib.tu.macros/mbql-query nil
-                                   {:source-query before})))))
+                                                           {:source-query before})))))
         (testing "nested 2 levels"
           (is (=? (lib.tu.macros/mbql-query nil
-                    {:source-query {:source-query after}})
+                                            {:source-query {:source-query after}})
                   (expand-macros
                    (lib.tu.macros/mbql-query nil
-                     {:source-query {:source-query before}})))))
+                                             {:source-query {:source-query before}})))))
         (testing "nested 3 levels"
           (is (=? (lib.tu.macros/mbql-query nil
-                    {:source-query {:source-query {:source-query after}}})
+                                            {:source-query {:source-query {:source-query after}}})
                   (expand-macros
                    (lib.tu.macros/mbql-query nil
-                     {:source-query {:source-query {:source-query before}}}))))))
+                                             {:source-query {:source-query {:source-query before}}}))))))
       (testing "inside :source-query inside :joins"
         (is (=? (lib.tu.macros/mbql-query checkins
-                  {:joins [{:condition    [:= [:field (meta/id :checkins :id) nil] 2]
-                            :source-query after}]})
+                                          {:joins [{:condition    [:= [:field (meta/id :checkins :id) nil] 2]
+                                                    :source-query after}]})
                 (expand-macros
                  (lib.tu.macros/mbql-query checkins
-                   {:joins [{:condition    [:= [:field (meta/id :checkins :id) nil] 2]
-                             :source-query before}]})))))
+                                           {:joins [{:condition    [:= [:field (meta/id :checkins :id) nil] 2]
+                                                     :source-query before}]})))))
 
       (testing "inside :joins inside :source-query"
         (is (=? (lib.tu.macros/mbql-query nil
-                  {:source-query {:source-table (meta/id :checkins)
-                                  :joins        [{:condition    [:= [:field (meta/id :checkins :venue-id) nil] 2]
-                                                  :source-query after}]}})
+                                          {:source-query {:source-table (meta/id :checkins)
+                                                          :joins        [{:condition    [:= [:field (meta/id :checkins :venue-id) nil] 2]
+                                                                          :source-query after}]}})
                 (expand-macros (lib.tu.macros/mbql-query nil
-                                 {:source-query {:source-table (meta/id :checkins)
-                                                 :joins
-                                                 [{:condition    [:= [:field (meta/id :checkins :venue-id) nil] 2]
-                                                   :source-query before}]}}))))))))
+                                                         {:source-query {:source-table (meta/id :checkins)
+                                                                         :joins
+                                                                         [{:condition    [:= [:field (meta/id :checkins :venue-id) nil] 2]
+                                                                           :source-query before}]}}))))))))
 
 (deftest ^:parallel model-based-metric-use-test
   (let [model {:lib/type :metadata/card
@@ -808,13 +808,13 @@
                                              :type :model}
                    :model/Card metric {:dataset_query
                                        (mt/mbql-query
-                                         orders
-                                         {:source-table (str "card__" (:id source-model))
-                                          :expressions {"somedays" [:datetime-diff
-                                                                    [:field "CREATED_AT" {:base-type :type/DateTime}]
-                                                                    (t/offset-date-time 2024 10 16 0 0 0)
-                                                                    :day]}
-                                          :aggregation [[:median [:expression "somedays" {:base-type :type/Integer}]]]})
+                                        orders
+                                        {:source-table (str "card__" (:id source-model))
+                                         :expressions {"somedays" [:datetime-diff
+                                                                   [:field "CREATED_AT" {:base-type :type/DateTime}]
+                                                                   (t/offset-date-time 2024 10 16 0 0 0)
+                                                                   :day]}
+                                         :aggregation [[:median [:expression "somedays" {:base-type :type/Integer}]]]})
                                        :database_id (mt/id)
                                        :name "somedays median"
                                        :type :metric}]
@@ -963,12 +963,12 @@
              {:type :metric
               :dataset_query (as-> (lib/query mp (lib.metadata/table mp (mt/id :orders))) $
                                (lib/join $ (lib/with-join-conditions
-                                            (lib/join-clause joined-metadata)
-                                            [(lib/=
-                                              (m/find-first (comp #{"Product ID"} :display-name)
-                                                            (lib/visible-columns $))
-                                              (m/find-first (comp #{"ID"} :display-name)
-                                                            (lib/returned-columns (lib/query mp joined-metadata))))]))
+                                             (lib/join-clause joined-metadata)
+                                             [(lib/=
+                                               (m/find-first (comp #{"Product ID"} :display-name)
+                                                             (lib/visible-columns $))
+                                               (m/find-first (comp #{"ID"} :display-name)
+                                                             (lib/returned-columns (lib/query mp joined-metadata))))]))
                                (lib/aggregate $ (lib/count))
                                (lib.convert/->legacy-MBQL $))}]
             (testing (format "Referencing stage with fk join with different target provokes an exception (joining %s)"
@@ -982,12 +982,12 @@
                            (qp/process-query
                             (as-> (lib/query mp (lib.metadata/table mp (mt/id :orders))) $
                               (lib/join $ (lib/with-join-conditions
-                                           (lib/join-clause joined-metadata)
-                                           [(lib/=
-                                             (m/find-first (comp #{"Product ID"} :display-name)
-                                                           (lib/visible-columns $))
-                                             (m/find-first (comp #{"ID"} :display-name)
-                                                           (lib/returned-columns (lib/query mp joined-metadata))))]))
+                                            (lib/join-clause joined-metadata)
+                                            [(lib/=
+                                              (m/find-first (comp #{"Product ID"} :display-name)
+                                                            (lib/visible-columns $))
+                                              (m/find-first (comp #{"ID"} :display-name)
+                                                            (lib/returned-columns (lib/query mp joined-metadata))))]))
                               (lib/aggregate $ (lib.metadata/metric mp no-join-id)))))))))))))
 
 (deftest join-operator-is-:=-test
@@ -1018,6 +1018,30 @@
                                                     (lib/aggregate (lib.metadata/metric mp no-join-id))))))))))
 
 ;;;; Filters
+
+(deftest no-filters-in-metrics-test
+  (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
+        metric-query-base (lib/query mp (lib.metadata/table mp (mt/id :orders)))]
+    (mt/with-temp
+      [:model/Card
+       {mid-cnt :id}
+       {:type :metric
+        :dataset_query (-> metric-query-base
+                           (lib/aggregate (lib/count))
+                           (lib.convert/->legacy-MBQL))}
+
+       :model/Card
+       {mid-sum :id}
+       {:type :metric
+        :dataset_query (-> metric-query-base
+                           (lib/aggregate (lib/sum (->> (lib/visible-columns metric-query-base)
+                                                        (m/find-first (comp #{"Total"} :display-name)))))
+                           (lib.convert/->legacy-MBQL))}]
+      (testing "Processing of query referencing metrics with compatible filters completes"
+        (is (=? {:status :completed}
+                (qp/process-query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                                      (lib/aggregate (lib.metadata/metric mp mid-cnt))
+                                      (lib/aggregate (lib.metadata/metric mp mid-sum))))))))))
 
 (deftest compatible-filters-in-metrics-test
   (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
@@ -1185,6 +1209,10 @@
                                       (lib/aggregate (lib.metadata/metric mp mid-gt))
                                       (lib/aggregate (lib.metadata/metric mp mid-lt))))))))))
 
+;; stage filters vs metrics
+
+;; all of those tests should be testing for identity
+
 (deftest only-referencing-stage-has-filter-test
   (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))]
     (mt/with-temp
@@ -1220,7 +1248,7 @@
                                         (lib/aggregate $ (lib.metadata/metric mp mid-1))
                                         (lib/aggregate $ (lib.metadata/metric mp mid-2))))))))))))
 
-(deftest same-filters-in-metrics-compatible-filter-in-query-test
+(deftest same-filters-in-metrics-compatible-no-ag-and-filter-on-stage-test
   (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))]
     (mt/with-temp
       [:model/Card
@@ -1262,7 +1290,7 @@
                                           (lib/aggregate $ (lib.metadata/metric mp mid-cnt))
                                           (lib/aggregate $ (lib.metadata/metric mp mid-sum)))))))))))))
 
-(deftest same-filters-in-metrics-less-strict-filter-in-query-test
+(deftest same-filters-in-metrics-aggregation-and-filter-on-stage-test
   (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))]
     (mt/with-temp
       [:model/Card
@@ -1296,15 +1324,16 @@
                                  (lib.convert/->legacy-MBQL))}]
             (testing (str "Processing of query with stage with less specific filter referencing metrics with "
                           "compatible filters throws (based on" query-base-type ")")
-              (is (thrown-with-msg? Throwable #"Stage filter is not compatible with metric \d+ filter"
+              (is (thrown-with-msg? Throwable #"It's not allowed to combine metrics having filters with other aggregations"
                                     (qp/process-query (as-> (lib/query mp query-base) $
                                                         (lib/filter $ (lib/> (m/find-first (comp #{"Total"} :display-name)
                                                                                            (lib/filterable-columns $))
                                                                              10))
+                                                        (lib/aggregate $ (lib/count))
                                                         (lib/aggregate $ (lib.metadata/metric mp mid-cnt))
                                                         (lib/aggregate $ (lib.metadata/metric mp mid-sum)))))))))))))
 
-(deftest one-metric-has-incompatible-filters-with-stage-other-doesnt-test
+(deftest incompatible-filters-in-metrics-with-filters-on-stage-test
   (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))]
     (mt/with-temp
       [:model/Card
@@ -1346,6 +1375,7 @@
                                                       (lib/aggregate $ (lib.metadata/metric mp mid-1))
                                                       (lib/aggregate $ (lib.metadata/metric mp mid-2))))))))))))
 
+;; TODO: Remove this? If we decide for the more strict condition this will come in handy!
 (deftest different-ordering-of-compatible-filter-clauses-in-stage-and-metrics-test
   (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))]
     (mt/with-temp

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -630,40 +630,40 @@
       (comment
         (testing "nested 1 level"
           (is (=? (lib.tu.macros/mbql-query nil
-                                            {:source-query after})
+                    {:source-query after})
                   (expand-macros (lib.tu.macros/mbql-query nil
-                                                           {:source-query before})))))
+                                   {:source-query before})))))
         (testing "nested 2 levels"
           (is (=? (lib.tu.macros/mbql-query nil
-                                            {:source-query {:source-query after}})
+                    {:source-query {:source-query after}})
                   (expand-macros
                    (lib.tu.macros/mbql-query nil
-                                             {:source-query {:source-query before}})))))
+                     {:source-query {:source-query before}})))))
         (testing "nested 3 levels"
           (is (=? (lib.tu.macros/mbql-query nil
-                                            {:source-query {:source-query {:source-query after}}})
+                    {:source-query {:source-query {:source-query after}}})
                   (expand-macros
                    (lib.tu.macros/mbql-query nil
-                                             {:source-query {:source-query {:source-query before}}}))))))
+                     {:source-query {:source-query {:source-query before}}}))))))
       (testing "inside :source-query inside :joins"
         (is (=? (lib.tu.macros/mbql-query checkins
-                                          {:joins [{:condition    [:= [:field (meta/id :checkins :id) nil] 2]
-                                                    :source-query after}]})
+                  {:joins [{:condition    [:= [:field (meta/id :checkins :id) nil] 2]
+                            :source-query after}]})
                 (expand-macros
                  (lib.tu.macros/mbql-query checkins
-                                           {:joins [{:condition    [:= [:field (meta/id :checkins :id) nil] 2]
-                                                     :source-query before}]})))))
+                   {:joins [{:condition    [:= [:field (meta/id :checkins :id) nil] 2]
+                             :source-query before}]})))))
 
       (testing "inside :joins inside :source-query"
         (is (=? (lib.tu.macros/mbql-query nil
-                                          {:source-query {:source-table (meta/id :checkins)
-                                                          :joins        [{:condition    [:= [:field (meta/id :checkins :venue-id) nil] 2]
-                                                                          :source-query after}]}})
+                  {:source-query {:source-table (meta/id :checkins)
+                                  :joins        [{:condition    [:= [:field (meta/id :checkins :venue-id) nil] 2]
+                                                  :source-query after}]}})
                 (expand-macros (lib.tu.macros/mbql-query nil
-                                                         {:source-query {:source-table (meta/id :checkins)
-                                                                         :joins
-                                                                         [{:condition    [:= [:field (meta/id :checkins :venue-id) nil] 2]
-                                                                           :source-query before}]}}))))))))
+                                 {:source-query {:source-table (meta/id :checkins)
+                                                 :joins
+                                                 [{:condition    [:= [:field (meta/id :checkins :venue-id) nil] 2]
+                                                   :source-query before}]}}))))))))
 
 (deftest ^:parallel model-based-metric-use-test
   (let [model {:lib/type :metadata/card
@@ -808,13 +808,13 @@
                                              :type :model}
                    :model/Card metric {:dataset_query
                                        (mt/mbql-query
-                                        orders
-                                        {:source-table (str "card__" (:id source-model))
-                                         :expressions {"somedays" [:datetime-diff
-                                                                   [:field "CREATED_AT" {:base-type :type/DateTime}]
-                                                                   (t/offset-date-time 2024 10 16 0 0 0)
-                                                                   :day]}
-                                         :aggregation [[:median [:expression "somedays" {:base-type :type/Integer}]]]})
+                                         orders
+                                         {:source-table (str "card__" (:id source-model))
+                                          :expressions {"somedays" [:datetime-diff
+                                                                    [:field "CREATED_AT" {:base-type :type/DateTime}]
+                                                                    (t/offset-date-time 2024 10 16 0 0 0)
+                                                                    :day]}
+                                          :aggregation [[:median [:expression "somedays" {:base-type :type/Integer}]]]})
                                        :database_id (mt/id)
                                        :name "somedays median"
                                        :type :metric}]
@@ -963,12 +963,12 @@
              {:type :metric
               :dataset_query (as-> (lib/query mp (lib.metadata/table mp (mt/id :orders))) $
                                (lib/join $ (lib/with-join-conditions
-                                             (lib/join-clause joined-metadata)
-                                             [(lib/=
-                                               (m/find-first (comp #{"Product ID"} :display-name)
-                                                             (lib/visible-columns $))
-                                               (m/find-first (comp #{"ID"} :display-name)
-                                                             (lib/returned-columns (lib/query mp joined-metadata))))]))
+                                            (lib/join-clause joined-metadata)
+                                            [(lib/=
+                                              (m/find-first (comp #{"Product ID"} :display-name)
+                                                            (lib/visible-columns $))
+                                              (m/find-first (comp #{"ID"} :display-name)
+                                                            (lib/returned-columns (lib/query mp joined-metadata))))]))
                                (lib/aggregate $ (lib/count))
                                (lib.convert/->legacy-MBQL $))}]
             (testing (format "Referencing stage with fk join with different target provokes an exception (joining %s)"
@@ -982,12 +982,12 @@
                            (qp/process-query
                             (as-> (lib/query mp (lib.metadata/table mp (mt/id :orders))) $
                               (lib/join $ (lib/with-join-conditions
-                                            (lib/join-clause joined-metadata)
-                                            [(lib/=
-                                              (m/find-first (comp #{"Product ID"} :display-name)
-                                                            (lib/visible-columns $))
-                                              (m/find-first (comp #{"ID"} :display-name)
-                                                            (lib/returned-columns (lib/query mp joined-metadata))))]))
+                                           (lib/join-clause joined-metadata)
+                                           [(lib/=
+                                             (m/find-first (comp #{"Product ID"} :display-name)
+                                                           (lib/visible-columns $))
+                                             (m/find-first (comp #{"ID"} :display-name)
+                                                           (lib/returned-columns (lib/query mp joined-metadata))))]))
                               (lib/aggregate $ (lib.metadata/metric mp no-join-id)))))))))))))
 
 (deftest join-operator-is-:=-test
@@ -1418,50 +1418,6 @@
                                                                            20))
                                                       (lib/aggregate $ (lib.metadata/metric mp mid-1))
                                                       (lib/aggregate $ (lib.metadata/metric mp mid-2))))))))))))
-
-;; TODO: Remove this? If we decide for the more strict condition this will come in handy!
-(deftest different-ordering-of-compatible-filter-clauses-in-stage-and-metrics-test
-  (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))]
-    (mt/with-temp
-      [:model/Card
-       {mid-1 :id}
-       {:type :metric
-        :dataset_query (as-> (lib/query mp (lib.metadata/table mp (mt/id :orders))) $
-                         (lib/filter $ (lib/> (m/find-first (comp #{"Product ID"} :display-name)
-                                                            (lib/filterable-columns $))
-                                              10))
-                         (lib/filter $ (lib/< (m/find-first (comp #{"User ID"} :display-name)
-                                                            (lib/filterable-columns $))
-                                              20))
-                         (lib/aggregate $ (lib/count))
-                         (lib.convert/->legacy-MBQL $))}
-
-       :model/Card
-       {mid-2 :id}
-       {:type :metric
-        :dataset_query (as-> (lib/query mp (lib.metadata/table mp (mt/id :orders))) $
-                         (lib/filter $ (lib/< (m/find-first (comp #{"User ID"} :display-name)
-                                                            (lib/filterable-columns $))
-                                              20))
-                         (lib/filter $ (lib/> (m/find-first (comp #{"Product ID"} :display-name)
-                                                            (lib/filterable-columns $))
-                                              10))
-                         (lib/aggregate $ (lib/count))
-                         (lib.convert/->legacy-MBQL $))}]
-      (testing "Processing of query with compatible filters with different ordering in metrics and referencing stage completes"
-        (is (=? {:status :completed}
-                (qp/process-query (as-> (lib/query mp (lib.metadata/table mp (mt/id :orders))) $
-                                    (lib/filter $ (lib/< (m/find-first (comp #{"Subtotal"} :display-name)
-                                                                       (lib/filterable-columns $))
-                                                         20))
-                                    (lib/filter $ (lib/> (m/find-first (comp #{"Product ID"} :display-name)
-                                                                       (lib/filterable-columns $))
-                                                         10))
-                                    (lib/filter $ (lib/< (m/find-first (comp #{"User ID"} :display-name)
-                                                                       (lib/filterable-columns $))
-                                                         20))
-                                    (lib/aggregate $ (lib.metadata/metric mp mid-1))
-                                    (lib/aggregate $ (lib.metadata/metric mp mid-2))))))))))
 
 (def efs @#'metrics/equal-filter?)
 

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -191,19 +191,19 @@
                        (lib/filter $q (lib/= (m/find-first (comp #{(meta/id :products :category)} :id) (lib/filterable-columns $q)) "Gadget"))
                        (lib/aggregate $q (lib.options/ensure-uuid [:metric {} (:id source-metric)])))))))
       (testing "With an implicit product join in consumer query"
-          (is (=?
-               {:stages [{:source-table (meta/id :orders)
-                          :joins [{:stages [{:source-table (meta/id :products)}]}]
+        (is (=?
+             {:stages [{:source-table (meta/id :orders)
+                        :joins [{:stages [{:source-table (meta/id :products)}]}]
                           ;; TODO: Search this file for `Duplicate value filter` for explanation of why filters are duplicated.
-                          :filters [[:= {} [:field {} (meta/id :products :title)] "foobar"]
-                                    [:= {} [:field {} (meta/id :products :category)] "Gadget"]
-                                    [:= {} [:field {} (meta/id :products :category)] [:value {} "Gadget"]]]
-                          :aggregation [[:count {}]]}]}
-               (adjust (as-> (lib/query mp (meta/table-metadata :orders)) $q
-                         (lib/filter $q (lib/= (m/find-first (comp #{(meta/id :products :title)} :id) (lib/filterable-columns $q))
-                                               "foobar"))
-                         (lib/filter $q (lib/= (m/find-first (comp #{(meta/id :products :category)} :id) (lib/filterable-columns $q)) "Gadget"))
-                         (lib/aggregate $q (lib.options/ensure-uuid [:metric {} (:id source-metric)]))))))))))
+                        :filters [[:= {} [:field {} (meta/id :products :title)] "foobar"]
+                                  [:= {} [:field {} (meta/id :products :category)] "Gadget"]
+                                  [:= {} [:field {} (meta/id :products :category)] [:value {} "Gadget"]]]
+                        :aggregation [[:count {}]]}]}
+             (adjust (as-> (lib/query mp (meta/table-metadata :orders)) $q
+                       (lib/filter $q (lib/= (m/find-first (comp #{(meta/id :products :title)} :id) (lib/filterable-columns $q))
+                                             "foobar"))
+                       (lib/filter $q (lib/= (m/find-first (comp #{(meta/id :products :category)} :id) (lib/filterable-columns $q)) "Gadget"))
+                       (lib/aggregate $q (lib.options/ensure-uuid [:metric {} (:id source-metric)]))))))))))
 
 (deftest ^:parallel multiple-source-metrics-with-implicit-join-test
   (let [[first-metric mp] (mock-metric (as-> (lib/query meta/metadata-provider (meta/table-metadata :orders)) $q
@@ -242,7 +242,7 @@
               adjusted)))))
 
 (deftest ^:parallel adjust-join-test
-  (let [[source-metric mp] (mock-metric (-> meta/metadata-provider 
+  (let [[source-metric mp] (mock-metric (-> meta/metadata-provider
                                             (lib/query (meta/table-metadata :orders))
                                             (lib/aggregate (lib/avg (meta/field-metadata :orders :total)))))
         query (-> (lib/query mp source-metric)
@@ -963,12 +963,12 @@
              {:type :metric
               :dataset_query (as-> (lib/query mp (lib.metadata/table mp (mt/id :orders))) $
                                (lib/join $ (lib/with-join-conditions
-                                             (lib/join-clause joined-metadata)
-                                             [(lib/=
-                                               (m/find-first (comp #{"Product ID"} :display-name)
-                                                             (lib/visible-columns $))
-                                               (m/find-first (comp #{"ID"} :display-name)
-                                                             (lib/returned-columns (lib/query mp joined-metadata))))]))
+                                            (lib/join-clause joined-metadata)
+                                            [(lib/=
+                                              (m/find-first (comp #{"Product ID"} :display-name)
+                                                            (lib/visible-columns $))
+                                              (m/find-first (comp #{"ID"} :display-name)
+                                                            (lib/returned-columns (lib/query mp joined-metadata))))]))
                                (lib/aggregate $ (lib/count))
                                (lib.convert/->legacy-MBQL $))}]
             (testing (format "Referencing stage with fk join with different target provokes an exception (joining %s)"
@@ -982,12 +982,12 @@
                            (qp/process-query
                             (as-> (lib/query mp (lib.metadata/table mp (mt/id :orders))) $
                               (lib/join $ (lib/with-join-conditions
-                                            (lib/join-clause joined-metadata)
-                                            [(lib/=
-                                              (m/find-first (comp #{"Product ID"} :display-name)
-                                                            (lib/visible-columns $))
-                                              (m/find-first (comp #{"ID"} :display-name)
-                                                            (lib/returned-columns (lib/query mp joined-metadata))))]))
+                                           (lib/join-clause joined-metadata)
+                                           [(lib/=
+                                             (m/find-first (comp #{"Product ID"} :display-name)
+                                                           (lib/visible-columns $))
+                                             (m/find-first (comp #{"ID"} :display-name)
+                                                           (lib/returned-columns (lib/query mp joined-metadata))))]))
                               (lib/aggregate $ (lib.metadata/metric mp no-join-id)))))))))))))
 
 (deftest join-operator-is-:=-test
@@ -1297,12 +1297,12 @@
             (testing (str "Processing of query with stage with less specific filter referencing metrics with "
                           "compatible filters throws (based on" query-base-type ")")
               (is (thrown-with-msg? Throwable #"Stage filter is not compatible with metric \d+ filter"
-                      (qp/process-query (as-> (lib/query mp query-base) $
-                                          (lib/filter $ (lib/> (m/find-first (comp #{"Total"} :display-name)
-                                                                             (lib/filterable-columns $))
-                                                               10))
-                                          (lib/aggregate $ (lib.metadata/metric mp mid-cnt))
-                                          (lib/aggregate $ (lib.metadata/metric mp mid-sum)))))))))))))
+                                    (qp/process-query (as-> (lib/query mp query-base) $
+                                                        (lib/filter $ (lib/> (m/find-first (comp #{"Total"} :display-name)
+                                                                                           (lib/filterable-columns $))
+                                                                             10))
+                                                        (lib/aggregate $ (lib.metadata/metric mp mid-cnt))
+                                                        (lib/aggregate $ (lib.metadata/metric mp mid-sum)))))))))))))
 
 (deftest one-metric-has-incompatible-filters-with-stage-other-doesnt-test
   (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))]
@@ -1393,19 +1393,19 @@
 
 (deftest equal-filter?-test
   (testing "Basic positive"
-    (is (true? (efs [:> {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 
+    (is (true? (efs [:> {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
                      [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 2] 1]
-                    [:> {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 
+                    [:> {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
                      [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 2] 1]))))
-  
+
   (testing "Different operator"
-    (is (false? (efs [:< {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 
-                      [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 2] 
+    (is (false? (efs [:< {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
+                      [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 2]
                       1]
                      [:> {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
                       [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 2]
                       1]))))
-  
+
   (testing "Nested clauses positive"
     (is (true? (efs [:< {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
                      [:+ {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
@@ -1421,7 +1421,7 @@
                        [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 2]
                        [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 300]]]
                      1]))))
-  
+
   (testing "Nested clause has a different operator"
     (is (false? (efs [:< {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
                       [:= {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
@@ -1437,7 +1437,7 @@
                         [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 2]
                         [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 300]]]
                       1]))))
-  
+
   (testing "Nested clause has different arg"
     (is (false? (efs [:< {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
                       [:= {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
@@ -1455,9 +1455,9 @@
                       1]))))
 
   (testing "Literal value and value clause work as expected"
-   (is (true? (efs [:> {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
-                    [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 10]
-                    100]
-                   [:> {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 
-                    [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 10] 
-                    [:value {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 100]])))))
+    (is (true? (efs [:> {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
+                     [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 10]
+                     100]
+                    [:> {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
+                     [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 10]
+                     [:value {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 100]])))))

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -873,8 +873,7 @@
                                             (lib/join (lib/join-clause (lib.metadata/table mp (mt/id :orders))))
                                             (lib/aggregate (lib.metadata/metric mp offending-id))))))))
 
-;;
-(deftest compatible-metric-joins-test-xix
+(deftest compatible-metric-joins-test
   (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))]
     (mt/with-temp
       [;; contains NON fk->pk join
@@ -1028,67 +1027,144 @@
                                    (lib/aggregate (lib.metadata/metric mp mid-gt))
                                    (lib/aggregate (lib.metadata/metric mp mid-lt))))))))))
 
-(def efs @#'metrics/equal-filter-shape?)
+(def efs @#'metrics/equal-filter?)
 
 ;; equal filter shape test
 ;; TMP: It seem
 (deftest equal-filter-shape-test
-  (is (true? (efs [:> {} [:field {} 2] 1]
-                  [:> {} [:field {} 2] 1])))
+  (is (true? (efs [:> {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 2] 1]
+                  [:> {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 2] 1])))
   
-  (is (false? (efs [:< {} [:field {} 2] 1]
-                   [:> {} [:field {} 2] 1])))
-  
-  (is (true? (efs [:< {}
-                   [:=
-                    [:field {} 100]
-                    [:+
-                     [:field {} 2]
-                     [:field {} 300]]]
-                   1]
-                   ;
-                  [:< {}
-                   [:=
-                    [:field {} 100]
-                    [:+
-                     [:field {} 2]
-                     [:field {} 300]]]
-                   1])))
-  
-  (is (false? (efs [:< {}
-                    [:=
-                     [:field {} 100]
-                     [:+
-                      [:field {} 2]
-                      [:field {} 300]]]
+  (is (false? (efs [:< {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 
+                    [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 2] 
                     1]
-                     ;
-                   [:< {}
-                    [:=
-                     [:field {} 100]
-                     [:-
-                      [:field {} 2]
-                      [:field {} 300]]]
+                   [:> {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
+                    [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 2]
                     1])))
   
-  (is (false? (efs [:< {}
-                    [:=
-                     [:field {} 100]
-                     [:+
-                      [:field {} 2]
-                      [:field {} 300]]]
+  (is (true? (efs [:< {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
+                   [:= {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
+                    [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 100]
+                    [:+ {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
+                     [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 2]
+                     [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 300]]]
+                   1]
+                   ;
+                  [:< {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
+                   [:= {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
+                    [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 100]
+                    [:+ {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
+                     [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 2]
+                     [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 300]]]
+                   1])))
+  
+  (is (false? (efs [:< {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
+                    [:= {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
+                     [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 100]
+                     [:+ {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
+                      [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 2]
+                      [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 300]]]
+                    1]
+                     ;
+                   [:< {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
+                    [:= {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
+                     [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 100]
+                     [:- {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
+                      [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 2]
+                      [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 300]]]
+                    1])))
+  
+  (is (false? (efs [:< {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
+                    [:= {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
+                     [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 100]
+                     [:+ {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
+                      [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 2]
+                      [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 300]]]
                     1]
                        ;
-                   [:< {}
-                    [:=
-                     [:field {} 100]
-                     [:+
-                      [:field {} 2]
-                      nil]]
-                    1]))))
+                   [:< {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
+                    [:= {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
+                     [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 100]
+                     [:+ {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
+                      [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 2]
+                      0]]
+                    1])))
 
-(deftest dummy-filter-test
+  (is (true? (efs [:> {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"}
+                   [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 10]
+                   100]
+                  [:> {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 
+                   [:field {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 10] 
+                   [:value {:lib/uuid "59209c3c-e806-402e-89c6-95de0cb21230"} 100]]))))
+
+;; TODO: Enable when fixed.
+(deftest compatible-filters-with-different-ordering-test
+  (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
+        metric-query-fn (fn [filter-op1 filter-op2]
+                          (as-> (lib/query mp (lib.metadata/table mp (mt/id :orders))) $
+                            (lib/filter $ (filter-op1 (m/find-first (comp #{"Total"} :display-name)
+                                                                    (lib/filterable-columns $))
+                                                      10))
+                            (lib/filter $ (filter-op2 (m/find-first (comp #{"Total"} :display-name)
+                                                                    (lib/filterable-columns $))
+                                                      10))
+                            (lib/aggregate $ (lib/count))
+                            (lib.convert/->legacy-MBQL $)))]
+    (mt/with-temp
+      [:model/Card
+       {mid-gt :id}
+       {:type :metric
+        :dataset_query (metric-query-fn lib/> lib/=)}
+
+       :model/Card
+       {mid-lt :id}
+       {:type :metric
+        :dataset_query (metric-query-fn lib/= lib/>)}]
+      (testing "Processing of query referencing metrics with same filters with different ordering should complete"
+        (is (=? {:status :completed}
+                (qp/process-query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                                      (lib/aggregate (lib.metadata/metric mp mid-gt))
+                                      (lib/aggregate (lib.metadata/metric mp mid-lt))))))))))
+
+;; simple case -- ok
+(deftest stage-filter-must-contain-filters-of-metrics-when-present-test-xxx
   (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))]
-    @(def qq (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
-                 (lib/filter (lib/= 2 (lib/+ 1 1)))
-                 (lib/filter (lib/= 3 (lib/+ 2 1)))))))
+    (mt/with-temp
+      [:model/Card
+       {mid :id}
+       {:type :metric
+        :dataset_query @(def qw (as-> (lib/query mp (lib.metadata/table mp (mt/id :orders))) $
+                                  (lib/filter $ (lib/= (m/find-first (comp #{"Total"} :display-name)
+                                                                     (lib/filterable-columns $))
+                                                       10))
+                                  (lib/aggregate $ (lib/count))
+                                  (lib.convert/->legacy-MBQL $)))}]
+      @(def rr (qp/process-query @(def qa (as-> (lib/query mp (lib.metadata/table mp (mt/id :orders))) $
+                                            (lib/filter $ (lib/= (m/find-first (comp #{"Total"} :display-name)
+                                                                               (lib/filterable-columns $))
+                                                                 10))
+                                            (lib/filter $ (lib/= (m/find-first (comp #{"Subtotal"} :display-name)
+                                                                               (lib/filterable-columns $))
+                                                                 20))
+                                            (lib/aggregate $ (lib.metadata/metric mp mid)))))))))
+
+;; simple failing case -- ok
+(deftest stage-filter-must-contain-filters-of-metrics-when-present-test
+  (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))]
+    (mt/with-temp
+      [:model/Card
+       {mid :id}
+       {:type :metric
+        :dataset_query (as-> (lib/query mp (lib.metadata/table mp (mt/id :orders))) $
+                         (lib/filter $ (lib/= (m/find-first (comp #{"Total"} :display-name)
+                                                            (lib/filterable-columns $))
+                                              10))
+                         (lib/aggregate $ (lib/count))
+                         (lib.convert/->legacy-MBQL $))}]
+      (is (thrown-with-msg?
+           Throwable #"Stage filter is not compatible with metric `\d+` filter"
+           @(def rr (qp/process-query (as-> (lib/query mp (lib.metadata/table mp (mt/id :orders))) $
+                                        (lib/filter $ (lib/= (m/find-first (comp #{"Total"} :display-name)
+                                                                           (lib/filterable-columns $))
+                                                             9999999999))
+                                        (lib/aggregate $ (lib.metadata/metric mp mid))))))))))

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -659,40 +659,40 @@
       (comment
         (testing "nested 1 level"
           (is (=? (lib.tu.macros/mbql-query nil
-                                            {:source-query after})
+                    {:source-query after})
                   (expand-macros (lib.tu.macros/mbql-query nil
-                                                           {:source-query before})))))
+                                   {:source-query before})))))
         (testing "nested 2 levels"
           (is (=? (lib.tu.macros/mbql-query nil
-                                            {:source-query {:source-query after}})
+                    {:source-query {:source-query after}})
                   (expand-macros
                    (lib.tu.macros/mbql-query nil
-                                             {:source-query {:source-query before}})))))
+                     {:source-query {:source-query before}})))))
         (testing "nested 3 levels"
           (is (=? (lib.tu.macros/mbql-query nil
-                                            {:source-query {:source-query {:source-query after}}})
+                    {:source-query {:source-query {:source-query after}}})
                   (expand-macros
                    (lib.tu.macros/mbql-query nil
-                                             {:source-query {:source-query {:source-query before}}}))))))
+                     {:source-query {:source-query {:source-query before}}}))))))
       (testing "inside :source-query inside :joins"
         (is (=? (lib.tu.macros/mbql-query checkins
-                                          {:joins [{:condition    [:= [:field (meta/id :checkins :id) nil] 2]
-                                                    :source-query after}]})
+                  {:joins [{:condition    [:= [:field (meta/id :checkins :id) nil] 2]
+                            :source-query after}]})
                 (expand-macros
                  (lib.tu.macros/mbql-query checkins
-                                           {:joins [{:condition    [:= [:field (meta/id :checkins :id) nil] 2]
-                                                     :source-query before}]})))))
+                   {:joins [{:condition    [:= [:field (meta/id :checkins :id) nil] 2]
+                             :source-query before}]})))))
 
       (testing "inside :joins inside :source-query"
         (is (=? (lib.tu.macros/mbql-query nil
-                                          {:source-query {:source-table (meta/id :checkins)
-                                                          :joins        [{:condition    [:= [:field (meta/id :checkins :venue-id) nil] 2]
-                                                                          :source-query after}]}})
+                  {:source-query {:source-table (meta/id :checkins)
+                                  :joins        [{:condition    [:= [:field (meta/id :checkins :venue-id) nil] 2]
+                                                  :source-query after}]}})
                 (expand-macros (lib.tu.macros/mbql-query nil
-                                                         {:source-query {:source-table (meta/id :checkins)
-                                                                         :joins
-                                                                         [{:condition    [:= [:field (meta/id :checkins :venue-id) nil] 2]
-                                                                           :source-query before}]}}))))))))
+                                 {:source-query {:source-table (meta/id :checkins)
+                                                 :joins
+                                                 [{:condition    [:= [:field (meta/id :checkins :venue-id) nil] 2]
+                                                   :source-query before}]}}))))))))
 
 (deftest ^:parallel model-based-metric-use-test
   (let [model {:lib/type :metadata/card
@@ -837,13 +837,13 @@
                                              :type :model}
                    :model/Card metric {:dataset_query
                                        (mt/mbql-query
-                                        orders
-                                        {:source-table (str "card__" (:id source-model))
-                                         :expressions {"somedays" [:datetime-diff
-                                                                   [:field "CREATED_AT" {:base-type :type/DateTime}]
-                                                                   (t/offset-date-time 2024 10 16 0 0 0)
-                                                                   :day]}
-                                         :aggregation [[:median [:expression "somedays" {:base-type :type/Integer}]]]})
+                                         orders
+                                         {:source-table (str "card__" (:id source-model))
+                                          :expressions {"somedays" [:datetime-diff
+                                                                    [:field "CREATED_AT" {:base-type :type/DateTime}]
+                                                                    (t/offset-date-time 2024 10 16 0 0 0)
+                                                                    :day]}
+                                          :aggregation [[:median [:expression "somedays" {:base-type :type/Integer}]]]})
                                        :database_id (mt/id)
                                        :name "somedays median"
                                        :type :metric}]
@@ -992,12 +992,12 @@
              {:type :metric
               :dataset_query (as-> (lib/query mp (lib.metadata/table mp (mt/id :orders))) $
                                (lib/join $ (lib/with-join-conditions
-                                             (lib/join-clause joined-metadata)
-                                             [(lib/=
-                                               (m/find-first (comp #{"Product ID"} :display-name)
-                                                             (lib/visible-columns $))
-                                               (m/find-first (comp #{"ID"} :display-name)
-                                                             (lib/returned-columns (lib/query mp joined-metadata))))]))
+                                            (lib/join-clause joined-metadata)
+                                            [(lib/=
+                                              (m/find-first (comp #{"Product ID"} :display-name)
+                                                            (lib/visible-columns $))
+                                              (m/find-first (comp #{"ID"} :display-name)
+                                                            (lib/returned-columns (lib/query mp joined-metadata))))]))
                                (lib/aggregate $ (lib/count))
                                (lib.convert/->legacy-MBQL $))}]
             (testing (format "Referencing stage with fk join with different target provokes an exception (joining %s)"
@@ -1011,12 +1011,12 @@
                            (qp/process-query
                             (as-> (lib/query mp (lib.metadata/table mp (mt/id :orders))) $
                               (lib/join $ (lib/with-join-conditions
-                                            (lib/join-clause joined-metadata)
-                                            [(lib/=
-                                              (m/find-first (comp #{"Product ID"} :display-name)
-                                                            (lib/visible-columns $))
-                                              (m/find-first (comp #{"ID"} :display-name)
-                                                            (lib/returned-columns (lib/query mp joined-metadata))))]))
+                                           (lib/join-clause joined-metadata)
+                                           [(lib/=
+                                             (m/find-first (comp #{"Product ID"} :display-name)
+                                                           (lib/visible-columns $))
+                                             (m/find-first (comp #{"ID"} :display-name)
+                                                           (lib/returned-columns (lib/query mp joined-metadata))))]))
                               (lib/aggregate $ (lib.metadata/metric mp no-join-id)))))))))))))
 
 (deftest join-operator-is-:=-test

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -875,7 +875,7 @@
                                (lib/aggregate (lib/count))
                                (lib.convert/->legacy-MBQL))}]
           (testing (format "Incompatible join in metric provokes an exception (joining %s)" joined-type)
-            (is (thrown-with-msg? Throwable #"Incompatible join in the metric \d+"
+            (is (thrown-with-msg? Throwable #"Incompatible join in the metric \S+"
                                   (qp/process-query (-> (lib/query mp (lib.metadata/table mp (mt/id :products)))
                                                         (lib/aggregate (lib.metadata/metric mp offending-id)))))))
           (testing (format "Incompatible join in referencing stage provokes an exception (joining %s)" joined-type)
@@ -973,7 +973,7 @@
                                (lib.convert/->legacy-MBQL $))}]
             (testing (format "Referencing stage with fk join with different target provokes an exception (joining %s)"
                              joined-type)
-              (is (thrown-with-msg? Throwable #"Incompatible join in the metric \d+"
+              (is (thrown-with-msg? Throwable #"Incompatible join in the metric \S+"
                                     (qp/process-query
                                      (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
                                          (lib/aggregate (lib.metadata/metric mp with-join-id)))))))
@@ -1007,7 +1007,7 @@
         :dataset_query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
                            (lib/aggregate (lib/count)))}]
       (testing "Processing of query referencing a metric with join with non-:= condition provokes an exception"
-        (is (thrown-with-msg? Throwable #"Incompatible join in the metric \d+"
+        (is (thrown-with-msg? Throwable #"Incompatible join in the metric \S+"
                               (qp/process-query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
                                                     (lib/aggregate (lib.metadata/metric mp incompatible-id)))))))
       (testing "Processing of query with join with non-:= condition referencing a metric provokes an exception"
@@ -1100,7 +1100,7 @@
             (testing (format "Processing of query (%s based) referencing metrics with conflicting filters throws"
                              query-base-type)
               (is (thrown-with-msg?
-                   Throwable #"Metrics \d+ and \d+ have incompatible filters"
+                   Throwable #"Metrics \S+ and \S+ have incompatible filters"
                    (qp/process-query (-> (lib/query mp query-base)
                                          (lib/aggregate (lib.metadata/metric mp mid-gt))
                                          (lib/aggregate (lib.metadata/metric mp mid-lt)))))))))))))
@@ -1135,7 +1135,7 @@
           (testing (format "Processing of query (%s based) referencing metrics with incompatible filters provokes an excpetion"
                            query-base-type)
             (is (thrown-with-msg?
-                 Throwable #"Metrics \d+ and \d+ have incompatible filters"
+                 Throwable #"Metrics \S+ and \S+ have incompatible filters"
                  (qp/process-query (-> (lib/query mp query-base)
                                        (lib/aggregate (lib.metadata/metric mp no-filter-id))
                                        (lib/aggregate (lib.metadata/metric mp with-filter-id))))))))))))
@@ -1176,7 +1176,7 @@
           (testing (format "Processing of query (%s based) referencing metrics one filter more strict provokes an excpetion"
                            query-base-type)
             (is (thrown-with-msg?
-                 Throwable #"Metrics \d+ and \d+ have incompatible filters"
+                 Throwable #"Metrics \S+ and \S+ have incompatible filters"
                  (qp/process-query (-> (lib/query mp query-base)
                                        (lib/aggregate (lib.metadata/metric mp no-filter-id))
                                        (lib/aggregate (lib.metadata/metric mp with-filter-id))))))))))))
@@ -1210,8 +1210,6 @@
                                       (lib/aggregate (lib.metadata/metric mp mid-lt))))))))))
 
 ;; stage filters vs metrics
-
-;; all of those tests should be testing for identity
 
 (deftest only-referencing-stage-has-filter-test
   (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))]
@@ -1366,7 +1364,7 @@
           (testing (format (str "Processing of query (%s based) with stage with filter compatible with one metric "
                                 "but not other should throw")
                            query-base-type)
-            (is (thrown-with-msg? Throwable #"Metrics \d+ and \d+ have incompatible filters"
+            (is (thrown-with-msg? Throwable #"Metrics \S+ and \S+ have incompatible filters"
                                   (qp/process-query (as-> (lib/query mp query-base-metadata) $
                                                       (lib/filter $ (lib/> (m/find-first (comp #{"Product ID"}
                                                                                                :display-name)

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -999,13 +999,15 @@
         :dataset_query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
                            (lib/aggregate (lib/count)))}]
       (testing "Processing of query referencing a metric with join with non-:= condition provokes an exception"
-        (is (thrown? Throwable (qp/process-query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
-                                                     (lib/aggregate (lib.metadata/metric mp incompatible-id)))))))
+        (is (thrown-with-msg? Throwable #"Incompatible join in the metric \d+"
+                              (qp/process-query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                                                    (lib/aggregate (lib.metadata/metric mp incompatible-id)))))))
       (testing "Processing of query with join with non-:= condition referencing a metric provokes an exception"
-        (is (thrown? Throwable (qp/process-query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
-                                                     (lib/join (lib.metadata/table mp (mt/id :products)))
-                                                     (lib.util/update-query-stage 0 assoc-in [:joins 0 :conditions 0 0] :>)
-                                                     (lib/aggregate (lib.metadata/metric mp no-join-id))))))))))
+        (is (thrown-with-msg? Throwable #"Incompatible join in a stage referencing a metric"
+                              (qp/process-query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                                                    (lib/join (lib.metadata/table mp (mt/id :products)))
+                                                    (lib.util/update-query-stage 0 assoc-in [:joins 0 :conditions 0 0] :>)
+                                                    (lib/aggregate (lib.metadata/metric mp no-join-id))))))))))
 
 ;; !!! TODO: Ensure that joins eg on following stages are not affected!
 

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -1,6 +1,6 @@
 (ns metabase.query-processor.middleware.metrics-test
   (:require
-   [clojure.test :refer [are deftest is testing]]
+   [clojure.test :refer [deftest is testing]]
    [java-time.api :as t]
    [mb.hawk.assert-exprs.approximately-equal :as =?]
    [medley.core :as m]

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -856,7 +856,7 @@
         (is (=? {:status :completed}
                 (qp/process-query (-> (lib/query mp (lib.metadata/table mp (mt/id :products)))
                                       (lib/aggregate (lib.metadata/metric mp none-id)))))))
-      (doseq [[joined-type joined-meta] [[:question (lib.metadata/table mp (mt/id :orders))]
+      (doseq [[joined-type joined-meta] [[:table (lib.metadata/table mp (mt/id :orders))]
                                          [:model (lib.metadata/card mp model-id)]]]
         (mt/with-temp
           [:model/Card
@@ -902,7 +902,7 @@
         (is (=? {:status :completed}
                 (qp/process-query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
                                       (lib/aggregate (lib.metadata/metric mp none-id)))))))
-      (doseq [[joined-type joined-metadata] [[:question (lib.metadata/table mp (mt/id :products))]
+      (doseq [[joined-type joined-metadata] [[:table (lib.metadata/table mp (mt/id :products))]
                                              [:model (lib.metadata/card mp model-id)]]]
         (mt/with-temp
           [:model/Card

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -630,40 +630,40 @@
       (comment
         (testing "nested 1 level"
           (is (=? (lib.tu.macros/mbql-query nil
-                                            {:source-query after})
+                    {:source-query after})
                   (expand-macros (lib.tu.macros/mbql-query nil
-                                                           {:source-query before})))))
+                                   {:source-query before})))))
         (testing "nested 2 levels"
           (is (=? (lib.tu.macros/mbql-query nil
-                                            {:source-query {:source-query after}})
+                    {:source-query {:source-query after}})
                   (expand-macros
                    (lib.tu.macros/mbql-query nil
-                                             {:source-query {:source-query before}})))))
+                     {:source-query {:source-query before}})))))
         (testing "nested 3 levels"
           (is (=? (lib.tu.macros/mbql-query nil
-                                            {:source-query {:source-query {:source-query after}}})
+                    {:source-query {:source-query {:source-query after}}})
                   (expand-macros
                    (lib.tu.macros/mbql-query nil
-                                             {:source-query {:source-query {:source-query before}}}))))))
+                     {:source-query {:source-query {:source-query before}}}))))))
       (testing "inside :source-query inside :joins"
         (is (=? (lib.tu.macros/mbql-query checkins
-                                          {:joins [{:condition    [:= [:field (meta/id :checkins :id) nil] 2]
-                                                    :source-query after}]})
+                  {:joins [{:condition    [:= [:field (meta/id :checkins :id) nil] 2]
+                            :source-query after}]})
                 (expand-macros
                  (lib.tu.macros/mbql-query checkins
-                                           {:joins [{:condition    [:= [:field (meta/id :checkins :id) nil] 2]
-                                                     :source-query before}]})))))
+                   {:joins [{:condition    [:= [:field (meta/id :checkins :id) nil] 2]
+                             :source-query before}]})))))
 
       (testing "inside :joins inside :source-query"
         (is (=? (lib.tu.macros/mbql-query nil
-                                          {:source-query {:source-table (meta/id :checkins)
-                                                          :joins        [{:condition    [:= [:field (meta/id :checkins :venue-id) nil] 2]
-                                                                          :source-query after}]}})
+                  {:source-query {:source-table (meta/id :checkins)
+                                  :joins        [{:condition    [:= [:field (meta/id :checkins :venue-id) nil] 2]
+                                                  :source-query after}]}})
                 (expand-macros (lib.tu.macros/mbql-query nil
-                                                         {:source-query {:source-table (meta/id :checkins)
-                                                                         :joins
-                                                                         [{:condition    [:= [:field (meta/id :checkins :venue-id) nil] 2]
-                                                                           :source-query before}]}}))))))))
+                                 {:source-query {:source-table (meta/id :checkins)
+                                                 :joins
+                                                 [{:condition    [:= [:field (meta/id :checkins :venue-id) nil] 2]
+                                                   :source-query before}]}}))))))))
 
 (deftest ^:parallel model-based-metric-use-test
   (let [model {:lib/type :metadata/card
@@ -808,13 +808,13 @@
                                              :type :model}
                    :model/Card metric {:dataset_query
                                        (mt/mbql-query
-                                        orders
-                                        {:source-table (str "card__" (:id source-model))
-                                         :expressions {"somedays" [:datetime-diff
-                                                                   [:field "CREATED_AT" {:base-type :type/DateTime}]
-                                                                   (t/offset-date-time 2024 10 16 0 0 0)
-                                                                   :day]}
-                                         :aggregation [[:median [:expression "somedays" {:base-type :type/Integer}]]]})
+                                         orders
+                                         {:source-table (str "card__" (:id source-model))
+                                          :expressions {"somedays" [:datetime-diff
+                                                                    [:field "CREATED_AT" {:base-type :type/DateTime}]
+                                                                    (t/offset-date-time 2024 10 16 0 0 0)
+                                                                    :day]}
+                                          :aggregation [[:median [:expression "somedays" {:base-type :type/Integer}]]]})
                                        :database_id (mt/id)
                                        :name "somedays median"
                                        :type :metric}]
@@ -963,12 +963,12 @@
              {:type :metric
               :dataset_query (as-> (lib/query mp (lib.metadata/table mp (mt/id :orders))) $
                                (lib/join $ (lib/with-join-conditions
-                                             (lib/join-clause joined-metadata)
-                                             [(lib/=
-                                               (m/find-first (comp #{"Product ID"} :display-name)
-                                                             (lib/visible-columns $))
-                                               (m/find-first (comp #{"ID"} :display-name)
-                                                             (lib/returned-columns (lib/query mp joined-metadata))))]))
+                                            (lib/join-clause joined-metadata)
+                                            [(lib/=
+                                              (m/find-first (comp #{"Product ID"} :display-name)
+                                                            (lib/visible-columns $))
+                                              (m/find-first (comp #{"ID"} :display-name)
+                                                            (lib/returned-columns (lib/query mp joined-metadata))))]))
                                (lib/aggregate $ (lib/count))
                                (lib.convert/->legacy-MBQL $))}]
             (testing (format "Referencing stage with fk join with different target provokes an exception (joining %s)"
@@ -982,12 +982,12 @@
                            (qp/process-query
                             (as-> (lib/query mp (lib.metadata/table mp (mt/id :orders))) $
                               (lib/join $ (lib/with-join-conditions
-                                            (lib/join-clause joined-metadata)
-                                            [(lib/=
-                                              (m/find-first (comp #{"Product ID"} :display-name)
-                                                            (lib/visible-columns $))
-                                              (m/find-first (comp #{"ID"} :display-name)
-                                                            (lib/returned-columns (lib/query mp joined-metadata))))]))
+                                           (lib/join-clause joined-metadata)
+                                           [(lib/=
+                                             (m/find-first (comp #{"Product ID"} :display-name)
+                                                           (lib/visible-columns $))
+                                             (m/find-first (comp #{"ID"} :display-name)
+                                                           (lib/returned-columns (lib/query mp joined-metadata))))]))
                               (lib/aggregate $ (lib.metadata/metric mp no-join-id)))))))))))))
 
 (deftest join-operator-is-:=-test

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -277,7 +277,7 @@
                                             (lib/expression "foobar" (lib/+ 1 1))
                                             (as-> $q
                                                   (lib/expression $q "qux" (lib/+ (lib/expression-ref $q "foobar") 1))
-                                              (lib/filter $q (lib/= (lib/expression-ref $q "foobar") (lib/expression-ref $q "qux"))))))
+                                              (lib/filter $q (lib/= (lib/expression-ref $q "qux") (lib/expression-ref $q "foobar"))))))
         query (-> (lib/query mp (meta/table-metadata :products))
                   (lib/expression "foobar" (lib/- 2 2))
                   (as-> $q
@@ -290,7 +290,7 @@
                                   [:+ {:lib/expression-name "foobar_2"} 1 1]
                                   [:+ {:lib/expression-name "qux_2"} [:expression {} "foobar_2"] 1]]
                     :filters [[:= {} [:expression {} "foobar"] [:expression {} "qux"]]
-                              [:= {} [:expression {} "foobar_2"] [:expression {} "qux_2"]]]
+                              [:= {} [:expression {} "qux_2"] [:expression {} "foobar_2"]]]
                     :aggregation [[:avg {} [:field {} (meta/id :products :rating)]]]}]}
          (adjust query)))))
 
@@ -630,40 +630,40 @@
       (comment
         (testing "nested 1 level"
           (is (=? (lib.tu.macros/mbql-query nil
-                    {:source-query after})
+                                            {:source-query after})
                   (expand-macros (lib.tu.macros/mbql-query nil
-                                   {:source-query before})))))
+                                                           {:source-query before})))))
         (testing "nested 2 levels"
           (is (=? (lib.tu.macros/mbql-query nil
-                    {:source-query {:source-query after}})
+                                            {:source-query {:source-query after}})
                   (expand-macros
                    (lib.tu.macros/mbql-query nil
-                     {:source-query {:source-query before}})))))
+                                             {:source-query {:source-query before}})))))
         (testing "nested 3 levels"
           (is (=? (lib.tu.macros/mbql-query nil
-                    {:source-query {:source-query {:source-query after}}})
+                                            {:source-query {:source-query {:source-query after}}})
                   (expand-macros
                    (lib.tu.macros/mbql-query nil
-                     {:source-query {:source-query {:source-query before}}}))))))
+                                             {:source-query {:source-query {:source-query before}}}))))))
       (testing "inside :source-query inside :joins"
         (is (=? (lib.tu.macros/mbql-query checkins
-                  {:joins [{:condition    [:= [:field (meta/id :checkins :id) nil] 2]
-                            :source-query after}]})
+                                          {:joins [{:condition    [:= [:field (meta/id :checkins :id) nil] 2]
+                                                    :source-query after}]})
                 (expand-macros
                  (lib.tu.macros/mbql-query checkins
-                   {:joins [{:condition    [:= [:field (meta/id :checkins :id) nil] 2]
-                             :source-query before}]})))))
+                                           {:joins [{:condition    [:= [:field (meta/id :checkins :id) nil] 2]
+                                                     :source-query before}]})))))
 
       (testing "inside :joins inside :source-query"
         (is (=? (lib.tu.macros/mbql-query nil
-                  {:source-query {:source-table (meta/id :checkins)
-                                  :joins        [{:condition    [:= [:field (meta/id :checkins :venue-id) nil] 2]
-                                                  :source-query after}]}})
+                                          {:source-query {:source-table (meta/id :checkins)
+                                                          :joins        [{:condition    [:= [:field (meta/id :checkins :venue-id) nil] 2]
+                                                                          :source-query after}]}})
                 (expand-macros (lib.tu.macros/mbql-query nil
-                                 {:source-query {:source-table (meta/id :checkins)
-                                                 :joins
-                                                 [{:condition    [:= [:field (meta/id :checkins :venue-id) nil] 2]
-                                                   :source-query before}]}}))))))))
+                                                         {:source-query {:source-table (meta/id :checkins)
+                                                                         :joins
+                                                                         [{:condition    [:= [:field (meta/id :checkins :venue-id) nil] 2]
+                                                                           :source-query before}]}}))))))))
 
 (deftest ^:parallel model-based-metric-use-test
   (let [model {:lib/type :metadata/card
@@ -808,13 +808,13 @@
                                              :type :model}
                    :model/Card metric {:dataset_query
                                        (mt/mbql-query
-                                         orders
-                                         {:source-table (str "card__" (:id source-model))
-                                          :expressions {"somedays" [:datetime-diff
-                                                                    [:field "CREATED_AT" {:base-type :type/DateTime}]
-                                                                    (t/offset-date-time 2024 10 16 0 0 0)
-                                                                    :day]}
-                                          :aggregation [[:median [:expression "somedays" {:base-type :type/Integer}]]]})
+                                        orders
+                                        {:source-table (str "card__" (:id source-model))
+                                         :expressions {"somedays" [:datetime-diff
+                                                                   [:field "CREATED_AT" {:base-type :type/DateTime}]
+                                                                   (t/offset-date-time 2024 10 16 0 0 0)
+                                                                   :day]}
+                                         :aggregation [[:median [:expression "somedays" {:base-type :type/Integer}]]]})
                                        :database_id (mt/id)
                                        :name "somedays median"
                                        :type :metric}]
@@ -963,12 +963,12 @@
              {:type :metric
               :dataset_query (as-> (lib/query mp (lib.metadata/table mp (mt/id :orders))) $
                                (lib/join $ (lib/with-join-conditions
-                                            (lib/join-clause joined-metadata)
-                                            [(lib/=
-                                              (m/find-first (comp #{"Product ID"} :display-name)
-                                                            (lib/visible-columns $))
-                                              (m/find-first (comp #{"ID"} :display-name)
-                                                            (lib/returned-columns (lib/query mp joined-metadata))))]))
+                                             (lib/join-clause joined-metadata)
+                                             [(lib/=
+                                               (m/find-first (comp #{"Product ID"} :display-name)
+                                                             (lib/visible-columns $))
+                                               (m/find-first (comp #{"ID"} :display-name)
+                                                             (lib/returned-columns (lib/query mp joined-metadata))))]))
                                (lib/aggregate $ (lib/count))
                                (lib.convert/->legacy-MBQL $))}]
             (testing (format "Referencing stage with fk join with different target provokes an exception (joining %s)"
@@ -982,12 +982,12 @@
                            (qp/process-query
                             (as-> (lib/query mp (lib.metadata/table mp (mt/id :orders))) $
                               (lib/join $ (lib/with-join-conditions
-                                           (lib/join-clause joined-metadata)
-                                           [(lib/=
-                                             (m/find-first (comp #{"Product ID"} :display-name)
-                                                           (lib/visible-columns $))
-                                             (m/find-first (comp #{"ID"} :display-name)
-                                                           (lib/returned-columns (lib/query mp joined-metadata))))]))
+                                            (lib/join-clause joined-metadata)
+                                            [(lib/=
+                                              (m/find-first (comp #{"Product ID"} :display-name)
+                                                            (lib/visible-columns $))
+                                              (m/find-first (comp #{"ID"} :display-name)
+                                                            (lib/returned-columns (lib/query mp joined-metadata))))]))
                               (lib/aggregate $ (lib.metadata/metric mp no-join-id)))))))))))))
 
 (deftest join-operator-is-:=-test


### PR DESCRIPTION
Closes #25455

As per [this discussion](https://metaboat.slack.com/archives/C0645JP1W81/p1737993666999469) it was decided that queries referencing metrics with incompatible filters (or joins) will be rejected. This PR adds those checks.

This PR implements solution 1 of corresponding [tech doc](https://www.notion.so/metabase/Tech-Prevent-combining-metrics-with-conflicting-filters-18869354c901809bba64f8131fc11435).