### PR TITLE
Manually backported "Fix drills for mapped model metadata"

### DIFF
--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -7,6 +7,7 @@
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.query :as lib.query]
+   [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
@@ -183,3 +184,15 @@
                         (lib.util/query-stage metric-query -1)
                         options)))
           (card-metadata-columns query card))))
+
+(mu/defn source-card-type :- [:maybe ::lib.schema.metadata/card.type]
+  "The type of the query's source-card, if it has one."
+  [query :- ::lib.schema/query]
+  (when-let [card-id (lib.util/source-card-id query)]
+    (when-let [card (lib.metadata/card query card-id)]
+      (:type card))))
+
+(mu/defn source-card-is-model? :- :boolean
+  "Is the query's source-card a model?"
+  [query :- ::lib.schema/query]
+  (= (source-card-type query) :model))

--- a/src/metabase/lib/drill_thru/pivot.cljc
+++ b/src/metabase/lib/drill_thru/pivot.cljc
@@ -165,9 +165,10 @@
   (get-in drill-thru [:pivots pivot-type]))
 
 (defn- breakouts->filters [query stage-number {:keys [column value] :as _dimension}]
-  (-> query
-      (lib.breakout/remove-existing-breakouts-for-column stage-number column)
-      (lib.filter/filter stage-number (lib.filter/= column value))))
+  (let [resolved-column (lib.drill-thru.common/breakout->resolved-column query stage-number column)]
+    (-> query
+        (lib.breakout/remove-existing-breakouts-for-column stage-number column)
+        (lib.filter/filter stage-number (lib.filter/= resolved-column value)))))
 
 ;; Pivot drills are in play when clicking an aggregation cell. Pivoting is applied by:
 ;; 1. For each "dimension", ie. the specific values for all breakouts at the originally clicked cell:

--- a/src/metabase/lib/drill_thru/sort.cljc
+++ b/src/metabase/lib/drill_thru/sort.cljc
@@ -80,10 +80,11 @@
     stage-number                 :- :int
     {:keys [column], :as _drill} :- ::lib.schema.drill-thru/drill-thru.sort
     direction                    :- ::lib.schema.order-by/direction]
-   (-> query
-       ;; remove all existing order bys (see #37633), then add the new one.
-       (lib.order-by/remove-all-order-bys stage-number)
-       (lib.order-by/order-by stage-number column (keyword direction)))))
+   (let [resolved-column (lib.drill-thru.common/breakout->resolved-column query stage-number column)]
+     (-> query
+         ;; remove all existing order bys (see #37633), then add the new one.
+         (lib.order-by/remove-all-order-bys stage-number)
+         (lib.order-by/order-by stage-number resolved-column (keyword direction))))))
 
 (defmethod lib.drill-thru.common/drill-thru-info-method :drill-thru/sort
   [_query _stage-number {directions :sort-directions}]

--- a/src/metabase/lib/drill_thru/underlying_records.cljc
+++ b/src/metabase/lib/drill_thru/underlying_records.cljc
@@ -120,7 +120,8 @@
    stage-number :- :int
    column       :- ::lib.schema.metadata/column
    value        :- :any]
-  (let [filter-clauses (or (when (lib.binning/binning column)
+  (let [column         (lib.drill-thru.common/breakout->resolved-column query stage-number column)
+        filter-clauses (or (when (lib.binning/binning column)
                              (let [unbinned-column (lib.binning/with-binning column nil)]
                                (if (some? value)
                                  (when-let [{:keys [min-value max-value]} (lib.binning/resolve-bin-width query column value)]

--- a/src/metabase/lib/drill_thru/zoom_in_bins.cljc
+++ b/src/metabase/lib/drill_thru/zoom_in_bins.cljc
@@ -129,11 +129,12 @@
 (mu/defn- update-breakout :- ::lib.schema/query
   [query        :- ::lib.schema/query
    stage-number :- :int
-   column       :- ::lib.schema.metadata/column
+   old-column   :- ::lib.schema.metadata/column
+   new-column   :- ::lib.schema.metadata/column
    new-binning  :- ::lib.schema.binning/binning]
-  (if-let [existing-breakout (first (lib.breakout/existing-breakouts query stage-number column))]
-    (lib.remove-replace/replace-clause query stage-number existing-breakout (lib.binning/with-binning column new-binning))
-    (lib.breakout/breakout query stage-number (lib.binning/with-binning column new-binning))))
+  (if-let [existing-breakout (first (lib.breakout/existing-breakouts query stage-number old-column))]
+    (lib.remove-replace/replace-clause query stage-number existing-breakout (lib.binning/with-binning new-column new-binning))
+    (lib.breakout/breakout query stage-number (lib.binning/with-binning new-column new-binning))))
 
 (mu/defmethod lib.drill-thru.common/drill-thru-method :drill-thru/zoom-in.binning :- ::lib.schema/query
   [query                                        :- ::lib.schema/query
@@ -143,11 +144,12 @@
   ;; where [[metabase.query-processor.middleware.binning/update-binning-strategy]] expects to find them. Adding the
   ;; filters to top-level-stage-number breaks the binning.
   (let [top-level-stage-number (lib.underlying/top-level-stage-number query)
+        resolved-column (lib.drill-thru.common/breakout->resolved-column query stage-number column)
         old-filters (filter (fn [[operator _opts filter-column]]
                               (and (#{:>= :<} operator)
                                    (lib.equality/find-matching-column filter-column [column])))
                             (lib.filter/filters query stage-number))]
     (-> (reduce #(lib.remove-replace/remove-clause %1 stage-number %2) query old-filters)
-        (update-breakout top-level-stage-number column new-binning)
-        (lib.filter/filter stage-number (lib.filter/>= column min-value))
-        (lib.filter/filter stage-number (lib.filter/< column max-value)))))
+        (update-breakout top-level-stage-number column resolved-column new-binning)
+        (lib.filter/filter stage-number (lib.filter/>= resolved-column min-value))
+        (lib.filter/filter stage-number (lib.filter/< resolved-column max-value)))))

--- a/src/metabase/lib/drill_thru/zoom_in_geographic.cljc
+++ b/src/metabase/lib/drill_thru/zoom_in_geographic.cljc
@@ -232,11 +232,12 @@
   [query                             :- ::lib.schema/query
    stage-number                      :- :int
    {:keys [column value], :as drill} :- ::lib.schema.drill-thru/drill-thru.zoom-in.geographic.country-state-city->binned-lat-lon]
-  (-> query
-      (lib.breakout/remove-existing-breakouts-for-column stage-number column)
-      ;; TODO -- remove/update existing filter?
-      (lib.filter/filter stage-number (lib.filter/= column value))
-      (add-or-update-lat-lon-binning stage-number drill)))
+  (let [resolved-column (lib.drill-thru.common/breakout->resolved-column query stage-number column)]
+    (-> query
+        (lib.breakout/remove-existing-breakouts-for-column stage-number column)
+        ;; TODO -- remove/update existing filter?
+        (lib.filter/filter stage-number (lib.filter/= resolved-column value))
+        (add-or-update-lat-lon-binning stage-number drill))))
 
 (mu/defn- apply-binned-lat-lon->binned-lat-lon-drill :- ::lib.schema/query
   [query        :- ::lib.schema/query

--- a/src/metabase/lib/drill_thru/zoom_in_timeseries.cljc
+++ b/src/metabase/lib/drill_thru/zoom_in_timeseries.cljc
@@ -129,7 +129,8 @@
   (let [{:keys [column value]} dimension
         old-breakout           (:column-ref dimension)
         new-breakout           (lib.temporal-bucket/with-temporal-bucket old-breakout next-unit)
-        stage-number           (lib.underlying/top-level-stage-number query)]
+        stage-number           (lib.underlying/top-level-stage-number query)
+        resovled-column        (lib.drill-thru.common/breakout->resolved-column query stage-number column)]
     (-> query
-        (lib.filter/filter stage-number (lib.filter/= column value))
+        (lib.filter/filter stage-number (lib.filter/= resovled-column value))
         (lib.remove-replace/replace-clause stage-number old-breakout new-breakout))))

--- a/test/metabase/lib/card_test.cljc
+++ b/test/metabase/lib/card_test.cljc
@@ -261,3 +261,13 @@
                         :fk-target-field-id nil}]
       (is (=? expected-col
               (#'lib.card/->card-metadata-column col card-id card field))))))
+
+(deftest ^:parallel source-card-type-test
+  (is (= :model (lib.card/source-card-type lib.tu/query-with-source-model)))
+  (is (= :question (lib.card/source-card-type lib.tu/query-with-source-card)))
+  (is (nil? (lib.card/source-card-type (lib/query meta/metadata-provider (meta/table-metadata :orders))))))
+
+(deftest ^:parallel source-card-is-model?-test
+  (is (lib.card/source-card-is-model? lib.tu/query-with-source-model))
+  (is (not (lib.card/source-card-is-model? lib.tu/query-with-source-card)))
+  (is (not (lib.card/source-card-is-model? (lib/query meta/metadata-provider (meta/table-metadata :orders))))))

--- a/test/metabase/lib/test_util.cljc
+++ b/test/metabase/lib/test_util.cljc
@@ -59,6 +59,7 @@
 (def ^:private cards
   {:cards [{:name          "My Card"
             :id            1
+            :type          :question
             :dataset-query {:database (meta/id)
                             :type     :query
                             :query    {:source-table (meta/id :checkins)
@@ -91,6 +92,14 @@
   'exports' two columns, `USER_ID` and `count`."
   {:lib/type     :mbql/query
    :lib/metadata metadata-provider-with-card
+   :database     (meta/id)
+   :stages       [{:lib/type    :mbql.stage/mbql
+                   :source-card 1}]})
+
+(def query-with-source-model
+  "Like [[query-with-source-card]], but where the card's type is :model"
+  {:lib/type     :mbql/query
+   :lib/metadata metadata-provider-with-model
    :database     (meta/id)
    :stages       [{:lib/type    :mbql.stage/mbql
                    :source-card 1}]})


### PR DESCRIPTION
Manual backport of #54057

There were no source conflicts here, but there was a logical conflict. See the commit in the x.53.x backport for the diff:

https://github.com/metabase/metabase/pull/54443/commits/ff4a9bdfcf0d9aca9eff8915760d98f7e46c79b1

This is a manual backport because I forgot to `double-backport` the original PR