### PR TITLE
tech-debt: move sync.concurrent out of sync module

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -526,7 +526,6 @@
 
   sync
   {:api #{metabase.sync.api
-          metabase.sync.concurrent
           metabase.sync.core
           metabase.sync.init
           metabase.sync.schedules

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/databases.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/databases.clj
@@ -6,6 +6,7 @@
    [metabase.models.setting :refer [defsetting]]
    [metabase.util :as u]
    [metabase.util.log :as log]
+   [metabase.util.quick-task :as quick-task]
    [toucan2.core :as t2]))
 
 (defsetting config-from-file-sync-databases
@@ -59,9 +60,8 @@
           (log/info (u/format-color :green "Creating new %s Database %s" (:engine database) (pr-str (:name database))))
           (let [db (first (t2/insert-returning-instances! :model/Database database))]
             (if (config-from-file-sync-databases)
-              (let [submit-task!   (requiring-resolve 'metabase.sync.core/submit-task!)
-                    sync-database! (requiring-resolve 'metabase.sync.core/sync-database!)]
-                (submit-task! (fn [] (sync-database! db))))
+              (let [sync-database! (requiring-resolve 'metabase.sync.core/sync-database!)]
+                (quick-task/submit-task! (fn [] (sync-database! db))))
               (log/info "Sync on database creation when initializing from file is disabled. Skipping sync."))))))))
 
 (defmethod advanced-config.file.i/initialize-section! :databases

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -12,12 +12,12 @@
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.permissions :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
-   [metabase.sync.concurrent :as sync.concurrent]
    [metabase.test :as mt]
    [metabase.test.data.sql :as sql.tx]
    [metabase.test.fixtures :as fixtures]
    [metabase.upload-test :as upload-test]
    [metabase.util :as u]
+   [metabase.util.quick-task :as quick-task]
    [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :db :test-users))
@@ -599,7 +599,7 @@
       (testing "A non-admin with no data access can trigger a re-scan of field values if they have data model perms"
         (t2/update! :model/FieldValues :field_id (mt/id :venues :price) {:values [10 20 30 40]})
         (is (= [10 20 30 40] (t2/select-one-fn :values :model/FieldValues, :field_id (mt/id :venues :price))))
-        (with-redefs [sync.concurrent/submit-task! (fn [task] (task))]
+        (with-redefs [quick-task/submit-task! (fn [task] (task))]
           (mt/with-all-users-data-perms-graph! {(mt/id) {:view-data      :blocked
                                                          :create-queries :no
                                                          :data-model     {:schemas {"PUBLIC" {(mt/id :venues) :all}}}}}

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -40,6 +40,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
+   [metabase.util.quick-task :as quick-task]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -986,7 +987,7 @@
                     e))]
       (throw (ex-info (ex-message ex) {:status-code 422}))
       (do
-        (sync/submit-task!
+        (quick-task/submit-task!
          (fn []
            (sync/sync-db-metadata! db)
            (sync/analyze-db! db)))
@@ -1028,7 +1029,7 @@
     ;; return any actual field values from this API. (#21764)
     (request/as-admin
       (if *rescan-values-async*
-        (sync/submit-task!
+        (quick-task/submit-task!
          (fn []
            (sync/update-field-values! db)))
         (sync/update-field-values! db))))

--- a/src/metabase/api/field.clj
+++ b/src/metabase/api/field.clj
@@ -19,6 +19,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
+   [metabase.util.quick-task :as quick-task]
    [metabase.xrays.core :as xrays]
    [toucan2.core :as t2])
   (:import
@@ -119,7 +120,7 @@
           ;; been synced when JSON unfolding was enabled. This assumes the JSON field is already updated to have
           ;; JSON unfolding enabled.
           (let [table (field/table old-field)]
-            (sync/submit-task! (fn [] (sync/sync-table! table))))))
+            (quick-task/submit-task! (fn [] (sync/sync-table! table))))))
       (t2/update! :model/Field
                   :table_id (:table_id old-field)
                   :nfc_path [:like (str "[\"" (:name old-field) "\",%]")]
@@ -190,7 +191,7 @@
                  (t2/hydrate :dimensions :has_field_values)
                  (field/hydrate-target-with-write-perms))
       (when (not= effective-type (:effective_type field))
-        (sync/submit-task! (fn [] (sync/refingerprint-field! <>)))))))
+        (quick-task/submit-task! (fn [] (sync/refingerprint-field! <>)))))))
 
 ;;; ------------------------------------------------- Field Metadata -------------------------------------------------
 

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -23,6 +23,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
+   [metabase.util.quick-task :as quick-task]
    [metabase.xrays.core :as xrays]
    [toucan2.core :as t2]))
 
@@ -84,7 +85,7 @@
   "Function to call on newly unhidden tables. Starts a thread to sync all tables."
   [newly-unhidden]
   (when (seq newly-unhidden)
-    (sync/submit-task!
+    (quick-task/submit-task!
      (fn []
        (let [database (table/database (first newly-unhidden))]
          ;; it's okay to allow testing H2 connections during sync. We only want to disallow you from testing them for the
@@ -580,7 +581,7 @@
     ;; return any actual field values from this API. (#21764)
     (request/as-admin
       ;; async so as not to block the UI
-      (sync/submit-task!
+      (quick-task/submit-task!
        (fn []
          (sync/update-field-values-for-table! table))))
     {:status :success}))

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -19,12 +19,12 @@
    [metabase.premium-features.core :as premium-features :refer [defenterprise]]
    ;; Trying to use metabase.search would cause a circular reference ;_;
    [metabase.search.spec :as search.spec]
-   [metabase.sync.concurrent :as sync.concurrent]
    [metabase.sync.schedules :as sync.schedules]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [trs]]
    [metabase.util.log :as log]
+   [metabase.util.quick-task :as quick-task]
    [methodical.core :as methodical]
    [toucan2.core :as t2]
    [toucan2.pipeline :as t2.pipeline]
@@ -169,7 +169,7 @@
   [{:keys [engine] :as database}]
   (when-not (or (:is_audit database) (:is_sample database))
     (log/info (u/format-color :cyan "Health check: queueing %s {:id %d}" (:name database) (:id database)))
-    (sync.concurrent/submit-task!
+    (quick-task/submit-task!
      (fn []
        (let [details (maybe-test-and-migrate-details! database)]
          (try

--- a/src/metabase/sync/core.clj
+++ b/src/metabase/sync/core.clj
@@ -3,7 +3,6 @@
   -- Tables and Fields."
   (:require
    [metabase.sync.analyze]
-   [metabase.sync.concurrent]
    [metabase.sync.field-values]
    [metabase.sync.sync]
    [metabase.sync.sync-metadata]
@@ -13,7 +12,6 @@
 
 (comment
   metabase.sync.analyze/keep-me
-  metabase.sync.concurrent/keep-me
   metabase.sync.field-values/keep-me
   metabase.sync.sync/keep-me
   metabase.sync.sync-metadata/keep-me
@@ -23,8 +21,6 @@
 (p/import-vars
  [metabase.sync.analyze
   analyze-db!]
- [metabase.sync.concurrent
-  submit-task!]
  [metabase.sync.field-values
   update-field-values!
   update-field-values-for-table!]

--- a/src/metabase/sync/events/sync_database.clj
+++ b/src/metabase/sync/events/sync_database.clj
@@ -1,11 +1,11 @@
 (ns metabase.sync.events.sync-database
   (:require
    [metabase.events :as events]
-   [metabase.sync.concurrent :as sync.concurrent]
    [metabase.sync.sync :as sync]
    [metabase.sync.sync-metadata :as sync-metadata]
    [metabase.util :as u]
    [metabase.util.log :as log]
+   [metabase.util.quick-task :as quick-task]
    [methodical.core :as methodical]))
 
 (derive ::event :metabase/event)
@@ -18,7 +18,7 @@
   (try
     (when database
       ;; just kick off a sync on another thread
-      (sync.concurrent/submit-task!
+      (quick-task/submit-task!
        (fn []
          (try
            ;; only do the 'full' sync if this is a "full sync" database. Otherwise just do metadata sync only

--- a/src/metabase/util/quick_task.clj
+++ b/src/metabase/util/quick_task.clj
@@ -1,5 +1,5 @@
-(ns metabase.sync.concurrent
-  "Namespace with helpers for concurrent tasks in sync. Intended for quick, one-off tasks like re-syncing a table,
+(ns metabase.util.quick-task
+  "Namespace with helpers for quick tasks. Intended for quick, one-off tasks like re-syncing a table,
   fingerprinting a field, etc."
   (:require
    [metabase.plugins.classloader :as classloader])

--- a/test/metabase/api/field_test.clj
+++ b/test/metabase/api/field_test.clj
@@ -7,12 +7,12 @@
    [metabase.driver :as driver]
    [metabase.driver.mysql :as mysql]
    [metabase.driver.util :as driver.u]
-   [metabase.sync.concurrent :as sync.concurrent]
    [metabase.sync.core :as sync]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.timeseries-query-processor-test.util :as tqpt]
    [metabase.util :as u]
+   [metabase.util.quick-task :as quick-task]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -197,7 +197,7 @@
   (testing "PUT /api/field/:id"
     (testing "updating coercion strategies"
       (testing "Refingerprints field when updated"
-        (with-redefs [sync.concurrent/submit-task! (fn [task] (task))]
+        (with-redefs [quick-task/submit-task! (fn [task] (task))]
           (mt/dataset integer-coerceable
             (sync/sync-database! (t2/select-one :model/Database :id (mt/id)))
             (let [field-id      (mt/id :t :f)

--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -15,7 +15,6 @@
    [metabase.models.serialization :as serdes]
    [metabase.query-processor.store :as qp.store]
    [metabase.request.core :as request]
-   [metabase.sync.concurrent :as sync.concurrent]
    [metabase.sync.task.sync-databases :as task.sync-databases]
    [metabase.task :as task]
    [metabase.test :as mt]
@@ -24,6 +23,7 @@
    [metabase.util :as u]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
+   [metabase.util.quick-task :as quick-task]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -64,7 +64,7 @@
 
 (deftest health-check-database-test
   (mt/test-drivers (mt/normal-drivers)
-    (with-redefs [sync.concurrent/submit-task! (fn [task] (task))]
+    (with-redefs [quick-task/submit-task! (fn [task] (task))]
       (binding [h2/*allow-testing-h2-connections* true]
         (testing "successes"
           (mt/with-prometheus-system! [_ system]

--- a/test/metabase/sync/analyze_test.clj
+++ b/test/metabase/sync/analyze_test.clj
@@ -10,13 +10,13 @@
    [metabase.analyze.fingerprint.fingerprinters :as fingerprinters]
    [metabase.models.interface :as mi]
    [metabase.sync.analyze :as analyze]
-   [metabase.sync.concurrent :as sync.concurrent]
    [metabase.sync.interface :as i]
    [metabase.sync.sync-metadata :as sync-metadata]
    [metabase.test :as mt]
    [metabase.test.data :as data]
    [metabase.test.sync :refer [sync-survives-crash?!]]
    [metabase.util :as u]
+   [metabase.util.quick-task :as quick-task]
    [toucan2.core :as t2]))
 
 (deftest skip-analysis-of-fields-with-current-fingerprint-version-test
@@ -232,7 +232,7 @@
 
 (deftest analyze-unhidden-tables-test
   (testing "un-hiding a table should cause it to be analyzed"
-    (with-redefs [sync.concurrent/submit-task! (fn [task] (task))]
+    (with-redefs [quick-task/submit-task! (fn [task] (task))]
       (mt/with-temp [:model/Table table (fake-table)
                      :model/Field field (fake-field table)]
         (set-table-visibility-type-via-api! table "hidden")


### PR DESCRIPTION
Moving this fixes a circular dependency with sync and models.database health check.
It is a utility for running tasks, so moved to util.