### PR TITLE
[Mantine 7] Fix disabled Select state UI

### DIFF
--- a/frontend/src/metabase/ui/components/inputs/Select/Select.module.css
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.module.css
@@ -44,6 +44,7 @@
 
   &[data-disabled] {
     opacity: 1;
+    color: var(--mb-color-text-light);
   }
 
   &::placeholder {
@@ -79,7 +80,7 @@
   [data-disabled] & {
     opacity: 1;
     color: var(--mb-color-text-light);
-    background-color: var(--mb-color-bg-light);
+    background-color: var(--mb-color-bg-medium);
 
     &::placeholder {
       color: var(--mb-color-text-light);


### PR DESCRIPTION
Relates to https://github.com/metabase/metabase/issues/45941

### Description

Fix Select disabled state after Mantine upgrade to v7

<table>
<tr>
<th> Before: </th>
<th> After: </th>
</tr>
<tr>
<td>

<img width="400" alt="Screenshot 2025-02-20 at 18 24 52" src="https://github.com/user-attachments/assets/f533a895-3bc7-47bc-89ce-c3195b494908" />

See that we don't have text - it is transparent

</td>
<td>

<img width="400" alt="Screenshot 2025-02-20 at 18 24 09" src="https://github.com/user-attachments/assets/c79794c1-007f-41ae-8eca-153c66719528" />

</td>
</tr>
</table>

### How to verify

1. `yarn storybook`
2. Open `http://localhost:6006/?path=/story/inputs-select--default&args=disabled:!true`

