### PR TITLE
Remove the legacy isModal context from ModalContent

### DIFF
--- a/frontend/src/metabase/components/ModalContent/ModalContent.tsx
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import PropTypes from "prop-types";
 import type { ReactNode } from "react";
 import { Component } from "react";
 
@@ -25,14 +24,6 @@ export default class ModalContent extends Component<ModalContentProps> {
   static defaultProps = {
     formModal: true,
   };
-
-  static childContextTypes = {
-    isModal: PropTypes.bool,
-  };
-
-  getChildContext() {
-    return { isModal: true };
-  }
 
   render() {
     const {


### PR DESCRIPTION
Closes EMB-216

We do not reference this `isModal` legacy context anywhere in the code, and we can safely assume that it is unused. This avoids the error when migrating to React 19.