### PR TITLE
fix: WRK-120 show set up channels CTA for users with settings access

### DIFF
--- a/frontend/src/metabase/notifications/modals/ChannelSetupModal.tsx
+++ b/frontend/src/metabase/notifications/modals/ChannelSetupModal.tsx
@@ -7,6 +7,7 @@ const CHANNELS_CONFIG: {
   title: string;
   icon: IconName;
   link: string;
+  testId?: string;
 }[] = [
   {
     title: t`Set up SMTP`,
@@ -22,16 +23,17 @@ const CHANNELS_CONFIG: {
     title: "Add a webhook",
     icon: "webhook",
     link: "/admin/settings/notifications",
+    testId: "alerts-channel-create-webhook",
   },
 ];
 
 type ChannelSetupContentProps = {
-  isAdmin: boolean;
+  userCanAccessSettings: boolean;
   onClose: () => void;
 };
 
 export const ChannelSetupModal = ({
-  isAdmin,
+  userCanAccessSettings,
   onClose,
 }: ChannelSetupContentProps) => {
   return (
@@ -44,14 +46,15 @@ export const ChannelSetupModal = ({
     >
       <Stack gap="0.5rem">
         <Text mb="1rem">
-          {isAdmin
+          {userCanAccessSettings
             ? t`To get notified when something happens, or to send this chart on a schedule, first set up SMTP, Slack, or a webhook.`
             : t`To get notified when something happens, or to send this chart on a schedule, ask your Admin to set up SMTP, Slack, or a webhook.`}
         </Text>
 
-        {isAdmin &&
-          CHANNELS_CONFIG.map(({ title, icon, link }) => (
+        {userCanAccessSettings &&
+          CHANNELS_CONFIG.map(({ title, icon, link, testId }) => (
             <Button
+              data-testid={testId}
               key={title}
               leftSection={<Icon name={icon} />}
               component={Link}

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
@@ -35,11 +35,7 @@ import {
   getVisualizationSettings,
 } from "metabase/query_builder/selectors";
 import { addUndo } from "metabase/redux/undo";
-import {
-  canAccessSettings,
-  getUser,
-  getUserIsAdmin,
-} from "metabase/selectors/user";
+import { canAccessSettings, getUser } from "metabase/selectors/user";
 import { Button, Flex, Modal, Select, Stack, Switch, rem } from "metabase/ui";
 import type {
   CreateAlertNotificationRequest,
@@ -107,7 +103,6 @@ export const CreateOrEditQuestionAlertModal = ({
   const question = useSelector(getQuestion);
   const visualizationSettings = useSelector(getVisualizationSettings);
   const user = useSelector(getUser);
-  const isAdmin = useSelector(getUserIsAdmin);
   const userCanAccessSettings = useSelector(canAccessSettings);
 
   const [notification, setNotification] = useState<
@@ -232,7 +227,12 @@ export const CreateOrEditQuestionAlertModal = ({
     : hasConfiguredEmailChannel;
 
   if (!isLoadingChannelInfo && channelSpec && !channelRequirementsMet) {
-    return <ChannelSetupModal isAdmin={isAdmin} onClose={onClose} />;
+    return (
+      <ChannelSetupModal
+        userCanAccessSettings={userCanAccessSettings}
+        onClose={onClose}
+      />
+    );
   }
 
   if (!notification || !subscription) {

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.unit.spec.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.unit.spec.tsx
@@ -92,6 +92,25 @@ describe("CreateOrEditQuestionAlertModal", () => {
 
     expect(screen.queryByTestId("alert-create")).not.toBeInTheDocument();
   });
+
+  it("should show set up channels model for non-admin users with access setting permission", async () => {
+    setup({
+      isEmailSetup: false,
+      isSlackSetup: false,
+      isHttpSetup: false,
+      userCanAccessSettings: true,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("alerts-channel-setup-modal"),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByTestId("alerts-channel-create-webhook"),
+    ).toBeInTheDocument();
+  });
 });
 
 function setup({


### PR DESCRIPTION
Shows setup channels CTO for non-admin users with settings access

Resolves [WRK-120](https://linear.app/metabase/issue/WRK-120/set-up-channels-cta-for-non-admin-users-with-settings-access)

![image](https://github.com/user-attachments/assets/25d8827a-5da4-4e63-a597-757de2d5ed8f)

