### PR TITLE
fix(sdk): Always set a ref in PivotTable to properly scale it

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/reproductions.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/reproductions.cy.spec.tsx
@@ -1,0 +1,68 @@
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { createQuestion } from "e2e/support/helpers";
+import {
+  mockAuthProviderAndJwtSignIn,
+  mountInteractiveQuestion,
+  signInAsAdminAndEnableEmbeddingSdk,
+} from "e2e/support/helpers/component-testing-sdk";
+import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
+
+const { PEOPLE, PRODUCTS, ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+const setup = (callback: () => void) => {
+  signInAsAdminAndEnableEmbeddingSdk();
+
+  callback();
+
+  cy.signOut();
+
+  mockAuthProviderAndJwtSignIn();
+};
+
+describe("scenarios > embedding-sdk > reproductions", () => {
+  describe("Pivot Table wrong size after switching from other visualization type (#53901)", () => {
+    beforeEach(() => {
+      setup(() => {
+        createQuestion({
+          name: "47563",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [["count"]],
+            breakout: [
+              [
+                "field",
+                PEOPLE.SOURCE,
+                { "base-type": "type/Text", "source-field": ORDERS.USER_ID },
+              ],
+              [
+                "field",
+                PRODUCTS.CATEGORY,
+                { "base-type": "type/Text", "source-field": ORDERS.PRODUCT_ID },
+              ],
+            ],
+          },
+          display: "table",
+        }).then(({ body: question }) => {
+          cy.wrap(question.id).as("questionId");
+          cy.wrap(question.entity_id).as("questionEntityId");
+        });
+      });
+    });
+
+    it("should set proper size for a Pivot Table", () => {
+      mountInteractiveQuestion();
+
+      getSdkRoot().within(() => {
+        cy.findByTestId("chart-type-selector-button").click();
+        cy.findByRole("menu").within(() => {
+          cy.findByText("Pivot Table").click();
+        });
+
+        cy.findByTestId("pivot-table").within(() => {
+          cy.findByText("Row totals").should("be.visible");
+          cy.findByText("Grand totals").should("be.visible");
+        });
+      });
+    });
+  });
+});

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
@@ -335,7 +335,8 @@ const PivotTableInner = forwardRef<HTMLDivElement, VisualizationProps>(
       !leftHeaderWidths ||
       (leftHeaderWidths?.length && columnsChanged)
     ) {
-      return null;
+      // We have to return an element to assign the ref to it
+      return <div ref={ref} />;
     }
 
     const {


### PR DESCRIPTION
Always set a ref in PivotTable to properly scale it.

Fixes https://github.com/metabase/metabase/issues/53901 (https://linear.app/metabase/issue/EMB-162/%5Bsdk%5D-pivot-table-values-does-not-show-up-when-switching-visualization)

The issue:
- The `PivotTable` is wrapped by the `ExplicitSize` component, that passes a `ref` prop down to the `PivotTable`
- The `ExplicitSize` needs a proper ref to define `width`/`height` values
- The `PivotTable` uses these `width`/`height` in its calculations for the Pivot Table size
- Also, the `PivotTable` has a branching logic that returns just `null` in some cases, so in this case, the `ref` is not set.
- It causes `ExplicitSize` to pass down the nullable `width`/`height` values, and these values result in incorrect table size.
- The solution - always set the `ref`.

Some other ways to fix it:
- the Pivot Table is the only component that uses `wrapped: false` for the `ExplicitSize`. Setting `true` also fixes the issue.

Before:
![image](https://github.com/user-attachments/assets/b8325bfd-f0cf-411b-8d3a-7149dab66590)


After: 
![image](https://github.com/user-attachments/assets/2c5379e1-6651-4513-864a-815570ea5d9f)

