### PR TITLE
devex: add user selector for the sdk storybook

### DIFF
--- a/.storybook-sdk/preview.tsx
+++ b/.storybook-sdk/preview.tsx
@@ -27,6 +27,18 @@ export const globalTypes: GlobalTypes = {
       icon: "paintbrush",
       items: storybookThemeOptions,
       showName: true,
+      dynamicTitle: true,
+    },
+  },
+  user: {
+    name: "User",
+    description: "User to use for sdk components",
+    defaultValue: "admin",
+    toolbar: {
+      icon: "user",
+      items: ["admin", "normal"],
+      showName: true,
+      dynamicTitle: true,
     },
   },
 };

--- a/enterprise/frontend/src/embedding-sdk/test/CommonSdkStoryWrapper.tsx
+++ b/enterprise/frontend/src/embedding-sdk/test/CommonSdkStoryWrapper.tsx
@@ -1,5 +1,6 @@
 import type { StoryFn } from "@storybook/react";
 import * as jose from "jose";
+import { useMemo } from "react";
 
 import { type MetabaseAuthConfig, MetabaseProvider } from "embedding-sdk";
 
@@ -19,13 +20,15 @@ const secret = new TextEncoder().encode(METABASE_JWT_SHARED_SECRET);
 /**
  * SDK auth config that signs the jwt on the FE
  */
-export const storybookSdkAuthDefaultConfig: MetabaseAuthConfig = {
+export const getStorybookSdkAuthConfigForUser = (
+  user: keyof typeof USERS = "normal",
+): MetabaseAuthConfig => ({
   metabaseInstanceUrl: METABASE_INSTANCE_URL,
   authProviderUri: `${METABASE_INSTANCE_URL}/sso/metabase`,
   fetchRequestToken: async () => {
     try {
       const signedUserData = await new jose.SignJWT({
-        email: USERS.normal.email,
+        email: USERS[user].email,
         exp: Math.round(Date.now() / 1000) + 10 * 60, // 10 minute expiration
       })
         .setProtectedHeader({ alg: "HS256" }) // algorithm
@@ -45,13 +48,23 @@ export const storybookSdkAuthDefaultConfig: MetabaseAuthConfig = {
       return `Failed to generate JWT for storybook: ${e}`;
     }
   },
-};
+});
+
+export const storybookSdkAuthDefaultConfig =
+  getStorybookSdkAuthConfigForUser("normal");
 
 export const CommonSdkStoryWrapper = (Story: StoryFn, context: any) => {
   const sdkTheme = context.globals.sdkTheme;
   const theme = sdkTheme ? storybookThemes[sdkTheme] : undefined;
+
+  const user = context.globals.user;
+
+  const authConfig = useMemo(() => {
+    return getStorybookSdkAuthConfigForUser(user);
+  }, [user]);
+
   return (
-    <MetabaseProvider authConfig={storybookSdkAuthDefaultConfig} theme={theme}>
+    <MetabaseProvider authConfig={authConfig} theme={theme} key={user}>
       <Story />
     </MetabaseProvider>
   );


### PR DESCRIPTION
This was something I drafted when I was working on  [fix(sdk):  handle 'personal' for collectionId when creating dashboards and in the collection browser](https://github.com/metabase/metabase/pull/53553).

I had the stash around and finally decided to take the 5 minutes needed to push it

https://github.com/user-attachments/assets/9cce4648-e6fc-484e-b2bf-2498432ea631

