### PR TITLE
Bump #p version, add :dev-start alias, and dev app allows #p

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -301,8 +301,7 @@
 
   ;; This is probably the best way to start the app for dev mode.
   ;; 1. Runs (dev) (start!) for you
-  ;; 2. This start the repl too
-  ;; 3. works with hashp
+  ;; 2. This starts the repl too: just like the :nrepl alias below. (see [[user/-main]])
   ;; clj -M:dev:dev-start:drivers:drivers-dev:ee:ee-dev
   :dev-start {:main-opts ["-m" "user"]}
 

--- a/deps.edn
+++ b/deps.edn
@@ -247,7 +247,7 @@
     com.gfredericks/test.chuck   {:mvn/version "0.2.14"}                    ; generating strings from regexes (useful with malli)
     criterium/criterium          {:mvn/version "0.4.6"}                     ; benchmarking library
     djblue/portal                {:mvn/version "0.58.5"}                    ; ui for inspecting values
-    hashp/hashp                  {:mvn/version "0.2.2"}                     ; debugging/spying utility
+    dev.weavejester/hashp        {:mvn/version "0.3.0"}                     ; debugging/spying utility
     io.github.camsaul/humane-are {:mvn/version "1.0.2"}
     io.github.metabase/hawk      {:mvn/version "1.0.7"}
     jonase/eastwood              {:mvn/version "1.4.3"                      ; inspects namespaces and reports possible problems using tools.analyzer
@@ -264,7 +264,6 @@
     rewrite-clj/rewrite-clj      {:mvn/version "1.1.49"}                    ; clojure source parsing and rewriting
     ring/ring-mock               {:mvn/version "0.4.0"}                     ; creating Ring request maps for testing purposes
     talltale/talltale            {:mvn/version "0.5.14"}}                   ; generates fake data, useful for prototyping or load testing
-
    :extra-paths ["dev/src" "local/src" "test" "test_resources" ".clj-kondo/src" ".clj-kondo/test"]
    :jvm-opts    ["-Dmb.run.mode=dev"
                  "-Dmb.field.filter.operators.enabled=true"
@@ -299,6 +298,13 @@
                  ;; https://community.snowflake.com/s/article/JDBC-Driver-Compatibility-Issue-With-JDK-16-and-Later
                  "--add-opens"
                  "java.base/java.nio=ALL-UNNAMED"]}
+
+  ;; This is probably the best way to start the app for dev mode.
+  ;; 1. Runs (dev) (start!) for you
+  ;; 2. This start the repl too
+  ;; 3. works with hashp
+  ;; clj -M:dev:dev-start:drivers:drivers-dev:ee:ee-dev
+  :dev-start {:main-opts ["-m" "user"]}
 
   ;; includes test code as source paths. Run tests with clojure -X:dev:test
   :test

--- a/deps.edn
+++ b/deps.edn
@@ -254,6 +254,7 @@
                                   :exclusions
                                   [org.ow2.asm/asm-all]}
     lambdaisland/deep-diff2      {:mvn/version "2.12.219"}                  ; way better diffs
+    nrepl/nrepl                  {:mvn/version "1.3.1"}                     ; nREPL server
     org.clojure/algo.generic     {:mvn/version "1.0.1"}
     peridot/peridot              {:git/url "https://github.com/piranha/peridot.git"
                                   :sha "db627c627db3b527a63caf472f0422e4cbfdf574"} ; mocking Ring requests; waiting for upstream release of commit 0fc7c01 (explicit charset)

--- a/deps.edn
+++ b/deps.edn
@@ -246,8 +246,8 @@
     {:mvn/version "0.4.0"}                     ; Enables easy memory measurement
     com.gfredericks/test.chuck   {:mvn/version "0.2.14"}                    ; generating strings from regexes (useful with malli)
     criterium/criterium          {:mvn/version "0.4.6"}                     ; benchmarking library
-    djblue/portal                {:mvn/version "0.58.5"}                    ; ui for inspecting values
     dev.weavejester/hashp        {:mvn/version "0.3.0"}                     ; debugging/spying utility
+    djblue/portal                {:mvn/version "0.58.5"}                    ; ui for inspecting values
     io.github.camsaul/humane-are {:mvn/version "1.0.2"}
     io.github.metabase/hawk      {:mvn/version "1.0.7"}
     jonase/eastwood              {:mvn/version "1.4.3"                      ; inspects namespaces and reports possible problems using tools.analyzer

--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -59,7 +59,7 @@
    [dev.migrate :as dev.migrate]
    [dev.model-tracking :as model-tracking]
    [dev.render-png :as render-png]
-   [hashp.core :as hashp]
+   [hashp.preload :as hashp]
    [honey.sql :as sql]
    [java-time.api :as t]
    [malli.dev :as malli-dev]

--- a/dev/src/user.clj
+++ b/dev/src/user.clj
@@ -52,7 +52,9 @@
   :loaded)
 
 (defn -main
-  "This is called by the `:dev-start` cli alias."
+  "This is called by the `:dev-start` cli alias.
+
+  Try it out: `clj -M:dev:dev-start:drivers:drivers-dev:ee:ee-dev`"
   [& _args]
   (future (nrepl.cmdline/-main "-p" "50605"))
   (dev)

--- a/dev/src/user.clj
+++ b/dev/src/user.clj
@@ -2,13 +2,17 @@
   (:require
    [clojure.java.io :as io]
    [environ.core :as env]
+   [hashp.preload]
    [metabase.core.bootstrap]
    [metabase.plugins.classloader :as classloader]
-   [metabase.util :as u]))
+   [metabase.util :as u]
+   [nrepl.cmdline]))
 
 (set! *warn-on-reflection* true)
 
-(comment metabase.core.bootstrap/keep-me)
+(comment
+  metabase.core.bootstrap/keep-me
+  hashp.preload/keep-me)
 
 ;; Load all user.clj files (including the system-wide one).
 (when *file* ; Ensure we don't load ourselves recursively, just in case.
@@ -23,22 +27,22 @@
 ;; libraries might not be available in the classpath
 (u/ignore-exceptions
  ;; make sure stuff like `=?` and what not are loaded
- (classloader/require 'mb.hawk.assert-exprs))
+  (classloader/require 'mb.hawk.assert-exprs))
 
 (u/ignore-exceptions
- (classloader/require 'metabase.test-runner.assert-exprs))
+  (classloader/require 'metabase.test-runner.assert-exprs))
 
 (u/ignore-exceptions
- (classloader/require 'humane-are.core)
- ((resolve 'humane-are.core/install!)))
+  (classloader/require 'humane-are.core)
+  ((resolve 'humane-are.core/install!)))
 
 (u/ignore-exceptions
- (classloader/require 'pjstadig.humane-test-output)
+  (classloader/require 'pjstadig.humane-test-output)
  ;; Initialize Humane Test Output if it's not already initialized. Don't enable humane-test-output when running tests
  ;; from the CLI, it breaks diffs. This uses [[env/env]] rather than [[metabase.config]] so we don't load that namespace
  ;; before we load [[metabase.core.bootstrap]]
- (when-not (= (env/env :mb-run-mode) "test")
-   ((resolve 'pjstadig.humane-test-output/activate!))))
+  (when-not (= (env/env :mb-run-mode) "test")
+    ((resolve 'pjstadig.humane-test-output/activate!))))
 
 (defn dev
   "Load and switch to the 'dev' namespace."
@@ -46,3 +50,12 @@
   (require 'dev)
   (in-ns 'dev)
   :loaded)
+
+(defn -main
+  "This is called by the `:dev-start` cli alias."
+  [& _args]
+  (future (nrepl.cmdline/-main "-p" "50605"))
+  (dev)
+  #_{:clj-kondo/ignore [:discouraged-var]}
+  (eval "(start!)")
+  (deref (promise)))

--- a/src/metabase/core/init.clj
+++ b/src/metabase/core/init.clj
@@ -1,5 +1,5 @@
 (ns metabase.core.init
-  "Loads all OSS namespaces that need to be loaded for side effects on system launch. By convention, these
+  "Loads all namespaces that need to be loaded for side effects on system launch. By convention, these
   namespaces should follow the pattern
 
     metabase.<module-name>.init


### PR DESCRIPTION
## Bump #p dependency

This branch bumps the hashp dependency. Why didn't it happen automatically? because it's name changed from `hashp/hashp` -> `dev.weavejester/hashp` so it's auto-updatable.

## #p is now ok during startup

This branch also allows us to start metabase backend even with `#p`'s littered around 🫨. Before this change, the app would _not start_ because hashp's reader literals

## dev-start alias

This starts the web app and nrepl in one fell swoop with: `clj -M:ee:ee-dev:drivers:drivers-dev:dev:dev-start`. That way it's additive and doesn't change the behavior of the app startup scripts unless you include the alias.

