### PR TITLE
fix: "Get embedding code" width too narrow

### DIFF
--- a/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
@@ -26,7 +26,12 @@ const { H } = cy;
           H.sharingMenu()
             .findByRole("menuitem", { name: "Embed" })
             .should("be.visible")
-            .and("be.enabled");
+            .and("be.enabled")
+            .click();
+          H.modal().within(() => {
+            cy.button("Get embedding code").click();
+          });
+          H.popover().findByTestId("copy-button").should("be.visible");
         });
       });
 

--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/PublicEmbedCard.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/PublicEmbedCard.tsx
@@ -40,7 +40,6 @@ export const PublicEmbedCard = ({
     post.`}
       </Text>
       <Popover
-        width={200}
         position="bottom"
         withArrow
         shadow="md"
@@ -56,7 +55,7 @@ export const PublicEmbedCard = ({
             onClick={() => setIsOpen(value => !value)}
           >{t`Get embedding code`}</Button>
         </Popover.Target>
-        <Popover.Dropdown w="28.5rem">
+        <Popover.Dropdown>
           <Stack p="lg" w="28rem" mih="7.5rem">
             {loading ? (
               <Center>


### PR DESCRIPTION
This is a followed up PR for https://github.com/metabase/metabase/pull/54414, which has fixed #54407. But with more idiomatic version

### Description

I think we fixed the problem wrong, we probably mistakenly set the popover width, and that does nothing on V6 for some reason, and it's only shown on v7.

We need to remove the fixed width and let the popover content dictates the popover size instead

### How to verify

1. Go to a question or a dashboard.
1. Click on the sharing icon > Embed
1. Click "Get embedding code" at the bottom of the modal.

### Demo

Their widths are actually different slightly, but it shouldn't be a concern.

#### This PR
![Screenshot 2025-03-03 at 1 26 25 PM](https://github.com/user-attachments/assets/36b5c333-59e8-46f8-b4ac-805961796072)

#### Master
![Screenshot 2025-03-03 at 1 26 34 PM](https://github.com/user-attachments/assets/fed1f525-2327-4f9d-a794-53a2d846c317)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR