### PR TITLE
Fix static viz to respect custom formatting

### DIFF
--- a/frontend/src/metabase/static-viz/index.js
+++ b/frontend/src/metabase/static-viz/index.js
@@ -7,6 +7,7 @@ import ReactDOMServer from "react-dom/server";
 import "metabase/lib/dayjs";
 
 import { updateStartOfWeek } from "metabase/lib/i18n";
+import MetabaseSettings from "metabase/lib/settings";
 import { StaticVisualization } from "metabase/static-viz/components/StaticVisualization";
 import { createStaticRenderingContext } from "metabase/static-viz/lib/rendering-context";
 import { measureTextEChartsAdapter } from "metabase/static-viz/lib/text";
@@ -49,6 +50,7 @@ export function RenderChart(rawSeries, dashcardSettings, options) {
   );
 
   updateStartOfWeek(options.startOfWeek);
+  MetabaseSettings.set("custom-formatting", options.customFormatting);
 
   const rawSeriesWithDashcardSettings = getRawSeriesWithDashcardSettings(
     rawSeries,

--- a/src/metabase/channel/render/js/svg.clj
+++ b/src/metabase/channel/render/js/svg.clj
@@ -164,7 +164,8 @@
                                                        (json/encode cards-with-data)
                                                        (json/encode dashcard-viz-settings)
                                                        (json/encode {:applicationColors (public-settings/application-colors)
-                                                                     :startOfWeek (public-settings/start-of-week)})))]
+                                                                     :startOfWeek (public-settings/start-of-week)
+                                                                     :customFormatting (public-settings/custom-formatting)})))]
     (-> response
         json/decode+kw
         (update :type (fnil keyword "unknown")))))

--- a/test/metabase/channel/render/body_test.clj
+++ b/test/metabase/channel/render/body_test.clj
@@ -1007,3 +1007,27 @@
                                       first)]
               (testing "Renders with correct day of week first"
                 (is (= "Monday" first-day-text))))))))))
+
+(deftest render-correct-custom-date-style
+  (testing "The static-viz respects custom formatting for temporal axis label"
+    (mt/with-temporary-setting-values [public-settings/custom-formatting {:type/Temporal
+                                                                          {:date_style "YYYY/M/D"
+                                                                           :date_separator "/"}}]
+      (mt/dataset test-data
+        (let [q    (mt/mbql-query products
+                     {:aggregation [[:count]]
+                      :breakout    [!month.created_at]})
+              card {:name                   "bar-test"
+                    :display                :bar
+                    :dataset_query          q
+                    :visualization_settings {:graph.dimensions ["CREATED_AT"]
+                                             :graph.metrics ["count"]}}]
+          (mt/with-temp [:model/Card {card-id :id} card]
+            (let [doc    (render.tu/render-card-as-hickory! card-id)
+                  label  (->> (hik.s/select (hik.s/tag :text) doc)
+                              (map (fn [el] (-> el :content first)))
+                              (take-last 3)
+                              (map str/trim)
+                              first)]
+              (testing "Renders with correct day of week first"
+                (is (= "2017/1" label))))))))))


### PR DESCRIPTION
Closes VIZ-68

- Pass value of `custom-formatting` env var into static viz JS bundle and have it update it accordingly so that temporal axis labels respect configured date styles