### PR TITLE
fix(sdk): Add missing support of mapQuestionClickActions plugin for InteractiveDashboard

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/plugins.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/plugins.cy.spec.tsx
@@ -1,0 +1,139 @@
+import { InteractiveDashboard } from "@metabase/embedding-sdk-react";
+
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import {
+  type StructuredQuestionDetails,
+  createDashboardWithQuestions,
+  createQuestion,
+} from "e2e/support/helpers";
+import {
+  mockAuthProviderAndJwtSignIn,
+  mountInteractiveQuestion,
+  mountSdkContent,
+  signInAsAdminAndEnableEmbeddingSdk,
+} from "e2e/support/helpers/component-testing-sdk";
+import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
+import type {
+  ClickAction,
+  CustomClickActionWithCustomView,
+} from "metabase/visualizations/types";
+
+const { ORDERS_ID, ORDERS, PEOPLE } = SAMPLE_DATABASE;
+
+const setup = (callback: () => void) => {
+  signInAsAdminAndEnableEmbeddingSdk();
+
+  callback();
+
+  cy.signOut();
+
+  mockAuthProviderAndJwtSignIn();
+};
+
+const BASE_QUESTION: StructuredQuestionDetails = {
+  name: "Orders",
+  query: {
+    "source-table": ORDERS_ID,
+    breakout: [
+      [
+        "field",
+        PEOPLE.SOURCE,
+        {
+          "base-type": "type/Text",
+          "source-field": ORDERS.USER_ID,
+        },
+      ],
+    ],
+    limit: 5,
+  },
+};
+
+const CUSTOM_ACTION_WITH_VIEW: CustomClickActionWithCustomView = {
+  name: "client-custom-action-2",
+  section: "custom",
+  type: "custom",
+  view: ({ closePopover }) => (
+    <button onClick={closePopover}>Custom element</button>
+  ),
+};
+
+describe("scenarios > embedding-sdk > plugins", () => {
+  describe("The `mapQuestionClickActions` plugin should work for `InteractiveDashboard`", () => {
+    beforeEach(() => {
+      setup(() => {
+        createDashboardWithQuestions({
+          dashboardName: "Orders in a dashboard",
+          questions: [BASE_QUESTION],
+          cards: [
+            {
+              size_x: 12,
+              col: 0,
+            },
+          ],
+        }).then(({ dashboard, questions: [question] }) => {
+          cy.wrap(dashboard.id).as("dashboardId");
+          cy.wrap(question.id).as("questionId");
+          cy.wrap(question.entity_id).as("questionEntityId");
+        });
+      });
+    });
+
+    it("should open a click actions popover with a custom item", () => {
+      cy.get<string>("@dashboardId").then(dashboardId => {
+        mountSdkContent(
+          <InteractiveDashboard
+            dashboardId={dashboardId}
+            plugins={{
+              mapQuestionClickActions: (clickActions: ClickAction[]) => [
+                ...clickActions,
+                CUSTOM_ACTION_WITH_VIEW,
+              ],
+            }}
+          />,
+        );
+      });
+
+      getSdkRoot().within(() => {
+        cy.findByText("Facebook").click();
+
+        cy.findByTestId("click-actions-popover").within(() => {
+          cy.findByText("Custom element").click();
+        });
+
+        cy.findByTestId("click-actions-popover").should("not.exist");
+      });
+    });
+  });
+
+  describe("The `mapQuestionClickActions` plugin should work for `InteractiveQuestion`", () => {
+    beforeEach(() => {
+      setup(() => {
+        createQuestion(BASE_QUESTION).then(({ body: question }) => {
+          cy.wrap(question.id).as("questionId");
+          cy.wrap(question.entity_id).as("questionEntityId");
+        });
+      });
+    });
+
+    it("should open a click actions popover with a custom item", () => {
+      mountInteractiveQuestion({
+        plugins: {
+          mapQuestionClickActions: (clickActions: ClickAction[]) => [
+            ...clickActions,
+            CUSTOM_ACTION_WITH_VIEW,
+          ],
+        },
+      });
+
+      getSdkRoot().within(() => {
+        cy.findByText("Facebook").click();
+
+        cy.findByTestId("click-actions-popover").within(() => {
+          cy.findByText("Custom element").click();
+        });
+
+        cy.findByTestId("click-actions-popover").should("not.exist");
+      });
+    });
+  });
+});

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/InteractiveQuestionProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/InteractiveQuestionProvider.tsx
@@ -126,7 +126,13 @@ export const InteractiveQuestionProvider = ({
   }, [globalPlugins, componentPlugins]);
 
   const mode = useMemo(() => {
-    return question && getEmbeddingMode(question, combinedPlugins ?? undefined);
+    return (
+      question &&
+      getEmbeddingMode({
+        question,
+        plugins: combinedPlugins ?? undefined,
+      })
+    );
   }, [question, combinedPlugins]);
 
   const questionContext: InteractiveQuestionContextType = {

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/InteractiveDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/InteractiveDashboard.tsx
@@ -113,6 +113,7 @@ const InteractiveDashboardInner = ({
             cardTitled={withCardTitle}
             withFooter={displayOptions.withFooter}
             theme={theme}
+            plugins={plugins}
             isFullscreen={isFullscreen}
             onFullscreenChange={onFullscreenChange}
             refreshPeriod={refreshPeriod}

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/InteractiveDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/InteractiveDashboard.tsx
@@ -28,7 +28,6 @@ import type { PublicOrEmbeddedDashboardEventHandlersProps } from "metabase/publi
 import { setErrorPage } from "metabase/redux/app";
 import { getErrorPage } from "metabase/selectors/app";
 import { getEmbeddingMode } from "metabase/visualizations/click-actions/lib/modes";
-import { EmbeddingSdkMode } from "metabase/visualizations/click-actions/modes/EmbeddingSdkMode";
 import type { ClickActionModeGetter } from "metabase/visualizations/types";
 
 import { InteractiveDashboardProvider } from "./context";
@@ -98,7 +97,6 @@ const InteractiveDashboardInner = ({
     ({ question }) =>
       getEmbeddingMode({
         question,
-        queryMode: EmbeddingSdkMode,
         plugins,
       }),
     [plugins],

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/InteractiveDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/InteractiveDashboard.tsx
@@ -1,4 +1,9 @@
-import { type CSSProperties, type ReactNode, useEffect } from "react";
+import {
+  type CSSProperties,
+  type ReactNode,
+  useCallback,
+  useEffect,
+} from "react";
 import _ from "underscore";
 
 import type { MetabasePluginsConfig } from "embedding-sdk";
@@ -22,6 +27,9 @@ import { PublicOrEmbeddedDashboard } from "metabase/public/containers/PublicOrEm
 import type { PublicOrEmbeddedDashboardEventHandlersProps } from "metabase/public/containers/PublicOrEmbeddedDashboard/types";
 import { setErrorPage } from "metabase/redux/app";
 import { getErrorPage } from "metabase/selectors/app";
+import { getEmbeddingMode } from "metabase/visualizations/click-actions/lib/modes";
+import { EmbeddingSdkMode } from "metabase/visualizations/click-actions/modes/EmbeddingSdkMode";
+import type { ClickActionModeGetter } from "metabase/visualizations/types";
 
 import { InteractiveDashboardProvider } from "./context";
 
@@ -86,6 +94,16 @@ const InteractiveDashboardInner = ({
 
   const { theme } = useEmbedTheme();
 
+  const getClickActionMode: ClickActionModeGetter = useCallback(
+    ({ question }) =>
+      getEmbeddingMode({
+        question,
+        queryMode: EmbeddingSdkMode,
+        plugins,
+      }),
+    [plugins],
+  );
+
   return (
     <StyledPublicComponentWrapper className={className} style={style} ref={ref}>
       {adhocQuestionUrl ? (
@@ -113,7 +131,7 @@ const InteractiveDashboardInner = ({
             cardTitled={withCardTitle}
             withFooter={displayOptions.withFooter}
             theme={theme}
-            plugins={plugins}
+            getClickActionMode={getClickActionMode}
             isFullscreen={isFullscreen}
             onFullscreenChange={onFullscreenChange}
             refreshPeriod={refreshPeriod}

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -54,7 +54,7 @@ export interface DashCardProps {
   gridItemWidth: number;
   totalNumGridCols: number;
   slowCards: Record<CardId, boolean>;
-  getMode?: ClickActionModeGetter;
+  getClickActionMode?: ClickActionModeGetter;
 
   clickBehaviorSidebarDashcard?: DashboardCard | null;
 
@@ -104,7 +104,7 @@ function DashCardInner({
   slowCards,
   gridItemWidth,
   totalNumGridCols,
-  getMode,
+  getClickActionMode,
   isEditing = false,
   isNightMode = false,
   isFullscreen = false,
@@ -369,7 +369,7 @@ function DashCardInner({
           dashboard={dashboard}
           dashcard={dashcard}
           series={series}
-          getMode={getMode}
+          getClickActionMode={getClickActionMode}
           gridSize={gridSize}
           gridItemWidth={gridItemWidth}
           totalNumGridCols={totalNumGridCols}

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -22,9 +22,8 @@ import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
 import { Box } from "metabase/ui";
 import { getVisualizationRaw } from "metabase/visualizations";
-import type { Mode } from "metabase/visualizations/click-actions/Mode";
 import { extendCardWithDashcardSettings } from "metabase/visualizations/lib/settings/typed-utils";
-import type { QueryClickActionsMode } from "metabase/visualizations/types";
+import type { ClickActionModeGetter } from "metabase/visualizations/types";
 import type {
   Card,
   CardId,
@@ -55,7 +54,7 @@ export interface DashCardProps {
   gridItemWidth: number;
   totalNumGridCols: number;
   slowCards: Record<CardId, boolean>;
-  mode?: QueryClickActionsMode | Mode;
+  getMode?: ClickActionModeGetter;
 
   clickBehaviorSidebarDashcard?: DashboardCard | null;
 
@@ -105,7 +104,7 @@ function DashCardInner({
   slowCards,
   gridItemWidth,
   totalNumGridCols,
-  mode,
+  getMode,
   isEditing = false,
   isNightMode = false,
   isFullscreen = false,
@@ -370,7 +369,7 @@ function DashCardInner({
           dashboard={dashboard}
           dashcard={dashcard}
           series={series}
-          mode={mode}
+          getMode={getMode}
           gridSize={gridSize}
           gridItemWidth={gridItemWidth}
           totalNumGridCols={totalNumGridCols}

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -43,7 +43,7 @@ interface DashCardVisualizationProps {
   dashboard: Dashboard;
   dashcard: DashboardCard;
   series: Series;
-  getMode?: ClickActionModeGetter;
+  getClickActionMode?: ClickActionModeGetter;
   getHref?: () => string | undefined;
 
   gridSize: {
@@ -93,7 +93,7 @@ export function DashCardVisualization({
   dashcard,
   dashboard,
   series,
-  getMode,
+  getClickActionMode,
   getHref,
   gridSize,
   gridItemWidth,
@@ -252,7 +252,7 @@ export function DashCardVisualization({
       dashcard={dashcard}
       rawSeries={series}
       metadata={metadata}
-      mode={getMode}
+      mode={getClickActionMode}
       getHref={getHref}
       gridSize={gridSize}
       totalNumGridCols={totalNumGridCols}

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -16,9 +16,8 @@ import { isUuid } from "metabase/lib/uuid";
 import { getMetadata } from "metabase/selectors/metadata";
 import { Flex, type IconName, type IconProps, Title } from "metabase/ui";
 import { getVisualizationRaw } from "metabase/visualizations";
-import type { Mode } from "metabase/visualizations/click-actions/Mode";
 import Visualization from "metabase/visualizations/components/Visualization";
-import type { QueryClickActionsMode } from "metabase/visualizations/types";
+import type { ClickActionModeGetter } from "metabase/visualizations/types";
 import Question from "metabase-lib/v1/Question";
 import type {
   DashCardId,
@@ -44,7 +43,7 @@ interface DashCardVisualizationProps {
   dashboard: Dashboard;
   dashcard: DashboardCard;
   series: Series;
-  mode?: QueryClickActionsMode | Mode;
+  getMode?: ClickActionModeGetter;
   getHref?: () => string | undefined;
 
   gridSize: {
@@ -94,7 +93,7 @@ export function DashCardVisualization({
   dashcard,
   dashboard,
   series,
-  mode,
+  getMode,
   getHref,
   gridSize,
   gridItemWidth,
@@ -253,7 +252,7 @@ export function DashCardVisualization({
       dashcard={dashcard}
       rawSeries={series}
       metadata={metadata}
-      mode={mode}
+      mode={getMode}
       getHref={getHref}
       gridSize={gridSize}
       totalNumGridCols={totalNumGridCols}

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -150,7 +150,7 @@ type OwnProps = {
   isNightMode: boolean;
   withCardTitle?: boolean;
   clickBehaviorSidebarDashcard: DashboardCard | null;
-  getMode?: ClickActionModeGetter;
+  getClickActionMode?: ClickActionModeGetter;
   // public dashboard passes it explicitly
   width?: number;
   // public or embedded dashboard passes it as noop
@@ -558,7 +558,7 @@ class DashboardGridInner extends Component<
         onReplaceAllDashCardVisualizationSettings={
           this.props.onReplaceAllDashCardVisualizationSettings
         }
-        getMode={this.props.getMode}
+        getClickActionMode={this.props.getClickActionMode}
         navigateToNewCardFromDashboard={
           this.props.navigateToNewCardFromDashboard
         }

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -32,9 +32,8 @@ import { connect } from "metabase/lib/redux";
 import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
 import { addUndo } from "metabase/redux/undo";
 import { Box, Flex } from "metabase/ui";
-import type { Mode } from "metabase/visualizations/click-actions/Mode";
 import LegendS from "metabase/visualizations/components/Legend.module.css";
-import type { QueryClickActionsMode } from "metabase/visualizations/types";
+import type { ClickActionModeGetter } from "metabase/visualizations/types";
 import {
   type BaseDashboardCard,
   type Card,
@@ -151,7 +150,7 @@ type OwnProps = {
   isNightMode: boolean;
   withCardTitle?: boolean;
   clickBehaviorSidebarDashcard: DashboardCard | null;
-  mode?: QueryClickActionsMode | Mode;
+  getMode?: ClickActionModeGetter;
   // public dashboard passes it explicitly
   width?: number;
   // public or embedded dashboard passes it as noop
@@ -559,7 +558,7 @@ class DashboardGridInner extends Component<
         onReplaceAllDashCardVisualizationSettings={
           this.props.onReplaceAllDashCardVisualizationSettings
         }
-        mode={this.props.mode}
+        getMode={this.props.getMode}
         navigateToNewCardFromDashboard={
           this.props.navigateToNewCardFromDashboard
         }

--- a/frontend/src/metabase/dashboard/types/embed-display-options.ts
+++ b/frontend/src/metabase/dashboard/types/embed-display-options.ts
@@ -1,4 +1,5 @@
 import type { DashboardNightModeControls } from "metabase/dashboard/types/display-options";
+import type { MetabasePluginsConfig } from "metabase/embedding-sdk/types/plugins";
 import type { DisplayTheme } from "metabase/public/lib/types";
 
 type EmbedBackground = boolean;
@@ -25,6 +26,7 @@ export type EmbedDisplayParams = {
   hideParameters: EmbedHideParameters;
   font: EmbedFont;
   theme: DisplayTheme;
+  plugins?: MetabasePluginsConfig;
   downloadsEnabled: boolean;
   withFooter: boolean;
 };

--- a/frontend/src/metabase/dashboard/types/embed-display-options.ts
+++ b/frontend/src/metabase/dashboard/types/embed-display-options.ts
@@ -1,6 +1,6 @@
 import type { DashboardNightModeControls } from "metabase/dashboard/types/display-options";
-import type { MetabasePluginsConfig } from "metabase/embedding-sdk/types/plugins";
 import type { DisplayTheme } from "metabase/public/lib/types";
+import type { ClickActionModeGetter } from "metabase/visualizations/types";
 
 type EmbedBackground = boolean;
 
@@ -26,7 +26,7 @@ export type EmbedDisplayParams = {
   hideParameters: EmbedHideParameters;
   font: EmbedFont;
   theme: DisplayTheme;
-  plugins?: MetabasePluginsConfig;
+  getClickActionMode?: ClickActionModeGetter;
   downloadsEnabled: boolean;
   withFooter: boolean;
 };

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboard.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboard.tsx
@@ -134,6 +134,7 @@ const PublicOrEmbeddedDashboardInner = ({
   bordered,
   titled,
   theme,
+  plugins,
   downloadsEnabled = true,
   hideParameters,
   withFooter,
@@ -235,6 +236,7 @@ const PublicOrEmbeddedDashboardInner = ({
         bordered={bordered}
         titled={titled}
         theme={theme}
+        plugins={plugins}
         hideParameters={hideParameters}
         navigateToNewCardFromDashboard={navigateToNewCardFromDashboard}
         slowCards={slowCards}

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboard.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboard.tsx
@@ -134,7 +134,7 @@ const PublicOrEmbeddedDashboardInner = ({
   bordered,
   titled,
   theme,
-  plugins,
+  getClickActionMode,
   downloadsEnabled = true,
   hideParameters,
   withFooter,
@@ -236,7 +236,7 @@ const PublicOrEmbeddedDashboardInner = ({
         bordered={bordered}
         titled={titled}
         theme={theme}
-        plugins={plugins}
+        getClickActionMode={getClickActionMode}
         hideParameters={hideParameters}
         navigateToNewCardFromDashboard={navigateToNewCardFromDashboard}
         slowCards={slowCards}

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardView.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardView.tsx
@@ -26,7 +26,6 @@ import type {
   EmbedHideParameters,
 } from "metabase/dashboard/types";
 import { isActionDashCard } from "metabase/dashboard/utils";
-import type { MetabasePluginsConfig } from "metabase/embedding-sdk/types/plugins";
 import { isWithinIframe } from "metabase/lib/dom";
 import ParametersS from "metabase/parameters/components/ParameterValueWidget.module.css";
 import type { DisplayTheme } from "metabase/public/lib/types";
@@ -64,7 +63,7 @@ interface InnerPublicOrEmbeddedDashboardViewProps {
   bordered: boolean;
   titled: boolean;
   theme: DisplayTheme;
-  plugins?: MetabasePluginsConfig;
+  getClickActionMode?: ClickActionModeGetter;
   hideParameters: EmbedHideParameters;
   navigateToNewCardFromDashboard?: (
     opts: NavigateToNewCardFromDashboardOpts,
@@ -102,7 +101,7 @@ export function PublicOrEmbeddedDashboardView({
   bordered,
   titled,
   theme,
-  plugins,
+  getClickActionMode: externalGetClickActionMode,
   hideParameters,
   withFooter,
   navigateToNewCardFromDashboard,
@@ -149,16 +148,16 @@ export function PublicOrEmbeddedDashboardView({
     background,
   });
 
-  const getMode: ClickActionModeGetter = useCallback(
+  const getClickActionMode: ClickActionModeGetter = useCallback(
     ({ question }) =>
+      externalGetClickActionMode?.({ question }) ??
       getEmbeddingMode({
         question,
         queryMode: navigateToNewCardFromDashboard
           ? EmbeddingSdkMode
           : PublicMode,
-        plugins,
       }),
-    [navigateToNewCardFromDashboard, plugins],
+    [externalGetClickActionMode, navigateToNewCardFromDashboard],
   );
 
   return (
@@ -223,7 +222,7 @@ export function PublicOrEmbeddedDashboardView({
               <DashboardGridConnected
                 dashboard={assoc(dashboard, "dashcards", visibleDashcards)}
                 isPublicOrEmbedded
-                getMode={getMode}
+                getClickActionMode={getClickActionMode}
                 selectedTabId={selectedTabId}
                 slowCards={slowCards}
                 isEditing={false}

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardView.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardView.tsx
@@ -1,5 +1,6 @@
 import cx from "classnames";
 import { assoc } from "icepick";
+import { useCallback } from "react";
 import type { HandleThunkActionCreator } from "react-redux";
 import _ from "underscore";
 
@@ -25,11 +26,14 @@ import type {
   EmbedHideParameters,
 } from "metabase/dashboard/types";
 import { isActionDashCard } from "metabase/dashboard/utils";
+import type { MetabasePluginsConfig } from "metabase/embedding-sdk/types/plugins";
 import { isWithinIframe } from "metabase/lib/dom";
 import ParametersS from "metabase/parameters/components/ParameterValueWidget.module.css";
 import type { DisplayTheme } from "metabase/public/lib/types";
+import { getEmbeddingMode } from "metabase/visualizations/click-actions/lib/modes";
 import { EmbeddingSdkMode } from "metabase/visualizations/click-actions/modes/EmbeddingSdkMode";
 import { PublicMode } from "metabase/visualizations/click-actions/modes/PublicMode";
+import type { ClickActionModeGetter } from "metabase/visualizations/types";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
 import type {
   Dashboard,
@@ -60,6 +64,7 @@ interface InnerPublicOrEmbeddedDashboardViewProps {
   bordered: boolean;
   titled: boolean;
   theme: DisplayTheme;
+  plugins?: MetabasePluginsConfig;
   hideParameters: EmbedHideParameters;
   navigateToNewCardFromDashboard?: (
     opts: NavigateToNewCardFromDashboardOpts,
@@ -97,6 +102,7 @@ export function PublicOrEmbeddedDashboardView({
   bordered,
   titled,
   theme,
+  plugins,
   hideParameters,
   withFooter,
   navigateToNewCardFromDashboard,
@@ -142,6 +148,18 @@ export function PublicOrEmbeddedDashboardView({
     theme,
     background,
   });
+
+  const getMode: ClickActionModeGetter = useCallback(
+    ({ question }) =>
+      getEmbeddingMode({
+        question,
+        queryMode: navigateToNewCardFromDashboard
+          ? EmbeddingSdkMode
+          : PublicMode,
+        plugins,
+      }),
+    [navigateToNewCardFromDashboard, plugins],
+  );
 
   return (
     <EmbedFrame
@@ -205,9 +223,7 @@ export function PublicOrEmbeddedDashboardView({
               <DashboardGridConnected
                 dashboard={assoc(dashboard, "dashcards", visibleDashcards)}
                 isPublicOrEmbedded
-                mode={
-                  navigateToNewCardFromDashboard ? EmbeddingSdkMode : PublicMode
-                }
+                getMode={getMode}
                 selectedTabId={selectedTabId}
                 slowCards={slowCards}
                 isEditing={false}

--- a/frontend/src/metabase/visualizations/click-actions/lib/modes.ts
+++ b/frontend/src/metabase/visualizations/click-actions/lib/modes.ts
@@ -1,4 +1,5 @@
 import type { MetabasePluginsConfig } from "metabase/embedding-sdk/types/plugins";
+import type { QueryClickActionsMode } from "metabase/visualizations/types";
 import type Question from "metabase-lib/v1/Question";
 
 import { Mode } from "../Mode";
@@ -11,9 +12,14 @@ export function getMode(question: Question): Mode | null {
   return new Mode(question, queryMode);
 }
 
-export function getEmbeddingMode(
-  question: Question,
-  plugins?: MetabasePluginsConfig,
-): Mode | null {
-  return new Mode(question, EmbeddingSdkMode, plugins);
+export function getEmbeddingMode({
+  question,
+  queryMode = EmbeddingSdkMode,
+  plugins,
+}: {
+  question: Question;
+  queryMode?: QueryClickActionsMode;
+  plugins?: MetabasePluginsConfig;
+}): Mode {
+  return new Mode(question, queryMode, plugins);
 }

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -217,16 +217,17 @@ class Visualization extends PureComponent {
   }
 
   getMode(modeOrModeGetter, question) {
-    if (typeof modeOrModeGetter === "function") {
-      modeOrModeGetter = modeOrModeGetter({ question });
+    const modeOrQueryMode =
+      typeof modeOrModeGetter === "function"
+        ? modeOrModeGetter({ question })
+        : modeOrModeGetter;
+
+    if (modeOrQueryMode instanceof Mode) {
+      return modeOrQueryMode;
     }
 
-    if (modeOrModeGetter instanceof Mode) {
-      return modeOrModeGetter;
-    }
-
-    if (question && modeOrModeGetter) {
-      return new Mode(question, modeOrModeGetter);
+    if (question && modeOrQueryMode) {
+      return new Mode(question, modeOrQueryMode);
     }
 
     if (question) {

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -216,13 +216,17 @@ class Visualization extends PureComponent {
       : undefined;
   }
 
-  getMode(maybeModeOrQueryMode, question) {
-    if (maybeModeOrQueryMode instanceof Mode) {
-      return maybeModeOrQueryMode;
+  getMode(modeOrModeGetter, question) {
+    if (typeof modeOrModeGetter === "function") {
+      modeOrModeGetter = modeOrModeGetter({ question });
     }
 
-    if (question && maybeModeOrQueryMode) {
-      return new Mode(question, maybeModeOrQueryMode);
+    if (modeOrModeGetter instanceof Mode) {
+      return modeOrModeGetter;
+    }
+
+    if (question && modeOrModeGetter) {
+      return new Mode(question, modeOrModeGetter);
     }
 
     if (question) {

--- a/frontend/src/metabase/visualizations/types/click-actions.ts
+++ b/frontend/src/metabase/visualizations/types/click-actions.ts
@@ -1,11 +1,16 @@
 import type React from "react";
 
 import type { IconName } from "metabase/ui";
+import type { Mode } from "metabase/visualizations/click-actions/Mode";
 import type * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 import type { ClickActionProps } from "metabase-lib/v1/queries/drills/types";
 import type { Card, Series, VisualizationSettings } from "metabase-types/api";
 import type { Dispatch, GetState } from "metabase-types/store";
+
+export type ClickActionModeGetter = (data: {
+  question: Question;
+}) => QueryClickActionsMode | Mode;
 
 export type {
   ClickActionProps,


### PR DESCRIPTION
Add missing support of mapQuestionClickActions plugin for InteractiveDashboard

Fixes: [#54208](https://github.com/metabase/metabase/issues/54208) (https://linear.app/metabase/issue/EMB-192/the-mapquestionclickactions-sdk-plugins-dont-work-for)

The mapQuestionClickActions SDK Plugins don't work for InteractiveDashboard
It happens because we don't properly set plugins when defining the mode prop.
It results in the empty plugins array inside frontend/src/metabase/visualizations/click-actions/Mode/Mode.ts

Also, we have to get access to a specific question.

The solution is to use a getter function that provides the question and returns the `mode` for it