### PR TITLE
[Impersonation] Adds e2e test for enforcement of impersonation on cached questions

### DIFF
--- a/e2e/test/scenarios/permissions/impersonated.cy.spec.js
+++ b/e2e/test/scenarios/permissions/impersonated.cy.spec.js
@@ -1,5 +1,6 @@
 const { H } = cy;
 import { USER_GROUPS } from "e2e/support/cypress_data";
+import * as PH from "e2e/test/scenarios/admin/performance/helpers/e2e-strategy-form-helpers";
 
 const { ALL_USERS_GROUP, COLLECTION_GROUP } = USER_GROUPS;
 
@@ -50,11 +51,11 @@ describe("impersonated permission", { tags: "@external" }, () => {
         H.setTokenFeatures("all");
 
         setImpersonatedPermission();
-
-        cy.signInAsImpersonatedUser();
       });
 
       it("have limited access", () => {
+        cy.signInAsImpersonatedUser();
+
         cy.visit(`/browse/databases/${PG_DB_ID}`);
 
         // No access through the visual query builder
@@ -94,6 +95,45 @@ describe("impersonated permission", { tags: "@external" }, () => {
         H.runNativeQuery();
 
         cy.findAllByTestId("header-cell").contains("subtotal");
+      });
+
+      it("caching should not circumvent impersonation permissions", () => {
+        cy.log(
+          "create a question for a table the impersonated user does not have access to",
+        );
+        H.startNewNativeQuestion();
+        cy.findByTestId("gui-builder-data").click();
+        cy.findByLabelText("QA Postgres12").click();
+        H.NativeEditor.type("select * from reviews");
+        H.runNativeQuery();
+        H.saveQuestion("foo", undefined, {
+          path: ["Our analytics", "First collection"],
+          select: true,
+          tab: "Browse",
+        });
+
+        cy.log("configure and prime the cache");
+        PH.openSidebar("question");
+        cy.findByLabelText("When to get new results").click();
+        PH.cacheStrategySidesheet().within(() => {
+          cy.findByText(/Use default/).click();
+          cy.findByText(/Caching settings/).should("be.visible");
+          PH.durationRadioButton().click();
+          cy.findByRole("button", { name: /Save/ }).click();
+        });
+        cy.reload();
+        cy.findAllByTestId("header-cell").contains("reviewer");
+
+        cy.log("switch to impersonated user");
+        cy.signOut();
+        cy.signInAsImpersonatedUser();
+        cy.reload();
+
+        cy.log("check that impersonation enforcement occurrs");
+        cy.findByTestId("query-builder-main").within(() => {
+          cy.findByText("An error occurred in your query");
+          cy.findByText("ERROR: permission denied for table reviews");
+        });
       });
     });
   });


### PR DESCRIPTION
### Description

Add test coverage for impersonation enforcement with cache questions to ensure this never breaks without us knowing.

### Demo

e2e test run
https://github.com/user-attachments/assets/2ce25224-6a19-4426-9425-518515129712

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
