### PR TITLE
Fix - Alignment in `DateOffsetIntervalPicker`

### DIFF
--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.module.css
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.module.css
@@ -5,3 +5,7 @@
   align-items: center;
   gap: 0.5rem;
 }
+
+.selectWrapper {
+  margin-top: 0;
+}

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.tsx
@@ -100,6 +100,9 @@ export function DateOffsetIntervalPicker({
           onChange={handleIntervalChange}
         />
         <Select
+          classNames={{
+            wrapper: S.selectWrapper,
+          }}
           data={unitOptions}
           value={value.unit}
           aria-label={t`Unit`}
@@ -118,6 +121,9 @@ export function DateOffsetIntervalPicker({
           onChange={handleOffsetIntervalChange}
         />
         <Select
+          classNames={{
+            wrapper: S.selectWrapper,
+          }}
           data={offsetUnitOptions}
           value={value.offsetUnit}
           aria-label={t`Starting from unit`}


### PR DESCRIPTION
### Description

Fixes an alignment issue in `DateOffsetIntervalPicker`.
No backport as it's not present in v53.

### How to reproduce

1. New > Question > Oders
2. Filter > Created At > Previous month
3. Click to edit the filter
4. Click "Starting from..."

### Demo

[before](https://github.com/user-attachments/assets/0db250af-eff6-4146-9336-3252be4265b5) vs [after](https://github.com/user-attachments/assets/6e3e130c-4ceb-44a3-b52b-65497db56ba2)