### PR TITLE
Fix two bugs in DQ updates/creation

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -443,12 +443,38 @@
                       {:type        card-type
                        :status-code 400})))))
 
+(defn- actual-collection-id
+  "Given a body from the `POST` endpoint to create a card, returns the `collection_id` that the card will be placed in.
+  Because creating a Dashboard Question does not require specifying a `collection_id` (it's inferred from the
+  `dashboard_id`), this may be different from the `collection_id`. Normally if you don't specify a `collection_id`
+  that means we put it in the root collection (`nil` id), but if you specify a `dashboard_id` we'll need to look it
+  up."
+  [body]
+  (let [[_ collection-id :as specified-collection-id?] (find body :collection_id)
+        ;; unlike collection_id, `dashboard_id=null` isn't different than not specifying it at all.
+        dashboard-id (:dashboard_id body)
+        dashboard-id->collection-id #(t2/select-one-fn :collection_id [:model/Dashboard :collection_id] %)]
+    (cond
+      ;; you specified both - they must match
+      (and specified-collection-id? dashboard-id)
+      (let [dashboard-collection-id (dashboard-id->collection-id dashboard-id)]
+        (api/check-400 (= collection-id dashboard-collection-id)
+                       (tru "Mismatch detected between Dashboard''s `collection_id` ({0}) and `collection_id` ({1})"
+                            dashboard-collection-id
+                            collection-id))
+        collection-id)
+
+      specified-collection-id? collection-id
+
+      dashboard-id (dashboard-id->collection-id dashboard-id)
+
+      :else nil)))
+
 (api.macros/defendpoint :post "/"
   "Create a new `Card`. Card `type` can be `question`, `metric`, or `model`."
   [_route-params
    _query-params
-   {collection-id :collection_id
-    query         :dataset_query
+   {query         :dataset_query
     card-type     :type
     :as           body} :- [:map
                             [:name                   ms/NonBlankString]
@@ -470,8 +496,10 @@
   (check-if-card-can-be-saved query card-type)
   ;; check that we have permissions to run the query that we're trying to save
   (card/check-run-permissions-for-query query)
-  ;; check that we have permissions for the collection we're trying to save this card to, if applicable
-  (collection/check-write-perms-for-collection collection-id)
+  ;; check that we have permissions for the collection we're trying to save this card to, if applicable.
+  ;; if a `dashboard-id` is specified, check permissions on the *dashboard's* collection ID.
+  (collection/check-write-perms-for-collection
+   (actual-collection-id body))
   (let [body (cond-> body
                (string? (:type body)) (update :type keyword))]
     (-> (card/create-card! body @api/*current-user*)
@@ -532,6 +560,19 @@
    [:dashboard_id           {:optional true} [:maybe ms/PositiveInt]]
    [:dashboard_tab_id       {:optional true} [:maybe ms/PositiveInt]]])
 
+(defn- maybe-populate-collection-id
+  "`card-updates` may contain either or both of a `collection_id` and a `dashboard_id`.
+  If either one is set, let's validate that they match using `actual-collection-id` and make sure that the
+  `card-updates` contains the updated `collection_id`."
+  [card-before-update card-updates]
+  (let [collection-id (when (or (contains? card-updates :collection_id)
+                                (contains? card-updates :dashboard_id))
+                        (actual-collection-id card-updates))]
+    (cond-> card-updates
+      (or (api/column-will-change? :dashboard_id card-before-update card-updates)
+          (api/column-will-change? :collection_id card-before-update card-updates))
+      (assoc :collection_id collection-id))))
+
 (mu/defn update-card!
   "Updates a card - impl"
   [id :- ms/PositiveInt
@@ -547,7 +588,9 @@
         (throw (ex-info (ex-message e) (assoc (ex-data e) :status-code 400))))))
   (let [card-before-update     (t2/hydrate (api/write-check :model/Card id)
                                            [:moderation_reviews :moderator_details])
-        card-updates           (api/updates-with-archived-directly card-before-update card-updates)
+        card-updates           (maybe-populate-collection-id
+                                card-before-update
+                                (api/updates-with-archived-directly card-before-update card-updates))
         is-model-after-update? (if (nil? type)
                                  (card/model? card-before-update)
                                  (card/model? card-updates))]

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -470,7 +470,11 @@
                              (:dashboard_id changes)))]
     (when will-be-dq?
       (cond
-        (not (or *updating-dashboard* (not (api/column-will-change? :collection_id card changes))))
+        (not (or *updating-dashboard*
+                 ;; if the `dashboard_id` is changing, allow specifying a `collection_id`. Note that if it's different
+                 ;; than the actual `collection_id` of the new dashboard we're moving to, it will be ignored.
+                 dq-will-change?
+                 (not (api/column-will-change? :collection_id card changes))))
         (tru "Invalid Dashboard Question: Cannot manually set `collection_id` on a Dashboard Question")
         (api/column-will-change? :collection_position card changes)
         (tru "Invalid Dashboard Question: Cannot set `collection_position` on a Dashboard Question")

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -4052,6 +4052,64 @@
            (-> (mt/user-http-request :rasta :get 200 (str "card/" card-id))
                :dashboard)))))
 
+(deftest dashboard-questions-can-be-created-without-specifying-a-collection-id
+  (mt/with-non-admin-groups-no-root-collection-perms
+    (mt/with-temp [:model/Collection {coll-id :id} {}
+                   :model/Dashboard {dash-id :id} {:name "My Dashboard"
+                                                   :collection_id coll-id}]
+      (perms/grant-collection-readwrite-permissions! (perms-group/all-users) coll-id)
+      (testing "Specifying only `collection_id` works"
+        (mt/user-http-request :rasta :post 200 "card/"
+                              (assoc (card-with-name-and-query)
+                                     :collection_id coll-id)))
+      (testing "Specifying only `dashboard_id` works"
+        (mt/user-http-request :rasta :post 200 "card/"
+                              (assoc (card-with-name-and-query)
+                                     :dashboard_id dash-id)))
+      (testing "Specifying both works"
+        (mt/user-http-request :rasta :post 200 "card/"
+                              (assoc (card-with-name-and-query)
+                                     :collection_id coll-id
+                                     :dashboard_id dash-id)))
+      (testing "Specifying both fails if they're different"
+        (is (= (format "Mismatch detected between Dashboard's `collection_id` (%d) and `collection_id` (%d)"
+                       coll-id
+                       nil)
+               (mt/user-http-request :rasta :post 400 "card/"
+                                     (assoc (card-with-name-and-query)
+                                            :collection_id nil
+                                            :dashboard_id dash-id))))))))
+
+(deftest cannot-move-question-to-dashboard-without-permissions
+  (mt/with-non-admin-groups-no-root-collection-perms
+    (mt/with-temp [:model/Collection {coll-id-1 :id} {}
+                   :model/Collection {coll-id-2 :id} {}
+                   :model/Dashboard {dash-id :id} {:collection_id coll-id-2}
+                   :model/Card {card-id :id} {:collection_id coll-id-1}]
+      (perms/grant-collection-readwrite-permissions! (perms-group/all-users) coll-id-1)
+      (testing "with read-only permissions on the destination collection"
+        (perms/revoke-collection-permissions! (perms-group/all-users) coll-id-2)
+        (perms/grant-collection-read-permissions! (perms-group/all-users) coll-id-2)
+        (testing "just to be sure, we can't directly move it to the read-only collection"
+          (mt/user-http-request :rasta :put 403 (str "card/" card-id) {:collection_id coll-id-2}))
+        (testing "we can't move it to the dashboard in the read-only collection"
+          (mt/user-http-request :rasta :put 403 (str "card/" card-id) {:dashboard_id dash-id})
+          (is (not= dash-id (t2/select-one-fn :dashboard_id :model/Card :id card-id)))))
+      (testing "with no permissions on the destination collection"
+        (perms/revoke-collection-permissions! (perms-group/all-users) coll-id-2)
+        (testing "just to be sure, we can't directly move it to the no-perms collection"
+          (mt/user-http-request :rasta :put 403 (str "card/" card-id) {:collection_id coll-id-2}))
+        (testing "we can't move it to the dashboard in the no-perms collection"
+          (mt/user-http-request :rasta :put 403 (str "card/" card-id) {:dashboard_id dash-id})
+          (is (not= dash-id (t2/select-one-fn :dashboard_id :model/Card :id card-id))))))
+    (testing "the root collection works the same way"
+      (mt/with-temp [:model/Collection {coll-id :id} {}
+                     :model/Dashboard {dash-id :id} {:collection_id nil}
+                     :model/Card {card-id :id} {:collection_id coll-id}]
+        (perms/grant-collection-readwrite-permissions! (perms-group/all-users) coll-id)
+        (testing "can't move to the root collection"
+          (mt/user-http-request :rasta :put 403 (str "card/" card-id) {:dashboard_id dash-id}))))))
+
 (deftest cannot-join-question-with-itself
   (testing "Cannot join card with itself."
     (let [mp (mt/metadata-provider)


### PR DESCRIPTION
- allow not specifying a `collection_id` when creating a new card (inferring it from the `dashboard_id` instead)

- correctly check perms on the *dashboard*'s `collection_id` when moving a card to a dashboard