### PR TITLE
Change offset help text

### DIFF
--- a/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
+++ b/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
@@ -99,12 +99,13 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
   {
     name: "offset",
     structure: "Offset",
-    description: () => t`Returns the value of an expression in a different row`,
+    description: () =>
+      t`Returns the value of an aggregation expression in a different row`,
     args: [
       {
         name: t`expression`,
         description: t`The value to get from a different row.`,
-        example: formatIdentifier(t`Total`),
+        example: `Sum(${formatIdentifier(t`Total`)})`,
       },
       {
         name: t`rowOffset`,

--- a/frontend/src/metabase-lib/v1/expressions/helper-text-strings.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/helper-text-strings.unit.spec.ts
@@ -54,6 +54,14 @@ describe("getHelpText", () => {
         expect.not.stringContaining("https"),
       );
     });
+
+    it("offset", () => {
+      const { database } = setup();
+      const helpText = getHelpText("offset", database, reportTimezone);
+
+      expect(helpText?.structure).toBe("Offset");
+      expect(helpText?.example).toBe("Offset(Sum([Total]), -1)");
+    });
   });
 
   describe("help texts customized per database engine", () => {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/54306

Clarifies the `offset` usage:
- Example - `Offset(Sum([Total]), -1)`
- Description - `Returns the value of an aggregation expression in a different row`

Before
![image](https://github.com/user-attachments/assets/ef31aac4-ebe7-4074-ba4b-17c267ca395e)

Now
<img width="788" alt="Screenshot 2025-02-27 at 15 47 04" src="https://github.com/user-attachments/assets/7d4c4453-279f-489c-9e05-0614481bc18c" />
