### PR TITLE
Create footer with easier viz type switching and settings

### DIFF
--- a/frontend/src/metabase/visualizer/components/Footer/Footer.module.css
+++ b/frontend/src/metabase/visualizer/components/Footer/Footer.module.css
@@ -1,0 +1,3 @@
+.footer {
+  border-top: 1px solid var(--mb-color-border);
+}

--- a/frontend/src/metabase/visualizer/components/Footer/Footer.tsx
+++ b/frontend/src/metabase/visualizer/components/Footer/Footer.tsx
@@ -1,0 +1,34 @@
+import { useCallback } from "react";
+import { t } from "ttag";
+
+import { useDispatch, useSelector } from "metabase/lib/redux";
+import { Button, Flex } from "metabase/ui";
+import { getVisualizationType } from "metabase/visualizer/selectors";
+import {
+  setDisplay,
+  toggleVizSettingsSidebar,
+} from "metabase/visualizer/visualizer.slice";
+import type { VisualizationDisplay } from "metabase-types/api";
+
+import { VisualizationPicker } from "../VisualizationPicker";
+
+export function Footer() {
+  const dispatch = useDispatch();
+  const display = useSelector(getVisualizationType);
+
+  const handleChangeDisplay = useCallback(
+    (nextDisplay: string) => {
+      dispatch(setDisplay(nextDisplay as VisualizationDisplay));
+    },
+    [dispatch],
+  );
+  return (
+    <Flex>
+      <VisualizationPicker value={display} onChange={handleChangeDisplay} />
+      <Button
+        ml="auto"
+        onClick={() => dispatch(toggleVizSettingsSidebar())}
+      >{t`Settings`}</Button>
+    </Flex>
+  );
+}

--- a/frontend/src/metabase/visualizer/components/Footer/Footer.tsx
+++ b/frontend/src/metabase/visualizer/components/Footer/Footer.tsx
@@ -12,6 +12,8 @@ import type { VisualizationDisplay } from "metabase-types/api";
 
 import { VisualizationPicker } from "../VisualizationPicker";
 
+import S from "./Footer.module.css";
+
 export function Footer() {
   const dispatch = useDispatch();
   const display = useSelector(getVisualizationType);
@@ -23,7 +25,7 @@ export function Footer() {
     [dispatch],
   );
   return (
-    <Flex>
+    <Flex className={S.footer} px="xl" py="md">
       <VisualizationPicker value={display} onChange={handleChangeDisplay} />
       <Button
         ml="auto"

--- a/frontend/src/metabase/visualizer/components/Footer/index.ts
+++ b/frontend/src/metabase/visualizer/components/Footer/index.ts
@@ -1,0 +1,1 @@
+export { Footer } from "./Footer";

--- a/frontend/src/metabase/visualizer/components/Header/Header.tsx
+++ b/frontend/src/metabase/visualizer/components/Header/Header.tsx
@@ -7,10 +7,7 @@ import {
   getCurrentVisualizerState,
   getIsDirty,
 } from "metabase/visualizer/selectors";
-import {
-  toggleFullscreenMode,
-  toggleVizSettingsSidebar,
-} from "metabase/visualizer/visualizer.slice";
+import { toggleFullscreenMode } from "metabase/visualizer/visualizer.slice";
 import type { VisualizerHistoryItem } from "metabase-types/store/visualizer";
 
 interface HeaderProps {
@@ -46,14 +43,6 @@ export function Header({ onSave, saveLabel }: HeaderProps) {
       </Flex>
 
       <Flex align="center" gap="sm">
-        <Tooltip label={t`Settings`}>
-          <ActionIcon
-            disabled={!isDirty}
-            onClick={() => dispatch(toggleVizSettingsSidebar())}
-          >
-            <Icon name="gear" />
-          </ActionIcon>
-        </Tooltip>
         <Tooltip label={t`Fullscreen`}>
           <ActionIcon
             disabled={!isDirty}

--- a/frontend/src/metabase/visualizer/components/VisualizationPicker/VisualizationPicker.tsx
+++ b/frontend/src/metabase/visualizer/components/VisualizationPicker/VisualizationPicker.tsx
@@ -1,10 +1,9 @@
 import { useMemo } from "react";
-import { t } from "ttag";
 import _ from "underscore";
 
 import IconButtonWrapper from "metabase/components/IconButtonWrapper";
 import { useSelector } from "metabase/lib/redux";
-import { Flex, Icon, Menu, Text } from "metabase/ui";
+import { Center, Flex, Icon, Menu, SegmentedControl, Text } from "metabase/ui";
 import visualizations from "metabase/visualizations";
 import { getVisualizerRawSeries } from "metabase/visualizer/selectors";
 import type { VisualizationDisplay } from "metabase-types/api";
@@ -15,7 +14,6 @@ interface VisualizationPickerProps {
   value: VisualizationDisplay | null;
   onChange: (vizType: string) => void;
 }
-
 export function VisualizationPicker({
   value,
   onChange,
@@ -48,51 +46,45 @@ export function VisualizationPicker({
   );
 
   return (
-    <Menu>
-      <Menu.Target>
-        <IconButtonWrapper style={{ marginRight: "4px" }}>
-          <Icon name={selectedOption?.icon ?? "empty"} />
-          <Icon name="chevrondown" size={8} />
-        </IconButtonWrapper>
-      </Menu.Target>
-      <Menu.Dropdown>
-        {sensibleOptions.map(({ label, value, icon }) => (
-          <Menu.Item
-            key={value}
-            className={S.ListItem}
-            aria-selected={value === selectedOption?.value}
-            onClick={() => onChange(value)}
-          >
-            <Flex align="center">
-              <Icon name={icon} />
-              <Text className={S.ListItemLabel} ml="sm">
-                {label}
-              </Text>
-            </Flex>
-          </Menu.Item>
-        ))}
-        {nonsensibleOptions.length > 0 && (
-          <>
-            <Menu.Divider />
-            <Menu.Label>{t`Other charts`}</Menu.Label>
-          </>
-        )}
-        {nonsensibleOptions.map(({ label, value, icon }) => (
-          <Menu.Item
-            key={value}
-            className={S.ListItem}
-            aria-selected={value === selectedOption?.value}
-            onClick={() => onChange(value)}
-          >
-            <Flex align="center">
-              <Icon name={icon} />
-              <Text className={S.ListItemLabel} ml="sm">
-                {label}
-              </Text>
-            </Flex>
-          </Menu.Item>
-        ))}
-      </Menu.Dropdown>
-    </Menu>
+    <>
+      <SegmentedControl
+        value={selectedOption?.value}
+        data={sensibleOptions.map((o, i) => ({
+          value: o.value,
+          label: (
+            <Center key={i} onClick={() => onChange(o.value)}>
+              <Icon name={o.icon} />
+            </Center>
+          ),
+        }))}
+      />
+      {nonsensibleOptions.length > 0 && (
+        <Menu>
+          <Menu.Target>
+            <IconButtonWrapper style={{ marginLeft: "4px" }}>
+              <Icon name="ellipsis" />
+              <Icon name="chevrondown" size={8} />
+            </IconButtonWrapper>
+          </Menu.Target>
+          <Menu.Dropdown>
+            {nonsensibleOptions.map(({ label, value, icon }) => (
+              <Menu.Item
+                key={value}
+                className={S.ListItem}
+                aria-selected={value === selectedOption?.value}
+                onClick={() => onChange(value)}
+              >
+                <Flex align="center">
+                  <Icon name={icon} />
+                  <Text className={S.ListItemLabel} ml="sm">
+                    {label}
+                  </Text>
+                </Flex>
+              </Menu.Item>
+            ))}
+          </Menu.Dropdown>
+        </Menu>
+      )}
+    </>
   );
 }

--- a/frontend/src/metabase/visualizer/components/Visualizer/Visualizer.tsx
+++ b/frontend/src/metabase/visualizer/components/Visualizer/Visualizer.tsx
@@ -20,27 +20,24 @@ import {
   getIsFullscreenModeEnabled,
   getIsVizSettingsSidebarOpen,
   getVisualizationTitle,
-  getVisualizationType,
 } from "metabase/visualizer/selectors";
 import { isValidDraggedItem } from "metabase/visualizer/utils";
 import {
   closeVizSettingsSidebar,
   handleDrop,
   resetVisualizer,
-  setDisplay,
   setDraggedItem,
   setTitle,
   turnOffFullscreenMode,
 } from "metabase/visualizer/visualizer.slice";
-import type { VisualizationDisplay } from "metabase-types/api";
 import type { VisualizerHistoryItem } from "metabase-types/store/visualizer";
 
 import { DataImporter } from "../DataImporter";
 import { DataManager } from "../DataManager";
 import { DragOverlay as VisualizerDragOverlay } from "../DragOverlay";
+import { Footer } from "../Footer";
 import { Header } from "../Header";
 import { VisualizationCanvas } from "../VisualizationCanvas";
-import { VisualizationPicker } from "../VisualizationPicker";
 import { VizSettingsSidebar } from "../VizSettingsSidebar/VizSettingsSidebar";
 
 interface VisualizerProps {
@@ -54,7 +51,6 @@ export const Visualizer = (props: VisualizerProps) => {
   const { canUndo, canRedo, undo, redo } = useVisualizerHistory();
 
   const title = useSelector(getVisualizationTitle);
-  const display = useSelector(getVisualizationType);
   const draggedItem = useSelector(getDraggedItem);
   const datasets = useSelector(getDatasets);
   const isFullscreen = useSelector(getIsFullscreenModeEnabled);
@@ -125,13 +121,6 @@ export const Visualizer = (props: VisualizerProps) => {
     [dispatch],
   );
 
-  const handleChangeDisplay = useCallback(
-    (nextDisplay: string) => {
-      dispatch(setDisplay(nextDisplay as VisualizationDisplay));
-    },
-    [dispatch],
-  );
-
   return (
     <DndContext
       sensors={[canvasSensor]}
@@ -169,15 +158,12 @@ export const Visualizer = (props: VisualizerProps) => {
                   initialValue={title}
                   onChange={handleChangeTitle}
                 />
-                <VisualizationPicker
-                  value={display}
-                  onChange={handleChangeDisplay}
-                />
               </Flex>
             )}
             <Box h="90%">
               <VisualizationCanvas />
             </Box>
+            {hasDatasets && <Footer />}
           </Box>
           {!isFullscreen && isVizSettingsSidebarOpen && (
             <Flex direction="column" miw={320}>

--- a/frontend/src/metabase/visualizer/components/Visualizer/Visualizer.tsx
+++ b/frontend/src/metabase/visualizer/components/Visualizer/Visualizer.tsx
@@ -143,7 +143,6 @@ export const Visualizer = (props: VisualizerProps) => {
           <Box
             w="100%"
             m={10}
-            px="xl"
             bg="white"
             style={{
               borderRadius: "var(--default-border-radius)",
@@ -153,14 +152,19 @@ export const Visualizer = (props: VisualizerProps) => {
             }}
           >
             {hasDatasets && (
-              <Flex direction="row" align="center" justify="space-between">
+              <Flex
+                direction="row"
+                align="center"
+                justify="space-between"
+                px="xl"
+              >
                 <EditableText
                   initialValue={title}
                   onChange={handleChangeTitle}
                 />
               </Flex>
             )}
-            <Box h="90%">
+            <Box h="87%" px="xl" mb="lg">
               <VisualizationCanvas />
             </Box>
             {hasDatasets && <Footer />}

--- a/frontend/src/metabase/visualizer/components/Visualizer/Visualizer.tsx
+++ b/frontend/src/metabase/visualizer/components/Visualizer/Visualizer.tsx
@@ -140,8 +140,9 @@ export const Visualizer = (props: VisualizerProps) => {
               </Box>
             </Flex>
           )}
-          <Box
+          <Flex
             w="100%"
+            direction="column"
             m={10}
             bg="white"
             style={{
@@ -164,11 +165,11 @@ export const Visualizer = (props: VisualizerProps) => {
                 />
               </Flex>
             )}
-            <Box h="87%" px="xl" mb="lg">
+            <Box px="xl" mb="lg" flex={1}>
               <VisualizationCanvas />
             </Box>
             {hasDatasets && <Footer />}
-          </Box>
+          </Flex>
           {!isFullscreen && isVizSettingsSidebarOpen && (
             <Flex direction="column" miw={320}>
               <VizSettingsSidebar />


### PR DESCRIPTION
Reworks the visualizer viz type picker to be a SegmentedControl in a new Footer component. 

![Screenshot 2025-03-04 at 10 57 19 AM](https://github.com/user-attachments/assets/00b12e90-f84b-4a12-a15b-f0983356ab23)
![Screenshot 2025-03-04 at 10 57 11 AM](https://github.com/user-attachments/assets/ace79b30-1a0d-4877-913d-853b5ea0ae28)
