### PR TITLE
Fix pivot csv export with multiple pivot cols and no row totals

### DIFF
--- a/src/metabase/query_processor/pivot/postprocess.clj
+++ b/src/metabase/query_processor/pivot/postprocess.clj
@@ -271,11 +271,12 @@
                               (recur (conj! acc (conj formatted (get column-titles (.next it)))))
                               (persistent! acc))))))
            col-combos))
-   (repeat (count pivot-measures)
-           (perf/concat
-            (when (and row-totals? (> (count pivot-cols) 0)) ["Row totals"])
-            (repeat (dec (count pivot-cols)) nil)
-            (when (and (seq pivot-cols) (> (count pivot-measures) 1)) [nil])))))
+   (when row-totals?
+     (repeat (count pivot-measures)
+             (perf/concat
+              (when (and row-totals? (> (count pivot-cols) 0)) ["Row totals"])
+              (repeat (dec (count pivot-cols)) nil)
+              (when (and (seq pivot-cols) (> (count pivot-measures) 1)) [nil]))))))
 
 (defn- build-headers
   "Combine row keys with column headers."

--- a/test/metabase/api/downloads_exports_test.clj
+++ b/test/metabase/api/downloads_exports_test.clj
@@ -403,8 +403,8 @@
 
 (deftest simple-pivot-export-row-col-totals-test
   (testing "Pivot table csv exports respect row/column totals viz-settings"
-    (doseq [row-totals? [true false]
-            col-totals? [true false]]
+    (doseq [row-totals? [#_true false]
+            col-totals? [#_true false]]
       (mt/dataset test-data
         (mt/with-temp [:model/Card card
                        {:display                :pivot

--- a/test/metabase/api/downloads_exports_test.clj
+++ b/test/metabase/api/downloads_exports_test.clj
@@ -403,8 +403,8 @@
 
 (deftest simple-pivot-export-row-col-totals-test
   (testing "Pivot table csv exports respect row/column totals viz-settings"
-    (doseq [row-totals? [#_true false]
-            col-totals? [#_true false]]
+    (doseq [row-totals? [true false]
+            col-totals? [true false]]
       (mt/dataset test-data
         (mt/with-temp [:model/Card card
                        {:display                :pivot
@@ -441,6 +441,49 @@
                         (group-by second)
                         ((fn [m] (update-vals m #(into #{} (mapv first %)))))
                         (apply concat))))))))))
+
+(deftest ^:parallel pivot-with-multiple-columns-no-row-totals
+  (testing "A pivot table with multiple pivot columns and no row totals can export correctly (#54530)"
+    (let [pivot-rows-query "SELECT *
+                              FROM (SELECT 4 AS A UNION ALL SELECT 3)
+                              CROSS JOIN (SELECT 'BA' AS B)
+                              CROSS JOIN (SELECT 3 AS C UNION ALL SELECT 4)
+                              CROSS JOIN (SELECT 1 AS MEASURE)"]
+      (mt/dataset test-data
+        (mt/with-temp [:model/Card {pivot-data-card-id :id}
+                       {:dataset_query {:database (mt/id)
+                                        :type     :native
+                                        :native
+                                        {:template-tags {}
+                                         :query         pivot-rows-query}}
+                        :result_metadata
+                        (into [] (for [[_ field-name {:keys [base-type]}] pivot-fields]
+                                   {:name         field-name
+                                    :display_name field-name
+                                    :field_ref    [:field field-name {:base-type base-type}]
+                                    :base_type    base-type}))}
+                       :model/Card pivot-card
+                       {:display                :pivot
+                        :visualization_settings {:pivot_table.column_split
+                                                 {:rows    ["C"]
+                                                  :columns ["A", "B"]
+                                                  :values  ["MEASURE"]}
+                                                 :pivot.show_row_totals    false
+                                                 :pivot.show_column_totals false}
+                        :dataset_query          (mt/mbql-query nil
+                                                  {:aggregation  [[:sum [:field "MEASURE" {:base-type :type/Integer}]]]
+                                                   :breakout
+                                                   [[:field "A" {:base-type :type/Integer}]
+                                                    [:field "B" {:base-type :type/Text}]
+                                                    [:field "C" {:base-type :type/Integer}]]
+                                                   :source-table (format "card__%s" pivot-data-card-id)})}]
+          (let [result (card-download pivot-card {:export-format :csv :pivot true})]
+            (is
+             (= [["C" "3" "4"]
+                 ["C" "BA" "BA"]
+                 ["3" "1" "1"]
+                 ["4" "1" "1"]]
+                result))))))))
 
 (deftest ^:parallel simple-pivot-export-works-even-with-table-column-ordering-test
   (testing "Pivot table exports are not affected by table sort settings"
@@ -620,10 +663,10 @@
   (testing "Row and Column Values that collide with indices don't break (#50207)"
     (testing "Other aggregations will produce the correct values in Totals rows."
       (let [pivot-rows-query "SELECT *
-         FROM (SELECT    4 AS A UNION ALL SELECT 3)
-   CROSS JOIN (SELECT 'BA' AS B)
-   CROSS JOIN (SELECT    3 AS C UNION ALL SELECT 4)
-   CROSS JOIN (SELECT 1 AS MEASURE)"]
+                              FROM (SELECT 4 AS A UNION ALL SELECT 3)
+                              CROSS JOIN (SELECT 'BA' AS B)
+                              CROSS JOIN (SELECT 3 AS C UNION ALL SELECT 4)
+                              CROSS JOIN (SELECT 1 AS MEASURE)"]
         (mt/dataset test-data
           (mt/with-temp [:model/Card {pivot-data-card-id :id}
                          {:dataset_query {:database (mt/id)


### PR DESCRIPTION
Closes VIZ-487

In CSV pivot exports, we have a piece of logic that generates the `Row Totals` column headers when row totals are enabled. When row totals aren't enabled, and `pivot-cols` has more than one column, this was generating `[nil]` which caused subsequent problems when passing the headers into `metabase.util.performance/transpose`.

We can fix this issue by skipping this code entirely when `row-totals?` is false. I've added a test that catches this as well.