### PR TITLE
fix(sdk): move import of mantine css to index file of sdk

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/index.ts
+++ b/enterprise/frontend/src/embedding-sdk/index.ts
@@ -1,3 +1,8 @@
+// Mantine styles need to be imported before any of our components so that our styles win over
+// the default mantine styles
+import "@mantine/core/styles.css";
+import "@mantine/dates/styles.css";
+
 // polyfills useSyncExternalStore for React 17
 import "./lib/polyfill/use-sync-external-store";
 

--- a/frontend/src/metabase/app.js
+++ b/frontend/src/metabase/app.js
@@ -1,3 +1,6 @@
+import "@mantine/core/styles.css";
+import "@mantine/dates/styles.css";
+
 import "regenerator-runtime/runtime";
 
 // This is conditionally aliased in the webpack config.

--- a/frontend/src/metabase/ui/components/theme/ThemeProvider/ThemeProvider.tsx
+++ b/frontend/src/metabase/ui/components/theme/ThemeProvider/ThemeProvider.tsx
@@ -12,9 +12,6 @@ import { type ReactNode, useMemo } from "react";
 import { getThemeOverrides } from "../../../theme";
 import { DatesProvider } from "../DatesProvider";
 
-import "@mantine/core/styles.css"; // TODO: how to use in embedding?
-import "@mantine/dates/styles.css";
-
 interface ThemeProviderProps {
   children: ReactNode;
 


### PR DESCRIPTION
In the sdk, we were loading mantine's css after some of our components, causing it to win over some of our styles.

This PR moves the import to be very very early on both core app and the sdk to fix the issue

See the original issues for the behaviour that this fixes, the screens are sdk from npm on the left and the sdk from this branch on the right, to show that it behaves as we expect

Fixes EMB-200:
<img width="1662" alt="image" src="https://github.com/user-attachments/assets/9b343ad7-83f1-468f-b453-fa3e7314b800" />



Fixes EMB-161:
<img width="1674" alt="image" src="https://github.com/user-attachments/assets/a439c29c-aa1e-4d3c-bc5d-6181548ffdb8" />




Also part of EMB-201 but not all of it (the icon is still missing):
<img width="1676" alt="image" src="https://github.com/user-attachments/assets/813c9708-532c-44d7-9360-607995806de4" />
