### PR TITLE
New tiles APIs to support parameterization and public sharing/embedding

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -197,7 +197,7 @@
 
   embed
   {:api  #{metabase.embed.settings}
-   :uses #{analytics models premium-features util}}
+   :uses #{analytics models premium-features tiles util}}
 
   events
   {:api  #{metabase.events metabase.events.init metabase.events.notification}
@@ -392,7 +392,7 @@
   {:api  #{metabase.public-sharing.api
            metabase.public-sharing.core
            metabase.public-sharing.init}
-   :uses #{actions analytics api db events lib models query-processor request util}}
+   :uses #{actions analytics api db events lib models query-processor request tiles util}}
 
   pulse
   {:api  #{metabase.pulse.api

--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -381,7 +381,7 @@
    :- [:merge
        :api.tiles/route-params
        [:map
-        [:token     string?]]]
+        [:token string?]]]
    {:keys [parameters]}
    :- [:map
        [:parameters {:optional true} ms/JSONString]]]
@@ -395,8 +395,8 @@
   "Generates a single tile image for a Card on an embedded Dashboard using the map visualization."
   [{:keys [token dashcard-id card-id zoom x y lat-field lon-field]}
    :- [:merge
+       :api.tiles/route-params
        [:map
-        :api.tiles/route-params
         [:token       string?]
         [:dashcard-id ms/PositiveInt]
         [:card-id     ms/PositiveInt]]]

--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -378,13 +378,10 @@
 (api.macros/defendpoint :get "/tiles/card/:token/:zoom/:x/:y/:lat-field/:lon-field"
   "Generates a single tile image for an embedded Card using the map visualization."
   [{:keys [token zoom x y lat-field lon-field]}
-   :- [:map
-       [:token     string?]
-       [:zoom      ms/Int]
-       [:x         ms/Int]
-       [:y         ms/Int]
-       [:lat-field ::api.tiles/field-id-or-name]
-       [:lon-field ::api.tiles/field-id-or-name]]
+   :- [:merge
+       :api.tiles/route-params
+       [:map
+        [:token     string?]]]
    {:keys [parameters]}
    :- [:map
        [:parameters {:optional true} ms/JSONString]]]
@@ -397,15 +394,12 @@
 (api.macros/defendpoint :get "/tiles/dashboard/:token/dashcard/:dashcard-id/card/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
   "Generates a single tile image for a Card on an embedded Dashboard using the map visualization."
   [{:keys [token dashcard-id card-id zoom x y lat-field lon-field]}
-   :- [:map
-       [:token       string?]
-       [:dashcard-id ms/PositiveInt]
-       [:card-id     ms/PositiveInt]
-       [:zoom        ms/Int]
-       [:x           ms/Int]
-       [:y           ms/Int]
-       [:lat-field   ::api.tiles/field-id-or-name]
-       [:lon-field   ::api.tiles/field-id-or-name]]
+   :- [:merge
+       [:map
+        :api.tiles/route-params
+        [:token       string?]
+        [:dashcard-id ms/PositiveInt]
+        [:card-id     ms/PositiveInt]]]
    {:keys [parameters]}
    :- [:map
        [:parameters {:optional true} ms/JSONString]]]

--- a/src/metabase/public_sharing/api.clj
+++ b/src/metabase/public_sharing/api.clj
@@ -731,7 +731,7 @@
    :- [:merge
        :api.tiles/route-params
        [:map
-        [:uuid      ms/UUIDString]]]
+        [:uuid ms/UUIDString]]]
    {:keys [parameters]}
    :- [:map
        [:parameters {:optional true} ms/JSONString]]]

--- a/src/metabase/public_sharing/api.clj
+++ b/src/metabase/public_sharing/api.clj
@@ -728,13 +728,10 @@
   "Generates a single tile image for a publicly-accessible Card using the map visualization. Does not require auth
   credentials. Public sharing must be enabled."
   [{:keys [uuid zoom x y lat-field lon-field]}
-   :- [:map
-       [:uuid      ms/UUIDString]
-       [:zoom      ms/Int]
-       [:x         ms/Int]
-       [:y         ms/Int]
-       [:lat-field ::api.tiles/field-id-or-name]
-       [:lon-field ::api.tiles/field-id-or-name]]
+   :- [:merge
+       :api.tiles/route-params
+       [:map
+        [:uuid      ms/UUIDString]]]
    {:keys [parameters]}
    :- [:map
        [:parameters {:optional true} ms/JSONString]]]
@@ -747,15 +744,12 @@
   "Generates a single tile image for a Card using the map visualization in a publicly-accessible Dashboard. Does not
   require auth credentials. Public sharing must be enabled."
   [{:keys [uuid dashcard-id card-id zoom x y lat-field lon-field]}
-   :- [:map
-       [:uuid        ms/UUIDString]
-       [:dashcard-id ms/PositiveInt]
-       [:card-id     ms/PositiveInt]
-       [:zoom        ms/Int]
-       [:x           ms/Int]
-       [:y           ms/Int]
-       [:lat-field   ::api.tiles/field-id-or-name]
-       [:lon-field   ::api.tiles/field-id-or-name]]
+   :- [:merge
+       :api.tiles/route-params
+       [:map
+        [:uuid        ms/UUIDString]
+        [:dashcard-id ms/PositiveInt]
+        [:card-id     ms/PositiveInt]]]
    {:keys [parameters]}
    :- [:map
        [:parameters {:optional true} ms/JSONString]]]

--- a/src/metabase/tiles/api.clj
+++ b/src/metabase/tiles/api.clj
@@ -171,8 +171,16 @@
 
 ;;; TODO -- what if the field name contains a slash? Are we expected to URL-encode it? I don't think we have any code
 ;;; that handles that.
-(mr/def ::field-id-or-name
+(mr/def :api.tiles/field-id-or-name
   [:string {:api/regex #"[^/]+"}])
+
+(mr/def :api.tiles/route-params
+  [:map
+   [:zoom        ms/Int]
+   [:x           ms/Int]
+   [:y           ms/Int]
+   [:lat-field   :api.tiles/field-id-or-name]
+   [:lon-field   :api.tiles/field-id-or-name]])
 
 (defn- result->points
   [{{:keys [rows cols]} :data} lat-field lon-field]
@@ -205,12 +213,7 @@
 ;; parallel.
 (api.macros/defendpoint :get "/:zoom/:x/:y/:lat-field/:lon-field"
   "Generates a single tile image for an ad-hoc query."
-  [{:keys [zoom x y lat-field lon-field]} :- [:map
-                                              [:zoom      ms/Int]
-                                              [:x         ms/Int]
-                                              [:y         ms/Int]
-                                              [:lat-field ::field-id-or-name]
-                                              [:lon-field ::field-id-or-name]]
+  [{:keys [zoom x y lat-field lon-field]} :- :api.tiles/route-params
    {:keys [query]} :- [:map
                        [:query ms/JSONString]]]
   (let [query         (json/decode+kw query)
@@ -264,13 +267,10 @@
 (api.macros/defendpoint :get "/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
   "Generates a single tile image for a saved Card."
   [{:keys [card-id zoom x y lat-field lon-field]}
-   :- [:map
-       [:card-id   ms/PositiveInt]
-       [:zoom      ms/Int]
-       [:x         ms/Int]
-       [:y         ms/Int]
-       [:lat-field ::field-id-or-name]
-       [:lon-field ::field-id-or-name]]
+   :- [:merge
+       :api.tiles/route-params
+       [:map
+        [:card-id ms/PositiveInt]]]
    {:keys [parameters]}
    :- [:map
        [:parameters {:optional true} ms/JSONString]]]
@@ -280,15 +280,12 @@
 (api.macros/defendpoint :get "/:dashboard-id/dashcard/:dashcard-id/card/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
   "Generates a single tile image for a dashcard."
   [{:keys [dashboard-id dashcard-id card-id zoom x y lat-field lon-field]}
-   :- [:map
-       [:dashboard-id ms/PositiveInt]
-       [:dashcard-id ms/PositiveInt]
-       [:card-id   ms/PositiveInt]
-       [:zoom      ms/Int]
-       [:x         ms/Int]
-       [:y         ms/Int]
-       [:lat-field ::field-id-or-name]
-       [:lon-field ::field-id-or-name]]
+   :- [:merge
+       :api.tiles/route-params
+       [:map
+        [:dashboard-id ms/PositiveInt]
+        [:dashcard-id ms/PositiveInt]
+        [:card-id   ms/PositiveInt]]]
    {:keys [parameters]}
    :- [:map
        [:parameters {:optional true} ms/JSONString]]]

--- a/src/metabase/tiles/api.clj
+++ b/src/metabase/tiles/api.clj
@@ -227,19 +227,9 @@
         points        (result->points result lat-field lon-field)]
     (tiles-response result zoom points)))
 
-(api.macros/defendpoint :get "/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
-  "Generates a single tile image for a saved Card."
-  [{:keys [card-id zoom x y lat-field lon-field]}
-   :- [:map
-       [:card-id   ms/PositiveInt]
-       [:zoom      ms/Int]
-       [:x         ms/Int]
-       [:y         ms/Int]
-       [:lat-field ::field-id-or-name]
-       [:lon-field ::field-id-or-name]]
-   {:keys [parameters]}
-   :- [:map
-       [:parameters {:optional true} ms/JSONString]]]
+(defn process-tiles-query-for-card
+  "Generates a single tile image for a dashcard and returns a Ring response that contains the data as a PNG"
+  [card-id parameters zoom x y lat-field lon-field]
   (let [parameters (json/decode+kw parameters)
         result
         (qp.card/process-query-for-card
@@ -257,21 +247,9 @@
         points (result->points result lat-field lon-field)]
     (tiles-response result zoom points)))
 
-(api.macros/defendpoint :get "/:dashboard-id/dashcard/:dashcard-id/card/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
-  "Generates a single tile image for a dashcard."
-  [{:keys [dashboard-id dashcard-id card-id zoom x y lat-field lon-field]}
-   :- [:map
-       [:dashboard-id ms/PositiveInt]
-       [:dashcard-id ms/PositiveInt]
-       [:card-id   ms/PositiveInt]
-       [:zoom      ms/Int]
-       [:x         ms/Int]
-       [:y         ms/Int]
-       [:lat-field ::field-id-or-name]
-       [:lon-field ::field-id-or-name]]
-   {:keys [parameters]}
-   :- [:map
-       [:parameters {:optional true} ms/JSONString]]]
+(defn process-tiles-query-for-dashcard
+  "Generates a single tile image for a dashcard and returns a Ring response that contains the data as a PNG"
+  [dashboard-id dashcard-id card-id parameters zoom x y lat-field lon-field]
   (let [parameters (json/decode+kw parameters)
         result
         (qp.dashboard/process-query-for-dashcard
@@ -290,3 +268,37 @@
                                qp/process-query))))
         points (result->points result lat-field lon-field)]
     (tiles-response result zoom points)))
+
+(api.macros/defendpoint :get "/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
+  "Generates a single tile image for a saved Card."
+  [{:keys [card-id zoom x y lat-field lon-field]}
+   :- [:map
+       [:card-id   ms/PositiveInt]
+       [:zoom      ms/Int]
+       [:x         ms/Int]
+       [:y         ms/Int]
+       [:lat-field ::field-id-or-name]
+       [:lon-field ::field-id-or-name]]
+   {:keys [parameters]}
+   :- [:map
+       [:parameters {:optional true} ms/JSONString]]]
+  (let [parameters (json/decode+kw parameters)]
+    (process-tiles-query-for-card card-id parameters zoom x y lat-field lon-field)))
+
+(api.macros/defendpoint :get "/:dashboard-id/dashcard/:dashcard-id/card/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
+  "Generates a single tile image for a dashcard."
+  [{:keys [dashboard-id dashcard-id card-id zoom x y lat-field lon-field]}
+   :- [:map
+       [:dashboard-id ms/PositiveInt]
+       [:dashcard-id ms/PositiveInt]
+       [:card-id   ms/PositiveInt]
+       [:zoom      ms/Int]
+       [:x         ms/Int]
+       [:y         ms/Int]
+       [:lat-field ::field-id-or-name]
+       [:lon-field ::field-id-or-name]]
+   {:keys [parameters]}
+   :- [:map
+       [:parameters {:optional true} ms/JSONString]]]
+  (let [parameters (json/decode+kw parameters)]
+    (process-tiles-query-for-dashcard dashboard-id dashcard-id card-id parameters zoom x y lat-field lon-field)))

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -2065,3 +2065,47 @@
            :status :invalid-format,
            :reason ["\"abcdefghijklmnopqrst\" should be 21 characters long, but it is 20"]}}
          (api.embed.common/model->entity-ids->ids {:card ["abcdefghijklmnopqrst"]}))))
+
+;;; ------------------------------------------ Tile endpoints ---------------------------------------------------------
+
+(defn- png? [s]
+  (= [\P \N \G] (drop 1 (take 4 s))))
+
+(defn- venues-query
+  []
+  {:database (mt/id)
+   :type     :query
+   :query    {:source-table (mt/id :people)
+              :fields [[:field (mt/id :people :id) nil]
+                       [:field (mt/id :people :state) nil]
+                       [:field (mt/id :people :latitude) nil]
+                       [:field (mt/id :people :longitude) nil]]}})
+
+(deftest card-tile-query-test
+  (testing "GET api/embed/tiles/card/:uuid/:zoom/:x/:y/:lat-field/:lon-field"
+    (with-embedding-enabled-and-new-secret-key!
+      (mt/with-temp [:model/Card {card-id :id} {:dataset_query (venues-query)
+                                                :enable_embedding true}]
+        (let [token (card-token card-id)]
+          (is (png? (mt/user-http-request
+                     :crowberto :get 200 (format "embed/tiles/card/%s/1/1/1/%d/%d"
+                                                 token
+                                                 (mt/id :people :latitude)
+                                                 (mt/id :people :longitude))))))))))
+
+(deftest dashcard-tile-query-test
+  (testing "GET api/embed/tiles/dashboard/:uuid/dashcard/:dashcard-id/card/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
+    (with-embedding-enabled-and-new-secret-key!
+      (mt/with-temp [:model/Dashboard     {dashboard-id :id} {:enable_embedding true}
+
+                     :model/Card          {card-id :id}      {:dataset_query (venues-query)}
+                     :model/DashboardCard {dashcard-id :id}  {:card_id card-id
+                                                              :dashboard_id dashboard-id}]
+        (let [token (dash-token dashboard-id)]
+          (is (png? (mt/user-http-request
+                     :crowberto :get 200 (format "embed/tiles/dashboard/%s/dashcard/%d/card/%d/1/1/1/%d/%d"
+                                                 token
+                                                 dashcard-id
+                                                 card-id
+                                                 (mt/id :people :latitude)
+                                                 (mt/id :people :longitude))))))))))

--- a/test/metabase/tiles/api_test.clj
+++ b/test/metabase/tiles/api_test.clj
@@ -3,38 +3,160 @@
   (:require
    [clojure.set :as set]
    [clojure.test :refer :all]
-   [metabase.query-processor.compile :as qp.compile]
    [metabase.test :as mt]
    [metabase.tiles.api :as api.tiles]
+   [metabase.util :as u]
    [metabase.util.json :as json]))
 
+;; TODO: Assert on the contents of the response, not just the format
 (defn- png? [s]
   (= [\P \N \G]
      (drop 1 (take 4 s))))
 
-(deftest basic-test
-  (let [venues-query {:database (mt/id)
-                      :type     :query
-                      :query    {:source-table (mt/id :venues)
-                                 :fields [[:field (mt/id :venues :name) nil]
-                                          [:field (mt/id :venues :latitude) nil]
-                                          [:field (mt/id :venues :longitude) nil]]}}]
-    (testing "GET /api/tiles/:zoom/:x/:y/:lat-field-id/:lon-field-id"
-      (is (png? (mt/user-http-request
-                 :crowberto :get 200 (format "tiles/1/1/1/%d/%d"
-                                             (mt/id :venues :latitude)
-                                             (mt/id :venues :longitude))
-                 :query (json/encode venues-query)))))
-    (testing "Works on native queries"
-      (let [native-query {:query (:query (qp.compile/compile venues-query))
-                          :template-tags {}}]
+(defn- venues-query
+  []
+  {:database (mt/id)
+   :type     :query
+   :query    {:source-table (mt/id :people)
+              :fields [[:field (mt/id :people :id) nil]
+                       [:field (mt/id :people :state) nil]
+                       [:field (mt/id :people :latitude) nil]
+                       [:field (mt/id :people :longitude) nil]]}})
+
+(defn- native-query
+  []
+  {:database (mt/id)
+   :type     :native
+   :native   {:query "SELECT LATITUDE, LONGITUDE FROM PEOPLE;"
+              :template-tags {}}})
+
+(defn- parameterized-native-query
+  []
+  {:database (mt/id)
+   :type     :native
+   :native   {:query "SELECT LATITUDE, LONGITUDE FROM PEOPLE WHERE STATE = {{state}};"
+              :template-tags {"state" {:id           "_STATE_"
+                                       :name         "state"
+                                       :display-name "State"
+                                       :type         "text"
+                                       :required     false}}}})
+
+(deftest ad-hoc-query-test
+  (testing "GET /api/tiles/:zoom/:x/:y/:lat-field/:lon-field"
+    (is (png? (mt/user-http-request
+               :crowberto :get 200 (format "tiles/4/2/4/%d/%d"
+                                           (mt/id :people :latitude)
+                                           (mt/id :people :longitude))
+               :query (json/encode (venues-query))))))
+  (testing "Works on native queries"
+    (is (png? (mt/user-http-request
+               :crowberto :get 200 (format "tiles/1/1/1/%s/%s"
+                                           "LATITUDE"
+                                           "LONGITUDE")
+               :query (json/encode (native-query)))))))
+
+(deftest saved-card-test
+  (testing "GET /api/tiles/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
+    (testing "MBQL saved card"
+      (mt/with-temp [:model/Card card {:dataset_query (venues-query)}]
         (is (png? (mt/user-http-request
-                   :crowberto :get 200 (format "tiles/1/1/1/%s/%s"
-                                               "LATITUDE" "LONGITUDE")
-                   :query (json/encode
-                           {:database (mt/id)
-                            :type :native
-                            :native native-query}))))))))
+                   :crowberto :get 200 (format "tiles/%d/1/1/1/%d/%d"
+                                               (u/id card)
+                                               (mt/id :people :latitude)
+                                               (mt/id :people :longitude)))))))
+
+    (testing "Native saved card"
+      (mt/with-temp [:model/Card card {:dataset_query (native-query)}]
+        (testing "GET /api/tiles/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
+          (is (png? (mt/user-http-request
+                     :crowberto :get 200 (format "tiles/%d/1/1/1/%s/%s"
+                                                 (u/id card)
+                                                 "LATITUDE" "LONGITUDE")))))))
+
+    (testing "Parameterized native saved card"
+      (mt/with-temp [:model/Card card {:dataset_query (parameterized-native-query)}]
+        (testing "GET /api/tiles/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
+          (is (png? (mt/user-http-request
+                     :crowberto :get 200 (format "tiles/%d/1/1/1/%s/%s"
+                                                 (u/id card)
+                                                 "LATITUDE"
+                                                 "LONGITUDE")
+                     :parameters (json/encode [{:type :text
+                                                :target [:variable [:template-tag :state]]
+                                                :value "CA"}])))))))))
+
+(deftest dashcard-test
+  (testing "GET /api/tiles/:dashboard-id/dashcard/:dashcard-id/card/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
+    (testing "MBQL dashcard"
+      (mt/with-temp [:model/Dashboard {dashboard-id :id} {}
+                     :model/Card {card-id :id} {:dataset_query (venues-query)}
+                     :model/DashboardCard {dashcard-id :id} {:card_id card-id
+                                                             :dashboard_id dashboard-id}]
+        (is (png? (mt/user-http-request
+                   :crowberto :get 200 (format "tiles/%d/dashcard/%d/card/%d/1/1/1/%d/%d"
+                                               dashboard-id
+                                               dashcard-id
+                                               card-id
+                                               (mt/id :people :latitude)
+                                               (mt/id :people :longitude)))))))
+
+    (testing "Native dashcard"
+      (mt/with-temp [:model/Dashboard {dashboard-id :id} {}
+                     :model/Card {card-id :id} {:dataset_query (native-query)}
+                     :model/DashboardCard {dashcard-id :id} {:card_id card-id
+                                                             :dashboard_id dashboard-id}]
+        (testing "GET /api/tiles/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
+          (is (png? (mt/user-http-request
+                     :crowberto :get 200 (format "tiles/%d/dashcard/%d/card/%d/1/1/1/%s/%s"
+                                                 dashboard-id
+                                                 dashcard-id
+                                                 card-id
+                                                 "LATITUDE"
+                                                 "LONGITUDE")))))))
+
+    (testing "Parameterized mbql dashcard"
+      (mt/with-temp [:model/Dashboard  {dashboard-id :id} {:parameters [{:name "State"
+                                                                         :id "_STATE_"
+                                                                         :type "text"}]}
+
+                     :model/Card {card-id :id} {:dataset_query (venues-query)}
+                     :model/DashboardCard {dashcard-id :id} {:card_id card-id
+                                                             :dashboard_id dashboard-id
+                                                             :parameter_mappings [{:parameter_id "_STATE_"
+                                                                                   :card_id card-id
+                                                                                   :target [:dimension (mt/$ids people $state)]}]}]
+        (testing "GET /api/tiles/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
+          (is (png? (mt/user-http-request
+                     :crowberto :get 200 (format "tiles/%d/dashcard/%d/card/%d/1/1/1/%s/%s"
+                                                 dashboard-id
+                                                 dashcard-id
+                                                 card-id
+                                                 (mt/id :people :latitude)
+                                                 (mt/id :people :longitude))
+                     :parameters (json/encode [{:id "_STATE_"
+                                                :value ["CA"]}])))))))
+
+    (testing "Parameterized native dashcard"
+      (mt/with-temp [:model/Dashboard  {dashboard-id :id} {:parameters [{:name "State"
+                                                                         :id "_STATE_"
+                                                                         :type "text"}]}
+
+                     :model/Card {card-id :id} {:dataset_query (parameterized-native-query)}
+                     :model/DashboardCard {dashcard-id :id} {:card_id card-id
+                                                             :dashboard_id dashboard-id
+                                                             :parameter_mappings [{:parameter_id "_STATE_"
+                                                                                   :card_id card-id
+                                                                                   :target [:variable ["template-tag" "state"]]}]}]
+        (testing "GET /api/tiles/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
+          (is (png? (mt/user-http-request
+                     :crowberto :get 200 (format "tiles/%d/dashcard/%d/card/%d/1/1/1/%s/%s"
+                                                 dashboard-id
+                                                 dashcard-id
+                                                 card-id
+                                                 "LATITUDE"
+                                                 "LONGITUDE")
+                     :parameters (json/encode [{:id "_STATE_"
+                                                :value ["CA"]}])))))))))
 
 (deftest query->tiles-query-test
   (letfn [(clean [q]

--- a/test/metabase/tiles/api_test.clj
+++ b/test/metabase/tiles/api_test.clj
@@ -157,7 +157,7 @@
                      :parameters (json/encode [{:id "_STATE_"
                                                 :value ["CA"]}])))))))))
 
-(deftest query->tiles-query-test
+(deftest tiles-query-test
   (letfn [(clean [q]
             (-> q
                 (update-in [:query :filter] #(take 3 %))))]
@@ -178,10 +178,8 @@
                           :limit 2000
                           :filter [:inside [:field 574 nil] [:field 576 nil]]}
                   :type :query}
-                 (clean (#'api.tiles/query->tiles-query query
-                                                        {:zoom 2 :x 3 :y 1
-                                                         :lat-field [:field 574 nil]
-                                                         :lon-field [:field 576 nil]})))))))
+                 (clean (#'api.tiles/tiles-query query 2 3 1 "574" "576")))))))
+
     (testing "native"
       (testing "nests the query, selects fields"
         (let [query {:type :native
@@ -197,10 +195,7 @@
                                    [:field "longitude" {:base-type :type/Float}]]
                           :limit  2000}
                   :type :query}
-                 (clean (@#'api.tiles/query->tiles-query query
-                                                         {:zoom 2 :x 2 :y 1
-                                                          :lat-field [:field "latitude" {:base-type :type/Float}]
-                                                          :lon-field [:field "longitude" {:base-type :type/Float}]})))))))))
+                 (clean (@#'api.tiles/tiles-query query 2 2 1 "latitude" "longitude")))))))))
 
 (deftest breakout-query-test
   (testing "the appropriate lat/lon fields are selected from the results, if the query contains a :breakout clause (#20182)"

--- a/test/metabase/tiles/api_test.clj
+++ b/test/metabase/tiles/api_test.clj
@@ -9,9 +9,8 @@
    [metabase.util.json :as json]))
 
 ;; TODO: Assert on the contents of the response, not just the format
-(defn- png? [s]
-  (= [\P \N \G]
-     (drop 1 (take 4 s))))
+(defn png? [s]
+  (= [\P \N \G] (drop 1 (take 4 s))))
 
 (defn- venues-query
   []
@@ -88,10 +87,10 @@
 (deftest dashcard-test
   (testing "GET /api/tiles/:dashboard-id/dashcard/:dashcard-id/card/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
     (testing "MBQL dashcard"
-      (mt/with-temp [:model/Dashboard {dashboard-id :id} {}
-                     :model/Card {card-id :id} {:dataset_query (venues-query)}
-                     :model/DashboardCard {dashcard-id :id} {:card_id card-id
-                                                             :dashboard_id dashboard-id}]
+      (mt/with-temp [:model/Dashboard     {dashboard-id :id} {}
+                     :model/Card          {card-id :id}      {:dataset_query (venues-query)}
+                     :model/DashboardCard {dashcard-id :id}  {:card_id card-id
+                                                              :dashboard_id dashboard-id}]
         (is (png? (mt/user-http-request
                    :crowberto :get 200 (format "tiles/%d/dashcard/%d/card/%d/1/1/1/%d/%d"
                                                dashboard-id
@@ -101,10 +100,10 @@
                                                (mt/id :people :longitude)))))))
 
     (testing "Native dashcard"
-      (mt/with-temp [:model/Dashboard {dashboard-id :id} {}
-                     :model/Card {card-id :id} {:dataset_query (native-query)}
-                     :model/DashboardCard {dashcard-id :id} {:card_id card-id
-                                                             :dashboard_id dashboard-id}]
+      (mt/with-temp [:model/Dashboard     {dashboard-id :id} {}
+                     :model/Card          {card-id :id}      {:dataset_query (native-query)}
+                     :model/DashboardCard {dashcard-id :id}  {:card_id card-id
+                                                              :dashboard_id dashboard-id}]
         (testing "GET /api/tiles/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
           (is (png? (mt/user-http-request
                      :crowberto :get 200 (format "tiles/%d/dashcard/%d/card/%d/1/1/1/%s/%s"
@@ -115,16 +114,16 @@
                                                  "LONGITUDE")))))))
 
     (testing "Parameterized mbql dashcard"
-      (mt/with-temp [:model/Dashboard  {dashboard-id :id} {:parameters [{:name "State"
-                                                                         :id "_STATE_"
-                                                                         :type "text"}]}
+      (mt/with-temp [:model/Dashboard     {dashboard-id :id} {:parameters [{:name "State"
+                                                                            :id "_STATE_"
+                                                                            :type "text"}]}
 
-                     :model/Card {card-id :id} {:dataset_query (venues-query)}
-                     :model/DashboardCard {dashcard-id :id} {:card_id card-id
-                                                             :dashboard_id dashboard-id
-                                                             :parameter_mappings [{:parameter_id "_STATE_"
-                                                                                   :card_id card-id
-                                                                                   :target [:dimension (mt/$ids people $state)]}]}]
+                     :model/Card          {card-id :id}      {:dataset_query (venues-query)}
+                     :model/DashboardCard {dashcard-id :id}  {:card_id card-id
+                                                              :dashboard_id dashboard-id
+                                                              :parameter_mappings [{:parameter_id "_STATE_"
+                                                                                    :card_id card-id
+                                                                                    :target [:dimension (mt/$ids people $state)]}]}]
         (testing "GET /api/tiles/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
           (is (png? (mt/user-http-request
                      :crowberto :get 200 (format "tiles/%d/dashcard/%d/card/%d/1/1/1/%s/%s"
@@ -137,16 +136,16 @@
                                                 :value ["CA"]}])))))))
 
     (testing "Parameterized native dashcard"
-      (mt/with-temp [:model/Dashboard  {dashboard-id :id} {:parameters [{:name "State"
-                                                                         :id "_STATE_"
-                                                                         :type "text"}]}
+      (mt/with-temp [:model/Dashboard     {dashboard-id :id} {:parameters [{:name "State"
+                                                                            :id "_STATE_"
+                                                                            :type "text"}]}
 
-                     :model/Card {card-id :id} {:dataset_query (parameterized-native-query)}
-                     :model/DashboardCard {dashcard-id :id} {:card_id card-id
-                                                             :dashboard_id dashboard-id
-                                                             :parameter_mappings [{:parameter_id "_STATE_"
-                                                                                   :card_id card-id
-                                                                                   :target [:variable ["template-tag" "state"]]}]}]
+                     :model/Card          {card-id :id}      {:dataset_query (parameterized-native-query)}
+                     :model/DashboardCard {dashcard-id :id}  {:card_id card-id
+                                                              :dashboard_id dashboard-id
+                                                              :parameter_mappings [{:parameter_id "_STATE_"
+                                                                                    :card_id card-id
+                                                                                    :target [:variable ["template-tag" "state"]]}]}]
         (testing "GET /api/tiles/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
           (is (png? (mt/user-http-request
                      :crowberto :get 200 (format "tiles/%d/dashcard/%d/card/%d/1/1/1/%s/%s"

--- a/test/metabase/tiles/api_test.clj
+++ b/test/metabase/tiles/api_test.clj
@@ -111,51 +111,52 @@
                                                  dashcard-id
                                                  card-id
                                                  "LATITUDE"
-                                                 "LONGITUDE")))))))
+                                                 "LONGITUDE")))))))))
 
-    (testing "Parameterized mbql dashcard"
-      (mt/with-temp [:model/Dashboard     {dashboard-id :id} {:parameters [{:name "State"
-                                                                            :id "_STATE_"
-                                                                            :type "text"}]}
+(deftest parameterized-dashcard-test
+  (testing "Parameterized mbql dashcard"
+    (mt/with-temp [:model/Dashboard     {dashboard-id :id} {:parameters [{:name "State"
+                                                                          :id "_STATE_"
+                                                                          :type "text"}]}
 
-                     :model/Card          {card-id :id}      {:dataset_query (venues-query)}
-                     :model/DashboardCard {dashcard-id :id}  {:card_id card-id
-                                                              :dashboard_id dashboard-id
-                                                              :parameter_mappings [{:parameter_id "_STATE_"
-                                                                                    :card_id card-id
-                                                                                    :target [:dimension (mt/$ids people $state)]}]}]
-        (testing "GET /api/tiles/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
-          (is (png? (mt/user-http-request
-                     :crowberto :get 200 (format "tiles/%d/dashcard/%d/card/%d/1/1/1/%s/%s"
-                                                 dashboard-id
-                                                 dashcard-id
-                                                 card-id
-                                                 (mt/id :people :latitude)
-                                                 (mt/id :people :longitude))
-                     :parameters (json/encode [{:id "_STATE_"
-                                                :value ["CA"]}])))))))
+                   :model/Card          {card-id :id}      {:dataset_query (venues-query)}
+                   :model/DashboardCard {dashcard-id :id}  {:card_id card-id
+                                                            :dashboard_id dashboard-id
+                                                            :parameter_mappings [{:parameter_id "_STATE_"
+                                                                                  :card_id card-id
+                                                                                  :target [:dimension (mt/$ids people $state)]}]}]
+      (testing "GET /api/tiles/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
+        (is (png? (mt/user-http-request
+                   :crowberto :get 200 (format "tiles/%d/dashcard/%d/card/%d/1/1/1/%s/%s"
+                                               dashboard-id
+                                               dashcard-id
+                                               card-id
+                                               (mt/id :people :latitude)
+                                               (mt/id :people :longitude))
+                   :parameters (json/encode [{:id "_STATE_"
+                                              :value ["CA"]}])))))))
 
-    (testing "Parameterized native dashcard"
-      (mt/with-temp [:model/Dashboard     {dashboard-id :id} {:parameters [{:name "State"
-                                                                            :id "_STATE_"
-                                                                            :type "text"}]}
+  (testing "Parameterized native dashcard"
+    (mt/with-temp [:model/Dashboard     {dashboard-id :id} {:parameters [{:name "State"
+                                                                          :id "_STATE_"
+                                                                          :type "text"}]}
 
-                     :model/Card          {card-id :id}      {:dataset_query (parameterized-native-query)}
-                     :model/DashboardCard {dashcard-id :id}  {:card_id card-id
-                                                              :dashboard_id dashboard-id
-                                                              :parameter_mappings [{:parameter_id "_STATE_"
-                                                                                    :card_id card-id
-                                                                                    :target [:variable ["template-tag" "state"]]}]}]
-        (testing "GET /api/tiles/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
-          (is (png? (mt/user-http-request
-                     :crowberto :get 200 (format "tiles/%d/dashcard/%d/card/%d/1/1/1/%s/%s"
-                                                 dashboard-id
-                                                 dashcard-id
-                                                 card-id
-                                                 "LATITUDE"
-                                                 "LONGITUDE")
-                     :parameters (json/encode [{:id "_STATE_"
-                                                :value ["CA"]}])))))))))
+                   :model/Card          {card-id :id}      {:dataset_query (parameterized-native-query)}
+                   :model/DashboardCard {dashcard-id :id}  {:card_id card-id
+                                                            :dashboard_id dashboard-id
+                                                            :parameter_mappings [{:parameter_id "_STATE_"
+                                                                                  :card_id card-id
+                                                                                  :target [:variable ["template-tag" "state"]]}]}]
+      (testing "GET /api/tiles/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
+        (is (png? (mt/user-http-request
+                   :crowberto :get 200 (format "tiles/%d/dashcard/%d/card/%d/1/1/1/%s/%s"
+                                               dashboard-id
+                                               dashcard-id
+                                               card-id
+                                               "LATITUDE"
+                                               "LONGITUDE")
+                   :parameters (json/encode [{:id "_STATE_"
+                                              :value ["CA"]}]))))))))
 
 (deftest tiles-query-test
   (letfn [(clean [q]


### PR DESCRIPTION
Pursuant to https://github.com/metabase/metabase/issues/53405

Our map visualization hits the `GET /api/tiles/:zoom/:x/:y/:lat-field/:long-field` API, passing `query` as a query parameter, to fetch each individual tile images. This doesn't currently support parameterization, and is also broken for public and embedded questions/dashboards.

In this PR I've done some refactor and added new versions of this endpoint for saved cards and dashcards.

* `GET /api/tiles/:card-id/:zoom/:x/:y/:lat-field/:lon-field`
* `GET /api/tiles/:dashboard-id/dashcard/:dashcard-id/card/:card-id/:zoom/:x/:y/:lat-field/:lon-field`
* `GET /api/public/tiles/card/:token/:zoom/:x/:y/:lat-field/:lon-field`
* `GET /api/public/tiles/dashboard/:token/dashcard/:dashcard-id/card/:card-id/:zoom/:x/:y/:lat-field/:lon-field`
* `GET /api/embed/tiles/card/:token/:zoom/:x/:y/:lat-field/:lon-field`
* `GET /api/embed/tiles/dashboard/:token/dashcard/:dashcard-id/card/:card-id/:zoom/:x/:y/:lat-field/:lon-field`

The key differences are that these take saved card/dashboard IDs and optional `parameters` as a query param. They also execute queries via the existing `process-query-for-card` and `process-query-for-dashcard` functions, passing custom `make-run` functions to generate the expected query for fetching the map tile. The existing endpoint is preserved as-is for ad-hoc queries.