### PR TITLE
Fix - Resize handle misplaced in Notebook view

### DIFF
--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetNotebook/DatasetNotebook.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetNotebook/DatasetNotebook.jsx
@@ -32,7 +32,7 @@ const Handle = forwardRef(function Handle(props, ref) {
       w="100%"
       h="sm"
       pos="absolute"
-      bottom={`-${rem(4)}`}
+      bottom={rem(-4)}
       style={{
         cursor: "row-resize",
       }}

--- a/frontend/src/metabase/querying/metrics/components/MetricEditor/MetricEditorBody/ResizableBoxHandle/ResizableBoxHandle.tsx
+++ b/frontend/src/metabase/querying/metrics/components/MetricEditor/MetricEditorBody/ResizableBoxHandle/ResizableBoxHandle.tsx
@@ -18,7 +18,7 @@ export const ResizableBoxHandle = forwardRef(function ResizableBoxHandle(
       w="100%"
       h="sm"
       pos="absolute"
-      bottom={`-${rem(4)}`}
+      bottom={rem(-4)}
       {..._.omit(props, "handleAxis")}
     >
       <Box w="6.25rem" h="xs" bg="border" />


### PR DESCRIPTION
Closes #53817

### Description

Caused by Mantine 7 upgrade (that's why no repro).

### Demo

[before](https://github.com/user-attachments/assets/8631851b-3a41-44b8-b46a-836a7227fa00) & [after](https://github.com/user-attachments/assets/1e4334f4-7f1c-42c7-962f-d3d60f5fda5a)
