### PR TITLE
add ability to style SpecialTagInput, update MultiAutocomplete styles

### DIFF
--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
@@ -99,7 +99,7 @@ export function SearchValuePicker({
       autoFocus={autoFocus}
       aria-label={t`Filter value`}
       shouldCreate={shouldCreate}
-      rightSection={isSearching ? <Loader /> : undefined}
+      rightSection={isSearching ? <Loader size="xs" /> : undefined}
       nothingFoundMessage={notFoundMessage}
       onChange={onChange}
       onSearchChange={handleSearchChange}

--- a/frontend/src/metabase/ui/components/feedback/Loader/Loader.tsx
+++ b/frontend/src/metabase/ui/components/feedback/Loader/Loader.tsx
@@ -10,5 +10,5 @@ const SIZES: Record<string, string> = {
 };
 
 export const Loader = ({ size = "md", ...props }: LoaderProps) => (
-  <MantineLoader {...props} size={getSize({ size, sizes: SIZES })} />
+  <MantineLoader {...props} size={getSize(SIZES[size])} />
 );

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.module.css
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.module.css
@@ -2,6 +2,10 @@
   --multiselect-pill-font-size: 0.875rem;
 }
 
+.pillList {
+  padding-right: var(--input-right-section-width);
+}
+
 .input {
   --input-fz: 0.875rem;
 

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.module.css
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.module.css
@@ -1,0 +1,29 @@
+.pill {
+  --multiselect-pill-font-size: 0.875rem;
+}
+
+.input {
+  --input-fz: 0.875rem;
+
+  input::placeholder {
+    color: var(--mb-color-text-tertiary);
+  }
+}
+
+.empty {
+  font-size: 0.875rem;
+}
+
+.optionList {
+  padding: 0.75rem;
+}
+
+.option {
+  font-size: 0.875rem;
+  padding: 0.75rem 0.5rem;
+
+  &:hover {
+    color: var(--mb-color-brand);
+    background-color: var(--mb-color-background-hover);
+  }
+}

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
@@ -140,6 +140,7 @@ export function MultiAutocomplete({
       {...props}
       classNames={{
         pill: Styles.pill,
+        pillsList: Styles.pillList,
         input: Styles.input,
         empty: Styles.empty,
         option: Styles.option,

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
@@ -8,6 +8,7 @@ import { t } from "ttag";
 import { color } from "metabase/lib/colors";
 import { Icon, SpecialTagsInput } from "metabase/ui";
 
+import Styles from "./MultiAutocomplete.module.css";
 import { parseValues, unique } from "./utils";
 
 export type MultiAutocompleteProps = Omit<TagsInputProps, "shouldCreate"> & {
@@ -137,6 +138,13 @@ export function MultiAutocomplete({
   return (
     <SpecialTagsInput
       {...props}
+      classNames={{
+        pill: Styles.pill,
+        input: Styles.input,
+        empty: Styles.empty,
+        option: Styles.option,
+        options: Styles.optionList,
+      }}
       data={items}
       value={lastSelectedValues}
       searchValue={searchValue}

--- a/frontend/src/metabase/ui/components/inputs/SpecialTagsInput/SpecialTagsInput.tsx
+++ b/frontend/src/metabase/ui/components/inputs/SpecialTagsInput/SpecialTagsInput.tsx
@@ -143,7 +143,7 @@ export const SpecialTagsInput = forwardRef(function _SpecialTagsInput(
 
   const getStyles = useStyles<TagsInputFactory>({
     name: "TagsInput",
-    classes: {} as any,
+    classes: {},
     props,
     classNames,
     styles,

--- a/frontend/src/metabase/ui/components/inputs/SpecialTagsInput/SpecialTagsInput.tsx
+++ b/frontend/src/metabase/ui/components/inputs/SpecialTagsInput/SpecialTagsInput.tsx
@@ -3,12 +3,16 @@ import {
   OptionsDropdown,
   Pill,
   PillsInput,
+  type TagsInputFactory,
   type TagsInputProps,
   __BaseInputProps,
   __InputStylesNames,
+  extractStyleProps,
   getOptionsLockup,
   getParsedComboboxData,
   useCombobox,
+  useResolvedStylesApi,
+  useStyles,
 } from "@mantine/core";
 import { useId, useMergedRef, useUncontrolled } from "@mantine/hooks";
 import type React from "react";
@@ -118,6 +122,11 @@ export const SpecialTagsInput = forwardRef(function _SpecialTagsInput(
     },
   });
 
+  const {
+    styleProps,
+    rest: { type, autoComplete, ...rest },
+  } = extractStyleProps(others);
+
   const [_value, setValue] = useUncontrolled({
     value,
     defaultValue,
@@ -131,6 +140,18 @@ export const SpecialTagsInput = forwardRef(function _SpecialTagsInput(
     finalValue: "",
     onChange: onSearchChange,
   });
+
+  const getStyles = useStyles<TagsInputFactory>({
+    name: "TagsInput",
+    classes: {} as any,
+    props,
+    classNames,
+    styles,
+    unstyled,
+  });
+
+  const { resolvedClassNames, resolvedStyles } =
+    useResolvedStylesApi<TagsInputFactory>({ props, styles, classNames });
 
   const handleValueSelect = (val: string) => {
     const isDuplicate = _value.some(
@@ -235,6 +256,7 @@ export const SpecialTagsInput = forwardRef(function _SpecialTagsInput(
         }}
         unstyled={unstyled}
         disabled={disabled}
+        {...getStyles("pill")}
       >
         {optionsLockup[item]?.label || item}
       </Pill>
@@ -269,6 +291,8 @@ export const SpecialTagsInput = forwardRef(function _SpecialTagsInput(
     <>
       <Combobox
         store={combobox}
+        classNames={resolvedClassNames}
+        styles={resolvedStyles}
         unstyled={unstyled}
         size={size}
         readOnly={readOnly}
@@ -286,7 +310,10 @@ export const SpecialTagsInput = forwardRef(function _SpecialTagsInput(
       >
         <Combobox.DropdownTarget>
           <PillsInput
+            {...styleProps}
             __staticSelector="TagsInput"
+            classNames={resolvedClassNames}
+            styles={resolvedStyles}
             unstyled={unstyled}
             size={size}
             className={className}
@@ -322,12 +349,18 @@ export const SpecialTagsInput = forwardRef(function _SpecialTagsInput(
             id={_id}
             mod={mod}
           >
-            <Pill.Group disabled={disabled} unstyled={unstyled} role="list">
+            <Pill.Group
+              disabled={disabled}
+              unstyled={unstyled}
+              role="list"
+              {...getStyles("pillsList")}
+            >
               {values}
-              <Combobox.EventsTarget>
-                {/* @ts-expect-error - I've removed some thing that mantine thinks is required as a library, as an end user aren't */}
+              <Combobox.EventsTarget autoComplete={autoComplete}>
                 <PillsInput.Field
+                  {...rest}
                   ref={_ref}
+                  {...getStyles("inputField")}
                   unstyled={unstyled}
                   onKeyDown={handleInputKeydown}
                   onFocus={event => {
@@ -346,8 +379,6 @@ export const SpecialTagsInput = forwardRef(function _SpecialTagsInput(
                   disabled={disabled}
                   readOnly={readOnly}
                   id={_id}
-                  // role="combobox"
-                  {...others}
                 />
               </Combobox.EventsTarget>
             </Pill.Group>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/54207
Closes https://github.com/metabase/metabase/issues/54412

### Description
Adds the ability to apply styles and classnames to the copied TagsInput from Mantine, and updates styling of the MultiAutoComplete to be more in line with v0.53

### How to verify
1. Go to any table viz, and click on the header of a string field
2. Filter on `is`. You'll notice that the font size is larger, as well as the options.

### Demo
![image](https://github.com/user-attachments/assets/8f2a2c15-83df-4966-aa42-6ee66895b5f8)

