### PR TITLE
Fix duplicates introduced by column sync

### DIFF
--- a/frontend/src/metabase/querying/viz-settings/utils/sync-viz-settings.ts
+++ b/frontend/src/metabase/querying/viz-settings/utils/sync-viz-settings.ts
@@ -137,9 +137,14 @@ function syncColumns<T>({
     }
     return settings;
   }, []);
+  const remappedNames = new Set(remappedSettings.map(getColumnName));
   const addedSettings = newColumns
-    .filter(column => !oldNameByKey[column.key])
-    .filter(shouldCreateSetting)
+    .filter(
+      column =>
+        !oldNameByKey[column.key] &&
+        !remappedNames.has(column.name) &&
+        shouldCreateSetting(column),
+    )
     .map(createSetting);
 
   return [...remappedSettings, ...addedSettings];

--- a/frontend/src/metabase/querying/viz-settings/utils/sync-viz-settings.unit.spec.tsx
+++ b/frontend/src/metabase/querying/viz-settings/utils/sync-viz-settings.unit.spec.tsx
@@ -155,6 +155,79 @@ describe("syncVizSettings", () => {
         ],
       });
     });
+
+    it("should not create duplicate entries when there is a mismatch between old columns and current settings (metabase#54547)", () => {
+      const oldColumns: ColumnInfo[] = [{ name: "A", key: "__A" }];
+      const newColumns: ColumnInfo[] = [
+        { name: "A", key: "__A" },
+        { name: "B", key: "__B" },
+        { name: "C", key: "__C" },
+      ];
+      const oldSettings = createMockVisualizationSettings({
+        "table.columns": [
+          createMockTableColumnOrderSetting({
+            name: "A",
+            enabled: true,
+          }),
+          createMockTableColumnOrderSetting({
+            name: "B",
+            enabled: true,
+          }),
+        ],
+      });
+
+      const newSettings = syncVizSettings(oldSettings, newColumns, oldColumns);
+      expect(newSettings).toEqual({
+        "table.columns": [
+          createMockTableColumnOrderSetting({
+            name: "A",
+            enabled: true,
+          }),
+          createMockTableColumnOrderSetting({
+            name: "B",
+            enabled: true,
+          }),
+          createMockTableColumnOrderSetting({
+            name: "C",
+            enabled: true,
+          }),
+        ],
+      });
+    });
+
+    it("should not create duplicate entries when there is a mismatch between old columns and current settings and column names have changed (metabase#54547)", () => {
+      const oldColumns: ColumnInfo[] = [
+        { name: "ID", key: "ID" },
+        { name: "ID_2", key: "PEOPLE__ID" },
+      ];
+      const newColumns: ColumnInfo[] = [
+        { name: "ID", key: "ID" },
+        { name: "ID_2", key: "PRODUCTS__ID" },
+        { name: "ID_3", key: "PEOPLE__ID" },
+      ];
+
+      const oldSettings = createMockVisualizationSettings({
+        "table.columns": [
+          createMockTableColumnOrderSetting({
+            name: "ID",
+            enabled: true,
+          }),
+          createMockTableColumnOrderSetting({
+            name: "ID_3",
+            enabled: false,
+          }),
+        ],
+      });
+
+      const newSettings = syncVizSettings(oldSettings, newColumns, oldColumns);
+      expect(newSettings).toEqual({
+        "table.columns": [
+          { name: "ID", enabled: true },
+          { name: "ID_3", enabled: false },
+          { name: "ID_2", enabled: true },
+        ],
+      });
+    });
   });
 
   describe("column_settings", () => {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/54547

Previously the column sync didn't expect a mismatch between old columns and old settings. This PR adds an additional check to not introduce duplicate entries. 

How to verify:
- open orders table
- reorder columns
- click on any column header -> distinct values
- remove the aggregation
- there should be no column duplicates

