### PR TITLE
Fix new dashboard subscription button UI

### DIFF
--- a/frontend/src/metabase/notifications/PulsesListSidebar.jsx
+++ b/frontend/src/metabase/notifications/PulsesListSidebar.jsx
@@ -7,7 +7,6 @@ import _ from "underscore";
 
 import Label from "metabase/components/type/Label";
 import Subhead from "metabase/components/type/Subhead";
-import Tooltip from "metabase/core/components/Tooltip";
 import CS from "metabase/css/core/index.css";
 import { Sidebar } from "metabase/dashboard/components/Sidebar";
 import { getParameters } from "metabase/dashboard/selectors";
@@ -18,7 +17,7 @@ import {
 import { getActivePulseParameters } from "metabase/lib/pulse";
 import { connect } from "metabase/lib/redux";
 import { formatFrame } from "metabase/lib/time";
-import { Icon } from "metabase/ui";
+import { Button, Icon, Tooltip } from "metabase/ui";
 
 import { PulseCard, SidebarActions } from "./PulsesListSidebar.styled";
 
@@ -52,32 +51,21 @@ function _PulsesListSidebar({
         <Subhead>{t`Subscriptions`}</Subhead>
 
         <SidebarActions>
-          <Tooltip tooltip={t`Set up a new schedule`}>
-            <Icon
-              name="add"
-              className={cx(
-                CS.textBrand,
-                CS.bgLightHover,
-                CS.rounded,
-                CS.p1,
-                CS.cursorPointer,
-                CS.mr1,
-              )}
-              size={18}
+          <Tooltip label={t`Set up a new schedule`}>
+            <Button
+              leftSection={<Icon name="add" size={16} />}
+              variant="subtle"
+              mr="1rem"
               onClick={createSubscription}
             />
           </Tooltip>
-          <Tooltip tooltip={t`Close`}>
-            <Icon
-              name="close"
-              className={cx(
-                CS.textLight,
-                CS.bgLightHover,
-                CS.rounded,
-                CS.p1,
-                CS.cursorPointer,
-              )}
-              size={22}
+
+          <Tooltip label={t`Close`}>
+            <Button
+              leftSection={<Icon name="close" size={16} />}
+              variant="subtle"
+              color="text-medium"
+              mr="-1rem"
               onClick={onCancel}
             />
           </Tooltip>


### PR DESCRIPTION
### Description

This fixes broken UI for new dashboard subscription button

<table>
<tr>
<th> Before: </th>
<th> After: </th>
</tr>
<tr>
<td>

<img width="600" alt="Screenshot 2025-02-20 at 18 24 52" src="https://github.com/user-attachments/assets/b9ff3ba4-85e1-42d6-beab-999d03398224" />

</td>
<td>

<img width="400" alt="Screenshot 2025-02-21 at 23 30 40" src="https://github.com/user-attachments/assets/0f34397a-b45c-4f51-aea2-ca07123b1f20" />

</td>
</tr>
</table>

### How to verify

1. Create a dashboard subscription.
2. Then try to add one more - sidebar buttons should look not tiny.

