### PR TITLE
fix: prevent icon overflow on resize

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -2451,3 +2451,42 @@ describe("issue 47940", () => {
     );
   });
 });
+
+describe("issue 53036", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+  });
+
+  const questionDetails = {
+    name: "Issue 53036",
+    query: {
+      "source-table": PRODUCTS_ID,
+      limit: 5,
+      joins: [
+        {
+          fields: "all",
+          alias: "Orders",
+          "source-table": ORDERS_ID,
+          strategy: "left-join",
+          condition: [
+            "=",
+            ["field", PRODUCTS.ID, null],
+            ["field", ORDERS.PRODUCT_ID, { "join-alias": "Orders" }],
+          ],
+        },
+      ],
+    },
+  };
+
+  it("should keep buttons usable on mid size screen (metabase#53036)", () => {
+    H.createQuestion(questionDetails, { visitQuestion: true });
+    H.openNotebook();
+
+    cy.viewport(650, 800);
+
+    cy.log("try to click on add button - it fails is there is an overlap");
+
+    H.getNotebookStep("join").icon("add").click();
+  });
+});

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -2487,6 +2487,9 @@ describe("issue 53036", () => {
 
     cy.log("try to click on add button - it fails is there is an overlap");
 
-    H.getNotebookStep("join").icon("add").click();
+    H.getNotebookStep("join").within(() => {
+      cy.icon("play").should("be.visible");
+      cy.icon("add").click();
+    });
   });
 });

--- a/frontend/src/metabase/querying/notebook/components/JoinStep/JoinComplete/JoinComplete.tsx
+++ b/frontend/src/metabase/querying/notebook/components/JoinStep/JoinComplete/JoinComplete.tsx
@@ -101,9 +101,9 @@ export function JoinComplete({
   };
 
   return (
-    <Flex miw="100%" gap="1rem">
+    <Flex direction={{ base: "column", md: "row" }} gap="sm">
       <NotebookCell className={S.JoinConditionCell} color={color}>
-        <Flex direction="row" gap={6}>
+        <Flex gap={6}>
           <NotebookCellItem color={color} disabled aria-label={t`Left table`}>
             {lhsTableName}
           </NotebookCellItem>
@@ -132,7 +132,7 @@ export function JoinComplete({
           />
         </Flex>
       </NotebookCell>
-      <Box mt="1.5rem">
+      <Box mt={{ md: "lg" }}>
         <Text color="brand" fw="bold">{t`on`}</Text>
       </Box>
       <NotebookCell className={S.JoinConditionCell} color={color}>

--- a/frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx
@@ -113,7 +113,7 @@ export function NotebookStep({
         </Box>
 
         <Flex align="center">
-          <Box w={`${(11 / 12) * 100}%`} maw="75rem">
+          <Box flex={`1 1 ${(11 / 12) * 100}%`} maw="75rem">
             <Step
               step={step}
               query={step.query}
@@ -126,7 +126,7 @@ export function NotebookStep({
             />
           </Box>
           {!readOnly && (
-            <Box w={`${(1 / 12) * 100}%`}>
+            <Box flex={`1 1 ${(1 / 12) * 100}%`}>
               <Box
                 className={cx(S.PreviewButton, {
                   [S.noPreviewButton]: !hasPreviewButton,


### PR DESCRIPTION
closes https://github.com/metabase/metabase/issues/53036

### Description

use flex-basis instead of width

### How to verify

follow steps in the issue

### Demo


https://github.com/user-attachments/assets/d61609b5-d470-46d9-bbeb-6b3554a1ff90




Example of test failure

<img width="1669" alt="Screenshot 2025-02-26 at 13 55 11" src="https://github.com/user-attachments/assets/4c2021a4-7b9f-4225-b8a3-ecd4bcf3af13" />
