### PR TITLE
Fix - Models shouldn't be represented by the sigma icon

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -1678,9 +1678,6 @@ describe("issue 54400", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsNormalUser();
-  });
-
-  it("should use model icon when source data is a model (metabase#54400)", () => {
     H.createQuestion(
       {
         name: "My model",
@@ -1691,20 +1688,26 @@ describe("issue 54400", () => {
         visitQuestion: true,
       },
     );
+  });
 
+  it("should use model icon when source data is a model (metabase#54400)", () => {
+    cy.log("filter modal");
     H.filter();
     verifyFilterModalTabIcon({ name: "My model", icon: "model" });
 
+    cy.log("filters");
     cy.realPress("Escape");
     H.openNotebook();
     H.filter({ mode: "notebook" });
     verifyPopoverItemIcon({ name: "My model", icon: "model" });
 
+    cy.log("aggregations");
     cy.realPress("Escape");
     H.summarize({ mode: "notebook" });
     H.popover().findByText("Sum of ...").click();
     verifyPopoverItemIcon({ name: "My model", icon: "model" });
 
+    cy.log("breakouts");
     H.getNotebookStep("summarize")
       .findByTestId("breakout-step")
       .findByTestId("notebook-cell-item")

--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -1673,3 +1673,53 @@ describe("issue 50731", () => {
       });
   });
 });
+
+describe("issue 54400", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should use model icon when source data is a model (metabase#54400)", () => {
+    H.createQuestion(
+      {
+        name: "My model",
+        type: "model",
+        query: { "source-table": ORDERS_ID },
+      },
+      {
+        visitQuestion: true,
+      },
+    );
+
+    H.filter();
+    verifyFilterModalTabIcon({ name: "My model", icon: "model" });
+
+    cy.realPress("Escape");
+    H.openNotebook();
+    H.filter({ mode: "notebook" });
+    verifyPopoverItemIcon({ name: "My model", icon: "model" });
+
+    cy.realPress("Escape");
+    H.summarize({ mode: "notebook" });
+    H.popover().findByText("Sum of ...").click();
+    verifyPopoverItemIcon({ name: "My model", icon: "model" });
+
+    H.getNotebookStep("summarize")
+      .findByTestId("breakout-step")
+      .findByTestId("notebook-cell-item")
+      .click();
+    verifyPopoverItemIcon({ name: "My model", icon: "model" });
+  });
+
+  function verifyPopoverItemIcon({ name, icon }) {
+    H.popover().findByText(name).prev().icon(icon).should("be.visible");
+  }
+
+  function verifyFilterModalTabIcon({ name, icon }) {
+    cy.findAllByRole("tab")
+      .filter(`:contains('${name}')`)
+      .icon(icon)
+      .should("be.visible");
+  }
+});

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -118,6 +118,7 @@ export type TableDisplayInfo = {
   name: string;
   displayName: string;
   isSourceTable: boolean;
+  isSourceCard: boolean;
   isFromJoin: boolean;
   isImplicitlyJoinable: boolean;
   schema: SchemaId;

--- a/frontend/src/metabase/common/utils/column-groups.ts
+++ b/frontend/src/metabase/common/utils/column-groups.ts
@@ -13,8 +13,8 @@ export function getColumnGroupIcon(
   if (groupInfo.isImplicitlyJoinable) {
     return "connections";
   }
-  if (groupInfo.isModel) {
-    return "model";
+  if (groupInfo.isSourceCard) {
+    return groupInfo.isModel ? "model" : "table";
   }
   if (groupInfo.isMainGroup) {
     return "sum";

--- a/frontend/src/metabase/common/utils/column-groups.ts
+++ b/frontend/src/metabase/common/utils/column-groups.ts
@@ -13,6 +13,9 @@ export function getColumnGroupIcon(
   if (groupInfo.isImplicitlyJoinable) {
     return "connections";
   }
+  if (groupInfo.isModel) {
+    return "model";
+  }
   if (groupInfo.isMainGroup) {
     return "sum";
   }

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -309,6 +309,8 @@
    [:is-main-group {:optional true} [:maybe :boolean]]
    ;; For the `:table` field of a Column, is this the source table, or a joined table?
    [:is-source-table {:optional true} [:maybe :boolean]]
+   ;; TODO: comment
+   [:is-source-card {:optional true} [:maybe :boolean]]
    ;; does this column occur in the breakout clause?
    [:is-breakout-column {:optional true} [:maybe :boolean]]
    ;; does this column occur in the order-by clause?
@@ -401,6 +403,7 @@
   [query stage-number table]
   (merge (default-display-info query stage-number table)
          {:is-source-table (= (lib.util/source-table-id query) (:id table))
+          :is-source-card (not (nil? (lib.util/source-card-id query)))
           :schema (:schema table)
           :visibility-type (:visibility-type table)}))
 


### PR DESCRIPTION
Fixes #54400

### Description

Changes icon of models when used as source in filter modal and notebook editor.

### Demo

[before](https://github.com/user-attachments/assets/9dfef2fe-33e5-44c1-92dc-882ea6ec3573) vs [after](https://github.com/user-attachments/assets/294318c6-1b34-4d1b-9419-159af9cd9be3)


### TODO

- [ ] `isSourceCard`
- [ ] add a test when source card is a question
