### PR TITLE
[refs] Make `lib.convert` internal; use `lib/query` etc. to convert

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -227,7 +227,6 @@
   {:api #{metabase.lib.binning
           metabase.lib.binning.util
           metabase.lib.card
-          metabase.lib.convert
           metabase.lib.core
           metabase.lib.equality
           metabase.lib.field

--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
@@ -10,8 +10,10 @@
    [metabase.api.common :as api :refer [*current-user* *current-user-id*]]
    [metabase.db :as mdb]
    [metabase.legacy-mbql.schema :as mbql.s]
-   [metabase.lib.convert :as lib.convert]
+   [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   ;; TODO: Why use the lib.metadata.protocols functions directly, instead of the lib.metadata wrappers?
+   ;; This should probably be enforced at the modules level.
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
@@ -125,9 +127,10 @@
     (let [query        {:database (u/the-id (lib.metadata/database (qp.store/metadata-provider)))
                         :type     :query
                         :query    source-query}
-          preprocessed (binding [lib.convert/*clean-query* false]
-                         (request/as-admin
-                           ((requiring-resolve 'metabase.query-processor.preprocess/preprocess) query)))]
+          preprocessed (lib/without-cleaning
+                        (fn []
+                          (request/as-admin
+                            ((requiring-resolve 'metabase.query-processor.preprocess/preprocess) query))))]
       (select-keys (:query preprocessed) [:source-query :source-metadata]))
     (catch Throwable e
       (throw (ex-info (tru "Error preprocessing source query when applying GTAP: {0}" (ex-message e))

--- a/enterprise/backend/test/metabase_enterprise/task/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/task/cache_test.clj
@@ -479,9 +479,11 @@
   "Compares a normal query result with a query result generated after a preemptive caching job runs, and asserts
   that all relevant fields are the same."
   [original-result cached-result]
-  (let [clean-result (fn [result]
+  (let [clean-col    #(dissoc % :ident :lib/source-uuid :lib/source_uuid)
+        clean-result (fn [result]
                        (-> result
                            (dissoc :running_time :average_execution_time :started_at :cached)
+                           (update-in [:data :cols] #(mapv clean-col %))
                            (m/dissoc-in [:json_query :cache-strategy])))]
     (is (= (clean-result original-result)
            (clean-result cached-result)))))

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -253,7 +253,9 @@
 (defn add-query-average-durations
   "Add a `average_execution_time` field to each card (and series) belonging to `dashboard`."
   [dashboard]
-  (update dashboard :dashcards add-query-average-duration-to-dashcards))
+  ;; Doall is needed to fetch the average durations in this thread, in the context of *dashboard-load-id*.
+  ;; Otherwise it happens on other threads without the MetadataProvider caching and makes many more AppDB requests.
+  (update dashboard :dashcards (comp doall add-query-average-duration-to-dashcards)))
 
 ;; ## Dashboard load caching
 ;; When the FE loads a dashboard, there is a burst of requests sent to the BE:

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -13,9 +13,8 @@
    [metabase.driver.sql.query-processor.deprecated :as sql.qp.deprecated]
    [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.legacy-mbql.util :as mbql.u]
-   [metabase.lib.convert :as lib.convert]
+   [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
-   [metabase.lib.query :as lib.query]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.query-processor.debug :as qp.debug]
@@ -1809,9 +1808,9 @@
   [inner-query :- mbql.s/MBQLQuery]
   (let [metadata-provider (qp.store/metadata-provider)
         database-id       (u/the-id (lib.metadata/database (qp.store/metadata-provider)))]
-    (-> (lib.query/query-from-legacy-inner-query metadata-provider database-id inner-query)
+    (-> (lib/query-from-legacy-inner-query metadata-provider database-id inner-query)
         qp.util.transformations.nest-breakouts/nest-breakouts-in-stages-with-window-aggregation
-        lib.convert/->legacy-MBQL
+        lib/->legacy-MBQL
         :query)))
 
 ;;; [[qp.util.transformations.nest-breakouts/nest-breakouts-in-stages-with-window-aggregation]] already does

--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -95,6 +95,14 @@
   When converting queries at later stages of the preprocessing pipeline, this cleaning might not be desirable."
   true)
 
+(defn without-cleaning
+  "Runs the provided function with cleaning of queries disabled.
+
+  This is preferred over directly cleaning the query."
+  [f]
+  (binding [*clean-query* false]
+    (f)))
+
 (defn- clean [almost-query]
   (if-not *clean-query*
     almost-query

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -121,7 +121,8 @@
   external-op]
  [lib.convert
   ->legacy-MBQL
-  ->pMBQL]
+  ->pMBQL
+  without-cleaning]
  [lib.database
   database-id]
  [lib.drill-thru
@@ -141,6 +142,7 @@
   expressions-metadata
   expressionable-columns
   expression-ref
+  resolve-expression
   with-expression-name
   +
   -
@@ -311,12 +313,14 @@
  [lib.normalize
   normalize]
  [lib.query
+  ->query
   can-preview
   can-run
   can-save
   check-overwrite
   preview-query
   query
+  query-from-legacy-inner-query
   stage-count
   uses-metric?
   uses-segment?

--- a/src/metabase/lib/metadata/jvm.clj
+++ b/src/metabase/lib/metadata/jvm.clj
@@ -1,6 +1,7 @@
 (ns metabase.lib.metadata.jvm
   "Implementation(s) of [[metabase.lib.metadata.protocols/MetadataProvider]] only for the JVM."
   (:require
+   [clojure.core.cache :as cache]
    [clojure.core.cache.wrapped :as cache.wrapped]
    [clojure.string :as str]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
@@ -408,6 +409,15 @@
 
   This is useful for an API request, or group fo API requests like a dashboard load, to reduce appdb traffic."
   nil)
+
+(defmacro with-metadata-provider-cache
+  "Wrapper to create a [[*metadata-provider-cache*]] for the duration of the `body`.
+
+  If there is already a [[*metadata-provider-cache*]], this leaves it in place."
+  [& body]
+  `(binding [*metadata-provider-cache* (or *metadata-provider-cache*
+                                           (atom (cache/basic-cache-factory {})))]
+     ~@body))
 
 (mu/defn application-database-metadata-provider :- ::lib.schema.metadata/metadata-provider
   "An implementation of [[metabase.lib.metadata.protocols/MetadataProvider]] for the application database.

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -295,6 +295,16 @@
    x]
   (lib.cache/attach-query-cache (query-method metadata-providerable x)))
 
+(mu/defn ->query :- ::lib.schema/query
+  "[[->]] friendly form of [[query]].
+
+  Create a new MBQL query from anything that could conceptually be an MBQL query, like a Database or Table or an
+  existing MBQL query or saved question or whatever. If the thing in question does not already include metadata, pass
+  it in separately -- metadata is needed for most query manipulation operations."
+  [x
+   metadata-providerable :- ::lib.schema.metadata/metadata-providerable]
+  (query metadata-providerable x))
+
 (mu/defn query-from-legacy-inner-query :- ::lib.schema/query
   "Create a pMBQL query from a legacy inner query."
   [metadata-providerable :- ::lib.schema.metadata/metadata-providerable

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -138,6 +138,19 @@
   [card]
   (= (keyword (:type card)) :model))
 
+(defn lib-query
+  "Given a card with at least its `:dataset_query` field, this returns the `metabase.lib` form of the query.
+
+  A `metadata-provider` may be passed as an optional first parameter, if the caller has one to hand."
+  ([{:keys [database_id dataset_query] :as card}]
+   (when dataset_query
+     (let [db-id (or database_id (:database dataset_query))
+           mp    (lib.metadata.jvm/application-database-metadata-provider db-id)]
+       (lib-query mp card))))
+  ([metadata-providerable {:keys [dataset_query] :as _card}]
+   (when dataset_query
+     (lib/query metadata-providerable dataset_query))))
+
 ;;; -------------------------------------------------- Hydration --------------------------------------------------
 
 (methodical/defmethod t2/batched-hydrate [:model/Card :dashboard_count]

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -10,7 +10,6 @@
    [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.legacy-mbql.util :as mbql.u]
    [metabase.lib.binning :as lib.binning]
-   [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
@@ -348,38 +347,35 @@
 (defn- mlv2-query [inner-query]
   (qp.store/cached [:mlv2-query (hash inner-query)]
     (try
-      (lib/query
+      (lib/query-from-legacy-inner-query
        (qp.store/metadata-provider)
-       (lib.convert/->pMBQL (lib.convert/legacy-query-from-inner-query
-                             (:id (lib.metadata/database (qp.store/metadata-provider)))
-                             (mbql.normalize/normalize-fragment [:query] inner-query))))
+       (:id (lib.metadata/database (qp.store/metadata-provider)))
+       (mbql.normalize/normalize-fragment [:query] inner-query))
       (catch Throwable e
         (throw (ex-info (tru "Error converting query to pMBQL: {0}" (ex-message e))
                         {:inner-query inner-query, :type qp.error-type/qp}
                         e))))))
 
-(mu/defn- col-info-for-aggregation-clause
-  "Return appropriate column metadata for an `:aggregation` clause."
-  ;; `clause` is normally an aggregation clause but this function can call itself recursively; see comments by the
-  ;; `match` pattern for field clauses below
-  [inner-query :- :map
-   clause]
-  (let [mlv2-clause (lib.convert/->pMBQL clause)]
-    ;; for some mystery reason it seems like the annotate code uses `:long` style display names when something appears
-    ;; inside an aggregation clause, e.g.
-    ;;
-    ;;    Distinct values of Category → Name
-    ;;
-    ;; but `:default` style names when they appear on their own or in breakouts, e.g.
-    ;;
-    ;;    Name
-    ;;
-    ;; why is this the case? Who knows! But that's the old pre-MLv2 behavior. I think we should try to fix it, but it's
-    ;; probably going to involve updating a ton of tests that encode the old behavior.
-    (binding [lib.metadata.calculation/*display-name-style* :long]
-      (-> (lib/metadata (mlv2-query inner-query) -1 mlv2-clause)
-          (update-keys u/->snake_case_en)
-          (dissoc :lib/type)))))
+(mu/defn- col-info-for-aggregation-clauses
+  "Return appropriate (legacy) column metadata for the `:aggregation` clauses of this legacy inner query, in order."
+  [inner-query]
+  ;; for some mystery reason it seems like the annotate code uses `:long` style display names when something appears
+  ;; inside an aggregation clause, e.g.
+  ;;
+  ;;    Distinct values of Category → Name
+  ;;
+  ;; but `:default` style names when they appear on their own or in breakouts, e.g.
+  ;;
+  ;;    Name
+  ;;
+  ;; why is this the case? Who knows! But that's the old pre-MLv2 behavior. I think we should try to fix it, but it's
+  ;; probably going to involve updating a ton of tests that encode the old behavior.
+  (when (seq (:aggregation inner-query))
+    (let [query (mlv2-query inner-query)]
+      (binding [lib.metadata.calculation/*display-name-style* :long]
+        (for [agg-metadata (lib/aggregations-metadata query -1)]
+          (-> (m/remove-keys #(= "lib" (namespace %)) agg-metadata)
+              (update-keys u/->snake_case_en)))))))
 
 (def ^:private LegacyInnerQuery
   [:and
@@ -388,6 +384,10 @@
     {:error/message "legacy inner-query with :source-table or :source-query"}
     (some-fn :source-table :source-query)]])
 
+;; TODO: This function is janky, and converts isolated legacy aggregations and expressions into pMBQL.
+;; The right approach here is to adjust the annotate middleware to ensure that all aggregations and expressions
+;; already have the right column names present in their options. Then this function can be deprecated, and replaced
+;; with another helper (probably in the driver or MBQL utils?) that grabs the :name for a clause from its options.
 (mu/defn aggregation-name :- ::lib.schema.common/non-blank-string
   "Return an appropriate aggregation name/alias *used inside a query* for an `:aggregation` subclause (an aggregation
   or expression). Takes an options map as schema won't support passing keypairs directly as a varargs.
@@ -395,7 +395,7 @@
   These names are also used directly in queries, e.g. in the equivalent of a SQL `AS` clause."
   [inner-query :- LegacyInnerQuery
    ag-clause]
-  (lib/column-name (mlv2-query inner-query) (lib.convert/->pMBQL ag-clause)))
+  (lib/column-name (mlv2-query inner-query) (lib/->pMBQL ag-clause)))
 
 ;;; ----------------------------------------- Putting it all together (MBQL) -----------------------------------------
 
@@ -422,13 +422,13 @@
            :source :fields)))
 
 (mu/defn- cols-for-ags-and-breakouts
-  [{aggregations :aggregation, breakouts :breakout, :as inner-query} :- :map]
+  [{breakouts :breakout, :as inner-query} :- :map]
   (concat
    (for [breakout breakouts]
      (assoc (col-info-for-field-clause inner-query breakout)
             :source :breakout))
-   (for [[i aggregation] (m/indexed aggregations)]
-     (assoc (col-info-for-aggregation-clause inner-query aggregation)
+   (for [[i aggregation] (m/indexed (col-info-for-aggregation-clauses inner-query))]
+     (assoc aggregation
             :source            :aggregation
             :field_ref         [:aggregation i]
             :aggregation_index i))))

--- a/src/metabase/query_processor/middleware/expand_macros.clj
+++ b/src/metabase/query_processor/middleware/expand_macros.clj
@@ -3,8 +3,7 @@
 
   (`:segment` forms are expanded into filter clauses.)"
   (:require
-   [metabase.legacy-mbql.normalize :as mbql.normalize]
-   [metabase.lib.convert :as lib.convert]
+   [metabase.lib.core :as lib]
    [metabase.lib.filter :as lib.filter]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema :as lib.schema]
@@ -59,8 +58,7 @@
                 :query    (merge {:source-table table-id}
                                  definition)
                 :database (u/the-id (lib.metadata/database metadata-providerable))}
-               mbql.normalize/normalize
-               lib.convert/->pMBQL
+               (lib/->query metadata-providerable)
                (lib.util/query-stage -1))
     (log/tracef "to pMBQL\n%s" (u/pprint-to-str <>))))
 

--- a/src/metabase/query_processor/middleware/fetch_source_query_legacy.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query_legacy.clj
@@ -6,7 +6,7 @@
    [metabase.driver.util :as driver.u]
    [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.legacy-mbql.schema :as mbql.s]
-   [metabase.lib.convert :as lib.convert]
+   [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.public-settings :as public-settings]
@@ -33,7 +33,7 @@
   "Get the query to be run from the card"
   [{dataset-query :dataset-query, card-id :id, :as card}]
   (let [dataset-query (cond-> dataset-query
-                        (:lib/type dataset-query) lib.convert/->legacy-MBQL)
+                        (:lib/type dataset-query) lib/->legacy-MBQL)
         {db-id                                           :database
          mbql-query                                      :query
          {template-tags :template-tags :as native-query} :native} dataset-query]

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -2,7 +2,6 @@
   (:require
    [medley.core :as m]
    [metabase.analytics.core :as analytics]
-   [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.util :as lib.util]
@@ -49,9 +48,10 @@
          (lib.metadata/bulk-metadata-or-throw query :metadata/card)
          (into {}
                (map (fn [card-metadata]
-                      (let [metric-query (lib.convert/->pMBQL
-                                          ((requiring-resolve 'metabase.query-processor.preprocess/preprocess)
-                                           (lib/query query (:dataset-query card-metadata))))
+                      (let [metric-query (->> (:dataset-query card-metadata)
+                                              (lib/query query)
+                                              ((requiring-resolve 'metabase.query-processor.preprocess/preprocess))
+                                              (lib/query query))
                             metric-name (:name card-metadata)]
                         (if-let [aggregation (first (lib/aggregations metric-query))]
                           [(:id card-metadata)

--- a/src/metabase/query_processor/middleware/normalize_query.clj
+++ b/src/metabase/query_processor/middleware/normalize_query.clj
@@ -18,6 +18,7 @@
                               (qp.store/metadata-provider))]
     ;; removing `:lib/converted?` will keep MLv2 from doing a bunch of extra transformations to something that's already
     ;; a well-formed pMBQL query, we don't need that and it actually ends up breaking some stuff
+    ;; TODO: Get the library to a stable state, where `lib/query` is idempotent, then this can be dropped.
     (lib/query metadata-provider (dissoc query :lib.convert/converted?))))
 
 (def ^:private NormalizedQuery

--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -5,7 +5,6 @@
   instead of running like 10 separate queries? -- Cam"
   (:require
    [medley.core :as m]
-   [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
    [metabase.lib.equality :as lib.equality]
    [metabase.lib.metadata :as lib.metadata]
@@ -575,7 +574,7 @@
   results -- "
   [query :- ::lib.schema/query]
   (let [remapped-query          (->> query
-                                     lib.convert/->legacy-MBQL
+                                     lib/->legacy-MBQL
                                      qp.add-dimension-projections/add-remapped-columns
                                      (lib.query/query (qp.store/metadata-provider)))
         remap                   (remapped-indexes (lib/breakouts remapped-query))

--- a/src/metabase/query_processor/preprocess.clj
+++ b/src/metabase/query_processor/preprocess.clj
@@ -1,8 +1,8 @@
 (ns metabase.query-processor.preprocess
   (:require
+   [medley.core :as m]
    [metabase.legacy-mbql.schema :as mbql.s]
-   [metabase.lib.convert :as lib.convert]
-   [metabase.lib.query :as lib.query]
+   [metabase.lib.core :as lib]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.query-processor.debug :as qp.debug]
    [metabase.query-processor.error-type :as qp.error-type]
@@ -55,7 +55,7 @@
 
 (mu/defn- ->legacy :- mbql.s/Query
   [query]
-  (lib.convert/->legacy-MBQL query))
+  (lib/->legacy-MBQL query))
 
 (defn- ^:deprecated ensure-legacy [middleware-fn]
   (-> (fn [query]
@@ -68,7 +68,7 @@
 (defn- ensure-pmbql [middleware-fn]
   (-> (fn [query]
         (let [query (cond->> query
-                      (not (:lib/type query)) (lib.query/query (qp.store/metadata-provider)))]
+                      (not (:lib/type query)) (lib/query (qp.store/metadata-provider)))]
           (vary-meta (middleware-fn query)
                      assoc :converted-form query)))
       (with-meta (meta middleware-fn))))
@@ -88,12 +88,12 @@
   [middleware-fn]
   (-> (fn [query]
         (mu/disable-enforcement
-          (binding [lib.convert/*clean-query* false]
-            (let [query' (-> (cond->> query
-                               (not (:lib/type query))
-                               (lib.query/query (qp.store/metadata-provider)))
-                             (copy-unconverted-properties query))]
-              (-> query' middleware-fn ->legacy)))))
+          (lib/without-cleaning
+           (fn []
+             (let [query' (-> (cond->> query
+                                (not (:lib/type query)) (lib/query (qp.store/metadata-provider)))
+                              (copy-unconverted-properties query))]
+               (-> query' middleware-fn ->legacy))))))
       (with-meta (meta middleware-fn))))
 
 (def ^:private middleware
@@ -201,5 +201,5 @@
            ;; remove MLv2 columns so we don't break a million tests. Once the whole QP is updated to use MLv2 metadata
            ;; directly we can stop stripping these out
            (mapv (fn [col]
-                   (dissoc col :lib/external_remap :lib/internal_remap)))
+                   (m/remove-keys #(= "lib" (namespace %)) col)))
            not-empty))))

--- a/src/metabase/query_processor/store.clj
+++ b/src/metabase/query_processor/store.clj
@@ -14,7 +14,7 @@
   those Fields potentially dozens of times in a single query execution."
   (:require
    [medley.core :as m]
-   [metabase.lib.convert :as lib.convert]
+   [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.schema.id :as lib.schema.id]
@@ -200,4 +200,6 @@
         (dissoc :lib/type)
         (update-keys u/->snake_case_en)
         (vary-meta assoc :type model)
-        (m/update-existing :field_ref lib.convert/->legacy-MBQL))))
+        ;; TODO: This is converting a freestanding field ref into legacy form. Then again, the `:field_ref` on MLv2
+        ;; metadata is already in legacy form.
+        (m/update-existing :field_ref lib/->legacy-MBQL))))

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -745,7 +745,7 @@
   "For models that depend on only one table, return its id, otherwise return nil. Doesn't support native queries."
   [model]
   ; dataset_query can be empty in tests
-  (when-let [query (some-> model :dataset_query lib/->pMBQL not-empty)]
+  (when-let [query (card/lib-query model)]
     (when (and (mbql? model) (no-joins? query))
       (lib/source-table-id query))))
 

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4727,8 +4727,9 @@
                                                        (:id dash) load-id))])))
               (testing "make fewer AppDB calls than uncached"
                 (is (< (call-count-fn) @uncached-calls)))))
-          (testing "don't construct any MetadataProviders in bulk mode"
-            (is (= {} @provider-counts))))))))
+          (testing "constructs only 1 MetadataProvider in bulk mode"
+            ;; It's needed to compute the query hashes, which is needed for the average duration mechanism.
+            (is (= {(mt/id) 1} @provider-counts))))))))
 
 (deftest ^:synchronized dashboard-table-prefetch-test
   (mt/with-temp

--- a/test/metabase/query_processor/middleware/add_source_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/add_source_metadata_test.clj
@@ -135,31 +135,31 @@
 
 (deftest ^:parallel named-aggregations-name-only-test
   (testing "w/ `:name` only"
-    (is (= [{:name          "some_generated_name"
-             :display_name  "Average of ID"
-             :base_type     :type/Float
-             :semantic_type :type/PK
-             :settings      nil
-             :field_ref     [:aggregation 0]}]
-           (source-metadata
-            (add-source-metadata
-             (lib.tu.macros/mbql-query venues
-               {:source-query {:source-table $$venues
-                               :aggregation  [[:aggregation-options [:avg $id] {:name "some_generated_name"}]]}})))))))
+    (is (=? [{:name          "some_generated_name"
+              :display_name  "Average of ID"
+              :base_type     :type/Float
+              :semantic_type :type/PK
+              :settings      nil
+              :field_ref     [:aggregation 0]}]
+            (source-metadata
+             (add-source-metadata
+              (lib.tu.macros/mbql-query venues
+                {:source-query {:source-table $$venues
+                                :aggregation  [[:aggregation-options [:avg $id] {:name "some_generated_name"}]]}})))))))
 
 (deftest ^:parallel named-aggregations-display-name-only-test
   (testing "w/ `:display-name` only"
-    (is (= [{:name          "avg"
-             :display_name  "My Cool Ag"
-             :base_type     :type/Float
-             :semantic_type :type/PK
-             :settings      nil
-             :field_ref     [:aggregation 0]}]
-           (source-metadata
-            (add-source-metadata
-             (lib.tu.macros/mbql-query venues
-               {:source-query {:source-table $$venues
-                               :aggregation  [[:aggregation-options [:avg $id] {:display-name "My Cool Ag"}]]}})))))))
+    (is (=? [{:name          "avg"
+              :display_name  "My Cool Ag"
+              :base_type     :type/Float
+              :semantic_type :type/PK
+              :settings      nil
+              :field_ref     [:aggregation 0]}]
+            (source-metadata
+             (add-source-metadata
+              (lib.tu.macros/mbql-query venues
+                {:source-query {:source-table $$venues
+                                :aggregation  [[:aggregation-options [:avg $id] {:display-name "My Cool Ag"}]]}})))))))
 
 (deftest ^:parallel nested-sources-test
   (testing (str "Can we automatically add source metadata to the parent level of a query? If the source query has a "

--- a/test/metabase/query_processor/test_util.clj
+++ b/test/metabase/query_processor/test_util.clj
@@ -130,7 +130,10 @@
 
 (defn- backfill-effective-type [{:keys [base_type effective_type] :as col}]
   (cond-> col
-    (and (nil? effective_type) base_type) (assoc :effective_type base_type)))
+    ;; If the :effective_type is missing, or the :base_type is more specific, copy it to the `:effective_type`.
+    ;; Some driver extensions set a specialized `:base_type` but not `:effective_type`.
+    (or (and (nil? effective_type) base_type)
+        (isa? base_type effective_type))      (assoc :effective_type base_type)))
 
 (defn aggregate-col
   "Return the column information we'd expect for an aggregate column. For all columns besides `:count`, you'll need to

--- a/test/metabase/query_processor/util/add_alias_info_test.clj
+++ b/test/metabase/query_processor/util/add_alias_info_test.clj
@@ -497,7 +497,7 @@
                                   [:field
                                    "strange count"
                                    outer-count-opts]
-                                  [:value 10 {:base_type :type/Integer}]]
+                                  [:value 10 {:base_type :type/Integer, :effective_type :type/Integer}]]
                          :limit 1}))
                     (-> (lib.tu.macros/mbql-query venues
                           {:source-query {:source-table $$venues

--- a/test/metabase/query_processor/util_test.clj
+++ b/test/metabase/query_processor/util_test.clj
@@ -3,7 +3,8 @@
   (:require
    [buddy.core.codecs :as codecs]
    [clojure.test :refer :all]
-   [metabase.query-processor.util :as qp.util]))
+   [metabase.query-processor.util :as qp.util]
+   [metabase.test :as mt]))
 
 (set! *warn-on-reflection* true)
 
@@ -27,26 +28,17 @@
              (query-hash-hex {:query :abc})))
       (is (= (query-hash-hex {:query :def})
              (query-hash-hex {:query :def})))
-      (let [q {:database 1,
-               :type :query,
-               :query {:source-table 8,
-                       :aggregation [[:count]],
-                       :breakout [[:field 58 {:base-type :type/Text}]],
-                       :order-by [[:asc [:aggregation 0]]],
-                       :aggregation-idents {:0 "TBwdYMnlfpE4wIW1QwtxZ"},
-                       :breakout-idents {:0 "_II7X6UsFBqw6sY3B3VIG"}},
-               :parameters []}]
+      (let [q (mt/mbql-query products
+                {:aggregation [[:count]]
+                 :breakout [$category]
+                 :order-by [[:asc [:aggregation 0]]]})]
         (is (= (query-hash-hex q)
                (query-hash-hex q)))))
     (testing "should handle parameter values that mix regular numbers with bigintegers stored as strings"
-      (let [q1 {:database 1,
-                :type :query,
-                :query {:source-table 8},
-                :parameters [{:name "p1", :value [1 "9223372036854775808"]}]}
-            q2 {:database 1,
-                :type :query,
-                :query {:source-table 8},
-                :parameters [{:name "p1", :value ["9223372036854775808" 1]}]}]
+      (let [q1 (-> (mt/mbql-query orders)
+                   (assoc :parameters [{:type :number, :name "p1", :value [1 "9223372036854775808"]}]))
+            q2 (-> (mt/mbql-query orders)
+                   (assoc :parameters [{:type :number, :name "p1", :value ["9223372036854775808" 1]}]))]
         (is (some? (query-hash-hex q1)))
         (is (= (query-hash-hex q1) (query-hash-hex q2)))))))
 
@@ -84,43 +76,23 @@
         {:lib/type :type/query, :constraints {:max-rows 1000}}
         {:lib/type :type/query, :constraints nil}
 
-        {:database 1,
-         :type :query,
-         :query {:source-table 8,
-                 :aggregation [[:count] [:cum-count]],
-                 :breakout [[:field 58 {:base-type :type/Text}]],
-                 :order-by [[:asc [:aggregation 0]]],
-                 :aggregation-idents {:0 "TBwdYMnlfpE4wIW1QwtxZ"},
-                 :breakout-idents {:0 "_II7X6UsFBqw6sY3B3VIG"}},
-         :parameters []}
-        {:database 1,
-         :type :query,
-         :query {:source-table 8,
-                 :aggregation [[:count] [:cum-count]],
-                 :breakout [[:field 58 {:base-type :type/Text}]],
-                 :order-by [[:asc [:aggregation 1]]],
-                 :aggregation-idents {:0 "TBwdYMnlfpE4wIW1QwtxZ"},
-                 :breakout-idents {:0 "_II7X6UsFBqw6sY3B3VIG"}},
-         :parameters []}
+        (mt/mbql-query products
+          {:aggregation [[:count] [:cum-count]]
+           :breakout [$category]
+           :order-by [[:asc [:aggregation 0]]]})
+        (mt/mbql-query products
+          {:aggregation [[:count] [:cum-count]]
+           :breakout [$category]
+           :order-by [[:asc [:aggregation 1]]]})
 
-        {:database 1,
-         :type :query,
-         :query {:source-table 8,
-                 :aggregation [[:count] [:cum-count]],
-                 :breakout [[:field 58 {:base-type :type/Text}]],
-                 :order-by [[:asc [:field 57 {:base-type :type/Text}]]],
-                 :aggregation-idents {:0 "TBwdYMnlfpE4wIW1QwtxZ"},
-                 :breakout-idents {:0 "_II7X6UsFBqw6sY3B3VIG"}},
-         :parameters []}
-        {:database 1,
-         :type :query,
-         :query {:source-table 8,
-                 :aggregation [[:count] [:cum-count]],
-                 :breakout [[:field 58 {:base-type :type/Text}]],
-                 :order-by [[:asc [:field 58 {:base-type :type/Text}]]],
-                 :aggregation-idents {:0 "TBwdYMnlfpE4wIW1QwtxZ"},
-                 :breakout-idents {:0 "_II7X6UsFBqw6sY3B3VIG"}},
-         :parameters []}))))
+        (mt/mbql-query products
+          {:aggregation [[:count] [:cum-count]],
+           :breakout [$category],
+           :order-by [[:asc $created_at]]})
+        (mt/mbql-query products
+          {:aggregation [[:count] [:cum-count]],
+           :breakout [$category],
+           :order-by [[:asc $rating]]})))))
 
 (deftest ^:parallel query-hash-test-3
   (testing "qp.util/query-hash"
@@ -163,10 +135,10 @@
 (deftest ^:parallel query-hash-test-8
   (testing "qp.util/query-hash"
     (testing "make sure two different native queries have different hashes!"
-      (is (not= (query-hash-hex {:database 2
+      (is (not= (query-hash-hex {:database (mt/id)
                                  :type     :native
                                  :native   {:query "SELECT pg_sleep(15), 1 AS one"}})
-                (query-hash-hex {:database 2
+                (query-hash-hex {:database (mt/id)
                                  :type     :native
                                  :native   {:query "SELECT pg_sleep(15), 2 AS two"}}))))))
 

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -459,15 +459,16 @@
 
   ([_driver aggregation-type {field-id :id, table-id :table_id}]
    {:pre [(some? table-id)]}
-   (merge
-    (first (qp.preprocess/query->expected-cols {:database (t2/select-one-fn :db_id :model/Table :id table-id)
-                                                :type     :query
-                                                :query    {:source-table table-id
-                                                           :aggregation  [[aggregation-type [:field-id field-id]]]
-                                                           :aggregation-idents {0 (u/generate-nano-id)}}}))
-    (when (= aggregation-type :cum-count)
-      {:base_type     :type/Decimal
-       :semantic_type :type/Quantity}))))
+   (-> (qp.preprocess/query->expected-cols {:database (t2/select-one-fn :db_id :model/Table :id table-id)
+                                            :type     :query
+                                            :query    {:source-table table-id
+                                                       :aggregation  [[aggregation-type [:field-id field-id]]]
+                                                       :aggregation-idents {0 (u/generate-nano-id)}}})
+       first
+       (merge (when (= aggregation-type :cum-count)
+                {:base_type     :type/Decimal
+                 :semantic_type :type/Quantity}))
+       (dissoc :ident :lib/source-uuid :lib/source_uuid))))
 
 (defmulti count-with-template-tag-query
   "Generate a native query for the count of rows in `table` matching a set of conditions where `field-name` is equal to


### PR DESCRIPTION
Fixes QUE-681.

### Description

Drops `metabase.lib.convert` from the "exported" namespaces under `lib` module, and refactors all usage to
prefer `lib/query` and friends. These require a `MetadataProvider` where `lib.convert/->pMBQL` does not, but
since most of the calls were in QP middleware there was already one handy.

A few API handlers were calling `lib.convert/->pMBQL` and some of those require new `MetadataProvider`s.

Note that currently `lib.convert/->pMBQL` and `->legacy-MBQL` are still exported from `metabase.lib.core`,
and used a few places in the QP! That's an unfortunate temporary measure, and I've started the ball rolling
on alternative ways to factor both of the main offenders (like `annotate/aggregation-name` called from some
drivers).

### How to verify

Should be no visible changes, so verify that the app still works and tests pass.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
