### PR TITLE
Fix alerts double sending on stats

### DIFF
--- a/src/metabase/core/core.clj
+++ b/src/metabase/core/core.clj
@@ -154,14 +154,14 @@
     (init-status/set-progress! 0.8))
   (ensure-audit-db-installed!)
   (notification/seed-notification!)
-  (task.notification/init-send-notification-triggers!)
-  (pulse/init-send-pulse-triggers!)
+
   (init-status/set-progress! 0.9)
   (embed.settings/check-and-sync-settings-on-startup! env/env)
   (init-status/set-progress! 0.95)
   (setting/migrate-encrypted-settings!)
-   ;; start scheduler at end of init!
   (task/start-scheduler!)
+  (task.notification/init-send-notification-triggers!)
+  (pulse/init-send-pulse-triggers!)
    ;; In case we could not do this earlier (e.g. for DBs added via config file), because the scheduler was not up yet:
   (database/check-health-and-schedule-tasks!)
   (init-status/set-complete!)

--- a/src/metabase/core/core.clj
+++ b/src/metabase/core/core.clj
@@ -24,10 +24,12 @@
    [metabase.plugins.classloader :as classloader]
    [metabase.premium-features.core :as premium-features :refer [defenterprise]]
    [metabase.public-settings :as public-settings]
+   [metabase.pulse.core :as pulse]
    [metabase.sample-data :as sample-data]
    [metabase.server.core :as server]
    [metabase.setup.core :as setup]
    [metabase.task :as task]
+   [metabase.task.notification :as task.notification]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.system-info :as u.system-info])
@@ -152,6 +154,8 @@
     (init-status/set-progress! 0.8))
   (ensure-audit-db-installed!)
   (notification/seed-notification!)
+  (task.notification/init-send-notification-triggers!)
+  (pulse/init-send-pulse-triggers!)
   (init-status/set-progress! 0.9)
   (embed.settings/check-and-sync-settings-on-startup! env/env)
   (init-status/set-progress! 0.95)

--- a/src/metabase/core/core.clj
+++ b/src/metabase/core/core.clj
@@ -24,6 +24,7 @@
    [metabase.plugins.classloader :as classloader]
    [metabase.premium-features.core :as premium-features :refer [defenterprise]]
    [metabase.public-settings :as public-settings]
+   ^{:clj-kondo/ignore [:deprecated-namespace]}
    [metabase.pulse.core :as pulse]
    [metabase.sample-data :as sample-data]
    [metabase.server.core :as server]

--- a/src/metabase/core/core.clj
+++ b/src/metabase/core/core.clj
@@ -24,13 +24,10 @@
    [metabase.plugins.classloader :as classloader]
    [metabase.premium-features.core :as premium-features :refer [defenterprise]]
    [metabase.public-settings :as public-settings]
-   ^{:clj-kondo/ignore [:deprecated-namespace]}
-   [metabase.pulse.core :as pulse]
    [metabase.sample-data :as sample-data]
    [metabase.server.core :as server]
    [metabase.setup.core :as setup]
    [metabase.task :as task]
-   [metabase.task.notification :as task.notification]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.system-info :as u.system-info])
@@ -161,8 +158,6 @@
   (init-status/set-progress! 0.95)
   (setting/migrate-encrypted-settings!)
   (task/start-scheduler!)
-  (task.notification/init-send-notification-triggers!)
-  (pulse/init-send-pulse-triggers!)
    ;; In case we could not do this earlier (e.g. for DBs added via config file), because the scheduler was not up yet:
   (database/check-health-and-schedule-tasks!)
   (init-status/set-complete!)

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -1765,13 +1765,7 @@
 ;; Migrate alerts to notifications
 ;; on migrate up:
 ;; - migrate alerts from pulse table to notification table
-;; - delete all the send pulse triggers
-;; - And then on startup new send notification triggers are created by running [[metabase.task.notification/InitNotificationTriggers]]
-;;   job once. This job is idempotent
-;; on migrate down:
-;; - we delete all the notifications
-;; - delete the [[metabase.task.send-pulses/InitSendPulseTriggers]] job so that when instance startup, this job is run
-;;   again so that it iterates all existing alerts and re-creates the send pulse triggers. This job is idempotent
-(define-reversible-migration MigrateAlertToNotification
-  (pulse-to-notification/migrate-alerts!)
-  (pulse-to-notification/remove-init-send-pulse-trigger!))
+;; - And then on startup new send notification triggers are created by running
+;; [[metabase.task.notification/init-send-notification-triggers!]]
+(define-migration MigrateAlertToNotification
+  (pulse-to-notification/migrate-alerts!))

--- a/src/metabase/db/custom_migrations/pulse_to_notification.clj
+++ b/src/metabase/db/custom_migrations/pulse_to_notification.clj
@@ -1,10 +1,6 @@
 (ns metabase.db.custom-migrations.pulse-to-notification
   (:require
    [clojure.string :as str]
-   [clojurewerkz.quartzite.jobs :as jobs]
-   [clojurewerkz.quartzite.scheduler :as qs]
-   [clojurewerkz.quartzite.triggers :as triggers]
-   [metabase.db.custom-migrations.util :as custom-migrations.util]
    [metabase.util.json :as json]
    [toucan2.core :as t2]))
 
@@ -85,17 +81,10 @@
              (assoc pc :recipients (get pc-id->recipients (:id pc))))
            pcs))))
 
-(defn- send-pulse-trigger-key
-  [pulse-id schedule-map]
-  (triggers/key (format "metabase.task.send-pulse.trigger.%d.%s"
-                        pulse-id (-> schedule-map
-                                     schedule-map->cron-string
-                                     (str/replace " " "_")))))
-
 (defn- alert->notification!
   "Create a new notification with `subsciptions`.
   Return the created notifications."
-  [scheduler pulse]
+  [pulse]
   (let [pulse-id   (:id pulse)
         pcs        (hydrate-recipients (t2/select :pulse_channel :pulse_id pulse-id :enabled true))
         ;; alerts have one pulse-card, but to be safe we select the latest one by id
@@ -147,25 +136,16 @@
                                      {:channel_type "channel/http"
                                       :channel_id    (:channel_id pc)})))
                                 pcs)]
-         (qs/delete-trigger scheduler (send-pulse-trigger-key pulse-id pc))
          (create-notification! notification subscriptions handlers))))))
 
 (defn migrate-alerts!
   "Migrate alerts from `pulse` to `notification`."
   []
   #_{:clj-kondo/ignore [:unresolved-symbol]}
-  (custom-migrations.util/with-temp-schedule! [scheduler]
-    (run! #(alert->notification! scheduler %)
-          (t2/reducible-query {:select [:*]
-                               :from   [:pulse]
-                               :where  [:and [:in :alert_condition ["rows" "goal"]] [:not :archived]]}))))
-
-(defn remove-init-send-pulse-trigger!
-  "Remove the init-send-pulse-triggers.trigger from the scheduler so that it can run again."
-  []
-  (custom-migrations.util/with-temp-schedule! [scheduler]
-    (qs/delete-job scheduler (jobs/key "metabase.task.send-pulses.init-send-pulse-triggers.job"))
-    (qs/delete-trigger scheduler (triggers/key "metabase.task.send-pulses.init-send-pulse-triggers.trigger"))))
+  (run! alert->notification!
+        (t2/reducible-query {:select [:*]
+                             :from   [:pulse]
+                             :where  [:and [:in :alert_condition ["rows" "goal"]] [:not :archived]]})))
 
 (comment
   (t2/delete! :model/Notification)

--- a/src/metabase/pulse/core.clj
+++ b/src/metabase/pulse/core.clj
@@ -5,6 +5,7 @@
   (:require
    [metabase.pulse.dashboard-subscription]
    [metabase.pulse.models.pulse]
+   [metabase.pulse.task.send-pulses]
    [metabase.pulse.update-alerts]
    [potemkin :as p]))
 
@@ -20,4 +21,6 @@
   retrieve-alerts-for-cards
   update-pulse!]
  [metabase.pulse.update-alerts
-  delete-alerts-if-needed!])
+  delete-alerts-if-needed!]
+ [metabase.pulse.task.send-pulses
+  init-send-pulse-triggers!])

--- a/src/metabase/pulse/core.clj
+++ b/src/metabase/pulse/core.clj
@@ -5,7 +5,6 @@
   (:require
    [metabase.pulse.dashboard-subscription]
    [metabase.pulse.models.pulse]
-   [metabase.pulse.task.send-pulses]
    [metabase.pulse.update-alerts]
    [potemkin :as p]))
 
@@ -21,6 +20,4 @@
   retrieve-alerts-for-cards
   update-pulse!]
  [metabase.pulse.update-alerts
-  delete-alerts-if-needed!]
- [metabase.pulse.task.send-pulses
-  init-send-pulse-triggers!])
+  delete-alerts-if-needed!])

--- a/src/metabase/pulse/task/send_pulses.clj
+++ b/src/metabase/pulse/task/send_pulses.clj
@@ -157,6 +157,7 @@
   "Update send pulse triggers for all active pulses.
   Called once when Metabase starts up to create triggers for all existing PulseChannels"
   []
+  (assert (task/scheduler) "Scheduler must be started before initializing SendPulse triggers")
   (log/info "Initializing SendPulse triggers")
   (task/delete-all-triggers-of-job! send-pulse-job-key)
   (let [trigger-slot->pc-ids (as-> (t2/select :model/PulseChannel

--- a/src/metabase/pulse/task/send_pulses.clj
+++ b/src/metabase/pulse/task/send_pulses.clj
@@ -158,7 +158,6 @@
   Called once when Metabase starts up to create triggers for all existing PulseChannels"
   []
   (assert (task/scheduler) "Scheduler must be started before initializing SendPulse triggers")
-  (log/info "Initializing SendPulse triggers for dashboard subscriptions")
   (task/delete-all-triggers-of-job! send-pulse-job-key)
   (let [trigger-slot->pc-ids (as-> (t2/select :model/PulseChannel
                                               {:select    [:pc.*]
@@ -233,6 +232,7 @@
     Do this every startup to make sure all active pulse channels are triggered correctly."}
   InitSendPulseTriggers
   [_context]
+  (log/info "Initializing SendPulse triggers for dashboard subscriptions")
   (init-dashboard-subscription-triggers!))
 
 ;;; -------------------------------------------------- Task init ------------------------------------------------

--- a/src/metabase/pulse/task/send_pulses.clj
+++ b/src/metabase/pulse/task/send_pulses.clj
@@ -151,8 +151,6 @@
   (let [{:strs [pulse-id channel-ids]} (qc/from-job-data context)]
     (send-pulse!* pulse-id channel-ids)))
 
-;;; ------------------------------------------------ Job: InitSendPulseTriggers ----------------------------------------------------
-
 (declare update-send-pulse-trigger-if-needed!)
 
 (defn init-send-pulse-triggers!
@@ -160,6 +158,7 @@
   Called once when Metabase starts up to create triggers for all existing PulseChannels"
   []
   (log/info "Initializing SendPulse triggers")
+  (task/delete-all-triggers-of-job! send-pulse-job-key)
   (let [trigger-slot->pc-ids (as-> (t2/select :model/PulseChannel
                                               {:select    [:pc.*]
                                                :from      [[:pulse_channel :pc]]
@@ -167,32 +166,15 @@
                                                            [:report_dashboard :d] [:= :p.dashboard_id :d.id]]
                                                :where     [:and
                                                            [:= :pc.enabled true]
-                                                           [:or
-                                                            ;; alerts
-                                                            [:= :p.dashboard_id nil]
-                                                            ;; if dashboard subscriptions, make sure it's not archived
-                                                            [:= :d.archived false]]]})
+                                                           ;; only do this for dashboard subscriptions, alert has been
+                                                           ;; migrated to notifications
+                                                           [:not= :p.dashboard_id nil]
+                                                           [:= :d.archived false]]})
                                    results
                                (group-by #(select-keys % [:pulse_id :schedule_type :schedule_day :schedule_hour :schedule_frame]) results)
                                (update-vals results #(map :id %)))]
     (doseq [[{:keys [pulse_id] :as schedule-map} pc-ids] trigger-slot->pc-ids]
       (update-send-pulse-trigger-if-needed! pulse_id schedule-map :add-pc-ids (set pc-ids)))))
-
-(jobs/defjob
-  ^{:doc
-    "Find all active pulse Channels, group them by pulse-id and schedule time and create a trigger for each.
-
-    This is basically a migration in disguise to move from the old SendPulses job to the new SendPulse job.
-
-    Context: prior to this, SendPulses is a single job that runs hourly and send all Pulses that are scheduled for that
-    hour.
-    Since that's inefficient and we want to be able to send pulses in parallel, we changed it so that each PulseChannel
-    of the same schedule will have its own SendPulse trigger.
-    During this transition, we need to schedule all the SendPulse triggers for existing PulseChannels, so we have this job
-    that run once on Metabase startup to do that."}
-  InitSendPulseTriggers
-  [_context]
-  (init-send-pulse-triggers!))
 
 ;;; --------------------------------------------- Helpers -------------------------------------------
 
@@ -251,14 +233,5 @@
                         (jobs/with-identity send-pulse-job-key)
                         (jobs/with-description "Send Pulse")
                         (jobs/of-type SendPulse)
-                        (jobs/store-durably))
-        init-job       (jobs/build
-                        (jobs/of-type InitSendPulseTriggers)
-                        (jobs/with-identity (jobs/key "metabase.task.send-pulses.init-send-pulse-triggers.job"))
-                        (jobs/store-durably))
-        init-trigger   (triggers/build
-                        (triggers/with-identity (triggers/key "metabase.task.send-pulses.init-send-pulse-triggers.trigger"))
-                        ;; run only once per MB instance (like a migration)
-                        (triggers/start-now))]
-    (task/add-job! send-pulse-job)
-    (task/schedule-task! init-job init-trigger)))
+                        (jobs/store-durably))]
+    (task/add-job! send-pulse-job)))

--- a/src/metabase/pulse/task/send_pulses.clj
+++ b/src/metabase/pulse/task/send_pulses.clj
@@ -153,12 +153,12 @@
 
 (declare update-send-pulse-trigger-if-needed!)
 
-(defn init-send-pulse-triggers!
+(defn init-dashboard-subscription-triggers!
   "Update send pulse triggers for all active pulses.
   Called once when Metabase starts up to create triggers for all existing PulseChannels"
   []
   (assert (task/scheduler) "Scheduler must be started before initializing SendPulse triggers")
-  (log/info "Initializing SendPulse triggers")
+  (log/info "Initializing SendPulse triggers for dashboard subscriptions")
   (task/delete-all-triggers-of-job! send-pulse-job-key)
   (let [trigger-slot->pc-ids (as-> (t2/select :model/PulseChannel
                                               {:select    [:pc.*]
@@ -227,6 +227,14 @@
         (task/delete-trigger! trigger-key)
         (task/add-trigger! (send-pulse-trigger pulse-id schedule-map new-pc-ids (send-trigger-timezone)))))))
 
+(jobs/defjob
+  ^{:doc
+    "Find all active Dashboard Subscriptino channels, group them by pulse-id and schedule time and create a trigger for each.
+    Do this every startup to make sure all active pulse channels are triggered correctly."}
+  InitSendPulseTriggers
+  [_context]
+  (init-dashboard-subscription-triggers!))
+
 ;;; -------------------------------------------------- Task init ------------------------------------------------
 
 (defmethod task/init! ::SendPulses [_]
@@ -234,5 +242,14 @@
                         (jobs/with-identity send-pulse-job-key)
                         (jobs/with-description "Send Pulse")
                         (jobs/of-type SendPulse)
-                        (jobs/store-durably))]
-    (task/add-job! send-pulse-job)))
+                        (jobs/store-durably))
+        init-job       (jobs/build
+                        (jobs/of-type InitSendPulseTriggers)
+                        (jobs/with-identity (jobs/key "metabase.task.send-pulses.init-send-pulse-triggers.job"))
+                        (jobs/store-durably))
+        init-trigger   (triggers/build
+                        ;; run once on startup
+                        (triggers/with-identity (triggers/key "metabase.task.send-pulses.init-send-pulse-triggers.trigger"))
+                        (triggers/start-now))]
+    (task/add-job! send-pulse-job)
+    (task/schedule-task! init-job init-trigger)))

--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -210,6 +210,12 @@
   (when-let [scheduler (scheduler)]
     (qs/delete-trigger scheduler trigger-key)))
 
+(mu/defn delete-all-triggers-of-job!
+  "Delete all triggers for a given job key."
+  [job-key :- (ms/InstanceOfClass JobKey)]
+  (when-let [scheduler (scheduler)]
+    (qs/delete-triggers scheduler (map #(.getKey ^Trigger %) (qs/get-triggers-of-job scheduler job-key)))))
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                 Scheduler Info                                                 |
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -36,7 +36,7 @@
   *quartz-scheduler*
   (atom nil))
 
-(defn- scheduler
+(defn scheduler
   "Fetch the instance of our Quartz scheduler."
   ^Scheduler []
   @*quartz-scheduler*)

--- a/src/metabase/task/notification.clj
+++ b/src/metabase/task/notification.clj
@@ -151,7 +151,6 @@
   Called when starting the instance."
   []
   (assert (task/scheduler) "Scheduler must be started before initializing SendPulse triggers")
-  (log/info "Initializing SendNotification triggers")
   (task/delete-all-triggers-of-job! send-notification-job-key)
   (run! create-new-trigger! (t2/reducible-select :model/NotificationSubscription :type :notification-subscription/cron)))
 
@@ -161,6 +160,7 @@
     Run once on startup."}
   InitNotificationTriggers
   [_context]
+  (log/info "Initializing SendNotification triggers")
   (init-send-notification-triggers!))
 
 (defmethod task/init! ::SendNotifications [_]

--- a/src/metabase/task/notification.clj
+++ b/src/metabase/task/notification.clj
@@ -153,7 +153,7 @@
   (assert (task/scheduler) "Scheduler must be started before initializing SendPulse triggers")
   (log/info "Initializing SendNotification triggers")
   (task/delete-all-triggers-of-job! send-notification-job-key)
-  (run! create-new-trigger! (t2/reducible-select :model/NotificationSubscription)))
+  (run! create-new-trigger! (t2/reducible-select :model/NotificationSubscription :type :notification-subscription/cron)))
 
 (defmethod task/init! ::SendNotifications [_]
   (let [send-notification-job              (jobs/build

--- a/src/metabase/task/notification.clj
+++ b/src/metabase/task/notification.clj
@@ -150,6 +150,7 @@
 
   Called when starting the instance."
   []
+  (assert (task/scheduler) "Scheduler must be started before initializing SendPulse triggers")
   (log/info "Initializing SendNotification triggers")
   (task/delete-all-triggers-of-job! send-notification-job-key)
   (run! create-new-trigger! (t2/reducible-select :model/NotificationSubscription)))

--- a/src/metabase/task/notification.clj
+++ b/src/metabase/task/notification.clj
@@ -53,9 +53,13 @@
    ;; higher than sync
    (triggers/with-priority 6)))
 
+(defn- create-new-trigger!
+  [{:keys [id cron_schedule] :as _notification-subscription}]
+  (task/add-trigger! (build-trigger id cron_schedule)))
+
 (defn update-subscription-trigger!
   "Update the trigger for a notification subscription if it exists and needs to be updated."
-  [{:keys [id type cron_schedule] :as _notification-subscription}]
+  [{:keys [id type cron_schedule] :as notification-subscription}]
   (let [existing-trigger (first (task/existing-triggers send-notification-job-key (send-notification-trigger-key id)))]
     (cond
      ;; delete trigger if type changes
@@ -74,13 +78,13 @@
       (not existing-trigger)
       (do
         (log/infof "Creating new trigger for subscription %d with schedule %s" id cron_schedule)
-        (task/add-trigger! (build-trigger id cron_schedule)))
+        (create-new-trigger! notification-subscription))
 
       (not= cron_schedule (:schedule existing-trigger))
       (do
         (log/infof "Rescheduling trigger for subscription %d from %s to %s" id (:schedule existing-trigger) cron_schedule)
         (task/delete-trigger! (-> existing-trigger :key triggers/key))
-        (task/add-trigger! (build-trigger id cron_schedule)))
+        (create-new-trigger! notification-subscription))
 
       :else
       (log/infof "No changes to trigger for subscription %d" id))))
@@ -141,30 +145,19 @@
   (let [{:strs [subscription-id]} (qc/from-job-data context)]
     (send-notification* subscription-id)))
 
-(jobs/defjob
-  ^{:doc
-    "Find all notification subscriptions with cron schedules and create a trigger for each.
+(defn init-send-notification-triggers!
+  "Initialize all notification subscription triggers.
 
-    Context: We've migrated alerts from pulse to notifications, see the `v53.2024-12-12T08:05:00` migration.
-    This job is needed to create triggers for all existing notification subscriptions.
-    Will only run once when Metabase starts up."}
-  InitNotificationTriggers
-  [_context]
-  (run! update-subscription-trigger! (t2/reducible-select :model/NotificationSubscription)))
+  Called when starting the instance."
+  []
+  (log/info "Initializing SendNotification triggers")
+  (task/delete-all-triggers-of-job! send-notification-job-key)
+  (run! create-new-trigger! (t2/reducible-select :model/NotificationSubscription)))
 
 (defmethod task/init! ::SendNotifications [_]
   (let [send-notification-job              (jobs/build
                                             (jobs/with-identity send-notification-job-key)
                                             (jobs/with-description "Send Notification")
                                             (jobs/of-type SendNotification)
-                                            (jobs/store-durably))
-        init-notification-triggers-job     (jobs/build
-                                            (jobs/of-type InitNotificationTriggers)
-                                            (jobs/with-identity (jobs/key "metabase.task.notification.init-notification-triggers.job"))
-                                            (jobs/store-durably))
-        init-notification-triggers-trigger (triggers/build
-                                            (triggers/with-identity (triggers/key "metabase.task.notification.init-notification-triggers.trigger"))
-                                            ;; run only once per MB instance (like a migration)
-                                            (triggers/start-now))]
-    (task/add-job! send-notification-job)
-    (task/schedule-task! init-notification-triggers-job init-notification-triggers-trigger)))
+                                            (jobs/store-durably))]
+    (task/add-job! send-notification-job)))

--- a/test/metabase/db/custom_migrations/pulse_to_notification_test.clj
+++ b/test/metabase/db/custom_migrations/pulse_to_notification_test.clj
@@ -4,7 +4,6 @@
    [clojure.test :refer :all]
    [metabase.db.custom-migrations.pulse-to-notification :as pulse-to-notification]
    [metabase.models.notification :as models.notification]
-   [metabase.task :as task]
    [metabase.test :as mt]
    [metabase.util.json :as json]
    [toucan2.core :as t2]))
@@ -14,8 +13,8 @@
   (update notiification :handler #(sort-by :channel_type %)))
 
 (defn migrate-alert!
-  [scheduler pulse-id]
-  (->> (#'pulse-to-notification/alert->notification! scheduler (t2/select-one :pulse pulse-id))
+  [pulse-id]
+  (->> (#'pulse-to-notification/alert->notification! (t2/select-one :pulse pulse-id))
        (map :id)
        (map (partial t2/select-one :model/Notification))
        (map models.notification/hydrate-notification)
@@ -64,112 +63,108 @@
   (testing "basic alert migration"
     (mt/with-model-cleanup [:model/Pulse :model/Notification]
       (mt/with-temp [:model/Card {card-id :id} {}]
-        (mt/with-temp-scheduler!
-          (testing "has one subscription, one email handler with one recipient"
-            (let [alert-id (create-alert! {} card-id [{:channel_type "email"
-                                                       :recipients  [{:user_id (mt/user->id :rasta)}]}])
-                  alert    (t2/select-one :model/Pulse alert-id)
-                  notification (first (migrate-alert! (#'task/scheduler) alert-id))]
-              (is (=? {:payload_type :notification/card
-                       :active       true
-                       :creator_id   (mt/user->id :crowberto)
-                       :subscriptions [{:type          :notification-subscription/cron
-                                        :cron_schedule cron-daily-6-am}]
-                       :handlers      [{:channel_type :channel/email
-                                        :recipients   [{:type :notification-recipient/user
-                                                        :user_id (mt/user->id :rasta)}]}]
-                       :created_at   (:created_at alert)
-                       :updated_at   (:updated_at alert)}
-                      notification)))))))))
-
-(deftest migrate-alert-http-test
-  (testing "migrate alert with http channel"
-    (mt/with-model-cleanup [:model/Pulse :model/Notification]
-      (mt/with-temp-scheduler!
-        (mt/with-temp [:model/Card {card-id :id} {}
-                       :model/Channel {channel-id :id} {}]
-          (let [alert-id (create-alert! {} card-id [{:channel_type "http"
-                                                     :channel_id   channel-id}])
-                notification (first (migrate-alert! (#'task/scheduler) alert-id))]
+        (testing "has one subscription, one email handler with one recipient"
+          (let [alert-id (create-alert! {} card-id [{:channel_type "email"
+                                                     :recipients  [{:user_id (mt/user->id :rasta)}]}])
+                alert    (t2/select-one :model/Pulse alert-id)
+                notification (first (migrate-alert! alert-id))]
             (is (=? {:payload_type :notification/card
-                     :payload      {:card_id        card-id
-                                    :send_once      false
-                                    :send_condition :has_result}
                      :active       true
                      :creator_id   (mt/user->id :crowberto)
                      :subscriptions [{:type          :notification-subscription/cron
                                       :cron_schedule cron-daily-6-am}]
-                     :handlers      [{:channel_type :channel/http
-                                      :channel_id   channel-id}]}
+                     :handlers      [{:channel_type :channel/email
+                                      :recipients   [{:type :notification-recipient/user
+                                                      :user_id (mt/user->id :rasta)}]}]
+                     :created_at   (:created_at alert)
+                     :updated_at   (:updated_at alert)}
                     notification))))))))
+
+(deftest migrate-alert-http-test
+  (testing "migrate alert with http channel"
+    (mt/with-model-cleanup [:model/Pulse :model/Notification]
+      (mt/with-temp [:model/Card {card-id :id} {}
+                     :model/Channel {channel-id :id} {}]
+        (let [alert-id (create-alert! {} card-id [{:channel_type "http"
+                                                   :channel_id   channel-id}])
+              notification (first (migrate-alert! alert-id))]
+          (is (=? {:payload_type :notification/card
+                   :payload      {:card_id        card-id
+                                  :send_once      false
+                                  :send_condition :has_result}
+                   :active       true
+                   :creator_id   (mt/user->id :crowberto)
+                   :subscriptions [{:type          :notification-subscription/cron
+                                    :cron_schedule cron-daily-6-am}]
+                   :handlers      [{:channel_type :channel/http
+                                    :channel_id   channel-id}]}
+                  notification)))))))
 
 (deftest migrate-alert-multiple-channels-test
   (testing "migrate alert with multiple channels 1 slack, 1 email with 1 external recipient and one user, 1 disabled email, one http"
     (mt/with-model-cleanup [:model/Pulse :model/Notification]
-      (mt/with-temp-scheduler!
-        (mt/with-temp [:model/Card {card-id :id} {}
-                       :model/Channel {channel-id :id} {:type "channel/http"}]
-          (let [alert-id (create-alert! {} card-id [{:channel_type "email"
-                                                     :enabled      true
-                                                     :details      (json/encode {:emails ["ngoc@metabase.com"]})
-                                                     :recipients   [{:user_id (mt/user->id :rasta)}]}
-                                                    {:channel_type "slack"
-                                                     :enabled      true
-                                                     :details      (json/encode {:channel "#test-channel"})}
-                                                    {:channel_type "http"
-                                                     :enabled      true
-                                                     :channel_id   channel-id}
-                                                    {:channel_type "email"
-                                                     :enabled      false
-                                                     :recipients   [{:user_id (mt/user->id :crowberto)}]}])
-                notification (first (migrate-alert! (#'task/scheduler) alert-id))]
-            (testing "are correctly migrated, the disabled channel is not migrated"
-              (is (=? {:payload_type :notification/card
-                       :active       true
-                       :creator_id   (mt/user->id :crowberto)
-                       :subscriptions [{:type          :notification-subscription/cron
-                                        :cron_schedule cron-daily-6-am}]
-                       :handlers      [{:channel_type :channel/email
-                                        :recipients   [{:type    :notification-recipient/user
-                                                        :user_id (mt/user->id :rasta)}
-                                                       {:type    :notification-recipient/raw-value
-                                                        :details {:value "ngoc@metabase.com"}}]}
-                                       {:channel_type :channel/slack
-                                        :recipients   [{:type    :notification-recipient/raw-value
-                                                        :details {:value "#test-channel"}}]}
-                                       {:channel_type :channel/http
-                                        :channel_id   channel-id}]}
-                      notification)))))))))
+      (mt/with-temp [:model/Card {card-id :id} {}
+                     :model/Channel {channel-id :id} {:type "channel/http"}]
+        (let [alert-id (create-alert! {} card-id [{:channel_type "email"
+                                                   :enabled      true
+                                                   :details      (json/encode {:emails ["ngoc@metabase.com"]})
+                                                   :recipients   [{:user_id (mt/user->id :rasta)}]}
+                                                  {:channel_type "slack"
+                                                   :enabled      true
+                                                   :details      (json/encode {:channel "#test-channel"})}
+                                                  {:channel_type "http"
+                                                   :enabled      true
+                                                   :channel_id   channel-id}
+                                                  {:channel_type "email"
+                                                   :enabled      false
+                                                   :recipients   [{:user_id (mt/user->id :crowberto)}]}])
+              notification (first (migrate-alert! alert-id))]
+          (testing "are correctly migrated, the disabled channel is not migrated"
+            (is (=? {:payload_type :notification/card
+                     :active       true
+                     :creator_id   (mt/user->id :crowberto)
+                     :subscriptions [{:type          :notification-subscription/cron
+                                      :cron_schedule cron-daily-6-am}]
+                     :handlers      [{:channel_type :channel/email
+                                      :recipients   [{:type    :notification-recipient/user
+                                                      :user_id (mt/user->id :rasta)}
+                                                     {:type    :notification-recipient/raw-value
+                                                      :details {:value "ngoc@metabase.com"}}]}
+                                     {:channel_type :channel/slack
+                                      :recipients   [{:type    :notification-recipient/raw-value
+                                                      :details {:value "#test-channel"}}]}
+                                     {:channel_type :channel/http
+                                      :channel_id   channel-id}]}
+                    notification))))))))
 
 (deftest migrate-alert-send-condition-test
   (testing "migrate alert with different send conditions"
     (mt/with-model-cleanup [:model/Pulse :model/Notification]
       (mt/with-temp [:model/Card {card-id :id} {}]
-        (mt/with-temp-scheduler!
-          (doseq [{:keys [expected alert-props]} [{:expected    {:send_condition :has_result
-                                                                 :send_once      false}
-                                                   :alert-props {:alert_condition "rows"
-                                                                 :alert_above_goal nil
-                                                                 :alert_first_only false}}
-                                                  {:expected    {:send_condition :goal_above
-                                                                 :send_once       false}
-                                                   :alert-props {:alert_condition "goal"
-                                                                 :alert_above_goal true
-                                                                 :alert_first_only false}}
-                                                  {:expected    {:send_condition :goal_below
-                                                                 :send_once       true}
-                                                   :alert-props {:alert_condition "goal"
-                                                                 :alert_above_goal false
-                                                                 :alert_first_only true}}]]
-            (testing (format "testing %s condition" alert-props)
-              (let [alert-id (create-alert! alert-props card-id [{:channel_type "email"
-                                                                  :recipients  [{:user_id (mt/user->id :rasta)}]}])
-                    notification (first (migrate-alert! (#'task/scheduler) alert-id))]
-                (is (=? {:payload_type :notification/card
-                         :payload      (merge {:card_id card-id} expected)
-                         :active       true
-                         :creator_id   (mt/user->id :crowberto)}
-                        notification))))))))))
+        (doseq [{:keys [expected alert-props]} [{:expected    {:send_condition :has_result
+                                                               :send_once      false}
+                                                 :alert-props {:alert_condition "rows"
+                                                               :alert_above_goal nil
+                                                               :alert_first_only false}}
+                                                {:expected    {:send_condition :goal_above
+                                                               :send_once       false}
+                                                 :alert-props {:alert_condition "goal"
+                                                               :alert_above_goal true
+                                                               :alert_first_only false}}
+                                                {:expected    {:send_condition :goal_below
+                                                               :send_once       true}
+                                                 :alert-props {:alert_condition "goal"
+                                                               :alert_above_goal false
+                                                               :alert_first_only true}}]]
+          (testing (format "testing %s condition" alert-props)
+            (let [alert-id (create-alert! alert-props card-id [{:channel_type "email"
+                                                                :recipients  [{:user_id (mt/user->id :rasta)}]}])
+                  notification (first (migrate-alert! alert-id))]
+              (is (=? {:payload_type :notification/card
+                       :payload      (merge {:card_id card-id} expected)
+                       :active       true
+                       :creator_id   (mt/user->id :crowberto)}
+                      notification)))))))))
 
 (defn- bit->boolean
   "Coerce a bit returned by some MySQL/MariaDB versions in some situations to Boolean."
@@ -181,27 +176,26 @@
 (defn test-alert-view!
   [{:keys [alert pcs expected-views]}]
   (mt/with-model-cleanup [:model/Pulse :model/Notification]
-    (mt/with-temp-scheduler!
-      (mt/with-temp [:model/Card {card-id :id} {}]
-        (let [alert-id (create-alert! alert card-id pcs)
-              notification-id (:id (first (migrate-alert! (#'task/scheduler) alert-id)))
-              entity-id       (format "notification_%s" notification-id)
-              card-entity-id  (format "card_%s" card-id)]
-          (is (=? (map #(assoc %
-                               :card_qualified_id card-entity-id
-                               :card_id card-id
-                               :entity_id notification-id)
-                       expected-views)
-                  (map #(-> %
-                            (update :archived bit->boolean)
-                            (update :recipients (fn [recipients]
-                                                  (some-> recipients
-                                                          (str/split #",")
-                                                          set))))
-                       (t2/query {:select [:*]
-                                  :from [:v_alerts]
-                                  :where [:= :entity_qualified_id entity-id]
-                                  :order-by [:recipient_type]})))))))))
+    (mt/with-temp [:model/Card {card-id :id} {}]
+      (let [alert-id (create-alert! alert card-id pcs)
+            notification-id (:id (first (migrate-alert! alert-id)))
+            entity-id       (format "notification_%s" notification-id)
+            card-entity-id  (format "card_%s" card-id)]
+        (is (=? (map #(assoc %
+                             :card_qualified_id card-entity-id
+                             :card_id card-id
+                             :entity_id notification-id)
+                     expected-views)
+                (map #(-> %
+                          (update :archived bit->boolean)
+                          (update :recipients (fn [recipients]
+                                                (some-> recipients
+                                                        (str/split #",")
+                                                        set))))
+                     (t2/query {:select [:*]
+                                :from [:v_alerts]
+                                :where [:= :entity_qualified_id entity-id]
+                                :order-by [:recipient_type]}))))))))
 
 (deftest v_alerts-test
   (testing "testing the new v_alerts view created by v53.2024-12-12T08:06:00 migration"

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -2551,104 +2551,68 @@
                   {}]
                  (query-viz-settings))))))))
 
-(defn- send-pulse-triggers
-  []
-  (:triggers (task/job-info "metabase.task.send-pulses.send-pulse.job")))
-
-(defn- send-notification-triggers
-  []
-  (:triggers (task/job-info "metabase.task.notification.send.job")))
-
 ;; see [[custom-migrations/MigrateAlertToNotification]] for info about how this migration works
 (deftest migrate-alert-to-notification-test
   (testing "v53.2024-12-12T08:06:00: migrate alerts from pulse to notification"
     (mt/with-temp-scheduler!
       (impl/test-migrations ["v53.2024-12-12T08:05:00"] [migrate!]
-        (with-redefs [;; redefs so that the init tasks that run in a separate with use this temp scheduler and temp connection
-                      task/*quartz-scheduler*         (atom @task/*quartz-scheduler*)
-                      mdb.connection/*application-db* mdb.connection/*application-db*]
-          (let [user-id     (:id (new-instance-with-default :core_user))
-                database-id (:id (new-instance-with-default :metabase_database))
-                card-id     (:id (new-instance-with-default :report_card
-                                                            {:creator_id  user-id
-                                                             :database_id database-id}))
-                pulse-id    (:id (new-instance-with-default :pulse
-                                                            {:name             "My Alert"
-                                                             :creator_id       user-id
-                                                             :alert_condition  "rows"
-                                                             :alert_first_only false
-                                                             :archived        false}))
-                _pc-id     (:id (new-instance-with-default :pulse_card
-                                                           {:pulse_id pulse-id
-                                                            :card_id  card-id
-                                                            :position 0}))
-                schedule   {:schedule_type "daily"
-                            :schedule_hour  18
-                            :schedule_day   nil
-                            :schedule_frame nil}
-                _pc-ch-id  (:id (new-instance-with-default :pulse_channel
-                                                           (merge schedule
-                                                                  {:pulse_id     pulse-id
-                                                                   :channel_type "email"
-                                                                   :details      (json/encode {:emails ["test@test.com"]})
-                                                                   :enabled      true})))]
+        (let [user-id     (:id (new-instance-with-default :core_user))
+              database-id (:id (new-instance-with-default :metabase_database))
+              card-id     (:id (new-instance-with-default :report_card
+                                                          {:creator_id  user-id
+                                                           :database_id database-id}))
+              pulse-id    (:id (new-instance-with-default :pulse
+                                                          {:name             "My Alert"
+                                                           :creator_id       user-id
+                                                           :alert_condition  "rows"
+                                                           :alert_first_only false
+                                                           :archived        false}))
+              _pc-id     (:id (new-instance-with-default :pulse_card
+                                                         {:pulse_id pulse-id
+                                                          :card_id  card-id
+                                                          :position 0}))
+              schedule   {:schedule_type "daily"
+                          :schedule_hour  18
+                          :schedule_day   nil
+                          :schedule_frame nil}
+              _pc-ch-id  (:id (new-instance-with-default :pulse_channel
+                                                         (merge schedule
+                                                                {:pulse_id     pulse-id
+                                                                 :channel_type "email"
+                                                                 :details      (json/encode {:emails ["test@test.com"]})
+                                                                 :enabled      true})))]
 
-            (testing "before migration there should be a trigger for the send pulse task"
-              (task/init! ::task.send-pulses/SendPulses)
-              (is (=? [{:key (format "metabase.task.send-pulse.trigger.%d.0_0_18_*_*_?_*" pulse-id)}]
-                      (u/poll {:thunk       send-pulse-triggers
-                               :done?       seq
-                               :interval-ms 20}))))
+          (testing "after migration"
+            (migrate!)
+            (testing "pulse is migrated to notification"
+              (let [notification (t2/select-one :notification)
+                    notification-card (t2/select-one :notification_card :id (:payload_id notification))
+                    subscription (t2/select-one :notification_subscription :notification_id (:id notification))
+                    handler      (t2/select-one :notification_handler :notification_id (:id notification))
+                    recipient    (t2/select-one :notification_recipient :notification_handler_id (:id handler))]
+                (is (= {:payload_type "notification/card"
+                        :active       true
+                        :creator_id   user-id}
+                       (select-keys notification [:payload_type :active :creator_id])))
 
-            (testing "after migration"
-              (migrate!)
-              (testing "pulse is migrated to notification"
-                (let [notification (t2/select-one :notification)
-                      notification-card (t2/select-one :notification_card :id (:payload_id notification))
-                      subscription (t2/select-one :notification_subscription :notification_id (:id notification))
-                      handler      (t2/select-one :notification_handler :notification_id (:id notification))
-                      recipient    (t2/select-one :notification_recipient :notification_handler_id (:id handler))]
-                  (is (= {:payload_type "notification/card"
-                          :active       true
-                          :creator_id   user-id}
-                         (select-keys notification [:payload_type :active :creator_id])))
+                (is (= {:card_id        card-id
+                        :send_once      false
+                        :send_condition "has_result"}
+                       (select-keys notification-card [:card_id :send_once :send_condition])))
 
-                  (is (= {:card_id        card-id
-                          :send_once      false
-                          :send_condition "has_result"}
-                         (select-keys notification-card [:card_id :send_once :send_condition])))
+                (is (= {:type          "notification-subscription/cron"
+                        :cron_schedule "0 0 18 * * ? *"}
+                       (select-keys subscription [:type :cron_schedule])))
 
-                  (is (= {:type          "notification-subscription/cron"
-                          :cron_schedule "0 0 18 * * ? *"}
-                         (select-keys subscription [:type :cron_schedule])))
+                (is (= {:channel_type "channel/email"}
+                       (select-keys handler [:channel_type])))
+                (is (= {:type    "notification-recipient/raw-value"
+                        :details "{\"value\":\"test@test.com\"}"}
+                       (select-keys recipient [:type :details])))
+                (is (= {:type    "notification-recipient/raw-value"
+                        :details "{\"value\":\"test@test.com\"}"}
+                       (select-keys recipient [:type :details]))))))
 
-                  (is (= {:channel_type "channel/email"}
-                         (select-keys handler [:channel_type])))
-                  (is (= {:type    "notification-recipient/raw-value"
-                          :details "{\"value\":\"test@test.com\"}"}
-                         (select-keys recipient [:type :details])))
-                  (is (= {:type    "notification-recipient/raw-value"
-                          :details "{\"value\":\"test@test.com\"}"}
-                         (select-keys recipient [:type :details])))
-
-                  (testing "send pulse trigger is deleted"
-                    (is (empty? (send-pulse-triggers))))
-
-                  (testing "init send notification creates new triggers"
-                    ;; simulate start up
-                    (task/init! ::task.notification/SendNotifications)
-                    (is (empty? (send-notification-triggers)))
-                    (is (=? [{:key (format "metabase.task.notification.trigger.subscription.%d" (:id subscription))}]
-                            (u/poll {:thunk       send-notification-triggers
-                                     :done?       seq
-                                     :interval-ms 20})))))))
-
-            (testing "after downgrade"
-              (migrate! :down 52)
-              (testing "init send pulse creates new trigger"
-                (task/init! ::task.send-pulses/SendPulses)
-                (is (=? [{:key (format "metabase.task.send-pulse.trigger.%d.0_0_18_*_*_?_*" pulse-id)}]
-                        (u/poll {:thunk       send-pulse-triggers
-                                 :done?       seq
-                                 :interval-ms 20})))
-                (is (zero? (t2/count :notification :payload_type "notification/card")))))))))))
+          (testing "after downgrade"
+            (migrate! :down 52)
+            (is (zero? (t2/count :notification :payload_type "notification/card")))))))))

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -35,7 +35,6 @@
    [metabase.search.ingestion :as search.ingestion]
    [metabase.sync.task.sync-databases-test :as task.sync-databases-test]
    [metabase.task :as task]
-   [metabase.task.notification :as task.notification]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]

--- a/test/metabase/models/notification_test.clj
+++ b/test/metabase/models/notification_test.clj
@@ -337,11 +337,11 @@
           (let [sub-id (t2/insert-returning-pk! :model/NotificationSubscription {:type            :notification-subscription/cron
                                                                                  :cron_schedule   "0 * * * * ? *"
                                                                                  :notification_id noti-id})]
-            (is (= [(subscription->trigger-info
+            (is (= [(notification.tu/subscription->trigger-info
                      sub-id
                      "0 * * * * ? *"
                      "Asia/Ho_Chi_Minh")]
-                   notification.tu/send-notification-triggers sub-id)))))))))
+                   (notification.tu/send-notification-triggers sub-id)))))))))
 
 (deftest archive-notification-triggers-test
   (mt/with-temp-scheduler!

--- a/test/metabase/models/notification_test.clj
+++ b/test/metabase/models/notification_test.clj
@@ -287,27 +287,6 @@
                                           :permissions_group_id 1
                                           :details              {:value "ngoc@metabase.com"}}))))))))
 
-(defn- send-notification-triggers
-  [subscription-id]
-  (map
-   #(select-keys % [:key :schedule :data :timezone])
-   (task/existing-triggers @#'task.notification/send-notification-job-key
-                           (#'task.notification/send-notification-trigger-key subscription-id))))
-
-(defn notification-triggers
-  [notification-id]
-  (let [subscription-ids (t2/select-pks-set :model/NotificationSubscription :notification_id notification-id)]
-    (mapcat send-notification-triggers subscription-ids)))
-
-(defn- subscription->trigger-info
-  ([subscription-id cron-schedule]
-   (subscription->trigger-info subscription-id cron-schedule "UTC"))
-  ([subscription-id cron-schedule timezone]
-   {:key      (.getName (#'task.notification/send-notification-trigger-key subscription-id))
-    :schedule cron-schedule
-    :data     {"subscription-id" subscription-id}
-    :timezone timezone}))
-
 (deftest update-subscription-trigger-test
   (mt/with-temp-scheduler!
     (task/init! ::task.notification/SendNotifications)
@@ -316,38 +295,38 @@
         (let [sub-id (t2/insert-returning-pk! :model/NotificationSubscription {:type            :notification-subscription/cron
                                                                                :cron_schedule   "0 * * * * ? *"
                                                                                :notification_id noti-id})]
-          (is (= [(subscription->trigger-info
+          (is (= [(notification.tu/subscription->trigger-info
                    sub-id
                    "0 * * * * ? *")]
-                 (send-notification-triggers sub-id)))
+                 (notification.tu/send-notification-triggers sub-id)))
           (testing "update trigger when cron schedule is changed"
             (t2/update! :model/NotificationSubscription sub-id {:cron_schedule "1 * * * * ? *"})
-            (is (= [(subscription->trigger-info
+            (is (= [(notification.tu/subscription->trigger-info
                      sub-id
                      "1 * * * * ? *")]
-                   (send-notification-triggers sub-id))))
+                   (notification.tu/send-notification-triggers sub-id))))
 
           (testing "delete the trigger when type changes"
             (t2/update! :model/NotificationSubscription sub-id {:type :notification-subscription/system-event
                                                                 :cron_schedule nil
                                                                 :event_name :event/card-create})
-            (is (empty? (send-notification-triggers sub-id))))))
+            (is (empty? (notification.tu/send-notification-triggers sub-id))))))
 
       (testing "delete the trigger when delete subscription"
         (let [sub-id (t2/insert-returning-pk! :model/NotificationSubscription {:type            :notification-subscription/cron
                                                                                :cron_schedule   "0 * * * * ? *"
                                                                                :notification_id noti-id})]
-          (is (not-empty (send-notification-triggers sub-id)))
+          (is (not-empty (notification.tu/send-notification-triggers sub-id)))
           (t2/delete! :model/NotificationSubscription sub-id)
-          (is (empty? (send-notification-triggers sub-id)))))
+          (is (empty? (notification.tu/send-notification-triggers sub-id)))))
 
       (testing "delete notification will delete all subscription triggers"
         (let [sub-id (t2/insert-returning-pk! :model/NotificationSubscription {:type            :notification-subscription/cron
                                                                                :cron_schedule   "0 * * * * ? *"
                                                                                :notification_id noti-id})]
-          (is (not-empty (send-notification-triggers sub-id)))
+          (is (not-empty (notification.tu/send-notification-triggers sub-id)))
           (t2/delete! :model/Notification noti-id)
-          (is (empty? (send-notification-triggers sub-id))))))))
+          (is (empty? (notification.tu/send-notification-triggers sub-id))))))))
 
 (deftest subscription-trigger-timezone-is-report-timezone-test
   (mt/with-temp-scheduler!
@@ -362,7 +341,7 @@
                      sub-id
                      "0 * * * * ? *"
                      "Asia/Ho_Chi_Minh")]
-                   (send-notification-triggers sub-id)))))))))
+                   notification.tu/send-notification-triggers sub-id)))))))))
 
 (deftest archive-notification-triggers-test
   (mt/with-temp-scheduler!
@@ -374,12 +353,12 @@
                                  {:type          :notification-subscription/cron
                                   :cron_schedule "1 * * * * ? *"}]}]
       (testing "sanity check that it has a trigger to begin with"
-        (is (= 2 (count (notification-triggers id)))))
+        (is (= 2 (count (notification.tu/notification-triggers id)))))
 
       (testing "disabled notification should remove triggers"
         (t2/update! :model/Notification id {:active false})
-        (is (empty? (notification-triggers id))))
+        (is (empty? (notification.tu/notification-triggers id))))
 
       (testing "activate notification should restore triggers"
         (t2/update! :model/Notification id {:active true})
-        (is (= 2 (count (notification-triggers id))))))))
+        (is (= 2 (count (notification.tu/notification-triggers id))))))))

--- a/test/metabase/notification/test_util.clj
+++ b/test/metabase/notification/test_util.clj
@@ -239,7 +239,7 @@
   [& body]
   `(do-with-mock-inbox-email! (fn [] ~@body)))
 
-(defn- send-notification-triggers
+(defn send-notification-triggers
   "Return the quartz triggers for a subscription."
   [subscription-id]
   (map

--- a/test/metabase/pulse/task/send_pulses_test.clj
+++ b/test/metabase/pulse/task/send_pulses_test.clj
@@ -140,7 +140,8 @@
   (testing "a SendJob trigger will send pulse to channels that have the same schedueld time"
     (pulse-channel-test/with-send-pulse-setup!
       (mt/with-temp
-        [:model/Pulse        {pulse-1 :id} {}
+        [:model/Dashboard    {dash-id :id} {}
+         :model/Pulse        {pulse-1 :id} {:dashboard_id dash-id}
          :model/PulseChannel {pc-1-1 :id}  (merge
                                             {:pulse_id     pulse-1
                                              :channel_type :slack
@@ -151,7 +152,7 @@
                                              :channel_type :slack
                                              :details      {:channel "#general"}}
                                             daily-at-1am)
-         :model/Pulse        {pulse-2 :id} {}
+         :model/Pulse        {pulse-2 :id} {:dashboard_id dash-id}
          :model/PulseChannel {pc-2-1 :id}  (merge
                                             {:pulse_id     pulse-2
                                              :channel_type :slack
@@ -168,7 +169,6 @@
                                              :channel_type :slack
                                              :details      {:channel "#general"}}
                                             daily-at-6pm)
-         :model/Dashboard    {dash-id :id} {}
          :model/Pulse        {pulse-3 :id} {:dashboard_id dash-id}
          :model/PulseChannel {pc-3-1 :id}  (merge
                                             {:enabled      true

--- a/test/metabase/pulse/task/send_pulses_test.clj
+++ b/test/metabase/pulse/task/send_pulses_test.clj
@@ -136,8 +136,8 @@
           (testing "channels that has no recipients are deleted"
             (is (false? (t2/exists? :model/PulseChannel pc-no-recipient)))))))))
 
-(deftest init-send-pulse-triggers!-group-runs-test
-  (testing "a SendJob trigger will send pulse to channels that have the same schedueld time"
+(deftest init-dashboard-subscription-triggers!-group-runs-test
+  (testing "a SendPulse trigger will send pulse to channels that have the same schedueld time"
     (pulse-channel-test/with-send-pulse-setup!
       (mt/with-temp
         [:model/Dashboard    {dash-id :id} {}
@@ -196,7 +196,7 @@
           (testing "sanity check that there are no triggers"
             (is (empty? (all-send-pulse-triggers))))
           (testing "init-send-pulse-triggers! should create triggers for each pulse-channel"
-            (#'task.send-pulses/init-send-pulse-triggers!)
+            (#'task.send-pulses/init-dashboard-subscription-triggers!)
             (is (=? #{(pulse-channel-test/pulse->trigger-info pulse-1 daily-at-1am [pc-1-1 pc-1-2])
                       ;; pc-2-1 has the same schedule as pc-1-1 and pc-1-2 but it's not on the same trigger because it's a
                       ;; different schedule
@@ -320,7 +320,7 @@
           (testing "sanity check that it has triggers to begin with"
             (is (not-empty pulse-triggers)))
           (testing "init send pulse triggers are idempotent if the pulse channel doesn't change"
-            (#'task.send-pulses/init-send-pulse-triggers!)
+            (#'task.send-pulses/init-dashboard-subscription-triggers!)
             (is (= pulse-triggers (pulse-channel-test/send-pulse-triggers pulse-id)))))))))
 
 (deftest init-send-pulse-triggers-skip-alert-test
@@ -338,5 +338,5 @@
           (testing "sanity check that it has triggers to begin with"
             (is (not-empty pulse-triggers)))
           (testing "init send pulse triggers skip alerts"
-            (#'task.send-pulses/init-send-pulse-triggers!)
+            (#'task.send-pulses/init-dashboard-subscription-triggers!)
             (is (empty? (pulse-channel-test/send-pulse-triggers pulse-id)))))))))

--- a/test/metabase/task/notification_test.clj
+++ b/test/metabase/task/notification_test.clj
@@ -48,3 +48,19 @@
                                           :notification_ids             [(:id noti)]}}
                           (u/poll {:thunk #(latest-task-history-entry "notification-trigger")
                                    :done? (fn [task] (= [(:id noti)] (get-in task [:task_details :notification_ids])))}))))))))))))
+
+(deftest init-send-notification-triggers-test
+  (mt/with-temp [:model/Notification]
+    (mt/with-temp-scheduler!
+      (task/init! ::task.notification/SendNotifications)
+      (let [notification (models.notification/create-notification!
+                          {:payload_type :notification/testing}
+                          [{:type :notification-subscription/cron
+                            :cron_schedule every-second}]
+                          [])
+            notification-triggers (notification.tu/notification-triggers (:id notification))]
+        (testing "sanity check that it has triggers to begin with"
+          (is (not-empty notification-triggers)))
+        (testing "init send notification triggers are idempotent if the subscription doesn't change"
+          (task.notification/init-send-notification-triggers!)
+          (is (= notification-triggers (notification.tu/notification-triggers (:id notification)))))))))


### PR DESCRIPTION
Stats are getting double alerts: https://metaboat.slack.com/archives/C013N8XL286/p1740697211921579

Here is why:
- We landed the new alerts a couple of days ago: https://github.com/metabase/metabase/pull/51101
- It has a migration to migrate alerts from the old pulse to new notifications
- The migration doesn't delete the alerts from pulse tables because we want users to be able to downgrade
- The problem is our quartz scheduler has triggers for sending alerts from both the old and new system
- But we removed the triggers for sending pulse during migration right?([code](https://github.com/metabase/metabase/blob/72538ba/src/metabase/db/custom_migrations/pulse_to_notification.clj#L150)) yes, we did! but it was added again, by [InitSendPulseTriggers](https://github.com/metabase/metabase/blob/master/src/72538ba/pulse/task/send_pulses.clj#L195) !!! 
- This job was _supposedly_  run once per MB instance like a migration, but turns out it runs on every startup. 

The fix:
- Update `InitSendPulseTriggers` and  `InitNotificationTriggers` to both remove all existing triggers and re-intialize them all.
- I also remove all triggers management code that we do during migration.

How to test:
- Check out ecb1d83170437ecbe7e8ae3c8b6080a7f6bcbbe1 (master before we merge the new alerts)
- Create an alert
- Run `select * from qrtz_cron_triggers where trigger_name like 'metabase.task.send-pulse%' order by trigger_name asc;`. there should be be one row for our alert
- Check out this branch and start up again
- Run `select * from qrtz_cron_triggers where trigger_name like 'metabase.task.send-pulse%' order by trigger_name asc;` should returns nothing
- Run `select * from qrtz_cron_triggers where trigger_name like 'metabase.task.notification%' order by trigger_name asc;` should return 1 row.