### PR TITLE
Add a clj-kondo hook for bad single-quotes in i18n

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -834,6 +834,7 @@
   source-namespaces
   {:linters
    {:metabase/validate-escaped-single-quotes-in-i18n {:level :warning}
+    :metabase/validate-string-or-str-args-to-i18n {:level :warning}
     :discouraged-var
     {clojure.core/with-redefs {:message "Don't use with-redefs outside of tests"}
      clojure.core/eval        {:message "Don't use eval outside of tests"}}}}

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -715,6 +715,10 @@
    metabase.test/with-temp-file                                                                                              hooks.metabase.test.util/with-temp-file
    metabase.test/with-prometheus-system!                                                                                     hooks.common/with-two-bindings
    metabase.test/with-temporary-setting-values                                                                               hooks.metabase.test.util/with-temporary-setting-values
+   metabase.util.i18n/tru                                                                                                    hooks.metabase.util.i18n/tru
+   metabase.util.i18n/deferred-tru                                                                                           hooks.metabase.util.i18n/deferred-tru
+   metabase.util.i18n/trs                                                                                                    hooks.metabase.util.i18n/trs
+   metabase.util.i18n/deferred-trs                                                                                           hooks.metabase.util.i18n/deferred-trs
    metabase.util.log.capture/with-log-messages-for-level                                                                     hooks.metabase.util.log.capture/with-log-messages-for-level
    metabase.util.log/debug                                                                                                   hooks.metabase.util.log/info
    metabase.util.log/debugf                                                                                                  hooks.metabase.util.log/infof
@@ -829,7 +833,8 @@
 
   source-namespaces
   {:linters
-   {:discouraged-var
+   {:metabase/validate-escaped-single-quotes-in-i18n {:level :warning}
+    :discouraged-var
     {clojure.core/with-redefs {:message "Don't use with-redefs outside of tests"}
      clojure.core/eval        {:message "Don't use eval outside of tests"}}}}
 

--- a/.clj-kondo/src/hooks/metabase/util/i18n.clj
+++ b/.clj-kondo/src/hooks/metabase/util/i18n.clj
@@ -24,17 +24,35 @@
               ;; Technically a string like "foo bar's happy but i'm not" is totally fine, but we'll say it's invalid
               ;; because... that inner string literal is probably not what we actually want. So since we've never done
               ;; this intentionally as far as I can tell, let's just remove the possibility to avoid ambiguity.
-            (and (next chars) (= (second chars) \{))
-            (let [rest-str (apply str (rest chars)) ; From '{
-                  closing-index (str/index-of rest-str "'")]
-              (if closing-index
-                (recur (drop (+ closing-index 2) chars)) ; Skip past }'
-                false)) ; No closing }' found
-
+            (= (second chars) \{)
+            (let [at-closing (drop-while #(not= \' %) (next chars))]
+              (if (seq at-closing)
+                (recur (next at-closing))
+                false))
               ;; Unpaired single quote: invalid
             :else
             false)
           (recur (rest chars)))))))
+
+(defn format-str-arg-node->str
+  [node]
+  (cond
+    ;; it's just a string literal
+    (api/string-node? node) (api/sexpr node)
+    ;; it's `(str "some" "strings")`
+    (and (api/list-node? node)
+         (= 'str (api/sexpr (first (:children node))))
+         (every? api/string-node? (rest (:children node))))
+    (apply str (map api/sexpr (rest (:children node))))
+
+    ;; it's something else, no good
+    :else
+    (do
+      (api/reg-finding!
+       (assoc (meta node)
+              :message "Must be a string literal or a call to `str` with string literal arguments."
+              :type :metabase/validate-string-or-str-args-to-i18n))
+      nil)))
 
 (defn strict-apostrophes
   "Checks the node to make sure it's not a i18n call that will result in dropped apostrophes."
@@ -42,10 +60,7 @@
   (let [format-str-arg (second (:children node))
         ;; `format-str-arg` must be either a `"string"` or `(str "a call " "to" "str")` (to allow for splitting long
         ;; strings into shorter lines)
-        format-str (if (api/string-node? format-str-arg)
-                     (api/sexpr format-str-arg)
-                     ;; (str "a" "b" "c") => a list-node with children "str", "a", "b", and "c"
-                     (apply str (map api/sexpr (rest (:children format-str-arg)))))]
+        format-str (format-str-arg-node->str format-str-arg)]
     (when-not (valid-apostrophes? format-str)
       (api/reg-finding!
        (assoc (meta node)

--- a/.clj-kondo/src/hooks/metabase/util/i18n.clj
+++ b/.clj-kondo/src/hooks/metabase/util/i18n.clj
@@ -1,0 +1,59 @@
+(ns hooks.metabase.util.i18n
+  (:require
+   [clj-kondo.hooks-api :as api]
+   [clojure.string :as str]
+   [hooks.common]))
+
+(defn- valid-apostrophes?
+  "Returns true if `s` contains only doubled quotes (''') or complete placeholder-escaping quotes ('{...}'), false otherwise."
+  [s]
+  (loop [chars (seq s)]
+    (if (empty? chars)
+      true
+      (let [c (first chars)]
+        (if (= c \')
+          (cond
+              ;; Doubled quotes: skip both
+            (and (next chars) (= (second chars) \'))
+            (recur (nthrest chars 2))
+
+              ;; Placeholder escape. We allow for intentional escaping, like either '{0}` or '{{`, but not 'arbitrary
+              ;; strings' So basically, just require the *next* character to be a `{`, find the next single-quote, and
+              ;; continue on from there.
+              ;;
+              ;; Technically a string like "foo bar's happy but i'm not" is totally fine, but we'll say it's invalid
+              ;; because... that inner string literal is probably not what we actually want. So since we've never done
+              ;; this intentionally as far as I can tell, let's just remove the possibility to avoid ambiguity.
+            (and (next chars) (= (second chars) \{))
+            (let [rest-str (apply str (rest chars)) ; From '{
+                  closing-index (str/index-of rest-str "'")]
+              (if closing-index
+                (recur (drop (+ closing-index 2) chars)) ; Skip past }'
+                false)) ; No closing }' found
+
+              ;; Unpaired single quote: invalid
+            :else
+            false)
+          (recur (rest chars)))))))
+
+(defn strict-apostrophes
+  "Checks the node to make sure it's not a i18n call that will result in dropped apostrophes."
+  [{:keys [node]}]
+  (let [format-str-arg (second (:children node))
+        ;; `format-str-arg` must be either a `"string"` or `(str "a call " "to" "str")` (to allow for splitting long
+        ;; strings into shorter lines)
+        format-str (if (api/string-node? format-str-arg)
+                     (api/sexpr format-str-arg)
+                     ;; (str "a" "b" "c") => a list-node with children "str", "a", "b", and "c"
+                     (apply str (map api/sexpr (rest (:children format-str-arg)))))]
+    (when-not (valid-apostrophes? format-str)
+      (api/reg-finding!
+       (assoc (meta node)
+              :message "Format string contains invalid single quote usage. Use '' for literals or '{...}' for escaping."
+              :type :metabase/validate-escaped-single-quotes-in-i18n))))
+  {:node node})
+
+(def tru strict-apostrophes)
+(def trs strict-apostrophes)
+(def deferred-tru strict-apostrophes)
+(def deferred-trs strict-apostrophes)

--- a/.clj-kondo/test/hooks/metabase/util/i18n_test.clj
+++ b/.clj-kondo/test/hooks/metabase/util/i18n_test.clj
@@ -1,0 +1,33 @@
+(ns hooks.metabase.util.i18n-test
+  (:require [clj-kondo.hooks-api :as api]
+            [clj-kondo.impl.utils]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest testing is are]]
+            [hooks.metabase.util.i18n]))
+
+(defn- warnings
+  [form]
+  (binding [clj-kondo.impl.utils/*ctx* {:config     {:linters {:metabase/validate-string-or-str-args-to-i18n {:level :warning}
+                                                               :metabase/validate-escaped-single-quotes-in-i18n {:level :warning}}}
+                                        :ignores    (atom nil)
+                                        :findings   (atom [])
+                                        :namespaces (atom {})}]
+    (hooks.metabase.util.i18n/strict-apostrophes {:node (api/parse-string (pr-str form))})
+    (mapv :message @(:findings clj-kondo.impl.utils/*ctx*))))
+
+(deftest ^:parallel strict-apostrophes-warns
+  (are [form] (= ["Format string contains invalid single quote usage. Use '' for literals or '{...}' for escaping."]
+                 (warnings (quote form)))
+    (metabase.util.i18n/tru "this isn't good bob")
+    (metabase.util.i18n/tru "'this is not good either'")
+    (metabase.util.i18n/tru "''this isn't''")
+    (metabase.util.i18n/tru "nope you can not escape 'like {{0}} so {{1}}'")
+    (metabase.util.i18n/tru (str "it works" "when strings" "are concatenated'"))))
+
+(deftest ^:parallel strict-apostrophes-doesnt-warn-on-good-ones
+  (are [form] (= []
+                 (warnings (quote form)))
+    (metabase.util.i18n/tru "this isn''t bad")
+    (metabase.util.i18n/tru (str "not sure why you'" "'d do this" "... but ok"))
+    (metabase.util.i18n/tru "you can '{{0}}' do things like that")
+    (metabase.util.i18n/tru "or '{{ this or }}}}}}}}}}' that")))

--- a/e2e/test/scenarios/admin/databases.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases.cy.spec.js
@@ -147,7 +147,7 @@ describe("admin > database > add", () => {
         });
 
         H.tooltip()
-          .findByText(/your databases ip address/i)
+          .findByText(/your database's ip address/i)
           .should("be.visible");
 
         cy.findByTestId("database-form").within(() => {

--- a/enterprise/backend/src/metabase_enterprise/llm/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/llm/settings.clj
@@ -4,7 +4,7 @@
    [metabase.util.i18n :refer [deferred-tru]]))
 
 (defsetting ee-openai-model
-  (deferred-tru "The OpenAI Model (e.g. 'gpt-4', 'gpt-3.5-turbo')")
+  (deferred-tru "The OpenAI Model (e.g. ''gpt-4'', ''gpt-3.5-turbo'')")
   :encryption :no
   :visibility :settings-manager
   :default "gpt-4-turbo-preview"

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -25,7 +25,7 @@
   (when-not (sso-settings/jwt-enabled)
     (throw
      (IllegalArgumentException.
-      (str (tru "Can't create new JWT user when JWT is not configured")))))
+      (str (tru "Can''t create new JWT user when JWT is not configured")))))
   (let [user {:first_name       first-name
               :last_name        last-name
               :email            email

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -86,11 +86,11 @@
   "Returns a Session for the given `email`. Will create the user if needed."
   [{:keys [first-name last-name email group-names user-attributes device-info]}]
   (when-not (sso-settings/saml-enabled)
-    (throw (IllegalArgumentException. (tru "Can't create new SAML user when SAML is not enabled"))))
+    (throw (IllegalArgumentException. (tru "Can''t create new SAML user when SAML is not enabled"))))
   (when-not email
     (throw (ex-info (str (tru "Invalid SAML configuration: could not find user email.")
                          " "
-                         (tru "We tried looking for {0}, but couldn't find the attribute."
+                         (tru "We tried looking for {0}, but couldn''t find the attribute."
                               (sso-settings/saml-attribute-email))
                          " "
                          (tru "Please make sure your SAML IdP is properly configured."))

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_settings.clj
@@ -69,7 +69,7 @@ using, this usually looks like `https://your-org-name.example.com` or `https://e
 
 (defsetting saml-identity-provider-certificate
   (deferred-tru "Encoded certificate for the identity provider. Depending on your IdP, you might need to download this,
-open it in a text editor, then copy and paste the certificate's contents here.")
+open it in a text editor, then copy and paste the certificate''s contents here.")
   :feature    :sso-saml
   :audit      :no-value
   :encryption :no
@@ -80,7 +80,7 @@ open it in a text editor, then copy and paste the certificate's contents here.")
                 (setting/set-value-of-type! :string :saml-identity-provider-certificate new-value)))
 
 (defsetting saml-identity-provider-issuer
-  (deferred-tru "This is a unique identifier for the IdP. Often referred to as Entity ID or simply 'Issuer'. Depending
+  (deferred-tru "This is a unique identifier for the IdP. Often referred to as Entity ID or simply ''Issuer''. Depending
 on your IdP, this usually looks something like `http://www.example.com/141xkex604w0Q5PN724v`")
   :encryption :when-encryption-key-set
   :feature    :sso-saml
@@ -212,28 +212,28 @@ on your IdP, this usually looks something like `http://www.example.com/141xkex60
   :audit      :no-value)
 
 (defsetting jwt-attribute-email
-  (deferred-tru "Key to retrieve the JWT user's email address")
+  (deferred-tru "Key to retrieve the JWT user''s email address")
   :encryption :when-encryption-key-set
   :default    "email"
   :feature    :sso-jwt
   :audit      :getter)
 
 (defsetting jwt-attribute-firstname
-  (deferred-tru "Key to retrieve the JWT user's first name")
+  (deferred-tru "Key to retrieve the JWT user''s first name")
   :encryption :when-encryption-key-set
   :default    "first_name"
   :feature    :sso-jwt
   :audit      :getter)
 
 (defsetting jwt-attribute-lastname
-  (deferred-tru "Key to retrieve the JWT user's last name")
+  (deferred-tru "Key to retrieve the JWT user''s last name")
   :encryption :when-encryption-key-set
   :default    "last_name"
   :feature    :sso-jwt
   :audit      :getter)
 
 (defsetting jwt-attribute-groups
-  (deferred-tru "Key to retrieve the JWT user's groups")
+  (deferred-tru "Key to retrieve the JWT user''s groups")
   :default    "groups"
   :feature    :sso-jwt
   :encryption :when-encryption-key-set

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file_test.clj
@@ -100,8 +100,8 @@
                                    (binding [advanced-config.file/*config* (mock-config-with-setting template)]
                                      (#'advanced-config.file/config)))
       ;; {{ without a corresponding }}
-      "{{}"                        (re-quote "Invalid query: found [[ or {{ with no matching ]] or }}")
-      "{{} }"                      (re-quote "Invalid query: found [[ or {{ with no matching ]] or }}")
+      "{{}"                        (re-quote "Invalid query: found '[[' or '{{' with no matching ']]' or '}}'")
+      "{{} }"                      (re-quote "Invalid query: found '[[' or '{{' with no matching ']]' or '}}'")
       ;; raw token, not a list
       "{{CONFIG_FILE_BIRD_NAME}}"  (re-quote "CONFIG_FILE_BIRD_NAME - failed: valid-template-type?")
       ;; unbalanced parens

--- a/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
+++ b/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
@@ -200,7 +200,7 @@
 (defmethod sql.qp/date [:sqlite :week-of-year-iso]
   [driver _ expr]
   ;; Maybe we can follow the algorithm here https://en.wikipedia.org/wiki/ISO_week_date#Algorithms
-  (throw (ex-info (tru "Sqlite doesn't support extract isoweek")
+  (throw (ex-info (tru "Sqlite doesn''t support extract isoweek")
                   {:driver driver
                    :form   expr
                    :type   qp.error-type/invalid-query})))

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -1339,7 +1339,7 @@
     [:map
      [:id ms/NonBlankString]]
     [:map-of :keyword :any]]
-   (deferred-tru "value must be a parameter map with an 'id' key")))
+   (deferred-tru "value must be a parameter map with an ''id'' key")))
 
 ;;; ---------------------------------- Executing the action associated with a Dashcard -------------------------------
 

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -292,7 +292,7 @@
    :- [:map
        [:include                     {:optional true} (mu/with-api-error-message
                                                        [:maybe [:= "tables"]]
-                                                       (deferred-tru "include must be either empty or the value 'tables'"))]
+                                                       (deferred-tru "include must be either empty or the value ''tables''"))]
        [:include_analytics           {:default false} [:maybe :boolean]]
        [:saved                       {:default false} [:maybe :boolean]]
        [:include_editable_data_model {:default false} [:maybe :boolean]]
@@ -612,7 +612,7 @@
 
 (defsetting native-query-autocomplete-match-style
   (deferred-tru
-   (str "Matching style for native query editor's autocomplete. Can be \"substring\", \"prefix\", or \"off\". "
+   (str "Matching style for native query editor''s autocomplete. Can be \"substring\", \"prefix\", or \"off\". "
         "Larger instances can have performance issues matching using substring, so can use prefix matching, "
         " or turn autocompletions off."))
   :visibility :public

--- a/src/metabase/api/embed/common.clj
+++ b/src/metabase/api/embed/common.clj
@@ -547,7 +547,7 @@
                              (pr-str searched-param-slug))
                         {:status-code 400})))
       (when (get slug-token-params (keyword searched-param-slug))
-        (throw (ex-info (tru "You can''t specify a value for {0} if it's already set in the JWT." (pr-str searched-param-slug))
+        (throw (ex-info (tru "You can''t specify a value for {0} if it''s already set in the JWT." (pr-str searched-param-slug))
                         {:status-code 400})))
       (try
         (binding [api/*current-user-permissions-set* (atom #{"/"})
@@ -605,7 +605,7 @@
         (throw (ex-info (tru "Cannot search for values: {0} is not an enabled parameter." (pr-str searched-param-slug))
                         {:status-code 400})))
       (when (get slug-token-params (keyword searched-param-slug))
-        (throw (ex-info (tru "You can''t specify a value for {0} if it's already set in the JWT." (pr-str searched-param-slug))
+        (throw (ex-info (tru "You can''t specify a value for {0} if it''s already set in the JWT." (pr-str searched-param-slug))
                         {:status-code 400})))
       ;; ok, at this point we can run the query
       (let [merged-id-params (param-values-merged-params id->slug slug->id embedding-params slug-token-params id-query-params)]

--- a/src/metabase/cloud_migration/settings.clj
+++ b/src/metabase/cloud_migration/settings.clj
@@ -73,7 +73,7 @@
 
 (defsetting read-only-mode
   (deferred-tru
-   (str "Boolean indicating whether a Metabase's is in read-only mode with regards to its app db. "
+   (str "Boolean indicating whether a Metabase instance is in read-only mode with regards to its app db. "
         "Will take up to 1m to propagate to other Metabase instances in a cluster."
         "Audit tables are excluded from read-only-mode mode."))
   :type       :boolean

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -18,7 +18,7 @@
   "Map of the db host details field, useful for `connection-properties` implementations"
   {:name         "host"
    :display-name (deferred-tru "Host")
-   :helper-text  (deferred-tru "Your database's IP address (e.g. 98.137.149.56) or its domain name (e.g. esc.mydatabase.com).")
+   :helper-text  (deferred-tru "Your database''s IP address (e.g. 98.137.149.56) or its domain name (e.g. esc.mydatabase.com).")
    :placeholder  "name.database.com"})
 
 (def default-port-details

--- a/src/metabase/driver/common/parameters/parse.clj
+++ b/src/metabase/driver/common/parameters/parse.clj
@@ -92,17 +92,17 @@
   (let [[k & more] (combine-adjacent-strings parsed)]
     (when (or (seq more)
               (not (string? k)))
-      (throw (ex-info (tru "Invalid '{{...}}' clause: expected a param name")
+      (throw (ex-info (tru "Invalid '''{{...}}''' clause: expected a param name")
                       {:type qp.error-type/invalid-query})))
     (let [k (str/trim k)]
       (when (empty? k)
-        (throw (ex-info (tru "'{{...}}' clauses cannot be empty.")
+        (throw (ex-info (tru "'''{{...}}''' clauses cannot be empty.")
                         {:type qp.error-type/invalid-query})))
       (params/->Param k))))
 
 (defn- optional [& parsed]
   (when-not (some params/Param? parsed)
-    (throw (ex-info (tru "'[[...]]' clauses must contain at least one '{{...}}' clause.")
+    (throw (ex-info (tru "[[...]] clauses must contain at least one '''{{...}}''' clause.")
                     {:type qp.error-type/invalid-query})))
   (params/->Optional (combine-adjacent-strings parsed)))
 
@@ -120,7 +120,7 @@
     (cond
       (nil? string-or-token)
       (if (or (pos? optional-level) (pos? param-level))
-        (throw (ex-info (tru "Invalid query: found '[[' or '{{' with no matching ']]' or '}}'")
+        (throw (ex-info (tru "Invalid query: found ''[['' or '''{{''' with no matching '']]'' or ''}}''")
                         {:type qp.error-type/invalid-query}))
         [acc nil])
 

--- a/src/metabase/driver/sql/util.clj
+++ b/src/metabase/driver/sql/util.clj
@@ -139,7 +139,7 @@
                      :target-timezone target-timezone
                      :source-timezone source-timezone})))
   (when (and (not has-timezone?) (not source-timezone))
-    (throw (ex-info (tru "input column doesn't have a set timezone. Please set the source parameter in convertTimezone to convert it.")
+    (throw (ex-info (tru "input column doesn''t have a set timezone. Please set the source parameter in convertTimezone to convert it.")
                     {:type            qp.error-type/invalid-query
                      :target-timezone target-timezone
                      :source-timezone source-timezone}))))

--- a/src/metabase/embed/settings.clj
+++ b/src/metabase/embed/settings.clj
@@ -216,7 +216,7 @@
 
 ;; settings for the embedding homepage
 (defsetting embedding-homepage
-  (deferred-tru "Embedding homepage status, indicating if it's visible, hidden or has been dismissed")
+  (deferred-tru "Embedding homepage status, indicating if it''s visible, hidden or has been dismissed")
   :type       :keyword
   :default    :hidden
   :export?    true

--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -46,7 +46,7 @@
 (defsetting slack-token-valid?
   (deferred-tru
    (str "Whether the current Slack app token, if set, is valid. "
-        "Set to 'false' if a Slack API request returns an auth error."))
+        "Set to ''false'' if a Slack API request returns an auth error."))
   :type       :boolean
   :visibility :settings-manager
   :doc        false

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -508,7 +508,7 @@
                                 (into {}))]
     (when (and (:dashboard_id changes) (seq dashboard-id->name))
       (throw (ex-info
-              (tru "Can't move question into dashboard. Questions saved in dashboards can't appear in other dashboards.")
+              (tru "Can''t move question into dashboard. Questions saved in dashboards can''t appear in other dashboards.")
               {:status-code 400
                :other-dashboards dashboard-id->name}))))
   (when-let [reason (invalid-dashboard-internal-card-update-reason? card changes)]

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -124,7 +124,7 @@
                      :status-code 400})))
 
   (when (and (= type :full) hash_key)
-    (throw (ex-info (tru "Full FieldValues shouldn't have hash_key.")
+    (throw (ex-info (tru "Full FieldValues shouldn''t have hash_key.")
                     {:type        type
                      :hash_key    hash_key
                      :status-code 400})))
@@ -136,7 +136,7 @@
 
 (defn- assert-no-identity-changes [id changes]
   (when (some #(contains? changes %) [:field_id :type :hash_key])
-    (throw (ex-info (tru "Can't update field_id, type, or hash_key for a FieldValues.")
+    (throw (ex-info (tru "Can''t update field_id, type, or hash_key for a FieldValues.")
                     {:id          id
                      :field_id    (:field_id changes)
                      :type        (:type changes)

--- a/src/metabase/models/native_query_snippet.clj
+++ b/src/metabase/models/native_query_snippet.clj
@@ -67,7 +67,7 @@
             (complement #(boolean (re-find #"^\s+" %)))
             (complement #(boolean (re-find #"}" %))))
            x))]
-   (deferred-tru "snippet names cannot include '}' or start with spaces")))
+   (deferred-tru "snippet names cannot include ''}'' or start with spaces")))
 
 ;;; ------------------------------------------------- Serialization --------------------------------------------------
 

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -434,7 +434,7 @@
 ;; NB: Settings are also defined where they're used, such as in [[metabase.events.view-log]]
 
 (defsetting last-acknowledged-version
-  (deferred-tru "The last version for which a user dismissed the 'What's new?' modal.")
+  (deferred-tru "The last version for which a user dismissed the ''What''s new?'' modal.")
   :encryption :no
   :user-local :only
   :type :string)
@@ -489,7 +489,7 @@
   :default    nil)
 
 (defsetting expand-browse-in-nav
-  (deferred-tru "User preference for whether the 'Browse' section of the nav is expanded.")
+  (deferred-tru "User preference for whether the ''Browse'' section of the nav is expanded.")
   :user-local :only
   :export?    false
   :visibility :authenticated
@@ -497,7 +497,7 @@
   :default    true)
 
 (defsetting expand-bookmarks-in-nav
-  (deferred-tru "User preference for whether the 'Bookmarks' section of the nav is expanded.")
+  (deferred-tru "User preference for whether the ''Bookmarks'' section of the nav is expanded.")
   :user-local :only
   :export?    false
   :visibility :authenticated
@@ -505,7 +505,7 @@
   :default    true)
 
 (defsetting browse-filter-only-verified-models
-  (deferred-tru "User preference for whether the 'Browse models' page should be filtered to show only verified models.")
+  (deferred-tru "User preference for whether the ''Browse models'' page should be filtered to show only verified models.")
   :user-local :only
   :export?    false
   :visibility :authenticated
@@ -513,7 +513,7 @@
   :default    true)
 
 (defsetting browse-filter-only-verified-metrics
-  (deferred-tru "User preference for whether the 'Browse metrics' page should be filtered to show only verified metrics.")
+  (deferred-tru "User preference for whether the ''Browse metrics'' page should be filtered to show only verified metrics.")
   :user-local :only
   :export?    false
   :visibility :authenticated

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -79,7 +79,7 @@
     (setting/set-value-of-type! :string :update-channel new-channel)))
 
 (defsetting update-channel
-  (deferred-tru "We'll notify you here when there's a new version of this type of release.")
+  (deferred-tru "We''ll notify you here when there''s a new version of this type of release.")
   :visibility :admin
   :type       :string
   :encryption :no
@@ -775,7 +775,7 @@ See [fonts](../configuring-metabase/fonts.md).")
   :audit      :getter)
 
 (defsetting source-address-header
-  (deferred-tru "Identify the source of HTTP requests by this header's value, instead of its remote address.")
+  (deferred-tru "Identify the source of HTTP requests by this header''s value, instead of its remote address.")
   :encryption :no
   :default "X-Forwarded-For"
   :export? true

--- a/src/metabase/pulse/api/unsubscribe.clj
+++ b/src/metabase/pulse/api/unsubscribe.clj
@@ -41,7 +41,7 @@
       (let [emails (get-in pulse-channel [:details :emails])]
         (if (some #{email} emails)
           (t2/update! :model/PulseChannel (:id pulse-channel) (update-in pulse-channel [:details :emails] #(remove #{email} %)))
-          (throw (ex-info (tru "Email for pulse-id doesn't exist.")
+          (throw (ex-info (tru "Email for pulse-id doesn''t exist.")
                           {:type        type
                            :status-code 400}))))
       (events/publish-event! :event/subscription-unsubscribe {:object {:email email}})

--- a/src/metabase/query_processor/middleware/process_userland_query.clj
+++ b/src/metabase/query_processor/middleware/process_userland_query.clj
@@ -42,7 +42,7 @@
    "Enable field usage analysis for queries. This will analyze the fields used in queries and store them in the
     application database.
 
-    Turn off by default since we haven't had an user-facing feature that uses this data yet.")
+    Turn off by default since we haven''t had an user-facing feature that uses this data yet.")
   :type    :boolean
   :export? false
   :audit   :never

--- a/src/metabase/request/cookies.clj
+++ b/src/metabase/request/cookies.clj
@@ -57,7 +57,7 @@
   (contains? possible-session-cookie-samesite-values normalized-value))
 
 (defsetting session-cookie-samesite
-  (deferred-tru "Value for the session cookie's `SameSite` directive.")
+  (deferred-tru "Value for the session cookie''s `SameSite` directive.")
   :type :keyword
   :visibility :settings-manager
   :default :lax

--- a/src/metabase/sso/google.clj
+++ b/src/metabase/sso/google.clj
@@ -14,7 +14,7 @@
    [toucan2.core :as t2]))
 
 (def ^:private non-existant-account-message
-  (deferred-tru "You'll need an administrator to create a Metabase account before you can use Google to log in."))
+  (deferred-tru "You''ll need an administrator to create a Metabase account before you can use Google to log in."))
 
 (def ^:private google-auth-token-info-url "https://www.googleapis.com/oauth2/v3/tokeninfo?id_token=%s")
 

--- a/src/metabase/sso/settings.clj
+++ b/src/metabase/sso/settings.clj
@@ -51,7 +51,7 @@
   :audit      :getter)
 
 (defsetting ldap-user-filter
-  (deferred-tru "User lookup filter. The placeholder '{login'} will be replaced by the user supplied login.")
+  (deferred-tru "User lookup filter. The placeholder '''{login}''' will be replaced by the user supplied login.")
   :default    "(&(objectClass=inetOrgPerson)(|(uid={login})(mail={login})))"
   :encryption :no
   :audit      :getter)

--- a/src/metabase/util/malli/schema.clj
+++ b/src/metabase/util/malli/schema.clj
@@ -401,7 +401,7 @@
     [:fn
      {:error/message "valid locale"}
      i18n/available-locale?]]
-   (deferred-tru "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'.")))
+   (deferred-tru "String must be a valid two-letter ISO language or language-country code e.g. ''en'' or ''en_US''.")))
 
 (def NanoIdString
   "Schema for a 21-character NanoID string, like \"FReCLx5hSWTBU7kjCWfuu\"."

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -3573,7 +3573,7 @@
                                          {:parameters [{:id    "_THIS_PARAMETER_DOES_NOT_EXIST_"
                                                         :value 3}]}))))
           (testing "Should return sensible error message for invalid parameter input"
-            (is (= {:errors {:parameters "nullable sequence of value must be a parameter map with an id key"},
+            (is (= {:errors {:parameters "nullable sequence of value must be a parameter map with an 'id' key"},
                     :specific-errors {:parameters ["invalid type, received: {:_PRICE_ 3}"]}}
                    (mt/user-http-request :rasta :post 400 url
                                          {:parameters {"_PRICE_" 3}}))))

--- a/test/metabase/models/field_values_test.clj
+++ b/test/metabase/models/field_values_test.clj
@@ -363,10 +363,10 @@
     (let [field-id (mt/id :venues :id)]
       (try
         (is (thrown-with-msg? ExceptionInfo
-                              #"Full FieldValues shouldnt have hash_key"
+                              #"Full FieldValues shouldn't have hash_key"
                               (t2/insert! :model/FieldValues :field_id field-id :hash_key "12345")))
         (is (thrown-with-msg? ExceptionInfo
-                              #"Full FieldValues shouldnt have hash_key"
+                              #"Full FieldValues shouldn't have hash_key"
                               (t2/insert! :model/FieldValues :field_id field-id :type :full :hash_key "12345")))
         (is (thrown-with-msg? ExceptionInfo
                               #"Advanced FieldValues require a hash_key"
@@ -398,7 +398,7 @@
                                [sandbox-id {:type :full, :hash_key nil}]
                                [full-id {:type :sandbox, :hash_key "random-hash"}]]]
         (is (thrown-with-msg? ExceptionInfo
-                              #"Cant update field_id, type, or hash_key for a FieldValues."
+                              #"Can't update field_id, type, or hash_key for a FieldValues."
                               (t2/update! :model/FieldValues id update-map)))))
 
     (testing "The model hooks permits mention of the existing values"

--- a/test/metabase/pulse/api/unsubscribe_test.clj
+++ b/test/metabase/pulse/api/unsubscribe_test.clj
@@ -32,7 +32,7 @@
       (testing "Valid hash but not email"
         (mt/with-temp [:model/Pulse        {pulse-id :id} {}
                        :model/PulseChannel _              {:pulse_id pulse-id}]
-          (is (= "Email for pulse-id doesnt exist."
+          (is (= "Email for pulse-id doesn't exist."
                  (mt/client :post 400 "pulse/unsubscribe" {:pulse-id pulse-id
                                                            :email    email
                                                            :hash     (messages/generate-pulse-unsubscribe-hash pulse-id email)})))))

--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -630,7 +630,7 @@
             (testing "source-timezone is required"
               (is (thrown-with-msg?
                    clojure.lang.ExceptionInfo
-                   #"input column doesnt have a set timezone. Please set the source parameter in convertTimezone to convert it."
+                   #"input column doesn't have a set timezone. Please set the source parameter in convertTimezone to convert it."
                    (mt/$ids (test-convert-tz
                              $times.dt
                              [:convert-timezone [:field (mt/id :times :dt) nil] "Asia/Seoul"]))))))

--- a/test/metabase/setup/api_test.clj
+++ b/test/metabase/setup/api_test.clj
@@ -231,11 +231,11 @@
     (testing "site locale"
       (testing "invalid format"
         (is (=? {:specific-errors {:prefs {:site_locale ["valid locale, received: \"eng-USA\""]}}
-                 :errors {:prefs #(str/includes? % ":site_locale (optional) -> <nullable String must be a valid two-letter ISO language or language-country code e.g. en or en_US.>")}}
+                 :errors {:prefs #(str/includes? % ":site_locale (optional) -> <nullable String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'.>")}}
                 (setup! assoc-in [:prefs :site_locale] "eng-USA"))))
       (testing "non-existent locale"
         (is (=? {:specific-errors {:prefs {:site_locale ["valid locale, received: \"en-EN\""]}}
-                 :errors {:prefs #(str/includes? % ":site_locale (optional) -> <nullable String must be a valid two-letter ISO language or language-country code e.g. en or en_US.>")}}
+                 :errors {:prefs #(str/includes? % ":site_locale (optional) -> <nullable String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'.>")}}
                 (setup! assoc-in [:prefs :site_locale] "en-EN")))))))
 
 (deftest setup-validation-test-4


### PR DESCRIPTION
For i18n, we had a lot of things like

```
(tru "this user's string will be broken")
```

During i18n, we use `java.text.MessageFormat` to format messages. These have a great idea: you can format messages with parameters like `{0}`, or escape these cases with single-quotes like `'{0}'` when you actually want the string "{0}". And of course, you can escape a single-quote itself just by doubling it, so "''" becomes a "'".

All this makes sense. But then they had a problem. What if there's an unescaped single-quote in the argument to MessageFormat?

A lesser program might have thrown an exception here, but not MessageFormat! Nay! We must persist, lads, not give up at the first sign of trouble!

Instead, let's just decide that the programmer probably *meant* to close that single-quote! So, for example, "This user's message is totally frickin broken" is interpreted AS IF you'd written "This user's message is totally frickin broken'" (which ends up as "This users message is totally frickin broken"), which - doubtless - is what you intended.

Unfortunately there are *some* few cases where - IT TURNS OUT - we don't actually want this behavior! For example,

```
(deferred-tru "Key to retrieve the JWT user's email address.")
```

becomes "Key to retrieve the JWT users email address." Which is slightly annoying.

So: let's have a kondo rule that will enforce statically that you don't have unescaped single-quotes in your template strings for `tru`, `deferred-tru`, `trs`, or `deferred-trs`.
