### PR TITLE
fix flaky test

### DIFF
--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -131,8 +131,10 @@ describe("issue 33327", () => {
     getRunQueryButton().click();
     cy.wait("@dataset");
 
-    cy.findByTestId("visualization-root").icon("warning").should("be.visible");
-    cy.findByTestId("scalar-value").should("not.exist");
+    cy.findByTestId("visualization-root").within(() => {
+      cy.icon("warning").should("be.visible");
+      cy.findByTestId("scalar-value").should("not.exist");
+    });
 
     H.NativeEditor.get().should("contain", "SELECT --1");
     H.NativeEditor.type("{leftarrow}{backspace}{backspace}");


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/DEV-362/stabilize-flaky-test

### Description

The problem is caused by improper usafe of cy.wrap() command. In this case, the test would:
1. select an element
2. use cy.wrap to wrap that element
3. find an icon
4. make an assertion on the icon

the problem would occur when between steps 1 and 3 the selected element re-rendered, which caused step 3 to fail, because cy.wrap would hold reference to that old element.

### Resolution

The custom `cy.icon()` command uses `cy.wrap` internally, which is not really a good approach and causes flakiness. instead, we’d wrap the `cy.icon()` inside `.within()` command to prevent the command from using `cy.wrap()`

### Stress test
https://github.com/metabase/metabase/actions/runs/13562536691