### PR TITLE
Do no singularize or pluralize table and column names in drills

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -132,7 +132,7 @@ describe("issue 33079", () => {
     H.createQuestion(questionDetails, { visitQuestion: true });
     H.cartesianChartCircle().eq(1).click({ force: true });
     H.popover()
-      .findByText(/Order/) // See these Orders
+      .findByText("Siehe diese Einträge") // See these records
       .click();
     cy.wait("@dataset");
     cy.findByTestId("question-row-count").should("contain", "19");

--- a/frontend/src/metabase/querying/drills/utils/fk-filter-drill.ts
+++ b/frontend/src/metabase/querying/drills/utils/fk-filter-drill.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { t } from "ttag";
 
 import {
@@ -14,8 +15,10 @@ export const fkFilterDrill: Drill<Lib.FKFilterDrillThruInfo> = ({
   applyDrill,
 }) => {
   const { tableName, columnName } = drillInfo;
-  const tableTitle = pluralize(tableName);
-  const columnTitle = singularize(stripId(columnName));
+  const locale = dayjs.locale();
+  const tableTitle = locale === "en" ? pluralize(tableName) : tableName;
+  const columnTitle =
+    locale === "en" ? singularize(stripId(columnName)) : stripId(columnName);
 
   return [
     {

--- a/frontend/src/metabase/querying/drills/utils/underlying-records-drill.ts
+++ b/frontend/src/metabase/querying/drills/utils/underlying-records-drill.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { msgid, ngettext } from "ttag";
 
 import { inflect } from "metabase/lib/formatting/strings";
@@ -13,9 +14,10 @@ export const underlyingRecordsDrill: Drill<
   Lib.UnderlyingRecordsDrillThruInfo
 > = ({ drill, drillInfo, applyDrill }): QuestionChangeClickAction[] => {
   const { tableName, rowCount } = drillInfo;
+  const locale = dayjs.locale();
 
   const tableTitle =
-    tableName && isShortTableName(tableName)
+    tableName && locale === "en" && isShortTableName(tableName)
       ? inflect(tableName, rowCount)
       : ngettext(msgid`record`, `records`, rowCount);
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/28559

For non-English locales, we will use `See this record` / `See these records` for `underlying-records-drill` and `View this ${columnTitle}'s ${tableTitle}` without transforming column and table names for `fk-filter-drill`.

`See these records` in German:
<img width="334" alt="Screenshot 2025-03-05 at 10 55 23" src="https://github.com/user-attachments/assets/65ef7283-9d37-4bd2-8c2e-eda49090fa26" />
