### PR TITLE
Guard enforced-sandboxes-for-user against nil user-ids

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -1801,7 +1801,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
 
       cy.button(DASHBOARD_FILTER_TEXT.name).click();
       H.dashboardParametersPopover().within(() => {
-        cy.findByPlaceholderText("Enter some text").type("Dell Adams");
+        cy.findByPlaceholderText("Search by name").type("Dell Adams");
         cy.button("Add filter").click();
       });
       onNextAnchorClick(anchor => {

--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -1801,7 +1801,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
 
       cy.button(DASHBOARD_FILTER_TEXT.name).click();
       H.dashboardParametersPopover().within(() => {
-        cy.findByPlaceholderText("Search by name").type("Dell Adams");
+        cy.findByPlaceholderText("Search the list").type("Dell Adams");
         cy.button("Add filter").click();
       });
       onNextAnchorClick(anchor => {

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -1387,7 +1387,8 @@
 ;;; ------------------------------------------------ Chain filtering -------------------------------------------------
 
 (defn- do-with-chain-filter-fixtures! [f]
-  (mt/with-additional-premium-features #{:sandboxes}
+  ;; Enable perms-related EE features to ensure changes to perms code don't break embedded chain filters (#54601)
+  (mt/with-additional-premium-features #{:sandboxes :advanced-permissions :impersonation}
     (with-embedding-enabled-and-new-secret-key!
       (api.dashboard-test/with-chain-filter-fixtures [{:keys [dashboard], :as m}]
         (t2/update! :model/Dashboard (u/the-id dashboard) {:enable_embedding true})

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -1387,21 +1387,22 @@
 ;;; ------------------------------------------------ Chain filtering -------------------------------------------------
 
 (defn- do-with-chain-filter-fixtures! [f]
-  (with-embedding-enabled-and-new-secret-key!
-    (api.dashboard-test/with-chain-filter-fixtures [{:keys [dashboard], :as m}]
-      (t2/update! :model/Dashboard (u/the-id dashboard) {:enable_embedding true})
-      (letfn [(token [params]
-                (dash-token dashboard (when params {:params params})))
-              (values-url [& [params param-key]]
-                (format "embed/dashboard/%s/params/%s/values"
-                        (token params) (or param-key "_CATEGORY_ID_")))
-              (search-url [& [params param-key query]]
-                (format "embed/dashboard/%s/params/%s/search/%s"
-                        (token params) (or param-key "_CATEGORY_NAME_") (or query "food")))]
-        (f (assoc m
-                  :token token
-                  :values-url values-url
-                  :search-url search-url))))))
+  (mt/with-additional-premium-features #{:sandboxes}
+    (with-embedding-enabled-and-new-secret-key!
+      (api.dashboard-test/with-chain-filter-fixtures [{:keys [dashboard], :as m}]
+        (t2/update! :model/Dashboard (u/the-id dashboard) {:enable_embedding true})
+        (letfn [(token [params]
+                  (dash-token dashboard (when params {:params params})))
+                (values-url [& [params param-key]]
+                  (format "embed/dashboard/%s/params/%s/values"
+                          (token params) (or param-key "_CATEGORY_ID_")))
+                (search-url [& [params param-key query]]
+                  (format "embed/dashboard/%s/params/%s/search/%s"
+                          (token params) (or param-key "_CATEGORY_NAME_") (or query "food")))]
+          (f (assoc m
+                    :token token
+                    :values-url values-url
+                    :search-url search-url)))))))
 
 (defmacro ^:private with-chain-filter-fixtures! [[binding] & body]
   `(do-with-chain-filter-fixtures! (fn [~binding] ~@body)))


### PR DESCRIPTION
`enforced-sandboxes-for-user` expects a `user-id` argument, but this can be `nil` in embedding contexts. This previously worked with a `nil` user ID but broke starting in https://github.com/metabase/metabase/pull/53849. And because we don't run backend tests with an EE token by default, the embedding tests didn't trigger this code path and it wasn't caught by CI.

In this PR:
* I've added a check for a nil user-id which skips the body of that function (since if there isn't an active user, there aren't any sandboxes enforced by definition)
* I've enabled perms-related feature flags in the embedding test which would have caught this in CI

Resolves GIT-6539 / #54601