### PR TITLE
sdk debug info component

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/debug/SdkDebugInfo.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/debug/SdkDebugInfo.tsx
@@ -1,0 +1,57 @@
+import dayjs from "dayjs";
+
+import { getEmbeddingSdkVersion } from "embedding-sdk/config";
+
+/**
+ * @internal
+ */
+export const SdkDebugInfo = (props: React.HTMLAttributes<HTMLDivElement>) => {
+  const shortCommit = process.env.GIT_COMMIT?.slice(0, 7);
+
+  const buildDate = process.env.BUILD_TIME
+    ? new Date(process.env.BUILD_TIME)
+    : null;
+  const formattedDate = buildDate
+    ? dayjs(buildDate).format("YYYY-MM-DD HH:mm")
+    : null;
+  const timeAgo = buildDate ? dayjs(buildDate).fromNow() : null;
+
+  return (
+    <div
+      {...props}
+      className={`sdk-debug-info mb-wrapper ${props.className}`}
+      style={{
+        fontSize: "12px",
+        textAlign: "left",
+        ...props.style,
+      }}
+    >
+      <table>
+        <tbody>
+          <tr>
+            <td>Sdk version:</td>
+            <td>
+              <b>{getEmbeddingSdkVersion()}</b>
+            </td>
+          </tr>
+          <tr>
+            <td>Built at:</td>
+            <td>
+              {buildDate && (
+                <span>
+                  {formattedDate} <b>({timeAgo})</b>
+                </span>
+              )}
+            </td>
+          </tr>
+          <tr>
+            <td>From branch:</td>
+            <td>
+              <b>{process.env.GIT_BRANCH}</b> ({shortCommit})
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/enterprise/frontend/src/embedding-sdk/components/public/index.ts
+++ b/enterprise/frontend/src/embedding-sdk/components/public/index.ts
@@ -42,3 +42,9 @@ export const defineMetabaseAuthConfig = (
 ): MetabaseAuthConfig => config;
 
 export { defineMetabaseTheme };
+
+/**
+ * Intended for debugging purposes only, so we don't want to expose it in the d.ts files.
+ * @internal
+ */
+export { SdkDebugInfo } from "./debug/SdkDebugInfo";

--- a/enterprise/frontend/src/embedding-sdk/index.ts
+++ b/enterprise/frontend/src/embedding-sdk/index.ts
@@ -28,9 +28,3 @@ export type {
 } from "metabase/embedding-sdk/theme";
 
 export type { Dashboard as MetabaseDashboard } from "metabase-types/api";
-
-/**
- * Intended for debugging purposes only, so we don't want to expose it in the d.ts files.
- * @internal
- */
-export { SdkDebugInfo } from "./components/public/debug/SdkDebugInfo";

--- a/enterprise/frontend/src/embedding-sdk/index.ts
+++ b/enterprise/frontend/src/embedding-sdk/index.ts
@@ -28,3 +28,9 @@ export type {
 } from "metabase/embedding-sdk/theme";
 
 export type { Dashboard as MetabaseDashboard } from "metabase-types/api";
+
+/**
+ * Intended for debugging purposes only, so we don't want to expose it in the d.ts files.
+ * @internal
+ */
+export { SdkDebugInfo } from "./components/public/debug/SdkDebugInfo";

--- a/tsconfig.sdk.json
+++ b/tsconfig.sdk.json
@@ -11,7 +11,8 @@
     "paths": {
       "*": ["./frontend/src/*", "./enterprise/frontend/src/*"],
       "cljs/*": ["./target/cljs_release/*"]
-    }
+    },
+    "stripInternal": true
   },
   "include": [
     "frontend/src/**/*.ts",

--- a/webpack.embedding-sdk.config.js
+++ b/webpack.embedding-sdk.config.js
@@ -156,13 +156,9 @@ module.exports = env => {
         IS_EMBEDDING_SDK: true,
       }),
       new webpack.DefinePlugin({
-        BUILD_TIME: webpack.DefinePlugin.runtimeValue(
-          () => JSON.stringify(new Date().toISOString()),
-          true, // This flag makes it update on each build
-        ),
         "process.env.BUILD_TIME": webpack.DefinePlugin.runtimeValue(
           () => JSON.stringify(new Date().toISOString()),
-          true,
+          true, // This flag makes it update on each build
         ),
       }),
       !skipDTS &&

--- a/webpack.embedding-sdk.config.js
+++ b/webpack.embedding-sdk.config.js
@@ -145,7 +145,25 @@ module.exports = env => {
       }),
       new webpack.EnvironmentPlugin({
         EMBEDDING_SDK_VERSION,
+        GIT_BRANCH: require("child_process")
+          .execSync("git rev-parse --abbrev-ref HEAD")
+          .toString()
+          .trim(),
+        GIT_COMMIT: require("child_process")
+          .execSync("git rev-parse HEAD")
+          .toString()
+          .trim(),
         IS_EMBEDDING_SDK: true,
+      }),
+      new webpack.DefinePlugin({
+        BUILD_TIME: webpack.DefinePlugin.runtimeValue(
+          () => JSON.stringify(new Date().toISOString()),
+          true, // This flag makes it update on each build
+        ),
+        "process.env.BUILD_TIME": webpack.DefinePlugin.runtimeValue(
+          () => JSON.stringify(new Date().toISOString()),
+          true,
+        ),
       }),
       !skipDTS &&
         new ForkTsCheckerWebpackPlugin({


### PR DESCRIPTION
<img width="369" alt="image" src="https://github.com/user-attachments/assets/0234f7cb-2225-4114-aed2-49b350a36f7c" />

https://metaboat.slack.com/archives/C063Q3F1HPF/p1740416508094859

This should help us notice if we're using cached/outdated versions of the sdk locally.

It's tagged as `@internal` to not show up on the generated d.ts files, so we'll have type errors when using it on host apps, but at least it won't show up to customers.

We may move it to a subpath in the future when our build system will make it easy to do