### PR TITLE
fix warning about missing ref on forwardref for FullWidthContainer

### DIFF
--- a/frontend/src/metabase/styled-components/layout/FullWidthContainer.tsx
+++ b/frontend/src/metabase/styled-components/layout/FullWidthContainer.tsx
@@ -8,8 +8,10 @@ import S from "./FullWidthContainer.module.css";
 export const FullWidthContainer = forwardRef<
   HTMLDivElement,
   BoxProps & { children: React.ReactNode }
->(function FullWidthContainer(props) {
+>(function FullWidthContainer(props, ref) {
   const { className, ...rest } = props;
 
-  return <Box className={cx(S.FullWidthContainer, className)} {...rest} />;
+  return (
+    <Box className={cx(S.FullWidthContainer, className)} {...rest} ref={ref} />
+  );
 });


### PR DESCRIPTION
I had this warning one all tests i was running

<img width="954" alt="image" src="https://github.com/user-attachments/assets/78ffed8e-9435-4a5d-b672-9d805128c1b8" />
