### PR TITLE
Remove unused timeline-related entries from `services.js`

### DIFF
--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -271,21 +271,6 @@ export const GoogleApi = {
   updateSettings: PUT("/api/google/settings"),
 };
 
-export const TimelineApi = {
-  list: GET("/api/timeline"),
-  listForCollection: GET("/api/timeline/collection/:collectionId"),
-  get: GET("/api/timeline/:id"),
-  create: POST("/api/timeline"),
-  update: PUT("/api/timeline/:id"),
-};
-
-export const TimelineEventApi = {
-  list: GET("/api/timeline-event"),
-  get: GET("/api/timeline-event/:id"),
-  create: POST("/api/timeline-event"),
-  update: PUT("/api/timeline-event/:id"),
-};
-
 export const MetabaseApi = {
   db_autocomplete_suggestions: GET(
     "/api/database/:dbId/autocomplete_suggestions?:matchStyle=:query",


### PR DESCRIPTION
We are not referencing these entries anymore anywhere in the app.
Everything related to timelines is now using RTK endpoints under the hood.