### PR TITLE
Adding deep link url support for visualizer cards in dashboard subs

### DIFF
--- a/src/metabase/channel/render/card.clj
+++ b/src/metabase/channel/render/card.clj
@@ -45,7 +45,10 @@
     (let [card-name    (or (-> dashcard :visualization_settings :card.title)
                            (-> card :name))
           image-bundle (when (:channel.render/include-buttons? options)
-                         (image-bundle/external-link-image-bundle render-type))]
+                         (image-bundle/external-link-image-bundle render-type))
+          title-href   (if (is-visualizer-dashcard? dashcard)
+                         (visualizer-dashcard-href dashcard)
+                         (card-href card))]
       {:attachments (when image-bundle
                       (image-bundle/image-bundle->attachment image-bundle))
        :content     [:table {:style (style/style {:margin-bottom   :2px
@@ -56,7 +59,7 @@
                        [:td {:style (style/style {:padding :0
                                                   :margin  :0})}
                         [:a {:style  (style/style (style/header-style))
-                             :href   (card-href card)
+                             :href   title-href
                              :target "_blank"
                              :rel    "noopener noreferrer"}
                          (h card-name)]]
@@ -76,13 +79,6 @@
                                             :font-size :12px
                                             :margin-bottom :8px})}
                  (markdown/process-markdown description :html)]})))
-
-(defn- is-visualizer-dashcard?
-  "true if dashcard has visualizer specific viz settings"
-  [dashcard]
-  (boolean
-   (and (some? dashcard)
-        (get-in dashcard [:visualization_settings :visualization]))))
 
 (defn- visualizer-display-type
   "Return dashcard's display type if it is a visualizer dashcard else nil"

--- a/src/metabase/channel/render/card.clj
+++ b/src/metabase/channel/render/card.clj
@@ -25,9 +25,19 @@
    [:channel.render/include-title?       {:description "default: false", :optional true} :boolean]
    [:channel.render/include-description? {:description "default: false", :optional true} :boolean]])
 
+(defn- is-visualizer-dashcard?
+  "Return true if this dashcard is a visualizer dashcard else false"
+  [dashcard]
+  (some? (get-in dashcard [:visualization_settings :visualization])))
+
 (defn- card-href
   [card]
   (h (urls/card-url (u/the-id card))))
+
+(defn- visualizer-dashcard-href
+  "Build deep linking href for visualizer dashcards"
+  [dashcard]
+  (h (str (urls/dashboard-url (:dashboard_id dashcard)) "#scrollTo=" (:id dashcard))))
 
 (mu/defn- make-title-if-needed :- [:maybe ::body/RenderedPartCard]
   [render-type card dashcard options :- [:maybe ::options]]
@@ -166,13 +176,16 @@
          {description :content}           (make-description-if-needed dashcard card options)
          {pulse-body       :content
           body-attachments :attachments
-          text             :render/text}  (render-pulse-card-body render-type timezone-id card dashcard results)]
+          text             :render/text}  (render-pulse-card-body render-type timezone-id card dashcard results)
+         attachment-href                  (if (is-visualizer-dashcard? dashcard)
+                                            (visualizer-dashcard-href dashcard)
+                                            (card-href card))]
      (cond-> {:attachments (merge title-attachments body-attachments)
               :content [:p
                         ;; Provide a horizontal scrollbar for tables that overflow container width.
                         ;; Surrounding <p> element prevents buggy behavior when dragging scrollbar.
                         [:div
-                         [:a {:href        (card-href card)
+                         [:a {:href        attachment-href
                               :target      "_blank"
                               :rel         "noopener noreferrer"
                               :style       (style/style

--- a/test/metabase/channel/render/card_test.clj
+++ b/test/metabase/channel/render/card_test.clj
@@ -291,3 +291,19 @@
                                                                                 {:channel.render/include-title? true}))]
           (is (some? (lib.util.match/match-one rendered-card-content
                        [:a (_ :guard #(= (format "https://mb.com/question/%d" (:id card)) (:href %))) "A Card"]))))))))
+
+(deftest visualizer-href-includes-scroll
+  (testing "the title and body hrefs for visualizer cards should be of the form '.../dashboard/<DASHBOARD_ID>#scrollTo=<DASHBOARD_CARD_ID>'"
+    (mt/with-temp [:model/Card           card {:name          "A Card"
+                                               :dataset_query (mt/mbql-query venues {:limit 1})}
+                   :model/Dashboard      dashboard {}
+                   :model/DashboardCard  dc1 {:dashboard_id (:id dashboard) :card_id (:id card) :visualization_settings {:visualization {}}}]
+      (mt/with-temp-env-var-value! [mb-site-url "https://mb.com"]
+        (let [rendered-card-content (:content (channel.render/render-pulse-card :inline
+                                                                                (channel.render/defaulted-timezone card)
+                                                                                card
+                                                                                dc1
+                                                                                (qp/process-query (:dataset_query card))
+                                                                                {:channel.render/include-title? true}))
+              expected-href         (format "https://mb.com/dashboard/%d#scrollTo=%d" (:dashboard_id dc1) (:id dc1))]
+          (is (every? true? (map #(= (:href %) expected-href) (lib.util.match/match rendered-card-content  {:href _})))))))))


### PR DESCRIPTION
- Adds support for deep link hrefs / urls in subscriptions for visualizer built dashcards

<details>
<summary>Screenshot of URL in subscription email</summary>
<img width="1141" alt="image" src="https://github.com/user-attachments/assets/69321e91-abe0-41ad-ad70-3177b2ce3df1" />
</details>