### PR TITLE
fix: BigQuery ClassNotFound in future

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -15,6 +15,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.models.table :as table]
+   [metabase.plugins.classloader :as classloader]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.pipeline :as qp.pipeline]
    [metabase.query-processor.store :as qp.store]
@@ -596,6 +597,8 @@
         result-promise (promise)
         request (build-bigquery-request sql parameters)
         query-future (future
+                       ;; ensure the classloader is available within the future.
+                       (classloader/the-classloader)
                        (try
                          (*page-callback*)
                          (if-let [result (.query client request (u/varargs BigQuery$JobOption))]

--- a/src/metabase/core/core.clj
+++ b/src/metabase/core/core.clj
@@ -107,6 +107,8 @@
   ;; First of all, lets register a shutdown hook that will tidy things up for us on app exit
   (.addShutdownHook (Runtime/getRuntime) (Thread. ^Runnable destroy!))
   (init-status/set-progress! 0.2)
+  ;; Ensure the classloader is installed as soon as possible.
+  (classloader/the-classloader)
   ;; load any plugins as needed
   (plugins/load-plugins!)
   (init-status/set-progress! 0.3)


### PR DESCRIPTION
Fixes #54511

Follow up to #52990

When `future` is called clojure uses `Executors.newCachedThreadPool` This means that the Threads remain in a pool for up to a minute.

That means that if `future` gets called anywhere before `classloader/the-classloader` is called then that `Thread` can remain in the pool with a bad classloader. Then when BigQuery's `future` tries to `Class/forName` `BigQuery$JobOption` it will be calling it from the classloader context of that initial `future` call and not be able to find the class.

This adds a very early call to `classloader/the-classloader` in `init!` and a safety call to it right in BigQuery. In the long term we should probably be much more strict and explicit about the executors we use.
