### PR TITLE
fix(sdk): Add dir attribute for PublicComponentStylesWrapper

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
@@ -27,6 +27,22 @@ describe("scenarios > embedding-sdk > styles", () => {
     cy.intercept("GET", "/api/user/current").as("getUser");
   });
 
+  describe("common", () => {
+    it('PublicComponentStylesWrapper should have the `dir="ltr"` attribute (#54082)', () => {
+      cy.mount(
+        <MetabaseProvider authConfig={DEFAULT_SDK_AUTH_PROVIDER_CONFIG}>
+          <StaticQuestion questionId={ORDERS_QUESTION_ID} />
+        </MetabaseProvider>,
+      );
+
+      cy.wait("@getUser").then(({ response }) => {
+        expect(response?.statusCode).to.equal(200);
+      });
+
+      getSdkRoot().children().should("have.attr", "dir", "ltr");
+    });
+  });
+
   describe("theming", () => {
     const theme = defineMetabaseTheme({
       colors: {

--- a/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentStylesWrapper.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentStylesWrapper.tsx
@@ -41,6 +41,7 @@ export const PublicComponentStylesWrapper = (
   return (
     <PublicComponentStylesWrapperInner
       {...props}
+      dir="ltr"
       // eslint-disable-next-line react/prop-types -- className is in div props :shrugs:
       className={`mb-wrapper ${props.className}`}
     />


### PR DESCRIPTION
Add `dir` attribute for `PublicComponentStylesWrapper`

Before:
![image](https://github.com/user-attachments/assets/38898acf-5d02-4f73-bd8c-9282b1a167ff)

After:
![image](https://github.com/user-attachments/assets/766e36e3-e112-47d7-8687-ea6910b5d255)


How to verify:
- check that the `serch` icon is displayed properly when inside storybook