### PR TITLE
Check caching schedule setting value exists

### DIFF
--- a/frontend/src/metabase/admin/performance/components/ModelPersistenceConfiguration.tsx
+++ b/frontend/src/metabase/admin/performance/components/ModelPersistenceConfiguration.tsx
@@ -178,7 +178,8 @@ export const ModelPersistenceConfiguration = () => {
           />
         </DelayedLoadingAndErrorWrapper>
       </Box>
-      {modelPersistenceEnabled && (
+      {/* modelCachingSchedule is sometimes undefined but TS thinks it is always a string */}
+      {modelPersistenceEnabled && modelCachingSchedule && (
         <div>
           <ModelCachingScheduleWidget
             setting={modelCachingSetting}


### PR DESCRIPTION
Addresses #53733
## Problem
`cannot read properties of undefined`

`ModelPersistenceConfiguration.tsx` loads `modelCachingSchedule` and passes it to`ModelCachingScheduleWidget.jsx` in the form of`setting.value`. The value of `modelCachingSchedule` is `undefined` at some point, hitting `cronExpression.split(" ");` and causing the error.

Note that I have been unable to reproduce the issue locally, so there is possibly a timing issue at play

## Quick solution
This PR is intentionally a quick-fix, but there are some potential gremlins lurking in the settings that need more investigating. 

The quick solution is to guard against the `modelCachingSchedule` being passed as undefined. 

## Deeper problem
`modelCachingSchedule` gets loaded from the settings slice, looking for `persisted-model-refresh-cron-schedule`
```
 const modelCachingSchedule = useSetting(
    "persisted-model-refresh-cron-schedule",
  );
  ```
  
The types in `ModelPersistenceConfiguration.tsx` say that `modelCachingSchedule` is always defined. Yet by inspecting our Redux state I can see that `persisted-model-refresh-cron-schedule` is not included in settings `initialState` - it gets populated when the settings load from the backend. This means there is a period of time that `persisted-model-refresh-cron-schedule` is not defined, but the types do not reflect this. This could affect other settings that are not in `initialState`.

Note: settings get initialised like so
```
export const settings = createReducer({ values: window.MetabaseBootstrap || {}, loading: false }, ...)
 ```
## Related tidy up
`ModelCachingScheduleWidget.jsx` should be converted to `.tsx`, and there are also `.styled` files that can be converted to css modules

I have made these changes already but I will make a seperate PR for them so that it's easier to validate the bug fix


