### PR TITLE
Create confirm modal component

### DIFF
--- a/frontend/src/metabase/components/ConfirmContent/ConfirmContent.tsx
+++ b/frontend/src/metabase/components/ConfirmContent/ConfirmContent.tsx
@@ -21,6 +21,7 @@ interface ConfirmContentProps {
   cancelButtonText?: string;
 }
 
+/** @deprecated use ConfirmModal.tsx instead */
 const ConfirmContent = ({
   "data-testid": dataTestId,
   title,

--- a/frontend/src/metabase/components/ConfirmModal/ConfirmModal.tsx
+++ b/frontend/src/metabase/components/ConfirmModal/ConfirmModal.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from "react";
+import { t } from "ttag";
+import _ from "underscore";
+
+import { Button, Flex, Modal, Text } from "metabase/ui";
+
+interface ConfirmModal {
+  opened: boolean | undefined;
+  "data-testid"?: string;
+  title: string | ReactNode;
+  content?: string;
+  message?: string | ReactNode;
+  onClose?: () => void;
+  onConfirm?: () => void;
+  confirmButtonText?: string;
+  confirmButtonPrimary?: boolean;
+}
+
+export const ConfirmModal = ({
+  opened,
+  "data-testid": dataTestId,
+  title,
+  content,
+  message = t`Are you sure you want to do this?`,
+  onClose = _.noop,
+  onConfirm = _.noop,
+  confirmButtonText = t`Yes`,
+  confirmButtonPrimary = false,
+}: ConfirmModal) => (
+  <Modal
+    data-testid={dataTestId}
+    opened={Boolean(opened)}
+    title={title}
+    onClose={onClose}
+    size="lg"
+  >
+    <Flex direction="column" gap="lg" mt="lg">
+      {content ? <Text lh="1.5rem">{content}</Text> : null}
+      <Text lh="1.5rem">{message}</Text>
+      <Flex justify="flex-end" gap="md">
+        <Button onClick={onClose}>{t`Cancel`}</Button>
+        <Button
+          color={confirmButtonPrimary ? "primary" : "danger"}
+          variant="filled"
+          onClick={onConfirm}
+        >
+          {confirmButtonText}
+        </Button>
+      </Flex>
+    </Flex>
+  </Modal>
+);

--- a/frontend/src/metabase/components/ConfirmModal/ConfirmModal.tsx
+++ b/frontend/src/metabase/components/ConfirmModal/ConfirmModal.tsx
@@ -35,8 +35,8 @@ export const ConfirmModal = ({
     size="lg"
   >
     <Flex direction="column" gap="lg" mt="lg">
-      {content ? <Text lh="1.5rem">{content}</Text> : null}
-      <Text lh="1.5rem">{message}</Text>
+      {content ? <Text>{content}</Text> : null}
+      <Text>{message}</Text>
       <Flex justify="flex-end" gap="md">
         <Button onClick={onClose}>{t`Cancel`}</Button>
         <Button

--- a/frontend/src/metabase/components/ConfirmModal/index.tsx
+++ b/frontend/src/metabase/components/ConfirmModal/index.tsx
@@ -1,0 +1,1 @@
+export { ConfirmModal } from "./ConfirmModal";

--- a/frontend/src/metabase/components/LeaveConfirmModal/LeaveConfirmModal.tsx
+++ b/frontend/src/metabase/components/LeaveConfirmModal/LeaveConfirmModal.tsx
@@ -1,0 +1,22 @@
+import { t } from "ttag";
+
+import { ConfirmModal } from "metabase/components/ConfirmModal/ConfirmModal";
+
+interface Props {
+  onConfirm?: () => void;
+  onCancel?: () => void;
+  onClose?: () => void;
+  opened: boolean | undefined;
+}
+
+export const LeaveConfirmModal = ({ onConfirm, onClose, opened }: Props) => (
+  <ConfirmModal
+    opened={opened}
+    confirmButtonText={t`Discard changes`}
+    data-testid="leave-confirm"
+    message={t`Your changes haven't been saved, so you'll lose them if you navigate away.`}
+    title={t`Discard your changes?`}
+    onConfirm={onConfirm}
+    onClose={onClose}
+  />
+);

--- a/frontend/src/metabase/components/LeaveConfirmModal/LeaveConfirmModal.tsx
+++ b/frontend/src/metabase/components/LeaveConfirmModal/LeaveConfirmModal.tsx
@@ -13,7 +13,7 @@ export const LeaveConfirmModal = ({ onConfirm, onClose, opened }: Props) => (
   <ConfirmModal
     opened={opened}
     confirmButtonText={t`Discard changes`}
-    data-testid="leave-confirm"
+    data-testid="leave-confirmation"
     message={t`Your changes haven't been saved, so you'll lose them if you navigate away.`}
     title={t`Discard your changes?`}
     onConfirm={onConfirm}

--- a/frontend/src/metabase/components/LeaveConfirmModal/LeaveRouteConfirmModal.tsx
+++ b/frontend/src/metabase/components/LeaveConfirmModal/LeaveRouteConfirmModal.tsx
@@ -2,24 +2,23 @@ import type { Location } from "history";
 import type { InjectedRouter, Route } from "react-router";
 import { withRouter } from "react-router";
 
-import Modal from "metabase/components/Modal";
 import { useConfirmRouteLeaveModal } from "metabase/hooks/use-confirm-route-leave-modal";
 
-import { LeaveConfirmationModalContent } from "./LeaveConfirmationModalContent";
+import { LeaveConfirmModal } from "./LeaveConfirmModal";
 
-interface Props {
+interface LeaveRouteConfirmModalProps {
   isEnabled: boolean;
   isLocationAllowed?: (location?: Location) => boolean;
   route: Route;
   router: InjectedRouter;
 }
 
-const LeaveConfirmationModalBase = ({
+const _LeaveRouteConfirmModal = ({
   isEnabled,
   isLocationAllowed,
   route,
   router,
-}: Props) => {
+}: LeaveRouteConfirmModalProps) => {
   const { opened, close, confirm } = useConfirmRouteLeaveModal({
     isEnabled,
     isLocationAllowed,
@@ -28,11 +27,8 @@ const LeaveConfirmationModalBase = ({
   });
 
   return (
-    <Modal isOpen={opened}>
-      <LeaveConfirmationModalContent onAction={confirm} onClose={close} />
-    </Modal>
+    <LeaveConfirmModal onConfirm={confirm} onClose={close} opened={opened} />
   );
 };
 
-/** @deprecated use LeaveConfirmModal/LeaveRouteConfirmModal.tsx instead */
-export const LeaveConfirmationModal = withRouter(LeaveConfirmationModalBase);
+export const LeaveRouteConfirmModal = withRouter(_LeaveRouteConfirmModal);

--- a/frontend/src/metabase/components/LeaveConfirmModal/index.ts
+++ b/frontend/src/metabase/components/LeaveConfirmModal/index.ts
@@ -1,0 +1,2 @@
+export { LeaveRouteConfirmModal } from "./LeaveRouteConfirmModal";
+export { LeaveConfirmModal } from "./LeaveConfirmModal";

--- a/frontend/src/metabase/components/LeaveConfirmationModal/LeaveConfirmationModalContent.tsx
+++ b/frontend/src/metabase/components/LeaveConfirmationModal/LeaveConfirmationModalContent.tsx
@@ -8,6 +8,7 @@ interface Props {
   onClose?: () => void;
 }
 
+/** @deprecated use LeaveConfirmModal/LeaveConfirmModal.tsx instead */
 export const LeaveConfirmationModalContent = ({
   onAction,
   onCancel,

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
@@ -7,7 +7,7 @@ import { useMount, usePrevious, useUnmount } from "react-use";
 import { t } from "ttag";
 import _ from "underscore";
 
-import { LeaveConfirmationModal } from "metabase/components/LeaveConfirmationModal";
+import { LeaveRouteConfirmModal } from "metabase/components/LeaveConfirmModal";
 import Bookmark from "metabase/entities/bookmarks";
 import Timelines from "metabase/entities/timelines";
 import title from "metabase/hoc/Title";
@@ -279,7 +279,7 @@ function QueryBuilderInner(props: QueryBuilderInnerProps) {
   };
 
   /**
-   * Navigation is scheduled so that LeaveConfirmationModal's isEnabled
+   * Navigation is scheduled so that LeaveRouteConfirmModal's isEnabled
    * prop has a chance to re-compute on re-render
    */
   const [isCallbackScheduled, scheduleCallback] = useCallbackEffect();
@@ -423,7 +423,7 @@ function QueryBuilderInner(props: QueryBuilderInnerProps) {
         isShowingToaster={isShowingToaster}
       />
 
-      <LeaveConfirmationModal
+      <LeaveRouteConfirmModal
         isEnabled={shouldShowUnsavedChangesWarning && !isCallbackScheduled}
         isLocationAllowed={isLocationAllowed}
         route={route}


### PR DESCRIPTION
Replaces part of #53814

Introduces a new `ConfirmModal` component, replacing the old modal with `metabase/ui/modal` 

Based on the feedback in the previous PR
- Named ConfirmModal instead of ConfirmationModal
- Uses `<Modal />` instead of composed `<Modal.Header>...`
- Uses default modal styles