### PR TITLE
fix(frontend): update single alert condition style

### DIFF
--- a/e2e/test/scenarios/sharing/alert/alert-types.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/alert-types.cy.spec.js
@@ -62,8 +62,8 @@ describe("scenarios > alert > types", { tags: "@external" }, () => {
           cy.findByText("New alert").should("be.visible");
 
           cy.findByTestId("alert-goal-select")
-            .should("be.disabled")
-            .should("have.value", "When this question has results");
+            .should("not.be.enabled")
+            .should("have.text", "When this question has results");
 
           cy.findByText("Done").click();
         });
@@ -129,8 +129,8 @@ describe("scenarios > alert > types", { tags: "@external" }, () => {
         cy.findByText("New alert").should("be.visible");
 
         cy.findByTestId("alert-goal-select")
-          .should("be.disabled")
-          .should("have.value", "When this question has results");
+          .should("not.be.enabled")
+          .should("have.text", "When this question has results");
 
         cy.findByText("Done").click();
       });

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
@@ -284,7 +284,6 @@ export const CreateOrEditQuestionAlertModal = ({
                     data={triggerOptions}
                     value={notification.payload.send_condition}
                     w={276}
-                    disabled={hasSingleTriggerOption}
                     onChange={value =>
                       setNotification({
                         ...notification,

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
@@ -36,7 +36,17 @@ import {
 } from "metabase/query_builder/selectors";
 import { addUndo } from "metabase/redux/undo";
 import { getUser, getUserIsAdmin } from "metabase/selectors/user";
-import { Button, Flex, Modal, Select, Stack, Switch, rem } from "metabase/ui";
+import {
+  Button,
+  Flex,
+  Modal,
+  Paper,
+  Select,
+  Stack,
+  Switch,
+  Text,
+  rem,
+} from "metabase/ui";
 import type {
   CreateAlertNotificationRequest,
   Notification,
@@ -257,22 +267,36 @@ export const CreateOrEditQuestionAlertModal = ({
             >
               <Flex gap="lg" align="center">
                 <AlertTriggerIcon />
-                <Select
-                  data-testid="alert-goal-select"
-                  data={triggerOptions}
-                  value={notification.payload.send_condition}
-                  w={276}
-                  disabled={hasSingleTriggerOption}
-                  onChange={value =>
-                    setNotification({
-                      ...notification,
-                      payload: {
-                        ...notification.payload,
-                        send_condition: value as NotificationCardSendCondition,
-                      },
-                    })
-                  }
-                />
+                {hasSingleTriggerOption ? (
+                  <Paper
+                    data-testid="alert-goal-select"
+                    withBorder
+                    shadow="none"
+                    py="sm"
+                    px="1.5rem"
+                    bg="transparent"
+                  >
+                    <Text>{triggerOptions[0].label}</Text>
+                  </Paper>
+                ) : (
+                  <Select
+                    data-testid="alert-goal-select"
+                    data={triggerOptions}
+                    value={notification.payload.send_condition}
+                    w={276}
+                    disabled={hasSingleTriggerOption}
+                    onChange={value =>
+                      setNotification({
+                        ...notification,
+                        payload: {
+                          ...notification.payload,
+                          send_condition:
+                            value as NotificationCardSendCondition,
+                        },
+                      })
+                    }
+                  />
+                )}
               </Flex>
             </AlertModalSettingsBlock>
             <AlertModalSettingsBlock title={t`When do you want to check this?`}>


### PR DESCRIPTION
Resolves [WRK-118](https://linear.app/metabase/issue/WRK-118/update-single-alert-condition-display-per-design-spec)

Changes the appearance of alert condition block when there's only 1 option available.

<img width="441" alt="image" src="https://github.com/user-attachments/assets/55a03271-9793-40ed-85d9-8ea03f7b111a" />