### PR TITLE
Fix - Card reference in a native query with a long title does not wrap

### DIFF
--- a/e2e/support/commands/ui/icon.ts
+++ b/e2e/support/commands/ui/icon.ts
@@ -1,3 +1,5 @@
+import type { IconName } from "metabase/ui";
+
 declare global {
   namespace Cypress {
     interface Chainable {
@@ -9,7 +11,7 @@ declare global {
        * cy.icon("bolt_filled").should("have.length", 4);
        * cy.findByTestId("app-bar").icon("add").click()
        */
-      icon(iconName: string): Cypress.Chainable<JQuery<HTMLElement>>;
+      icon(iconName: IconName): Cypress.Chainable<JQuery<HTMLElement>>;
     }
   }
 }

--- a/e2e/support/helpers/e2e-ui-elements-overflow-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-overflow-helpers.js
@@ -34,12 +34,16 @@ export const assertDescendantNotOverflowsContainer = (
     return;
   }
 
-  expect(descendantRect.bottom, `${message} bottom`).to.be.lte(
+  const getMessage = suffix => {
+    return [message, suffix].filter(Boolean).join(" ");
+  };
+
+  expect(descendantRect.bottom, getMessage("bottom")).to.be.lte(
     containerRect.bottom,
   );
-  expect(descendantRect.top, `${message} top`).to.be.gte(containerRect.top);
-  expect(descendantRect.left, `${message} left`).to.be.gte(containerRect.left);
-  expect(descendantRect.right, `${message} right`).to.be.lte(
+  expect(descendantRect.top, getMessage("top")).to.be.gte(containerRect.top);
+  expect(descendantRect.left, getMessage("left")).to.be.gte(containerRect.left);
+  expect(descendantRect.right, getMessage("right")).to.be.lte(
     containerRect.right,
   );
 };

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -1,5 +1,6 @@
 const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import type { IconName } from "metabase/ui";
 
 import { getRunQueryButton } from "../native-filters/helpers/e2e-sql-filter-helpers";
 const { ORDERS_ID, REVIEWS } = SAMPLE_DATABASE;
@@ -253,4 +254,55 @@ describe("issue 53299", { tags: ["@mongo"] }, () => {
     H.selectNativeEditorDataSource("QA Mongo");
     H.nativeEditorDataSource().should("contain", "QA Mongo");
   });
+});
+
+describe("issue 53171", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+    H.createQuestion(
+      {
+        name: `Question ${"a".repeat(100)}`,
+        query: { "source-table": ORDERS_ID },
+      },
+      {
+        idAlias: "longNameQuestionId",
+        wrapId: true,
+      },
+    );
+  });
+
+  it("title and icons in data reference sidebar should not overflow (metabase#53171)", () => {
+    H.startNewNativeQuestion();
+
+    cy.get("@longNameQuestionId").then(longNameQuestion => {
+      H.NativeEditor.type(`{{#${longNameQuestion}`);
+    });
+
+    cy.findByTestId("sidebar-content").within($container => {
+      const [container] = $container;
+
+      cy.findByTestId("sidebar-header").should($header => {
+        const [header] = $header;
+        const headerDescendants = header.querySelectorAll("*");
+
+        headerDescendants.forEach(descendant => {
+          H.assertDescendantNotOverflowsContainer(descendant, container);
+        });
+      });
+
+      verifyIconVisibleAndSized("chevronleft", 16);
+      verifyIconVisibleAndSized("table", 16);
+      verifyIconVisibleAndSized("close", 18);
+    });
+  });
+
+  function verifyIconVisibleAndSized(iconName: IconName, size: number) {
+    cy.icon(iconName)
+      .should("be.visible")
+      .and(icon => {
+        expect(icon.outerWidth()).to.equal(size);
+        expect(icon.outerHeight()).to.equal(size);
+      });
+  }
 });

--- a/frontend/src/metabase/query_builder/components/SidebarHeader/SidebarHeader.module.css
+++ b/frontend/src/metabase/query_builder/components/SidebarHeader/SidebarHeader.module.css
@@ -1,7 +1,6 @@
 .CloseButton {
   color: var(--mb-color-text-dark);
   text-decoration: none;
-  margin-left: auto;
 
   &:hover {
     color: var(--mb-color-brand);
@@ -9,12 +8,9 @@
 }
 
 .HeaderTitleContainer {
-  display: flex;
-  align-items: center;
+  flex: 1;
   font-size: 1.17em;
   font-weight: bold;
-  margin-top: 0;
-  margin-bottom: 0;
 }
 
 .backButton {
@@ -35,4 +31,12 @@
   &:hover {
     color: var(--mb-color-brand);
   }
+}
+
+.icon {
+  flex: 0 0 auto;
+}
+
+.title {
+  word-break: break-word;
 }

--- a/frontend/src/metabase/query_builder/components/SidebarHeader/SidebarHeader.tsx
+++ b/frontend/src/metabase/query_builder/components/SidebarHeader/SidebarHeader.tsx
@@ -44,7 +44,12 @@ function SidebarHeader({ className, title, icon, onBack, onClose }: Props) {
   });
 
   return (
-    <Flex className={className} gap="sm">
+    <Flex
+      align="flex-start"
+      className={className}
+      data-testid="sidebar-header"
+      gap="sm"
+    >
       <Flex
         className={cx(SidebarHeaderS.HeaderTitleContainer, {
           [SidebarHeaderS.backButton]: headerVariant === "back-button",

--- a/frontend/src/metabase/query_builder/components/SidebarHeader/SidebarHeader.tsx
+++ b/frontend/src/metabase/query_builder/components/SidebarHeader/SidebarHeader.tsx
@@ -1,7 +1,7 @@
 import cx from "classnames";
 import { t } from "ttag";
 
-import type { FlexProps, IconName } from "metabase/ui";
+import type { IconName } from "metabase/ui";
 import { Box, Flex, Icon } from "metabase/ui";
 
 import SidebarHeaderS from "./SidebarHeader.module.css";
@@ -35,10 +35,6 @@ function getHeaderVariant({
   return "default";
 }
 
-const SidebarHeaderRoot = (props: FlexProps) => {
-  return <Flex align="center" {...props} />;
-};
-
 function SidebarHeader({ className, title, icon, onBack, onClose }: Props) {
   const hasDefaultBackButton = !title && !!onBack;
 
@@ -48,29 +44,41 @@ function SidebarHeader({ className, title, icon, onBack, onClose }: Props) {
   });
 
   return (
-    <SidebarHeaderRoot className={className}>
-      <Box
-        component="span"
+    <Flex className={className} gap="sm">
+      <Flex
         className={cx(SidebarHeaderS.HeaderTitleContainer, {
           [SidebarHeaderS.backButton]: headerVariant === "back-button",
           [SidebarHeaderS.defaultBackButton]:
             headerVariant === "default-back-button",
         })}
+        gap="sm"
         onClick={onBack}
         data-testid="sidebar-header-title"
       >
-        {onBack && <Icon mr="sm" name="chevronleft" />}
-        {icon && <Icon mr="sm" name={icon} />}
-        {hasDefaultBackButton ? t`Back` : title}
-      </Box>
+        {onBack && <Icon className={SidebarHeaderS.icon} name="chevronleft" />}
+        {icon && <Icon className={SidebarHeaderS.icon} name={icon} />}
+        {hasDefaultBackButton ? (
+          t`Back`
+        ) : (
+          <Box
+            className={SidebarHeaderS.title}
+            component="span"
+            pos="relative"
+            top={-1}
+          >
+            {title}
+          </Box>
+        )}
+      </Flex>
+
       {onClose && (
         <a className={SidebarHeaderS.CloseButton} onClick={onClose}>
           <Icon name="close" size={18} />
         </a>
       )}
-    </SidebarHeaderRoot>
+    </Flex>
   );
 }
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
-export default Object.assign(SidebarHeader, { Root: SidebarHeaderRoot });
+export default Object.assign(SidebarHeader);


### PR DESCRIPTION
Closes #53171

### Description

Icons are no longer centered vertically against the text. The "x" button surely is meant to be in the top-right corner of the sidebar, and it looks really weird if the other icons do not follow that pattern.

No backport as it's not in v53.

### How to verify

Browse data reference in native SQL editor (anything: questions, databases, schemas, fields), especially the ones with long names.

### Demo

Long text: [before](https://github.com/user-attachments/assets/3ec399f0-5161-475b-b120-a63e3d1bd6b9) & [after](https://github.com/user-attachments/assets/d043332c-2fbf-4ae2-9c7d-39f9b079e3f1)
Long text no whitespace: [before](https://github.com/user-attachments/assets/36f8db7f-e79e-479a-b8dc-cd3149899b23) & [after](https://github.com/user-attachments/assets/a8dd3940-952d-4626-b024-4da8e1282c24)









