### PR TITLE
Allow search results to include dashboard saved questions

### DIFF
--- a/frontend/src/metabase/visualizer/components/DataImporter/SearchResultsList.tsx
+++ b/frontend/src/metabase/visualizer/components/DataImporter/SearchResultsList.tsx
@@ -25,6 +25,7 @@ export function SearchResultsList({
           q: search,
           limit: 10,
           models: ["card"],
+          include_dashboard_questions: true,
         }
       : skipToken,
     {


### PR DESCRIPTION
Closes VIZ-464

- Enable dashboard saved questions to show up in visualizer data importer / search results