### PR TITLE
Fixed UI issues after mantine upgrade

### DIFF
--- a/frontend/src/metabase/components/SchedulePicker/SchedulePicker.tsx
+++ b/frontend/src/metabase/components/SchedulePicker/SchedulePicker.tsx
@@ -16,7 +16,7 @@ import {
 import { capitalize } from "metabase/lib/formatting/strings";
 import { useSelector } from "metabase/lib/redux";
 import { getApplicationName } from "metabase/selectors/whitelabel";
-import { Box } from "metabase/ui";
+import { Box, type BoxProps } from "metabase/ui";
 import type {
   ScheduleDayType,
   ScheduleFrameType,
@@ -55,6 +55,8 @@ export interface SchedulePickerProps {
     nextSchedule: ScheduleSettings,
     change: ScheduleChangeProp,
   ) => void;
+
+  mt?: BoxProps["mt"];
 }
 
 const DEFAULT_DAY = "mon";
@@ -247,13 +249,19 @@ class SchedulePicker extends Component<SchedulePickerProps> {
   }
 
   render() {
-    const { schedule, scheduleOptions, textBeforeInterval, className, style } =
-      this.props;
+    const {
+      schedule,
+      scheduleOptions,
+      textBeforeInterval,
+      className,
+      style,
+      mt = "lg",
+    } = this.props;
 
     const scheduleType = schedule.schedule_type;
 
     return (
-      <Box mt="lg" className={className} style={style}>
+      <Box mt={mt} className={className} style={style}>
         <PickerRow>
           <PickerText>{textBeforeInterval}</PickerText>
           <Select

--- a/frontend/src/metabase/notifications/NotificationsActionsMenu/CommonNotificationsMenuItem.tsx
+++ b/frontend/src/metabase/notifications/NotificationsActionsMenu/CommonNotificationsMenuItem.tsx
@@ -18,7 +18,6 @@ export const CommonNotificationsMenuItem = ({
   return (
     <Menu.Item
       data-testid="question-alert-menu-item"
-      my="sm"
       leftSection={
         <Center mr="xs">
           <Icon name={iconName} />

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.module.css
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.module.css
@@ -1,3 +1,0 @@
-.noMarginTop {
-  margin-top: 0;
-}

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
@@ -250,12 +250,12 @@ export const CreateOrEditQuestionAlertModal = ({
           <Modal.Title>{isEditMode ? t`Edit alert` : t`New alert`}</Modal.Title>
           <Modal.CloseButton />
         </Modal.Header>
-        <Modal.Body p="2.5rem" pt="0" pb="2rem">
-          <Stack gap="2rem">
+        <Modal.Body p="0 2.5rem 2rem">
+          <Stack gap="xl">
             <AlertModalSettingsBlock
               title={t`What do you want to be alerted about?`}
             >
-              <Flex gap="1.5rem" align="center">
+              <Flex gap="lg" align="center">
                 <AlertTriggerIcon />
                 <Select
                   data-testid="alert-goal-select"
@@ -339,7 +339,7 @@ export const CreateOrEditQuestionAlertModal = ({
         <Flex
           justify="space-between"
           px="2.5rem"
-          py="1.5rem"
+          py="lg"
           className={CS.borderTop}
         >
           <Button

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
@@ -52,7 +52,6 @@ import { NotificationChannelsPicker } from "../components/NotificationChannelsPi
 
 import { AlertModalSettingsBlock } from "./AlertModalSettingsBlock";
 import { AlertTriggerIcon } from "./AlertTriggerIcon";
-import S from "./CreateOrEditQuestionAlertModal.module.css";
 import type { NotificationTriggerOption } from "./types";
 
 const ALERT_TRIGGER_OPTIONS_MAP: Record<
@@ -251,12 +250,12 @@ export const CreateOrEditQuestionAlertModal = ({
           <Modal.Title>{isEditMode ? t`Edit alert` : t`New alert`}</Modal.Title>
           <Modal.CloseButton />
         </Modal.Header>
-        <Modal.Body p="2.5rem">
-          <Stack gap="2.5rem">
+        <Modal.Body p="2.5rem" pt="0" pb="2rem">
+          <Stack gap="2rem">
             <AlertModalSettingsBlock
               title={t`What do you want to be alerted about?`}
             >
-              <Flex gap="1.5rem">
+              <Flex gap="1.5rem" align="center">
                 <AlertTriggerIcon />
                 <Select
                   data-testid="alert-goal-select"
@@ -278,7 +277,7 @@ export const CreateOrEditQuestionAlertModal = ({
             </AlertModalSettingsBlock>
             <AlertModalSettingsBlock title={t`When do you want to check this?`}>
               <SchedulePicker
-                className={S.noMarginTop}
+                mt={0}
                 schedule={
                   cronToScheduleSettings(subscription.cron_schedule) ||
                   DEFAULT_ALERT_SCHEDULE // default is just for typechecking

--- a/frontend/src/metabase/notifications/modals/QuestionAlertListModal/AlertListItem.tsx
+++ b/frontend/src/metabase/notifications/modals/QuestionAlertListModal/AlertListItem.tsx
@@ -100,8 +100,7 @@ export const AlertListItem = ({
         )}
         {user && (
           <>
-            {/* eslint-disable-next-line no-restricted-syntax */}
-            <Text size="sm" c="var(--mb-base-color-orion-20)">
+            <Text size="sm" c="text-light">
               •
             </Text>
             <Text size="sm" c="inherit">

--- a/frontend/src/metabase/notifications/modals/QuestionAlertListModal/AlertListItem.tsx
+++ b/frontend/src/metabase/notifications/modals/QuestionAlertListModal/AlertListItem.tsx
@@ -92,7 +92,7 @@ export const AlertListItem = ({
       <Text className={S.itemTitle} size="md" lineClamp={1} fw="bold">
         {formatTitle(alert.payload.send_condition)}
       </Text>
-      <Group gap="0.25rem" align="center" c="text-medium">
+      <Group gap="0.25rem" align="center" c="text-secondary">
         {subscription && (
           <Text size="sm" c="inherit">
             {formatNotificationSchedule(subscription)}
@@ -100,7 +100,8 @@ export const AlertListItem = ({
         )}
         {user && (
           <>
-            <Text size="sm" c="text-light">
+            {/* eslint-disable-next-line no-restricted-syntax */}
+            <Text size="sm" c="var(--mb-base-color-orion-20)">
               •
             </Text>
             <Text size="sm" c="inherit">
@@ -113,24 +114,24 @@ export const AlertListItem = ({
       <Stack className={S.handlersContainer} gap="0.5rem" mt="1rem">
         {emailHandler && (
           <Group gap="0.5rem" wrap="nowrap">
-            <FixedSizeIcon name="mail" size={16} c="text-medium" />
-            <Text lineClamp={1} c="inherit">
+            <FixedSizeIcon name="mail" size={16} c="text-secondary" />
+            <Text size="sm" lineClamp={1} c="inherit">
               {formatEmailHandlerInfo(emailHandler, users)}
             </Text>
           </Group>
         )}
         {slackHandler && (
           <Group gap="0.5rem" wrap="nowrap">
-            <FixedSizeIcon name="slack" size={16} c="text-medium" />
-            <Text lineClamp={1} c="inherit">
+            <FixedSizeIcon name="slack" size={16} c="text-secondary" />
+            <Text size="sm" lineClamp={1} c="inherit">
               {formatSlackHandlerInfo(slackHandler)}
             </Text>
           </Group>
         )}
         {hookHandlers && (
           <Group gap="0.5rem" wrap="nowrap">
-            <FixedSizeIcon name="webhook" size={16} c="text-medium" />
-            <Text lineClamp={1} c="inherit">
+            <FixedSizeIcon name="webhook" size={16} c="text-secondary" />
+            <Text size="sm" lineClamp={1} c="inherit">
               {formatHttpHandlersInfo(hookHandlers, httpChannelsConfig)}
             </Text>
           </Group>

--- a/frontend/src/metabase/notifications/modals/QuestionAlertListModal/AlertListItem.tsx
+++ b/frontend/src/metabase/notifications/modals/QuestionAlertListModal/AlertListItem.tsx
@@ -92,7 +92,7 @@ export const AlertListItem = ({
       <Text className={S.itemTitle} size="md" lineClamp={1} fw="bold">
         {formatTitle(alert.payload.send_condition)}
       </Text>
-      <Group gap="0.25rem" align="center" c="text-secondary">
+      <Group gap="xs" align="center" c="text-secondary">
         {subscription && (
           <Text size="sm" c="inherit">
             {formatNotificationSchedule(subscription)}
@@ -112,7 +112,7 @@ export const AlertListItem = ({
 
       <Stack className={S.handlersContainer} gap="0.5rem" mt="1rem">
         {emailHandler && (
-          <Group gap="0.5rem" wrap="nowrap">
+          <Group gap="sm" wrap="nowrap">
             <FixedSizeIcon name="mail" size={16} c="text-secondary" />
             <Text size="sm" lineClamp={1} c="inherit">
               {formatEmailHandlerInfo(emailHandler, users)}
@@ -120,7 +120,7 @@ export const AlertListItem = ({
           </Group>
         )}
         {slackHandler && (
-          <Group gap="0.5rem" wrap="nowrap">
+          <Group gap="sm" wrap="nowrap">
             <FixedSizeIcon name="slack" size={16} c="text-secondary" />
             <Text size="sm" lineClamp={1} c="inherit">
               {formatSlackHandlerInfo(slackHandler)}
@@ -128,7 +128,7 @@ export const AlertListItem = ({
           </Group>
         )}
         {hookHandlers && (
-          <Group gap="0.5rem" wrap="nowrap">
+          <Group gap="sm" wrap="nowrap">
             <FixedSizeIcon name="webhook" size={16} c="text-secondary" />
             <Text size="sm" lineClamp={1} c="inherit">
               {formatHttpHandlersInfo(hookHandlers, httpChannelsConfig)}

--- a/frontend/src/metabase/notifications/modals/QuestionAlertListModal/AlertListModal.tsx
+++ b/frontend/src/metabase/notifications/modals/QuestionAlertListModal/AlertListModal.tsx
@@ -63,12 +63,12 @@ export const AlertListModal = ({
     >
       <Modal.Overlay />
       <Modal.Content>
-        <Modal.Header p="2rem" pb="2rem">
+        <Modal.Header p="2rem" pb="1.5rem">
           <Modal.Title>{t`Edit alerts`}</Modal.Title>
           <Modal.CloseButton />
         </Modal.Header>
-        <Modal.Body p="2rem">
-          <Stack gap="1rem" mb="2rem">
+        <Modal.Body p="2rem" pt="0">
+          <Stack gap="1.5rem" mb="1.5rem">
             {sortedQuestionAlerts.map(alert => {
               const canEditAlert =
                 isAdmin ||

--- a/frontend/src/metabase/notifications/modals/QuestionAlertListModal/AlertListModal.tsx
+++ b/frontend/src/metabase/notifications/modals/QuestionAlertListModal/AlertListModal.tsx
@@ -63,12 +63,12 @@ export const AlertListModal = ({
     >
       <Modal.Overlay />
       <Modal.Content>
-        <Modal.Header p="2rem" pb="1.5rem">
+        <Modal.Header p="xl" pb="lg">
           <Modal.Title>{t`Edit alerts`}</Modal.Title>
           <Modal.CloseButton />
         </Modal.Header>
-        <Modal.Body p="2rem" pt="0">
-          <Stack gap="1.5rem" mb="1.5rem">
+        <Modal.Body p="xl" pt="0">
+          <Stack gap="lg" mb="lg">
             {sortedQuestionAlerts.map(alert => {
               const canEditAlert =
                 isAdmin ||

--- a/frontend/src/metabase/notifications/modals/components/NotificationChannelsAddMenu.tsx
+++ b/frontend/src/metabase/notifications/modals/components/NotificationChannelsAddMenu.tsx
@@ -128,7 +128,7 @@ export const NotificationChannelsAddMenu = ({
             component={Link}
             to="/admin/settings/notifications"
             target="_blank"
-            pl="0.5rem"
+            pl="sm"
           >
             <Text size="sm" c="inherit">{t`Manage destination channels`}</Text>
           </Button>

--- a/frontend/src/metabase/notifications/modals/components/NotificationChannelsAddMenu.tsx
+++ b/frontend/src/metabase/notifications/modals/components/NotificationChannelsAddMenu.tsx
@@ -62,8 +62,10 @@ export const NotificationChannelsAddMenu = ({
 
   const hasAddedEmail = channelsSpec.email?.configured && !!emailHandler;
   const hasAddedSlack = channelsSpec.slack?.configured && !!slackHandler;
+  const canAddEmail = channelsSpec.email?.configured && !emailHandler;
+  const canAddSlack = channelsSpec.slack?.configured && !slackHandler;
   const hasChannelsToAdd =
-    !hasAddedEmail || !hasAddedSlack || notAddedHookChannels.length > 0;
+    canAddEmail || canAddSlack || notAddedHookChannels.length > 0;
   const hasAddedNoChannels = !notificationHandlers.length;
 
   if (!isAdmin && !hasChannelsToAdd) {
@@ -77,7 +79,7 @@ export const NotificationChannelsAddMenu = ({
   return (
     <Menu position="bottom-start">
       <Menu.Target>
-        <Button variant="subtle">
+        <Button variant="subtle" p={0} mt="-0.75rem" mb="-0.75rem">
           {hasAddedNoChannels
             ? t`Add a destination`
             : t`Add another destination`}
@@ -139,6 +141,9 @@ export const NotificationChannelsAddMenu = ({
 const ManageDestinationsButton = () => (
   <Button
     variant="subtle"
+    p={0}
+    mt="-0.75rem"
+    mb="-0.75rem"
     component={Link}
     to="/admin/settings/notifications"
     target="_blank"


### PR DESCRIPTION
Relates to https://github.com/metabase/metabase/issues/50766

### Description

This fixes various small UI issues in Alerts migration scope found after Mantine v7 upgrade.
Design - https://www.figma.com/design/gj4D3g2P32nzNslR9sJSs8/Alerts-Redesign?node-id=1514-189879&m=dev

### How to verify

1. Open existing question
2. Click "Share" icon button, then "Create an alert" or "Edit alerts"
3. Modals should have new UI. 

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
