### PR TITLE
use new endpoints for tiles in the pin map viz

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -191,6 +191,16 @@ export function DashCardVisualization({
     series,
   ]);
 
+  const token = useMemo(
+    () =>
+      isJWT(dashcard.dashboard_id) ? String(dashcard.dashboard_id) : undefined,
+    [dashcard],
+  );
+  const uuid = useMemo(
+    () => (isUuid(dashcard.dashboard_id) ? dashcard.dashboard_id : undefined),
+    [dashcard],
+  );
+
   const actionButtons = useMemo(() => {
     if (!question) {
       return null;
@@ -278,6 +288,8 @@ export function DashCardVisualization({
       onTogglePreviewing={onTogglePreviewing}
       onChangeCardAndRun={onChangeCardAndRun}
       onChangeLocation={onChangeLocation}
+      token={token}
+      uuid={uuid}
     />
   );
 }

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestionView.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestionView.tsx
@@ -118,6 +118,8 @@ export function PublicOrEmbeddedQuestionView({
             mode={PublicMode}
             metadata={metadata}
             onChangeCardAndRun={() => {}}
+            token={token}
+            uuid={uuid}
           />
         )}
       </LoadingAndErrorWrapper>

--- a/frontend/src/metabase/visualizations/components/LeafletTilePinMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletTilePinMap.jsx
@@ -1,5 +1,7 @@
 import L from "leaflet";
 
+import { getTileUrl } from "../lib/map";
+
 import LeafletMap from "./LeafletMap";
 
 export default class LeafletTilePinMap extends LeafletMap {
@@ -28,32 +30,38 @@ export default class LeafletTilePinMap extends LeafletMap {
   _getTileUrl = (coord, zoom) => {
     const [
       {
-        card: { dataset_query },
-        data: { cols },
+        card: { dataset_query, id },
+        data,
       },
     ] = this.props.series;
 
     const { latitudeIndex, longitudeIndex } = this._getLatLonIndexes();
-    const latitudeField = cols[latitudeIndex];
-    const longitudeField = cols[longitudeIndex];
+    const latitudeField = data.cols[latitudeIndex];
+    const longitudeField = data.cols[longitudeIndex];
 
     if (!latitudeField || !longitudeField) {
       return;
     }
 
-    return (
-      "api/tiles/" +
-      zoom +
-      "/" +
-      coord.x +
-      "/" +
-      coord.y +
-      "/" +
-      (latitudeField.id || encodeURIComponent(latitudeField.name)) +
-      "/" +
-      (longitudeField.id || encodeURIComponent(longitudeField.name)) +
-      "?query=" +
-      encodeURIComponent(JSON.stringify(dataset_query))
-    );
+    const latFieldParam =
+      latitudeField.id || encodeURIComponent(latitudeField.name);
+    const lonFieldParam =
+      longitudeField.id || encodeURIComponent(longitudeField.name);
+
+    const { dashboard, dashcard, uuid, token } = this.props;
+
+    return getTileUrl({
+      cardId: id,
+      dashboardId: dashboard?.id,
+      dashcardId: dashcard?.id,
+      zoom,
+      coord,
+      latField: latFieldParam,
+      lonField: lonFieldParam,
+      datasetQuery: dataset_query,
+      uuid,
+      token,
+      data,
+    });
   };
 }

--- a/frontend/src/metabase/visualizations/components/LeafletTilePinMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletTilePinMap.jsx
@@ -61,7 +61,7 @@ export default class LeafletTilePinMap extends LeafletMap {
       datasetQuery: dataset_query,
       uuid,
       token,
-      data,
+      datasetResult: this.props.series[0],
     });
   };
 }

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -117,6 +117,7 @@ type VisualizationOwnProps = {
   gridUnit?: number;
   handleVisualizationClick?: (clicked: ClickObject) => void;
   headerIcon?: IconProps;
+  width?: number | null;
   height?: number | null;
   isAction?: boolean;
   isDashboard?: boolean;
@@ -134,7 +135,8 @@ type VisualizationOwnProps = {
   showWarnings?: boolean;
   style?: CSSProperties;
   timelineEvents?: TimelineEvent[];
-  width?: number | null;
+  uuid?: string;
+  token?: string;
   onOpenChartSettings?: (data: {
     initialChartSettings: { section: string };
     showSidebarTitle?: boolean;
@@ -553,7 +555,9 @@ class Visualization extends PureComponent<
       showTitle,
       tableHeaderHeight,
       timelineEvents,
+      token,
       totalNumGridCols,
+      uuid,
       width: rawWidth,
       onDeselectTimelineEvents,
       onOpenChartSettings,
@@ -789,6 +793,8 @@ class Visualization extends PureComponent<
                   totalNumGridCols={totalNumGridCols}
                   visualizationIsClickable={this.visualizationIsClickable}
                   width={rawWidth}
+                  uuid={uuid}
+                  token={token}
                   onActionDismissal={this.hideActions}
                   onChangeCardAndRun={
                     this.props.onChangeCardAndRun

--- a/frontend/src/metabase/visualizations/lib/map.ts
+++ b/frontend/src/metabase/visualizations/lib/map.ts
@@ -1,0 +1,257 @@
+import type { Dataset, JsonQuery } from "metabase-types/api";
+
+interface TileCoordinate {
+  x: number | string;
+  y: number | string;
+}
+
+interface TileUrlParams {
+  cardId?: number;
+  dashboardId?: number;
+  dashcardId?: number;
+  zoom: string | number;
+  coord: TileCoordinate;
+  latField: string;
+  lonField: string;
+  datasetQuery?: JsonQuery;
+  uuid?: string;
+  token?: string;
+  data?: Dataset;
+}
+
+export function getParametersFromData({
+  data,
+  uuid,
+  token,
+}: {
+  data?: Dataset;
+  uuid?: string;
+  token?: string;
+}): unknown[] {
+  if (uuid != null) {
+    return data?.json_query?.parameters ?? [];
+  }
+
+  if (token != null && typeof window !== "undefined") {
+    const urlParams = new URLSearchParams(window.location.search);
+    return urlParams.size > 0 ? [Object.fromEntries(urlParams)] : [];
+  }
+
+  return data?.json_query?.parameters ?? [];
+}
+
+export function getTileUrl(params: TileUrlParams): string {
+  const {
+    cardId,
+    dashboardId,
+    dashcardId,
+    zoom,
+    coord,
+    latField,
+    lonField,
+    datasetQuery,
+    uuid,
+    token,
+    data,
+  } = params;
+
+  const parameters = getParametersFromData({
+    data,
+    uuid,
+    token,
+  });
+
+  const isDashboard = dashboardId && dashcardId && cardId;
+
+  if (isDashboard) {
+    const isPublicDashboard = uuid;
+
+    if (isPublicDashboard) {
+      return publicDashboardTileUrl(
+        uuid,
+        dashcardId,
+        cardId,
+        zoom,
+        coord,
+        latField,
+        lonField,
+        parameters,
+      );
+    }
+
+    const isEmbedDashboard = token;
+    if (isEmbedDashboard) {
+      return embedDashboardTileUrl(
+        token,
+        dashcardId,
+        cardId,
+        zoom,
+        coord,
+        latField,
+        lonField,
+        parameters,
+      );
+    }
+
+    return dashboardTileUrl(
+      dashboardId,
+      dashcardId,
+      cardId,
+      zoom,
+      coord,
+      latField,
+      lonField,
+      parameters,
+    );
+  }
+
+  if (cardId) {
+    const isPublicQuestion = uuid;
+
+    if (isPublicQuestion) {
+      return publicCardTileUrl(
+        uuid,
+        zoom,
+        coord,
+        latField,
+        lonField,
+        parameters,
+      );
+    }
+
+    const isEmbedQuestion = token;
+    if (isEmbedQuestion) {
+      return embedCardTileUrl(
+        token,
+        zoom,
+        coord,
+        latField,
+        lonField,
+        parameters,
+      );
+    }
+
+    return savedQuestionTileUrl(
+      cardId,
+      zoom,
+      coord,
+      latField,
+      lonField,
+      parameters,
+    );
+  }
+
+  if (datasetQuery) {
+    return adhocQueryTileUrl(zoom, coord, latField, lonField, datasetQuery);
+  }
+
+  throw new Error("Invalid tile URL parameters");
+}
+
+function adhocQueryTileUrl(
+  zoom: string | number,
+  coord: TileCoordinate,
+  latField: string,
+  lonField: string,
+  datasetQuery: any,
+): string {
+  return `/api/tiles/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}?query=${encodeURIComponent(
+    JSON.stringify(datasetQuery),
+  )}`;
+}
+
+function savedQuestionTileUrl(
+  cardId: number,
+  zoom: string | number,
+  coord: TileCoordinate,
+  latField: string,
+  lonField: string,
+  parameters?: unknown[],
+): string {
+  let url = `/api/tiles/${cardId}/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}`;
+  if (parameters && parameters.length > 0) {
+    url += `?parameters=${encodeURIComponent(JSON.stringify(parameters))}`;
+  }
+  return url;
+}
+
+function dashboardTileUrl(
+  dashboardId: number,
+  dashcardId: number,
+  cardId: number,
+  zoom: string | number,
+  coord: TileCoordinate,
+  latField: string,
+  lonField: string,
+  parameters?: unknown[],
+): string {
+  let url = `/api/tiles/${dashboardId}/dashcard/${dashcardId}/card/${cardId}/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}`;
+  if (parameters && parameters.length > 0) {
+    url += `?parameters=${encodeURIComponent(JSON.stringify(parameters))}`;
+  }
+  return url;
+}
+
+function publicCardTileUrl(
+  token: string,
+  zoom: string | number,
+  coord: TileCoordinate,
+  latField: string,
+  lonField: string,
+  parameters?: unknown[],
+): string {
+  let url = `/api/public/tiles/card/${token}/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}`;
+  if (parameters && parameters.length > 0) {
+    url += `?parameters=${encodeURIComponent(JSON.stringify(parameters))}`;
+  }
+  return url;
+}
+
+function publicDashboardTileUrl(
+  token: string,
+  dashcardId: number,
+  cardId: number,
+  zoom: string | number,
+  coord: TileCoordinate,
+  latField: string,
+  lonField: string,
+  parameters?: unknown[],
+): string {
+  let url = `/api/public/tiles/dashboard/${token}/dashcard/${dashcardId}/card/${cardId}/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}`;
+  if (parameters && parameters.length > 0) {
+    url += `?parameters=${encodeURIComponent(JSON.stringify(parameters))}`;
+  }
+  return url;
+}
+
+function embedCardTileUrl(
+  token: string,
+  zoom: string | number,
+  coord: TileCoordinate,
+  latField: string,
+  lonField: string,
+  parameters?: unknown[],
+): string {
+  let url = `/api/embed/tiles/card/${token}/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}`;
+  if (parameters && parameters.length > 0) {
+    url += `?parameters=${encodeURIComponent(JSON.stringify(parameters))}`;
+  }
+  return url;
+}
+
+function embedDashboardTileUrl(
+  token: string,
+  dashcardId: number,
+  cardId: number,
+  zoom: string | number,
+  coord: TileCoordinate,
+  latField: string,
+  lonField: string,
+  parameters?: unknown[],
+): string {
+  let url = `/api/embed/tiles/dashboard/${token}/dashcard/${dashcardId}/card/${cardId}/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}`;
+  if (parameters && parameters.length > 0) {
+    url += `?parameters=${encodeURIComponent(JSON.stringify(parameters))}`;
+  }
+  return url;
+}

--- a/frontend/src/metabase/visualizations/lib/map.ts
+++ b/frontend/src/metabase/visualizations/lib/map.ts
@@ -16,28 +16,7 @@ interface TileUrlParams {
   datasetQuery?: JsonQuery;
   uuid?: string;
   token?: string;
-  data?: Dataset;
-}
-
-export function getParametersFromData({
-  data,
-  uuid,
-  token,
-}: {
-  data?: Dataset;
-  uuid?: string;
-  token?: string;
-}): unknown[] {
-  if (uuid != null) {
-    return data?.json_query?.parameters ?? [];
-  }
-
-  if (token != null && typeof window !== "undefined") {
-    const urlParams = new URLSearchParams(window.location.search);
-    return urlParams.size > 0 ? [Object.fromEntries(urlParams)] : [];
-  }
-
-  return data?.json_query?.parameters ?? [];
+  datasetResult?: Dataset;
 }
 
 export function getTileUrl(params: TileUrlParams): string {
@@ -52,14 +31,10 @@ export function getTileUrl(params: TileUrlParams): string {
     datasetQuery,
     uuid,
     token,
-    data,
+    datasetResult,
   } = params;
 
-  const parameters = getParametersFromData({
-    data,
-    uuid,
-    token,
-  });
+  const parameters = datasetResult?.json_query?.parameters ?? [];
 
   const isDashboard = dashboardId && dashcardId && cardId;
 

--- a/frontend/src/metabase/visualizations/lib/map.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/map.unit.spec.ts
@@ -1,0 +1,288 @@
+import type { JsonQuery } from "metabase-types/api";
+import { createMockDataset } from "metabase-types/api/mocks/dataset";
+
+import { getTileUrl } from "./map";
+
+describe("map", () => {
+  describe("getTileUrl", () => {
+    const coord = { x: "{x}", y: "{y}" };
+    const zoom = "{z}";
+    const latField = "latitude";
+    const lonField = "longitude";
+    const parameters = [{ id: "param1", value: "value1" }];
+    const encodedParameters = encodeURIComponent(JSON.stringify(parameters));
+
+    describe("adhoc query", () => {
+      it("should generate url for adhoc query", () => {
+        const datasetQuery: JsonQuery = {
+          database: 1,
+          type: "query",
+          query: { "source-table": 1 },
+        } as JsonQuery;
+        const encodedQuery = encodeURIComponent(JSON.stringify(datasetQuery));
+
+        const url = getTileUrl({
+          zoom,
+          coord,
+          latField,
+          lonField,
+          datasetQuery,
+        });
+
+        expect(url).toBe(
+          `/api/tiles/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}?query=${encodedQuery}`,
+        );
+      });
+    });
+
+    describe("saved question", () => {
+      it("should generate url for saved question without parameters", () => {
+        const url = getTileUrl({
+          cardId: 123,
+          zoom,
+          coord,
+          latField,
+          lonField,
+        });
+
+        expect(url).toBe(
+          `/api/tiles/123/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}`,
+        );
+      });
+
+      it("should generate url for saved question with parameters", () => {
+        const datasetResult = createMockDataset({
+          json_query: {
+            parameters,
+          } as JsonQuery,
+        });
+
+        const url = getTileUrl({
+          cardId: 123,
+          zoom,
+          coord,
+          latField,
+          lonField,
+          datasetResult,
+        });
+
+        expect(url).toBe(
+          `/api/tiles/123/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}?parameters=${encodedParameters}`,
+        );
+      });
+    });
+
+    describe("dashboard", () => {
+      it("should generate url for dashboard without parameters", () => {
+        const url = getTileUrl({
+          dashboardId: 10,
+          dashcardId: 20,
+          cardId: 30,
+          zoom,
+          coord,
+          latField,
+          lonField,
+        });
+
+        expect(url).toBe(
+          `/api/tiles/10/dashcard/20/card/30/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}`,
+        );
+      });
+
+      it("should generate url for dashboard with parameters", () => {
+        const datasetResult = createMockDataset({
+          json_query: {
+            parameters,
+          } as JsonQuery,
+        });
+
+        const url = getTileUrl({
+          dashboardId: 10,
+          dashcardId: 20,
+          cardId: 30,
+          zoom,
+          coord,
+          latField,
+          lonField,
+          datasetResult,
+        });
+
+        expect(url).toBe(
+          `/api/tiles/10/dashcard/20/card/30/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}?parameters=${encodedParameters}`,
+        );
+      });
+    });
+
+    describe("public question", () => {
+      it("should generate url for public question without parameters", () => {
+        const url = getTileUrl({
+          cardId: 123,
+          zoom,
+          coord,
+          latField,
+          lonField,
+          uuid: "abc-123",
+        });
+
+        expect(url).toBe(
+          `/api/public/tiles/card/abc-123/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}`,
+        );
+      });
+
+      it("should generate url for public question with parameters", () => {
+        const datasetResult = createMockDataset({
+          json_query: {
+            parameters,
+          } as JsonQuery,
+        });
+
+        const url = getTileUrl({
+          cardId: 123,
+          zoom,
+          coord,
+          latField,
+          lonField,
+          uuid: "abc-123",
+          datasetResult,
+        });
+
+        expect(url).toBe(
+          `/api/public/tiles/card/abc-123/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}?parameters=${encodedParameters}`,
+        );
+      });
+    });
+
+    describe("public dashboard", () => {
+      it("should generate url for public dashboard without parameters", () => {
+        const url = getTileUrl({
+          dashboardId: 10,
+          dashcardId: 20,
+          cardId: 30,
+          zoom,
+          coord,
+          latField,
+          lonField,
+          uuid: "abc-123",
+        });
+
+        expect(url).toBe(
+          `/api/public/tiles/dashboard/abc-123/dashcard/20/card/30/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}`,
+        );
+      });
+
+      it("should generate url for public dashboard with parameters", () => {
+        const datasetResult = createMockDataset({
+          json_query: {
+            parameters,
+          } as JsonQuery,
+        });
+
+        const url = getTileUrl({
+          dashboardId: 10,
+          dashcardId: 20,
+          cardId: 30,
+          zoom,
+          coord,
+          latField,
+          lonField,
+          uuid: "abc-123",
+          datasetResult,
+        });
+
+        expect(url).toBe(
+          `/api/public/tiles/dashboard/abc-123/dashcard/20/card/30/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}?parameters=${encodedParameters}`,
+        );
+      });
+    });
+
+    describe("embed question", () => {
+      it("should generate url for embed question without parameters", () => {
+        const url = getTileUrl({
+          cardId: 123,
+          zoom,
+          coord,
+          latField,
+          lonField,
+          token: "embed-token",
+        });
+
+        expect(url).toBe(
+          `/api/embed/tiles/card/embed-token/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}`,
+        );
+      });
+
+      it("should generate url for embed question with parameters", () => {
+        const datasetResult = createMockDataset({
+          json_query: {
+            parameters: [{ id: "original", value: "original" }],
+          } as JsonQuery,
+        });
+
+        const url = getTileUrl({
+          cardId: 123,
+          zoom,
+          coord,
+          latField,
+          lonField,
+          token: "embed-token",
+          datasetResult,
+        });
+
+        const expectedParameters = encodeURIComponent(
+          JSON.stringify([{ id: "original", value: "original" }]),
+        );
+
+        expect(url).toBe(
+          `/api/embed/tiles/card/embed-token/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}?parameters=${expectedParameters}`,
+        );
+      });
+    });
+
+    describe("embed dashboard", () => {
+      it("should generate url for embed dashboard without parameters", () => {
+        const url = getTileUrl({
+          dashboardId: 10,
+          dashcardId: 20,
+          cardId: 30,
+          zoom,
+          coord,
+          latField,
+          lonField,
+          token: "embed-token",
+        });
+
+        expect(url).toBe(
+          `/api/embed/tiles/dashboard/embed-token/dashcard/20/card/30/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}`,
+        );
+      });
+
+      it("should generate url for embed dashboard with parameters", () => {
+        const datasetResult = createMockDataset({
+          json_query: {
+            parameters: [{ id: "original", value: "original" }],
+          } as JsonQuery,
+        });
+
+        const url = getTileUrl({
+          dashboardId: 10,
+          dashcardId: 20,
+          cardId: 30,
+          zoom,
+          coord,
+          latField,
+          lonField,
+          token: "embed-token",
+          datasetResult,
+        });
+
+        const expectedParameters = encodeURIComponent(
+          JSON.stringify([{ id: "original", value: "original" }]),
+        );
+
+        expect(url).toBe(
+          `/api/embed/tiles/dashboard/embed-token/dashcard/20/card/30/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}?parameters=${expectedParameters}`,
+        );
+      });
+    });
+  });
+});

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -207,6 +207,10 @@ export type VisualizationPassThroughProps = {
 
   // frontend/src/metabase/visualizations/components/ChartSettings/ChartSettingsVisualization/ChartSettingsVisualization.tsx
   isSettings?: boolean;
+
+  // Public & Embedded questions, needed for pin maps to generate the correct tile URL
+  uuid?: string;
+  token?: string;
 };
 
 export type ColumnSettingDefinition<TValue, TProps = unknown> = {

--- a/src/metabase/public_sharing/api.clj
+++ b/src/metabase/public_sharing/api.clj
@@ -738,7 +738,8 @@
   (validation/check-public-sharing-enabled)
   (let [card-id    (api/check-404 (t2/select-one-pk :model/Card :public_uuid uuid, :archived false))
         parameters (json/decode+kw parameters)]
-    (api.tiles/process-tiles-query-for-card card-id parameters zoom x y lat-field lon-field)))
+    (request/as-admin
+      (api.tiles/process-tiles-query-for-card card-id parameters zoom x y lat-field lon-field))))
 
 (api.macros/defendpoint :get "/tiles/dashboard/:uuid/dashcard/:dashcard-id/card/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
   "Generates a single tile image for a Card using the map visualization in a publicly-accessible Dashboard. Does not
@@ -756,7 +757,8 @@
   (validation/check-public-sharing-enabled)
   (let [dashboard-id (api/check-404 (t2/select-one-pk :model/Dashboard :public_uuid uuid, :archived false))
         parameters   (json/decode+kw parameters)]
-    (api.tiles/process-tiles-query-for-dashcard dashboard-id dashcard-id card-id parameters zoom x y lat-field lon-field)))
+    (request/as-admin
+      (api.tiles/process-tiles-query-for-dashcard dashboard-id dashcard-id card-id parameters zoom x y lat-field lon-field))))
 
 ;;; ----------------------------------------- Route Definitions & Complaints -----------------------------------------
 

--- a/test/metabase/public_sharing/api_test.clj
+++ b/test/metabase/public_sharing/api_test.clj
@@ -1965,11 +1965,10 @@
       (mt/with-temporary-setting-values [enable-public-sharing true]
         (mt/with-temp [:model/Card _card {:dataset_query (venues-query)
                                           :public_uuid uuid}]
-          (is (png? (mt/user-http-request
-                     :crowberto :get 200 (format "public/tiles/card/%s/1/1/1/%d/%d"
-                                                 uuid
-                                                 (mt/id :people :latitude)
-                                                 (mt/id :people :longitude))))))))))
+          (is (png? (client/client :get 200 (format "public/tiles/card/%s/1/1/1/%d/%d"
+                                                    uuid
+                                                    (mt/id :people :latitude)
+                                                    (mt/id :people :longitude))))))))))
 
 (deftest dashcard-tile-query-test
   (testing "GET api/public/tiles/dashboard/:uuid/dashcard/:dashcard-id/card/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
@@ -1979,10 +1978,9 @@
                        :model/Card          {card-id :id}      {:dataset_query (venues-query)}
                        :model/DashboardCard {dashcard-id :id}  {:card_id card-id
                                                                 :dashboard_id dashboard-id}]
-          (is (png? (mt/user-http-request
-                     :crowberto :get 200 (format "public/tiles/dashboard/%s/dashcard/%d/card/%d/1/1/1/%d/%d"
-                                                 uuid
-                                                 dashcard-id
-                                                 card-id
-                                                 (mt/id :people :latitude)
-                                                 (mt/id :people :longitude))))))))))
+          (is (png? (client/client :get 200 (format "public/tiles/dashboard/%s/dashcard/%d/card/%d/1/1/1/%d/%d"
+                                                    uuid
+                                                    dashcard-id
+                                                    card-id
+                                                    (mt/id :people :latitude)
+                                                    (mt/id :people :longitude))))))))))


### PR DESCRIPTION
Closes [VIZ-455](https://linear.app/metabase/issue/VIZ-455/fe-portion-of-viz-399) 

### Description

Uses [new backend endpoints](https://github.com/metabase/metabase/pull/54150) to load correct map tiles in the leaflet pin map.
Previously, in `LeafletTilePinMap.jsx` we always used one url that stringified a dataset query and sent it in a query param when requesting tiles. This does not work when the sender does not have the access to run arbitrary queries on a database, for example, when user does not have such permission, or when requesting public or staticly embedded dashboards.

### How to verify

- Create a pin map question (New -> People -> Map, set latitude and longitude) 
- Verify this question shows markers as a dirty question, saved question, public question, dashboard question, public dashboard, embedded question, embedded dashboard. It must include parameters in the url.

### Demo

<img width="1663" alt="Screenshot 2025-03-03 at 11 18 23 PM" src="https://github.com/user-attachments/assets/1f6795ca-6e64-4e5b-9d41-c203203e6463" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
