### PR TITLE
Don't update dashboards when only last_viewed_at changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -489,5 +489,6 @@
   },
   "browserslist": [
     "defaults"
-  ]
+  ],
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -489,6 +489,5 @@
   },
   "browserslist": [
     "defaults"
-  ],
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  ]
 }

--- a/src/metabase/api/field.clj
+++ b/src/metabase/api/field.clj
@@ -306,8 +306,7 @@
                                   :human_readable_values (when human-readable-values?
                                                            (map second value-pairs))}
           updated-pk             (mdb.query/update-or-insert! :model/FieldValues {:field_id (u/the-id field), :type :full}
-                                                              (constantly update-map))]
-      (api/check-500 (pos? updated-pk))))
+                                                              (constantly update-map))]))
   {:status :success})
 
 (api.macros/defendpoint :post "/:id/rescan_values"

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -71,7 +71,7 @@
   (when-let [changes (not-empty (u/select-keys-when body
                                                     :non-nil [:display_name :show_in_getting_started :entity_type :field_order]
                                                     :present [:description :caveats :points_of_interest :visibility_type]))]
-    (api/check-500 (pos? (t2/update! :model/Table id changes))))
+    (t2/update! :model/Table id changes))
   (let [updated-table        (t2/select-one :model/Table :id id)
         changed-field-order? (not= (:field_order updated-table) (:field_order existing-table))]
     (if changed-field-order?

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -568,5 +568,5 @@
               (throw (ex-info (tru "Unrecognized modal: {0}" modal)
                               {:modal modal
                                :allowable-modals #{"qbnewb" "datasetnewb"}})))]
-    (api/check-500 (pos? (t2/update! :model/User id {:type :personal} {k false}))))
+    (t2/update! :model/User id {:type :personal} {k false}))
   {:success true})

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -65,6 +65,9 @@
   ([_ pk]
    (mi/can-read? (t2/select-one :model/Dashboard :id pk))))
 
+(defmethod mi/non-timestamped-fields :model/Dashboard [_]
+  #{:last_viewed_at})
+
 (t2/deftransforms :model/Dashboard
   {:parameters       mi/transform-card-parameters-list
    :embedding_params mi/transform-json})

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -133,7 +133,7 @@
 
 (t2/define-before-update :model/Field
   [field]
-  (u/prog1 (t2/changes field)
+  (u/prog1 (or (t2/changes field) {})
     (when (false? (:active <>))
       (t2/update! :model/Field {:fk_target_field_id (:id field)} {:semantic_type      nil
                                                                   :fk_target_field_id nil}))))

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -534,7 +534,7 @@
                                     (:updated_at obj))))
         ; don't stomp on `:updated_at` if it's already explicitly specified.
         changes-already-include-updated-at? (some #{:updated_at} changed-fields)
-        has-non-ignored-fields? (or (empty? changed-fields) (seq (set/difference changed-fields (non-timestamped-fields obj))))]
+        has-non-ignored-fields? (seq (set/difference changed-fields (non-timestamped-fields obj)))]
     (cond-> obj
       (and has-non-ignored-fields? (not changes-already-include-updated-at?)) (assoc :updated_at (now)))))
 

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -529,14 +529,12 @@
     (not (:created_at obj)) (assoc :created_at (now))))
 
 (defn- add-updated-at-timestamp [obj]
-  (let [changed-fields (set (keys (if (t2/instance obj)
-                                    (t2/changes obj)
-                                    (:updated_at obj))))
-        ; don't stomp on `:updated_at` if it's already explicitly specified.
-        changes-already-include-updated-at? (some #{:updated_at} changed-fields)
-        has-non-ignored-fields? (seq (set/difference changed-fields (non-timestamped-fields obj)))]
+  ;; don't stomp on `:updated_at` if it's already explicitly specified.
+  (let [changes-already-include-updated-at? (if (t2/instance? obj)
+                                              (:updated_at (t2/changes obj))
+                                              (:updated_at obj))]
     (cond-> obj
-      (and has-non-ignored-fields? (not changes-already-include-updated-at?)) (assoc :updated_at (now)))))
+      (not changes-already-include-updated-at?) (assoc :updated_at (now)))))
 
 (t2/define-before-insert :hook/timestamped?
   [instance]

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -529,14 +529,14 @@
     (not (:created_at obj)) (assoc :created_at (now))))
 
 (defn- add-updated-at-timestamp [obj]
-  ;; don't stomp on `:updated_at` if it's already explicitly specified.
-  (let [changed-fields (keys (if (t2/instance obj)
-                               (t2/changes obj)
-                               obj))
+  (let [changed-fields (set (keys (if (t2/instance obj)
+                                    (t2/changes obj)
+                                    (:updated_at obj))))
+        ; don't stomp on `:updated_at` if it's already explicitly specified.
         changes-already-include-updated-at? (some #{:updated_at} changed-fields)
-        includes-non-ignored-fields? (not-empty (set/difference (set changed-fields) (non-timestamped-fields obj)))]
+        has-non-ignored-fields? (or (empty? changed-fields) (not (empty? (set/difference changed-fields (non-timestamped-fields obj)))))]
     (cond-> obj
-      (and includes-non-ignored-fields? (not changes-already-include-updated-at?)) (assoc :updated_at (now)))))
+      (and has-non-ignored-fields? (not changes-already-include-updated-at?)) (assoc :updated_at (now)))))
 
 (t2/define-before-insert :hook/timestamped?
   [instance]

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -534,7 +534,7 @@
                                     (:updated_at obj))))
         ; don't stomp on `:updated_at` if it's already explicitly specified.
         changes-already-include-updated-at? (some #{:updated_at} changed-fields)
-        has-non-ignored-fields? (or (empty? changed-fields) (not (empty? (set/difference changed-fields (non-timestamped-fields obj)))))]
+        has-non-ignored-fields? (or (empty? changed-fields) (seq (set/difference changed-fields (non-timestamped-fields obj))))]
     (cond-> obj
       (and has-non-ignored-fields? (not changes-already-include-updated-at?)) (assoc :updated_at (now)))))
 

--- a/src/metabase/models/legacy_metric.clj
+++ b/src/metabase/models/legacy_metric.clj
@@ -38,7 +38,7 @@
 
 (t2/define-before-update :model/LegacyMetric
   [{:keys [id], :as metric}]
-  (u/prog1 #p (or (t2/changes metric) {})
+  (u/prog1 (or (t2/changes metric) {})
     ;; throw an Exception if someone tries to update creator_id
     (when (contains? <> :creator_id)
       (when (not= (:creator_id <>) (t2/select-one-fn :creator_id :model/LegacyMetric :id id))

--- a/src/metabase/models/legacy_metric.clj
+++ b/src/metabase/models/legacy_metric.clj
@@ -38,7 +38,7 @@
 
 (t2/define-before-update :model/LegacyMetric
   [{:keys [id], :as metric}]
-  (u/prog1 (t2/changes metric)
+  (u/prog1 #p (or (t2/changes metric) {})
     ;; throw an Exception if someone tries to update creator_id
     (when (contains? <> :creator_id)
       (when (not= (:creator_id <>) (t2/select-one-fn :creator_id :model/LegacyMetric :id id))

--- a/src/metabase/models/native_query_snippet.clj
+++ b/src/metabase/models/native_query_snippet.clj
@@ -29,7 +29,7 @@
 
 (t2/define-before-update :model/NativeQuerySnippet
   [{:keys [id], :as snippet}]
-  (u/prog1 (t2/changes snippet)
+  (u/prog1 (or (t2/changes snippet) {})
     ;; throw an Exception if someone tries to update creator_id
     (when (contains? <> :creator_id)
       (when (not= (:creator_id <>) (t2/select-one-fn :creator_id :model/NativeQuerySnippet :id id))

--- a/src/metabase/models/parameter_card.clj
+++ b/src/metabase/models/parameter_card.clj
@@ -34,7 +34,7 @@
 
 (t2/define-before-update :model/ParameterCard
   [pc]
-  (u/prog1 (t2/changes pc)
+  (u/prog1 (or (t2/changes pc) {})
     (when (:parameterized_object_type <>)
       (validate-parameterized-object-type <>))))
 

--- a/src/metabase/pulse/models/pulse.clj
+++ b/src/metabase/pulse/models/pulse.clj
@@ -95,9 +95,11 @@
                (contains? notification :dashboard_id)
                (not= (:dashboard_id notification) dashboard_id))
       (throw (ex-info (tru "dashboard ID of a dashboard subscription cannot be modified") notification))))
-  (u/prog1 (t2/changes notification)
-    (assert-valid-parameters notification)
-    (collection/check-collection-namespace :model/Pulse (:collection_id notification))))
+  (or
+   (u/prog1 (t2/changes notification)
+     (assert-valid-parameters notification)
+     (collection/check-collection-namespace :model/Pulse (:collection_id notification)))
+   {}))
 
 (t2/define-before-delete :model/Pulse
   [pulse]

--- a/src/metabase/segments/models/segment.clj
+++ b/src/metabase/segments/models/segment.clj
@@ -53,7 +53,7 @@
    (mi/can-read? (t2/select-one model pk))))
 
 (t2/define-before-update :model/Segment  [{:keys [id], :as segment}]
-  (u/prog1 (t2/changes segment)
+  (u/prog1 (or (t2/changes segment) {})
     ;; throw an Exception if someone tries to update creator_id
     (when (contains? <> :creator_id)
       (when (not= (:creator_id <>) (t2/select-one-fn :creator_id :model/Segment :id id))

--- a/test/metabase/channel/models/channel_test.clj
+++ b/test/metabase/channel/models/channel_test.clj
@@ -23,7 +23,6 @@
                                          :enabled true}]
     (testing "do not try to delete pulse-channel if active doesn't change"
       (is (pos? (t2/update! :model/Channel id {:name "New name"})))
-      (is (pos? (t2/update! :model/Channel id {:active true})))
       (is (t2/exists? :model/PulseChannel pc-id)))
 
     (testing "deactivate channel"

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -123,7 +123,7 @@
                                                  :col     0
                                                  :size_x  4
                                                  :size_y  4}])
-        (t2/update! :model/Dashboard dashboard-id {:name "Lucky's Close Shaves"})
+        (t2/update! :model/Dashboard dashboard-id {:name "Lucky's Close Shaves2"})
         (is (not (nil? (t2/select-one :model/PulseCard :card_id new-card-id))))))))
 
 (deftest parameter-card-test

--- a/test/metabase/models/interface_test.clj
+++ b/test/metabase/models/interface_test.clj
@@ -9,7 +9,8 @@
    [metabase.util.encryption :as encryption]
    [metabase.util.encryption-test :as encryption-test]
    [metabase.util.json :as json]
-   [toucan2.core :as t2])
+   [toucan2.core :as t2]
+   [toucan2.model :as t2.model])
   (:import (com.fasterxml.jackson.core JsonParseException)))
 
 ;; let's make sure the `transform-metabase-query`/`transform-metric-segment-definition`/`transform-parameters-list`
@@ -244,3 +245,28 @@
 
   (testing "A passed string is not elided"
     (is (= (apply str (repeat 1000 "a")) (#'mi/json-in-with-eliding (apply str (repeat 1000 "a")))))))
+
+(defmethod mi/non-timestamped-fields :test-model/updated-at-tester [_]
+  #{:non_timestamped :other})
+
+(deftest add-updated-at-timestamp-test
+  (testing "Should set updated_at timestamp to a map"
+    (is (= {:a 1 :updated_at [:metabase.util.honey-sql-2/typed :%now {:database-type "timestamptz"}]}
+           (#'mi/add-updated-at-timestamp {:a 1}))))
+  (testing "Does not add timestamp if a value is already set"
+    (is (= {:a 1 :updated_at "x"}
+           (#'mi/add-updated-at-timestamp {:a 1 :updated_at "x"}))))
+  (testing "Does not add a timestamp if it only includes non-timestamped fields"
+    (let [instance (-> (t2/instance :test-model/updated-at-tester {:non_timestamped nil})
+                       (assoc :non_timestamped 1))]
+      (is (= {:non_timestamped 1}
+             (#'mi/add-updated-at-timestamp instance)))))
+  (testing "Adds a timestamp if it includes other fields"
+    (let [instance (-> (t2/instance :test-model/updated-at-tester {:non_timestamped nil :included nil})
+                       (assoc :non_timestamped 1)
+                       (assoc :included 2))]
+      (is (= {:non_timestamped 1 :included 2 :updated_at [:metabase.util.honey-sql-2/typed :%now {:database-type "timestamptz"}]}
+             (#'mi/add-updated-at-timestamp instance))))))
+;;=> #'metabase.models.interface-test/add-updated-at-timestamp-test
+
+(comment (t2.model/resolve-model obj))

--- a/test/metabase/models/interface_test.clj
+++ b/test/metabase/models/interface_test.clj
@@ -109,6 +109,22 @@
                    :updated_at expected-timestamp}
                   field)))))))
 
+(defmethod mi/non-timestamped-fields :test-model/updated-at-tester [_]
+  #{:non_timestamped :other})
+
+(deftest timestamped-property-skips-non-timestamped-fields-test
+  (testing "Does not add a timestamp if it only includes non-timestamped fields"
+    (let [instance (-> (t2/instance :test-model/updated-at-tester {:non_timestamped nil})
+                       (assoc :non_timestamped 1))]
+      (is (= {:non_timestamped 1}
+             (#'mi/add-updated-at-timestamp instance)))))
+  (testing "Adds a timestamp if it includes other fields"
+    (let [instance (-> (t2/instance :test-model/updated-at-tester {:non_timestamped nil :included nil})
+                       (assoc :non_timestamped 1)
+                       (assoc :included 2))]
+      (is (= {:non_timestamped 1 :included 2 :updated_at (mi/now)}
+             (#'mi/add-updated-at-timestamp instance))))))
+
 (deftest ^:parallel upgrade-to-v2-viz-settings-test
   (let [migrate #(select-keys (#'mi/migrate-viz-settings %)
                               [:version :pie.percent_visibility])]
@@ -229,28 +245,3 @@
 
   (testing "A passed string is not elided"
     (is (= (apply str (repeat 1000 "a")) (#'mi/json-in-with-eliding (apply str (repeat 1000 "a")))))))
-
-(defmethod mi/non-timestamped-fields :test-model/updated-at-tester [_]
-  #{:non_timestamped :other})
-
-(deftest add-updated-at-timestamp-test
-  (testing "Should set updated_at timestamp to a map"
-    (is (= {:a 1 :updated_at [:metabase.util.honey-sql-2/typed :%now {:database-type "timestamptz"}]}
-           (#'mi/add-updated-at-timestamp {:a 1}))))
-  (testing "Does not add timestamp if a value is already set"
-    (is (= {:a 1 :updated_at "x"}
-           (#'mi/add-updated-at-timestamp {:a 1 :updated_at "x"}))))
-  (testing "Does not add a timestamp if it only includes non-timestamped fields"
-    (let [instance (-> (t2/instance :test-model/updated-at-tester {:non_timestamped nil})
-                       (assoc :non_timestamped 1))]
-      (is (= {:non_timestamped 1}
-             (#'mi/add-updated-at-timestamp instance)))))
-  (testing "Adds a timestamp if it includes other fields"
-    (let [instance (-> (t2/instance :test-model/updated-at-tester {:non_timestamped nil :included nil})
-                       (assoc :non_timestamped 1)
-                       (assoc :included 2))]
-      (is (= {:non_timestamped 1 :included 2 :updated_at [:metabase.util.honey-sql-2/typed :%now {:database-type "timestamptz"}]}
-             (#'mi/add-updated-at-timestamp instance))))))
-;;=> #'metabase.models.interface-test/add-updated-at-timestamp-test
-
-(comment (t2.model/resolve-model obj))

--- a/test/metabase/models/interface_test.clj
+++ b/test/metabase/models/interface_test.clj
@@ -9,8 +9,7 @@
    [metabase.util.encryption :as encryption]
    [metabase.util.encryption-test :as encryption-test]
    [metabase.util.json :as json]
-   [toucan2.core :as t2]
-   [toucan2.model :as t2.model])
+   [toucan2.core :as t2])
   (:import (com.fasterxml.jackson.core JsonParseException)))
 
 ;; let's make sure the `transform-metabase-query`/`transform-metric-segment-definition`/`transform-parameters-list`

--- a/test/metabase/models/interface_test.clj
+++ b/test/metabase/models/interface_test.clj
@@ -245,28 +245,3 @@
 
   (testing "A passed string is not elided"
     (is (= (apply str (repeat 1000 "a")) (#'mi/json-in-with-eliding (apply str (repeat 1000 "a")))))))
-
-(defmethod mi/non-timestamped-fields :test-model/updated-at-tester [_]
-  #{:non_timestamped :other})
-
-(deftest add-updated-at-timestamp-test
-  (testing "Should set updated_at timestamp to a map"
-    (is (= {:a 1 :updated_at [:metabase.util.honey-sql-2/typed :%now {:database-type "timestamptz"}]}
-           (#'mi/add-updated-at-timestamp {:a 1}))))
-  (testing "Does not add timestamp if a value is already set"
-    (is (= {:a 1 :updated_at "x"}
-           (#'mi/add-updated-at-timestamp {:a 1 :updated_at "x"}))))
-  (testing "Does not add a timestamp if it only includes non-timestamped fields"
-    (let [instance (-> (t2/instance :test-model/updated-at-tester {:non_timestamped nil})
-                       (assoc :non_timestamped 1))]
-      (is (= {:non_timestamped 1}
-             (#'mi/add-updated-at-timestamp instance)))))
-  (testing "Adds a timestamp if it includes other fields"
-    (let [instance (-> (t2/instance :test-model/updated-at-tester {:non_timestamped nil :included nil})
-                       (assoc :non_timestamped 1)
-                       (assoc :included 2))]
-      (is (= {:non_timestamped 1 :included 2 :updated_at [:metabase.util.honey-sql-2/typed :%now {:database-type "timestamptz"}]}
-             (#'mi/add-updated-at-timestamp instance))))))
-;;=> #'metabase.models.interface-test/add-updated-at-timestamp-test
-
-(comment (t2.model/resolve-model obj))

--- a/test/metabase/models/legacy_metric_test.clj
+++ b/test/metabase/models/legacy_metric_test.clj
@@ -23,5 +23,5 @@
              (t2/update! :model/LegacyMetric id {:creator_id nil}))))
 
       (testing "However calling `update!` with a value that is the same as the current value shouldn't throw an Exception"
-        (is (= 1
+        (is (= 0
                (t2/update! :model/LegacyMetric id {:creator_id (mt/user->id :rasta)})))))))

--- a/test/metabase/segments/models/segment_test.clj
+++ b/test/metabase/segments/models/segment_test.clj
@@ -25,7 +25,7 @@
              (t2/update! :model/Segment id {:creator_id nil}))))
 
       (testing "calling `update!` with a value that is the same as the current value shouldn't throw an Exception"
-        (is (= 1
+        (is (= 0
                (t2/update! :model/Segment id {:creator_id (mt/user->id :rasta)})))))))
 
 (deftest identity-hash-test


### PR DESCRIPTION
Closes #53687

### Description

Adds a new `mi/non-timestamped-fields` defmulti which allows models to define a set of fields which do should not update the updated_at field when those are the only fields changed.

Used the new feature to fix the bug in dashboard when only last_viewed_at changes

### How to verify

1. Create a subscription on dashboard 1 
2. Reload the dashboard in the browser
3. See that the updated_at field does not change in `report_dashboard`, `report_card`, and `pulse`

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
