### PR TITLE
Small pivot table perf improvements

### DIFF
--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -29,7 +29,8 @@
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :as perf]))
 
 (set! *warn-on-reflection* true)
 
@@ -226,7 +227,7 @@
   [pivot-column-mapping :- ::pivot-column-mapping]
   ;; the first query doesn't need any special mapping, it already has all the columns
   (if pivot-column-mapping
-    (apply juxt (for [mapping pivot-column-mapping]
+    (perf/juxt* (for [mapping pivot-column-mapping]
                   (if mapping
                     #(nth % mapping)
                     (constantly nil))))


### PR DESCRIPTION
These two improvements attribute to no more than 5% of the pivot table generation time because most time is spent waiting on the DB. However, the CPU time will become more relevant if I manage to reduce the number of queries given that some of them look a bit redundant. So, all in all, these optimizations don't need to be passed on.