### PR TITLE
fix series names overflow available space in viz settings

### DIFF
--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -355,6 +355,67 @@ describe("scenarios > question > settings", () => {
         });
     });
 
+    it("should show all series settings without text overflowing (metabase#52975)", () => {
+      const regularColumnName = "regular column";
+      const longColumnName1 =
+        "very very very very very very very very very very very long column 1";
+      const longColumnName2 =
+        "very very very very very very very very very very very long column 2";
+
+      H.createNativeQuestion(
+        {
+          name: "52975",
+          native: {
+            query: `select 'foo' x, 10 "${regularColumnName}", 20 "${longColumnName1}", 20 "${longColumnName2}"`,
+          },
+          display: "bar",
+        },
+        { visitQuestion: true },
+      );
+
+      H.openVizSettingsSidebar();
+
+      H.sidebar()
+        .findAllByTestId("chartsettings-field-picker")
+        .eq(3)
+        .within(() => {
+          cy.findByTestId("color-selector-button").should("be.visible");
+          cy.findByLabelText("chevrondown icon").should("not.exist");
+          cy.findByLabelText("ellipsis icon").should("be.visible");
+          cy.findByLabelText("grabber icon").should("be.visible");
+          cy.get("input").should("have.value", longColumnName2);
+          cy.findByLabelText("close icon").should("be.visible");
+
+          cy.findByTestId(`remove-${longColumnName2}`).click();
+        });
+
+      H.sidebar()
+        .findAllByTestId("chartsettings-field-picker")
+        .eq(2)
+        .within(() => {
+          cy.findByTestId("color-selector-button").should("be.visible");
+          cy.findByLabelText("chevrondown icon").should("be.visible");
+          cy.findByLabelText("ellipsis icon").should("be.visible");
+          cy.findByLabelText("grabber icon").should("be.visible");
+          cy.get("input").should("have.value", longColumnName1);
+          cy.findByLabelText("close icon").should("be.visible");
+
+          cy.findByTestId(`remove-${longColumnName1}`).click();
+        });
+
+      H.sidebar()
+        .findAllByTestId("chartsettings-field-picker")
+        .eq(1)
+        .within(() => {
+          cy.findByTestId("color-selector-button").should("be.visible");
+          cy.findByLabelText("chevrondown icon").should("be.visible");
+          cy.findByLabelText("ellipsis icon").should("be.visible");
+          cy.findByLabelText("grabber icon").should("not.exist");
+          cy.get("input").should("have.value", regularColumnName);
+          cy.findByLabelText("close icon").should("not.exist");
+        });
+    });
+
     it.skip("should allow hiding and showing aggregated columns with a post-aggregation custom column (metabase#22563)", () => {
       // products joined to orders with breakouts on 3 product columns followed by a custom column
       H.createQuestion(

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
@@ -16,6 +16,8 @@ import {
 } from "./ChartSettingFieldPicker.styled";
 import { ChartSettingSelect } from "./ChartSettingSelect";
 
+const RIGHT_SECTION_BUTTON_WIDTH = 22;
+
 export const ChartSettingFieldPicker = ({
   value,
   options,
@@ -80,6 +82,10 @@ export const ChartSettingFieldPicker = ({
 
   const hasLeftSection = showDragHandle || (showColorPicker && seriesKey);
 
+  const rightSectionWidth =
+    [!disabled, !!menuWidgetInfo, !!onRemove].filter(Boolean).length *
+    RIGHT_SECTION_BUTTON_WIDTH;
+
   return (
     <ChartSettingFieldPickerRoot
       className={className}
@@ -123,18 +129,9 @@ export const ChartSettingFieldPicker = ({
         }
         placeholderNoOptions={t`No valid fields`}
         placeholder={t`Select a field`}
-        rightSectionWidth="100px"
+        rightSectionWidth={`${rightSectionWidth}px`}
         rightSection={
-          <Group
-            wrap="nowrap"
-            gap="sm"
-            p="xs"
-            mr="sm"
-            miw={
-              [!disabled, !!menuWidgetInfo, !!onRemove].filter(Boolean).length *
-              42
-            }
-          >
+          <>
             {!disabled && (
               <ActionIcon c="text-medium" size="sm" radius="xl" p={0}>
                 <Icon name="chevrondown" />
@@ -154,7 +151,7 @@ export const ChartSettingFieldPicker = ({
                 onClick={onRemove}
               />
             )}
-          </Group>
+          </>
         }
         styles={{
           root: {
@@ -181,6 +178,7 @@ export const ChartSettingFieldPicker = ({
             color: "var(--mb-color-text-primary)",
             cursor: "pointer",
             pointerEvents: "unset",
+            paddingRight: `${rightSectionWidth + 8}px`,
           },
         }}
       />

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.jsx
@@ -64,7 +64,6 @@ export const ChartSettingSelect = ({
       placeholder={options.length === 0 ? placeholderNoOptions : placeholder}
       initiallyOpened={isInitiallyOpen}
       searchable={!!searchProp}
-      rightSectionWidth={rightSectionWidth ?? "10px"}
       comboboxProps={{
         withinPortal: false,
         floatingStrategy: "fixed",
@@ -75,6 +74,9 @@ export const ChartSettingSelect = ({
       pr={pr}
       leftSection={leftSection}
       rightSection={rightSection}
+      rightSectionProps={
+        rightSectionWidth ? { style: { width: rightSectionWidth } } : undefined
+      }
       styles={styles}
       w={w}
       defaultDropdownOpened={defaultDropdownOpened}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/52975

### Description

Fixes incorrect layout of series viz settings items in cartesian charts.

The `release-x.53.x` branch has been fixed separately in https://github.com/metabase/metabase/pull/54099

### How to verify

Query:
```
select 'foo' x, 10 "very very very long column", 20 "very very very very very very very very very very very long column 2", 20 "very very very very very very very very very very very long column 3"
```

- Create a native question
- Make it a bar chart
- Ensure series items in viz settings have correct layouts

### Demo

Before
<img width="313" alt="Screenshot 2025-02-20 at 9 28 37 PM" src="https://github.com/user-attachments/assets/9681845e-3e00-48d2-9927-45d0b5e27f07" />


After
<img width="319" alt="Screenshot 2025-02-20 at 9 28 13 PM" src="https://github.com/user-attachments/assets/39f792bc-6328-42d2-ad2f-ffd8e8b2f82c" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
