### PR TITLE
Only include actual users in admin recipients

### DIFF
--- a/src/metabase/channel/email/messages.clj
+++ b/src/metabase/channel/email/messages.clj
@@ -94,7 +94,7 @@
   []
   (concat (when-let [admin-email (public-settings/admin-email)]
             [admin-email])
-          (t2/select-fn-set :email 'User, :is_superuser true, :is_active true, {:order-by [[:id :asc]]})))
+          (t2/select-fn-set :email 'User, :is_superuser true, :is_active true, :type "personal" {:order-by [[:id :asc]]})))
 
 (defn send-user-joined-admin-notification-email!
   "Send an email to the `invitor` (the Admin who invited `new-user`) letting them know `new-user` has joined."

--- a/test/metabase/channel/email/messages_test.clj
+++ b/test/metabase/channel/email/messages_test.clj
@@ -5,6 +5,7 @@
    [metabase.channel.email :as email]
    [metabase.channel.email-test :as et]
    [metabase.channel.email.messages :as messages]
+   [metabase.models.api-key :as api-key]
    [metabase.test :as mt]
    [metabase.test.util :as tu]
    [metabase.util.cron :as u.cron]
@@ -149,3 +150,14 @@
           (is (= {:numberOfSuccessfulCallsWithRetryAttempt 1}
                  (get-positive-retry-metrics test-retry)))
           (is (= 1 (count @mt/inbox))))))))
+
+(deftest all-admin-recipients
+  (mt/with-temp [:model/ApiKey _ {:unhashed_key  (api-key/generate-key)
+                                  :name          "Test API key"
+                                  :user_id       (mt/user->id :crowberto)
+                                  :creator_id    (mt/user->id :crowberto)
+                                  :updated_by_id (mt/user->id :crowberto)}]
+    (testing "all-admin-recipients returns all admin emails"
+      (let [emails (#'messages/all-admin-recipients)]
+        (is (some #(= % "crowberto@metabase.com") emails))
+        (is (not (some #(str/starts-with? % "api-key-user") emails)))))))


### PR DESCRIPTION
Closes #54347 

### Description

The `all-admin-recipients` function was returning everything from the users table that has admin access, including API key rows.

This updates the query to only include type='personal' users which are the actual users.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
