### PR TITLE
Fix - Uncaught TypeError when making native query parameter required

### DIFF
--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -354,6 +354,7 @@ describe("issues 52811, 52812", () => {
     H.NativeEditor.type("{{x");
     cy.findByLabelText("Variable type").click();
 
+    cy.log("popover should close when clicking away (metabase#52811)");
     H.popover().findByText("Field Filter").click();
     clickAway();
     cy.get(H.POPOVER_ELEMENT).should("not.exist");
@@ -366,6 +367,9 @@ describe("issues 52811, 52812", () => {
       .should("not.exist");
     cy.findByLabelText("Always require a value").should("not.exist");
 
+    cy.log(
+      "existing popover should close when opening a new one (metabase#52811)",
+    );
     cy.findByTestId("sidebar-content").findByText("Select...").click();
     cy.findByLabelText("Variable type").click();
     H.popover()

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -343,13 +343,13 @@ describe("issue 54124", () => {
   });
 });
 
-describe("issue 52811", () => {
+describe("issues 52811, 52812", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsNormalUser();
   });
 
-  it("popovers should close when clicking outside (metabase#52811)", () => {
+  it("popovers should close when clicking outside (metabase#52811, metabase#52812)", () => {
     H.startNewNativeQuestion();
     H.NativeEditor.type("{{x");
     cy.findByLabelText("Variable type").click();
@@ -357,6 +357,14 @@ describe("issue 52811", () => {
     H.popover().findByText("Field Filter").click();
     clickAway();
     cy.get(H.POPOVER_ELEMENT).should("not.exist");
+
+    cy.log(
+      "the default value input should not be rendered when 'Field to map to' is not set yet (metabase#52812)",
+    );
+    H.rightSidebar()
+      .findByText("Default filter widget value")
+      .should("not.exist");
+    cy.findByLabelText("Always require a value").should("not.exist");
 
     cy.findByTestId("sidebar-content").findByText("Select...").click();
     cy.findByLabelText("Variable type").click();

--- a/frontend/src/metabase/query_builder/actions/native.ts
+++ b/frontend/src/metabase/query_builder/actions/native.ts
@@ -9,7 +9,7 @@ import type {
   CardId,
   DatabaseId,
   NativeQuerySnippet,
-  Parameter,
+  ParameterValuesConfig,
   TemplateTag,
 } from "metabase-types/api";
 import type { Dispatch, GetState } from "metabase-types/store";
@@ -172,7 +172,7 @@ export const setTemplateTag = createThunkAction(
 export const SET_TEMPLATE_TAG_CONFIG = "metabase/qb/SET_TEMPLATE_TAG_CONFIG";
 export const setTemplateTagConfig = createThunkAction(
   SET_TEMPLATE_TAG_CONFIG,
-  (tag: TemplateTag, parameter: Parameter) => {
+  (tag: TemplateTag, parameter: ParameterValuesConfig) => {
     return (dispatch: Dispatch, getState: GetState) => {
       const question = getQuestion(getState());
       if (!question) {

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
@@ -180,23 +180,39 @@ class TagEditorParamInner extends Component<Props> {
   };
 
   setQueryType = (queryType: ValuesQueryType) => {
-    const { tag, setTemplateTagConfig } = this.props;
+    const { tag, parameter, setTemplateTagConfig } = this.props;
 
-    setTemplateTagConfig(tag, {
-      values_query_type: queryType,
-    });
+    if (parameter) {
+      setTemplateTagConfig(tag, {
+        values_source_type: parameter.values_source_type,
+        values_source_config: parameter.values_source_config,
+        values_query_type: queryType,
+      });
+    } else {
+      setTemplateTagConfig(tag, {
+        values_query_type: queryType,
+      });
+    }
   };
 
   setSourceSettings = (
     sourceType: ValuesSourceType,
     sourceConfig: ValuesSourceConfig,
   ) => {
-    const { tag, setTemplateTagConfig } = this.props;
+    const { tag, parameter, setTemplateTagConfig } = this.props;
 
-    setTemplateTagConfig(tag, {
-      values_source_type: sourceType,
-      values_source_config: sourceConfig,
-    });
+    if (parameter) {
+      setTemplateTagConfig(tag, {
+        values_source_type: sourceType,
+        values_source_config: sourceConfig,
+        values_query_type: parameter.values_query_type,
+      });
+    } else {
+      setTemplateTagConfig(tag, {
+        values_source_type: sourceType,
+        values_source_config: sourceConfig,
+      });
+    }
   };
 
   setParameterAttribute(attr: keyof TemplateTag, val: any) {

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
@@ -25,6 +25,7 @@ import type {
   DimensionReference,
   FieldId,
   Parameter,
+  ParameterValuesConfig,
   RowValue,
   TemplateTag,
   TemplateTagId,
@@ -63,7 +64,10 @@ interface Props {
   metadata: Metadata;
   originalQuestion?: Question;
   setTemplateTag: (tag: TemplateTag) => void;
-  setTemplateTagConfig: (tag: TemplateTag, config: Partial<Parameter>) => void;
+  setTemplateTagConfig: (
+    tag: TemplateTag,
+    config: ParameterValuesConfig,
+  ) => void;
   setParameterValue: (tagId: TemplateTagId, value: RowValue) => void;
   fetchField: (fieldId: FieldId, force?: boolean) => void;
 }

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
@@ -182,17 +182,10 @@ class TagEditorParamInner extends Component<Props> {
   setQueryType = (queryType: ValuesQueryType) => {
     const { tag, parameter, setTemplateTagConfig } = this.props;
 
-    if (parameter) {
-      setTemplateTagConfig(tag, {
-        values_source_type: parameter.values_source_type,
-        values_source_config: parameter.values_source_config,
-        values_query_type: queryType,
-      });
-    } else {
-      setTemplateTagConfig(tag, {
-        values_query_type: queryType,
-      });
-    }
+    setTemplateTagConfig(tag, {
+      ...(parameter ?? {}),
+      values_query_type: queryType,
+    });
   };
 
   setSourceSettings = (
@@ -201,18 +194,11 @@ class TagEditorParamInner extends Component<Props> {
   ) => {
     const { tag, parameter, setTemplateTagConfig } = this.props;
 
-    if (parameter) {
-      setTemplateTagConfig(tag, {
-        values_source_type: sourceType,
-        values_source_config: sourceConfig,
-        values_query_type: parameter.values_query_type,
-      });
-    } else {
-      setTemplateTagConfig(tag, {
-        values_source_type: sourceType,
-        values_source_config: sourceConfig,
-      });
-    }
+    setTemplateTagConfig(tag, {
+      ...(parameter ?? {}),
+      values_source_type: sourceType,
+      values_source_config: sourceConfig,
+    });
   };
 
   setParameterAttribute(attr: keyof TemplateTag, val: any) {

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.tsx
@@ -159,7 +159,10 @@ interface SettingsPaneProps {
   databaseFields: Field[];
   parametersById: Record<ParameterId, Parameter>;
   setTemplateTag: (tag: TemplateTag) => void;
-  setTemplateTagConfig: (tag: TemplateTag, config: Partial<Parameter>) => void;
+  setTemplateTagConfig: (
+    tag: TemplateTag,
+    config: ParameterValuesConfig,
+  ) => void;
   setParameterValue: (tagId: TemplateTagId, value: RowValue) => void;
   getEmbeddedParameterVisibility: GetEmbeddedParamVisibility;
 }

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.tsx
@@ -17,6 +17,7 @@ import type {
   NativeDatasetQuery,
   Parameter,
   ParameterId,
+  ParameterValuesConfig,
   RowValue,
   TemplateTag,
   TemplateTagId,
@@ -38,7 +39,10 @@ interface TagEditorSidebarProps {
   sampleDatabaseId: DatabaseId;
   setDatasetQuery: (query: NativeDatasetQuery) => void;
   setTemplateTag: (tag: TemplateTag) => void;
-  setTemplateTagConfig: (tag: TemplateTag, config: Parameter) => void;
+  setTemplateTagConfig: (
+    tag: TemplateTag,
+    config: ParameterValuesConfig,
+  ) => void;
   setParameterValue: (tagId: TemplateTagId, value: RowValue) => void;
   onClose: () => void;
   getEmbeddedParameterVisibility: GetEmbeddedParamVisibility;
@@ -155,7 +159,7 @@ interface SettingsPaneProps {
   databaseFields: Field[];
   parametersById: Record<ParameterId, Parameter>;
   setTemplateTag: (tag: TemplateTag) => void;
-  setTemplateTagConfig: (tag: TemplateTag, config: Parameter) => void;
+  setTemplateTagConfig: (tag: TemplateTag, config: Partial<Parameter>) => void;
   setParameterValue: (tagId: TemplateTagId, value: RowValue) => void;
   getEmbeddedParameterVisibility: GetEmbeddedParamVisibility;
 }


### PR DESCRIPTION
Fixes #52812

### Description

Hides "Default filter widget value" input when "Variable type" is "Field Filter" but "Field to map to" has not been selected yet.
The `onChange` handler of "Default filter widget value" would not work in that state.
Other inputs that depend on "Field to map to" being selected are also hidden in the same way.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New > SQL Query
2. `{{x}}`
3. Change variable type to "Field Filter"
4. Notice Field picker automatically opened
5. Close the field picker by click on "Select..."

The "Default filter widget value" input should not be rendered.
