### PR TITLE
Enable custom no-color-literals ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -171,6 +171,7 @@ module.exports = {
       files: ["*.js", "*.jsx", "*.ts", "*.tsx"],
       rules: {
         "no-unconditional-metabase-links-render": "error",
+        "no-color-literals": "error",
         "no-literal-metabase-strings": "error",
         "depend/ban-dependencies": [
           "error",
@@ -192,11 +193,13 @@ module.exports = {
         "frontend/src/metabase/setup/**/*",
         "frontend/lint/**/*",
         "*.stories.*",
+        "stories-data.*",
         "e2e/**/*",
         "**/tests/*",
         "release/**/*",
       ],
       rules: {
+        "no-color-literals": "off",
         "no-unconditional-metabase-links-render": "off",
         "no-literal-metabase-strings": "off",
       },

--- a/enterprise/frontend/src/embedding-sdk/cli/.eslintrc
+++ b/enterprise/frontend/src/embedding-sdk/cli/.eslintrc
@@ -1,6 +1,7 @@
 {
   "rules": {
     "no-literal-metabase-strings": "off",
+    "no-color-literals": "off",
     "no-console": "off"
   }
 }

--- a/enterprise/frontend/src/embedding-sdk/lib/log-utils.ts
+++ b/enterprise/frontend/src/embedding-sdk/lib/log-utils.ts
@@ -1,4 +1,6 @@
-// Note: this functions need to return an array of two elements, when styling
+/* eslint-disable no-color-literals */
+
+// Note: these functions need to return an array of two elements, when styling
 // console.logs, the style needs to passed as second argument
 // To use them, do `console.log(...bigWarningHeader("message"), "rest of the message")`
 

--- a/enterprise/frontend/src/embedding-sdk/lib/print-usage-problem.ts
+++ b/enterprise/frontend/src/embedding-sdk/lib/print-usage-problem.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-color-literals */
+
 import { match } from "ts-pattern";
 
 import type { SdkUsageProblem } from "embedding-sdk/types/usage-problem";

--- a/enterprise/frontend/src/embedding-sdk/test/.eslintrc
+++ b/enterprise/frontend/src/embedding-sdk/test/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-color-literals": "off"
+  }
+}

--- a/frontend/lint/eslint-rules/no-color-literals.js
+++ b/frontend/lint/eslint-rules/no-color-literals.js
@@ -8,7 +8,7 @@
 //------------------------------------------------------------------------------
 
 const COLOR_REGEX =
-  /(?:#[a-fA-F0-9]{3}(?:[a-fA-F0-9]{3})?\b|(?:rgb|hsl)a?\(\s*\d+\s*(?:,\s*\d+(?:\.\d+)?%?\s*){2,3}\))/g;
+  /(?:#[a-fA-F0-9]{3}(?:[a-fA-F0-9]{3})?\b|(?:rgb|hsl)a?\(\s*\d+\s*(?:,\s*\d+(?:\.\d+)?%?\s*){2,3}\))/;
 const LINT_MESSAGE =
   "Color literals forbidden. Import colors from 'metabase/lib/colors'.";
 

--- a/frontend/lint/eslint-rules/no-color-literals.js
+++ b/frontend/lint/eslint-rules/no-color-literals.js
@@ -8,7 +8,7 @@
 //------------------------------------------------------------------------------
 
 const COLOR_REGEX =
-  /(?:#[a-fA-F0-9]{3}(?:[a-fA-F0-9]{3})?\b|(?:rgb|hsl)a?\(\s*\d+\s*(?:,\s*\d+(?:\.\d+)?%?\s*){2,3}\))/;
+  /(?:#[a-fA-F0-9]{3}(?:[a-fA-F0-9]{3})?\b|(?:rgb|hsl)a?\(\s*\d+\s*(?:,\s*\d+(?:\.\d+)?%?\s*){2,3}\))/g;
 const LINT_MESSAGE =
   "Color literals forbidden. Import colors from 'metabase/lib/colors'.";
 

--- a/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.styled.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.styled.tsx
@@ -18,6 +18,7 @@ export const ActionSettingsHeader = styled.h2`
 `;
 
 // make strolling nicer by fading out the top and bottom of the column
+// eslint-disable-next-line no-color-literals
 const fade = (side: "top" | "bottom") => `
   content  : "";
   position : absolute;

--- a/frontend/src/metabase/browse/databases/BrowseDatabases.tsx
+++ b/frontend/src/metabase/browse/databases/BrowseDatabases.tsx
@@ -123,6 +123,7 @@ const CardImageWrapper = ({ database }: { database: string }) => {
       className={CS.rounded}
       style={{
         boxShadow:
+          // eslint-disable-next-line no-color-literals
           "0px 0px 0px 1px rgba(0, 0, 0, 0.05), 0px 1px 4px 0px rgba(0, 0, 0, 0.10)",
       }}
     >

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/TabsView.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/TabsView.tsx
@@ -50,6 +50,7 @@ export const TabsView = <
         <Tabs.List
           h="2.5rem"
           style={{
+            // eslint-disable-next-line no-color-literals
             "--tab-border-color": "rgba(0, 0, 0, 0)",
           }}
         >

--- a/frontend/src/metabase/components/TextEditor/TextEditor.styled.tsx
+++ b/frontend/src/metabase/components/TextEditor/TextEditor.styled.tsx
@@ -3,6 +3,7 @@ import styled from "@emotion/styled";
 
 import { alpha, color } from "metabase/lib/colors";
 
+// eslint-disable-next-line no-color-literals
 export const TextEditorRoot = styled.div`
   color: #000;
   background: #fff;

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.styled.tsx
@@ -13,6 +13,7 @@ export const ContentContainer = styled.div`
 // to fix this we copy relevant styles here
 // https://github.com/casesandberg/react-color/blob/v2.18.1/src/components/common/Hue.js#L78
 // https://github.com/casesandberg/react-color/blob/v2.18.1/src/components/common/Saturation.js#L94
+// eslint-disable-next-line no-color-literals
 export const ControlsRoot = styled.div`
   .hue-horizontal {
     background: linear-gradient(

--- a/frontend/src/metabase/css/core/overlays/OverlaysDemo.tsx
+++ b/frontend/src/metabase/css/core/overlays/OverlaysDemo.tsx
@@ -231,6 +231,7 @@ export const OverlaysDemo = ({ enableNesting }: OverlaysDemoProps) => {
         >
           <CloseButton
             onClick={() => setActionToastCount(c => c - 1)}
+            // eslint-disable-next-line no-color-literals
             c="#fff"
             bg="transparent"
           />

--- a/frontend/src/metabase/dashboard/components/ClickMappings.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickMappings.jsx
@@ -246,6 +246,7 @@ function TargetWithSource({
           CS.flex,
           CS.alignCenter,
         )}
+        // eslint-disable-next-line no-color-literals
         style={{ borderColor: "#E2E4E8" }}
       >
         <svg
@@ -259,12 +260,14 @@ function TargetWithSource({
           <g opacity="0.6">
             <path
               d="M9 32C9 33.6569 7.65685 35 6 35C4.34315 35 3 33.6569 3 32C3 30.3431 4.34315 29 6 29C7.65685 29 9 30.3431 9 32Z"
+              // eslint-disable-next-line no-color-literals
               fill="#509EE3"
             />
             <path
               fillRule="evenodd"
               clipRule="evenodd"
               d="M12 6C12 8.973 9.83771 11.441 7 11.917V26.083C9.83771 26.559 12 29.027 12 32C12 35.3137 9.31371 38 6 38C2.68629 38 0 35.3137 0 32C0 29.027 2.16229 26.559 5 26.083V11.917C2.16229 11.441 0 8.973 0 6C0 2.68629 2.68629 0 6 0C9.31371 0 12 2.68629 12 6ZM6 10C8.20914 10 10 8.20914 10 6C10 3.79086 8.20914 2 6 2C3.79086 2 2 3.79086 2 6C2 8.20914 3.79086 10 6 10ZM6 36C8.20914 36 10 34.2091 10 32C10 29.7909 8.20914 28 6 28C3.79086 28 2 29.7909 2 32C2 34.2091 3.79086 36 6 36Z"
+              // eslint-disable-next-line no-color-literals
               fill="#509EE3"
             />
           </g>

--- a/frontend/src/metabase/lib/analytics.ts
+++ b/frontend/src/metabase/lib/analytics.ts
@@ -47,6 +47,7 @@ export function trackSchemaEvent(schema: SchemaType, event: SchemaEvent): void {
       // eslint-disable-next-line no-console
       console.log(
         `%c[SNOWPLOW EVENT]%c, ${type}`,
+        // eslint-disable-next-line no-color-literals
         "background: #222; color: #bada55",
         "color: ",
         other,

--- a/frontend/src/metabase/lib/colors/palette.ts
+++ b/frontend/src/metabase/lib/colors/palette.ts
@@ -6,6 +6,7 @@ import type { ColorPalette } from "./types";
 
 export const ACCENT_COUNT = 8;
 
+/* eslint-disable no-color-literals */
 // NOTE: DO NOT ADD COLORS WITHOUT EXTREMELY GOOD REASON AND DESIGN REVIEW
 // NOTE: KEEP SYNCRONIZED WITH:
 // frontend/src/metabase/css/core/colors.module.css

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/PreviewPane/utils.ts
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/PreviewPane/utils.ts
@@ -10,7 +10,9 @@ export function getCheckerBoardDataUri(
 ) {
   const [color1, color2] = match(theme)
     .returnType<[string, string]>()
+    // eslint-disable-next-line no-color-literals
     .with("checkerboard-light", () => ["#ededed", "transparent"])
+    // eslint-disable-next-line no-color-literals
     .with("checkerboard-dark", () => ["#000000", "#323232"])
     .exhaustive();
 

--- a/frontend/src/metabase/static-viz/components/FunnelChart/FunnelChart.tsx
+++ b/frontend/src/metabase/static-viz/components/FunnelChart/FunnelChart.tsx
@@ -29,8 +29,11 @@ const layout = {
   nameFontSize: 16,
   stepTextOffset: 8,
   colors: {
+    // eslint-disable-next-line no-color-literals
     textMedium: "#949aab",
+    // eslint-disable-next-line no-color-literals
     brand: "#509ee3",
+    // eslint-disable-next-line no-color-literals
     border: "#f0f0f0",
   },
   paddingLeft: 10,

--- a/frontend/src/metabase/static-viz/components/ProgressBar/ProgressBar.tsx
+++ b/frontend/src/metabase/static-viz/components/ProgressBar/ProgressBar.tsx
@@ -105,6 +105,7 @@ const ProgressBar = ({
           <>
             <CheckMarkIcon
               size={layout.iconSize}
+              // eslint-disable-next-line no-color-literals
               color="#ffffff"
               x={10}
               y={(layout.barHeight - layout.iconSize) / 2}
@@ -116,6 +117,7 @@ const ProgressBar = ({
               x={layout.iconSize + 16}
               y={layout.barHeight / 2}
               verticalAnchor="middle"
+              // eslint-disable-next-line no-color-literals
               fill="#ffffff"
             >
               {barText}

--- a/frontend/src/metabase/static-viz/components/Text/Text.tsx
+++ b/frontend/src/metabase/static-viz/components/Text/Text.tsx
@@ -8,5 +8,6 @@ type Props = Omit<TextProps, "color"> & {
 };
 
 export const Text = (props: Props) => {
+  // eslint-disable-next-line no-color-literals
   return <VText fontFamily="Lato" fontSize="13" fill="#4C5773" {...props} />;
 };

--- a/frontend/src/metabase/ui/theme.ts
+++ b/frontend/src/metabase/ui/theme.ts
@@ -63,7 +63,9 @@ export const getThemeOverrides = (): MantineThemeOverride => ({
   primaryColor: "brand",
   primaryShade: 0,
   shadows: {
+    // eslint-disable-next-line no-color-literals
     sm: "0px 1px 4px 2px rgba(0, 0, 0, 0.08)",
+    // eslint-disable-next-line no-color-literals
     md: "0px 4px 20px 0px rgba(0, 0, 0, 0.05)",
   },
   spacing: {

--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -31,7 +31,9 @@ import LeafletChoropleth from "./LeafletChoropleth";
 import LegacyChoropleth from "./LegacyChoropleth";
 
 // TODO COLOR
+// eslint-disable-next-line no-color-literals
 const HEAT_MAP_COLORS = ["#C4E4FF", "#81C5FF", "#51AEFF", "#1E96FF", "#0061B5"];
+// eslint-disable-next-line no-color-literals
 const HEAT_MAP_ZERO_COLOR = "#CCC";
 
 export function getColorplethColorScale(

--- a/frontend/src/metabase/visualizations/components/skeletons/ScalarSkeleton/ScalarSkeleton.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/skeletons/ScalarSkeleton/ScalarSkeleton.styled.tsx
@@ -5,6 +5,7 @@ import { VisualizationRoot } from "metabase/visualizations/components/Visualizat
 import { animationStyles } from "metabase/visualizations/components/skeletons/ChartSkeleton/ChartSkeleton.styled";
 import SkeletonCaption from "metabase/visualizations/components/skeletons/SkeletonCaption";
 
+// eslint-disable-next-line no-color-literals
 export const PositionedActionMenu = styled.div`
   position: absolute;
   top: 0.3125rem;

--- a/frontend/src/metabase/visualizations/echarts/cartesian/timeline-events/option.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/timeline-events/option.ts
@@ -114,6 +114,7 @@ export const getTimelineEventsSeries = (
       symbol: "none",
       lineStyle: {
         type: "solid",
+        // eslint-disable-next-line no-color-literals
         color: "rgba(105, 110, 123, 0.2)",
         width: 2,
       },

--- a/frontend/src/metabase/visualizations/echarts/graph/sankey/constants/style.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/sankey/constants/style.ts
@@ -15,6 +15,7 @@ export const SANKEY_CHART_STYLE = {
     minPadding: 24,
   },
   edgeColor: {
+    // eslint-disable-next-line no-color-literals
     gray: "#81898e", // --mb-base-color-orion-50
   },
 };


### PR DESCRIPTION
### Description

Our custom `no-color-literals` rule was not enabled.

All `eslint-disable-next-line` directives are actual violations and should eventually be fixed.

----

Slack thread: https://metaboat.slack.com/archives/C505ZNNH4/p1740584751518219