### PR TITLE
Use `select 1` for query in `permissions.cy.spec`

### DIFF
--- a/e2e/test/scenarios/collections/permissions.cy.spec.js
+++ b/e2e/test/scenarios/collections/permissions.cy.spec.js
@@ -120,7 +120,7 @@ describe("collection permissions", () => {
                     name: "Model",
                     type: "model",
                     native: {
-                      query: "SELECT * FROM ORDERS",
+                      query: "SELECT 1",
                     },
                   });
                   archiveUnarchive("Model", "model");


### PR DESCRIPTION
I made a list of places where `SELECT *` is being used in our cypress tests and just felt like solving some easy ones

https://gist.github.com/oisincoveney/41254628b03389121d40af7853c23232