### PR TITLE
skip running v49.2024-01-22T11:52:00 for new instances

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5464,6 +5464,13 @@ databaseChangeLog:
       id: v49.2024-01-22T11:52:00
       author: qnkhuat
       comment: Backfill `report_card.type`
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+          - sqlCheck:
+              sql: >-
+                SELECT COUNT(*) FROM revision
+              expectedResult: 0
       changes:
         - customChange:
             class: "metabase.db.custom_migrations.CardRevisionAddType"


### PR DESCRIPTION
Related: https://github.com/metabase/metabase/issues/54066, WRK-85

This does not fix the issue but will skip the migration for new instances that does not have revisions