### PR TITLE
fix(sdk): move some emotion to css, scope it to .mb-wrapper and use it in the sdk

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/interactive-dashboard.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-dashboard.cy.spec.tsx
@@ -128,6 +128,9 @@ describe("scenarios > embedding-sdk > interactive-dashboard", () => {
       },
     ];
 
+    // Those tests are sometimes rendering 6 rows, sometimes 7 rows, we don't want this to be flaky
+    const rowsTextRegex = /Rows 1-[6,7] of first 2000/;
+
     successTestCases.forEach(({ name, dashboardIdAlias }) => {
       it(`should load dashboard content for ${name}`, () => {
         cy.get(dashboardIdAlias).then(dashboardId => {
@@ -137,7 +140,7 @@ describe("scenarios > embedding-sdk > interactive-dashboard", () => {
         getSdkRoot().within(() => {
           cy.findByText("Orders in a dashboard").should("be.visible");
           cy.findByText("Orders").should("be.visible");
-          cy.findByText("Rows 1-6 of first 2000").should("be.visible");
+          cy.findByText(rowsTextRegex).should("be.visible");
           cy.findByText("Test text card").should("be.visible");
         });
       });
@@ -153,7 +156,7 @@ describe("scenarios > embedding-sdk > interactive-dashboard", () => {
 
           cy.findByText("Orders in a dashboard").should("not.exist");
           cy.findByText("Orders").should("not.exist");
-          cy.findByText("Rows 1-6 of first 2000").should("not.exist");
+          cy.findByText(rowsTextRegex).should("not.exist");
           cy.findByText("Test text card").should("not.exist");
         });
       });

--- a/e2e/test-component/scenarios/embedding-sdk/static-dashboard.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/static-dashboard.cy.spec.tsx
@@ -107,6 +107,9 @@ describe("scenarios > embedding-sdk > static-dashboard", () => {
       },
     ];
 
+    // Those tests are sometimes rendering 6 rows, sometimes 7 rows, we don't want this to be flaky
+    const rowsTextRegex = /Rows 1-[6,7] of first 2000/;
+
     successTestCases.forEach(({ name, dashboardIdAlias }) => {
       it(`should load dashboard content for ${name}`, () => {
         cy.get(dashboardIdAlias).then(dashboardId => {
@@ -116,7 +119,7 @@ describe("scenarios > embedding-sdk > static-dashboard", () => {
         getSdkRoot().within(() => {
           cy.findByText("Embedding SDK Test Dashboard").should("be.visible");
           cy.findByText("Test question card").should("be.visible");
-          cy.findByText("Rows 1-6 of first 2000").should("be.visible");
+          cy.findByText(rowsTextRegex).should("be.visible");
           cy.findByText("Test text card").should("be.visible");
         });
       });
@@ -132,7 +135,7 @@ describe("scenarios > embedding-sdk > static-dashboard", () => {
 
           cy.findByText("Orders in a dashboard").should("not.exist");
           cy.findByText("Orders").should("not.exist");
-          cy.findByText("Rows 1-6 of first 2000").should("not.exist");
+          cy.findByText(rowsTextRegex).should("not.exist");
           cy.findByText("Test text card").should("not.exist");
         });
       });

--- a/frontend/src/metabase/css/core/base.styled.ts
+++ b/frontend/src/metabase/css/core/base.styled.ts
@@ -44,47 +44,4 @@ export const baseStyle = css`
     margin: 0;
     list-style-type: none;
   }
-
-  /*
-  explicitly set the th text alignment to left. this is required for IE
-  which follows the suggested rendering and defaults to center, whereas
-  chrome and others do not
-*/
-  th {
-    text-align: left;
-  }
-
-  /* reset button element */
-  button {
-    font-size: 100%;
-    -webkit-appearance: none;
-    border: 0;
-    padding: 0;
-    margin: 0;
-    outline: none;
-    background-color: transparent;
-  }
-
-  a:focus,
-  button:focus,
-  [role="button"]:focus {
-    outline: 2px solid var(--mb-color-focus);
-  }
-
-  a {
-    color: inherit;
-    cursor: pointer;
-    text-decoration: none;
-  }
-
-  button,
-  input,
-  textarea {
-    font-family: var(--mb-default-font-family), "Helvetica Neue", Helvetica,
-      sans-serif;
-  }
-
-  textarea {
-    min-height: 110px;
-  }
 `;

--- a/frontend/src/metabase/css/index.module.css
+++ b/frontend/src/metabase/css/index.module.css
@@ -7,3 +7,4 @@
 @import "./dashboard.module.css";
 @import "./query_builder.module.css";
 @import "./core/animation.module.css";
+@import "./reset.module.css";

--- a/frontend/src/metabase/css/reset.module.css
+++ b/frontend/src/metabase/css/reset.module.css
@@ -1,0 +1,63 @@
+/** CSS reset scoped to the .mb-wrapper class so we can use it in the SDK */
+
+:where(:global(.mb-wrapper)) {
+  /*
+  override default padding and margin on lists
+  in most cases we won't be using list-style so
+  the padding isn't necessary
+  */
+  ul,
+  ol {
+    padding: 0;
+    margin: 0;
+    list-style-type: none;
+  }
+
+  /*
+  explicitly set the th text alignment to left. this is required for IE
+  which follows the suggested rendering and defaults to center, whereas
+  chrome and others do not
+  */
+  th {
+    text-align: left;
+  }
+
+  /* reset button element */
+  button {
+    font-size: 100%;
+    -webkit-appearance: none;
+    border: 0;
+    padding: 0;
+    margin: 0;
+    outline: none;
+    background-color: transparent;
+  }
+
+  a {
+    color: inherit;
+    cursor: pointer;
+    text-decoration: none;
+
+    &:focus {
+      outline: 2px solid var(--mb-color-focus);
+    }
+  }
+
+  button,
+  [role="button"] {
+    &:focus {
+      outline: 2px solid var(--mb-color-focus);
+    }
+  }
+
+  button,
+  input,
+  textarea {
+    font-family: var(--mb-default-font-family), "Helvetica Neue", Helvetica,
+      sans-serif;
+  }
+
+  textarea {
+    min-height: 110px;
+  }
+}


### PR DESCRIPTION
closes [EMB-173: default vite css code leaks inside the sdk and messes up the chard legends](https://linear.app/metabase/issue/EMB-173/default-vite-css-code-leaks-inside-the-sdk-and-messes-up-the-chard)

We had some css reset on `frontend/src/metabase/css/core/base.styled.ts`, but that was only used in `frontend/src/metabase/styled-components/containers/GlobalStyles/GlobalStyles.tsx` which is not used on the sdk.

This moves that css reset on a css files, it makes it only work inside `.mb-wrapper` and adds it to the core css file so it's loaded automatically in the sdk and core app.

