### PR TITLE
Manual Backport of echarts tooltip and dashcard viz modal adjustments

### DIFF
--- a/e2e/support/helpers/e2e-visual-tests-helpers.js
+++ b/e2e/support/helpers/e2e-visual-tests-helpers.js
@@ -161,7 +161,7 @@ export function echartsTooltip() {
 
     // (metabase#52732): tooltip container must have the correct z-index (200)
     // this assertion prevents the tooltip from being rendered below charts.
-    expect(Number(tooltipContainerStyle.zIndex)).to.equal(200);
+    expect(Number(tooltipContainerStyle.zIndex)).to.equal(201);
 
     // Return the visible tooltip
     return visibleTooltip;

--- a/e2e/test-component/scenarios/embedding-sdk/tooltip-reproductions.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/tooltip-reproductions.cy.spec.tsx
@@ -54,10 +54,10 @@ describe("scenarios > embedding-sdk > tooltip-reproductions", () => {
   it("should have the correct tooltip position and z-index (metabase#51904, metabase#52732)", () => {
     const testCases = [
       // should use the user-supplied z-index
-      { input: 1337, expected: 1337 },
+      { input: 1337, expected: 1338 },
 
       // should use the default z-index of 200
-      { input: undefined, expected: 200 },
+      { input: undefined, expected: 201 },
     ];
 
     testCases.forEach(zIndexTestCase => {

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ChartSettingsButton/ChartSettingsButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ChartSettingsButton/ChartSettingsButton.tsx
@@ -39,8 +39,8 @@ export function ChartSettingsButton({
 
       <Modal.Root opened={isOpened} onClose={close} size="85%">
         <Modal.Overlay />
-        <Modal.Content mih="85%">
-          <Modal.Body>
+        <Modal.Content h="85%">
+          <Modal.Body h="100%" p={0}>
             <DashboardChartSettings
               series={series}
               onChange={onReplaceAllVisualizationSettings}

--- a/frontend/src/metabase/visualizations/components/ChartSettings/DashboardChartSettings/DashboardChartSettings.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/DashboardChartSettings/DashboardChartSettings.tsx
@@ -73,7 +73,7 @@ export const DashboardChartSettings = ({
   );
 
   return (
-    <Flex justify="unset" align="unset" wrap="nowrap">
+    <Flex justify="unset" align="unset" wrap="nowrap" h="100%">
       <BaseChartSettings
         className={cx(CS.overflowHidden, DashboardChartSettingsS.Sidebar)}
         series={series}

--- a/frontend/src/metabase/visualizations/echarts/tooltip/index.tsx
+++ b/frontend/src/metabase/visualizations/echarts/tooltip/index.tsx
@@ -78,7 +78,10 @@ export const getTooltipBaseOption = (
         container.style.setProperty("position", "fixed");
         container.style.setProperty("inset", "0");
         container.style.setProperty("pointer-events", "none");
-        container.style.setProperty("z-index", "var(--mb-overlay-z-index)");
+        container.style.setProperty(
+          "z-index",
+          "calc(var(--mb-overlay-z-index) + 1)",
+        );
 
         document.body.append(container);
       }


### PR DESCRIPTION
Backport of VIZ-475 and GIT-6488

### Description
Applies a static height to the Dashcard viz modal, and has it's children grow to it's size. Also adjust the echarts tooltip so that it is not stuck behind modals

### How to verify
1. In a new instance, go to the Sample `E-commerce insights` dashboard
2. Click Edit, and examine the viz settings for each dashcard
3. Visualizations should render to fit the space given, and only the settings panel should be scrollable
4. Hovering over the rendered char should show tooltips above the modal, not underneith

### Demo
https://github.com/user-attachments/assets/8d1faf75-9785-455d-96f7-b10718cd06f0

