### PR TITLE
fix: remove typo from packages we remove from the filter list

### DIFF
--- a/bin/embedding-sdk/generate-sdk-package-files.js
+++ b/bin/embedding-sdk/generate-sdk-package-files.js
@@ -9,7 +9,7 @@ const IGNORED_PACKAGES = [
   "react-dom",
   "@types/react",
   "@types/react-dom",
-  "@types/react-router#",
+  "@types/react-router",
   "@types/redux-auth-wrapper",
   "@visx/axis",
   "@visx/clip-path",


### PR DESCRIPTION
Yeah that's on me, I was copying the package names from, `yarn why` output and left that there

Part of [EMB-139: Type errors on Nextjs (and possibly others) "'MetabaseProvider' cannot be used as a JSX component."](https://linear.app/metabase/issue/EMB-139/type-errors-on-nextjs-and-possibly-others-metabaseprovider-cannot-be)