### PR TITLE
stabilize flaky test

### DIFF
--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.js
@@ -621,6 +621,10 @@ describe("issue 34330", () => {
   });
 
   it("should only call the autocompleter with all text typed (metabase#34330)", () => {
+    cy.findByTestId("query-visualization-root")
+      .findByText("Here's where your results will appear")
+      .should("be.visible");
+
     H.NativeEditor.type("SEAT", { delay: 10 });
     H.NativeEditor.completion("SEATS").should("be.visible");
 


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/DEV-355/stabilize-flaky-test-should-only-call-the-autocompleter-with-all-text

### Description

Test sometimes flaked because an API request that was asserted would not have the proper search query parameter, [as seen here](https://github.com/metabase/metabase/actions/runs/13392677739/job/37404361785?pr=53904). The test would start interacting with the editor too early, causing the request to fire too soon,

### Resolution

Added an assertion to make sure UI is completely loaded.

### Stress test
https://github.com/metabase/metabase/actions/runs/13585163544
