### PR TITLE
POC of being able to enable and reset ee plugins when we want

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
@@ -41,7 +41,7 @@ const BLOCK_PERMISSION_OPTION = {
   icon: "close",
   iconColor: "danger",
 };
-
+export const activate = () => {
 if (hasPremiumFeature("advanced_permissions")) {
   const addSelectedAdvancedPermission = (options, value) => {
     if (value === IMPERSONATED_PERMISSION_OPTION.value) {
@@ -162,3 +162,5 @@ const getEditImpersonationUrl = (entityId, groupId, view) =>
   view === "database"
     ? getDatabaseViewImpersonationModalUrl(entityId, groupId)
     : getGroupViewImpersonationModalUrl(entityId, groupId);
+
+};

--- a/enterprise/frontend/src/metabase-enterprise/application_permissions/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/application_permissions/index.ts
@@ -14,7 +14,7 @@ import {
   monitoringPermissionAllowedPathGetter,
   settingsPermissionAllowedPathGetter,
 } from "./utils";
-
+export const activate = () => {
 if (hasPremiumFeature("advanced_permissions")) {
   PLUGIN_ADMIN_ALLOWED_PATH_GETTERS.push(monitoringPermissionAllowedPathGetter);
   PLUGIN_ADMIN_ALLOWED_PATH_GETTERS.push(settingsPermissionAllowedPathGetter);
@@ -30,3 +30,5 @@ if (hasPremiumFeature("advanced_permissions")) {
   };
   PLUGIN_REDUCERS.applicationPermissionsPlugin = applicationPermissionsReducer;
 }
+
+};

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/index.js
@@ -10,7 +10,7 @@ import { hasPremiumFeature } from "metabase-enterprise/settings";
 import { InsightsLink } from "./components/InsightsLink";
 import { getUserMenuRotes } from "./routes";
 import { isAuditDb } from "./utils";
-
+export const activate = () => {
 if (hasPremiumFeature("audit_app")) {
   PLUGIN_ADMIN_USER_MENU_ITEMS.push(user => [
     {
@@ -25,3 +25,5 @@ if (hasPremiumFeature("audit_app")) {
 
   PLUGIN_AUDIT.InsightsLink = InsightsLink;
 }
+
+};

--- a/enterprise/frontend/src/metabase-enterprise/auth/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/auth/index.js
@@ -28,7 +28,7 @@ import SettingsSAMLForm from "./components/SettingsSAMLForm";
 import { SsoButton } from "./components/SsoButton";
 import JwtAuthCard from "./containers/JwtAuthCard";
 import SamlAuthCard from "./containers/SamlAuthCard";
-
+export const activate = () => {
 PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections =>
   updateIn(sections, ["authentication", "settings"], settings => {
     const [apiKeySettings, otherSettings] = _.partition(
@@ -310,3 +310,5 @@ if (hasPremiumFeature("sso_ldap")) {
 if (hasPremiumFeature("session_timeout_config")) {
   PLUGIN_REDUX_MIDDLEWARES.push(createSessionMiddleware([LOGIN, LOGIN_GOOGLE]));
 }
+
+};

--- a/enterprise/frontend/src/metabase-enterprise/caching/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/index.tsx
@@ -14,7 +14,7 @@ import {
   getEnterprisePerformanceTabMetadata,
 } from "./constants";
 import { hasQuestionCacheSection } from "./utils";
-
+export const activate = () => {
 if (hasPremiumFeature("cache_granular_controls")) {
   PLUGIN_CACHING.isGranularCachingEnabled = () => true;
   PLUGIN_CACHING.StrategyFormLauncherPanel = StrategyFormLauncherPanel;
@@ -41,3 +41,5 @@ if (hasPremiumFeature("cache_granular_controls")) {
 if (hasPremiumFeature("cache_preemptive")) {
   PLUGIN_CACHING.PreemptiveCachingSwitch = PreemptiveCachingSwitch;
 }
+
+};

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/index.tsx
@@ -12,7 +12,7 @@ import { hasPremiumFeature } from "metabase-enterprise/settings";
 import { CleanupCollectionModal } from "./CleanupCollectionModal";
 import { getDateFilterValue } from "./CleanupCollectionModal/utils";
 import { canCleanUp } from "./utils";
-
+export const activate = () => {
 if (hasPremiumFeature("collection_cleanup")) {
   PLUGIN_COLLECTIONS.canCleanUp = canCleanUp;
 
@@ -67,3 +67,5 @@ if (hasPremiumFeature("collection_cleanup")) {
     <ModalRoute path="cleanup" modal={CleanupCollectionModal} />
   );
 }
+
+};

--- a/enterprise/frontend/src/metabase-enterprise/collections/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/collections/index.tsx
@@ -25,7 +25,7 @@ import {
   getIcon,
   isRegularCollection,
 } from "./utils";
-
+export const activate = () => {
 if (hasPremiumFeature("official_collections")) {
   PLUGIN_COLLECTIONS.isRegularCollection = isRegularCollection;
 
@@ -90,3 +90,5 @@ if (hasPremiumFeature("audit_app")) {
 
   PLUGIN_COLLECTIONS.INSTANCE_ANALYTICS_ADMIN_READONLY_MESSAGE = t`This instance analytics collection is read-only for admin users`;
 }
+
+};

--- a/enterprise/frontend/src/metabase-enterprise/content_verification/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_verification/index.ts
@@ -4,7 +4,7 @@ import { hasPremiumFeature } from "metabase-enterprise/settings";
 import { VerifiedFilter } from "./VerifiedFilter";
 import { MetricFilterControls, getDefaultMetricFilters } from "./metrics";
 import { ModelFilterControls, getDefaultModelFilters } from "./models";
-
+export const activate = () => {
 if (hasPremiumFeature("content_verification")) {
   Object.assign(PLUGIN_CONTENT_VERIFICATION, {
     contentVerificationEnabled: true,
@@ -17,3 +17,5 @@ if (hasPremiumFeature("content_verification")) {
     MetricFilterControls,
   });
 }
+
+};

--- a/enterprise/frontend/src/metabase-enterprise/email_allow_list/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/email_allow_list/index.ts
@@ -5,7 +5,7 @@ import type { ADMIN_SETTINGS_SECTIONS } from "metabase/admin/settings/selectors"
 import type { SettingElement } from "metabase/admin/settings/types";
 import { PLUGIN_ADMIN_SETTINGS_UPDATES } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
-
+export const activate = () => {
 if (hasPremiumFeature("email_allow_list")) {
   PLUGIN_ADMIN_SETTINGS_UPDATES.push(
     (sections: typeof ADMIN_SETTINGS_SECTIONS) =>
@@ -23,3 +23,5 @@ if (hasPremiumFeature("email_allow_list")) {
       ),
   );
 }
+
+};

--- a/enterprise/frontend/src/metabase-enterprise/email_restrict_recipients/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/email_restrict_recipients/index.ts
@@ -5,7 +5,7 @@ import type { ADMIN_SETTINGS_SECTIONS } from "metabase/admin/settings/selectors"
 import type { SettingElement } from "metabase/admin/settings/types";
 import { PLUGIN_ADMIN_SETTINGS_UPDATES } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
-
+export const activate = () => {
 if (hasPremiumFeature("email_restrict_recipients")) {
   PLUGIN_ADMIN_SETTINGS_UPDATES.push(
     (sections: typeof ADMIN_SETTINGS_SECTIONS) =>
@@ -32,3 +32,5 @@ if (hasPremiumFeature("email_restrict_recipients")) {
       ),
   );
 }
+
+};

--- a/enterprise/frontend/src/metabase-enterprise/embedding-sdk/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/embedding-sdk/index.js
@@ -1,6 +1,8 @@
 import { PLUGIN_EMBEDDING_SDK } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
-
+export const activate = () => {
 if (hasPremiumFeature("embedding_sdk")) {
   PLUGIN_EMBEDDING_SDK.isEnabled = () => true;
 }
+
+};

--- a/enterprise/frontend/src/metabase-enterprise/embedding/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/embedding/index.js
@@ -3,7 +3,7 @@ import { isInteractiveEmbeddingEnabled } from "metabase-enterprise/embedding/sel
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { InteractiveEmbeddingSettings } from "./components/InteractiveEmbeddingSettings";
-
+export const activate = () => {
 if (hasPremiumFeature("embedding")) {
   PLUGIN_EMBEDDING.isEnabled = () => true;
   PLUGIN_EMBEDDING.isInteractiveEmbeddingEnabled =
@@ -12,3 +12,5 @@ if (hasPremiumFeature("embedding")) {
   PLUGIN_ADMIN_SETTINGS.InteractiveEmbeddingSettings =
     InteractiveEmbeddingSettings;
 }
+
+};

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/index.ts
@@ -14,7 +14,7 @@ import {
   databaseManagementPermissionAllowedPathGetter,
   getDataColumns,
 } from "./utils";
-
+export const activate = () => {
 if (hasPremiumFeature("advanced_permissions")) {
   PLUGIN_ADMIN_ALLOWED_PATH_GETTERS.push(dataModelPermissionAllowedPathGetter);
   PLUGIN_ADMIN_ALLOWED_PATH_GETTERS.push(
@@ -37,3 +37,5 @@ if (hasPremiumFeature("advanced_permissions")) {
     exclude_uneditable_details: true,
   };
 }
+
+};

--- a/enterprise/frontend/src/metabase-enterprise/group_managers/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/group_managers/index.ts
@@ -16,7 +16,7 @@ import {
   getRemoveMembershipConfirmation,
   groupManagerAllowedPathGetter,
 } from "./utils";
-
+export const activate = () => {
 if (hasPremiumFeature("advanced_permissions")) {
   PLUGIN_ADMIN_ALLOWED_PATH_GETTERS.push(groupManagerAllowedPathGetter);
 
@@ -32,3 +32,5 @@ if (hasPremiumFeature("advanced_permissions")) {
   PLUGIN_GROUP_MANAGERS.confirmDeleteMembershipAction = confirmDeleteMembership;
   PLUGIN_GROUP_MANAGERS.confirmUpdateMembershipAction = confirmUpdateMembership;
 }
+
+};

--- a/enterprise/frontend/src/metabase-enterprise/hosting/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/hosting/index.js
@@ -6,7 +6,7 @@ import { PLUGIN_ADMIN_SETTINGS_UPDATES } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { SettingsCloudStoreLink } from "./components/SettingsCloudStoreLink";
-
+export const activate = () => {
 if (hasPremiumFeature("hosting")) {
   PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections => _.omit(sections, ["updates"]));
 
@@ -32,3 +32,5 @@ if (hasPremiumFeature("hosting")) {
     },
   }));
 }
+
+};

--- a/enterprise/frontend/src/metabase-enterprise/license/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/license/index.js
@@ -4,7 +4,7 @@ import { t } from "ttag";
 import { PLUGIN_ADMIN_SETTINGS_UPDATES } from "metabase/plugins";
 
 import LicenseAndBillingSettings from "./components/LicenseAndBillingSettings";
-
+export const activate = () => {
 PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections =>
   updateIn(sections, ["license"], license => {
     return {
@@ -15,3 +15,5 @@ PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections =>
     };
   }),
 );
+
+};

--- a/enterprise/frontend/src/metabase-enterprise/llm_autodescription/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/llm_autodescription/index.ts
@@ -2,8 +2,10 @@ import { PLUGIN_LLM_AUTODESCRIPTION } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { LLMSuggestQuestionInfo } from "./LLMSuggestQuestionInfo";
-
+export const activate = () => {
 if (hasPremiumFeature("llm_autodescription")) {
   PLUGIN_LLM_AUTODESCRIPTION.isEnabled = () => true;
   PLUGIN_LLM_AUTODESCRIPTION.LLMSuggestQuestionInfo = LLMSuggestQuestionInfo;
 }
+
+};

--- a/enterprise/frontend/src/metabase-enterprise/model_persistence/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/model_persistence/index.ts
@@ -2,8 +2,10 @@ import { PLUGIN_MODEL_PERSISTENCE } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { ModelCacheToggle } from "./components/ModelCacheControl";
-
+export const activate = () => {
 if (hasPremiumFeature("cache_granular_controls")) {
   PLUGIN_MODEL_PERSISTENCE.isModelLevelPersistenceEnabled = () => true;
   PLUGIN_MODEL_PERSISTENCE.ModelCacheToggle = ModelCacheToggle;
 }
+
+};

--- a/enterprise/frontend/src/metabase-enterprise/moderation/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/index.js
@@ -18,7 +18,7 @@ import {
   getQuestionIcon,
   getStatusIcon,
 } from "./service";
-
+export const activate = () => {
 if (hasPremiumFeature("content_verification")) {
   Object.assign(PLUGIN_MODERATION, {
     isEnabled: () => true,
@@ -35,3 +35,5 @@ if (hasPremiumFeature("content_verification")) {
     useDashboardMenuItems,
   });
 }
+
+};

--- a/enterprise/frontend/src/metabase-enterprise/plugins.js
+++ b/enterprise/frontend/src/metabase-enterprise/plugins.js
@@ -1,37 +1,77 @@
 import { PLUGIN_IS_EE_BUILD } from "metabase/plugins";
 
 // SETTINGS OVERRIDES:
+const activateIsEEBuildPlugin = () => {
 PLUGIN_IS_EE_BUILD.isEEBuild = () => true;
+};
 
 import "./shared";
 
 // PLUGINS:
 
-import "./hosting";
-import "./tools";
-import "./sandboxes";
-import "./auth";
-import "./caching";
-import "./collections";
-import "./content_verification";
-import "./whitelabel";
-import "./embedding";
-import "./embedding-sdk";
-import "./snippets";
-import "./sharing";
-import "./moderation";
-import "./email_allow_list";
-import "./email_restrict_recipients";
-import "./advanced_permissions";
-import "./audit_app";
-import "./license";
-import "./model_persistence";
-import "./feature_level_permissions";
-import "./application_permissions";
-import "./group_managers";
-import "./llm_autodescription";
-import "./upload_management";
-import "./resource_downloads";
-import "./user_provisioning";
-import "./clean_up";
-import "./troubleshooting";
+import * as hosting from "./hosting";
+import * as tools from "./tools";
+import * as sandboxes from "./sandboxes";
+import * as auth from "./auth";
+import * as caching from "./caching";
+import * as collections from "./collections";
+import * as content_verification from "./content_verification";
+import * as whitelabel from "./whitelabel";
+import * as embedding from "./embedding";
+import * as sdk from "./embedding-sdk";
+import * as snippets from "./snippets";
+import * as sharing from "./sharing";
+import * as moderation from "./moderation";
+import * as email_allow_list from "./email_allow_list";
+import * as email_restrict_recipients from "./email_restrict_recipients";
+import * as advanced_permissions from "./advanced_permissions";
+import * as audit_app from "./audit_app";
+import * as license from "./license";
+import * as model_persistence from "./model_persistence";
+import * as feature_level_permissions from "./feature_level_permissions";
+import * as application_permissions from "./application_permissions";
+import * as group_managers from "./group_managers";
+import * as llm_autodescription from "./llm_autodescription";
+import * as upload_management from "./upload_management";
+import * as resource_downloads from "./resource_downloads";
+import * as user_provisioning from "./user_provisioning";
+import * as clean_up from "./clean_up";
+import * as troubleshooting from "./troubleshooting";
+
+const eePluginActivators = [
+  activateIsEEBuildPlugin,
+  hosting.activate,
+  tools.activate,
+  sandboxes.activate,
+  auth.activate,
+  caching.activate,
+  collections.activate,
+  content_verification.activate,
+  whitelabel.activate,
+  embedding.activate,
+  sdk.activate,
+  snippets.activate,
+  sharing.activate,
+  moderation.activate,
+  email_allow_list.activate,
+  email_restrict_recipients.activate,
+  advanced_permissions.activate,
+  audit_app.activate,
+  license.activate,
+  model_persistence.activate,
+  feature_level_permissions.activate,
+  application_permissions.activate,
+  group_managers.activate,
+  llm_autodescription.activate,
+  upload_management.activate,
+  resource_downloads.activate,
+  user_provisioning.activate,
+  clean_up.activate,
+  troubleshooting.activate,
+];
+
+const activateEEPlugins = () => {
+  eePluginActivators.forEach(activate => activate());
+};
+
+activateEEPlugins();

--- a/enterprise/frontend/src/metabase-enterprise/plugins.js
+++ b/enterprise/frontend/src/metabase-enterprise/plugins.js
@@ -1,8 +1,8 @@
-import { PLUGIN_IS_EE_BUILD } from "metabase/plugins";
+import { EE_PLUGINS_SYSTEM, PLUGIN_IS_EE_BUILD } from "metabase/plugins";
 
 // SETTINGS OVERRIDES:
 const activateIsEEBuildPlugin = () => {
-PLUGIN_IS_EE_BUILD.isEEBuild = () => true;
+  PLUGIN_IS_EE_BUILD.isEEBuild = () => true;
 };
 
 import "./shared";
@@ -75,3 +75,13 @@ const activateEEPlugins = () => {
 };
 
 activateEEPlugins();
+
+const activatePluginsSystem = () => {
+  // console.log("activating plugins (ee", { eePluginActivators });
+  EE_PLUGINS_SYSTEM.activatePlugins = () => {
+    // console.log("activating plugins (ee)");
+    activateEEPlugins();
+  };
+};
+
+export { activatePluginsSystem };

--- a/enterprise/frontend/src/metabase-enterprise/resource_downloads/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/resource_downloads/index.ts
@@ -1,1 +1,1 @@
-import "./resource_downloads_plugin";
+export * from "./resource_downloads_plugin";

--- a/enterprise/frontend/src/metabase-enterprise/resource_downloads/resource_downloads_plugin.ts
+++ b/enterprise/frontend/src/metabase-enterprise/resource_downloads/resource_downloads_plugin.ts
@@ -3,26 +3,29 @@ import { match } from "ts-pattern";
 import { PLUGIN_RESOURCE_DOWNLOADS } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
-if (hasPremiumFeature("whitelabel")) {
-  /**
-   * Returns if 'download results' on cards and pdf exports are enabled in public and embedded contexts.
-   */
-  PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled = ({
-    hide_download_button,
-    downloads,
-  }: {
-    hide_download_button?: boolean | null;
-    downloads?: boolean | null;
-  }) => {
-    return (
-      match({ hide_download_button, downloads })
-        // `downloads` has priority over `hide_download_button`
-        .with({ downloads: true }, () => true)
-        .with({ downloads: false }, () => false)
-        // but we still support the old `hide_download_button` option
-        .with({ hide_download_button: true }, () => false)
-        // by default downloads are enabled
-        .otherwise(() => true)
-    );
-  };
-}
+export const activate = () => {
+  // console.log("activating resource downloads plugin");
+  if (hasPremiumFeature("whitelabel")) {
+    /**
+     * Returns if 'download results' on cards and pdf exports are enabled in public and embedded contexts.
+     */
+    PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled = ({
+      hide_download_button,
+      downloads,
+    }: {
+      hide_download_button?: boolean | null;
+      downloads?: boolean | null;
+    }) => {
+      return (
+        match({ hide_download_button, downloads })
+          // `downloads` has priority over `hide_download_button`
+          .with({ downloads: true }, () => true)
+          .with({ downloads: false }, () => false)
+          // but we still support the old `hide_download_button` option
+          .with({ hide_download_button: true }, () => false)
+          // by default downloads are enabled
+          .otherwise(() => true)
+      );
+    };
+  }
+};

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/index.js
@@ -55,6 +55,7 @@ const getEditSegementedAccessUrl = (entityId, groupId, view) =>
 const getEditSegmentedAccessPostAction = (entityId, groupId, view) =>
   push(getEditSegementedAccessUrl(entityId, groupId, view));
 
+export const activate = () => {
 if (hasPremiumFeature("sandboxes")) {
   PLUGIN_ADMIN_USER_FORM_FIELDS.FormLoginAttributes = LoginAttributesWidget;
 
@@ -96,3 +97,5 @@ if (hasPremiumFeature("sandboxes")) {
   PLUGIN_DATA_PERMISSIONS.hasChanges.push(hasPolicyChanges);
   PLUGIN_REDUCERS.sandboxingPlugin = sandboxingReducer;
 }
+
+};

--- a/enterprise/frontend/src/metabase-enterprise/sharing/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/sharing/index.js
@@ -1,8 +1,10 @@
 import { PLUGIN_DASHBOARD_SUBSCRIPTION_PARAMETERS_SECTION_OVERRIDE } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 import { MutableParametersSection } from "metabase-enterprise/sharing/components/MutableParametersSection";
-
+export const activate = () => {
 if (hasPremiumFeature("dashboard_subscription_filters")) {
   PLUGIN_DASHBOARD_SUBSCRIPTION_PARAMETERS_SECTION_OVERRIDE.Component =
     MutableParametersSection;
 }
+
+};

--- a/enterprise/frontend/src/metabase-enterprise/snippets/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/snippets/index.js
@@ -14,7 +14,7 @@ import { hasPremiumFeature } from "metabase-enterprise/settings";
 import CollectionOptionsButton from "./components/CollectionOptionsButton";
 import CollectionRow from "./components/CollectionRow";
 import SnippetCollectionFormModal from "./components/SnippetCollectionFormModal";
-
+export const activate = () => {
 if (hasPremiumFeature("snippet_collections")) {
   PLUGIN_SNIPPET_SIDEBAR_PLUS_MENU_OPTIONS.push(snippetSidebar => ({
     icon: "folder",
@@ -82,3 +82,5 @@ if (hasPremiumFeature("snippet_collections")) {
     );
   });
 }
+
+};

--- a/enterprise/frontend/src/metabase-enterprise/tools/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/tools/index.js
@@ -2,7 +2,9 @@ import { PLUGIN_ADMIN_TOOLS } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import ErrorOverview from "./ErrorOverview";
-
+export const activate = () => {
 if (hasPremiumFeature("audit_app")) {
   PLUGIN_ADMIN_TOOLS.COMPONENT = ErrorOverview;
 }
+
+};

--- a/enterprise/frontend/src/metabase-enterprise/troubleshooting/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/troubleshooting/index.tsx
@@ -10,7 +10,7 @@ import {
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { QueryValidator } from "./components/QueryValidator";
-
+export const activate = () => {
 if (hasPremiumFeature("query_reference_validation")) {
   PLUGIN_ADMIN_TROUBLESHOOTING.EXTRA_ROUTES = [
     <Route
@@ -39,3 +39,5 @@ if (hasPremiumFeature("query_reference_validation")) {
     ]),
   );
 }
+
+};

--- a/enterprise/frontend/src/metabase-enterprise/upload_management/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/upload_management/index.ts
@@ -2,7 +2,9 @@ import { PLUGIN_UPLOAD_MANAGEMENT } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { UploadManagementTable } from "./UploadManagementTable";
-
+export const activate = () => {
 if (hasPremiumFeature("upload_management")) {
   PLUGIN_UPLOAD_MANAGEMENT.UploadManagementTable = UploadManagementTable;
 }
+
+};

--- a/enterprise/frontend/src/metabase-enterprise/user_provisioning/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/user_provisioning/index.ts
@@ -7,7 +7,7 @@ import {
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { UserProvisioning } from "./components/UserProvisioning";
-
+export const activate = () => {
 if (hasPremiumFeature("scim")) {
   PLUGIN_ADMIN_SETTINGS_AUTH_TABS.push({
     name: t`User Provisioning`,
@@ -54,3 +54,5 @@ if (hasPremiumFeature("scim")) {
     },
   }));
 }
+
+};

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/index.js
@@ -42,6 +42,7 @@ import {
 import { getLoadingMessageOptions } from "./lib/loading-message";
 import { updateColors } from "./lib/whitelabel";
 
+export const activate = () => {
 if (hasPremiumFeature("whitelabel")) {
   PLUGIN_LANDING_PAGE.push(() => MetabaseSettings.get("landing-page"));
   PLUGIN_ADMIN_SETTINGS_UPDATES.push(
@@ -321,3 +322,5 @@ if (hasPremiumFeature("whitelabel")) {
   PLUGIN_SELECTORS.getNoDataIllustration = getNoDataIllustration;
   PLUGIN_SELECTORS.getNoObjectIllustration = getNoObjectIllustration;
 }
+
+};

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
@@ -527,6 +527,7 @@ describe("[EE, with token] embedding settings", () => {
     await setup({
       settings: [createMockSettingDefinition({ key: "enable-embedding" })],
       settingValues: createMockSettings({ "enable-embedding": false }),
+      // This test was supposed to be broken, it's CHANGING the token features in a test that was using other token features
       tokenFeatures: createMockTokenFeatures({
         embedding: false,
         embedding_sdk: false,

--- a/frontend/src/metabase/lib/noop.js
+++ b/frontend/src/metabase/lib/noop.js
@@ -1,4 +1,13 @@
 // there's nothing here!
 
+import { EE_PLUGINS_SYSTEM } from "metabase/plugins";
+
 // This file is the alternative to importing EE plugins.
 // Either way we import something to ensure a consisten import order.
+
+const activatePluginsSystem = () => {
+  // console.log("noop deactivating plugins system");
+  EE_PLUGINS_SYSTEM.activatePlugins = () => {};
+};
+
+export { activatePluginsSystem };

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line depend/ban-dependencies
+import { cloneDeep } from "lodash";
 import type React from "react";
 import type {
   ComponentType,
@@ -562,4 +564,98 @@ export const PLUGIN_RESOURCE_DOWNLOADS = {
     hide_download_button?: boolean | null;
     downloads?: boolean | null;
   }) => true,
+};
+
+// just a reference to all the plugins so we can iterate easily on them
+const PLUGINS = {
+  PLUGIN_APP_INIT_FUNCTIONS,
+  PLUGIN_LANDING_PAGE,
+  PLUGIN_REDUX_MIDDLEWARES,
+  PLUGIN_LOGO_ICON_COMPONENTS,
+  PLUGIN_ADMIN_NAV_ITEMS,
+  PLUGIN_ADMIN_ROUTES,
+  PLUGIN_ADMIN_ALLOWED_PATH_GETTERS,
+  PLUGIN_ADMIN_TOOLS,
+  PLUGIN_ADMIN_TROUBLESHOOTING,
+  PLUGIN_ADMIN_SETTINGS,
+  PLUGIN_ADMIN_SETTINGS_UPDATES,
+  PLUGIN_ADMIN_PERMISSIONS_DATABASE_ROUTES,
+  PLUGIN_ADMIN_PERMISSIONS_DATABASE_GROUP_ROUTES,
+  PLUGIN_ADMIN_PERMISSIONS_DATABASE_POST_ACTIONS,
+  PLUGIN_ADMIN_PERMISSIONS_DATABASE_ACTIONS,
+  PLUGIN_ADMIN_PERMISSIONS_TABLE_OPTIONS,
+  PLUGIN_ADMIN_PERMISSIONS_TABLE_ROUTES,
+  PLUGIN_ADMIN_PERMISSIONS_TABLE_GROUP_ROUTES,
+  PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_OPTIONS,
+  PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_CONFIRMATIONS,
+  PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_ACTIONS,
+  PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_POST_ACTION,
+  PLUGIN_DATA_PERMISSIONS,
+  PLUGIN_ADMIN_USER_FORM_FIELDS,
+  PLUGIN_ADMIN_USER_MENU_ITEMS,
+  PLUGIN_ADMIN_USER_MENU_ROUTES,
+  PLUGIN_ADMIN_SETTINGS_AUTH_TABS,
+  PLUGIN_AUTH_PROVIDERS,
+  PLUGIN_LDAP_FORM_FIELDS,
+  PLUGIN_IS_PASSWORD_USER,
+  PLUGIN_SELECTORS,
+  PLUGIN_FORM_WIDGETS,
+  PLUGIN_SNIPPET_SIDEBAR_PLUS_MENU_OPTIONS,
+  PLUGIN_SNIPPET_SIDEBAR_ROW_RENDERERS,
+  PLUGIN_SNIPPET_SIDEBAR_MODALS,
+  PLUGIN_SNIPPET_SIDEBAR_HEADER_BUTTONS,
+  PLUGIN_DASHBOARD_SUBSCRIPTION_PARAMETERS_SECTION_OVERRIDE,
+  PLUGIN_LLM_AUTODESCRIPTION,
+  PLUGIN_COLLECTIONS,
+  PLUGIN_COLLECTION_COMPONENTS,
+  PLUGIN_MODERATION,
+  PLUGIN_CACHING,
+  PLUGIN_REDUCERS,
+  PLUGIN_ADVANCED_PERMISSIONS,
+  PLUGIN_FEATURE_LEVEL_PERMISSIONS,
+  PLUGIN_APPLICATION_PERMISSIONS,
+  PLUGIN_GROUP_MANAGERS,
+  PLUGIN_MODEL_PERSISTENCE,
+  PLUGIN_EMBEDDING,
+  PLUGIN_EMBEDDING_SDK,
+  PLUGIN_CONTENT_VERIFICATION,
+  PLUGIN_AUDIT,
+  PLUGIN_UPLOAD_MANAGEMENT,
+  PLUGIN_IS_EE_BUILD,
+  PLUGIN_RESOURCE_DOWNLOADS,
+};
+
+// initial oss plugins, needed so we can restore them
+export const INITIAL_OSS_PLUGINS = cloneDeep(PLUGINS);
+
+export const EE_PLUGINS_SYSTEM = {
+  activatePlugins: () => {
+    // noop on oss
+    // will be implemented for ee plugins
+  },
+
+  restoreOssPlugins: () => {
+    // console.log("restoring oss plugins");
+    Object.keys(INITIAL_OSS_PLUGINS).forEach(k => {
+      const key = k as keyof typeof INITIAL_OSS_PLUGINS;
+      const initialPlugin = INITIAL_OSS_PLUGINS[key];
+      const plugin = PLUGINS[key];
+
+      if (Array.isArray(plugin)) {
+        plugin.length = 0;
+        // @ts-expect-error -- 🤷
+        plugin.push(...initialPlugin);
+      } else {
+        Object.keys(plugin).forEach(k => {
+          delete (plugin as any)[k];
+        });
+        Object.assign(plugin, initialPlugin);
+      }
+    });
+  },
+
+  calculatePlugins: () => {
+    EE_PLUGINS_SYSTEM.restoreOssPlugins();
+    EE_PLUGINS_SYSTEM.activatePlugins();
+  },
 };

--- a/frontend/src/metabase/plugins/plugin-system.unit.spec.tsx
+++ b/frontend/src/metabase/plugins/plugin-system.unit.spec.tsx
@@ -1,0 +1,67 @@
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
+import type { TokenFeatures } from "metabase-types/api";
+import { createMockTokenFeatures } from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { PLUGIN_IS_EE_BUILD, PLUGIN_RESOURCE_DOWNLOADS } from ".";
+
+const TestComponent = () => {
+  const isRunningEELogic =
+    PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled({
+      hide_download_button: true,
+    }) === false;
+
+  const isEeBuild = PLUGIN_IS_EE_BUILD.isEEBuild();
+
+  return (
+    <div>
+      <div>{isRunningEELogic ? "ee-logic" : "oss-logic"}</div>
+      <div>{isEeBuild ? "ee-build" : "oss-build"}</div>
+    </div>
+  );
+};
+
+const setup = ({
+  eeBuild,
+  tokenFeatures = {},
+}: {
+  eeBuild: boolean;
+  tokenFeatures: Partial<TokenFeatures>;
+}) => {
+  const initialState = createMockState({
+    settings: mockSettings({
+      "token-features": createMockTokenFeatures(tokenFeatures),
+    }),
+  });
+
+  setupEnterprisePlugins(eeBuild);
+
+  renderWithProviders(<TestComponent />, {
+    storeInitialState: initialState,
+  });
+};
+
+describe("EE_PLUGINS_SYSTEM", () => {
+  // do multiple runs to make sure we're cleaning things properly
+  describe.each([1, 2, 3])("run %s", () => {
+    it("should use oss plugins by default", () => {
+      setup({ eeBuild: false, tokenFeatures: {} });
+      expect(screen.getByText("oss-build")).toBeInTheDocument();
+      expect(screen.getByText("oss-logic")).toBeInTheDocument();
+    });
+
+    it("should use ee logic when the whitelabel feature is enabled", () => {
+      setup({ eeBuild: true, tokenFeatures: { whitelabel: true } });
+      expect(screen.getByText("ee-build")).toBeInTheDocument();
+      expect(screen.getByText("ee-logic")).toBeInTheDocument();
+    });
+
+    it("should use oss logic when ee build but the whitelabel feature is disabled", () => {
+      setup({ eeBuild: true, tokenFeatures: { whitelabel: false } });
+      expect(screen.getByText("ee-build")).toBeInTheDocument();
+      expect(screen.getByText("oss-logic")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/test/__support__/enterprise.js
+++ b/frontend/test/__support__/enterprise.js
@@ -1,3 +1,5 @@
+import { EE_PLUGINS_SYSTEM } from "metabase/plugins";
+
 /**
  * @deprecated use setupEnterprisePlugins with settings set via mockSettings
  */
@@ -9,6 +11,11 @@ export function setupEnterpriseTest() {
   setupEnterprisePlugins();
 }
 
-export function setupEnterprisePlugins() {
-  require("metabase-enterprise/plugins");
+export function setupEnterprisePlugins(isEnterpriseBuild = true) {
+  if (isEnterpriseBuild) {
+    require("metabase-enterprise/plugins").activatePluginsSystem();
+  } else {
+    require("metabase/lib/noop").activatePluginsSystem();
+  }
+  EE_PLUGINS_SYSTEM.calculatePlugins();
 }


### PR DESCRIPTION
> [!Warning]
> Read this commit by commit 


This would allow us to:
- use the ee plugins on the sdk, as we can enable them when we want and not just at module init
- test multiple token features set in the same file



The first commit just wraps side effects into functions instead.
Formatting is deliberately broken when i wrap the code in functions so that diff is smaller.
Some tests fail, some are expected to fail because they were changing token-features in the same file, that wasn't really working but with this pr it is.