### PR TITLE
Add prometheus info metric

### DIFF
--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -183,7 +183,10 @@
 (defn- product-collectors
   []
   ;; Iapetos will use "default" if we do not provide a namespace, so explicitly set, e.g. `metabase-email`:
-  [(prometheus/counter :metabase-csv-upload/failed
+  [(prometheus/gauge :metabase-info/build
+                     {:description "An info metric used to attach build info like version, which is high cardinality."
+                      :labels [:tag :hash :date :version :major-version]})
+   (prometheus/counter :metabase-csv-upload/failed
                        {:description "Number of failures when uploading CSV."})
    (prometheus/counter :metabase-email/messages
                        {:description "Number of emails sent."})

--- a/src/metabase/core/core.clj
+++ b/src/metabase/core/core.clj
@@ -57,6 +57,17 @@
              "See https://www.metabase.com/license/commercial/ for details.")
         "Metabase Enterprise Edition extensions are NOT PRESENT.")))
 
+;;; --------------------------------------------------- Info Metric---------------------------------------------------
+
+(defmethod analytics/known-labels :metabase-info/build
+  [_]
+  ;; We need to update the labels configured for this metric before we expose anything new added to `mb-version-info`
+  [(merge (select-keys config/mb-version-info [:tag :hash :date])
+          {:version       config/mb-version-string
+           :major-version (config/current-major-version)})])
+
+(defmethod analytics/initial-value :metabase-info/build [_ _] 1)
+
 ;;; --------------------------------------------------- Lifecycle ----------------------------------------------------
 
 (defn- print-setup-url


### PR DESCRIPTION
Add a "dummy" metric that is always 1, but is tagged with a bunch of metadata about the server's build.

It can be multiplied with other metrics to give them labels for the Metabase version etc.