### PR TITLE
Allow configuration of mantine tooltip color

### DIFF
--- a/frontend/src/metabase/ui/components/overlays/Tooltip/Tooltip.config.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Tooltip/Tooltip.config.tsx
@@ -20,6 +20,7 @@ export const tooltipOverrides: MantineThemeOverride["components"] = {
         focus: true,
         touch: true,
       },
+      color: "var(--mb-color-tooltip-background)",
     },
     classNames: {
       tooltip: cx(TooltipStyles.tooltip, ZIndex.Overlay),

--- a/frontend/src/metabase/ui/components/overlays/Tooltip/Tooltip.module.css
+++ b/frontend/src/metabase/ui/components/overlays/Tooltip/Tooltip.module.css
@@ -1,5 +1,4 @@
 .tooltip {
-  background-color: var(--mb-color-tooltip-background);
   color: var(--mb-color-tooltip-text);
   font-size: var(--mantine-font-size-sm);
   font-weight: bold;

--- a/frontend/src/metabase/ui/components/overlays/Tooltip/Tooltip.stories.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Tooltip/Tooltip.stories.tsx
@@ -26,6 +26,9 @@ const argTypes = {
     ],
     control: { type: "select" },
   },
+  color: {
+    control: { type: "text" },
+  },
 };
 
 const DefaultTemplate = (args: TooltipProps) => (


### PR DESCRIPTION
Sets the default via default props instead of hard coding in CSS enabling pretty stuff like this:

![Screen Shot 2025-02-28 at 10 18 53 AM](https://github.com/user-attachments/assets/dee6a00c-6605-4897-8aca-d702389e4856) ![Screen Shot 2025-02-28 at 10 18 46 AM](https://github.com/user-attachments/assets/d375a622-e610-44fe-b202-e33f9151be33) ![Screen Shot 2025-02-28 at 10 18 38 AM](https://github.com/user-attachments/assets/476ccdf0-a50b-4957-a7fa-6e10291afac8)
