### PR TITLE
Fix invisible close icons on some legacy modals

### DIFF
--- a/frontend/src/metabase/components/Modal/Modal.tsx
+++ b/frontend/src/metabase/components/Modal/Modal.tsx
@@ -3,6 +3,7 @@ import { WindowModal } from "metabase/components/Modal/WindowModal";
 
 export type ModalProps = WindowModalProps;
 
+/** @deprecated use Modal from metabase/ui */
 const Modal = ({ isOpen = true, ...props }: ModalProps) => {
   return <WindowModal isOpen={isOpen} {...props} />;
 };

--- a/frontend/src/metabase/components/ModalContent/ModalContent.styled.ts
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.styled.ts
@@ -14,7 +14,6 @@ export const ActionsWrapper = styled.div`
 export const ModalContentActionIcon = styled(Icon)`
   color: var(--mb-color-text-light);
   cursor: pointer;
-  padding: 0.5rem;
 
   &:hover {
     color: var(--mb-color-text-medium);

--- a/frontend/src/metabase/components/ModalContent/ModalContent.styled.ts
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.styled.ts
@@ -7,8 +7,6 @@ export const ActionsWrapper = styled.div`
   display: flex;
   flex-direction: row;
   gap: 0.5rem;
-
-  margin: -0.5rem -0.5rem -0.5rem 0;
 `;
 
 export const ModalContentActionIcon = styled(Icon)`


### PR DESCRIPTION
Fixes ADM-397

With Mantine v7, we globally set our box-sizing to border-box, but this broke some modal close buttons because they had padding that pushed them into invisiiblity.

Before | After
---|---
<img width="677" alt="Screen Shot 2025-02-19 at 5 51 36 PM" src="https://github.com/user-attachments/assets/4e65f8ee-e711-42cc-8930-3acdaba648bb" /> | <img width="708" alt="Screen Shot 2025-02-19 at 5 49 30 PM" src="https://github.com/user-attachments/assets/84b20aea-f31f-449a-9ce9-38a179a7ce17" />
![Screen Shot 2025-02-28 at 1 20 18 PM](https://github.com/user-attachments/assets/738459d1-a1c4-411a-8079-f9afc3c4b913) | ![Screen Shot 2025-02-28 at 1 19 57 PM](https://github.com/user-attachments/assets/fcd2aaf5-926f-4bb8-bd93-c816e6e96f8a)
