### PR TITLE
fix hover state on split items in dashboard question picker

### DIFF
--- a/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionList.tsx
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionList.tsx
@@ -18,7 +18,7 @@ import { usePagination } from "metabase/hooks/use-pagination";
 import { DEFAULT_SEARCH_LIMIT } from "metabase/lib/constants";
 import { useDispatch } from "metabase/lib/redux";
 import { PLUGIN_MODERATION } from "metabase/plugins";
-import { Box, Flex, Icon, Tooltip } from "metabase/ui";
+import { ActionIcon, Flex, Icon, Tooltip } from "metabase/ui";
 import { VisualizerModal } from "metabase/visualizer/components/VisualizerModal";
 import type { CardId, CollectionId } from "metabase-types/api";
 
@@ -136,13 +136,9 @@ export function QuestionList({
     <>
       <SelectList>
         {list.map(item => (
-          <Flex
-            key={item.id}
-            className={S.questionItem}
-            align="center"
-            justify="space-between"
-          >
+          <Flex key={item.id} className={S.questionItem}>
             <QuestionListItem
+              className={S.questionListItem}
               id={item.id}
               name={item.getName()}
               icon={{
@@ -155,13 +151,14 @@ export function QuestionList({
               )}
             />
             <Tooltip label={t`Visualize another way`}>
-              <Box
+              <ActionIcon
                 className={S.visualizerButton}
+                size="41px"
                 ml="auto"
                 onClick={() => setVisualizerModalCardId(Number(item.id))}
               >
                 <Icon name="add_data" />
-              </Box>
+              </ActionIcon>
             </Tooltip>
           </Flex>
         ))}

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionPicker.module.css
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionPicker.module.css
@@ -29,6 +29,10 @@ button.newButton {
   }
 }
 
+.questionListItem {
+  flex: 1;
+}
+
 .visualizerButton {
   visibility: hidden;
 }
@@ -37,8 +41,6 @@ button.newButton {
   visibility: visible;
   background-color: var(--mb-color-brand);
   color: white;
-  padding: 0.75em;
   margin-left: 2px;
   cursor: pointer;
-  border-radius: 6px;
 }


### PR DESCRIPTION
Closes VIZ-299

Previously the list item name wasn't filling the rest of the space resulting in bad vibes.

After:
![Screenshot 2025-02-25 at 2 19 25 PM](https://github.com/user-attachments/assets/df31adf7-3a9c-43c4-b893-3503532a40bf)

Before:
![Screenshot 2025-02-25 at 2 20 44 PM](https://github.com/user-attachments/assets/1718c205-36e7-4b37-af56-8fd24b36f737)

I swapped out to use ActionIcon as well instead of Box for the wrapping component for the icon. In this context I think eventually we should go with `Button.Group` but I think that would be a refactor I'd rather save for another time.