### PR TITLE
Repro for "Date filter translations: Key not being translated"

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -4345,7 +4345,7 @@ describe("issue 48824", () => {
     name: "Date filter",
     slug: "filter-date",
     type: "date/all-options",
-    default: "past30days",
+    default: "past30days-from-7days",
   };
 
   beforeEach(() => {
@@ -4380,7 +4380,17 @@ describe("issue 48824", () => {
     });
 
     cy.log("check translations");
-    H.visitDashboard(ORDERS_DASHBOARD_ID);
-    H.filterWidget().findByText("Vorheriger 30 Tage").should("be.visible"); // Previous 30 days
+    H.visitDashboard(ORDERS_DASHBOARD_ID, {
+      params: { [dateParameter.slug]: "past30days" },
+    });
+
+    cy.log("Previous 30 days");
+    H.filterWidget().findByText("Vorheriger 30 Tage").should("be.visible");
+    H.filterWidget().icon("revert").click();
+
+    cy.log("Previous 30 days, starting 7 days ago");
+    H.filterWidget()
+      .findByText("Vorheriger 30 Tage, ab vor 7 tage")
+      .should("be.visible");
   });
 });


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/48824
Fixes https://github.com/metabase/metabase/issues/24624

After date parameter refactoring, some of translation issues are fixed.

How to verify:
- Use relative date filters with a non-English locale in dashboards
- There should be no untranslated terms
- Some terms could be translated incorrectly because we concatenate strings

<img width="255" alt="Screenshot 2025-03-03 at 15 16 42" src="https://github.com/user-attachments/assets/6e571363-2301-4312-9ea3-28d8f7973676" />
