### PR TITLE
SDK legalese text overflow

### DIFF
--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkLegaleseModal/EmbeddingSdkLegaleseModal.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkLegaleseModal/EmbeddingSdkLegaleseModal.tsx
@@ -44,10 +44,10 @@ export const EmbeddingSdkLegaleseModal = ({
         {t`When using the Embedded analytics SDK, each end user should have their own Metabase account.`}
       </Text>
       <List mt="xs">
-        <List.Item>
+        <List.Item mr="md">
           <Text>{t`Sharing Metabase accounts is a security risk. Even if you filter data on the client side, each user could use their token to view any data visible to that shared user account.`}</Text>
         </List.Item>
-        <List.Item>
+        <List.Item mr="md">
           <Text>{t`That, and we consider shared accounts to be unfair usage. Fair usage of the SDK involves giving each end-user of the embedded analytics their own Metabase account.`}</Text>
         </List.Item>
       </List>


### PR DESCRIPTION
Closes EMB-93 - notice that `each` that overflows on the right side of the modal

Before:

<img width="737" alt="image" src="https://github.com/user-attachments/assets/7d7e5a78-bcca-4df3-b420-4518a65cb930" />


After:

<img width="694" alt="image" src="https://github.com/user-attachments/assets/cec87399-54b5-4b48-ba34-ae40a569434c" />


I'm not sure if this is the _best_ solution but it definitely works for what is very much a P3 of P3s