### PR TITLE
Remove Unsubscribe link from unsaved subscription test email for non-users

### DIFF
--- a/src/metabase/channel/email/dashboard_subscription.hbs
+++ b/src/metabase/channel/email/dashboard_subscription.hbs
@@ -49,7 +49,9 @@
             <hr>
             <div class="footer" style="font-size: 11px; width: max-content; margin: 0 auto">
               Sent from <a href="{{context.site_url}}" style="color: {{context.application_color}}">{{context.site_url}}</a>.
-              <a href="{{computed.management_url}}" style="color: {{context.application_color}}">{{computed.management_text}}</a>
+              {{#if computed.management_url}}
+                <a href="{{computed.management_url}}" style="color: {{context.application_color}}">{{computed.management_text}}</a>
+              {{/if}}
             </div>
           </div>
         </td>

--- a/src/metabase/channel/impl/email.clj
+++ b/src/metabase/channel/impl/email.clj
@@ -60,12 +60,16 @@
                   :pulse-id pulse-id}))))
 
 (defn- unsubscribe-url-for-non-user
+  "Given a `dashboard-subscription-id` and a `non-user-email`, returns a URL that can be used to unsubscribe from a
+  pulse for a non-logged in user. If `dashboard-subscription-id` is `nil`, returns `nil`, since
+  there is nothing to unsubscribe from."
   [dashboard-subscription-id non-user-email]
-  (str (urls/unsubscribe-url)
-       "?"
-       (codec/form-encode {:hash     (generate-dashboard-sub-unsubscribe-hash dashboard-subscription-id non-user-email)
-                           :email    non-user-email
-                           :pulse-id dashboard-subscription-id})))
+  (when dashboard-subscription-id
+    (str (urls/unsubscribe-url)
+         "?"
+         (codec/form-encode {:hash     (generate-dashboard-sub-unsubscribe-hash dashboard-subscription-id non-user-email)
+                             :email    non-user-email
+                             :pulse-id dashboard-subscription-id}))))
 
 (defn- render-part
   [timezone part options]

--- a/test/metabase/pulse/api/pulse_test.clj
+++ b/test/metabase/pulse/api/pulse_test.clj
@@ -992,7 +992,7 @@
                        (mt/summarize-multipart-single-email (-> channel-messages :channel/email first) #"Daily Sad Toucans")))))))))))
 
 (deftest send-test-pulse-to-non-user-test
-  (testing "POST /api/pulse/test"
+  (testing "sending test email to non user won't include unsubscribe link (#43391)"
     (mt/with-non-admin-groups-no-root-collection-perms
       (mt/with-fake-inbox
         (mt/dataset sad-toucan-incidents

--- a/test/metabase/pulse/api/pulse_test.clj
+++ b/test/metabase/pulse/api/pulse_test.clj
@@ -991,6 +991,45 @@
                         :recipient-type nil}
                        (mt/summarize-multipart-single-email (-> channel-messages :channel/email first) #"Daily Sad Toucans")))))))))))
 
+(deftest send-test-pulse-to-non-user-test
+  (testing "POST /api/pulse/test"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-fake-inbox
+        (mt/dataset sad-toucan-incidents
+          (mt/with-temp [:model/Collection collection {}
+                         :model/Dashboard {dashboard-id :id} {:name       "Unsaved Subscription Test"
+                                                              :parameters [{:name    "X"
+                                                                            :slug    "x"
+                                                                            :id      "__X__"
+                                                                            :type    "category"
+                                                                            :default 3}]}
+                         :model/Card       card  {:dataset_query (mt/mbql-query incidents {:aggregation [[:count]]})}]
+            (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
+            (api.card-test/with-cards-in-readable-collection! [card]
+              (let [channel-messages (pulse.test-util/with-captured-channel-send-messages!
+                                       (is (= {:ok true}
+                                              (mt/user-http-request :rasta :post 200 "pulse/test"
+                                                                    {:name          (mt/random-name)
+                                                                     :dashboard_id  dashboard-id
+                                                                     :cards         [{:id                (:id card)
+                                                                                      :include_csv       false
+                                                                                      :include_xls       false
+                                                                                      :dashboard_card_id nil}]
+                                                                     :channels      [{:enabled       true
+                                                                                      :channel_type  "email"
+                                                                                      :schedule_type "daily"
+                                                                                      :schedule_hour 12
+                                                                                      :schedule_day  nil
+                                                                                      :recipients    [{:email "nonuser@metabase.com"}]}]
+                                                                     :skip_if_empty false}))))]
+                (is (= {:message [{"Unsaved Subscription Test" true, "Unsubscribe" false}
+                                  pulse.test-util/png-attachment]
+                        :message-type :attachments,
+                        :recipients #{"nonuser@metabase.com"}
+                        :subject "Unsaved Subscription Test"
+                        :recipient-type nil}
+                       (mt/summarize-multipart-single-email (-> channel-messages :channel/email first) #"Unsaved Subscription Test" #"Unsubscribe")))))))))))
+
 (deftest send-test-alert-with-http-channel-test
   (testing "POST /api/pulse/test send test alert to a http channel"
     (notification.tu/with-send-notification-sync


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/43391

Closes [WRK-80](https://linear.app/metabase/issue/WRK-80/unsubscribe-on-unsaved-pulse-doesnt-work)

### Description

This PR resolves the issue where test emails for non-users sent from unsaved subscription menu contained a broken "Unsubscribe" link, since `pulse-id` parameter for the link didn't exist at this moment yet. For such scenarios, it was decided to remove "Unsubscribe" link completely, since it's impossible to tie it to the entity.

### How to verify

1. Create a dashboard, add a question, save.
2. Click "Sharing - Subscriptions - Email it"
3. Enter an email for non-registered user which you have access to (when developing locally, start local email backend - `docker run -p 1080:1080 -p 1025:1025  maildev/maildev`)
4. Click "Send email now" without clicking "Done" to save the subscription.

### Demo
**Before**
<img width="721" alt="image" src="https://github.com/user-attachments/assets/99916cd0-fb1c-45fa-adbd-fe2a0e26ad97" />

**After**
<img width="721" alt="image" src="https://github.com/user-attachments/assets/07deb77a-5298-47f8-865b-f30a1b894f6b" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
