### PR TITLE
Fix - Cannot use offset units smaller than interval unit in relative date filters

### DIFF
--- a/e2e/test/scenarios/filters/relative-datetime.cy.spec.js
+++ b/e2e/test/scenarios/filters/relative-datetime.cy.spec.js
@@ -87,7 +87,7 @@ describe("scenarios > question > relative-datetime", () => {
   }
 
   describe("basic functionality", () => {
-    it("starting from should contain units only equal or greater than the filter unit", () => {
+    it("starting from should contain all units, including those smaller than the filter unit (metabase#53734)", () => {
       H.openOrdersTable();
 
       H.tableHeaderClick("Created At");
@@ -103,6 +103,8 @@ describe("scenarios > question > relative-datetime", () => {
         .click();
 
       assertOptions([
+        "minutes ago",
+        "hours ago",
         "days ago",
         "weeks ago",
         "months ago",
@@ -115,7 +117,15 @@ describe("scenarios > question > relative-datetime", () => {
         .findByRole("textbox", { name: "Starting from unit" })
         .click();
 
-      assertOptions(["quarters ago", "years ago"]);
+      assertOptions([
+        "minutes ago",
+        "hours ago",
+        "days ago",
+        "weeks ago",
+        "months ago",
+        "quarters ago",
+        "years ago",
+      ]);
     });
 
     it("should go back to shortcuts view", () => {

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.module.css
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.module.css
@@ -5,3 +5,7 @@
   align-items: center;
   gap: 0.5rem;
 }
+
+.selectWrapper {
+  margin-top: 0;
+}

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.tsx
@@ -100,6 +100,9 @@ export function DateOffsetIntervalPicker({
           onChange={handleIntervalChange}
         />
         <Select
+          classNames={{
+            wrapper: S.selectWrapper,
+          }}
           data={unitOptions}
           value={value.unit}
           aria-label={t`Unit`}
@@ -118,6 +121,9 @@ export function DateOffsetIntervalPicker({
           onChange={handleOffsetIntervalChange}
         />
         <Select
+          classNames={{
+            wrapper: S.selectWrapper,
+          }}
           data={offsetUnitOptions}
           value={value.offsetUnit}
           aria-label={t`Starting from unit`}

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.unit.spec.tsx
@@ -285,7 +285,7 @@ describe("DateOffsetIntervalPicker", () => {
         expect(onSubmit).not.toHaveBeenCalled();
       });
 
-      it("should only show offset units larger or equal to the current one", async () => {
+      it("should show all offset units, including those smaller than the current one (metabase#53734)", async () => {
         setup({
           value: {
             ...defaultValue,
@@ -300,12 +300,8 @@ describe("DateOffsetIntervalPicker", () => {
         expect(screen.getByText(/months (ago|from now)/)).toBeInTheDocument();
         expect(screen.getByText(/quarters (ago|from now)/)).toBeInTheDocument();
         expect(screen.getByText(/years (ago|from now)/)).toBeInTheDocument();
-        expect(
-          screen.queryByText(/hours (ago|from now)/),
-        ).not.toBeInTheDocument();
-        expect(
-          screen.queryByText(/days (ago|from now)/),
-        ).not.toBeInTheDocument();
+        expect(screen.getByText(/hours (ago|from now)/)).toBeInTheDocument();
+        expect(screen.getByText(/days (ago|from now)/)).toBeInTheDocument();
       });
 
       it("should display the actual date range", () => {

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.unit.spec.tsx
@@ -297,11 +297,13 @@ describe("DateOffsetIntervalPicker", () => {
           screen.getByRole("textbox", { name: "Starting from unit" }),
         );
 
+        expect(screen.getByText(/minutes (ago|from now)/)).toBeInTheDocument();
+        expect(screen.getByText(/hours (ago|from now)/)).toBeInTheDocument();
+        expect(screen.getByText(/days (ago|from now)/)).toBeInTheDocument();
+        expect(screen.getByText(/weeks (ago|from now)/)).toBeInTheDocument();
         expect(screen.getByText(/months (ago|from now)/)).toBeInTheDocument();
         expect(screen.getByText(/quarters (ago|from now)/)).toBeInTheDocument();
         expect(screen.getByText(/years (ago|from now)/)).toBeInTheDocument();
-        expect(screen.getByText(/hours (ago|from now)/)).toBeInTheDocument();
-        expect(screen.getByText(/days (ago|from now)/)).toBeInTheDocument();
       });
 
       it("should display the actual date range", () => {

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/utils.ts
@@ -57,14 +57,11 @@ export function getOffsetUnitOptions(
 ) {
   const truncationUnits = getAvailableTruncationUnits(availableUnits);
   const direction = getDirection(value);
-  const unitIndex = truncationUnits.indexOf(value.unit);
 
-  return truncationUnits
-    .filter((_, index) => index >= unitIndex)
-    .map(unit => ({
-      value: unit,
-      label: getOffsetUnitText(unit, direction, value.offsetValue),
-    }));
+  return truncationUnits.map(unit => ({
+    value: unit,
+    label: getOffsetUnitText(unit, direction, value.offsetValue),
+  }));
 }
 
 function getOffsetUnitText(


### PR DESCRIPTION
Fixes #53734 / QUE-633

### Description

#53734 contradicts #23099 / #23116.
Given that #53734 has been reported with an actual use case in mind, I believe removing the superficial limitation is the right thing to do.

This PR also fixes small alignment issue (see demo section below).

### How to verify

1. New > Question > Orders
2. Add filter > Created At > Previous 3 Months
3. Click the filter to edit it
4. Click "Starting from..." button
5. Open the dropdown labeled "Starting from"

All units should be present in the dropdown, including the ones smaller than a month.

### Demo

Units: [before](https://github.com/user-attachments/assets/54cc6c85-3ccd-477b-b08f-a2ed9af4f2a1) vs [after](https://github.com/user-attachments/assets/cc5df83a-f734-4960-887f-dcf6e3b50445)

Alignment: [before](https://github.com/user-attachments/assets/0db250af-eff6-4146-9336-3252be4265b5) vs [after](https://github.com/user-attachments/assets/6e3e130c-4ceb-44a3-b52b-65497db56ba2)



