### PR TITLE
Allow zoom on joined binned column

### DIFF
--- a/src/metabase/lib/breakout.cljc
+++ b/src/metabase/lib/breakout.cljc
@@ -113,7 +113,9 @@
           (filter (fn [[_ref {:keys [join-alias source-field]} _id-or-name :as a-breakout]]
                     (and (lib.equality/find-matching-column query stage-number a-breakout [column] {:generous? true})
                          (= source-field (:fk-field-id column)) ; Must match, including both being nil/missing.
-                         (= join-alias   (::lib.join/join-alias column))  ; Must match, including both being nil/missing.
+                         (or
+                          (= join-alias (::lib.join/join-alias column))  ; Must match, including both being nil/missing.
+                          (= join-alias (:source-alias column)))
                          (or (not same-temporal-bucket?)
                              (= (lib.temporal-bucket/temporal-bucket a-breakout)
                                 (lib.temporal-bucket/temporal-bucket column)))

--- a/src/metabase/lib/breakout.cljc
+++ b/src/metabase/lib/breakout.cljc
@@ -110,12 +110,8 @@
                                                        [:same-temporal-bucket? {:optional true} [:maybe :boolean]]]]]
    (not-empty
     (into []
-          (filter (fn [[_ref {:keys [join-alias source-field]} _id-or-name :as a-breakout]]
-                    (and (lib.equality/find-matching-column query stage-number a-breakout [column] {:generous? false})
-                         #_(= source-field (:fk-field-id column)) ; Must match, including both being nil/missing.
-                         #_(or
-                            (= join-alias (::lib.join/join-alias column))  ; Must match, including both being nil/missing.
-                            (= join-alias (:source-alias column)))
+          (filter (fn [a-breakout]
+                    (and (lib.equality/find-matching-column query stage-number a-breakout [column])
                          (or (not same-temporal-bucket?)
                              (= (lib.temporal-bucket/temporal-bucket a-breakout)
                                 (lib.temporal-bucket/temporal-bucket column)))

--- a/src/metabase/lib/breakout.cljc
+++ b/src/metabase/lib/breakout.cljc
@@ -111,11 +111,11 @@
    (not-empty
     (into []
           (filter (fn [[_ref {:keys [join-alias source-field]} _id-or-name :as a-breakout]]
-                    (and (lib.equality/find-matching-column query stage-number a-breakout [column] {:generous? true})
-                         (= source-field (:fk-field-id column)) ; Must match, including both being nil/missing.
-                         (or
-                          (= join-alias (::lib.join/join-alias column))  ; Must match, including both being nil/missing.
-                          (= join-alias (:source-alias column)))
+                    (and (lib.equality/find-matching-column query stage-number a-breakout [column] {:generous? false})
+                         #_(= source-field (:fk-field-id column)) ; Must match, including both being nil/missing.
+                         #_(or
+                            (= join-alias (::lib.join/join-alias column))  ; Must match, including both being nil/missing.
+                            (= join-alias (:source-alias column)))
                          (or (not same-temporal-bucket?)
                              (= (lib.temporal-bucket/temporal-bucket a-breakout)
                                 (lib.temporal-bucket/temporal-bucket column)))

--- a/src/metabase/lib/breakout.cljc
+++ b/src/metabase/lib/breakout.cljc
@@ -3,7 +3,6 @@
    [clojure.string :as str]
    [metabase.lib.binning :as lib.binning]
    [metabase.lib.equality :as lib.equality]
-   [metabase.lib.join :as-alias lib.join]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.ref :as lib.ref]
    [metabase.lib.remove-replace :as lib.remove-replace]

--- a/test/metabase/lib/drill_thru/zoom_in_bins_test.cljc
+++ b/test/metabase/lib/drill_thru/zoom_in_bins_test.cljc
@@ -405,4 +405,5 @@
 
       (testing "zoom-in binning should not depend on join order"
         (is (= orders-people-zoom
-               (update people-orders-zoom :column dissoc :source-alias)))))))
+               (some-> people-orders-zoom
+                       (update :column dissoc :source-alias))))))))

--- a/test/metabase/lib/drill_thru/zoom_in_bins_test.cljc
+++ b/test/metabase/lib/drill_thru/zoom_in_bins_test.cljc
@@ -7,8 +7,7 @@
    [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
    [metabase.lib.drill-thru.test-util.canned :as canned]
    [metabase.lib.drill-thru.zoom-in-bins :as zoom-in]
-   [metabase.lib.test-metadata :as meta]
-   [metabase.query-processor.store :as qp.store]))
+   [metabase.lib.test-metadata :as meta]))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 
@@ -328,82 +327,81 @@
           :expected-query (variant-expected-query-with-count-filter-stage (:expected-query base-case))})))))
 
 (deftest ^:parallel join-order-doesnt-matter-for-zooming-53956
-  (qp.store/with-metadata-provider meta/metadata-provider
-    (let [orders-people-query
-          (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
-              (lib/join (lib/join-clause (meta/table-metadata :people)
-                                         [(lib/= (meta/field-metadata :orders :user-id)
-                                                 (meta/field-metadata :people :id))]
-                                         :left-join))
-              (lib/aggregate (lib/count)))
+  (let [orders-people-query
+        (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+            (lib/join (lib/join-clause (meta/table-metadata :people)
+                                       [(lib/= (meta/field-metadata :orders :user-id)
+                                               (meta/field-metadata :people :id))]
+                                       :left-join))
+            (lib/aggregate (lib/count)))
 
-          orders-people-column
-          (-> orders-people-query
-              lib/breakoutable-columns
-              (->> (m/find-first (comp #{"Total"} :display-name)))
-              (lib/with-binning {:strategy :num-bins, :min-value 0, :max-value 160, :num-bins 8, :bin-width 20}))
+        orders-people-column
+        (-> orders-people-query
+            lib/breakoutable-columns
+            (->> (m/find-first (comp #{"Total"} :display-name)))
+            (lib/with-binning {:strategy :num-bins, :min-value 0, :max-value 160, :num-bins 8, :bin-width 20}))
 
-          orders-people-query-breakout
-          (lib/breakout orders-people-query orders-people-column)
+        orders-people-query-breakout
+        (lib/breakout orders-people-query orders-people-column)
 
-          orders-people-ref
-          (first (lib/breakouts orders-people-query-breakout))
+        orders-people-ref
+        (first (lib/breakouts orders-people-query-breakout))
 
-          orders-people-clicked-column
-          (-> (meta/field-metadata :orders :total)
-              (lib/with-binning {:strategy :num-bins, :min-value 0, :max-value 160, :num-bins 8, :bin-width 20}))
+        orders-people-clicked-column
+        (-> (meta/field-metadata :orders :total)
+            (lib/with-binning {:strategy :num-bins, :min-value 0, :max-value 160, :num-bins 8, :bin-width 20}))
 
-          orders-people-zoom
-          (zoom-in/zoom-in-binning-drill orders-people-query-breakout
-                                         -1
-                                         {:column orders-people-clicked-column
-                                          :column-ref orders-people-ref
-                                          :value 80})
+        orders-people-zoom
+        (zoom-in/zoom-in-binning-drill orders-people-query-breakout
+                                       -1
+                                       {:column orders-people-clicked-column
+                                        :column-ref orders-people-ref
+                                        :value 80})
 
-          people-orders-query
-          (-> (lib/query meta/metadata-provider (meta/table-metadata :people))
-              (lib/join (lib/join-clause (meta/table-metadata :orders)
-                                         [(lib/= (meta/field-metadata :people :id)
-                                                 (meta/field-metadata :orders :user-id))]
-                                         :left-join))
-              (lib/aggregate (lib/count)))
+        people-orders-query
+        (-> (lib/query meta/metadata-provider (meta/table-metadata :people))
+            (lib/join (lib/join-clause (meta/table-metadata :orders)
+                                       [(lib/= (meta/field-metadata :people :id)
+                                               (meta/field-metadata :orders :user-id))]
+                                       :left-join))
+            (lib/aggregate (lib/count)))
 
-          people-orders-column
-          (-> people-orders-query
-              lib/breakoutable-columns
-              (->> (m/find-first (comp #{"Total"} :display-name)))
-              (lib/with-binning {:strategy :num-bins, :min-value 0, :max-value 160, :num-bins 8, :bin-width 20}))
+        people-orders-column
+        (-> people-orders-query
+            lib/breakoutable-columns
+            (->> (m/find-first (comp #{"Total"} :display-name)))
+            (lib/with-binning {:strategy :num-bins, :min-value 0, :max-value 160, :num-bins 8, :bin-width 20}))
 
-          people-orders-query-breakout
-          (lib/breakout people-orders-query people-orders-column)
+        people-orders-query-breakout
+        (lib/breakout people-orders-query people-orders-column)
 
-          people-orders-clicked-column
-          (-> (meta/field-metadata :orders :total)
-              (lib/with-binning {:strategy :num-bins, :min-value 0, :max-value 160, :num-bins 8, :bin-width 20})
-              ;; I have to construct this weird column because I cannot find a way to reproduce
-              ;; the columns that lib/existing-breakouts is being passed
-              (assoc :source-alias "Orders"))
+        people-orders-clicked-column
+        (-> (meta/field-metadata :orders :total)
+            (lib/with-binning {:strategy :num-bins, :min-value 0, :max-value 160, :num-bins 8, :bin-width 20})
+            ;; I have to construct this weird column because I cannot find a way to reproduce
+            ;; the columns that lib/existing-breakouts is being passed
+            (assoc :source-alias "Orders"))
 
-          people-orders-ref
-          (first (lib/breakouts people-orders-query-breakout))
+        people-orders-ref
+        (first (lib/breakouts people-orders-query-breakout))
 
-          people-orders-zoom
-          (zoom-in/zoom-in-binning-drill people-orders-query-breakout
-                                         -1
-                                         {:column people-orders-clicked-column
-                                          :column-ref people-orders-ref
-                                          :value 80})]
+        people-orders-zoom
+        (zoom-in/zoom-in-binning-drill people-orders-query-breakout
+                                       -1
+                                       {:column people-orders-clicked-column
+                                        :column-ref people-orders-ref
+                                        :value 80})]
     ;; make sure we're testing the right thing
-      (assert (get-in people-orders-ref [1 :join-alias]))
-      (assert (nil? (:metabase.lib.join/join-alias people-orders-clicked-column)))
+    (assert (get-in people-orders-ref [1 :join-alias]))
+    (assert (nil? (:metabase.lib.join/join-alias people-orders-clicked-column)))
     ;; somehow the column (as printed out in console.log) has :source-alias but not :metabase.lib.join/join-alias
-      (assert (:source-alias people-orders-clicked-column))
+    (assert (:source-alias people-orders-clicked-column))
 
-      (assert (nil? (get-in orders-people-ref [1 :join-alias])))
-      (assert (nil? (:metabase.lib.join/join-alias orders-people-clicked-column)))
-      (assert (nil? (:source-alias orders-people-clicked-column)))
+    (assert (nil? (get-in orders-people-ref [1 :join-alias])))
+    (assert (nil? (:metabase.lib.join/join-alias orders-people-clicked-column)))
+    (assert (nil? (:source-alias orders-people-clicked-column)))
 
-      (testing "zoom-in binning should not depend on join order"
-        (is (= orders-people-zoom
-               (some-> people-orders-zoom
-                       (update :column dissoc :source-alias))))))))
+    (testing "zoom-in binning should not depend on join order"
+      (is (= orders-people-zoom
+             (some-> people-orders-zoom
+                     (update :column dissoc :source-alias)))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/53956

### Description

Check this issue this closes for a great video showing the problem.

### How to verify

1. Open Sample Database -> Peopl
2. Join on Orders (ID=ID)
3. Visualize in a table
4. Scroll to the right, click column pill for Orders->Total
5. Distribution
6. Visualize as bar chart
7. Click on any bar, note that there is a Zoom In option

### Demo

https://www.loom.com/share/f00cdb183da94959ad686f1602e627b8?sid=52707c32-d359-4153-b516-f8e9e684913d
