### PR TITLE
Widen the 'Get embedding code' popover so we can see the copy link button

### DIFF
--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/PublicEmbedCard.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/PublicEmbedCard.tsx
@@ -56,7 +56,7 @@ export const PublicEmbedCard = ({
             onClick={() => setIsOpen(value => !value)}
           >{t`Get embedding code`}</Button>
         </Popover.Target>
-        <Popover.Dropdown>
+        <Popover.Dropdown w="28.5rem">
           <Stack p="lg" w="28rem" mih="7.5rem">
             {loading ? (
               <Center>


### PR DESCRIPTION
Closes #54407

Before:

![widen-get-embedding-popover--before.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/b08058f1-4b63-4331-9067-b4e629b338fd.png)

After:

![widen-get-embedding-popover--after.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/3aef6862-fa57-4275-a52a-420563c0f623.png)

