### PR TITLE
Generate site-wide session tokens for the AI service

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -33,6 +33,7 @@
   :sensitive? true
   :feature    :metabot-v3
   :doc        false
+  :export?    false
   :base       setting/uuid-nonce-base)
 
 (defsetting metabot-ai-service-token-ttl
@@ -42,6 +43,7 @@
   :default    180
   :feature    :metabot-v3
   :doc        false
+  :export?    true
   :audit      :never)
 
 (defn- get-ai-service-token

--- a/test_resources/serialization_baseline/settings.yaml
+++ b/test_resources/serialization_baseline/settings.yaml
@@ -30,6 +30,7 @@ landing-page-illustration-custom: null
 loading-message: null
 login-page-illustration: null
 login-page-illustration-custom: null
+metabot-ai-service-token-ttl: nil
 native-query-autocomplete-match-style: null
 no-data-illustration: null
 no-data-illustration-custom: null


### PR DESCRIPTION
Fixes BOT-38.

This PR also allows the V2 tool API endpoints to be used by other existing authentication methods like API keys and Metabase sessions.

Relevant Slack conversations:
* [Supporting multi-instance sites](https://metaboat.slack.com/archives/C07SJT1P0ET/p1740430523303609?thread_ts=1740419001.982849&cid=C07SJT1P0ET)
* [Allowing API key auth](https://metaboat.slack.com/archives/C07SJT1P0ET/p1740430977188149)
