### PR TITLE
stale-while-revalidate suggestion

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -1295,6 +1295,9 @@ describe("issue 50373", () => {
       {
         method: "GET",
         url: /^\/app\/dist\/(.*)\.js$/,
+        // it would be good to also match the fonts so they can be cacheable
+        // url: /^\/app\/fonts\(.*)$"
+        // /app/fonts/Lato/lato-v16-latin-regular.woff2
       },
       req => {
         // When running in development (e.g. with `yarn dev`),
@@ -1307,7 +1310,8 @@ describe("issue 50373", () => {
           expect(
             res.headers["cache-control"],
             `Invalid Cache-Control header for ${req.url}`,
-          ).to.equal("public, max-age=31536000");
+          ).to.equal("public, max-age=31536000, stale-while-revalidate=30240000");
+        // 31536000 secs = 356 days, 30240000 = 350 days
         });
       },
     );

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -652,7 +652,7 @@
      ;; so let them cache response to make autocomplete feel fast. 60 seconds
      ;; is not enough to be a nuisance when schema or permissions change. Cache
      ;; is user-specific since we're checking for permissions.
-     :headers {"Cache-Control" "public, max-age=60"
+     :headers {"Cache-Control" "public, max-age=70, stale-while-revalidate=60"
                "Vary"          "Cookie"}
      :body    (cond
                 substring (autocomplete-suggestions id (str "%" substring "%"))

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -47,7 +47,7 @@
 
 (def cache-far-future-headers
   "Headers that tell browsers to cache a static resource for a long time."
-  {"Cache-Control" "public, max-age=31536000"})
+  {"Cache-Control" "public, max-age=31536000, stale-while-revalidate=30240000"});; 31536000=356 days, 30240000=350 days
 
 (def ^:private ^:const strict-transport-security-header
   "Tell browsers to only access this resource over HTTPS for the next year (prevent MTM attacks). (This only applies if

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -763,7 +763,7 @@
 (deftest ^:parallel autocomplete-suggestions-test-2
   (testing "GET /api/database/:id/autocomplete_suggestions"
     (testing " returns sane Cache-Control headers"
-      (is (=? {"Cache-Control" "public, max-age=60"
+      (is (=? {"Cache-Control" "public, max-age=70, stale-while-revalidate=60"
                "Vary"          "Cookie"}
               (-> (client/client-full-response (test.users/username->token :rasta) :get 200
                                                (format "database/%s/autocomplete_suggestions" (mt/id))


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.
NA

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

I filled in the google form, for randomizedcoder

Relates to:
https://discourse.metabase.com/t/http-caching-for-javascript/212910

### Description

Small pull request to suggest potential improves to the cache control headers, to add stale-while-revalidate, which should make content updates happen in the background, improving user experience.

This pull request DOES NOT add caching to the fonts.  It would be great to make them cacheable also.

This pull request also does NOT update the documentation with respect to the HTTP caching.
https://github.com/metabase/metabase/blob/master/docs/configuring-metabase/caching.md

### How to verify

This is a demonstration only

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
