### PR TITLE
Fix embedding data picker not filtering by selected database

### DIFF
--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -886,7 +886,7 @@ describe("scenarios > embedding > full app", () => {
       });
 
       it(
-        "should select a table when there are multiple databases",
+        "should select a table when there are multiple databases (metabase#54127)",
         { tags: "@external" },
         () => {
           H.restore("postgres-12");

--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -891,6 +891,10 @@ describe("scenarios > embedding > full app", () => {
         () => {
           H.restore("postgres-12");
           cy.signInAsAdmin();
+          H.createModelFromTableName({
+            tableName: "orders",
+            modelName: "Orders Model (Postgres)",
+          });
           startNewEmbeddingQuestion({ isMultiStageDataPicker: true });
           selectTable({ tableName: "Orders", databaseName: "QA Postgres12" });
           clickOnDataSource("Orders");
@@ -910,13 +914,18 @@ describe("scenarios > embedding > full app", () => {
             cy.findByRole("heading", { name: "QA Postgres12" }).should(
               "be.visible",
             );
+
+            cy.icon("chevronleft").click();
+            cy.findByText("Models").click();
+            cy.findByText("Orders Model").should("be.visible");
+            cy.findByText("Orders Model (Postgres)").should("be.visible");
           });
 
           cy.log("close the data picker popover");
           cy.findByTestId("data-step-cell").click();
 
           cy.log(
-            "assert that the data sources should be filtered by the selected database from the starting data source.",
+            "assert that the tables should be filtered by the selected database from the starting data source.",
           );
           H.getNotebookStep("data").button("Join data").click();
           H.popover().within(() => {
@@ -927,6 +936,16 @@ describe("scenarios > embedding > full app", () => {
             cy.findByRole("heading", { name: "QA Postgres12" }).should(
               "be.visible",
             );
+          });
+
+          cy.log(
+            "assert that the models should be filtered by the selected database from the starting data source.",
+          );
+          H.popover().within(() => {
+            cy.icon("chevronleft").click();
+            cy.findByText("Models").click();
+            cy.findByText("Orders Model").should("not.exist");
+            cy.findByText("Orders Model (Postgres)").should("be.visible");
           });
         },
       );

--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -898,6 +898,36 @@ describe("scenarios > embedding > full app", () => {
             tableName: "Orders",
             databaseName: "QA Postgres12",
           });
+
+          cy.log(
+            "assert that even after selecting a data source from one database, the data picker still shows the other data sources database",
+          );
+          H.popover().within(() => {
+            cy.icon("chevronleft").click();
+            cy.findByRole("heading", { name: "Sample Database" }).should(
+              "be.visible",
+            );
+            cy.findByRole("heading", { name: "QA Postgres12" }).should(
+              "be.visible",
+            );
+          });
+
+          cy.log("close the data picker popover");
+          cy.findByTestId("data-step-cell").click();
+
+          cy.log(
+            "assert that the data sources should be filtered by the selected database from the starting data source.",
+          );
+          H.getNotebookStep("data").button("Join data").click();
+          H.popover().within(() => {
+            cy.icon("chevronleft").click();
+            cy.findByRole("heading", { name: "Sample Database" }).should(
+              "not.exist",
+            );
+            cy.findByRole("heading", { name: "QA Postgres12" }).should(
+              "be.visible",
+            );
+          });
         },
       );
 

--- a/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityList.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityList.tsx
@@ -9,7 +9,7 @@ import { PERSONAL_COLLECTIONS } from "metabase/entities/collections/constants";
 import { PLUGIN_MODERATION } from "metabase/plugins";
 import { Box } from "metabase/ui";
 import { getQuestionVirtualTableId } from "metabase-lib/v1/metadata/utils/saved-questions";
-import type { CardType, Collection } from "metabase-types/api";
+import type { CardType, Collection, DatabaseId } from "metabase-types/api";
 import { SortDirection } from "metabase-types/api/sorting";
 
 import SavedEntityListS from "./SavedEntityList.module.css";
@@ -18,6 +18,7 @@ import { CARD_INFO } from "./constants";
 interface SavedEntityListProps {
   type: CardType;
   selectedId: string;
+  databaseId: DatabaseId;
   collection?: Collection;
   onSelect: (tableOrModelId: string) => void;
 }
@@ -25,6 +26,7 @@ interface SavedEntityListProps {
 const SavedEntityList = ({
   type,
   selectedId,
+  databaseId,
   collection,
   onSelect,
 }: SavedEntityListProps): JSX.Element => {
@@ -47,6 +49,10 @@ const SavedEntityList = ({
       : skipToken,
   );
   const list = data?.data ?? [];
+  const filteredList = databaseId
+    ? // When `databaseId` is provided, we're joining data, so we need to filter out items that don't belong to the current database
+      list.filter(collectionItem => collectionItem.database_id === databaseId)
+    : list;
 
   return (
     <Box p="sm" w="100%">
@@ -57,7 +63,7 @@ const SavedEntityList = ({
           error={error}
         >
           <Fragment>
-            {list.map(collectionItem => {
+            {filteredList.map(collectionItem => {
               const { id, name, moderated_status } = collectionItem;
               const virtualTableId = getQuestionVirtualTableId(id);
 
@@ -81,7 +87,7 @@ const SavedEntityList = ({
                 />
               );
             })}
-            {list.length === 0 ? emptyState : null}
+            {filteredList.length === 0 ? emptyState : null}
           </Fragment>
           {isVirtualCollection && emptyState}
         </LoadingAndErrorWrapper>

--- a/frontend/src/metabase/querying/notebook/components/JoinStep/JoinTablePicker/JoinTablePicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/JoinStep/JoinTablePicker/JoinTablePicker.tsx
@@ -1,10 +1,13 @@
 import type { CSSProperties, ReactNode } from "react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { t } from "ttag";
 
 import IconButtonWrapper from "metabase/components/IconButtonWrapper";
+import { useSelector } from "metabase/lib/redux";
+import { getMetadata } from "metabase/selectors/metadata";
 import { Icon, Popover, Tooltip } from "metabase/ui";
-import type * as Lib from "metabase-lib";
+import * as Lib from "metabase-lib";
+import type { Database } from "metabase-types/api";
 
 import { NotebookCellItem } from "../../NotebookCell";
 import { CONTAINER_PADDING } from "../../NotebookCell/constants";
@@ -33,6 +36,17 @@ export function JoinTablePicker({
 }: JoinTablePickerProps) {
   const isDisabled = isReadOnly;
 
+  const metadata = useSelector(getMetadata);
+  const databaseId = useMemo(() => {
+    return Lib.databaseID(query);
+  }, [query]);
+  const databases = useMemo(() => {
+    const database = metadata.database(databaseId);
+    return [database, metadata.savedQuestionsDatabase()].filter(
+      Boolean,
+    ) as Database[];
+  }, [databaseId, metadata]);
+
   return (
     <NotebookCellItem
       inactive={!table}
@@ -52,6 +66,7 @@ export function JoinTablePicker({
         title={t`Pick data to join`}
         query={query}
         stageIndex={stageIndex}
+        databases={databases}
         table={table}
         placeholder={t`Pick data…`}
         canChangeDatabase={false}

--- a/frontend/src/metabase/querying/notebook/components/JoinStep/JoinTablePicker/JoinTablePicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/JoinStep/JoinTablePicker/JoinTablePicker.tsx
@@ -1,13 +1,10 @@
 import type { CSSProperties, ReactNode } from "react";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { t } from "ttag";
 
 import IconButtonWrapper from "metabase/components/IconButtonWrapper";
-import { useSelector } from "metabase/lib/redux";
-import { getMetadata } from "metabase/selectors/metadata";
 import { Icon, Popover, Tooltip } from "metabase/ui";
-import * as Lib from "metabase-lib";
-import type { Database } from "metabase-types/api";
+import type * as Lib from "metabase-lib";
 
 import { NotebookCellItem } from "../../NotebookCell";
 import { CONTAINER_PADDING } from "../../NotebookCell/constants";
@@ -36,17 +33,6 @@ export function JoinTablePicker({
 }: JoinTablePickerProps) {
   const isDisabled = isReadOnly;
 
-  const metadata = useSelector(getMetadata);
-  const databaseId = useMemo(() => {
-    return Lib.databaseID(query);
-  }, [query]);
-  const databases = useMemo(() => {
-    const database = metadata.database(databaseId);
-    return [database, metadata.savedQuestionsDatabase()].filter(
-      Boolean,
-    ) as Database[];
-  }, [databaseId, metadata]);
-
   return (
     <NotebookCellItem
       inactive={!table}
@@ -66,7 +52,6 @@ export function JoinTablePicker({
         title={t`Pick data to join`}
         query={query}
         stageIndex={stageIndex}
-        databases={databases}
         table={table}
         placeholder={t`Pick data…`}
         canChangeDatabase={false}

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
@@ -19,7 +19,7 @@ import { getMetadata } from "metabase/selectors/metadata";
 import type { IconName } from "metabase/ui";
 import { Flex, Icon, Tooltip, UnstyledButton } from "metabase/ui";
 import * as Lib from "metabase-lib";
-import type { TableId } from "metabase-types/api";
+import type { Database, TableId } from "metabase-types/api";
 
 import {
   type NotebookContextType,
@@ -33,6 +33,7 @@ interface NotebookDataPickerProps {
   title: string;
   query: Lib.Query;
   stageIndex: number;
+  databases: Database[];
   table: Lib.TableMetadata | Lib.CardMetadata | undefined;
   placeholder?: string;
   canChangeDatabase: boolean;
@@ -48,6 +49,7 @@ export function NotebookDataPicker({
   title,
   query,
   stageIndex,
+  databases,
   table,
   placeholder = title,
   canChangeDatabase,
@@ -76,6 +78,7 @@ export function NotebookDataPicker({
       <EmbeddingDataPicker
         query={query}
         stageIndex={stageIndex}
+        databases={databases}
         table={table}
         placeholder={placeholder}
         canChangeDatabase={canChangeDatabase}
@@ -193,6 +196,7 @@ function ModernDataPicker({
 type LegacyDataPickerProps = {
   query: Lib.Query;
   stageIndex: number;
+  databases: Database[];
   table: Lib.TableMetadata | Lib.CardMetadata | undefined;
   placeholder: string;
   canChangeDatabase: boolean;
@@ -204,6 +208,7 @@ type LegacyDataPickerProps = {
 function EmbeddingDataPicker({
   query,
   stageIndex,
+  databases,
   table,
   placeholder,
   canChangeDatabase,
@@ -256,10 +261,13 @@ function EmbeddingDataPicker({
       />
     );
   }
+
   return (
     <DataSourceSelector
       key={pickerInfo?.tableId}
       isInitiallyOpen={!table}
+      databases={databases}
+      canChangeDatabase={canChangeDatabase}
       selectedDatabaseId={databaseId}
       selectedTableId={pickerInfo?.tableId}
       selectedCollectionId={card?.collection_id}

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
@@ -33,7 +33,7 @@ interface NotebookDataPickerProps {
   title: string;
   query: Lib.Query;
   stageIndex: number;
-  databases: Database[];
+  databases?: Database[];
   table: Lib.TableMetadata | Lib.CardMetadata | undefined;
   placeholder?: string;
   canChangeDatabase: boolean;
@@ -196,7 +196,7 @@ function ModernDataPicker({
 type LegacyDataPickerProps = {
   query: Lib.Query;
   stageIndex: number;
-  databases: Database[];
+  databases?: Database[];
   table: Lib.TableMetadata | Lib.CardMetadata | undefined;
   placeholder: string;
   canChangeDatabase: boolean;

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
@@ -237,7 +237,10 @@ function EmbeddingDataPicker({
   const databases = useMemo(() => {
     // We're joining data
     if (!canChangeDatabase) {
-      return [metadata.database(databaseId)];
+      return [
+        metadata.database(databaseId),
+        metadata.savedQuestionsDatabase(),
+      ].filter(Boolean);
     }
 
     /**


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/54127, EMB-181

### Description
This PR fixes 2 things.
1. We can select tables other than the source query table when joining. This issues happens after we brought back the picker for interactive embedding in https://github.com/metabase/metabase/pull/50535
2. We can select models/saved questions from a different DB than the selected database. This issue has existed since 49, the last version that this picker is used in Metabase for internal use cases before it was changed to the entity picker.

### How to verify

You can embed the app interactively and test it, but I'd just run Metabase locally and modify this function to return `true`
https://github.com/metabase/metabase/blob/f7f70649ba337d91b88cd44282945020c12e8e27/frontend/src/metabase/lib/dom.js#L16

And mock the embedding picker here by setting it to `false`, so it always returns the multi-stage data picker (old embedding picker), otherwise, the current logic is that you need to have at least 100 tables + models to fall back to the old multi-stage data picker.
https://github.com/metabase/metabase/blob/0b5e82ce41c6832fb1148b27d4a3c74651260859/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx#L241

1. Ensure you have more than 1 database, you can use the QA db for that, I recommend postgres.
    1.1 `docker compose -f ./e2e/test/scenarios/docker-compose.yml up -d`
    1.2 use this credential https://github.com/metabase/metabase/blob/f7f70649ba337d91b88cd44282945020c12e8e27/e2e/support/cypress_data.js#L177-L183
    1.3 for Postgres it's port 5404
1. Ensure you have at least a model from each database
2. Embed Metabase interactively, or mock the function above.
3. Set the URL to or go to `/question/notebook` if you decide to mock `dom.js`
4. Select a starting DB, ensure you can still select every data source (tables/models) from all databases
5. Select join, and ensure that only tables and models from the starting query database is selectable.

Or you could follow the test I modified in `e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js`, it's basically what I wrote above.

### Demo

#### After
- ![Screenshot 2025-02-26 at 6 34 46 PM](https://github.com/user-attachments/assets/2acf1f2a-a507-49b0-b792-85b6229c6659)
- ![Screenshot 2025-02-26 at 6 34 52 PM](https://github.com/user-attachments/assets/cb1e5c73-1aa8-4337-b193-8b2ada07370f)


#### Before
- ![Screenshot 2025-02-26 at 6 35 23 PM](https://github.com/user-attachments/assets/76c14566-c79a-4280-90e8-f0913bb903ce)
- ![Screenshot 2025-02-26 at 6 35 27 PM](https://github.com/user-attachments/assets/e4c42ceb-c392-45ed-a977-2b81d95b24e5)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
