### PR TITLE
54138 Upgrade node to v22 in Dockerfile & docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # STAGE 1: builder
 ###################
 
-FROM node:18-bullseye as builder
+FROM node:22-bullseye as builder
 
 ARG MB_EDITION=oss
 ARG VERSION

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -74,7 +74,7 @@ services:
 #       Hopefully one of our node geniuses can figure it out.
   # Just build the frontend. Mounts local dev so nothing else needed
   fe-builder:
-    image: node:18.14
+    image: node:22.14.0
     container_name: fe-builder
     working_dir: /dev/metabase
     volumes:

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -74,7 +74,7 @@ services:
 #       Hopefully one of our node geniuses can figure it out.
   # Just build the frontend. Mounts local dev so nothing else needed
   fe-builder:
-    image: node:22.14.0
+    image: node:22-bullseye
     container_name: fe-builder
     working_dir: /dev/metabase
     volumes:


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/54138

### Description

This PR upgrades the node version from 18 to 22, as 18 is not supported anymore.

### How to verify

![image](https://github.com/user-attachments/assets/6690845a-e13c-42dd-ab4f-ed05a594828d)
