### PR TITLE
fix(sdk): [EMB-154] Pivot table visualization settings tabs caused jarring width change

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/QuestionSettings/QuestionSettings.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/QuestionSettings/QuestionSettings.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 
+import type { StackProps } from "metabase/ui";
 import {
   BaseChartSettings,
   useChartSettingsState,
@@ -17,6 +18,7 @@ const QuestionSettingsContent = ({
   question,
   queryResults,
   updateQuestion,
+  ...stackProps
 }: {
   question: Question;
   queryResults?: any[];
@@ -54,6 +56,7 @@ const QuestionSettingsContent = ({
 
   return (
     <BaseChartSettings
+      {...stackProps}
       question={question}
       series={series}
       onChange={onChange}
@@ -64,7 +67,7 @@ const QuestionSettingsContent = ({
   );
 };
 
-export const QuestionSettings = () => {
+export const QuestionSettings = (stackProps: StackProps) => {
   const { question, queryResults, updateQuestion } =
     useInteractiveQuestionContext();
 
@@ -77,6 +80,7 @@ export const QuestionSettings = () => {
       question={question}
       queryResults={queryResults}
       updateQuestion={updateQuestion}
+      {...stackProps}
     />
   );
 };

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/QuestionSettings/QuestionSettingsDropdown/QuestionSettingsDropdown.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/QuestionSettings/QuestionSettingsDropdown/QuestionSettingsDropdown.tsx
@@ -28,7 +28,7 @@ export const QuestionSettingsDropdown = ({
       />
     </Popover.Target>
     <Popover.Dropdown miw="20rem" mah={height ?? FLEXIBLE_SIZE_DEFAULT_HEIGHT}>
-      <InteractiveQuestion.QuestionSettings />
+      <InteractiveQuestion.QuestionSettings maw="20rem" />
     </Popover.Dropdown>
   </Popover>
 );

--- a/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/BaseChartSettings.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/BaseChartSettings.styled.tsx
@@ -27,12 +27,6 @@ export const SectionContainer = styled.div`
   }
 `;
 
-export const ChartSettingsMenu = styled.div`
-  flex: 1 0 0;
-  display: flex;
-  flex-direction: column;
-`;
-
 export const ChartSettingsListContainer = styled.div`
   position: relative;
   padding: 1.5rem 0;

--- a/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/BaseChartSettings.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/BaseChartSettings.tsx
@@ -189,12 +189,7 @@ export const BaseChartSettings = ({
 
   return (
     <>
-      <Stack
-        data-testid="chartsettings-sidebar"
-        gap={0}
-        w="100%"
-        {...stackProps}
-      >
+      <Stack data-testid="chartsettings-sidebar" gap={0} {...stackProps}>
         {showSectionPicker && (
           <SectionContainer>
             <Radio

--- a/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/BaseChartSettings.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/BaseChartSettings.tsx
@@ -189,7 +189,12 @@ export const BaseChartSettings = ({
 
   return (
     <>
-      <Stack data-testid="chartsettings-sidebar" gap={0} {...stackProps}>
+      <Stack
+        data-testid="chartsettings-sidebar"
+        gap={0}
+        w="100%"
+        {...stackProps}
+      >
         {showSectionPicker && (
           <SectionContainer>
             <Radio

--- a/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/BaseChartSettings.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/BaseChartSettings.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import _ from "underscore";
 
 import Radio from "metabase/core/components/Radio";
+import CS from "metabase/css/core/index.css";
 import { Stack } from "metabase/ui";
 import { updateSeriesColor } from "metabase/visualizations/lib/series";
 import {
@@ -189,7 +190,13 @@ export const BaseChartSettings = ({
 
   return (
     <>
-      <Stack data-testid="chartsettings-sidebar" gap={0} {...stackProps}>
+      <Stack
+        data-testid="chartsettings-sidebar"
+        h="100%"
+        gap={0}
+        className={CS.overflowHidden}
+        {...stackProps}
+      >
         {showSectionPicker && (
           <SectionContainer>
             <Radio

--- a/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/BaseChartSettings.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/BaseChartSettings.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import _ from "underscore";
 
 import Radio from "metabase/core/components/Radio";
+import { Stack } from "metabase/ui";
 import { updateSeriesColor } from "metabase/visualizations/lib/series";
 import {
   getComputedSettings,
@@ -18,7 +19,6 @@ import type { Widget } from "../types";
 
 import {
   ChartSettingsListContainer,
-  ChartSettingsMenu,
   SectionContainer,
 } from "./BaseChartSettings.styled";
 import { useChartSettingsSections } from "./hooks";
@@ -33,6 +33,7 @@ export const BaseChartSettings = ({
   widgets,
   chartSettings,
   transformedSeries,
+  ...stackProps
 }: BaseChartSettingsProps) => {
   const {
     chartSettingCurrentSection,
@@ -188,7 +189,7 @@ export const BaseChartSettings = ({
 
   return (
     <>
-      <ChartSettingsMenu data-testid="chartsettings-sidebar">
+      <Stack data-testid="chartsettings-sidebar" gap={0} {...stackProps}>
         {showSectionPicker && (
           <SectionContainer>
             <Radio
@@ -208,7 +209,7 @@ export const BaseChartSettings = ({
             extraWidgetProps={extraWidgetProps}
           />
         </ChartSettingsListContainer>
-      </ChartSettingsMenu>
+      </Stack>
       <ChartSettingsWidgetPopover
         anchor={popoverRef as HTMLElement}
         widgets={[styleWidget, formattingWidget].filter(

--- a/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/types.ts
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/types.ts
@@ -1,3 +1,4 @@
+import type { StackProps } from "metabase/ui";
 import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
 import type Question from "metabase-lib/v1/Question";
 import type { QueryBuilderUIControls } from "metabase-types/store";
@@ -11,4 +12,5 @@ export type BaseChartSettingsProps = {
   question?: Question;
   widgets: Widget[];
 } & CommonChartSettingsProps &
-  Pick<UseChartSettingsStateReturned, "chartSettings" | "transformedSeries">;
+  Pick<UseChartSettingsStateReturned, "chartSettings" | "transformedSeries"> &
+  StackProps;

--- a/frontend/src/metabase/visualizations/components/ChartSettings/ChartSettings.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/ChartSettings.styled.tsx
@@ -1,8 +1,0 @@
-// eslint-disable-next-line no-restricted-imports
-import styled from "@emotion/styled";
-
-export const ChartSettingsRoot = styled.div`
-  display: flex;
-  flex-grow: 1;
-  height: 100%;
-`;

--- a/frontend/src/metabase/visualizations/components/ChartSettings/ChartSettingsVisualization/ChartSettingsVisualization.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/ChartSettingsVisualization/ChartSettingsVisualization.styled.tsx
@@ -12,14 +12,6 @@ export const SectionWarnings = styled(Warnings)`
   z-index: 2;
 `;
 
-export const ChartSettingsPreview = styled.div`
-  flex: 2 0 0;
-  display: flex;
-  flex-direction: column;
-  border-left: 1px solid var(--mb-color-border);
-  padding-top: 1.5rem;
-`;
-
 export const ChartSettingsVisualizationContainer = styled.div`
   position: relative;
   margin: 0 2rem;

--- a/frontend/src/metabase/visualizations/components/ChartSettings/ChartSettingsVisualization/ChartSettingsVisualization.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/ChartSettingsVisualization/ChartSettingsVisualization.tsx
@@ -1,12 +1,12 @@
 import { useState } from "react";
 
 import CS from "metabase/css/core/index.css";
+import { Stack } from "metabase/ui";
 import Visualization from "metabase/visualizations/components/Visualization";
 
 import { ChartSettingsFooter } from "../ChartSettingsFooter";
 
 import {
-  ChartSettingsPreview,
   ChartSettingsVisualizationContainer,
   SectionWarnings,
 } from "./ChartSettingsVisualization.styled";
@@ -20,11 +20,12 @@ export const ChartSettingsVisualization = ({
   onReset,
   onUpdateVisualizationSettings,
   rawSeries,
+  ...stackProps
 }: ChartSettingsVisualizationProps) => {
   const [warnings, setWarnings] = useState<string[]>();
 
   return (
-    <ChartSettingsPreview>
+    <Stack pt="md" {...stackProps}>
       <SectionWarnings warnings={warnings} size={20} />
       <ChartSettingsVisualizationContainer>
         <Visualization
@@ -46,6 +47,6 @@ export const ChartSettingsVisualization = ({
         onCancel={onCancel}
         onReset={onReset}
       />
-    </ChartSettingsPreview>
+    </Stack>
   );
 };

--- a/frontend/src/metabase/visualizations/components/ChartSettings/ChartSettingsVisualization/types.ts
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/ChartSettingsVisualization/types.ts
@@ -1,3 +1,4 @@
+import type { StackProps } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";
 import type {
   Dashboard,
@@ -8,7 +9,7 @@ import type {
 
 import type { ChartSettingsFooterProps } from "../ChartSettingsFooter";
 
-export type ChartSettingsVisualizationProps = {
+export type ChartSettingsVisualizationProps = Omit<StackProps, "onReset"> & {
   rawSeries: RawSeries;
   dashboard?: Dashboard;
   dashcard?: DashboardCard;

--- a/frontend/src/metabase/visualizations/components/ChartSettings/DashboardChartSettings/DashboardChartSettings.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/DashboardChartSettings/DashboardChartSettings.tsx
@@ -1,12 +1,12 @@
 import { useCallback, useMemo, useState } from "react";
 import _ from "underscore";
 
+import { Divider, Flex } from "metabase/ui";
 import { getClickBehaviorSettings } from "metabase/visualizations/lib/settings";
 import { getSettingsWidgetsForSeries } from "metabase/visualizations/lib/settings/visualization";
 import type { VisualizationSettings } from "metabase-types/api";
 
 import { BaseChartSettings } from "../BaseChartSettings";
-import { ChartSettingsRoot } from "../ChartSettings.styled";
 import { ChartSettingsVisualization } from "../ChartSettingsVisualization";
 import { useChartSettingsState } from "../hooks";
 
@@ -70,15 +70,18 @@ export const DashboardChartSettings = ({
   );
 
   return (
-    <ChartSettingsRoot>
+    <Flex justify="unset" align="unset" wrap="nowrap">
       <BaseChartSettings
+        flex="1 0 0"
         series={series}
         onChange={setTempSettings}
         chartSettings={chartSettings}
         widgets={widgets}
         transformedSeries={transformedSeries}
       />
+      <Divider orientation="vertical"></Divider>
       <ChartSettingsVisualization
+        flex="2 0 0"
         rawSeries={chartSettingsRawSeries}
         dashboard={dashboard}
         dashcard={dashcard}
@@ -87,6 +90,6 @@ export const DashboardChartSettings = ({
         onCancel={() => onClose?.()}
         onReset={onResetToDefault}
       />
-    </ChartSettingsRoot>
+    </Flex>
   );
 };

--- a/frontend/src/metabase/visualizations/components/ChartSettings/QuestionChartSettings/QuestionChartSettings.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/QuestionChartSettings/QuestionChartSettings.tsx
@@ -3,7 +3,6 @@ import { useMemo } from "react";
 import { getSettingsWidgetsForSeries } from "metabase/visualizations/lib/settings/visualization";
 
 import { BaseChartSettings } from "../BaseChartSettings";
-import { ChartSettingsRoot } from "../ChartSettings.styled";
 import { useChartSettingsState } from "../hooks";
 
 import type { QuestionChartSettingsProps } from "./types";
@@ -31,17 +30,16 @@ export const QuestionChartSettings = ({
   );
 
   return (
-    <ChartSettingsRoot>
-      <BaseChartSettings
-        question={question}
-        series={series}
-        onChange={onChange}
-        initial={initial}
-        computedSettings={computedSettings}
-        chartSettings={chartSettings}
-        transformedSeries={transformedSeries}
-        widgets={widgets}
-      />
-    </ChartSettingsRoot>
+    <BaseChartSettings
+      question={question}
+      series={series}
+      onChange={onChange}
+      initial={initial}
+      computedSettings={computedSettings}
+      chartSettings={chartSettings}
+      transformedSeries={transformedSeries}
+      widgets={widgets}
+      w="100%"
+    />
   );
 };


### PR DESCRIPTION
EMB-154

Adds a `max-width` property to the SDK specific variant of the `QuestionSettings` SDK component. Also adds `StackProps` to the container for future styling and other mantine props we decide to add or use.

I've also made a few changes to the `QuestionChartSettings` and `DashboardChartSettings` components to allow me to make these changes. I've moved the job of "containing" the `BaseChartSettings` component to their mode-specific components, so there's no `flex` or `height` properties on the `BaseChartSettings` component itself.

In terms of testing in the core app, this should not change anything. It affects the sidebar in the query builder and when editing the visualization settings of a dashcard, but there should be no discernible visual difference.

On the SDK side, this is what happens:

Before:

<img width="715" alt="image" src="https://github.com/user-attachments/assets/8bef2ce3-58d5-40ed-96df-3b0f7b12332f" />


After

<img width="343" alt="image" src="https://github.com/user-attachments/assets/fe5e7d02-1eeb-4636-af4e-5254aac34539" />


Tested and developed using the storybook `InteractiveQuestion > Default` story