### PR TITLE
Drop public channel requirement for slack images

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -11035,10 +11035,6 @@ redirect_from:
                   "slack-bug-report-channel" : {
                     "type" : "string"
                   },
-                  "slack-files-channel" : {
-                    "description" : "value must be a non-blank string.",
-                    "$ref" : "#/components/schemas/metabase.lib.schema.common~1non-blank-string"
-                  }
                 }
               }
             }

--- a/docs/configuring-metabase/config-template.md
+++ b/docs/configuring-metabase/config-template.md
@@ -238,7 +238,6 @@ config:
     site-url: null
     slack-app-token: null
     slack-bug-report-channel: metabase-bugs
-    slack-files-channel: metabase_files
     source-address-header: X-Forwarded-For
     sql-jdbc-fetch-size: 500
     sql-parsing-enabled: true

--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -1607,13 +1607,14 @@ Bot user OAuth token for connecting the Metabase Slack app. This should be used 
 
 The name of the channel where bug reports should be posted.
 
-### `MB_SLACK_FILES_CHANNEL`
+### `[DEPRECATED] MB_SLACK_FILES_CHANNEL`
 
 - Type: string
 - Default: `metabase_files`
 - [Configuration file name](./config-file.md): `slack-files-channel`
+- Deprecated since: `v0.54.0`
 
-The name of the channel to which Metabase files should be initially uploaded.
+The name of the channel to which Metabase files should be initially uploaded. Deprecated (and does nothing) starting with metabase v0.54.0.
 
 ### `MB_SOURCE_ADDRESS_HEADER`
 

--- a/docs/configuring-metabase/slack.md
+++ b/docs/configuring-metabase/slack.md
@@ -68,15 +68,9 @@ On the Slack site for your newly created app, in the **Settings** > **Basic Info
 
 On the Slack site page for your Slack app, on the left in the **Features** section, click on **OAuth and Permissions** in the Slack Apps sidebar and then copy the **Bot User OAuth Token**. Return to the Slack settings page in your Metabase and paste this token in the Metabase field with the same name.
 
-## Create a channel in your Slack to store image files
-
-In your Slack workspace, create a public channel named whatever you want — we think something like "metabase" does just fine — then enter that channel's name in the **Public channel to store image files** field in Metabase. We'll upload charts and tables here before sending out [dashboard subscriptions](../dashboards/subscriptions.md#slack-subscription-options). This allows your Metabase to post to your Slack workspace without having to deal with unnecessary permissions. Make sure the channel you create is the same channel that you enter in this field in Metabase (omit the "#" prefix).
-
-> If you rename the channel in Slack, you'll need to update the **Public channel to store image files** in Metabase to that new name. This channel does not have to be the same as the channel where you send dashboard subscriptions. It's only used for storing image files.
-
 ## Save your changes in Metabase
 
-In Metabase, click on the **Save changes** button and that’s it! Metabase will automatically run a quick test to check that the API token and your dedicated Slack channel are working properly. If something goes wrong, it'll give you an error message.
+In Metabase, click on the **Save changes** button and that’s it! Metabase will automatically run a quick test to check that the API token is working properly. If something goes wrong, it'll give you an error message.
 
 ## Sending alerts and subscriptions to private Slack channels
 
@@ -88,7 +82,7 @@ In Slack, go to the private channel and mention the Metabase app. For example, i
 
 It can take a little time for metabase to see all the channels the app has been invited to. New channels may not appear in listings for up to 10 minutes after inviting the app to the channel.
 
-In order for metabase to see private channels, the app must have the `groups:read` oauth scope. Although this scope should be granted when setting up the app through metabase, older installations might not have this scope. 
+In order for metabase to see private channels, the app must have the `groups:read` oauth scope. Although this scope should be granted when setting up the app through metabase, older installations might not have this scope.
 If you think this might be the case [visit the app settings in slack](https://api.slack.com/apps/):
 - Click on the metabase app in the app listing.
 - Click on **OAuth & Permissions** in the sidebar.

--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -301,9 +301,6 @@ H.describeWithSnowplow("scenarios > admin > settings", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Metabase on Slack");
       cy.findByLabelText("Slack Bot User OAuth Token").type("xoxb");
-      cy.findByLabelText("Public channel to store image files").type(
-        "metabase_files",
-      );
       cy.button("Save changes").click();
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -263,7 +263,6 @@ export const createMockSettings = (
   "site-url": "http://localhost:3000",
   "site-uuid": "1234",
   "slack-app-token": null,
-  "slack-files-channel": null,
   "slack-token": null,
   "slack-token-valid?": false,
   "start-of-week": "sunday",

--- a/frontend/src/metabase-types/api/mocks/slack.ts
+++ b/frontend/src/metabase-types/api/mocks/slack.ts
@@ -4,7 +4,6 @@ export const createMockSlackSettings = (
   opts?: Partial<SlackSettings>,
 ): SlackSettings => ({
   "slack-app-token": null,
-  "slack-files-channel": null,
   "slack-bug-report-channel": null,
   ...opts,
 });

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -329,7 +329,6 @@ interface SettingsManagerSettings {
   "session-cookie-samesite": SessionCookieSameSite;
   "slack-app-token": string | null;
   "slack-bug-report-channel": string | null;
-  "slack-files-channel": string | null;
   "slack-token": string | null;
   "slack-token-valid?": boolean;
 }

--- a/frontend/src/metabase-types/api/slack.ts
+++ b/frontend/src/metabase-types/api/slack.ts
@@ -1,5 +1,4 @@
 export interface SlackSettings {
   "slack-app-token": string | null;
-  "slack-files-channel": string | null;
   "slack-bug-report-channel": string | null;
 }

--- a/frontend/src/metabase/admin/settings/slack/components/SlackForm/SlackForm.styled.tsx
+++ b/frontend/src/metabase/admin/settings/slack/components/SlackForm/SlackForm.styled.tsx
@@ -1,7 +1,0 @@
-// eslint-disable-next-line no-restricted-imports
-import styled from "@emotion/styled";
-
-export const SlackFormMessage = styled.div`
-  color: var(--mb-color-text-medium);
-  margin: 2rem 0 1rem;
-`;

--- a/frontend/src/metabase/admin/settings/slack/components/SlackForm/SlackForm.tsx
+++ b/frontend/src/metabase/admin/settings/slack/components/SlackForm/SlackForm.tsx
@@ -14,10 +14,6 @@ import { SlackFormMessage } from "./SlackForm.styled";
 
 const SLACK_SCHEMA = Yup.object({
   "slack-app-token": Yup.string().ensure().required(Errors.required),
-  "slack-files-channel": Yup.string()
-    .ensure()
-    .required(Errors.required)
-    .lowercase(),
   "slack-bug-report-channel": Yup.string()
     .nullable()
     .default(null)
@@ -61,13 +57,6 @@ const SlackForm = ({
             {SLACK_CHANNEL_PROMPT} {SLACK_CHANNEL_DESCRIPTION}
           </SlackFormMessage>
         )}
-        <FormInput
-          name="slack-files-channel"
-          title={t`Public channel to store image files`}
-          description={isReadOnly ? SLACK_CHANNEL_DESCRIPTION : undefined}
-          placeholder="metabase_files"
-          readOnly={isReadOnly}
-        />
         {isBugReportingEnabled && (
           <FormInput
             name="slack-bug-report-channel"

--- a/frontend/src/metabase/admin/settings/slack/components/SlackForm/SlackForm.tsx
+++ b/frontend/src/metabase/admin/settings/slack/components/SlackForm/SlackForm.tsx
@@ -10,8 +10,6 @@ import { Form, FormProvider } from "metabase/forms";
 import * as Errors from "metabase/lib/errors";
 import type { SlackSettings } from "metabase-types/api";
 
-import { SlackFormMessage } from "./SlackForm.styled";
-
 const SLACK_SCHEMA = Yup.object({
   "slack-app-token": Yup.string().ensure().required(Errors.required),
   "slack-bug-report-channel": Yup.string()
@@ -52,11 +50,6 @@ const SlackForm = ({
           placeholder="xoxb-781236542736-2364535789652-GkwFDQoHqzXDVsC6GzqYUypD"
           readOnly={isReadOnly}
         />
-        {!isReadOnly && (
-          <SlackFormMessage>
-            {SLACK_CHANNEL_PROMPT} {SLACK_CHANNEL_DESCRIPTION}
-          </SlackFormMessage>
-        )}
         {isBugReportingEnabled && (
           <FormInput
             name="slack-bug-report-channel"
@@ -77,8 +70,6 @@ const SlackForm = ({
   );
 };
 
-const SLACK_CHANNEL_PROMPT = t`Finally, open Slack, create a public channel and enter its name below.`;
-const SLACK_CHANNEL_DESCRIPTION = t`This channel shouldn't really be used by anyone — we'll upload charts and tables here before sending out dashboard subscriptions (it's a Slack requirement).`;
 const SLACK_BUG_REPORT_DESCRIPTION = t`This channel will receive bug reports submitted by users.`;
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage

--- a/frontend/src/metabase/admin/settings/slack/components/SlackSetupForm/SlackSetupForm.tsx
+++ b/frontend/src/metabase/admin/settings/slack/components/SlackSetupForm/SlackSetupForm.tsx
@@ -4,7 +4,6 @@ import SlackForm from "../SlackForm";
 
 const DEFAULT_SETTINGS: SlackSettings = {
   "slack-app-token": "",
-  "slack-files-channel": "",
   "slack-bug-report-channel": "",
 };
 

--- a/frontend/src/metabase/admin/settings/slack/selectors.ts
+++ b/frontend/src/metabase/admin/settings/slack/selectors.ts
@@ -5,7 +5,6 @@ import type { State } from "metabase-types/store";
 export const getSlackSettings = (state: State): SlackSettings => {
   return {
     "slack-app-token": getSetting(state, "slack-app-token"),
-    "slack-files-channel": getSetting(state, "slack-files-channel"),
     "slack-bug-report-channel": getSetting(state, "slack-bug-report-channel"),
   };
 };

--- a/src/metabase/api/slack.clj
+++ b/src/metabase/api/slack.clj
@@ -155,12 +155,9 @@
                                          ;; TODO FIXME -- this should not use `camelCase` keys
                                          [:diagnosticInfo map?]]]
   (try
-    (let [files-channel (slack/files-channel)
-          bug-report-channel (slack/bug-report-channel)
+    (let [bug-report-channel (slack/bug-report-channel)
           file-content (.getBytes (json/encode diagnostic-info {:pretty true}))
-          file-info (slack/upload-file! file-content
-                                        "diagnostic-info.json"
-                                        files-channel)
+          file-info (slack/upload-file! file-content "diagnostic-info.json")
           blocks (create-slack-message-blocks diagnostic-info file-info)]
       (slack/post-chat-message!
        bug-report-channel

--- a/src/metabase/api/slack.clj
+++ b/src/metabase/api/slack.clj
@@ -83,10 +83,9 @@
   3. truthy, valid token   -> refresh "
   [_route-params
    _query-params
-   {:keys [slack-app-token slack-files-channel slack-bug-report-channel]}
+   {:keys [slack-app-token slack-bug-report-channel]}
    :- [:map
        [:slack-app-token          {:optional true} [:maybe ms/NonBlankString]]
-       [:slack-files-channel      {:optional true} [:maybe ms/NonBlankString]]
        [:slack-bug-report-channel {:optional true} [:maybe :string]]]]
   (validation/check-has-application-permission :setting)
   (try
@@ -94,9 +93,6 @@
     (when (nil? slack-app-token)
       (slack/slack-app-token! nil)
       (slack/clear-channel-cache!))
-
-    (when (nil? slack-files-channel)
-      (slack/slack-files-channel! "metabase_files"))
 
     (when (and slack-app-token
                (not config/is-test?)
@@ -113,18 +109,6 @@
           (slack/refresh-channels-and-usernames-when-needed!))
       ;; clear user/conversation cache when token is newly empty
       (slack/clear-channel-cache!))
-
-    (when slack-files-channel
-      (let [processed-files-channel (slack/process-files-channel-name slack-files-channel)]
-        (when-not (slack/channel-exists? processed-files-channel)
-          ;; Files channel could not be found; clear the token we had previously set since the integration should not be
-          ;; enabled.
-          (slack/slack-token-valid?! false)
-          (slack/slack-app-token! nil)
-          (slack/clear-channel-cache!)
-          (throw (ex-info (tru "Slack channel not found.")
-                          {:errors {:slack-files-channel (tru "channel not found")}})))
-        (slack/slack-files-channel! processed-files-channel)))
 
     (when slack-bug-report-channel
       (let [processed-bug-channel (slack/process-files-channel-name slack-bug-report-channel)]

--- a/src/metabase/channel/impl/slack.clj
+++ b/src/metabase/channel/impl/slack.clj
@@ -17,6 +17,15 @@
   (when (= (:type notification-recipient) :notification-recipient/raw-value)
     (-> notification-recipient :details :value)))
 
+(defn- escape-mkdwn
+  "Escapes slack mkdwn special characters in the string, as specified here:
+  https://api.slack.com/reference/surfaces/formatting."
+  [s]
+  (-> s
+      (str/replace "&" "&amp;")
+      (str/replace "<" "&lt;")
+      (str/replace ">" "&gt;")))
+
 (defn- truncate-mrkdwn
   "If a mrkdwn string is greater than Slack's length limit, truncates it to fit the limit and
   adds an ellipsis character to the end."
@@ -75,7 +84,8 @@
                               (if (:render/text rendered-info)
                                 {:blocks [{:type "section"
                                            :text {:type "mrkdwn"
-                                                  :text (format "<%s|%s>" title_link title)}}
+                                                  :text (format "<%s|%s>" title_link (escape-mkdwn title))
+                                                  :verbatim true}}
                                           {:type "section"
                                            :text {:type "plain_text"
                                                   :text (:render/text rendered-info)}}]}
@@ -83,7 +93,8 @@
                                       {file-id :id} (slack/upload-file! image-bytes attachment-name)]
                                   {:blocks [{:type "section"
                                              :text {:type "mrkdwn"
-                                                    :text (format "<%s|%s>" title_link title)}}
+                                                    :text (format "<%s|%s>" title_link (escape-mkdwn title))
+                                                    :verbatim true}}
                                             {:type "image"
                                              :slack_file {:id file-id}
                                              :alt_text title}]})))))

--- a/src/metabase/channel/impl/slack.clj
+++ b/src/metabase/channel/impl/slack.clj
@@ -99,8 +99,11 @@
 
 (mu/defmethod channel/send! :channel/slack
   [_channel message :- SlackMessage]
-  (let [{:keys [channel-id attachments]} message]
-    (slack/post-chat-message! channel-id nil (create-and-upload-slack-attachments! attachments))))
+  (let [{:keys [channel-id attachments]} message
+        message-content (create-and-upload-slack-attachments! attachments)
+        blocks (mapcat :blocks message-content)]
+    (doseq [block-chunk (partition-all 50 blocks)]
+      (slack/post-chat-message! channel-id nil [{:blocks block-chunk}]))))
 
 ;; ------------------------------------------------------------------------------------------------;;
 ;;                                      Notification Card                                          ;;

--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -360,10 +360,9 @@
           (complete!)
           (catch Throwable e
             (throw (ex-info (ex-message e) (assoc (ex-data e) :filename filename)))))
-        uploaded? (fn [file] (seq (:filetype file)))
-        thunk     (fn [] (:file (GET "files.info" {:file file-id})))
-        _ (when-not (or (uploaded? (first (:files complete-response)))
-                        (u/poll {:thunk thunk
+        uploaded? (fn [complete-response] (seq (get-in complete-response [:files 0 :filetype])))
+        _ (when-not (or (uploaded? complete-response)
+                        (u/poll {:thunk complete!
                                  :done? uploaded?
                                  ;; Cal 2024-04-30: this typically takes 1-2 seconds to succeed.
                                  ;; If it takes more than 20 seconds, something else is wrong and we should abort.

--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -311,22 +311,6 @@
       (when (needs-refresh?)
         (refresh-channels-and-usernames!)))))
 
-(defn files-channel
-  "Looks in [[slack-cached-channels-and-usernames]] to check whether a channel exists with the expected name from the
-  [[slack-files-channel]] setting with an # prefix. If it does, returns the channel details as a map. If it doesn't,
-  throws an error that advises an admin to create it."
-  []
-  (let [channel-name (slack-files-channel)]
-    (if (channel-exists? channel-name)
-      channel-name
-      (let [message (str (tru "Slack channel named `{0}` is missing!" channel-name)
-                         " "
-                         (tru "Please create or unarchive the channel in order to complete the Slack integration.")
-                         " "
-                         (tru "The channel is used for storing images that are included in dashboard subscriptions."))]
-        (log/error (u/format-color 'red message))
-        (throw (ex-info message {:status-code 400}))))))
-
 (defn bug-report-channel
   "Looks in [[slack-cached-channels-and-usernames]] to check whether a channel exists with the expected name from the
   [[slack-bug-report-channel]] setting with an # prefix. If it does, returns the channel details as a map. If it doesn't,

--- a/test/metabase/api/slack_test.clj
+++ b/test/metabase/api/slack_test.clj
@@ -137,8 +137,7 @@
         (with-redefs [slack/upload-file! (constantly mock-file-info)
                       slack/post-chat-message! (constantly nil)
                       slack/channel-exists? (constantly true)]
-          (mt/with-temporary-setting-values [slack-files-channel "test-files"
-                                             slack-bug-report-channel "test-bugs"]
+          (mt/with-temporary-setting-values [slack-bug-report-channel "test-bugs"]
             (let [response (mt/user-http-request :crowberto :post 200 "slack/bug-report"
                                                  {:diagnosticInfo diagnostic-info})]
               (is (= expected-blocks (#'api.slack/create-slack-message-blocks diagnostic-info mock-file-info)))
@@ -150,8 +149,7 @@
         (with-redefs [slack/upload-file! (constantly mock-file-info)
                       slack/post-chat-message! (constantly nil)
                       slack/channel-exists? (constantly true)]
-          (mt/with-temporary-setting-values [slack-files-channel "test-files"
-                                             slack-bug-report-channel "test-bugs"]
+          (mt/with-temporary-setting-values [slack-bug-report-channel "test-bugs"]
             (let [anonymous-info (dissoc diagnostic-info :reporter)
                   anonymous-blocks (walk/postwalk
                                     (fn [m] (if (and (map? m) (= (:type m) "link") (str/starts-with? (:url m) "mailto:"))

--- a/test/metabase/api/slack_test.clj
+++ b/test/metabase/api/slack_test.clj
@@ -37,47 +37,20 @@
             (is (= {:channels []}
                    (slack/slack-cached-channels-and-usernames)))))))
 
-    (testing "The Slack files channel setting can be set by an admin, and the leading # is stripped if it is present"
-      (mt/with-temporary-setting-values [slack-files-channel                       nil
-                                         slack-channels-and-usernames-last-updated nil]
-        (with-redefs [slack/channel-exists? (constantly true)]
-          (mt/user-http-request :crowberto :put 200 "slack/settings" {:slack-files-channel "fake-channel"})
-          (is (= "fake-channel" (slack/slack-files-channel)))
-
-          (mt/user-http-request :crowberto :put 200 "slack/settings" {:slack-files-channel "#fake-channel"})
-          (is (= "fake-channel" (slack/slack-files-channel))))))
-
-    (testing "An error is returned if the Slack files channel cannot be found, and the integration is not enabled"
-      (with-redefs [slack/channel-exists?                             (constantly nil)
-                    slack/valid-token?                                (constantly true)
-                    slack/refresh-channels-and-usernames!             (constantly nil)
-                    slack/refresh-channels-and-usernames-when-needed! (constantly nil)]
-        (let [response (mt/user-http-request :crowberto :put 400 "slack/settings"
-                                             {:slack-files-channel "fake-channel"
-                                              :slack-app-token     "fake-token"})]
-          (is (= {:slack-files-channel "channel not found"} (:errors response)))
-          (is (nil? (slack/slack-app-token)))
-          (is (= "metabase_files" (slack/slack-files-channel))))))
-
-    (testing "The Slack app token or files channel settings are cleared if no value is sent in the request"
+    (testing "The Slack app token and channel settings are cleared if no value is sent in the request"
       (mt/with-temporary-setting-values [slack-app-token                                 "fake-token"
-                                         slack-files-channel                             "fake-channel"
                                          slack/slack-cached-channels-and-usernames       ["fake_channel"]
                                          slack/slack-channels-and-usernames-last-updated (t/zoned-date-time)]
         (mt/user-http-request :crowberto :put 200 "slack/settings" {})
         (is (= nil (slack/slack-app-token)))
-        ;; The files channel is reset to its default value
-        (is (= "metabase_files" (slack/slack-files-channel)))
         ;; The cache is empty, and its last-updated value is reset to its default value
         (is (= {:channels []}
                (slack/slack-cached-channels-and-usernames)))
         (is (= @#'slack/zoned-time-epoch (slack/slack-channels-and-usernames-last-updated)))))
 
-    (testing "A non-admin cannot modify the Slack app token or files channel settings"
+    (testing "A non-admin cannot modify the Slack app token"
       (mt/user-http-request :rasta :put 403 "slack/settings"
-                            {:slack-app-token "fake-token"})
-      (mt/user-http-request :rasta :put 403 "slack/settings"
-                            {:slack-files-channel "fake-channel"}))))
+                            {:slack-app-token "fake-token"}))))
 
 (deftest manifest-test
   (testing "GET /api/slack/manifest"

--- a/test/metabase/channel/impl/slack_test.clj
+++ b/test/metabase/channel/impl/slack_test.clj
@@ -26,7 +26,7 @@
                              :rendered-info   {:attachments nil
                                                :content     [:div "hi again"]}}]
             processed      (with-redefs [slack/upload-file! (slack-uploader titles)]
-                             (#'channel.slack/create-and-upload-slack-attachments! attachments))]
+                             (mapv #'channel.slack/create-and-upload-slack-attachment! attachments))]
         (is (= [{:blocks [{:type "section"
                            :text {:type "mrkdwn", :text "<a.com|a>", :verbatim true}}
                           {:type "image"
@@ -53,7 +53,7 @@
                                                :content     [:div "hi again"]
                                                :render/text "hi again"}}]
             processed      (with-redefs [slack/upload-file! (slack-uploader titles)]
-                             (#'channel.slack/create-and-upload-slack-attachments! attachments))]
+                             (mapv #'channel.slack/create-and-upload-slack-attachment! attachments))]
         (is (= [{:blocks [{:type "section"
                            :text {:text "<a.com|a>", :type "mrkdwn", :verbatim true}}
                           {:type "image"
@@ -96,7 +96,7 @@
                                             :content     [:div "hi again"]
                                             :render/text "hi again"}}]
             processed   (with-redefs [slack/upload-file! mock-upload-file!]
-                          (#'channel.slack/create-and-upload-slack-attachments! attachments))]
+                          (mapv #'channel.slack/create-and-upload-slack-attachment! attachments))]
         (is (= [{:blocks [{:type "section"
                            :text {:type "mrkdwn", :text "<a.com|&amp;amp;a>", :verbatim true}}
                           {:type "image"

--- a/test/metabase/channel/impl/slack_test.clj
+++ b/test/metabase/channel/impl/slack_test.clj
@@ -6,37 +6,48 @@
 
 (deftest create-and-upload-slack-attachments!-test
   (let [slack-uploader (fn [storage]
-                         (fn [_bytes attachment-name _channel-id]
+                         (fn [_bytes attachment-name]
                            (swap! storage conj attachment-name)
                            {:url (str "http://uploaded/" attachment-name)
                             :id (str "ID_" attachment-name)}))]
     (testing "Uploads files"
       (let [titles         (atom [])
             attachments    [{:title           "a"
+                             :title_link      "a.com"
                              :attachment-name "a.png"
                              :rendered-info   {:attachments nil
                                                :content     [:div "hi"]}
                              :channel-id      "FOO"}
                             {:title           "b"
+                             :title_link      "b.com"
                              :attachment-name "b.png"
                              :rendered-info   {:attachments nil
                                                :content     [:div "hi again"]}
                              :channel-id      "FOO"}]
             processed      (with-redefs [slack/upload-file! (slack-uploader titles)]
                              (#'channel.slack/create-and-upload-slack-attachments! attachments))]
-        (is (= [{:title "a", :image_url "http://uploaded/a.png"}
-                {:title "b", :image_url "http://uploaded/b.png"}]
+        (is (= [{:blocks [{:type "section"
+                           :text {:type "mrkdwn", :text "<a.com|a>"}}
+                          {:type "image"
+                           :alt_text "a",
+                           :slack_file {:id "ID_a.png"}}]}
+                {:blocks [{:type "section" :text {:type "mrkdwn", :text "<b.com|b>"}}
+                          {:type "image"
+                           :alt_text "b",
+                           :slack_file {:id "ID_b.png"}}]}]
                processed))
         (is (= ["a.png" "b.png"]
                @titles))))
     (testing "Uses the raw text when present"
       (let [titles         (atom [])
             attachments    [{:title           "a"
+                             :title_link      "a.com"
                              :attachment-name "a.png"
                              :rendered-info   {:attachments nil
                                                :content     [:div "hi"]}
                              :channel-id      "FOO"}
                             {:title           "b"
+                             :title_link      "b.com"
                              :attachment-name "b.png"
                              :rendered-info   {:attachments nil
                                                :content     [:div "hi again"]
@@ -44,8 +55,15 @@
                              :channel-id      "FOO"}]
             processed      (with-redefs [slack/upload-file! (slack-uploader titles)]
                              (#'channel.slack/create-and-upload-slack-attachments! attachments))]
-        (is (= [{:title "a", :image_url "http://uploaded/a.png"}
-                {:title "b", :text "hi again"}]
+        (is (= [{:blocks [{:type "section"
+                           :text {:text "<a.com|a>", :type "mrkdwn"}}
+                          {:type "image"
+                           :alt_text "a",
+                           :slack_file {:id "ID_a.png"}}]}
+                {:blocks [{:type "section"
+                           :text {:text "<b.com|b>", :type "mrkdwn"}}
+                          {:type "section"
+                           :text {:type "plain_text", :text "hi again"}}]}]
                processed))
         (is (= ["a.png"]
                @titles))))))

--- a/test/metabase/channel/impl/slack_test.clj
+++ b/test/metabase/channel/impl/slack_test.clj
@@ -16,14 +16,12 @@
                              :title_link      "a.com"
                              :attachment-name "a.png"
                              :rendered-info   {:attachments nil
-                                               :content     [:div "hi"]}
-                             :channel-id      "FOO"}
+                                               :content     [:div "hi"]}}
                             {:title           "b"
                              :title_link      "b.com"
                              :attachment-name "b.png"
                              :rendered-info   {:attachments nil
-                                               :content     [:div "hi again"]}
-                             :channel-id      "FOO"}]
+                                               :content     [:div "hi again"]}}]
             processed      (with-redefs [slack/upload-file! (slack-uploader titles)]
                              (#'channel.slack/create-and-upload-slack-attachments! attachments))]
         (is (= [{:blocks [{:type "section"
@@ -44,15 +42,13 @@
                              :title_link      "a.com"
                              :attachment-name "a.png"
                              :rendered-info   {:attachments nil
-                                               :content     [:div "hi"]}
-                             :channel-id      "FOO"}
+                                               :content     [:div "hi"]}}
                             {:title           "b"
                              :title_link      "b.com"
                              :attachment-name "b.png"
                              :rendered-info   {:attachments nil
                                                :content     [:div "hi again"]
-                                               :render/text "hi again"}
-                             :channel-id      "FOO"}]
+                                               :render/text "hi again"}}]
             processed      (with-redefs [slack/upload-file! (slack-uploader titles)]
                              (#'channel.slack/create-and-upload-slack-attachments! attachments))]
         (is (= [{:blocks [{:type "section"

--- a/test/metabase/dashboard_subscription_test.clj
+++ b/test/metabase/dashboard_subscription_test.clj
@@ -349,7 +349,6 @@
                                        :content     true}
                      :title_link      (str "https://testmb.com/question/" card-id)
                      :attachment-name "image.png"
-                     :channel-id      "FOO"
                      :fallback        pulse.test-util/card-name}]}
                   (pulse.test-util/thunk->boolean pulse-results))))
          (testing "attached-results-text should be invoked exactly once"
@@ -398,7 +397,6 @@
                    :rendered-info   {:attachments false, :content true, :render/text true},
                    :title_link      (str "https://testmb.com/question/" card-id)
                    :attachment-name "image.png"
-                   :channel-id      "FOO"
                    :fallback        pulse.test-util/card-name}
                   {:blocks [{:type "section" :text {:type "mrkdwn" :text "*header*"}}]}]}
                 (pulse.test-util/thunk->boolean pulse-results)))))}}))
@@ -444,7 +442,6 @@
                    :rendered-info   {:attachments false, :content true, :render/text true},
                    :title_link      (str "https://testmb.com/question/" card-id)
                    :attachment-name "image.png"
-                   :channel-id      "FOO"
                    :fallback        pulse.test-util/card-name}
                   {:blocks [{:type "section" :text {:type "mrkdwn" :text "*# header, quote isn't escaped*"}}]}]}
                 (pulse.test-util/thunk->boolean pulse-results)))))}}))
@@ -492,7 +489,6 @@
                      :rendered-info   {:attachments false, :content true, :render/text true},
                      :title_link      (str "https://testmb.com/question/" card-id)
                      :attachment-name "image.png"
-                     :channel-id      "FOO"
                      :fallback        pulse.test-util/card-name}]}
                   (pulse.test-util/thunk->boolean pulse-results)))))}})))
 
@@ -561,7 +557,6 @@
                   :rendered-info {:attachments false, :content true, :render/text true},
                   :title_link #"https://testmb.com/question/.+",
                   :attachment-name "image.png",
-                  :channel-id "FOO",
                   :fallback "Test card"}
                  {:blocks
                   [{:type "section",
@@ -972,7 +967,6 @@
                   :rendered-info {:attachments false, :content true, :render/text true},
                   :title_link #"https://testmb.com/question/.+",
                   :attachment-name "image.png",
-                  :channel-id "FOO",
                   :fallback "Test card"}
                  {:blocks [{:type "section", :text {:type "mrkdwn", :text "Card 1 tab-1"}}]}
                  {:blocks [{:type "section", :text {:type "mrkdwn", :text "Card 2 tab-1"}}]}

--- a/test/metabase/integrations/slack_test.clj
+++ b/test/metabase/integrations/slack_test.clj
@@ -175,28 +175,10 @@
               (is (= expected-result
                      (slack/users-list))))))))))
 
-(deftest files-channel-test
-  (testing "files-channel"
-    (testing "Should be able to get the files-channel from the cache (if it exists)"
-      (tu/with-temporary-setting-values [slack-files-channel "general"
-                                         slack-cached-channels-and-usernames
-                                         {:channels (mapv (fn [c] {:name c :id c})
-                                                          ["general" "random" "off-topic"
-                                                           "cooking" "john" "james" "jordan"])}]
-        (is (= "general" (slack/files-channel))))
-      (tu/with-temporary-setting-values [slack-files-channel "not_in_the_cache"
-                                         slack-cached-channels-and-usernames
-                                         {:channels [{:name "general" :id "C0G9QKBBL"}]}]
-        (is (thrown-with-msg?
-             clojure.lang.ExceptionInfo
-             #"Slack channel named.*is missing.*"
-             (slack/files-channel)))))))
-
 (deftest upload-file!-test
   (testing "upload-file!"
     (let [image-bytes (.getBytes "fake-picture")
           filename    "wow.gif"
-          channel-id  "C13372B6X"
           upload-url  "https://files.slack.com/upload/v1/CwABAAAAWgoAAZnBg"
           fake-upload-routes {#"^https://slack.com/api/files\.getUploadURLExternal.*"
                               (fn [_] (mock-200-response {:ok         true
@@ -213,7 +195,7 @@
                                            slack-app-token nil]
           (is (= {:url "https://files.slack.com/files-pri/DDDDDDDDD-EEEEEEEEE/wow.gif"
                   :id "DDDDDDDDD-EEEEEEEEE"}
-                 (slack/upload-file! image-bytes filename channel-id)))))
+                 (slack/upload-file! image-bytes filename)))))
       ;; Slack app token requires joining the `metabase_files` channel before uploading a file
       (http-fake/with-fake-routes
         (assoc fake-upload-routes
@@ -223,67 +205,7 @@
                                            slack-app-token "test-token"]
           (is (= {:url "https://files.slack.com/files-pri/DDDDDDDDD-EEEEEEEEE/wow.gif"
                   :id "DDDDDDDDD-EEEEEEEEE"}
-                 (slack/upload-file! image-bytes filename channel-id))))
-        (testing (str "upload-file! will attempt to join channels by internal slack id"
-                      " but we can continue to use the channel name for posting")
-          (let [filename    "wow.gif"
-                channel-id  "metabase_files"
-                slack-id    "CQXPZKNQ3RK"
-                joined?     (atom false)
-                channel-info [{:display-name "#random",
-                               :name "random",
-                               :id "CT2FNGZSRPL",
-                               :type "channel"}
-                              {:display-name "#general",
-                               :name "general",
-                               :id "C4Q6LXLRA46",
-                               :type "channel"}
-                              {:display-name "#metabase_files",
-                               :name channel-id,
-                               ;; must look up "metabase_files" and find the id below
-                               :id slack-id,
-                               :type "channel"}]
-                post          (var-get #'slack/POST)]
-            (with-redefs [slack/POST (fn [endpoint payload]
-                                       (case endpoint
-                                         "files.completeUploadExternal"
-                                         (if @joined?
-                                           (json/decode+kw (slurp "./test_resources/slack_upload_file_response.json"))
-                                           (throw (ex-info "Not in that channel"
-                                                           {:error-code "not_in_channel"})))
-                                         "conversations.join"
-                                         (reset! joined? (= (-> payload :form-params :channel)
-                                                            slack-id))
-                                         (post endpoint payload)))]
-              (tu/with-temporary-setting-values [slack/slack-app-token "slack-configured?"
-                                                 slack/slack-cached-channels-and-usernames
-                                                 {:channels channel-info}]
-                (slack/upload-file! (.getBytes "fake-picture") filename channel-id)
-                (is @joined? (str "Did not attempt to join with slack-id " slack-id))))))))))
-
-(deftest maybe-lookup-id-test
-  (let [f (var-get #'slack/maybe-lookup-id)]
-    (testing "On new v2 shape"
-      (testing "Returns original if not found"
-        (is (= "needle"
-               (f "needle" {:channels [{:display-name "#other1"
-                                        :name         "other1"
-                                        :type         "channel"
-                                        :id           "CR65C4ZJVIW"}
-                                       {:display-name "#other2"
-                                        :name         "other2"
-                                        :type         "channel"
-                                        :id           "C87LQNL0Y23"}]}))))
-      (testing "Returns the slack internal id if found"
-        (is (= "slack-id"
-               (f "needle" {:channels [{:display-name "#other1"
-                                        :name         "other1"
-                                        :type         "channel"
-                                        :id           "CR65C4ZJVIW"}
-                                       {:display-name "#needle"
-                                        :name         "needle"
-                                        :type         "channel"
-                                        :id           "slack-id"}]})))))))
+                 (slack/upload-file! image-bytes filename))))))))
 
 (deftest post-chat-message!-test
   (testing "post-chat-message!"

--- a/test/metabase/notification/payload/impl/card_test.clj
+++ b/test/metabase/notification/payload/impl/card_test.clj
@@ -74,7 +74,6 @@
                                                            :type "plain_text"}
                                                     :type "header"}]}
                                          {:attachment-name "image.png"
-                                          :channel-id "FOO"
                                           :fallback "Card notification test card",
                                           :rendered-info {:attachments false
                                                           :content true
@@ -129,7 +128,6 @@
                                                    :type "plain_text"}
                                             :type "header"}]}
                                  {:attachment-name "image.png"
-                                  :channel-id "FOO"
                                   :fallback "Card notification test card"
                                   :rendered-info {:attachments false :content true}
                                   :title "Card notification test card"}]

--- a/test/metabase/notification/test_util.clj
+++ b/test/metabase/notification/test_util.clj
@@ -7,7 +7,6 @@
    [metabase.channel.core :as channel]
    [metabase.channel.email :as email]
    [metabase.events.notification :as events.notification]
-   [metabase.integrations.slack :as slack]
    [metabase.notification.core :as notification]
    [metabase.notification.models :as models.notification]
    [metabase.notification.payload.core :as notification.payload]
@@ -187,8 +186,7 @@
                                                                  email-smtp-port 587
                                                                  site-url        "https://testmb.com/"]
                                 (thunk)))
-   :channel/slack (fn [thunk] (with-redefs [slack/files-channel (constantly "FOO")]
-                                (thunk)))})
+   :channel/slack (fn [thunk] (thunk))})
 
 (defn apply-channel-fixtures
   [channel-types thunk]

--- a/test/metabase/pulse/send_test.clj
+++ b/test/metabase/pulse/send_test.clj
@@ -714,8 +714,7 @@
 
 (def ^:private fake-slack-notification
   {:channel-id  "#test-channel"
-   :message     "test message body"
-   :attachments []})
+   :attachments [{:blocks [{:type "section", :text {:type "plain_text", :text ""}}]}]})
 
 (deftest slack-notification-retry-test
   (notification.tu/with-send-notification-sync

--- a/test/metabase/pulse/send_test.clj
+++ b/test/metabase/pulse/send_test.clj
@@ -203,7 +203,6 @@
                                    :content     true}
                  :title_link      (str "https://testmb.com/question/" card-id)
                  :attachment-name "image.png"
-                 :channel-id      "FOO"
                  :fallback        pulse.test-util/card-name}]}
               (pulse.test-util/thunk->boolean pulse-results))))
 
@@ -263,7 +262,6 @@
                                               :content     true}
                             :title_link      (str "https://testmb.com/question/" card-id)
                             :attachment-name "image.png"
-                            :channel-id      "FOO"
                             :fallback        pulse.test-util/card-name}]}
                          (pulse.test-util/thunk->boolean pulse-results))))
                 (testing "attached-results-text should be invoked exactly once"
@@ -404,7 +402,6 @@
                                                          :content     true}
                                        :title_link      (str "https://testmb.com/question/" card-id)
                                        :attachment-name "image.png"
-                                       :channel-id      "FOO"
                                        :fallback        pulse.test-util/card-name}]}
                        (pulse.test-util/thunk->boolean result)))
                 (is (every? produces-bytes? (rest (:attachments result)))))}}

--- a/test/metabase/pulse/test_util.clj
+++ b/test/metabase/pulse/test_util.clj
@@ -2,7 +2,6 @@
   (:require
    [medley.core :as m]
    [metabase.channel.core :as channel]
-   [metabase.integrations.slack :as slack]
    [metabase.notification.payload.execute :as notification.payload.execute]
    [metabase.notification.test-util :as notification.tu]
    [metabase.pulse.send :as pulse.send]
@@ -64,8 +63,7 @@
 (defmacro slack-test-setup!
   "Macro that ensures test-data is present and disables sending of all notifications"
   [& body]
-  `(with-redefs [channel/send!       (constantly :noop)
-                 slack/files-channel (constantly "FOO")]
+  `(with-redefs [channel/send!       (constantly :noop)]
      (do-with-site-url! (fn [] ~@body))))
 
 (defmacro with-captured-channel-send-messages!


### PR DESCRIPTION
Previously, before a file could be embedded in a bot post (e.g. images in a dashboard subscription post), it first had to be uploaded to the slack-files-channel. This PR makes it so that the slack-files-channel is no longer necessary, and images can be embedded directly in posts without additional ceremony.

When setting up the slack integration, users no longer need to specify a files channel name. They now only need provide the oauth token.

To be clear, if this PR is merged we will no longer post images to the configured files channel - so if users somehow depend on that (not only the dashboard/alert posts themselves, but the file post) then we might break them. On balance I consider this unlikely enough that the additional complexity required to support any such use cases would not be worth it. 

This has a few advantages:

- Fewer requirements of users to get started with slack, less likely to bounce off due to confusion etc
- Privacy and security is improved
  e.g say you had a dashboard of employee stats, salary, sick days etc - you might hesitate setting up a subscription because all your slack users would be able to see the dashboard images.
- Less complexity, tests, documentation needed
- We could not get private channels to work as a files channel, this bypasses that problem.

> **downgrades note** This is a code only change, the setting is not deleted from existing instances, so if downgraded - the slack integration will start using the files channel again. If a new slack installation (that has never used the files channel) is downgraded, then the files channel will need to be added before the integration works again.

Closes https://github.com/metabase/metabase/issues/53319

Closes WRK-59

### Description

This is made possible by dropping the legacy slack 'attachment' used for images, and instead utilising the blockkit `image` element, which permits [sending private files directly](https://slack.com/intl/en-gb/blog/developers/uploading-private-images-blockkit) using the `slack_file` field.

For large dashboards, more than one slack post will be made per notification, to work around block limits (50 per message).

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Setup a new slack integration
   - admin settings
   - notifications
   - create slack app (I used my own slack developer workspace)

2. Create a dashboard

3. Test a subscription
   - click on sharing
   - click on subscriptions
   - click 'send it to slack'
   - choose a channel to post to (private or public is fine)
   - click send to slack now

4. Observe the post in slack, image is shared directly without posting to a files channel

### Checklist

- [x] Tests have been added/updated to cover changes in this PR.