### PR TITLE
Add created and recipient notifications to the list

### DIFF
--- a/e2e/test/scenarios/onboarding/notifications.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/notifications.cy.spec.js
@@ -38,10 +38,16 @@ describe("scenarios > account > notifications", () => {
     beforeEach(() => {
       cy.signInAsAdmin().then(() => {
         H.getCurrentUser().then(({ body: { id: admin_id } }) => {
+          cy.wrap(admin_id).as("admin_id");
+
           cy.signInAsNormalUser().then(() => {
             H.getCurrentUser().then(({ body: { id: user_id } }) => {
+              cy.wrap(user_id).as("user_id");
+
               H.createQuestion(getQuestionDetails()).then(
                 ({ body: { id: card_id } }) => {
+                  cy.wrap(card_id).as("card_id");
+
                   H.createQuestionAlert({
                     user_id: admin_id,
                     card_id,
@@ -88,12 +94,11 @@ describe("scenarios > account > notifications", () => {
     it("should be able to see alerts notifications", () => {
       openUserNotifications();
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Question");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Daily at 9:00 am", { exact: false });
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Created by you", { exact: false });
+      cy.findByTestId("notifications-list").within(() => {
+        cy.findByText("Question");
+        cy.findByText("Daily at 9:00 am", { exact: false });
+        cy.findByText("Created by you", { exact: false });
+      });
     });
 
     it("should be able to delete an alert when the user created it and he is a single recipient", () => {
@@ -105,8 +110,8 @@ describe("scenarios > account > notifications", () => {
       );
       cy.intercept("PUT", "/api/notification/*").as("alertDelete");
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Question");
+      cy.findByTestId("notifications-list").findByText("Question");
+
       clickUnsubscribe();
 
       cy.wait("@getAlert");
@@ -140,8 +145,10 @@ describe("scenarios > account > notifications", () => {
       cy.signInAsAdmin();
       openUserNotifications();
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Question");
+      cy.findByTestId("notifications-list")
+        .findByText("Created by Robert Tableton", { exact: false })
+        .should("exist");
+
       clickUnsubscribe();
 
       H.modal().within(() => {
@@ -149,8 +156,51 @@ describe("scenarios > account > notifications", () => {
         cy.findByText("Unsubscribe").click();
       });
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Question").should("not.exist");
+      cy.findByTestId("notifications-list")
+        .findByText("Created by Robert Tableton", { exact: false })
+        .should("not.exist");
+    });
+
+    it("should be able to see created notifications that a user is not subscribed to", () => {
+      cy.get("@admin_id").then(admin_id =>
+        cy.get("@card_id").then(card_id => {
+          H.createQuestionAlert({
+            admin_id,
+            card_id,
+            cron_schedule: "0 0 2 * * ?",
+            handlers: [
+              {
+                channel_type: "channel/email",
+                recipients: [
+                  {
+                    type: "notification-recipient/user",
+                    user_id: admin_id,
+                    details: null,
+                  },
+                ],
+              },
+            ],
+          });
+        }),
+      );
+
+      openUserNotifications();
+
+      cy.findByTestId("notifications-list").within(() => {
+        cy.findByText("Check daily at 2:00 AM").should("exist");
+
+        const notificationCard = cy
+          .findByText("Check daily at 2:00 AM")
+          .closest("[data-testid=notification-alert-item]")
+          .should("exist");
+
+        notificationCard.within(() => {
+          cy.findByText("Created by you", { exact: false }).should("exist");
+          cy.icon("close").should("exist").click();
+        });
+      });
+
+      H.modal().findByText("Delete this alert?").should("exist");
     });
   });
 

--- a/frontend/src/metabase-types/api/notification.ts
+++ b/frontend/src/metabase-types/api/notification.ts
@@ -120,6 +120,7 @@ export interface ListNotificationsRequest extends PaginationRequest {
   include_inactive?: boolean;
   creator_id?: UserId;
   recipient_id?: UserId;
+  creator_or_recipient_id?: UserId;
   card_id?: CardId;
   permission_group_id?: number;
 }

--- a/frontend/src/metabase/account/notifications/components/NotificationCard/NotificationCard.tsx
+++ b/frontend/src/metabase/account/notifications/components/NotificationCard/NotificationCard.tsx
@@ -57,7 +57,7 @@ export const NotificationCard = ({
   }, [listItem, onArchive]);
 
   return (
-    <NotificationCardRoot>
+    <NotificationCardRoot data-testid="notification-alert-item">
       <NotificationContent>
         <Link variant="brandBold" to={entityLink}>
           {formatTitle(listItem)}

--- a/frontend/src/metabase/account/notifications/containers/NotificationsApp/NotificationsApp.tsx
+++ b/frontend/src/metabase/account/notifications/containers/NotificationsApp/NotificationsApp.tsx
@@ -36,7 +36,7 @@ const NotificationsAppInner = ({
   const { data: questionNotifications = [] } = useListNotificationsQuery(
     user
       ? {
-          recipient_id: user.id,
+          creator_or_recipient_id: user.id,
           include_inactive: false,
         }
       : skipToken,


### PR DESCRIPTION
Relates to https://github.com/metabase/metabase/issues/50766

### Description

Fixes issue that not all available notifications are listed in Account Settings > Notifications

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
