### PR TITLE
fix(sdk): add forwardRef to remove 'Function components cannot be given

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentStylesWrapper.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentStylesWrapper.tsx
@@ -1,6 +1,7 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import type React from "react";
+import { forwardRef } from "react";
 
 import { saveDomImageStyles } from "metabase/visualizations/lib/save-chart-image";
 
@@ -35,18 +36,21 @@ const PublicComponentStylesWrapperInner = styled.div`
   ${saveDomImageStyles}
 `;
 
-export const PublicComponentStylesWrapper = (
-  props: React.ComponentProps<"div">,
-) => {
+export const PublicComponentStylesWrapper = forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div">
+>(function PublicComponentStylesWrapper(props, ref) {
   return (
     <PublicComponentStylesWrapperInner
       {...props}
+      ref={ref}
       dir="ltr"
       // eslint-disable-next-line react/prop-types -- className is in div props :shrugs:
       className={`mb-wrapper ${props.className}`}
     />
   );
-};
+});
+
 /**
  * We can't apply a global css reset as it would leak into the host app but we
  * can't also apply our entire css reset scoped to this container, as it would


### PR DESCRIPTION
refs' console.error

Closes EMB-143 / [EMB-143: Dev console error: Function components cannot be given refs](https://linear.app/metabase/issue/EMB-143/dev-console-error-function-components-cannot-be-given-refs)