### PR TITLE
Fix embedding SDK admin settings typo

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettings.tsx
@@ -96,7 +96,7 @@ export function InteractiveEmbeddingSettings({
             variant="outline"
             component={ExternalLink}
             href={quickStartUrl}
-          >{t`Check out the Quick Start`}</Button>
+          >{t`Check out the Quickstart`}</Button>
         </Box>
 
         <Box>

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/common.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/common.embedding.unit.spec.tsx
@@ -538,7 +538,7 @@ describe("[OSS] embedding settings", () => {
         );
       });
 
-      it("should show quick start section", () => {
+      it("should show quickstart section", () => {
         expect(
           screen.getByText("Try Embedded analytics SDK"),
         ).toBeInTheDocument();
@@ -547,7 +547,7 @@ describe("[OSS] embedding settings", () => {
         ).toBeInTheDocument();
 
         expect(
-          screen.getByRole("link", { name: "Check out the Quick Start" }),
+          screen.getByRole("link", { name: "Check out the Quickstart" }),
         ).toHaveProperty(
           "href",
           "https://metaba.se/sdk-quick-start?utm_source=product&utm_medium=docs&utm_campaign=embedding-sdk&utm_content=embedding-sdk-admin&source_plan=oss",

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/enterprise.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/enterprise.embedding.unit.spec.tsx
@@ -537,7 +537,7 @@ describe("[EE, no token] embedding settings", () => {
         );
       });
 
-      it("should show quick start section", () => {
+      it("should show quickstart section", () => {
         expect(
           screen.getByText("Try Embedded analytics SDK"),
         ).toBeInTheDocument();
@@ -546,7 +546,7 @@ describe("[EE, no token] embedding settings", () => {
         ).toBeInTheDocument();
 
         expect(
-          screen.getByRole("link", { name: "Check out the Quick Start" }),
+          screen.getByRole("link", { name: "Check out the Quickstart" }),
         ).toHaveProperty(
           "href",
           "https://metaba.se/sdk-quick-start?utm_source=product&utm_medium=docs&utm_campaign=embedding-sdk&utm_content=embedding-sdk-admin&source_plan=starter",

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
@@ -478,10 +478,10 @@ describe("[EE, with token] embedding settings", () => {
         );
 
         expect(
-          screen.getByRole("link", { name: "Check out the Quick Start" }),
+          screen.getByRole("link", { name: "Check out the Quickstart" }),
         ).toBeInTheDocument();
         expect(
-          screen.getByRole("link", { name: "Check out the Quick Start" }),
+          screen.getByRole("link", { name: "Check out the Quickstart" }),
         ).toHaveProperty(
           "href",
           /**
@@ -578,14 +578,14 @@ describe("[EE, with token] embedding settings", () => {
         );
       });
 
-      it("should show quick start section", () => {
+      it("should show quickstart section", () => {
         expect(screen.getByText("Get started")).toBeInTheDocument();
         expect(
           screen.queryByText("Use the SDK with API keys for development."),
         ).not.toBeInTheDocument();
 
         expect(
-          screen.getByRole("link", { name: "Check out the Quick Start" }),
+          screen.getByRole("link", { name: "Check out the Quickstart" }),
         ).toHaveProperty(
           "href",
           "https://metaba.se/sdk-quick-start?utm_source=product&utm_medium=docs&utm_campaign=embedding-sdk&utm_content=embedding-sdk-admin&source_plan=pro-self-hosted",
@@ -671,14 +671,14 @@ describe("[EE, with token] embedding settings", () => {
         );
       });
 
-      it("should show quick start section", () => {
+      it("should show quickstart section", () => {
         expect(screen.getByText("Get started")).toBeInTheDocument();
         expect(
           screen.queryByText("Use the SDK with API keys for development."),
         ).not.toBeInTheDocument();
 
         expect(
-          screen.getByRole("link", { name: "Check out the Quick Start" }),
+          screen.getByRole("link", { name: "Check out the Quickstart" }),
         ).toHaveProperty(
           "href",
           "https://metaba.se/sdk-quick-start?utm_source=product&utm_medium=docs&utm_campaign=embedding-sdk&utm_content=embedding-sdk-admin&source_plan=pro-cloud",

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/setup.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/setup.tsx
@@ -61,7 +61,7 @@ export const getInteractiveEmbeddingQuickStartLink = () => {
     screen.getByRole("article", {
       name: "Interactive embedding",
     }),
-  ).getByRole("link", { name: "Check out our Quick Start" });
+  ).getByRole("link", { name: "Check out our Quickstart" });
 };
 
 export const embeddingSettingsUrl =

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
@@ -151,7 +151,7 @@ export function EmbeddingSdkSettings({
           size="large"
           crumbs={[
             [t`Embedding`, "/admin/settings/embedding-in-other-applications"],
-            [t`Embedding SDK for React`],
+            [t`Embedded analytics SDK`],
           ]}
         />
         <SwitchWithSetByEnvVar
@@ -202,7 +202,7 @@ export function EmbeddingSdkSettings({
             variant="outline"
             component={ExternalLink}
             href={quickStartUrl}
-          >{t`Check out the Quick Start`}</Button>
+          >{t`Check out the Quickstart`}</Button>
         </Box>
         <Box>
           <SettingHeader

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/common.unit.spec.tsx
@@ -61,7 +61,7 @@ describe("EmbeddingSdkSettings (OSS)", () => {
       });
 
       it("should show the modal when the user loads the page", () => {
-        expect(screen.getByText("Embedding SDK for React")).toBeInTheDocument();
+        expect(screen.getByText("Embedded analytics SDK")).toBeInTheDocument();
         assertLegaleseModal();
       });
     });

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/premium.unit.spec.tsx
@@ -74,12 +74,12 @@ describe("EmbeddingSdkSettings (EE with Embedding SDK token)", () => {
       });
 
       it("should show the modal when the user loads the page", () => {
-        expect(screen.getByText("Embedding SDK for React")).toBeInTheDocument();
+        expect(screen.getByText("Embedded analytics SDK")).toBeInTheDocument();
         assertLegaleseModal();
       });
 
       it("should show the modal when the user declines the modal then tries to edit CORS settings", async () => {
-        expect(screen.getByText("Embedding SDK for React")).toBeInTheDocument();
+        expect(screen.getByText("Embedded analytics SDK")).toBeInTheDocument();
         assertLegaleseModal();
         await userEvent.click(screen.getByText("Decline and go back"));
         expect(screen.queryByRole("dialog")).not.toBeInTheDocument();

--- a/frontend/src/metabase/admin/settings/components/widgets/EmbeddingOption/InteractiveEmbeddingOptionCard/InteractiveEmbeddingOptionCard.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/EmbeddingOption/InteractiveEmbeddingOptionCard/InteractiveEmbeddingOptionCard.tsx
@@ -74,7 +74,7 @@ export const InteractiveEmbeddingOptionCard = ({
         href={quickStartUrl}
         target="_blank"
       >
-        {t`Check out our Quick Start`}{" "}
+        {t`Check out our Quickstart`}{" "}
         <Box ml="sm" top="2.5px" pos="absolute" component="span">
           <Icon name="share" aria-hidden />
         </Box>

--- a/frontend/src/metabase/home/components/EmbedHomepage/InteractiveContent.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/InteractiveContent.tsx
@@ -25,7 +25,7 @@ export const InteractiveContent = ({
     </Text>
     <Group gap="md">
       <ExternalLink href={interactiveEmbeddingQuickstartUrl}>
-        <Button variant="outline">{t`Check out the Quick Start`}</Button>
+        <Button variant="outline">{t`Check out the Quickstart`}</Button>
       </ExternalLink>
       <ExternalLink href={learnMoreInteractiveEmbedUrl}>
         <Button variant="subtle">{t`Read the docs`}</Button>

--- a/frontend/src/metabase/home/components/EmbedHomepage/SDKContent.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/SDKContent.tsx
@@ -32,7 +32,7 @@ export const SDKContent = ({
     </Text>
     <Group gap="md">
       <ExternalLink href={sdkQuickstartUrl}>
-        <Button variant="outline">{t`Check out the Quick Start`}</Button>
+        <Button variant="outline">{t`Check out the Quickstart`}</Button>
       </ExternalLink>
       <ExternalLink href={sdkDocsUrl}>
         <Button variant="subtle">{t`Read the docs`}</Button>

--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/EmbedHomepage.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/EmbedHomepage.unit.spec.tsx
@@ -36,7 +36,7 @@ describe("EmbedHomepage (OSS)", () => {
     setup();
 
     expect(
-      screen.getAllByRole("link", { name: "Check out the Quick Start" })[0],
+      screen.getAllByRole("link", { name: "Check out the Quickstart" })[0],
     ).toHaveAttribute(
       "href",
       "https://metaba.se/sdk-quick-start?utm_source=product&source_plan=oss&utm_content=embedding-homepage",


### PR DESCRIPTION
Please see this [Slack discussion.](https://metaboat.slack.com/archives/C063Q3F1HPF/p1740147652193729)
### Backport reason
These settings are introduced in 51, but we would only backport to 2 most recent versions and that should be enough.

### Description
Fix the typo.

### How to verify

Visit http://localhost:3000/admin/settings/embedding-in-other-applications/sdk

### Demo
#### After
![image](https://github.com/user-attachments/assets/6e980244-bde6-4dec-a48c-9fb88b90e3f6)

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
