### PR TITLE
Fix the sorting of custom column from a saved card in a new question

### DIFF
--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -484,8 +484,7 @@
     ;; reference. `:lib/expression-name` is only set for expression references, so if it's set, we have to generate an
     ;; expression ref, otherwise we generate a normal field ref.
     (:source/fields :source/breakouts)
-    (if (and (:lib/expression-name metadata)
-             (:fingerprint metadata))
+    (if (:lib/expression-name metadata)
       (lib.expression/column-metadata->expression-ref metadata)
       (column-metadata->field-ref metadata))
 

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -484,7 +484,8 @@
     ;; reference. `:lib/expression-name` is only set for expression references, so if it's set, we have to generate an
     ;; expression ref, otherwise we generate a normal field ref.
     (:source/fields :source/breakouts)
-    (if (:lib/expression-name metadata)
+    (if (and (:lib/expression-name metadata)
+             (:fingerprint metadata))
       (lib.expression/column-metadata->expression-ref metadata)
       (column-metadata->field-ref metadata))
 

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -237,7 +237,6 @@
    {:name            expression-name
     :display_name    expression-name
     ;; provided so the FE can add easily add sorts and the like when someone clicks a column header
-    :expression_name expression-name
     :field_ref       (fe-friendly-expression-ref clause)}
    (when temporal-unit
      {:unit temporal-unit})))

--- a/test/metabase/query_processor/middleware/annotate_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_test.clj
@@ -297,7 +297,6 @@
       (is (= {:base_type       :type/Float
               :name            "double-price"
               :display_name    "double-price"
-              :expression_name "double-price"
               :field_ref       [:expression "double-price"]}
              (lib.tu.macros/$ids venues
                (#'annotate/col-info-for-field-clause
@@ -338,7 +337,6 @@
               :base_type          :type/DateTime,
               :name               "last-login-converted",
               :display_name       "last-login-converted",
-              :expression_name    "last-login-converted",
               :field_ref          [:expression "last-login-converted"]}
              (lib.tu.macros/$ids users
                (#'annotate/col-info-for-field-clause
@@ -348,7 +346,6 @@
               :base_type          :type/DateTime,
               :name               "last-login-converted",
               :display_name       "last-login-converted",
-              :expression_name    "last-login-converted",
               :field_ref          [:expression "last-login-converted"]}
              (lib.tu.macros/$ids users
                (#'annotate/col-info-for-field-clause
@@ -533,7 +530,6 @@
           (is (= {:semantic_type :type/Name,
                   :coercion_strategy nil,
                   :name "expr",
-                  :expression_name "expr",
                   :source :fields,
                   :field_ref [:expression "expr"],
                   :effective_type :type/Text,
@@ -547,7 +543,6 @@
           (is (= {:base_type :type/Text,
                   :name "expr",
                   :display_name "expr",
-                  :expression_name "expr",
                   :field_ref [:expression "expr"],
                   :source :fields}
                  (infer [:coalesce "bar" [:field (meta/id :venues :name) nil]]))))))
@@ -557,7 +552,6 @@
           (is (= {:semantic_type :type/Name,
                   :coercion_strategy nil,
                   :name "expr",
-                  :expression_name "expr",
                   :source :fields,
                   :field_ref [:expression "expr"],
                   :effective_type :type/Text,
@@ -669,7 +663,6 @@
     (is (= {:name            "discount_price"
             :display_name    "discount_price"
             :base_type       :type/Float
-            :expression_name "discount_price"
             :source          :fields
             :field_ref       [:expression "discount_price"]}
            (-> (add-column-info
@@ -692,7 +685,7 @@
                          :limit       10})
                       {})))))
     (testing "named :expressions"
-      (is (=? [{:name "prev_month", :display_name "prev_month", :base_type :type/DateTime, :expression_name "prev_month", :source :fields, :field_ref [:expression "prev_month"]}]
+      (is (=? [{:name "prev_month", :display_name "prev_month", :base_type :type/DateTime, :source :fields, :field_ref [:expression "prev_month"]}]
               (:cols (add-column-info
                       (lib.tu.macros/mbql-query users
                         {:expressions {:prev_month [:+ $last-login [:interval -1 :month]]}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/49305

### Description
There is a data inconsistency issue about custom column.

e.g. 1. New -> Question -> Products -> Add a custom column named `Exp1` -> Save as `Q1` (`POST
/api/card/`).
 `result_metadata` in table `REPORT_CARD`:
```json
[{"base_type":"type/Text", "name":"Exp1","display_name":"Exp1", "expression_name":"Exp1", "field_ref":["expression","Exp1"], "source":"fields"}]
```
e.g. 2. New -> Question -> Products -> Add a custom column named `Exp2` -> Save as `Q2` (`POST
/api/card/`) -> Visualization (`POST /api/card/:card_id/query`).
 `result_metadata` in table `REPORT_CARD` (`:expression_name` has been removed, but `:fingerprint` has been added.):
```json
[{"base_type":"type/Text", "name":"Exp2", "display_name":"Exp2", "field_ref":["expression","Exp2"], "effective_type":"type/Text", "database_type":"CHARACTER VARYING", "semantic_type":null, "fingerprint":{"global":{"distinct-count":200,"nil%":0.0},"type":{"type/Text":{"percent-json":0.0,"percent-url":0.0,"percent-email":0.0,"percent-state":0.0,"average-length":2.46}}}}]
```


When i create a new question by follow steps:

New -> Question -> `Q1`/`Q2` -> Group by `Exp1`/`Exp2` -> Sort by `Exp1`/`Exp2`.

We will convert the all stages by `lib.convert/->pMBQL`.
```clojure
(defmethod lib.ref/ref-method :metadata/column
  [{source :lib/source, :as metadata}]
  (case source
    :source/aggregations (lib.aggregation/column-metadata->aggregation-ref metadata)
    :source/expressions  (lib.expression/column-metadata->expression-ref metadata)

    (:source/fields :source/breakouts)
    (if (:lib/expression-name metadata)
      (lib.expression/column-metadata->expression-ref metadata)
      (column-metadata->field-ref metadata))

    #_else
    (column-metadata->field-ref metadata)))
```

 Because `Exp1` have `:expression_name`, so its order by will be `[:asc {:lib/uuid 97066726-9ccf-4763-9248-c8c15022f986} [:expression {:base-type :type/Text, :lib/uuid afafb8d0-3947-4e64-804b-21746178fb2b} Exp1]]`, and Exp2 has no `:expression_name`, so Exp2s order by will be `[:asc {:lib/uuid 2acf4793-de4d-4681-84e4-1c30ca8db79f} [:field {:base-type :type/Text, :lib/uuid 6d5dcaf7-f0d7-4c36-afc4-93c110a6118a} Exp2]]`.

The sorting statement for `Exp1` will be removed through the following verification method.
```clojure
 (defn- expression-ref-errors-for-stage [stage]
  (let [expression-names (into #{} (map (comp :lib/expression-name second)) (:expressions stage))
        pred #(bad-ref-clause? :expression expression-names %)
        form (stage-with-joins-and-namespaced-keys-removed stage)]
    (when (mbql.u/pred-matches-form? form pred)
      (mbql.u/matching-locations form pred))))
```
Actually, at this moment, `Exp1`/`Exp2` should be regarded as fields rather than expressions.

There are two ways to solve this problem: One is to remove the expression-name when creating and saving a question,  expression-name will be remove actually after reopen by  method `POST /api/card/:card_id/query` (Is this a better option?). The other is to modify the conversion code to treat them as fields.

### How to verify

1. New -> Question -> Products -> Add a custom column named `Exp1` -> Save as `Q1` 
2. New -> Question -> `Q1` -> Group by `Exp1` -> Order by `Exp1` normally

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
