### PR TITLE
Track notification wait time and total send time

### DIFF
--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -237,11 +237,21 @@
    (prometheus/counter :metabase-notification/send-error
                        {:description "Number of errors when sending notifications."
                         :labels [:payload-type]})
-   (prometheus/histogram :metabase-notification/send-duration-ms
-                         {:description "Duration of notification sends in milliseconds."
+   (prometheus/histogram :metabase-notification/wait-duration-ms
+                         {:description "Duration in milliseconds that notifications wait in the processing queue before being picked up for delivery."
                           :labels [:payload-type]
                           ;; 1ms -> 10minutes
-                          :buckets [1 10 50 100 500 1000 5000 10000 30000 60000 120000 300000 600000]})
+                          :buckets [1 500 1000 5000 10000 30000 60000 120000 300000 600000]})
+   (prometheus/histogram :metabase-notification/send-duration-ms
+                         {:description "Duration in milliseconds spent actively sending/delivering the notification after being picked up from the queue."
+                          :labels [:payload-type]
+                          ;; 1ms -> 10minutes
+                          :buckets [1 500 1000 5000 10000 30000 60000 120000 300000 600000]})
+   (prometheus/histogram :metabase-notification/total-duration-ms
+                         {:description "Total duration in milliseconds from when notification was queued until delivery completion (sum of wait and send durations)."
+                          :labels [:payload-type]
+                          ;; 1ms -> 10minutes
+                          :buckets [1 500 1000 5000 10000 30000 60000 120000 300000 600000]})
    (prometheus/counter :metabase-notification/channel-send-ok
                        {:description "Number of successful channel sends."
                         :labels [:payload-type :channel-type]})

--- a/src/metabase/notification/core.clj
+++ b/src/metabase/notification/core.clj
@@ -4,6 +4,7 @@
    [metabase.notification.payload.core :as notification.payload]
    [metabase.notification.seed :as notification.seed]
    [metabase.notification.send :as notification.send]
+   [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [potemkin :as p]))
@@ -31,7 +32,8 @@
 (mu/defn send-notification!
   "The function to send a notification. Defaults to `notification.send/send-notification-async!`."
   [notification & {:keys [] :as options} :- [:maybe Options]]
-  (let [options (merge *default-options* options)]
+  (let [options      (merge *default-options* options)
+        notification (with-meta notification {:notification/triggered-at-ns (u/start-timer)})]
     (log/debugf "Sending notification: %s %s" (:id notification) (if (:notification/sync? options) "synchronously" "asynchronously"))
     (if (:notification/sync? options)
       (notification.send/send-notification-sync! notification)

--- a/src/metabase/notification/send.clj
+++ b/src/metabase/notification/send.clj
@@ -134,7 +134,9 @@
 (defmethod prometheus/known-labels :metabase-notification/channel-send-ok [_] payload-channel-labels)
 (defmethod prometheus/known-labels :metabase-notification/channel-send-error [_] payload-channel-labels)
 
-(def ^:private time-since-trigger-time #(-> % meta :notification/triggered-at-ns u/since-ms))
+(defn- time-since-trigger-time
+  [notification-info]
+  (some-> notification-info meta :notification/triggered-at-ns u/since-ms))
 
 (mu/defn send-notification-sync!
   "Send the notification to all handlers synchronously. Do not use this directly, use *send-notification!* instead."

--- a/test/metabase/notification/send_test.clj
+++ b/test/metabase/notification/send_test.clj
@@ -4,6 +4,7 @@
    [metabase.analytics.prometheus-test :as prometheus-test]
    [metabase.channel.core :as channel]
    [metabase.models.notification :as models.notification]
+   [metabase.notification.core :as notification]
    [metabase.notification.send :as notification.send]
    [metabase.notification.test-util :as notification.tu]
    [metabase.test :as mt]
@@ -136,7 +137,7 @@
                                                         (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-notification/concurrent-tasks {:payload-type "notification/testing"}))))
                                                       (apply original-render args))]
             (notification.tu/with-captured-channel-send!
-              (notification.send/send-notification-sync! n)))
+              (notification/send-notification! n {:notification/sync? true})))
           (testing "once the execution is done, concurrent tasks is decreased"
             (is (prometheus-test/approx= 0 (mt/metric-value system :metabase-notification/concurrent-tasks {:payload-type "notification/testing"}))))
           (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-notification/send-ok {:payload-type "notification/testing"})))
@@ -144,7 +145,9 @@
                                                                                                          :channel-type "channel/metabase-test"})))
           (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-notification/channel-send-ok {:payload-type "notification/testing"
                                                                                                          :channel-type "channel/metabase-test"})))
-          (is (prometheus-test/approx= 1 (:count (mt/metric-value system :metabase-notification/send-duration-ms {:payload-type "notification/testing"})))))))))
+          (is (prometheus-test/approx= 1 (:count (mt/metric-value system :metabase-notification/send-duration-ms {:payload-type "notification/testing"}))))
+          (is (prometheus-test/approx= 1 (:count (mt/metric-value system :metabase-notification/wait-duration-ms {:payload-type "notification/testing"}))))
+          (is (prometheus-test/approx= 1 (:count (mt/metric-value system :metabase-notification/total-duration-ms {:payload-type "notification/testing"})))))))))
 
 (deftest send-notification-record-prometheus-error-metrics-test
   (mt/with-prometheus-system! [_ system]


### PR DESCRIPTION
We send notification asynchronously with a fixed queue, so there are wait time we need to take into account.
The current: send-duration-ms metrics only track the execution time, which does not tell you the whole story, let's track the wait time and also total send notification time