### PR TITLE
Fix static fix thai translations

### DIFF
--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -6,7 +6,7 @@ ARG GIT_COMMIT_SHA
 ENV GIT_COMMIT_SHA=${GIT_COMMIT_SHA}
 
 # dependencies
-RUN apk add -U bash fontconfig curl font-noto font-noto-arabic font-noto-hebrew font-noto-cjk java-cacerts && \
+RUN apk add -U bash fontconfig curl font-noto font-noto-arabic font-noto-hebrew font-noto-cjk font-noto-thai java-cacerts && \
     apk upgrade && \
     rm -rf /var/cache/apk/* && \
     mkdir -p /app/certs && \


### PR DESCRIPTION
Closes VIZ-161

- Need to add `font-noto-thai` to release dockerfile so that cloud instances have support for thai translations in static viz

Tested via:
- Updated `./Dockerfile` (root docker file) with the addition of `font-noto-thai`
- Built & ran with:
```
docker build --build-arg MB_EDITION=ee --build-arg VERSION=v0.53.3 -t metabase:v0.53.3 .
docker run -d -p 3000:3000 --name metabase-fix metabase:v0.53.3
```

<details>
<summary>Before & After</summary>
<img width="631" alt="image" src="https://github.com/user-attachments/assets/abd055d1-5b63-49f2-9ec1-eac6289b8146" />
<img width="638" alt="image" src="https://github.com/user-attachments/assets/7df0d103-bce2-410f-9992-009b2222c06c" />
</details>