### PR TITLE
ci: Fix wrong code format failing linter

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -2634,7 +2634,7 @@ const onNextAnchorClick = callback => {
   cy.window().then(window => {
     const originalClick = window.HTMLAnchorElement.prototype.click;
 
-    window.HTMLAnchorElement.prototype.click = function() {
+    window.HTMLAnchorElement.prototype.click = function () {
       callback(this);
       window.HTMLAnchorElement.prototype.click = originalClick;
     };


### PR DESCRIPTION
This PR fixes the format change introduced by https://github.com/metabase/metabase/pull/54628, I assume it was introduced mistakenly from a merge conflict resolution.

This would unblock all backports which runs `frontend-tests` job. [Example](https://github.com/metabase/metabase/actions/runs/13648658989/job/38154505943?pr=54637)

### How to verify
run `yarn lint-prettier-pure` and it shouldn't fail
