### PR TITLE
Fix a case with broken dates and timelines

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
@@ -1237,3 +1237,36 @@ describe("issue 49160", () => {
     H.leftSidebar().findByText("Gizmo");
   });
 });
+
+describe("issue 54271", () => {
+  const questionDetails = {
+    query: {
+      "source-table": REVIEWS_ID,
+      aggregation: [["count"]],
+      breakout: [["field", REVIEWS.REVIEWER, null]],
+    },
+    display: "line",
+    visualization_settings: {
+      "graph.dimensions": ["REVIEWER"],
+      "graph.metrics": [["count"]],
+    },
+  };
+
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should not crash the app when rendering a line chart with broken viz settings and table metadata (metabase#54271)", () => {
+    cy.log("broken semantic type - the field cannot be parsed as a date");
+    cy.request("PUT", `/api/field/${REVIEWS.REVIEWER}`, {
+      semantic_type: "type/CreationDate",
+    });
+
+    cy.log("broken viz settings - dimensions cannot have a text column");
+    H.createQuestion(questionDetails, { visitQuestion: true });
+
+    cy.log("no clear expectations but the app should not crash");
+    H.assertQueryBuilderRowCount(1076);
+  });
+});

--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -79,7 +79,9 @@ export function getXValues({ settings, series }) {
         isDescending = isDescending && value <= lastValue;
       }
       lastValue = value;
-      uniqueValues.add(value);
+      if (value != null) {
+        uniqueValues.add(value);
+      }
     }
   }
   let xValues = Array.from(uniqueValues);

--- a/frontend/src/metabase/visualizations/lib/renderer_utils.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.unit.spec.js
@@ -164,6 +164,17 @@ describe("getXValues", () => {
     const formattedXValues = xValues.map(v => v.format("YYYY-MM-DD"));
     expect(formattedXValues).toEqual(["2019-01-02", "2019-01-03"]);
   });
+
+  it("should exclude values that cannot be parsed according to the column type", () => {
+    const xValues = getXValuesForRows(
+      [[["2019-01-02"], ["abc"], ["2019-01-03"]]],
+      {
+        "graph.x_axis.scale": "timeseries",
+      },
+    );
+    const formattedXValues = xValues.map(v => v.format("YYYY-MM-DD"));
+    expect(formattedXValues).toEqual(["2019-01-02", "2019-01-03"]);
+  });
 });
 
 describe("parseXValue", () => {


### PR DESCRIPTION
Previously, if you create a question with broken viz settings which use a column with a broken semantic type, the app could fail. This PR resolves the issue.

Repro:
- Admin -> Table Metadata -> Reviews -> Body -> Set Field Type for Reviewer to Creation Timestamp
- New -> Question -> Reviews -> Count -> Group by reviewer -> Visualize
- Viz settings -> Line
- There would be an exception thrown

<img width="1008" alt="Screenshot 2025-02-25 at 10 17 50" src="https://github.com/user-attachments/assets/5f7cfc7a-717b-4a08-a261-d51f0d2b0377" />
