### PR TITLE
[Cards in Dashboards] Allow changing save location when saving a modified dashboard question

### DIFF
--- a/frontend/src/metabase/collections/containers/FormCollectionAndDashboardPicker/FormCollectionAndDashboardPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionAndDashboardPicker/FormCollectionAndDashboardPicker.tsx
@@ -171,7 +171,7 @@ export function FormCollectionAndDashboardPicker({
       const dashboardId = model === "dashboard" ? id : undefined;
       dashboardIdHelpers.setValue(dashboardId);
 
-      // preload dashboard tab before close if tab field is tracked
+      // preload dashboard tabs before the picker closes for better UX, but only if tab field is tracked
       if (dashboardTabIdFieldName) {
         try {
           const dashboard = dashboardId

--- a/frontend/src/metabase/components/SaveQuestionForm/SaveQuestionForm.tsx
+++ b/frontend/src/metabase/components/SaveQuestionForm/SaveQuestionForm.tsx
@@ -14,9 +14,7 @@ import {
   FormTextInput,
   FormTextarea,
 } from "metabase/forms";
-import { isNullOrUndefined } from "metabase/lib/types";
 import { Button, Radio, Stack, rem } from "metabase/ui";
-import type { Dashboard } from "metabase-types/api";
 
 import S from "./SaveQuestionForm.module.css";
 import { useSaveQuestionContext } from "./context";
@@ -31,14 +29,18 @@ const labelStyles = {
 export const SaveQuestionForm = ({
   onCancel,
   onSaveSuccess,
-  saveToDashboard,
 }: {
   onCancel?: () => void;
   onSaveSuccess?: () => void;
-  saveToDashboard?: Dashboard | null | undefined;
 }) => {
-  const { question, originalQuestion, showSaveType, values, saveToCollection } =
-    useSaveQuestionContext();
+  const {
+    question,
+    originalQuestion,
+    showSaveType,
+    values,
+    saveToCollection,
+    saveToDashboard,
+  } = useSaveQuestionContext();
 
   const nameInputPlaceholder = getPlaceholder(question.type());
   const isDashboardQuestion = !!question.dashboardId();
@@ -50,13 +52,13 @@ export const SaveQuestionForm = ({
     ? t`Save changes`
     : t`Replace original question, "${originalQuestion?.displayName()}"`;
 
-  const isCollectionPickerEnabled = isNullOrUndefined(saveToCollection);
   const models: CollectionPickerModel[] =
     question.type() === "question"
       ? ["collection", "dashboard"]
       : ["collection"];
 
-  const showPickerInput = values.saveType === "create" && !saveToDashboard;
+  const showPickerInput =
+    values.saveType === "create" && !saveToCollection && !saveToDashboard;
 
   return (
     <Form>
@@ -116,7 +118,7 @@ export const SaveQuestionForm = ({
           />
 
           <div>
-            {isCollectionPickerEnabled && showPickerInput && (
+            {showPickerInput && (
               <FormCollectionAndDashboardPicker
                 collectionIdFieldName="collection_id"
                 dashboardIdFieldName="dashboard_id"
@@ -133,19 +135,17 @@ export const SaveQuestionForm = ({
               />
             )}
 
-            {values.saveType === "create" && (
-              <FormDashboardTabSelect
-                name="dashboard_tab_id"
-                label="Which tab should this go on?"
-                dashboardId={values.dashboard_id}
-                styles={{
-                  label: {
-                    ...labelStyles,
-                    marginBottom: rem("3px"),
-                  },
-                }}
-              />
-            )}
+            <FormDashboardTabSelect
+              name="dashboard_tab_id"
+              label="Which tab should this go on?"
+              dashboardId={values.dashboard_id}
+              styles={{
+                label: {
+                  ...labelStyles,
+                  marginBottom: rem("3px"),
+                },
+              }}
+            />
           </div>
         </Stack>
       )}

--- a/frontend/src/metabase/components/SaveQuestionForm/context.tsx
+++ b/frontend/src/metabase/components/SaveQuestionForm/context.tsx
@@ -16,7 +16,7 @@ import { FormProvider } from "metabase/forms";
 import { useSelector } from "metabase/lib/redux";
 import { isNotNull } from "metabase/lib/types";
 import type Question from "metabase-lib/v1/Question";
-import type { CollectionId } from "metabase-types/api";
+import type { CollectionId, DashboardId } from "metabase-types/api";
 
 import { SAVE_QUESTION_SCHEMA } from "./schema";
 import type { FormValues, SaveQuestionProps } from "./types";
@@ -32,6 +32,7 @@ type SaveQuestionContextType = {
   showSaveType: boolean;
   multiStep: boolean;
   saveToCollection?: CollectionId;
+  saveToDashboard?: DashboardId;
 };
 
 export const SaveQuestionContext =
@@ -160,6 +161,10 @@ export const SaveQuestionProvider = ({
     originalQuestion.type() !== "metric" &&
     originalQuestion.canWrite();
 
+  const saveToDashboard = originalQuestion
+    ? undefined
+    : (question.dashboardId() ?? undefined);
+
   return (
     <FormProvider
       initialValues={{ ...initialValues }}
@@ -179,6 +184,7 @@ export const SaveQuestionProvider = ({
             showSaveType,
             multiStep,
             saveToCollection,
+            saveToDashboard,
           }}
         >
           {children}

--- a/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.tsx
@@ -1,4 +1,3 @@
-import { skipToken, useGetDashboardQuery } from "metabase/api";
 import {
   LLMSuggestionQuestionInfo,
   SaveQuestionForm,
@@ -22,11 +21,6 @@ export const SaveQuestionModal = ({
   saveToCollection,
   ...modalProps
 }: SaveQuestionModalProps) => {
-  const saveToDashboardId = question.dashboardId();
-  const { data: saveToDashboard } = useGetDashboardQuery(
-    saveToDashboardId ? { id: saveToDashboardId } : skipToken,
-  );
-
   return (
     <SaveQuestionProvider
       question={question}
@@ -59,7 +53,6 @@ export const SaveQuestionModal = ({
           </Modal.Header>
           <Modal.Body>
             <SaveQuestionForm
-              saveToDashboard={saveToDashboard}
               onSaveSuccess={() => closeOnSuccess && modalProps.onClose()}
               onCancel={modalProps.onClose}
             />


### PR DESCRIPTION
Closes ADM-361

### Description

If you visit a dedicated dashboard question page, edit the question, then try to save as a new question the save question modal wouldn't let you choose a new destination to save it to. This is due to an incorrect calculation that the user is coming from a dashboard. This PR changes that calculation to make sure that this is not a new question before forcing a user into that flow.

### How to verify

- Visit dedicated dashboard question
- Edit the question and then save as new
- You should now see the collection/dashboard picker

### Demo

https://github.com/user-attachments/assets/da396bc2-f409-4aa5-9668-79a6f10bde25

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
