### PR TITLE
chore: remove css import from sdk storybook

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/test/CommonSdkStoryWrapper.tsx
+++ b/enterprise/frontend/src/embedding-sdk/test/CommonSdkStoryWrapper.tsx
@@ -3,9 +3,6 @@ import * as jose from "jose";
 
 import { type MetabaseAuthConfig, MetabaseProvider } from "embedding-sdk";
 
-import "@mantine/core/styles.css"; // TODO: how to use in embedding?
-import "@mantine/dates/styles.css";
-
 import { USERS } from "../../../../../e2e/support/cypress_data";
 
 import { storybookThemes } from "./storybook-themes";


### PR DESCRIPTION
Not sure why that was added, the sdk stories should start from a clean page and just render the sdk, to simulate real usage.

The css files are already imported from the sdk theme provider