### PR TITLE
fix: clear dashboard url from undefined when filter is removed

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -209,7 +209,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       });
 
       clickLineChartPoint();
-      // TODO: fix it, currently we drill down to the quesiton on dot click
+      // TODO: fix it, currently we drill down to the question on dot click
       // assertDrillThroughMenuOpen();
     });
 
@@ -2622,6 +2622,82 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
           `/dashboard/${targetDashboard.id}`,
         );
         cy.location("search").should("eq", `?tab=${firstTab.id}-first-tab`);
+      });
+    });
+  });
+
+  it("should handle redirect to a dashboard with a filter, when filter was removed (metabase#35444)", () => {
+    const questionDetails = QUESTION_LINE_CHART;
+    H.createDashboard(
+      {
+        ...TARGET_DASHBOARD,
+        parameters: [DASHBOARD_FILTER_TEXT],
+      },
+      {
+        wrapId: true,
+        idAlias: "targetDashboardId",
+      },
+    ).then(dashboardId => {
+      cy.request("PUT", `/api/dashboard/${dashboardId}`, {
+        dashcards: [
+          createMockDashboardCard({
+            card_id: ORDERS_QUESTION_ID,
+            parameter_mappings: [
+              createTextFilterMapping({ card_id: ORDERS_QUESTION_ID }),
+            ],
+          }),
+        ],
+      });
+    });
+
+    H.createQuestionAndDashboard({ questionDetails }).then(({ body: card }) => {
+      H.visitDashboard(card.dashboard_id);
+
+      H.editDashboard();
+
+      H.getDashboardCard().realHover().icon("click").click();
+      addDashboardDestination();
+      getClickMapping("Text filter").click();
+
+      H.popover().findByText("Count").click();
+      H.saveDashboard();
+    });
+
+    cy.get("@targetDashboardId").then(targetDashboardId => {
+      cy.log("remove filter from the target dashboard");
+
+      cy.request("PUT", `/api/dashboard/${targetDashboardId}`, {
+        parameters: [],
+      });
+
+      cy.log(
+        "reload source dashboard to apply removed filter of target dashboard in the mappings",
+      );
+
+      cy.reload();
+
+      H.editDashboard();
+
+      H.getDashboardCard().realHover().icon("click").click();
+
+      cy.get("aside").should("contain", "No available targets");
+      cy.get("aside").button("Done").click();
+
+      H.saveDashboard({ awaitRequest: false });
+      cy.wait("@saveDashboard-getDashboard");
+
+      clickLineChartPoint();
+
+      cy.findByTestId("dashboard-header").should(
+        "contain",
+        TARGET_DASHBOARD.name,
+      );
+
+      cy.log("search shouldn't contain `undefined=`");
+
+      cy.location().should(({ pathname, search }) => {
+        expect(pathname).to.equal(`/dashboard/${targetDashboardId}`);
+        expect(search).to.equal("");
       });
     });
   });

--- a/frontend/src/metabase-lib/v1/queries/drills/dashboard-click-drill.js
+++ b/frontend/src/metabase-lib/v1/queries/drills/dashboard-click-drill.js
@@ -199,15 +199,18 @@ function getParameterValuesBySlug(
   parameterMapping,
   { data, extraData, clickBehavior },
 ) {
-  return _.chain(parameterMapping)
-    .values()
-    .map(({ source, target }) => [
-      getTargetForQueryParams(target, { extraData, clickBehavior }),
-      formatSourceForTarget(source, target, { data, extraData, clickBehavior }),
-    ])
-    .filter(([key, value]) => value != null)
-    .object()
-    .value();
+  return Object.fromEntries(
+    Object.values(parameterMapping)
+      .map(({ source, target }) => [
+        getTargetForQueryParams(target, { extraData, clickBehavior }),
+        formatSourceForTarget(source, target, {
+          data,
+          extraData,
+          clickBehavior,
+        }),
+      ])
+      .filter(([key, value]) => key != null && value != null),
+  );
 }
 
 function getTypeForSource(source, data, extraData) {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/35444

### Description

When source dashboard's dashcard points out to the filter of a target dashboard and a filter is removed from the target dashboard, we calculated URL for click action in a wrong way.

We filtered empty values, but not empty keys in calculating of possible click actions. now it's fixed.


### How to verify

follow steps from the issue


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
