### PR TITLE
feat(sdk): remove dependencies from package.json

### DIFF
--- a/bin/embedding-sdk/generate-sdk-package-files.js
+++ b/bin/embedding-sdk/generate-sdk-package-files.js
@@ -4,29 +4,17 @@
 const fs = require("fs");
 const path = require("path");
 
-const IGNORED_PACKAGES = [
-  "react",
-  "react-dom",
-  "@types/react",
-  "@types/react-dom",
-  "@types/react-router#",
-  "@types/redux-auth-wrapper",
-  "@visx/axis",
-  "@visx/clip-path",
-  "@visx/grid",
-  "@visx/group",
-  "@visx/shape",
-  "@visx/text",
-  "formik",
-  "react-beautiful-dnd",
+const DEPS_WE_NEED = [
+  // yep, empty for now 🤞
 ];
+
 const SDK_DIST_DIR = path.resolve("./resources/embedding-sdk");
 
-function filterOuDependencies(object) {
+function pickDependencies(object) {
   const result = {};
 
   Object.entries(object).forEach(([packageName, version]) => {
-    if (!IGNORED_PACKAGES.includes(packageName)) {
+    if (DEPS_WE_NEED.includes(packageName)) {
       result[packageName] = version;
     }
   });
@@ -61,8 +49,8 @@ function generateSdkPackage() {
 
   const mergedContent = {
     ...sdkPackageTemplateJsonContent,
-    dependencies: filterOuDependencies(mainPackageJsonContent.dependencies),
-    resolutions: filterOuDependencies(mainPackageJsonContent.resolutions),
+    dependencies: pickDependencies(mainPackageJsonContent.dependencies),
+    resolutions: pickDependencies(mainPackageJsonContent.resolutions),
     version: maybeCommitHash
       ? `${sdkPackageTemplateJsonContent.version}-${todayDate}-${maybeCommitHash}`
       : sdkPackageTemplateJsonContent.version,

--- a/webpack.embedding-sdk.config.js
+++ b/webpack.embedding-sdk.config.js
@@ -118,7 +118,7 @@ module.exports = env => {
     },
 
     externals: {
-      ...mainConfig.externals,
+      // ...mainConfig.externals,
       react: "react",
       "react-dom": "react-dom",
       "react/jsx-runtime": "react/jsx-runtime",


### PR DESCRIPTION
Closes [EMB-153 [Task] Remove dependencies that we don't need in the package.json of the sdk](https://linear.app/metabase/issue/EMB-153/[task]-remove-dependencies-that-we-dont-need-in-the-packagejson-of-the)

This will 

- remove _a few_ warnings when installind the sdk
- speed up the installation of the sdk as it won't install non-used deps
- reduce the node_modules size of the host apps

Example from new vite project:
before:
<img width="797" alt="image" src="https://github.com/user-attachments/assets/b0c3117d-37a0-4a65-9700-a87a772cddc6" />
after:
<img width="594" alt="image" src="https://github.com/user-attachments/assets/eb24e266-d26f-422c-989b-7e56161c67e7" />

Also ran a little benchmark on a fresh vite app:
```
hyperfine \
    --prepare 'sed -i "" "/@metabase\/embedding-sdk-react/d" package.json && rm -rf node_modules yarn.lock && yarn cache clean' \
    --runs 5 \
    'yarn add ./without-deps.tgz' \
    'yarn add ./with-deps.tgz'
```
<img width="601" alt="image" src="https://github.com/user-attachments/assets/e7dc1461-1131-4985-a20b-7c6a074e6b0a" />


