### PR TITLE
Convert RulePreview to Mantine

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/RulePreview.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/RulePreview.tsx
@@ -4,7 +4,15 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import CS from "metabase/css/core/index.css";
-import { Icon } from "metabase/ui";
+import {
+  ActionIcon,
+  Divider,
+  Group,
+  Icon,
+  Paper,
+  type PaperProps,
+  Text,
+} from "metabase/ui";
 import type {
   ColumnFormattingSetting,
   DatasetColumn,
@@ -18,52 +26,42 @@ export const RulePreview = ({
   cols,
   onClick,
   onRemove,
+  ...paperProps
 }: {
   rule: ColumnFormattingSetting;
   cols: DatasetColumn[];
   onClick: MouseEventHandler<HTMLDivElement>;
   onRemove: () => void;
-}) => (
-  <div
-    className={cx(
-      CS.my2,
-      CS.bordered,
-      CS.rounded,
-      CS.shadowed,
-      CS.cursorPointer,
-      CS.bgWhite,
-    )}
+} & PaperProps) => (
+  <Paper
+    withBorder
+    className={CS.overflowHidden}
     onClick={onClick}
-    data-testid="formatting-rule-preview"
+    {...paperProps}
   >
-    <div className={cx(CS.p1, CS.borderBottom, CS.relative, CS.bgLight)}>
-      <div className={cx(CS.px1, CS.flex, CS.alignCenter, CS.relative)}>
-        <span className={cx(CS.h4, CS.flexAuto, CS.textDark, CS.textWrap)}>
-          {rule.columns.length > 0 ? (
-            rule.columns
-              .map(
-                name =>
-                  (_.findWhere(cols, { name }) || {}).display_name || name,
-              )
-              .join(", ")
-          ) : (
-            <span
-              style={{ fontStyle: "oblique" }}
-            >{t`No columns selected`}</span>
-          )}
-        </span>
-        <Icon
-          name="close"
-          className={cx(CS.cursorPointer, CS.textLight, CS.textMediumHover)}
-          style={{ minWidth: 16 }}
-          onClick={e => {
-            e.stopPropagation();
-            onRemove();
-          }}
-        />
-      </div>
-    </div>
-    <div className={cx(CS.p2, CS.flex, CS.alignCenter)}>
+    <Group wrap="nowrap" px="md" bg="bg-light">
+      <Text flex="1" fw="bold" fz="md">
+        {rule.columns.length > 0 ? (
+          rule.columns
+            .map(
+              name => (_.findWhere(cols, { name }) || {}).display_name || name,
+            )
+            .join(", ")
+        ) : (
+          <Text fs="oblique">{t`No columns selected`}</Text>
+        )}
+      </Text>
+      <ActionIcon
+        onClick={e => {
+          e.stopPropagation();
+          onRemove();
+        }}
+      >
+        <Icon name="close" />{" "}
+      </ActionIcon>
+    </Group>
+    <Divider></Divider>
+    <Group wrap="nowrap" p="md" gap="xs">
       <RuleBackground
         rule={rule}
         className={cx(CS.mr2, CS.flexNoShrink, CS.rounded, {
@@ -72,6 +70,6 @@ export const RulePreview = ({
         style={{ width: 40, height: 40 }}
       />
       <RuleDescription rule={rule} />
-    </div>
-  </div>
+    </Group>
+  </Paper>
 );

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/RulePreview.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/RulePreview.tsx
@@ -37,6 +37,7 @@ export const RulePreview = ({
     withBorder
     className={CS.overflowHidden}
     onClick={onClick}
+    data-testid="formatting-rule-preview"
     {...paperProps}
   >
     <Group wrap="nowrap" px="md" bg="bg-light">

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/RulePreview.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/RulePreview.tsx
@@ -44,9 +44,7 @@ export const RulePreview = ({
       <Text flex="1" fw="bold" fz="md">
         {rule.columns.length > 0 ? (
           rule.columns
-            .map(
-              name => (_.findWhere(cols, { name }) || {}).display_name || name,
-            )
+            .map(name => _.findWhere(cols, { name })?.display_name ?? name)
             .join(", ")
         ) : (
           <Text fs="oblique">{t`No columns selected`}</Text>
@@ -58,7 +56,7 @@ export const RulePreview = ({
           onRemove();
         }}
       >
-        <Icon name="close" />{" "}
+        <Icon name="close" />
       </ActionIcon>
     </Group>
     <Divider></Divider>

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/SortableRuleList.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/SortableRuleList.tsx
@@ -63,6 +63,7 @@ export const SortableRuleList = ({
         cols={cols}
         onClick={() => handleEdit(id)}
         onRemove={() => handleRemove(id)}
+        my="md"
       />
     </Sortable>
   );


### PR DESCRIPTION
Converts the `RulePreview` component, which shows a little blurb about the rule and its background, to Mantine. Nothing should change except the font size on the header of the card, which now uses the `md` font size in the design system (using `lg` was much too large)

Before:
<img width="306" alt="image" src="https://github.com/user-attachments/assets/e0a3ac6c-6b36-4c8e-b672-6135cb7c7a9f" />

After:

<img width="306" alt="image" src="https://github.com/user-attachments/assets/62a4118d-ad63-4ccf-bee7-0f57b5208e2e" />
