### PR TITLE
remove typing delays from .type and .realType commands

### DIFF
--- a/e2e/support/cypress.js
+++ b/e2e/support/cypress.js
@@ -171,3 +171,5 @@ beforeEach(function () {
     cy.skipOn(true);
   }
 });
+
+Cypress.Keyboard.defaults({ keystrokeDelay: 0 });

--- a/e2e/support/helpers/e2e-models-metadata-helpers.js
+++ b/e2e/support/helpers/e2e-models-metadata-helpers.js
@@ -36,7 +36,9 @@ export function setColumnType(oldType, newType) {
 
   popover().within(() => {
     cy.findByText(oldType).closest(".ReactVirtualized__Grid").scrollTo(0, 0); // HACK: scroll to the top of the list. Ideally we should probably disable AccordionList virtualization
-    cy.findByPlaceholderText("Search for a special type").realType(newType);
+    cy.findByPlaceholderText("Search for a special type").realType(newType, {
+      pressDelay: 0,
+    });
     cy.findByLabelText(newType).click();
   });
 }

--- a/e2e/support/helpers/e2e-native-editor-helpers.ts
+++ b/e2e/support/helpers/e2e-native-editor-helpers.ts
@@ -53,7 +53,7 @@ type TypeOptions = {
 
 function nativeEditorType(
   text: string,
-  { delay = 10, focus = true }: TypeOptions = {},
+  { delay = 0, focus = true }: TypeOptions = {},
 ) {
   if (focus) {
     focusNativeEditor();


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/DEV-360/set-keystrokedelay-to-0-in-cypress-for-faster-performance

### Description

Every keystroke in `cy.type()` is delayed by 10 ms and every keystroke in `cy.realType()` is delayed by 20 ms. There’s no real benefit to this so we’ll just try to remove it
