### PR TITLE
Viz 277 remove share icon from visualizer

### DIFF
--- a/frontend/src/metabase/visualizer/components/Header/Header.tsx
+++ b/frontend/src/metabase/visualizer/components/Header/Header.tsx
@@ -54,11 +54,6 @@ export function Header({ onSave, saveLabel }: HeaderProps) {
             <Icon name="gear" />
           </ActionIcon>
         </Tooltip>
-        <Tooltip label={t`Share`}>
-          <ActionIcon>
-            <Icon name="share" />
-          </ActionIcon>
-        </Tooltip>
         <Tooltip label={t`Fullscreen`}>
           <ActionIcon
             disabled={!isDirty}


### PR DESCRIPTION
Closes VIZ-277

Removes the share icon in visualizer modal:
![image](https://github.com/user-attachments/assets/fee8c1dd-0526-496f-a4ed-631bfa01c57b)
