### PR TITLE
Small UI fixes

### DIFF
--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
@@ -19,7 +19,6 @@ export const Sidebar = styled.aside<{ isOpen: boolean }>`
   flex-shrink: 0;
   align-items: center;
   background-color: var(--mb-color-bg-white);
-  overflow: auto;
   z-index: 4;
   width: ${NAV_SIDEBAR_WIDTH};
   border-inline-end: 1px solid var(--mb-color-border);

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/utils.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/utils.tsx
@@ -17,6 +17,7 @@ import type NativeQuery from "metabase-lib/v1/queries/NativeQuery";
 import * as ML_Urls from "metabase-lib/v1/urls";
 
 import { HeadBreadcrumbs } from "../HeaderBreadcrumbs/HeaderBreadcrumbs";
+import HeaderS from "../HeaderBreadcrumbs/HeaderBreadcrumbs.module.css";
 
 import S from "./QuestionDataSource.module.css";
 
@@ -164,6 +165,7 @@ function QuestionTableBadges({
               icon="info_filled"
               size={12}
               position="bottom"
+              className={HeaderS.HeaderBadgeIcon}
             />
           </span>
         )}

--- a/frontend/src/metabase/querying/filters/components/FilterModal/FilterOperatorPicker/FilterOperatorPicker.module.css
+++ b/frontend/src/metabase/querying/filters/components/FilterModal/FilterOperatorPicker/FilterOperatorPicker.module.css
@@ -1,0 +1,3 @@
+.Root {
+  flex-shrink: 0;
+}

--- a/frontend/src/metabase/querying/filters/components/FilterModal/FilterOperatorPicker/FilterOperatorPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterModal/FilterOperatorPicker/FilterOperatorPicker.tsx
@@ -3,6 +3,8 @@ import { t } from "ttag";
 
 import { Button, Icon, Menu } from "metabase/ui";
 
+import Styles from "./FilterOperatorPicker.module.css";
+
 type Option<T> = {
   name: string;
   operator: T;
@@ -37,6 +39,9 @@ export function FilterOperatorPicker<T extends string>({
           rightSection={<Icon name="chevrondown" size={8} />}
           p="xs"
           aria-label={t`Filter operator`}
+          classNames={{
+            root: Styles.Root,
+          }}
         >
           {label}
         </Button>

--- a/frontend/src/metabase/querying/filters/components/FilterModal/TimeFilterEditor/TimeFilterEditor.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterModal/TimeFilterEditor/TimeFilterEditor.tsx
@@ -67,7 +67,7 @@ export function TimeFilterEditor({
 
   return (
     <HoverParent data-testid="time-filter-editor">
-      <Grid grow>
+      <Grid grow align="center">
         <Grid.Col span="auto">
           <FilterTitle
             stageIndex={stageIndex}

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterOperatorPicker/FilterOperatorPicker.module.css
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterOperatorPicker/FilterOperatorPicker.module.css
@@ -1,0 +1,3 @@
+.Root {
+  flex-shrink: 0;
+}

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterOperatorPicker/FilterOperatorPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterOperatorPicker/FilterOperatorPicker.tsx
@@ -2,6 +2,8 @@ import { t } from "ttag";
 
 import { Button, Icon, Menu } from "metabase/ui";
 
+import Styles from "./FilterOperatorPicker.module.css";
+
 type Option<T> = {
   name: string;
   operator: T;
@@ -27,6 +29,9 @@ export function FilterOperatorPicker<T extends string>({
           fw="normal"
           rightSection={<Icon name="chevrondown" />}
           aria-label={t`Filter operator`}
+          classNames={{
+            root: Styles.Root,
+          }}
         >
           {selectedOption?.name ?? t`Select operator`}
         </Button>

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
@@ -169,9 +169,7 @@ export const ChartSettingFieldPicker = ({
             textOverflow: "ellipsis",
             fontWeight: "bold",
 
-            backgroundColor: disabled
-              ? "var(--mb-color-bg-white) !important"
-              : "inherit",
+            backgroundColor: disabled ? "var(--mb-color-bg-white)" : "inherit",
 
             border: "none",
             width: "100%",


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/54181
Closes https://github.com/metabase/metabase/issues/54115
Closes https://github.com/metabase/metabase/issues/54196

### Description
A collection of small UI fixes that have been identified over the past couple of weeks. They include:
- Filter Operator Picker getting the space it needs to render
- Main app bar not having horizontal scrolling
- Query Builder Header icon being the correct size
- Improving UI for disabled field pickers in firefox


### How to verify
1. (in firefox) Go to New -> Question -> Orders
2. Create any custom column with a really long name
3. try to add a filter to that column. Ensure that the operator selector is given the space it needs
4. Next, open the Orders table directly though the command palette. There should be an info icon in the header that is 16x16
5. Open the Main app side bar and notice that there is no horizontal scrolling
6. Summarize the Orders table (count by created at month) and view the chart settings. The field pickers should not have a weird grey background


### Demo
![image](https://github.com/user-attachments/assets/175bfd1e-abd0-4e41-b268-b1f24d15ad34)
![image](https://github.com/user-attachments/assets/87f71a50-063f-4350-bca0-0240f34c1752)
![image](https://github.com/user-attachments/assets/2bfd1d75-8f26-48cb-be69-876c8439fba5)
![image](https://github.com/user-attachments/assets/8aaaa51b-badf-4848-ab64-5bf4bd551870)

