### PR TITLE
Build multi-arch arm images

### DIFF
--- a/.github/actions/fetch-artifact/action.yml
+++ b/.github/actions/fetch-artifact/action.yml
@@ -1,0 +1,63 @@
+name: Fetch artifact
+description: Fetches a specific artifact and downloads it to the current directory
+
+inputs:
+  name:
+    description: The name of the artifact to fetch
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: find_release_artifact
+      id: find_release_artifact
+      uses: actions/github-script@v7
+      with:
+        result-encoding: string
+        script: | # js
+          const fs = require('fs');
+
+          const artifacts = await github.rest.actions.listArtifactsForRepo({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            name: "${{ inputs.name }}",
+            per_page: 1,
+          });
+
+          if (!artifacts.data?.artifacts?.[0]?.id) {
+            throw new Error(`No artifacts found for ${{ inputs.commit }}`);
+          }
+
+          const artifact_id = artifacts.data.artifacts[0].id;
+
+          const download = await github.rest.actions.downloadArtifact({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            artifact_id: artifact_id,
+            archive_format: 'zip',
+          });
+
+          fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/mb.zip`, Buffer.from(download.data));
+
+    - name: unzip uberjar artifact
+      shell: bash
+      run: unzip mb.zip
+    - name: Move the Uberjar
+      shell: bash
+      run: | # bash
+        if [ -e "metabase.jar" ]; then
+          echo "metabase.jar is already in the right place"
+        else if [ -e "target/uberjar/metabase.jar" ]; then
+          # Move the file to the destination directory
+          mv target/uberjar/metabase.jar metabase.jar
+        else
+          echo "Could not find the metabase.jar file"
+          exit 1
+        fi
+
+    - name: Verify that this is a valid JAR file
+      shell: bash
+      run: file --mime-type ./metabase.jar | grep "application/zip"
+    - name: Reveal its version.properties
+      shell: bash
+      run: jar xf metabase.jar version.properties && cat version.properties

--- a/.github/actions/fetch-artifact/action.yml
+++ b/.github/actions/fetch-artifact/action.yml
@@ -43,7 +43,7 @@ runs:
       shell: bash
       run: unzip mb.zip
     - name: Move the Uberjar
-      shell: sh
+      shell: bash
       run: | # bash
         if [ -e "metabase.jar" ]; then
           echo "metabase.jar is already in the right place"

--- a/.github/actions/fetch-artifact/action.yml
+++ b/.github/actions/fetch-artifact/action.yml
@@ -43,12 +43,12 @@ runs:
       shell: bash
       run: unzip mb.zip
     - name: Move the Uberjar
-      shell: bash
+      shell: sh
       run: | # bash
         if [ -e "metabase.jar" ]; then
           echo "metabase.jar is already in the right place"
-        else if [ -e "target/uberjar/metabase.jar" ]; then
-          # Move the file to the destination directory
+        elif [ -e "target/uberjar/metabase.jar" ]; then
+            echo "moving metabase.jar to current directory"
           mv target/uberjar/metabase.jar metabase.jar
         else
           echo "Could not find the metabase.jar file"
@@ -57,7 +57,7 @@ runs:
 
     - name: Verify that this is a valid JAR file
       shell: bash
-      run: file --mime-type ./metabase.jar | grep "application/zip"
+      run: file --mime-type ./metabase.jar
     - name: Reveal its version.properties
       shell: bash
       run: jar xf metabase.jar version.properties && cat version.properties

--- a/.github/workflows/containerize-jar.yml
+++ b/.github/workflows/containerize-jar.yml
@@ -44,16 +44,6 @@ jobs:
       uses: ./.github/actions/fetch-artifact
       with:
         name: ${{ inputs.artifact-name }}
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v3
     - name: Prepare build scripts
       run: cd ${{ github.workspace }}/release && yarn && yarn build
     - name: Get platforms
@@ -62,16 +52,30 @@ jobs:
       with:
         result-encoding: string
         script: | # js
-          const version = "${{ inputs.tag }}";
-          const { getBuildRequirements } = require('${{ github.workspace }}/release/dist/index.cjs');
+          const { getBuildRequirements, isValidVersionString} = require('${{ github.workspace }}/release/dist/index.cjs');
+          const version = "${{ inputs.tag }}".split('-')[0];
 
+          if (!isValidVersionString(version)) {
+            return "linux/amd64";
+          }
           // versions before 53 need to be handled differently
           const buildInfo = getBuildRequirements(version);
           return buildInfo.platforms;
     - name: Move the Uberjar to the context dir
       run: mv ./metabase.jar bin/docker/.
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
+    - name: Set up QEMU
+      if: contains(steps.platforms.outputs.result, 'arm')
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      if: contains(steps.platforms.outputs.result, 'arm')
+      uses: docker/setup-buildx-action@v3
     - name: Build multi-arch container
-      if: contains(steps.platforms.outputs.result, 'linux/arm64')
+      if: contains(steps.platforms.outputs.result, 'arm')
       uses: docker/build-push-action@v6
       with:
         context: bin/docker/.
@@ -81,16 +85,15 @@ jobs:
         no-cache: true
         push: true
 
+    # we need to do this to get the nice fallback behavior of the legacy manifest file
     - name: Build container (x86 only)
-      if: contains(steps.platforms.outputs.result, 'linux/arm64') == false
-      uses: docker/build-push-action@v6
-      with:
-        context: bin/docker/.
-        platforms: linux/amd64
-        network: host
-        tags: ${{ inputs.repo }}:${{ inputs.tag }}
-        no-cache: true
-        push: true
+      if: contains(steps.platforms.outputs.result, 'arm') == false
+      run: | # bash
+        docker build \
+          -t ${{ inputs.repo }}:${{ inputs.tag }} \
+          --network=host \
+          --push \
+          bin/docker/.
 
   verify-docker-pull:
     runs-on: ubuntu-latest

--- a/.github/workflows/containerize-jar.yml
+++ b/.github/workflows/containerize-jar.yml
@@ -1,0 +1,98 @@
+name: Containerize Uberjar
+run-name: Containerize ${{ inputs.tag }} Uberjar
+
+on:
+  workflow_call:
+    inputs:
+      artifact-name:
+        type: string
+      repo:
+        description: owner and repo like "metabase/metabase"
+        type: string
+      tag:
+        type: string
+      commit:
+        type: string
+  workflow_dispatch:
+    inputs:
+      artifact-name:
+        description: usually something like "metabase-release-{{ edition }}-{{ hash }}-uberjar"
+        type: string
+      repo:
+        description: owner and repo like "metabase/metabase"
+        type: string
+      tag:
+        description: usually a version like 1.87.2
+        type: string
+      commit:
+        description: the full commit hash
+        type: string
+
+jobs:
+  containerize:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        # checkout the commit that was tagged so we get the right dockerfile
+        ref: ${{ inputs.commit }}
+
+    - name: Retrieve test build uberjar artifact
+      uses: ./.github/actions/fetch-artifact
+      with:
+        name: ${{ inputs.artifact-name }}
+    - name: Move the Uberjar to the context dir
+      run: mv ./metabase.jar bin/docker/.
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Build container
+      uses: docker/build-push-action@v6
+      with:
+        context: bin/docker/.
+        platforms: linux/amd64,linux/arm64
+        network: host
+        tags: ${{ inputs.repo }}:${{ inputs.tag }}
+        no-cache: true
+        push: true
+
+  verify-docker-pull:
+    runs-on: ubuntu-latest
+    needs: containerize
+    timeout-minutes: 15
+    steps:
+    - name: Login to Docker Hub # authenticated, to avoid being rate-throttled
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
+    - name: Pull the container image
+      run: docker pull ${{ inputs.repo }}:${{ inputs.tag }}
+    - name: Launch container
+      run: docker run --rm -dp 3000:3000 ${{ inputs.repo }}:${{ inputs.tag }}
+      timeout-minutes: 5
+    - name: Wait for Metabase to start
+      run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
+      timeout-minutes: 5
+
+  verify-docker-pull-arm:
+    runs-on: arm-ubuntu-24-2core
+    needs: containerize
+    timeout-minutes: 15
+    steps:
+    - name: Login to Docker Hub # authenticated, to avoid being rate-throttled
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
+    - name: Pull the container image
+      run: docker pull ${{ inputs.repo }}:${{ inputs.tag }}
+    - name: Launch container
+      run: docker run --rm -dp 3000:3000 ${{ inputs.repo }}:${{ inputs.tag }}
+      timeout-minutes: 5
+    - name: Wait for Metabase to start
+      run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
+      timeout-minutes: 5

--- a/.github/workflows/containerize-jar.yml
+++ b/.github/workflows/containerize-jar.yml
@@ -19,10 +19,10 @@ on:
         description: usually something like "metabase-release-{{ edition }}-{{ hash }}-uberjar"
         type: string
       repo:
-        description: owner and repo like "metabase/metabase"
+        description: docker owner and repo like "metabase/metabase"
         type: string
       tag:
-        description: usually a version like 1.87.2
+        description: usually a version like v1.87.2
         type: string
       commit:
         description: the full commit hash
@@ -32,28 +32,61 @@ jobs:
   containerize:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    outputs:
+      platforms: ${{ steps.platforms.outputs.result }}
     steps:
     - uses: actions/checkout@v4
       with:
-        # checkout the commit that was tagged so we get the right dockerfile
-        ref: ${{ inputs.commit }}
-
+        fetch-depth: 0
+      # we want the dockerfile from the commit we're building
+    - run: git checkout ${{ inputs.commit }} -- bin/docker
     - name: Retrieve test build uberjar artifact
       uses: ./.github/actions/fetch-artifact
       with:
         name: ${{ inputs.artifact-name }}
-    - name: Move the Uberjar to the context dir
-      run: mv ./metabase.jar bin/docker/.
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v3
-    - name: Build container
+    - name: Prepare build scripts
+      run: cd ${{ github.workspace }}/release && yarn && yarn build
+    - name: Get platforms
+      id: platforms
+      uses: actions/github-script@v7
+      with:
+        result-encoding: string
+        script: | # js
+          const version = "${{ inputs.tag }}";
+          const { getBuildRequirements } = require('${{ github.workspace }}/release/dist/index.cjs');
+
+          // versions before 53 need to be handled differently
+          const buildInfo = getBuildRequirements(version);
+          return buildInfo.platforms;
+    - name: Move the Uberjar to the context dir
+      run: mv ./metabase.jar bin/docker/.
+    - name: Build multi-arch container
+      if: contains(steps.platforms.outputs.result, 'linux/arm64')
       uses: docker/build-push-action@v6
       with:
         context: bin/docker/.
-        platforms: linux/amd64,linux/arm64
+        platforms: ${{ steps.platforms.outputs.result }}
+        network: host
+        tags: ${{ inputs.repo }}:${{ inputs.tag }}
+        no-cache: true
+        push: true
+
+    - name: Build container (x86 only)
+      if: contains(steps.platforms.outputs.result, 'linux/arm64') == false
+      uses: docker/build-push-action@v6
+      with:
+        context: bin/docker/.
+        platforms: linux/amd64
         network: host
         tags: ${{ inputs.repo }}:${{ inputs.tag }}
         no-cache: true
@@ -64,7 +97,7 @@ jobs:
     needs: containerize
     timeout-minutes: 15
     steps:
-    - name: Login to Docker Hub # authenticated, to avoid being rate-throttled
+    - name: Login to Docker Hub
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
@@ -81,9 +114,10 @@ jobs:
   verify-docker-pull-arm:
     runs-on: arm-ubuntu-24-2core
     needs: containerize
+    if: contains(needs.containerize.outputs.platforms, 'linux/arm64')
     timeout-minutes: 15
     steps:
-    - name: Login to Docker Hub # authenticated, to avoid being rate-throttled
+    - name: Login to Docker Hub
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -35,41 +35,12 @@ jobs:
       oss_version: ${{ steps.version-properties.outputs.oss_version }}
       commit: ${{ steps.version-properties.outputs.commit }}
     steps:
-      - name: find_release_artifact
-        id: find_release_artifact
-        uses: actions/github-script@v7
+      - name: Retrieve test build uberjar artifact for ${{ matrix.edition }}
+        uses: ./.github/actions/fetch-artifact
         with:
-          result-encoding: string
-          script: | # js
-            const fs = require('fs');
+          name: metabase-release-${{ matrix.edition }}-${{ inputs.commit }}-uberjar
 
-            const artifacts = await github.rest.actions.listArtifactsForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: `metabase-release-${{ matrix.edition }}-${{ inputs.commit }}-uberjar`,
-              per_page: 1,
-            });
-
-            if (!artifacts.data?.artifacts?.[0]?.id) {
-              throw new Error(`No artifacts found for ${{ inputs.commit }}`);
-            }
-
-            const artifact_id = artifacts.data.artifacts[0].id;
-
-            const download = await github.rest.actions.downloadArtifact({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              artifact_id: artifact_id,
-              archive_format: 'zip',
-            });
-
-            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/mb.zip`, Buffer.from(download.data));
-      - name: Unzip Metabase artifact containing an uberjar
-        run: unzip mb.zip
-      - name: Extract the version.properties file from the JAR
-        run: |
-          jar xf metabase.jar version.properties
-      - name: Reveal Metabase ${{ matrix.edition }} properties
+      - name: Extract version number from  version.properties
         id: version-properties
         run: |
           cat version.properties
@@ -204,121 +175,30 @@ jobs:
             ./logs/test.log
           if-no-files-found: ignore
 
-  containerize:
-    needs: [release-artifact]
-    runs-on: ubuntu-22.04
-    timeout-minutes: 15
-    strategy:
-      matrix:
-        edition: [oss, ee]
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
-    outputs:
-      image_tag: ${{ steps.target.outputs.image_tag }}
-    steps:
-      - name: Get the version
-        run: |
-          if [[ "${{ matrix.edition }}" == "ee" ]]; then
-            echo "VERSION=${{ needs.release-artifact.outputs.ee_version }}" >> $GITHUB_ENV
-          else
-            echo "VERSION=${{ needs.release-artifact.outputs.oss_version }}" >> $GITHUB_ENV
-          fi
-      - name: Check out the code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.release-artifact.outputs.commit }}
-      - uses: actions/download-artifact@v4
-        name: Retrieve uberjar artifact
-        with:
-          name: metabase-test-${{ matrix.edition }}-uberjar
-      - name: Move the Uberjar to the context dir
-        run: mv metabase.jar bin/docker/.
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          driver-opts: network=host
-      - name: Build ${{ matrix.edition }} container
-        uses: docker/build-push-action@v6
-        with:
-          context: bin/docker/.
-          platforms: linux/amd64
-          network: host
-          tags: localhost:5000/local-metabase:${{ env.VERSION }}
-          no-cache: true
-          push: true
+  containerize-oss:
+    needs: release-artifact
+    uses: ./.github/workflows/containerize-jar.yml
+    secrets: inherit
+    with:
+      artifact-name: metabase-release-oss-${{ inputs.commit }}-uberjar
+      commit: ${{ inputs.commit }}
+      repo: ${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_STAGING_REPO }}
+      tag: ${{ needs.release-artifact.outputs.oss_version }}-${{ inputs.commit }}
 
-      - name: Launch container
-        run: docker run --rm -dp 3000:3000 localhost:5000/local-metabase:${{ env.VERSION }}
-        timeout-minutes: 5
-      - name: Wait for Metabase to start
-        run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
-        timeout-minutes: 3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
-      - name: Retag and push container image to ${{ vars.DOCKERHUB_OWNER }} staging Docker Hub repo
-        id: target
-        run: |
-          # SHA-1 truncated to 7 digits should be enough
-          SHORT_HASH=${COMMIT:0:7}
-
-          IMAGE_TAG=$VERSION-$SHORT_HASH
-          CONTAINER_IMAGE=${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_STAGING_REPO }}:$IMAGE_TAG
-
-          echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
-
-          echo "Retag local image for staging"
-          docker tag localhost:5000/local-metabase:$VERSION $CONTAINER_IMAGE
-
-          echo "Pushing container image $CONTAINER_IMAGE ..."
-          docker push $CONTAINER_IMAGE
-
-          echo "Finished!"
-        shell: bash
-        env:
-          COMMIT: ${{ needs.release-artifact.outputs.commit }}
-
-  verify-docker-pull:
-    runs-on: ubuntu-22.04
-    needs: [release-artifact, containerize]
-    timeout-minutes: 15
-    strategy:
-      matrix:
-        edition: [oss, ee]
-    env:
-      IMAGE_TAG: ${{ needs.containerize.outputs.image_tag }}
-    steps:
-      - name: Login to Docker Hub # authenticated, to avoid being rate-throttled
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
-      - name: Pull the container image
-        run: |
-          CONTAINER_IMAGE=${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_STAGING_REPO }}:$IMAGE_TAG
-          echo "Pulling container image $CONTAINER_IMAGE ..."
-          docker pull $CONTAINER_IMAGE
-          echo "Successful!"
-      - name: Launch container
-        run: |
-          CONTAINER_IMAGE=${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_STAGING_REPO }}:$IMAGE_TAG
-          docker run --rm -dp 3000:3000 $CONTAINER_IMAGE
-        timeout-minutes: 5
-      - name: Wait for Metabase to start
-        run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
-        timeout-minutes: 3
+  containerize-ee:
+    needs: release-artifact
+    uses: ./.github/workflows/containerize-jar.yml
+    secrets: inherit
+    with:
+      artifact-name: metabase-release-ee-${{ inputs.commit }}-uberjar
+      commit: ${{ inputs.commit }}
+      repo: ${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_STAGING_REPO }}
+      tag: ${{ needs.release-artifact.outputs.ee_version }}-${{ inputs.commit }}
 
   tests-complete-message:
     if: always()
     runs-on: ubuntu-22.04
-    needs: [run-sanity-check, check-uberjar-health, verify-docker-pull]
+    needs: [run-sanity-check, check-uberjar-health, containerize-ee, containerize-oss]
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -338,7 +218,8 @@ jobs:
             const allJobsSuccessful =
               '${{ needs.run-sanity-check.result }}' === 'success' &&
               '${{ needs.check-uberjar-health.result }}' === 'success' &&
-              '${{ needs.verify-docker-pull.result }}' === 'success';
+              '${{ needs.containerize-ee.result }}' === 'success' &&
+              '${{ needs.containerize-oss.result }}' === 'success';
 
             await sendTestsCompleteMessage({
               owner: context.repo.owner,

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -35,6 +35,9 @@ jobs:
       oss_version: ${{ steps.version-properties.outputs.oss_version }}
       commit: ${{ steps.version-properties.outputs.commit }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
       - name: Retrieve test build uberjar artifact for ${{ matrix.edition }}
         uses: ./.github/actions/fetch-artifact
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,8 @@ jobs:
     outputs:
       ee: ${{ fromJson(steps.canonical_version.outputs.result).ee }}
       oss: ${{ fromJson(steps.canonical_version.outputs.result).oss }}
+      ee_tag: ${{ fromJson(steps.canonical_version.outputs.result).ee_tag }}
+      oss_tag: ${{ fromJson(steps.canonical_version.outputs.result).oss_tag }}
     steps:
     - name: Fail early on the incorrect version format
       if: ${{ !(startsWith(inputs.version,'v0.') || startsWith(inputs.version,'v1.')) }}
@@ -88,6 +90,11 @@ jobs:
             oss: getCanonicalVersion(version, 'oss'),
           };
 
+          const tags = {
+            ee_tag: `${{vars.DOCKERHUB_REPO}}-enterprise:${versions.ee}`,
+            oss_tag: `${{vars.DOCKERHUB_REPO}}:${versions.oss}`,
+          };
+
           const released = await hasBeenReleased({
             github,
             owner: context.repo.owner,
@@ -99,7 +106,15 @@ jobs:
             throw new Error("This version has already been released!", version);
           }
 
-          return versions;
+          console.log({
+            versions,
+            tags,
+          });
+
+          return {
+            ...versions,
+            ...tags,
+          };
 
   publish-start-message:
     runs-on: ubuntu-22.04
@@ -247,7 +262,6 @@ jobs:
         --distribution-id ${{ vars.AWS_CLOUDFRONT_DOWNLOADS_ID }} \
         --paths /${{ steps.version_path.outputs.result }}/metabase.jar
 
-
   verify-s3-download:
     runs-on: ubuntu-22.04
     needs: upload-to-s3
@@ -288,6 +302,9 @@ jobs:
     strategy:
       matrix:
         edition: [oss, ee]
+    env:
+      OSS_TAG: ${{ needs.check-version.outputs.oss_tag }}
+      EE_TAG: ${{ needs.check-version.outputs.ee_tag }}
     services:
       registry:
         image: registry:2
@@ -298,118 +315,112 @@ jobs:
       with:
         # checkout the commit that was tagged so we get the right dockerfile
         ref: ${{ inputs.commit }}
-        fetch-depth: 0  # IMPORTANT! to get all the tags
-    - name: prepare release scripts
-      run: cd release && yarn && yarn build
     - name: Determine the docker version tag
       uses: actions/github-script@v7
-      id: canonical_version
+      id: get_tag
       with:
         result-encoding: string
-        script: |
-          const version = '${{ inputs.version }}';
-          const edition = '${{ matrix.edition }}';
+        script: | # js
+          const tag = '${{ matrix.edition }}' === 'ee'
+            ? '${{ needs.check-version.outputs.ee_tag }}'
+            : '${{ needs.check-version.outputs.oss_tag }}';
 
-          const canonical_version = edition === 'ee'
-            ? '${{ needs.check-version.outputs.ee }}'
-            : '${{ needs.check-version.outputs.oss }}';
+          console.log("The docker tag for this ", edition, "edition is", tag);
 
-          console.log("The canonical version of this Metabase", edition, "edition is", canonical_version);
+          return tag;
 
-          return canonical_version;
     - uses: actions/download-artifact@v4
       name: Retrieve previously downloaded Uberjar
       with:
         name: metabase-${{ matrix.edition }}-uberjar
     - name: Move the Uberjar to the context dir
       run: mv ./metabase.jar bin/docker/.
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v2
-      with:
-        driver-opts: network=host
+      uses: docker/setup-buildx-action@v3
     - name: Build ${{ matrix.edition }} container
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v6
       with:
         context: bin/docker/.
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64
         network: host
-        tags: localhost:5000/local-metabase:${{ steps.canonical_version.outputs.result }}
+        tags: ${{ steps.get_tag.outputs.result }}
         no-cache: true
         push: true
 
-    - name: Launch container
-      run: docker run --rm -dp 3000:3000 localhost:5000/local-metabase:${{ steps.canonical_version.outputs.result }}
-      timeout-minutes: 5
-    - name: Wait for Metabase to start
-      run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
-      timeout-minutes: 3
-
-    - name: Determine the target Docker Hub repository
-      run: |
-        if [[ "${{ matrix.edition }}" == "ee" ]]; then
-          echo "Metabase EE: image is going to be pushed to ${{ github.repository_owner }}/metabase-enterprise"
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase-enterprise" >> $GITHUB_ENV
-        else
-          echo "Metabase OSS: image is going to be pushed to ${{ github.repository_owner }}/metabase"
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase" >> $GITHUB_ENV
-        fi
-
-    - name: Login to Docker Hub
-      uses: docker/login-action@v2
-      with:
-        username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
-    - name: Retag and push container image to Docker Hub
-      run: |
-        echo "Pushing ${{ steps.canonical_version.outputs.result }} to ${{ env.DOCKERHUB_REPO }} ..."
-        docker tag localhost:5000/local-metabase:${{ steps.canonical_version.outputs.result }} ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }}
-        docker push ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }}
-        echo "Finished!"
-
   verify-docker-pull:
     runs-on: ubuntu-22.04
-    needs: containerize
+    needs: [check-version, containerize]
     timeout-minutes: 15
     strategy:
       matrix:
         edition: [oss, ee]
     steps:
+    - name: Determine the docker version tag
+      uses: actions/github-script@v7
+      id: get_tag
+      with:
+        result-encoding: string
+        script: | # js
+          const tag = '${{ matrix.edition }}' === 'ee'
+            ? '${{ needs.check-version.outputs.ee_tag }}'
+            : '${{ needs.check-version.outputs.oss_tag }}';
+
+          console.log("The docker tag for this ", edition, "edition is", tag);
+
+          return tag;
     - name: Login to Docker Hub # authenticated, to avoid being rate-throttled
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
         password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
-    - name: Determine the container image to pull
-      run: |
-        if [[ "${{ matrix.edition }}" = "ee" ]]; then
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase-enterprise" >> $GITHUB_ENV
-        else
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase" >> $GITHUB_ENV
-        fi
-    - name: Determine the docker version tag
-      uses: actions/github-script@v7
-      id: canonical_version
-      with:
-        result-encoding: string
-        script: |
-          const version = '${{ inputs.version }}';
-          const edition = '${{ matrix.edition }}';
-
-          const canonical_version = edition === "ee"
-            ? version.replace(/^v0\./, "v1.") // always e.g. v1.47.2
-            : version.replace(/^v1\./, "v0."); // always e.g. v0.47.2
-
-          console.log("The canonical version of this Metabase", edition, "edition is", canonical_version);
-
-          return canonical_version;
     - name: Pull the container image
       run: |
-        echo "Pulling container image ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }} ..."
-        docker pull ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }}
+        echo "Pulling container image ${{ vars.DOCKERHUB_OWNER }}:${{ steps.get_tag.outputs.result }} ..."
+        docker pull ${{ vars.DOCKERHUB_OWNER }}:${{ steps.get_tag.outputs.result }}
         echo "Successful!"
     - name: Launch container
-      run: docker run --rm -dp 3000:3000 ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }}
+      run: docker run --rm -dp 3000:3000 ${{ vars.DOCKERHUB_OWNER }}:${{ steps.get_tag.outputs.result }}
+      timeout-minutes: 5
+    - name: Wait for Metabase to start
+      run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
+      timeout-minutes: 3
+
+  verify-docker-pull-arm:
+    runs-on: arm-ubuntu-24-2core
+    needs: [check-version, containerize]
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        edition: [oss, ee]
+    steps:
+    - name: Determine the docker version tag
+      uses: actions/github-script@v7
+      id: get_tag
+      with:
+        result-encoding: string
+        script: | # js
+          const tag = '${{ matrix.edition }}' === 'ee'
+            ? '${{ needs.check-version.outputs.ee_tag }}'
+            : '${{ needs.check-version.outputs.oss_tag }}';
+
+          console.log("The docker tag for this ", edition, "edition is", tag);
+
+          return tag;
+    - name: Login to Docker Hub # authenticated, to avoid being rate-throttled
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
+    - name: Pull the container image
+      run: |
+        echo "Pulling container image ${{ vars.DOCKERHUB_OWNER }}:${{ steps.get_tag.outputs.result }} ..."
+        docker pull ${{ vars.DOCKERHUB_OWNER }}:${{ steps.get_tag.outputs.result }}
+        echo "Successful!"
+    - name: Launch container
+      run: docker run --rm -dp 3000:3000 ${{ vars.DOCKERHUB_OWNER }}:${{ steps.get_tag.outputs.result }}
       timeout-minutes: 5
     - name: Wait for Metabase to start
       run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,11 +99,7 @@ jobs:
             throw new Error("This version has already been released!", version);
           }
 
-          console.log({
-            versions,
-          });
-
-          return versions
+          return versions;
 
   publish-start-message:
     runs-on: ubuntu-22.04
@@ -141,13 +137,41 @@ jobs:
       matrix:
         edition: [oss, ee]
     steps:
-    - uses: actions/checkout@v4
+    - name: find_release_artifact
+      id: find_release_artifact
+      uses: actions/github-script@v7
       with:
-        sparse-checkout: .github
-    - name: Retrieve test build uberjar artifact for ${{ matrix.edition }}
-      uses: ./.github/actions/fetch-artifact
-      with:
-        name: metabase-release-${{ matrix.edition }}-${{ inputs.commit }}-uberjar
+        result-encoding: string
+        script: | # js
+          const fs = require('fs');
+
+          const artifacts = await github.rest.actions.listArtifactsForRepo({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            name: `metabase-release-${{ matrix.edition }}-${{ inputs.commit }}-uberjar`,
+            per_page: 1,
+          });
+
+          if (!artifacts.data?.artifacts?.[0]?.id) {
+            throw new Error(`No artifacts found for ${{ inputs.commit }}`);
+          }
+
+          const artifact_id = artifacts.data.artifacts[0].id;
+
+          const download = await github.rest.actions.downloadArtifact({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            artifact_id: artifact_id,
+            archive_format: 'zip',
+          });
+
+          fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/mb.zip`, Buffer.from(download.data));
+    - name: unzip uberjar artifact
+      run: unzip mb.zip
+    - name: Verify that this is a valid JAR file
+      run: file --mime-type ./metabase.jar | grep "application/zip"
+    - name: Reveal its version.properties
+      run: jar xf metabase.jar version.properties && cat version.properties
     - name: Check JAR version properties
       run: |
         # ensure actual jar checksum matches checksum file
@@ -223,6 +247,7 @@ jobs:
         --distribution-id ${{ vars.AWS_CLOUDFRONT_DOWNLOADS_ID }} \
         --paths /${{ steps.version_path.outputs.result }}/metabase.jar
 
+
   verify-s3-download:
     runs-on: ubuntu-22.04
     needs: upload-to-s3
@@ -256,29 +281,143 @@ jobs:
     - name: Verify Checksum
       run: grep -q $(sha256sum ./metabase-downloaded.jar) SHA256.sum && echo "checksums match" || exit 1
 
-  containerize-oss:
-    needs: check-version
-    uses: ./.github/workflows/containerize-jar.yml
-    secrets: inherit
-    with:
-      artifact-name: metabase-release-oss-${{ inputs.commit }}-uberjar
-      commit: ${{ inputs.commit }}
-      repo: ${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_REPO }}
-      tag: ${{ needs.check-version.outputs.oss }}
+  containerize:
+    runs-on: ubuntu-22.04
+    needs: [check-version, download-uberjar]
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        edition: [oss, ee]
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        # checkout the commit that was tagged so we get the right dockerfile
+        ref: ${{ inputs.commit }}
+        fetch-depth: 0  # IMPORTANT! to get all the tags
+    - name: prepare release scripts
+      run: cd release && yarn && yarn build
+    - name: Determine the docker version tag
+      uses: actions/github-script@v7
+      id: canonical_version
+      with:
+        result-encoding: string
+        script: |
+          const version = '${{ inputs.version }}';
+          const edition = '${{ matrix.edition }}';
 
-  containerize-ee:
-    needs: check-version
-    uses: ./.github/workflows/containerize-jar.yml
-    secrets: inherit
-    with:
-      artifact-name: metabase-release-ee-${{ inputs.commit }}-uberjar
-      commit: ${{ inputs.commit }}
-      repo: ${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_REPO }}-enterprise
-      tag: ${{ needs.check-version.outputs.ee }}
+          const canonical_version = edition === 'ee'
+            ? '${{ needs.check-version.outputs.ee }}'
+            : '${{ needs.check-version.outputs.oss }}';
+
+          console.log("The canonical version of this Metabase", edition, "edition is", canonical_version);
+
+          return canonical_version;
+    - uses: actions/download-artifact@v4
+      name: Retrieve previously downloaded Uberjar
+      with:
+        name: metabase-${{ matrix.edition }}-uberjar
+    - name: Move the Uberjar to the context dir
+      run: mv ./metabase.jar bin/docker/.
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        driver-opts: network=host
+    - name: Build ${{ matrix.edition }} container
+      uses: docker/build-push-action@v3
+      with:
+        context: bin/docker/.
+        platforms: linux/amd64
+        network: host
+        tags: localhost:5000/local-metabase:${{ steps.canonical_version.outputs.result }}
+        no-cache: true
+        push: true
+
+    - name: Launch container
+      run: docker run --rm -dp 3000:3000 localhost:5000/local-metabase:${{ steps.canonical_version.outputs.result }}
+      timeout-minutes: 5
+    - name: Wait for Metabase to start
+      run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
+      timeout-minutes: 3
+
+    - name: Determine the target Docker Hub repository
+      run: |
+        if [[ "${{ matrix.edition }}" == "ee" ]]; then
+          echo "Metabase EE: image is going to be pushed to ${{ github.repository_owner }}/metabase-enterprise"
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase-enterprise" >> $GITHUB_ENV
+        else
+          echo "Metabase OSS: image is going to be pushed to ${{ github.repository_owner }}/metabase"
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase" >> $GITHUB_ENV
+        fi
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
+    - name: Retag and push container image to Docker Hub
+      run: |
+        echo "Pushing ${{ steps.canonical_version.outputs.result }} to ${{ env.DOCKERHUB_REPO }} ..."
+        docker tag localhost:5000/local-metabase:${{ steps.canonical_version.outputs.result }} ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }}
+        docker push ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }}
+        echo "Finished!"
+
+  verify-docker-pull:
+    runs-on: ubuntu-22.04
+    needs: containerize
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        edition: [oss, ee]
+    steps:
+    - name: Login to Docker Hub # authenticated, to avoid being rate-throttled
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
+    - name: Determine the container image to pull
+      run: |
+        if [[ "${{ matrix.edition }}" = "ee" ]]; then
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase-enterprise" >> $GITHUB_ENV
+        else
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase" >> $GITHUB_ENV
+        fi
+    - name: Determine the docker version tag
+      uses: actions/github-script@v7
+      id: canonical_version
+      with:
+        result-encoding: string
+        script: |
+          const version = '${{ inputs.version }}';
+          const edition = '${{ matrix.edition }}';
+
+          const canonical_version = edition === "ee"
+            ? version.replace(/^v0\./, "v1.") // always e.g. v1.47.2
+            : version.replace(/^v1\./, "v0."); // always e.g. v0.47.2
+
+          console.log("The canonical version of this Metabase", edition, "edition is", canonical_version);
+
+          return canonical_version;
+    - name: Pull the container image
+      run: |
+        echo "Pulling container image ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }} ..."
+        docker pull ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }}
+        echo "Successful!"
+    - name: Launch container
+      run: docker run --rm -dp 3000:3000 ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }}
+      timeout-minutes: 5
+    - name: Wait for Metabase to start
+      run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
+      timeout-minutes: 3
 
   push-tags:
     permissions: write-all
-    needs: [verify-s3-download, containerize-oss, containerize-ee, check-version]
+    needs: [verify-s3-download, verify-docker-pull, check-version]
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
@@ -337,8 +476,7 @@ jobs:
     needs:
       - get-extra-tags
       - push-tags
-      - containerize-ee
-      - containerize-oss
+      - verify-docker-pull
       - verify-s3-download
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,9 @@ jobs:
       matrix:
         edition: [oss, ee]
     steps:
+    - uses: actions/checkout@v4
+      with:
+        sparse-checkout: .github
     - name: Retrieve test build uberjar artifact for ${{ matrix.edition }}
       uses: ./.github/actions/fetch-artifact
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,6 @@ jobs:
     outputs:
       ee: ${{ fromJson(steps.canonical_version.outputs.result).ee }}
       oss: ${{ fromJson(steps.canonical_version.outputs.result).oss }}
-      ee_tag: ${{ fromJson(steps.canonical_version.outputs.result).ee_tag }}
-      oss_tag: ${{ fromJson(steps.canonical_version.outputs.result).oss_tag }}
     steps:
     - name: Fail early on the incorrect version format
       if: ${{ !(startsWith(inputs.version,'v0.') || startsWith(inputs.version,'v1.')) }}
@@ -90,11 +88,6 @@ jobs:
             oss: getCanonicalVersion(version, 'oss'),
           };
 
-          const tags = {
-            ee_tag: `${{vars.DOCKERHUB_REPO}}-enterprise:${versions.ee}`,
-            oss_tag: `${{vars.DOCKERHUB_REPO}}:${versions.oss}`,
-          };
-
           const released = await hasBeenReleased({
             github,
             owner: context.repo.owner,
@@ -108,13 +101,9 @@ jobs:
 
           console.log({
             versions,
-            tags,
           });
 
-          return {
-            ...versions,
-            ...tags,
-          };
+          return versions
 
   publish-start-message:
     runs-on: ubuntu-22.04
@@ -152,41 +141,10 @@ jobs:
       matrix:
         edition: [oss, ee]
     steps:
-    - name: find_release_artifact
-      id: find_release_artifact
-      uses: actions/github-script@v7
+    - name: Retrieve test build uberjar artifact for ${{ matrix.edition }}
+      uses: ./.github/actions/fetch-artifact
       with:
-        result-encoding: string
-        script: | # js
-          const fs = require('fs');
-
-          const artifacts = await github.rest.actions.listArtifactsForRepo({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            name: `metabase-release-${{ matrix.edition }}-${{ inputs.commit }}-uberjar`,
-            per_page: 1,
-          });
-
-          if (!artifacts.data?.artifacts?.[0]?.id) {
-            throw new Error(`No artifacts found for ${{ inputs.commit }}`);
-          }
-
-          const artifact_id = artifacts.data.artifacts[0].id;
-
-          const download = await github.rest.actions.downloadArtifact({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            artifact_id: artifact_id,
-            archive_format: 'zip',
-          });
-
-          fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/mb.zip`, Buffer.from(download.data));
-    - name: unzip uberjar artifact
-      run: unzip mb.zip
-    - name: Verify that this is a valid JAR file
-      run: file --mime-type ./metabase.jar | grep "application/zip"
-    - name: Reveal its version.properties
-      run: jar xf metabase.jar version.properties && cat version.properties
+        name: metabase-release-${{ matrix.edition }}-${{ inputs.commit }}-uberjar
     - name: Check JAR version properties
       run: |
         # ensure actual jar checksum matches checksum file
@@ -295,140 +253,29 @@ jobs:
     - name: Verify Checksum
       run: grep -q $(sha256sum ./metabase-downloaded.jar) SHA256.sum && echo "checksums match" || exit 1
 
-  containerize:
-    runs-on: ubuntu-22.04
-    needs: [check-version, download-uberjar]
-    timeout-minutes: 15
-    strategy:
-      matrix:
-        edition: [oss, ee]
-    env:
-      OSS_TAG: ${{ needs.check-version.outputs.oss_tag }}
-      EE_TAG: ${{ needs.check-version.outputs.ee_tag }}
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        # checkout the commit that was tagged so we get the right dockerfile
-        ref: ${{ inputs.commit }}
-    - name: Determine the docker version tag
-      uses: actions/github-script@v7
-      id: get_tag
-      with:
-        result-encoding: string
-        script: | # js
-          const tag = '${{ matrix.edition }}' === 'ee'
-            ? '${{ needs.check-version.outputs.ee_tag }}'
-            : '${{ needs.check-version.outputs.oss_tag }}';
+  containerize-oss:
+    needs: check-version
+    uses: ./.github/workflows/containerize-jar.yml
+    secrets: inherit
+    with:
+      artifact-name: metabase-release-oss-${{ inputs.commit }}-uberjar
+      commit: ${{ inputs.commit }}
+      repo: ${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_REPO }}
+      tag: ${{ needs.check-version.outputs.oss }}
 
-          console.log("The docker tag for this ", edition, "edition is", tag);
-
-          return tag;
-
-    - uses: actions/download-artifact@v4
-      name: Retrieve previously downloaded Uberjar
-      with:
-        name: metabase-${{ matrix.edition }}-uberjar
-    - name: Move the Uberjar to the context dir
-      run: mv ./metabase.jar bin/docker/.
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v3
-    - name: Build ${{ matrix.edition }} container
-      uses: docker/build-push-action@v6
-      with:
-        context: bin/docker/.
-        platforms: linux/amd64,linux/arm64
-        network: host
-        tags: ${{ steps.get_tag.outputs.result }}
-        no-cache: true
-        push: true
-
-  verify-docker-pull:
-    runs-on: ubuntu-22.04
-    needs: [check-version, containerize]
-    timeout-minutes: 15
-    strategy:
-      matrix:
-        edition: [oss, ee]
-    steps:
-    - name: Determine the docker version tag
-      uses: actions/github-script@v7
-      id: get_tag
-      with:
-        result-encoding: string
-        script: | # js
-          const tag = '${{ matrix.edition }}' === 'ee'
-            ? '${{ needs.check-version.outputs.ee_tag }}'
-            : '${{ needs.check-version.outputs.oss_tag }}';
-
-          console.log("The docker tag for this ", edition, "edition is", tag);
-
-          return tag;
-    - name: Login to Docker Hub # authenticated, to avoid being rate-throttled
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
-    - name: Pull the container image
-      run: |
-        echo "Pulling container image ${{ vars.DOCKERHUB_OWNER }}:${{ steps.get_tag.outputs.result }} ..."
-        docker pull ${{ vars.DOCKERHUB_OWNER }}:${{ steps.get_tag.outputs.result }}
-        echo "Successful!"
-    - name: Launch container
-      run: docker run --rm -dp 3000:3000 ${{ vars.DOCKERHUB_OWNER }}:${{ steps.get_tag.outputs.result }}
-      timeout-minutes: 5
-    - name: Wait for Metabase to start
-      run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
-      timeout-minutes: 3
-
-  verify-docker-pull-arm:
-    runs-on: arm-ubuntu-24-2core
-    needs: [check-version, containerize]
-    timeout-minutes: 15
-    strategy:
-      matrix:
-        edition: [oss, ee]
-    steps:
-    - name: Determine the docker version tag
-      uses: actions/github-script@v7
-      id: get_tag
-      with:
-        result-encoding: string
-        script: | # js
-          const tag = '${{ matrix.edition }}' === 'ee'
-            ? '${{ needs.check-version.outputs.ee_tag }}'
-            : '${{ needs.check-version.outputs.oss_tag }}';
-
-          console.log("The docker tag for this ", edition, "edition is", tag);
-
-          return tag;
-    - name: Login to Docker Hub # authenticated, to avoid being rate-throttled
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
-    - name: Pull the container image
-      run: |
-        echo "Pulling container image ${{ vars.DOCKERHUB_OWNER }}:${{ steps.get_tag.outputs.result }} ..."
-        docker pull ${{ vars.DOCKERHUB_OWNER }}:${{ steps.get_tag.outputs.result }}
-        echo "Successful!"
-    - name: Launch container
-      run: docker run --rm -dp 3000:3000 ${{ vars.DOCKERHUB_OWNER }}:${{ steps.get_tag.outputs.result }}
-      timeout-minutes: 5
-    - name: Wait for Metabase to start
-      run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
-      timeout-minutes: 3
+  containerize-ee:
+    needs: check-version
+    uses: ./.github/workflows/containerize-jar.yml
+    secrets: inherit
+    with:
+      artifact-name: metabase-release-ee-${{ inputs.commit }}-uberjar
+      commit: ${{ inputs.commit }}
+      repo: ${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_REPO }}-enterprise
+      tag: ${{ needs.check-version.outputs.ee }}
 
   push-tags:
     permissions: write-all
-    needs: [verify-s3-download, verify-docker-pull, check-version]
+    needs: [verify-s3-download, containerize-oss, containerize-ee, check-version]
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
@@ -487,7 +334,8 @@ jobs:
     needs:
       - get-extra-tags
       - push-tags
-      - verify-docker-pull
+      - containerize-ee
+      - containerize-oss
       - verify-s3-download
     strategy:
       matrix:

--- a/.github/workflows/tag-for-release.yml
+++ b/.github/workflows/tag-for-release.yml
@@ -135,6 +135,9 @@ jobs:
     env:
       INTERACTIVE: false
     steps:
+    - uses: actions/checkout@v4
+      with:
+        sparse-checkout: .github
     - name: Get correct version number
       run: | # bash
         if [ '${{matrix.edition}}' == 'ee' ]; then

--- a/.github/workflows/tag-for-release.yml
+++ b/.github/workflows/tag-for-release.yml
@@ -151,54 +151,9 @@ jobs:
         java-version: 21
 
     - name: Retrieve test build uberjar artifact for ${{ matrix.edition }}
-      id: find_release_artifact
-      uses: actions/github-script@v7
+      uses: ./.github/actions/fetch-artifact
       with:
-        result-encoding: string
-        script: | # js
-          const fs = require('fs');
-
-          const artifacts = await github.rest.actions.listArtifactsForRepo({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            name: `metabase-${{ matrix.edition }}-${{ inputs.commit }}-uberjar`,
-            per_page: 1,
-          });
-
-          if (!artifacts.data?.artifacts?.[0]?.id) {
-            console.warn(`No existing artifacts found for ${{ inputs.commit }}, need to build jar`);
-
-            if ("${{matrix.edition}}" === 'oss') {
-              // only trigger the build job on OSS, otherwise we'll get double builds
-              github.rest.actions.createWorkflowDispatch({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: 'build-for-release.yml',
-                ref: 'refs/heads/master',
-                inputs: {
-                  commit: '${{ inputs.commit }}',
-                  version: '${{ inputs.version }}',
-                }
-              });
-            }
-
-            throw new Error('aborting in favor of build script');
-          }
-
-          const artifact_id = artifacts.data.artifacts[0].id;
-
-          const download = await github.rest.actions.downloadArtifact({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            artifact_id: artifact_id,
-            archive_format: 'zip',
-          });
-
-          fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/mb.zip`, Buffer.from(download.data));
-    - name: Unzip Metabase artifact containing an uberjar
-      run: |
-        unzip mb.zip
-        mv target/uberjar/metabase.jar metabase.jar
+        name: metabase-${{ matrix.edition }}-${{ inputs.commit }}-uberjar
 
     - name: Update version.properties in jar
       run: | # sh

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -228,19 +228,19 @@ export const getMajorVersionNumberFromReleaseBranch = (branch: string) => {
 
 export const versionRequirements: Record<
   number,
-  { java: number; node: number }
+  { java: number; node: number, platforms: string }
 > = {
-  43: { java: 8, node: 14 },
-  44: { java: 11, node: 14 },
-  45: { java: 11, node: 14 },
-  46: { java: 11, node: 16 },
-  47: { java: 11, node: 18 },
-  48: { java: 11, node: 18 },
-  49: { java: 11, node: 18 },
-  50: { java: 11, node: 18 },
-  51: { java: 11, node: 18 },
-  52: { java: 11, node: 18 },
-  53: { java: 21, node: 22 },
+  43: { java: 8, node: 14, platforms: "linux/amd64" },
+  44: { java: 11, node: 14, platforms: "linux/amd64" },
+  45: { java: 11, node: 14, platforms: "linux/amd64" },
+  46: { java: 11, node: 16, platforms: "linux/amd64" },
+  47: { java: 11, node: 18, platforms: "linux/amd64" },
+  48: { java: 11, node: 18, platforms: "linux/amd64" },
+  49: { java: 11, node: 18, platforms: "linux/amd64" },
+  50: { java: 11, node: 18, platforms: "linux/amd64" },
+  51: { java: 11, node: 18, platforms: "linux/amd64" },
+  52: { java: 11, node: 18, platforms: "linux/amd64" },
+  53: { java: 21, node: 22, platforms: "linux/amd64,linux/arm64" },
 };
 
 export const getBuildRequirements = (version: string) => {

--- a/release/src/version-helpers.unit.spec.ts
+++ b/release/src/version-helpers.unit.spec.ts
@@ -260,6 +260,7 @@ describe("version-helpers", () => {
       expect(getBuildRequirements("v1.47.2.1")).toEqual({
         node: 18,
         java: 11,
+        platforms: "linux/amd64",
       });
     });
 
@@ -267,6 +268,7 @@ describe("version-helpers", () => {
       expect(getBuildRequirements("v0.47.2.1")).toEqual({
         node: 18,
         java: 11,
+        platforms: "linux/amd64",
       });
     });
 
@@ -274,6 +276,7 @@ describe("version-helpers", () => {
       expect(getBuildRequirements("v0.47.0")).toEqual({
         node: 18,
         java: 11,
+        platforms: "linux/amd64",
       });
     });
 
@@ -281,6 +284,7 @@ describe("version-helpers", () => {
       expect(getBuildRequirements("v0.47.0-RC7")).toEqual({
         node: 18,
         java: 11,
+        platforms: "linux/amd64",
       });
     });
 
@@ -293,6 +297,7 @@ describe("version-helpers", () => {
       expect(getBuildRequirements("v0.99.0")).toEqual({
         node: 22,
         java: 21,
+        platforms: "linux/amd64,linux/arm64",
       });
     });
   });


### PR DESCRIPTION
## Description

Now that we are on Java 21, we can build multi-arch containers that will perform natively on arm or x86 host machines.

1. Extracted jar-fetching logic into its own `fetch-artifact` action to dry up several workflows
2. Extracted containerization logic into it's own `containerize-jar` workflow that we can call and DRY up a few workflows and ensure we're doing it consistently everywhere
3. Had to do some special stuff to make it so that pre-53 builds don't build multi-arch images, AND that they get pushed with legacy manifest files that don't specify an architecture so that apple silicon users don't get error messages when pulling them

## Tests
All of these tests are in my fork, and one step is totally untested: testing the docker container on an arm container in CI
- [x] [containerizing a 53 jar](https://github.com/iethree/metabase/actions/runs/13577481818) (which builds a multi-arch image)
- [x] [containerizing a pre-53 jar](https://github.com/iethree/metabase/actions/runs/13577486469) (which builds a single-arch image)
- [x] [release tagging build for a v53 release](https://github.com/iethree/metabase/actions/runs/13575701033)

sample multi-arch image in dockerhub:
```
docker pull iethree/mb-staging:v0.53.95
```

sample legacy single-arch image in dockerhub:
```
docker pull iethree/mb-staging:v0.52.95
```


> [!Note]
> Out of an abundance of caution, I'm only using this in the pre-release workflow, and waiting to see that go well before enabling it in the publish workflow (but that PR is already ready: https://github.com/metabase/metabase/pull/54473)