### PR TITLE
Check for min arg count in expressions

### DIFF
--- a/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
@@ -1289,3 +1289,24 @@ describe("issue 50925", () => {
       );
   });
 });
+
+describe("issue 53682", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should show an error message when trying to use a multi-arg expression function with not enough arguments (metabase#53682)", () => {
+    H.openProductsTable({ mode: "notebook" });
+    H.getNotebookStep("data").button("Custom column").click();
+    H.enterCustomColumnDetails({
+      formula: "contains([Category])",
+    });
+    H.popover().within(() => {
+      cy.findByText("Function contains expects at least 2 arguments").should(
+        "be.visible",
+      );
+      cy.button("Done").should("be.disabled");
+    });
+  });
+});

--- a/frontend/src/metabase-lib/v1/expressions/config.ts
+++ b/frontend/src/metabase-lib/v1/expressions/config.ts
@@ -118,7 +118,7 @@ export const MBQL_CLAUSES: MBQLClauseMap = {
   concat: {
     displayName: `concat`,
     type: "string",
-    args: ["expression"],
+    args: ["expression", "expression"],
     multiple: true,
   },
   replace: {

--- a/frontend/src/metabase-lib/v1/expressions/recursive-parser.js
+++ b/frontend/src/metabase-lib/v1/expressions/recursive-parser.js
@@ -270,7 +270,7 @@ export const adjustOptions = tree =>
       if (operands.length > 0) {
         const clause = MBQL_CLAUSES[operator];
         if (clause && clause.hasOptions) {
-          if (operands.length === clause.args.length + 1 || clause.multiple) {
+          if (operands.length > clause.args.length) {
             // the last one holds the function options
             const options = operands[operands.length - 1];
 

--- a/frontend/src/metabase-lib/v1/expressions/resolver.js
+++ b/frontend/src/metabase-lib/v1/expressions/resolver.js
@@ -193,8 +193,10 @@ export function resolve({
       }
     }
     if (multiple) {
+      const argCount = operands.filter(arg => !isOptionsObject(arg)).length;
       const minArgCount = args.length;
-      if (operands.length < minArgCount) {
+
+      if (argCount < minArgCount) {
         throw new ResolverError(
           ngettext(
             msgid`Function ${displayName} expects at least ${minArgCount} argument`,

--- a/frontend/src/metabase-lib/v1/expressions/resolver.js
+++ b/frontend/src/metabase-lib/v1/expressions/resolver.js
@@ -192,7 +192,19 @@ export function resolve({
         throw new ResolverError(validationError, expression.node);
       }
     }
-    if (!multiple) {
+    if (multiple) {
+      const minArgCount = args.length;
+      if (operands.length < minArgCount) {
+        throw new ResolverError(
+          ngettext(
+            msgid`Function ${displayName} expects at least ${minArgCount} argument`,
+            `Function ${displayName} expects at least ${minArgCount} arguments`,
+            minArgCount,
+          ),
+          expression.node,
+        );
+      }
+    } else {
       const expectedArgsLength = args.length;
       const maxArgCount = hasOptions
         ? expectedArgsLength + 1

--- a/frontend/test/metabase/lib/expressions/recursive-parser.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/recursive-parser.unit.spec.js
@@ -134,6 +134,10 @@ describe("metabase-lib/v1/expressions/recursive-parser", () => {
 
   it.each([
     {
+      source: "contains(B, 'case-insensitive')",
+      expression: ["contains", B, "case-insensitive"],
+    },
+    {
       source: "contains(B, C, 'case-insensitive')",
       expression: ["contains", B, C, { "case-sensitive": false }],
     },

--- a/frontend/test/metabase/lib/expressions/resolver.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/resolver.unit.spec.js
@@ -171,18 +171,28 @@ describe("metabase-lib/v1/expressions/resolve", () => {
         expect(() => expr(["substring", "foo", 1, 1])).not.toThrow();
       });
 
-      it.each(["contains", "does-not-contain", "starts-with", "ends-with"])(
-        "should reject multi-arg function calls with not enough arguments",
+      it.each(["in", "not-in"])(
+        "should reject multi-arg function calls without options when there is not enough arguments",
         tag => {
           expect(() => expr([tag])).toThrow();
           expect(() => expr([tag, A])).toThrow();
-          expect(() => expr([tag, A, { "case-sensitive": true }])).toThrow();
+          expect(() => expr([tag, A, B])).not.toThrow();
+          expect(() => expr([tag, A, B, C])).not.toThrow();
+        },
+      );
+
+      it.each(["contains", "does-not-contain", "starts-with", "ends-with"])(
+        "should reject multi-arg function calls with options when there is not enough arguments",
+        tag => {
+          const options = { "case-sensitive": true };
+          expect(() => expr([tag])).toThrow();
+          expect(() => expr([tag, A])).toThrow();
+          expect(() => expr([tag, A, options])).toThrow();
           expect(() => expr([tag, A, "abc"])).not.toThrow();
           expect(() => expr([tag, A, B])).not.toThrow();
           expect(() => expr([tag, A, B, C])).not.toThrow();
-          expect(() =>
-            expr([tag, A, B, { "case-sensitive": true }]),
-          ).not.toThrow();
+          expect(() => expr([tag, A, B, options])).not.toThrow();
+          expect(() => expr([tag, options, A, B, C])).not.toThrow();
         },
       );
     });

--- a/frontend/test/metabase/lib/expressions/resolver.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/resolver.unit.spec.js
@@ -170,6 +170,21 @@ describe("metabase-lib/v1/expressions/resolve", () => {
       it("should allow substring with index=1", () => {
         expect(() => expr(["substring", "foo", 1, 1])).not.toThrow();
       });
+
+      it.each(["contains", "does-not-contain", "starts-with", "ends-with"])(
+        "should reject multi-arg function calls with not enough arguments",
+        tag => {
+          expect(() => expr([tag])).toThrow();
+          expect(() => expr([tag, A])).toThrow();
+          expect(() => expr([tag, A, { "case-sensitive": true }])).toThrow();
+          expect(() => expr([tag, A, "abc"])).not.toThrow();
+          expect(() => expr([tag, A, B])).not.toThrow();
+          expect(() => expr([tag, A, B, C])).not.toThrow();
+          expect(() =>
+            expr([tag, A, B, { "case-sensitive": true }]),
+          ).not.toThrow();
+        },
+      );
     });
 
     describe("datetime functions", () => {


### PR DESCRIPTION
Fixes https://metaboat.slack.com/archives/C05NXACAG1G/p1739461293440689
Fixes #53682

Checks for the min number of args for multi-arg operators. 

How to verify:
- New -> Question -> Products -> Custom column
- Try `contains()`, `contains([Category])`. It should be rejected.
- Try `contains([Category], "A")`, `contains([Category], "case-insensitive")`, `contains([Category], "A", "case-insensitive")`, `contains([Category], "A", "B")`, `contains([Category], "A", "B", "case-insensitive")`. It should be allowed.

<img width="513" alt="Screenshot 2025-02-19 at 15 35 53" src="https://github.com/user-attachments/assets/68356af9-ce08-43ed-82e3-ab4554b235fe" />
<img width="517" alt="Screenshot 2025-02-19 at 15 36 07" src="https://github.com/user-attachments/assets/6dd5c366-15aa-4316-ae01-f61411affd11" />
<img width="520" alt="Screenshot 2025-02-19 at 15 36 18" src="https://github.com/user-attachments/assets/cc66cf19-0833-4269-bd30-c6a62d12ffb8" />
<img width="523" alt="Screenshot 2025-02-19 at 15 36 25" src="https://github.com/user-attachments/assets/c4b954a5-42af-440c-9e91-f889a65cdcee" />
