### PR TITLE
Recalculate columns for Upload model when updating

### DIFF
--- a/src/metabase/models/card/metadata.clj
+++ b/src/metabase/models/card/metadata.clj
@@ -159,6 +159,13 @@ saved later when it is ready."
         (catch Throwable e
           (log/errorf e "Error updating metadata for Card %d asynchronously: %s" id (ex-message e)))))))
 
+(defn infer-metadata
+  "Infer the default result_metadata to store for MBQL cards."
+  [query]
+  (not-empty (request/with-current-user nil
+               (u/ignore-exceptions
+                 (qp.preprocess/query->expected-cols query)))))
+
 (defn populate-result-metadata
   "When inserting/updating a Card, populate the result metadata column if not already populated by inferring the
   metadata from the query."
@@ -197,7 +204,4 @@ saved later when it is ready."
     :else
     (do
       (log/debug "Attempting to infer result metadata for Card")
-      (let [inferred-metadata (not-empty (request/with-current-user nil
-                                           (u/ignore-exceptions
-                                             (qp.preprocess/query->expected-cols query))))]
-        (assoc card :result_metadata inferred-metadata)))))
+      (assoc card :result_metadata (infer-metadata query)))))

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -755,7 +755,7 @@
                             seq)]
     ;; Ideally we would do all the filtering in the query, but this would not allow us to leverage mlv2.
     (model-persistence/invalidate! {:card_id [:in model-ids]})
-    ;; Also purge the metadata, so that newly added columns are visible, and types are updated.
+    ;; Also refresh the metadata, so that newly added columns are visible, and types are updated.
     (doseq [id model-ids]
       (let [card     (t2/select-one [:model/Card :dataset_query :result_metadata] id)
             ;; Unclear why this is required, would expect it to get this from the field's display name, as it does for

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -19,6 +19,7 @@
    [metabase.lib.util :as lib.util]
    [metabase.model-persistence.core :as model-persistence]
    [metabase.models.card :as card]
+   [metabase.models.card.metadata :as card.metadata]
    [metabase.models.collection :as collection]
    [metabase.models.humanization :as humanization]
    [metabase.models.interface :as mi]
@@ -742,7 +743,7 @@
       (lib/source-table-id query))))
 
 (defn- invalidate-cached-models!
-  "Invalidate the model caches for all cards whose `:based_on_upload` value resolves to the given table."
+  "Invalidate the model cache and result metadata for all models where `:based_on_upload` resolves to the given table."
   [table]
   ;; NOTE: It is important that this logic is kept in sync with `model-hydrate-based-on-upload`
   (when-let [model-ids (->> (t2/select [:model/Card :id :dataset_query]
@@ -753,7 +754,12 @@
                             (map :id)
                             seq)]
     ;; Ideally we would do all the filtering in the query, but this would not allow us to leverage mlv2.
-    (model-persistence/invalidate! {:card_id [:in model-ids]})))
+    (model-persistence/invalidate! {:card_id [:in model-ids]})
+    ;; Also purge the metadata, so that newly added columns are visible, and types are updated.
+    (doseq [id model-ids]
+      (let [query    (t2/select-one-fn :dataset_query [:model/Card :dataset_query] id)
+            metadata (card.metadata/infer-metadata query)]
+        (t2/update! :model/Card id {:result_metadata metadata})))))
 
 (defn- update-with-csv! [database table filename file & {:keys [replace-rows?]}]
   (try

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1900,7 +1900,7 @@
       (testing (action-testing-str action)
         (with-upload-table! [table (create-upload-table!)]
           (let [table-id    (:id table)
-                csv-rows    ["name" "Luke Skywalker"]
+                csv-rows    ["name, age" "Luke Skywalker, 57"]
                 file        (csv-file-with csv-rows)
                 other-id    (mt/id :venues)
                 other-table (t2/select-one :model/Table other-id)
@@ -1931,7 +1931,9 @@
                   (testing "No unwanted caches were invalidated"
                     (is (= #{model-id} (set/difference cached-before cached-after))))
                   (testing "We can see the new row when querying the model"
-                    (is (some (fn [[_ row-name]] (= "Luke Skywalker" row-name))
+                    (is (some (fn [[_ row-name age]]
+                                (and (= "Luke Skywalker" row-name)
+                                     (= 57 age)))
                               (rows-for-model (:db_id table) model-id)))))))
 
             (io/delete-file file)))))))

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -509,6 +509,11 @@
        mt/cols
        (map :display_name)))
 
+(defn- column-display-names-for-model [db-id model-id]
+  (->> (query db-id  (str "card__" model-id))
+       mt/cols
+       (map :display_name)))
+
 (defn- column-names-for-table [table]
   (->> (query-table table)
        mt/cols
@@ -1930,6 +1935,9 @@
                     (is (not (contains? cached-after model-id))))
                   (testing "No unwanted caches were invalidated"
                     (is (= #{model-id} (set/difference cached-before cached-after))))
+                  (testing "We can see the new column when querying the model"
+                    (is (= (header-with-auto-pk ["Name" "Age"])
+                           (column-display-names-for-model (:db_id table) model-id))))
                   (testing "We can see the new row when querying the model"
                     (is (some (fn [[_ row-name age]]
                                 (and (= "Luke Skywalker" row-name)


### PR DESCRIPTION
This is a stop gap solution for #54065.

Without this change, new columns would not be visible on the canonical upload model after we append to it.

This breaks encapsulation of the card however, and we probably want a more pervasive solution that will cover edits via the upcoming grid component. Perhaps even custom SQL actions and out-of-band modifications made directly to the table.

Closes WRK-84