### PR TITLE
fix(sdk): Use `onDismiss` not `onClose` for question popovers

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/util/MultiStepPopover/MultiStepPopover.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/util/MultiStepPopover/MultiStepPopover.tsx
@@ -58,7 +58,7 @@ const MultiStepPopoverContent = ({
     <Popover
       position="bottom-start"
       opened={currentStep !== null}
-      onClose={onClose}
+      onDismiss={onClose}
       {...popoverProps}
     >
       <Popover.Target>{targetElement}</Popover.Target>


### PR DESCRIPTION
Mantine introduced `onDismiss` in the v7 version of its `Popover` component, and described as:
```
Called when the popover is dismissed by clicking outside or by pressing escape
```

This seems to replicate the behavior that `onClose` had in v6, but got moved to `onDismiss` instead here in v7.

In any case, this was tested manually using the `InteractiveQuestion` `Default` story on the SDK storybook (`yarn storybook-embedding-sdk`). You should be able to click `Filter`, `Summarize`, and `Group` and each popover should open, and the other ones should close at the same time.