### PR TITLE
Updating InputWithSelectPrefix to Mantine components

### DIFF
--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -113,13 +113,10 @@ H.describeWithSnowplow("scenarios > admin > settings", () => {
     cy.contains("Redirect to HTTPS").should("not.exist");
 
     // switch site url to use https
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains("Site URL")
-      .parent()
-      .parent()
-      .findByTestId("select-button")
+    cy.findByTestId("site-url-setting")
+      .findByRole("textbox", { name: "input-prefix" })
       .click();
-    H.popover().contains("https://").click({ force: true });
+    H.popover().contains("https://").click();
 
     cy.wait("@httpsCheck");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -135,13 +132,10 @@ H.describeWithSnowplow("scenarios > admin > settings", () => {
       req.reply({ forceNetworkError: true });
     }).as("httpsCheck");
     // switch site url to use https
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains("Site URL")
-      .parent()
-      .parent()
-      .findByTestId("select-button")
+    cy.findByTestId("site-url-setting")
+      .findByRole("textbox", { name: "input-prefix" })
       .click();
-    H.popover().contains("https://").click({ force: true });
+    H.popover().contains("https://").click();
 
     cy.wait("@httpsCheck");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/frontend/src/metabase/components/InputWithSelectPrefix/InputWithSelectPrefix.jsx
+++ b/frontend/src/metabase/components/InputWithSelectPrefix/InputWithSelectPrefix.jsx
@@ -69,6 +69,7 @@ export default class InputWithSelectPrefix extends Component {
     return (
       <Flex w="400px" p={0} className={FormS.FormInput}>
         <Select
+          aria-label="input-prefix"
           classNames={{
             root: CS.borderRight,
             input: CS.borderless,
@@ -77,6 +78,10 @@ export default class InputWithSelectPrefix extends Component {
           onChange={val => this.setState({ prefix: val })}
           w="6.5rem"
           styles={{
+            root: {
+              borderTopLeftRadius: "0.5rem",
+              borderBottomLeftRadius: "0.5rem",
+            },
             wrapper: {
               height: "100%",
             },

--- a/frontend/src/metabase/components/InputWithSelectPrefix/InputWithSelectPrefix.jsx
+++ b/frontend/src/metabase/components/InputWithSelectPrefix/InputWithSelectPrefix.jsx
@@ -1,11 +1,9 @@
-import cx from "classnames";
 import PropTypes from "prop-types";
 import { Component } from "react";
 
-import Select, { Option } from "metabase/core/components/Select";
-import AdminS from "metabase/css/admin.module.css";
 import FormS from "metabase/css/components/form.module.css";
 import CS from "metabase/css/core/index.css";
+import { Flex, Select } from "metabase/ui";
 
 import { SelectPrefixInput } from "./InputWithSelectPrefix.styled";
 
@@ -69,27 +67,25 @@ export default class InputWithSelectPrefix extends Component {
     const { prefixes, defaultPrefix } = this.props;
     const { prefix, rest } = this.state;
     return (
-      <div
-        className={cx(
-          CS.flex,
-          CS.alignStretch,
-          AdminS.SettingsInput,
-          FormS.FormInput,
-          CS.p0,
-        )}
-      >
+      <Flex w="400px" p={0} className={FormS.FormInput}>
         <Select
-          className={CS.borderRight}
+          classNames={{
+            root: CS.borderRight,
+            input: CS.borderless,
+          }}
           value={prefix || defaultPrefix}
-          onChange={e => this.setState({ prefix: e.target.value })}
-          buttonProps={{ className: CS.borderless }}
-        >
-          {prefixes.map(p => (
-            <Option key={p} value={p}>
-              {p}
-            </Option>
-          ))}
-        </Select>
+          onChange={val => this.setState({ prefix: val })}
+          w="6.5rem"
+          styles={{
+            wrapper: {
+              height: "100%",
+            },
+            input: {
+              height: "100%",
+            },
+          }}
+          data={prefixes}
+        />
         <SelectPrefixInput
           type="text"
           className={CS.flexFull}
@@ -98,7 +94,7 @@ export default class InputWithSelectPrefix extends Component {
           onBlurChange={e => this.setState({ rest: e.target.value })}
           size="large"
         />
-      </div>
+      </Flex>
     );
   }
 }


### PR DESCRIPTION
Closes ADM-367

### Description
Updates the InputWithSelectPrefix component. I believe that at some point, the `buttonProps` prop got ignored. I remember back when the styling used to look different, so I re-implemented that

### How to verify

1. Admin -> Settings
2. View the Site Url input
3. That's literally the only place this is used lol

Before:
![image](https://github.com/user-attachments/assets/9d300a4c-f100-44a2-83b6-977a3ecd1c62)

After:
![image](https://github.com/user-attachments/assets/1418c5a0-bfe5-452d-b8d6-1ccea0c3934e)
