### PR TITLE
Fix chart settings field picker

### DIFF
--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -355,6 +355,67 @@ describe("scenarios > question > settings", () => {
         });
     });
 
+    it("should show all series settings without text overflowing (metabase#54074)", () => {
+      const regularColumnName = "regular column";
+      const longColumnName1 =
+        "very very very very very very very very very very very long column 1";
+      const longColumnName2 =
+        "very very very very very very very very very very very long column 2";
+
+      H.createNativeQuestion(
+        {
+          name: "54074",
+          native: {
+            query: `select 'foo' x, 10 "${regularColumnName}", 20 "${longColumnName1}", 20 "${longColumnName2}"`,
+          },
+          display: "bar",
+        },
+        { visitQuestion: true },
+      );
+
+      H.openVizSettingsSidebar();
+
+      H.sidebar()
+        .findAllByTestId("chartsettings-field-picker")
+        .eq(3)
+        .within(() => {
+          cy.findByTestId("color-selector-button").should("be.visible");
+          cy.findByLabelText("chevrondown icon").should("not.exist");
+          cy.findByLabelText("ellipsis icon").should("be.visible");
+          cy.findByLabelText("grabber icon").should("be.visible");
+          cy.get("input").should("have.value", longColumnName2);
+          cy.findByLabelText("close icon").should("be.visible");
+
+          cy.findByTestId(`remove-${longColumnName2}`).click();
+        });
+
+      H.sidebar()
+        .findAllByTestId("chartsettings-field-picker")
+        .eq(2)
+        .within(() => {
+          cy.findByTestId("color-selector-button").should("be.visible");
+          cy.findByLabelText("chevrondown icon").should("be.visible");
+          cy.findByLabelText("ellipsis icon").should("be.visible");
+          cy.findByLabelText("grabber icon").should("be.visible");
+          cy.get("input").should("have.value", longColumnName1);
+          cy.findByLabelText("close icon").should("be.visible");
+
+          cy.findByTestId(`remove-${longColumnName1}`).click();
+        });
+
+      H.sidebar()
+        .findAllByTestId("chartsettings-field-picker")
+        .eq(1)
+        .within(() => {
+          cy.findByTestId("color-selector-button").should("be.visible");
+          cy.findByLabelText("chevrondown icon").should("be.visible");
+          cy.findByLabelText("ellipsis icon").should("be.visible");
+          cy.findByLabelText("grabber icon").should("not.exist");
+          cy.get("input").should("have.value", regularColumnName);
+          cy.findByLabelText("close icon").should("not.exist");
+        });
+    });
+
     it.skip("should allow hiding and showing aggregated columns with a post-aggregation custom column (metabase#22563)", () => {
       // products joined to orders with breakouts on 3 product columns followed by a custom column
       H.createQuestion(

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
@@ -16,6 +16,8 @@ import {
 } from "./ChartSettingFieldPicker.styled";
 import { ChartSettingSelect } from "./ChartSettingSelect";
 
+const RIGHT_SECTION_BUTTON_WIDTH = 22;
+
 export const ChartSettingFieldPicker = ({
   value,
   options,
@@ -78,6 +80,10 @@ export const ChartSettingFieldPicker = ({
     options.length === 0 ||
     (options.length === 1 && options[0].value === value);
 
+  const rightSectionWidth =
+    [!disabled, !!menuWidgetInfo, !!onRemove].filter(Boolean).length *
+    RIGHT_SECTION_BUTTON_WIDTH;
+
   return (
     <ChartSettingFieldPickerRoot
       className={className}
@@ -96,7 +102,7 @@ export const ChartSettingFieldPicker = ({
         onChange={onChange}
         icon={
           showDragHandle || (showColorPicker && seriesKey) ? (
-            <Group wrap="nowrap" gap="xs" p="xs" ml="sm" mr="md" align="center">
+            <Group noWrap spacing="xs" p="xs" ml="sm" align="center">
               {showDragHandle && (
                 <GrabberHandle
                   name="grabber"
@@ -124,16 +130,7 @@ export const ChartSettingFieldPicker = ({
         iconWidth="auto"
         rightSectionWidth="auto"
         rightSection={
-          <Group
-            wrap="nowrap"
-            gap="sm"
-            p="xs"
-            mr="sm"
-            miw={
-              [!disabled, !!menuWidgetInfo, !!onRemove].filter(Boolean).length *
-              42
-            }
-          >
+          <>
             {!disabled && (
               <ActionIcon c="text-medium" size="sm" radius="xl" p={0}>
                 <Icon name="chevrondown" />
@@ -153,7 +150,7 @@ export const ChartSettingFieldPicker = ({
                 onClick={onRemove}
               />
             )}
-          </Group>
+          </>
         }
         styles={{
           wrapper: {
@@ -175,12 +172,12 @@ export const ChartSettingFieldPicker = ({
             },
             border: "none",
             width: "100%",
-            color: "var(--mb-color-text-primary)",
-            cursor: "pointer",
-            pointerEvents: "unset",
+            paddingRight: `${rightSectionWidth}px`,
           },
           rightSection: {
             pointerEvents: "none",
+            width: `${rightSectionWidth}px`,
+            paddingRight: "0.75rem",
           },
         }}
       />

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.jsx
@@ -21,9 +21,7 @@ export const ChartSettingSelect = ({
   iconWidth,
   pl,
   pr,
-  leftSection,
   rightSection,
-  rightSectionWidth,
   styles,
   w,
 }) => {
@@ -58,16 +56,11 @@ export const ChartSettingSelect = ({
       placeholder={options.length === 0 ? placeholderNoOptions : placeholder}
       initiallyOpened={isInitiallyOpen}
       searchable={!!searchProp}
-      rightSectionWidth={rightSectionWidth ?? "10px"}
-      comboboxProps={{
-        withinPortal: false,
-        floatingStrategy: "fixed",
-      }}
+      rightSectionWidth="10px"
       icon={icon}
       iconWidth={iconWidth}
       pl={pl}
       pr={pr}
-      leftSection={leftSection}
       rightSection={rightSection}
       styles={styles}
       w={w}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/54074

### Description

The issue does not exist on `master`.

The original issue shows series items in viz settings with cut off remove button:
<img width="284" alt="Screenshot 2025-02-20 at 3 30 20 PM" src="https://github.com/user-attachments/assets/8625d57f-241e-46d5-aee4-5fba4ff3b866" />

Then https://github.com/metabase/metabase/pull/53828 got backported and it made the situation slightly better by making the remove button accidentally visible although it shouldn't have been backported as it was implemented on a different mantine version on `master` so it broke the layout on the release branch:
<img width="314" alt="Screenshot 2025-02-20 at 3 32 14 PM" src="https://github.com/user-attachments/assets/d4667d75-801d-4f7c-aa73-0214e025eefc" />

### How to verify

Query:
```
select 'foo' x, 10 "very very very long column", 20 "very very very very very very very very very very very long column 2", 20 "very very very very very very very very very very very long column 3"
```

- Create a native question
- Make it a bar chart
- Ensure series items in viz settings have correct layouts

### Demo

<img width="316" alt="Screenshot 2025-02-20 at 3 34 00 PM" src="https://github.com/user-attachments/assets/7ae6658d-2934-4824-b746-7b580fa8e360" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
