### PR TITLE
Fewer warnings in visualizer

### DIFF
--- a/frontend/src/metabase/components/EditBar/EditBar.styled.tsx
+++ b/frontend/src/metabase/components/EditBar/EditBar.styled.tsx
@@ -1,4 +1,5 @@
 // eslint-disable-next-line no-restricted-imports
+import isPropValid from "@emotion/is-prop-valid";
 import styled from "@emotion/styled";
 
 import ButtonsS from "metabase/css/components/buttons.module.css";
@@ -6,7 +7,9 @@ import { alpha, color } from "metabase/lib/colors";
 import { FullWidthContainer } from "metabase/styled-components/layout/FullWidthContainer";
 import { Icon } from "metabase/ui";
 
-export const Root = styled(FullWidthContainer)<{ admin: boolean }>`
+export const Root = styled(FullWidthContainer, {
+  shouldForwardProp: isPropValid,
+})<{ admin: boolean }>`
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -136,9 +136,7 @@ export function DashCardVisualization({
   downloadsEnabled,
   editDashboard,
 }: DashCardVisualizationProps) {
-  const datasets = useSelector(
-    state => getDashcardData(state, dashcard.id) ?? {},
-  );
+  const datasets = useSelector(state => getDashcardData(state, dashcard.id));
   const [
     isVisualizerModalOpen,
     { open: openVisualizerModal, close: closeVisualizerModal },

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -83,7 +83,7 @@ export const getDashcardDataMap = (state: State) =>
 export const getDashcardData = createSelector(
   [getDashcardDataMap, (_state: State, dashcardId: DashCardId) => dashcardId],
   (dashcardDataMap, dashcardId) => {
-    return dashcardDataMap[dashcardId];
+    return dashcardDataMap[dashcardId] ?? {};
   },
 );
 


### PR DESCRIPTION
Closes nothing, fixes two warnings I had been seing in the last couple of days:
 - one that happend when editing a dashboard, mentioning some invalid props being passed to a DOM element
 - another mentioning an unstable value being handled by a selector