### PR TITLE
Fix cyclic payload.core dependency

### DIFF
--- a/src/metabase/notification/core.clj
+++ b/src/metabase/notification/core.clj
@@ -4,6 +4,7 @@
    [metabase.notification.payload.core :as notification.payload]
    [metabase.notification.seed :as notification.seed]
    [metabase.notification.send :as notification.send]
+   [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [potemkin :as p]))
@@ -36,3 +37,11 @@
     (if (:notification/sync? options)
       (notification.send/send-notification-sync! notification)
       (notification.send/send-notification-async! notification))))
+
+;; ------------------------------------------------------------------------------------------------;;
+;;                                    Load the implementations                                     ;;
+;; ------------------------------------------------------------------------------------------------;;
+(when-not *compile-files*
+  ;; load payload impls here rather than payload.core.
+  ;; the impls depend on payload.core and would cause a cyclic dependency
+  (u/find-and-load-namespaces! "metabase.notification.payload.impl"))

--- a/src/metabase/notification/payload/core.clj
+++ b/src/metabase/notification/payload/core.clj
@@ -4,7 +4,6 @@
    [metabase.models.notification :as models.notification]
    [metabase.notification.payload.execute :as notification.payload.execute]
    [metabase.public-settings :as public-settings]
-   [metabase.util :as u]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
    [potemkin :as p]
@@ -155,9 +154,3 @@
 (defmethod should-send-notification? :default
   [_notification-payload]
   true)
-
-;; ------------------------------------------------------------------------------------------------;;
-;;                                    Load the implementations                                     ;;
-;; ------------------------------------------------------------------------------------------------;;
-(when-not *compile-files*
-  (u/find-and-load-namespaces! "metabase.notification.payload.impl"))


### PR DESCRIPTION
Move payload impl load to the notifications.core to avoid cycles. 