### PR TITLE
Remove unnecessary step that updates GH CLI

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -212,10 +212,6 @@ jobs:
 
       - name: Create a PR updating readme + published version, and changelog (using GitHub Metabase Automation account)
         run: |
-          # TODO: Remove this step once github includes the new gh CLI version 2.65.0
-          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          brew install gh
-
           git checkout -b update-sdk-version-${{ env.sdk_version }}
           git commit -a -m 'Update Readme version references and published npm version to ${{ env.sdk_version }}'
           git push origin HEAD


### PR DESCRIPTION
### Description

Undo a fix introduced in https://github.com/metabase/metabase/pull/52015. This isn't needed anymore because GitHub runner already include the GH CLI v2.67.0

https://github.com/actions/runner-images/blob/f5963b2ba57bd6370de145343a3b36a62aa48bc9/images/ubuntu/Ubuntu2204-Readme.md?plain=1#L115

It was needed because the older version has a bug which prevent one of pushing or creating a PR (I don't quite remember).

I also hope this somewhat fixes the [failure when deploying SDK v52](https://github.com/metabase/metabase/actions/workflows/release-embedding-sdk.yml) for some reason.

### Backport reason
This isn't really needed since the workflow is run solely on `master`. But I backport to prevent any future conflicts.

