### PR TITLE
Make `:time-interval` work with `0` instead of `:current` in the UI

### DIFF
--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -415,7 +415,7 @@ export type SpecificDateFilterParts = {
 export type RelativeDateFilterParts = {
   column: ColumnMetadata;
   unit: RelativeDateFilterUnit;
-  value: number | "current";
+  value: number;
   offsetUnit: RelativeDateFilterUnit | null;
   offsetValue: number | null;
   options: RelativeDateFilterOptions;

--- a/frontend/src/metabase/querying/filters/components/DatePicker/DateOperatorPicker/DateOperatorPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/DateOperatorPicker/DateOperatorPicker.unit.spec.tsx
@@ -46,7 +46,7 @@ describe("DateOperatorPicker", () => {
 
     expect(onChange).toHaveBeenCalledWith({
       type: "relative",
-      value: "current",
+      value: 0,
       unit: "day",
     });
   });

--- a/frontend/src/metabase/querying/filters/components/DatePicker/DateOperatorPicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/DateOperatorPicker/utils.ts
@@ -31,7 +31,7 @@ export function getOptionType(value: DatePickerValue | undefined): OptionType {
     case "specific":
       return value.operator;
     case "relative":
-      if (value.value === "current") {
+      if (value.value === 0) {
         return "current";
       } else {
         return value.value < 0 ? "last" : "next";

--- a/frontend/src/metabase/querying/filters/components/DatePicker/DateOperatorPicker/utils.unit.spec.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/DateOperatorPicker/utils.unit.spec.ts
@@ -292,18 +292,21 @@ describe("setOptionType", () => {
       "month",
       "quarter",
       "year",
-    ])('should preserve "%s" unit and use default value for 0 value', unit => {
-      const value: DatePickerValue = {
-        type: "relative",
-        value: 0,
-        unit,
-      };
-      expect(setOptionType(value, "last")).toEqual({
-        type: "relative",
-        value: -30,
-        unit,
-      });
-    });
+    ])(
+      'should preserve "%s" unit and use default value for "0" value',
+      unit => {
+        const value: DatePickerValue = {
+          type: "relative",
+          value: 0,
+          unit,
+        };
+        expect(setOptionType(value, "last")).toEqual({
+          type: "relative",
+          value: -30,
+          unit,
+        });
+      },
+    );
 
     it.each<DatePickerTruncationUnit>([
       "minute",
@@ -347,18 +350,21 @@ describe("setOptionType", () => {
       "month",
       "quarter",
       "year",
-    ])('should preserve "%s" unit and use default value for 0 value', unit => {
-      const value: DatePickerValue = {
-        type: "relative",
-        value: 0,
-        unit,
-      };
-      expect(setOptionType(value, "next")).toEqual({
-        type: "relative",
-        value: 30,
-        unit,
-      });
-    });
+    ])(
+      'should preserve "%s" unit and use default value for "0" value',
+      unit => {
+        const value: DatePickerValue = {
+          type: "relative",
+          value: 0,
+          unit,
+        };
+        expect(setOptionType(value, "next")).toEqual({
+          type: "relative",
+          value: 30,
+          unit,
+        });
+      },
+    );
 
     it.each<DatePickerTruncationUnit>([
       "minute",

--- a/frontend/src/metabase/querying/filters/components/DatePicker/DateOperatorPicker/utils.unit.spec.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/DateOperatorPicker/utils.unit.spec.ts
@@ -50,7 +50,7 @@ describe("getAvailableOptions", () => {
       "All time",
       "Previous",
       "Next",
-      0,
+      "Current",
     ]);
   });
 

--- a/frontend/src/metabase/querying/filters/components/DatePicker/DateOperatorPicker/utils.unit.spec.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/DateOperatorPicker/utils.unit.spec.ts
@@ -388,7 +388,7 @@ describe("setOptionType", () => {
     });
   });
 
-  describe(0, () => {
+  describe("current", () => {
     it.each([...SPECIFIC_VALUES, ...EXCLUDE_VALUES])(
       'should return default value for "$operator" operator',
       value => {

--- a/frontend/src/metabase/querying/filters/components/DatePicker/DateOperatorPicker/utils.unit.spec.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/DateOperatorPicker/utils.unit.spec.ts
@@ -34,7 +34,7 @@ const SPECIFIC_VALUES: SpecificDatePickerValue[] = [
 const RELATIVE_VALUES: RelativeDatePickerValue[] = [
   { type: "relative", value: -1, unit: "minute" },
   { type: "relative", value: 1, unit: "hour" },
-  { type: "relative", value: "current", unit: "day" },
+  { type: "relative", value: 0, unit: "day" },
 ];
 
 const EXCLUDE_VALUES: ExcludeDatePickerValue[] = [
@@ -50,7 +50,7 @@ describe("getAvailableOptions", () => {
       "All time",
       "Previous",
       "Next",
-      "Current",
+      0,
     ]);
   });
 
@@ -292,21 +292,18 @@ describe("setOptionType", () => {
       "month",
       "quarter",
       "year",
-    ])(
-      'should preserve "%s" unit and use default value for "current" value',
-      unit => {
-        const value: DatePickerValue = {
-          type: "relative",
-          value: "current",
-          unit,
-        };
-        expect(setOptionType(value, "last")).toEqual({
-          type: "relative",
-          value: -30,
-          unit,
-        });
-      },
-    );
+    ])('should preserve "%s" unit and use default value for 0 value', unit => {
+      const value: DatePickerValue = {
+        type: "relative",
+        value: 0,
+        unit,
+      };
+      expect(setOptionType(value, "last")).toEqual({
+        type: "relative",
+        value: -30,
+        unit,
+      });
+    });
 
     it.each<DatePickerTruncationUnit>([
       "minute",
@@ -350,21 +347,18 @@ describe("setOptionType", () => {
       "month",
       "quarter",
       "year",
-    ])(
-      'should preserve "%s" unit and use default value for "current" value',
-      unit => {
-        const value: DatePickerValue = {
-          type: "relative",
-          value: "current",
-          unit,
-        };
-        expect(setOptionType(value, "next")).toEqual({
-          type: "relative",
-          value: 30,
-          unit,
-        });
-      },
-    );
+    ])('should preserve "%s" unit and use default value for 0 value', unit => {
+      const value: DatePickerValue = {
+        type: "relative",
+        value: 0,
+        unit,
+      };
+      expect(setOptionType(value, "next")).toEqual({
+        type: "relative",
+        value: 30,
+        unit,
+      });
+    });
 
     it.each<DatePickerTruncationUnit>([
       "minute",
@@ -388,13 +382,13 @@ describe("setOptionType", () => {
     });
   });
 
-  describe("current", () => {
+  describe(0, () => {
     it.each([...SPECIFIC_VALUES, ...EXCLUDE_VALUES])(
       'should return default value for "$operator" operator',
       value => {
         expect(setOptionType(value, "current")).toEqual({
           type: "relative",
-          value: "current",
+          value: 0,
           unit: "day",
         });
       },
@@ -411,7 +405,7 @@ describe("setOptionType", () => {
           };
           expect(setOptionType(value, "current")).toEqual({
             type: "relative",
-            value: "current",
+            value: 0,
             unit: "day",
           });
         });
@@ -433,7 +427,7 @@ describe("setOptionType", () => {
         };
         expect(setOptionType(value, "current")).toEqual({
           type: "relative",
-          value: "current",
+          value: 0,
           unit,
         });
       });

--- a/frontend/src/metabase/querying/filters/components/DatePicker/DatePicker.stories.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/DatePicker.stories.tsx
@@ -134,7 +134,7 @@ export const ExcludeDayOfWeekDarkTheme = merge(ExcludeDayOfWeek, {
 export const RelativeCurrent = {
   render: Template,
   args: {
-    value: { type: "relative", unit: "day", value: "current" },
+    value: { type: "relative", unit: "day", value: 0 },
   },
   play: async ({ canvasElement }: { canvasElement: HTMLCanvasElement }) => {
     const canvas = within(canvasElement);

--- a/frontend/src/metabase/querying/filters/components/DatePicker/DatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/DatePicker.unit.spec.tsx
@@ -25,7 +25,7 @@ describe("DatePicker", () => {
 
     expect(onChange).toHaveBeenCalledWith({
       type: "relative",
-      value: "current",
+      value: 0,
       unit: "day",
     });
   });

--- a/frontend/src/metabase/querying/filters/components/DatePicker/DateShortcutPicker/DateShortcutPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/DateShortcutPicker/DateShortcutPicker.unit.spec.tsx
@@ -42,7 +42,7 @@ describe("DateShortcutPicker", () => {
     await userEvent.click(screen.getByText("Today"));
     expect(onChange).toHaveBeenCalledWith({
       type: "relative",
-      value: "current",
+      value: 0,
       unit: "day",
     });
   });

--- a/frontend/src/metabase/querying/filters/components/DatePicker/DateShortcutPicker/constants.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/DateShortcutPicker/constants.ts
@@ -10,7 +10,7 @@ const DAY_WEEK_SHORTCUT_OPTIONS: ShortcutOption[] = [
     shortcut: "today",
     value: {
       type: "relative",
-      value: "current",
+      value: 0,
       unit: "day",
     },
   },

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/CurrentDatePicker/CurrentDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/CurrentDatePicker/CurrentDatePicker.unit.spec.tsx
@@ -11,7 +11,7 @@ import { CurrentDatePicker } from "./CurrentDatePicker";
 
 const DEFAULT_VALUE: RelativeDatePickerValue = {
   type: "relative",
-  value: "current",
+  value: 0,
   unit: "hour",
 };
 
@@ -54,7 +54,7 @@ describe("CurrentDatePicker", () => {
 
     expect(onChange).toHaveBeenCalledWith({
       type: "relative",
-      value: "current",
+      value: 0,
       unit: "week",
     });
   });

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/CurrentDatePicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/CurrentDatePicker/utils.ts
@@ -9,7 +9,7 @@ import { UNIT_GROUPS } from "./constants";
 export function getCurrentValue(
   unit: DatePickerTruncationUnit,
 ): RelativeDatePickerValue {
-  return { type: "relative", value: "current", unit };
+  return { type: "relative", value: 0, unit };
 }
 
 export function getUnitGroups(availableUnits: DatePickerUnit[]) {

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
@@ -1,7 +1,10 @@
 import type { FormEvent } from "react";
 import { t } from "ttag";
 
-import type { DatePickerUnit } from "metabase/querying/filters/types";
+import type {
+  DatePickerUnit,
+  RelativeDatePickerValue,
+} from "metabase/querying/filters/types";
 import {
   Button,
   Divider,
@@ -15,7 +18,6 @@ import {
 } from "metabase/ui";
 
 import { IncludeCurrentSwitch } from "../IncludeCurrentSwitch";
-import type { DateIntervalValue } from "../types";
 import {
   formatDateRange,
   getInterval,
@@ -26,10 +28,10 @@ import {
 import { setDefaultOffset, setUnit } from "./utils";
 
 interface DateIntervalPickerProps {
-  value: DateIntervalValue;
+  value: RelativeDatePickerValue;
   availableUnits: DatePickerUnit[];
   submitButtonLabel: string;
-  onChange: (value: DateIntervalValue) => void;
+  onChange: (value: RelativeDatePickerValue) => void;
   onSubmit: () => void;
 }
 

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.unit.spec.tsx
@@ -8,16 +8,15 @@ import {
 import { DATE_PICKER_UNITS } from "metabase/querying/filters/constants";
 import type {
   DatePickerUnit,
+  RelativeDatePickerValue,
   RelativeIntervalDirection,
 } from "metabase/querying/filters/types";
-
-import type { DateIntervalValue } from "../types";
 
 import { DateIntervalPicker } from "./DateIntervalPicker";
 
 function getDefaultValue(
   direction: RelativeIntervalDirection,
-): DateIntervalValue {
+): RelativeDatePickerValue {
   return {
     type: "relative",
     value: direction === "last" ? -30 : 30,
@@ -26,7 +25,7 @@ function getDefaultValue(
 }
 
 interface SetupOpts {
-  value: DateIntervalValue;
+  value: RelativeDatePickerValue;
   availableUnits?: DatePickerUnit[];
   submitButtonLabel?: string;
 }

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/SimpleDateIntervalPicker/SimpleDateIntervalPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/SimpleDateIntervalPicker/SimpleDateIntervalPicker.tsx
@@ -1,17 +1,19 @@
 import { t } from "ttag";
 
-import type { DatePickerUnit } from "metabase/querying/filters/types";
+import type {
+  DatePickerUnit,
+  RelativeDatePickerValue,
+} from "metabase/querying/filters/types";
 import { Group, NumberInput, Select } from "metabase/ui";
 
 import { IncludeCurrentSwitch } from "../../IncludeCurrentSwitch";
-import type { DateIntervalValue } from "../../types";
 import { getInterval, getUnitOptions, setInterval } from "../../utils";
 import { setUnit } from "../utils";
 
 interface SimpleDateIntervalPickerProps {
-  value: DateIntervalValue;
+  value: RelativeDatePickerValue;
   availableUnits: DatePickerUnit[];
-  onChange: (value: DateIntervalValue) => void;
+  onChange: (value: RelativeDatePickerValue) => void;
 }
 
 export function SimpleDateIntervalPicker({

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/SimpleDateIntervalPicker/SimpleDateIntervalPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/SimpleDateIntervalPicker/SimpleDateIntervalPicker.unit.spec.tsx
@@ -8,16 +8,15 @@ import {
 import { DATE_PICKER_UNITS } from "metabase/querying/filters/constants";
 import type {
   DatePickerUnit,
+  RelativeDatePickerValue,
   RelativeIntervalDirection,
 } from "metabase/querying/filters/types";
-
-import type { DateIntervalValue } from "../../types";
 
 import { SimpleDateIntervalPicker } from "./SimpleDateIntervalPicker";
 
 function getDefaultValue(
   direction: RelativeIntervalDirection,
-): DateIntervalValue {
+): RelativeDatePickerValue {
   return {
     type: "relative",
     value: direction === "last" ? -30 : 30,
@@ -26,7 +25,7 @@ function getDefaultValue(
 }
 
 interface SetupOpts {
-  value: DateIntervalValue;
+  value: RelativeDatePickerValue;
   availableUnits?: DatePickerUnit[];
 }
 

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/utils.ts
@@ -1,18 +1,21 @@
-import type { DatePickerTruncationUnit } from "metabase/querying/filters/types";
+import type {
+  DatePickerTruncationUnit,
+  RelativeDatePickerValue,
+} from "metabase/querying/filters/types";
 import * as Lib from "metabase-lib";
-
-import type { DateIntervalValue } from "../types";
 
 import { DEFAULT_OFFSETS } from "./constants";
 
 export function setUnit(
-  value: DateIntervalValue,
+  value: RelativeDatePickerValue,
   unit: DatePickerTruncationUnit,
-): DateIntervalValue {
+): RelativeDatePickerValue {
   return { ...value, unit };
 }
 
-export function setDefaultOffset(value: DateIntervalValue): DateIntervalValue {
+export function setDefaultOffset(
+  value: RelativeDatePickerValue,
+): RelativeDatePickerValue {
   return {
     ...value,
     offsetValue: DEFAULT_OFFSETS[value.unit] * Math.sign(value.value),
@@ -21,7 +24,7 @@ export function setDefaultOffset(value: DateIntervalValue): DateIntervalValue {
   };
 }
 
-export function getIncludeCurrent(value: DateIntervalValue): boolean {
+export function getIncludeCurrent(value: RelativeDatePickerValue): boolean {
   return value.options?.includeCurrent ?? false;
 }
 
@@ -30,8 +33,8 @@ export function getIncludeCurrentLabel(unit: DatePickerTruncationUnit): string {
 }
 
 export function setIncludeCurrent(
-  value: DateIntervalValue,
+  value: RelativeDatePickerValue,
   includeCurrent: boolean,
-): DateIntervalValue {
+): RelativeDatePickerValue {
   return { ...value, options: { includeCurrent: includeCurrent } };
 }

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.tsx
@@ -1,7 +1,10 @@
 import type { FormEvent } from "react";
 import { t } from "ttag";
 
-import type { DatePickerUnit } from "metabase/querying/filters/types";
+import type {
+  DatePickerUnit,
+  RelativeDatePickerValue,
+} from "metabase/querying/filters/types";
 import {
   Box,
   Button,
@@ -13,7 +16,7 @@ import {
   Text,
 } from "metabase/ui";
 
-import type { DateIntervalValue, DateOffsetIntervalValue } from "../types";
+import type { DateOffsetIntervalValue } from "../types";
 import {
   formatDateRange,
   getInterval,
@@ -36,7 +39,7 @@ interface DateOffsetIntervalPickerProps {
   value: DateOffsetIntervalValue;
   availableUnits: DatePickerUnit[];
   submitButtonLabel: string;
-  onChange: (value: DateIntervalValue) => void;
+  onChange: (value: RelativeDatePickerValue) => void;
   onSubmit: () => void;
 }
 

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.tsx
@@ -16,7 +16,6 @@ import {
   Text,
 } from "metabase/ui";
 
-import type { DateOffsetIntervalValue } from "../types";
 import {
   formatDateRange,
   getInterval,
@@ -36,7 +35,7 @@ import {
 } from "./utils";
 
 interface DateOffsetIntervalPickerProps {
-  value: DateOffsetIntervalValue;
+  value: RelativeDatePickerValue;
   availableUnits: DatePickerUnit[];
   submitButtonLabel: string;
   onChange: (value: RelativeDatePickerValue) => void;

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.unit.spec.tsx
@@ -8,16 +8,15 @@ import {
 import { DATE_PICKER_UNITS } from "metabase/querying/filters/constants";
 import type {
   DatePickerUnit,
+  RelativeDatePickerValue,
   RelativeIntervalDirection,
 } from "metabase/querying/filters/types";
-
-import type { DateOffsetIntervalValue } from "../types";
 
 import { DateOffsetIntervalPicker } from "./DateOffsetIntervalPicker";
 
 function getDefaultValue(
   direction: RelativeIntervalDirection,
-): DateOffsetIntervalValue {
+): RelativeDatePickerValue {
   return {
     type: "relative",
     value: direction === "last" ? -30 : 30,
@@ -32,7 +31,7 @@ const userEvent = _userEvent.setup({
 });
 
 interface SetupOpts {
-  value: DateOffsetIntervalValue;
+  value: RelativeDatePickerValue;
   availableUnits?: DatePickerUnit[];
   submitButtonLabel?: string;
 }

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/utils.ts
@@ -8,29 +8,28 @@ import type {
 } from "metabase/querying/filters/types";
 import * as Lib from "metabase-lib";
 
-import type { DateOffsetIntervalValue } from "../types";
 import { getAvailableTruncationUnits, getDirection } from "../utils";
 
-export function getDirectionText(value: DateOffsetIntervalValue): string {
+export function getDirectionText(value: RelativeDatePickerValue): string {
   const direction = getDirection(value);
   return direction === "last" ? t`Previous` : t`Next`;
 }
 
 export function setUnit(
-  value: DateOffsetIntervalValue,
+  value: RelativeDatePickerValue,
   unit: DatePickerTruncationUnit,
-): DateOffsetIntervalValue {
+): RelativeDatePickerValue {
   return { ...value, unit, offsetUnit: unit };
 }
 
-export function getOffsetInterval(value: DateOffsetIntervalValue): number {
-  return Math.abs(value.offsetValue);
+export function getOffsetInterval(value: RelativeDatePickerValue): number {
+  return Math.abs(value.offsetValue ?? 0);
 }
 
 export function setOffsetInterval(
-  value: DateOffsetIntervalValue,
+  value: RelativeDatePickerValue,
   offsetValue: number,
-): DateOffsetIntervalValue {
+): RelativeDatePickerValue {
   if (offsetValue === 0) {
     return { ...value, offsetValue: 0 };
   } else {
@@ -40,20 +39,20 @@ export function setOffsetInterval(
 }
 
 export function setOffsetUnit(
-  value: DateOffsetIntervalValue,
+  value: RelativeDatePickerValue,
   offsetUnit: DatePickerTruncationUnit,
-): DateOffsetIntervalValue {
+): RelativeDatePickerValue {
   return { ...value, offsetUnit };
 }
 
 export function removeOffset(
-  value: DateOffsetIntervalValue,
+  value: RelativeDatePickerValue,
 ): RelativeDatePickerValue {
   return { ...value, offsetValue: undefined, offsetUnit: undefined };
 }
 
 export function getOffsetUnitOptions(
-  value: DateOffsetIntervalValue,
+  value: RelativeDatePickerValue,
   availableUnits: DatePickerUnit[],
 ) {
   const truncationUnits = getAvailableTruncationUnits(availableUnits);
@@ -64,7 +63,7 @@ export function getOffsetUnitOptions(
     .filter((_, index) => index >= unitIndex)
     .map(unit => ({
       value: unit,
-      label: getOffsetUnitText(unit, direction, value.offsetValue),
+      label: getOffsetUnitText(unit, direction, value.offsetValue ?? 0),
     }));
 }
 

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/utils.ts
@@ -3,11 +3,12 @@ import { t } from "ttag";
 import type {
   DatePickerTruncationUnit,
   DatePickerUnit,
+  RelativeDatePickerValue,
   RelativeIntervalDirection,
 } from "metabase/querying/filters/types";
 import * as Lib from "metabase-lib";
 
-import type { DateIntervalValue, DateOffsetIntervalValue } from "../types";
+import type { DateOffsetIntervalValue } from "../types";
 import { getAvailableTruncationUnits, getDirection } from "../utils";
 
 export function getDirectionText(value: DateOffsetIntervalValue): string {
@@ -47,7 +48,7 @@ export function setOffsetUnit(
 
 export function removeOffset(
   value: DateOffsetIntervalValue,
-): DateIntervalValue {
+): RelativeDatePickerValue {
   return { ...value, offsetValue: undefined, offsetUnit: undefined };
 }
 

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/IncludeCurrentSwitch/IncludeCurrentSwitch.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/IncludeCurrentSwitch/IncludeCurrentSwitch.tsx
@@ -1,5 +1,6 @@
 import { t } from "ttag";
 
+import type { RelativeDatePickerValue } from "metabase/querying/filters/types";
 import { Switch } from "metabase/ui";
 
 import {
@@ -7,11 +8,10 @@ import {
   getIncludeCurrentLabel,
   setIncludeCurrent,
 } from "../DateIntervalPicker/utils";
-import type { DateIntervalValue } from "../types";
 
 interface IncludeCurrentSwitchProps {
-  value: DateIntervalValue;
-  onChange: (value: DateIntervalValue) => void;
+  value: RelativeDatePickerValue;
+  onChange: (value: RelativeDatePickerValue) => void;
 }
 
 export const IncludeCurrentSwitch = ({

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.tsx
@@ -66,7 +66,7 @@ export function RelativeDatePicker({
       <Divider />
       {TABS.map(tab => (
         <Tabs.Panel key={tab.direction} value={tab.direction}>
-          {isOffsetIntervalValue(value) ? (
+          {value != null && isOffsetIntervalValue(value) ? (
             <DateOffsetIntervalPicker
               value={value}
               availableUnits={availableUnits}
@@ -74,7 +74,7 @@ export function RelativeDatePicker({
               onChange={setValue}
               onSubmit={handleSubmit}
             />
-          ) : isIntervalValue(value) ? (
+          ) : value != null && isIntervalValue(value) ? (
             <DateIntervalPicker
               value={value}
               availableUnits={availableUnits}

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.unit.spec.tsx
@@ -88,7 +88,7 @@ describe("RelativeDatePicker", () => {
 
     expect(onChange).toHaveBeenCalledWith({
       type: "relative",
-      value: "current",
+      value: 0,
       unit: "week",
     });
   });

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/types.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/types.ts
@@ -9,11 +9,7 @@ export interface Tab {
   direction: RelativeIntervalDirection;
 }
 
-export interface DateIntervalValue extends RelativeDatePickerValue {
-  value: number;
-}
-
-export interface DateOffsetIntervalValue extends DateIntervalValue {
+export interface DateOffsetIntervalValue extends RelativeDatePickerValue {
   offsetValue: number;
   offsetUnit: DatePickerTruncationUnit;
 }

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/types.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/types.ts
@@ -1,15 +1,6 @@
-import type {
-  DatePickerTruncationUnit,
-  RelativeDatePickerValue,
-  RelativeIntervalDirection,
-} from "metabase/querying/filters/types";
+import type { RelativeIntervalDirection } from "metabase/querying/filters/types";
 
 export interface Tab {
   label: string;
   direction: RelativeIntervalDirection;
-}
-
-export interface DateOffsetIntervalValue extends RelativeDatePickerValue {
-  offsetValue: number;
-  offsetUnit: DatePickerTruncationUnit;
 }

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/utils.ts
@@ -9,7 +9,6 @@ import type {
 import * as Lib from "metabase-lib";
 
 import { DEFAULT_VALUE } from "./constants";
-import type { DateOffsetIntervalValue } from "./types";
 
 export function isRelativeValue(
   value: DatePickerValue | undefined,
@@ -17,13 +16,11 @@ export function isRelativeValue(
   return value != null && value.type === "relative";
 }
 
-export function isIntervalValue(value: RelativeDatePickerValue | undefined) {
-  return value != null && value.value !== 0;
+export function isIntervalValue(value: RelativeDatePickerValue) {
+  return value.value !== 0;
 }
 
-export function isOffsetIntervalValue(
-  value: RelativeDatePickerValue,
-): value is DateOffsetIntervalValue {
+export function isOffsetIntervalValue(value: RelativeDatePickerValue) {
   return (
     isIntervalValue(value) &&
     value.offsetValue != null &&

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/utils.ts
@@ -9,7 +9,7 @@ import type {
 import * as Lib from "metabase-lib";
 
 import { DEFAULT_VALUE } from "./constants";
-import type { DateIntervalValue, DateOffsetIntervalValue } from "./types";
+import type { DateOffsetIntervalValue } from "./types";
 
 export function isRelativeValue(
   value: DatePickerValue | undefined,
@@ -17,17 +17,14 @@ export function isRelativeValue(
   return value != null && value.type === "relative";
 }
 
-export function isIntervalValue(
-  value: RelativeDatePickerValue | undefined,
-): value is DateIntervalValue {
-  return value != null && value.value !== "current";
+export function isIntervalValue(value: RelativeDatePickerValue | undefined) {
+  return value != null && value.value !== 0;
 }
 
 export function isOffsetIntervalValue(
-  value: RelativeDatePickerValue | undefined,
+  value: RelativeDatePickerValue,
 ): value is DateOffsetIntervalValue {
   return (
-    value != null &&
     isIntervalValue(value) &&
     value.offsetValue != null &&
     value.offsetUnit != null
@@ -37,7 +34,7 @@ export function isOffsetIntervalValue(
 export function getDirection(
   value: RelativeDatePickerValue | undefined,
 ): RelativeIntervalDirection {
-  if (value == null || value.value === "current") {
+  if (value == null || value.value === 0) {
     return "current";
   } else {
     return value.value < 0 ? "last" : "next";
@@ -55,7 +52,7 @@ export function setDirection(
 ): RelativeDatePickerValue | undefined {
   if (direction === "current") {
     return fallbackUnit
-      ? { type: "relative", value: "current", unit: fallbackUnit }
+      ? { type: "relative", value: 0, unit: fallbackUnit }
       : undefined;
   }
 
@@ -90,14 +87,14 @@ export function setDirectionAndCoerceUnit(
   return setDirection(value, direction, fallbackUnit);
 }
 
-export function getInterval(value: DateIntervalValue): number {
+export function getInterval(value: RelativeDatePickerValue): number {
   return Math.abs(value.value);
 }
 
 export function setInterval(
-  value: DateIntervalValue,
+  value: RelativeDatePickerValue,
   interval: number,
-): DateIntervalValue {
+): RelativeDatePickerValue {
   const sign = Math.sign(value.value);
 
   return {
@@ -113,7 +110,7 @@ export function getAvailableTruncationUnits(availableUnits: DatePickerUnit[]) {
 }
 
 export function getUnitOptions(
-  value: DateIntervalValue,
+  value: RelativeDatePickerValue,
   availableUnits: DatePickerUnit[],
 ) {
   const truncationUnits = getAvailableTruncationUnits(availableUnits);

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/utils.unit.spec.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/utils.unit.spec.ts
@@ -29,7 +29,7 @@ describe("setDirection", () => {
     it("should convert a current value", () => {
       const value: RelativeDatePickerValue = {
         type: "relative",
-        value: "current",
+        value: 0,
         unit: "week",
       };
       expect(setDirection(value, "last")).toEqual({
@@ -75,7 +75,7 @@ describe("setDirection", () => {
     it("should convert a current value", () => {
       const value: RelativeDatePickerValue = {
         type: "relative",
-        value: "current",
+        value: 0,
         unit: "week",
       };
       expect(setDirection(value, "next")).toEqual({

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SimpleDatePicker/SimpleDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SimpleDatePicker/SimpleDatePicker.unit.spec.tsx
@@ -56,7 +56,7 @@ describe("SimpleDatePicker", () => {
 
     expect(onChange).toHaveBeenCalledWith({
       type: "relative",
-      value: "current",
+      value: 0,
       unit: "month",
     });
   });

--- a/frontend/src/metabase/querying/filters/components/FilterModal/DateFilterEditor/DateFilterEditor.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterModal/DateFilterEditor/DateFilterEditor.unit.spec.tsx
@@ -73,7 +73,7 @@ describe("DateFilterEditor", () => {
       stageIndex,
       Lib.relativeDateFilterClause({
         column,
-        value: "current",
+        value: 0,
         unit: "day",
         offsetValue: null,
         offsetUnit: null,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.unit.spec.tsx
@@ -96,7 +96,7 @@ describe("DateFilterPicker", () => {
     expect(getNextFilterColumnName()).toBe(COLUMN_NAME);
     expect(getNextRelativeFilterParts()).toMatchObject({
       column: expect.anything(),
-      value: "current",
+      value: 0,
       unit: "day",
     });
   });

--- a/frontend/src/metabase/querying/filters/components/RelativeDateShortcutPicker/RelativeDateShortcutPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/RelativeDateShortcutPicker/RelativeDateShortcutPicker.unit.spec.tsx
@@ -13,7 +13,7 @@ type TestCase = {
 const TEST_CASES: TestCase[] = [
   {
     label: "Today",
-    value: { type: "relative", value: "current", unit: "day" },
+    value: { type: "relative", value: 0, unit: "day" },
   },
   {
     label: "Yesterday",

--- a/frontend/src/metabase/querying/filters/components/RelativeDateShortcutPicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/RelativeDateShortcutPicker/utils.ts
@@ -9,7 +9,7 @@ export function getShortcutGroups(): ShortcutGroup[] {
       shortcuts: [
         {
           label: t`Today`,
-          value: { type: "relative", value: "current", unit: "day" },
+          value: { type: "relative", value: 0, unit: "day" },
         },
         {
           label: t`Yesterday`,
@@ -49,15 +49,15 @@ export function getShortcutGroups(): ShortcutGroup[] {
       shortcuts: [
         {
           label: t`Week`,
-          value: { type: "relative", value: "current", unit: "week" },
+          value: { type: "relative", value: 0, unit: "week" },
         },
         {
           label: t`Month`,
-          value: { type: "relative", value: "current", unit: "month" },
+          value: { type: "relative", value: 0, unit: "month" },
         },
         {
           label: t`Year`,
-          value: { type: "relative", value: "current", unit: "year" },
+          value: { type: "relative", value: 0, unit: "year" },
         },
       ],
     },

--- a/frontend/src/metabase/querying/filters/components/TimeseriesChrome/TimeseriesFilterPicker/TimeseriesFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/TimeseriesChrome/TimeseriesFilterPicker/TimeseriesFilterPicker.unit.spec.tsx
@@ -87,7 +87,7 @@ describe("TimeseriesFilterPicker", () => {
     await userEvent.click(screen.getByText("Apply"));
 
     expect(getNextFilterParts()).toMatchObject({
-      value: "current",
+      value: 0,
     });
   });
 

--- a/frontend/src/metabase/querying/filters/types.ts
+++ b/frontend/src/metabase/querying/filters/types.ts
@@ -66,7 +66,7 @@ export interface SpecificDatePickerValue {
 export interface RelativeDatePickerValue {
   type: "relative";
   unit: DatePickerTruncationUnit;
-  value: number | "current";
+  value: number;
   offsetUnit?: DatePickerTruncationUnit;
   offsetValue?: number;
   options?: RelativeDatePickerOptions;

--- a/frontend/src/metabase/querying/filters/utils/dates.unit.spec.ts
+++ b/frontend/src/metabase/querying/filters/utils/dates.unit.spec.ts
@@ -63,7 +63,7 @@ describe("getDateFilterClause", () => {
       displayName: "Created At is Feb 2 – Dec 20, 2024",
     },
     {
-      value: { type: "relative", value: "current", unit: "day" },
+      value: { type: "relative", value: 0, unit: "day" },
       displayName: "Created At is today",
     },
     {
@@ -212,11 +212,11 @@ describe("getDateFilterDisplayName", () => {
       displayName: "January 1, 2024 10:20 AM - December 31, 2024 11:15 PM",
     },
     {
-      value: { type: "relative", value: "current", unit: "day" },
+      value: { type: "relative", value: 0, unit: "day" },
       displayName: "Today",
     },
     {
-      value: { type: "relative", value: "current", unit: "year" },
+      value: { type: "relative", value: 0, unit: "year" },
       displayName: "This Year",
     },
     {

--- a/frontend/src/metabase/querying/parameters/utils/parsing.ts
+++ b/frontend/src/metabase/querying/parameters/utils/parsing.ts
@@ -241,7 +241,7 @@ const DATE_FILTER_SERIALIZERS: DateFilterSerializer[] = [
     deserialize: () => {
       return {
         type: "relative",
-        value: "current",
+        value: 0,
         unit: "day",
       };
     },
@@ -263,7 +263,7 @@ const DATE_FILTER_SERIALIZERS: DateFilterSerializer[] = [
   {
     regex: /^this(\w+)$/,
     serialize: value => {
-      if (value.type === "relative" && value.value === "current") {
+      if (value.type === "relative" && value.value === 0) {
         return `this${value.unit}`;
       }
     },
@@ -272,7 +272,7 @@ const DATE_FILTER_SERIALIZERS: DateFilterSerializer[] = [
       if (isDatePickerTruncationUnit(unit)) {
         return {
           type: "relative",
-          value: "current",
+          value: 0,
           unit,
         };
       }
@@ -300,7 +300,7 @@ const DATE_FILTER_SERIALIZERS: DateFilterSerializer[] = [
     serialize: value => {
       if (
         value.type === "relative" &&
-        value.value !== "current" &&
+        value.value !== 0 &&
         value.value < 0 &&
         value.offsetValue == null &&
         value.offsetUnit == null
@@ -329,7 +329,7 @@ const DATE_FILTER_SERIALIZERS: DateFilterSerializer[] = [
     serialize: value => {
       if (
         value.type === "relative" &&
-        value.value !== "current" &&
+        value.value !== 0 &&
         value.value > 0 &&
         value.offsetValue == null &&
         value.offsetUnit == null
@@ -358,7 +358,7 @@ const DATE_FILTER_SERIALIZERS: DateFilterSerializer[] = [
     serialize: value => {
       if (
         value.type === "relative" &&
-        value.value !== "current" &&
+        value.value !== 0 &&
         value.value < 0 &&
         value.offsetValue != null &&
         value.offsetValue < 0 &&
@@ -394,7 +394,7 @@ const DATE_FILTER_SERIALIZERS: DateFilterSerializer[] = [
     serialize: value => {
       if (
         value.type === "relative" &&
-        value.value !== "current" &&
+        value.value !== 0 &&
         value.value > 0 &&
         value.offsetValue != null &&
         value.offsetValue > 0 &&

--- a/frontend/src/metabase/querying/parameters/utils/parsing.unit.spec.ts
+++ b/frontend/src/metabase/querying/parameters/utils/parsing.unit.spec.ts
@@ -184,7 +184,7 @@ describe("date parameters", () => {
       value: "thisday",
       expectedValue: {
         type: "relative",
-        value: "current",
+        value: 0,
         unit: "day",
       },
     },
@@ -192,7 +192,7 @@ describe("date parameters", () => {
       value: "thisyear",
       expectedValue: {
         type: "relative",
-        value: "current",
+        value: 0,
         unit: "year",
       },
     },

--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -399,7 +399,7 @@
 (def ^:private RelativeDateFilterParts
   [:map
    [:column       ::lib.schema.metadata/column]
-   [:value        [:or number? [:enum :current]]]
+   [:value        number?]
    [:unit         ::lib.schema.temporal-bucketing/unit.date-time.interval]
    [:offset-value {:optional true} [:maybe number?]]
    [:offset-unit  {:optional true} [:maybe ::lib.schema.temporal-bucketing/unit.date-time.interval]]
@@ -409,7 +409,7 @@
   "Creates a relative date filter clause based on FE-friendly filter parts. It should be possible to destructure each
    created expression with [[relative-date-filter-parts]]."
   [column       :- ::lib.schema.metadata/column
-   value        :- [:or number? [:enum :current]]
+   value        :- number?
    unit         :- ::lib.schema.temporal-bucketing/unit.date-time.interval
    offset-value :- [:maybe number?]
    offset-unit  :- [:maybe ::lib.schema.temporal-bucketing/unit.date-time.interval]
@@ -434,7 +434,7 @@
        (value :guard #(or (number? %) (= :current %)))
        (unit :guard keyword?)]
       {:column       (ref->col col-ref)
-       :value        value
+       :value        (if (= value :current) 0 value)
        :unit         unit
        :options      (select-keys opts [:include-current])}
 

--- a/src/metabase/lib/filter.cljc
+++ b/src/metabase/lib/filter.cljc
@@ -330,6 +330,7 @@
   [query stage-number [_tag _opts expr n unit] style]
   (if (clojure.core/or
        (clojure.core/= n :current)
+       (clojure.core/= n 0)
        (clojure.core/and
         (clojure.core/= (abs n) 1)
         (clojure.core/= unit :day)))

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -1126,7 +1126,7 @@
    created expression with [[relative-date-filter-parts]]."
   [column value unit offset-value offset-unit options]
   (lib.core/relative-date-filter-clause column
-                                        (if (string? value) (keyword value) value)
+                                        value
                                         (keyword unit)
                                         offset-value
                                         (some-> offset-unit keyword)
@@ -1139,7 +1139,7 @@
   (when-let [filter-parts (lib.core/relative-date-filter-parts a-query stage-number a-filter-clause)]
     (let [{:keys [column value unit offset-value offset-unit options]} filter-parts]
       #js {:column      column
-           :value       (if (keyword? value) (name value) value)
+           :value       value
            :unit        (name unit)
            :offsetValue offset-value
            :offsetUnit  (some-> offset-unit name)

--- a/test/metabase/lib/fe_util_test.cljc
+++ b/test/metabase/lib/fe_util_test.cljc
@@ -403,9 +403,9 @@
   (let [query  (lib.tu/venues-query)
         column (meta/field-metadata :checkins :date)]
     (testing "clause to parts roundtrip"
-      (doseq [[clause parts] {(lib.filter/time-interval column :current :day)
+      (doseq [[clause parts] {(lib.filter/time-interval column 0 :day)
                               {:column column
-                               :value  :current
+                               :value  0
                                :unit   :day}
 
                               (lib.filter/time-interval column -10 :month)
@@ -446,6 +446,10 @@
                                                                            offset-value
                                                                            offset-unit
                                                                            options)))))))
+    (testing "should convert `:current` to `0` for backward compatibility"
+      (let [clause (lib.filter/time-interval column :current :day)
+            parts  {:column column, :value  0, :unit :day}]
+        (is (=? parts (lib.fe-util/relative-date-filter-parts query -1 clause)))))
     (testing "unsupported clauses"
       (are [clause] (nil? (lib.fe-util/relative-date-filter-parts query -1 clause))
         (lib.filter/is-null column)

--- a/test/metabase/lib/filter_test.cljc
+++ b/test/metabase/lib/filter_test.cljc
@@ -791,6 +791,11 @@
       {:clause [:time-interval created-at :current :quarter],
        :name "Created At is this quarter"}
       {:clause [:time-interval created-at :current :year], :name "Created At is this year"}
+      {:clause [:time-interval created-at 0 :day], :name "Created At is today"}
+      {:clause [:time-interval created-at 0 :week], :name "Created At is this week"}
+      {:clause [:time-interval created-at 0 :month], :name "Created At is this month"}
+      {:clause [:time-interval created-at 0 :quarter], :name "Created At is this quarter"}
+      {:clause [:time-interval created-at 0 :year], :name "Created At is this year"}
       {:clause [:time-interval created-at 1 :minute], :name "Created At is in the next minute"}
       {:clause [:time-interval created-at 3 :minute], :name "Created At is in the next 3 minutes"}
       {:clause [:time-interval created-at 1 :hour], :name "Created At is in the next hour"}


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/54191

Now "current" relative date filters will use `0` instead of `"current"` in the corresponding expression.

How to verify:
- New -> Question -> Products
- Filter -> Created At -> Relative -> Current -> Pick any unit
- Click on the filter -> Back -> Back -> Custom expression -> Check the expression
- Check that the display name of the filter is now fixed as well

<img width="362" alt="Screenshot 2025-02-28 at 12 31 24" src="https://github.com/user-attachments/assets/6e435ab2-a72e-488d-a3d6-5c3999e91650" />
<img width="533" alt="Screenshot 2025-02-28 at 12 31 34" src="https://github.com/user-attachments/assets/b1bd15b2-a368-4385-8669-927a79b59bf5" />
