### PR TITLE
Robustly initialize notification triggers

### DIFF
--- a/src/metabase/task/notification.clj
+++ b/src/metabase/task/notification.clj
@@ -1,5 +1,6 @@
 (ns metabase.task.notification
   (:require
+   [clojure.data :refer [diff]]
    [clojurewerkz.quartzite.conversion :as qc]
    [clojurewerkz.quartzite.jobs :as jobs]
    [clojurewerkz.quartzite.schedule.cron :as cron]
@@ -151,8 +152,17 @@
   Called when starting the instance."
   []
   (assert (task/scheduler) "Scheduler must be started before initializing SendPulse triggers")
-  (task/delete-all-triggers-of-job! send-notification-job-key)
-  (run! create-new-trigger! (t2/reducible-select :model/NotificationSubscription :type :notification-subscription/cron)))
+
+  ;; Get all existing triggers and subscription IDs
+  (let [existing-triggers                  (:triggers (task/job-info send-notification-job-key))
+        existing-triggers-subscription-ids (map #(get-in % [:data "subscription-id"]) existing-triggers)
+        subscription-id->cron              (t2/select-pk->fn identity :model/NotificationSubscription :type :notification-subscription/cron)
+        db-subscription-ids                (keys subscription-id->cron)
+        [to-delete to-create _to-skip]     (diff existing-triggers-subscription-ids db-subscription-ids)]
+    (doseq [subscription-id to-delete]
+      (delete-trigger-for-subscription! subscription-id))
+    (doseq [subscription-id to-create]
+      (create-new-trigger! (get subscription-id->cron subscription-id)))))
 
 (jobs/defjob
   ^{:doc

--- a/test/metabase/task/notification_test.clj
+++ b/test/metabase/task/notification_test.clj
@@ -8,7 +8,9 @@
    [metabase.task.notification :as task.notification]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2])
+  (:import
+   (org.quartz TriggerKey)))
 
 (set! *warn-on-reflection* true)
 
@@ -50,17 +52,34 @@
                                    :done? (fn [task] (= [(:id noti)] (get-in task [:task_details :notification_ids])))}))))))))))))
 
 (deftest init-send-notification-triggers-test
-  (mt/with-temp [:model/Notification]
+  (mt/with-model-cleanup [:model/Notification]
     (mt/with-temp-scheduler!
       (task/init! ::task.notification/SendNotifications)
-      (let [notification (models.notification/create-notification!
-                          {:payload_type :notification/testing}
-                          [{:type :notification-subscription/cron
-                            :cron_schedule every-second}]
-                          [])
-            notification-triggers (notification.tu/notification-triggers (:id notification))]
+      (let [notification          (models.notification/create-notification!
+                                   {:payload_type :notification/testing}
+                                   [{:type :notification-subscription/cron
+                                     :cron_schedule "0 0 * 1/1 * ? *"}]
+                                   [])
+            subscription-id       (-> notification models.notification/hydrate-notification :subscriptions first :id)
+            notification-triggers #p (notification.tu/send-notification-triggers subscription-id)]
         (testing "sanity check that it has triggers to begin with"
           (is (not-empty notification-triggers)))
         (testing "init send notification triggers are idempotent if the subscription doesn't change"
           (task.notification/init-send-notification-triggers!)
-          (is (= notification-triggers (notification.tu/notification-triggers (:id notification)))))))))
+          (is (= notification-triggers (notification.tu/send-notification-triggers subscription-id))))
+
+        (testing "Re-create triggers if it's not existed"
+          (task/delete-trigger! (TriggerKey. (-> notification-triggers first :key)))
+          (testing "sanity check that the trigger is deleted"
+            (is (empty? (notification.tu/send-notification-triggers subscription-id))))
+          (task.notification/init-send-notification-triggers!)
+          (is (= notification-triggers (notification.tu/send-notification-triggers subscription-id))))
+
+        (testing "deletes triggers for subscriptions that no longer exist"
+          (let [subscription-id (first (t2/select-pks-vec :model/NotificationSubscription
+                                                          :notification_id (:id notification)))]
+            (t2/delete! :notification_subscription subscription-id)
+            (testing "sanity check that it has trigger before"
+              (is (not-empty (notification.tu/send-notification-triggers subscription-id))))
+            (task.notification/init-send-notification-triggers!)
+            (is (empty? (notification.tu/send-notification-triggers subscription-id)))))))))

--- a/test/metabase/task/notification_test.clj
+++ b/test/metabase/task/notification_test.clj
@@ -61,7 +61,7 @@
                                      :cron_schedule "0 0 * 1/1 * ? *"}]
                                    [])
             subscription-id       (-> notification models.notification/hydrate-notification :subscriptions first :id)
-            notification-triggers #p (notification.tu/send-notification-triggers subscription-id)]
+            notification-triggers (notification.tu/send-notification-triggers subscription-id)]
         (testing "sanity check that it has triggers to begin with"
           (is (not-empty notification-triggers)))
         (testing "init send notification triggers are idempotent if the subscription doesn't change"


### PR DESCRIPTION
A follow up of https://github.com/metabase/metabase/pull/54478, this change the initialization process from delete everything then create everything to delete and create things that are needed.