### PR TITLE
fix(sdk): Adjust SDK version compatibility warning color

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/lib/log-utils.ts
+++ b/enterprise/frontend/src/embedding-sdk/lib/log-utils.ts
@@ -8,7 +8,7 @@
 export const bigWarningHeader = (message: string) => {
   return [
     `%c${message}\n`,
-    "color: #FCF0A6; font-size: 16px; font-weight: bold;",
+    "color: #F28222; font-size: 16px; font-weight: bold;",
   ];
 };
 


### PR DESCRIPTION
Adjust SDK version compatibility warning color

Closes [EMB-144](https://linear.app/metabase/issue/EMB-144/sdk-version-compatibility-warning-not-visible)

![image](https://github.com/user-attachments/assets/ee37183d-e090-49f8-99d0-6230068a00ca)
