### PR TITLE
Clean template tags when changing databases

### DIFF
--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.js
@@ -526,8 +526,6 @@ describe("issue 31926", { tags: "@external" }, () => {
     });
     // run button disabled
     cy.findAllByTestId("run-button").filter(":visible").should("be.disabled");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    //cy.contains(`Can\'t find field with ID: ${PRODUCTS.CATEGORY}`);
 
     // Try to save the native query
     // save button disabled

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.js
@@ -482,10 +482,9 @@ describe("issue 21550", () => {
   });
 });
 
-describe("issue 21597", { tags: "@external" }, () => {
+describe("issue 31926", { tags: "@external" }, () => {
   const databaseName = "Sample Database";
   const databaseCopyName = `${databaseName} copy`;
-  const secondDatabaseId = SAMPLE_DB_ID + 1;
 
   beforeEach(() => {
     H.restore();
@@ -493,7 +492,7 @@ describe("issue 21597", { tags: "@external" }, () => {
   });
 
   it("display the relevant error message in save question modal (metabase#21597)", () => {
-    cy.intercept("POST", "/api/card").as("saveNativeQuestion");
+    cy.intercept({ method: "POST", url: "/api/card" });
 
     // Second DB (copy)
     H.addPostgresDatabase(databaseCopyName);
@@ -525,19 +524,69 @@ describe("issue 21597", { tags: "@external" }, () => {
     H.popover().within(() => {
       cy.findByText(databaseCopyName).click();
     });
-    cy.findByTestId("native-query-editor-container").icon("play").click();
+    // run button disabled
+    cy.findAllByTestId("run-button").filter(":visible").should("be.disabled");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains(`Can\'t find field with ID: ${PRODUCTS.CATEGORY}`);
+    //cy.contains(`Can\'t find field with ID: ${PRODUCTS.CATEGORY}`);
+
+    // Try to save the native query
+    // save button disabled
+    cy.findByTestId("qb-save-button").should(
+      "have.attr",
+      "data-disabled",
+      "true",
+    );
+  });
+});
+
+describe("issue 21597", { tags: "@external" }, () => {
+  /*
+   *
+   * Greetings and welcome to this weird test. It has a history! A long legacy! Allow me to explain:
+   *
+   * This test was originally using changing the DB on a native query with field filters to trigger an error that
+   * would show up in the save modal.
+   *
+   * PR#54453 fixes this error by removing the field filters that refer to the old database, which means that it won't
+   * save.
+   *
+   * So in order to trigger an error, we are intercepting the POST /api/card and manually responding with an error.
+   *
+   * We then assert that the message makes it to the save modal.
+   *
+   * The End
+   */
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+  });
+
+  it("display the relevant error message in save question modal (metabase#21597)", () => {
+    const message =
+      'Invalid Field Filter: Field 164574 "PRODUCTS"."CATEGORY" belongs to Database 2276 "sample-dataset", but the query is against Database 2275 "test-data"';
+    cy.intercept({ method: "POST", url: "/api/card" }, request => {
+      request.reply({
+        body: {
+          message: message,
+          _status: 400,
+        },
+        statusCode: 400,
+      });
+    }).as("saveNativeQuestion");
+
+    // Create a native query and run it
+    H.startNewNativeQuestion();
+    H.NativeEditor.type("SELECT 1");
 
     // Try to save the native query
     cy.findByTestId("qb-header-action-panel").findByText("Save").click();
-    cy.findByTestId("save-question-modal").within(modal => {
-      cy.findByPlaceholderText("What is the name of your question?").type("Q");
+    H.modal().within(() => {
+      cy.findByPlaceholderText("What is the name of your question?").type(
+        "The question name",
+      );
       cy.findByText("Save").click();
       cy.wait("@saveNativeQuestion");
-      cy.findByText(
-        `Invalid Field Filter: Field ${PRODUCTS.CATEGORY} "PRODUCTS"."CATEGORY" belongs to Database ${SAMPLE_DB_ID} "${databaseName}", but the query is against Database ${secondDatabaseId} "${databaseCopyName}"`,
-      );
+      cy.findByText(message);
     });
   });
 });

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -178,8 +178,10 @@
   [query :- ::lib.schema/query
    metadata-provider :- ::lib.schema.metadata/metadata-providerable]
   (assert-native-query! (lib.util/query-stage query 0))
-   ;; Changing the database should also clean up template tags, see #31926
-  (lib.query/query-with-stages metadata-provider (:stages query)))
+  (let [stages-without-fields (->> (:stages query)
+                                   (mapv (fn [stage]
+                                           (update stage :template-tags update-vals #(dissoc % :dimension)))))]
+    (lib.query/query-with-stages metadata-provider stages-without-fields)))
 
 (mu/defn native-extras :- [:maybe ::native-extras]
   "Returns the extra keys for native queries associated with this query."

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -258,7 +258,11 @@
   (and
    (set/subset? (required-native-extras query)
                 (set (keys (native-extras query))))
-   (not (str/blank? (raw-native-query query)))))
+   (not (str/blank? (raw-native-query query)))
+   (every? #(if (= :dimension (:type %))
+              (:dimension %)
+              true)
+           (vals (template-tags query)))))
 
 (mu/defn engine :- [:maybe :keyword]
   "Returns the database engine.

--- a/src/metabase/lib/schema/template_tag.cljc
+++ b/src/metabase/lib/schema/template_tag.cljc
@@ -62,7 +62,8 @@
    [:ref ::value.common]
    [:map
     [:type        [:= :dimension]]
-    [:dimension   [:ref :mbql.clause/field]]
+    ;; field filters can have missing dimension before it is set
+    [:dimension {:optional true} [:ref :mbql.clause/field]]
     ;; which type of widget the frontend should show for this Field Filter; this also affects which parameter types
     ;; are allowed to be specified for it.
     [:widget-type [:ref ::widget-type]]

--- a/test/metabase/lib/native_test.cljc
+++ b/test/metabase/lib/native_test.cljc
@@ -316,6 +316,7 @@
                             {"foo" {:type :dimension
                                     :id "1"
                                     :name "foo"
+                                    ;; missing :dimension
                                     :widget-type :text
                                     :display-name "foo"}})
                           :question)))

--- a/test/metabase/lib/native_test.cljc
+++ b/test/metabase/lib/native_test.cljc
@@ -409,7 +409,6 @@
                                             :name "mytag"
                                             :type :dimension
                                             :widget-type :date/range}}))]
-    (prn query)
     (testing "remove dimensions from template tags"
       (is (empty? (-> query
                       (lib/with-different-database


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31926

### Description

If you changed the database on a native query, it would keep the old template tags around, even those that referred to fields in the old database. This fix simply deletes those field refs from the template tags as the database is switched. Everything else (name of the template tag, default value, etc.) stays.

### How to verify

1. New native query on sample db
2. type "SELECT * FROM people where {{X}}"
3. Edit template tag X to be field filter on name, string contains "A"
4. Run it to verify it's 👍 
5. Switch databases (top left)
6. It should not let you run 🆗 
7. Edit template tag X, should not have field selected. Select a field (name, for instance)
8. Run it to verify it works

