### PR TITLE
Gracefully handle null arrays in results

### DIFF
--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -598,7 +598,9 @@
 
 (defmethod read-column-thunk [:sql-jdbc Types/ARRAY]
   [_driver ^java.sql.ResultSet rs _rsmeta ^Integer i]
-  (fn [] (vec (.getArray ^java.sql.Array (.getObject rs i)))))
+  (fn []
+    (when-let [obj (.getObject rs i)]
+      (vec (.getArray ^java.sql.Array obj)))))
 
 (defmethod read-column-thunk [:sql-jdbc Types/TIMESTAMP_WITH_TIMEZONE]
   [_ rs _ i]

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -700,6 +700,6 @@
   (testing "a null array should be handled gracefully and return nil"
     (mt/test-drivers (mt/normal-drivers-with-feature :test/null-arrays)
       (is (= [[nil]]
-             (->> (mt/native-query {:query (tx/native-null-array-query driver/*driver*)})
-                  mt/process-query
-                  mt/rows))))))
+             (-> (mt/native-query {:query (tx/native-null-array-query driver/*driver*)})
+                 mt/process-query
+                 mt/rows))))))

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -7,6 +7,7 @@
    [metabase.driver :as driver]
    [metabase.query-processor :as qp]
    [metabase.test :as mt]
+   [metabase.test.data.interface :as tx]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
    [toucan2.core :as t2]))
@@ -694,3 +695,11 @@
           (mt/with-native-query-testing-context query
             (is (= [[1020]]
                    (mt/formatted-rows [int] (qp/process-query query))))))))))
+
+(deftest ^:parallel null-array-test
+  (testing "a null array should be handled gracefully and return nil"
+    (mt/test-drivers (mt/normal-drivers-with-feature :test/null-arrays)
+      (is (= [[nil]]
+             (->> (mt/native-query {:query (tx/native-null-array-query driver/*driver*)})
+                  mt/process-query
+                  mt/rows))))))

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -876,7 +876,7 @@
     [_driver]
     {:access_key (u.random/random-name)}))
 
-(doseq [driver [:postgres :mysql :snowflake :databricks :redshift :sqlite :vertica :athena]]
+(doseq [driver [:postgres :mysql :snowflake :databricks :redshift :sqlite :vertica :athena :oracle]]
   (defmethod driver/database-supports? [driver :test/arrays]
     [_driver _feature _database]
     true))
@@ -903,6 +903,32 @@
 (defmethod native-array-query :snowflake
   [_driver]
   "select array_construct('a', 'b', 'c')")
+
+(defmethod native-array-query :oracle
+  [_driver]
+  "select cast(collect(1) as sys.odcinumberlist) from dual")
+
+(doseq [driver [:postgres :vertica :athena :oracle]]
+  (defmethod driver/database-supports? [driver :test/null-arrays]
+    [_driver _feature _database]
+    true))
+
+(defmulti native-null-array-query
+  {:arglists '([driver])}
+  dispatch-on-driver-with-test-extensions
+  :hierarchy #'driver/hierarchy)
+
+(defmethod native-null-array-query :default
+  [_driver]
+  "select cast(null as integer[])")
+
+(defmethod native-null-array-query :athena
+  [_driver]
+  "select cast(null as array<integer>)")
+
+(defmethod native-null-array-query :oracle
+  [_driver]
+  "select cast(null as sys.odcinumberlist) from dual")
 
 (doseq [driver [:postgres :athena :oracle]]
   (defmethod driver/database-supports? [driver :test/array-aggregation]

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -913,6 +913,11 @@
     [_driver _feature _database]
     true))
 
+;; redshift doesn't have a way to to return null as an array
+(defmethod driver/database-supports? [:redshift :test/null-arrays]
+  [_driver _feature _database]
+  false)
+
 (defmulti native-null-array-query
   {:arglists '([driver])}
   dispatch-on-driver-with-test-extensions


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/54190
Closes https://linear.app/metabase/issue/DRI-149/postgresql-integer-array-column-breaks-showing-query-in-v05334

### Description

Checks that the array is not null before attempting to get the array. 

### How to verify

1. Run `select cast(null as integer[])` on a Postgres database
2. It should return `null` instead of an error

### Demo

https://github.com/user-attachments/assets/1e04ec8a-5b2f-4937-b0ac-2f094b3c8175

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
