### PR TITLE
[MBQL Lib] Joins added after summaries have no `:fields`

### DIFF
--- a/test/metabase/lib/remove_replace_test.cljc
+++ b/test/metabase/lib/remove_replace_test.cljc
@@ -228,7 +228,8 @@
                    :conditions [[:= {}
                                  [:field {:join-alias "Venues"} (meta/id :venues :category-id)]
                                  [:field {} (meta/id :categories :id)]]]
-                   :fields :all
+                   ;; No :fields :all because it gets removed on joins when there are aggregations/breakouts.
+                   :fields (symbol "nil #_\"key is not present.\"")
                    :alias "Venues"}]}]}
               (lib/replace-clause query'
                                   (first aggs)

--- a/test/metabase/lib/test_util/generators.cljc
+++ b/test/metabase/lib/test_util/generators.cljc
@@ -360,13 +360,17 @@
         (is (= (inc (count before-joins))
                (count after-joins)))
         (testing "at the end"
-          (is (=? {:lib/type   :mbql/join
-                   :strategy   strategy
-                   :alias      string?
-                   :fields     :all
-                   :stages     [{:source-table (:id target)}]
-                   :conditions [condition]}
-                  (last after-joins))))))))
+          (let [summaries? (or (seq (lib/aggregations after))
+                               (seq (lib/breakouts after)))]
+            (is (=? {:lib/type   :mbql/join
+                     :strategy   strategy
+                     :alias      string?
+                     :fields     (if summaries?
+                                   (symbol "nil #_\"key is not present.\"")
+                                   :all)
+                     :stages     [{:source-table (:id target)}]
+                     :conditions [condition]}
+                    (last after-joins)))))))))
 
 ;; Append stage ==================================================================================
 (add-step {:kind   :append-stage


### PR DESCRIPTION
### Description

When you add a summary clause (aggregation or breakout), any `:fields`
clauses are removed from the stage and its joins.

However the reverse order was not correct: a join clause added after
summaries would keep its specified `:fields` clause, or get the default
`:fields :all`.

This change fixes that quirk. It also adds `lib.helpers` for "late"
utilities. That is, utilities that depend on most of the library, rather
than being depended **on** by most of the library like `lib.util` and
`lib.common`. It's a good place to put `has-summaries?` and other
functions that want to use the library to answer questions.

### How to verify

Add a join after a breakout or aggregation; it should not have a `:fields` clause.

I'm not 100% sure this can happen in the QB, but it can happen in the library.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
