### PR TITLE
ci: make the sdk e2e run on draft prs and comment non-used stub

### DIFF
--- a/.github/workflows/e2e-component-tests-embedding-sdk.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk.yml
@@ -67,7 +67,6 @@ jobs:
     needs: [files-changed, get-build-requirements]
     if: |
       !cancelled() &&
-      github.event.pull_request.draft == false &&
       needs.files-changed.outputs.e2e_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 25
@@ -203,14 +202,15 @@ jobs:
 
              await core.summary.addRaw(summary).write();
 
-  e2e-tests-skipped-stub:
-    needs: [e2e-tests]
-    if: |
-      !cancelled() &&
-      needs.e2e-tests.result == 'skipped'
-    runs-on: ubuntu-22.04
-    timeout-minutes: 5
-    name: e2e-component-tests-embedding-sdk
-    steps:
-      - run: |
-          echo "Didn't run due to conditional filtering"
+# This doesn't do anything at the moment, this was used as stub when the task was required but the job is currently not required (but it should)
+# e2e-tests-skipped-stub:
+#   needs: [e2e-tests]
+#   if: |
+#     !cancelled() &&
+#     needs.e2e-tests.result == 'skipped'
+#   runs-on: ubuntu-22.04
+#   timeout-minutes: 5
+#   name: e2e-tests-embedding-sdk
+#   steps:
+#     - run: |
+#         echo "Didn't run due to conditional filtering"


### PR DESCRIPTION
We changed all tests to run on draft prs but we forgot this.

This also (temporarily) comments (and renames) a stub job that was supposed to make the ci green when the job was required, at the moment the job is not required and it only creates confusion.
see [EMB-141: consolidate the sdk e2e jobs names](https://linear.app/metabase/issue/EMB-141/consolidate-the-sdk-e2e-jobs-names)