### PR TITLE
Convert rest of RuleEditor to Mantine

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/RuleEditor.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/RuleEditor.tsx
@@ -9,7 +9,6 @@ import CS from "metabase/css/core/index.css";
 import {
   Box,
   Button,
-  Flex,
   MultiSelect,
   Select,
   Stack,
@@ -155,15 +154,13 @@ export const RuleEditor = ({
           <Stack gap="xs" align="flex-start">
             <Text fw="bold" fz="lg">{t`…turn its background this color:`}</Text>
 
-            <Flex align="left">
-              <ColorSelector
-                data-testid="conditional-formatting-color-selector"
-                value={rule.color}
-                colors={COLORS}
-                onChange={color => onChange({ ...rule, color })}
-                withinPortal={false}
-              />
-            </Flex>
+            <ColorSelector
+              data-testid="conditional-formatting-color-selector"
+              value={rule.color}
+              colors={COLORS}
+              onChange={color => onChange({ ...rule, color })}
+              withinPortal={false}
+            />
           </Stack>
           {canHighlightRow && (
             <Stack gap="xs">

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/RuleEditor.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/RuleEditor.tsx
@@ -15,11 +15,13 @@ import {
   Text,
   TextInputBlurChange,
 } from "metabase/ui";
+import type { TextInputBlurChangeProps } from "metabase/ui/components/inputs/TextInputBlurChange/TextInputBlurChange";
 import { isBoolean } from "metabase-lib/v1/types/utils/isa";
 import type {
   ColumnFormattingOperator,
   ColumnFormattingSetting,
   ColumnRangeFormattingSetting,
+  ColumnSingleFormattingSetting,
   ConditionalFormattingBooleanOperator,
   ConditionalFormattingComparisonOperator,
   DatasetColumn,

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/RuleEditor.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/RuleEditor.tsx
@@ -7,19 +7,20 @@ import { ColorRangeSelector } from "metabase/core/components/ColorRangeSelector"
 import { ColorSelector } from "metabase/core/components/ColorSelector";
 import CS from "metabase/css/core/index.css";
 import {
+  Box,
   Button,
   Flex,
   MultiSelect,
   Select,
+  Stack,
+  Text,
   TextInputBlurChange,
 } from "metabase/ui";
-import type { TextInputBlurChangeProps } from "metabase/ui/components/inputs/TextInputBlurChange/TextInputBlurChange";
 import { isBoolean } from "metabase-lib/v1/types/utils/isa";
 import type {
   ColumnFormattingOperator,
   ColumnFormattingSetting,
   ColumnRangeFormattingSetting,
-  ColumnSingleFormattingSetting,
   ConditionalFormattingBooleanOperator,
   ConditionalFormattingComparisonOperator,
   DatasetColumn,
@@ -85,24 +86,27 @@ export const RuleEditor = ({
 
     onChange({ ...rule, columns, ...operatorUpdate });
   };
+
   return (
-    <div>
-      <h3 className={CS.mb1}>{t`Which columns should be affected?`}</h3>
-      <MultiSelect
-        comboboxProps={{ withinPortal: false }}
-        value={rule.columns}
-        onChange={handleColumnChange}
-        defaultDropdownOpened={rule.columns.length === 0}
-        placeholder={t`Choose a column`}
-        data={cols.map(col => ({
-          value: col.name,
-          label: col.display_name,
-          disabled: isFieldDisabled(col),
-        }))}
-      />
+    <Stack gap="xl">
+      <Stack gap="sm">
+        <Text fw="bold" fz="lg">{t`Which columns should be affected?`}</Text>
+        <MultiSelect
+          comboboxProps={{ withinPortal: false }}
+          value={rule.columns}
+          onChange={handleColumnChange}
+          defaultDropdownOpened={rule.columns.length === 0}
+          placeholder={t`Choose a column`}
+          data={cols.map(col => ({
+            value: col.name,
+            label: col.display_name,
+            disabled: isFieldDisabled(col),
+          }))}
+        />
+      </Stack>
       {isNumericRule && !isKeyRule && (
-        <div>
-          <h3 className={cx(CS.mt3, CS.mb1)}>{t`Formatting style`}</h3>
+        <Stack gap="sm">
+          <Text fw="bold" fz="lg">{t`Formatting style`}</Text>
           <ChartSettingRadio
             options={[
               { name: t`Single color`, value: "single" },
@@ -116,53 +120,54 @@ export const RuleEditor = ({
               })
             }
           />
-        </div>
+        </Stack>
       )}
       {rule.type === "single" ? (
-        <div>
-          <h3 className={cx(CS.mt3, CS.mb1)}>
-            {ngettext(
-              msgid`When a cell in this column…`,
-              `When any cell in these columns…`,
-              selectedColumns.length,
-            )}
-          </h3>
-          <Select<ColumnFormattingOperator>
-            disabled={selectedColumns.length === 0}
-            comboboxProps={{ withinPortal: false }}
-            value={rule.operator}
-            onChange={operator => onChange({ ...rule, operator })}
-            data={_.pairs(operators).map(([value, label]) => ({
-              value,
-              label,
-            }))}
-            data-testid="conditional-formatting-value-operator-button"
-          />
-          <RuleEditorValueInput
-            disabled={selectedColumns.length === 0}
-            hasOperand={hasOperand}
-            isNumericRule={isNumericRule}
-            isKeyRule={isKeyRule}
-            rule={rule}
-            onChange={onChange}
-          />
-          <h3
-            className={cx(CS.mt3, CS.mb1)}
-          >{t`…turn its background this color:`}</h3>
-          <Flex align="left">
-            <ColorSelector
-              data-testid="conditional-formatting-color-selector"
-              value={rule.color}
-              colors={COLORS}
-              onChange={color => onChange({ ...rule, color })}
-              withinPortal={false}
-            />
-          </Flex>
+        <>
+          <Stack gap="sm">
+            <Text fw="bold" fz="lg">
+              {ngettext(
+                msgid`When a cell in this column…`,
+                `When any cell in these columns…`,
+                selectedColumns.length,
+              )}
+            </Text>
+            <Box>
+              <Select<ColumnFormattingOperator>
+                comboboxProps={{ withinPortal: false }}
+                value={rule.operator}
+                onChange={operator => onChange({ ...rule, operator })}
+                data={_.pairs(operators).map(([value, label]) => ({
+                  value,
+                  label,
+                }))}
+                data-testid="conditional-formatting-value-operator-button"
+              />
+              <RuleEditorValueInput
+                hasOperand={hasOperand}
+                isNumericRule={isNumericRule}
+                isKeyRule={isKeyRule}
+                rule={rule}
+                onChange={onChange}
+              />
+            </Box>
+          </Stack>
+          <Stack gap="sm">
+            <Text fw="bold" fz="lg">{t`…turn its background this color:`}</Text>
+
+            <Flex align="left">
+              <ColorSelector
+                data-testid="conditional-formatting-color-selector"
+                value={rule.color}
+                colors={COLORS}
+                onChange={color => onChange({ ...rule, color })}
+                withinPortal={false}
+              />
+            </Flex>
+          </Stack>
           {canHighlightRow && (
-            <>
-              <h3
-                className={cx(CS.mt3, CS.mb1)}
-              >{t`Highlight the whole row`}</h3>
+            <Stack gap="sm">
+              <Text fw="bold" fz="lg">{t`Highlight the whole row`}</Text>
 
               <ChartSettingToggle
                 value={rule.highlight_row}
@@ -173,82 +178,89 @@ export const RuleEditor = ({
                   })
                 }
               />
-            </>
+            </Stack>
           )}
-        </div>
+        </>
       ) : rule.type === "range" ? (
-        <div>
-          <h3 className={cx(CS.mt3, CS.mb1)}>{t`Colors`}</h3>
-          <ColorRangeSelector
-            value={rule.colors}
-            onChange={colors => {
-              onChange({ ...rule, colors });
-            }}
-            colors={COLORS}
-            colorRanges={COLOR_RANGES}
-            withinPortal={false}
-          />
-          <h3 className={cx(CS.mt3, CS.mb1)}>{t`Start the range at`}</h3>
-          <ChartSettingRadio
-            value={rule.min_type}
-            onChange={min_type =>
-              onChange({
-                ...rule,
-                min_type: min_type as ColumnRangeFormattingSetting["min_type"],
-              })
-            }
-            options={(rule.columns.length <= 1
-              ? [{ name: t`Smallest value in this column`, value: null }]
-              : [
-                  { name: t`Smallest value in each column`, value: null },
-                  {
-                    name: t`Smallest value in all of these columns`,
-                    value: "all",
-                  },
-                ]
-            ).concat([{ name: t`Custom value`, value: "custom" }])}
-          />
-          {rule.min_type === "custom" && (
-            <ChartSettingInputNumeric
-              className={INPUT_CLASSNAME}
-              value={rule.min_value}
-              onChange={min_value =>
-                onChange({ ...rule, min_value: min_value ?? undefined })
-              }
+        <>
+          <Stack gap="sm">
+            <Text fw="bold" fz="lg">{t`Colors`}</Text>
+            <ColorRangeSelector
+              value={rule.colors}
+              onChange={colors => {
+                onChange({ ...rule, colors });
+              }}
+              colors={COLORS}
+              colorRanges={COLOR_RANGES}
             />
-          )}
-          <h3 className={cx(CS.mt3, CS.mb1)}>{t`End the range at`}</h3>
-          <ChartSettingRadio
-            value={rule.max_type}
-            onChange={max_type =>
-              onChange({
-                ...rule,
-                max_type: max_type as ColumnRangeFormattingSetting["max_type"],
-              })
-            }
-            options={(rule.columns.length <= 1
-              ? [{ name: t`Largest value in this column`, value: null }]
-              : [
-                  { name: t`Largest value in each column`, value: null },
-                  {
-                    name: t`Largest value in all of these columns`,
-                    value: "all",
-                  },
-                ]
-            ).concat([{ name: t`Custom value`, value: "custom" }])}
-          />
-          {rule.max_type === "custom" && (
-            <ChartSettingInputNumeric
-              className={INPUT_CLASSNAME}
-              value={rule.max_value}
-              onChange={max_value =>
-                onChange({ ...rule, max_value: max_value ?? undefined })
+          </Stack>
+          <Stack gap="sm">
+            <Text fw="bold" fz="lg">{t`Start the range at`}</Text>
+            <ChartSettingRadio
+              value={rule.min_type}
+              onChange={min_type =>
+                onChange({
+                  ...rule,
+                  min_type:
+                    min_type as ColumnRangeFormattingSetting["min_type"],
+                })
               }
+              options={(rule.columns.length <= 1
+                ? [{ name: t`Smallest value in this column`, value: null }]
+                : [
+                    { name: t`Smallest value in each column`, value: null },
+                    {
+                      name: t`Smallest value in all of these columns`,
+                      value: "all",
+                    },
+                  ]
+              ).concat([{ name: t`Custom value`, value: "custom" }])}
             />
-          )}
-        </div>
+            {rule.min_type === "custom" && (
+              <ChartSettingInputNumeric
+                className={INPUT_CLASSNAME}
+                value={rule.min_value}
+                onChange={min_value =>
+                  onChange({ ...rule, min_value: min_value ?? undefined })
+                }
+              />
+            )}
+          </Stack>
+          <Stack gap="sm">
+            <Text fw="bold" fz="lg">{t`End the range at`}</Text>
+            <ChartSettingRadio
+              value={rule.max_type}
+              onChange={max_type =>
+                onChange({
+                  ...rule,
+                  max_type:
+                    max_type as ColumnRangeFormattingSetting["max_type"],
+                })
+              }
+              options={(rule.columns.length <= 1
+                ? [{ name: t`Largest value in this column`, value: null }]
+                : [
+                    { name: t`Largest value in each column`, value: null },
+                    {
+                      name: t`Largest value in all of these columns`,
+                      value: "all",
+                    },
+                  ]
+              ).concat([{ name: t`Custom value`, value: "custom" }])}
+            />
+            {rule.max_type === "custom" && (
+              <ChartSettingInputNumeric
+                className={INPUT_CLASSNAME}
+                value={rule.max_value}
+                onChange={max_value =>
+                  onChange({ ...rule, max_value: max_value ?? undefined })
+                }
+              />
+            )}
+          </Stack>
+        </>
       ) : null}
-      <div className={CS.mt4}>
+      <Box>
         {rule.columns.length === 0 ? (
           <Button variant="filled" onClick={onRemove}>
             {isNew ? t`Cancel` : t`Delete`}
@@ -258,8 +270,8 @@ export const RuleEditor = ({
             {isNew ? t`Add rule` : t`Update rule`}
           </Button>
         )}
-      </div>
-    </div>
+      </Box>
+    </Stack>
   );
 };
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/RuleEditor.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/RuleEditor.tsx
@@ -88,8 +88,8 @@ export const RuleEditor = ({
   };
 
   return (
-    <Stack gap="xl">
-      <Stack gap="sm">
+    <Stack gap="lg">
+      <Stack gap="xs">
         <Text fw="bold" fz="lg">{t`Which columns should be affected?`}</Text>
         <MultiSelect
           comboboxProps={{ withinPortal: false }}
@@ -105,7 +105,7 @@ export const RuleEditor = ({
         />
       </Stack>
       {isNumericRule && !isKeyRule && (
-        <Stack gap="sm">
+        <Stack gap="xs">
           <Text fw="bold" fz="lg">{t`Formatting style`}</Text>
           <ChartSettingRadio
             options={[
@@ -124,7 +124,7 @@ export const RuleEditor = ({
       )}
       {rule.type === "single" ? (
         <>
-          <Stack gap="sm">
+          <Stack gap="xs">
             <Text fw="bold" fz="lg">
               {ngettext(
                 msgid`When a cell in this column…`,
@@ -152,7 +152,7 @@ export const RuleEditor = ({
               />
             </Box>
           </Stack>
-          <Stack gap="sm">
+          <Stack gap="xs">
             <Text fw="bold" fz="lg">{t`…turn its background this color:`}</Text>
 
             <Flex align="left">
@@ -166,7 +166,7 @@ export const RuleEditor = ({
             </Flex>
           </Stack>
           {canHighlightRow && (
-            <Stack gap="sm">
+            <Stack gap="xs">
               <Text fw="bold" fz="lg">{t`Highlight the whole row`}</Text>
 
               <ChartSettingToggle
@@ -183,7 +183,7 @@ export const RuleEditor = ({
         </>
       ) : rule.type === "range" ? (
         <>
-          <Stack gap="sm">
+          <Stack gap="xs">
             <Text fw="bold" fz="lg">{t`Colors`}</Text>
             <ColorRangeSelector
               value={rule.colors}
@@ -195,7 +195,7 @@ export const RuleEditor = ({
               withinPortal={false}
             />
           </Stack>
-          <Stack gap="sm">
+          <Stack gap="xs">
             <Text fw="bold" fz="lg">{t`Start the range at`}</Text>
             <ChartSettingRadio
               value={rule.min_type}
@@ -227,7 +227,7 @@ export const RuleEditor = ({
               />
             )}
           </Stack>
-          <Stack gap="sm">
+          <Stack gap="xs">
             <Text fw="bold" fz="lg">{t`End the range at`}</Text>
             <ChartSettingRadio
               value={rule.max_type}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/RuleEditor.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/RuleEditor.tsx
@@ -152,7 +152,7 @@ export const RuleEditor = ({
               />
             </Box>
           </Stack>
-          <Stack gap="xs">
+          <Stack gap="xs" align="flex-start">
             <Text fw="bold" fz="lg">{t`…turn its background this color:`}</Text>
 
             <Flex align="left">

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/RuleEditor.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/RuleEditor.tsx
@@ -192,6 +192,7 @@ export const RuleEditor = ({
               }}
               colors={COLORS}
               colorRanges={COLOR_RANGES}
+              withinPortal={false}
             />
           </Stack>
           <Stack gap="sm">


### PR DESCRIPTION
Converts the remaining components in `RuleEditor` to Mantine. No visual changes except maybe tightening some gaps between related text and adding gaps between unrelated items. You'll see below.

Otherwise, no functional differences or anything of the sort. This should just help us with getting these components to Mantine and eventually make theming and maintenance easier within the SDK.

**Single Rule**
Before:
<img width="356" alt="image" src="https://github.com/user-attachments/assets/3390c0fc-537b-4cb8-8332-75d6d80665ef" />

After (edited based on Sasha's request below)
<img width="329" alt="image" src="https://github.com/user-attachments/assets/123c90bb-5b22-41d1-81b5-409defd85e98" />

**Range Rule**
Before:
<img width="363" alt="image" src="https://github.com/user-attachments/assets/c6b39c53-9e78-41f7-a29b-e45f138f6fc5" />

After:
<img width="347" alt="image" src="https://github.com/user-attachments/assets/55b920bf-a5b8-4b85-b932-56c0fc50cd1d" />
