### PR TITLE
defendpoint less noise + add call-core-fn

### DIFF
--- a/test/metabase/api/open_api_test.clj
+++ b/test/metabase/api/open_api_test.clj
@@ -186,3 +186,20 @@
 (deftest ^:parallel openapi-all-routes
   (testing "Make sure we can successfully generate an OpenAPI spec for the entire API"
     (is (open-api/root-open-api-object #'routes/routes))))
+
+(deftest ^:parallel get-core-fn!-test
+  (is (= {:status 200, :headers {}, :body 12345}
+         (->
+          (api.macros/defendpoint :get "add/:a"
+            "Adds id, qp-one, qp-two, and body."
+            [{:keys [a]} :- [:map [:a :int]]
+             {:keys [b c]} :- [:map [:b :int] [:c :int]]
+             {:keys [d]} :- [:map [:d :int]]
+             {{e :e} :headers} :- [:map [:headers [:map [:e :int]]]]]
+            (+ a b c d e))
+          (api.macros/call-core-fn
+           {:a 5}                   ;; route params
+           {:b 40 :c 300}           ;; query params
+           {:d 2000}                ;; body
+           {:headers {:e "10000"}}) ;; the entire ring request map
+          ))))


### PR DESCRIPTION
Resolves https://linear.app/metabase/issue/GIT-6498/defendpoint-is-too-noisy-for-conjure-users

There have been complaints that defendpoint's output is too noisy, and that it is difficult to call the endpoint handlers as functions.

This solves both:

`defendpoint` now returns a thunk. when you call that thunk you get the map generated by the macro.

`call-core-fn` automatically gets the value, and the :core-fn, and calls it on a variable number of args.

So instead of the big map, defendpoint will now return something like: `#function[metabase.session.api/eval212370/post--reset-password--thunk--212383]`