### PR TITLE
Fix e2e test flake for issue 29943 reproduction

### DIFF
--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -15,15 +15,23 @@ describe("issue 29943", () => {
     getHeaderCell(1, "Total").should("exist");
     getHeaderCell(2, "Custom").should("exist");
 
-    // drag & drop the Custom column 100 px to the left to switch it with Total column
+    // drag & drop the Total column 10 px to the right of the Custom column to swap their positions
     cy.findAllByTestId("header-cell")
       .contains("Custom")
       .then(customColumn => {
-        const rect = customColumn[0].getBoundingClientRect();
-        cy.wrap(customColumn)
-          .trigger("mousedown")
-          .trigger("mousemove", { clientX: rect.x - 100, clientY: rect.y })
-          .trigger("mouseup");
+        const customColumnRect = customColumn[0].getBoundingClientRect();
+        cy.findAllByTestId("header-cell")
+          .contains("Total")
+          .then(totalColumn => {
+            const totalColumnRect = totalColumn[0].getBoundingClientRect();
+            cy.wrap(totalColumn)
+              .trigger("mousedown")
+              .trigger("mousemove", {
+                clientX: customColumnRect.right + 10,
+                clientY: totalColumnRect.y,
+              })
+              .trigger("mouseup");
+          });
       });
 
     getHeaderCell(1, "Custom").should("exist");


### PR DESCRIPTION
### Description

Attempt to fix an e2e test flake that failed in a recent PR

https://github.com/metabase/metabase/actions/runs/13512937589/attempts/2?pr=54057
https://app.trunk.io/metabase/flaky-tests/test/4c0b3502-c67c-5b61-9b6a-7b514c3fd40a?repo=metabase%2Fmetabase

This test attempts to reorder two columns starting from this state

![Screenshot 2025-02-25 at 10 27 03 AM](https://github.com/user-attachments/assets/54112981-850d-480f-a678-afe899a29264)

The desired final state is to swap the Total and Custom columns like so

![Screenshot 2025-02-25 at 10 26 50 AM](https://github.com/user-attachments/assets/8b6fd58c-6926-4535-97e3-1319fc7c9cac)

but for some reason the test sometimes winds up moving the Custom column all the way to left like so, causing the test to fail.

![Screenshot 2025-02-25 at 10 27 26 AM](https://github.com/user-attachments/assets/5a06486c-1058-4503-a86d-1b60d2bfc3cb)

The fix: Rather than dragging the Custom column left by a fixed -100 px, drag the Total column right 10 px past the right edge of the Custom column's bounding box. The idea is to make the test more flake resistant since (1) we drag based on the size of the target column header rather than a fixed offset, (2) since there are no more columns to the right of Custom, it's OK if we overshoot the distance slightly.

Actually, looking closer at the failures reported in trunk.io, this seems like a fairly recent thing that it started failing in this way. First failure is from Feb 13th. Any recent changes come to mind that could have caused it start failing? In the frames leading up to the test failure you can see the ID column is sort of truncated. Unclear if that is the cause of the failure or not. Maybe we want to keep the fixed offset in this test to detect these kinds of changes?

![Screenshot 2025-02-25 at 10 31 56 AM](https://github.com/user-attachments/assets/ed0f39a7-4c73-4b68-a8ae-ca81bae239c3)


### How to verify

Run test `"selects the right column when clicking a column header (metabase#29943)"`

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
