### PR TITLE
Hide metrics/saved questions from multi-stage data picker

### DIFF
--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -165,6 +165,7 @@ export class UnconnectedDataSelector extends Component {
     canChangeDatabase: PropTypes.bool,
     containerClassName: PropTypes.string,
     canSelectMetric: PropTypes.bool,
+    canSelectSavedQuestion: PropTypes.bool,
 
     // from search entity list loader
     allError: PropTypes.bool,
@@ -197,6 +198,7 @@ export class UnconnectedDataSelector extends Component {
     isPopover: true,
     isMantine: false,
     canSelectMetric: false,
+    canSelectSavedQuestion: true,
   };
 
   isPopoverOpen() {
@@ -478,7 +480,11 @@ export class UnconnectedDataSelector extends Component {
   };
 
   hasSavedQuestions = () => {
-    return this.state.databases.some(database => database.is_saved_questions);
+    const { canSelectSavedQuestion } = this.props;
+    return (
+      this.state.databases.some(database => database.is_saved_questions) &&
+      canSelectSavedQuestion
+    );
   };
 
   getDatabases = () => {
@@ -1009,10 +1015,10 @@ export class UnconnectedDataSelector extends Component {
     }
     if (!selectedDataBucketId) {
       return [
-        "card",
         "dataset",
         "table",
         ...(this.props.canSelectMetric ? ["metric"] : []),
+        ...(this.props.canSelectSavedQuestion ? ["card"] : []),
       ];
     }
     return {

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
@@ -260,6 +260,7 @@ function EmbeddingDataPicker({
       selectedCollectionId={card?.collection_id}
       databaseQuery={{ saved: true }}
       canSelectMetric={false}
+      canSelectSavedQuestion={false}
       triggerElement={
         <DataPickerTarget
           tableInfo={tableInfo}

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
@@ -79,7 +79,6 @@ export function NotebookDataPicker({
         table={table}
         placeholder={placeholder}
         canChangeDatabase={canChangeDatabase}
-        hasMetrics={hasMetrics}
         isDisabled={isDisabled}
         onChange={handleChange}
       />
@@ -196,7 +195,6 @@ type LegacyDataPickerProps = {
   table: Lib.TableMetadata | Lib.CardMetadata | undefined;
   placeholder: string;
   canChangeDatabase: boolean;
-  hasMetrics: boolean;
   isDisabled: boolean;
   onChange: (tableId: TableId) => void;
 };
@@ -207,7 +205,6 @@ function EmbeddingDataPicker({
   table,
   placeholder,
   canChangeDatabase,
-  hasMetrics,
   isDisabled,
   onChange,
 }: LegacyDataPickerProps) {
@@ -224,8 +221,6 @@ function EmbeddingDataPicker({
   const { data: card } = useGetCardQuery(
     pickerInfo?.cardId != null ? { id: pickerInfo.cardId } : skipToken,
   );
-  const context = useNotebookContext();
-  const modelList = getModelFilterList(context, hasMetrics);
 
   if (isDataSourceCountLoading) {
     return null;
@@ -264,7 +259,7 @@ function EmbeddingDataPicker({
       selectedTableId={pickerInfo?.tableId}
       selectedCollectionId={card?.collection_id}
       databaseQuery={{ saved: true }}
-      canSelectMetric={modelList.includes("metric")}
+      canSelectMetric={false}
       triggerElement={
         <DataPickerTarget
           tableInfo={tableInfo}


### PR DESCRIPTION
Closes EMB-187, EMB-188
- https://metaboat.slack.com/archives/C063Q3F1HPF/p1739179977011369?thread_ts=1738786031.232769&cid=C063Q3F1HPF

### Description

Since we only show tables and models on the simple data picker, the fallback picker, multi-stage data picker, should also have the same behavior. This PR does that by hiding `Saved Questions` and `Metrics` from the bucket step, so the 2 pickers function the same.

### How to verify

You can embed the app interactively and test it, but I'd just run Metabase locally and modify this function to return `true`
https://github.com/metabase/metabase/blob/f7f70649ba337d91b88cd44282945020c12e8e27/frontend/src/metabase/lib/dom.js#L16

And mock the embedding picker here by setting it to `false`, so it always returns the multi-stage data picker (old embedding picker), otherwise, the current logic is that you need to have at least 100 tables + models to fall back to the old multi-stage data picker.
https://github.com/metabase/metabase/blob/0b5e82ce41c6832fb1148b27d4a3c74651260859/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx#L241

1. Make sure you have models and metrics in your Metabase instance. If you initialize a new instance, you should already have those on hand.
2. Ensure you mock the embedding picker above and `dom.js` if you decide not to test in interactive embedding.
3. Go to `/question/notebook`
4. Play around with the multi-stage data picker, you should only see 2 options in the bucket step
    ![image](https://github.com/user-attachments/assets/0ddf7660-82a0-4142-8606-b6ff884783a6)
5. Ensure that you see only these 2 options and `saved questions` and `metrics` are now gone.

### Demo
![image](https://github.com/user-attachments/assets/0ddf7660-82a0-4142-8606-b6ff884783a6)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
