### PR TITLE
fix(sdk): Fix ColorRangeSelector in Conditional Formatting

### DIFF
--- a/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.stories.tsx
+++ b/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.stories.tsx
@@ -3,7 +3,8 @@ import type { StoryFn } from "@storybook/react";
 
 import { color } from "metabase/lib/colors";
 
-import ColorRangeSelector, {
+import {
+  ColorRangeSelector,
   type ColorRangeSelectorProps,
 } from "./ColorRangeSelector";
 

--- a/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.tsx
+++ b/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.tsx
@@ -1,8 +1,9 @@
+import { useDisclosure } from "@mantine/hooks";
 import type { HTMLAttributes, Ref } from "react";
 import { forwardRef } from "react";
 
-import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import ColorRange from "metabase/core/components/ColorRange";
+import { Popover } from "metabase/ui";
 
 import ColorRangePopover from "./ColorRangePopover";
 
@@ -20,7 +21,7 @@ export interface ColorRangeSelectorProps extends ColorRangeSelectorAttributes {
   onChange?: (newValue: string[]) => void;
 }
 
-const ColorRangeSelector = forwardRef(function ColorRangeSelector(
+export const ColorRangeSelector = forwardRef(function ColorRangeSelector(
   {
     value,
     colors,
@@ -32,19 +33,20 @@ const ColorRangeSelector = forwardRef(function ColorRangeSelector(
   }: ColorRangeSelectorProps,
   ref: Ref<HTMLDivElement>,
 ) {
+  const [opened, { close, toggle }] = useDisclosure(false);
   return (
-    <TippyPopoverWithTrigger
-      renderTrigger={({ onClick }) => (
+    <Popover opened={opened} onDismiss={close} onClose={close}>
+      <Popover.Target>
         <ColorRange
           {...props}
           ref={ref}
           colors={value}
           isQuantile={isQuantile}
-          onClick={onClick}
+          onClick={toggle}
           role="button"
         />
-      )}
-      popoverContent={({ closePopover }) => (
+      </Popover.Target>
+      <Popover.Dropdown>
         <ColorRangePopover
           initialValue={value}
           colors={colors}
@@ -52,12 +54,9 @@ const ColorRangeSelector = forwardRef(function ColorRangeSelector(
           colorMapping={colorMapping}
           isQuantile={isQuantile}
           onChange={onChange}
-          onClose={closePopover}
+          onClose={close}
         />
-      )}
-    />
+      </Popover.Dropdown>
+    </Popover>
   );
 });
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default ColorRangeSelector;

--- a/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.tsx
+++ b/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.tsx
@@ -39,8 +39,8 @@ export const ColorRangeSelector = forwardRef(function ColorRangeSelector(
   return (
     <Popover
       opened={opened}
-      onDismiss={close}
-      onClose={close}
+      onChange={toggle}
+      floatingStrategy="fixed"
       withinPortal={withinPortal}
     >
       <Popover.Target>

--- a/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.tsx
+++ b/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.tsx
@@ -3,14 +3,15 @@ import type { HTMLAttributes, Ref } from "react";
 import { forwardRef } from "react";
 
 import ColorRange from "metabase/core/components/ColorRange";
-import { Popover } from "metabase/ui";
+import { Popover, type PopoverProps } from "metabase/ui";
 
 import ColorRangePopover from "./ColorRangePopover";
 
 export type ColorRangeSelectorAttributes = Omit<
   HTMLAttributes<HTMLDivElement>,
   "onChange" | "onSelect"
->;
+> &
+  Pick<PopoverProps, "withinPortal">;
 
 export interface ColorRangeSelectorProps extends ColorRangeSelectorAttributes {
   value: string[];
@@ -29,13 +30,19 @@ export const ColorRangeSelector = forwardRef(function ColorRangeSelector(
     colorMapping,
     isQuantile,
     onChange,
+    withinPortal,
     ...props
   }: ColorRangeSelectorProps,
   ref: Ref<HTMLDivElement>,
 ) {
   const [opened, { close, toggle }] = useDisclosure(false);
   return (
-    <Popover opened={opened} onDismiss={close} onClose={close}>
+    <Popover
+      opened={opened}
+      onDismiss={close}
+      onClose={close}
+      withinPortal={withinPortal}
+    >
       <Popover.Target>
         <ColorRange
           {...props}

--- a/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.unit.spec.tsx
@@ -33,7 +33,7 @@ describe("ColorRangeSelector", () => {
     const { onChange } = setup();
 
     screen.getByRole("button").click();
-    expect(await screen.findByRole("tooltip")).toBeInTheDocument();
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
 
     (await screen.findByLabelText(color("summarize"))).click();
     expect(onChange).toHaveBeenCalled();
@@ -46,7 +46,7 @@ describe("ColorRangeSelector", () => {
     const { onChange } = setup();
 
     screen.getByRole("button").click();
-    expect(await screen.findByRole("tooltip")).toBeInTheDocument();
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
 
     (await screen.findByLabelText(getColorRangeLabel(DEFAULT_VALUE))).click();
     expect(onChange).not.toHaveBeenCalled();

--- a/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.unit.spec.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "__support__/ui";
 import { color } from "metabase/lib/colors";
 
-import ColorRangeSelector from "./ColorRangeSelector";
+import { ColorRangeSelector } from "./ColorRangeSelector";
 import { getColorRangeLabel } from "./ColorRangeToggle";
 
 const DEFAULT_VALUE = [color("white"), color("brand")];

--- a/frontend/src/metabase/core/components/ColorRangeSelector/index.ts
+++ b/frontend/src/metabase/core/components/ColorRangeSelector/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./ColorRangeSelector";
+export { ColorRangeSelector } from "./ColorRangeSelector";

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/RuleEditor.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/RuleEditor.tsx
@@ -3,7 +3,7 @@ import { useMemo } from "react";
 import { msgid, ngettext, t } from "ttag";
 import _ from "underscore";
 
-import ColorRangeSelector from "metabase/core/components/ColorRangeSelector";
+import { ColorRangeSelector } from "metabase/core/components/ColorRangeSelector";
 import { ColorSelector } from "metabase/core/components/ColorSelector";
 import CS from "metabase/css/core/index.css";
 import { Button, MultiSelect, Select, TextInputBlurChange } from "metabase/ui";

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/RuleEditor.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/RuleEditor.tsx
@@ -175,6 +175,7 @@ export const RuleEditor = ({
             }}
             colors={COLORS}
             colorRanges={COLOR_RANGES}
+            withinPortal={false}
           />
           <h3 className={cx(CS.mt3, CS.mb1)}>{t`Start the range at`}</h3>
           <ChartSettingRadio

--- a/frontend/src/metabase/visualizations/visualizations/Map/Map.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Map/Map.jsx
@@ -3,7 +3,7 @@ import { Component } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
-import ColorRangeSelector from "metabase/core/components/ColorRangeSelector";
+import { ColorRangeSelector } from "metabase/core/components/ColorRangeSelector";
 import { getAccentColors } from "metabase/lib/colors/groups";
 import MetabaseSettings from "metabase/lib/settings";
 import { ChartSettingsError } from "metabase/visualizations/lib/errors";


### PR DESCRIPTION
Ensures that the `ColorRangeSelector` doesn't close the whole popover when used in the SDK `QuestionSettings` component.

Nothing changes visually - this just uses the Mantine Popover so we can ensure that nested popovers in the SDK don't crash