### PR TITLE
fix flaky test about sticky panel

### DIFF
--- a/frontend/src/metabase/dashboard/hooks/use-is-parameter-panel-sticky.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/hooks/use-is-parameter-panel-sticky.unit.spec.tsx
@@ -103,6 +103,8 @@ describe("useIsParameterPanelSticky", () => {
   it("sets isStickyStateChanging to true and false before and after isSticky is changed", async () => {
     const { result } = setup();
 
+    const unmockRaf = mockRaf();
+
     await waitFor(() => {
       expect(mockObserve).toHaveBeenCalledTimes(1);
     });
@@ -116,6 +118,8 @@ describe("useIsParameterPanelSticky", () => {
     await waitFor(() => {
       expect(result.current.isStickyStateChanging).toBe(false);
     });
+
+    unmockRaf();
   });
 
   it("disconnects the observer on unmount", () => {
@@ -125,3 +129,15 @@ describe("useIsParameterPanelSticky", () => {
     expect(mockDisconnect).toHaveBeenCalledTimes(1);
   });
 });
+
+// JSDOM uses its own implementation of requestAnimationFrame, which appears to
+// be flaky in our tests. This mock is attempt to make results more consistent.
+function mockRaf() {
+  const originalRaf = global.requestAnimationFrame;
+
+  global.requestAnimationFrame = callback => setTimeout(callback, 0);
+
+  return function unmockRaf() {
+    global.requestAnimationFrame = originalRaf;
+  };
+}

--- a/frontend/src/metabase/dashboard/hooks/use-is-parameter-panel-sticky.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/hooks/use-is-parameter-panel-sticky.unit.spec.tsx
@@ -2,11 +2,6 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 
 import { useIsParameterPanelSticky } from "./use-is-parameter-panel-sticky";
 
-type IOCallback = (
-  entries: IntersectionObserverEntry[],
-  observer: IntersectionObserver,
-) => void;
-
 const setup = () => {
   const parameterPanelRef: React.RefObject<HTMLDivElement> = {
     current: document.createElement("div"),
@@ -26,7 +21,7 @@ describe("useIsParameterPanelSticky", () => {
   let originalIntersectionObserver: typeof IntersectionObserver;
   let mockObserve: jest.Mock;
   let mockDisconnect: jest.Mock;
-  let intersectionCallback: IOCallback | null = null;
+  let intersectionCallback: IntersectionObserverCallback | null = null;
 
   const invokeIntersection = (ratio: number) => {
     act(() => {
@@ -114,9 +109,7 @@ describe("useIsParameterPanelSticky", () => {
 
     invokeIntersection(0.7);
 
-    await waitFor(() => {
-      expect(result.current.isStickyStateChanging).toBe(true);
-    });
+    expect(result.current.isStickyStateChanging).toBe(true);
 
     expect(result.current.isSticky).toBe(true);
 

--- a/frontend/src/metabase/dashboard/hooks/use-is-parameter-panel-sticky.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/hooks/use-is-parameter-panel-sticky.unit.spec.tsx
@@ -105,6 +105,11 @@ describe("useIsParameterPanelSticky", () => {
 
   it("sets isStickyStateChanging to true and false before and after isSticky is changed", async () => {
     const { result } = setup();
+    const originalRaf = global.requestAnimationFrame;
+
+    (global as any).requestAnimationFrame = jest.fn(cb => {
+      setTimeout(cb, 0);
+    });
 
     await waitFor(() => {
       expect(mockObserve).toHaveBeenCalledTimes(1);
@@ -121,6 +126,8 @@ describe("useIsParameterPanelSticky", () => {
     await waitFor(() => {
       expect(result.current.isStickyStateChanging).toBe(false);
     });
+
+    (global as any).requestAnimationFrame = originalRaf;
   });
 
   it("disconnects the observer on unmount", () => {


### PR DESCRIPTION
closes QUE-690

### Description

attempt to fix a flaky test. main code uses rAF and _probably_ because of its async nature we have not deterministic results.

It's really hard to reproduce the problem both locally and at ci - stress tests pass, but this test is flaky 100%

<img width="1583" alt="image" src="https://github.com/user-attachments/assets/c06b8cdd-f398-427c-9a28-bace05358c5b" />

failures appear even after adding `waitFor`

```
     await waitFor(() => {
    > 116 |       expect(result.current.isStickyStateChanging).toBe(true);
          |                                                    ^
      117 |     });
```

which means that rAF already fired

```
requestAnimationFrame(() => {
        setIsStickyStateChanging(false);
      });
```


### How did I test it

```
hyperfine --runs 100 "node 'node_modules/.bin/jest' '/p/metabase/frontend/src/metabase/dashboard/hooks/use-is-parameter-panel-sticky.unit.spec.tsx' -t 'useIsParameterPanelSticky' --no-coverage --no-cache" --show-output
```

and ran `yarn jest` in a separate tab to take all CPU.

sometimes previous version failed, I wasn't able to fail a new version
