### PR TITLE
Add e2e tests that parameter values can be sandboxed

### DIFF
--- a/e2e/test/scenarios/permissions/sandboxing/helpers/e2e-sandboxing-helpers.ts
+++ b/e2e/test/scenarios/permissions/sandboxing/helpers/e2e-sandboxing-helpers.ts
@@ -334,7 +334,7 @@ export const valuesShouldContainOnlyGizmos = (
   valuesArray: (FieldValue | ParameterValue)[],
 ) => {
   const values = valuesArray.map(val => val[0]);
-  expect(values).to.deep.equal([["Gizmo"]]);
+  expect(values).to.deep.equal(["Gizmo"]);
 };
 
 export const getDashcardResponses = (items: SandboxableItems) => {

--- a/e2e/test/scenarios/permissions/sandboxing/helpers/e2e-sandboxing-helpers.ts
+++ b/e2e/test/scenarios/permissions/sandboxing/helpers/e2e-sandboxing-helpers.ts
@@ -1,7 +1,12 @@
 import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import type { StructuredQuestionDetails } from "e2e/support/helpers";
-import type { GetFieldValuesResponse } from "metabase-types/api";
+import type {
+  FieldValue,
+  GetFieldValuesResponse,
+  ParameterValue,
+  ParameterValues,
+} from "metabase-types/api";
 
 import type {
   DashcardQueryResponse,
@@ -317,6 +322,21 @@ export function rowsShouldContainOnlyGizmos(responses: DatasetResponse[]) {
   ).to.be.true;
 }
 
+export const valuesShouldContainGizmosAndWidgets = (
+  valuesArray: (FieldValue | ParameterValue)[],
+) => {
+  const values = valuesArray.map(val => val[0]);
+  expect(values).to.contain("Gizmo");
+  expect(values).to.contain("Widget");
+};
+
+export const valuesShouldContainOnlyGizmos = (
+  valuesArray: (FieldValue | ParameterValue)[],
+) => {
+  const values = valuesArray.map(val => val[0]);
+  expect(values).to.deep.equal([["Gizmo"]]);
+};
+
 export const getDashcardResponses = (items: SandboxableItems) => {
   signInAsNormalUser();
 
@@ -342,8 +362,22 @@ export const getCardResponses = (items: SandboxableItems) => {
   ) as Cypress.Chainable<DatasetResponse[]>;
 };
 
-export const getFieldValues = () =>
+export const getFieldValuesForProductCategories = () =>
   cy.request<GetFieldValuesResponse>(
     "GET",
     `/api/field/${SAMPLE_DATABASE.PRODUCTS.CATEGORY}/values`,
   );
+
+export const getParameterValuesForProductCategories = () =>
+  cy.request<ParameterValues>("POST", "/api/dataset/parameter/values", {
+    parameter: {
+      id: "1234",
+      name: "Text",
+      slug: "text",
+      type: "string/=",
+      values_query_type: "list",
+      values_source_type: null,
+      values_source_config: {},
+    },
+    field_ids: [SAMPLE_DATABASE.PRODUCTS.CATEGORY],
+  });

--- a/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-ui.cy.spec.ts
+++ b/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-ui.cy.spec.ts
@@ -17,7 +17,6 @@ import {
   valuesShouldContainOnlyGizmos,
 } from "./helpers/e2e-sandboxing-helpers";
 import type { DatasetResponse, SandboxableItems } from "./helpers/types";
-import { CacheConfig, CacheDurationUnit, DurationStrategy } from "metabase-types/api";
 
 const { H } = cy;
 
@@ -51,28 +50,6 @@ describe(
       });
       // @ts-expect-error - this isn't typed yet
       cy.createUserFromRawData(user);
-
-      cy.log(
-        "We additionally want to ensure that sandboxed users see filtered results even if the unsandboxed results are cached",
-      );
-      if (shouldCacheResults) {
-        // TODO: Cache results here
-        // Then ensure that the sandboxed results are not cached
-      }
-      const strategy: DurationStrategy = {
-        type: "duration",
-        duration: 1,
-        unit: CacheDurationUnit.hours,
-        refresh_automatically: false;
-      }
-
-      const cacheConfig: CacheConfig = {
-        model: "root",
-        model_id: 0,
-        strategy
-      }
-
-      cy.request("PUT", "/api/cache", cacheConfig);
 
       // this setup is a bit heavy, so let's just do it once
       H.snapshot("sandboxing-on-postgres-12");
@@ -111,7 +88,7 @@ describe(
         cy.signInAsAdmin();
       });
 
-      it.only("to a table filtered using a question as a custom view", () => {
+      it("to a table filtered using a question as a custom view", () => {
         configureSandboxPolicy({
           filterTableBy: "custom_view",
           customViewType: "Question" as const,

--- a/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-ui.cy.spec.ts
+++ b/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-ui.cy.spec.ts
@@ -7,11 +7,14 @@ import {
   createSandboxingDashboardAndQuestions,
   getCardResponses,
   getDashcardResponses,
-  getFieldValues,
+  getFieldValuesForProductCategories,
+  getParameterValuesForProductCategories,
   rowsShouldContainGizmosAndWidgets,
   rowsShouldContainOnlyGizmos,
   signInAsNormalUser,
   sandboxingUser as user,
+  valuesShouldContainGizmosAndWidgets,
+  valuesShouldContainOnlyGizmos,
 } from "./helpers/e2e-sandboxing-helpers";
 import type { DatasetResponse, SandboxableItems } from "./helpers/types";
 
@@ -70,14 +73,13 @@ describe(
         rowsShouldContainGizmosAndWidgets([response]),
       );
 
-      getFieldValues().then(response => {
-        const values = response.body.values.map(val => val[0]);
-        expect(values.length).to.equal(4);
-        expect(values).to.contain("Doohickey");
-        expect(values).to.contain("Gizmo");
-        expect(values).to.contain("Gadget");
-        expect(values).to.contain("Widget");
-      });
+      getFieldValuesForProductCategories().then(response =>
+        valuesShouldContainGizmosAndWidgets(response.body.values),
+      );
+
+      getParameterValuesForProductCategories().then(response =>
+        valuesShouldContainGizmosAndWidgets(response.body.values),
+      );
     });
 
     describe("we can apply a sandbox policy", () => {
@@ -96,9 +98,12 @@ describe(
         H.visitQuestionAdhoc(adhocQuestionData).then(({ response }) =>
           rowsShouldContainOnlyGizmos([response as DatasetResponse]),
         );
-        getFieldValues().then(response => {
-          expect(response.body.values).to.deep.equal([["Gizmo"]]);
-        });
+        getFieldValuesForProductCategories().then(response =>
+          valuesShouldContainOnlyGizmos(response.body.values),
+        );
+        getParameterValuesForProductCategories().then(response =>
+          valuesShouldContainOnlyGizmos(response.body.values),
+        );
       });
 
       it("to a table filtered using a model as a custom view", () => {
@@ -112,9 +117,12 @@ describe(
         H.visitQuestionAdhoc(adhocQuestionData).then(({ response }) =>
           rowsShouldContainOnlyGizmos([response as DatasetResponse]),
         );
-        getFieldValues().then(response => {
-          expect(response.body.values).to.deep.equal([["Gizmo"]]);
-        });
+        getFieldValuesForProductCategories().then(response =>
+          valuesShouldContainOnlyGizmos(response.body.values),
+        );
+        getParameterValuesForProductCategories().then(response =>
+          valuesShouldContainOnlyGizmos(response.body.values),
+        );
       });
 
       it("to a table filtered by a regular column", () => {
@@ -128,9 +136,12 @@ describe(
         H.visitQuestionAdhoc(adhocQuestionData).then(({ response }) =>
           rowsShouldContainOnlyGizmos([response as DatasetResponse]),
         );
-        getFieldValues().then(response => {
-          expect(response.body.values).to.deep.equal([["Gizmo"]]);
-        });
+        getFieldValuesForProductCategories().then(response =>
+          valuesShouldContainOnlyGizmos(response.body.values),
+        );
+        getParameterValuesForProductCategories().then(response =>
+          valuesShouldContainOnlyGizmos(response.body.values),
+        );
       });
     });
 
@@ -166,6 +177,14 @@ describe(
               expect(response?.body.data.rows).to.have.length(0);
               expect(response?.body.error_type).to.contain("invalid-query");
             });
+          });
+
+          getFieldValuesForProductCategories().then(response => {
+            expect(response.body.values).to.have.length(0);
+          });
+
+          getParameterValuesForProductCategories().then(response => {
+            expect(response.body.values).to.have.length(0);
           });
         });
       });

--- a/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-ui.cy.spec.ts
+++ b/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-ui.cy.spec.ts
@@ -17,6 +17,7 @@ import {
   valuesShouldContainOnlyGizmos,
 } from "./helpers/e2e-sandboxing-helpers";
 import type { DatasetResponse, SandboxableItems } from "./helpers/types";
+import { CacheConfig, CacheDurationUnit, DurationStrategy } from "metabase-types/api";
 
 const { H } = cy;
 
@@ -50,6 +51,29 @@ describe(
       });
       // @ts-expect-error - this isn't typed yet
       cy.createUserFromRawData(user);
+
+      cy.log(
+        "We additionally want to ensure that sandboxed users see filtered results even if the unsandboxed results are cached",
+      );
+      if (shouldCacheResults) {
+        // TODO: Cache results here
+        // Then ensure that the sandboxed results are not cached
+      }
+      const strategy: DurationStrategy = {
+        type: "duration",
+        duration: 1,
+        unit: CacheDurationUnit.hours,
+        refresh_automatically: false;
+      }
+
+      const cacheConfig: CacheConfig = {
+        model: "root",
+        model_id: 0,
+        strategy
+      }
+
+      cy.request("PUT", "/api/cache", cacheConfig);
+
       // this setup is a bit heavy, so let's just do it once
       H.snapshot("sandboxing-on-postgres-12");
     });
@@ -87,7 +111,7 @@ describe(
         cy.signInAsAdmin();
       });
 
-      it("to a table filtered using a question as a custom view", () => {
+      it.only("to a table filtered using a question as a custom view", () => {
         configureSandboxPolicy({
           filterTableBy: "custom_view",
           customViewType: "Question" as const,


### PR DESCRIPTION
Continuing our project of improving e2e tests for sandboxing, this branch adds tests that parameter values are correctly filtered by the sandboxing system. Various sandboxing policies are tested out.

Since we already test that the custom-column sandboxing policies fail closed, this branch also tests that these policies cause the parameter value endpoint to return no values at all.