### PR TITLE
Enable multi-arch builds in publish workflow

### DIFF
--- a/.github/actions/fetch-artifact/action.yml
+++ b/.github/actions/fetch-artifact/action.yml
@@ -43,7 +43,7 @@ runs:
       shell: bash
       run: unzip mb.zip
     - name: Move the Uberjar
-      shell: bash
+      shell: sh
       run: | # bash
         if [ -e "metabase.jar" ]; then
           echo "metabase.jar is already in the right place"

--- a/.github/actions/fetch-artifact/action.yml
+++ b/.github/actions/fetch-artifact/action.yml
@@ -43,7 +43,7 @@ runs:
       shell: bash
       run: unzip mb.zip
     - name: Move the Uberjar
-      shell: sh
+      shell: bash
       run: | # bash
         if [ -e "metabase.jar" ]; then
           echo "metabase.jar is already in the right place"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,8 @@ jobs:
     outputs:
       ee: ${{ fromJson(steps.canonical_version.outputs.result).ee }}
       oss: ${{ fromJson(steps.canonical_version.outputs.result).oss }}
+      ee_tag: ${{ fromJson(steps.canonical_version.outputs.result).ee_tag }}
+      oss_tag: ${{ fromJson(steps.canonical_version.outputs.result).oss_tag }}
     steps:
     - name: Fail early on the incorrect version format
       if: ${{ !(startsWith(inputs.version,'v0.') || startsWith(inputs.version,'v1.')) }}
@@ -88,6 +90,11 @@ jobs:
             oss: getCanonicalVersion(version, 'oss'),
           };
 
+          const tags = {
+            ee_tag: `${{vars.DOCKERHUB_REPO}}-enterprise:${versions.ee}`,
+            oss_tag: `${{vars.DOCKERHUB_REPO}}:${versions.oss}`,
+          };
+
           const released = await hasBeenReleased({
             github,
             owner: context.repo.owner,
@@ -99,7 +106,15 @@ jobs:
             throw new Error("This version has already been released!", version);
           }
 
-          return versions;
+          console.log({
+            versions,
+            tags,
+          });
+
+          return {
+            ...versions,
+            ...tags,
+          };
 
   publish-start-message:
     runs-on: ubuntu-22.04
@@ -247,7 +262,6 @@ jobs:
         --distribution-id ${{ vars.AWS_CLOUDFRONT_DOWNLOADS_ID }} \
         --paths /${{ steps.version_path.outputs.result }}/metabase.jar
 
-
   verify-s3-download:
     runs-on: ubuntu-22.04
     needs: upload-to-s3
@@ -288,6 +302,9 @@ jobs:
     strategy:
       matrix:
         edition: [oss, ee]
+    env:
+      OSS_TAG: ${{ needs.check-version.outputs.oss_tag }}
+      EE_TAG: ${{ needs.check-version.outputs.ee_tag }}
     services:
       registry:
         image: registry:2
@@ -298,118 +315,112 @@ jobs:
       with:
         # checkout the commit that was tagged so we get the right dockerfile
         ref: ${{ inputs.commit }}
-        fetch-depth: 0  # IMPORTANT! to get all the tags
-    - name: prepare release scripts
-      run: cd release && yarn && yarn build
     - name: Determine the docker version tag
       uses: actions/github-script@v7
-      id: canonical_version
+      id: get_tag
       with:
         result-encoding: string
-        script: |
-          const version = '${{ inputs.version }}';
-          const edition = '${{ matrix.edition }}';
+        script: | # js
+          const tag = '${{ matrix.edition }}' === 'ee'
+            ? '${{ needs.check-version.outputs.ee_tag }}'
+            : '${{ needs.check-version.outputs.oss_tag }}';
 
-          const canonical_version = edition === 'ee'
-            ? '${{ needs.check-version.outputs.ee }}'
-            : '${{ needs.check-version.outputs.oss }}';
+          console.log("The docker tag for this ", edition, "edition is", tag);
 
-          console.log("The canonical version of this Metabase", edition, "edition is", canonical_version);
+          return tag;
 
-          return canonical_version;
     - uses: actions/download-artifact@v4
       name: Retrieve previously downloaded Uberjar
       with:
         name: metabase-${{ matrix.edition }}-uberjar
     - name: Move the Uberjar to the context dir
       run: mv ./metabase.jar bin/docker/.
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v2
-      with:
-        driver-opts: network=host
+      uses: docker/setup-buildx-action@v3
     - name: Build ${{ matrix.edition }} container
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v6
       with:
         context: bin/docker/.
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64
         network: host
-        tags: localhost:5000/local-metabase:${{ steps.canonical_version.outputs.result }}
+        tags: ${{ steps.get_tag.outputs.result }}
         no-cache: true
         push: true
 
-    - name: Launch container
-      run: docker run --rm -dp 3000:3000 localhost:5000/local-metabase:${{ steps.canonical_version.outputs.result }}
-      timeout-minutes: 5
-    - name: Wait for Metabase to start
-      run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
-      timeout-minutes: 3
-
-    - name: Determine the target Docker Hub repository
-      run: |
-        if [[ "${{ matrix.edition }}" == "ee" ]]; then
-          echo "Metabase EE: image is going to be pushed to ${{ github.repository_owner }}/metabase-enterprise"
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase-enterprise" >> $GITHUB_ENV
-        else
-          echo "Metabase OSS: image is going to be pushed to ${{ github.repository_owner }}/metabase"
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase" >> $GITHUB_ENV
-        fi
-
-    - name: Login to Docker Hub
-      uses: docker/login-action@v2
-      with:
-        username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
-    - name: Retag and push container image to Docker Hub
-      run: |
-        echo "Pushing ${{ steps.canonical_version.outputs.result }} to ${{ env.DOCKERHUB_REPO }} ..."
-        docker tag localhost:5000/local-metabase:${{ steps.canonical_version.outputs.result }} ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }}
-        docker push ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }}
-        echo "Finished!"
-
   verify-docker-pull:
     runs-on: ubuntu-22.04
-    needs: containerize
+    needs: [check-version, containerize]
     timeout-minutes: 15
     strategy:
       matrix:
         edition: [oss, ee]
     steps:
+    - name: Determine the docker version tag
+      uses: actions/github-script@v7
+      id: get_tag
+      with:
+        result-encoding: string
+        script: | # js
+          const tag = '${{ matrix.edition }}' === 'ee'
+            ? '${{ needs.check-version.outputs.ee_tag }}'
+            : '${{ needs.check-version.outputs.oss_tag }}';
+
+          console.log("The docker tag for this ", edition, "edition is", tag);
+
+          return tag;
     - name: Login to Docker Hub # authenticated, to avoid being rate-throttled
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
         password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
-    - name: Determine the container image to pull
-      run: |
-        if [[ "${{ matrix.edition }}" = "ee" ]]; then
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase-enterprise" >> $GITHUB_ENV
-        else
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase" >> $GITHUB_ENV
-        fi
-    - name: Determine the docker version tag
-      uses: actions/github-script@v7
-      id: canonical_version
-      with:
-        result-encoding: string
-        script: |
-          const version = '${{ inputs.version }}';
-          const edition = '${{ matrix.edition }}';
-
-          const canonical_version = edition === "ee"
-            ? version.replace(/^v0\./, "v1.") // always e.g. v1.47.2
-            : version.replace(/^v1\./, "v0."); // always e.g. v0.47.2
-
-          console.log("The canonical version of this Metabase", edition, "edition is", canonical_version);
-
-          return canonical_version;
     - name: Pull the container image
       run: |
-        echo "Pulling container image ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }} ..."
-        docker pull ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }}
+        echo "Pulling container image ${{ vars.DOCKERHUB_OWNER }}:${{ steps.get_tag.outputs.result }} ..."
+        docker pull ${{ vars.DOCKERHUB_OWNER }}:${{ steps.get_tag.outputs.result }}
         echo "Successful!"
     - name: Launch container
-      run: docker run --rm -dp 3000:3000 ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }}
+      run: docker run --rm -dp 3000:3000 ${{ vars.DOCKERHUB_OWNER }}:${{ steps.get_tag.outputs.result }}
+      timeout-minutes: 5
+    - name: Wait for Metabase to start
+      run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
+      timeout-minutes: 3
+
+  verify-docker-pull-arm:
+    runs-on: arm-ubuntu-24-2core
+    needs: [check-version, containerize]
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        edition: [oss, ee]
+    steps:
+    - name: Determine the docker version tag
+      uses: actions/github-script@v7
+      id: get_tag
+      with:
+        result-encoding: string
+        script: | # js
+          const tag = '${{ matrix.edition }}' === 'ee'
+            ? '${{ needs.check-version.outputs.ee_tag }}'
+            : '${{ needs.check-version.outputs.oss_tag }}';
+
+          console.log("The docker tag for this ", edition, "edition is", tag);
+
+          return tag;
+    - name: Login to Docker Hub # authenticated, to avoid being rate-throttled
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
+    - name: Pull the container image
+      run: |
+        echo "Pulling container image ${{ vars.DOCKERHUB_OWNER }}:${{ steps.get_tag.outputs.result }} ..."
+        docker pull ${{ vars.DOCKERHUB_OWNER }}:${{ steps.get_tag.outputs.result }}
+        echo "Successful!"
+    - name: Launch container
+      run: docker run --rm -dp 3000:3000 ${{ vars.DOCKERHUB_OWNER }}:${{ steps.get_tag.outputs.result }}
       timeout-minutes: 5
     - name: Wait for Metabase to start
       run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,11 @@ jobs:
             throw new Error("This version has already been released!", version);
           }
 
-          return versions;
+          console.log({
+            versions,
+          });
+
+          return versions
 
   publish-start-message:
     runs-on: ubuntu-22.04
@@ -137,41 +141,13 @@ jobs:
       matrix:
         edition: [oss, ee]
     steps:
-    - name: find_release_artifact
-      id: find_release_artifact
-      uses: actions/github-script@v7
+    - uses: actions/checkout@v4
       with:
-        result-encoding: string
-        script: | # js
-          const fs = require('fs');
-
-          const artifacts = await github.rest.actions.listArtifactsForRepo({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            name: `metabase-release-${{ matrix.edition }}-${{ inputs.commit }}-uberjar`,
-            per_page: 1,
-          });
-
-          if (!artifacts.data?.artifacts?.[0]?.id) {
-            throw new Error(`No artifacts found for ${{ inputs.commit }}`);
-          }
-
-          const artifact_id = artifacts.data.artifacts[0].id;
-
-          const download = await github.rest.actions.downloadArtifact({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            artifact_id: artifact_id,
-            archive_format: 'zip',
-          });
-
-          fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/mb.zip`, Buffer.from(download.data));
-    - name: unzip uberjar artifact
-      run: unzip mb.zip
-    - name: Verify that this is a valid JAR file
-      run: file --mime-type ./metabase.jar | grep "application/zip"
-    - name: Reveal its version.properties
-      run: jar xf metabase.jar version.properties && cat version.properties
+        sparse-checkout: .github
+    - name: Retrieve test build uberjar artifact for ${{ matrix.edition }}
+      uses: ./.github/actions/fetch-artifact
+      with:
+        name: metabase-release-${{ matrix.edition }}-${{ inputs.commit }}-uberjar
     - name: Check JAR version properties
       run: |
         # ensure actual jar checksum matches checksum file
@@ -247,7 +223,6 @@ jobs:
         --distribution-id ${{ vars.AWS_CLOUDFRONT_DOWNLOADS_ID }} \
         --paths /${{ steps.version_path.outputs.result }}/metabase.jar
 
-
   verify-s3-download:
     runs-on: ubuntu-22.04
     needs: upload-to-s3
@@ -281,143 +256,29 @@ jobs:
     - name: Verify Checksum
       run: grep -q $(sha256sum ./metabase-downloaded.jar) SHA256.sum && echo "checksums match" || exit 1
 
-  containerize:
-    runs-on: ubuntu-22.04
-    needs: [check-version, download-uberjar]
-    timeout-minutes: 15
-    strategy:
-      matrix:
-        edition: [oss, ee]
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        # checkout the commit that was tagged so we get the right dockerfile
-        ref: ${{ inputs.commit }}
-        fetch-depth: 0  # IMPORTANT! to get all the tags
-    - name: prepare release scripts
-      run: cd release && yarn && yarn build
-    - name: Determine the docker version tag
-      uses: actions/github-script@v7
-      id: canonical_version
-      with:
-        result-encoding: string
-        script: |
-          const version = '${{ inputs.version }}';
-          const edition = '${{ matrix.edition }}';
+  containerize-oss:
+    needs: check-version
+    uses: ./.github/workflows/containerize-jar.yml
+    secrets: inherit
+    with:
+      artifact-name: metabase-release-oss-${{ inputs.commit }}-uberjar
+      commit: ${{ inputs.commit }}
+      repo: ${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_REPO }}
+      tag: ${{ needs.check-version.outputs.oss }}
 
-          const canonical_version = edition === 'ee'
-            ? '${{ needs.check-version.outputs.ee }}'
-            : '${{ needs.check-version.outputs.oss }}';
-
-          console.log("The canonical version of this Metabase", edition, "edition is", canonical_version);
-
-          return canonical_version;
-    - uses: actions/download-artifact@v4
-      name: Retrieve previously downloaded Uberjar
-      with:
-        name: metabase-${{ matrix.edition }}-uberjar
-    - name: Move the Uberjar to the context dir
-      run: mv ./metabase.jar bin/docker/.
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v2
-      with:
-        driver-opts: network=host
-    - name: Build ${{ matrix.edition }} container
-      uses: docker/build-push-action@v3
-      with:
-        context: bin/docker/.
-        platforms: linux/amd64
-        network: host
-        tags: localhost:5000/local-metabase:${{ steps.canonical_version.outputs.result }}
-        no-cache: true
-        push: true
-
-    - name: Launch container
-      run: docker run --rm -dp 3000:3000 localhost:5000/local-metabase:${{ steps.canonical_version.outputs.result }}
-      timeout-minutes: 5
-    - name: Wait for Metabase to start
-      run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
-      timeout-minutes: 3
-
-    - name: Determine the target Docker Hub repository
-      run: |
-        if [[ "${{ matrix.edition }}" == "ee" ]]; then
-          echo "Metabase EE: image is going to be pushed to ${{ github.repository_owner }}/metabase-enterprise"
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase-enterprise" >> $GITHUB_ENV
-        else
-          echo "Metabase OSS: image is going to be pushed to ${{ github.repository_owner }}/metabase"
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase" >> $GITHUB_ENV
-        fi
-
-    - name: Login to Docker Hub
-      uses: docker/login-action@v2
-      with:
-        username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
-    - name: Retag and push container image to Docker Hub
-      run: |
-        echo "Pushing ${{ steps.canonical_version.outputs.result }} to ${{ env.DOCKERHUB_REPO }} ..."
-        docker tag localhost:5000/local-metabase:${{ steps.canonical_version.outputs.result }} ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }}
-        docker push ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }}
-        echo "Finished!"
-
-  verify-docker-pull:
-    runs-on: ubuntu-22.04
-    needs: containerize
-    timeout-minutes: 15
-    strategy:
-      matrix:
-        edition: [oss, ee]
-    steps:
-    - name: Login to Docker Hub # authenticated, to avoid being rate-throttled
-      uses: docker/login-action@v2
-      with:
-        username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
-    - name: Determine the container image to pull
-      run: |
-        if [[ "${{ matrix.edition }}" = "ee" ]]; then
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase-enterprise" >> $GITHUB_ENV
-        else
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase" >> $GITHUB_ENV
-        fi
-    - name: Determine the docker version tag
-      uses: actions/github-script@v7
-      id: canonical_version
-      with:
-        result-encoding: string
-        script: |
-          const version = '${{ inputs.version }}';
-          const edition = '${{ matrix.edition }}';
-
-          const canonical_version = edition === "ee"
-            ? version.replace(/^v0\./, "v1.") // always e.g. v1.47.2
-            : version.replace(/^v1\./, "v0."); // always e.g. v0.47.2
-
-          console.log("The canonical version of this Metabase", edition, "edition is", canonical_version);
-
-          return canonical_version;
-    - name: Pull the container image
-      run: |
-        echo "Pulling container image ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }} ..."
-        docker pull ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }}
-        echo "Successful!"
-    - name: Launch container
-      run: docker run --rm -dp 3000:3000 ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }}
-      timeout-minutes: 5
-    - name: Wait for Metabase to start
-      run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
-      timeout-minutes: 3
+  containerize-ee:
+    needs: check-version
+    uses: ./.github/workflows/containerize-jar.yml
+    secrets: inherit
+    with:
+      artifact-name: metabase-release-ee-${{ inputs.commit }}-uberjar
+      commit: ${{ inputs.commit }}
+      repo: ${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_REPO }}-enterprise
+      tag: ${{ needs.check-version.outputs.ee }}
 
   push-tags:
     permissions: write-all
-    needs: [verify-s3-download, verify-docker-pull, check-version]
+    needs: [verify-s3-download, containerize-oss, containerize-ee, check-version]
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
@@ -476,7 +337,8 @@ jobs:
     needs:
       - get-extra-tags
       - push-tags
-      - verify-docker-pull
+      - containerize-ee
+      - containerize-oss
       - verify-s3-download
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,11 +99,7 @@ jobs:
             throw new Error("This version has already been released!", version);
           }
 
-          console.log({
-            versions,
-          });
-
-          return versions
+          return versions;
 
   publish-start-message:
     runs-on: ubuntu-22.04
@@ -141,13 +137,41 @@ jobs:
       matrix:
         edition: [oss, ee]
     steps:
-    - uses: actions/checkout@v4
+    - name: find_release_artifact
+      id: find_release_artifact
+      uses: actions/github-script@v7
       with:
-        sparse-checkout: .github
-    - name: Retrieve test build uberjar artifact for ${{ matrix.edition }}
-      uses: ./.github/actions/fetch-artifact
-      with:
-        name: metabase-release-${{ matrix.edition }}-${{ inputs.commit }}-uberjar
+        result-encoding: string
+        script: | # js
+          const fs = require('fs');
+
+          const artifacts = await github.rest.actions.listArtifactsForRepo({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            name: `metabase-release-${{ matrix.edition }}-${{ inputs.commit }}-uberjar`,
+            per_page: 1,
+          });
+
+          if (!artifacts.data?.artifacts?.[0]?.id) {
+            throw new Error(`No artifacts found for ${{ inputs.commit }}`);
+          }
+
+          const artifact_id = artifacts.data.artifacts[0].id;
+
+          const download = await github.rest.actions.downloadArtifact({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            artifact_id: artifact_id,
+            archive_format: 'zip',
+          });
+
+          fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/mb.zip`, Buffer.from(download.data));
+    - name: unzip uberjar artifact
+      run: unzip mb.zip
+    - name: Verify that this is a valid JAR file
+      run: file --mime-type ./metabase.jar | grep "application/zip"
+    - name: Reveal its version.properties
+      run: jar xf metabase.jar version.properties && cat version.properties
     - name: Check JAR version properties
       run: |
         # ensure actual jar checksum matches checksum file
@@ -223,6 +247,7 @@ jobs:
         --distribution-id ${{ vars.AWS_CLOUDFRONT_DOWNLOADS_ID }} \
         --paths /${{ steps.version_path.outputs.result }}/metabase.jar
 
+
   verify-s3-download:
     runs-on: ubuntu-22.04
     needs: upload-to-s3
@@ -256,29 +281,143 @@ jobs:
     - name: Verify Checksum
       run: grep -q $(sha256sum ./metabase-downloaded.jar) SHA256.sum && echo "checksums match" || exit 1
 
-  containerize-oss:
-    needs: check-version
-    uses: ./.github/workflows/containerize-jar.yml
-    secrets: inherit
-    with:
-      artifact-name: metabase-release-oss-${{ inputs.commit }}-uberjar
-      commit: ${{ inputs.commit }}
-      repo: ${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_REPO }}
-      tag: ${{ needs.check-version.outputs.oss }}
+  containerize:
+    runs-on: ubuntu-22.04
+    needs: [check-version, download-uberjar]
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        edition: [oss, ee]
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        # checkout the commit that was tagged so we get the right dockerfile
+        ref: ${{ inputs.commit }}
+        fetch-depth: 0  # IMPORTANT! to get all the tags
+    - name: prepare release scripts
+      run: cd release && yarn && yarn build
+    - name: Determine the docker version tag
+      uses: actions/github-script@v7
+      id: canonical_version
+      with:
+        result-encoding: string
+        script: |
+          const version = '${{ inputs.version }}';
+          const edition = '${{ matrix.edition }}';
 
-  containerize-ee:
-    needs: check-version
-    uses: ./.github/workflows/containerize-jar.yml
-    secrets: inherit
-    with:
-      artifact-name: metabase-release-ee-${{ inputs.commit }}-uberjar
-      commit: ${{ inputs.commit }}
-      repo: ${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_REPO }}-enterprise
-      tag: ${{ needs.check-version.outputs.ee }}
+          const canonical_version = edition === 'ee'
+            ? '${{ needs.check-version.outputs.ee }}'
+            : '${{ needs.check-version.outputs.oss }}';
+
+          console.log("The canonical version of this Metabase", edition, "edition is", canonical_version);
+
+          return canonical_version;
+    - uses: actions/download-artifact@v4
+      name: Retrieve previously downloaded Uberjar
+      with:
+        name: metabase-${{ matrix.edition }}-uberjar
+    - name: Move the Uberjar to the context dir
+      run: mv ./metabase.jar bin/docker/.
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        driver-opts: network=host
+    - name: Build ${{ matrix.edition }} container
+      uses: docker/build-push-action@v3
+      with:
+        context: bin/docker/.
+        platforms: linux/amd64
+        network: host
+        tags: localhost:5000/local-metabase:${{ steps.canonical_version.outputs.result }}
+        no-cache: true
+        push: true
+
+    - name: Launch container
+      run: docker run --rm -dp 3000:3000 localhost:5000/local-metabase:${{ steps.canonical_version.outputs.result }}
+      timeout-minutes: 5
+    - name: Wait for Metabase to start
+      run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
+      timeout-minutes: 3
+
+    - name: Determine the target Docker Hub repository
+      run: |
+        if [[ "${{ matrix.edition }}" == "ee" ]]; then
+          echo "Metabase EE: image is going to be pushed to ${{ github.repository_owner }}/metabase-enterprise"
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase-enterprise" >> $GITHUB_ENV
+        else
+          echo "Metabase OSS: image is going to be pushed to ${{ github.repository_owner }}/metabase"
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase" >> $GITHUB_ENV
+        fi
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
+    - name: Retag and push container image to Docker Hub
+      run: |
+        echo "Pushing ${{ steps.canonical_version.outputs.result }} to ${{ env.DOCKERHUB_REPO }} ..."
+        docker tag localhost:5000/local-metabase:${{ steps.canonical_version.outputs.result }} ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }}
+        docker push ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }}
+        echo "Finished!"
+
+  verify-docker-pull:
+    runs-on: ubuntu-22.04
+    needs: containerize
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        edition: [oss, ee]
+    steps:
+    - name: Login to Docker Hub # authenticated, to avoid being rate-throttled
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
+    - name: Determine the container image to pull
+      run: |
+        if [[ "${{ matrix.edition }}" = "ee" ]]; then
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase-enterprise" >> $GITHUB_ENV
+        else
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase" >> $GITHUB_ENV
+        fi
+    - name: Determine the docker version tag
+      uses: actions/github-script@v7
+      id: canonical_version
+      with:
+        result-encoding: string
+        script: |
+          const version = '${{ inputs.version }}';
+          const edition = '${{ matrix.edition }}';
+
+          const canonical_version = edition === "ee"
+            ? version.replace(/^v0\./, "v1.") // always e.g. v1.47.2
+            : version.replace(/^v1\./, "v0."); // always e.g. v0.47.2
+
+          console.log("The canonical version of this Metabase", edition, "edition is", canonical_version);
+
+          return canonical_version;
+    - name: Pull the container image
+      run: |
+        echo "Pulling container image ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }} ..."
+        docker pull ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }}
+        echo "Successful!"
+    - name: Launch container
+      run: docker run --rm -dp 3000:3000 ${{ env.DOCKERHUB_REPO }}:${{ steps.canonical_version.outputs.result }}
+      timeout-minutes: 5
+    - name: Wait for Metabase to start
+      run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
+      timeout-minutes: 3
 
   push-tags:
     permissions: write-all
-    needs: [verify-s3-download, containerize-oss, containerize-ee, check-version]
+    needs: [verify-s3-download, verify-docker-pull, check-version]
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
@@ -337,8 +476,7 @@ jobs:
     needs:
       - get-extra-tags
       - push-tags
-      - containerize-ee
-      - containerize-oss
+      - verify-docker-pull
       - verify-s3-download
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,9 @@ jobs:
       matrix:
         edition: [oss, ee]
     steps:
+    - uses: actions/checkout@v4
+      with:
+        sparse-checkout: .github
     - name: Retrieve test build uberjar artifact for ${{ matrix.edition }}
       uses: ./.github/actions/fetch-artifact
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,6 @@ jobs:
     outputs:
       ee: ${{ fromJson(steps.canonical_version.outputs.result).ee }}
       oss: ${{ fromJson(steps.canonical_version.outputs.result).oss }}
-      ee_tag: ${{ fromJson(steps.canonical_version.outputs.result).ee_tag }}
-      oss_tag: ${{ fromJson(steps.canonical_version.outputs.result).oss_tag }}
     steps:
     - name: Fail early on the incorrect version format
       if: ${{ !(startsWith(inputs.version,'v0.') || startsWith(inputs.version,'v1.')) }}
@@ -90,11 +88,6 @@ jobs:
             oss: getCanonicalVersion(version, 'oss'),
           };
 
-          const tags = {
-            ee_tag: `${{vars.DOCKERHUB_REPO}}-enterprise:${versions.ee}`,
-            oss_tag: `${{vars.DOCKERHUB_REPO}}:${versions.oss}`,
-          };
-
           const released = await hasBeenReleased({
             github,
             owner: context.repo.owner,
@@ -108,13 +101,9 @@ jobs:
 
           console.log({
             versions,
-            tags,
           });
 
-          return {
-            ...versions,
-            ...tags,
-          };
+          return versions
 
   publish-start-message:
     runs-on: ubuntu-22.04
@@ -152,41 +141,10 @@ jobs:
       matrix:
         edition: [oss, ee]
     steps:
-    - name: find_release_artifact
-      id: find_release_artifact
-      uses: actions/github-script@v7
+    - name: Retrieve test build uberjar artifact for ${{ matrix.edition }}
+      uses: ./.github/actions/fetch-artifact
       with:
-        result-encoding: string
-        script: | # js
-          const fs = require('fs');
-
-          const artifacts = await github.rest.actions.listArtifactsForRepo({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            name: `metabase-release-${{ matrix.edition }}-${{ inputs.commit }}-uberjar`,
-            per_page: 1,
-          });
-
-          if (!artifacts.data?.artifacts?.[0]?.id) {
-            throw new Error(`No artifacts found for ${{ inputs.commit }}`);
-          }
-
-          const artifact_id = artifacts.data.artifacts[0].id;
-
-          const download = await github.rest.actions.downloadArtifact({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            artifact_id: artifact_id,
-            archive_format: 'zip',
-          });
-
-          fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/mb.zip`, Buffer.from(download.data));
-    - name: unzip uberjar artifact
-      run: unzip mb.zip
-    - name: Verify that this is a valid JAR file
-      run: file --mime-type ./metabase.jar | grep "application/zip"
-    - name: Reveal its version.properties
-      run: jar xf metabase.jar version.properties && cat version.properties
+        name: metabase-release-${{ matrix.edition }}-${{ inputs.commit }}-uberjar
     - name: Check JAR version properties
       run: |
         # ensure actual jar checksum matches checksum file
@@ -295,140 +253,29 @@ jobs:
     - name: Verify Checksum
       run: grep -q $(sha256sum ./metabase-downloaded.jar) SHA256.sum && echo "checksums match" || exit 1
 
-  containerize:
-    runs-on: ubuntu-22.04
-    needs: [check-version, download-uberjar]
-    timeout-minutes: 15
-    strategy:
-      matrix:
-        edition: [oss, ee]
-    env:
-      OSS_TAG: ${{ needs.check-version.outputs.oss_tag }}
-      EE_TAG: ${{ needs.check-version.outputs.ee_tag }}
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        # checkout the commit that was tagged so we get the right dockerfile
-        ref: ${{ inputs.commit }}
-    - name: Determine the docker version tag
-      uses: actions/github-script@v7
-      id: get_tag
-      with:
-        result-encoding: string
-        script: | # js
-          const tag = '${{ matrix.edition }}' === 'ee'
-            ? '${{ needs.check-version.outputs.ee_tag }}'
-            : '${{ needs.check-version.outputs.oss_tag }}';
+  containerize-oss:
+    needs: check-version
+    uses: ./.github/workflows/containerize-jar.yml
+    secrets: inherit
+    with:
+      artifact-name: metabase-release-oss-${{ inputs.commit }}-uberjar
+      commit: ${{ inputs.commit }}
+      repo: ${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_REPO }}
+      tag: ${{ needs.check-version.outputs.oss }}
 
-          console.log("The docker tag for this ", edition, "edition is", tag);
-
-          return tag;
-
-    - uses: actions/download-artifact@v4
-      name: Retrieve previously downloaded Uberjar
-      with:
-        name: metabase-${{ matrix.edition }}-uberjar
-    - name: Move the Uberjar to the context dir
-      run: mv ./metabase.jar bin/docker/.
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v3
-    - name: Build ${{ matrix.edition }} container
-      uses: docker/build-push-action@v6
-      with:
-        context: bin/docker/.
-        platforms: linux/amd64,linux/arm64
-        network: host
-        tags: ${{ steps.get_tag.outputs.result }}
-        no-cache: true
-        push: true
-
-  verify-docker-pull:
-    runs-on: ubuntu-22.04
-    needs: [check-version, containerize]
-    timeout-minutes: 15
-    strategy:
-      matrix:
-        edition: [oss, ee]
-    steps:
-    - name: Determine the docker version tag
-      uses: actions/github-script@v7
-      id: get_tag
-      with:
-        result-encoding: string
-        script: | # js
-          const tag = '${{ matrix.edition }}' === 'ee'
-            ? '${{ needs.check-version.outputs.ee_tag }}'
-            : '${{ needs.check-version.outputs.oss_tag }}';
-
-          console.log("The docker tag for this ", edition, "edition is", tag);
-
-          return tag;
-    - name: Login to Docker Hub # authenticated, to avoid being rate-throttled
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
-    - name: Pull the container image
-      run: |
-        echo "Pulling container image ${{ vars.DOCKERHUB_OWNER }}:${{ steps.get_tag.outputs.result }} ..."
-        docker pull ${{ vars.DOCKERHUB_OWNER }}:${{ steps.get_tag.outputs.result }}
-        echo "Successful!"
-    - name: Launch container
-      run: docker run --rm -dp 3000:3000 ${{ vars.DOCKERHUB_OWNER }}:${{ steps.get_tag.outputs.result }}
-      timeout-minutes: 5
-    - name: Wait for Metabase to start
-      run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
-      timeout-minutes: 3
-
-  verify-docker-pull-arm:
-    runs-on: arm-ubuntu-24-2core
-    needs: [check-version, containerize]
-    timeout-minutes: 15
-    strategy:
-      matrix:
-        edition: [oss, ee]
-    steps:
-    - name: Determine the docker version tag
-      uses: actions/github-script@v7
-      id: get_tag
-      with:
-        result-encoding: string
-        script: | # js
-          const tag = '${{ matrix.edition }}' === 'ee'
-            ? '${{ needs.check-version.outputs.ee_tag }}'
-            : '${{ needs.check-version.outputs.oss_tag }}';
-
-          console.log("The docker tag for this ", edition, "edition is", tag);
-
-          return tag;
-    - name: Login to Docker Hub # authenticated, to avoid being rate-throttled
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
-    - name: Pull the container image
-      run: |
-        echo "Pulling container image ${{ vars.DOCKERHUB_OWNER }}:${{ steps.get_tag.outputs.result }} ..."
-        docker pull ${{ vars.DOCKERHUB_OWNER }}:${{ steps.get_tag.outputs.result }}
-        echo "Successful!"
-    - name: Launch container
-      run: docker run --rm -dp 3000:3000 ${{ vars.DOCKERHUB_OWNER }}:${{ steps.get_tag.outputs.result }}
-      timeout-minutes: 5
-    - name: Wait for Metabase to start
-      run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
-      timeout-minutes: 3
+  containerize-ee:
+    needs: check-version
+    uses: ./.github/workflows/containerize-jar.yml
+    secrets: inherit
+    with:
+      artifact-name: metabase-release-ee-${{ inputs.commit }}-uberjar
+      commit: ${{ inputs.commit }}
+      repo: ${{ vars.DOCKERHUB_OWNER }}/${{ vars.DOCKERHUB_REPO }}-enterprise
+      tag: ${{ needs.check-version.outputs.ee }}
 
   push-tags:
     permissions: write-all
-    needs: [verify-s3-download, verify-docker-pull, check-version]
+    needs: [verify-s3-download, containerize-oss, containerize-ee, check-version]
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
@@ -487,7 +334,8 @@ jobs:
     needs:
       - get-extra-tags
       - push-tags
-      - verify-docker-pull
+      - containerize-ee
+      - containerize-oss
       - verify-s3-download
     strategy:
       matrix:


### PR DESCRIPTION
Follow up to #54156 enabling actual publishes of multi-arch docker containers

recent test builds pushed multi-arch containers as expected ❤️ 


![Screen Shot 2025-03-04 at 3 18 34 PM](https://github.com/user-attachments/assets/a0f667f3-f70c-4c82-83b8-020dd39a374a)


