### PR TITLE
Streamline sandboxing e2e tests

### DIFF
--- a/e2e/support/helpers/api/addQuestionToDashboard.ts
+++ b/e2e/support/helpers/api/addQuestionToDashboard.ts
@@ -1,0 +1,30 @@
+import type { CardId, DashboardCard, DashboardId } from "metabase-types/api";
+
+export const addQuestionToDashboard = ({
+  dashboardId,
+  cardId,
+}: {
+  dashboardId: DashboardId;
+  cardId: CardId;
+}): Cypress.Chainable<Cypress.Response<DashboardCard>> =>
+  cy.request(`/api/dashboard/${dashboardId}`).then(({ body: { dashcards } }) =>
+    cy
+      .request("PUT", `/api/dashboard/${dashboardId}`, {
+        dashcards: [
+          ...dashcards,
+          {
+            id: -1,
+            card_id: cardId,
+            // Add sane defaults for the dashboard card size and position
+            row: 0,
+            col: 0,
+            size_x: 11,
+            size_y: 8,
+          },
+        ],
+      })
+      .then(response => ({
+        ...response,
+        body: response.body.dashcards.at(-1),
+      })),
+  );

--- a/e2e/support/helpers/api/createCollection.ts
+++ b/e2e/support/helpers/api/createCollection.ts
@@ -5,18 +5,26 @@ export const createCollection = ({
   description = null,
   parent_id = null,
   authority_level = null,
+  alias,
 }: {
   name: string;
   description?: string | null;
   parent_id?: RegularCollectionId | null;
   authority_level?: "official" | null;
+  alias?: string;
 }): Cypress.Chainable<Cypress.Response<Collection>> => {
   cy.log(`Create a collection: ${name}`);
 
-  return cy.request("POST", "/api/collection", {
-    name,
-    description,
-    parent_id,
-    authority_level,
-  });
+  return cy
+    .request("POST", "/api/collection", {
+      name,
+      description,
+      parent_id,
+      authority_level,
+    })
+    .then(response => {
+      if (alias) {
+        cy.wrap(response.body.id).as(alias);
+      }
+    });
 };

--- a/e2e/support/helpers/api/index.ts
+++ b/e2e/support/helpers/api/index.ts
@@ -1,4 +1,5 @@
 export { addOrUpdateDashboardCard } from "./addOrUpdateDashboardCard";
+export { addQuestionToDashboard } from "./addQuestionToDashboard";
 export { archiveCollection } from "./archiveCollection";
 export { archiveDashboard } from "./archiveDashboard";
 export { archiveQuestion } from "./archiveQuestion";

--- a/e2e/support/helpers/e2e-permissions-helpers.js
+++ b/e2e/support/helpers/e2e-permissions-helpers.js
@@ -167,6 +167,7 @@ export function blockUserGroupPermissions(groupId, databaseId = SAMPLE_DB_ID) {
 }
 
 export function saveChangesToPermissions() {
+  cy.intercept("PUT", "/api/permissions/graph").as("updatePermissions");
   cy.log("Save changes to permissions");
 
   cy.findByTestId("edit-bar")
@@ -178,4 +179,5 @@ export function saveChangesToPermissions() {
     cy.findByText("Are you sure you want to do this?");
     cy.button("Yes").click();
   });
+  cy.wait("@updatePermissions");
 }


### PR DESCRIPTION
Building on #53776

1. Instead of creating a complex network of functions to conditionally create models and questions and sometimes add them to dashboard, use existing helpers to create all the questions and models once, and add them all to a dashboard.
2. Use snapshotting to only do setup once.
3. Since we are using all the same questions in all tests, we can now assert once that the admin view contains all types of data
4. Deletes a lot of unnecessary code, and pulls some logic up to the test level, rather than in helpers

Benefits:
1. Should give us the same coverage
2. Should be easier to read
3. Adds less new helper code
4. Suite runs in under 2 minutes locally (vs. not being able to run locally without running out of memory)

![Screen Shot 2025-02-28 at 10 11 36 PM](https://github.com/user-attachments/assets/2cb04410-f7aa-4ecf-b748-0c10fdfd08b6)

In CI we're looking at 8 min vs 2 min

before | after
--|--
![Screen Shot 2025-02-28 at 10 45 54 PM](https://github.com/user-attachments/assets/1ae3aa3b-e8e1-4c67-9d16-b89a4f4d51c7) | ![Screen Shot 2025-02-28 at 10 44 43 PM](https://github.com/user-attachments/assets/aead075b-8172-482e-beac-e7b85a409cbf)


